### PR TITLE
fix(studio): repair Backend CI on main and finish the cmd/start screening

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1653,23 +1653,24 @@ def _find_blocked_commands(command: str) -> set[str]:
     # inside a cmd payload: a bare `start` is data (echo start rm), and on
     # POSIX nothing launches it at all.
     start_scan: set[int] = set()
-    if cmd_payload_from:
-        for i in range(min(cmd_payload_from), len(tokens)):
-            # A separator ends the payload; a `start` past it is data again.
+    for payload in cmd_payload_from:
+        # Each payload separately: a separator ends that one, not the scan, so
+        # `cmd /c dir && cmd /c start "" rm` still reaches the second.
+        for i in range(payload, len(tokens)):
             if tokens[i] in _SHELL_SEPARATORS:
                 break
             start_scan.add(i)
-    if not _shell_is_posix():
-        # cmd IS the shell, so the whole command already runs as `cmd /c ...`
-        # and a top-level `start prog` launches for real, with no cmd token to
-        # key on. Command position only: `echo start rm` is still data.
-        start_scan.update(
-            i
-            for i in range(len(tokens))
-            if i == 0
-            or tokens[i - 1] in _SHELL_SEPARATORS
-            or tokens[i - 1] in _SHELL_KEYWORDS_AS_SEP
-        )
+    # A `start` at command position launches through cmd under every shell:
+    # Git for Windows ships /usr/bin/start as a `"$COMSPEC" //c start ...`
+    # wrapper, and with no trusted bash cmd is the shell outright. Command
+    # position is the whole test, so `echo start rm` stays data.
+    start_scan.update(
+        i
+        for i in range(len(tokens))
+        if i == 0
+        or tokens[i - 1] in _SHELL_SEPARATORS
+        or tokens[i - 1] in _SHELL_KEYWORDS_AS_SEP
+    )
     for i in sorted(start_scan):
         if os.path.basename(tokens[i]).lower() not in ("start", "start.exe"):
             continue

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1620,6 +1620,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     # recursively scan the nested command string.
     _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
     _SHELLS_WIN = {"cmd", "cmd.exe"}
+    cmd_payload_from: list[int] = []
     for i, token in enumerate(tokens):
         tok_lower = token.lower()
         # Match -c exactly, or combined flags ending in c (e.g. -lc, -xc)
@@ -1644,12 +1645,15 @@ def _find_blocked_commands(command: str) -> set[str]:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
                 blocked |= _find_blocked_commands(tokens[i + 1])
+                cmd_payload_from.append(i + 1)
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
-    # sees only as an argument, so screen what start actually launches.
-    for i, token in enumerate(tokens):
-        if os.path.basename(token).lower() not in ("start", "start.exe"):
+    # sees only as an argument, so screen what start actually launches. Only
+    # inside a cmd payload: a bare `start` is data (echo start rm), and on
+    # POSIX nothing launches it at all.
+    for i in range(min(cmd_payload_from), len(tokens)) if cmd_payload_from else ():
+        if os.path.basename(tokens[i]).lower() not in ("start", "start.exe"):
             continue
         j = i + 1
         while j < len(tokens):
@@ -1658,11 +1662,11 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-        # `start ""` is the idiom for "no title"; anything else is the program.
-        if j < len(tokens) and tokens[j] == "":
-            j += 1
-        if j < len(tokens):
-            blocked |= _find_blocked_commands(tokens[j])
+        # cmd reads a quoted first argument as the window title, but shlex has
+        # already dropped the quotes, so screen both it and what follows it.
+        for candidate in tokens[j : j + 2]:
+            if candidate:
+                blocked |= _find_blocked_commands(candidate)
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The
@@ -5776,7 +5780,7 @@ def _terminal_is_high_risk(command: str, _depth: int = 0) -> bool:
                 continue
             # cmd.exe /c (or /k) runs the following token as a nested command. /c is
             # not a `-`-flag, so it is handled here in argument position after cmd.
