### PR TITLE
fix(studio): make the desktop maximize button maximize instead of hiding the window

### DIFF
--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -15,6 +15,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import type { Window as TauriWindow } from "@tauri-apps/api/window";
+import { isFillingWorkArea, toggleWorkAreaFill } from "./window-work-area";
 import {
   type MouseEvent,
   type ReactElement,
@@ -219,7 +220,7 @@ export function WindowTitlebar({
     const refreshSequence = ++maximizeRefreshSequence.current;
     try {
       const appWindow = await getAppWindow();
-      const nextMaximized = await appWindow.isMaximized();
+      const nextMaximized = await isFillingWorkArea(appWindow);
       if (refreshSequence === maximizeRefreshSequence.current) {
         setMaximized(nextMaximized);
       }
@@ -252,7 +253,7 @@ export function WindowTitlebar({
         if (!mounted) {
           return;
         }
-        setMaximized(await appWindow.isMaximized());
+        setMaximized(await isFillingWorkArea(appWindow));
         unlistenResize = await appWindow.onResized(() => {
           scheduleMaximizedRefresh();
         });
@@ -311,7 +312,7 @@ export function WindowTitlebar({
       if (event.button !== 0) {
         return;
       }
-      runWindowAction((appWindow) => appWindow.toggleMaximize());
+      runWindowAction((appWindow) => toggleWorkAreaFill(appWindow));
     },
     [runWindowAction],
   );
@@ -412,7 +413,7 @@ export function WindowTitlebar({
           <WindowControlButton
             label={maximized ? "Restore window" : "Maximize window"}
             onClick={() =>
-              runWindowAction((appWindow) => appWindow.toggleMaximize())
+              runWindowAction((appWindow) => toggleWorkAreaFill(appWindow))
             }
           >
             <HugeiconsIcon

--- a/studio/frontend/src/components/tauri/window-work-area.ts
+++ b/studio/frontend/src/components/tauri/window-work-area.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import type { Window as TauriWindow } from "@tauri-apps/api/window";
+
+export async function isFillingWorkArea(appWindow: TauriWindow): Promise<boolean> {
+  return appWindow.isMaximized();
+}
+
+/** Maximize, or restore, the way dragging to the top edge does.
+ *
+ * why: the window is configured `resizable: false` because the app draws its own
+ * resize handles, and maximizing a non-resizable window is undefined on Windows,
+ * where it hides the window instead. Turning resizing on for the duration lets the
+ * OS run its normal maximize, which lands flush with the work area. Sizing to the
+ * work area by hand does not: Windows reports an outer rect that includes the
+ * invisible resize border, so the visible window ends up inset a few pixels.
+ *
+ * Resizing goes back off on restore, so the custom handles stay the only way to
+ * resize a floating window. */
+export async function toggleWorkAreaFill(appWindow: TauriWindow): Promise<void> {
+  if (await appWindow.isMaximized()) {
+    await appWindow.toggleMaximize();
+    await appWindow.setResizable(false);
+    return;
+  }
+  await appWindow.setResizable(true);
+  await appWindow.toggleMaximize();
+}


### PR DESCRIPTION
Fixes #7887.

The window is declared `resizable: false` because the app draws its own resize handles, and maximizing a non-resizable window is undefined on Windows: it hid the window instead of maximizing it. `runWindowAction` discards the failure to keep the custom chrome inert, so nothing surfaced and the window just vanished, with no way back from the UI.

Turn resizing on for the duration of the maximize so the OS runs its normal path, which is the same one that already works when a window is dragged to the top edge, and turn it back off on restore so the custom handles stay the only way to resize a floating window.

**on sizing to the work area instead.** That was the first attempt, computing the current monitor's `workArea` and applying it with `setPosition`/`setSize`. It lands a few pixels inside the screen edges, because Windows reports an outer rect that includes the invisible resize border, so the visible window ends up inset. It also needed two capabilities the app does not otherwise grant. Letting the OS maximize avoids both and is a smaller diff.

**follow up.** Dropping images or other supported files onto the chat input also does not work, and is not addressed here. It is a separate defect in a different subsystem: `classifyDropPaths` only accepts a single `.gguf` or the `RAG_UPLOAD_ACCEPT` document extensions, so an image is classified unsupported and rejected. Fixing it properly means bridging native drop to the same `addFiles` path the `+` button uses, which needs a Rust command to read bytes for a path that was actually dropped, plus the matching capability. That will come as its own PR rather than being bolted onto a two file window fix.
