### PR TITLE
fix(studio): keep child spawns alive under a pid-1 parent

### DIFF
--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -157,25 +157,47 @@ def test_pdeathsig_exits_when_reparented_away_from_the_owner(monkeypatch):
         _run_preexec(monkeypatch, owner_pid = 4242, getppid = 1)
 
 
-def test_bind_passes_the_creating_process_pid(monkeypatch):
-    # multiprocessing workers get no preexec_fn, so they read the creator's pid
-    # from multiprocessing itself; None outside a worker keeps the fallback.
+def _bind_with_parent(monkeypatch, parent):
     import multiprocessing
 
-    seen = []
+    seen, exited = [], []
     monkeypatch.setattr(pl, "_is_linux", lambda: True)
     monkeypatch.setattr(pl, "_pdeathsig_preexec", lambda owner: seen.append(owner))
+    monkeypatch.setattr(pl.os, "_exit", lambda code: exited.append(code))
+    monkeypatch.setattr(multiprocessing, "parent_process", lambda: parent)
+    pl.bind_current_process_to_parent_lifetime()
+    return seen, exited
 
-    monkeypatch.setattr(multiprocessing, "parent_process", lambda: _FakeParent(4242))
-    pl.bind_current_process_to_parent_lifetime()
-    monkeypatch.setattr(multiprocessing, "parent_process", lambda: None)
-    pl.bind_current_process_to_parent_lifetime()
-    assert seen == [4242, None]
+
+def test_bind_keeps_a_worker_whose_creator_is_alive(monkeypatch):
+    # The orphan decision comes from the creator's sentinel, not a pid compare:
+    # under forkserver the kernel parent is the fork server, so comparing pids
+    # would read every healthy worker as orphaned and kill it before its target.
+    seen, exited = _bind_with_parent(monkeypatch, _FakeParent(4242, alive = True))
+    assert seen == [os.getppid()]  # PDEATHSIG still bound to the kernel parent
+    assert exited == []
+
+
+def test_bind_exits_when_the_creator_is_already_gone(monkeypatch):
+    seen, exited = _bind_with_parent(monkeypatch, _FakeParent(4242, alive = False))
+    assert seen == [os.getppid()]
+    assert exited == [1]
+
+
+def test_bind_falls_back_outside_a_multiprocessing_worker(monkeypatch):
+    # No creator to consult: keep the historical "reparented to init" heuristic.
+    seen, exited = _bind_with_parent(monkeypatch, None)
+    assert seen == [None]
+    assert exited == []
 
 
 class _FakeParent:
-    def __init__(self, pid):
+    def __init__(self, pid, alive = True):
         self.pid = pid
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
 
 
 # ── Real Linux PDEATHSIG: child dies when the parent dies abnormally ──

--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -192,13 +192,8 @@ def test_bind_falls_back_outside_a_multiprocessing_worker(monkeypatch):
 
 
 class _FakeParent:
-    def __init__(
-        self,
-        pid,
-        alive = True,
-    ):
-        self.pid = pid
-        self._alive = alive
+    def __init__(self, pid, alive):
+        self.pid, self._alive = pid, alive
 
     def is_alive(self):
         return self._alive

--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -184,10 +184,26 @@ def test_bind_exits_when_the_creator_is_already_gone(monkeypatch):
     assert exited == [1]
 
 
-def test_bind_falls_back_outside_a_multiprocessing_worker(monkeypatch):
-    # No creator to consult: keep the historical "reparented to init" heuristic.
+def test_bind_only_arms_pdeathsig_outside_a_multiprocessing_worker(monkeypatch):
+    # No creator to consult and nothing orphaned: arm PDEATHSIG, decide nothing.
     seen, exited = _bind_with_parent(monkeypatch, None)