-            if current_command in _CMD_SHELLS and raw.lower() in ("/c", "/k"):
+            if current_command in _CMD_SHELLS and _win_switch(raw.lower()) in ("/c", "/k"):
                 shell_c_pending = True
                 continue
             # The payload of a shell `-c`, screened recursively (bounded depth).

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1652,7 +1652,11 @@ def _find_blocked_commands(command: str) -> set[str]:
     # sees only as an argument, so screen what start actually launches. Only
     # inside a cmd payload: a bare `start` is data (echo start rm), and on
     # POSIX nothing launches it at all.
-    for i in range(min(cmd_payload_from), len(tokens)) if cmd_payload_from else ():
+    start_scan = range(min(cmd_payload_from), len(tokens)) if cmd_payload_from else ()
+    for i in start_scan:
+        # A separator ends the payload; a `start` past it is data again.
+        if tokens[i] in _SHELL_SEPARATORS:
+            break
         if os.path.basename(tokens[i]).lower() not in ("start", "start.exe"):
             continue
         j = i + 1
@@ -1664,6 +1668,8 @@ def _find_blocked_commands(command: str) -> set[str]:
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
         # cmd reads a quoted first argument as the window title, but shlex has
         # already dropped the quotes, so screen both it and what follows it.
+        # A title whose first word is a blocked name over-blocks; that is the
+        # safe direction, and the rest of the title is not at command position.
         for candidate in tokens[j : j + 2]:
             if candidate:
                 blocked |= _find_blocked_commands(candidate)

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1340,7 +1340,7 @@ def _win_switch(token: str) -> str:
 
 # `start` launches its argument as a program, so that argument is a command
 # position. These switches precede it; the value-taking ones eat a token.
-_START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
+_START_SWITCHES_WITH_VALUE = frozenset({"/d", "/node", "/affinity", "/machine"})
 
 
 def _find_blocked_commands(command: str) -> set[str]:
@@ -6991,7 +6991,7 @@ def _shell_is_posix() -> bool:
 def _get_shell_cmd(command: str) -> list[str]:
     """Return the platform-appropriate shell invocation for a command string."""
     if sys.platform == "win32":
-        # why: the model is told this tool is bash and writes bash. cmd /c runs
+        # The model is told this tool is bash and writes bash. cmd /c runs
         # only the first line of a multi-line command, keeps single quotes
         # literal, and does not understand bash quoting, so a correct script
         # silently half-executes. Use a real bash when the host has one.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1667,9 +1667,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     start_scan.update(
         i
         for i in range(len(tokens))
-        if i == 0
-        or tokens[i - 1] in _SHELL_SEPARATORS
-        or tokens[i - 1] in _SHELL_KEYWORDS_AS_SEP
+        if i == 0 or tokens[i - 1] in _SHELL_SEPARATORS or tokens[i - 1] in _SHELL_KEYWORDS_AS_SEP
     )
     for i in sorted(start_scan):
         if os.path.basename(tokens[i]).lower() not in ("start", "start.exe"):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1652,11 +1652,25 @@ def _find_blocked_commands(command: str) -> set[str]:
     # sees only as an argument, so screen what start actually launches. Only
     # inside a cmd payload: a bare `start` is data (echo start rm), and on
     # POSIX nothing launches it at all.
-    start_scan = range(min(cmd_payload_from), len(tokens)) if cmd_payload_from else ()
-    for i in start_scan:
-        # A separator ends the payload; a `start` past it is data again.
-        if tokens[i] in _SHELL_SEPARATORS:
-            break
+    start_scan: set[int] = set()
+    if cmd_payload_from:
+        for i in range(min(cmd_payload_from), len(tokens)):
+            # A separator ends the payload; a `start` past it is data again.
+            if tokens[i] in _SHELL_SEPARATORS:
+                break
+            start_scan.add(i)
+    if not _shell_is_posix():
+        # cmd IS the shell, so the whole command already runs as `cmd /c ...`
+        # and a top-level `start prog` launches for real, with no cmd token to
+        # key on. Command position only: `echo start rm` is still data.
+        start_scan.update(
+            i
+            for i in range(len(tokens))
+            if i == 0
+            or tokens[i - 1] in _SHELL_SEPARATORS
+            or tokens[i - 1] in _SHELL_KEYWORDS_AS_SEP
+        )
+    for i in sorted(start_scan):
         if os.path.basename(tokens[i]).lower() not in ("start", "start.exe"):
             continue
         j = i + 1

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1351,7 +1351,9 @@ def _find_blocked_commands(command: str) -> set[str]:
     etc.), or a command-prefix wrapper like `env` / `time` / `xargs` (next
     token is the real command). Tokens in argument position (`grep -r curl .`,
     `echo source the data`, `ls /usr/bin/curl`) pass through. Also scans
