### PR TITLE
Studio: prevent long streaming Markdown stalls

### DIFF
--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -24,7 +24,12 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { createMathPlugin } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Block, type BlockProps, Streamdown } from "streamdown";
+import {
+  Block,
+  type BlockProps,
+  Streamdown,
+  type StreamdownProps,
+} from "streamdown";
 import { createCodePlugin } from "./code-plugin";
 import "katex/dist/katex.min.css";
 import { AudioPlayer } from "./audio-player";
@@ -35,6 +40,15 @@ const code = createCodePlugin({
   themes: [unslothLightTheme, unslothDarkTheme],
 });
 const { withSmoothContextProvider } = INTERNAL;
+
+// Streamdown 2.5 schedules ordinary streaming blocks in an interruptible React
+// transition. A continuous token stream can starve that transition for seconds.
+// Its animated path commits every block update directly; zero duration preserves
+// that scheduling behavior without adding a visible text animation.
+const STREAMDOWN_IMMEDIATE_UPDATES = {
+  duration: 0,
+  stagger: 0,
+} satisfies NonNullable<StreamdownProps["animated"]>;
 
 const STREAMDOWN_COMPONENTS = {
   a: ({ href, children, ...props }: React.ComponentProps<"a">) => (
@@ -395,6 +409,7 @@ const MarkdownTextImpl = () => {
         key={messageId}
         mode="streaming"
         isAnimating={status.type === "running"}
+        animated={STREAMDOWN_IMMEDIATE_UPDATES}
         plugins={{ code, math, mermaid }}
         components={STREAMDOWN_COMPONENTS}
         urlTransform={safeMarkdownUrl}

--- a/studio/frontend/tests/markdown-streaming-scheduling.test.ts
+++ b/studio/frontend/tests/markdown-streaming-scheduling.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import ts from "typescript";
+
+const MARKDOWN_TEXT_PATH = new URL(
+  "../src/components/assistant-ui/markdown-text.tsx",
+  import.meta.url,
+);
+const source = ts.createSourceFile(
+  MARKDOWN_TEXT_PATH.pathname,
+  readFileSync(MARKDOWN_TEXT_PATH, "utf8"),
+  ts.ScriptTarget.ESNext,
+  true,
+  ts.ScriptKind.TSX,
+);
+
+function findImmediateUpdateConfig(): ts.ObjectLiteralExpression | null {
+  let config: ts.ObjectLiteralExpression | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.name.getText(source) === "STREAMDOWN_IMMEDIATE_UPDATES" &&
+      node.initializer &&
+      ts.isSatisfiesExpression(node.initializer) &&
+      ts.isObjectLiteralExpression(node.initializer.expression)
+    ) {
+      config = node.initializer.expression;
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  return config;
+}
+
+function findChatStreamdown(): ts.JsxOpeningLikeElement | null {
+  let streamdown: ts.JsxOpeningLikeElement | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+      node.tagName.getText(source) === "Streamdown"
+    ) {
+      streamdown = node;
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  return streamdown;
+}
+
+function jsxAttribute(
+  opening: ts.JsxOpeningLikeElement,
+  name: string,
+): ts.JsxAttribute | null {
+  for (const attribute of opening.attributes.properties) {
+    if (
+      ts.isJsxAttribute(attribute) &&
+      attribute.name.getText(source) === name
+    ) {
+      return attribute;
+    }
+  }
+  return null;
+}
+
+test("chat streaming bypasses Streamdown's starvable transition without visible animation", () => {
+  const config = findImmediateUpdateConfig();
+  assert.ok(config, "STREAMDOWN_IMMEDIATE_UPDATES is missing");
+
+  const values = new Map(
+    config.properties.flatMap((property) => {
+      if (
+        !(
+          ts.isPropertyAssignment(property) &&
+          ts.isNumericLiteral(property.initializer)
+        )
+      ) {
+        return [];
+      }
+      return [
+        [property.name.getText(source), Number(property.initializer.text)],
+      ];
+    }),
+  );
+  assert.equal(values.get("duration"), 0);
+  assert.equal(values.get("stagger"), 0);
+
+  const streamdown = findChatStreamdown();
+  assert.ok(streamdown, "chat <Streamdown> is missing");
+  assert.equal(
+    jsxAttribute(streamdown, "mode")?.initializer?.getText(source),
+    '"streaming"',
+  );
+  assert.equal(
+    jsxAttribute(streamdown, "animated")?.initializer?.getText(source),
+    "{STREAMDOWN_IMMEDIATE_UPDATES}",
+  );
+});


### PR DESCRIPTION
While an answer is streaming, the chat UI can stop updating for several seconds even though tokens are still arriving from the server. The user sees no progress and then gets a large wall of text all at once.

Long answers with many LaTeX equations trigger this most easily because rendering the Markdown and equations is more expensive. Slower client computers are affected more often because rendering happens in the browser.

This PR keeps the displayed answer updating throughout the stream. In the throttled production test, the median longest freeze fell from **9.86 seconds to 0.34 seconds**.

## Root cause

Streamdown 2.5 puts normal streaming block updates inside a low-priority React transition. New text keeps arriving as higher-priority work, so React can repeatedly interrupt the block update before it reaches the screen.

The network stream is not stalled. The browser has the new text but continues displaying an older render.

## Fix

Use Streamdown's direct-update path for active chat messages through a zero-duration, zero-stagger animation configuration. This bypasses the starved transition without adding a visible animation.

The existing streaming mode, custom code and Mermaid handling, and final completed markup remain unchanged. A regression test protects the direct-update configuration.

## Measured improvement

The production Studio chat page replayed the same 13,919-character answer at 1,400 characters per second with 4x browser CPU throttling. The answer contained 59 rendered KaTeX equations and streamed for about ten seconds.

| Measurement | Before | After |
|---|---:|---:|
| Visible updates during the stream | 1 | 57 to 60 |
| Median longest freeze | 9.86s | 0.34s |
| Longest freeze across all runs | 9.88s | 0.37s |
| Runs with a freeze over 1s | 3 of 3 | 0 of 3 |

A final run after rebuilding the complete diff produced 49 visible updates and a 0.31-second longest freeze.

## Testing

- `npm run typecheck`
- `npm test` (372 passed)
- `npm run build`
- Focused ESLint and Biome checks
- `git diff --check`

This changes only the active chat Markdown renderer. Backend streaming, SSE parsing, and static Markdown previews are unchanged.