-    assert seen == [None]
+    assert seen == [os.getppid()]
+    assert exited == []
+
+
+def test_bind_keeps_a_non_worker_whose_parent_is_pid_1(monkeypatch):
+    # Runs the REAL hook, not a stub: a non-worker under a container init sees
+    # getppid() == 1, and the bare fallback killed it outright with no output.
+    import ctypes
+    import multiprocessing
+
+    exited = []
+    monkeypatch.setattr(pl, "_is_linux", lambda: True)
+    monkeypatch.setattr(ctypes, "CDLL", lambda *a, **k: type("L", (), {"prctl": lambda *_: 0})())
+    monkeypatch.setattr(pl.os, "getppid", lambda: 1)
+    monkeypatch.setattr(pl.os, "_exit", lambda code: exited.append(code))
+    monkeypatch.setattr(multiprocessing, "parent_process", lambda: None)
+    pl.bind_current_process_to_parent_lifetime()
     assert exited == []
 
 

--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -98,9 +98,9 @@ def test_child_popen_kwargs_linux_vs_other(monkeypatch):
 def test_compose_preexec_runs_pdeathsig_then_existing(monkeypatch):
     calls = []
     monkeypatch.setattr(pl, "_is_linux", lambda: True)
-    monkeypatch.setattr(pl, "_pdeathsig_preexec", lambda: calls.append("death"))
-    pl.compose_preexec(lambda: calls.append("existing"))()
-    assert calls == ["death", "existing"]  # ordering matters for sandbox hooks
+    monkeypatch.setattr(pl, "_pdeathsig_preexec", lambda owner: calls.append(("death", owner)))
+    pl.compose_preexec(lambda: calls.append("existing"), 4242)()
+    assert calls == [("death", 4242), "existing"]  # ordering matters for sandbox hooks
 
 
 def test_compose_preexec_passthrough_off_linux(monkeypatch):
@@ -108,6 +108,74 @@ def test_compose_preexec_passthrough_off_linux(monkeypatch):
     sentinel = lambda: None  # noqa: E731
     assert pl.compose_preexec(sentinel) is sentinel
     assert pl.compose_preexec(None) is None
+
+
+def test_child_popen_kwargs_binds_the_spawning_pid(monkeypatch):
+    # The preexec must compare against the pid of the process that forked it, so
+    # a healthy child of a pid-1 parent is not mistaken for an orphan (#7886).
+    seen = []
+    monkeypatch.setattr(pl, "_is_linux", lambda: True)
+    monkeypatch.setattr(pl, "_pdeathsig_preexec", lambda owner: seen.append(owner))
+    pl.child_popen_kwargs()["preexec_fn"]()
+    assert seen == [os.getpid()]
+
+
+# ── Orphan decision inside the preexec hook ──
+
+
+class _ExitCalled(BaseException):
+    """Stands in for os._exit, which a test cannot survive. A BaseException so
+    the hook's own `except Exception` does not swallow it."""
+
+
+def _run_preexec(monkeypatch, *, owner_pid, getppid):
+    # prctl is stubbed so the decision is exercised on any platform.
+    import ctypes
+
+    class _Libc:
+        def prctl(self, *args):
+            return 0
+
+    def _no_exit(code):
+        raise _ExitCalled(code)
+
+    monkeypatch.setattr(ctypes, "CDLL", lambda *a, **k: _Libc())
+    monkeypatch.setattr(pl.os, "getppid", lambda: getppid)
+    monkeypatch.setattr(pl.os, "_exit", _no_exit)
+    pl._pdeathsig_preexec(owner_pid)
+
+
+def test_pdeathsig_keeps_child_whose_parent_is_pid_1(monkeypatch):
+    # Unsloth Studio launched as a container entrypoint runs as pid 1, so a
+    # healthy child sees getppid() == 1. Killing it there took down every
+    # llama-server spawn before exec (#7886).
+    _run_preexec(monkeypatch, owner_pid = 1, getppid = 1)
+
+
+def test_pdeathsig_exits_when_reparented_away_from_the_owner(monkeypatch):
+    with pytest.raises(_ExitCalled):
+        _run_preexec(monkeypatch, owner_pid = 4242, getppid = 1)
+
+
+def test_bind_passes_the_creating_process_pid(monkeypatch):
+    # multiprocessing workers get no preexec_fn, so they read the creator's pid
+    # from multiprocessing itself; None outside a worker keeps the fallback.
+    import multiprocessing
+
+    seen = []
+    monkeypatch.setattr(pl, "_is_linux", lambda: True)
+    monkeypatch.setattr(pl, "_pdeathsig_preexec", lambda owner: seen.append(owner))
+
+    monkeypatch.setattr(multiprocessing, "parent_process", lambda: _FakeParent(4242))
+    pl.bind_current_process_to_parent_lifetime()
+    monkeypatch.setattr(multiprocessing, "parent_process", lambda: None)
+    pl.bind_current_process_to_parent_lifetime()
+    assert seen == [4242, None]
+
+
+class _FakeParent:
+    def __init__(self, pid):
+        self.pid = pid
 
 
 # ── Real Linux PDEATHSIG: child dies when the parent dies abnormally ──

