### PR TITLE
Keep the file-edit turn 2 prompt to one instruction, and stop waiving its cap

### DIFF
--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -174,8 +174,8 @@ run_timed() {  # $1=outfile, rest=command
   # Neither status proves expiry on its own. 137 is also an unrelated SIGKILL,
   # and 124 is also whatever the CLI itself chose to exit with -- timeout(1)
   # otherwise returns "the exit status of COMMAND", and an agent that hit its
-  # own internal request timeout can exit 124 early, after leaving hello.py or
-  # ran.txt behind. So both statuses have to agree with the clock. SECONDS is
+  # own internal request timeout can exit 124 early, after leaving hello.py
+  # behind. So both statuses have to agree with the clock. SECONDS is
   # truncated to whole seconds at both ends, so allow one second of slack;
   # a CLI-originated 124 returns nowhere near the cap.
   local expired=0
@@ -462,10 +462,13 @@ case "$MODE" in
     OUT1="$LOGS_DIR/${AGENT}-fileedit-turn1.txt"
     OUT2="$LOGS_DIR/${AGENT}-fileedit-turn2.txt"
     T1='Create a file named hello.py in the current directory whose entire contents are a single line: print("Hello"). Do not run it.'
-    # T2 asks for ran.txt as well as the printed output. Only the normal path
-    # is judged on the transcript; ran.txt is what a waived cap falls back on,
-    # because it is the one artifact a narrated answer cannot produce.
-    T2='Run hello.py with python, show me the exact output, and write that output to ran.txt.'
+    # Keep T2 to one instruction. Asking for the output AND for it to be saved
+    # to ran.txt was meant to give a capped turn something verifiable to judge,
+    # but on a CPU-served 4B it degraded the agents instead: opencode answered
+    # the two-part version by narrating "[runs bash command `python hello.py >
+    # ran.txt`]" and "ran.txt created." while creating no such file, having run
+    # the one-part version for real in ~90s on every prior run.
+    T2='Run hello.py with python and show me the exact output.'
 
     # The start.py recipe writers + crosscheck must see the repo; run them
     # from the repo root BEFORE cd-ing into the scratch work dir. opencode/openclaw
@@ -546,26 +549,18 @@ case "$MODE" in
 
     # Turn 2: same cwd + session continuation; assert the agent's run output
     # contains Hello. Narration drift is WARN-only, missing output is a hard fail.
+    # Turn 2 gets NO cap waiver. Turn 1 earns one because the harness re-runs
+    # hello.py itself, but turn 1's assertions all ran before turn 2 started, so
+    # a capped turn 2 has only its transcript left -- and 'Hello' is hello.py's
+    # own source, the program's stdout, and a plausible narration of the answer
+    # all at once. Waiving it on text was unsound, and the artifact that would
+    # have made it sound cannot be asked for without breaking the turn (see T2).
+    # So a cap here is fatal, as it is for connection, resume and attribution-ab.
     invoke_turn "$OUT2" continue "$T2"
     rc=$?
-    [ "$rc" -eq 0 ] || [ "${TIMED_OUT:-0}" = 1 ] \
+    [ "$rc" -eq 0 ] \
       || { echo "[$AGENT] turn-2 transcript:"; tail -60 "$OUT2" 2>/dev/null || true; \
       guide_fail "turn 2 (run hello.py) exited non-zero (rc=$rc)"; }
-    # Turn 1's side effects were asserted before turn 2 started, so on a waived
-    # cap nothing below judges this turn but the transcript -- and no transcript
-    # can. 'Hello' is hello.py's own source, the program's stdout, AND a
-    # plausible narration of the answer by a model that never ran anything; the
-    # three are indistinguishable as text. ran.txt is the one thing only an
-    # executed tool call leaves behind, so the waiver hangs off that.
-    if [ "${TIMED_OUT:-0}" = 1 ]; then
-      [ -f ran.txt ] || {
-        echo "[$AGENT] turn-2 transcript:"; tail -60 "$OUT2" 2>/dev/null || true
-        guide_fail "turn 2 timed out without leaving ran.txt, so nothing shows it ran hello.py rather than describing it"
-      }
-      _ran="$(tr -d '[:space:]' < ran.txt)"
-      [ "$_ran" = "Hello" ] || guide_fail "turn 2 timed out and ran.txt holds '$_ran', expected 'Hello'"
-      echo "[$AGENT] turn 2 capped, but ran.txt proves hello.py actually ran"
-    fi
     if grep -q 'Hello' "$OUT2"; then
       echo "[$AGENT] turn 2 OK (run output contains 'Hello')"
     else

--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -462,12 +462,9 @@ case "$MODE" in
     OUT1="$LOGS_DIR/${AGENT}-fileedit-turn1.txt"
     OUT2="$LOGS_DIR/${AGENT}-fileedit-turn2.txt"
     T1='Create a file named hello.py in the current directory whose entire contents are a single line: print("Hello"). Do not run it.'
-    # Keep T2 to one instruction. Asking for the output AND for it to be saved
-    # to ran.txt was meant to give a capped turn something verifiable to judge,
-    # but on a CPU-served 4B it degraded the agents instead: opencode answered
-    # the two-part version by narrating "[runs bash command `python hello.py >
-    # ran.txt`]" and "ran.txt created." while creating no such file, having run
-    # the one-part version for real in ~90s on every prior run.
+    # One instruction only. Also asking for a ran.txt copy (#7838) made opencode
+    # narrate the tool call and create no file, where the one-part prompt had run
+    # for real in ~90s every time.
     T2='Run hello.py with python and show me the exact output.'
 
     # The start.py recipe writers + crosscheck must see the repo; run them
@@ -549,13 +546,10 @@ case "$MODE" in
 
     # Turn 2: same cwd + session continuation; assert the agent's run output
     # contains Hello. Narration drift is WARN-only, missing output is a hard fail.
-    # Turn 2 gets NO cap waiver. Turn 1 earns one because the harness re-runs
-    # hello.py itself, but turn 1's assertions all ran before turn 2 started, so
-    # a capped turn 2 has only its transcript left -- and 'Hello' is hello.py's
-    # own source, the program's stdout, and a plausible narration of the answer
-    # all at once. Waiving it on text was unsound, and the artifact that would
-    # have made it sound cannot be asked for without breaking the turn (see T2).
-    # So a cap here is fatal, as it is for connection, resume and attribution-ab.
+    # No cap waiver here, unlike turn 1, whose side effect the harness re-runs
+    # itself: turn 1's assertions all ran before this started, so a cap leaves
+    # only the transcript, and 'Hello' is hello.py's source, its stdout and a
+    # narration of it alike. Fatal, as for connection, resume, attribution-ab.
     invoke_turn "$OUT2" continue "$T2"
     rc=$?
     [ "$rc" -eq 0 ] \

--- a/tests/sh/test_agent_guides_timeout_classification.sh
+++ b/tests/sh/test_agent_guides_timeout_classification.sh
@@ -19,13 +19,14 @@
 # caller's own assertions, and neither disposition touches the non-timeout
 # exit paths.
 #
-# Three call sites deliberately do NOT get the waiver. `connection` has no
+# Four call sites deliberately do NOT get the waiver. `connection` has no
 # assertion that can tell a completed reply from a startup banner (assert_reply
 # checks for non-empty text without the connection/auth error strings, not for
 # the requested "pong"), `resume` reads a session-store delta that a partial turn
-# would corrupt, and `attribution-ab` judges by a llama-server log slice. Only
-# the two file-edit turns qualify, and turn 2 falls back on ran.txt rather than
-# its transcript.
+# would corrupt, `attribution-ab` judges by a llama-server log slice, and
+# file-edit turn 2 has only its transcript, which cannot separate the program's
+# stdout from a narration of it. Turn 1 is the only site that qualifies, because
+# the harness re-runs hello.py itself.
 #
 # Expiry is read off the wall clock, not the exit status: --kill-after bounds a
 # TERM-resistant CLI but makes it exit 137, which is also what an unrelated
@@ -166,15 +167,16 @@ assert_eq "rc preserved"                "$(field "$OUT" RC)" 3
 assert_eq "TIMED_OUT cleared"           "$(field "$OUT" TIMED_OUT)" 0
 assert_eq "no guide_fail"               "$(count "$OUT" 'GUIDE_FAIL')" 0
 
-echo "6. only the file-edit turns rescue a soft timeout"
-# Both file-edit turns judge the turn on real side effects: turn 1 on hello.py
-# (which the harness runs itself), turn 2 on ran.txt. connection, resume and
-# attribution-ab have no such assertion, so a cap stays fatal for them.
+echo "6. only file-edit turn 1 rescues a soft timeout"
+# Turn 1 is judged on a side effect the harness verifies itself (it runs
+# hello.py and compares the output). Everything else -- turn 2, connection,
+# resume, attribution-ab -- has only text or a partial store to go on, so a cap
+# stays fatal there.
 # Count every waiver regardless of how the statement is wrapped: an escape
 # rewritten onto one line must still be counted, or this guard checks nothing.
 RESCUERS="$(grep -c 'TIMED_OUT:-0}" = 1 \]' "$DRIVE_SH" || true)"
