### PR TITLE
Keep the package importable on the Python floor pyproject declares

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -342,6 +342,16 @@ jobs:
         run: |
           python -m pytest -v --tb=short tests/test_callback_signature_drift.py
 
+      - name: python floor compatibility (HARD GATE)
+        # pyproject declares requires-python >=3.9 but every job here pins 3.12,
+        # so nothing ran the floor: registry.py grew a dataclass field annotated
+        # `list[QuantType] | dict[...]`, which evaluates at class creation and is
+        # a TypeError below 3.10. Static AST check, no torch and no network. It
+        # reads the floor from pyproject, so raising requires-python relaxes it
+        # rather than making it lie.
+        run: |
+          python -m pytest -v --tb=short tests/test_python39_compatibility.py
+
       - name: generation correctness guards (HARD GATE)
         # Deterministic CPU guards, each validated to fail on its pre-fix code:
         # leftpad = batched left-padded generation (#1066/#3699, fixed by

--- a/studio/backend/hub/workers/hf_download.py
+++ b/studio/backend/hub/workers/hf_download.py
@@ -32,6 +32,7 @@ import sys
 import threading
 import time
 from pathlib import Path
+from typing import Union
 
 _HERE = Path(__file__).resolve().parent
 _BACKEND = _HERE.parent.parent
@@ -49,7 +50,9 @@ from hub.utils.gguf_plan import (
 )
 from hub.utils.state_dir import RepoType
 
-HfTokenArg = str | bool | None
+# typing.Union, not `str | bool | None`: an alias is evaluated on import, and PEP 604
+# raises below the 3.10 floor. The future import does not defer an assigned value.
+HfTokenArg = Union[str, bool, None]
 
 
 # Bound the metadata fetch so a stalled connection fails the worker (exit 1)

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -26,7 +26,7 @@ PACKAGE_ROOT = REPO_ROOT / "unsloth"
 def declared_floor():
     """The ``>=X.Y`` in requires-python, as a tuple for ast.parse(feature_version=)."""
     text = (REPO_ROOT / "pyproject.toml").read_text(encoding = "utf-8")
