### PR TITLE
Skip an unreadable notebooks candidate instead of failing collection

### DIFF
--- a/tests/notebooks/test_validator_fixtures.py
+++ b/tests/notebooks/test_validator_fixtures.py
@@ -224,14 +224,23 @@ def test_environment_classifier(path, expected):
 # ---------- Integration: walk the live notebooks repo (skipped if absent) -- #
 
 
-def _live_notebooks_dir() -> Path | None:
-    candidates = [
-        Path(__file__).resolve().parents[3] / "notebooks",  # workspace sibling
-        Path("/mnt/disks/unslothai/ubuntu/workspace_12/notebooks"),
-    ]
+def _live_notebooks_dir(candidates: list[Path] | None = None) -> Path | None:
+    if candidates is None:
+        candidates = [
+            Path(__file__).resolve().parents[3] / "notebooks",  # workspace sibling
+            Path("/mnt/disks/unslothai/ubuntu/workspace_12/notebooks"),
+        ]
     for p in candidates:
-        if (p / "update_all_notebooks.py").is_file():
-            return p
+        # is_file() only swallows ENOENT/ENOTDIR; an unreadable candidate raises
+        # EACCES on Python <= 3.13 (3.14 suppresses it, gh-101357). These are
+        # absolute paths outside the repo, so on a shared machine one can belong
+        # to another user. The skipif decorators below call this at import time,
+        # so a raise here aborts collection of the whole file.
+        try:
+            if (p / "update_all_notebooks.py").is_file():
+                return p
+        except OSError:
+            continue
     return None
 
 
@@ -270,3 +279,32 @@ def test_lint_smoke_no_module_errors():
     )
     # rc=0 means clean, rc=1 means findings reported, rc=2 means crash.
     assert rc.returncode in (0, 1), rc.stderr[-2000:]
+
+
+def test_live_notebooks_dir_skips_an_unreadable_candidate(tmp_path):
+    """An unreadable candidate must read as absent rather than raise.
+
+    The skipif decorators above call ``_live_notebooks_dir`` at import time, so an
+    uncaught EACCES there aborts collection of this whole file, taking the entire
+    Repo tests (CPU) job with it. The candidates are absolute paths outside the repo,
+    so on a shared machine one of them can belong to another user.
+    """
+    blocked_parent = tmp_path / "blocked"
+    blocked = blocked_parent / "notebooks"
+    blocked.mkdir(parents = True)
+    (blocked / "update_all_notebooks.py").write_text("")
+    readable = tmp_path / "readable" / "notebooks"
+    readable.mkdir(parents = True)
+    (readable / "update_all_notebooks.py").write_text("")
+
+    blocked_parent.chmod(0o000)
+    try:
+        try:
+            (blocked / "update_all_notebooks.py").is_file()
+        except OSError:
+            pass
+        else:
+            pytest.skip("filesystem does not enforce the permission (root?)")
+        assert _live_notebooks_dir([blocked, readable]) == readable
+    finally:
+        blocked_parent.chmod(0o755)


### PR DESCRIPTION
## The bug

`Repo tests (CPU)` aborts collection on any machine where the hardcoded notebooks candidate exists but is not readable by the current user:

```
ERROR tests/notebooks/test_validator_fixtures.py - PermissionError: [Errno 13] Permission denied:
  '/mnt/disks/unslothai/ubuntu/workspace_12/notebooks/update_all_notebooks.py'
!!!!!! Interrupted: 1 error during collection !!!!!!
```

`_live_notebooks_dir()` probes two absolute paths outside the repo, and the second is a fixed workspace path. `Path.is_file()` only swallows `ENOENT` and `ENOTDIR`, so an unreadable candidate raises `EACCES` on every Python this repo supports up to 3.13 (3.14 suppresses it, [gh-101357](https://github.com/python/cpython/issues/101357)). Confirmed on 3.12 and 3.13.

The helper is called at import time by the two `@pytest.mark.skipif` decorators below it, so the raise happens during collection. Pytest reports `Interrupted` and the whole job fails, not just this file's tests.

It stays green on GitHub runners only because that path is absent there, which makes the error `ENOENT` rather than `EACCES`. Any shared multi-user machine where a sibling workspace is present but not world-readable hits it.

This is the same failure mode `tests/test_recommended_folders_permission.py` already documents for `/recommended-folders`, and the reason there are five `_safe_is_dir` helpers in the tree.

## Changes

`tests/notebooks/test_validator_fixtures.py`

- Guard the candidate probe with `except OSError: continue`, so an un-stattable candidate reads as absent instead of raising.
- Let `_live_notebooks_dir` take an explicit candidate list, so the guard is testable without touching real paths.
- Add `test_live_notebooks_dir_skips_an_unreadable_candidate`, which puts a valid candidate behind a `chmod 000` parent, asserts the next candidate wins, and self-skips if the filesystem does not enforce the permission (running as root).

The hardcoded path is left in place. Removing it would break the local runs it serves, and guarding the probe is the smaller fix.

## Testing

Full `Repo tests (CPU)` invocation from `studio-backend-ci.yml`, against `main` at 3867b667 with CPU torch 2.10.0 and transformers 5.4.0:

| | result |
|---|---|
| before | `Interrupted: 1 error during collection`, no tests run |
| after | **4111 passed, 61 skipped, 23 deselected** |

The new test is non-vacuous: strip only the `try/except` and collection fails again with the identical `PermissionError`. `tests/notebooks/test_validator_fixtures.py` alone is 20 passed, 2 skipped. `ruff check` clean.

The single remaining failure in that run, `tests/fast_inference/test_fast_inference.py`, is `ImportError: Please install vLLM before enabling fast_inference` and is unrelated to this change; vLLM is not installed in the local environment.
