### PR TITLE
Studio: make the sidebar menu separators visible in dark mode

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1946,7 +1946,7 @@ export function AppSidebar() {
                       })}
                       {/* Way out of the flyout: jump straight to the control that
                           decides what lives here vs. on the sidebar itself. */}
-                      <DropdownMenuSeparator className="mx-1! my-1.5! h-0! border-t border-border/70 bg-transparent!" />
+                      <DropdownMenuSeparator className="mx-1! my-1.5! h-0! border-t border-border/70 bg-transparent! dark:border-white/15" />
                       <DropdownMenuItem
                         onSelect={() =>
                           useSettingsDialogStore
@@ -2439,7 +2439,7 @@ export function AppSidebar() {
                     );
                   })}
                 </DropdownMenuGroup>
-                <DropdownMenuSeparator className="mx-1! my-2.5! h-0! border-t border-border/70 bg-transparent!" />
+                <DropdownMenuSeparator className="mx-1! my-2.5! h-0! border-t border-border/70 bg-transparent! dark:border-white/15" />
                 <DropdownMenuItem
                   onSelect={() => useSettingsDialogStore.getState().openDialog("about")}
                 >


### PR DESCRIPTION
The rule above Customize sidebar in the More menu is invisible in dark mode, and the same one in the profile menu has the same problem.

Both use `border-border/70`. In dark mode `--border` is `#303030` sitting on a `#212121` popover, so at 70% it lands around `#2a2a2a`, which is barely a step off the background. Dark mode now uses a white alpha (`#ffffff26`) instead, which reads clearly without turning into a hard line. Light mode is untouched.

Only the two separators that share this override are changed. The shared `DropdownMenuSeparator` default (`bg-border/50`) has the same weakness, but it backs every menu in the app and is worth its own pass.
