### PR TITLE
Don't send desktop startup requests to an unvalidated port 8888

### DIFF
--- a/studio/frontend/src/lib/api-base.ts
+++ b/studio/frontend/src/lib/api-base.ts
@@ -12,10 +12,10 @@ function detectTauri(): boolean {
 }
 
 const isTauri = detectTauri()
-const isViteDev = import.meta.env.DEV
 
-if (isTauri && !isViteDev) {
-  apiBase = 'http://127.0.0.1:8888'
+if (isTauri) {
+  // never connects; real port arrives via server-port
+  apiBase = 'http://127.0.0.1:0'
 }
 
 const initialApiBase = apiBase


### PR DESCRIPTION
With Jupyter running on port 8888, the backend notices the port is taken and starts on 8889, but the app's first few requests still go to 8888 because that port is hardcoded as the starting API base. Jupyter ends up receiving the app's health and hardware requests, the app briefly shows the wrong hardware (chat-only mode on Mac), and on a relaunch the saved auth token also gets sent to whatever is sitting on 8888. The same thing happens in tauri dev through the vite proxy.

This changes the starting API base to http://127.0.0.1:0, which can never connect, so those early requests just fail quietly instead of reaching some other process. Once the backend reports its real port the app switches over like it already did before. Tested with Jupyter on 8888: the backend moves to 8889, Jupyter gets no requests from the app, and everything loads normally.