### PR TITLE
Desktop: publish drafts without rebuilding

### DIFF
--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -1,0 +1,193 @@
+name: Publish Desktop Updater
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-desktop-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  publish-updater:
+    name: Advance desktop updater channel
+    if: startsWith(github.event.release.tag_name, 'desktop-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_REPO: ${{ github.repository }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Download updater metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/desktop-updater" "$RUNNER_TEMP/desktop-current"
+          gh release download "$RELEASE_TAG" --pattern latest.json --dir "$RUNNER_TEMP/desktop-updater"
+          test -s "$RUNNER_TEMP/desktop-updater/latest.json"
+          gh release download desktop-latest --pattern latest.json --dir "$RUNNER_TEMP/desktop-current" 2>/dev/null || true
+
+      - name: Remove standalone signature assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          signature_assets="$(
+            gh release view "$RELEASE_TAG" --json assets \
+              --jq '.assets[].name | select(endswith(".sig"))'
+          )"
+          while IFS= read -r asset_name; do
+            [[ -z "$asset_name" ]] || gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
+          done <<< "$signature_assets"
+
+      - name: Validate updater metadata
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+          import sys
+
+          def parse(value: str):
+              value = value.removeprefix('v')
+              match = re.fullmatch(
+                  r'(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)'
+                  r'(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?'
+                  r'(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?',
+                  value,
+              )
+              if not match:
+                  sys.exit(f'Invalid desktop updater version: {value}')
+              major, minor, patch, prerelease = match.groups()
+              return (int(major), int(minor), int(patch), prerelease)
+
+          def compare_identifier(left: str, right: str) -> int:
+              if left.isdigit() and right.isdigit():
+                  return (int(left) > int(right)) - (int(left) < int(right))
+              if left.isdigit():
+                  return -1
+              if right.isdigit():
+                  return 1
+              left_tail = re.fullmatch(r'([A-Za-z-]+)(\d+)', left)
+              right_tail = re.fullmatch(r'([A-Za-z-]+)(\d+)', right)
+              if left_tail and right_tail and left_tail.group(1).lower() == right_tail.group(1).lower():
+                  return (int(left_tail.group(2)) > int(right_tail.group(2))) - (
+                      int(left_tail.group(2)) < int(right_tail.group(2))
+                  )
+              return (left > right) - (left < right)
+
+          def compare(left: str, right: str) -> int:
+              left_major, left_minor, left_patch, left_pre = parse(left)
+              right_major, right_minor, right_patch, right_pre = parse(right)
+              left_core = (left_major, left_minor, left_patch)
+              right_core = (right_major, right_minor, right_patch)
+              if left_core != right_core:
+                  return (left_core > right_core) - (left_core < right_core)
+              if left_pre == right_pre:
+                  return 0
+              if left_pre is None:
+                  return 1
+              if right_pre is None:
+                  return -1
+              left_parts = left_pre.split('.')
+              right_parts = right_pre.split('.')
+              for left_part, right_part in zip(left_parts, right_parts):
+                  order = compare_identifier(left_part, right_part)
+                  if order:
+                      return order
+              return (len(left_parts) > len(right_parts)) - (len(left_parts) < len(right_parts))
+
+          release_tag = os.environ['RELEASE_TAG']
+          tag_match = re.fullmatch(r'desktop-v(.+)', release_tag)
+          if not tag_match:
+              sys.exit(f'Not a desktop version release: {release_tag}')
+
+          latest_path = pathlib.Path(os.environ['RUNNER_TEMP'], 'desktop-updater', 'latest.json')
+          data = json.loads(latest_path.read_text())
+          if not isinstance(data, dict):
+              sys.exit('latest.json must be a JSON object')
+          version = data.get('version')
+          if not isinstance(version, str) or version.removeprefix('v') != tag_match.group(1):
+              sys.exit(f'latest.json version {version!r} does not match {release_tag}')
+          parse(version)
+
+          platforms = data.get('platforms')
+          if not isinstance(platforms, dict) or not platforms:
+              sys.exit('latest.json missing platforms')
+          required = {'darwin-aarch64': False, 'linux-x86_64': False, 'windows-x86_64': False}
+          expected_prefix = f'https://github.com/{os.environ["GITHUB_REPOSITORY"]}/releases/download/{release_tag}/'
+          for platform, entry in platforms.items():
+              if not isinstance(entry, dict):
+                  sys.exit(f'Platform {platform} must be an object')
+              url = entry.get('url')
+              signature = entry.get('signature')
+              if not isinstance(url, str) or not url.startswith(expected_prefix):
+                  sys.exit(f'Platform {platform} URL must point at {release_tag}: {url}')
+              if not isinstance(signature, str) or not signature.strip():
+                  sys.exit(f'Platform {platform} missing signature')
+              for family in required:
+                  if platform == family or platform.startswith(family + '-'):
+                      required[family] = True
+          missing = [family for family, found in required.items() if not found]
+          if missing:
+              sys.exit('latest.json missing required platform families: ' + ', '.join(missing))
+
+          current_path = pathlib.Path(os.environ['RUNNER_TEMP'], 'desktop-current', 'latest.json')
+          if current_path.is_file():
+              current = json.loads(current_path.read_text()).get('version')
+              if not isinstance(current, str):
+                  sys.exit('desktop-latest latest.json has missing version')
+              if compare(version, current) < 0:
+                  sys.exit(f'Refusing to move desktop-latest from {current} to older version {version}.')
+          PY
+
+      - name: Ensure updater channel release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          channel_json="$RUNNER_TEMP/desktop-latest-release.json"
+          if ! gh api "repos/${GITHUB_REPOSITORY}/releases/tags/desktop-latest" > "$channel_json" 2>/dev/null; then
+            gh release create desktop-latest \
+              --title "Unsloth Desktop updater channel" \
+              --notes "Machine-managed desktop updater channel; latest.json follows published desktop releases." \
+              --prerelease \
+              --latest=false \
+              --target "$GITHUB_SHA"
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/desktop-latest" > "$channel_json"
+          fi
+
+          python3 <<'PY'
+          import json
+          import os
+          import pathlib
+          import sys
+
+          channel = json.loads(pathlib.Path(os.environ['RUNNER_TEMP'], 'desktop-latest-release.json').read_text())
+          if channel.get('draft'):
+              sys.exit('desktop-latest release is draft')
+          if channel.get('immutable'):
+              sys.exit('desktop-latest release is immutable')
+          if not channel.get('prerelease'):
+              sys.exit('desktop-latest release must be a prerelease')
+          PY
+
+      - name: Publish updater channel metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload desktop-latest "$RUNNER_TEMP/desktop-updater/latest.json" --clobber
+          test "$(gh release view desktop-latest --json assets --jq '[.assets[] | select(.name == "latest.json")] | length')" = 1

