### PR TITLE
Studio: stop the New chat row looking hovered on a blank new chat

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1874,12 +1874,11 @@ export function AppSidebar() {
               }
               // Off-route this row is the only sign chats are still running.
               spinner={anyChatRunning && !isChatRoute}
-              active={
-                isChatRoute &&
-                !search.thread &&
-                !search.compare &&
-                !search.project
-              }
+              // An action, not a destination, so it never marks itself active:
+              // the active pill is the hover pill, and on a blank new chat it
+              // left the row looking permanently hovered. Search below is the
+              // same kind of row and has always passed false.
+              active={false}
               onClick={() => {
                 if (showReturnToChat) {
                   // Prefer the running thread so we return to the live generation,

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+// The pinned top rows run an action rather than open a page, so neither may
+// mark itself active: nav rows paint one pill for both states, and an active
+// action row therefore sits there looking permanently hovered.
+
+async function sidebarSource(): Promise<string> {
+  return readFile(
+    new URL("../src/components/app-sidebar.tsx", import.meta.url),
+    "utf8",
+  );
+}
+
+/** The props of the NavItem carrying `label`, from its tag to the next one. */
+function navItemFor(source: string, label: string): string {
+  const rows = source.split("<NavItem").slice(1);
+  const row = rows.find((chunk) => chunk.includes(label));
+  assert.ok(row, `no NavItem renders ${label}`);
+  return row;
+}
+
+test("New chat never marks itself active", async () => {
+  const row = navItemFor(await sidebarSource(), "shell.navigation.newChat");
+  assert.match(row, /active=\{false\}/);
+});
+
+test("Search never marks itself active either", async () => {
+  const row = navItemFor(
+    await sidebarSource(),
+    'label={t("shell.navigation.search")}',
+  );
+  assert.match(row, /active=\{false\}/);
+});
+
+test("a nav row paints the same pill when active and when hovered", async () => {
+  // The reason the rows above pass false. If active ever gets its own
+  // background, that reason is gone and this can be revisited.
+  const css = await readFile(
+    new URL("../src/index.css", import.meta.url),
+    "utf8",
+  );
+  const rule = /([^}]*)\{\s*background-color: var\(--nav-surface-hover\)/.exec(
+    css,
+  );
+  assert.ok(rule, "no rule paints a nav row with --nav-surface-hover");
+  assert.match(rule[1], /\.sidebar-nav-btn:hover/);
+  assert.match(rule[1], /\.sidebar-nav-btn\[data-active="true"\]/);
+});


### PR DESCRIPTION
### What

On a blank new chat, the sidebar's New chat row sat there looking permanently hovered.

Nav rows paint one pill for both states. In `index.css`, `.sidebar-nav-btn:hover` and `.sidebar-nav-btn[data-active="true"]` are in the same selector list with a single `background-color: var(--nav-surface-hover)` declaration, so "active" and "hovered" are visually the same row. New chat set `active` whenever the chat route carried no thread, compare or project, which is exactly the state you land in after opening a new chat, so the row stayed lit with the pointer nowhere near it.

### Change

New chat is an action rather than a destination, so it no longer marks itself active. That matches the Search row directly below it, which has always passed `active={false}`. Hovering still lights the row, and nothing about the click behaviour, the running-chat spinner or the Return to chat label changes.

### Notes

The pinned group at the top of the sidebar is the only place this applies. Model hub, Projects, Images, Video and Train are destinations and still mark themselves active on their own pages.

### Testing

`tests/sidebar-action-rows-inert.test.ts` pins both action rows as never-active, and pins the shared hover/active pill that is the reason for it, so if that rule ever splits the constraint is visible.

- `npm test` 387 passing
- `npm run typecheck`
- `npm run i18n:check`
- `npm run build`