-# 2 file-edit turn guards + turn 2's ran.txt branch + resume + attribution-ab.
-assert_eq "exactly the expected TIMED_OUT sites" "$RESCUERS" 5
+# Only turn 1's guard, plus the resume and attribution-ab fatal checks.
+assert_eq "exactly the expected TIMED_OUT sites" "$RESCUERS" 3
 assert_eq "resume keeps a hang fatal" \
     "$(grep -c 'a resume pass cannot be judged from a partial turn' "$DRIVE_SH" || true)" 1
 assert_eq "attribution-ab keeps a hang fatal" \
@@ -192,22 +194,22 @@ assert_eq "connection guard has no TIMED_OUT escape" \
 assert_eq "connection guard still fails on a bare rc" \
     "$(echo "$CONN_STMT" | grep -c '\[ "\$rc" -eq 0 \] || guide_fail' || true)" 1
 
-echo "7. a waived file-edit turn 2 is judged on a real artifact, not on text"
-# 'Hello' is hello.py's own source, the program's stdout, and a plausible
-# narration of the answer all at once, so no transcript grep can separate them.
-# ran.txt can only exist if a tool call actually ran.
-assert_eq "T2 asks for the artifact" \
-    "$(grep -c "write that output to ran.txt" "$DRIVE_SH" || true)" 1
-# Grep the guard itself, not its message: the message survives inside a block
-# that has been short-circuited, so it proves nothing on its own.
-assert_eq "the waived path requires it" \
-    "$(grep -c '^ *\[ -f ran.txt \] || {' "$DRIVE_SH" || true)" 1
-assert_eq "and says so when it is missing" \
-    "$(grep -c 'without leaving ran.txt' "$DRIVE_SH" || true)" 1
-assert_eq "and checks its contents" \
-    "$(grep -c "_ran\" = \"Hello" "$DRIVE_SH" || true)" 1
-assert_eq "no transcript-only fallback survives" \
-    "$(grep -c "hello.py's output on a line of its own" "$DRIVE_SH" || true)" 0
+echo "7. file-edit turn 2 keeps a cap fatal, and asks one thing"
+# The two-part T2 that would have made a waived turn 2 verifiable degraded the
+# agents: opencode narrated the tool call instead of running it and created no
+# file, having executed the one-part prompt for real on every prior run.
+assert_eq "T2 is a single instruction" \
+    "$(grep -c "T2='Run hello.py with python and show me the exact output.'" "$DRIVE_SH" || true)" 1
+# Only the comment explaining why it was dropped may mention it; no live line
+# may ask for it or read it.
+assert_eq "no ran.txt artifact in live code" \
+    "$(grep -v '^[[:space:]]*#' "$DRIVE_SH" | grep -c 'ran.txt' || true)" 0
+TURN2_LINE="$(grep -n 'turn 2 (run hello.py) exited non-zero' "$DRIVE_SH" | cut -d: -f1)"
+TURN2_STMT="$(sed -n "$((TURN2_LINE - 2)),${TURN2_LINE}p" "$DRIVE_SH")"
+assert_eq "turn 2 has no TIMED_OUT escape" \
+    "$(echo "$TURN2_STMT" | grep -c 'TIMED_OUT' || true)" 0
+assert_eq "turn 2 still fails on a bare rc" \
+    "$(echo "$TURN2_STMT" | grep -c '\[ "\$rc" -eq 0 \] \\' || true)" 1
 
 echo "8. the cap keeps a finite kill fallback, but expiry comes from the clock"
 # Cases 3b/3c/3d prove the behaviour; these pin the shape, so a refactor cannot


