### PR TITLE
Fix sidebar bottom fade cutting off the last row mid-glyph

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -2390,10 +2390,13 @@ export function AppSidebar() {
         <div
           aria-hidden="true"
           className={cn(
-            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
-            // Shorter fade when the update card sits above the profile so the
-            // list reads closer to it.
-            showUpdateCard ? "h-3" : "h-10",
+            // The scroll area hard-clips at the fade's bottom edge, so a plain
+            // ramp is still part-transparent there and slices the last row
+            // mid-glyph. from-[16px] holds it opaque across the clip.
+            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[16px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
+            // Shorter fade with the update card so the list reads closer to
+            // it, but still tall enough to clear a row.
+            showUpdateCard ? "h-9" : "h-14",
             canScrollDown ? "opacity-100" : "opacity-0",
           )}
         />


### PR DESCRIPTION
## Problem

The sidebar's bottom fade (the wash from the chat list into the profile footer) cuts off partway, leaving the last visible row sliced through mid-glyph instead of dissolving.

The fade is an overlay pinned with `bottom-full`, so it sits over the last rows of the scroll area. It used a plain `bg-gradient-to-t from-[var(--sidebar-surface)] to-transparent`, which is a straight 0-100% alpha ramp and is only fully opaque at its very last pixel. The scroll container hard-clips its content at exactly that edge, so a few pixels up the gradient is still 60-75% transparent. A half-scrolled row was therefore still clearly readable right where the clip lands, giving a sharp horizontal cut through the text.

The `showUpdateCard` variant was worse: at `h-3` (12px) the fade was shorter than a single text row, so it could not fade a row at all.

## Fix

Give the gradient an opaque plateau at the bottom and lengthen it:

- `from-[16px]` holds the sidebar colour fully opaque for the last 16px, so the clip edge is fully covered and there is nothing left to slice.
- `h-10` to `h-14`, and `h-3` to `h-9`, leaving a real ramp above the plateau (40px and 20px) so the dissolve still reads smoothly.

The plateau absorbs the clip, the ramp above it does the actual fading. Behaviour is otherwise unchanged: the fade is still gated on `canScrollDown`, so at the bottom of the list (or for short lists) it stays hidden and the last row shows in full.

## Notes

One file, styling only. No behaviour or state changes.

Unrelated, but `.sidebar-bottom-fade` in `studio/frontend/src/index.css` is dead code: a sticky `::after` variant of this same fade that nothing renders. Left alone here, worth removing separately.
