### PR TITLE
Studio: detect stalled Deep Research output streams

### DIFF
--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -147,10 +147,9 @@ _MODEL_WAIT_POLL_SECONDS = 2.0
 # otherwise re-send forever, so cap how many times one call may wait.
 _MAX_MODEL_WAITS = 3
 _NO_MODEL_LOADED_DETAIL = "No model loaded"
-# Transport keepalives prevent HTTP read timeouts without proving that the model is progressing.
-# Give prompt processing more time than a mid-response pause, while the run's absolute model
-# timeout remains the final upper bound for either stage.
-_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS = 300.0
+# Transport keepalives prevent HTTP read timeouts without proving that a model which already
+# started answering is still progressing. Prefill remains governed by modelTimeoutSeconds because
+# CPU and offloaded models can legitimately take many minutes to produce their first token.
 _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS = 120.0
 
 
@@ -573,10 +572,6 @@ class LeaseLost(Exception):
     pass
 
 
-class ModelFirstOutputTimeout(httpx.ReadTimeout):
-    pass
-
-
 class ModelOutputIdleTimeout(httpx.ReadTimeout):
     pass
 
@@ -586,8 +581,6 @@ class ModelWallClockTimeout(httpx.ReadTimeout):
 
 
 def _safe_error(exc: BaseException) -> str:
-    if isinstance(exc, ModelFirstOutputTimeout):
-        return "Local model did not produce output before its first-output timeout"
     if isinstance(exc, ModelOutputIdleTimeout):
         return "Local model stopped producing output before completion"
     if isinstance(exc, ModelWallClockTimeout):
@@ -1634,20 +1627,20 @@ class ResearchSupervisor:
         self,
         run_id: str,
         response: httpx.Response,
-        semantic_deadline: Callable[[], tuple[float, bool]] | None = None,
+        semantic_deadline: Callable[[], float | None] | None = None,
     ) -> AsyncIterator[str]:
         iterator = response.aiter_lines().__aiter__()
 
         def wait_timeout() -> float:
             if semantic_deadline is None:
                 return 0.2
-            deadline, has_output = semantic_deadline()
+            deadline = semantic_deadline()
+            if deadline is None:
+                return 0.2
             remaining = deadline - asyncio.get_running_loop().time()
             if remaining > 0:
                 return min(0.2, remaining)
-            if has_output:
-                raise ModelOutputIdleTimeout("Local model stopped producing semantic output")
-            raise ModelFirstOutputTimeout("Local model did not produce semantic output")
+            raise ModelOutputIdleTimeout("Local model stopped producing output")
 
         while True:
             timeout = wait_timeout()
@@ -1791,15 +1784,11 @@ class ResearchSupervisor:
             model_timeout = float(config["budgets"]["modelTimeoutSeconds"])
             timeout = httpx.Timeout(model_timeout)
             loop = asyncio.get_running_loop()
-            request_started_at = loop.time()
 
-            def semantic_deadline() -> tuple[float, bool]:
+            def semantic_deadline() -> float | None:
                 if semantic_output_at is None:
