### PR TITLE
Studio: keep Video under More until a user pins it

### DIFF
--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -1067,7 +1067,7 @@ SIDEBAR_NAV_ITEM_DEFAULTS = {
     "hub": True,
     "projects": True,
     "images": True,
-    "video": True,
+    "video": False,
     "train": True,
     "recipes": False,
     "export": False,

--- a/studio/backend/tests/test_personalization_settings.py
+++ b/studio/backend/tests/test_personalization_settings.py
@@ -157,7 +157,7 @@ FRONTEND_SHIPPED_SIDEBAR_NAV = [
     ("hub", True),
     ("projects", True),
     ("images", True),
-    ("video", True),
+    ("video", False),
     ("train", True),
     ("recipes", False),
     ("export", False),

--- a/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
+++ b/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
@@ -8,6 +8,7 @@ import {
   isDefaultCustomization,
   isPalette,
   loadPersonalization,
+  migrateShippedSidebarNavDefault,
   sanitizeCustomization,
   savePersonalization,
   setPalette,
@@ -18,11 +19,11 @@ import {
 } from "@/features/settings";
 import {
   DEFAULT_LOCALE_PREFERENCE,
+  type LocalePreference,
   getLocalePreference,
   isLocalePreference,
   setLocale,
   useLocalePreference,
-  type LocalePreference,
 } from "@/i18n";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -36,7 +37,8 @@ const PUSH_DEBOUNCE_MS = 800;
 // Version 2 payloads store the language preference ("auto" or a pinned
 // locale). Version 1 always serialized the resolved locale, so its "en" is
 // usually the old default rather than an explicit pick.
-const PERSONALIZATION_VERSION = 2;
+// Version 3 migrates untouched sidebar layouts to keep Video under More.
+const PERSONALIZATION_VERSION = 3;
 
 type ProfileSnapshot = {
   displayName: string;
@@ -261,8 +263,13 @@ export function usePersonalizationSync(enabled: boolean): void {
           const keepLocalPalette =
             remote.paletteSaved === false && localPalette !== "standard";
           const nextPalette = keepLocalPalette ? localPalette : remotePalette;
-          const remoteCustomization = sanitizeCustomization(
+          const storedRemoteCustomization = sanitizeCustomization(
             remote.appearance.customization,
+          );
+          const remoteCustomization = migrateShippedSidebarNavDefault(
+            storedRemoteCustomization,
+            remote.version,
+            PERSONALIZATION_VERSION,
           );
           const localCustomization = latestCustomizationRef.current;
           const keepLocalCustomization =
@@ -293,15 +300,18 @@ export function usePersonalizationSync(enabled: boolean): void {
           // lastSaved records what the server actually has (server-side defaults
           // for legacy fields) so the debounced push re-uploads preserved local
           // values.
-          lastSavedRef.current = serialized(
-            payload(
+          lastSavedRef.current = serialized({
+            ...payload(
               { ...nextProfile, showGreetingSloth: remoteGreeting },
               nextTheme,
               remotePalette,
-              remoteCustomization,
+              storedRemoteCustomization,
               nextLanguage,
             ),
-          );
+            // Preserve the server's actual version here so a legacy record is
+            // re-saved even when the sidebar layout itself was customized.
+            version: remote.version,
+          });
         } else {
           const rawProfile = profileSnapshot();
           const nextProfile = normalizeProfile(rawProfile);

--- a/studio/frontend/src/features/settings/index.ts
+++ b/studio/frontend/src/features/settings/index.ts
@@ -24,6 +24,7 @@ export {
   DEFAULT_CUSTOMIZATION,
   applyCustomizationToDocument,
   isDefaultCustomization,
+  migrateShippedSidebarNavDefault,
   prefersReducedMotion,
   sanitizeCustomization,
   useAppearanceCustomStore,

--- a/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
+++ b/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
@@ -113,7 +113,8 @@ export const SIDEBAR_NAV_DEFAULT_PINNED: Record<SidebarNavItemId, boolean> = {
   hub: true,
   projects: true,
   images: true,
-  video: true,
+  // Under "More" until a user pins it.
+  video: false,
   train: true,
   recipes: false,
   export: false,
@@ -121,7 +122,8 @@ export const SIDEBAR_NAV_DEFAULT_PINNED: Record<SidebarNavItemId, boolean> = {
 };
 
 /** Every previously shipped layout, so a migration can tell an untouched install from one the
- *  user arranged themselves. v3 pinned Video under Images; v4 moved Model hub above Projects. */
+ *  user arranged themselves. v3 pinned Video under Images; v4 moved Model hub above Projects;
+ *  v5 put Video back under "More". */
 const SHIPPED_SIDEBAR_NAV_DEFAULTS: SidebarNavItemPref[][] = [
   [
     { id: "projects", pinned: true },
@@ -135,6 +137,15 @@ const SHIPPED_SIDEBAR_NAV_DEFAULTS: SidebarNavItemPref[][] = [
   [
     { id: "projects", pinned: true },
     { id: "hub", pinned: true },
+    { id: "images", pinned: true },
+    { id: "video", pinned: true },
+    { id: "train", pinned: true },
+    { id: "recipes", pinned: false },
+    { id: "export", pinned: false },
+  ],
+  [
+    { id: "hub", pinned: true },
+    { id: "projects", pinned: true },
     { id: "images", pinned: true },
     { id: "video", pinned: true },
     { id: "train", pinned: true },
@@ -441,17 +452,19 @@ export const useAppearanceCustomStore = create<AppearanceCustomState>()(
     }),
     {
       name: "unsloth_appearance_customization",
-      version: 4,
+      version: 5,
       storage: createJSONStorage(() => guardedLocalStorage),
       migrate: (persisted, version) => {
         const state = (persisted ?? {}) as Partial<AppearanceCustomState>;
         const customization = sanitizeCustomization(state.customization);
         // Adopt the new layout only where the stored one is still a shipped
         // default, so a user's own arrangement survives.
-        if (version < 4) {
+        if (version < 5) {
           const stored = JSON.stringify(customization.sidebarNav);
+          // Sanitize each layout too: the stored one has since gained any ids
+          // added after it was written, so a raw compare would never match.
           const untouched = SHIPPED_SIDEBAR_NAV_DEFAULTS.some(
-            (layout) => JSON.stringify(layout) === stored,
+            (layout) => JSON.stringify(sanitizeSidebarNav(layout)) === stored,
           );
           if (untouched) {
             customization.sidebarNav = [...DEFAULT_CUSTOMIZATION.sidebarNav];

--- a/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
+++ b/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
@@ -378,6 +378,29 @@ export function sanitizeCustomization(value: unknown): AppearanceCustomization {
   };
 }
 
+/** Adopt the latest default only when the sidebar still matches one we shipped. */
+export function migrateShippedSidebarNavDefault(
+  customization: AppearanceCustomization,
+  storedVersion: number,
+  migrationVersion: number,
+): AppearanceCustomization {
+  // Once this migration version has been persisted, the same layout may be a
+  // deliberate user choice and must never be adopted again.
+  if (storedVersion >= migrationVersion) return customization;
+  const stored = JSON.stringify(customization.sidebarNav);
+  // Sanitize each layout too: the stored one has since gained any ids added
+  // after it was written, so a raw compare would never match.
+  const untouched = SHIPPED_SIDEBAR_NAV_DEFAULTS.some(
+    (layout) => JSON.stringify(sanitizeSidebarNav(layout)) === stored,
+  );
+  return untouched
+    ? {
+        ...customization,
+        sidebarNav: [...DEFAULT_CUSTOMIZATION.sidebarNav],
+      }
+    : customization;
+}
+
 export function isDefaultCustomization(c: AppearanceCustomization): boolean {
   return JSON.stringify(c) === JSON.stringify(DEFAULT_CUSTOMIZATION);
 }
@@ -456,20 +479,11 @@ export const useAppearanceCustomStore = create<AppearanceCustomState>()(
       storage: createJSONStorage(() => guardedLocalStorage),
       migrate: (persisted, version) => {
         const state = (persisted ?? {}) as Partial<AppearanceCustomState>;
-        const customization = sanitizeCustomization(state.customization);
-        // Adopt the new layout only where the stored one is still a shipped
-        // default, so a user's own arrangement survives.
-        if (version < 5) {
-          const stored = JSON.stringify(customization.sidebarNav);
-          // Sanitize each layout too: the stored one has since gained any ids
-          // added after it was written, so a raw compare would never match.
-          const untouched = SHIPPED_SIDEBAR_NAV_DEFAULTS.some(
-            (layout) => JSON.stringify(sanitizeSidebarNav(layout)) === stored,
-          );
-          if (untouched) {
-            customization.sidebarNav = [...DEFAULT_CUSTOMIZATION.sidebarNav];
-          }
-        }
+        const customization = migrateShippedSidebarNavDefault(
+          sanitizeCustomization(state.customization),
+          version,
+          5,
+        );
         return { customization } as AppearanceCustomState;
       },
       // Sanitize on EVERY rehydrate, not just version bumps: a same-version

--- a/studio/frontend/tests/sidebar-nav-backend-parity.test.ts
+++ b/studio/frontend/tests/sidebar-nav-backend-parity.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { DEFAULT_CUSTOMIZATION } from "../src/features/settings/stores/appearance-custom-store.ts";
+
+// A record predating sidebarNav is served the backend's own defaults, so a drift there
+// hands the user a layout this side never shipped. settings.py says the two must match;
+// the backend's parity test compares against a hand-copied list, which cannot catch a
+// frontend-only change. Read the real constant instead.
+test("the backend sidebar nav defaults match the frontend", async () => {
+  const source = await readFile(
+    new URL("../../backend/routes/settings.py", import.meta.url),
+    "utf8",
+  );
+  const block = /SIDEBAR_NAV_ITEM_DEFAULTS = \{([\s\S]*?)^\}/m.exec(source);
+  assert.ok(block, "could not find SIDEBAR_NAV_ITEM_DEFAULTS in settings.py");
+  const backend = [...block[1].matchAll(/"([a-z]+)":\s*(True|False)/g)].map((m) => ({
+    id: m[1],
+    pinned: m[2] === "True",
+  }));
+  // Order matters too: the backend appends its missing ids in this order.
+  assert.deepEqual(backend, DEFAULT_CUSTOMIZATION.sidebarNav);
+});

--- a/studio/frontend/tests/sidebar-nav-migration.test.ts
+++ b/studio/frontend/tests/sidebar-nav-migration.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_CUSTOMIZATION,
+  type SidebarNavItemPref,
+  migrateShippedSidebarNavDefault,
+  sanitizeCustomization,
+} from "../src/features/settings/stores/appearance-custom-store.ts";
+
+const shippedLayouts: SidebarNavItemPref[][] = [
+  [
+    { id: "projects", pinned: true },
+    { id: "hub", pinned: true },
+    { id: "images", pinned: true },
+    { id: "train", pinned: true },
+    { id: "video", pinned: false },
+    { id: "recipes", pinned: false },
+    { id: "export", pinned: false },
+  ],
+  [
+    { id: "projects", pinned: true },
+    { id: "hub", pinned: true },
+    { id: "images", pinned: true },
+    { id: "video", pinned: true },
+    { id: "train", pinned: true },
+    { id: "recipes", pinned: false },
+    { id: "export", pinned: false },
+  ],
+  [
+    { id: "hub", pinned: true },
+    { id: "projects", pinned: true },
+    { id: "images", pinned: true },
+    { id: "video", pinned: true },
+    { id: "train", pinned: true },
+    { id: "recipes", pinned: false },
+    { id: "export", pinned: false },
+  ],
+];
+
+test("every previously shipped sidebar adopts the current default", () => {
+  for (const sidebarNav of shippedLayouts) {
+    const customization = sanitizeCustomization({ sidebarNav });
+    assert.deepEqual(
+      migrateShippedSidebarNavDefault(customization, 4, 5).sidebarNav,
+      DEFAULT_CUSTOMIZATION.sidebarNav,
+    );
+  }
+});
+
+test("a user-arranged sidebar survives the migration", () => {
+  const customization = sanitizeCustomization({
+    sidebarNav: DEFAULT_CUSTOMIZATION.sidebarNav.map((item) =>
+      item.id === "recipes" ? { ...item, pinned: true } : item,
+    ),
+  });
+  assert.strictEqual(
+    migrateShippedSidebarNavDefault(customization, 4, 5),
+    customization,
+  );
+});
+
+test("a shipped-looking layout chosen after migration is preserved", () => {
+  const customization = sanitizeCustomization({
+    sidebarNav: shippedLayouts[2],
+  });
+  assert.strictEqual(
+    migrateShippedSidebarNavDefault(customization, 5, 5),
+    customization,
+  );
+});


### PR DESCRIPTION
Video shipped pinned to the sidebar. It should not take a top-level row by default, so it now sits under More with Recipes, Export and API, and only moves up if the user pins it from Customize sidebar.

Existing installs move too. The persisted layout is at v5, and the migration adopts the new default only where the stored layout is still one we shipped, so anyone who arranged their own sidebar keeps it. The v4 layout is now registered alongside the earlier two so it can be recognised.

That comparison was also broken, and this fixes it. Stored layouts pick up any nav id added after they were written, API being the most recent, while the shipped constants stayed at the older id set. So the raw JSON compare could never match and the v4 migration ("Model hub above Projects") had quietly become a no-op. Both sides now go through `sanitizeSidebarNav`, which keeps the check correct as more rows get added.

Checked the outcome against five stored layouts: the pre-v3, v3 and v4 shipped layouts all adopt the new default, while a layout with Recipes pinned or Video moved to the top is left alone.
