### PR TITLE
Guard the release-desktop version input and document the Cargo version

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -2,13 +2,28 @@ name: Release Desktop App
 
 on:
   workflow_dispatch:
+    # Both version inputs are free text in the dispatch UI, and studio_version
+    # alone decides the release tag, all nine asset filenames and the updater
+    # manifest version together. Near-miss tags are the failure mode worth
+    # guarding, because they look right at a glance:
+    #
+    #   studio_version   v0.1.52-beta     correct
+    #                    v.0.1.52-beta    rejected: stray dot after the leading v
+    #                    0.1.52-beta      rejected: missing leading v
+    #                    2026.8.3         rejected: that is the PyPI version
+    #
+    #   pypi_version     2026.8.3         correct, no leading v
+    #
+    # "Validate release versions" below rejects each of those by name before any
+    # binary is built. Keep the examples here, in the descriptions, and in that
+    # step's error messages on the same version so they cannot drift apart.
     inputs:
       studio_version:
-        description: 'Unsloth version tag to release (for example, v0.1.39-beta)'
+        description: 'Unsloth SemVer tag to release, leading v with no dot after it (for example, v0.1.52-beta)'
         type: string
         required: true
       pypi_version:
-        description: 'Exact PyPI unsloth version just published/stamped (for example, 2026.5.3); leave blank to use MIN_DESKTOP_BACKEND_VERSION'
+        description: 'Exact PyPI unsloth version just published/stamped, no leading v (for example, 2026.8.3); leave blank to use MIN_DESKTOP_BACKEND_VERSION'
         type: string
         required: false
       draft:
@@ -68,16 +83,29 @@ jobs:
 
           studio_version = os.environ['INPUT_STUDIO_VERSION'].strip()
           if not studio_version:
-              sys.exit('studio_version is required, for example v0.1.39-beta')
+              sys.exit('studio_version is required, for example v0.1.52-beta')
           if re.fullmatch(r'v?20\d{2}\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?', studio_version):
               sys.exit(f'studio_version must be an Unsloth SemVer tag, not a date-style backend version: {studio_version}')
+
+          # Name the single wrong character for the near-miss shapes. The generic
+          # SemVer error below is easy to skim past when everything except one
+          # separator looks correct, so spell out the correction instead.
+          separator_after_v = re.fullmatch(r'v[._\-](\d[0-9A-Za-z.\-+]*)', studio_version)
+          if separator_after_v:
+              suggestion = f'v{separator_after_v.group(1)}'
+              sys.exit(
+                  'studio_version must not have a separator after the leading v: '
+                  f'{studio_version} (did you mean {suggestion}?)'
+              )
 
           semver_tag = re.compile(
               r'^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)'
               r'(?:-[0-9A-Za-z.][0-9A-Za-z.-]*)?$'
           )
+          if semver_tag.fullmatch(f'v{studio_version}'):
+              sys.exit(f'studio_version must start with v, for example v{studio_version}')
           if not semver_tag.fullmatch(studio_version):
-              sys.exit(f'studio_version must be a SemVer tag with leading v, for example v0.1.39-beta: {studio_version}')
+              sys.exit(f'studio_version must be a SemVer tag with leading v, for example v0.1.52-beta: {studio_version}')
 
           app_version = studio_version.removeprefix('v')
           asset_version = re.sub(r'[^0-9A-Za-z]+', '_', app_version).strip('_')

--- a/studio/src-tauri/Cargo.toml
+++ b/studio/src-tauri/Cargo.toml
@@ -1,5 +1,11 @@
 [package]
 name = "unsloth-studio"
+# Placeholder, not the released app version. release-desktop.yml rewrites this
+# field (and the unsloth-studio entry in Cargo.lock) to the dispatched
+# studio_version before every release build, so editing it here changes nothing
+# that ships. tauri.conf.json declares no version of its own, which is why the
+# app version comes from this field rather than from there. The stale CalVer
+# below is also the wrong shape: release builds always write SemVer, e.g. 0.1.52-beta.
 version = "2026.4.8"
 description = "Unsloth Desktop App"
 authors = ["Unsloth AI"]


### PR DESCRIPTION
## Why

The `v0.1.52-beta` desktop release failed in `Prepare release versions` ([run 30929244674](https://github.com/unslothai/unsloth/actions/runs/30929244674)) because it was dispatched as `v.0.1.52-beta`:

```
studio_version must be a SemVer tag with leading v, for example v0.1.39-beta: v.0.1.52-beta
```

The guard did its job, and no binary was built. But the message only says the tag needs a leading `v`, which `v.0.1.52-beta` appears to have, so the one wrong character is easy to skim past. The input description already carried an example and the typo still happened, so an example alone is not enough.

This input is worth hardening: one typed string sets the release tag, all nine asset filenames and the updater manifest version together.

## What

`release-desktop.yml`

- Reject `v.`, `v-`, `v_` prefixes by name and print the corrected tag: `studio_version must not have a separator after the leading v: v.0.1.52-beta (did you mean v0.1.52-beta?)`
- Reject a missing leading `v`, deriving the check from the existing `semver_tag` regex rather than restating it, so the two cannot drift apart.
- State the rule in the dispatch UI descriptions instead of only showing a sample, since that is the text visible while typing.
- Tabulate the accepted and rejected shapes in a comment above `inputs:`.
- Refresh the stale `v0.1.39-beta` / `2026.5.3` examples so the comment, descriptions and error messages all agree on one release.

`studio/src-tauri/Cargo.toml`

- Note that the committed `2026.4.8` is a placeholder `release-desktop.yml` overwrites on every release build, not a shipped version, and that the app version comes from this field because `tauri.conf.json` declares none. As committed it is also the wrong shape: a CalVer string in a field release builds always write as SemVer.

No behaviour change for valid input.

## Test plan

Ran the real validator heredoc extracted from the modified workflow, not a reimplementation:

- [x] rejected: `v.0.1.52-beta`, `v-0.1.52-beta`, `v_0.1.52-beta`, `0.1.52-beta`, `2026.8.3`, `v2026.8.3`, empty, `v0.1..52-beta`
- [x] accepted `v0.1.52-beta` -> `app=0.1.52-beta asset=0_1_52_beta tag=desktop-v0.1.52-beta prerelease=true`
- [x] accepted `v0.1.512-beta` and `v0.1.52` (the latter `prerelease=false`)
- [x] workflow YAML parses, all 3 jobs intact
- [x] the Cargo.toml patch step still finds and rewrites `version` with the new comment above it