-                    return (
-                        request_started_at + _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS,
-                        False,
-                    )
-                return semantic_output_at + _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS, True
+                    return None
+                return semantic_output_at + _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS
 
             async with (
                 _wall_clock_timeout(model_timeout),
@@ -1811,8 +1800,6 @@ class ResearchSupervisor:
                 attempt = 0
                 try:
                     while True:
-                        # A model-unloaded wait or transport retry starts a fresh upstream attempt.
-                        request_started_at = loop.time()
                         request = client.build_request(
                             "POST",
                             self._endpoint(),
@@ -1830,23 +1817,9 @@ class ResearchSupervisor:
                                     except asyncio.CancelledError:
                                         pass
                                     await self._check_active(run["id"])
-                                if (
-                                    loop.time() - request_started_at
-                                    >= _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
-                                ):
-                                    send_task.cancel()
-                                    try:
-                                        await send_task
-                                    except asyncio.CancelledError:
-                                        pass
-                                    raise ModelFirstOutputTimeout(
-                                        "Local model did not produce response headers"
-                                    )
                             response = await send_task
                             response.raise_for_status()
                             break
-                        except ModelFirstOutputTimeout:
-                            raise
                         except (httpx.TransportError, httpx.HTTPStatusError) as exc:
                             # Only reachable before a body byte is touched (the stream is consumed
                             # after this loop), so a re-send cannot duplicate report text.
@@ -1886,7 +1859,9 @@ class ResearchSupervisor:
                         if not line.startswith("data:"):
                             continue
                         data = line[5:].strip()
-                        if not data or data == "[DONE]":
+                        if data == "[DONE]":
+                            break
+                        if not data:
                             continue
                         try:
                             chunk = json.loads(data)
@@ -1901,15 +1876,13 @@ class ResearchSupervisor:
                             continue
                         thought = delta.get("reasoning_content")
                         if isinstance(thought, str) and thought:
-                            if thought.strip():
-                                semantic_output_at = loop.time()
+                            semantic_output_at = loop.time()
                             if not pending_reasoning:
                                 pending_reasoning_offset = len(reasoning)
                             reasoning += thought
                             pending_reasoning += thought
                         if isinstance(text, str) and text:
-                            if text.strip():
-                                semantic_output_at = loop.time()
+                            semantic_output_at = loop.time()
                             report += text
                             pending_report += text
                         pending_chars = len(pending_reasoning) + len(pending_report)
@@ -1937,7 +1910,16 @@ class ResearchSupervisor:
                         except Exception:
                             pass
                     if response is not None:
-                        await response.aclose()
+                        try:
+                            await response.aclose()
+                        except Exception:
+                            # Closing a broken stream is best-effort and must not replace the
+                            # generation result or the timeout/error that caused teardown.
+                            logger.warning(
+                                "research.stream_cleanup_failed run_id=%s",
+                                run["id"],
+                                exc_info = True,
+                            )
             await flush_progress()
             return report, reasoning, finish_reason
         except (TimeoutError, asyncio.TimeoutError) as exc:

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -15,7 +15,7 @@ import threading
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Callable
 
 import httpx
 
@@ -147,6 +147,11 @@ _MODEL_WAIT_POLL_SECONDS = 2.0
 # otherwise re-send forever, so cap how many times one call may wait.
 _MAX_MODEL_WAITS = 3
 _NO_MODEL_LOADED_DETAIL = "No model loaded"
+# Transport keepalives prevent HTTP read timeouts without proving that the model is progressing.
+# Give prompt processing more time than a mid-response pause, while the run's absolute model
+# timeout remains the final upper bound for either stage.
+_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS = 300.0
+_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS = 120.0
 
 
 def _auto_scrape_default() -> int:
@@ -568,7 +573,25 @@ class LeaseLost(Exception):
     pass
 
 
+class ModelFirstOutputTimeout(httpx.ReadTimeout):
+    pass
+
+
+class ModelOutputIdleTimeout(httpx.ReadTimeout):
+    pass
+
+
+class ModelWallClockTimeout(httpx.ReadTimeout):
+    pass
+
+
 def _safe_error(exc: BaseException) -> str:
+    if isinstance(exc, ModelFirstOutputTimeout):
+        return "Local model did not produce output before its first-output timeout"
+    if isinstance(exc, ModelOutputIdleTimeout):
+        return "Local model stopped producing output before completion"
+    if isinstance(exc, ModelWallClockTimeout):
+        return "Local model request exhausted its total time budget"
     if isinstance(exc, httpx.TimeoutException):
         return "Local model request timed out"
     if isinstance(exc, httpx.HTTPStatusError):
@@ -1607,13 +1630,31 @@ class ResearchSupervisor:
                     "research.api_key_cleanup_failed run_id=%s", run["id"], exc_info = True
                 )
 
-    async def _iter_stream_lines(self, run_id: str, response: httpx.Response) -> AsyncIterator[str]:
+    async def _iter_stream_lines(
+        self,
+        run_id: str,
+        response: httpx.Response,
+        semantic_deadline: Callable[[], tuple[float, bool]] | None = None,
+    ) -> AsyncIterator[str]:
         iterator = response.aiter_lines().__aiter__()
+
+        def wait_timeout() -> float:
+            if semantic_deadline is None:
+                return 0.2
+            deadline, has_output = semantic_deadline()
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining > 0:
+                return min(0.2, remaining)
+            if has_output:
+                raise ModelOutputIdleTimeout("Local model stopped producing semantic output")
+            raise ModelFirstOutputTimeout("Local model did not produce semantic output")
+
         while True:
+            timeout = wait_timeout()
             line_task = asyncio.create_task(anext(iterator))
             try:
                 while not line_task.done():
-                    await asyncio.wait({line_task}, timeout = 0.2)
+                    await asyncio.wait({line_task}, timeout = timeout)
                     if self._cancel_event(run_id).is_set():
                         line_task.cancel()
                         try:
@@ -1621,6 +1662,7 @@ class ResearchSupervisor:
                         except asyncio.CancelledError:
                             pass
                         await self._check_active(run_id)
+                    timeout = wait_timeout()
                 try:
                     line = line_task.result()
                 except StopAsyncIteration:
@@ -1686,6 +1728,7 @@ class ResearchSupervisor:
         pending_reasoning_offset = 0
         last_progress_flush = asyncio.get_running_loop().time()
         finish_reason: str | None = None
+        semantic_output_at: float | None = None
 
         async def flush_progress() -> None:
             nonlocal pending_report, pending_reasoning, pending_reasoning_offset
@@ -1747,6 +1790,17 @@ class ResearchSupervisor:
         try:
             model_timeout = float(config["budgets"]["modelTimeoutSeconds"])
             timeout = httpx.Timeout(model_timeout)
+            loop = asyncio.get_running_loop()
+            request_started_at = loop.time()
+
+            def semantic_deadline() -> tuple[float, bool]:
+                if semantic_output_at is None:
+                    return (
+                        request_started_at + _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS,
+                        False,
+                    )
+                return semantic_output_at + _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS, True
+
             async with (
                 _wall_clock_timeout(model_timeout),
                 httpx.AsyncClient(timeout = timeout, trust_env = False) as client,
@@ -1757,6 +1811,8 @@ class ResearchSupervisor:
                 attempt = 0
                 try:
                     while True:
+                        # A model-unloaded wait or transport retry starts a fresh upstream attempt.
+                        request_started_at = loop.time()
                         request = client.build_request(
                             "POST",
                             self._endpoint(),
@@ -1774,9 +1830,23 @@ class ResearchSupervisor:
                                     except asyncio.CancelledError:
                                         pass
                                     await self._check_active(run["id"])
+                                if (
+                                    loop.time() - request_started_at
+                                    >= _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
+                                ):
+                                    send_task.cancel()
+                                    try:
+                                        await send_task
+                                    except asyncio.CancelledError:
+                                        pass
+                                    raise ModelFirstOutputTimeout(
+                                        "Local model did not produce response headers"
+                                    )
                             response = await send_task
                             response.raise_for_status()
                             break
+                        except ModelFirstOutputTimeout:
+                            raise
                         except (httpx.TransportError, httpx.HTTPStatusError) as exc:
                             # Only reachable before a body byte is touched (the stream is consumed
                             # after this loop), so a re-send cannot duplicate report text.
@@ -1808,7 +1878,9 @@ class ResearchSupervisor:
                                 await asyncio.sleep(2**attempt)
                                 attempt += 1
                                 await self._check_active(run["id"])
-                    async for line in self._iter_stream_lines(run["id"], response):
+                    async for line in self._iter_stream_lines(
+                        run["id"], response, semantic_deadline
+                    ):
                         if self._cancel_event(run["id"]).is_set():
                             await self._check_active(run["id"])
                         if not line.startswith("data:"):
@@ -1829,11 +1901,15 @@ class ResearchSupervisor:
                             continue
                         thought = delta.get("reasoning_content")
                         if isinstance(thought, str) and thought:
+                            if thought.strip():
+                                semantic_output_at = loop.time()
                             if not pending_reasoning:
                                 pending_reasoning_offset = len(reasoning)
                             reasoning += thought
                             pending_reasoning += thought
                         if isinstance(text, str) and text:
+                            if text.strip():
+                                semantic_output_at = loop.time()
                             report += text
                             pending_report += text
                         pending_chars = len(pending_reasoning) + len(pending_report)
@@ -1865,7 +1941,9 @@ class ResearchSupervisor:
             await flush_progress()
             return report, reasoning, finish_reason
         except (TimeoutError, asyncio.TimeoutError) as exc:
-            raise httpx.ReadTimeout("Local model request exceeded its wall-clock timeout") from exc
+            raise ModelWallClockTimeout(
+                "Local model request exceeded its wall-clock timeout"
+            ) from exc
         finally:
             try:
                 await asyncio.to_thread(auth_storage.revoke_internal_api_key, int(key["id"]))

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -860,6 +860,157 @@ def test_stream_completion_timeout_is_absolute_despite_keepalives(monkeypatch):
     assert state == {"iteratorClosed": True, "responseClosed": True}
 
 
+def test_stream_completion_times_out_when_only_transport_noise_arrives(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.1)
+    state = {"iteratorClosed": False, "responseClosed": False}
+
+    class _NoiseStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            state["responseClosed"] = True
+
+        async def aiter_lines(self):
+            try:
+                noise = (
+                    ": keep-alive",
+                    'data: {"choices":[{"delta":{"role":"assistant"}}]}',
+                    'data: {"choices":[{"delta":{"content":""}}]}',
+                    'data: {"choices":[{"delta":{"content":" \\n"}}]}',
+                    'data: {"choices":[{"delta":{"reasoning_content":"\\t"}}]}',
+                    'data: {"choices":[],"usage":{"prompt_tokens":1}}',
+                )
+                while True:
+                    for line in noise:
+                        await asyncio.sleep(0.01)
+                        yield line
+            finally:
+                state["iteratorClosed"] = True
+
+    _install_fake_client(monkeypatch, [_NoiseStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        _run_stream(supervisor, timeout_seconds = 1.0)
+
+    assert state == {"iteratorClosed": True, "responseClosed": True}
+
+
+def test_stream_completion_first_output_timeout_covers_response_headers(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
+    state = {"sendCancelled": False}
+
+    class _BlockingClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+        def build_request(self, method, url, **kwargs):
+            return (method, url)
+
+        async def send(self, request, *, stream = False):
+            try:
+                await asyncio.Event().wait()
+            finally:
+                state["sendCancelled"] = True
+
+    monkeypatch.setattr(research_runs.httpx, "AsyncClient", _BlockingClient)
+    monkeypatch.setattr(
+        research_runs.auth_storage, "create_api_key", lambda **kwargs: ("token", {"id": 1})
+    )
+    monkeypatch.setattr(research_runs.auth_storage, "revoke_internal_api_key", lambda key_id: None)
+    supervisor = _make_supervisor(_noop_check_active)
+
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        _run_stream(supervisor, timeout_seconds = 1.0)
+
+    assert state["sendCancelled"] is True
+
+
+def test_stream_completion_times_out_when_output_stalls(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.1)
+
+    class _StalledStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            yield 'data: {"choices":[{"delta":{"content":"started"}}]}'
+            while True:
+                await asyncio.sleep(0.01)
+                yield ": keep-alive"
+
+    _install_fake_client(monkeypatch, [_StalledStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    with pytest.raises(research_runs.ModelOutputIdleTimeout):
+        _run_stream(supervisor, timeout_seconds = 1.0)
+
+
+def test_stream_completion_semantic_output_resets_the_idle_timeout(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(research_runs.db, "append_worker_event", lambda *args, **kwargs: 1)
+
+    class _ProgressStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            await asyncio.sleep(0.04)
+            yield 'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}'
+            await asyncio.sleep(0.04)
+            yield 'data: {"choices":[{"delta":{"content":"report"}}]}'
+            await asyncio.sleep(0.04)
+            yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'
+            yield "data: [DONE]"
+
+    _install_fake_client(monkeypatch, [_ProgressStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "thinking", "stop")
+
+
+@pytest.mark.parametrize(
+    ("exc", "message"),
+    (
+        (
+            research_runs.ModelFirstOutputTimeout("first"),
+            "Local model did not produce output before its first-output timeout",
+        ),
+        (
+            research_runs.ModelOutputIdleTimeout("idle"),
+            "Local model stopped producing output before completion",
+        ),
+        (
+            research_runs.ModelWallClockTimeout("wall"),
+            "Local model request exhausted its total time budget",
+        ),
+    ),
+)
+def test_research_timeout_errors_are_distinct(exc, message):
+    assert research_runs._safe_error(exc) == message
+
+
 def test_wall_clock_timeout_supports_python_without_asyncio_timeout(monkeypatch):
     # raising=False: on Python 3.10 asyncio.timeout does not exist to begin with,
     # which is the very case these tests cover.

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -860,88 +860,7 @@ def test_stream_completion_timeout_is_absolute_despite_keepalives(monkeypatch):
     assert state == {"iteratorClosed": True, "responseClosed": True}
 
 
-def test_stream_completion_times_out_when_only_transport_noise_arrives(monkeypatch):
-    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.1)
-    state = {"iteratorClosed": False, "responseClosed": False}
-
-    class _NoiseStream:
-        status_code = 200
-
-        def raise_for_status(self):
-            return self
-
-        async def aclose(self):
-            state["responseClosed"] = True
-
-        async def aiter_lines(self):
-            try:
-                noise = (
-                    ": keep-alive",
-                    'data: {"choices":[{"delta":{"role":"assistant"}}]}',
-                    'data: {"choices":[{"delta":{"content":""}}]}',
-                    'data: {"choices":[{"delta":{"content":" \\n"}}]}',
-                    'data: {"choices":[{"delta":{"reasoning_content":"\\t"}}]}',
-                    'data: {"choices":[],"usage":{"prompt_tokens":1}}',
-                )
-                while True:
-                    for line in noise:
-                        await asyncio.sleep(0.01)
-                        yield line
-            finally:
-                state["iteratorClosed"] = True
-
-    _install_fake_client(monkeypatch, [_NoiseStream()])
-    supervisor = _make_supervisor(_noop_check_active)
-
-    with pytest.raises(research_runs.ModelFirstOutputTimeout):
-        _run_stream(supervisor, timeout_seconds = 1.0)
-
-    assert state == {"iteratorClosed": True, "responseClosed": True}
-
-
-def test_stream_completion_first_output_timeout_covers_response_headers(monkeypatch):
-    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
-    state = {"sendCancelled": False}
-
-    class _BlockingClient:
-        def __init__(self, **kwargs):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *exc_info):
-            return False
-
-        def build_request(self, method, url, **kwargs):
-            return (method, url)
-
-        async def send(
-            self,
-            request,
-            *,
-            stream = False,
-        ):
-            try:
-                await asyncio.Event().wait()
-            finally:
-                state["sendCancelled"] = True
-
-    monkeypatch.setattr(research_runs.httpx, "AsyncClient", _BlockingClient)
-    monkeypatch.setattr(
-        research_runs.auth_storage, "create_api_key", lambda **kwargs: ("token", {"id": 1})
-    )
-    monkeypatch.setattr(research_runs.auth_storage, "revoke_internal_api_key", lambda key_id: None)
-    supervisor = _make_supervisor(_noop_check_active)
-
-    with pytest.raises(research_runs.ModelFirstOutputTimeout):
-        _run_stream(supervisor, timeout_seconds = 1.0)
-
-    assert state["sendCancelled"] is True
-
-
 def test_stream_completion_times_out_when_output_stalls(monkeypatch):
-    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.2)
     monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.1)
 
     class _StalledStream:
@@ -966,8 +885,32 @@ def test_stream_completion_times_out_when_output_stalls(monkeypatch):
         _run_stream(supervisor, timeout_seconds = 1.0)
 
 
+def test_stream_cleanup_error_does_not_replace_output_stall(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.05)
+
+    class _BrokenStalledStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            raise httpx.CloseError("socket already failed")
+
+        async def aiter_lines(self):
+            yield 'data: {"choices":[{"delta":{"content":"started"}}]}'
+            while True:
+                await asyncio.sleep(0.01)
+                yield ": keep-alive"
+
+    _install_fake_client(monkeypatch, [_BrokenStalledStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    with pytest.raises(research_runs.ModelOutputIdleTimeout):
+        _run_stream(supervisor, timeout_seconds = 1.0)
+
+
 def test_stream_completion_semantic_output_resets_the_idle_timeout(monkeypatch):
-    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.1)
     monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.1)
     monkeypatch.setattr(research_runs.db, "append_worker_event", lambda *args, **kwargs: 1)
 
@@ -995,13 +938,89 @@ def test_stream_completion_semantic_output_resets_the_idle_timeout(monkeypatch):
     assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "thinking", "stop")
 
 
+def test_stream_completion_does_not_apply_idle_timeout_during_prefill(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.03)
+
+    class _SlowPrefillStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            for _ in range(5):
+                await asyncio.sleep(0.02)
+                yield ": keep-alive"
+            yield 'data: {"choices":[{"delta":{"content":"report"}}]}'
+            yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'
+            yield "data: [DONE]"
+
+    _install_fake_client(monkeypatch, [_SlowPrefillStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "", "stop")
+
+
+def test_stream_completion_counts_whitespace_tokens_as_output(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.15)
+
+    class _WhitespaceStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            for text in (" ", "\n", "\t"):
+                await asyncio.sleep(0.04)
+                yield f'data: {{"choices":[{{"delta":{{"content":{json.dumps(text)}}}}}]}}'
+            yield 'data: {"choices":[{"delta":{"content":"report"}}]}'
+            yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'
+            yield "data: [DONE]"
+
+    _install_fake_client(monkeypatch, [_WhitespaceStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    assert _run_stream(supervisor, timeout_seconds = 1.0) == (" \n\treport", "", "stop")
+
+
+def test_stream_completion_stops_at_done_even_if_socket_stays_open(monkeypatch):
+    state = {"iteratorClosed": False, "responseClosed": False}
+
+    class _OpenSocketAfterDone:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            state["responseClosed"] = True
+
+        async def aiter_lines(self):
+            try:
+                yield 'data: {"choices":[{"delta":{"content":"report"}}]}'
+                yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'
+                yield "data: [DONE]"
+                await asyncio.Event().wait()
+            finally:
+                state["iteratorClosed"] = True
+
+    _install_fake_client(monkeypatch, [_OpenSocketAfterDone()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "", "stop")
+    assert state == {"iteratorClosed": True, "responseClosed": True}
+
+
 @pytest.mark.parametrize(
     ("exc", "message"),
     (
-        (
-            research_runs.ModelFirstOutputTimeout("first"),
-            "Local model did not produce output before its first-output timeout",
-        ),
         (
             research_runs.ModelOutputIdleTimeout("idle"),
             "Local model stopped producing output before completion",

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -916,7 +916,12 @@ def test_stream_completion_first_output_timeout_covers_response_headers(monkeypa
         def build_request(self, method, url, **kwargs):
             return (method, url)
 
-        async def send(self, request, *, stream = False):
+        async def send(
+            self,
+            request,
+            *,
+            stream = False,
+        ):
             try:
                 await asyncio.Event().wait()
             finally:


### PR DESCRIPTION
## Summary
- stop a Deep Research model stream after 120 seconds with no model token **only after output has already started**
- treat any non-empty content or reasoning delta, including whitespace tokens, as progress
- terminate immediately on the OpenAI `[DONE]` sentinel even if the socket remains open
- distinguish a post-output stall from total wall-clock budget exhaustion
- keep response cleanup best-effort so a secondary close error cannot replace the real generation result

## Before and after

### Before
- HTTPX measured transport activity, so proxy/admission keepalives could keep a stream transport-active after model output stopped. The request then waited for the full `modelTimeoutSeconds` budget (900 seconds by default) and surfaced as a generic timeout.
- Deep Research ignored `[DONE]`; a conforming upstream that sent `[DONE]` but left the connection open also waited for the full budget.
- Header waits, admission waits, and slow prefill were allowed to use the configured 10-3600 second model budget.

### After
- Once a real content/reasoning token arrives, 120 seconds without another token raises `Local model stopped producing output before completion`; keepalives, role frames, empty deltas, usage frames, and malformed SSE do not reset that deadline.
- `[DONE]` ends consumption immediately.
- Header waits, admission waits, and first-token/prefill behavior are unchanged and remain governed only by `modelTimeoutSeconds`. This preserves slow CPU/offloaded GGUF, native, and MLX paths.
- Total budget exhaustion reports `Local model request exhausted its total time budget`.

## Is this a real issue?
Yes, for post-output stalls and open-after-`[DONE]` streams. An isolated old-versus-new probe produced:

```text
main:   post-token keepalive stall -> ReadTimeout at 0.302s total budget
branch: post-token keepalive stall -> ModelOutputIdleTimeout at 0.052s idle budget

main:   [DONE] + open socket -> ReadTimeout at 0.302s total budget
branch: [DONE] + open socket -> success in 0.001s
```

The reported zero-output Windows run is still not sufficient to prove whether the request was in prefill/admission or whether its upstream omitted termination. This PR deliberately does **not** shorten pre-first-token waits, because doing so would break supported slow inference. It fixes the reproducible stream-state defects without claiming to prove that separate upstream cause.

## Compatibility and regression safety
- backend-only; no response schema, frontend, browser API, model routing, or hardware path changes
- GGUF, native/Transformers, and MLX all use the same OpenAI delta semantics handled here
- cancellation and lease-loss checks retain priority over the idle deadline
- pre-body transport retries and no-mid-body-retry behavior are unchanged
- whitespace generation resets progress
- slow prefill receives no idle deadline

## Validation

Isolated `uv venv` environments under `./temp`:
- Python 3.10: 207 affected Research tests passed
- Python 3.11: 207 affected Research tests passed
- Python 3.12: 207 affected Research tests passed
- Python 3.13: 207 affected Research tests passed
- Python 3.9 and 3.14: changed files compile; full Studio dependency resolution is unavailable because current pins require Python >=3.10 and `unpdf` has no cp314 wheel
- timing-sensitive edge matrix repeated 20 times per supported interpreter: 140/140 passed on each of 3.10, 3.11, 3.12, and 3.13

Broad isolated Python 3.12 backend run:
- 14,711 passed, 113 skipped, 35 intentionally deselected, 9 subtests passed

Additional:
- llama.cpp stall tests: 2 passed
- llama route timeout tests: 9 passed
- Deep Research frontend contract: 12 passed
- Ruff, `py_compile`, and `git diff --check`: passed

Browser-specific testing is not required for this patch: no frontend code or browser-facing protocol changes. Existing Chat UI CI covers Linux, macOS, and Windows, while the new backend CI run validates this final revision.