--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -192,7 +192,11 @@ def test_bind_falls_back_outside_a_multiprocessing_worker(monkeypatch):
 
 
 class _FakeParent:
-    def __init__(self, pid, alive = True):
+    def __init__(
+        self,
+        pid,
+        alive = True,
+    ):
         self.pid = pid
         self._alive = alive
 

--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -111,8 +111,8 @@ def test_compose_preexec_passthrough_off_linux(monkeypatch):
 
 
 def test_child_popen_kwargs_binds_the_spawning_pid(monkeypatch):
-    # The preexec must compare against the pid of the process that forked it, so
-    # a healthy child of a pid-1 parent is not mistaken for an orphan (#7886).
+    # Compare against the forking pid, so a healthy child of a pid-1 parent is
+    # not mistaken for an orphan (#7886).
     seen = []
     monkeypatch.setattr(pl, "_is_linux", lambda: True)
     monkeypatch.setattr(pl, "_pdeathsig_preexec", lambda owner: seen.append(owner))
@@ -129,7 +129,7 @@ class _ExitCalled(BaseException):
 
 
 def _run_preexec(monkeypatch, *, owner_pid, getppid):
-    # prctl is stubbed so the decision is exercised on any platform.
+    # prctl is stubbed so the decision runs on any platform.
     import ctypes
 
     class _Libc:
@@ -146,9 +146,8 @@ def _run_preexec(monkeypatch, *, owner_pid, getppid):
 
 
 def test_pdeathsig_keeps_child_whose_parent_is_pid_1(monkeypatch):
-    # Unsloth Studio launched as a container entrypoint runs as pid 1, so a
-    # healthy child sees getppid() == 1. Killing it there took down every
-    # llama-server spawn before exec (#7886).
+    # Studio as a container entrypoint runs as pid 1, so a healthy child sees
+    # getppid() == 1; killing it took down every llama-server spawn (#7886).
     _run_preexec(monkeypatch, owner_pid = 1, getppid = 1)
 
 
@@ -170,9 +169,9 @@ def _bind_with_parent(monkeypatch, parent):
 
 
 def test_bind_keeps_a_worker_whose_creator_is_alive(monkeypatch):
-    # The orphan decision comes from the creator's sentinel, not a pid compare:
-    # under forkserver the kernel parent is the fork server, so comparing pids
-    # would read every healthy worker as orphaned and kill it before its target.
+    # The decision comes from the creator's sentinel, not a pid compare: under
+    # forkserver the kernel parent is the fork server, so pids would read every
+    # healthy worker as orphaned.
     seen, exited = _bind_with_parent(monkeypatch, _FakeParent(4242, alive = True))
     assert seen == [os.getppid()]  # PDEATHSIG still bound to the kernel parent
     assert exited == []
@@ -192,8 +191,8 @@ def test_bind_only_arms_pdeathsig_outside_a_multiprocessing_worker(monkeypatch):
 
 
 def test_bind_keeps_a_non_worker_whose_parent_is_pid_1(monkeypatch):