### PR DESCRIPTION
Follow-up to #7838. One change in that PR was wrong and I should have caught it before it merged.

## What broke

To give a capped `file-edit` turn 2 something verifiable to judge, #7838 changed T2 from

```
Run hello.py with python and show me the exact output.
```

to

```
Run hello.py with python, show me the exact output, and write that output to ran.txt.
```

On a CPU-served 4B that made the turn worse, not safer. Staging run [149](https://github.com/Datta0/unsloth-staging-3/pull/149) came back with `file-edit (opencode)` red, and opencode is not `best_effort`, so it fails the workflow. Its turn-2 transcript is:

```
[runs bash command `python hello.py > ran.txt` to execute the script and save the output to ran.txt]
ran.txt created.
```

It narrated the tool call rather than making it. The uploaded `agent-workdir/opencode/` contains `hello.py` and no `ran.txt`, so nothing ran, and `grep -q 'Hello' "$OUT2"` then failed on a transcript with no program output in it. The same agent ran the one-instruction version for real in about 90 seconds on every prior run, including twice on 2026-08-04.

So the artifact meant to prove execution is exactly what stopped execution happening.

## What this does

Reverts T2 to the single instruction, and removes the turn-2 cap waiver rather than trying to prop it up with a weaker check.

Turn 2 has no side effect of its own. Turn 1's three assertions all run before turn 2 starts, and the harness executes `python3 hello.py` itself there, which is real verification. A capped turn 2 has only its transcript, and `Hello` is hello.py's own source, the program's stdout, and a plausible narration of the answer all at once. That was the point of #7838's review thread, and asking for `ran.txt` was the one way to settle it that does not survive contact with the model. So a cap on turn 2 is fatal again, as it already is for `connection`, `resume` and `attribution-ab`.

Turn 1 keeps its waiver, and everything else from #7838 stands: the empty-transcript case is still fatal guide drift, a transcript-producing cap still warns instead of blaming `unsloth_cli/commands/start.py`, expiry is still read off the clock rather than the exit status, and the Colab oracle changes are untouched.

The cost is stated plainly: an intermittent opencode hang on turn 2, which is the failure that opened #7838, will fail the leg again. That failure is intermittent (turn 2 took 90s on 2026-07-27, over 1200s on 2026-08-03, 93s and 82s on 2026-08-04), and a waiver that cannot tell execution from narration is worse than a red leg that says so.

## Tests

`tests/sh/test_agent_guides_timeout_classification.sh` is 43 assertions. Section 6 now expects three `TIMED_OUT` sites rather than five, and section 7 asserts T2 is a single instruction, that no live line asks for or reads `ran.txt`, and that the turn-2 guard is a bare `rc` test with no escape.

Both mutations go red: re-adding the turn-2 waiver fails 3 assertions, and restoring the two-part T2 fails 2.

Verified locally: all 36 `tests/sh` files pass and `tests/notebooks` is 34 passed.
