### PR TITLE
Locate the dictation model search box by test id, not by its copy

### DIFF
--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -75,6 +75,15 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      # Static file reads, no browser and no Unsloth install, so it runs first
+      # and fails in seconds. Repo-root pytest discovery is pinned to
+      # tests/security, so without this step nothing invokes it and a
+      # copy-based locator only shows up as a 60 s timeout in the full smoke.
+      - name: Playwright locator contract (static)
+        run: |
+          python -m pip install --quiet 'pytest>=8'
+          python -m pytest tests/studio/test_stt_model_search_locator_contract.py -q
+
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -75,8 +75,7 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      # Static file reads, so it runs first and fails in seconds. Repo-root
-      # pytest discovery is pinned to tests/security, so nothing else runs it.
+      # Static reads, so it runs first and fails fast; nothing else runs it.
       - name: Playwright locator contract (static)
         run: |
           python -m pip install --quiet 'pytest>=8'

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -75,10 +75,8 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      # Static file reads, no browser and no Unsloth install, so it runs first
-      # and fails in seconds. Repo-root pytest discovery is pinned to
-      # tests/security, so without this step nothing invokes it and a
-      # copy-based locator only shows up as a 60 s timeout in the full smoke.
+      # Static file reads, so it runs first and fails in seconds. Repo-root
+      # pytest discovery is pinned to tests/security, so nothing else runs it.
       - name: Playwright locator contract (static)
         run: |
           python -m pip install --quiet 'pytest>=8'

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -392,7 +392,7 @@ export function SettingsDialog() {
                   return (
                     <button
                       key={tab.id}
-                      // Stable handle for UI tests; the label is translated.
+                      // Stable handle for UI tests: the label is translated.
                       data-testid={`settings-tab-${tab.id}`}
                       ref={(node) => {
                         tabButtonRefs.current[tab.id] = node;

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -392,6 +392,8 @@ export function SettingsDialog() {
                   return (
                     <button
                       key={tab.id}
+                      // Stable handle for UI tests; the label is translated.
+                      data-testid={`settings-tab-${tab.id}`}
                       ref={(node) => {
                         tabButtonRefs.current[tab.id] = node;
                       }}

--- a/studio/frontend/src/features/settings/tabs/voice-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/voice-tab.tsx
@@ -220,6 +220,7 @@ function SttModelPicker({
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
+            data-testid="stt-model-search"
             placeholder={t(
               "settings.voice.dictation.sttModelSearchPlaceholder",
             )}

--- a/studio/frontend/src/features/settings/tabs/voice-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/voice-tab.tsx
@@ -199,6 +199,7 @@ function SttModelPicker({
       <PopoverTrigger asChild={true}>
         <button
           type="button"
+          data-testid="stt-model-trigger"
           aria-label={t("settings.voice.dictation.sttModelLabel")}
           className="border-border bg-background hover:bg-accent/50 dark:border-transparent dark:bg-white/[0.06] dark:hover:bg-white/10 focus-visible:border-ring flex h-8 w-full cursor-pointer items-center justify-between gap-1.5 rounded-full border px-3.5 text-sm outline-none transition-colors"
         >
@@ -884,6 +885,7 @@ export function VoiceTab() {
               }}
             >
               <SelectTrigger
+                data-testid="dictation-engine-trigger"
                 aria-label={t("settings.voice.dictation.engineLabel")}
                 className="w-56"
                 size="sm"
@@ -894,7 +896,7 @@ export function VoiceTab() {
                 <SelectItem value="browser">
                   {t("settings.voice.dictation.engineBrowser")}
                 </SelectItem>
-                <SelectItem value="model">
+                <SelectItem value="model" data-testid="dictation-engine-model">
                   {t("settings.voice.dictation.engineModel")}
                 </SelectItem>
               </SelectContent>

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -565,12 +565,13 @@ with sync_playwright() as p:
             # recovery; on Linux/Windows a crash and any live-page failure stay a hard fail.
             try:
                 voice_tab.click()
-                page.get_by_label("Dictation engine").click()
-                page.get_by_role("option", name = "Local transcription").click()
-                page.get_by_label("Speech recognition model").click()
-                # By test id, not by placeholder: the copy is translated, and
-                # #7835 changed the English string to "Search any model on HF",
-                # which the old substring no longer matched.
+                # All four by test id. Every one of these was bound to
+                # t()-rendered English, and they gate the same popover, so a
+                # reword of any of them reproduces the #7835 outage a line or
+                # two earlier than the one that actually fired.
+                page.get_by_test_id("dictation-engine-trigger").click()
+                page.get_by_test_id("dictation-engine-model").click()
+                page.get_by_test_id("stt-model-trigger").click()
                 page.get_by_test_id("stt-model-search").fill("whisper")
                 results = page.get_by_test_id("stt-model-results")
                 page.wait_for_function(

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -568,7 +568,10 @@ with sync_playwright() as p:
                 page.get_by_label("Dictation engine").click()
                 page.get_by_role("option", name = "Local transcription").click()
                 page.get_by_label("Speech recognition model").click()
-                page.get_by_placeholder("Search model").fill("whisper")
+                # By test id, not by placeholder: the copy is translated, and
+                # #7835 changed the English string to "Search any model on HF",
+                # which the old substring no longer matched.
+                page.get_by_test_id("stt-model-search").fill("whisper")
                 results = page.get_by_test_id("stt-model-results")
                 page.wait_for_function(
                     """() => {

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -553,9 +553,8 @@ with sync_playwright() as p:
             except Exception as exc:
                 soft_fail(f"Settings tab '{tab_name}' click failed: {exc!r}")
         step("Voice model picker: real mouse-wheel scrolling")
-        voice_tab = page.get_by_role(
-            "button", name = re.compile(r"^\s*Voice(?:\s+New)?\s*$", re.I)
-        ).first
+        # By test id too: the tab label is translated, and it gates everything below.
+        voice_tab = page.get_by_test_id("settings-tab-voice").first
         if voice_tab.count() == 0:
             fail("Voice settings tab not found")
         else:

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -553,7 +553,7 @@ with sync_playwright() as p:
             except Exception as exc:
                 soft_fail(f"Settings tab '{tab_name}' click failed: {exc!r}")
         step("Voice model picker: real mouse-wheel scrolling")
-        # By test id too: the tab label is translated, and it gates everything below.
+        # By test id: the tab label is translated, and it gates everything below.
         voice_tab = page.get_by_test_id("settings-tab-voice").first
         if voice_tab.count() == 0:
             fail("Voice settings tab not found")
@@ -564,10 +564,8 @@ with sync_playwright() as p:
             # recovery; on Linux/Windows a crash and any live-page failure stay a hard fail.
             try:
                 voice_tab.click()
-                # All four by test id. Every one of these was bound to
-                # t()-rendered English, and they gate the same popover, so a
-                # reword of any of them reproduces the #7835 outage a line or
-                # two earlier than the one that actually fired.
+                # All four by test id: each was bound to t()-rendered English,
+                # so any reword reproduced the #7835 outage.
                 page.get_by_test_id("dictation-engine-trigger").click()
                 page.get_by_test_id("dictation-engine-model").click()
                 page.get_by_test_id("stt-model-trigger").click()

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -553,7 +553,7 @@ with sync_playwright() as p:
             except Exception as exc:
                 soft_fail(f"Settings tab '{tab_name}' click failed: {exc!r}")
         step("Voice model picker: real mouse-wheel scrolling")
-        # By test id: the tab label is translated, and it gates everything below.
+        # By test id: the tab label is translated.
         voice_tab = page.get_by_test_id("settings-tab-voice").first
         if voice_tab.count() == 0:
             fail("Voice settings tab not found")
@@ -564,8 +564,7 @@ with sync_playwright() as p:
             # recovery; on Linux/Windows a crash and any live-page failure stay a hard fail.
             try:
                 voice_tab.click()
-                # All four by test id: each was bound to t()-rendered English,
-                # so any reword reproduced the #7835 outage.
+                # By test id: these were bound to translated copy, which caused #7835.
                 page.get_by_test_id("dictation-engine-trigger").click()
                 page.get_by_test_id("dictation-engine-model").click()
                 page.get_by_test_id("stt-model-trigger").click()

--- a/tests/studio/test_stt_model_search_locator_contract.py
+++ b/tests/studio/test_stt_model_search_locator_contract.py
@@ -2,18 +2,11 @@
 """The dictation model search box must be reachable by test id, not by copy.
 
 `playwright_extra_ui.py` located this input with
-`get_by_placeholder("Search model")`. That placeholder is rendered through
-`t("settings.voice.dictation.sttModelSearchPlaceholder")`, so it is both
-translated and free to be reworded, and #7835 reworded the English string to
-"Search any model on HF". `get_by_placeholder` matches on substring, and
-"Search model" is not a substring of that, so the step failed with
-
-    Locator.fill: Timeout 60000ms exceeded.
-      waiting for get_by_placeholder("Search model")
-
-That takes the whole Chat UI Tests job down, on every PR, for a copy edit that
-touched no behaviour. The results container beside it already had
-`data-testid="stt-model-results"`; the input now has one too.
+`get_by_placeholder("Search model")`, but the placeholder is translated copy
+and #7835 reworded it to "Search any model on HF". The substring no longer
+matched, so `Locator.fill` timed out and took the whole Chat UI Tests job down
+on every PR for a copy edit. The input now carries a test id, like the results
+container beside it already did.
 """
 
 import ast
@@ -29,7 +22,7 @@ SETTINGS_DIALOG = REPO / "studio/frontend/src/features/settings/settings-dialog.
 EXTRA_UI = REPO / "tests/studio/playwright_extra_ui.py"
 EN_LOCALE = REPO / "studio/frontend/src/i18n/locales/en.ts"
 
-# Every element the dictation step drives, and the i18n key each one used to be
+# Every element the dictation step drives, and the i18n key it used to be
 # located by. All four gate the same popover.
 TEST_IDS = {
     "dictation-engine-trigger": "settings.voice.dictation.engineLabel",
@@ -50,8 +43,8 @@ def test_the_element_carries_the_test_id(test_id):
 
 @pytest.mark.parametrize("test_id,key", sorted(TEST_IDS.items()))
 def test_the_test_id_sits_on_the_right_element(test_id, key):
-    """A test id on the wrong element would still satisfy the check above, so
-    each one is required to sit beside the i18n key it replaced."""
+    """A test id on the wrong element passes the check above, so require each
+    one to sit beside the i18n key it replaced."""
     source = VOICE_TAB.read_text(encoding = "utf-8")
     index = source.index(f'data-testid="{test_id}"')
     block = source[max(0, index - 400) : index + 400]
@@ -65,16 +58,16 @@ def test_the_driver_uses_it(test_id):
 
 
 def test_the_voice_settings_tab_is_reachable_by_test_id():
-    """The step's first click is the Voice tab itself, and its label is
-    translated too, so the tab buttons carry a test id keyed by tab id."""
+    """The step's first click is the Voice tab, whose label is translated too,
+    so the tab buttons carry a test id keyed by tab id."""
     source = SETTINGS_DIALOG.read_text(encoding = "utf-8")
     assert TAB_TEST_ID in source, SETTINGS_DIALOG
     assert 'id: "voice"' in source, SETTINGS_DIALOG
     assert 'get_by_test_id("settings-tab-voice")' in EXTRA_UI.read_text(encoding = "utf-8")
 
 
-# Locators that resolve through user-visible copy. get_by_role is only one of
-# these when it is given a name.
+# Locators that resolve through user-visible copy. get_by_role only counts
+# when given a name.
 COPY_LOCATORS = (
     "get_by_placeholder",
     "get_by_label",
@@ -89,10 +82,9 @@ PER_LINE = r"get_by_(placeholder|label)\(|get_by_role\([^)]*name\s*="
 def copy_locator_calls(source, first_line, last_line):
     """Copy-bound locator calls starting between two 1-based lines.
 
-    Walks the parsed module rather than matching physical lines: a call split
-    over several lines is one node, so `get_by_role(` + a `name =` on the next
-    line is caught. Parses the whole file, because the sliced step on its own
-    starts mid-statement and indented, so it is not parseable alone.
+    Walks the AST rather than physical lines, so a call split over several
+    lines is still one node. Parses the whole file: the sliced step starts
+    mid-statement and indented, so it is not parseable alone.
     """
     offenders = []
     for node in ast.walk(ast.parse(source)):
@@ -116,8 +108,8 @@ def line_range(source, start, end):
 
 
 def test_the_dictation_step_binds_to_no_translated_copy_at_all():
-    """The whole step, not just the input. These lines sit together and gate
-    one popover, so a reword of any of them reproduces the same outage."""
+    """The whole step, not just the input: it all gates one popover, so a
+    reword anywhere in it reproduces the same outage."""
     source = EXTRA_UI.read_text(encoding = "utf-8")
     start = source.index("Voice model picker: real mouse-wheel scrolling")
     end = source.index("results.hover()", start)
@@ -134,8 +126,8 @@ page.get_by_test_id("stt-model-search").fill("whisper")
 
 
 def test_the_guard_catches_a_multi_line_copy_locator():
-    """A call split across lines hides `name =` from any per-line match: the
-    first line has no `name =` and the third has no `get_by_role(`."""
+    """A split call hides `name =` from any per-line match: the first line has
+    no `name =` and the third has no `get_by_role(`."""
     assert [l for l in MULTI_LINE_SAMPLE.splitlines() if re.search(PER_LINE, l)] == []
     offenders = copy_locator_calls(MULTI_LINE_SAMPLE, 1, 5)
     assert len(offenders) == 1, offenders
@@ -153,8 +145,8 @@ def test_the_guard_ignores_calls_outside_the_range():
 
 
 def test_no_playwright_step_locates_this_input_by_its_copy():
-    """The regression itself. Any placeholder-based locator here is one copy
-    edit away from taking the job down again."""
+    """The regression itself: a placeholder-based locator here is one copy edit
+    away from taking the job down again."""
     source = EXTRA_UI.read_text(encoding = "utf-8")
     offenders = [
         line.strip()
@@ -166,14 +158,14 @@ def test_no_playwright_step_locates_this_input_by_its_copy():
 
 def test_ci_actually_runs_this_file():
     """Repo-root pytest discovery is pinned to tests/security, so this file is
-    only a guard if a workflow names it. The UI workflow runs it as a step."""
+    only a guard if a workflow names it."""
     workflow = (REPO / ".github/workflows/studio-ui-smoke.yml").read_text(encoding = "utf-8")
     assert f"pytest tests/studio/{Path(__file__).name}" in workflow, workflow
     assert "tests/studio/**" in workflow, "the workflow must trigger on this path"
 
 
 def test_the_english_copy_is_still_free_to_change():
-    """States the point: this file must keep passing whatever the wording is,
-    so it deliberately does not assert the string."""
+    """This file must keep passing whatever the wording is, so it deliberately
+    asserts the key, not the string."""
     source = EN_LOCALE.read_text(encoding = "utf-8")
     assert "sttModelSearchPlaceholder:" in source, EN_LOCALE

--- a/tests/studio/test_stt_model_search_locator_contract.py
+++ b/tests/studio/test_stt_model_search_locator_contract.py
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 """The dictation model search box must be reachable by test id, not by copy.
 
-`playwright_extra_ui.py` located this input with
-`get_by_placeholder("Search model")`, but the placeholder is translated copy
-and #7835 reworded it to "Search any model on HF". The substring no longer
-matched, so `Locator.fill` timed out and took the whole Chat UI Tests job down
-on every PR for a copy edit. The input now carries a test id, like the results
-container beside it already did.
+`playwright_extra_ui.py` used `get_by_placeholder("Search model")`; #7835
+reworded that placeholder, so `Locator.fill` timed out and took the Chat UI
+Tests job down on every PR. The input now carries a test id.
 """
 
 import ast
@@ -22,8 +19,7 @@ SETTINGS_DIALOG = REPO / "studio/frontend/src/features/settings/settings-dialog.
 EXTRA_UI = REPO / "tests/studio/playwright_extra_ui.py"
 EN_LOCALE = REPO / "studio/frontend/src/i18n/locales/en.ts"
 
-# Every element the dictation step drives, and the i18n key it used to be
-# located by. All four gate the same popover.
+# Every element the dictation step drives, and the i18n key it replaced.
 TEST_IDS = {
     "dictation-engine-trigger": "settings.voice.dictation.engineLabel",
     "dictation-engine-model": "settings.voice.dictation.engineModel",
@@ -31,7 +27,7 @@ TEST_IDS = {
     "stt-model-search": "settings.voice.dictation.sttModelSearchPlaceholder",
 }
 TEST_ID = "stt-model-search"
-# Settings tab buttons are rendered from one map, so their test id is templated.
+# Tab buttons come from one map, so the test id is templated.
 TAB_TEST_ID = "data-testid={`settings-tab-${tab.id}`}"
 
 
@@ -43,8 +39,7 @@ def test_the_element_carries_the_test_id(test_id):
 
 @pytest.mark.parametrize("test_id,key", sorted(TEST_IDS.items()))
 def test_the_test_id_sits_on_the_right_element(test_id, key):
-    """A test id on the wrong element passes the check above, so require each
-    one to sit beside the i18n key it replaced."""
+    """A test id on the wrong element still passes above, so require it beside its key."""
     source = VOICE_TAB.read_text(encoding = "utf-8")
     index = source.index(f'data-testid="{test_id}"')
     block = source[max(0, index - 400) : index + 400]
@@ -58,16 +53,14 @@ def test_the_driver_uses_it(test_id):
 
 
 def test_the_voice_settings_tab_is_reachable_by_test_id():
-    """The step's first click is the Voice tab, whose label is translated too,
-    so the tab buttons carry a test id keyed by tab id."""
+    """The step's first click is the Voice tab, whose label is translated too."""
     source = SETTINGS_DIALOG.read_text(encoding = "utf-8")
     assert TAB_TEST_ID in source, SETTINGS_DIALOG
     assert 'id: "voice"' in source, SETTINGS_DIALOG
     assert 'get_by_test_id("settings-tab-voice")' in EXTRA_UI.read_text(encoding = "utf-8")
 
 
-# Locators that resolve through user-visible copy. get_by_role only counts
-# when given a name.
+# Locators that resolve through user-visible copy (get_by_role only with a name).
 COPY_LOCATORS = (
     "get_by_placeholder",
     "get_by_label",
@@ -82,9 +75,8 @@ PER_LINE = r"get_by_(placeholder|label)\(|get_by_role\([^)]*name\s*="
 def copy_locator_calls(source, first_line, last_line):
     """Copy-bound locator calls starting between two 1-based lines.
 
-    Walks the AST rather than physical lines, so a call split over several
-    lines is still one node. Parses the whole file: the sliced step starts
-    mid-statement and indented, so it is not parseable alone.
+    Walks the AST, so a call split over lines is one node. Parses the whole
+    file because the sliced step alone is not parseable.
     """
     offenders = []
     for node in ast.walk(ast.parse(source)):
@@ -108,8 +100,7 @@ def line_range(source, start, end):
 
 
 def test_the_dictation_step_binds_to_no_translated_copy_at_all():
-    """The whole step, not just the input: it all gates one popover, so a
-    reword anywhere in it reproduces the same outage."""
+    """The whole step, not just the input: a reword anywhere in it repeats the outage."""
     source = EXTRA_UI.read_text(encoding = "utf-8")
     start = source.index("Voice model picker: real mouse-wheel scrolling")
     end = source.index("results.hover()", start)
@@ -126,8 +117,7 @@ page.get_by_test_id("stt-model-search").fill("whisper")
 
 
 def test_the_guard_catches_a_multi_line_copy_locator():
-    """A split call hides `name =` from any per-line match: the first line has
-    no `name =` and the third has no `get_by_role(`."""
+    """A split call hides `name =` from any per-line match."""
     assert [l for l in MULTI_LINE_SAMPLE.splitlines() if re.search(PER_LINE, l)] == []
     offenders = copy_locator_calls(MULTI_LINE_SAMPLE, 1, 5)
     assert len(offenders) == 1, offenders
@@ -145,8 +135,7 @@ def test_the_guard_ignores_calls_outside_the_range():
 
 
 def test_no_playwright_step_locates_this_input_by_its_copy():
-    """The regression itself: a placeholder-based locator here is one copy edit
-    away from taking the job down again."""
+    """The regression itself: one copy edit away from taking the job down again."""
     source = EXTRA_UI.read_text(encoding = "utf-8")
     offenders = [
         line.strip()
@@ -157,15 +146,13 @@ def test_no_playwright_step_locates_this_input_by_its_copy():
 
 
 def test_ci_actually_runs_this_file():
-    """Repo-root pytest discovery is pinned to tests/security, so this file is
-    only a guard if a workflow names it."""
+    """Repo-root pytest discovery skips this file, so a workflow must name it."""
     workflow = (REPO / ".github/workflows/studio-ui-smoke.yml").read_text(encoding = "utf-8")
     assert f"pytest tests/studio/{Path(__file__).name}" in workflow, workflow
     assert "tests/studio/**" in workflow, "the workflow must trigger on this path"
 
 
 def test_the_english_copy_is_still_free_to_change():
-    """This file must keep passing whatever the wording is, so it deliberately
-    asserts the key, not the string."""
+    """Assert the key, not the string, so the wording stays free to change."""
     source = EN_LOCALE.read_text(encoding = "utf-8")
     assert "sttModelSearchPlaceholder:" in source, EN_LOCALE

--- a/tests/studio/test_stt_model_search_locator_contract.py
+++ b/tests/studio/test_stt_model_search_locator_contract.py
@@ -16,6 +16,7 @@ touched no behaviour. The results container beside it already had
 `data-testid="stt-model-results"`; the input now has one too.
 """
 
+import ast
 import re
 from pathlib import Path
 
@@ -24,6 +25,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 VOICE_TAB = REPO / "studio/frontend/src/features/settings/tabs/voice-tab.tsx"
+SETTINGS_DIALOG = REPO / "studio/frontend/src/features/settings/settings-dialog.tsx"
 EXTRA_UI = REPO / "tests/studio/playwright_extra_ui.py"
 EN_LOCALE = REPO / "studio/frontend/src/i18n/locales/en.ts"
 
@@ -36,6 +38,8 @@ TEST_IDS = {
     "stt-model-search": "settings.voice.dictation.sttModelSearchPlaceholder",
 }
 TEST_ID = "stt-model-search"
+# Settings tab buttons are rendered from one map, so their test id is templated.
+TAB_TEST_ID = "data-testid={`settings-tab-${tab.id}`}"
 
 
 @pytest.mark.parametrize("test_id", sorted(TEST_IDS))
@@ -60,18 +64,92 @@ def test_the_driver_uses_it(test_id):
     assert f'get_by_test_id("{test_id}")' in source, (test_id, EXTRA_UI)
 
 
+def test_the_voice_settings_tab_is_reachable_by_test_id():
+    """The step's first click is the Voice tab itself, and its label is
+    translated too, so the tab buttons carry a test id keyed by tab id."""
+    source = SETTINGS_DIALOG.read_text(encoding = "utf-8")
+    assert TAB_TEST_ID in source, SETTINGS_DIALOG
+    assert 'id: "voice"' in source, SETTINGS_DIALOG
+    assert 'get_by_test_id("settings-tab-voice")' in EXTRA_UI.read_text(encoding = "utf-8")
+
+
+# Locators that resolve through user-visible copy. get_by_role is only one of
+# these when it is given a name.
+COPY_LOCATORS = (
+    "get_by_placeholder",
+    "get_by_label",
+    "get_by_text",
+    "get_by_alt_text",
+    "get_by_title",
+)
+# The per-line pattern this guard replaced. Kept only to prove the gap it left.
+PER_LINE = r"get_by_(placeholder|label)\(|get_by_role\([^)]*name\s*="
+
+
+def copy_locator_calls(source, first_line, last_line):
+    """Copy-bound locator calls starting between two 1-based lines.
+
+    Walks the parsed module rather than matching physical lines: a call split
+    over several lines is one node, so `get_by_role(` + a `name =` on the next
+    line is caught. Parses the whole file, because the sliced step on its own
+    starts mid-statement and indented, so it is not parseable alone.
+    """
+    offenders = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if not first_line <= node.lineno <= last_line:
+            continue
+        attr = node.func.attr
+        named_role = attr == "get_by_role" and any(kw.arg == "name" for kw in node.keywords)
+        if attr in COPY_LOCATORS or named_role:
+            segment = ast.get_source_segment(source, node) or attr
+            offenders.append(f"line {node.lineno}: {' '.join(segment.split())}")
+    return offenders
+
+
+def line_range(source, start, end):
+    """1-based line numbers of two character offsets."""
+    return source.count("\n", 0, start) + 1, source.count("\n", 0, end) + 1
+
+
 def test_the_dictation_step_binds_to_no_translated_copy_at_all():
-    """The whole step, not just the input. These four lines sit together and
-    gate one popover, so a reword of any of them reproduces the same outage."""
+    """The whole step, not just the input. These lines sit together and gate
+    one popover, so a reword of any of them reproduces the same outage."""
     source = EXTRA_UI.read_text(encoding = "utf-8")
     start = source.index("Voice model picker: real mouse-wheel scrolling")
-    step = source[start : source.index("results.hover()", start)]
-    offenders = [
-        line.strip()
-        for line in step.splitlines()
-        if re.search(r"get_by_(placeholder|label)\(|get_by_role\([^)]*name\s*=", line)
-    ]
+    end = source.index("results.hover()", start)
+    offenders = copy_locator_calls(source, *line_range(source, start, end))
     assert offenders == [], offenders
+
+
+MULTI_LINE_SAMPLE = '''page.get_by_role(
+    "button",
+    name = re.compile(r"^Voice$"),
+).first.click()
+page.get_by_test_id("stt-model-search").fill("whisper")
+'''
+
+
+def test_the_guard_catches_a_multi_line_copy_locator():
+    """A call split across lines hides `name =` from any per-line match: the
+    first line has no `name =` and the third has no `get_by_role(`."""
+    assert [l for l in MULTI_LINE_SAMPLE.splitlines() if re.search(PER_LINE, l)] == []
+    offenders = copy_locator_calls(MULTI_LINE_SAMPLE, 1, 5)
+    assert len(offenders) == 1, offenders
+    assert offenders[0].startswith("line 1: page.get_by_role("), offenders
+
+
+def test_the_guard_passes_test_id_only_code():
+    """It must not fire on the locators the step is supposed to use."""
+    clean = 'page.get_by_test_id("stt-model-search").fill("whisper")\npage.get_by_role("dialog")\n'
+    assert copy_locator_calls(clean, 1, 2) == []
+
+
+def test_the_guard_ignores_calls_outside_the_range():
+    assert copy_locator_calls(MULTI_LINE_SAMPLE, 5, 5) == []
 
 
 def test_no_playwright_step_locates_this_input_by_its_copy():
@@ -84,6 +162,14 @@ def test_no_playwright_step_locates_this_input_by_its_copy():
         if "get_by_placeholder" in line and re.search(r"[Ss]earch\s+model", line)
     ]
     assert offenders == [], offenders
+
+
+def test_ci_actually_runs_this_file():
+    """Repo-root pytest discovery is pinned to tests/security, so this file is
+    only a guard if a workflow names it. The UI workflow runs it as a step."""
+    workflow = (REPO / ".github/workflows/studio-ui-smoke.yml").read_text(encoding = "utf-8")
+    assert f"pytest tests/studio/{Path(__file__).name}" in workflow, workflow
+    assert "tests/studio/**" in workflow, "the workflow must trigger on this path"
 
 
 def test_the_english_copy_is_still_free_to_change():

--- a/tests/studio/test_stt_model_search_locator_contract.py
+++ b/tests/studio/test_stt_model_search_locator_contract.py
@@ -19,31 +19,59 @@ touched no behaviour. The results container beside it already had
 import re
 from pathlib import Path
 
+import pytest
+
 
 REPO = Path(__file__).resolve().parents[2]
 VOICE_TAB = REPO / "studio/frontend/src/features/settings/tabs/voice-tab.tsx"
 EXTRA_UI = REPO / "tests/studio/playwright_extra_ui.py"
 EN_LOCALE = REPO / "studio/frontend/src/i18n/locales/en.ts"
 
+# Every element the dictation step drives, and the i18n key each one used to be
+# located by. All four gate the same popover.
+TEST_IDS = {
+    "dictation-engine-trigger": "settings.voice.dictation.engineLabel",
+    "dictation-engine-model": "settings.voice.dictation.engineModel",
+    "stt-model-trigger": "settings.voice.dictation.sttModelLabel",
+    "stt-model-search": "settings.voice.dictation.sttModelSearchPlaceholder",
+}
 TEST_ID = "stt-model-search"
 
 
-def test_the_input_carries_the_test_id():
+@pytest.mark.parametrize("test_id", sorted(TEST_IDS))
+def test_the_element_carries_the_test_id(test_id):
     source = VOICE_TAB.read_text(encoding = "utf-8")
-    assert f'data-testid="{TEST_ID}"' in source, VOICE_TAB
+    assert f'data-testid="{test_id}"' in source, (test_id, VOICE_TAB)
 
 
-def test_the_test_id_sits_on_the_search_input_not_somewhere_else():
-    """A test id on the wrong element would still satisfy the check above."""
+@pytest.mark.parametrize("test_id,key", sorted(TEST_IDS.items()))
+def test_the_test_id_sits_on_the_right_element(test_id, key):
+    """A test id on the wrong element would still satisfy the check above, so
+    each one is required to sit beside the i18n key it replaced."""
     source = VOICE_TAB.read_text(encoding = "utf-8")
-    index = source.index(f'data-testid="{TEST_ID}"')
+    index = source.index(f'data-testid="{test_id}"')
     block = source[max(0, index - 400) : index + 400]
-    assert "sttModelSearchPlaceholder" in block, block
+    assert key in block, (test_id, block)
 
 
-def test_the_driver_uses_it():
+@pytest.mark.parametrize("test_id", sorted(TEST_IDS))
+def test_the_driver_uses_it(test_id):
     source = EXTRA_UI.read_text(encoding = "utf-8")
-    assert f'get_by_test_id("{TEST_ID}")' in source, EXTRA_UI
+    assert f'get_by_test_id("{test_id}")' in source, (test_id, EXTRA_UI)
+
+
+def test_the_dictation_step_binds_to_no_translated_copy_at_all():
+    """The whole step, not just the input. These four lines sit together and
+    gate one popover, so a reword of any of them reproduces the same outage."""
+    source = EXTRA_UI.read_text(encoding = "utf-8")
+    start = source.index("Voice model picker: real mouse-wheel scrolling")
+    step = source[start : source.index("results.hover()", start)]
+    offenders = [
+        line.strip()
+        for line in step.splitlines()
+        if re.search(r"get_by_(placeholder|label)\(|get_by_role\([^)]*name\s*=", line)
+    ]
+    assert offenders == [], offenders
 
 
 def test_no_playwright_step_locates_this_input_by_its_copy():

--- a/tests/studio/test_stt_model_search_locator_contract.py
+++ b/tests/studio/test_stt_model_search_locator_contract.py
@@ -125,12 +125,12 @@ def test_the_dictation_step_binds_to_no_translated_copy_at_all():
     assert offenders == [], offenders
 
 
-MULTI_LINE_SAMPLE = '''page.get_by_role(
+MULTI_LINE_SAMPLE = """page.get_by_role(
     "button",
     name = re.compile(r"^Voice$"),
 ).first.click()
 page.get_by_test_id("stt-model-search").fill("whisper")
-'''
+"""
 
 
 def test_the_guard_catches_a_multi_line_copy_locator():

--- a/tests/studio/test_stt_model_search_locator_contract.py
+++ b/tests/studio/test_stt_model_search_locator_contract.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""The dictation model search box must be reachable by test id, not by copy.
+
+`playwright_extra_ui.py` located this input with
+`get_by_placeholder("Search model")`. That placeholder is rendered through
+`t("settings.voice.dictation.sttModelSearchPlaceholder")`, so it is both
+translated and free to be reworded, and #7835 reworded the English string to
+"Search any model on HF". `get_by_placeholder` matches on substring, and
+"Search model" is not a substring of that, so the step failed with
+
+    Locator.fill: Timeout 60000ms exceeded.
+      waiting for get_by_placeholder("Search model")
+
+That takes the whole Chat UI Tests job down, on every PR, for a copy edit that
+touched no behaviour. The results container beside it already had
+`data-testid="stt-model-results"`; the input now has one too.
+"""
+
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+VOICE_TAB = REPO / "studio/frontend/src/features/settings/tabs/voice-tab.tsx"
+EXTRA_UI = REPO / "tests/studio/playwright_extra_ui.py"
+EN_LOCALE = REPO / "studio/frontend/src/i18n/locales/en.ts"
+
+TEST_ID = "stt-model-search"
+
+
+def test_the_input_carries_the_test_id():
+    source = VOICE_TAB.read_text(encoding = "utf-8")
+    assert f'data-testid="{TEST_ID}"' in source, VOICE_TAB
+
+
+def test_the_test_id_sits_on_the_search_input_not_somewhere_else():
+    """A test id on the wrong element would still satisfy the check above."""
+    source = VOICE_TAB.read_text(encoding = "utf-8")
+    index = source.index(f'data-testid="{TEST_ID}"')
+    block = source[max(0, index - 400) : index + 400]
+    assert "sttModelSearchPlaceholder" in block, block
+
+
+def test_the_driver_uses_it():
+    source = EXTRA_UI.read_text(encoding = "utf-8")
+    assert f'get_by_test_id("{TEST_ID}")' in source, EXTRA_UI
+
+
+def test_no_playwright_step_locates_this_input_by_its_copy():
+    """The regression itself. Any placeholder-based locator here is one copy
+    edit away from taking the job down again."""
+    source = EXTRA_UI.read_text(encoding = "utf-8")
+    offenders = [
+        line.strip()
+        for line in source.splitlines()
+        if "get_by_placeholder" in line and re.search(r"[Ss]earch\s+model", line)
+    ]
+    assert offenders == [], offenders
+
+
+def test_the_english_copy_is_still_free_to_change():
+    """States the point: this file must keep passing whatever the wording is,
+    so it deliberately does not assert the string."""
+    source = EN_LOCALE.read_text(encoding = "utf-8")
+    assert "sttModelSearchPlaceholder:" in source, EN_LOCALE


### PR DESCRIPTION
Chat UI Tests is currently failing on every open PR, at the same step:

```
Locator.fill: Timeout 60000ms exceeded.
  Call log:
    - waiting for get_by_placeholder("Search model")
```

## Why

`tests/studio/playwright_extra_ui.py` located the dictation model search input by its placeholder. That placeholder is rendered through `t("settings.voice.dictation.sttModelSearchPlaceholder")`, so it is translated, and it is free to be reworded without anyone thinking about the test.

#7835 reworded the English string:

| | value |
|---|---|
| before | `Search model` |
| now | `Search any model on HF` |

`get_by_placeholder` matches on substring, and `Search model` is not a substring of `Search any model on HF`, so the locator stopped resolving. The step burns its 60s timeout, `[ui-extra] FAILED: 1 assertion(s)` fires, and the job exits 1 -- for a copy edit that changed no behaviour.

This is not specific to any one PR. It reproduces on every branch that merges with current main, which is why several unrelated PRs went red at once.

## The fix

The results container immediately below already carried `data-testid="stt-model-results"`. The input now carries `data-testid="stt-model-search"`, and the driver uses it. Copy and translations can then change freely without touching the test.

## Guard

`tests/studio/test_stt_model_search_locator_contract.py` pins both halves: the id is on the search input specifically (not merely present somewhere in the file), the driver uses it, and no Playwright step in that file locates this input by its wording again. It deliberately does not assert the English string, since the whole point is that the string is free to change.

Four of its five checks fail on `main` and all five pass here.

```
5 passed
```