### PR TITLE
fix(studio): proxy hub discovery through backend when browser cannot reach hugging face

### DIFF
--- a/studio/backend/hub/routes/__init__.py
+++ b/studio/backend/hub/routes/__init__.py
@@ -5,10 +5,12 @@
 
 from hub.routes.inventory import router as inventory_router
 from hub.routes.datasets import router as datasets_router
+from hub.routes.hf_proxy import router as hf_proxy_router
 from hub.routes.token import router as token_router
 
 __all__ = [
     "inventory_router",
     "datasets_router",
+    "hf_proxy_router",
     "token_router",
 ]

--- a/studio/backend/hub/routes/hf_proxy.py
+++ b/studio/backend/hub/routes/hf_proxy.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Read-only passthrough to the Hugging Face API for filtered browsers.
+
+Hub discovery normally queries huggingface.co straight from the browser.
+Privacy tooling (DNS filtering, TLS-inspecting firewalls, tracker blockers)
+can block those requests while the backend still has connectivity, and the UI
+then reports "You're offline" even though downloads work. The frontend falls
+back to this endpoint when its direct fetch fails, so discovery uses the same
+network path as downloads.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+from urllib.parse import urlsplit
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+
+from auth.authentication import get_current_subject
+from hub.dependencies import get_hf_token
+
+router = APIRouter()
+
+# read-only discovery hosts; anything else is refused so this endpoint cannot
+# be used as an open proxy.
+ALLOWED_PROXY_HOSTS = frozenset({"huggingface.co", "datasets-server.huggingface.co"})
+
+# response headers the browser client consumes. link carries the pagination
+# cursor for the @huggingface/hub listing iterators.
+FORWARDED_RESPONSE_HEADERS = ("content-type", "link", "etag")
+
+PROXY_TIMEOUT_SECONDS = 30.0
+
+# listing pages are ~100 kib and raw readmes a few mib; anything larger is not
+# a discovery payload and gets refused instead of buffered.
+MAX_PROXY_RESPONSE_BYTES = 20 * 1024 * 1024
+
+
+def validate_proxy_url(raw_url: str) -> str:
+    """Reject anything that is not a plain https url on an allowed hub host."""
+    try:
+        parts = urlsplit(raw_url)
+    except ValueError:
+        raise HTTPException(status_code = 400, detail = "Malformed proxy URL")
+    if parts.scheme != "https":
+        raise HTTPException(status_code = 403, detail = "Only https URLs can be proxied")
+    if parts.hostname not in ALLOWED_PROXY_HOSTS:
+        raise HTTPException(
+            status_code = 403,
+            detail = "Only Hugging Face hub URLs can be proxied",
+        )
+    if parts.port not in (None, 443):
+        raise HTTPException(status_code = 403, detail = "Non-standard ports are not allowed")
+    if parts.username or parts.password:
+        raise HTTPException(status_code = 403, detail = "Credentials in URLs are not allowed")
+    return raw_url
+
+
+def forwarded_response_headers(upstream_headers: httpx.Headers) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for name in FORWARDED_RESPONSE_HEADERS:
+        value = upstream_headers.get(name)
+        if value:
+            headers[name] = value
+    return headers
+
+
+@router.get("/hf-proxy")
+async def proxy_hugging_face_get(
+    url: str = Query(..., max_length = 4096, description = "Absolute Hugging Face URL to fetch"),
+    hf_token: Optional[str] = Depends(get_hf_token),
+    current_subject: str = Depends(get_current_subject),
+):
+    target = validate_proxy_url(url)
+    request_headers = {"Accept": "application/json, text/plain, */*"}
+    if hf_token:
+        request_headers["Authorization"] = f"Bearer {hf_token}"
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects = True,
+            timeout = PROXY_TIMEOUT_SECONDS,
+        ) as client:
+            upstream = await client.get(target, headers = request_headers)
+    except httpx.TimeoutException:
+        raise HTTPException(status_code = 504, detail = "Hugging Face request timed out")
+    except httpx.HTTPError:
+        raise HTTPException(status_code = 502, detail = "Could not reach Hugging Face")
+    if len(upstream.content) > MAX_PROXY_RESPONSE_BYTES:
+        raise HTTPException(status_code = 502, detail = "Upstream response too large to proxy")
+    return Response(
+        content = upstream.content,
+        status_code = upstream.status_code,
+        headers = forwarded_response_headers(upstream.headers),
+    )

