### PR TITLE
Studio: return 400 for a rejected dataset path in check-format

### DIFF
--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -535,7 +535,12 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
 
         logger.info(f"Checking format for dataset: {request.dataset_name}")
 
-        dataset_path = resolve_dataset_path(request.dataset_name)
+        try:
+            dataset_path = resolve_dataset_path(request.dataset_name)
+        except ValueError as e:
+            # Malformed path (null bytes, '..', outside roots) is a client error:
+            # surface 400 rather than the generic 500 below.
+            raise HTTPException(status_code = 400, detail = str(e)) from e
         total_rows = None
 
         # Uploads and recipes always arrive as absolute paths, so a missing one is a

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -132,9 +132,8 @@ def test_rejected_paths_are_client_errors(dataset_name, expected, isolated_studi
     fault, and must never reach the Hub. Matches the hub check-format twin."""
     from utils.paths import dataset_uploads_root
 
-    # Anchor of the studio home, so the out-of-root path is absolute on POSIX
-    # ("/x") and on Windows ("C:\\x") alike. A hardcoded "/etc/x" is relative on
-    # Windows, so it never reaches the branch under test.
+    # Anchor of the studio home: absolute on POSIX ("/x") and Windows ("C:\\x").
+    # A hardcoded "/etc/x" is relative on Windows and misses the branch entirely.
     error = _check(
         dataset_name.format(
             anchor = isolated_studio_home.anchor,

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -117,3 +117,23 @@ def test_hub_repo_id_never_reports_a_deleted_file(no_hub):
 
     assert error.status_code != 404
     assert no_hub, "the Hub branch is where a relative reference belongs"
+
+
+@pytest.mark.parametrize(
+    ("dataset_name", "expected"),
+    [
+        pytest.param("/etc/not-a-dataset.jsonl", "under a dataset root", id = "outside-roots"),
+        pytest.param("{uploads}/../escape.jsonl", "'..' segments", id = "traversal"),
+        pytest.param("uploads/nul\x00byte.jsonl", "null bytes", id = "null-byte"),
+    ],
+)
+def test_rejected_paths_are_client_errors(dataset_name, expected, no_hub):
+    """A path resolve_dataset_path refuses is the caller's mistake, not a server
+    fault, and must never reach the Hub. Matches the hub check-format twin."""
+    from utils.paths import dataset_uploads_root
+
+    error = _check(dataset_name.format(uploads = dataset_uploads_root()))
+
+    assert error.status_code == 400
+    assert expected in str(error.detail)
+    assert no_hub == []

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -122,17 +122,25 @@ def test_hub_repo_id_never_reports_a_deleted_file(no_hub):
 @pytest.mark.parametrize(
     ("dataset_name", "expected"),
     [
-        pytest.param("/etc/not-a-dataset.jsonl", "under a dataset root", id = "outside-roots"),
+        pytest.param("{anchor}not-a-dataset.jsonl", "under a dataset root", id = "outside-roots"),
         pytest.param("{uploads}/../escape.jsonl", "'..' segments", id = "traversal"),
         pytest.param("uploads/nul\x00byte.jsonl", "null bytes", id = "null-byte"),
     ],
 )
-def test_rejected_paths_are_client_errors(dataset_name, expected, no_hub):
+def test_rejected_paths_are_client_errors(dataset_name, expected, isolated_studio_home, no_hub):
     """A path resolve_dataset_path refuses is the caller's mistake, not a server
     fault, and must never reach the Hub. Matches the hub check-format twin."""
     from utils.paths import dataset_uploads_root
 
-    error = _check(dataset_name.format(uploads = dataset_uploads_root()))
+    # Anchor of the studio home, so the out-of-root path is absolute on POSIX
+    # ("/x") and on Windows ("C:\\x") alike. A hardcoded "/etc/x" is relative on
+    # Windows, so it never reaches the branch under test.
+    error = _check(
+        dataset_name.format(
+            anchor = isolated_studio_home.anchor,
+            uploads = dataset_uploads_root(),
+        )
+    )
 
     assert error.status_code == 400
     assert expected in str(error.detail)


### PR DESCRIPTION
Follow-up to #7800.

`resolve_dataset_path` raises `ValueError` for three inputs it refuses outright: a path containing null bytes, a path with a `..` segment, and an absolute path that lands outside every dataset root. In `POST /api/datasets/check-format` that call was unguarded, so the exception fell through to the blanket handler and came back as `500 "Failed to check dataset format"`. A malformed request read as a server fault, and the caller never learned why.

The hub twin already handles this. `hub/services/datasets/formatting.py` wraps the same call and returns 400 with the resolver's own message, so this is straight parity rather than a new contract.

### Before and after

Driving `check_format` directly, with the Hub stubbed and an isolated `UNSLOTH_STUDIO_HOME`:

| request | before | after |
|---|---|---|
| absolute path outside every dataset root | 500 | **400** `dataset path must be relative or under a dataset root: ...` |
| absolute path containing `..` | 500 | **400** `dataset path may not contain '..' segments: ...` |
| path containing a null byte | 500 | **400** `dataset path may not contain null bytes` |
| deleted local file | 404 | 404 |
| corrupt but present local file | 500 | 500 |
| valid local file | 200 | 200 |
| Hub repo id, and `uploads/` or `recipes/` namespaced ids | 500 via the Hub branch | unchanged |

Only the two rows the resolver rejects move. Every other case is byte for byte identical.

The detail is the resolver's own message, which only ever echoes the caller's own input. Any inner containment failure is caught inside `resolve_dataset_path` and re-raised as the "must be relative or under a dataset root" message, so no server path is exposed.

No frontend change is needed. The deleted-file recovery keys on 404 specifically, so a 400 falls through to the normal error display with a message that now says what was wrong.

### Tests

Three parametrised cases added to `test_dataset_check_format_missing.py`, one per rejected input. They fail on `main` (3 failed, 7 passed) and pass here (10 passed), and they assert the Hub was never contacted.

The whole file stays hermetic under a socket-blocking plugin: no outbound connections. Targeted backend regression over the dataset, path, storage-root, training-start, recipe and upload tests: 672 passed, 0 failed. `ruff check` clean.
