### PR TITLE
Keep the signed NSIS plugin directory across a bundler upgrade, and retry the vc_redist fetch

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -2027,8 +2027,31 @@ jobs:
           if (-not (Test-VCRedistInstalled)) { throw 'Detection did not recover after restoring the registry (test restore bug).' }
 
           Write-Host '== C. Literal uninstall on this throwaway VM (official installer), observe detection =='
+          # aka.ms redirects to a CDN that intermittently cuts the response mid
+          # body ("The response ended prematurely"), which failed this job twice
+          # in one day. Retry with backoff, and require a plausible size so a
+          # truncated download is caught here rather than as a mystery exit code
+          # from Start-Process below.
           $exe = Join-Path $env:RUNNER_TEMP 'vc_redist.x64.exe'
-          Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile $exe
+          $vcUrl = 'https://aka.ms/vs/17/release/vc_redist.x64.exe'
+          $got = $false
+          foreach ($attempt in 1..4) {
+              try {
+                  Remove-Item $exe -Force -ErrorAction SilentlyContinue
+                  Invoke-WebRequest -Uri $vcUrl -OutFile $exe -UseBasicParsing -TimeoutSec 180
+                  $size = (Get-Item $exe -ErrorAction Stop).Length
+                  if ($size -lt 10MB) { throw "truncated download: $size bytes" }
+                  $sig = Get-AuthenticodeSignature $exe
+                  if ($sig.Status -ne 'Valid') { throw "signature is $($sig.Status)" }
+                  Write-Host ("  vc_redist.x64.exe {0:N0} bytes, signed by {1}" -f $size, $sig.SignerCertificate.Subject)
+                  $got = $true
+                  break
+              } catch {
+                  Write-Host "  vc_redist download attempt $attempt failed: $($_.Exception.Message)"
+                  if ($attempt -lt 4) { Start-Sleep -Seconds (10 * $attempt) }
+              }
+          }
+          if (-not $got) { throw 'Could not download vc_redist.x64.exe after 4 attempts.' }
           Start-Process -FilePath $exe -ArgumentList '/uninstall', '/quiet', '/norestart' -Wait
           Show-GroundTruth
           Write-Host ("  Test-VCRedistInstalled after uninstall -> {0}" -f (Test-VCRedistInstalled))

--- a/studio/src-tauri/windows/installer.nsi
+++ b/studio/src-tauri/windows/installer.nsi
@@ -7,6 +7,9 @@
 ; Local patches:
 ; - UNSLOTH_PATCH_START: non-WiX newer/unknown upgrades install in place.
 ; - UNSLOTH_PATCH_START: guard non-WiX upgrade leave routing.
+; - Signed plugin directory, via both the pinned bundler's NSISPLUGINS env var
+;   and 2.9.3's signed_plugins_path. Drop the env var form once the CLI is
+;   upgraded past tauri-apps/tauri#15422.
 
 Unicode true
 ManifestDPIAware true
@@ -23,11 +26,16 @@ ManifestDPIAwareness PerMonitorV2
   SetCompressor /SOLID "{{compression}}"
 !endif
 
-; Signed NSIS plugins. tauri-bundler signs a copy and exports NSISPLUGINS, but no
-; template consumes it, so only nsis_tauri_utils.dll ships signed and the rest
-; (NSISdl/System/StartMenu/nsDialogs) run unsigned from $PLUGINSDIR, tripping AV.
-; Must precede any plugin use; a missing directory is a silent no-op.
+; Signed NSIS plugins, or NSISdl/System/StartMenu/nsDialogs run unsigned from
+; $PLUGINSDIR and trip AV. Must precede any plugin use; a missing directory is a
+; silent no-op. Both forms are here on purpose: the pinned bundler (2.8.1) only
+; exports the NSISPLUGINS env var, and tauri-apps/tauri#15422 replaced it with
+; signed_plugins_path in 2.9.3. Whichever is absent expands to nothing, so this
+; keeps working across that upgrade instead of silently shipping unsigned DLLs.
 !addplugindir "$%NSISPLUGINS%\x86-unicode"
