### PR TITLE
Desktop: fix Linux release asset names

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1165,12 +1165,12 @@ jobs:
           suffix_names = (
               ('.app.tar.gz.sig', f'{base_name}-ARM64.app.tar.gz.sig'),
               ('.app.tar.gz', f'{base_name}-ARM64.app.tar.gz'),
-              ('.AppImage.sig', f'{base_name}-Ubuntu.AppImage.sig'),
-              ('.AppImage', f'{base_name}-Ubuntu.AppImage'),
+              ('.AppImage.sig', f'{base_name}-Linux.AppImage.sig'),
+              ('.AppImage', f'{base_name}-Linux.AppImage'),
               ('-setup.exe.sig', f'{base_name}-Windows.exe.sig'),
               ('-setup.exe', f'{base_name}-Windows.exe'),
               ('.dmg', f'{base_name}-MacOS.dmg'),
-              ('.deb', f'{base_name}-Linux.deb'),
+              ('.deb', f'{base_name}-Ubuntu.deb'),
           )
           staged = []
           for raw_path in artifact_paths:
@@ -1251,9 +1251,9 @@ jobs:
               f'{base_name}-MacOS.dmg',
               f'{base_name}-ARM64.app.tar.gz',
               f'{base_name}-ARM64.app.tar.gz.sig',
-              f'{base_name}-Ubuntu.AppImage',
-              f'{base_name}-Ubuntu.AppImage.sig',
-              f'{base_name}-Linux.deb',
+              f'{base_name}-Linux.AppImage',
+              f'{base_name}-Linux.AppImage.sig',
+              f'{base_name}-Ubuntu.deb',
               f'{base_name}-Windows.exe',
               f'{base_name}-Windows.exe.sig',
           }

--- a/tests/studio/test_tauri_branding_contract.py
+++ b/tests/studio/test_tauri_branding_contract.py
@@ -126,9 +126,9 @@ def test_desktop_release_asset_names_are_human_readable() -> None:
         "MacOS.dmg",
         "ARM64.app.tar.gz",
         "ARM64.app.tar.gz.sig",
-        "Ubuntu.AppImage",
-        "Ubuntu.AppImage.sig",
-        "Linux.deb",
+        "Linux.AppImage",
+        "Linux.AppImage.sig",
+        "Ubuntu.deb",
         "Windows.exe",
         "Windows.exe.sig",
     }


### PR DESCRIPTION
## Summary
- rename AppImage asset suffix to `Linux.AppImage`
- rename deb asset suffix to `Ubuntu.deb`
- keep updater signature mapping intact

## Tests
- `15 passed` release/security/branding tests
- workflow trigger lint