### PR TITLE
Locate the dictation model search box by test id, not by placeholder copy

### DIFF
--- a/studio/frontend/src/features/settings/tabs/voice-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/voice-tab.tsx
@@ -220,6 +220,7 @@ function SttModelPicker({
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
+            data-testid="stt-model-search"
             placeholder={t(
               "settings.voice.dictation.sttModelSearchPlaceholder",
             )}

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -568,7 +568,9 @@ with sync_playwright() as p:
                 page.get_by_label("Dictation engine").click()
                 page.get_by_role("option", name = "Local transcription").click()
                 page.get_by_label("Speech recognition model").click()
-                page.get_by_placeholder("Search model").fill("whisper")
+                # By test id: the placeholder is translated, so re-worded copy stops
+                # matching and times out here instead of failing the real assertion.
+                page.get_by_test_id("stt-model-search").fill("whisper")
                 results = page.get_by_test_id("stt-model-results")
                 page.wait_for_function(
                     """() => {


### PR DESCRIPTION
`playwright_extra_ui.py` locates the dictation model search box by its placeholder copy. #7835 changed that copy, so the locator stopped matching and the step times out:

```
studio/frontend/src/i18n/locales/en.ts:139
-  sttModelSearchPlaceholder: "Search model",
+  sttModelSearchPlaceholder: "Search any model on HF",
```

`get_by_placeholder` is a case-insensitive substring match, and `Search model` is not a substring of `Search any model on HF`, so `.fill()` waits out its full 60s:

```
[ui-extra] FAIL: Voice model picker did not wheel-scroll: TimeoutError('Locator.fill:
Timeout 60000ms exceeded. waiting for get_by_placeholder("Search model")')
```

This is red on main right now, on both Unsloth UI CI and Windows Unsloth UI CI, so it fails every open PR. Bisected on a staging repo tracking main with nothing merged:

| main commit | Unsloth UI CI |
|---|---|
| `3746465e` (before #7835) | success |
| `f61103d4` (#7835) | failure |
| `1301e160` | failure |

Rather than repoint the assertion at the new wording, this keys it off a test id, so translated copy cannot break it again. The component right below it already exposes `data-testid="stt-model-results"`, so the pattern is local and consistent. `Input` spreads `...props` onto the native `input`, and the attribute is present in the production bundle.

Checked: `npm run build` clean, eslint clean, the 434 frontend tests pass, and no other test referenced the old placeholder.
