### PR TITLE
tests: assert the translated chat toggle label by key

### DIFF
--- a/tests/studio/test_chat_response_details_ui_contract.py
+++ b/tests/studio/test_chat_response_details_ui_contract.py
@@ -17,6 +17,7 @@ REASONING_TSX = REPO / "studio/frontend/src/components/assistant-ui/reasoning.ts
 ADAPTER_TS = REPO / "studio/frontend/src/features/chat/api/chat-adapter.ts"
 CHAT_PREFS_TS = REPO / "studio/frontend/src/features/chat/stores/chat-preferences-store.ts"
 CHAT_TAB_TSX = REPO / "studio/frontend/src/features/settings/tabs/chat-tab.tsx"
+EN_LOCALE_TS = REPO / "studio/frontend/src/i18n/locales/en.ts"
 
 
 def test_assistant_more_menu_exposes_response_details_action():
@@ -53,8 +54,12 @@ def test_response_model_badge_is_user_configurable_and_rendered_once_per_message
     assert "showResponseModel: boolean" in prefs_src
     assert "showResponseModel: false" in prefs_src
     assert "showResponseModel: saved?.showResponseModel ?? false" in prefs_src
-    assert "Show response model" in chat_tab_src
+    # The label is translated, so assert the key here and the English text in
+    # the catalog. Asserting the literal in the tsx breaks on every i18n move.
+    assert 't("settings.chat.showResponseModel")' in chat_tab_src
     assert "setShowResponseModel" in chat_tab_src
+    en_src = EN_LOCALE_TS.read_text(encoding = "utf-8")
+    assert 'showResponseModel: "Show response model"' in en_src
     details_src = DETAILS_TSX.read_text(encoding = "utf-8")
     assert (
         "aui-response-model-badge pointer-events-none relative inline-flex min-h-5" in details_src


### PR DESCRIPTION
`tests/studio/test_chat_response_details_ui_contract.py` fails on main:

```
FAILED tests/studio/test_chat_response_details_ui_contract.py::test_response_model_badge_is_user_configurable_and_rendered_once_per_message
  AssertionError: assert 'Show response model' in '// SPDX-License-Identifier: AGPL-3.0-only ...'
```

The toggle itself is fine. Its label just moved into the translation catalog, so `chat-tab.tsx` now renders `t("settings.chat.showResponseModel")` and the English text lives in `i18n/locales/en.ts`. The test was still grepping the tsx for the literal.

Assert the key in the tsx and the English string in `en.ts`. Same coverage, and it does not break the next time a label is translated.

`tests/studio`: 2521 passed, 3 skipped.