### PR TITLE
fix(studio): stop showing manifest-less cache entries as downloading (#7858)

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -419,6 +419,12 @@ export async function getGgufDownloadProgress(
 
 export interface DownloadProgressResponse {
   downloaded_bytes: number;
+  /**
+   * Finalized-blob bytes only. Bytes still landing in a `.incomplete` blob count
+   * toward `downloaded_bytes` but not here, so the two are equal exactly when
+   * nothing is in flight.
+   */
+  completed_bytes: number;
   expected_bytes: number;
   progress: number;
   /**

--- a/studio/frontend/src/features/studio/download-state.ts
+++ b/studio/frontend/src/features/studio/download-state.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The download state the training-start overlay renders, plus the coercion that
+// decides whether a resource is still arriving or merely unverified. Kept apart
+// from the overlay so the rule can be exercised without mounting the component.
+
+export type DownloadState = {
+  downloadedBytes: number;
+  // Finalized-blob bytes only, mirroring the backend field of the same name:
+  // bytes still landing in a `.incomplete` blob count toward `downloadedBytes`
+  // but not here.
+  completedBytes: number;
+  totalBytes: number;
+  percent: number;
+  cachePath: string | null;
+};
+
+export const EMPTY_DOWNLOAD_STATE: DownloadState = {
+  downloadedBytes: 0,
+  completedBytes: 0,
+  totalBytes: 0,
+  percent: 0,
+  cachePath: null,
+};
+
+/**
+ * Present a cached resource as ready once nothing is left to transfer.
+ *
+ * The backend holds progress at 99% until a Studio download manifest verifies the
+ * snapshot on disk. Hugging Face cache entries created outside Studio -- or before
+ * the manifest system existed -- never get one, so they stay unverified with every
+ * byte already present, and the overlay rendered them as an active transfer
+ * indefinitely (#7858).
+ *
+ * `completedBytes` is what separates the two cases: it counts finalized blobs
+ * only, so all of them being present means nothing is in flight and the remaining
+ * gap is verification rather than transfer. A resumed download -- where finalized
+ * bytes can sit near the total while `.incomplete` blobs are still growing -- keeps
+ * reporting progress, which is what the backend's 99% cap exists to protect.
+ */
+export function coerceCachedStateReady(state: DownloadState): DownloadState {
+  if (!state.cachePath) return state;
+  const everyByteFinalized =
+    state.totalBytes > 0 && state.completedBytes >= state.totalBytes;
+  if (state.downloadedBytes > 0 && state.percent < 100 && !everyByteFinalized) {
+    return state;
+  }
+  const totalBytes =
+    state.totalBytes > 0 ? state.totalBytes : state.downloadedBytes;
+  if (totalBytes <= 0) {
+    return { ...state, percent: 100 };
+  }
+  return {
+    ...state,
+    downloadedBytes: totalBytes,
+    completedBytes: totalBytes,
+    totalBytes,
+    percent: 100,
+  };
+}

--- a/studio/frontend/src/features/studio/training-start-overlay.tsx
+++ b/studio/frontend/src/features/studio/training-start-overlay.tsx
@@ -27,6 +27,11 @@ import {
 import { useTransferStats } from "@/features/chat/hooks/use-transfer-stats";
 import { formatEta, formatRate } from "@/features/chat/utils/format-transfer";
 import {
+  EMPTY_DOWNLOAD_STATE,
+  coerceCachedStateReady,
+  type DownloadState,
+} from "@/features/studio/download-state";
+import {
   useTrainingActions,
   useTrainingConfigStore,
   useTrainingRuntimeStore,
@@ -55,36 +60,6 @@ function formatCachePath(path: string): string {
   return path
     .replace(/^\/(?:home|Users)\/[^/]+/, "~")
     .replace(/^[A-Za-z]:[/\\]Users[/\\][^/\\]+/, "~");
-}
-
-type DownloadState = {
-  downloadedBytes: number;
-  totalBytes: number;
-  percent: number;
-  cachePath: string | null;
-};
-
-const EMPTY_DOWNLOAD_STATE: DownloadState = {
-  downloadedBytes: 0,
-  totalBytes: 0,
-  percent: 0,
-  cachePath: null,
-};
-
-function coerceCachedStateReady(state: DownloadState): DownloadState {
-  if (!state.cachePath) return state;
-  if (state.downloadedBytes > 0 && state.percent < 100) return state;
-  const totalBytes =
-    state.totalBytes > 0 ? state.totalBytes : state.downloadedBytes;
-  if (totalBytes <= 0) {
-    return { ...state, percent: 100 };
-  }
-  return {
-    ...state,
-    downloadedBytes: totalBytes,
-    totalBytes,
-    percent: 100,
-  };
 }
 
 type Fetcher = (repoId: string) => Promise<DownloadProgressResponse>;
@@ -133,6 +108,7 @@ function useHfDownloadProgress(
           total > 0 ? Math.min(100, Math.round(ratio * 100)) : 0;
         setState({
           downloadedBytes: downloaded,
+          completedBytes: prog.completed_bytes ?? 0,
           totalBytes: total,
           percent: pct,
           cachePath: prog.cache_path ?? null,

--- a/studio/frontend/tests/training-start-cached-progress.test.ts
+++ b/studio/frontend/tests/training-start-cached-progress.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The training-start overlay showed cached resources as "Downloading -- 99%" with no
+// download running (#7858): the backend caps progress at 99% until a Studio manifest
+// verifies the snapshot, and cache entries made outside Studio never have one. These
+// pin the distinction the overlay now draws -- finalized bytes decide whether anything
+// is still arriving -- including the resumed-download case the 99% cap exists for.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type DownloadState,
+  coerceCachedStateReady,
+} from "../src/features/studio/download-state.ts";
+
+const MB = 1e6;
+const GB = 1e9;
+
+function state(over: Partial<DownloadState> = {}): DownloadState {
+  return {
+    downloadedBytes: 0,
+    completedBytes: 0,
+    totalBytes: 0,
+    percent: 0,
+    cachePath: "/home/u/.cache/huggingface/hub/datasets--unsloth--alpaca-cleaned",
+    ...over,
+  };
+}
+
+test("a cache entry with no manifest reads as ready, not as a transfer", () => {
+  // Observed with unsloth/alpaca-cleaned: 42.3 MB of 42.3 MB, no worker running.
+  const coerced = coerceCachedStateReady(
+    state({
+      downloadedBytes: 42.3 * MB,
+      completedBytes: 42.3 * MB,
+      totalBytes: 42.3 * MB,
+      percent: 99,
+    }),
+  );
+  assert.equal(coerced.percent, 100);
+});
+
+test("a resumed download still reports progress while blobs are incomplete", () => {
+  // The case the backend's 99% cap protects: finalized bytes sit just under the
+  // total while the remaining `.incomplete` blob is still growing.
+  const resuming = state({
+    downloadedBytes: 20 * GB,
+    completedBytes: 19.9 * GB,
+    totalBytes: 20 * GB,
+    percent: 99,
+  });
+  assert.deepEqual(coerceCachedStateReady(resuming), resuming);
+});
+
+test("an ordinary in-flight download is left alone", () => {
+  const downloading = state({
+    downloadedBytes: 5 * GB,
+    completedBytes: 4.8 * GB,
+    totalBytes: 20 * GB,
+    percent: 25,
+  });
+  assert.deepEqual(coerceCachedStateReady(downloading), downloading);
+});
+
+test("a resource with no cache path is never coerced", () => {
+  const uncached = state({
+    downloadedBytes: 42.3 * MB,
+    completedBytes: 42.3 * MB,
+    totalBytes: 42.3 * MB,
+    percent: 99,
+    cachePath: null,
+  });
+  assert.deepEqual(coerceCachedStateReady(uncached), uncached);
+});
+
+test("a cached entry of unknown size still settles instead of hanging", () => {
+  const unsized = coerceCachedStateReady(
+    state({ downloadedBytes: 0, completedBytes: 0, totalBytes: 0, percent: 0 }),
+  );
+  assert.equal(unsized.percent, 100);
+});


### PR DESCRIPTION
Fixes #7858.

## The problem

`snapshot_progress.py` reports `1.0` only when `complete_on_disk` succeeds, and that
check requires a readable Studio download manifest. Cache entries created outside
Studio — or before the manifest system existed — never have one, so they stay
unverified and the reported fraction is capped at `0.99`.

The training-start overlay labels anything under 100% as **Downloading**, and its
cached-state coercion bailed out whenever `downloadedBytes > 0 && percent < 100`.
That is exactly the shape of a fully cached resource, so it sat at
`Downloading — 99%` forever with no worker running (reproduced with
`unsloth/alpaca-cleaned`: 42.3 MB / 42.3 MB, no active dataset download).

## The fix

The progress response already carries the field that separates the two cases:

```python
# Finalized-blob bytes only (no ``.incomplete``).
completed_bytes: int = 0
```

Every expected byte being *finalized* means nothing is in flight, so the remaining
gap is verification rather than transfer. The overlay now carries `completed_bytes`
through and lets it settle the cached state.

Crucially this keeps the case the `0.99` cap exists for: on resume, finalized bytes
can approach the total while `.incomplete` blobs are still growing, so
`completedBytes < totalBytes` and the row keeps reporting progress.

| state | completed / total | before | after |
|---|---|---|---|
| cached, no manifest | 42.3 MB / 42.3 MB | Downloading 99% | **Ready** |
| resuming, blobs incomplete | 19.9 GB / 20 GB | Downloading 99% | Downloading 99% |
| ordinary transfer | 4.8 GB / 20 GB | Downloading 25% | Downloading 25% |

The state type and coercion move into `download-state.ts` so the rule can be
exercised without mounting the overlay; the overlay is otherwise unchanged.

## Tests

`studio/frontend/tests/training-start-cached-progress.test.ts` — 5 cases covering
the cached entry, the resumed download, an ordinary transfer, an uncached resource,
and a cached entry of unknown size.

Verified in both directions: with the previous guard restored the cached-entry case
fails, and the two "still downloading" cases pass either way, so the change does not
weaken the cap.

```
✔ a cache entry with no manifest reads as ready, not as a transfer
✔ a resumed download still reports progress while blobs are incomplete
✔ an ordinary in-flight download is left alone
✔ a resource with no cache path is never coerced
✔ a cached entry of unknown size still settles instead of hanging
ℹ pass 5  ℹ fail 0
```

Not addressed here: #7858 also suggests surfacing "cached but unverified" as a
distinct third state. That is a UX/i18n decision rather than a bug fix, so this PR
only stops the misreport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