-    # Runs the REAL hook, not a stub: a non-worker under a container init sees
-    # getppid() == 1, and the bare fallback killed it outright with no output.
+    # Runs the REAL hook: a non-worker under a container init sees getppid() == 1,
+    # which the bare fallback killed outright.
     import ctypes
     import multiprocessing
 

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -182,19 +182,25 @@ def bind_current_process_to_parent_lifetime() -> None:
     PR_SET_PDEATHSIG for them -- the child must do it itself at startup."""
     if not _is_linux():
         return
-    # multiprocessing records the pid of the process that created this worker,
-    # which the spawn and fork contexts (the only ones Unsloth uses) both make
-    # its direct parent. Passing it keeps the orphan check off the "reparented
-    # to init" fallback, which kills every worker of a pid-1 parent (#7886).
-    owner_pid = None
+    parent = None
     try:
         import multiprocessing
         parent = multiprocessing.parent_process()
-        if parent is not None:
-            owner_pid = parent.pid
     except Exception:
         pass
-    _pdeathsig_preexec(owner_pid)
+    if parent is None:
+        _pdeathsig_preexec(None)  # not a worker: keep the getppid() == 1 heuristic
+        return
+    # PDEATHSIG binds to the kernel parent, but "orphaned" comes from the creator's
+    # sentinel, not a pid compare: getppid() is the creator only under fork/spawn,
+    # while under forkserver it is the fork server, so comparing would kill every
+    # healthy worker. The sentinel is exact for all three and survives pid reuse.
+    _pdeathsig_preexec(os.getppid())
+    try:
+        if not parent.is_alive():
+            os._exit(1)
+    except Exception:
+        pass
 
 
 def compose_preexec(

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -191,10 +191,11 @@ def bind_current_process_to_parent_lifetime() -> None:
     if parent is None:
         _pdeathsig_preexec(None)  # not a worker: keep the getppid() == 1 heuristic
         return
-    # PDEATHSIG binds to the kernel parent, but "orphaned" comes from the creator's
-    # sentinel, not a pid compare: getppid() is the creator only under fork/spawn,
-    # while under forkserver it is the fork server, so comparing would kill every
-    # healthy worker. The sentinel is exact for all three and survives pid reuse.
+    # PDEATHSIG binds to the kernel parent; "orphaned" comes from the creator's
+    # sentinel, not a pid compare, since getppid() is the creator only under
+    # fork/spawn -- under forkserver it is the fork server, so comparing would kill
+    # every healthy worker. The sentinel is exact for all three and survives pid
+    # reuse. A forkserver creator dying later stays uncovered, as it is on main.
     _pdeathsig_preexec(os.getppid())
     try:
         if not parent.is_alive():

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -152,13 +152,24 @@ def _install_windows_job() -> None:
 # ── Child binding ──
 
 
-def _pdeathsig_preexec() -> None:
+def _pdeathsig_preexec(owner_pid: Optional[int] = None) -> None:
     # Runs in the forked child before exec. prctl is Linux-only; the getppid
-    # check closes the race where the parent died before this ran.
+    # check closes the race where the parent died before this ran, leaving the
+    # child with no death signal (PR_SET_PDEATHSIG does not survive the fork).
+    #
+    # owner_pid is the spawning process's own pid, read before the fork. Compare
+    # against it rather than testing for "reparented to init": a bare
+    # `getppid() == 1` also matches a parent that legitimately IS pid 1, which is
+    # how Unsloth Studio runs as a container entrypoint. There the check fired on
+    # every healthy spawn and killed llama-server before exec, so the load failed
+    # with exit code 1 and no output at all (#7886). It also misses reparenting
+    # to a subreaper, whose pid is not 1.
     try:
         import ctypes
         ctypes.CDLL("libc.so.6", use_errno = True).prctl(_PR_SET_PDEATHSIG, signal.SIGTERM)
-        if os.getppid() == 1:
+        parent_pid = os.getppid()
+        orphaned = parent_pid != owner_pid if owner_pid is not None else parent_pid == 1
+        if orphaned:
             os._exit(1)
     except Exception:
         pass
@@ -168,20 +179,35 @@ def bind_current_process_to_parent_lifetime() -> None:
     """Bind the CURRENT process to its parent's death (Linux). For multiprocessing
     children, which cannot take a preexec_fn, so the parent cannot set
     PR_SET_PDEATHSIG for them -- the child must do it itself at startup."""
-    if _is_linux():
-        _pdeathsig_preexec()
+    if not _is_linux():
+        return
+    # multiprocessing records the pid of the process that created this worker,
+    # which the spawn and fork contexts (the only ones Unsloth uses) both make
+    # its direct parent. Passing it keeps the orphan check off the "reparented
+    # to init" fallback, which kills every worker of a pid-1 parent (#7886).
+    owner_pid = None
+    try:
+        import multiprocessing
+        parent = multiprocessing.parent_process()
+        if parent is not None:
+            owner_pid = parent.pid
+    except Exception:
+        pass
+    _pdeathsig_preexec(owner_pid)
 
 
-def compose_preexec(existing: Optional[Callable[[], None]]) -> Optional[Callable[[], None]]:
+def compose_preexec(
+    existing: Optional[Callable[[], None]],
+    owner_pid: Optional[int] = None,
+) -> Optional[Callable[[], None]]:
     """Run the PDEATHSIG hook then any caller-supplied preexec (Linux only)."""
     if not _is_linux():
         return existing
-    if existing is None:
-        return _pdeathsig_preexec
 
     def _composed() -> None:
-        _pdeathsig_preexec()
-        existing()
+        _pdeathsig_preexec(owner_pid)
+        if existing is not None:
+            existing()
 
     return _composed
 
@@ -194,7 +220,9 @@ def child_popen_kwargs(preexec_fn: Optional[Callable[[], None]] = None) -> dict:
     ``**child_popen_kwargs()`` alongside the caller's existing kwargs.
     """
     if _is_linux():
