### PR TITLE
Studio: stop the Images Train settings columns overlapping

### DIFF
--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -140,7 +140,10 @@ const DATASET_FILE_ACCEPT = ".png,.jpg,.jpeg,.webp,.bmp,.txt,.caption,.jsonl";
 const selectClass =
   "h-8 w-full min-w-0 text-xs *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:truncate";
 // Every settings cell is a grid item, so it needs min-w-0 to be allowed to shrink.
-const fieldClass = "grid min-w-0 gap-2";
+// grid-cols-1 is what carries that shrink to the contents: a bare `grid` leaves the
+// implicit column auto-sized, so the track froze at its widest child's min-content
+// (150px for the run-length pair) and the cell painted over the next column.
+const fieldClass = "grid grid-cols-1 min-w-0 gap-2";
 
 /** A field's label with its guidance behind an "i" tooltip, keeping the grid scannable.
  *  Only facts a user must act on stay on the page as text. */
@@ -153,7 +156,9 @@ function FieldLabel({
 }) {
   return (
     <div className="flex min-w-0 items-center gap-1">
-      <Label className="min-w-0 truncate text-xs">{children}</Label>
+      {/* block, not Label's default flex: text-overflow does nothing on a flex
+          container, so truncate cut the text mid-glyph instead of ellipsing it. */}
+      <Label className="block min-w-0 truncate text-xs">{children}</Label>
       {hint ? <InfoHint>{hint}</InfoHint> : null}
     </div>
   );
@@ -941,9 +946,14 @@ export function DiffusionTrainPanel({
   };
 
   // The training settings, shown as the run area's MAIN content before a run starts; the run view replaces them afterwards.
+  // Columns key off this pane's OWN width, not the window's: the pane is whatever is
+  // left beside the 416px form column, so a viewport breakpoint put three columns in a
+  // ~280px pane and every cell spilled into its neighbour. A cell needs 150px (the run
+  // length pair's floor: 66px number field + 6px gap + 78px unit select), hence 324px
+  // for two columns and 498px for three.
   const trainingSettings = (
-    <div className="flex flex-col gap-6">
-      <div className="grid grid-cols-2 gap-x-6 gap-y-5 lg:grid-cols-3">
+    <div className="@container flex flex-col gap-6">
+      <div className="grid grid-cols-1 gap-x-6 gap-y-5 @min-[324px]:grid-cols-2 @min-[498px]:grid-cols-3">
         {durationField}
         {numberField("LoRA rank", rank, setRank, 1, {
           hint: "How much the adapter can learn. Higher captures more detail and makes a bigger file; 16 suits most styles, 32+ for complex subjects.",
@@ -965,7 +975,7 @@ export function DiffusionTrainPanel({
         })}
       </div>
 
-      <div className="grid grid-cols-2 items-start gap-x-6 gap-y-5 lg:grid-cols-3">
+      <div className="grid grid-cols-1 items-start gap-x-6 gap-y-5 @min-[324px]:grid-cols-2 @min-[498px]:grid-cols-3">
         {numberField("Learning rate", learningRate, setLearningRate, 0.0001, {
           min: 0,
           step: 0.00001,
@@ -997,7 +1007,7 @@ export function DiffusionTrainPanel({
           })}
       </div>
 
-      <div className="grid grid-cols-2 items-start gap-x-6 gap-y-5 lg:grid-cols-3">
+      <div className="grid grid-cols-1 items-start gap-x-6 gap-y-5 @min-[324px]:grid-cols-2 @min-[498px]:grid-cols-3">
         <div className={fieldClass}>
           <FieldLabel hint="Recomputes activations instead of holding them in memory: less VRAM, slightly slower steps.">
             Gradient checkpointing

--- a/tests/studio/test_diffusion_train_settings_layout_contract.py
+++ b/tests/studio/test_diffusion_train_settings_layout_contract.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Layout contract for the Images -> Train "Training settings" grid.
+
+The panel is a fraction of the window, so a viewport breakpoint put three columns
+in a ~280px pane; and each cell was a bare `grid`, whose implicit column is
+auto-sized and froze at its widest child's min-content, so the cell painted over
+its neighbour instead of shrinking. Both fixes have to stay: the container query
+keeps cells wide enough, grid-cols-1 keeps a cell inside its column if it ever
+is not.
+"""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+PANEL_TSX = REPO / "studio/frontend/src/features/images/train/diffusion-train-panel.tsx"
+
+
+def _source() -> str:
+    return PANEL_TSX.read_text(encoding = "utf-8")
+
+
+def test_settings_cell_cannot_outgrow_its_grid_column():
+    assert 'const fieldClass = "grid grid-cols-1 min-w-0 gap-2";' in _source()
+
+
+def test_settings_columns_key_off_the_pane_width_not_the_viewport():
+    source = _source()
+
+    # The run area declares itself the query container...
+    assert '<div className="@container flex flex-col gap-6">' in source
+    # ...and all three settings grids step up on ITS width. 324px fits two 150px
+    # cells plus the 24px gutter, 498px fits three.
+    assert source.count("@min-[324px]:grid-cols-2 @min-[498px]:grid-cols-3") == 3
+    # No viewport breakpoint left behind: that is what put 3 columns in a 280px pane.
+    assert "lg:grid-cols-3" not in source
+
+
+def test_field_label_ellipses_instead_of_cutting_mid_glyph():
+    # Label's own display is flex and text-overflow does nothing on a flex
+    # container, so truncate only ellipses when paired with block.
+    assert (
+        '<Label className="block min-w-0 truncate text-xs">{children}</Label>'
+        in _source()
+    )

--- a/tests/studio/test_diffusion_train_settings_layout_contract.py
+++ b/tests/studio/test_diffusion_train_settings_layout_contract.py
@@ -41,7 +41,4 @@ def test_settings_columns_key_off_the_pane_width_not_the_viewport():
 def test_field_label_ellipses_instead_of_cutting_mid_glyph():
     # Label's own display is flex and text-overflow does nothing on a flex
     # container, so truncate only ellipses when paired with block.
-    assert (
-        '<Label className="block min-w-0 truncate text-xs">{children}</Label>'
-        in _source()
-    )
+    assert '<Label className="block min-w-0 truncate text-xs">{children}</Label>' in _source()


### PR DESCRIPTION
On Images -> Train, the run-length unit `Select` in the Training settings panel is painted on top of the LoRA rank input beside it, and several labels in the same panel are cut mid-word: "Grad accumulatior", "Gradient checkpoi", "On (less VF".

## What I measured

I drove a live Studio with Playwright and read the geometry out of the DOM rather than judging it by eye, sweeping the window from 1024px to 1920px:

| window | settings pane | column | run-length row | unit select -> LoRA rank |
|---|---|---|---|---|
| 1024px | 242px | 64.7px | 150px | **-61.3px (overlap)** |
| 1060px | 278px | 76.7px | 150px | **-49.3px (overlap)** |
| 1100px | 318px | 90px | 150px | **-36.0px (overlap)** |
| 1152px | 370px | 107.3px | 150px | **-18.7px (overlap)** |
| 1200px | 418px | 123.3px | 150px | **-2.7px (overlap)** |
| 1280px | 498px | 150px | 150px | 24px |
| 1440px | 658px | 203.3px | 203.3px | 24px |

Two things combine.

The grid steps to three columns on `lg:` (a **viewport** breakpoint), but the panel is not the viewport: it is whatever is left beside the 416px form column. At a 1060px window that pane is 278px, so a column is 77px, while the run-length cell needs 150px (measured min-content: ~66px number field + 6px gap + ~78px unit select).

The cell could not shrink into its column either. `fieldClass` is a bare `grid`, so its implicit column is `grid-auto-columns: auto`, whose base size is the widest item's min-content. `getComputedStyle` reports that inner track as a flat `150px` at *every* window width, inside a cell that is 90px at 1100px. The 60px it overflows lands on the next column, 24px of gutter away, hence the 36px of overlap. `min-w-0` on the cell lets the cell shrink but does nothing for the track inside it.

This is not only cosmetic. `document.elementFromPoint` at the centre of the unit select returns the LoRA rank input instead, so the control is unclickable at those widths; Playwright's own actionability check refuses to click it.

The label clipping is the same overflow. `truncate` was already on the label; it does not ellipse because `Label`'s own display is `flex`, and `text-overflow` has no effect on a flex container, so the text is hard-cut instead.

## The fix

- Size the columns off the pane's own width with a container query: `@container` on the run area, `@min-[324px]:grid-cols-2 @min-[498px]:grid-cols-3` (324px = two 150px cells plus the gutter, 498px = three). Windows at 1280px and up keep exactly the three-column layout they have today; only the widths that were broken change.
- `grid-cols-1` on `fieldClass`, so the cell's own track is `minmax(0, 1fr)` and a cell can never outgrow its column again, whatever ends up inside it.
- `block` alongside `truncate` on the field label, so if it ever does have to clip it ellipses rather than cutting a glyph in half.

The pane is `window - sidebar - 502px`, so the 1280px crossover is the figure for the default 280px sidebar on a platform with overlay scrollbars. The sidebar is user-resizable (260-480) and collapsible, and on a platform with classic scrollbars a scrolling pane gives up another ~15px, which puts the three-column crossover nearer 1295px there. In every one of those cases the layout simply holds one fewer column; it never overlaps again.

## Before / after

1060px window, the width in the report:

![Training settings at 1060px, before and after](https://raw.githubusercontent.com/unslothai/unsloth-staging-1/57ae8ec6202162aa4f102d2c9ba60374ce5d43b4/evidence/studio-uifix/issue1_train_settings_1060.png)

1200px window, where the overlap is smaller but the labels are still cut:

![Training settings at 1200px, before and after](https://raw.githubusercontent.com/unslothai/unsloth-staging-1/57ae8ec6202162aa4f102d2c9ba60374ce5d43b4/evidence/studio-uifix/issue1_train_settings_1200.png)

## Verification

The same Playwright probe now reports no intersection between the unit select and the LoRA rank input at 1024 / 1060 / 1100 / 1152 / 1200 / 1280 / 1366 / 1440 / 1920, and no element in the panel with `scrollWidth > clientWidth` at any of them (before: overlap at the first five widths, and up to 67px of clipped label text). The sweep was repeated in Chromium, Firefox and WebKit, which agreed to within 0.01px, and the 1280px and 1920px frames are pixel-identical to the current build.

`tests/studio/test_diffusion_train_settings_layout_contract.py` pins all three parts as a source contract.