+{{#if signed_plugins_path}}
+!addplugindir "{{signed_plugins_path}}"
+{{/if}}
 
 !include MUI2.nsh
 !include FileFunc.nsh

--- a/tests/studio/test_nsis_signed_plugins_contract.py
+++ b/tests/studio/test_nsis_signed_plugins_contract.py
@@ -48,7 +48,10 @@ def _line_of(template: str, needle: str) -> int:
 def _signed_dir_lines(template: str) -> dict[str, int]:
     # Each form is checked on its own. Only one resolves per bundler version, so
     # taking the earliest would let the other drift below an include unnoticed.
-    return {"env var": _line_of(template, ENV_FORM), "template var": _line_of(template, TEMPLATE_FORM)}
+    return {
+        "env var": _line_of(template, ENV_FORM),
+        "template var": _line_of(template, TEMPLATE_FORM),
+    }
 
 
 @pytest.mark.parametrize("form", ["env var", "template var"])

--- a/tests/studio/test_nsis_signed_plugins_contract.py
+++ b/tests/studio/test_nsis_signed_plugins_contract.py
@@ -40,12 +40,23 @@ def test_the_template_form_is_guarded(template: str) -> None:
     assert guard < template.index(TEMPLATE_FORM) < template.index("{{/if}}", guard)
 
 
-def test_signed_plugin_dirs_precede_every_plugin_use(template: str) -> None:
+def _line_of(template: str, needle: str) -> int:
+    lines = template.splitlines()
+    return next(i for i, line in enumerate(lines) if line.strip() == needle)
+
+
+def _signed_dir_lines(template: str) -> dict[str, int]:
+    # Each form is checked on its own. Only one resolves per bundler version, so
+    # taking the earliest would let the other drift below an include unnoticed.
+    return {"env var": _line_of(template, ENV_FORM), "template var": _line_of(template, TEMPLATE_FORM)}
+
+
+@pytest.mark.parametrize("form", ["env var", "template var"])
+def test_signed_plugin_dir_precedes_every_plugin_use(template: str, form: str) -> None:
     # !addplugindir after a plugin call raises "conflicts with a plugin in
     # another directory" at compile time, or silently loses to an already
     # packed default.
     lines = template.splitlines()
-    first_dir = min(i for i, l in enumerate(lines) if l.strip().startswith("!addplugindir"))
     plugin_calls = [
         i
         for i, l in enumerate(lines)
@@ -57,11 +68,10 @@ def test_signed_plugin_dirs_precede_every_plugin_use(template: str) -> None:
         )
     ]
     assert plugin_calls, "expected the template to call NSIS plugins"
-    assert first_dir < min(plugin_calls)
+    assert _signed_dir_lines(template)[form] < min(plugin_calls)
 
 
-def test_includes_come_after_the_signed_plugin_dirs(template: str) -> None:
-    lines = template.splitlines()
-    first_dir = min(i for i, l in enumerate(lines) if l.strip().startswith("!addplugindir"))
-    mui = next(i for i, l in enumerate(lines) if l.strip().startswith("!include MUI2.nsh"))
-    assert first_dir < mui
+@pytest.mark.parametrize("form", ["env var", "template var"])
+def test_includes_come_after_the_signed_plugin_dir(template: str, form: str) -> None:
+    mui = _line_of(template, "!include MUI2.nsh")
+    assert _signed_dir_lines(template)[form] < mui

--- a/tests/studio/test_nsis_signed_plugins_contract.py
+++ b/tests/studio/test_nsis_signed_plugins_contract.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Keep the NSIS plugin DLLs coming from the signed copy.
+
+NSIS runs its plugin DLLs out of $PLUGINSDIR, so the installer being signed says
+nothing about them. tauri-bundler signs a copy and points at it two different
+ways depending on version: the NSISPLUGINS env var up to bundler 2.8.1, and the
+signed_plugins_path template variable from 2.9.3 (tauri-apps/tauri#15422). The
+template carries both, because a missing plugin directory is a silent no-op, so
+dropping the wrong one ships unsigned DLLs with no build error.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+TEMPLATE = REPO / "studio/src-tauri/windows/installer.nsi"
+
+ENV_FORM = '!addplugindir "$%NSISPLUGINS%\\x86-unicode"'
+TEMPLATE_FORM = '!addplugindir "{{signed_plugins_path}}"'
+
+
+@pytest.fixture(scope = "module")
+def template() -> str:
+    return TEMPLATE.read_text(encoding = "utf-8")
+
+
+def test_both_signed_plugin_directory_forms_are_present(template: str) -> None:
+    assert ENV_FORM in template, "the pinned bundler only exports NSISPLUGINS"
+    assert TEMPLATE_FORM in template, "bundler 2.9.3+ only exports signed_plugins_path"
+
+
+def test_the_template_form_is_guarded(template: str) -> None:
+    # Unsigned builds omit signed_plugins_path entirely; rendering it unguarded
+    # would point !addplugindir at an empty path.
+    guard = template.index("{{#if signed_plugins_path}}")
+    assert guard < template.index(TEMPLATE_FORM) < template.index("{{/if}}", guard)
+
+
+def test_signed_plugin_dirs_precede_every_plugin_use(template: str) -> None:
+    # !addplugindir after a plugin call raises "conflicts with a plugin in
+    # another directory" at compile time, or silently loses to an already
+    # packed default.
+    lines = template.splitlines()
+    first_dir = min(i for i, l in enumerate(lines) if l.strip().startswith("!addplugindir"))
+    plugin_calls = [
+        i for i, l in enumerate(lines)
+        if "::" in l and not l.strip().startswith((";", "#", "!"))
+        and any(p in l for p in ("System::", "nsDialogs::", "StartMenu::", "NSISdl::", "nsis_tauri_utils::"))
+    ]
+    assert plugin_calls, "expected the template to call NSIS plugins"
+    assert first_dir < min(plugin_calls)
+
+
+def test_includes_come_after_the_signed_plugin_dirs(template: str) -> None:
+    lines = template.splitlines()
+    first_dir = min(i for i, l in enumerate(lines) if l.strip().startswith("!addplugindir"))
+    mui = next(i for i, l in enumerate(lines) if l.strip().startswith("!include MUI2.nsh"))
+    assert first_dir < mui

--- a/tests/studio/test_nsis_signed_plugins_contract.py
+++ b/tests/studio/test_nsis_signed_plugins_contract.py
@@ -47,9 +47,14 @@ def test_signed_plugin_dirs_precede_every_plugin_use(template: str) -> None:
     lines = template.splitlines()
     first_dir = min(i for i, l in enumerate(lines) if l.strip().startswith("!addplugindir"))
     plugin_calls = [
-        i for i, l in enumerate(lines)
-        if "::" in l and not l.strip().startswith((";", "#", "!"))
-        and any(p in l for p in ("System::", "nsDialogs::", "StartMenu::", "NSISdl::", "nsis_tauri_utils::"))
+        i
+        for i, l in enumerate(lines)
+        if "::" in l
+        and not l.strip().startswith((";", "#", "!"))
+        and any(
+            p in l
+            for p in ("System::", "nsDialogs::", "StartMenu::", "NSISdl::", "nsis_tauri_utils::")
+        )
     ]
     assert plugin_calls, "expected the template to call NSIS plugins"
     assert first_dir < min(plugin_calls)


### PR DESCRIPTION
Two Windows fixes, both found while validating the desktop release.

### The signed NSIS plugin directory would have vanished on a CLI upgrade

NSIS runs its plugin DLLs out of `$PLUGINSDIR`, so the installer being signed says nothing about them. #7819 pointed the template at the bundler's signed copy through the `NSISPLUGINS` environment variable, which is what our pinned bundler (2.8.1) exports.

That variable no longer exists upstream. [tauri-apps/tauri#15422](https://github.com/tauri-apps/tauri/pull/15422), merged 2026-05-23 and shipped in `tauri-bundler-v2.9.3`, removed it and replaced it with a `signed_plugins_path` template variable. I confirmed there are zero references to `NSISPLUGINS` anywhere in the current bundler source.

Since we ship our own template, upgrading the CLI would not have brought upstream's directive with it. It would have left ours expanding to a literal `$%NSISPLUGINS%`, and `!addplugindir` on a path that does not exist is a silent no-op, so the four stock DLLs would have gone back to shipping unsigned with no build error and no warning. The release gate would have caught it, but only as a late failure with a confusing cause.

So the template now carries both forms. Whichever mechanism is absent expands to nothing:

- on the pinned bundler, the env var resolves and `{{#if signed_plugins_path}}` renders nothing
- on 2.9.3 and later, the template variable resolves and the env var form is the silent no-op

The env var form goes away once the CLI is upgraded, and the header comment says so.

Worth noting the `{{#if}}` guard is not decoration. Upstream inserts `signed_plugins_path` only when signing is configured, so unsigned builds omit the key entirely, and rendering it unguarded would point `!addplugindir` at an empty path.

### Tests

`tests/studio/test_nsis_signed_plugins_contract.py` covers the wiring, which nothing did before. It pins both forms, the `{{#if}}` guard, and the ordering, because `!addplugindir` after a plugin call either fails at compile time with `conflicts with a plugin in another directory` or quietly loses to an already packed default.

I mutation tested it rather than trusting a green run. Dropping the env var form, moving the block below the includes, and unguarding the template form each fail exactly one test, and the clean tree passes all four.

### The vc_redist download had no retry

`studio-windows-inference-smoke.yml` fetched `vc_redist.x64.exe` with a bare `Invoke-WebRequest` against `aka.ms`. That redirects to a CDN which twice in one day cut the response mid body:

```
Invoke-WebRequest: One or more errors occurred. (The response ended prematurely. (ResponseEnded))
```

Both times it failed the job in 19 seconds and looked like a real regression on unrelated PRs. It now retries four times with linear backoff, and rejects anything under 10MB or without a valid Authenticode signature, so a truncated download is reported as itself instead of surfacing later as an unexplained installer exit code.

### Validation

- `yaml.safe_load` on the workflow, and all 20 `pwsh` blocks in it AST parse with `Parser::ParseFile`, zero errors
- `tests/studio/test_nsis_signed_plugins_contract.py`, `test_tauri_branding_contract.py`, `test_tauri_installer_resource_contract.py`: 10 passed
- The truncation guard checked behaviourally in pwsh
- The signed plugin wiring itself is already proven end to end: a real Trusted Signing build of this template reports all nine files in the bundle signed, including `nsDialogs.dll`, `StartMenu.dll` and `System.dll`