-        return {"preexec_fn": compose_preexec(preexec_fn)}
+        # os.getpid() runs in the spawning process, so the child can tell a real
+        # reparenting apart from a parent that is pid 1 (see _pdeathsig_preexec).
+        return {"preexec_fn": compose_preexec(preexec_fn, os.getpid())}
     return {}
 
 

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -166,6 +166,7 @@ def _pdeathsig_preexec(owner_pid: Optional[int] = None) -> None:
     # to a subreaper, whose pid is not 1.
     try:
         import ctypes
+
         ctypes.CDLL("libc.so.6", use_errno = True).prctl(_PR_SET_PDEATHSIG, signal.SIGTERM)
         parent_pid = os.getppid()
         orphaned = parent_pid != owner_pid if owner_pid is not None else parent_pid == 1
@@ -197,8 +198,7 @@ def bind_current_process_to_parent_lifetime() -> None:
 
 
 def compose_preexec(
-    existing: Optional[Callable[[], None]],
-    owner_pid: Optional[int] = None,
+    existing: Optional[Callable[[], None]], owner_pid: Optional[int] = None
 ) -> Optional[Callable[[], None]]:
     """Run the PDEATHSIG hook then any caller-supplied preexec (Linux only)."""
     if not _is_linux():

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -189,13 +189,17 @@ def bind_current_process_to_parent_lifetime() -> None:
     except Exception:
         pass
     if parent is None:
-        _pdeathsig_preexec(None)  # not a worker: keep the getppid() == 1 heuristic
+        # No creator to consult and nothing orphaned, so only arm PDEATHSIG. The
+        # bare getppid() == 1 test would kill a process whose parent legitimately
+        # IS pid 1, which is #7886 reached through this entrypoint.
+        _pdeathsig_preexec(os.getppid())
         return
     # PDEATHSIG binds to the kernel parent; "orphaned" comes from the creator's
