### PR TITLE
Studio: even out the gap around the More flyout's rule

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -2066,8 +2066,10 @@ export function AppSidebar() {
                         );
                       })}
                       {/* Way out of the flyout: jump straight to the control that
-                          decides what lives here vs. on the sidebar itself. */}
-                      <DropdownMenuSeparator className="mx-1! my-1.5! h-0! border-t border-border/70 bg-transparent! dark:border-white/15" />
+                          decides what lives here vs. on the sidebar itself.
+                          my-1 matches the menu's own p-1, so the gap either side
+                          of the rule equals the one under the last row. */}
+                      <DropdownMenuSeparator className="mx-1! my-1! h-0! border-t border-border/70 bg-transparent! dark:border-white/15" />
                       <DropdownMenuItem
                         onSelect={() =>
                           useSettingsDialogStore

--- a/studio/frontend/tests/more-menu-separator-gap.test.ts
+++ b/studio/frontend/tests/more-menu-separator-gap.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+// The More flyout ends with a rule and the Customize sidebar row. The rule's
+// vertical margin has to equal the menu's own padding, or the gap above that
+// last row reads as bigger than the one below it.
+const TAILWIND_UNIT = 4;
+
+function spacing(classes: string, prefix: string): number {
+  const m = new RegExp(`(?:^| )${prefix}-([0-9.]+)!?(?: |$)`).exec(classes);
+  assert.ok(m, `no ${prefix}-* in "${classes}"`);
+  return Number(m[1]) * TAILWIND_UNIT;
+}
+
+test("the More flyout's rule sits as far from its rows as the menu's own edge", async () => {
+  const source = await readFile(
+    new URL("../src/components/app-sidebar.tsx", import.meta.url),
+    "utf8",
+  );
+
+  const menu =
+    /onPointerLeave=\{closeMoreSoon\}\s*\n\s*className="([^"]*)"/.exec(source);
+  assert.ok(menu, "could not find the More flyout's DropdownMenuContent");
+  const rule = /<DropdownMenuSeparator className="(mx-1![^"]*)"/.exec(source);
+  assert.ok(rule, "could not find the More flyout's separator");
+
+  assert.equal(spacing(rule[1], "my"), spacing(menu[1], "p"));
+});


### PR DESCRIPTION
### What

In the More flyout, the gap between API and the rule, and between the rule and Customize sidebar, was wider than the gap under Customize sidebar.

The separator carried `my-1.5!` (6px above and below) inside a `DropdownMenuContent` padded `p-1` (4px). The 4px under the last row is the menu's own padding, so the rule was sitting 50% further from its neighbours than the menu edge sits from the row above it.

### Change

The separator drops to `my-1!`, which is the same 4px. The gap above the rule, below the rule and under Customize sidebar are now all equal. The rule's colour, width and inset are unchanged.

### Notes

Only the More flyout's separator is touched. The account menu at the bottom of the sidebar uses a deliberately wider `my-2.5!` and is left alone.

### Testing

`tests/more-menu-separator-gap.test.ts` reads the separator's margin and the menu's padding out of the source and asserts they are equal, so the two cannot drift apart again. Verified it fails on `main` (6 vs 4) and passes here.

- `npm test` 385 passing
- `npm run typecheck`
- `npm run i18n:check`
- `npm run build`