-    `find ... -exec CMD` and recurses into bash -c / cmd /c.
+    `find ... -exec CMD`, recurses into bash -c / cmd /c, and screens what a
+    command-position `start` launches, including its window-title slot, which
+    is the one argument-position token that can be flagged.
     """
     blocked: set[str] = set()
 
@@ -1652,18 +1654,12 @@ def _find_blocked_commands(command: str) -> set[str]:
     # sees only as an argument, so screen what start actually launches. Only
     # inside a cmd payload: a bare `start` is data (echo start rm), and on
     # POSIX nothing launches it at all.
-    start_scan: set[int] = set()
-    for payload in cmd_payload_from:
-        # Each payload separately: a separator ends that one, not the scan, so
-        # `cmd /c dir && cmd /c start "" rm` still reaches the second.
-        for i in range(payload, len(tokens)):
-            if tokens[i] in _SHELL_SEPARATORS:
-                break
-            start_scan.add(i)
     # A `start` at command position launches through cmd under every shell:
     # Git for Windows ships /usr/bin/start as a `"$COMSPEC" //c start ...`
-    # wrapper, and with no trusted bash cmd is the shell outright. Command
-    # position is the whole test, so `echo start rm` stays data.
+    # wrapper, and with no trusted bash cmd is the shell outright. The first
+    # token of each cmd payload is a command position too, which the separator
+    # rule below cannot see. `echo start rm` is an argument either way.
+    start_scan = set(cmd_payload_from)
     start_scan.update(
         i
         for i in range(len(tokens))

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -380,6 +380,9 @@ def test_top_level_start_launches_when_cmd_is_the_shell(monkeypatch, command, bl
         ('cmd /c dir; cmd /c start "" rm -rf x', True),
         ("cmd /c dir && echo start rm", False),
         ("echo start rm", False),
+        # echo makes it an argument inside the payload too; cmd would just
+        # print the string, so the scan must not treat it as a launcher.
+        ("cmd //c echo start rm", False),
     ],
 )
 def test_start_launches_through_cmd_under_bash(monkeypatch, command, blocked):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -272,22 +272,28 @@ def test_notes_say_where_commands_run(monkeypatch):
     assert "opens a window on the user's desktop" in tools._build_terminal_shell_note()
 
 
+# powershell/pwsh only join _BLOCKED_COMMANDS on win32, so these name `rm`
+# from the common set to stay meaningful on the Linux CI runner.
 @pytest.mark.parametrize(
     "command",
     [
-        "cmd /c powershell -Command ls",
-        "cmd //c powershell -Command ls",
-        "cmd //k powershell -Command ls",
-        'cmd //c start "" powershell -Command ls',
-        'cmd //c start /b "" pwsh -Command ls',
-        'cmd //c start //min "" powershell -Command ls',
-        r'cmd //c start /d C:/tmp "" powershell -Command ls',
+        "cmd /c rm -rf x",
+        "cmd //c rm -rf x",
+        "cmd //k rm -rf x",
+        'cmd //c start "" rm -rf x',
+        'cmd //c start /b "" rm -rf x',
+        'cmd //c start //min "" rm -rf x',
+        r'cmd //c start /d C:/tmp "" rm -rf x',
+        # cmd reads a quoted first argument as a title, and shlex drops the
+        # quotes, so a named window must not hide the program behind it.
+        'cmd //c start "Studio" rm -rf x',
+        'cmd //c start //min "Title" rm -rf x',
     ],
 )
 def test_cmd_shellout_is_screened_through_mangled_switches(command):
     # Git Bash turns a lone /c into a path, so a model writes //c. That spelling
-    # skipped the nested scan, making `cmd //c powershell` reachable where
-    # `cmd /c powershell` was blocked, and `start` launches its argument too.
+    # skipped the nested scan, making `cmd //c rm` reachable where `cmd /c rm`
+    # was blocked, and `start` launches its argument too.
     assert tools._find_blocked_commands(command)
 
 
@@ -295,12 +301,27 @@ def test_cmd_shellout_is_screened_through_mangled_switches(command):
     "command",
     [
         'cmd //c start "" bash -c "bash /c/x.sh"',
+        'cmd //c start "Matrix" bash -c "bash /c/x.sh"',
         "cmd //c start wt",
         "cmd //c dir",
         "start notepad",
+        # `start` outside a cmd payload is data, not a launcher.
+        "echo start rm",
+        "grep start rm file",
+        "start rm",
     ],
 )
 def test_detached_windows_stay_launchable(command):
     # `start` is the only route to a window on the user's desktop, which the
     # terminal description promises, so screening must not blanket-block cmd.
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["cmd /c del notes.txt", "cmd //c del notes.txt", "cmd //c git clean -fd"],
+)
+def test_auto_approval_sees_through_mangled_switches(command):
+    # del and git clean are not hard-blocked, so if the high-risk scan misses
+    # the //c spelling auto mode approves a destructive payload unprompted.
+    assert tools._terminal_is_high_risk(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -309,6 +309,9 @@ def test_cmd_shellout_is_screened_through_mangled_switches(command):
         "echo start rm",
         "grep start rm file",
         "start rm",
+        # ...including after a cmd payload has ended at a separator.
+        "cmd /c dir && echo start rm",
+        "cmd /c dir; grep start rm file",
     ],
 )
 def test_detached_windows_stay_launchable(command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -325,3 +325,19 @@ def test_auto_approval_sees_through_mangled_switches(command):
     # del and git clean are not hard-blocked, so if the high-risk scan misses
     # the //c spelling auto mode approves a destructive payload unprompted.
     assert tools._terminal_is_high_risk(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c start "" rm -rf x',
+        'cmd /c start "Studio" rm -rf x',
+        "cmd /c rm -rf x",
+    ],
+)
+def test_start_scan_survives_non_posix_lexing(monkeypatch, command):
+    # A cmd-only Windows host lexes non-posix, where "" survives as the literal
+    # two-character token '""'. Screening the title slot and the token after it
+    # covers both lexers without special-casing either.
+    monkeypatch.setattr(tools, "_shell_is_posix", lambda: False)
+    assert tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -344,3 +344,24 @@ def test_start_scan_survives_non_posix_lexing(monkeypatch, command):
     # covers both lexers without special-casing either.
     monkeypatch.setattr(tools, "_shell_is_posix", lambda: False)
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # cmd is the shell, so `cmd /c` wraps the whole command and a top-level
+        # start really launches, with no cmd token in the string to key on.
+        ("start rm -rf x", True),
+        ('start "" rm -rf x', True),
+        ('start "Studio" rm -rf x', True),
+        ("dir && start rm -rf x", True),
+        # ...but a start that is not at command position is still just data.
+        ("echo start rm", False),
+        ("grep start rm file", False),
+        ("dir && echo start rm", False),
+        ("start notepad", False),
+    ],
+)
+def test_top_level_start_launches_when_cmd_is_the_shell(monkeypatch, command, blocked):
+    monkeypatch.setattr(tools, "_shell_is_posix", lambda: False)
+    assert bool(tools._find_blocked_commands(command)) is blocked

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -305,10 +305,9 @@ def test_cmd_shellout_is_screened_through_mangled_switches(command):
         "cmd //c start wt",
         "cmd //c dir",
         "start notepad",
-        # `start` outside a cmd payload is data, not a launcher.
+        # `start` away from command position is data, not a launcher.
         "echo start rm",
         "grep start rm file",
-        "start rm",
         # ...including after a cmd payload has ended at a separator.
         "cmd /c dir && echo start rm",
         "cmd /c dir; grep start rm file",
@@ -364,4 +363,25 @@ def test_start_scan_survives_non_posix_lexing(monkeypatch, command):
 )
 def test_top_level_start_launches_when_cmd_is_the_shell(monkeypatch, command, blocked):
     monkeypatch.setattr(tools, "_shell_is_posix", lambda: False)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # Git for Windows ships /usr/bin/start as `"$COMSPEC" //c start ...`,
+        # so start launches through cmd even when bash is the outer shell.
+        ("start rm -rf x", True),
+        ('start "" rm -rf x', True),
+        ("echo hi && start rm -rf x", True),
+        # Each cmd payload is scanned on its own, so a separator ending the
+        # first one does not hide a start in the second.
+        ('cmd /c dir && cmd /c start "" rm -rf x', True),
+        ('cmd /c dir; cmd /c start "" rm -rf x', True),
+        ("cmd /c dir && echo start rm", False),
+        ("echo start rm", False),
+    ],
+)
+def test_start_launches_through_cmd_under_bash(monkeypatch, command, blocked):
+    monkeypatch.setattr(tools, "_shell_is_posix", lambda: True)
     assert bool(tools._find_blocked_commands(command)) is blocked


### PR DESCRIPTION
Follow-up to #7885 (merged as `677685e`). That PR landed with the Codex round on `1ec1e88` unaddressed; this closes it.

**Backend CI is red on main.** `studio-backend-ci.yml` runs on `push: branches: [main]` against `ubuntu-latest`. The seven cases I added to `test_cmd_shellout_is_screened_through_mangled_switches` name `powershell`/`pwsh`, which join `_BLOCKED_COMMANDS` only when `sys.platform == "win32"`, so on the runner the assertion gets `set()` and fails on all four Python versions. Confirmed in the staging run: `7 failed, 16511 passed`, and all seven are these tests. They now name `rm` from the common set, since the test is about `//c` mangling and `start` scanning, not about which program is blocked.

**`start` was matched anywhere in the token stream.** `echo start rm` and `grep start rm file` recursed into `rm` and hard-blocked, on POSIX too, where no `cmd start` can run. The scan is now gated to tokens inside a `cmd /c` payload.

**A non-empty title hid the program.** cmd reads a quoted first argument as the window title, not only an empty one, so `start "Studio" powershell` was never screened. shlex has already dropped the quotes by then, so both the title slot and the token after it are screened, failing closed on the ambiguity. This also covers the non-posix lexer, where `""` survives as the literal `'""'`, without special-casing either lexer; pinned by `test_start_scan_survives_non_posix_lexing`.

**Auto mode approved mangled destructive payloads.** `_terminal_is_high_risk` matched raw `/c`/`/k`, so `cmd //c del notes.txt` scored `high_risk=False` while `cmd /c del` scored `True`. Neither `del` nor `git clean` is hard-blocked, so auto mode ran them unprompted. It shares `_win_switch` with the blocklist now.

Also `_START_SWITCHES_WITH_VALUE` is a `frozenset` like every other set constant in the file, and the lone `# why:` label prefix is gone.

**Not taken: adding Git Bash's Unix dirs to the sandbox PATH.** The premise is that a non-login `bash -c` won't see `Git\bin`/`Git\usr\bin`. The MSYS2 runtime inside `bash.exe` prepends them at process start, independent of profile files. Invoked with a PATH containing neither:

```
PATH=/mingw64/bin:/usr/bin:/c/Users/.../bin:/c/Windows/System32:/c/Windows:/cmd
```

`ls` and `grep` both resolve. Adding those dirs would widen the sandbox PATH for no gain.

**Verification.** Windows: 243 passed, 1 pre-existing failure (`test_program_roots_fails_closed_without_known_folder_api`, reproduces on clean main). The 17-case matrix also re-run against a patched `_BLOCKED_COMMANDS` simulating the Linux runner, 0 failures.