-    match = re.search(r"^requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.M)
+    match = re.search(r"^requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.MULTILINE)
     assert match, "no requires-python in pyproject.toml"
     floor = re.search(r">=\s*(\d+)\.(\d+)", match.group(1))
     assert floor, f"no >= lower bound in requires-python = {match.group(1)!r}"
@@ -39,12 +39,8 @@ def package_files():
     return files
 
 
-def annotations_of(node):
-    """Annotation expressions that this node evaluates at def/exec time."""
-    if isinstance(node, ast.AnnAssign):
-        return [node.annotation] if node.annotation else []
-    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        return []
+def signature_annotations(node):
+    """Parameter and return annotations, evaluated when the ``def`` executes."""
     args = node.args
     out = [
         a.annotation
@@ -53,6 +49,63 @@ def annotations_of(node):
     ]
     if node.returns:
         out.append(node.returns)
+    return out
+
+
+def evaluated_annotations(tree):
+    """Annotations Python evaluates, so the future import is what defers them.
+
+    Variable annotations are evaluated at module and class scope only; inside a function
+    body they are never evaluated, so flagging those is a false positive. Signature
+    annotations are evaluated wherever their ``def`` is.
+    """
+    out = []
+
+    def walk(node, in_function):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.AnnAssign) and child.annotation and not in_function:
+                out.append(child.annotation)
+            elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                out.extend(signature_annotations(child))
+            nested = isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda))
+            walk(child, in_function or nested)
+
+    walk(tree, False)
+    return out
+
+
+def looks_like_a_type(node):
+    """Conservative: enough for ``str | Path``, not enough for ``re.A | re.M``.
+
+    Flag constants are ALL_CAPS by convention, so requiring a non-caps name keeps bitwise
+    arithmetic (``re.DOTALL | re.MULTILINE``, ``os.W_OK | os.X_OK``) out.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value is None
+    if isinstance(node, ast.Subscript):
+        return looks_like_a_type(node.value)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return looks_like_a_type(node.left) and looks_like_a_type(node.right)
+    name = getattr(node, "id", None) or getattr(node, "attr", None)
+    return bool(name) and not name.isupper()
+
+
+def evaluated_values(tree):
+    """Assigned values at module and class scope, which run on import.
+
+    Type aliases are the case that matters: ``PathLike = str | Path`` raises below 3.10
+    and, unlike an annotation, the future import does not defer it.
+    """
+    out = []
+
+    def walk(node):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.Assign, ast.AnnAssign)) and child.value is not None:
+                out.append(child.value)
+            if isinstance(child, ast.ClassDef):
+                walk(child)
+
+    walk(tree)
     return out
 
 
@@ -70,7 +123,11 @@ def test_every_module_parses_on_the_declared_floor():
     broken = []
     for path in package_files():
         try:
-            ast.parse(path.read_text(encoding = "utf-8"), filename = str(path), feature_version = floor)
+            ast.parse(
+                path.read_text(encoding = "utf-8"),
+                filename = str(path),
+                feature_version = floor,
+            )
         except SyntaxError as error:
             broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
     assert not broken, (
@@ -81,23 +138,33 @@ def test_every_module_parses_on_the_declared_floor():
 
 
 def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
-    """`X | Y` is a TypeError below 3.10 unless the module defers annotations."""
+    """``X | Y`` is a TypeError below 3.10 unless the module defers it."""
     if declared_floor() >= (3, 10):
         pytest.skip("floor is 3.10+, PEP 604 evaluates fine")
     offenders = []
     for path in package_files():
         tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
-        if has_future_annotations(tree):
-            continue
-        for node in ast.walk(tree):
-            for annotation in annotations_of(node):
-                for inner in ast.walk(annotation):
-                    if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
-                        offenders.append(
-                            f"{path.relative_to(REPO_ROOT)}:{inner.lineno}: "
-                            f"{ast.unparse(inner)}"
-                        )
+        where = path.relative_to(REPO_ROOT)
+        # The future import defers annotations only; an assigned value still runs.
+        deferred = has_future_annotations(tree)
+        for expression in [] if deferred else evaluated_annotations(tree):
+            for inner in ast.walk(expression):
+                if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
+                    offenders.append(
+                        f"{where}:{inner.lineno}: {ast.unparse(inner)} (annotation)"
+                    )
+        for expression in evaluated_values(tree):
+            for inner in ast.walk(expression):
+                if (
+                    isinstance(inner, ast.BinOp)
+                    and isinstance(inner.op, ast.BitOr)
+                    and looks_like_a_type(inner)
+                ):
+                    offenders.append(
+                        f"{where}:{inner.lineno}: {ast.unparse(inner)} (type alias)"
+                    )
     assert not offenders, (
-        "PEP 604 unions evaluated at def time; add `from __future__ import "
-        "annotations` to these modules:\n  " + "\n  ".join(sorted(set(offenders)))
+        "PEP 604 unions evaluated below 3.10. Annotations are deferred by `from __future__ "
+        "import annotations`; type aliases need typing.Union, which that import does NOT "
+        "defer:\n  " + "\n  ".join(sorted(set(offenders)))
     )

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -111,27 +111,70 @@ def evaluated_annotations(tree):
                 out.append(child.annotation)
             elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 out.extend(signature_annotations(child))
-            nested = isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda))
-            walk(child, in_function or nested)
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                walk(child, True)
+            elif isinstance(child, ast.ClassDef):
+                walk(child, False)   # a class body is class scope wherever it sits
+            else:
+                walk(child, in_function)
 
     walk(tree, False)
     return out
 
 
-def looks_like_a_type(node):
-    """Conservative: enough for ``str | Path``, not enough for ``re.A | re.M``.
+# A `|` between these is a union, not arithmetic: builtin types, `None`, and whatever the
+# module pulled in from typing.
+TYPE_ANCHORS = frozenset({
+    "str", "int", "float", "bool", "bytes", "bytearray", "complex", "object", "type",
+    "list", "dict", "tuple", "set", "frozenset",
+})
+TYPING_MODULES = frozenset({"typing", "typing_extensions", "collections.abc"})
 
