### PR TITLE
Studio: locate the STT model search by test id, not by its placeholder

### DIFF
--- a/studio/frontend/src/features/settings/tabs/voice-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/voice-tab.tsx
@@ -220,6 +220,10 @@ function SttModelPicker({
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
+            // Paired with stt-model-results below: the UI test drives this
+            // input, and its placeholder is translated copy that has already
+            // been reworded once out from under the test.
+            data-testid="stt-model-search"
             placeholder={t(
               "settings.voice.dictation.sttModelSearchPlaceholder",
             )}

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -568,7 +568,7 @@ with sync_playwright() as p:
                 page.get_by_label("Dictation engine").click()
                 page.get_by_role("option", name = "Local transcription").click()
                 page.get_by_label("Speech recognition model").click()
-                page.get_by_placeholder("Search model").fill("whisper")
+                page.get_by_test_id("stt-model-search").fill("whisper")
                 results = page.get_by_test_id("stt-model-results")
                 page.wait_for_function(
                     """() => {


### PR DESCRIPTION
`Unsloth UI CI` and `Windows Unsloth UI CI` have been failing on `main` since #7835 landed at 2026-08-04 23:29. Both fail on the same assertion:

```
[ui-extra] FAIL: Voice model picker did not wheel-scroll:
  TimeoutError('Locator.fill: Timeout 60000ms exceeded.
    Call log: - waiting for get_by_placeholder("Search model")')
```

## Cause

`tests/studio/playwright_extra_ui.py:571` locates the STT model search input by its placeholder text. #7095 added both the input and the test together, with the placeholder reading `Search model`, so they matched. #7835 reworded `settings.voice.dictation.sttModelSearchPlaceholder` to `Search any model on HF` and did not update the test. `get_by_placeholder` is a substring match and `Search model` is not a substring of `Search any model on HF`, so the locator stopped resolving and the step times out after 60s.

Confirmed it is not PR-specific: the same assertion fails on both staging mirrors' own `main` and on five unrelated PR branches (7871, 7830, 7793, 7829, 7857), and the two failing workflows are red on `main` itself.

## Fix

The input gets a `data-testid`, and the test uses it. The list immediately below it already carries `data-testid="stt-model-results"` and the test already locates that one by test id, so this just makes the pair consistent.

The underlying problem is that a UI test was pinned to translated display copy. Placeholder text is exactly the kind of string that gets reworded, and it has now been reworded once out from under this test. A test id does not move when the copy does.

I left the other two `get_by_placeholder` calls in that file alone: one matches a regex on `hf_`-style token prefixes rather than prose, and the other is currently passing. Only the broken locator changed.

## Verification

`typecheck` clean, `test` 434/434, `build` clean, `git diff --check` clean, pre-push gate passes, and `python3 -m py_compile` on the test file is clean.

`data-testid` survives the production build: after `npm run build`, `stt-model-search` is present in `dist/assets/index-*.js`, so the attribute the test looks for really is in the bundle CI serves.

The real check is the workflow itself. This branch is staged so `Unsloth UI CI` runs against it; that job is currently red on main, so it going green here is the proof.