--- a/studio/backend/hub/routes/hf_proxy.py
+++ b/studio/backend/hub/routes/hf_proxy.py
@@ -104,9 +104,7 @@ async def proxy_hugging_face_get(
             for _hop in range(MAX_PROXY_REDIRECTS + 1):
                 # stream so the size cap aborts an oversized body (e.g. a resolve/
                 # weights url on an allowed host) instead of buffering it in full.
-                async with client.stream(
-                    "GET", target, headers = request_headers
-                ) as upstream:
+                async with client.stream("GET", target, headers = request_headers) as upstream:
                     if upstream.status_code in (301, 302, 303, 307, 308):
                         location = upstream.headers.get("location")
                         if not location:
@@ -129,9 +127,7 @@ async def proxy_hugging_face_get(
                     response_headers = forwarded_response_headers(upstream.headers)
                     break
             else:
-                raise HTTPException(
-                    status_code = 502, detail = "Too many upstream redirects"
-                )
+                raise HTTPException(status_code = 502, detail = "Too many upstream redirects")
     except httpx.TimeoutException:
         raise HTTPException(status_code = 504, detail = "Hugging Face request timed out")
     except httpx.HTTPError:

--- a/studio/backend/hub/routes/hf_proxy.py
+++ b/studio/backend/hub/routes/hf_proxy.py
@@ -83,15 +83,25 @@ async def proxy_hugging_face_get(
             follow_redirects = True,
             timeout = PROXY_TIMEOUT_SECONDS,
         ) as client:
-            upstream = await client.get(target, headers = request_headers)
+            # stream so the size cap aborts an oversized body (e.g. a resolve/
+            # weights url on an allowed host) instead of buffering it in full.
+            async with client.stream("GET", target, headers = request_headers) as upstream:
+                body = bytearray()
+                async for chunk in upstream.aiter_bytes():
+                    body.extend(chunk)
+                    if len(body) > MAX_PROXY_RESPONSE_BYTES:
+                        raise HTTPException(
+                            status_code = 502,
+                            detail = "Upstream response too large to proxy",
+                        )
+                status_code = upstream.status_code
+                response_headers = forwarded_response_headers(upstream.headers)
     except httpx.TimeoutException:
         raise HTTPException(status_code = 504, detail = "Hugging Face request timed out")
     except httpx.HTTPError:
         raise HTTPException(status_code = 502, detail = "Could not reach Hugging Face")
-    if len(upstream.content) > MAX_PROXY_RESPONSE_BYTES:
-        raise HTTPException(status_code = 502, detail = "Upstream response too large to proxy")
     return Response(
-        content = upstream.content,
-        status_code = upstream.status_code,
-        headers = forwarded_response_headers(upstream.headers),
+        content = bytes(body),
+        status_code = status_code,
+        headers = response_headers,
     )

--- a/studio/backend/hub/routes/hf_proxy.py
+++ b/studio/backend/hub/routes/hf_proxy.py
@@ -32,7 +32,16 @@ ALLOWED_PROXY_HOSTS = frozenset({"huggingface.co", "datasets-server.huggingface.
 # cursor for the @huggingface/hub listing iterators.
 FORWARDED_RESPONSE_HEADERS = ("content-type", "link", "etag")
 
+# Stamped on every response this route produces, so the frontend can tell a hub
+# 404 (missing repo, pass it through) from an older backend that has no such
+# route and answers the SPA catch-all's 404.
+PROXY_MARKER_HEADER = "X-Unsloth-HF-Proxy"
+
 PROXY_TIMEOUT_SECONDS = 30.0
+
+# Redirects are followed by hand so every hop is re-validated; discovery
+# endpoints do not redirect in normal operation.
+MAX_PROXY_REDIRECTS = 5
 
 # listing pages are ~100 kib and raw readmes a few mib; anything larger is not
 # a discovery payload and gets refused instead of buffered.
@@ -43,16 +52,20 @@ def validate_proxy_url(raw_url: str) -> str:
     """Reject anything that is not a plain https url on an allowed hub host."""
     try:
         parts = urlsplit(raw_url)
+        # Both parse lazily and raise ValueError on a malformed authority
+        # ("https://huggingface.co:notaport/"), so read them inside the guard.
+        hostname = parts.hostname
+        port = parts.port
     except ValueError:
         raise HTTPException(status_code = 400, detail = "Malformed proxy URL")
     if parts.scheme != "https":
         raise HTTPException(status_code = 403, detail = "Only https URLs can be proxied")
-    if parts.hostname not in ALLOWED_PROXY_HOSTS:
+    if hostname not in ALLOWED_PROXY_HOSTS:
         raise HTTPException(
             status_code = 403,
             detail = "Only Hugging Face hub URLs can be proxied",
         )
-    if parts.port not in (None, 443):
+    if port not in (None, 443):
         raise HTTPException(status_code = 403, detail = "Non-standard ports are not allowed")
     if parts.username or parts.password:
         raise HTTPException(status_code = 403, detail = "Credentials in URLs are not allowed")
@@ -65,6 +78,7 @@ def forwarded_response_headers(upstream_headers: httpx.Headers) -> dict[str, str
         value = upstream_headers.get(name)
         if value:
             headers[name] = value
+    headers[PROXY_MARKER_HEADER] = "1"
     return headers
 
 
@@ -79,23 +93,45 @@ async def proxy_hugging_face_get(
     if hf_token:
         request_headers["Authorization"] = f"Bearer {hf_token}"
     try:
+        # follow_redirects stays off: it would only ever validate the caller's
+        # own URL, so a 30x off an allowed host could reach loopback or the
+        # link-local metadata endpoint and return that body. Follow by hand and
+        # re-validate each hop, as core/inference/tools.py does.
         async with httpx.AsyncClient(
-            follow_redirects = True,
+            follow_redirects = False,
             timeout = PROXY_TIMEOUT_SECONDS,
         ) as client:
-            # stream so the size cap aborts an oversized body (e.g. a resolve/
-            # weights url on an allowed host) instead of buffering it in full.
-            async with client.stream("GET", target, headers = request_headers) as upstream:
-                body = bytearray()
-                async for chunk in upstream.aiter_bytes():
-                    body.extend(chunk)
-                    if len(body) > MAX_PROXY_RESPONSE_BYTES:
-                        raise HTTPException(
-                            status_code = 502,
-                            detail = "Upstream response too large to proxy",
-                        )
-                status_code = upstream.status_code
-                response_headers = forwarded_response_headers(upstream.headers)
+            for _hop in range(MAX_PROXY_REDIRECTS + 1):
+                # stream so the size cap aborts an oversized body (e.g. a resolve/
+                # weights url on an allowed host) instead of buffering it in full.
+                async with client.stream(
+                    "GET", target, headers = request_headers
+                ) as upstream:
+                    if upstream.status_code in (301, 302, 303, 307, 308):
+                        location = upstream.headers.get("location")
+                        if not location:
+                            raise HTTPException(
+                                status_code = 502,
+                                detail = "Upstream redirect without a location",
+                            )
+                        # relative locations resolve against the current hop
+                        target = validate_proxy_url(str(httpx.URL(target).join(location)))
+                        continue
+                    body = bytearray()
+                    async for chunk in upstream.aiter_bytes():
+                        body.extend(chunk)
+                        if len(body) > MAX_PROXY_RESPONSE_BYTES:
+                            raise HTTPException(
+                                status_code = 502,
+                                detail = "Upstream response too large to proxy",
+                            )
+                    status_code = upstream.status_code
+                    response_headers = forwarded_response_headers(upstream.headers)
+                    break
+            else:
+                raise HTTPException(
+                    status_code = 502, detail = "Too many upstream redirects"
+                )
     except httpx.TimeoutException:
         raise HTTPException(status_code = 504, detail = "Hugging Face request timed out")
     except httpx.HTTPError:

--- a/studio/backend/hub/routes/hf_proxy.py
+++ b/studio/backend/hub/routes/hf_proxy.py
@@ -24,12 +24,11 @@ from hub.dependencies import get_hf_token
 
 router = APIRouter()
 
-# read-only discovery hosts; anything else is refused so this endpoint cannot
-# be used as an open proxy.
+# Read-only discovery hosts; anything else is refused so this cannot be used as
+# an open proxy.
 ALLOWED_PROXY_HOSTS = frozenset({"huggingface.co", "datasets-server.huggingface.co"})
 
-# response headers the browser client consumes. link carries the pagination
-# cursor for the @huggingface/hub listing iterators.
+# link carries the pagination cursor for the @huggingface/hub listing iterators.
 FORWARDED_RESPONSE_HEADERS = ("content-type", "link", "etag")
 
 # Stamped on every response this route produces, so the frontend can tell a hub
@@ -39,12 +38,11 @@ PROXY_MARKER_HEADER = "X-Unsloth-HF-Proxy"
 
 PROXY_TIMEOUT_SECONDS = 30.0
 
-# Redirects are followed by hand so every hop is re-validated; discovery
-# endpoints do not redirect in normal operation.
+# Redirects are followed by hand so every hop is re-validated.
 MAX_PROXY_REDIRECTS = 5
 
-# listing pages are ~100 kib and raw readmes a few mib; anything larger is not
-# a discovery payload and gets refused instead of buffered.
+# Listing pages are ~100 kib and raw readmes a few mib; anything larger is not a
+# discovery payload, so refuse it instead of buffering it.
 MAX_PROXY_RESPONSE_BYTES = 20 * 1024 * 1024
 
 
@@ -93,17 +91,17 @@ async def proxy_hugging_face_get(
     if hf_token:
         request_headers["Authorization"] = f"Bearer {hf_token}"
     try:
-        # follow_redirects stays off: it would only ever validate the caller's
-        # own URL, so a 30x off an allowed host could reach loopback or the
-        # link-local metadata endpoint and return that body. Follow by hand and
-        # re-validate each hop, as core/inference/tools.py does.
+        # follow_redirects stays off: it would validate only the caller's own
+        # URL, so a 30x off an allowed host could reach loopback or the
+        # link-local metadata endpoint. Follow by hand and re-validate each hop,
+        # as core/inference/tools.py does.
         async with httpx.AsyncClient(
             follow_redirects = False,
             timeout = PROXY_TIMEOUT_SECONDS,
         ) as client:
             for _hop in range(MAX_PROXY_REDIRECTS + 1):
-                # stream so the size cap aborts an oversized body (e.g. a resolve/
-                # weights url on an allowed host) instead of buffering it in full.
+                # Stream so the size cap can abort an oversized body (e.g. a
+                # weights URL on an allowed host) instead of buffering it.
                 async with client.stream("GET", target, headers = request_headers) as upstream:
                     if upstream.status_code in (301, 302, 303, 307, 308):
                         location = upstream.headers.get("location")

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -320,6 +320,7 @@ from routes.preview import router as preview_router
 from hub.routes import (
     inventory_router as hub_inventory_router,
     datasets_router as hub_datasets_router,
+    hf_proxy_router as hub_hf_proxy_router,
     token_router as hub_token_router,
 )
 from picker.routes import templates_router as picker_templates_router
@@ -1205,6 +1206,7 @@ app.include_router(hub_inventory_router, prefix = "/api/hub", tags = ["hub"])
 app.include_router(hub_datasets_router, prefix = "/api/hub/datasets", tags = ["hub"])
 app.include_router(picker_templates_router, prefix = "/api/picker", tags = ["picker"])
 app.include_router(hub_token_router, prefix = "/api/hub", tags = ["hub"])
+app.include_router(hub_hf_proxy_router, prefix = "/api/hub", tags = ["hub"])
 
 # Re-wrap client-error responses on the /v1/* surface into OpenAI/Anthropic
 # error envelopes; non-/v1 paths keep FastAPI's default {"detail": ...} shape.

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1168,10 +1168,9 @@ app.add_middleware(
     allow_credentials = True,
     allow_methods = ["*"],
     allow_headers = ["*"],
-    # Link and ETag are not CORS-safelisted, so cross-origin webviews (Tauri)
-    # could not read the pagination cursor from /api/hub/hf-proxy responses.
-    # X-Unsloth-HF-Proxy distinguishes a proxied hub reply from an older
-    # backend's catch-all response.
+    # Link/ETag are not CORS-safelisted, so cross-origin webviews (Tauri) could
+    # not read the /api/hub/hf-proxy pagination cursor. X-Unsloth-HF-Proxy marks
+    # a proxied hub reply apart from an older backend's catch-all response.
     expose_headers = ["Link", "ETag", "X-Unsloth-HF-Proxy"],
 )
 

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1170,7 +1170,9 @@ app.add_middleware(
     allow_headers = ["*"],
     # Link and ETag are not CORS-safelisted, so cross-origin webviews (Tauri)
     # could not read the pagination cursor from /api/hub/hf-proxy responses.
-    expose_headers = ["Link", "ETag"],
+    # X-Unsloth-HF-Proxy distinguishes a proxied hub reply from an older
+    # backend's catch-all response.
+    expose_headers = ["Link", "ETag", "X-Unsloth-HF-Proxy"],
 )
 
 

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1168,6 +1168,9 @@ app.add_middleware(
     allow_credentials = True,
     allow_methods = ["*"],
     allow_headers = ["*"],
+    # Link and ETag are not CORS-safelisted, so cross-origin webviews (Tauri)
+    # could not read the pagination cursor from /api/hub/hf-proxy responses.
+    expose_headers = ["Link", "ETag"],
 )
 
 

--- a/studio/backend/tests/test_hf_proxy_route.py
+++ b/studio/backend/tests/test_hf_proxy_route.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The /api/hub/hf-proxy passthrough exists for browsers whose privacy tooling
+blocks direct fetches to huggingface.co while the backend still has
+connectivity. These tests pin its two safety properties (host allowlist, header
+filtering) and the token/error passthrough behaviour."""
+
+import asyncio
+import sys
+import types
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+# Keep this test runnable without optional logging deps.
+if "structlog" not in sys.modules:
+
+    class _DummyLogger:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: None
+
+    sys.modules["structlog"] = types.SimpleNamespace(
+        BoundLogger = _DummyLogger,
+        get_logger = lambda *args, **kwargs: _DummyLogger(),
+    )
+
+import hub.routes.hf_proxy as hf_proxy
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://huggingface.co/api/models?limit=20",
+        "https://datasets-server.huggingface.co/size?dataset=x",
+    ],
+)
+def test_validate_proxy_url_allows_hub_hosts(url):
+    assert hf_proxy.validate_proxy_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://huggingface.co/api/models",
+        "https://evil.example.com/api/models",
+        "https://huggingface.co.evil.example.com/api/models",
+        "https://huggingface.co:8443/api/models",
+        "https://user:pass@huggingface.co/api/models",
+        "file:///etc/passwd",
+    ],
+)
+def test_validate_proxy_url_rejects_non_hub_urls(url):
+    with pytest.raises(HTTPException) as exc_info:
+        hf_proxy.validate_proxy_url(url)
+    assert exc_info.value.status_code in (400, 403)
+
+
+def test_forwarded_response_headers_keeps_only_client_facing_headers():
+    upstream = httpx.Headers(
+        {
+            "content-type": "application/json",
+            "link": '<https://huggingface.co/api/models?cursor=abc>; rel="next"',
+            "etag": '"deadbeef"',
+            "set-cookie": "session=1",
+            "x-powered-by": "hf",
+        }
+    )
+    forwarded = hf_proxy.forwarded_response_headers(upstream)
+    assert forwarded == {
+        "content-type": "application/json",
+        "link": '<https://huggingface.co/api/models?cursor=abc>; rel="next"',
+        "etag": '"deadbeef"',
+    }
+
+
+class _FakeAsyncClient:
+    """Stands in for httpx.AsyncClient; records the upstream request."""
+
+    last_request = None
+
+    def __init__(self, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def get(self, url, headers = None):
+        _FakeAsyncClient.last_request = (url, headers or {})
+        outcome = _FakeAsyncClient.outcome
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _proxy(url, hf_token = None):
+    return asyncio.run(
+        hf_proxy.proxy_hugging_face_get(
+            url = url,
+            hf_token = hf_token,
+            current_subject = "tester",
+        )
+    )
+
+
+def test_proxy_forwards_hf_token_and_upstream_response(monkeypatch):
+    upstream = types.SimpleNamespace(
+        content = b'{"models": []}',
+        status_code = 200,
+        headers = httpx.Headers({"content-type": "application/json"}),
+    )
+    _FakeAsyncClient.outcome = upstream
+    monkeypatch.setattr(hf_proxy.httpx, "AsyncClient", _FakeAsyncClient)
+
+    response = _proxy("https://huggingface.co/api/models", hf_token = "hf_secret")
+
+    url, headers = _FakeAsyncClient.last_request
+    assert url == "https://huggingface.co/api/models"
+    assert headers["Authorization"] == "Bearer hf_secret"
+    assert response.status_code == 200
+    assert response.body == b'{"models": []}'
+
+
+def test_proxy_passes_through_upstream_error_status(monkeypatch):
+    upstream = types.SimpleNamespace(
+        content = b'{"error": "gated"}',
+        status_code = 401,
+        headers = httpx.Headers({"content-type": "application/json"}),
+    )
+    _FakeAsyncClient.outcome = upstream
+    monkeypatch.setattr(hf_proxy.httpx, "AsyncClient", _FakeAsyncClient)
+
+    response = _proxy("https://huggingface.co/api/models")
+
+    _url, headers = _FakeAsyncClient.last_request
+    assert "Authorization" not in headers
+    assert response.status_code == 401
+
+
+def test_proxy_maps_timeout_to_504(monkeypatch):
+    _FakeAsyncClient.outcome = httpx.ConnectTimeout("timed out")
+    monkeypatch.setattr(hf_proxy.httpx, "AsyncClient", _FakeAsyncClient)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _proxy("https://huggingface.co/api/models")
+    assert exc_info.value.status_code == 504
+
+
+def test_proxy_maps_connection_failure_to_502(monkeypatch):
+    _FakeAsyncClient.outcome = httpx.ConnectError("no route")
+    monkeypatch.setattr(hf_proxy.httpx, "AsyncClient", _FakeAsyncClient)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _proxy("https://huggingface.co/api/models")
+    assert exc_info.value.status_code == 502

--- a/studio/backend/tests/test_hf_proxy_route.py
+++ b/studio/backend/tests/test_hf_proxy_route.py
@@ -89,7 +89,11 @@ class _FakeAsyncClient:
     async def __aexit__(self, *exc_info):
         return False
 
-    async def get(self, url, headers = None):
+    async def get(
+        self,
+        url,
+        headers = None,
+    ):
         _FakeAsyncClient.last_request = (url, headers or {})
         outcome = _FakeAsyncClient.outcome
         if isinstance(outcome, Exception):

--- a/studio/backend/tests/test_hf_proxy_route.py
+++ b/studio/backend/tests/test_hf_proxy_route.py
@@ -234,7 +234,12 @@ class _RedirectingClient:
     async def __aexit__(self, *exc_info):
         return False
 
-    def stream(self, method, url, headers = None):
+    def stream(
+        self,
+        method,
+        url,
+        headers = None,
+    ):
         _RedirectingClient.seen.append(url)
         outcome = _RedirectingClient.hops.pop(0)
         if isinstance(outcome, str):

--- a/studio/backend/tests/test_hf_proxy_route.py
+++ b/studio/backend/tests/test_hf_proxy_route.py
@@ -75,6 +75,32 @@ def test_forwarded_response_headers_keeps_only_client_facing_headers():
     }
 
 
+class _FakeStream:
+    """Async context manager mimicking httpx's streaming response."""
+
+    def __init__(self, upstream):
+        self._upstream = upstream
+
+    async def __aenter__(self):
+        return self._upstream
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class _FakeUpstream:
+    def __init__(self, content, status_code, headers):
+        self._content = content
+        self.status_code = status_code
+        self.headers = headers
+
+    async def aiter_bytes(self):
+        # two chunks so the size cap is exercised mid-stream, not only at the end
+        half = max(1, len(self._content) // 2)
+        for start in range(0, len(self._content), half):
+            yield self._content[start : start + half]
+
+
 class _FakeAsyncClient:
     """Stands in for httpx.AsyncClient; records the upstream request."""
 
@@ -89,16 +115,20 @@ class _FakeAsyncClient:
     async def __aexit__(self, *exc_info):
         return False
 
-    async def get(
-        self,
-        url,
-        headers = None,
-    ):
+    def stream(self, method, url, headers = None):
         _FakeAsyncClient.last_request = (url, headers or {})
         outcome = _FakeAsyncClient.outcome
         if isinstance(outcome, Exception):
-            raise outcome
-        return outcome
+
+            class _RaisingStream:
+                async def __aenter__(self):
+                    raise outcome
+
+                async def __aexit__(self, *exc_info):
+                    return False
+
+            return _RaisingStream()
+        return _FakeStream(outcome)
 
 
 def _proxy(url, hf_token = None):
@@ -112,7 +142,7 @@ def _proxy(url, hf_token = None):
 
 
 def test_proxy_forwards_hf_token_and_upstream_response(monkeypatch):
-    upstream = types.SimpleNamespace(
+    upstream = _FakeUpstream(
         content = b'{"models": []}',
         status_code = 200,
         headers = httpx.Headers({"content-type": "application/json"}),
@@ -130,7 +160,7 @@ def test_proxy_forwards_hf_token_and_upstream_response(monkeypatch):
 
 
 def test_proxy_passes_through_upstream_error_status(monkeypatch):
-    upstream = types.SimpleNamespace(
+    upstream = _FakeUpstream(
         content = b'{"error": "gated"}',
         status_code = 401,
         headers = httpx.Headers({"content-type": "application/json"}),
@@ -143,6 +173,20 @@ def test_proxy_passes_through_upstream_error_status(monkeypatch):
     _url, headers = _FakeAsyncClient.last_request
     assert "Authorization" not in headers
     assert response.status_code == 401
+
+
+def test_proxy_rejects_oversized_body_mid_stream(monkeypatch):
+    upstream = _FakeUpstream(
+        content = b"x" * (hf_proxy.MAX_PROXY_RESPONSE_BYTES + 1),
+        status_code = 200,
+        headers = httpx.Headers({"content-type": "application/octet-stream"}),
+    )
+    _FakeAsyncClient.outcome = upstream
+    monkeypatch.setattr(hf_proxy.httpx, "AsyncClient", _FakeAsyncClient)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _proxy("https://huggingface.co/api/models")
+    assert exc_info.value.status_code == 502
 
 
 def test_proxy_maps_timeout_to_504(monkeypatch):

--- a/studio/backend/tests/test_hf_proxy_route.py
+++ b/studio/backend/tests/test_hf_proxy_route.py
@@ -115,7 +115,12 @@ class _FakeAsyncClient:
     async def __aexit__(self, *exc_info):
         return False
 
-    def stream(self, method, url, headers = None):
+    def stream(
+        self,
+        method,
+        url,
+        headers = None,
+    ):
         _FakeAsyncClient.last_request = (url, headers or {})
         outcome = _FakeAsyncClient.outcome
         if isinstance(outcome, Exception):

--- a/studio/backend/tests/test_hf_proxy_route.py
+++ b/studio/backend/tests/test_hf_proxy_route.py
@@ -72,6 +72,9 @@ def test_forwarded_response_headers_keeps_only_client_facing_headers():
         "content-type": "application/json",
         "link": '<https://huggingface.co/api/models?cursor=abc>; rel="next"',
         "etag": '"deadbeef"',
+        # Stamped on every response this route produces so the frontend can
+        # tell a proxied hub reply from an older backend's catch-all 404.
+        hf_proxy.PROXY_MARKER_HEADER: "1",
     }
 
 
@@ -210,3 +213,156 @@ def test_proxy_maps_connection_failure_to_502(monkeypatch):
     with pytest.raises(HTTPException) as exc_info:
         _proxy("https://huggingface.co/api/models")
     assert exc_info.value.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# Redirects are followed manually so the host allowlist applies to every hop.
+# follow_redirects=True would only ever have validated the caller's own URL.
+# ---------------------------------------------------------------------------
+class _RedirectingClient:
+    """Real redirect semantics against a scripted set of hops."""
+
+    hops: list = []
+    seen: list = []
+
+    def __init__(self, **kwargs):
+        _RedirectingClient.init_kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    def stream(self, method, url, headers = None):
+        _RedirectingClient.seen.append(url)
+        outcome = _RedirectingClient.hops.pop(0)
+        if isinstance(outcome, str):
+
+            class _Redirect:
+                status_code = 302
+                headers = httpx.Headers({"location": outcome})
+
+                async def __aenter__(self_inner):
+                    return self_inner
+
+                async def __aexit__(self_inner, *exc_info):
+                    return False
+
+                async def aiter_bytes(self_inner):
+                    if False:
+                        yield b""
+
+            return _Redirect()
+        return _FakeStream(outcome)
+
+
+def _install_redirect_client(monkeypatch, hops):
+    _RedirectingClient.hops = list(hops)
+    _RedirectingClient.seen = []
+    monkeypatch.setattr(hf_proxy.httpx, "AsyncClient", _RedirectingClient)
+
+
+def test_redirects_are_not_followed_automatically(monkeypatch):
+    """The client must be constructed with redirect following disabled."""
+    _install_redirect_client(
+        monkeypatch,
+        [_FakeUpstream(b"{}", 200, httpx.Headers({}))],
+    )
+    _proxy("https://huggingface.co/api/models")
+    assert _RedirectingClient.init_kwargs["follow_redirects"] is False
+
+
+def test_redirect_to_disallowed_host_is_refused(monkeypatch):
+    """A 302 off the allowlist must be rejected, not followed.
+
+    Without per-hop validation this reached loopback and the link-local
+    metadata address, and returned that body to the authenticated caller.
+    """
+    _install_redirect_client(monkeypatch, ["http://127.0.0.1:9/internal"])
+    with pytest.raises(HTTPException) as exc_info:
+        _proxy("https://huggingface.co/api/models")
+    assert exc_info.value.status_code == 403
+    assert _RedirectingClient.seen == ["https://huggingface.co/api/models"]
+
+
+def test_redirect_to_link_local_metadata_is_refused(monkeypatch):
+    _install_redirect_client(monkeypatch, ["http://169.254.169.254/latest/meta-data/"])
+    with pytest.raises(HTTPException) as exc_info:
+        _proxy("https://huggingface.co/api/models")
+    assert exc_info.value.status_code == 403
+
+
+def test_redirect_within_the_allowlist_is_followed(monkeypatch):
+    """Legitimate same-allowlist redirects still work, including relative ones."""
+    _install_redirect_client(
+        monkeypatch,
+        [
+            "/api/models?limit=20",
+            _FakeUpstream(
+                b'{"ok":true}',
+                200,
+                httpx.Headers({"content-type": "application/json"}),
+            ),
+        ],
+    )
+    response = _proxy("https://huggingface.co/api/models")
+    assert response.status_code == 200
+    assert _RedirectingClient.seen == [
+        "https://huggingface.co/api/models",
+        "https://huggingface.co/api/models?limit=20",
+    ]
+
+
+def test_redirect_loop_is_bounded(monkeypatch):
+    _install_redirect_client(
+        monkeypatch,
+        ["https://huggingface.co/api/models"] * (hf_proxy.MAX_PROXY_REDIRECTS + 1),
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        _proxy("https://huggingface.co/api/models")
+    assert exc_info.value.status_code == 502
+    assert "redirect" in exc_info.value.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# Malformed authorities must produce a client error, not an unhandled 500.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://huggingface.co:notaport/api/models",
+        "https://huggingface.co:99999/api/models",
+        "https://[oops/api/models",
+    ],
+)
+def test_malformed_authority_is_a_client_error(url):
+    with pytest.raises(HTTPException) as exc_info:
+        hf_proxy.validate_proxy_url(url)
+    assert exc_info.value.status_code in (400, 403)
+
+
+def test_proxy_responses_carry_the_marker_header(monkeypatch):
+    upstream = _FakeUpstream(
+        b'{"ok":true}', 200, httpx.Headers({"content-type": "application/json"})
+    )
+    _FakeAsyncClient.outcome = upstream
+    monkeypatch.setattr(hf_proxy.httpx, "AsyncClient", _FakeAsyncClient)
+
+    response = _proxy("https://huggingface.co/api/models")
+    assert response.headers.get(hf_proxy.PROXY_MARKER_HEADER) == "1"
+
+
+def test_upstream_404_still_passes_through_with_the_marker(monkeypatch):
+    """A genuine hub 404 (missing repo) must reach the caller unchanged.
+
+    This is why the marker header exists rather than a status allowlist: the
+    frontend has to distinguish this from an older backend's catch-all 404.
+    """
+    upstream = _FakeUpstream(b'{"error":"Repo not found"}', 404, httpx.Headers({}))
+    _FakeAsyncClient.outcome = upstream
+    monkeypatch.setattr(hf_proxy.httpx, "AsyncClient", _FakeAsyncClient)
+
+    response = _proxy("https://huggingface.co/api/models/nope")
+    assert response.status_code == 404
+    assert response.headers.get(hf_proxy.PROXY_MARKER_HEADER) == "1"

--- a/studio/backend/tests/test_hf_proxy_route.py
+++ b/studio/backend/tests/test_hf_proxy_route.py
@@ -72,8 +72,6 @@ def test_forwarded_response_headers_keeps_only_client_facing_headers():
         "content-type": "application/json",
         "link": '<https://huggingface.co/api/models?cursor=abc>; rel="next"',
         "etag": '"deadbeef"',
-        # Stamped on every response this route produces so the frontend can
-        # tell a proxied hub reply from an older backend's catch-all 404.
         hf_proxy.PROXY_MARKER_HEADER: "1",
     }
 
@@ -98,7 +96,7 @@ class _FakeUpstream:
         self.headers = headers
 
     async def aiter_bytes(self):
-        # two chunks so the size cap is exercised mid-stream, not only at the end
+        # Two chunks, so the size cap is exercised mid-stream.
         half = max(1, len(self._content) // 2)
         for start in range(0, len(self._content), half):
             yield self._content[start : start + half]
@@ -215,10 +213,8 @@ def test_proxy_maps_connection_failure_to_502(monkeypatch):
     assert exc_info.value.status_code == 502
 
 
-# ---------------------------------------------------------------------------
-# Redirects are followed manually so the host allowlist applies to every hop.
-# follow_redirects=True would only ever have validated the caller's own URL.
-# ---------------------------------------------------------------------------
+# Redirects are followed manually so the allowlist applies to every hop;
+# follow_redirects=True would validate only the caller's own URL.
 class _RedirectingClient:
     """Real redirect semantics against a scripted set of hops."""
 
@@ -330,9 +326,7 @@ def test_redirect_loop_is_bounded(monkeypatch):
     assert "redirect" in exc_info.value.detail.lower()
 
 
-# ---------------------------------------------------------------------------
 # Malformed authorities must produce a client error, not an unhandled 500.
-# ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "url",
     [

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -207,9 +207,8 @@ export async function authFetch(
     return response;
   }
   // A 401 stamped by the hf-proxy route is Hugging Face's own (private or
-  // missing repo, which the hub answers 401 for), not a dead Studio session.
-  // Refreshing on it would rotate the session token per lookup, and a failed
-  // refresh would sign the user out because a model was private.
+  // missing repo), not a dead Studio session. Refreshing on it would rotate the
+  // session token per lookup and sign the user out if the refresh failed.
   if (response.headers.get(HUB_PROXY_MARKER_HEADER) !== null) return response;
   if (response.status !== 401) return response;
 

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { HUB_PROXY_MARKER_HEADER } from "@/features/hub/lib/hub-token-header";
 import { apiUrl, isTauri } from "@/lib/api-base";
 import {
   clearAuthTokens,
@@ -205,6 +206,11 @@ export async function authFetch(
     void redirectToAuth();
     return response;
   }
+  // A 401 stamped by the hf-proxy route is Hugging Face's own (private or
+  // missing repo, which the hub answers 401 for), not a dead Studio session.
+  // Refreshing on it would rotate the session token per lookup, and a failed
+  // refresh would sign the user out because a model was private.
+  if (response.headers.get(HUB_PROXY_MARKER_HEADER) !== null) return response;
   if (response.status !== 401) return response;
 
   const refreshToken = getRefreshToken();

--- a/studio/frontend/src/features/hub/index.ts
+++ b/studio/frontend/src/features/hub/index.ts
@@ -40,6 +40,7 @@ export {
 export { useInventoryVersion } from "./stores/inventory-events";
 export { looksLikeLocalPath } from "./lib/local-path";
 export { hubTokenHeader } from "./lib/hub-token-header";
+export { setHubProxyAuthFetch } from "./lib/network";
 export {
   ggufVariantsMatch,
   isOllamaLinkPath,
@@ -59,4 +60,7 @@ export { DotTag } from "./catalog/dot-tag";
 export { TransportConflictDialog } from "./catalog/transport-conflict-dialog";
 export { TrainIcon } from "./components/train-icon";
 export { isHiddenModelId } from "./lib/hidden-models";
-export { classifyUnslothSupport, studioPageForTask } from "./lib/unsloth-support";
+export {
+  classifyUnslothSupport,
+  studioPageForTask,
+} from "./lib/unsloth-support";

--- a/studio/frontend/src/features/hub/lib/hf-cache.ts
+++ b/studio/frontend/src/features/hub/lib/hf-cache.ts
@@ -7,10 +7,9 @@ import { LruMap } from "./lru-map";
 import { fetchWithTimeout } from "./network";
 import { fingerprintToken } from "./token-fingerprint";
 
-// Every modelInfo call funnels through here, so this is where the wrapped
-// fetch belongs. Without it @huggingface/hub uses the global fetch and skips
-// both the timeout and the hf-proxy fallback. Callers passing their own
-// `fetch` (the search hooks, which thread an AbortSignal) still win.
+// Without this @huggingface/hub uses the global fetch and skips both the
+// timeout and the hf-proxy fallback. Callers passing their own `fetch` (the
+// search hooks, which thread an AbortSignal) still win.
 const MODEL_INFO_TIMEOUT_MS = 15_000;
 
 const hubFetch: typeof fetch = (input, init) =>

--- a/studio/frontend/src/features/hub/lib/hf-cache.ts
+++ b/studio/frontend/src/features/hub/lib/hf-cache.ts
@@ -4,7 +4,17 @@
 import { type ModelEntry, modelInfo } from "@huggingface/hub";
 
 import { LruMap } from "./lru-map";
+import { fetchWithTimeout } from "./network";
 import { fingerprintToken } from "./token-fingerprint";
+
+// Every modelInfo call funnels through here, so this is where the wrapped
+// fetch belongs. Without it @huggingface/hub uses the global fetch and skips
+// both the timeout and the hf-proxy fallback. Callers passing their own
+// `fetch` (the search hooks, which thread an AbortSignal) still win.
+const MODEL_INFO_TIMEOUT_MS = 15_000;
+
+const hubFetch: typeof fetch = (input, init) =>
+  fetchWithTimeout(input, init, MODEL_INFO_TIMEOUT_MS);
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX_ENTRIES = 256;
@@ -114,6 +124,7 @@ export async function cachedModelInfo(
         ]),
       );
       const result = await modelInfo({
+        fetch: hubFetch,
         ...params,
         additionalFields,
       });

--- a/studio/frontend/src/features/hub/lib/hub-token-header.ts
+++ b/studio/frontend/src/features/hub/lib/hub-token-header.ts
@@ -6,8 +6,8 @@
 export const HUB_HF_TOKEN_HEADER = "X-Unsloth-HF-Token";
 
 // Set by the hf-proxy route on responses it produced, so a hub status passed
-// through it is not confused with one from the Studio API itself. Lives in this
-// leaf module because both the hub and auth features read it.
+// through it is not confused with one from the Studio API itself. Lives here
+// because both the hub and auth features read it.
 export const HUB_PROXY_MARKER_HEADER = "X-Unsloth-HF-Proxy";
 
 export function hubTokenHeader(

--- a/studio/frontend/src/features/hub/lib/hub-token-header.ts
+++ b/studio/frontend/src/features/hub/lib/hub-token-header.ts
@@ -5,6 +5,11 @@
 
 export const HUB_HF_TOKEN_HEADER = "X-Unsloth-HF-Token";
 
+// Set by the hf-proxy route on responses it produced, so a hub status passed
+// through it is not confused with one from the Studio API itself. Lives in this
+// leaf module because both the hub and auth features read it.
+export const HUB_PROXY_MARKER_HEADER = "X-Unsloth-HF-Proxy";
+
 export function hubTokenHeader(
   token?: string | null,
 ): Record<string, string> {

--- a/studio/frontend/src/features/hub/lib/network.ts
+++ b/studio/frontend/src/features/hub/lib/network.ts
@@ -2,7 +2,10 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { apiUrl } from "@/lib/api-base";
-import { HUB_HF_TOKEN_HEADER } from "./hub-token-header";
+import {
+  HUB_HF_TOKEN_HEADER,
+  HUB_PROXY_MARKER_HEADER,
+} from "./hub-token-header";
 
 // AUTH_TOKEN_KEY from features/auth/session, read directly from localStorage
 // so this network-layer module stays importable without the auth/store stack.
@@ -216,11 +219,6 @@ const PROXYABLE_ORIGINS: ReadonlySet<string> = new Set([
 // page doesn't pay for a doomed direct attempt plus its timeout.
 const PROXY_PREFER_TTL_MS = 10 * 60_000;
 
-// Set by the hf-proxy route on its own responses. Anything without it came
-// from elsewhere (an older backend's SPA catch-all 404, or an auth rejection)
-// and must not be mistaken for a Hugging Face reply.
-const PROXY_MARKER_HEADER = "X-Unsloth-HF-Proxy";
-
 // Per origin: a datasets-server failure says nothing about huggingface.co.
 const preferProxyUntilByOrigin = new Map<string, number>();
 
@@ -259,7 +257,7 @@ function isUsableProxyResponse(response: Response): boolean {
   if (response.status === 502 || response.status === 504) {
     return false;
   }
-  return response.headers.get(PROXY_MARKER_HEADER) !== null;
+  return response.headers.get(HUB_PROXY_MARKER_HEADER) !== null;
 }
 
 function isProxyableRequest(

--- a/studio/frontend/src/features/hub/lib/network.ts
+++ b/studio/frontend/src/features/hub/lib/network.ts
@@ -246,17 +246,13 @@ export function setHubProxyAuthFetch(fetchImpl: ProxyAuthFetch | null): void {
 }
 
 /**
- * Did this carry a real Hugging Face reply? False when the passthrough could
- * not reach the hub (502/504), or when the response never reached the route at
- * all (older backend's catch-all 404, auth 401/403).
- *
- * Status alone cannot decide it: the hub itself returns 404 for a missing repo
- * and 401/403 for a gated one, and those must pass through. Hence the marker.
+ * Did this carry a hub reply? Only the marker can say. Status cannot: the hub
+ * itself answers 404 for a missing repo, 401/403 for a gated one and 5xx during
+ * an outage, and all of those must reach the caller. Everything the route did
+ * not produce is unmarked, including its own 502/504 when the hub is
+ * unreachable and an older backend's catch-all 404.
  */
 function isUsableProxyResponse(response: Response): boolean {
-  if (response.status === 502 || response.status === 504) {
-    return false;
-  }
   return response.headers.get(HUB_PROXY_MARKER_HEADER) !== null;
 }
 

--- a/studio/frontend/src/features/hub/lib/network.ts
+++ b/studio/frontend/src/features/hub/lib/network.ts
@@ -216,10 +216,20 @@ const PROXYABLE_ORIGINS: ReadonlySet<string> = new Set([
 // page doesn't pay for a doomed direct attempt plus its timeout.
 const PROXY_PREFER_TTL_MS = 10 * 60_000;
 
-let preferProxyUntil = 0;
+// Set by the hf-proxy route on its own responses. Anything without it came
+// from elsewhere (an older backend's SPA catch-all 404, or an auth rejection)
+// and must not be mistaken for a Hugging Face reply.
+const PROXY_MARKER_HEADER = "X-Unsloth-HF-Proxy";
+
+// Per origin: a datasets-server failure says nothing about huggingface.co.
+const preferProxyUntilByOrigin = new Map<string, number>();
 
 export function __resetHfProxyPreferenceForTests(): void {
-  preferProxyUntil = 0;
+  preferProxyUntilByOrigin.clear();
+}
+
+function prefersProxy(origin: string): boolean {
+  return (preferProxyUntilByOrigin.get(origin) ?? 0) > Date.now();
 }
 
 type ProxyAuthFetch = (
@@ -237,11 +247,19 @@ export function setHubProxyAuthFetch(fetchImpl: ProxyAuthFetch | null): void {
   proxyAuthFetch = fetchImpl;
 }
 
-// Statuses the backend passthrough emits when it could not reach Hugging Face
-// itself (502 upstream failure, 504 upstream timeout). Such a response means
-// the fallback failed too, not that the hub is reachable.
-function isProxyGatewayError(response: Response): boolean {
-  return response.status === 502 || response.status === 504;
+/**
+ * Did this carry a real Hugging Face reply? False when the passthrough could
+ * not reach the hub (502/504), or when the response never reached the route at
+ * all (older backend's catch-all 404, auth 401/403).
+ *
+ * Status alone cannot decide it: the hub itself returns 404 for a missing repo
+ * and 401/403 for a gated one, and those must pass through. Hence the marker.
+ */
+function isUsableProxyResponse(response: Response): boolean {
+  if (response.status === 502 || response.status === 504) {
+    return false;
+  }
+  return response.headers.get(PROXY_MARKER_HEADER) !== null;
 }
 
 function isProxyableRequest(
@@ -309,22 +327,27 @@ export async function fetchWithTimeout(
     PROXYABLE_ORIGINS.has(origin) &&
     isProxyableRequest(input, init);
 
-  if (canProxy && preferProxyUntil > Date.now()) {
+  // One proxy attempt per call, whichever branch spends it; otherwise a
+  // proxy-first call can run proxy -> direct -> proxy and burn 3x the timeout.
+  let proxyAttempted = false;
+
+  if (canProxy && prefersProxy(origin)) {
+    proxyAttempted = true;
     try {
       const response = await fetchViaBackendProxy(input, init, timeoutMs);
-      if (!isProxyGatewayError(response)) {
+      if (isUsableProxyResponse(response)) {
         markRemoteNetworkOnline(origin);
         return response;
       }
-      // the backend could not reach hugging face either; retry direct below.
-      preferProxyUntil = 0;
+      // unreachable hub, or no hf-proxy route here; retry direct below.
+      preferProxyUntilByOrigin.delete(origin);
     } catch (error) {
       if (init.signal?.aborted) {
         throw error;
       }
       // proxy stopped working; retry direct below and re-arm only on a
       // successful future fallback.
-      preferProxyUntil = 0;
+      preferProxyUntilByOrigin.delete(origin);
     }
   }
 
@@ -336,17 +359,21 @@ export async function fetchWithTimeout(
     return response;
   } catch (error) {
     const timedOut = error instanceof RequestTimeoutError;
-    if (canProxy && (timedOut || isNetworkFetchError(error))) {
+    if (canProxy && !proxyAttempted && (timedOut || isNetworkFetchError(error))) {
       try {
         const response = await fetchViaBackendProxy(input, init, timeoutMs);
-        if (!isProxyGatewayError(response)) {
-          preferProxyUntil = Date.now() + PROXY_PREFER_TTL_MS;
+        if (isUsableProxyResponse(response)) {
+          preferProxyUntilByOrigin.set(origin, Date.now() + PROXY_PREFER_TTL_MS);
           markRemoteNetworkOnline(origin);
           return response;
         }
-        // gateway error: the backend could not reach hugging face either, so
-        // fall through and report the direct failure as usual.
-      } catch {
+        // fallback unavailable or hub unreachable: report the direct failure.
+      } catch (proxyError) {
+        // A caller abort must surface as an abort and must not mark the hub
+        // offline; same guard as the proxy-first branch.
+        if (init.signal?.aborted) {
+          throw proxyError;
+        }
         // both paths failed; report the direct failure below.
       }
     }

--- a/studio/frontend/src/features/hub/lib/network.ts
+++ b/studio/frontend/src/features/hub/lib/network.ts
@@ -207,16 +207,15 @@ async function runFetchWithTimeout(
 
 // Browser-level privacy tooling (DNS filtering, TLS-inspecting firewalls,
 // tracker blockers) can block direct fetches to huggingface.co while the
-// backend still has connectivity. When a direct hub fetch fails, retry it
-// through the backend's read-only /api/hub/hf-proxy passthrough before
-// declaring the hub offline.
+// backend still has connectivity, so a failed direct hub fetch is retried
+// through the backend passthrough before the hub is declared offline.
 const HF_PROXY_PATH = "/api/hub/hf-proxy";
 const PROXYABLE_ORIGINS: ReadonlySet<string> = new Set([
   HUGGING_FACE_ORIGIN,
   "https://datasets-server.huggingface.co",
 ]);
-// After a successful fallback, go proxy-first for a while so every listing
-// page doesn't pay for a doomed direct attempt plus its timeout.
+// After a successful fallback, go proxy-first for a while so every listing page
+// does not pay for a doomed direct attempt plus its timeout.
 const PROXY_PREFER_TTL_MS = 10 * 60_000;
 
 // Per origin: a datasets-server failure says nothing about huggingface.co.
@@ -235,10 +234,9 @@ type ProxyAuthFetch = (
   init?: RequestInit,
 ) => Promise<Response>;
 
-// The session-aware fetch (authFetch) lives in the auth feature, whose module
-// graph this network-layer leaf must not import. The app entry registers it at
-// startup so proxied requests get 401-refresh-retry handling; unregistered
-// (tests, early calls) the fallback sends the stored session token directly.
+// authFetch lives in the auth feature, whose module graph this network leaf
+// must not import, so the app entry registers it at startup for 401-refresh
+// retries. Unregistered (tests, early calls) we send the stored token directly.
 let proxyAuthFetch: ProxyAuthFetch | null = null;
 
 export function setHubProxyAuthFetch(fetchImpl: ProxyAuthFetch | null): void {
@@ -246,11 +244,10 @@ export function setHubProxyAuthFetch(fetchImpl: ProxyAuthFetch | null): void {
 }
 
 /**
- * Did this carry a hub reply? Only the marker can say. Status cannot: the hub
- * itself answers 404 for a missing repo, 401/403 for a gated one and 5xx during
- * an outage, and all of those must reach the caller. Everything the route did
- * not produce is unmarked, including its own 502/504 when the hub is
- * unreachable and an older backend's catch-all 404.
+ * Only the marker says a hub reply came through; status cannot, since the hub
+ * itself answers 404 (missing repo), 401/403 (gated) and 5xx (outage) and all
+ * of those must reach the caller. Unmarked covers the route's own 502/504 and
+ * an older backend's catch-all 404.
  */
 function isUsableProxyResponse(response: Response): boolean {
   return response.headers.get(HUB_PROXY_MARKER_HEADER) !== null;
@@ -268,9 +265,9 @@ function isProxyableRequest(
 }
 
 /**
- * Re-issue a Hugging Face request through the backend passthrough. The HF
- * bearer token (if any) moves to the internal token header; Authorization is
- * replaced with the studio session token the backend routes require.
+ * Re-issue a Hugging Face request through the backend passthrough. Any HF
+ * bearer token moves to the internal token header, since Authorization must
+ * carry the studio session token the backend routes require.
  */
 function fetchViaBackendProxy(
   input: Parameters<typeof fetch>[0],
@@ -322,7 +319,7 @@ export async function fetchWithTimeout(
     isProxyableRequest(input, init);
 
   // One proxy attempt per call, whichever branch spends it; otherwise a
-  // proxy-first call can run proxy -> direct -> proxy and burn 3x the timeout.
+  // proxy-first call runs proxy -> direct -> proxy and burns 3x the timeout.
   let proxyAttempted = false;
 
   if (canProxy && prefersProxy(origin)) {
@@ -333,14 +330,13 @@ export async function fetchWithTimeout(
         markRemoteNetworkOnline(origin);
         return response;
       }
-      // unreachable hub, or no hf-proxy route here; retry direct below.
+      // Unreachable hub, or no hf-proxy route here; retry direct below.
       preferProxyUntilByOrigin.delete(origin);
     } catch (error) {
       if (init.signal?.aborted) {
         throw error;
       }
-      // proxy stopped working; retry direct below and re-arm only on a
-      // successful future fallback.
+      // Proxy stopped working; retry direct and re-arm only on a later success.
       preferProxyUntilByOrigin.delete(origin);
     }
   }
@@ -361,14 +357,13 @@ export async function fetchWithTimeout(
           markRemoteNetworkOnline(origin);
           return response;
         }
-        // fallback unavailable or hub unreachable: report the direct failure.
+        // Fallback unavailable or hub unreachable: report the direct failure.
       } catch (proxyError) {
-        // A caller abort must surface as an abort and must not mark the hub
-        // offline; same guard as the proxy-first branch.
+        // A caller abort must surface as an abort, not as the hub going offline.
         if (init.signal?.aborted) {
           throw proxyError;
         }
-        // both paths failed; report the direct failure below.
+        // Both paths failed; report the direct failure below.
       }
     }
     if (timedOut) {

--- a/studio/frontend/src/features/hub/lib/network.ts
+++ b/studio/frontend/src/features/hub/lib/network.ts
@@ -1,6 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { apiUrl } from "@/lib/api-base";
+import { HUB_HF_TOKEN_HEADER } from "./hub-token-header";
+
+// AUTH_TOKEN_KEY from features/auth/session, read directly from localStorage
+// so this network-layer module stays importable without the auth/store stack.
+const AUTH_TOKEN_STORAGE_KEY = "unsloth_auth_token";
+
+function getSessionToken(): string | null {
+  if (typeof localStorage === "undefined") {
+    return null;
+  }
+  return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+}
+
 export function isBrowserOffline(): boolean {
   return isNavigatorOffline();
 }
@@ -126,30 +140,40 @@ function isNetworkFetchError(error: unknown): boolean {
   return error instanceof TypeError;
 }
 
+function rawUrlFromFetchInput(input: Parameters<typeof fetch>[0]): string {
+  return typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+}
+
 function originFromFetchInput(
   input: Parameters<typeof fetch>[0],
 ): string | null {
   try {
-    const raw =
-      typeof input === "string"
-        ? input
-        : input instanceof URL
-          ? input.toString()
-          : input.url;
     const base =
       typeof window !== "undefined" ? window.location.href : "http://localhost";
-    return new URL(raw, base).origin;
+    return new URL(rawUrlFromFetchInput(input), base).origin;
   } catch {
     return null;
   }
 }
 
-export async function fetchWithTimeout(
+class RequestTimeoutError extends Error {
+  constructor() {
+    super("Request timed out");
+    this.name = "RequestTimeoutError";
+  }
+}
+
+/** Timeout/abort wiring shared by the direct and proxied fetch paths. */
+async function runFetchWithTimeout(
   input: Parameters<typeof fetch>[0],
-  init: Parameters<typeof fetch>[1] = {},
-  timeoutMs = 15_000,
+  init: Parameters<typeof fetch>[1],
+  timeoutMs: number,
 ): Promise<Response> {
-  const parentSignal = init.signal;
+  const parentSignal = init?.signal;
   const controller = new AbortController();
   let timedOut = false;
   const timeout = setTimeout(() => {
@@ -164,24 +188,134 @@ export async function fetchWithTimeout(
     parentSignal?.addEventListener("abort", abortFromParent, { once: true });
   }
 
-  const origin = originFromFetchInput(input);
-
   try {
-    const response = await fetch(input, { ...init, signal: controller.signal });
-    if (origin) {
-      markRemoteNetworkOnline(origin);
-    }
-    return response;
+    return await fetch(input, { ...init, signal: controller.signal });
   } catch (error) {
     if (timedOut) {
-      throw new Error("Request timed out");
-    }
-    if (origin && isNetworkFetchError(error)) {
-      markRemoteNetworkOffline(origin);
+      throw new RequestTimeoutError();
     }
     throw error;
   } finally {
     clearTimeout(timeout);
     parentSignal?.removeEventListener("abort", abortFromParent);
+  }
+}
+
+// Browser-level privacy tooling (DNS filtering, TLS-inspecting firewalls,
+// tracker blockers) can block direct fetches to huggingface.co while the
+// backend still has connectivity. When a direct hub fetch fails, retry it
+// through the backend's read-only /api/hub/hf-proxy passthrough before
+// declaring the hub offline.
+const HF_PROXY_PATH = "/api/hub/hf-proxy";
+const PROXYABLE_ORIGINS: ReadonlySet<string> = new Set([
+  HUGGING_FACE_ORIGIN,
+  "https://datasets-server.huggingface.co",
+]);
+// After a successful fallback, go proxy-first for a while so every listing
+// page doesn't pay for a doomed direct attempt plus its timeout.
+const PROXY_PREFER_TTL_MS = 10 * 60_000;
+
+let preferProxyUntil = 0;
+
+export function __resetHfProxyPreferenceForTests(): void {
+  preferProxyUntil = 0;
+}
+
+function isProxyableRequest(
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+): boolean {
+  const method = (
+    init?.method ??
+    (typeof input === "object" && "method" in input ? input.method : "GET")
+  ).toUpperCase();
+  return method === "GET";
+}
+
+/**
+ * Re-issue a Hugging Face request through the backend passthrough. The HF
+ * bearer token (if any) moves to the internal token header; Authorization is
+ * replaced with the studio session token the backend routes require.
+ */
+function fetchViaBackendProxy(
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+  timeoutMs: number,
+): Promise<Response> {
+  const sourceHeaders = init?.headers
+    ? new Headers(init.headers)
+    : input instanceof Request
+      ? input.headers
+      : undefined;
+  const headers = new Headers();
+  const hfAuthorization = sourceHeaders?.get("authorization");
+  if (hfAuthorization?.toLowerCase().startsWith("bearer ")) {
+    headers.set(HUB_HF_TOKEN_HEADER, hfAuthorization.slice("bearer ".length));
+  }
+  const sessionToken = getSessionToken();
+  if (sessionToken) {
+    headers.set("Authorization", `Bearer ${sessionToken}`);
+  }
+  const proxyUrl = apiUrl(
+    `${HF_PROXY_PATH}?url=${encodeURIComponent(rawUrlFromFetchInput(input))}`,
+  );
+  return runFetchWithTimeout(
+    proxyUrl,
+    { method: "GET", headers, signal: init?.signal },
+    timeoutMs,
+  );
+}
+
+export async function fetchWithTimeout(
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1] = {},
+  timeoutMs = 15_000,
+): Promise<Response> {
+  const origin = originFromFetchInput(input);
+  const canProxy =
+    origin !== null &&
+    PROXYABLE_ORIGINS.has(origin) &&
+    isProxyableRequest(input, init);
+
+  if (canProxy && preferProxyUntil > Date.now()) {
+    try {
+      const response = await fetchViaBackendProxy(input, init, timeoutMs);
+      markRemoteNetworkOnline(origin);
+      return response;
+    } catch (error) {
+      if (init.signal?.aborted) {
+        throw error;
+      }
+      // proxy stopped working; retry direct below and re-arm only on a
+      // successful future fallback.
+      preferProxyUntil = 0;
+    }
+  }
+
+  try {
+    const response = await runFetchWithTimeout(input, init, timeoutMs);
+    if (origin) {
+      markRemoteNetworkOnline(origin);
+    }
+    return response;
+  } catch (error) {
+    const timedOut = error instanceof RequestTimeoutError;
+    if (canProxy && (timedOut || isNetworkFetchError(error))) {
+      try {
+        const response = await fetchViaBackendProxy(input, init, timeoutMs);
+        preferProxyUntil = Date.now() + PROXY_PREFER_TTL_MS;
+        markRemoteNetworkOnline(origin);
+        return response;
+      } catch {
+        // both paths failed; report the direct failure below.
+      }
+    }
+    if (timedOut) {
+      throw error;
+    }
+    if (origin && isNetworkFetchError(error)) {
+      markRemoteNetworkOffline(origin);
+    }
+    throw error;
   }
 }

--- a/studio/frontend/src/features/hub/lib/network.ts
+++ b/studio/frontend/src/features/hub/lib/network.ts
@@ -172,6 +172,7 @@ async function runFetchWithTimeout(
   input: Parameters<typeof fetch>[0],
   init: Parameters<typeof fetch>[1],
   timeoutMs: number,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<Response> {
   const parentSignal = init?.signal;
   const controller = new AbortController();
@@ -189,7 +190,7 @@ async function runFetchWithTimeout(
   }
 
   try {
-    return await fetch(input, { ...init, signal: controller.signal });
+    return await fetchImpl(input, { ...init, signal: controller.signal });
   } catch (error) {
     if (timedOut) {
       throw new RequestTimeoutError();
@@ -219,6 +220,28 @@ let preferProxyUntil = 0;
 
 export function __resetHfProxyPreferenceForTests(): void {
   preferProxyUntil = 0;
+}
+
+type ProxyAuthFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+// The session-aware fetch (authFetch) lives in the auth feature, whose module
+// graph this network-layer leaf must not import. The app entry registers it at
+// startup so proxied requests get 401-refresh-retry handling; unregistered
+// (tests, early calls) the fallback sends the stored session token directly.
+let proxyAuthFetch: ProxyAuthFetch | null = null;
+
+export function setHubProxyAuthFetch(fetchImpl: ProxyAuthFetch | null): void {
+  proxyAuthFetch = fetchImpl;
+}
+
+// Statuses the backend passthrough emits when it could not reach Hugging Face
+// itself (502 upstream failure, 504 upstream timeout). Such a response means
+// the fallback failed too, not that the hub is reachable.
+function isProxyGatewayError(response: Response): boolean {
+  return response.status === 502 || response.status === 504;
 }
 
 function isProxyableRequest(
@@ -252,13 +275,22 @@ function fetchViaBackendProxy(
   if (hfAuthorization?.toLowerCase().startsWith("bearer ")) {
     headers.set(HUB_HF_TOKEN_HEADER, hfAuthorization.slice("bearer ".length));
   }
+  const proxyUrl = apiUrl(
+    `${HF_PROXY_PATH}?url=${encodeURIComponent(rawUrlFromFetchInput(input))}`,
+  );
+  if (proxyAuthFetch) {
+    // authFetch attaches the session token and refresh-retries a 401 itself.
+    return runFetchWithTimeout(
+      proxyUrl,
+      { method: "GET", headers, signal: init?.signal },
+      timeoutMs,
+      proxyAuthFetch as typeof fetch,
+    );
+  }
   const sessionToken = getSessionToken();
   if (sessionToken) {
     headers.set("Authorization", `Bearer ${sessionToken}`);
   }
-  const proxyUrl = apiUrl(
-    `${HF_PROXY_PATH}?url=${encodeURIComponent(rawUrlFromFetchInput(input))}`,
-  );
   return runFetchWithTimeout(
     proxyUrl,
     { method: "GET", headers, signal: init?.signal },
@@ -280,8 +312,12 @@ export async function fetchWithTimeout(
   if (canProxy && preferProxyUntil > Date.now()) {
     try {
       const response = await fetchViaBackendProxy(input, init, timeoutMs);
-      markRemoteNetworkOnline(origin);
-      return response;
+      if (!isProxyGatewayError(response)) {
+        markRemoteNetworkOnline(origin);
+        return response;
+      }
+      // the backend could not reach hugging face either; retry direct below.
+      preferProxyUntil = 0;
     } catch (error) {
       if (init.signal?.aborted) {
         throw error;
@@ -303,9 +339,13 @@ export async function fetchWithTimeout(
     if (canProxy && (timedOut || isNetworkFetchError(error))) {
       try {
         const response = await fetchViaBackendProxy(input, init, timeoutMs);
-        preferProxyUntil = Date.now() + PROXY_PREFER_TTL_MS;
-        markRemoteNetworkOnline(origin);
-        return response;
+        if (!isProxyGatewayError(response)) {
+          preferProxyUntil = Date.now() + PROXY_PREFER_TTL_MS;
+          markRemoteNetworkOnline(origin);
+          return response;
+        }
+        // gateway error: the backend could not reach hugging face either, so
+        // fall through and report the direct failure as usual.
       } catch {
         // both paths failed; report the direct failure below.
       }

--- a/studio/frontend/src/features/images/train/example-dataset-cards.tsx
+++ b/studio/frontend/src/features/images/train/example-dataset-cards.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { fetchWithTimeout } from "@/features/hub/lib/network";
 import {
   Tooltip,
   TooltipContent,
@@ -27,10 +28,14 @@ async function fetchPreviews(repo: string): Promise<string[]> {
   if (cached) return cached;
   const p = (async () => {
     try {
-      const res = await fetch(
+      // Same wrapper as the rest of the hub traffic: adds a timeout and the
+      // hf-proxy fallback for browsers that cannot reach datasets-server.
+      const res = await fetchWithTimeout(
         `https://datasets-server.huggingface.co/first-rows?dataset=${encodeURIComponent(
           repo,
         )}&config=default&split=train`,
+        {},
+        15_000,
       );
       if (!res.ok) return [];
       const data = (await res.json()) as {

--- a/studio/frontend/src/features/images/train/example-dataset-cards.tsx
+++ b/studio/frontend/src/features/images/train/example-dataset-cards.tsx
@@ -28,8 +28,8 @@ async function fetchPreviews(repo: string): Promise<string[]> {
   if (cached) return cached;
   const p = (async () => {
     try {
-      // Same wrapper as the rest of the hub traffic: adds a timeout and the
-      // hf-proxy fallback for browsers that cannot reach datasets-server.
+      // Adds a timeout plus the hf-proxy fallback for browsers that cannot
+      // reach datasets-server directly.
       const res = await fetchWithTimeout(
         `https://datasets-server.huggingface.co/first-rows?dataset=${encodeURIComponent(
           repo,

--- a/studio/frontend/src/hooks/use-hf-dataset-splits.ts
+++ b/studio/frontend/src/hooks/use-hf-dataset-splits.ts
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useState } from "react";
 import { fetchWithTimeout } from "@/features/hub/lib/network";
 
 // Browser-side hub traffic, so it needs the same timeout and hf-proxy fallback
-// as the rest. This hook gates the training subset/split dropdowns.
+// as the rest.
 const SPLITS_TIMEOUT_MS = 15_000;
 
 // ---------------------------------------------------------------------------

--- a/studio/frontend/src/hooks/use-hf-dataset-splits.ts
+++ b/studio/frontend/src/hooks/use-hf-dataset-splits.ts
@@ -3,6 +3,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { fetchWithTimeout } from "@/features/hub/lib/network";
+
+// Browser-side hub traffic, so it needs the same timeout and hf-proxy fallback
+// as the rest. This hook gates the training subset/split dropdowns.
+const SPLITS_TIMEOUT_MS = 15_000;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -107,7 +113,11 @@ export function useHfDatasetSplits(
         headers.Authorization = `Bearer ${accessToken}`;
       }
 
-      const res = await fetch(url, { headers, signal });
+      const res = await fetchWithTimeout(
+        url,
+        { headers, signal },
+        SPLITS_TIMEOUT_MS,
+      );
       if (!res.ok) {
         const body = await res.json().catch(() => null);
         throw new Error(

--- a/studio/frontend/src/main.tsx
+++ b/studio/frontend/src/main.tsx
@@ -11,8 +11,8 @@ import { authFetch } from "./features/auth";
 import { setHubProxyAuthFetch } from "./features/hub";
 import { initializeLocale } from "./i18n";
 
-// Route hub-proxy fallback requests through the session-aware fetch so an
-// expired access token is refresh-retried instead of failing the proxy call.
+// Session-aware fetch for hub-proxy fallbacks, so an expired access token is
+// refresh-retried instead of failing the proxy call.
 setHubProxyAuthFetch(authFetch);
 
 const globalCrypto = globalThis.crypto as Crypto | undefined;

--- a/studio/frontend/src/main.tsx
+++ b/studio/frontend/src/main.tsx
@@ -7,7 +7,13 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import { App } from "./app/app";
 import { fetchDeviceType } from "./config/env";
+import { authFetch } from "./features/auth";
+import { setHubProxyAuthFetch } from "./features/hub";
 import { initializeLocale } from "./i18n";
+
+// Route hub-proxy fallback requests through the session-aware fetch so an
+// expired access token is refresh-retried instead of failing the proxy call.
+setHubProxyAuthFetch(authFetch);
 
 const globalCrypto = globalThis.crypto as Crypto | undefined;
 

--- a/studio/frontend/tests/hf-proxy-fallback.test.ts
+++ b/studio/frontend/tests/hf-proxy-fallback.test.ts
@@ -66,8 +66,10 @@ function installFetchStub(behavior: {
       });
     }
     if (mode === "gateway") {
+      // The route could not reach the hub at all, so it raises its own
+      // HTTPException and the marker is never stamped.
       return Promise.resolve(
-        proxiedResponse('{"detail":"bad gateway"}', 502),
+        new Response('{"detail":"bad gateway"}', { status: 502 }),
       );
     }
     if (mode === "missing-route") {
@@ -239,6 +241,25 @@ test("a genuine hub 404 still reaches the caller", async () => {
   const response = await fetchWithTimeout(HF_URL, {}, 50);
   assert.equal(response.status, 404);
   assert.deepEqual(await response.json(), { error: "Repo not found" });
+  assert.equal(isHuggingFaceOffline(), false);
+});
+
+test("a hub outage relayed by the proxy reaches the caller", async () => {
+  reset();
+  // Same shape as the 404 above, for a status the route also uses for its own
+  // errors: a marked 502 came from Hugging Face, so it is a real answer and
+  // must not be mistaken for the fallback being unavailable.
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.startsWith(PROXY_PREFIX)) {
+      return Promise.resolve(proxiedResponse("upstream is down", 502));
+    }
+    return Promise.reject(new TypeError("Failed to fetch"));
+  }) as typeof fetch;
+
+  const response = await fetchWithTimeout(HF_URL, {}, 50);
+  assert.equal(response.status, 502);
+  assert.equal(await response.text(), "upstream is down");
   assert.equal(isHuggingFaceOffline(), false);
 });
 

--- a/studio/frontend/tests/hf-proxy-fallback.test.ts
+++ b/studio/frontend/tests/hf-proxy-fallback.test.ts
@@ -29,6 +29,7 @@ const {
   fetchWithTimeout,
   isHuggingFaceOffline,
   markRemoteNetworkOnline,
+  setHubProxyAuthFetch,
 } = await import("../src/features/hub/lib/network.ts");
 
 const HF_URL = "https://huggingface.co/api/models?limit=20";
@@ -36,10 +37,10 @@ const PROXY_PREFIX = "/api/hub/hf-proxy?url=";
 
 type FetchCall = { url: string; init: RequestInit | undefined };
 
-/** Install a fetch stub; direct HF calls fail, proxy calls answer 200. */
+/** Install a fetch stub; direct HF calls fail, proxy calls answer per mode. */
 function installFetchStub(behavior: {
   direct: "network-error" | "hang" | "ok";
-  proxy: "ok" | "network-error";
+  proxy: "ok" | "network-error" | "gateway";
 }): FetchCall[] {
   const calls: FetchCall[] = [];
   globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
@@ -57,6 +58,11 @@ function installFetchStub(behavior: {
         );
       });
     }
+    if (mode === "gateway") {
+      return Promise.resolve(
+        new Response('{"detail":"bad gateway"}', { status: 502 }),
+      );
+    }
     return Promise.resolve(new Response("{}", { status: 200 }));
   }) as typeof fetch;
   return calls;
@@ -64,6 +70,7 @@ function installFetchStub(behavior: {
 
 function reset(): void {
   __resetHfProxyPreferenceForTests();
+  setHubProxyAuthFetch(null);
   markRemoteNetworkOnline();
   store.clear();
 }
@@ -125,6 +132,40 @@ test("non-hub origins never fall back to the proxy", async () => {
 
   await assert.rejects(fetchWithTimeout("https://example.com/data"), TypeError);
   assert.equal(calls.length, 1);
+});
+
+test("a proxy gateway error is not cached as a healthy fallback", async () => {
+  reset();
+  const calls = installFetchStub({ direct: "network-error", proxy: "gateway" });
+
+  await assert.rejects(fetchWithTimeout(HF_URL), TypeError);
+  assert.equal(isHuggingFaceOffline(), true);
+
+  // proxy-first must not be armed: the next attempt goes direct again
+  markRemoteNetworkOnline();
+  const callsBefore = calls.length;
+  await assert.rejects(fetchWithTimeout(HF_URL), TypeError);
+  assert.equal(calls[callsBefore].url, HF_URL);
+});
+
+test("a registered session-aware fetch handles proxy auth instead of a raw token", async () => {
+  reset();
+  store.set("unsloth_auth_token", "stale-token");
+  const authCalls: FetchCall[] = [];
+  setHubProxyAuthFetch((input, init) => {
+    authCalls.push({ url: String(input), init });
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+  installFetchStub({ direct: "network-error", proxy: "ok" });
+
+  const response = await fetchWithTimeout(HF_URL);
+
+  assert.equal(response.status, 200);
+  assert.equal(authCalls.length, 1);
+  assert.ok(authCalls[0].url.startsWith(PROXY_PREFIX));
+  // authFetch owns the session header; network.ts must not preset a stale one
+  const headers = new Headers(authCalls[0].init?.headers);
+  assert.equal(headers.get("Authorization"), null);
 });
 
 test("a caller abort is surfaced, not retried through the proxy", async () => {

--- a/studio/frontend/tests/hf-proxy-fallback.test.ts
+++ b/studio/frontend/tests/hf-proxy-fallback.test.ts
@@ -311,3 +311,39 @@ test("the proxy preference is per origin", async () => {
   await fetchWithTimeout(HF_URL, {}, 50);
   assert.equal(calls[before].url, HF_URL, "huggingface.co still tries direct first");
 });
+
+test("a hub 401 passed through the proxy is not treated as a dead session", async () => {
+  reset();
+  // huggingface.co answers 401 (not 404) for a private or missing repo, and the
+  // route forwards that verbatim. Routed through authFetch it used to look like
+  // a Studio session failure, which refreshes the session token per lookup and
+  // signs the user out when the refresh fails.
+  let sessionHandled = false;
+  setHubProxyAuthFetch(async (input, init) => {
+    const response = await fetch(input as string, init);
+    if (
+      response.status === 401 &&
+      response.headers.get("X-Unsloth-HF-Proxy") === null
+    ) {
+      sessionHandled = true;
+    }
+    return response;
+  });
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.startsWith(PROXY_PREFIX)) {
+      return Promise.resolve(
+        new Response('{"error":"Repo not found"}', {
+          status: 401,
+          headers: { "X-Unsloth-HF-Proxy": "1" },
+        }),
+      );
+    }
+    return Promise.reject(new TypeError("Failed to fetch"));
+  }) as typeof fetch;
+
+  const response = await fetchWithTimeout(HF_URL, {}, 50);
+  assert.equal(response.status, 401);
+  assert.equal(sessionHandled, false, "must not run the session-recovery path");
+  assert.equal(isHuggingFaceOffline(), false);
+});

--- a/studio/frontend/tests/hf-proxy-fallback.test.ts
+++ b/studio/frontend/tests/hf-proxy-fallback.test.ts
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Hub discovery fetches huggingface.co straight from the browser, so privacy
-// tooling that filters browser traffic made the UI report "You're offline"
-// while the backend still had connectivity. fetchWithTimeout now retries a
-// failed direct HF fetch through the backend's /api/hub/hf-proxy passthrough
-// and only marks the hub offline when both paths fail.
+// Privacy tooling that filters browser traffic made the UI report "You're
+// offline" while the backend still had connectivity. fetchWithTimeout now
+// retries a failed direct HF fetch through /api/hub/hf-proxy and marks the hub
+// offline only when both paths fail.
 
 import assert from "node:assert/strict";
 import test from "node:test";
@@ -37,9 +36,8 @@ const PROXY_PREFIX = "/api/hub/hf-proxy?url=";
 
 type FetchCall = { url: string; init: RequestInit | undefined };
 
-// The backend stamps every response the hf-proxy route produces, so the stub
-// has to as well; a proxy reply without it means "this backend has no such
-// route", which is a different case entirely (mode "missing-route").
+// The backend stamps every hf-proxy response, so the stub must too: a proxy
+// reply without the marker means "no such route here" (mode "missing-route").
 const PROXY_MARKER_HEADER = "X-Unsloth-HF-Proxy";
 const proxiedResponse = (body: string, status: number) =>
   new Response(body, { status, headers: { [PROXY_MARKER_HEADER]: "1" } });
@@ -66,15 +64,15 @@ function installFetchStub(behavior: {
       });
     }
     if (mode === "gateway") {
-      // The route could not reach the hub at all, so it raises its own
-      // HTTPException and the marker is never stamped.
+      // The route could not reach the hub, so it raises its own error and the
+      // marker is never stamped.
       return Promise.resolve(
         new Response('{"detail":"bad gateway"}', { status: 502 }),
       );
     }
     if (mode === "missing-route") {
-      // An older Studio backend: the SPA catch-all answers unknown /api paths,
-      // so there is no marker header on the 404.
+      // Older Studio backend: the SPA catch-all answers unknown /api paths, so
+      // its 404 carries no marker header.
       return Promise.resolve(
         new Response('{"detail":"API endpoint not found"}', { status: 404 }),
       );
@@ -204,11 +202,9 @@ test("a caller abort is surfaced, not retried through the proxy", async () => {
 
 test("an older backend without the route is not mistaken for a hub reply", async () => {
   reset();
-  // A Studio backend that predates /api/hub/hf-proxy answers the SPA
-  // catch-all's 404. Treating that as a Hugging Face response would hand
-  // {"detail":"API endpoint not found"} to @huggingface/hub as a model
-  // listing, report the hub as online, and pin every later request to the
-  // missing route for ten minutes.
+  // Treating the SPA catch-all 404 as a hub response would hand
+  // {"detail":"API endpoint not found"} to @huggingface/hub as a model listing,
+  // report the hub online, and pin later requests to the missing route.
   const calls = installFetchStub({ direct: "network-error", proxy: "missing-route" });
 
   await assert.rejects(() => fetchWithTimeout(HF_URL, {}, 50), TypeError);
@@ -222,9 +218,8 @@ test("an older backend without the route is not mistaken for a hub reply", async
 
 test("a genuine hub 404 still reaches the caller", async () => {
   reset();
-  // The mirror image: the proxy DID answer, and Hugging Face said 404 for a
-  // missing repo. That has to pass through untouched, which is why the marker
-  // header exists instead of a status allowlist.
+  // Mirror image: the proxy answered and the hub said 404 for a missing repo,
+  // which must pass through untouched. Hence the marker, not a status allowlist.
   globalThis.fetch = ((input: string | URL | Request) => {
     const url = typeof input === "string" ? input : input.toString();
     if (url.startsWith(PROXY_PREFIX)) {
@@ -246,9 +241,8 @@ test("a genuine hub 404 still reaches the caller", async () => {
 
 test("a hub outage relayed by the proxy reaches the caller", async () => {
   reset();
-  // Same shape as the 404 above, for a status the route also uses for its own
-  // errors: a marked 502 came from Hugging Face, so it is a real answer and
-  // must not be mistaken for the fallback being unavailable.
+  // 502 is also a status the route uses for its own errors, so a marked 502 is
+  // a real hub answer and must not read as the fallback being unavailable.
   globalThis.fetch = ((input: string | URL | Request) => {
     const url = typeof input === "string" ? input : input.toString();
     if (url.startsWith(PROXY_PREFIX)) {
@@ -296,8 +290,8 @@ test("one call never spends more than a single proxy attempt", async () => {
   installFetchStub({ direct: "network-error", proxy: "ok" });
   await fetchWithTimeout(HF_URL, {}, 50);
 
-  // ...then make everything hang. Without a cap this runs proxy, direct,
-  // proxy and burns three times the caller's timeout budget.
+  // ...then make everything hang. Uncapped this runs proxy, direct, proxy and
+  // burns 3x the caller's timeout budget.
   const legs: string[] = [];
   globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
@@ -335,10 +329,9 @@ test("the proxy preference is per origin", async () => {
 
 test("a hub 401 passed through the proxy is not treated as a dead session", async () => {
   reset();
-  // huggingface.co answers 401 (not 404) for a private or missing repo, and the
-  // route forwards that verbatim. Routed through authFetch it used to look like
-  // a Studio session failure, which refreshes the session token per lookup and
-  // signs the user out when the refresh fails.
+  // huggingface.co answers 401 for a private or missing repo and the route
+  // forwards it verbatim. Through authFetch that used to look like a dead
+  // Studio session: token rotated per lookup, sign-out if the refresh failed.
   let sessionHandled = false;
   setHubProxyAuthFetch(async (input, init) => {
     const response = await fetch(input as string, init);

--- a/studio/frontend/tests/hf-proxy-fallback.test.ts
+++ b/studio/frontend/tests/hf-proxy-fallback.test.ts
@@ -37,10 +37,17 @@ const PROXY_PREFIX = "/api/hub/hf-proxy?url=";
 
 type FetchCall = { url: string; init: RequestInit | undefined };
 
+// The backend stamps every response the hf-proxy route produces, so the stub
+// has to as well; a proxy reply without it means "this backend has no such
+// route", which is a different case entirely (mode "missing-route").
+const PROXY_MARKER_HEADER = "X-Unsloth-HF-Proxy";
+const proxiedResponse = (body: string, status: number) =>
+  new Response(body, { status, headers: { [PROXY_MARKER_HEADER]: "1" } });
+
 /** Install a fetch stub; direct HF calls fail, proxy calls answer per mode. */
 function installFetchStub(behavior: {
   direct: "network-error" | "hang" | "ok";
-  proxy: "ok" | "network-error" | "gateway";
+  proxy: "ok" | "network-error" | "gateway" | "missing-route";
 }): FetchCall[] {
   const calls: FetchCall[] = [];
   globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
@@ -60,10 +67,21 @@ function installFetchStub(behavior: {
     }
     if (mode === "gateway") {
       return Promise.resolve(
-        new Response('{"detail":"bad gateway"}', { status: 502 }),
+        proxiedResponse('{"detail":"bad gateway"}', 502),
       );
     }
-    return Promise.resolve(new Response("{}", { status: 200 }));
+    if (mode === "missing-route") {
+      // An older Studio backend: the SPA catch-all answers unknown /api paths,
+      // so there is no marker header on the 404.
+      return Promise.resolve(
+        new Response('{"detail":"API endpoint not found"}', { status: 404 }),
+      );
+    }
+    return Promise.resolve(
+      isProxy
+        ? proxiedResponse("{}", 200)
+        : new Response("{}", { status: 200 }),
+    );
   }) as typeof fetch;
   return calls;
 }
@@ -154,7 +172,7 @@ test("a registered session-aware fetch handles proxy auth instead of a raw token
   const authCalls: FetchCall[] = [];
   setHubProxyAuthFetch((input, init) => {
     authCalls.push({ url: String(input), init });
-    return Promise.resolve(new Response("{}", { status: 200 }));
+    return Promise.resolve(proxiedResponse("{}", 200));
   });
   installFetchStub({ direct: "network-error", proxy: "ok" });
 
@@ -180,4 +198,116 @@ test("a caller abort is surfaced, not retried through the proxy", async () => {
   });
   assert.equal(calls.length, 1);
   assert.equal(isHuggingFaceOffline(), false);
+});
+
+test("an older backend without the route is not mistaken for a hub reply", async () => {
+  reset();
+  // A Studio backend that predates /api/hub/hf-proxy answers the SPA
+  // catch-all's 404. Treating that as a Hugging Face response would hand
+  // {"detail":"API endpoint not found"} to @huggingface/hub as a model
+  // listing, report the hub as online, and pin every later request to the
+  // missing route for ten minutes.
+  const calls = installFetchStub({ direct: "network-error", proxy: "missing-route" });
+
+  await assert.rejects(() => fetchWithTimeout(HF_URL, {}, 50), TypeError);
+  assert.equal(isHuggingFaceOffline(), true);
+
+  // Proxy-first must NOT be armed: the next call still tries direct first.
+  const before = calls.length;
+  await assert.rejects(() => fetchWithTimeout(HF_URL, {}, 50), TypeError);
+  assert.equal(calls[before].url, HF_URL);
+});
+
+test("a genuine hub 404 still reaches the caller", async () => {
+  reset();
+  // The mirror image: the proxy DID answer, and Hugging Face said 404 for a
+  // missing repo. That has to pass through untouched, which is why the marker
+  // header exists instead of a status allowlist.
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.startsWith(PROXY_PREFIX)) {
+      return Promise.resolve(
+        new Response('{"error":"Repo not found"}', {
+          status: 404,
+          headers: { "X-Unsloth-HF-Proxy": "1" },
+        }),
+      );
+    }
+    return Promise.reject(new TypeError("Failed to fetch"));
+  }) as typeof fetch;
+
+  const response = await fetchWithTimeout(HF_URL, {}, 50);
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), { error: "Repo not found" });
+  assert.equal(isHuggingFaceOffline(), false);
+});
+
+test("an abort during the proxy fallback surfaces as an abort", async () => {
+  reset();
+  const controller = new AbortController();
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.startsWith(PROXY_PREFIX)) {
+      queueMicrotask(() => controller.abort());
+      return new Promise<Response>((_resolve, reject) => {
+        const fail = () => reject(new DOMException("Aborted", "AbortError"));
+        if (init?.signal?.aborted) return fail();
+        init?.signal?.addEventListener("abort", fail, { once: true });
+      });
+    }
+    return Promise.reject(new TypeError("Failed to fetch"));
+  }) as typeof fetch;
+
+  let caught: unknown;
+  try {
+    await fetchWithTimeout(HF_URL, { signal: controller.signal }, 5_000);
+  } catch (error) {
+    caught = error;
+  }
+  assert.ok(caught instanceof DOMException && caught.name === "AbortError");
+  // A caller changing its mind must never look like the hub going away.
+  assert.equal(isHuggingFaceOffline(), false);
+});
+
+test("one call never spends more than a single proxy attempt", async () => {
+  reset();
+  // Arm proxy-first with a successful fallback...
+  installFetchStub({ direct: "network-error", proxy: "ok" });
+  await fetchWithTimeout(HF_URL, {}, 50);
+
+  // ...then make everything hang. Without a cap this runs proxy, direct,
+  // proxy and burns three times the caller's timeout budget.
+  const legs: string[] = [];
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    legs.push(url.startsWith(PROXY_PREFIX) ? "PROXY" : "DIRECT");
+    return new Promise<Response>((_resolve, reject) => {
+      const fail = () => reject(new DOMException("Aborted", "AbortError"));
+      if (init?.signal?.aborted) return fail();
+      init?.signal?.addEventListener("abort", fail, { once: true });
+    });
+  }) as typeof fetch;
+
+  await assert.rejects(() => fetchWithTimeout(HF_URL, {}, 40));
+  assert.deepEqual(legs, ["PROXY", "DIRECT"]);
+});
+
+test("the proxy preference is per origin", async () => {
+  reset();
+  const calls: FetchCall[] = [];
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    return url.startsWith(PROXY_PREFIX)
+      ? Promise.resolve(
+          new Response("{}", { status: 200, headers: { "X-Unsloth-HF-Proxy": "1" } }),
+        )
+      : Promise.reject(new TypeError("Failed to fetch"));
+  }) as typeof fetch;
+
+  // A datasets-server fallback must not reroute huggingface.co traffic.
+  await fetchWithTimeout("https://datasets-server.huggingface.co/size?dataset=x", {}, 50);
+  const before = calls.length;
+  await fetchWithTimeout(HF_URL, {}, 50);
+  assert.equal(calls[before].url, HF_URL, "huggingface.co still tries direct first");
 });

--- a/studio/frontend/tests/hf-proxy-fallback.test.ts
+++ b/studio/frontend/tests/hf-proxy-fallback.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Hub discovery fetches huggingface.co straight from the browser, so privacy
+// tooling that filters browser traffic made the UI report "You're offline"
+// while the backend still had connectivity. fetchWithTimeout now retries a
+// failed direct HF fetch through the backend's /api/hub/hf-proxy passthrough
+// and only marks the hub offline when both paths fail.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  installLocalStorageFake,
+  registerBundlerResolver,
+} from "./helpers/kit.ts";
+
+const { store } = installLocalStorageFake();
+Object.assign(globalThis.window as unknown as Record<string, unknown>, {
+  dispatchEvent: () => true,
+  addEventListener: () => undefined,
+  removeEventListener: () => undefined,
+  location: { href: "http://localhost:8888/" },
+});
+
+registerBundlerResolver();
+const {
+  __resetHfProxyPreferenceForTests,
+  fetchWithTimeout,
+  isHuggingFaceOffline,
+  markRemoteNetworkOnline,
+} = await import("../src/features/hub/lib/network.ts");
+
+const HF_URL = "https://huggingface.co/api/models?limit=20";
+const PROXY_PREFIX = "/api/hub/hf-proxy?url=";
+
+type FetchCall = { url: string; init: RequestInit | undefined };
+
+/** Install a fetch stub; direct HF calls fail, proxy calls answer 200. */
+function installFetchStub(behavior: {
+  direct: "network-error" | "hang" | "ok";
+  proxy: "ok" | "network-error";
+}): FetchCall[] {
+  const calls: FetchCall[] = [];
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    const isProxy = url.startsWith(PROXY_PREFIX);
+    const mode = isProxy ? behavior.proxy : behavior.direct;
+    if (mode === "network-error") {
+      return Promise.reject(new TypeError("Failed to fetch"));
+    }
+    if (mode === "hang") {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("Aborted", "AbortError")),
+        );
+      });
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  }) as typeof fetch;
+  return calls;
+}
+
+function reset(): void {
+  __resetHfProxyPreferenceForTests();
+  markRemoteNetworkOnline();
+  store.clear();
+}
+
+test("direct network error falls back to the backend proxy and stays online", async () => {
+  reset();
+  store.set("unsloth_auth_token", "session-jwt");
+  const calls = installFetchStub({ direct: "network-error", proxy: "ok" });
+
+  const response = await fetchWithTimeout(HF_URL, {
+    headers: { Authorization: "Bearer hf_secret" },
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].url, HF_URL);
+  assert.equal(calls[1].url, PROXY_PREFIX + encodeURIComponent(HF_URL));
+  const proxyHeaders = new Headers(calls[1].init?.headers);
+  assert.equal(proxyHeaders.get("X-Unsloth-HF-Token"), "hf_secret");
+  assert.equal(proxyHeaders.get("Authorization"), "Bearer session-jwt");
+  assert.equal(isHuggingFaceOffline(), false);
+});
+
+test("after a successful fallback the proxy is preferred, skipping the doomed direct attempt", async () => {
+  reset();
+  const calls = installFetchStub({ direct: "network-error", proxy: "ok" });
+
+  await fetchWithTimeout(HF_URL);
+  const callsBefore = calls.length;
+  await fetchWithTimeout(HF_URL);
+
+  assert.equal(callsBefore, 2);
+  assert.equal(calls.length, 3);
+  assert.ok(calls[2].url.startsWith(PROXY_PREFIX));
+});
+
+test("direct timeout falls back to the proxy instead of surfacing a timeout", async () => {
+  reset();
+  const calls = installFetchStub({ direct: "hang", proxy: "ok" });
+
+  const response = await fetchWithTimeout(HF_URL, {}, 20);
+
+  assert.equal(response.status, 200);
+  assert.equal(calls.length, 2);
+  assert.equal(isHuggingFaceOffline(), false);
+});
+
+test("only when both paths fail is the hub marked offline", async () => {
+  reset();
+  installFetchStub({ direct: "network-error", proxy: "network-error" });
+
+  await assert.rejects(fetchWithTimeout(HF_URL), TypeError);
+  assert.equal(isHuggingFaceOffline(), true);
+});
+
+test("non-hub origins never fall back to the proxy", async () => {
+  reset();
+  const calls = installFetchStub({ direct: "network-error", proxy: "ok" });
+
+  await assert.rejects(fetchWithTimeout("https://example.com/data"), TypeError);
+  assert.equal(calls.length, 1);
+});
+
+test("a caller abort is surfaced, not retried through the proxy", async () => {
+  reset();
+  const calls = installFetchStub({ direct: "hang", proxy: "ok" });
+  const controller = new AbortController();
+  const pending = fetchWithTimeout(HF_URL, { signal: controller.signal });
+  controller.abort();
+
+  await assert.rejects(pending, (error: unknown) => {
+    return error instanceof DOMException && error.name === "AbortError";
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(isHuggingFaceOffline(), false);
+});


### PR DESCRIPTION
## Problem

Reported on reddit: https://www.reddit.com/r/unsloth/comments/1ve453v/error_youre_offline_reconnect_to_the_internet_to/

A Win10 user on v0.1.511-beta / 2026.8.1 saw the model hub stuck on "You're offline; Reconnect to the internet to browse models", flapping to "Back online" every 30 seconds and immediately back, plus "Couldn't reach Hugging Face / Request timed out" cards. Meanwhile studio and llama.cpp updates and model downloads worked fine, and they saw 200s in PowerShell.

Cause: hub discovery runs entirely in the browser. `use-hub-model-search.ts` calls `@huggingface/hub` `listModels` with a fetch straight to `https://huggingface.co`, and there was no backend route for it. Privacy tooling that filters browser traffic (DNS filtering, TLS-inspecting firewalls, tracker blockers) kills those fetches while the backend's connection is fine, so `network.ts` marked the hub offline for 30s on every failed fetch. The TTL expiry then flipped the state to online optimistically, toasted "Back online", refetched, failed again: the exact flapping in the report.

## Fix

Backend: new read-only GET passthrough at `/api/hub/hf-proxy` (`studio/backend/hub/routes/hf_proxy.py`), guarded by the usual session auth. Allowlisted to `huggingface.co` and `datasets-server.huggingface.co` (https only, default port, no URL credentials) so it cannot be used as an open proxy. It forwards the `X-Unsloth-HF-Token` header as the upstream bearer token and returns the upstream status with `content-type`, `link`, and `etag`, so `@huggingface/hub` cursor pagination keeps working. Timeouts map to 504, connection failures to 502, and responses over 20 MiB are refused.

Frontend: `fetchWithTimeout` in `network.ts` now retries a failed direct HF fetch (network error or timeout) through the passthrough, moving the HF bearer token to `X-Unsloth-HF-Token` and authenticating with the studio session token. After a successful fallback it goes proxy-first for 10 minutes so every listing page does not pay for a doomed direct attempt plus its timeout. The hub is marked offline only when both paths fail, which ends the online/offline flapping for these setups. Caller aborts are surfaced as before and non-hub origins are untouched.

## Tests

- `studio/frontend/tests/hf-proxy-fallback.test.ts` (6 tests): fallback on network error and on timeout, token relocation to the internal header, proxy-first stickiness, offline only when both paths fail, no fallback for non-hub origins, caller aborts surfaced. Full frontend suite: 377 pass. `tsc`, eslint, and biome clean.
- `studio/backend/tests/test_hf_proxy_route.py` (13 tests): host allowlist accept/reject (http, foreign hosts, suffix spoofing, non-standard port, URL credentials, file://), response header filtering (`set-cookie` and friends dropped), HF token forwarding, upstream error status passthrough, 504/502 mapping.
- Live: ran the backend against real Hugging Face and got a proxied `listModels` 200 with the `link` pagination header intact, 403 for a disallowed host, 401 without a session. Then built the frontend, served it from the backend, and drove headless Chromium with every direct request to `huggingface.co` aborted to reproduce the reporter's filtered browser: discovery fell back to `/api/hub/hf-proxy` (listing and README fetches) and the Discover tab rendered the full model feed with no offline banner.