-    Flag constants are ALL_CAPS by convention, so requiring a non-caps name keeps bitwise
-    arithmetic (``re.DOTALL | re.MULTILINE``, ``os.W_OK | os.X_OK``) out.
-    """
-    if isinstance(node, ast.Constant):
-        return node.value is None
-    if isinstance(node, ast.Subscript):
-        return looks_like_a_type(node.value)
+
+def typing_names(tree):
+    """Names this module bound with ``from typing import X`` and friends."""
+    return {
+        alias.asname or alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module in TYPING_MODULES
+        for alias in node.names
+    }
+
+
+def union_operands(node):
+    """Operands of an ``A | B | C`` chain, or None if any part is not name-shaped."""
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return looks_like_a_type(node.left) and looks_like_a_type(node.right)
-    name = getattr(node, "id", None) or getattr(node, "attr", None)
-    return bool(name) and not name.isupper()
+        left, right = union_operands(node.left), union_operands(node.right)
+        return None if left is None or right is None else left + right
+    if isinstance(node, ast.Subscript):
+        return union_operands(node.value)
+    if isinstance(node, (ast.Name, ast.Attribute)):
+        return [node]
+    if isinstance(node, ast.Constant) and (node.value is None or isinstance(node.value, str)):
+        return [node]
+    return None
+
+
+def looks_like_a_type_alias(node, known_typing_names):
+    """``PathLike = str | Path`` yes; ``defaults | extra`` and ``re.A | re.M`` no.
+
+    Every operand must be name-shaped and at least one must be a recognisable type.
+    Without that anchor a ``|`` between plain names is far more likely to be a dict merge
+    (PEP 584, valid on 3.9), a set union or flag arithmetic, and failing the gate on those
+    would block code that runs perfectly well on the floor.
+    """
+    operands = union_operands(node)
+    if not operands:
+        return False
+    for operand in operands:
+        if isinstance(operand, ast.Constant):
+            if operand.value is None:
+                return True
+            continue  # a bare string is a forward reference, never an anchor alone
+        name = operand.id if isinstance(operand, ast.Name) else operand.attr
+        if name in TYPE_ANCHORS or name in known_typing_names:
+            return True
+    return False
 
 
 def evaluated_values(tree):
@@ -211,6 +254,7 @@ def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
     for path in package_files():
         tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
         where = path.relative_to(REPO_ROOT)
+        known_typing_names = typing_names(tree)
         # The future import defers annotations only; an assigned value still runs.
         deferred = has_future_annotations(tree)
         for expression in [] if deferred else evaluated_annotations(tree):
@@ -222,7 +266,7 @@ def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
                 if (
                     isinstance(inner, ast.BinOp)
                     and isinstance(inner.op, ast.BitOr)
-                    and looks_like_a_type(inner)
+                    and looks_like_a_type_alias(inner, known_typing_names)
                 ):
                     offenders.append(f"{where}:{inner.lineno}: {ast.unparse(inner)} (type alias)")
     assert not offenders, (

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -150,9 +150,7 @@ def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
         for expression in [] if deferred else evaluated_annotations(tree):
             for inner in ast.walk(expression):
                 if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
-                    offenders.append(
-                        f"{where}:{inner.lineno}: {ast.unparse(inner)} (annotation)"
-                    )
+                    offenders.append(f"{where}:{inner.lineno}: {ast.unparse(inner)} (annotation)")
         for expression in evaluated_values(tree):
             for inner in ast.walk(expression):
                 if (
@@ -160,9 +158,7 @@ def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
                     and isinstance(inner.op, ast.BitOr)
                     and looks_like_a_type(inner)
                 ):
-                    offenders.append(
-                        f"{where}:{inner.lineno}: {ast.unparse(inner)} (type alias)"
-                    )
+                    offenders.append(f"{where}:{inner.lineno}: {ast.unparse(inner)} (type alias)")
     assert not offenders, (
         "PEP 604 unions evaluated below 3.10. Annotations are deferred by `from __future__ "
         "import annotations`; type aliases need typing.Union, which that import does NOT "

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -114,7 +114,7 @@ def evaluated_annotations(tree):
             if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
                 walk(child, True)
             elif isinstance(child, ast.ClassDef):
-                walk(child, False)   # a class body is class scope wherever it sits
+                walk(child, False)  # a class body is class scope wherever it sits
             else:
                 walk(child, in_function)
 
@@ -124,10 +124,24 @@ def evaluated_annotations(tree):
 
 # A `|` between these is a union, not arithmetic: builtin types, `None`, and whatever the
 # module pulled in from typing.
-TYPE_ANCHORS = frozenset({
-    "str", "int", "float", "bool", "bytes", "bytearray", "complex", "object", "type",
-    "list", "dict", "tuple", "set", "frozenset",
-})
+TYPE_ANCHORS = frozenset(
+    {
+        "str",
+        "int",
+        "float",
+        "bool",
+        "bytes",
+        "bytearray",
+        "complex",
+        "object",
+        "type",
+        "list",
+        "dict",
+        "tuple",
+        "set",
+        "frozenset",
+    }
+)
 TYPING_MODULES = frozenset({"typing", "typing_extensions", "collections.abc"})
 
 

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -1,0 +1,99 @@
+"""The package must stay importable on the Python floor ``pyproject.toml`` declares.
+
+It was not. ``requires-python`` says ``>=3.9`` while ``registry/registry.py`` annotated a
+dataclass field ``list[QuantType] | dict[str, list[QuantType]]``, which evaluates at class
+creation, so importing ``unsloth.registry.registry`` died with ``TypeError: unsupported
+operand type(s) for |``. Nothing caught it: every CI job here pins 3.12.
+
+The floor is read from ``pyproject.toml`` rather than hardcoded, so raising
+``requires-python`` relaxes these checks instead of turning them into a false alarm.
+
+This is a static AST check. It imports nothing from the package, so it needs no torch, no
+GPU and no network, and it sees files that are never imported at test time.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "unsloth"
+
+
+def declared_floor():
+    """The ``>=X.Y`` in requires-python, as a tuple for ast.parse(feature_version=)."""
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r"^requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.M)
+    assert match, "no requires-python in pyproject.toml"
+    floor = re.search(r">=\s*(\d+)\.(\d+)", match.group(1))
+    assert floor, f"no >= lower bound in requires-python = {match.group(1)!r}"
+    return int(floor.group(1)), int(floor.group(2))
+
+
+def package_files():
+    files = sorted(p for p in PACKAGE_ROOT.rglob("*.py") if "__pycache__" not in p.parts)
+    assert len(files) > 50, f"only found {len(files)} files, the glob is wrong"
+    return files
+
+
+def annotations_of(node):
+    """Annotation expressions that this node evaluates at def/exec time."""
+    if isinstance(node, ast.AnnAssign):
+        return [node.annotation] if node.annotation else []
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return []
+    args = node.args
+    out = [a.annotation for a in
+           [*args.args, *args.kwonlyargs, *args.posonlyargs, args.vararg, args.kwarg]
+           if a is not None and a.annotation is not None]
+    if node.returns:
+        out.append(node.returns)
+    return out
+
+
+def has_future_annotations(tree):
+    return any(isinstance(n, ast.ImportFrom) and n.module == "__future__"
+               and any(alias.name == "annotations" for alias in n.names)
+               for n in tree.body)
+
+
+def test_every_module_parses_on_the_declared_floor():
+    floor = declared_floor()
+    broken = []
+    for path in package_files():
+        try:
+            ast.parse(path.read_text(encoding="utf-8"), filename=str(path),
+                      feature_version=floor)
+        except SyntaxError as error:
+            broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
+    assert not broken, (
+        "syntax newer than the declared floor "
+        f"{floor[0]}.{floor[1]}; either rewrite it or raise requires-python:\n  "
+        + "\n  ".join(broken)
+    )
+
+
+def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
+    """`X | Y` is a TypeError below 3.10 unless the module defers annotations."""
+    if declared_floor() >= (3, 10):
+        pytest.skip("floor is 3.10+, PEP 604 evaluates fine")
+    offenders = []
+    for path in package_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if has_future_annotations(tree):
+            continue
+        for node in ast.walk(tree):
+            for annotation in annotations_of(node):
+                for inner in ast.walk(annotation):
+                    if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
+                        offenders.append(
+                            f"{path.relative_to(REPO_ROOT)}:{inner.lineno}: "
+                            f"{ast.unparse(inner)}"
+                        )
+    assert not offenders, (
+        "PEP 604 unions evaluated at def time; add `from __future__ import "
+        "annotations` to these modules:\n  " + "\n  ".join(sorted(set(offenders)))
+    )

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -42,7 +42,8 @@ def declared_floor():
 
 def package_files(root = PACKAGE_ROOT, minimum = 50):
     files = sorted(
-        p for p in root.rglob("*.py")
+        p
+        for p in root.rglob("*.py")
         if "__pycache__" not in p.parts and "node_modules" not in p.parts
     )
     assert len(files) >= minimum, f"only found {len(files)} files under {root}, glob is wrong"

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -201,8 +201,17 @@ def evaluated_values(tree):
     those only execute when called.
     """
     out = []
-    scoped = (ast.If, ast.Try, ast.With, ast.AsyncWith, ast.For, ast.AsyncFor,
-              ast.While, ast.ExceptHandler, ast.ClassDef)
+    scoped = (
+        ast.If,
+        ast.Try,
+        ast.With,
+        ast.AsyncWith,
+        ast.For,
+        ast.AsyncFor,
+        ast.While,
+        ast.ExceptHandler,
+        ast.ClassDef,
+    )
 
     def walk(node):
         for child in ast.iter_child_nodes(node):
@@ -210,7 +219,7 @@ def evaluated_values(tree):
                 out.extend(child.decorator_list)
                 out.extend(d for d in child.args.defaults if d is not None)
                 out.extend(d for d in child.args.kw_defaults if d is not None)
-                continue   # the body only runs when called
+                continue  # the body only runs when called
             if isinstance(child, ast.ClassDef):
                 out.extend(child.decorator_list)
             if isinstance(child, (ast.Assign, ast.AnnAssign)) and child.value is not None:
@@ -263,8 +272,7 @@ def test_every_packaged_module_compiles():
     for root in packaged_roots():
         for path in package_files(root, minimum = 1):
             try:
-                compile(path.read_text(encoding = "utf-8"), str(path), "exec",
-                        dont_inherit = True)
+                compile(path.read_text(encoding = "utf-8"), str(path), "exec", dont_inherit = True)
             except SyntaxError as error:
                 broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
     assert not broken, "these modules do not compile:\n  " + "\n  ".join(broken)

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -192,18 +192,30 @@ def looks_like_a_type_alias(node, known_typing_names):
 
 
 def evaluated_values(tree):
-    """Assigned values at module and class scope, which run on import.
+    """Expressions that run at import, at module or class scope.
 
     Type aliases are the case that matters: ``PathLike = str | Path`` raises below 3.10
-    and, unlike an annotation, the future import does not defer it.
+    and, unlike an annotation, the future import does not defer it. Decorator expressions
+    and parameter defaults are evaluated the same way, so they belong here too. Control
+    flow is descended into (a branch that runs, runs) but function bodies are not, since
+    those only execute when called.
     """
     out = []
