### PR TITLE
Studio: quiet the image and video generation progress polls

### DIFF
--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -41,6 +41,10 @@ _ACCESS_LOG_DEDUP_MS = _env_int("UNSLOTH_STUDIO_ACCESS_LOG_DEDUP_MS", 300)
 # Liveness/UI polls whose line means only "still polling"; collapse to a longer
 # heartbeat. First hit and errors still log. 0 = off.
 _QUIET_POLL_DEDUP_MS = _env_int("UNSLOTH_STUDIO_ACCESS_LOG_POLL_DEDUP_MS", 10000)
+# Both windows off is exactly what `unsloth studio --verbose` sets, and that flag
+# promises to log every request. The drop-the-2xx suppressor below has no window of
+# its own, so it has to read the same signal or --verbose cannot reach those paths.
+_VERBOSE_ACCESS_LOG = _ACCESS_LOG_DEDUP_MS <= 0 and _QUIET_POLL_DEDUP_MS <= 0
 _QUIET_POLL_PATHS = {
     "/api/health",
     "/api/auth/status",
@@ -61,6 +65,12 @@ _QUIET_POLL_PATHS = {
     "/api/inference/video/generate-progress",
     # Diffusion training status, polled every 1.5s while the train UI is open.
     "/api/train/diffusion/status",
+    # Unlike /api/inference/load-progress, whose handler emits inference_load_progress
+    # every 10%, these two only read state, and diffusion.loaded / video.loaded fire
+    # once the load is already done. A diffusion load runs minutes (download, quant,
+    # compile), so a pulse is the only sign it is still moving.
+    "/api/inference/images/load-progress",
+    "/api/inference/video/load-progress",
 }
 _DEDUP_MAP_MAX = 4096
 _NATIVE_PATH_LEASE_RE = re.compile(
@@ -87,9 +97,6 @@ _EXCLUDED_SUFFIXES = (
 # events; the legacy /api/models and /api/datasets ones heartbeat via _QUIET_POLL_PATHS.
 _QUIET_SUCCESS_PATHS = {
     "/api/inference/load-progress",
-    # Load phases are already logged by diffusion.loaded / video.loaded.
-    "/api/inference/images/load-progress",
-    "/api/inference/video/load-progress",
     "/api/llama/update-status",
     "/api/export/logs",
     "/api/export/status",
@@ -119,8 +126,8 @@ def _is_quiet_success(method: str, path: str, status_code: int, pre_auth: bool) 
     """GET-only. Suppress a 2xx poll line that carries no signal, plus a chat list
     poll's transient pre-auth 401 (only in the bootstrap window before the first
     successful token refresh). Mutations, real (post-refresh) auth failures, and
-    all other errors always log."""
-    if method != "GET":
+    all other errors always log. --verbose disables the whole suppressor."""
+    if _VERBOSE_ACCESS_LOG or method != "GET":
         return False
     if 200 <= status_code < 300:
         return path in _QUIET_SUCCESS_PATHS or path in _CHAT_LIST_PATHS

--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -55,12 +55,11 @@ _QUIET_POLL_PATHS = {
     "/api/models/download-progress",
     "/api/models/gguf-download-progress",
     "/api/datasets/download-progress",
-    # Image/video generation is fire-and-forget: the POST returns at once and the terminal
-    # outcome only reaches the UI through these polls, so keep a "still generating" pulse
-    # instead of dropping them. The Image/Video tabs poll every 300ms while a job runs.
+    # Generation is fire-and-forget: the outcome only reaches the UI through these 300ms
+    # polls, so keep a "still generating" pulse instead of dropping them.
     "/api/inference/images/generate-progress",
     "/api/inference/video/generate-progress",
-    # Diffusion training status, polled every 1.5s while the train panel or dialog is open.
+    # Diffusion training status, polled every 1.5s while the train UI is open.
     "/api/train/diffusion/status",
 }
 _DEDUP_MAP_MAX = 4096
@@ -88,8 +87,7 @@ _EXCLUDED_SUFFIXES = (
 # events; the legacy /api/models and /api/datasets ones heartbeat via _QUIET_POLL_PATHS.
 _QUIET_SUCCESS_PATHS = {
     "/api/inference/load-progress",
-    # Same poll as above for the image/video engines; the load phases are already logged
-    # by diffusion.loaded / video.loaded.
+    # Load phases are already logged by diffusion.loaded / video.loaded.
     "/api/inference/images/load-progress",
     "/api/inference/video/load-progress",
     "/api/llama/update-status",

--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -55,6 +55,13 @@ _QUIET_POLL_PATHS = {
     "/api/models/download-progress",
     "/api/models/gguf-download-progress",
     "/api/datasets/download-progress",
+    # Image/video generation is fire-and-forget: the POST returns at once and the terminal
+    # outcome only reaches the UI through these polls, so keep a "still generating" pulse
+    # instead of dropping them. The Image/Video tabs poll every 300ms while a job runs.
+    "/api/inference/images/generate-progress",
+    "/api/inference/video/generate-progress",
+    # Diffusion training status, polled every 1.5s while the train panel or dialog is open.
+    "/api/train/diffusion/status",
 }
 _DEDUP_MAP_MAX = 4096
 _NATIVE_PATH_LEASE_RE = re.compile(
@@ -81,6 +88,10 @@ _EXCLUDED_SUFFIXES = (
 # events; the legacy /api/models and /api/datasets ones heartbeat via _QUIET_POLL_PATHS.
 _QUIET_SUCCESS_PATHS = {
     "/api/inference/load-progress",
+    # Same poll as above for the image/video engines; the load phases are already logged
+    # by diffusion.loaded / video.loaded.
+    "/api/inference/images/load-progress",
+    "/api/inference/video/load-progress",
     "/api/llama/update-status",
     "/api/export/logs",
     "/api/export/status",

--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -41,9 +41,8 @@ _ACCESS_LOG_DEDUP_MS = _env_int("UNSLOTH_STUDIO_ACCESS_LOG_DEDUP_MS", 300)
 # Liveness/UI polls whose line means only "still polling"; collapse to a longer
 # heartbeat. First hit and errors still log. 0 = off.
 _QUIET_POLL_DEDUP_MS = _env_int("UNSLOTH_STUDIO_ACCESS_LOG_POLL_DEDUP_MS", 10000)
-# Both windows off is exactly what `unsloth studio --verbose` sets, and that flag
-# promises to log every request. The drop-the-2xx suppressor below has no window of
-# its own, so it has to read the same signal or --verbose cannot reach those paths.
+# Both windows off is what --verbose sets; the drop-the-2xx suppressor below has no
+# window of its own, so it must read the same signal to honour --verbose.
 _VERBOSE_ACCESS_LOG = _ACCESS_LOG_DEDUP_MS <= 0 and _QUIET_POLL_DEDUP_MS <= 0
 _QUIET_POLL_PATHS = {
     "/api/health",
@@ -59,16 +58,14 @@ _QUIET_POLL_PATHS = {
     "/api/models/download-progress",
     "/api/models/gguf-download-progress",
     "/api/datasets/download-progress",
-    # Generation is fire-and-forget: the outcome only reaches the UI through these 300ms
-    # polls, so keep a "still generating" pulse instead of dropping them.
+    # Generation is fire-and-forget: its outcome only reaches the UI via these polls.
     "/api/inference/images/generate-progress",
     "/api/inference/video/generate-progress",
-    # Diffusion training status, polled every 1.5s while the train UI is open.
+    # Polled every 1.5s while the train UI is open.
     "/api/train/diffusion/status",
-    # Unlike /api/inference/load-progress, whose handler emits inference_load_progress
-    # every 10%, these two only read state, and diffusion.loaded / video.loaded fire
-    # once the load is already done. A diffusion load runs minutes (download, quant,
-    # compile), so a pulse is the only sign it is still moving.
+    # Unlike /api/inference/load-progress, these handlers log nothing and
+    # diffusion.loaded / video.loaded are terminal, so a minutes-long load would
+    # otherwise emit nothing at all.
     "/api/inference/images/load-progress",
     "/api/inference/video/load-progress",
 }

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -357,3 +357,61 @@ def test_legacy_download_progress_heartbeats_not_suppressed(logs, monkeypatch):
     for _ in range(3):
         _run(mw(_http_scope("/api/models/download-progress"), _noop_receive, _drop))
     assert _paths_logged(logs) == ["/api/models/download-progress"]
+
+
+def test_generation_progress_polls_heartbeat(logs, monkeypatch):
+    # The Image/Video tabs poll generate-progress every 300ms, which outran the base
+    # dedup window, so a single clip filled the log. They heartbeat like the legacy
+    # download polls: first hit logs, the rest of the burst collapses.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
+    for path in (
+        "/api/inference/images/generate-progress",
+        "/api/inference/video/generate-progress",
+        "/api/train/diffusion/status",
+    ):
+        mw = LoggingMiddleware(_status_app(200))
+        for _ in range(5):
+            _run(mw(_http_scope(path), _noop_receive, _drop))
+        assert _paths_logged(logs) == [path]
+        logs.events.clear()
+
+
+def test_generation_progress_errors_still_log(logs, monkeypatch):
+    # A failing poll must stay visible: heartbeat dedup is GET/2xx only.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
+    mw = LoggingMiddleware(_status_app(500))
+    for _ in range(3):
+        _run(mw(_http_scope("/api/inference/images/generate-progress"), _noop_receive, _drop))
+    assert _paths_logged(logs) == ["/api/inference/images/generate-progress"] * 3
+
+
+def test_image_video_load_progress_suppressed_errors_logged(logs):
+    # The per-engine load polls mirror /api/inference/load-progress: the 2xx is dropped
+    # (diffusion.loaded / video.loaded carry the phases), the failure is not.
+    for path in ("/api/inference/images/load-progress", "/api/inference/video/load-progress"):
+        _run(LoggingMiddleware(_status_app(200))(_http_scope(path), _noop_receive, _drop))
+    assert logs.events == []
+    _run(
+        LoggingMiddleware(_status_app(503))(
+            _http_scope("/api/inference/images/load-progress"), _noop_receive, _drop
+        )
+    )
+    assert _paths_logged(logs) == ["/api/inference/images/load-progress"]
+
+
+def test_unrelated_image_routes_still_log(logs, monkeypatch):
+    # Only the timer-polled paths are quieted; the tabs' event-driven reads are untouched.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    for path in (
+        "/api/inference/images/status",
+        "/api/inference/images/info",
+        "/api/inference/video/status",
+    ):
+        _run(LoggingMiddleware(_status_app(200))(_http_scope(path), _noop_receive, _drop))
+    assert _paths_logged(logs) == [
+        "/api/inference/images/status",
+        "/api/inference/images/info",
+        "/api/inference/video/status",
+    ]

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -360,9 +360,8 @@ def test_legacy_download_progress_heartbeats_not_suppressed(logs, monkeypatch):
 
 
 def test_generation_progress_polls_heartbeat(logs, monkeypatch):
-    # The Image/Video tabs poll generate-progress every 300ms, which outran the base
-    # dedup window, so a single clip filled the log. They heartbeat like the legacy
-    # download polls: first hit logs, the rest of the burst collapses.
+    # 300ms polls outran the base dedup window; now they heartbeat: first hit logs,
+    # the rest of the burst collapses.
     monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
     for path in (
@@ -388,8 +387,7 @@ def test_generation_progress_errors_still_log(logs, monkeypatch):
 
 
 def test_image_video_load_progress_suppressed_errors_logged(logs):
-    # The per-engine load polls mirror /api/inference/load-progress: the 2xx is dropped
-    # (diffusion.loaded / video.loaded carry the phases), the failure is not.
+    # 2xx is dropped (diffusion.loaded / video.loaded carry the phases), the failure is not.
     for path in ("/api/inference/images/load-progress", "/api/inference/video/load-progress"):
         _run(LoggingMiddleware(_status_app(200))(_http_scope(path), _noop_receive, _drop))
     assert logs.events == []

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -385,17 +385,20 @@ def test_generation_progress_errors_still_log(logs, monkeypatch):
     assert _paths_logged(logs) == ["/api/inference/images/generate-progress"] * 3
 
 
-def test_image_video_load_progress_suppressed_errors_logged(logs):
-    # 2xx is dropped (diffusion.loaded / video.loaded carry the phases), the failure is not.
+def test_image_video_load_progress_heartbeats(logs, monkeypatch):
+    # These handlers log nothing themselves, so keep a pulse for a multi-minute load.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
     for path in ("/api/inference/images/load-progress", "/api/inference/video/load-progress"):
-        _run(LoggingMiddleware(_status_app(200))(_http_scope(path), _noop_receive, _drop))
-    assert logs.events == []
-    _run(
-        LoggingMiddleware(_status_app(503))(
-            _http_scope("/api/inference/images/load-progress"), _noop_receive, _drop
-        )
-    )
-    assert _paths_logged(logs) == ["/api/inference/images/load-progress"]
+        mw = LoggingMiddleware(_status_app(200))
+        for _ in range(5):
+            _run(mw(_http_scope(path), _noop_receive, _drop))
+        assert _paths_logged(logs) == [path]
+        logs.events.clear()
+    mw = LoggingMiddleware(_status_app(503))
+    for _ in range(3):
+        _run(mw(_http_scope("/api/inference/images/load-progress"), _noop_receive, _drop))
+    assert _paths_logged(logs) == ["/api/inference/images/load-progress"] * 3
 
 
 def test_unrelated_image_routes_still_log(logs, monkeypatch):
@@ -412,3 +415,30 @@ def test_unrelated_image_routes_still_log(logs, monkeypatch):
         "/api/inference/images/info",
         "/api/inference/video/status",
     ]
+
+
+def test_verbose_restores_the_dropped_success_polls(logs, monkeypatch):
+    # `unsloth studio --verbose` zeroes both windows and promises every request is
+    # logged, so the drop-the-2xx suppressor has to stand down too.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_VERBOSE_ACCESS_LOG", True)
+    for path in (
+        "/api/inference/load-progress",
+        "/api/hub/download-progress",
+        "/api/export/status",
+        "/api/chat/threads",
+    ):
+        mw = LoggingMiddleware(_status_app(200))
+        for _ in range(3):
+            _run(mw(_http_scope(path), _noop_receive, _drop))
+        assert _paths_logged(logs) == [path] * 3
+        logs.events.clear()
+
+
+def test_verbose_off_by_default_keeps_the_polls_quiet(logs):
+    # The default env leaves both windows set, so nothing changes for a normal launch.
+    assert hmod._VERBOSE_ACCESS_LOG is False
+    for path in ("/api/inference/load-progress", "/api/hub/download-progress"):
+        _run(LoggingMiddleware(_status_app(200))(_http_scope(path), _noop_receive, _drop))
+    assert logs.events == []

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -360,8 +360,7 @@ def test_legacy_download_progress_heartbeats_not_suppressed(logs, monkeypatch):
 
 
 def test_generation_progress_polls_heartbeat(logs, monkeypatch):
-    # 300ms polls outran the base dedup window; now they heartbeat: first hit logs,
-    # the rest of the burst collapses.
+    # The 300ms poll timer always landed just outside the 300ms base dedup window.
     monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
     for path in (

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -376,7 +376,7 @@ def test_generation_progress_polls_heartbeat(logs, monkeypatch):
 
 
 def test_generation_progress_errors_still_log(logs, monkeypatch):
-    # A failing poll must stay visible: heartbeat dedup is GET/2xx only.
+    # Heartbeat dedup is GET/2xx only, so a failing poll stays visible.
     monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
     mw = LoggingMiddleware(_status_app(500))
@@ -402,7 +402,7 @@ def test_image_video_load_progress_heartbeats(logs, monkeypatch):
 
 
 def test_unrelated_image_routes_still_log(logs, monkeypatch):
-    # Only the timer-polled paths are quieted; the tabs' event-driven reads are untouched.
+    # Only the timer-polled paths are quieted, not the event-driven reads.
     monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
     for path in (
         "/api/inference/images/status",
@@ -418,8 +418,7 @@ def test_unrelated_image_routes_still_log(logs, monkeypatch):
 
 
 def test_verbose_restores_the_dropped_success_polls(logs, monkeypatch):
-    # `unsloth studio --verbose` zeroes both windows and promises every request is
-    # logged, so the drop-the-2xx suppressor has to stand down too.
+    # --verbose zeroes both windows, so the 2xx suppressor must stand down too.
     monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 0)
     monkeypatch.setattr(hmod, "_VERBOSE_ACCESS_LOG", True)
@@ -437,7 +436,7 @@ def test_verbose_restores_the_dropped_success_polls(logs, monkeypatch):
 
 
 def test_verbose_off_by_default_keeps_the_polls_quiet(logs):
-    # The default env leaves both windows set, so nothing changes for a normal launch.
+    # Default env leaves both windows set, so a normal launch is unchanged.
     assert hmod._VERBOSE_ACCESS_LOG is False
     for path in ("/api/inference/load-progress", "/api/hub/download-progress"):
         _run(LoggingMiddleware(_status_app(200))(_http_scope(path), _noop_receive, _drop))


### PR DESCRIPTION
Generating a single image floods stdout with one access-log line per progress poll:

```
{"level": "info", "event": "request_completed", "method": "GET", "path": "/api/inference/images/generate-progress", "status_code": 200, "process_time_ms": 1.64}
```

The Image and Video tabs poll `generate-progress` every 300ms while a job is running, plus a 1s recovery loop, so a one minute generation produces a couple of hundred of these lines and buries everything else.

### Why the existing suppressors missed it

The access log already has two guards in `studio/backend/loggers/handlers.py`, and both are exact-path matches:

- `_QUIET_SUCCESS_PATHS` drops the 2xx line entirely for polls whose signal is carried by real events.
- `_QUIET_POLL_PATHS` collapses liveness polls to a 10s heartbeat.

Everything else falls back to `_ACCESS_LOG_DEDUP_MS`, a 300ms burst window meant for the SPA fanning one cache invalidation into several list fetches. A poll running at 300ms or slower always lands just outside that window, so every single request logged.

Both lists were written before the image and video routes existed, and those routes live one segment deeper (`/api/inference/images/...`, `/api/inference/video/...`) than the already-listed `/api/inference/load-progress`, so none of the new polls ever matched. The same applies to the diffusion training status poll.

### What changed

Added the timer-polled paths to the existing lists. No new mechanism.

Heartbeat every 10s (`_QUIET_POLL_PATHS`):

- `/api/inference/images/generate-progress`
- `/api/inference/video/generate-progress`
- `/api/train/diffusion/status`

Generation is fire-and-forget: the POST returns immediately and the terminal outcome only reaches the UI through these polls, so I kept a pulse rather than dropping them outright.

Suppressed on 2xx (`_QUIET_SUCCESS_PATHS`):

- `/api/inference/images/load-progress`
- `/api/inference/video/load-progress`

These mirror `/api/inference/load-progress`, which is already on the list. The load phases are logged by `diffusion.loaded` and `video.loaded`.

### What stays logged

- Any non-2xx on those paths, every time. A failing poll stays fully visible.
- The first hit of each heartbeat burst.
- All mutations, including the POST that starts a generation.
- The event-driven reads that are not on a timer, such as `/api/inference/images/status`, `/api/inference/images/info` and `/api/inference/video/status`.

### Tests

Extended `studio/backend/tests/test_logging_middleware.py` with four cases: the polls collapse to one heartbeat, a repeated 500 on the same path logs every time, the load polls are suppressed while a 503 still logs, and the unrelated image and video routes are untouched.

`studio/backend/tests`: 16523 passed, 20 failed, 68 skipped. The 20 failures are pre-existing on main (mcp stdio, openai tool passthrough, live studio_api server tests) and reproduce unchanged on an untouched checkout.
`studio/backend/hub/tests`: 172 passed.