--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -10,6 +10,7 @@ permissions:
 concurrency:
   group: release-desktop-${{ github.repository }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   publish-updater:
@@ -34,9 +35,35 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/desktop-updater" "$RUNNER_TEMP/desktop-current"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+            > "$RUNNER_TEMP/source-release.json"
           gh release download "$RELEASE_TAG" --pattern latest.json --dir "$RUNNER_TEMP/desktop-updater"
           test -s "$RUNNER_TEMP/desktop-updater/latest.json"
-          gh release download desktop-latest --pattern latest.json --dir "$RUNNER_TEMP/desktop-current" 2>/dev/null || true
+
+          channel_json="$RUNNER_TEMP/desktop-latest-release.json"
+          channel_error="$RUNNER_TEMP/desktop-latest-error.txt"
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/desktop-latest" \
+            > "$channel_json" 2> "$channel_error"; then
+            if python3 - "$channel_json" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          channel = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          names = {asset.get('name') for asset in channel.get('assets', [])}
+          sys.exit(0 if 'latest.json' in names else 1)
+          PY
+            then
+              gh release download desktop-latest --pattern latest.json --dir "$RUNNER_TEMP/desktop-current"
+            else
+              echo "desktop-latest has no latest.json; allowing first channel publish."
+            fi
+          elif grep -Fq '(HTTP 404)' "$channel_error"; then
+            echo "No desktop-latest release found; allowing first channel publish."
+          else
+            cat "$channel_error" >&2
+            exit 1
+          fi
 
       - name: Remove standalone signature assets
         env:
@@ -59,6 +86,7 @@ jobs:
           import pathlib
           import re
           import sys
+          import urllib.parse
 
           def parse(value: str):
               value = value.removeprefix('v')
@@ -114,6 +142,12 @@ jobs:
           if not tag_match:
               sys.exit(f'Not a desktop version release: {release_tag}')
 
+          source_path = pathlib.Path(os.environ['RUNNER_TEMP'], 'source-release.json')
+          source = json.loads(source_path.read_text())
+          if source.get('tag_name') != release_tag or source.get('draft'):
+              sys.exit(f'Source release is not the published release {release_tag}')
+          release_assets = {asset.get('name') for asset in source.get('assets', [])}
+
           latest_path = pathlib.Path(os.environ['RUNNER_TEMP'], 'desktop-updater', 'latest.json')
           data = json.loads(latest_path.read_text())
           if not isinstance(data, dict):
@@ -137,6 +171,9 @@ jobs:
                   sys.exit(f'Platform {platform} URL must point at {release_tag}: {url}')
               if not isinstance(signature, str) or not signature.strip():
                   sys.exit(f'Platform {platform} missing signature')
+              bundle_name = urllib.parse.unquote(urllib.parse.urlparse(url).path.rsplit('/', 1)[-1])
+              if bundle_name not in release_assets:
+                  sys.exit(f'Platform {platform} bundle is missing from release assets: {bundle_name}')
               for family in required:
                   if platform == family or platform.startswith(family + '-'):
                       required[family] = True

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -27,7 +27,7 @@ on:
         type: string
         required: false
       draft:
-        description: 'Create as draft release; draft runs do not advance desktop-latest updater channel'
+        description: 'Create as draft; publishing it later advances desktop-latest without rebuilding'
         type: boolean
         default: true
 
@@ -1319,7 +1319,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh release upload "$DESKTOP_RELEASE_TAG" "$RUNNER_TEMP/desktop-release-assets"/* --clobber
+          signature_assets="$(
+            gh release view "$DESKTOP_RELEASE_TAG" --json assets \
+              --jq '.assets[].name | select(endswith(".sig"))'
+          )"
+          while IFS= read -r asset_name; do
+            [[ -z "$asset_name" ]] || gh release delete-asset "$DESKTOP_RELEASE_TAG" "$asset_name" --yes
+          done <<< "$signature_assets"
+
+          release_assets=()
+          for asset in "$RUNNER_TEMP/desktop-release-assets"/*; do
+            [[ "$asset" == *.sig ]] || release_assets+=("$asset")
+          done
+          gh release upload "$DESKTOP_RELEASE_TAG" "${release_assets[@]}" --clobber
 
       - name: Generate and publish versioned updater metadata
         shell: bash

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -72,6 +72,7 @@ def test_publishing_draft_advances_updater_without_rebuilding():
     workflow = yaml.safe_load(UPDATER_WORKFLOW.read_text(encoding = "utf-8"))
     assert workflow.get("on", workflow.get(True)) == {"release": {"types": ["published"]}}
     assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"]["queue"] == "max"
 
     job = workflow["jobs"]["publish-updater"]
     assert "build" not in workflow["jobs"]
@@ -80,3 +81,11 @@ def test_publishing_draft_advances_updater_without_rebuilding():
     assert not any("actions/checkout" in step.get("uses", "") for step in job["steps"])
     assert any("desktop-latest" in step.get("run", "") for step in job["steps"])
     assert any("gh release delete-asset" in step.get("run", "") for step in job["steps"])
+
+    download = next(step for step in job["steps"] if step.get("name") == "Download updater metadata")
+    assert "HTTP 404" in download["run"]
+    assert "desktop-current" not in download["run"] or "|| true" not in download["run"]
+
+    validate = next(step for step in job["steps"] if step.get("name") == "Validate updater metadata")
+    assert "source-release.json" in validate["run"]
+    assert "bundle_name not in release_assets" in validate["run"]

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -82,10 +82,14 @@ def test_publishing_draft_advances_updater_without_rebuilding():
     assert any("desktop-latest" in step.get("run", "") for step in job["steps"])
     assert any("gh release delete-asset" in step.get("run", "") for step in job["steps"])
 
-    download = next(step for step in job["steps"] if step.get("name") == "Download updater metadata")
+    download = next(
+        step for step in job["steps"] if step.get("name") == "Download updater metadata"
+    )
     assert "HTTP 404" in download["run"]
     assert "desktop-current" not in download["run"] or "|| true" not in download["run"]
 
-    validate = next(step for step in job["steps"] if step.get("name") == "Validate updater metadata")
+    validate = next(
+        step for step in job["steps"] if step.get("name") == "Validate updater metadata"
+    )
     assert "source-release.json" in validate["run"]
     assert "bundle_name not in release_assets" in validate["run"]

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -7,6 +7,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-desktop.yml"
+UPDATER_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-desktop-updater.yml"
 
 
 def _workflow():
@@ -56,3 +57,26 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     )
     assert "gh release view" in release_step["run"]
     assert "--json tagName,isDraft,isPrerelease" in release_step["run"]
+
+
+def test_versioned_release_hides_updater_signature_assets():
+    steps = _workflow()["jobs"]["publish-release"]["steps"]
+    publish = next(step for step in steps if step.get("name") == "Publish versioned release assets")
+
+    assert '[[ "$asset" == *.sig ]] || release_assets+=("$asset")' in publish["run"]
+    assert "gh release delete-asset" in publish["run"]
+    assert '"${release_assets[@]}"' in publish["run"]
+
+
+def test_publishing_draft_advances_updater_without_rebuilding():
+    workflow = yaml.safe_load(UPDATER_WORKFLOW.read_text(encoding="utf-8"))
+    assert workflow.get("on", workflow.get(True)) == {"release": {"types": ["published"]}}
+    assert workflow["permissions"] == {"contents": "read"}
+
+    job = workflow["jobs"]["publish-updater"]
+    assert "build" not in workflow["jobs"]
+    assert job["permissions"] == {"contents": "write"}
+    assert "startsWith(github.event.release.tag_name, 'desktop-v')" in job["if"]
+    assert not any("actions/checkout" in step.get("uses", "") for step in job["steps"])
+    assert any("desktop-latest" in step.get("run", "") for step in job["steps"])
+    assert any("gh release delete-asset" in step.get("run", "") for step in job["steps"])

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -69,7 +69,7 @@ def test_versioned_release_hides_updater_signature_assets():
 
 
 def test_publishing_draft_advances_updater_without_rebuilding():
-    workflow = yaml.safe_load(UPDATER_WORKFLOW.read_text(encoding="utf-8"))
+    workflow = yaml.safe_load(UPDATER_WORKFLOW.read_text(encoding = "utf-8"))
     assert workflow.get("on", workflow.get(True)) == {"release": {"types": ["published"]}}
     assert workflow["permissions"] == {"contents": "read"}
 


### PR DESCRIPTION
## Summary
- hide standalone updater `.sig` release assets
- advance `desktop-latest` when a draft is published
- reuse draft-generated `latest.json`; no rebuild

## Tests
- `15 passed` release/security/branding tests
- workflow trigger lint
- bash syntax checks