+    scoped = (ast.If, ast.Try, ast.With, ast.AsyncWith, ast.For, ast.AsyncFor,
+              ast.While, ast.ExceptHandler, ast.ClassDef)
 
     def walk(node):
         for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                out.extend(child.decorator_list)
+                out.extend(d for d in child.args.defaults if d is not None)
+                out.extend(d for d in child.args.kw_defaults if d is not None)
+                continue   # the body only runs when called
+            if isinstance(child, ast.ClassDef):
+                out.extend(child.decorator_list)
             if isinstance(child, (ast.Assign, ast.AnnAssign)) and child.value is not None:
                 out.append(child.value)
-            if isinstance(child, ast.ClassDef):
+            if isinstance(child, scoped):
                 walk(child)
 
     walk(tree)
@@ -240,6 +252,24 @@ def test_every_packaged_module_parses_on_the_declared_floor():
     )
 
 
+def test_every_packaged_module_compiles():
+    """``ast.parse`` accepts things ``compile`` rejects, and only compile runs on import.
+
+    A misplaced ``from __future__ import annotations`` is the case that bites here: it
+    parses, it makes ``has_future_annotations`` suppress the union check, and it still
+    raises SyntaxError on import.
+    """
+    broken = []
+    for root in packaged_roots():
+        for path in package_files(root, minimum = 1):
+            try:
+                compile(path.read_text(encoding = "utf-8"), str(path), "exec",
+                        dont_inherit = True)
+            except SyntaxError as error:
+                broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
+    assert not broken, "these modules do not compile:\n  " + "\n  ".join(broken)
+
+
 def test_studio_evaluated_unions_do_not_grow():
     """studio/ is shipped on the same floor but still carries unions that raise there.
 
@@ -265,13 +295,16 @@ def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
     if declared_floor() >= (3, 10):
         pytest.skip("floor is 3.10+, PEP 604 evaluates fine")
     offenders = []
-    for path in package_files():
+    scanned = [p for root in packaged_roots() for p in package_files(root, minimum = 1)]
+    for path in scanned:
         tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
         where = path.relative_to(REPO_ROOT)
         known_typing_names = typing_names(tree)
         # The future import defers annotations only; an assigned value still runs.
         deferred = has_future_annotations(tree)
-        for expression in [] if deferred else evaluated_annotations(tree):
+        in_unsloth = PACKAGE_ROOT in path.parents
+        annotation_sources = [] if (deferred or not in_unsloth) else evaluated_annotations(tree)
+        for expression in annotation_sources:
             for inner in ast.walk(expression):
                 if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
                     offenders.append(f"{where}:{inner.lineno}: {ast.unparse(inner)} (annotation)")

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -25,7 +25,7 @@ PACKAGE_ROOT = REPO_ROOT / "unsloth"
 
 def declared_floor():
     """The ``>=X.Y`` in requires-python, as a tuple for ast.parse(feature_version=)."""
-    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding = "utf-8")
     match = re.search(r"^requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.M)
     assert match, "no requires-python in pyproject.toml"
     floor = re.search(r">=\s*(\d+)\.(\d+)", match.group(1))
@@ -46,18 +46,23 @@ def annotations_of(node):
     if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
         return []
     args = node.args
-    out = [a.annotation for a in
-           [*args.args, *args.kwonlyargs, *args.posonlyargs, args.vararg, args.kwarg]
-           if a is not None and a.annotation is not None]
+    out = [
+        a.annotation
+        for a in [*args.args, *args.kwonlyargs, *args.posonlyargs, args.vararg, args.kwarg]
+        if a is not None and a.annotation is not None
+    ]
     if node.returns:
         out.append(node.returns)
     return out
 
 
 def has_future_annotations(tree):
-    return any(isinstance(n, ast.ImportFrom) and n.module == "__future__"
-               and any(alias.name == "annotations" for alias in n.names)
-               for n in tree.body)
+    return any(
+        isinstance(n, ast.ImportFrom)
+        and n.module == "__future__"
+        and any(alias.name == "annotations" for alias in n.names)
+        for n in tree.body
+    )
 
 
 def test_every_module_parses_on_the_declared_floor():
@@ -65,8 +70,7 @@ def test_every_module_parses_on_the_declared_floor():
     broken = []
     for path in package_files():
         try:
-            ast.parse(path.read_text(encoding="utf-8"), filename=str(path),
-                      feature_version=floor)
+            ast.parse(path.read_text(encoding = "utf-8"), filename = str(path), feature_version = floor)
         except SyntaxError as error:
             broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
     assert not broken, (
@@ -82,7 +86,7 @@ def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
         pytest.skip("floor is 3.10+, PEP 604 evaluates fine")
     offenders = []
     for path in package_files():
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
         if has_future_annotations(tree):
             continue
         for node in ast.walk(tree):

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -22,6 +22,13 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_ROOT = REPO_ROOT / "unsloth"
 
+# studio/ ships under the same requires-python, so it is held to the syntax check. Its
+# evaluated-union debt is ratcheted rather than fixed here: the 35 files involved include
+# FastAPI routers and pydantic models, where `from __future__ import annotations` is
+# supported but has real failure modes around class dependencies, so converting them needs
+# Studio actually booted and its routes exercised. The ratchet stops the debt growing.
+STUDIO_UNION_DEBT = 35
+
 
 def declared_floor():
     """The ``>=X.Y`` in requires-python, as a tuple for ast.parse(feature_version=)."""
@@ -33,10 +40,46 @@ def declared_floor():
     return int(floor.group(1)), int(floor.group(2))
 
 
-def package_files():
-    files = sorted(p for p in PACKAGE_ROOT.rglob("*.py") if "__pycache__" not in p.parts)
-    assert len(files) > 50, f"only found {len(files)} files, the glob is wrong"
+def package_files(root = PACKAGE_ROOT, minimum = 50):
+    files = sorted(
+        p for p in root.rglob("*.py")
+        if "__pycache__" not in p.parts and "node_modules" not in p.parts
+    )
+    assert len(files) >= minimum, f"only found {len(files)} files under {root}, glob is wrong"
     return files
+
+
+def packaged_roots():
+    """Top-level directories setuptools ships, from the `include` list in pyproject.
+
+    Read rather than hardcoded so a newly packaged directory cannot silently escape the
+    floor guarantee.
+    """
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding = "utf-8")
+    block = re.search(r"^include\s*=\s*\[(.*?)\]", text, re.MULTILINE | re.DOTALL)
+    assert block, "no packages.find include list in pyproject.toml"
+    roots = []
+    for pattern in re.findall(r"[\"']([^\"']+)[\"']", block.group(1)):
+        top = pattern.split(".")[0].rstrip("*")
+        candidate = REPO_ROOT / top
+        if candidate.is_dir() and candidate not in roots:
+            roots.append(candidate)
+    assert roots, "no packaged directories resolved from pyproject"
+    return roots
+
+
+def evaluated_union_files(root):
+    """Files under `root` that would raise on the floor, i.e. need the future import."""
+    offenders = set()
+    for path in package_files(root, minimum = 1):
+        tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
+        if has_future_annotations(tree):
+            continue
+        for expression in evaluated_annotations(tree):
+            for inner in ast.walk(expression):
+                if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
+                    offenders.add(path)
+    return offenders
 
 
 def signature_annotations(node):
@@ -118,22 +161,44 @@ def has_future_annotations(tree):
     )
 
 
-def test_every_module_parses_on_the_declared_floor():
+def test_every_packaged_module_parses_on_the_declared_floor():
+    """Every directory pyproject ships, not just unsloth/ - studio/ is packaged too."""
     floor = declared_floor()
     broken = []
-    for path in package_files():
-        try:
-            ast.parse(
-                path.read_text(encoding = "utf-8"),
-                filename = str(path),
-                feature_version = floor,
-            )
-        except SyntaxError as error:
-            broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
+    for root in packaged_roots():
+        for path in package_files(root, minimum = 1):
+            try:
+                ast.parse(
+                    path.read_text(encoding = "utf-8"),
+                    filename = str(path),
+                    feature_version = floor,
+                )
+            except SyntaxError as error:
+                broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
     assert not broken, (
         "syntax newer than the declared floor "
-        f"{floor[0]}.{floor[1]}; either rewrite it or raise requires-python:\n  "
-        + "\n  ".join(broken)
+        f"{floor[0]}.{floor[1]} in a packaged directory; either rewrite it or raise "
+        "requires-python:\n  " + "\n  ".join(broken)
+    )
+
+
+def test_studio_evaluated_unions_do_not_grow():
+    """studio/ is shipped on the same floor but still carries unions that raise there.
+
+    A ratchet, not a pass: converting those files needs Studio booted and its routes
+    exercised, because FastAPI resolves annotations when it builds each endpoint. This
+    keeps the debt from growing in the meantime.
+    """
+    if declared_floor() >= (3, 10):
+        pytest.skip("floor is 3.10+, PEP 604 evaluates fine")
+    studio = REPO_ROOT / "studio"
+    if not studio.is_dir():
+        pytest.skip("no studio/ directory in this checkout")
+    offenders = evaluated_union_files(studio)
+    assert len(offenders) <= STUDIO_UNION_DEBT, (
+        f"{len(offenders)} studio files now evaluate PEP 604 unions on the floor, up from "
+        f"{STUDIO_UNION_DEBT}. Add `from __future__ import annotations` to the new ones:\n  "
+        + "\n  ".join(sorted(str(p.relative_to(REPO_ROOT)) for p in offenders))[:2000]
     )
 
 

--- a/unsloth/kernels/moe/benchmark/benchmark_fused_moe.py
+++ b/unsloth/kernels/moe/benchmark/benchmark_fused_moe.py
@@ -1,3 +1,7 @@
+# setup_model/run_benchmark below annotate with PEP 604 unions, which evaluate at
+# def time and are a TypeError on the 3.9 floor pyproject declares.
+from __future__ import annotations
+
 import argparse
 import time
 from contextlib import nullcontext

--- a/unsloth/registry/registry.py
+++ b/unsloth/registry/registry.py
@@ -1,3 +1,8 @@
+# ModelMeta.quant_types below is a dataclass field annotated with a PEP 604 union,
+# which evaluates at class creation and is a TypeError on the 3.9 floor pyproject
+# declares.
+from __future__ import annotations
+
 import warnings
 from dataclasses import dataclass, field
 from enum import Enum


### PR DESCRIPTION
Companion to unslothai/unsloth-zoo#982. **That one should land first** - `unsloth_zoo` is itself un-importable on 3.9, so this fix is not observable until it does.

## The problem

`pyproject.toml` declares `requires-python = ">=3.9,<3.15"`, but on a real CPython 3.9.25:

```
File "unsloth/registry/registry.py", line 90, in ModelMeta
    quant_types: list[QuantType] | dict[str, list[QuantType]] = field(default_factory = list)
TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'types.GenericAlias'
```

It is a **dataclass field**, so the annotation evaluates at class creation rather than lazily - importing the module is enough. `unsloth/kernels/moe/benchmark/benchmark_fused_moe.py:123,175` has the same defect in two function signatures.

Nothing caught either: every job in `consolidated-tests-ci.yml` pins `python-version: '3.12'`, so the declared floor is never exercised.

## Scope

Established by parsing every module at `ast.parse(feature_version=(3,9))`:

- **0** constructs that 3.9 cannot parse.
- **3** PEP 604 unions in runtime-evaluated positions, across the 2 files above.

That is the whole surface - much smaller than the zoo's, which also had a `match` statement on its eager import path.

## The fix

`from __future__ import annotations` in both files. No annotation text is touched. Safe because:

- nothing in the package calls `get_type_hints` or reads `__annotations__` back (checked);
- `dataclasses` handles string annotations natively - `ModelMeta` still resolves all 8 fields, with `quant_types` stored as the string `'list[QuantType] | dict[str, list[QuantType]]'`.

## The regression gate

`tests/test_python39_compatibility.py` is a static AST check - it imports nothing from the package, so it needs no torch, no GPU and no network, and it sees files that are never imported at test time (like the benchmark script). It reads the floor **from `pyproject.toml`** rather than hardcoding it, so raising `requires-python` relaxes it instead of turning it into a false alarm.

Runs as a HARD GATE in the `consolidated` job.

## Verification

- **Non-vacuity.** Confirmed the failure on unfixed `main` against a real 3.9.25 before writing anything.
- **After the fix**, on the same interpreter: `unsloth.registry.registry` imports and `ModelMeta`'s fields resolve.
- **Mutation-tested.** Removing the `registry.py` future import makes the new test fail, naming the exact line.
- Sweep after the fix: 0 syntax failures, 0 evaluated unions.

## Note

A 3.9 **install** is still blocked by a dependency, not by source: `peft>=0.18.0` requires Python 3.10+. Same situation as unsloth-zoo#982, and called out there in more detail. Verification here used `peft 0.17.1`.