### PR TITLE
Do not enter CUDA autocast for a float32 model during generate

### DIFF
--- a/tests/test_float32_generate_autocast.py
+++ b/tests/test_float32_generate_autocast.py
@@ -60,8 +60,11 @@ def _the_autocaster_call():
     for node in ast.walk(ast.parse(SRC)):
         if not isinstance(node, ast.Assign):
             continue
-        if not (len(node.targets) == 1 and isinstance(node.targets[0], ast.Name)
-                and node.targets[0].id == "autocaster"):
+        if not (
+            len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "autocaster"
+        ):
             continue
         call = node.value
         if not isinstance(call, ast.Call):
@@ -85,11 +88,14 @@ def test_the_forced_float16_branch_is_left_alone():
     assert "dtype = torch.float16)" in SRC
 
 
-@pytest.mark.parametrize("dtype,expected", [
-    (torch.float32, False),
-    (torch.float16, True),
-    (torch.bfloat16, True),
-])
+@pytest.mark.parametrize(
+    "dtype,expected",
+    [
+        (torch.float32, False),
+        (torch.float16, True),
+        (torch.bfloat16, True),
+    ],
+)
 def test_the_gate_by_execution(dtype, expected):
     assert (dtype in (torch.float16, torch.bfloat16)) is expected
 
@@ -107,8 +113,9 @@ def test_cuda_really_does_accept_float32_as_an_autocast_dtype():
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs a CUDA device")
 def test_the_gate_turns_that_into_a_no_op():
     dtype = torch.float32
-    with torch.autocast(device_type = "cuda", dtype = dtype,
-                        enabled = dtype in (torch.float16, torch.bfloat16)):
+    with torch.autocast(
+        device_type = "cuda", dtype = dtype, enabled = dtype in (torch.float16, torch.bfloat16)
+    ):
         assert torch.is_autocast_enabled("cuda") is False
 
 

--- a/tests/test_float32_generate_autocast.py
+++ b/tests/test_float32_generate_autocast.py
@@ -1,0 +1,116 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`torch.autocast(dtype = torch.float32)` on CUDA is enabled, not a no-op.
+
+The generate wrapper builds its autocaster from the model's own dtype. For a
+model the user deliberately loaded in float32 -- Spark-TTS is the live case,
+its notebook says "Spark seems to only work on float32 for now" -- that asks
+CUDA to autocast *to* float32.
+
+torch's CPU, XPU and MPS paths reject an unsupported autocast dtype. The CUDA
+path does not, so this enters genuinely enabled:
+
+    torch.is_autocast_enabled("cuda")   -> True
+    torch.get_autocast_dtype("cuda")    -> torch.float32
+
+Under torch.compile the first decode step of a freshly loaded, never-trained
+model then returns 166000/166000 non-finite logits, and generation dies in
+`torch.multinomial` on a distribution full of NaN. Forcing eager
+(UNSLOTH_COMPILE_DISABLE=1) makes the same call finite, which is what places
+the fault in the compiled graph rather than in the weights -- they were finite
+throughout.
+
+A float32 model has nothing to autocast to, so the fix is `enabled`, not a
+different dtype. That is the same idiom rl_replacements.py already uses.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+VISION = REPO_ROOT / "unsloth" / "models" / "vision.py"
+SRC = VISION.read_text(encoding = "utf-8")
+
+
+def _the_autocaster_call():
+    """The `else` branch's autocast call, as an AST node.
+
+    Located structurally rather than by line number so a later edit above it
+    does not silently retarget this test at the UNSLOTH_FORCE_FLOAT32 branch,
+    which builds its own float16 autocaster and is deliberately untouched.
+    """
+    for node in ast.walk(ast.parse(SRC)):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not (len(node.targets) == 1 and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == "autocaster"):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        kwargs = {k.arg: k.value for k in call.keywords}
+        # The forced-float16 branch passes a literal; this one forwards `dtype`.
+        if isinstance(kwargs.get("dtype"), ast.Name) and kwargs["dtype"].id == "dtype":
+            return kwargs
+    raise AssertionError("no autocaster assignment forwarding `dtype` found")
+
+
+def test_the_generate_autocaster_is_gated_on_a_dtype_it_can_use():
+    kwargs = _the_autocaster_call()
+    assert "enabled" in kwargs, "autocast is entered unconditionally"
+    expression = ast.unparse(kwargs["enabled"])
+    assert "float16" in expression and "bfloat16" in expression, expression
+
+
+def test_the_forced_float16_branch_is_left_alone():
+    """UNSLOTH_FORCE_FLOAT32 builds a float16 autocaster on purpose."""
+    assert "dtype = torch.float16)" in SRC
+
+
+@pytest.mark.parametrize("dtype,expected", [
+    (torch.float32, False),
+    (torch.float16, True),
+    (torch.bfloat16, True),
+])
+def test_the_gate_by_execution(dtype, expected):
+    assert (dtype in (torch.float16, torch.bfloat16)) is expected
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs a CUDA device")
+def test_cuda_really_does_accept_float32_as_an_autocast_dtype():
+    """The premise. If torch ever starts rejecting or ignoring this, the fix
+    above is no longer load-bearing and this test says so rather than letting
+    it rot in place."""
+    with torch.autocast(device_type = "cuda", dtype = torch.float32):
+        assert torch.is_autocast_enabled("cuda") is True
+        assert torch.get_autocast_dtype("cuda") == torch.float32
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs a CUDA device")
+def test_the_gate_turns_that_into_a_no_op():
+    dtype = torch.float32
+    with torch.autocast(device_type = "cuda", dtype = dtype,
+                        enabled = dtype in (torch.float16, torch.bfloat16)):
+        assert torch.is_autocast_enabled("cuda") is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -559,7 +559,8 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
         # no-op, and the compiled graph then returns inf/NaN logits. A float32 model has
         # nothing to autocast to; disable instead of asking for a dtype that is not one.
         autocaster = torch.autocast(
-            device_type = DEVICE_TYPE_TORCH, dtype = dtype,
+            device_type = DEVICE_TYPE_TORCH,
+            dtype = dtype,
             enabled = dtype in (torch.float16, torch.bfloat16),
         )
     # Prepare LoRA

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -554,7 +554,14 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
         autocaster = torch.autocast(device_type = DEVICE_TYPE_TORCH, dtype = torch.float16)
         dtype = torch.float16
     else:
