### PR TITLE
Report min_length as 0 when no sample has content

### DIFF
--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -615,7 +615,6 @@ def test_validate_dataset_reports_zero_min_length_when_nothing_has_content():
     return True
 
 
-
 if __name__ == "__main__":
     success = test_raw_text_loader()
     success = test_smart_chunk_text_single_chunk_no_eos_returns_plain_list() and success

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -584,6 +584,38 @@ def test_validate_dataset_streams_instead_of_materialising_columns():
     return True
 
 
+def test_validate_dataset_reports_zero_min_length_when_nothing_has_content():
+    """`min_length` must not come back as infinity.
+
+    It is seeded with float("inf") and only ever lowered inside the loop, on exactly
+    the iterations that also append to `text_lengths`. The inf->0 normalisation sat
+    inside `if text_lengths:`, so within that guard it could never see inf: the branch
+    was dead, and the case it existed for, a dataset where no sample has content,
+    skipped the line entirely and returned min_length = inf to the caller.
+
+    The warning guard has to move with it. With the normalisation hoisted, min_length
+    becomes 0 for an empty dataset, and `0 < 10` would newly claim "some samples are
+    very short" about zero measured samples.
+    """
+
+    preprocessor = TextPreprocessor()
+
+    for label, texts in (("all blank", ["", "   ", "\n"]), ("no rows", [])):
+        stats = preprocessor.validate_dataset({"text": texts})
+        assert stats["min_length"] == 0, (label, stats)
+        assert stats["max_length"] == 0, (label, stats)
+        assert not any("very short" in w for w in stats["warnings"]), (label, stats)
+
+    # a genuinely short sample must still be reported
+    stats = preprocessor.validate_dataset({"text": ["hi", "a much longer sample of text"]})
+    assert stats["min_length"] == 2, stats
+    assert any("very short" in w for w in stats["warnings"]), stats
+
+    print("test_validate_dataset_reports_zero_min_length_when_nothing_has_content passed")
+    return True
+
+
+
 if __name__ == "__main__":
     success = test_raw_text_loader()
     success = test_smart_chunk_text_single_chunk_no_eos_returns_plain_list() and success
@@ -593,4 +625,5 @@ if __name__ == "__main__":
     success = test_validate_dataset_handles_tokenized_and_text_columns() and success
     success = test_validate_dataset_accepts_objects_without_column_names() and success
     success = test_validate_dataset_streams_instead_of_materialising_columns() and success
+    success = test_validate_dataset_reports_zero_min_length_when_nothing_has_content() and success
     sys.exit(0 if success else 1)

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -417,7 +417,11 @@ class TextPreprocessor:
         # Calculate average length
         if text_lengths:
             stats["avg_length"] = sum(text_lengths) / len(text_lengths)
-            stats["min_length"] = stats["min_length"] if stats["min_length"] != float("inf") else 0
+
+        # No sample had content, so min_length is still its float("inf") seed. Report 0,
+        # like max_length and avg_length beside it, rather than handing back an infinity.
+        if stats["min_length"] == float("inf"):
+            stats["min_length"] = 0
 
         # Generate warnings
         if stats["empty_samples"] > 0:
@@ -429,7 +433,9 @@ class TextPreprocessor:
         if stats["encoding_issues"] > 0:
             stats["warnings"].append(f"Found {stats['encoding_issues']} encoding issues")
 
-        if stats["min_length"] < 10:
+        # Guard on text_lengths, not on min_length: with nothing measured it is now 0,
+        # and zero measured samples is not "some samples are very short".
+        if text_lengths and stats["min_length"] < 10:
             stats["warnings"].append("Some samples are very short (< 10 characters)")
 
         return stats


### PR DESCRIPTION
## The bug

`TextPreprocessor.validate_dataset` hands back `min_length: inf` whenever no sample has content:

```
all rows blank: min_length=inf max_length=0 avg=0 warnings=['Found 3 empty samples']
zero rows:      min_length=inf max_length=0 avg=0 warnings=[]
one real row:   min_length=21  max_length=21 avg=21.0 warnings=[]
```

The dict is internally inconsistent as well as wrong: `max_length` and `avg_length` are correctly `0` for exactly the same input, and only `min_length` comes back as a float infinity. Anything that formats, compares or serialises the stats then has to cope with an `inf` that the other two fields never produce.

## Root cause

`min_length` is seeded with `float("inf")` and lowered only inside the loop:

```python
length = len(text)
text_lengths.append(length)
stats["min_length"] = min(stats["min_length"], length)
```

so it is lowered on exactly the iterations that also append to `text_lengths`. The normalisation that exists to undo the seed sits inside `if text_lengths:`:

```python
if text_lengths:
    stats["avg_length"] = sum(text_lengths) / len(text_lengths)
    stats["min_length"] = stats["min_length"] if stats["min_length"] != float("inf") else 0
```

Inside that guard `min_length` can never be `inf`, because a non-empty `text_lengths` means the `min()` ran at least once. So the branch is dead, and the one case it was written for, no sample with content, skips the line entirely.

## The fix

Two lines. Hoist the normalisation out of the guard so it runs whether or not anything was measured, and move the short-sample warning onto `text_lengths` at the same time:

```python
if stats["min_length"] < 10:
    stats["warnings"].append("Some samples are very short (< 10 characters)")
```

That guard reads `min_length`, which is `inf` today, and `inf < 10` is false. Once the normalisation is hoisted it becomes `0`, and `0 < 10` would newly claim "Some samples are very short" about zero measured samples. So the warning has to key off `text_lengths` instead, which is the thing that actually says whether anything was measured. Hoisting alone would trade one wrong output for another.

After:

```
all rows blank: min_length=0 max_length=0 avg=0 warnings=['Found 3 empty samples']
zero rows:      min_length=0 max_length=0 avg=0 warnings=[]
one real row:   min_length=21 max_length=21 avg=21.0 warnings=[]
```

and a genuinely short sample still warns:

```
['hi', 'a much longer sample of text'] -> min_length=2, warnings=['Some samples are very short (< 10 characters)']
```

## Scope, stated plainly

This is a correctness fix on a diagnostics dict rather than on training data. `validate_dataset` is public (`unsloth/dataprep/__init__.py` does `from .raw_text import *`) so a caller can see the `inf`, but nothing inside the repo consumes these stats, so the blast radius is the returned value and the warning list. I would rather say that up front than dress it up.

## Tests

Added `test_validate_dataset_reports_zero_min_length_when_nothing_has_content` to the existing `tests/test_raw_text.py`, following that file's convention of a plain function that asserts, prints and returns `True`, and wired into the `__main__` block with the others. It covers both empty shapes (all-blank rows and zero rows), asserts no spurious "very short" warning, and separately asserts that a genuinely short sample still warns, so a fix that hoisted the normalisation without moving the guard would fail it.

Three runs, including a clean-tree control:

```
control   upstream raw_text.py + upstream tests   8 passed
before    upstream raw_text.py + this test        1 failed
after     this branch                             9 passed
```

`ruff check` with the repo's own `pyproject.toml` reports `All checks passed!` on both changed files, and the same on the unmodified ones, so that is a real comparison rather than a config that checks nothing.

The file is picked up by `Repo tests (CPU)` in `studio-backend-ci.yml`, which auto-discovers `tests/` and does not ignore this path, so the new test runs in CI without a workflow change.

## Prior art

None. `gh issue list --search "validate_dataset min_length" --state all` returns nothing; `gh pr list --search "validate_dataset" --state all` returns nothing; `--search "raw_text" --state all` returns only #3612, the PR that introduced the file. No open PR touches `unsloth/dataprep/raw_text.py`.