-    # sentinel, not a pid compare, since getppid() is the creator only under
-    # fork/spawn -- under forkserver it is the fork server, so comparing would kill
-    # every healthy worker. The sentinel is exact for all three and survives pid
-    # reuse. A forkserver creator dying later stays uncovered, as it is on main.
+    # sentinel, not a pid compare, since under forkserver the kernel parent is the
+    # fork server and comparing would kill every healthy worker. The sentinel is
+    # exact under spawn and forkserver; under fork a sibling can inherit the
+    # creator's write end and read stale-alive, but PDEATHSIG already covers fork.
+    # A forkserver creator dying later stays uncovered, as it is on main.
     _pdeathsig_preexec(os.getppid())
     try:
         if not parent.is_alive():

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -153,17 +153,12 @@ def _install_windows_job() -> None:
 
 
 def _pdeathsig_preexec(owner_pid: Optional[int] = None) -> None:
-    # Runs in the forked child before exec. prctl is Linux-only; the getppid
-    # check closes the race where the parent died before this ran, leaving the
-    # child with no death signal (PR_SET_PDEATHSIG does not survive the fork).
-    #
-    # owner_pid is the spawning process's own pid, read before the fork. Compare
-    # against it rather than testing for "reparented to init": a bare
-    # `getppid() == 1` also matches a parent that legitimately IS pid 1, which is
-    # how Unsloth Studio runs as a container entrypoint. There the check fired on
-    # every healthy spawn and killed llama-server before exec, so the load failed
-    # with exit code 1 and no output at all (#7886). It also misses reparenting
-    # to a subreaper, whose pid is not 1.
+    # Runs in the forked child before exec (PR_SET_PDEATHSIG does not survive the
+    # fork); the getppid check closes the race where the parent died first.
+    # owner_pid is the spawner's pid, read pre-fork. A bare `getppid() == 1` also
+    # matches a parent that legitimately IS pid 1, which is how Studio runs as a
+    # container entrypoint: it killed every llama-server before exec (#7886). It
+    # also misses reparenting to a subreaper, whose pid is not 1.
     try:
         import ctypes
 
@@ -189,17 +184,16 @@ def bind_current_process_to_parent_lifetime() -> None:
     except Exception:
         pass
     if parent is None:
-        # No creator to consult and nothing orphaned, so only arm PDEATHSIG. The
-        # bare getppid() == 1 test would kill a process whose parent legitimately
-        # IS pid 1, which is #7886 reached through this entrypoint.
+        # No creator to consult and nothing orphaned, so only arm PDEATHSIG: the
+        # bare getppid() == 1 test would kill a parent-is-pid-1 process (#7886).
         _pdeathsig_preexec(os.getppid())
         return
     # PDEATHSIG binds to the kernel parent; "orphaned" comes from the creator's
     # sentinel, not a pid compare, since under forkserver the kernel parent is the
     # fork server and comparing would kill every healthy worker. The sentinel is
     # exact under spawn and forkserver; under fork a sibling can inherit the
-    # creator's write end and read stale-alive, but PDEATHSIG already covers fork.
-    # A forkserver creator dying later stays uncovered, as it is on main.
+    # creator's write end and read stale-alive, but PDEATHSIG covers fork. A
+    # forkserver creator dying later stays uncovered, as on main.
     _pdeathsig_preexec(os.getppid())
     try:
         if not parent.is_alive():