-        autocaster = torch.autocast(device_type = DEVICE_TYPE_TORCH, dtype = dtype)
+        # CUDA autocast does not validate its dtype the way the CPU/XPU/MPS paths do,
+        # so autocast(dtype = torch.float32) enters ENABLED rather than turning into a
+        # no-op, and the compiled graph then returns inf/NaN logits. A float32 model has
+        # nothing to autocast to; disable instead of asking for a dtype that is not one.
+        autocaster = torch.autocast(
+            device_type = DEVICE_TYPE_TORCH, dtype = dtype,
+            enabled = dtype in (torch.float16, torch.bfloat16),
+        )
     # Prepare LoRA
     # state_dict = convert_lora_modules(self, dtype = dtype)
 


### PR DESCRIPTION
The generate wrapper in `unsloth/models/vision.py` builds its autocaster from the model's own dtype:

```python
autocaster = torch.autocast(device_type = DEVICE_TYPE_TORCH, dtype = dtype)
```

For a model the user deliberately loaded in float32, that asks CUDA to autocast *to* float32. torch's CPU, XPU and MPS paths reject an unsupported autocast dtype. The CUDA path does not, so this enters genuinely enabled:

```
torch.is_autocast_enabled("cuda")   -> True
torch.get_autocast_dtype("cuda")    -> torch.float32
```

## What that does

Under `torch.compile`, the first decode step of a **freshly loaded, never-trained** Spark-TTS returns 166000/166000 non-finite logits, and generation dies inside `torch.multinomial` on a distribution full of NaN. Narrowing it down:

| test | result |
|---|---|
| plain `model(**ids)` forward | finite |
| `model._old_generate(...)` (transformers' own) | finite |
| `model.generate(...)` (the unsloth wrapper) | **non-finite** |
| same, with `UNSLOTH_COMPILE_DISABLE=1` | finite, 3/3, 2048 tokens |
| bare forward inside `torch.autocast("cuda", torch.float32)` | **non-finite** |

The weights are finite throughout (`NONFINITE_PARAMS 0`), so this is not a divergence. It is the compiled graph under an enabled float32 autocast.

## The fix

A float32 model has nothing to autocast to, so gate on `enabled` rather than asking for a dtype that is not one. This is the same idiom `rl_replacements.py` already uses.

The `UNSLOTH_FORCE_FLOAT32` branch builds its own float16 autocaster on purpose and is untouched.

## Scope

This is separate from #7867. That PR fixes the *training* half of the same notebook, where a float32 model was wrapped in float16 autocast on a T4 and diverged to `nan x 7`. This one reproduces with zero training and affects models #7867 never touches, so it is kept apart deliberately.

Caveat worth stating: *why* the compiled graph goes non-finite under an enabled float32 autocast is empirical, not root-caused. What is established is that the autocast is enabled when it should not be, and that disabling it fixes generation.

## Verification

Untrained Spark-TTS, simulated T4, compile on, `max_new_tokens = 2048`: 3/3 attempts fail at step 1 before, 3/3 OK after. End to end with #7867 applied as well: `ACCELERATE_MIXED_PRECISION = no`, losses `13.92 -> 8.99`, generation OK.

`tests/test_float32_generate_autocast.py` locates the call structurally by AST rather than by line number, so a later edit cannot silently retarget it at the forced-float16 branch. It fails on `main` and passes here. One test pins the premise itself (that CUDA really does accept float32 as an autocast dtype), so if torch ever changes that, the suite says so rather than letting the guard rot.

```
7 passed
```