### PR TITLE
Studio: drop the New badge from the Video nav row

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -992,7 +992,6 @@ export function AppSidebar() {
     video: {
       icon: FlimSlateIcon,
       label: t("shell.navigation.video"),
-      badge: t("shell.navigation.newBadge"),
       active: pathname === "/video" || pathname.startsWith("/video/"),
       disabled: chatOnly,
       tooltip: chatOnly


### PR DESCRIPTION
Video has been in the sidebar long enough that the New pill is no longer telling anyone anything, so it comes off the row.

One line. The `NavBadge` component and the `shell.navigation.newBadge` string stay in place for the next tab that wants them.
