### PR TITLE
Fix the stale response-model label assertion that has main red

### DIFF
--- a/tests/studio/test_chat_response_details_ui_contract.py
+++ b/tests/studio/test_chat_response_details_ui_contract.py
@@ -17,6 +17,7 @@ REASONING_TSX = REPO / "studio/frontend/src/components/assistant-ui/reasoning.ts
 ADAPTER_TS = REPO / "studio/frontend/src/features/chat/api/chat-adapter.ts"
 CHAT_PREFS_TS = REPO / "studio/frontend/src/features/chat/stores/chat-preferences-store.ts"
 CHAT_TAB_TSX = REPO / "studio/frontend/src/features/settings/tabs/chat-tab.tsx"
+EN_LOCALE_TS = REPO / "studio/frontend/src/i18n/locales/en.ts"
 
 
 def test_assistant_more_menu_exposes_response_details_action():
@@ -53,7 +54,9 @@ def test_response_model_badge_is_user_configurable_and_rendered_once_per_message
     assert "showResponseModel: boolean" in prefs_src
     assert "showResponseModel: false" in prefs_src
     assert "showResponseModel: saved?.showResponseModel ?? false" in prefs_src
-    assert "Show response model" in chat_tab_src
+    # The visible label lives in the locale file; the tab holds only the key that resolves to it.
+    assert 'showResponseModel: "Show response model"' in EN_LOCALE_TS.read_text(encoding = "utf-8")
+    assert 't("settings.chat.showResponseModel")' in chat_tab_src
     assert "setShowResponseModel" in chat_tab_src
     details_src = DETAILS_TSX.read_text(encoding = "utf-8")
     assert (


### PR DESCRIPTION
Found while triaging staging CI for another PR. `tests/studio/test_chat_response_details_ui_contract.py::test_response_model_badge_is_user_configurable_and_rendered_once_per_message` fails on untouched `main`, so it is not specific to any branch in flight.

### Cause

The chat settings label moved into i18n. `chat-tab.tsx` now renders

```tsx
label={t("settings.chat.showResponseModel")}
```

and the literal lives in `studio/frontend/src/i18n/locales/en.ts`:

```ts
showResponseModel: "Show response model",
```

The contract test still asserted the literal string inside the tab file, so it went red at the move.

### What this does not change

The control is intact: `showResponseModel` and `setShowResponseModel` are still wired through `chat-preferences-store.ts` into the tab, and the rest of the test (store defaults, badge markup, single render per message) passes untouched. This is a stale assertion, not a regression.

Rather than just deleting the assertion, the test now checks both halves, the key in the tab and the English string in the locale, so the contract still fails if either side is removed.

`tests/studio/` 2521 passed, 3 skipped. The same file goes from 5 passed / 1 failed to 6 passed.