### PR TITLE
Studio: show generated media unrounded, and fix the selected thumbnail

### DIFF
--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -3105,7 +3105,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
                 <img
                   src={selectedSrc}
                   alt={selected.prompt}
-                  className="max-h-full max-w-full rounded-xl object-contain shadow-sm"
+                  className="max-h-full max-w-full object-contain shadow-sm"
                 />
                 {/* Actions grouped in one glass toolbar so they stay legible over any image. Size/seed live in the Recipe popover. */}
                 <div className="absolute bottom-4 right-4 flex items-center gap-0.5 rounded-xl bg-background/80 p-1 shadow-lg ring-1 ring-border backdrop-blur">
@@ -3233,7 +3233,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
                   )}
                   {/* Selection marker on a non-focusable overlay, so the button own focus state can never mask it. */}
                   {image.id === selected?.id && (
-                    <span className="pointer-events-none absolute inset-0 rounded-lg border-2 border-primary" />
+                    <span className="pointer-events-none absolute inset-0 rounded-[10px] border border-border bg-white/35 dark:border-white/25 dark:bg-white/20" />
                   )}
                 </button>
               ))}

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1719,7 +1719,7 @@ export function VideoPage({ active = true }: { active?: boolean }) {
                     }
                   }}
                   onError={() => remintSrc(selected)}
-                  className="max-h-full max-w-full rounded-xl object-contain shadow-sm"
+                  className="max-h-full max-w-full object-contain shadow-sm"
                 />
                 {selected.has_audio && (
                   <div className="absolute left-4 top-4 flex items-center gap-1 rounded-lg bg-background/80 px-2 py-1 text-ui-11 font-medium shadow-lg ring-1 ring-border backdrop-blur">
@@ -1858,7 +1858,7 @@ export function VideoPage({ active = true }: { active?: boolean }) {
                   </span>
                   {/* Selection marker on a non-focusable overlay. */}
                   {video.id === selected?.id && (
-                    <span className="pointer-events-none absolute inset-0 z-20 rounded-[10px] border-2 border-primary" />
+                    <span className="pointer-events-none absolute inset-0 z-20 rounded-[10px] border border-border bg-white/35 dark:border-white/25 dark:bg-white/20" />
                   )}
                 </button>
                 </TooltipTrigger>


### PR DESCRIPTION
Two fixes to how generated output is presented, on Images and Video.

**The output is no longer rounded.** The main preview applied `rounded-xl` to the image or clip, so a generated result did not read as its own shape. The radius is gone; the shadow still separates it from the pane.

**The selected thumbnail.** On Images the selection marker was `rounded-lg` sitting over a `rounded-[10px]` tile, so its corners cut across the picture. The radius now matches.

Both filmstrips also swap the 2px accent border for a 1px grey one plus a white wash over the thumbnail, so selection reads as the picture lightening rather than a heavy outline. The wash is white rather than a lower image opacity because opacity lightens in light mode but darkens in dark mode.

Four lines, two files.