@@ -231,8 +225,8 @@ def child_popen_kwargs(preexec_fn: Optional[Callable[[], None]] = None) -> dict:
     ``**child_popen_kwargs()`` alongside the caller's existing kwargs.
     """
     if _is_linux():
-        # os.getpid() runs in the spawning process, so the child can tell a real
-        # reparenting apart from a parent that is pid 1 (see _pdeathsig_preexec).
+        # os.getpid() runs in the spawner, so the child tells real reparenting
+        # apart from a parent that is pid 1 (see _pdeathsig_preexec).
         return {"preexec_fn": compose_preexec(preexec_fn, os.getpid())}
     return {}
 


### PR DESCRIPTION
Fixes #7886.

## Cause

`_pdeathsig_preexec` runs in the forked child before exec and ends with:

```python
if os.getppid() == 1:
    os._exit(1)
```

That closes a real race: `PR_SET_PDEATHSIG` does not survive the fork, so a parent that dies before the prctl call leaves the child with no death signal. But "reparented to init" also describes a child whose parent legitimately is pid 1, and that is exactly how the backend runs under a container entrypoint:

```bash
docker run -d ... unsloth:main bash -c "/root/.local/bin/unsloth studio -H 0.0.0.0 -p 8888"
```

`bash -c` execs a single simple command rather than forking, `unsloth_cli/commands/studio.py:1617` then `os.execvp`s into the studio venv python, and `run_server()` starts uvicorn in-process. Nothing forks along that chain, so the process that spawns `llama-server` is pid 1 and every child self-killed before reaching the binary.

The reporter's log shows the signature: exit code 1 about 140 ms after the spawn, with an empty output tail.

```
INF event=Starting llama-server: /root/.unsloth/llama.cpp/llama-server -m ... --chat-template-kwargs {"enable_thinking": true}
INF event=llama-server stdout/stderr -> /root/.unsloth/studio/logs/llama-server/llama-1785862631-port-39059-try0.log
ERR event=llama-server exited with code 1. Output (tail):  Full log: ...
```

The empty tail is what identifies it. `llama-server` is spawned with `stdout=PIPE, stderr=STDOUT`, so anything it prints is captured. A mangled `--chat-template-kwargs` under that exact setup yields 554 characters and exit 1; here nothing was captured at all, because `os._exit(1)` ran before exec. The JSON parse error in the report comes from pasting the logged command into a shell, which strips the quotes around the JSON. Studio passes argv as a list, so no shell splitting happens on the real path.

This affected every model load in that deployment, not only reasoning models.

## Fix

Compare against the spawning process's pid instead of testing for pid 1.

- `child_popen_kwargs()` reads `os.getpid()` in the parent, before the fork, and binds it into the composed preexec. Covers llama-server, sd-cpp, the STT sidecar, cloudflared and the RAG embed server.
- `bind_current_process_to_parent_lifetime()` has no preexec to carry a value, so the worker binds itself: it installs PDEATHSIG against its kernel parent and takes the orphan decision from `multiprocessing.parent_process().is_alive()`, which polls the creator's sentinel. Comparing that pid against `getppid()` was tried first, but under `forkserver` the kernel parent is the fork server rather than the creator, so it read every healthy worker as orphaned and killed it before its target ran. The sentinel is exact under fork, spawn and forkserver, and survives pid reuse and an unreaped zombie creator. Covers the training, export and data-recipe workers, which self-killed the same way.

  One limitation stays, and it matches `main`: under `forkserver` a creator that dies *after* the worker has bound is not caught, because PDEATHSIG follows the fork server. Every worker site pins `mp.get_context("spawn")`, so the tree never takes that path.

The comparison is also strictly tighter than the old one: it catches reparenting to a subreaper, whose pid is not 1.

## Testing

`studio/backend/tests/test_process_lifetime.py`: 22 tests. 21 passed and 1 skipped on Linux (the skip is the Windows Job Object case), 19 passed and 3 skipped on macOS, where the two Linux `PR_SET_PDEATHSIG` cases skip as well.

New coverage:

- a child whose parent really is pid 1 is left alone
- a child reparented away from its owner still exits
- `child_popen_kwargs()` binds the spawning pid
- a worker whose creator is alive is left alone, including under `forkserver`
- a worker whose creator is already gone exits
- a broken sentinel fails open rather than killing a healthy worker

To exercise the real path on a Linux host, without docker or a model:

```bash
unshare -rpf --mount-proc python3 - <<'EOF'
import os, subprocess, sys
sys.path.insert(0, "studio/backend")
from utils.process_lifetime import child_popen_kwargs
print("pid", os.getpid())
p = subprocess.run(["/bin/echo", "hi"], **child_popen_kwargs(), capture_output = True)
print("rc", p.returncode, "out", p.stdout)
EOF
```

Before: `rc 1 out b''`. After: `rc 0 out b'hi\n'`.

