### PR TITLE
Studio: format profile stat numbers with the chosen locale

### DIFF
--- a/studio/frontend/src/features/profile/components/stats/insights-card.tsx
+++ b/studio/frontend/src/features/profile/components/stats/insights-card.tsx
@@ -15,6 +15,7 @@ import { StatMeter, StatRow, StatsCard } from "./stat-primitives";
 /** Left column: the "how you use Unsloth" numbers. */
 export function ActivityInsightsCard({ stats }: { stats: ProfileStats }) {
   const t = useT();
+  const locale = useLocale();
   const { totals, speed } = stats;
   const averageTokensPerChat =
     totals.threads > 0 ? totals.totalTokens / totals.threads : 0;
@@ -26,34 +27,34 @@ export function ActivityInsightsCard({ stats }: { stats: ProfileStats }) {
       <div className="flex flex-col divide-y divide-border/60">
         <StatRow
           label={t("settings.profile.stats.totalChats")}
-          value={formatFullNumber(totals.threads)}
+          value={formatFullNumber(totals.threads, locale)}
         />
         <StatRow
           label={t("settings.profile.stats.totalMessages")}
-          value={formatFullNumber(totals.messages)}
+          value={formatFullNumber(totals.messages, locale)}
         />
         <StatRow
           label={t("settings.profile.stats.tokensIn")}
-          value={formatCompactNumber(totals.promptTokens)}
+          value={formatCompactNumber(totals.promptTokens, locale)}
         />
         <StatRow
           label={t("settings.profile.stats.tokensOut")}
-          value={formatCompactNumber(totals.completionTokens)}
+          value={formatCompactNumber(totals.completionTokens, locale)}
         />
         <StatRow
           label={t("settings.profile.stats.cachedTokens")}
           value={
             cacheShare > 0
               ? t("settings.profile.stats.cachedValue", {
-                  tokens: formatCompactNumber(totals.cachedTokens),
+                  tokens: formatCompactNumber(totals.cachedTokens, locale),
                   percent: Math.round(cacheShare * 100),
                 })
-              : formatCompactNumber(totals.cachedTokens)
+              : formatCompactNumber(totals.cachedTokens, locale)
           }
         />
         <StatRow
           label={t("settings.profile.stats.avgTokensPerChat")}
-          value={formatCompactNumber(averageTokensPerChat)}
+          value={formatCompactNumber(averageTokensPerChat, locale)}
         />
         <StatRow
           label={t("settings.profile.stats.timeInChat")}
@@ -61,15 +62,15 @@ export function ActivityInsightsCard({ stats }: { stats: ProfileStats }) {
         />
         <StatRow
           label={t("settings.profile.stats.activeDays")}
-          value={formatFullNumber(totals.activeDays)}
+          value={formatFullNumber(totals.activeDays, locale)}
         />
         <StatRow
           label={t("settings.profile.stats.toolCalls")}
-          value={formatFullNumber(totals.toolCalls)}
+          value={formatFullNumber(totals.toolCalls, locale)}
         />
         <StatRow
           label={t("settings.profile.stats.attachments")}
-          value={formatFullNumber(totals.attachments)}
+          value={formatFullNumber(totals.attachments, locale)}
         />
         <StatRow
           label={t("settings.profile.stats.avgSpeed")}
@@ -142,7 +143,7 @@ export function TopModelsCard({ stats }: { stats: ProfileStats }) {
                       model.tokens,
                       "token",
                       locale,
-                      formatCompactNumber(model.tokens),
+                      formatCompactNumber(model.tokens, locale),
                     ),
                     messages: formatProfileCount(
                       model.messages,

--- a/studio/frontend/src/features/profile/components/stats/stats-highlights.tsx
+++ b/studio/frontend/src/features/profile/components/stats/stats-highlights.tsx
@@ -20,12 +20,12 @@ export function StatsHighlights({ stats }: { stats: ProfileStats }) {
   return (
     <div className="grid grid-cols-2 gap-y-5 rounded-2xl border border-border bg-background dark:border-transparent dark:bg-white/[0.06] px-4 py-5 sm:grid-cols-3 lg:grid-cols-5">
       <StatTile
-        value={formatCompactNumber(totals.totalTokens)}
+        value={formatCompactNumber(totals.totalTokens, locale)}
         label={t("settings.profile.stats.lifetimeTokens")}
-        hint={formatFullNumber(totals.totalTokens)}
+        hint={formatFullNumber(totals.totalTokens, locale)}
       />
       <StatTile
-        value={peakDay ? formatCompactNumber(peakDay.tokens) : "—"}
+        value={peakDay ? formatCompactNumber(peakDay.tokens, locale) : "—"}
         label={t("settings.profile.stats.peakTokens")}
         {...(peakDay ? { hint: peakDay.date } : {})}
       />

--- a/studio/frontend/src/features/profile/components/stats/token-activity-card.tsx
+++ b/studio/frontend/src/features/profile/components/stats/token-activity-card.tsx
@@ -318,7 +318,7 @@ export function TokenActivityCard({ daily }: { daily: ProfileStatsDay[] }) {
           visibleTotal,
           "token",
           locale,
-          formatCompactNumber(visibleTotal),
+          formatCompactNumber(visibleTotal, locale),
         ),
         weeks: formatProfileCount(grid.length, "week", locale),
       })}

--- a/studio/frontend/src/features/profile/components/stats/training-card.tsx
+++ b/studio/frontend/src/features/profile/components/stats/training-card.tsx
@@ -32,19 +32,19 @@ export function TrainingHighlightsCard({ stats }: { stats: ProfileStats }) {
     >
       <div className="grid grid-cols-2 gap-y-4 sm:grid-cols-3 lg:grid-cols-6">
         <StatTile
-          value={formatFullNumber(training.runs)}
+          value={formatFullNumber(training.runs, locale)}
           label={t("settings.profile.stats.trainingRuns")}
         />
         <StatTile
-          value={formatFullNumber(training.completed)}
+          value={formatFullNumber(training.completed, locale)}
           label={t("settings.profile.stats.trainingCompleted")}
         />
         <StatTile
-          value={formatCompactNumber(training.steps)}
+          value={formatCompactNumber(training.steps, locale)}
           label={t("settings.profile.stats.trainingSteps")}
         />
         <StatTile
-          value={formatCompactNumber(training.tokens)}
+          value={formatCompactNumber(training.tokens, locale)}
           label={t("settings.profile.stats.trainingTokens")}
         />
         <StatTile

--- a/studio/frontend/src/features/profile/utils/stats-format.ts
+++ b/studio/frontend/src/features/profile/utils/stats-format.ts
@@ -15,8 +15,9 @@ const FULL_FORMATTERS = new Map<Locale, Intl.NumberFormat>();
 function compactFormatter(
   locale: Locale,
   maximumFractionDigits: 0 | 1,
+  numberingSystem?: "latn",
 ): Intl.NumberFormat {
-  const key = `${locale}:${maximumFractionDigits}`;
+  const key = `${locale}:${maximumFractionDigits}:${numberingSystem ?? ""}`;
   const cached = COMPACT_FORMATTERS.get(key);
   if (cached) {
     return cached;
@@ -24,6 +25,7 @@ function compactFormatter(
   const formatter = new Intl.NumberFormat(locale, {
     notation: "compact",
     maximumFractionDigits,
+    ...(numberingSystem ? { numberingSystem } : {}),
   });
   COMPACT_FORMATTERS.set(key, formatter);
   return formatter;
@@ -31,9 +33,16 @@ function compactFormatter(
 
 /** Magnitude of the compact form, so "past 100 of a unit" is asked of Intl
  * rather than derived from a hardcoded 1e3/1e6/1e9 ladder that only matches
- * locales grouping in thousands. ja and zh group in 万, hi in लाख. */
+ * locales grouping in thousands. ja and zh group in 万, hi in लाख.
+ *
+ * Probed through a latn formatter, never the display one: the default numbering
+ * system is per-locale AND per-ICU-build, and ar-EG / ar-SA resolve to `arab`,
+ * where the integer part is "١" and Number() gives NaN. NaN < 100 is false, so
+ * every Arabic value silently lost its decimal ("٢ مليون" for 1.9M). The unit
+ * grouping is identical across numbering systems, so this only changes the
+ * digits we parse, not which unit Intl picked. */
 function compactInteger(locale: Locale, value: number): number {
-  for (const part of compactFormatter(locale, 1).formatToParts(value)) {
+  for (const part of compactFormatter(locale, 1, "latn").formatToParts(value)) {
     if (part.type === "integer") {
       return Math.abs(Number(part.value));
     }

--- a/studio/frontend/src/features/profile/utils/stats-format.ts
+++ b/studio/frontend/src/features/profile/utils/stats-format.ts
@@ -9,42 +9,59 @@
 
 import type { Locale } from "@/i18n";
 
-const TRAILING_ZERO_DECIMAL = /\.0$/;
+const COMPACT_FORMATTERS = new Map<string, Intl.NumberFormat>();
+const FULL_FORMATTERS = new Map<Locale, Intl.NumberFormat>();
 
-/** Compact form used on every stat tile: 12.3K, 4.5M, 19.8B. */
-export function formatCompactNumber(value: number): string {
-  if (!Number.isFinite(value)) return "0";
-  const abs = Math.abs(value);
-  if (abs < 1000) return String(Math.round(value));
-
-  const units: Array<{ limit: number; suffix: string }> = [
-    { limit: 1e12, suffix: "T" },
-    { limit: 1e9, suffix: "B" },
-    { limit: 1e6, suffix: "M" },
-    { limit: 1e3, suffix: "K" },
-  ];
-  for (const [index, { limit, suffix }] of units.entries()) {
-    if (abs < limit) continue;
-    const scaled = value / limit;
-    // One decimal below 100 keeps "1.9B" readable; above it the decimal is noise.
-    const rounded =
-      Math.abs(scaled) >= 100 ? Math.round(scaled) : Number(scaled.toFixed(1));
-    // Rounding can push a value over the next boundary, and "1000K" is not
-    // compact. Step up a unit rather than print four digits.
-    const next = units[index - 1];
-    if (next && Math.abs(rounded) >= 1000) {
-      return `${(value / next.limit).toFixed(1).replace(TRAILING_ZERO_DECIMAL, "")}${next.suffix}`;
-    }
-    const text =
-      Math.abs(scaled) >= 100 ? rounded.toString() : scaled.toFixed(1);
-    return `${text.replace(TRAILING_ZERO_DECIMAL, "")}${suffix}`;
+function compactFormatter(
+  locale: Locale,
+  maximumFractionDigits: 0 | 1,
+): Intl.NumberFormat {
+  const key = `${locale}:${maximumFractionDigits}`;
+  const cached = COMPACT_FORMATTERS.get(key);
+  if (cached) {
+    return cached;
   }
-  return String(Math.round(value));
+  const formatter = new Intl.NumberFormat(locale, {
+    notation: "compact",
+    maximumFractionDigits,
+  });
+  COMPACT_FORMATTERS.set(key, formatter);
+  return formatter;
 }
 
-export function formatFullNumber(value: number): string {
+/** Magnitude of the compact form, so "past 100 of a unit" is asked of Intl
+ * rather than derived from a hardcoded 1e3/1e6/1e9 ladder that only matches
+ * locales grouping in thousands. ja and zh group in 万, hi in लाख. */
+function compactInteger(locale: Locale, value: number): number {
+  for (const part of compactFormatter(locale, 1).formatToParts(value)) {
+    if (part.type === "integer") {
+      return Math.abs(Number(part.value));
+    }
+  }
+  return 0;
+}
+
+/**
+ * Compact form used on every stat tile: 12.3K, 4.5M, 19.8B in English, and
+ * each locale's own units elsewhere (1.2万 in ja, 1,9 Mrd. in de, 1.2 लाख in
+ * hi). One decimal below 100 of a unit keeps "1.9B" readable; above it the
+ * decimal is noise, and asking for zero digits also avoids "1000K", which is
+ * not compact.
+ */
+export function formatCompactNumber(value: number, locale: Locale): string {
   if (!Number.isFinite(value)) return "0";
-  return Math.round(value).toLocaleString();
+  return compactInteger(locale, value) < 100
+    ? compactFormatter(locale, 1).format(value)
+    : compactFormatter(locale, 0).format(value);
+}
+
+/** The exact count behind a tile, grouped the way the chosen locale groups. */
+export function formatFullNumber(value: number, locale: Locale): string {
+  if (!Number.isFinite(value)) return "0";
+  const cached = FULL_FORMATTERS.get(locale);
+  const formatter = cached ?? new Intl.NumberFormat(locale);
+  if (!cached) FULL_FORMATTERS.set(locale, formatter);
+  return formatter.format(Math.round(value));
 }
 
 const DAY_FORMATTERS = new Map<Locale, Intl.NumberFormat>();

--- a/studio/frontend/src/features/profile/utils/stats-format.ts
+++ b/studio/frontend/src/features/profile/utils/stats-format.ts
@@ -50,6 +50,14 @@ function compactInteger(locale: Locale, value: number): number {
   return 0;
 }
 
+/** Whether the compact form actually applied a unit (K / 万 / लाख), probed in latn for the
+ * same reason as compactInteger. */
+function hasCompactUnit(locale: Locale, value: number): boolean {
+  return compactFormatter(locale, 1, "latn")
+    .formatToParts(value)
+    .some((part) => part.type === "compact");
+}
+
 /**
  * Compact form used on every stat tile: 12.3K, 4.5M, 19.8B in English, and
  * each locale's own units elsewhere (1.2万 in ja, 1,9 Mrd. in de, 1.2 लाख in
@@ -59,6 +67,12 @@ function compactInteger(locale: Locale, value: number): number {
  */
 export function formatCompactNumber(value: number, locale: Locale): string {
   if (!Number.isFinite(value)) return "0";
+  // Below the locale's first compact unit there is no unit to be a fraction OF, and these
+  // are whole things: averageTokensPerChat is the one fractional caller, and "12.5 tokens"
+  // reads as false precision where the pre-localization code said 13. Asked of Intl (is there
+  // a `compact` part?) rather than a hardcoded 1000, because the first unit is per-locale:
+  // en and hi compact at 1K, ja and de not until 万 and Mio.
+  if (!hasCompactUnit(locale, value)) return compactFormatter(locale, 0).format(value);
   return compactInteger(locale, value) < 100
     ? compactFormatter(locale, 1).format(value)
     : compactFormatter(locale, 0).format(value);

--- a/studio/frontend/tests/profile-stats-format.test.ts
+++ b/studio/frontend/tests/profile-stats-format.test.ts
@@ -29,6 +29,25 @@ test("compact numbers match the tile format", () => {
   assert.equal(formatCompactNumber(Number.NaN, "en"), "0");
 });
 
+test("sub-unit counts stay whole, in every locale", () => {
+  // averageTokensPerChat is the one fractional caller and these are whole tokens:
+  // 25 across 2 chats is 13, not 12.5. The pre-localization code rounded anything
+  // under 1000; the unit boundary replaces that hardcoded 1000 because it is
+  // per-locale (ja and de do not compact until \u4e07 / Mio.).
+  assert.equal(formatCompactNumber(12.5, "en"), "13");
+  assert.equal(formatCompactNumber(12.4, "en"), "12");
+  assert.equal(formatCompactNumber(0.5, "en"), "1");
+  // Intl rounds half away from zero, Math.round rounds half UP, so an exact negative
+  // half differs from the pre-localization code (-13 vs -12). Every caller here is a
+  // count, so this is unreachable in practice; pinned so the difference is deliberate.
+  assert.equal(formatCompactNumber(-12.5, "en"), "-13");
+  // ja does not compact below \u4e07, so a four-digit value is still whole there.
+  assert.equal(formatCompactNumber(5000.4, "ja"), "5000");
+  // ...and past the unit the decimal comes back.
+  assert.equal(formatCompactNumber(12_340, "en"), "12.3K");
+  assert.equal(formatCompactNumber(12_340, "ja"), "1.2\u4e07");
+});
+
 test("a non-Latin numbering system keeps its decimal", () => {
   // The threshold used to be read off the DISPLAY string, so a locale whose
   // digits are not ASCII gave Number("\u0661") -> NaN, NaN < 100 -> false, and every

--- a/studio/frontend/tests/profile-stats-format.test.ts
+++ b/studio/frontend/tests/profile-stats-format.test.ts
@@ -8,6 +8,7 @@ import {
   formatCompactNumber,
   formatDayCount,
   formatDuration,
+  formatFullNumber,
   formatMilliseconds,
   formatProfileCount,
   heatLevel,
@@ -17,26 +18,52 @@ import {
 } from "../src/features/profile/utils/stats-format.ts";
 
 test("compact numbers match the tile format", () => {
-  assert.equal(formatCompactNumber(0), "0");
-  assert.equal(formatCompactNumber(999), "999");
-  assert.equal(formatCompactNumber(1000), "1K");
-  assert.equal(formatCompactNumber(12_340), "12.3K");
-  assert.equal(formatCompactNumber(1_900_000_000), "1.9B");
-  assert.equal(formatCompactNumber(19_800_000_000), "19.8B");
+  assert.equal(formatCompactNumber(0, "en"), "0");
+  assert.equal(formatCompactNumber(999, "en"), "999");
+  assert.equal(formatCompactNumber(1000, "en"), "1K");
+  assert.equal(formatCompactNumber(12_340, "en"), "12.3K");
+  assert.equal(formatCompactNumber(1_900_000_000, "en"), "1.9B");
+  assert.equal(formatCompactNumber(19_800_000_000, "en"), "19.8B");
   // Past 100 of a unit the decimal is noise.
-  assert.equal(formatCompactNumber(123_400), "123K");
-  assert.equal(formatCompactNumber(Number.NaN), "0");
+  assert.equal(formatCompactNumber(123_400, "en"), "123K");
+  assert.equal(formatCompactNumber(Number.NaN, "en"), "0");
 });
 
 test("rounding up a unit steps to the next suffix", () => {
   // Rounding 999.5K to "1000K" is four digits, which is not compact.
-  assert.equal(formatCompactNumber(999_999), "1M");
-  assert.equal(formatCompactNumber(999_500), "1M");
-  assert.equal(formatCompactNumber(999_999_999), "1B");
-  assert.equal(formatCompactNumber(999_999_999_999), "1T");
-  assert.equal(formatCompactNumber(-999_999), "-1M");
+  assert.equal(formatCompactNumber(999_999, "en"), "1M");
+  assert.equal(formatCompactNumber(999_500, "en"), "1M");
+  assert.equal(formatCompactNumber(999_999_999, "en"), "1B");
+  assert.equal(formatCompactNumber(999_999_999_999, "en"), "1T");
+  assert.equal(formatCompactNumber(-999_999, "en"), "-1M");
   // Just below the rounding boundary the unit is unchanged.
-  assert.equal(formatCompactNumber(999_499), "999K");
+  assert.equal(formatCompactNumber(999_499, "en"), "999K");
+});
+
+test("compact numbers use each locale's own magnitude units", () => {
+  // K/M/B is an English convention. ja and ko group in 万/억, zh in 万/亿,
+  // and hi in लाख, so a hardcoded ladder is wrong in half the locales.
+  assert.equal(formatCompactNumber(12_340, "ja"), "1.2万");
+  assert.equal(formatCompactNumber(1_900_000_000, "ja"), "19億");
+  assert.equal(formatCompactNumber(12_340, "zh-CN"), "1.2万");
+  assert.equal(formatCompactNumber(1_900_000_000, "zh-CN"), "19亿");
+  // U+00A0, not a plain space: CLDR keeps the unit from wrapping away from
+  // its number, so an assertion with a normal space silently fails.
+  assert.equal(formatCompactNumber(1_900_000, "hi"), "19\u00a0लाख");
+  // Decimal separator and unit word follow the locale too.
+  assert.equal(formatCompactNumber(1_900_000, "de"), "1,9\u00a0Mio.");
+  assert.equal(formatCompactNumber(1_900_000, "ru"), "1,9\u00a0млн");
+  // German CLDR has no short form below a million, so thousands stay written
+  // out. That is the locale's rule, not a fallback.
+  assert.equal(formatCompactNumber(12_340, "de"), "12.340");
+});
+
+test("full numbers group the way the chosen locale groups", () => {
+  assert.equal(formatFullNumber(1_234_567, "en"), "1,234,567");
+  assert.equal(formatFullNumber(1_234_567, "de"), "1.234.567");
+  // Indian grouping is 2-2-3, not 3-3-3.
+  assert.equal(formatFullNumber(1_234_567, "hi"), "12,34,567");
+  assert.equal(formatFullNumber(Number.NaN, "en"), "0");
 });
 
 test("durations read the way the header does", () => {

--- a/studio/frontend/tests/profile-stats-format.test.ts
+++ b/studio/frontend/tests/profile-stats-format.test.ts
@@ -29,6 +29,34 @@ test("compact numbers match the tile format", () => {
   assert.equal(formatCompactNumber(Number.NaN, "en"), "0");
 });
 
+test("a non-Latin numbering system keeps its decimal", () => {
+  // The threshold used to be read off the DISPLAY string, so a locale whose
+  // digits are not ASCII gave Number("\u0661") -> NaN, NaN < 100 -> false, and every
+  // Arabic value silently lost its decimal. Which locales default to `arab`
+  // varies by ICU build, so pin an explicit one rather than bare "ar".
+  const arab = "ar-EG" as Parameters<typeof formatCompactNumber>[1];
+  const onePointNine = formatCompactNumber(1_900_000, arab);
+  // The decimal separator is the Arabic one; what matters is that a fraction survived.
+  assert.ok(
+    /\u0661[\u066b.,]\u0669/.test(onePointNine),
+    `expected a 1.9-style value, got ${onePointNine}`,
+  );
+  // ...and past 100 of a unit it is still dropped, exactly as in en.
+  assert.ok(
+    !/[\u066b.,]/.test(formatCompactNumber(190_000_000, arab)),
+    "expected no decimal past 100 of a unit",
+  );
+});
+
+test("the latn probe does not change which unit Intl picked", () => {
+  // Unit grouping is a locale property, not a numbering-system one, so probing
+  // in latn must leave ja/zh (\u4e07) and hi (\u0932\u093e\u0916) exactly as they were.
+  assert.equal(formatCompactNumber(1_900_000, "ja"), "190\u4e07");
+  assert.equal(formatCompactNumber(190_000_000, "ja"), "1.9\u5104");
+  assert.equal(formatCompactNumber(1_900_000, "zh-CN"), "190\u4e07");
+  assert.equal(formatCompactNumber(1_234, "en"), "1.2K");
+});
+
 test("rounding up a unit steps to the next suffix", () => {
   // Rounding 999.5K to "1000K" is four digits, which is not compact.
   assert.equal(formatCompactNumber(999_999, "en"), "1M");


### PR DESCRIPTION
The profile stats panel is already carefully localized: `stats-format.ts` threads `locale` through `formatDayCount`, keeps per-locale plural templates for tokens, messages and steps, and drives them with `Intl.PluralRules`. Two functions in that same file ignore the locale entirely.

## `formatCompactNumber` hardcoded an English magnitude ladder

```ts
const units = [
  { limit: 1e12, suffix: "T" },
  { limit: 1e9,  suffix: "B" },
  { limit: 1e6,  suffix: "M" },
  { limit: 1e3,  suffix: "K" },
];
```

K/M/B/T and grouping in thousands are English conventions. What each locale actually writes for the same numbers:

| | 12,340 | 1,900,000 | 1,900,000,000 |
|---|---|---|---|
| en | 12.3K | 1.9M | 1.9B |
| ja | 1.2万 | 190万 | 19億 |
| zh-CN | 1.2万 | 190万 | 19亿 |
| ko | 1.2만 | 190만 | 19억 |
| hi | 12.3 हज़ार | 19 लाख | 1.9 अ॰ |
| de | 12.340 | 1,9 Mio. | 1,9 Mrd. |
| ru | 12,3 тыс. | 1,9 млн | 1,9 млрд |
| fr | 12,3 k | 1,9 M | 1,9 Md |

Japanese, Korean and Chinese do not group in thousands at all, and Hindi uses लाख/करोड़. German has no short form below a million, so it writes thousands out. A hardcoded ladder is wrong in most of the twelve locales, not just cosmetically off.

## `formatFullNumber` used the browser's locale, not the app's

```ts
return Math.round(value).toLocaleString();
```

With no argument, `toLocaleString` uses the runtime default, which is the browser or OS language. Studio has its own language picker, so a German user on an English browser saw `1,234,567` where the app should say `1.234.567`, and a Hindi user got 3-3-3 grouping instead of `12,34,567`.

## The change

Both take `locale` and go through `Intl.NumberFormat`, matching everything else in the file. Every call site already had `useLocale()` in scope except `ActivityInsightsCard`, which gains one line.

English output is unchanged. All thirteen existing expectations still pass, including the two deliberate behaviours the old code documented: one decimal below 100 of a unit, and never printing `1000K`. Those come out of a two-pass call now, formatting with `maximumFractionDigits: 1` and re-formatting with `0` when the compact integer part reaches 100, rather than a hand-rolled scale-and-round. Reading the magnitude with `formatToParts` rather than dividing by `1e3`/`1e6` is what makes it work for locales whose units are not powers of a thousand.

## Verification

`i18n:check:strict` exits 0, `typecheck` clean, `test` 436/436, `build` clean, `git diff --check` clean, pre-push gate passes. `stats-format.ts` is byte-identical to its own Biome-formatted output, and its Biome diagnostic count drops from 17 to 16.

New test coverage: the locale units above, plus grouping for en/de/hi in `formatFullNumber`.

Two things I checked rather than assumed:

**CLDR joins the number and unit with U+00A0**, not a plain space, in every locale that uses one. The test asserts `"1,9 Mio."` with an explicit escape rather than an invisible character in the source; an assertion written with a normal space passes review and fails CI.

**Tile layout holds.** The new strings are wider than `1.9B`, and a non-breaking space cannot wrap, so I measured it in Chromium against the real chain (960px dialog, 248px settings aside, `p-6`, scrollbar gutter, panel `px-4`, `lg:grid-cols-5`, cell `px-2`). At the tightest breakpoint the cell box is 123px; the widest value is Russian `19,8 млрд` at 118px. Every locale renders on one line box, nothing escapes its cell, and the grid never gains a horizontal scrollbar.

## Not included

Around 40 other bare `toLocaleString()` calls sit elsewhere in the app. Most are inside hardcoded English sentences (`Show all (N earlier lines hidden)`, `Scanned N results`, `N rows`), where localizing only the number would not make the string any more translated. Those belong with whatever change translates the surrounding copy.

Arabic digits are also left alone. On WebKit, `ar` resolves to `arab` digits where Chromium and Firefox use `latn`; I measured that directly in all three engines. That is a platform default and arguably the more faithful rendering, so forcing `numberingSystem: "latn"` is a product call rather than a bug fix.
