### PR TITLE
Studio: bound every teardown await so a swallowed cancel cannot wedge the API

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1662,6 +1662,10 @@ async def _aclose_stream_resources(
     # closes below, which are what actually stop llama-server decoding. #7617
     live = [w for w in watchers if w is not None]
     if live:
+        # cancel before the first await: a cancel landing here would otherwise stop the
+        # gather before it steps its children, leaving watchers never even cancelled.
+        for watcher in live:
+            watcher.cancel()
         try:
             await asyncio.gather(
                 *(_stop_local_disconnect_cancel_watcher(w) for w in live),
@@ -1695,6 +1699,11 @@ async def _aclose_stream_resources(
         raise asyncio.CancelledError()
 
 
+# the loop holds only weak references to tasks, so a bare ensure_future() close can be
+# collected before it runs. Strong ref until done, discarded after.
+_LATE_CLOSE_TASKS: set = set()
+
+
 async def _aclose_quietly(obj) -> None:
     try:
         await obj.aclose()
@@ -1718,9 +1727,11 @@ def _discard_task_outcome(task: asyncio.Task) -> None:
         return
     if result is not None and hasattr(result, "aclose") and not getattr(result, "is_closed", False):
         try:
-            asyncio.ensure_future(_aclose_quietly(result))
+            closing = asyncio.ensure_future(_aclose_quietly(result))
         except RuntimeError:
-            pass
+            return
+        _LATE_CLOSE_TASKS.add(closing)
+        closing.add_done_callback(_LATE_CLOSE_TASKS.discard)
 
 
 def _release_admission(admission_lease = None, tracker = None) -> None:
@@ -1783,7 +1794,11 @@ async def _send_stream_with_preheader_cancel(
             send_task.add_done_callback(_discard_task_outcome)
             return
         try:
-            send_task.result()
+            # closing the client does not close a response the send already produced during
+            # the aclose() above, so close it here rather than drop it.
+            sent = send_task.result()
+            if sent is not None:
+                await _aclose_quietly(sent)
         except (asyncio.CancelledError, Exception):
             pass
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1750,9 +1750,7 @@ async def _send_stream_with_preheader_cancel(
         # bounded like every other teardown await: the client is already closed, so an
         # abandoned send owns nothing and its result is drained by the callback. #7617
         send_task.cancel()
-        done, _pending = await asyncio.wait(
-            {send_task}, timeout = _TEARDOWN_TASK_STOP_TIMEOUT_S
-        )
+        done, _pending = await asyncio.wait({send_task}, timeout = _TEARDOWN_TASK_STOP_TIMEOUT_S)
         if not done:
             send_task.add_done_callback(_discard_task_outcome)
             return
@@ -17835,9 +17833,7 @@ async def _openai_passthrough_stream_admitted(
         # bounded: the send polls Request.is_disconnected() before dispatch, which can
         # swallow cancel(). abandoning it is safe because the caller closes the per-request
         # client right after, which tears down whatever response it later produces. #7617
-        done, _pending = await asyncio.wait(
-            {task}, timeout = _TEARDOWN_TASK_STOP_TIMEOUT_S
-        )
+        done, _pending = await asyncio.wait({task}, timeout = _TEARDOWN_TASK_STOP_TIMEOUT_S)
         if not done:
             task.add_done_callback(_discard_task_outcome)
             return

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1128,6 +1128,10 @@ _OPENAI_PASSTHROUGH_PREHEADER_STATUS_WINDOW_S = 0.1
 _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S = 5.0
 _OPENAI_PASSTHROUGH_SSE_KEEPALIVE = ": keep-alive\n\n"
 _OPENAI_LLAMA_ADMISSION_POLL_S = 0.25
+# Upper bound on waiting for a cancelled teardown task to settle. Request.is_disconnected()
+# can swallow cancel() outright (#7617), so every teardown await is bounded and abandons
+# the task instead of holding the response, and the process-wide slot, open forever.
+_TEARDOWN_TASK_STOP_TIMEOUT_S = 5.0
 # Idle window before a local tool-loop stream emits an SSE keepalive comment
 # (e.g. prompt prefill between tool iterations). A second layer atop the
 # tool_stream_exec heartbeats, keeping proxies (Cloudflare drops idle at ~100s).
@@ -1648,15 +1652,17 @@ async def _aclose_stream_resources(
     client = None,
 ) -> None:
     """Tear down an httpx streaming generator's resources in the required order:
-    cancel + await each watcher task, then aclose() the byte/line iterator, the
-    response, and the client. Each step swallows its own exceptions so teardown
+    cancel + bounded-wait each watcher task, then aclose() the byte/line iterator,
+    the response, and the client. Each step swallows its own exceptions so teardown
     always completes; a close-time CancelledError is re-raised only after every
     step has run. See _anthropic_passthrough_stream for the ordering rationale."""
     for watcher in watchers:
         if watcher is not None:
-            watcher.cancel()
             try:
-                await watcher
+                # bounded: a watcher parked in Request.is_disconnected() can swallow
+                # our cancel() outright, so awaiting it here would hold the response
+                # open until the client itself gives up. see #7617.
+                await _stop_local_disconnect_cancel_watcher(watcher)
             except (asyncio.CancelledError, Exception):
                 pass
     close_cancelled = False
@@ -1683,6 +1689,27 @@ async def _aclose_stream_resources(
             pass
     if close_cancelled:
         raise asyncio.CancelledError()
+
+
+def _discard_task_outcome(task: asyncio.Task) -> None:
+    """Drain an abandoned teardown task so asyncio does not log its result as unretrieved."""
+    if not task.cancelled():
+        task.exception()
+
+
+def _release_admission(admission_lease = None, tracker = None) -> None:
+    """Give back the process-wide llama-server slot and the cancel-registry entry.
+
+    Synchronous and called before a stream's teardown awaits, not after: the generation is
+    already finished upstream by then, and both are shared by every client, so anything that
+    stalls between here and the end of teardown must not keep holding them. #7617
+    """
+    try:
+        if admission_lease is not None:
+            admission_lease.release()
+    finally:
+        if tracker is not None:
+            tracker.__exit__(None, None, None)
 
 
 async def _preheader_cancelled(cancel_event = None, request: Optional[Request] = None) -> bool:
@@ -1720,9 +1747,17 @@ async def _send_stream_with_preheader_cancel(
             await client.aclose()
         except Exception:
             pass
+        # bounded like every other teardown await: the client is already closed, so an
+        # abandoned send owns nothing and its result is drained by the callback. #7617
         send_task.cancel()
+        done, _pending = await asyncio.wait(
+            {send_task}, timeout = _TEARDOWN_TASK_STOP_TIMEOUT_S
+        )
+        if not done:
+            send_task.add_done_callback(_discard_task_outcome)
+            return
         try:
-            await send_task
+            send_task.result()
         except (asyncio.CancelledError, Exception):
             pass
 
@@ -1742,9 +1777,11 @@ async def _send_stream_with_preheader_cancel(
         await _stop_send_task()
         raise
     finally:
-        cancel_task.cancel()
+        # bounded: cancel_task polls Request.is_disconnected(), which can swallow
+        # cancel(). this finally also runs on the success path, so an unbounded wait
+        # here stalls the stream before its first byte. see #7617.
         try:
-            await cancel_task
+            await _stop_local_disconnect_cancel_watcher(cancel_task)
         except (asyncio.CancelledError, Exception):
             pass
 
@@ -2595,7 +2632,9 @@ async def _await_cancel_or_disconnect_then_close_client(
         return
 
 
-async def _stop_local_disconnect_cancel_watcher(watcher, timeout_s: float = 5.0) -> None:
+async def _stop_local_disconnect_cancel_watcher(
+    watcher, timeout_s: float = _TEARDOWN_TASK_STOP_TIMEOUT_S
+) -> None:
     # Bounded: this runs in the stream's finally, so awaiting the watcher outright would let a
     # wedged poll loop hold the response open forever. asyncio.wait neither cancels nor re-raises,
     # and an abandoned watcher owns no resources.
@@ -16955,17 +16994,15 @@ async def _anthropic_passthrough_stream(
                     yield event
                 return
         finally:
-            # Same shape as the OpenAI passthrough: a close-time CancelledError
-            # re-raised by _aclose_stream_resources must not skip the tracker exit.
-            try:
-                await _aclose_stream_resources(
-                    watchers = (cancel_watcher, disconnect_watcher),
-                    iterator = lines_iter,
-                    resp = resp,
-                    client = client,
-                )
-            finally:
-                _tracker.__exit__(None, None, None)
+            # Same shape as the OpenAI passthrough: exit the tracker before the teardown
+            # awaits so a close-time stall cannot keep the cancel-registry entry alive.
+            _release_admission(tracker = _tracker)
+            await _aclose_stream_resources(
+                watchers = (cancel_watcher, disconnect_watcher),
+                iterator = lines_iter,
+                resp = resp,
+                client = client,
+            )
 
         for line in emitter.finish():
             yield line
@@ -17795,8 +17832,17 @@ async def _openai_passthrough_stream_admitted(
             return
         if not task.done():
             task.cancel()
+        # bounded: the send polls Request.is_disconnected() before dispatch, which can
+        # swallow cancel(). abandoning it is safe because the caller closes the per-request
+        # client right after, which tears down whatever response it later produces. #7617
+        done, _pending = await asyncio.wait(
+            {task}, timeout = _TEARDOWN_TASK_STOP_TIMEOUT_S
+        )
+        if not done:
+            task.add_done_callback(_discard_task_outcome)
+            return
         try:
-            task_resp = await task
+            task_resp = task.result()
             if task_resp is not None:
                 try:
                     await task_resp.aclose()
@@ -17857,6 +17903,9 @@ async def _openai_passthrough_stream_admitted(
                 # llama-server subprocess crashed / starting / unreachable.
                 logger.error("openai passthrough stream: upstream unreachable: %s", e)
                 api_monitor.fail(monitor_id, _friendly_error(e))
+                # the outer handler releases too, but both are idempotent and nothing
+                # process-wide should be held across the closes below. #7617
+                _release_admission(admission_lease, _tracker)
                 await _aclose_send_task(send_task)
                 await _aclose_stream_resources(resp = resp, client = client)
                 raise HTTPException(
@@ -17869,14 +17918,9 @@ async def _openai_passthrough_stream_admitted(
                 if cancel_event is not None:
                     cancel_event.set()
                 api_monitor.finish(monitor_id, "cancelled")
-                try:
-                    await _aclose_send_task(send_task)
-                    await _aclose_stream_resources(client = client)
-                finally:
-                    try:
-                        admission_lease.release()
-                    finally:
-                        _tracker.__exit__(None, None, None)
+                _release_admission(admission_lease, _tracker)
+                await _aclose_send_task(send_task)
+                await _aclose_stream_resources(client = client)
                 return _SameTaskStreamingResponse(
                     iter(()),
                     media_type = "text/event-stream",
@@ -18411,35 +18455,26 @@ async def _openai_passthrough_stream_admitted(
                 err = _openai_stream_error_chunk(e)
                 yield _openai_stream_error_sse(err)
             finally:
-                # _aclose_stream_resources re-raises a close-time CancelledError
-                # only after finishing teardown, and the tracker exits either way.
-                try:
-                    await _aclose_send_task(send_task)
-                    await _aclose_stream_resources(
-                        watchers = (cancel_watcher, disconnect_watcher),
-                        iterator = lines_iter,
-                        resp = resp,
-                        client = client,
-                    )
-                finally:
-                    try:
-                        admission_lease.release()
-                    finally:
-                        _tracker.__exit__(None, None, None)
+                # Free the slot and the cancel-registry entry before any teardown await:
+                # llama-server has already released its own slot by here, and holding ours
+                # across the closes let one wedged teardown starve every client. #7617
+                _release_admission(admission_lease, _tracker)
+                await _aclose_send_task(send_task)
+                await _aclose_stream_resources(
+                    watchers = (cancel_watcher, disconnect_watcher),
+                    iterator = lines_iter,
+                    resp = resp,
+                    client = client,
+                )
 
         async def _unstarted_cleanup() -> None:
             # Client disconnected before the body stream started, so _stream()'s
             # finally never ran. Release the eagerly-opened upstream resp/client
             # and the cancel-registry entry here; the watchers and line iterator
             # are created inside _stream(), so there is nothing else to close.
-            try:
-                await _aclose_send_task(send_task)
-                await _aclose_stream_resources(resp = resp, client = client)
-            finally:
-                try:
-                    admission_lease.release()
-                finally:
-                    _tracker.__exit__(None, None, None)
+            _release_admission(admission_lease, _tracker)
+            await _aclose_send_task(send_task)
+            await _aclose_stream_resources(resp = resp, client = client)
 
         return _SameTaskStreamingResponse(
             _stream(),
@@ -18459,14 +18494,9 @@ async def _openai_passthrough_stream_admitted(
         else:
             detail = exc.detail if isinstance(exc, HTTPException) else _friendly_error(exc)
             api_monitor.fail(monitor_id, str(detail))
-        try:
-            await _aclose_send_task(send_task)
-            await _aclose_stream_resources(resp = resp, client = client)
-        finally:
-            try:
-                admission_lease.release()
-            finally:
-                _tracker.__exit__(None, None, None)
+        _release_admission(admission_lease, _tracker)
+        await _aclose_send_task(send_task)
+        await _aclose_stream_resources(resp = resp, client = client)
         raise
 
 
@@ -18634,9 +18664,10 @@ async def _openai_passthrough_non_streaming_upstream(
                 raise asyncio.CancelledError()
             return response
         finally:
-            watcher.cancel()
+            # bounded: the watcher polls Request.is_disconnected(), which can swallow
+            # cancel(). the client it owns is closed below either way. see #7617.
             try:
-                await watcher
+                await _stop_local_disconnect_cancel_watcher(watcher)
             except (asyncio.CancelledError, Exception):
                 pass
             try:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1128,9 +1128,9 @@ _OPENAI_PASSTHROUGH_PREHEADER_STATUS_WINDOW_S = 0.1
 _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S = 5.0
 _OPENAI_PASSTHROUGH_SSE_KEEPALIVE = ": keep-alive\n\n"
 _OPENAI_LLAMA_ADMISSION_POLL_S = 0.25
-# Upper bound on waiting for a cancelled teardown task to settle. Request.is_disconnected()
-# can swallow cancel() outright (#7617), so every teardown await is bounded and abandons
-# the task instead of holding the response, and the process-wide slot, open forever.
+# Cap on waiting for a cancelled teardown task. Request.is_disconnected() can swallow
+# cancel() (#7617), so teardown abandons the task rather than hold the response, and
+# the process-wide slot, open forever.
 _TEARDOWN_TASK_STOP_TIMEOUT_S = 5.0
 # Idle window before a local tool-loop stream emits an SSE keepalive comment
 # (e.g. prompt prefill between tool iterations). A second layer atop the
@@ -1656,14 +1656,13 @@ async def _aclose_stream_resources(
     the response, and the client. Each step swallows its own exceptions so teardown
     always completes; a close-time CancelledError is re-raised only after every
     step has run. See _anthropic_passthrough_stream for the ordering rationale."""
-    # bounded: a watcher parked in Request.is_disconnected() can swallow cancel(), so an
-    # unbounded await here holds the response open until the client gives up. Stopped
-    # together, not in sequence, so N watchers cost one bound rather than N before the
-    # closes below, which are what actually stop llama-server decoding. #7617
+    # Bounded: a watcher parked in Request.is_disconnected() can swallow cancel(), so an
+    # unbounded await holds the response open. Stopped together, so N watchers cost one
+    # bound before the closes, which are what stop llama-server decoding. #7617
     live = [w for w in watchers if w is not None]
     if live:
-        # cancel before the first await: a cancel landing here would otherwise stop the
-        # gather before it steps its children, leaving watchers never even cancelled.
+        # Cancel before the first await, else a cancel here stops the gather before it
+        # steps its children, leaving watchers never cancelled.
         for watcher in live:
             watcher.cancel()
         try:
@@ -1699,8 +1698,8 @@ async def _aclose_stream_resources(
         raise asyncio.CancelledError()
 
 
-# the loop holds only weak references to tasks, so a bare ensure_future() close can be
-# collected before it runs. Strong ref until done, discarded after.
+# The loop holds only weak refs to tasks, so a bare ensure_future() close can be collected
+# before it runs. Strong ref until done.
 _LATE_CLOSE_TASKS: set = set()
 
 
@@ -1714,8 +1713,8 @@ async def _aclose_quietly(obj) -> None:
 def _discard_task_outcome(task: asyncio.Task) -> None:
     """Drain an abandoned teardown task, closing a late response rather than dropping it.
 
-    Closing the per-request client does not close a response the send goes on to produce on
-    a connection opened after that close. Never raises: this is a done callback. #7617
+    Closing the per-request client does not close a response the send produces on a
+    connection opened after that close. Never raises: this is a done callback. #7617
     """
     try:
         if task.cancelled():
@@ -1737,11 +1736,9 @@ def _discard_task_outcome(task: asyncio.Task) -> None:
 def _release_admission(admission_lease = None, tracker = None) -> None:
     """Give back the process-wide llama-server slot and the cancel-registry entry.
 
-    Must run *after* the upstream response is closed, never before. On the disconnect path
-    the stream's finally is entered by a CancelledError thrown into the generator while
-    llama-server is still decoding; closing ``resp`` is what actually stops it, so handing
-    the slot back first would admit a second request past --parallel. Safe to leave behind
-    the closes only because every teardown await is bounded. #7617
+    Must run after the upstream response is closed: on disconnect llama-server keeps
+    decoding until ``resp`` is closed, so releasing first admits a second request past
+    --parallel. Safe behind the closes only because every teardown await is bounded. #7617
     """
     try:
         if admission_lease is not None:
@@ -1786,16 +1783,15 @@ async def _send_stream_with_preheader_cancel(
             await client.aclose()
         except Exception:
             pass
-        # bounded like every other teardown await: the client is already closed, so an
-        # abandoned send owns nothing and its result is drained by the callback. #7617
+        # Bounded: the client is already closed, so an abandoned send owns nothing and
+        # the callback drains its result. #7617
         send_task.cancel()
         done, _pending = await asyncio.wait({send_task}, timeout = _TEARDOWN_TASK_STOP_TIMEOUT_S)
         if not done:
             send_task.add_done_callback(_discard_task_outcome)
             return
         try:
-            # closing the client does not close a response the send already produced during
-            # the aclose() above, so close it here rather than drop it.
+            # The aclose() above does not close a response the send produced during it.
             sent = send_task.result()
             if sent is not None:
                 await _aclose_quietly(sent)
@@ -1818,9 +1814,8 @@ async def _send_stream_with_preheader_cancel(
         await _stop_send_task()
         raise
     finally:
-        # bounded: cancel_task polls Request.is_disconnected(), which can swallow
-        # cancel(). this finally also runs on the success path, so an unbounded wait
-        # here stalls the stream before its first byte. see #7617.
+        # Bounded: cancel_task polls Request.is_disconnected(), which can swallow cancel(),
+        # and this finally also runs on the success path, before the first byte. #7617
         try:
             await _stop_local_disconnect_cancel_watcher(cancel_task)
         except (asyncio.CancelledError, Exception):
@@ -2682,8 +2677,8 @@ async def _stop_local_disconnect_cancel_watcher(
     watcher.cancel()
     done, _pending = await asyncio.wait({watcher}, timeout = timeout_s)
     if not done:
-        # _wait_preheader_cancel has no exception handler, so a raise after we stop waiting
-        # would surface as "Task exception was never retrieved". Same drain the sends use.
+        # _wait_preheader_cancel has no exception handler, so a raise after we stop
+        # waiting would surface as "Task exception was never retrieved".
         watcher.add_done_callback(_discard_task_outcome)
         return
     try:
@@ -17039,7 +17034,7 @@ async def _anthropic_passthrough_stream(
                 return
         finally:
             # Same shape as the OpenAI passthrough: the tracker exits after the closes,
-            # and the teardown awaits are bounded so it cannot be held indefinitely.
+            # and the bounded teardown awaits cannot hold it indefinitely.
             try:
                 await _aclose_stream_resources(
                     watchers = (cancel_watcher, disconnect_watcher),
@@ -17878,9 +17873,9 @@ async def _openai_passthrough_stream_admitted(
             return
         if not task.done():
             task.cancel()
-        # bounded: the send polls Request.is_disconnected() before dispatch, which can
-        # swallow cancel(). abandoning it is safe because the caller closes the per-request
-        # client right after, which tears down whatever response it later produces. #7617
+        # Bounded: the send polls Request.is_disconnected() before dispatch, which can
+        # swallow cancel(). Abandoning it is safe because the caller closes the per-request
+        # client right after, tearing down whatever response it later produces. #7617
         done, _pending = await asyncio.wait({task}, timeout = _TEARDOWN_TASK_STOP_TIMEOUT_S)
         if not done:
             task.add_done_callback(_discard_task_outcome)
@@ -17947,8 +17942,8 @@ async def _openai_passthrough_stream_admitted(
                 # llama-server subprocess crashed / starting / unreachable.
                 logger.error("openai passthrough stream: upstream unreachable: %s", e)
                 api_monitor.fail(monitor_id, _friendly_error(e))
-                # the outer handler releases too, but _release_admission is idempotent.
-                # nested so a cancel inside _aclose_send_task's wait cannot skip the closes.
+                # Nested so a cancel inside _aclose_send_task's wait cannot skip the closes.
+                # The outer handler releases too, but _release_admission is idempotent.
                 try:
                     await _aclose_send_task(send_task)
                 finally:
@@ -18507,11 +18502,11 @@ async def _openai_passthrough_stream_admitted(
                 err = _openai_stream_error_chunk(e)
                 yield _openai_stream_error_sse(err)
             finally:
-                # Close the upstream stream first: on the disconnect path llama-server is
-                # still decoding until resp is closed, so releasing the slot before that
-                # would admit a second request past --parallel. Safe to hold across these
-                # closes because every task await in them is bounded; the aclose() calls
-                # are not, but on HTTP/1.1 to a local llama-server they do not block. #7617
+                # Close the upstream stream first: on disconnect llama-server keeps decoding
+                # until resp is closed, so releasing the slot earlier admits a second request
+                # past --parallel. Safe to hold the slot across these closes because every
+                # task await in them is bounded, and the aclose() calls do not block on
+                # HTTP/1.1 to a local llama-server. #7617
                 try:
                     await _aclose_send_task(send_task)
                 finally:
@@ -18730,8 +18725,8 @@ async def _openai_passthrough_non_streaming_upstream(
                 raise asyncio.CancelledError()
             return response
         finally:
-            # bounded: the watcher polls Request.is_disconnected(), which can swallow
-            # cancel(). the client it owns is closed below either way. see #7617.
+            # Bounded: the watcher polls Request.is_disconnected(), which can swallow
+            # cancel(). The client it owns is closed below either way. #7617
             try:
                 await _stop_local_disconnect_cancel_watcher(watcher)
             except (asyncio.CancelledError, Exception):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1700,9 +1700,11 @@ def _discard_task_outcome(task: asyncio.Task) -> None:
 def _release_admission(admission_lease = None, tracker = None) -> None:
     """Give back the process-wide llama-server slot and the cancel-registry entry.
 
-    Synchronous and called before a stream's teardown awaits, not after: the generation is
-    already finished upstream by then, and both are shared by every client, so anything that
-    stalls between here and the end of teardown must not keep holding them. #7617
+    Must run *after* the upstream response is closed, never before. On the disconnect path
+    the stream's finally is entered by a CancelledError thrown into the generator while
+    llama-server is still decoding; closing ``resp`` is what actually stops it, so handing
+    the slot back first would admit a second request past --parallel. Safe to leave behind
+    the closes only because every teardown await is bounded. #7617
     """
     try:
         if admission_lease is not None:
@@ -16992,15 +16994,17 @@ async def _anthropic_passthrough_stream(
                     yield event
                 return
         finally:
-            # Same shape as the OpenAI passthrough: exit the tracker before the teardown
-            # awaits so a close-time stall cannot keep the cancel-registry entry alive.
-            _release_admission(tracker = _tracker)
-            await _aclose_stream_resources(
-                watchers = (cancel_watcher, disconnect_watcher),
-                iterator = lines_iter,
-                resp = resp,
-                client = client,
-            )
+            # Same shape as the OpenAI passthrough: the tracker exits after the closes,
+            # and the teardown awaits are bounded so it cannot be held indefinitely.
+            try:
+                await _aclose_stream_resources(
+                    watchers = (cancel_watcher, disconnect_watcher),
+                    iterator = lines_iter,
+                    resp = resp,
+                    client = client,
+                )
+            finally:
+                _release_admission(tracker = _tracker)
 
         for line in emitter.finish():
             yield line
@@ -17899,11 +17903,12 @@ async def _openai_passthrough_stream_admitted(
                 # llama-server subprocess crashed / starting / unreachable.
                 logger.error("openai passthrough stream: upstream unreachable: %s", e)
                 api_monitor.fail(monitor_id, _friendly_error(e))
-                # the outer handler releases too, but both are idempotent and nothing
-                # process-wide should be held across the closes below. #7617
-                _release_admission(admission_lease, _tracker)
-                await _aclose_send_task(send_task)
-                await _aclose_stream_resources(resp = resp, client = client)
+                # the outer handler releases too, but _release_admission is idempotent.
+                try:
+                    await _aclose_send_task(send_task)
+                    await _aclose_stream_resources(resp = resp, client = client)
+                finally:
+                    _release_admission(admission_lease, _tracker)
                 raise HTTPException(
                     status_code = 502,
                     detail = _friendly_error(e),
@@ -17914,9 +17919,11 @@ async def _openai_passthrough_stream_admitted(
                 if cancel_event is not None:
                     cancel_event.set()
                 api_monitor.finish(monitor_id, "cancelled")
-                _release_admission(admission_lease, _tracker)
-                await _aclose_send_task(send_task)
-                await _aclose_stream_resources(client = client)
+                try:
+                    await _aclose_send_task(send_task)
+                    await _aclose_stream_resources(client = client)
+                finally:
+                    _release_admission(admission_lease, _tracker)
                 return _SameTaskStreamingResponse(
                     iter(()),
                     media_type = "text/event-stream",
@@ -18451,26 +18458,31 @@ async def _openai_passthrough_stream_admitted(
                 err = _openai_stream_error_chunk(e)
                 yield _openai_stream_error_sse(err)
             finally:
-                # Free the slot and the cancel-registry entry before any teardown await:
-                # llama-server has already released its own slot by here, and holding ours
-                # across the closes let one wedged teardown starve every client. #7617
-                _release_admission(admission_lease, _tracker)
-                await _aclose_send_task(send_task)
-                await _aclose_stream_resources(
-                    watchers = (cancel_watcher, disconnect_watcher),
-                    iterator = lines_iter,
-                    resp = resp,
-                    client = client,
-                )
+                # Close the upstream stream first: on the disconnect path llama-server is
+                # still decoding until resp is closed, so releasing the slot before that
+                # would admit a second request past --parallel. Holding it across these
+                # closes is safe now only because every await in them is bounded. #7617
+                try:
+                    await _aclose_send_task(send_task)
+                    await _aclose_stream_resources(
+                        watchers = (cancel_watcher, disconnect_watcher),
+                        iterator = lines_iter,
+                        resp = resp,
+                        client = client,
+                    )
+                finally:
+                    _release_admission(admission_lease, _tracker)
 
         async def _unstarted_cleanup() -> None:
             # Client disconnected before the body stream started, so _stream()'s
             # finally never ran. Release the eagerly-opened upstream resp/client
             # and the cancel-registry entry here; the watchers and line iterator
             # are created inside _stream(), so there is nothing else to close.
-            _release_admission(admission_lease, _tracker)
-            await _aclose_send_task(send_task)
-            await _aclose_stream_resources(resp = resp, client = client)
+            try:
+                await _aclose_send_task(send_task)
+                await _aclose_stream_resources(resp = resp, client = client)
+            finally:
+                _release_admission(admission_lease, _tracker)
 
         return _SameTaskStreamingResponse(
             _stream(),
@@ -18490,9 +18502,11 @@ async def _openai_passthrough_stream_admitted(
         else:
             detail = exc.detail if isinstance(exc, HTTPException) else _friendly_error(exc)
             api_monitor.fail(monitor_id, str(detail))
-        _release_admission(admission_lease, _tracker)
-        await _aclose_send_task(send_task)
-        await _aclose_stream_resources(resp = resp, client = client)
+        try:
+            await _aclose_send_task(send_task)
+            await _aclose_stream_resources(resp = resp, client = client)
+        finally:
+            _release_admission(admission_lease, _tracker)
         raise
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1656,15 +1656,19 @@ async def _aclose_stream_resources(
     the response, and the client. Each step swallows its own exceptions so teardown
     always completes; a close-time CancelledError is re-raised only after every
     step has run. See _anthropic_passthrough_stream for the ordering rationale."""
-    for watcher in watchers:
-        if watcher is not None:
-            try:
-                # bounded: a watcher parked in Request.is_disconnected() can swallow
-                # our cancel() outright, so awaiting it here would hold the response
-                # open until the client itself gives up. see #7617.
-                await _stop_local_disconnect_cancel_watcher(watcher)
-            except (asyncio.CancelledError, Exception):
-                pass
+    # bounded: a watcher parked in Request.is_disconnected() can swallow cancel(), so an
+    # unbounded await here holds the response open until the client gives up. Stopped
+    # together, not in sequence, so N watchers cost one bound rather than N before the
+    # closes below, which are what actually stop llama-server decoding. #7617
+    live = [w for w in watchers if w is not None]
+    if live:
+        try:
+            await asyncio.gather(
+                *(_stop_local_disconnect_cancel_watcher(w) for w in live),
+                return_exceptions = True,
+            )
+        except (asyncio.CancelledError, Exception):
+            pass
     close_cancelled = False
     if iterator is not None:
         try:
@@ -1691,10 +1695,32 @@ async def _aclose_stream_resources(
         raise asyncio.CancelledError()
 
 
+async def _aclose_quietly(obj) -> None:
+    try:
+        await obj.aclose()
+    except Exception:
+        pass
+
+
 def _discard_task_outcome(task: asyncio.Task) -> None:
-    """Drain an abandoned teardown task so asyncio does not log its result as unretrieved."""
-    if not task.cancelled():
-        task.exception()
+    """Drain an abandoned teardown task, closing a late response rather than dropping it.
+
+    Closing the per-request client does not close a response the send goes on to produce on
+    a connection opened after that close. Never raises: this is a done callback. #7617
+    """
+    try:
+        if task.cancelled():
+            return
+        if task.exception() is not None:
+            return
+        result = task.result()
+    except Exception:
+        return
+    if result is not None and hasattr(result, "aclose") and not getattr(result, "is_closed", False):
+        try:
+            asyncio.ensure_future(_aclose_quietly(result))
+        except RuntimeError:
+            pass
 
 
 def _release_admission(admission_lease = None, tracker = None) -> None:
@@ -2641,6 +2667,9 @@ async def _stop_local_disconnect_cancel_watcher(
     watcher.cancel()
     done, _pending = await asyncio.wait({watcher}, timeout = timeout_s)
     if not done:
+        # _wait_preheader_cancel has no exception handler, so a raise after we stop waiting
+        # would surface as "Task exception was never retrieved". Same drain the sends use.
+        watcher.add_done_callback(_discard_task_outcome)
         return
     try:
         watcher.result()
@@ -17904,11 +17933,14 @@ async def _openai_passthrough_stream_admitted(
                 logger.error("openai passthrough stream: upstream unreachable: %s", e)
                 api_monitor.fail(monitor_id, _friendly_error(e))
                 # the outer handler releases too, but _release_admission is idempotent.
+                # nested so a cancel inside _aclose_send_task's wait cannot skip the closes.
                 try:
                     await _aclose_send_task(send_task)
-                    await _aclose_stream_resources(resp = resp, client = client)
                 finally:
-                    _release_admission(admission_lease, _tracker)
+                    try:
+                        await _aclose_stream_resources(resp = resp, client = client)
+                    finally:
+                        _release_admission(admission_lease, _tracker)
                 raise HTTPException(
                     status_code = 502,
                     detail = _friendly_error(e),
@@ -17921,9 +17953,11 @@ async def _openai_passthrough_stream_admitted(
                 api_monitor.finish(monitor_id, "cancelled")
                 try:
                     await _aclose_send_task(send_task)
-                    await _aclose_stream_resources(client = client)
                 finally:
-                    _release_admission(admission_lease, _tracker)
+                    try:
+                        await _aclose_stream_resources(client = client)
+                    finally:
+                        _release_admission(admission_lease, _tracker)
                 return _SameTaskStreamingResponse(
                     iter(()),
                     media_type = "text/event-stream",
@@ -18460,18 +18494,21 @@ async def _openai_passthrough_stream_admitted(
             finally:
                 # Close the upstream stream first: on the disconnect path llama-server is
                 # still decoding until resp is closed, so releasing the slot before that
-                # would admit a second request past --parallel. Holding it across these
-                # closes is safe now only because every await in them is bounded. #7617
+                # would admit a second request past --parallel. Safe to hold across these
+                # closes because every task await in them is bounded; the aclose() calls
+                # are not, but on HTTP/1.1 to a local llama-server they do not block. #7617
                 try:
                     await _aclose_send_task(send_task)
-                    await _aclose_stream_resources(
-                        watchers = (cancel_watcher, disconnect_watcher),
-                        iterator = lines_iter,
-                        resp = resp,
-                        client = client,
-                    )
                 finally:
-                    _release_admission(admission_lease, _tracker)
+                    try:
+                        await _aclose_stream_resources(
+                            watchers = (cancel_watcher, disconnect_watcher),
+                            iterator = lines_iter,
+                            resp = resp,
+                            client = client,
+                        )
+                    finally:
+                        _release_admission(admission_lease, _tracker)
 
         async def _unstarted_cleanup() -> None:
             # Client disconnected before the body stream started, so _stream()'s
@@ -18480,9 +18517,11 @@ async def _openai_passthrough_stream_admitted(
             # are created inside _stream(), so there is nothing else to close.
             try:
                 await _aclose_send_task(send_task)
-                await _aclose_stream_resources(resp = resp, client = client)
             finally:
-                _release_admission(admission_lease, _tracker)
+                try:
+                    await _aclose_stream_resources(resp = resp, client = client)
+                finally:
+                    _release_admission(admission_lease, _tracker)
 
         return _SameTaskStreamingResponse(
             _stream(),
@@ -18504,9 +18543,11 @@ async def _openai_passthrough_stream_admitted(
             api_monitor.fail(monitor_id, str(detail))
         try:
             await _aclose_send_task(send_task)
-            await _aclose_stream_resources(resp = resp, client = client)
         finally:
-            _release_admission(admission_lease, _tracker)
+            try:
+                await _aclose_stream_resources(resp = resp, client = client)
+            finally:
+                _release_admission(admission_lease, _tracker)
         raise
 
 

--- a/studio/backend/tests/test_disconnect_watcher_teardown.py
+++ b/studio/backend/tests/test_disconnect_watcher_teardown.py
@@ -113,9 +113,9 @@ def test_aclose_stream_resources_is_not_blocked_by_a_wedged_watcher(monkeypatch)
             assert finished, "teardown blocked on a watcher that ignores cancel()"
             assert stopped == [watcher], "the watcher must go through the bounded stop"
             assert not watcher.done(), "watcher should have been abandoned, not awaited"
-            assert iterator.closed and resp.closed and client.closed, (
-                "teardown must still close the upstream resources after abandoning it"
-            )
+            assert (
+                iterator.closed and resp.closed and client.closed
+            ), "teardown must still close the upstream resources after abandoning it"
         finally:
             await _release(release, [watcher, teardown])
 
@@ -133,7 +133,11 @@ def test_send_stream_preheader_finally_is_not_blocked_by_a_wedged_watcher(monkey
         sent = httpx.Response(200)
 
         class _Client:
-            async def send(self, req, stream = False):
+            async def send(
+                self,
+                req,
+                stream = False,
+            ):
                 return sent
 
             async def aclose(self):
@@ -278,9 +282,9 @@ def test_admission_is_released_before_any_teardown_await(func_name):
             f"{func_name}: teardown block has no _release_admission() before it:\n"
             + "\n".join(ast.unparse(stmt) for stmt in block)
         )
-        assert release_at < teardown_at, (
-            f"{func_name}: _release_admission() must precede the teardown awaits"
-        )
+        assert (
+            release_at < teardown_at
+        ), f"{func_name}: _release_admission() must precede the teardown awaits"
         checked += 1
 
     assert checked, f"{func_name}: found no teardown block to check"

--- a/studio/backend/tests/test_disconnect_watcher_teardown.py
+++ b/studio/backend/tests/test_disconnect_watcher_teardown.py
@@ -263,31 +263,49 @@ def _first_index(block, names):
     "func_name",
     ["_openai_passthrough_stream_admitted", "_anthropic_passthrough_stream"],
 )
-def test_admission_is_released_before_any_teardown_await(func_name):
-    """A wedged teardown must never keep the process-wide slot or registry entry.
+def test_admission_is_released_after_the_upstream_stream_is_closed(func_name):
+    """The slot must be handed back only once the upstream response is closed.
 
-    The lease and the cancel tracker are shared by every client, so once they sat behind
-    the teardown awaits a single stuck close starved every session until Studio restarted.
+    On the disconnect path the stream's finally is entered by a CancelledError thrown into
+    the generator while llama-server is still decoding; closing resp is what stops it, so
+    releasing first admits another request past --parallel. The release must still always
+    run, from the finally of the same try, which is bounded only because every teardown
+    await is.
     """
     func = getattr(inference_route, func_name)
     tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
 
-    checked = 0
+    # a release must never sit ahead of a close in the same block
     for block in _blocks(tree):
-        teardown_at = _first_index(block, _TEARDOWN_CALLS)
-        if teardown_at is None:
-            continue
         release_at = _first_index(block, ("_release_admission",))
-        assert release_at is not None, (
-            f"{func_name}: teardown block has no _release_admission() before it:\n"
+        teardown_at = _first_index(block, _TEARDOWN_CALLS)
+        if release_at is None or teardown_at is None:
+            continue
+        assert teardown_at < release_at, (
+            f"{func_name}: _release_admission() runs before the upstream closes; on a "
+            f"disconnect that hands the slot back while llama-server is still decoding:\n"
             + "\n".join(ast.unparse(stmt) for stmt in block)
         )
-        assert (
-            release_at < teardown_at
-        ), f"{func_name}: _release_admission() must precede the teardown awaits"
-        checked += 1
 
-    assert checked, f"{func_name}: found no teardown block to check"
+    # and every close must be inside a try whose finally does release, so a stalled
+    # close cannot drop the lease entirely
+    releasing = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try) and _first_index(
+            node.finalbody, ("_release_admission",)
+        ) is not None:
+            releasing.update(id(stmt) for stmt in node.body)
+
+    teardowns = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Expr) and _called_name(node) in _TEARDOWN_CALLS
+    ]
+    assert teardowns, f"{func_name}: found no teardown await to check"
+    for node in teardowns:
+        assert id(node) in releasing, (
+            f"{func_name}: teardown await is not in the body of a try that releases "
+            f"admission in its finally:\n{ast.unparse(node)}"
+        )
 
 
 def test_release_admission_exits_the_tracker_even_if_the_lease_release_raises():

--- a/studio/backend/tests/test_disconnect_watcher_teardown.py
+++ b/studio/backend/tests/test_disconnect_watcher_teardown.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""A disconnect watcher that never settles must not block a stream's teardown.
+
+Starlette's Request.is_disconnected() awaits receive() inside an anyio CancelScope it has
+already cancelled. Under uvicorn's h11 protocol that receive() genuinely parks, so a watcher
+polling it is suspended inside that scope. An external cancel() arriving in that window is
+counted by CPython as a second cancellation, and the scope's __exit__ then uncancel()s and
+swallows the CancelledError as its own. The watcher survives cancel() and keeps polling.
+
+Every teardown that awaited such a watcher outright therefore blocked until the client itself
+disconnected, holding the ASGI response open and, on the passthrough paths, stranding the
+llama-server admission lease released behind it. #7617.
+
+These tests wait on a task rather than asyncio.wait_for: a stub that ignores cancel() cannot
+be unblocked by cancelling it, so a wait_for here would hang instead of failing.
+"""
+
+import ast
+import asyncio
+import inspect
+import textwrap
+import threading
+
+import httpx
+import pytest
+from starlette.requests import Request
+
+import routes.inference as inference_route
+
+_TEARDOWN_CALLS = ("_aclose_send_task", "_aclose_stream_resources")
+
+
+class _Closeable:
+    def __init__(self):
+        self.closed = False
+
+    async def aclose(self):
+        self.closed = True
+
+
+def _bounded_stop(monkeypatch, collected):
+    """Keep the real bounded stop, record what it was handed, shorten its 5s default."""
+    real_stop = inference_route._stop_local_disconnect_cancel_watcher
+
+    def _stop(task, timeout_s = 0.05):
+        collected.append(task)
+        return real_stop(task, timeout_s)
+
+    monkeypatch.setattr(inference_route, "_stop_local_disconnect_cancel_watcher", _stop)
+
+
+def _swallowing_watcher(release, created):
+    """Stands in for a watcher suspended inside is_disconnected()'s cancelled scope.
+
+    Records its own task so cleanup has a handle even when the teardown under test
+    never hands it to the bounded stop.
+    """
+
+    async def _poll(*_args, **_kwargs):
+        created.append(asyncio.current_task())
+        while not release.is_set():
+            try:
+                await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                continue
+
+    return _poll
+
+
+async def _finished(coro, timeout_s = 5.0):
+    """Run coro to completion without cancelling it on timeout; report whether it ended."""
+    task = asyncio.create_task(coro)
+    done, _pending = await asyncio.wait({task}, timeout = timeout_s)
+    return task, bool(done)
+
+
+async def _release(release, tasks):
+    """Must run even on failure: a stub that swallows cancel() wedges loop shutdown."""
+    release.set()
+    for task in tasks:
+        if task is None:
+            continue
+        await asyncio.wait({task}, timeout = 2.0)
+        if not task.done():
+            task.cancel()
+            await asyncio.wait({task}, timeout = 2.0)
+
+
+def test_aclose_stream_resources_is_not_blocked_by_a_wedged_watcher(monkeypatch):
+    """_aclose_stream_resources runs in the stream's finally; it must stay bounded."""
+    stopped = []
+    _bounded_stop(monkeypatch, stopped)
+
+    async def _run():
+        release = asyncio.Event()
+        watcher = asyncio.create_task(_swallowing_watcher(release, [])())
+        teardown = None
+        try:
+            await asyncio.sleep(0)
+            iterator, resp, client = _Closeable(), _Closeable(), _Closeable()
+
+            teardown, finished = await _finished(
+                inference_route._aclose_stream_resources(
+                    watchers = (watcher,),
+                    iterator = iterator,
+                    resp = resp,
+                    client = client,
+                )
+            )
+
+            assert finished, "teardown blocked on a watcher that ignores cancel()"
+            assert stopped == [watcher], "the watcher must go through the bounded stop"
+            assert not watcher.done(), "watcher should have been abandoned, not awaited"
+            assert iterator.closed and resp.closed and client.closed, (
+                "teardown must still close the upstream resources after abandoning it"
+            )
+        finally:
+            await _release(release, [watcher, teardown])
+
+    asyncio.run(_run())
+
+
+def test_send_stream_preheader_finally_is_not_blocked_by_a_wedged_watcher(monkeypatch):
+    """The preheader finally runs on the success path too, before the first byte."""
+    stopped = []
+    _bounded_stop(monkeypatch, stopped)
+
+    async def _run():
+        release = asyncio.Event()
+        created = []
+        sent = httpx.Response(200)
+
+        class _Client:
+            async def send(self, req, stream = False):
+                return sent
+
+            async def aclose(self):
+                pass
+
+        class _Request:
+            async def is_disconnected(self):
+                return False
+
+        monkeypatch.setattr(
+            inference_route, "_wait_preheader_cancel", _swallowing_watcher(release, created)
+        )
+        send = None
+        try:
+            send, finished = await _finished(
+                inference_route._send_stream_with_preheader_cancel(
+                    _Client(),
+                    httpx.Request("POST", "http://llama.test/v1/chat/completions"),
+                    threading.Event(),
+                    request = _Request(),
+                )
+            )
+
+            assert finished, "preheader send blocked on a cancel task that ignores cancel()"
+            assert send.result() is sent, "the upstream response must still be returned"
+            assert stopped, "the preheader cancel task must go through the bounded stop"
+            assert not stopped[0].done(), "cancel task should have been abandoned"
+        finally:
+            await _release(release, created + [send])
+
+    asyncio.run(_run())
+
+
+def test_real_disconnect_watcher_can_survive_cancel_inside_is_disconnected():
+    """Pins the upstream behaviour the bounded teardown exists for.
+
+    A real Studio watcher on a real starlette Request, cancelled while suspended inside
+    is_disconnected()'s already-cancelled anyio scope, keeps running: the scope's __exit__
+    swallows the CancelledError as its own. Sweeps the loop ticks around the poll rather
+    than assuming one, since the window is a single event-loop iteration.
+
+    If this ever stops reproducing, the unbounded awaits it justifies are still wrong to
+    restore -- the point is that cancel() is not guaranteed to land here.
+    """
+
+    async def _survives_cancel_at(offset):
+        parked = asyncio.Queue()
+        release = asyncio.Event()
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [],
+            "query_string": b"",
+            "client": ("127.0.0.1", 12345),
+        }
+
+        async def receive():
+            parked.put_nowait(None)
+            await release.wait()
+            return {"type": "http.disconnect"}
+
+        watcher = asyncio.create_task(
+            inference_route._await_disconnect_then_close(
+                Request(scope, receive), _Closeable(), threading.Event()
+            )
+        )
+        try:
+            await parked.get()
+            for _ in range(offset):
+                await asyncio.sleep(0)
+            watcher.cancel()
+            done, _pending = await asyncio.wait({watcher}, timeout = 0.5)
+            return not done
+        finally:
+            await _release(release, [watcher])
+
+    async def _run():
+        for offset in range(8):
+            if await _survives_cancel_at(offset):
+                return offset
+        return None
+
+    offset = asyncio.run(_run())
+    if offset is None:
+        pytest.skip("is_disconnected() delivered cancel() at every tick on this runtime")
+
+
+def _blocks(tree):
+    """Every statement list in the tree, so ordering is checked within one scope."""
+    for node in ast.walk(tree):
+        for field in ("body", "orelse", "finalbody"):
+            block = getattr(node, field, None)
+            if isinstance(block, list) and block and isinstance(block[0], ast.stmt):
+                yield block
+
+
+def _called_name(stmt):
+    """The name a bare `foo(...)` / `await foo(...)` statement calls, else None.
+
+    Structural rather than textual so an enclosing try/finally does not match on the
+    calls nested inside it.
+    """
+    if not isinstance(stmt, ast.Expr):
+        return None
+    value = stmt.value
+    if isinstance(value, ast.Await):
+        value = value.value
+    if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
+        return value.func.id
+    return None
+
+
+def _first_index(block, names):
+    for index, stmt in enumerate(block):
+        if _called_name(stmt) in names:
+            return index
+    return None
+
+
+@pytest.mark.parametrize(
+    "func_name",
+    ["_openai_passthrough_stream_admitted", "_anthropic_passthrough_stream"],
+)
+def test_admission_is_released_before_any_teardown_await(func_name):
+    """A wedged teardown must never keep the process-wide slot or registry entry.
+
+    The lease and the cancel tracker are shared by every client, so once they sat behind
+    the teardown awaits a single stuck close starved every session until Studio restarted.
+    """
+    func = getattr(inference_route, func_name)
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+
+    checked = 0
+    for block in _blocks(tree):
+        teardown_at = _first_index(block, _TEARDOWN_CALLS)
+        if teardown_at is None:
+            continue
+        release_at = _first_index(block, ("_release_admission",))
+        assert release_at is not None, (
+            f"{func_name}: teardown block has no _release_admission() before it:\n"
+            + "\n".join(ast.unparse(stmt) for stmt in block)
+        )
+        assert release_at < teardown_at, (
+            f"{func_name}: _release_admission() must precede the teardown awaits"
+        )
+        checked += 1
+
+    assert checked, f"{func_name}: found no teardown block to check"
+
+
+def test_release_admission_exits_the_tracker_even_if_the_lease_release_raises():
+    """Both are process-wide; one failing must not strand the other."""
+    exited = []
+
+    class _Lease:
+        def release(self):
+            raise RuntimeError("queue gone")
+
+    class _Tracker:
+        def __exit__(self, *exc):
+            exited.append(exc)
+            return False
+
+    with pytest.raises(RuntimeError):
+        inference_route._release_admission(_Lease(), _Tracker())
+
+    assert exited == [(None, None, None)], "tracker must still exit"

--- a/studio/backend/tests/test_disconnect_watcher_teardown.py
+++ b/studio/backend/tests/test_disconnect_watcher_teardown.py
@@ -4,14 +4,13 @@
 """A disconnect watcher that never settles must not block a stream's teardown.
 
 Starlette's Request.is_disconnected() awaits receive() inside an anyio CancelScope it has
-already cancelled. Under uvicorn's h11 protocol that receive() genuinely parks, so a watcher
-polling it is suspended inside that scope. An external cancel() arriving in that window is
-counted by CPython as a second cancellation, and the scope's __exit__ then uncancel()s and
-swallows the CancelledError as its own. The watcher survives cancel() and keeps polling.
+already cancelled, and under uvicorn's h11 protocol that receive() genuinely parks. A cancel()
+arriving in that window counts as a second cancellation, so the scope's __exit__ uncancel()s
+and swallows the CancelledError as its own: the watcher survives cancel() and keeps polling.
 
-Every teardown that awaited such a watcher outright therefore blocked until the client itself
-disconnected, holding the ASGI response open and, on the passthrough paths, stranding the
-llama-server admission lease released behind it. #7617.
+Teardown that awaited such a watcher outright therefore blocked until the client itself
+disconnected, holding the ASGI response open and stranding the llama-server admission lease
+released behind it. #7617.
 
 These tests wait on a task rather than asyncio.wait_for: a stub that ignores cancel() cannot
 be unblocked by cancelling it, so a wait_for here would hang instead of failing.
@@ -54,8 +53,8 @@ def _bounded_stop(monkeypatch, collected):
 def _swallowing_watcher(release, created):
     """Stands in for a watcher suspended inside is_disconnected()'s cancelled scope.
 
-    Records its own task so cleanup has a handle even when the teardown under test
-    never hands it to the bounded stop.
+    Records its own task so cleanup has a handle even when the teardown never hands it
+    to the bounded stop.
     """
 
     async def _poll(*_args, **_kwargs):
@@ -174,13 +173,12 @@ def test_send_stream_preheader_finally_is_not_blocked_by_a_wedged_watcher(monkey
 def test_real_disconnect_watcher_can_survive_cancel_inside_is_disconnected():
     """Pins the upstream behaviour the bounded teardown exists for.
 
-    A real Studio watcher on a real starlette Request, cancelled while suspended inside
-    is_disconnected()'s already-cancelled anyio scope, keeps running: the scope's __exit__
-    swallows the CancelledError as its own. Sweeps the loop ticks around the poll rather
-    than assuming one, since the window is a single event-loop iteration.
+    A real watcher on a real starlette Request, cancelled while suspended inside
+    is_disconnected()'s already-cancelled anyio scope, keeps running. The window is a
+    single loop iteration, so sweep the ticks around the poll rather than assume one.
 
-    If this ever stops reproducing, the unbounded awaits it justifies are still wrong to
-    restore -- the point is that cancel() is not guaranteed to land here.
+    If this stops reproducing, the unbounded awaits are still wrong to restore: the point
+    is that cancel() is not guaranteed to land here.
     """
 
     async def _survives_cancel_at(offset):
@@ -239,8 +237,8 @@ def _blocks(tree):
 def _called_name(stmt):
     """The name a bare `foo(...)` / `await foo(...)` statement calls, else None.
 
-    Structural rather than textual so an enclosing try/finally does not match on the
-    calls nested inside it.
+    Structural rather than textual so an enclosing try/finally does not match on the calls
+    nested inside it.
     """
     if not isinstance(stmt, ast.Expr):
         return None
@@ -266,11 +264,9 @@ def _first_index(block, names):
 def test_admission_is_released_after_the_upstream_stream_is_closed(func_name):
     """The slot must be handed back only once the upstream response is closed.
 
-    On the disconnect path the stream's finally is entered by a CancelledError thrown into
-    the generator while llama-server is still decoding; closing resp is what stops it, so
-    releasing first admits another request past --parallel. The release must still always
-    run, from the finally of the same try, which is bounded only because every teardown
-    await is.
+    On disconnect llama-server keeps decoding until resp is closed, so releasing first
+    admits another request past --parallel. The release must still always run, from the
+    finally of the same try, which is bounded only because every teardown await is.
     """
     func = getattr(inference_route, func_name)
     tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
@@ -287,11 +283,10 @@ def test_admission_is_released_after_the_upstream_stream_is_closed(func_name):
             + "\n".join(ast.unparse(stmt) for stmt in block)
         )
 
-    # and every close must be protected by a try whose finally releases, so a stalled close
-    # cannot drop the lease. Checked by ancestry, not direct membership in a try's body:
-    # the nesting that stops a cancel in _aclose_send_task's wait from skipping the later
-    # closes puts the first teardown one level up, and membership rejects that even though
-    # it is strictly safer. Ancestry is the property that matters: some enclosing try releases.
+    # and every close must sit under a try whose finally releases, so a stalled close cannot
+    # drop the lease. By ancestry, not direct membership: the nesting that stops a cancel in
+    # _aclose_send_task's wait from skipping the later closes puts the first teardown one
+    # level up, which membership would reject even though it is strictly safer.
     parents = {}
     for parent in ast.walk(tree):
         for child in ast.iter_child_nodes(parent):

--- a/studio/backend/tests/test_disconnect_watcher_teardown.py
+++ b/studio/backend/tests/test_disconnect_watcher_teardown.py
@@ -291,13 +291,15 @@ def test_admission_is_released_after_the_upstream_stream_is_closed(func_name):
     # close cannot drop the lease entirely
     releasing = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Try) and _first_index(
-            node.finalbody, ("_release_admission",)
-        ) is not None:
+        if (
+            isinstance(node, ast.Try)
+            and _first_index(node.finalbody, ("_release_admission",)) is not None
+        ):
             releasing.update(id(stmt) for stmt in node.body)
 
     teardowns = [
-        node for node in ast.walk(tree)
+        node
+        for node in ast.walk(tree)
         if isinstance(node, ast.Expr) and _called_name(node) in _TEARDOWN_CALLS
     ]
     assert teardowns, f"{func_name}: found no teardown await to check"

--- a/studio/backend/tests/test_disconnect_watcher_teardown.py
+++ b/studio/backend/tests/test_disconnect_watcher_teardown.py
@@ -287,15 +287,38 @@ def test_admission_is_released_after_the_upstream_stream_is_closed(func_name):
             + "\n".join(ast.unparse(stmt) for stmt in block)
         )
 
-    # and every close must be inside a try whose finally does release, so a stalled
-    # close cannot drop the lease entirely
-    releasing = set()
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Try)
-            and _first_index(node.finalbody, ("_release_admission",)) is not None
-        ):
-            releasing.update(id(stmt) for stmt in node.body)
+    # and every close must be protected by a try whose finally releases, so a stalled close
+    # cannot drop the lease. Checked by ancestry, not direct membership in a try's body:
+    # the nesting that stops a cancel in _aclose_send_task's wait from skipping the later
+    # closes puts the first teardown one level up, and membership rejects that even though
+    # it is strictly safer. Ancestry is the property that matters: some enclosing try releases.
+    parents = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    def _finally_releases(stmts):
+        """A release anywhere under the finally counts, including nested in another try."""
+        for stmt in stmts:
+            for node in ast.walk(stmt):
+                if isinstance(node, ast.Expr) and _called_name(node) == "_release_admission":
+                    return True
+        return False
+
+    def _protected(node):
+        seen = node
+        current = parents.get(node)
+        while current is not None:
+            if (
+                isinstance(current, ast.Try)
+                and _finally_releases(current.finalbody)
+                # a teardown sitting *in* the releasing finally is not protected by it
+                and not any(seen is stmt for stmt in current.finalbody)
+            ):
+                return True
+            seen = current
+            current = parents.get(current)
+        return False
 
     teardowns = [
         node
@@ -304,8 +327,8 @@ def test_admission_is_released_after_the_upstream_stream_is_closed(func_name):
     ]
     assert teardowns, f"{func_name}: found no teardown await to check"
     for node in teardowns:
-        assert id(node) in releasing, (
-            f"{func_name}: teardown await is not in the body of a try that releases "
+        assert _protected(node), (
+            f"{func_name}: teardown await is not inside a try that releases "
             f"admission in its finally:\n{ast.unparse(node)}"
         )
 


### PR DESCRIPTION
# Studio: bound every teardown await so a swallowed cancel cannot wedge the API

Closes #7617. Recurrence of #6380; #6835 fixed a related pre-header stall on the same path.

## What was wrong

Agent clients (Pi, Hermes, OpenCode, Zed, Roo Code, agent-zero, VS Code Copilot) talking to
Studio's OpenAI-compatible API intermittently sat at "Working..." for tens of minutes with
nothing running: no GPU use, no CPU use, and llama-server's log already showing the request
finished (`slot release ... stop processing`). Once it happened, **no client got served again
until the Studio process was restarted**. Pointing the same client straight at llama-server's
own port avoided it entirely, so the fault was in Studio's proxy layer.

## How it went wrong

### 1. `Request.is_disconnected()` can consume an external `cancel()` and survive it

Starlette awaits `receive()` inside an `anyio.CancelScope` it has *already* cancelled
(`starlette/requests.py`):

```python
async def is_disconnected(self) -> bool:
    if not self._is_disconnected:
        message: Message = {}
        # If message isn't immediately available, move on
        with anyio.CancelScope() as cs:
            cs.cancel()
            message = await self._receive()
```

Studio installs uvicorn without `[standard]`, so it runs the **h11** protocol on the plain
asyncio loop, and `MaxBodyMiddleware` fully buffers the request body before routing. By the
time a watcher polls, h11's `receive()` reaches `await self.message_event.wait()` and
genuinely **parks** — so the watcher task is suspended inside that cancelled scope on every
poll, ten times a second, for the life of every request.

If an external `task.cancel()` lands in that window, two things combine:

- CPython's `Task.cancel()` sees `_num_cancels_requested > 1` (anyio already counted one),
  returns early, and never sets `_must_cancel`.
- anyio's `CancelScope.__exit__` calls `host_task.uncancel()` for its pending uncancellation,
  sees `is_anyio_cancellation(exc_val)` is true, and **swallows** the `CancelledError` as its
  own.

The external cancellation is consumed with no effect. The watcher survives `cancel()` and
keeps polling. Reproduced against Studio's own functions, no llama-server needed:

```
_await_cancel_or_disconnect_then_close_client   offset 2: settled=False  <-- cancel SWALLOWED
_aclose_stream_resources(watchers=(...))        offset 1: returned <1s: False  <-- WEDGED
  after client disconnect -> teardown completed: True
poll #1 / #2 / #3 / #5: window RECURS
```

### 2. Five teardowns awaited such a task outright

`_stop_local_disconnect_cancel_watcher` already existed as the bounded way to stop these, and
its own comment names the hazard. Twelve call sites used it. Five did not, and they were all
on the paths this issue implicates:

| Site | Watcher | Reached from |
|---|---|---|
| `_aclose_stream_resources` | `_await_disconnect_then_close` | OpenAI + Anthropic passthrough streams, `_responses_stream`, `openai_completions` |
| `_send_stream_with_preheader_cancel` finally | `_wait_preheader_cancel` | every streaming passthrough |
| `_stop_send_task` | upstream `client.send()` | preheader cancel path |
| `_aclose_send_task` | the preheader send | passthrough stream teardown |
| `_openai_passthrough_non_streaming_upstream._post` finally | `_await_cancel_or_disconnect_then_close_client` | non-streaming passthrough |

The preheader one is what produced the symptom users actually saw. Its `finally` runs on the
**success** path — upstream headers received, streaming about to begin — at an instant chosen
by llama-server and uncorrelated with the watcher's 20 Hz poll phase. When it wedged,
`_send_stream_with_preheader_cancel` never returned, so the outer `send_task` never completed,
so the body generator's `while not send_task.done():` loop spun forever **emitting an SSE
keepalive every 5 s**. The client saw a live connection with no content and therefore never
timed out — which is why Hermes waited 30,000+ s instead of hitting its 900 s provider timeout.

The wedge only released when the client itself disconnected. That is exactly the trace in
[#6380](https://github.com/unslothai/unsloth/issues/6380#issuecomment-4826295061): status 200,
`process_time_ms` 305413 ≈ the client's own 300 s timeout. The request "completed" because the
client gave up.

### 3. Why one wedge killed the whole process

`admission_lease.release()` and `_tracker.__exit__()` sat in the *inner* `finally`, behind
those awaits:

```python
finally:
    try:
        await _aclose_send_task(send_task)
        await _aclose_stream_resources(watchers = (cancel_watcher, disconnect_watcher), ...)
    finally:
        try:
            admission_lease.release()
        finally:
            _tracker.__exit__(None, None, None)
```

So a wedged teardown never released the slot. And the admission queue is unforgiving about
that: capacity is `effective_parallel_slots` (1–4), the queue is keyed by llama-server's
`base_url` so it is **shared by every client and every session**, and
`DEFAULT_ADMISSION_QUEUE_TIMEOUT_S = None` — a queued request waits **forever**.

Leaking `capacity` leases therefore wedged every `/v1/chat/completions` and `/v1/messages`
from every client, permanently, with no error and no timeout. That is the "new sessions and
restarting the client do not recover; only restarting Studio does" symptom, and it explains
why reporters saw two different outcomes: where the client timed out and disconnected, the
wedge released and later requests worked; where SSE keepalives kept the client waiting, the
lease was never released and Studio was dead.

## The fix

**Bound every teardown await.** All five sites now go through the existing
`_stop_local_disconnect_cancel_watcher`, or the same `asyncio.wait` + abandon shape where the
task is an upstream send rather than a watcher. No new timeout pattern, and no blanket request
timeout — long generations are still unbounded. The bound is a named constant,
`_TEARDOWN_TASK_STOP_TIMEOUT_S = 5.0`, also used as the helper's default.

5 s is workable at each site because a watcher's only remaining work is an `aclose()` on a
response or client that the very next lines close. An abandoned *send* can still produce a
response after the bound expires, which is why the done-callback closes it. Watchers are
stopped together rather than in sequence, so a site with two of them costs one bound, not two,
before reaching the closes that actually stop llama-server decoding. On the healthy path the
wait costs nothing: `asyncio.wait` returns the moment the task settles.

Abandoned tasks self-terminate rather than leak: once the response completes, uvicorn's
`receive()` returns `http.disconnect` immediately, so the watcher's next poll exits its loop.
Every abandoned task, watcher or send, gets a `_discard_task_outcome` done-callback so asyncio
does not log its result as unretrieved, and so a send that goes on to succeed has its response
closed rather than dropped.

**Release the process-wide state after the upstream stream is closed.** New
`_release_admission()` gives back the admission lease and the cancel-registry entry from the
finally of the same try as the closes, at all five passthrough teardown sites plus the
Anthropic stream. It runs after them, never before: on the disconnect path the stream's
finally is entered by a CancelledError thrown into the generator while llama-server is still
decoding, and closing `resp` is what actually stops it, so handing the slot back first would
admit a second request past `--parallel`. That is the same ordering `main` already used; it is
safe to hold across the closes because every task await in them is bounded. Both releases are
idempotent, so the paths where an outer handler also releases are unaffected.

**Cancellation semantics are unchanged.** A client that really disconnects still sets
`cancel_event`, still cancels the upstream request, and still closes its per-request client.

## What it fixes

- A completed generation can no longer fail to reach the client because a teardown is stuck.
- A stuck teardown can no longer strand the llama-server admission slot, so one bad request
  can no longer take out every other client and session until Studio is restarted.
- The endless-SSE-keepalive failure mode is gone, so clients no longer wait indefinitely on a
  connection that will never carry content.
- Worst case for this class of fault is now a bounded teardown delay on an already-finished
  request, instead of an unbounded hang: 5 s at the single-task sites and 10 s at the OpenAI
  stream teardown, which stops a send task and the watchers.

## Testing

`studio/backend/tests/test_disconnect_watcher_teardown.py`, 6 tests:

- teardown is not blocked by a watcher that ignores `cancel()`, and still closes the iterator,
  response and client;
- the preheader `finally` is not blocked on its cancel task;
- a **real** starlette `Request` whose `receive()` parks reproduces the swallowed cancel,
  pinning the upstream behaviour the bound exists for;
- AST guards over `_openai_passthrough_stream_admitted` and `_anthropic_passthrough_stream`
  asserting `_release_admission()` follows the teardown awaits, and that every teardown sits
  inside a try whose finally releases;
- `_release_admission()` exits the tracker even if the lease release raises.

They wait on a task rather than `asyncio.wait_for`, because a stub that ignores `cancel()`
cannot be unblocked by cancelling it — a `wait_for` there hangs instead of failing. Verified
against the unfixed tree: the teardown tests fail with `teardown blocked on a watcher that
ignores cancel()` and `preheader send blocked on a cancel task that ignores cancel()`, and the
ordering guards fail on the old nesting.

Full backend suite as CI runs it: 14,646 passed. 34 pre-existing failures (HF cache
resolution, llama.cpp setup, training streaming) reproduce identically on unmodified `main`
and are untouched by this change.

### End-to-end, on real hardware

Reproduced and then verified against a real llama-server, since this class of bug cannot be
caught by a TestClient or raw-ASGI harness: it needs uvicorn's h11 `receive()` to genuinely
park inside the cancelled anyio scope.

Topology: real httpx client -> real uvicorn (h11) -> the Studio proxy -> real llama-server
(gemma-4-E2B-it Q5_K_M, Metal, Apple M4, `--parallel 1`). `--parallel 1` makes a single
stranded lease immediately fatal. Requests carry `response_format`, which takes the same
`_openai_passthrough_stream_admitted` branch as tool calls without needing a tool-calling
chat template.

|  | before | after |
|---|---|---|
| requests | 161 | **500** |
| hangs | **2** | **0** |
| worst request | 120.8 s | 0.79 s |
| a *second* client blocked meanwhile | ~109 s, both times | never |

Both pre-fix hangs matched the reported signature exactly: llama-server finished generating in
~0.7 s, the client received nothing for 120 s, the request completed only when the client gave
up, and a fresh client from a separate session was locked out for ~109 s while the GPU sat
idle — the "no client gets served again" symptom, live.

One caveat on reproducing it: the harness runs a background task burning ~1 ms per event-loop
tick, standing in for a busy Studio relaying SSE and healing tool calls. The vulnerable window
is one loop iteration out of each 100 ms poll, so on an idle loop with sub-100 µs ticks it is
roughly 1000x narrower. That is why this reads as intermittent to reporters rather than
deterministic, and why it survived the existing suite.

## Not changed, deliberately

`DEFAULT_ADMISSION_QUEUE_TIMEOUT_S` stays `None`. A default queue timeout is the wrong
instrument here: any value small enough to rescue a hang would reject legitimate requests
queued behind a long generation, and any value large enough to be safe would not help. The
leak is fixed structurally instead. Operators who want a bound already have
`UNSLOTH_LLAMA_ADMISSION_QUEUE_TIMEOUT`.

