### PR TITLE
Studio: restore the MLX gradient-norm chart by matching CUDA's clipping default

### DIFF
--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -117,7 +117,7 @@ def _coerce_optional_nonneg_float(name: str, value):
     except (TypeError, ValueError):
         raise ValueError(f"Unsloth: {name}={value!r} must be a non-negative float or None.")
     if coerced < 0:
-        raise ValueError(f"Unsloth: {name}={coerced} must be >= 0 (use 0 or None to disable).")
+        raise ValueError(f"Unsloth: {name}={coerced} must be >= 0.")
     return coerced
 
 
@@ -174,7 +174,9 @@ def _build_training_worker_config(values: dict[str, Any]) -> dict[str, Any]:
         "max_steps": values.get("max_steps", 0),
         "save_steps": values.get("save_steps", 0),
         "weight_decay": values.get("weight_decay", 0.001),
-        "max_grad_norm": values.get("max_grad_norm", 0.0),
+        "max_grad_norm": _coerce_optional_nonneg_float(
+            "max_grad_norm", values.get("max_grad_norm")
+        ),
         "max_grad_value": _coerce_optional_nonneg_float(
             "max_grad_value", values.get("max_grad_value")
         ),

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -109,11 +109,7 @@ def _coerce_optional_bool(value, default: bool) -> bool:
 
 
 def _coerce_optional_nonneg_float(name: str, value):
-    """Reject negatives and non-finite; HTTP `ge=0` misses raw `**kwargs` callers.
-
-    inf clears `ge=0` but never binds, so the run would train unclipped while
-    the config reports a threshold.
-    """
+    """Reject negatives and non-finite; `ge=0` misses raw callers, and inf never binds."""
     if value is None:
         return None
     try:

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -109,15 +109,19 @@ def _coerce_optional_bool(value, default: bool) -> bool:
 
 
 def _coerce_optional_nonneg_float(name: str, value):
-    """Reject negatives; HTTP `ge=0` doesn't cover raw `**kwargs` callers."""
+    """Reject negatives and non-finite; HTTP `ge=0` misses raw `**kwargs` callers.
+
+    inf clears `ge=0` but never binds, so the run would train unclipped while
+    the config reports a threshold.
+    """
     if value is None:
         return None
     try:
         coerced = float(value)
     except (TypeError, ValueError):
         raise ValueError(f"Unsloth: {name}={value!r} must be a non-negative float or None.")
-    if coerced < 0:
-        raise ValueError(f"Unsloth: {name}={coerced} must be >= 0.")
+    if coerced < 0 or not math.isfinite(coerced):
+        raise ValueError(f"Unsloth: {name}={coerced} must be finite and >= 0.")
     return coerced
 
 

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1510,6 +1510,32 @@ def _resolve_mlx_output_dir(config, model_name):
     return str(resolve_output_dir(output_dir))
 
 
+def _resolve_mlx_max_grad_norm(value):
+    """Global-norm clip threshold for MLX runs; None selects the default.
+
+    1.0 is what the CUDA text path trains with (TRL's SFTConfig default) and
+    what the public MLX API applies when no clipping knob is given, so an
+    unset value lands on the same threshold everywhere. CUDA's vision branch
+    uses 0.3, which is not mirrored here. Explicit 0 turns global-norm
+    clipping off, which leaves MLX's per-parameter clipping in force unless
+    max_grad_leaf_norm is also set to 0.
+    """
+    if value is None:
+        return 1.0
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Unsloth MLX: max_grad_norm={value!r} must be a non-negative float or None."
+        )
+    if value < 0:
+        raise ValueError(
+            f"Unsloth MLX: max_grad_norm={value} must be >= 0 "
+            "(use 0 to disable global norm clipping)."
+        )
+    return value
+
+
 def _run_mlx_training(event_queue, stop_queue, config):
     """Self-contained MLX training path for Apple Silicon.
 
@@ -1960,9 +1986,10 @@ def _run_mlx_training(event_queue, stop_queue, config):
     else:
         eval_steps_val = int(eval_steps_val)
 
-    # Per-element clipping only; trainer owns the None default. Re-validate
-    # for direct worker callers (training.py normalizes the main path).
-    max_grad_norm = 0.0
+    # Re-validate for direct worker callers (training.py normalizes the main
+    # path). Clipping globally also yields the pre-clip norm the gradient-norm
+    # chart plots, at the same cost the opt-in report_grad_norm would pay.
+    max_grad_norm = _resolve_mlx_max_grad_norm(config.get("max_grad_norm"))
     max_grad_value = config.get("max_grad_value")
     if max_grad_value is not None:
         max_grad_value = float(max_grad_value)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1513,12 +1513,10 @@ def _resolve_mlx_output_dir(config, model_name):
 def _resolve_mlx_max_grad_norm(value):
     """Global-norm clip threshold for MLX runs; None selects the default.
 
-    1.0 is what the CUDA text path trains with (TRL's SFTConfig default) and
-    what the public MLX API applies when no clipping knob is given, so an
-    unset value lands on the same threshold everywhere. CUDA's vision branch
-    uses 0.3, which is not mirrored here. Explicit 0 turns global-norm
-    clipping off, which leaves MLX's per-parameter clipping in force unless
-    max_grad_leaf_norm is also set to 0.
+    1.0 matches the CUDA text path (TRL's SFTConfig default) and the public MLX
+    API, so unset lands on the same threshold everywhere; CUDA's vision 0.3 is
+    not mirrored. Explicit 0 turns global-norm clipping off but leaves MLX's
+    per-parameter clipping in force unless max_grad_leaf_norm is also 0.
     """
     if value is None:
         return 1.0
@@ -1528,8 +1526,7 @@ def _resolve_mlx_max_grad_norm(value):
         raise ValueError(
             f"Unsloth MLX: max_grad_norm={value!r} must be a non-negative float or None."
         )
-    # inf satisfies a >= 0 check but never binds, so the run would train
-    # unclipped while reporting a threshold.
+    # inf clears a >= 0 check but never binds, so the run would train unclipped.
     if value < 0 or not math.isfinite(value):
         raise ValueError(
             f"Unsloth MLX: max_grad_norm={value} must be a finite value >= 0 "
@@ -1995,17 +1992,17 @@ def _run_mlx_training(event_queue, stop_queue, config):
     max_grad_value = config.get("max_grad_value")
     if max_grad_value is not None:
         max_grad_value = float(max_grad_value)
-        if max_grad_value < 0:
+        if max_grad_value < 0 or not math.isfinite(max_grad_value):
             raise ValueError(
-                f"Unsloth MLX: max_grad_value={max_grad_value} must be >= 0 "
+                f"Unsloth MLX: max_grad_value={max_grad_value} must be finite and >= 0 "
                 "(0 or None disables elementwise clipping)."
             )
     max_grad_leaf_norm = config.get("max_grad_leaf_norm")
     if max_grad_leaf_norm is not None:
         max_grad_leaf_norm = float(max_grad_leaf_norm)
-        if max_grad_leaf_norm < 0:
+        if max_grad_leaf_norm < 0 or not math.isfinite(max_grad_leaf_norm):
             raise ValueError(
-                f"Unsloth MLX: max_grad_leaf_norm={max_grad_leaf_norm} must be >= 0 "
+                f"Unsloth MLX: max_grad_leaf_norm={max_grad_leaf_norm} must be finite and >= 0 "
                 "(0 or None disables proportional leaf-norm clipping)."
             )
     weight_decay = config.get("weight_decay", 0.001)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1985,9 +1985,8 @@ def _run_mlx_training(event_queue, stop_queue, config):
     else:
         eval_steps_val = int(eval_steps_val)
 
-    # Re-validate for direct worker callers (training.py normalizes the main
-    # path). Clipping globally also yields the pre-clip norm the gradient-norm
-    # chart plots, at the same cost the opt-in report_grad_norm would pay.
+    # Re-validate for direct worker callers; training.py normalizes the main path.
+    # Global clipping also yields the pre-clip norm the gradient-norm chart plots.
     max_grad_norm = _resolve_mlx_max_grad_norm(config.get("max_grad_norm"))
     max_grad_value = config.get("max_grad_value")
     if max_grad_value is not None:

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1528,9 +1528,11 @@ def _resolve_mlx_max_grad_norm(value):
         raise ValueError(
             f"Unsloth MLX: max_grad_norm={value!r} must be a non-negative float or None."
         )
-    if value < 0:
+    # inf satisfies a >= 0 check but never binds, so the run would train
+    # unclipped while reporting a threshold.
+    if value < 0 or not math.isfinite(value):
         raise ValueError(
-            f"Unsloth MLX: max_grad_norm={value} must be >= 0 "
+            f"Unsloth MLX: max_grad_norm={value} must be a finite value >= 0 "
             "(use 0 to disable global norm clipping)."
         )
     return value

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1511,15 +1511,15 @@ def _resolve_mlx_output_dir(config, model_name):
 
 
 def _resolve_mlx_max_grad_norm(value):
-    """Global-norm clip threshold for MLX runs; None selects the default.
+    """Global-norm clip threshold for MLX runs; None keeps the trainer's default.
 
-    1.0 matches the CUDA text path (TRL's SFTConfig default) and the public MLX
-    API, so unset lands on the same threshold everywhere; CUDA's vision 0.3 is
-    not mirrored. Explicit 0 turns global-norm clipping off but leaves MLX's
-    per-parameter clipping in force unless max_grad_leaf_norm is also 0.
+    The worker used to hardcode 0.0 and drop the requested value, so an API caller
+    asking for a threshold got none. Unset stays 0.0 so MLX keeps its cheap
+    per-parameter clipping: the gradient-norm chart is fed by report_grad_norm
+    instead, which measures the same norm without changing what gets clipped.
     """
     if value is None:
-        return 1.0
+        return 0.0
     try:
         value = float(value)
     except (TypeError, ValueError):
@@ -1986,7 +1986,6 @@ def _run_mlx_training(event_queue, stop_queue, config):
         eval_steps_val = int(eval_steps_val)
 
     # Re-validate for direct worker callers; training.py normalizes the main path.
-    # Global clipping also yields the pre-clip norm the gradient-norm chart plots.
     max_grad_norm = _resolve_mlx_max_grad_norm(config.get("max_grad_norm"))
     max_grad_value = config.get("max_grad_value")
     if max_grad_value is not None:
@@ -2046,6 +2045,12 @@ def _run_mlx_training(event_queue, stop_queue, config):
         mlx_config_kwargs["dataset_order"] = "torch_randperm"
     if "max_grad_leaf_norm" in _supported_fields:
         mlx_config_kwargs["max_grad_leaf_norm"] = max_grad_leaf_norm
+    if "report_grad_norm" in _supported_fields:
+        # What refills the gradient-norm chart. MLX returns a norm for free only
+        # under global-norm clipping, so ask for it rather than switching clip
+        # modes to get it: switching would alter the loss trajectory and, on VLMs,
+        # make the run ineligible for mx.compile whenever grad accum > 1.
+        mlx_config_kwargs["report_grad_norm"] = True
     if "append_eos" in _supported_fields:
         # Unsloth SFT formatting owns rendered examples; raw/CPT text still
         # needs MLX to append EOS like the CUDA raw-text path.

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2046,10 +2046,9 @@ def _run_mlx_training(event_queue, stop_queue, config):
     if "max_grad_leaf_norm" in _supported_fields:
         mlx_config_kwargs["max_grad_leaf_norm"] = max_grad_leaf_norm
     if "report_grad_norm" in _supported_fields:
-        # What refills the gradient-norm chart. MLX returns a norm for free only
-        # under global-norm clipping, so ask for it rather than switching clip
-        # modes to get it: switching would alter the loss trajectory and, on VLMs,
-        # make the run ineligible for mx.compile whenever grad accum > 1.
+        # Refills the gradient-norm chart. MLX returns a norm for free only under
+        # global-norm clipping; asking for it beats switching clip modes, which
+        # would alter the loss trajectory and cost VLM runs mx.compile.
         mlx_config_kwargs["report_grad_norm"] = True
     if "append_eos" in _supported_fields:
         # Unsloth SFT formatting owns rendered examples; raw/CPT text still

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -414,10 +414,9 @@ class TrainingStartRequest(BaseModel):
     max_steps: Optional[int] = Field(None, description = "Maximum training steps")
     save_steps: int = Field(100, description = "Steps between checkpoints")
     weight_decay: float = Field(0.001, description = "Weight decay")
-    # Finite as well as non-negative: JSON accepts 1e309 (and FastAPI's parser
-    # the Infinity literal), which floats to inf and satisfies a ge-only
-    # constraint. An inf threshold never binds, so the run trains unclipped
-    # while the config reports clipping.
+    # All three clip knobs are finite as well as non-negative: JSON 1e309 (and
+    # FastAPI's Infinity literal) floats to inf, which clears ge=0 but never
+    # binds, so the run would train unclipped while reporting a threshold.
     max_grad_norm: Optional[float] = Field(
         None,
         ge = 0,
@@ -433,6 +432,7 @@ class TrainingStartRequest(BaseModel):
     max_grad_value: Optional[float] = Field(
         None,
         ge = 0,
+        allow_inf_nan = False,
         description = (
             "MLX-only elementwise gradient value clipping threshold. "
             "If unset, MLX uses its runtime default."
@@ -441,6 +441,7 @@ class TrainingStartRequest(BaseModel):
     max_grad_leaf_norm: Optional[float] = Field(
         None,
         ge = 0,
+        allow_inf_nan = False,
         description = (
             "MLX-only proportional per-parameter gradient norm cap. "
             "Preserves each tensor's gradient direction without global norm "

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -414,10 +414,16 @@ class TrainingStartRequest(BaseModel):
     max_steps: Optional[int] = Field(None, description = "Maximum training steps")
     save_steps: int = Field(100, description = "Steps between checkpoints")
     weight_decay: float = Field(0.001, description = "Weight decay")
-    max_grad_norm: float = Field(
-        0.0,
+    max_grad_norm: Optional[float] = Field(
+        None,
         ge = 0,
-        description = "Global gradient norm clipping threshold. Set 0 to disable.",
+        description = (
+            "Global gradient norm clipping threshold. Unset lets the training "
+            "backend apply its default; 0 turns global-norm clipping off, "
+            "which on MLX leaves per-parameter clipping in force unless "
+            "max_grad_leaf_norm is also 0. Honored on MLX; the CUDA path "
+            "trains with its own fixed thresholds."
+        ),
     )
     max_grad_value: Optional[float] = Field(
         None,

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -414,9 +414,14 @@ class TrainingStartRequest(BaseModel):
     max_steps: Optional[int] = Field(None, description = "Maximum training steps")
     save_steps: int = Field(100, description = "Steps between checkpoints")
     weight_decay: float = Field(0.001, description = "Weight decay")
+    # Finite as well as non-negative: JSON accepts 1e309 (and FastAPI's parser
+    # the Infinity literal), which floats to inf and satisfies a ge-only
+    # constraint. An inf threshold never binds, so the run trains unclipped
+    # while the config reports clipping.
     max_grad_norm: Optional[float] = Field(
         None,
         ge = 0,
+        allow_inf_nan = False,
         description = (
             "Global gradient norm clipping threshold. Unset lets the training "
             "backend apply its default; 0 turns global-norm clipping off, "

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -422,11 +422,11 @@ class TrainingStartRequest(BaseModel):
         ge = 0,
         allow_inf_nan = False,
         description = (
-            "Global gradient norm clipping threshold. Unset lets the training "
-            "backend apply its default; 0 turns global-norm clipping off, "
-            "which on MLX leaves per-parameter clipping in force unless "
-            "max_grad_leaf_norm is also 0. Honored on MLX; the CUDA path "
-            "trains with its own fixed thresholds."
+            "Global gradient norm clipping threshold. Unset keeps the training "
+            "backend's own default; 0 turns global-norm clipping off, which on "
+            "MLX leaves per-parameter clipping in force unless max_grad_leaf_norm "
+            "is also 0. Honored on MLX; the CUDA path trains with its own fixed "
+            "thresholds."
         ),
     )
     max_grad_value: Optional[float] = Field(

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -162,9 +162,8 @@ class TestTrainingRawSupport(unittest.TestCase):
 
     def test_mlx_max_grad_norm_is_honored_without_changing_the_default(self):
         # The worker used to hardcode 0.0 and drop the request, so an explicit
-        # threshold never reached the trainer. Explicit values must now pass
-        # through, while unset stays 0.0 so the clip mode is unchanged: the chart
-        # is fed by report_grad_norm, not by switching to global-norm clipping.
+        # threshold never reached the trainer. Explicit values must pass through,
+        # while unset stays 0.0 so the clip mode is unchanged.
         from pydantic import ValidationError
 
         from core.training.worker import _resolve_mlx_max_grad_norm
@@ -202,10 +201,8 @@ class TestTrainingRawSupport(unittest.TestCase):
         )
 
     def test_mlx_worker_asks_the_trainer_to_report_the_gradient_norm(self):
-        # What refills Studio's Gradient Norm chart on Apple Silicon. MLX returns a
-        # norm for free only under global-norm clipping, so the worker opts in
-        # explicitly; switching clip modes to get it would change the loss
-        # trajectory and cost VLM runs their mx.compile eligibility.
+        # What refills Studio's Gradient Norm chart on Apple Silicon; see the
+        # rationale at the opt-in site in worker.py.
         source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
         self.assertIn('if "report_grad_norm" in _supported_fields:', source)
         self.assertIn('mlx_config_kwargs["report_grad_norm"] = True', source)

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -160,6 +160,80 @@ class TestTrainingRawSupport(unittest.TestCase):
         self.assertNotIn("model_random_state", config)
         self.assertNotIn("lora_random_state", config)
 
+    def test_mlx_max_grad_norm_defaults_to_the_cuda_threshold(self):
+        # Unset must reach the trainer as the CUDA text path's 1.0, the mode
+        # that also makes MLX report the gradient norm the chart plots.
+        from core.training.worker import _resolve_mlx_max_grad_norm
+
+        self.assertEqual(_resolve_mlx_max_grad_norm(None), 1.0)
+        self.assertEqual(_resolve_mlx_max_grad_norm(0), 0.0)
+        self.assertEqual(_resolve_mlx_max_grad_norm(0.3), 0.3)
+        with self.assertRaises(ValueError):
+            _resolve_mlx_max_grad_norm(-1)
+        with self.assertRaises(ValueError):
+            _resolve_mlx_max_grad_norm("nope")
+
+        # An unset request must stay unset all the way to the resolver: a
+        # schema default of 0.0 would turn global-norm clipping off first.
+        from models.training import TrainingStartRequest
+
+        self.assertIsNone(
+            TrainingStartRequest(
+                model_name = "unsloth/test",
+                training_type = "LoRA/QLoRA",
+                format_type = "auto",
+            ).max_grad_norm
+        )
+        source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
+        self.assertIn(
+            'max_grad_norm = _resolve_mlx_max_grad_norm(config.get("max_grad_norm"))',
+            source,
+        )
+
+    def test_start_training_leaves_unset_max_grad_norm_for_worker_default(self):
+        # A None here is what lets the worker apply the CUDA-matching default;
+        # a coerced 0.0 would silently drop every UI run back off global-norm
+        # clipping, which is what emptied the gradient-norm chart.
+        backend = TrainingBackend()
+
+        class DummyProcess:
+            pid = 4321
+
+            def start(self):
+                return None
+
+        class DummyThread:
+            def start(self):
+                return None
+
+        dummy_queue = object()
+
+        with (
+            patch(
+                "core.training.training.prepare_gpu_selection",
+                return_value = ([0], {"selection_mode": "auto"}),
+            ),
+            patch(
+                "core.training.training._CTX.Queue",
+                side_effect = [dummy_queue, dummy_queue],
+            ),
+            patch(
+                "core.training.training._CTX.Process", return_value = DummyProcess()
+            ) as mock_process,
+            patch(
+                "core.training.training.threading.Thread",
+                return_value = DummyThread(),
+            ),
+        ):
+            backend.start_training(
+                job_id = "test-grad-clip-default",
+                model_name = "unsloth/test",
+                training_type = "LoRA/QLoRA",
+            )
+
+        config = mock_process.call_args.kwargs["kwargs"]["config"]
+        self.assertIsNone(config["max_grad_norm"])
+
     def test_route_forwards_all_grad_clipping_fields(self):
         # The HTTP route builds the config dict by hand; a schema field that
         # is not forwarded here is silently dropped for REST callers.
@@ -211,12 +285,13 @@ class TestTrainingRawSupport(unittest.TestCase):
         )
 
     def test_training_backend_normalizes_explicit_none_seed_and_dtypes(self):
-        # Raw / backend callers can pass `random_seed=None`,
-        # `cast_norm_output_to_input_dtype=None`, and MLX clip knobs
-        # as None (or omit them) and must NOT leak the
-        # `None` past `TrainingBackend.start_training`. Otherwise
+        # Raw / backend callers can pass `random_seed=None` and
+        # `cast_norm_output_to_input_dtype=None` (or omit them), and those must
+        # NOT leak the `None` past `TrainingBackend.start_training`. Otherwise
         # transformers.set_seed(None) raises, PEFT init becomes
-        # nondeterministic, and the MLX norm-output cast silently flips.
+        # nondeterministic, and the MLX norm-output cast silently flips. The
+        # MLX clip knobs are the exception: None survives, so each one's owner
+        # (the MLX trainer, or the worker for max_grad_norm) picks the default.
         from core.training.training import (
             _coerce_seed,
             _coerce_optional_bool,

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -212,7 +212,9 @@ class TestTrainingRawSupport(unittest.TestCase):
         # Feature-detected like the other newer fields, so an older unsloth_zoo
         # without the flag keeps working instead of raising on construction.
         gated = source.split("_supported_fields = ")[1]
-        self.assertNotIn("report_grad_norm = True,", gated.split("MLXTrainer(")[0].split("dict(")[0])
+        self.assertNotIn(
+            "report_grad_norm = True,", gated.split("MLXTrainer(")[0].split("dict(")[0]
+        )
 
     def test_start_training_leaves_unset_max_grad_norm_for_worker_default(self):
         # None is what lets the worker apply the default; a coerced 0.0 would drop

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -160,16 +160,19 @@ class TestTrainingRawSupport(unittest.TestCase):
         self.assertNotIn("model_random_state", config)
         self.assertNotIn("lora_random_state", config)
 
-    def test_mlx_max_grad_norm_defaults_to_the_cuda_threshold(self):
-        # Unset must reach the trainer as 1.0 (the CUDA text default), the mode
-        # that also makes MLX report the gradient norm the chart plots.
+    def test_mlx_max_grad_norm_is_honored_without_changing_the_default(self):
+        # The worker used to hardcode 0.0 and drop the request, so an explicit
+        # threshold never reached the trainer. Explicit values must now pass
+        # through, while unset stays 0.0 so the clip mode is unchanged: the chart
+        # is fed by report_grad_norm, not by switching to global-norm clipping.
         from pydantic import ValidationError
 
         from core.training.worker import _resolve_mlx_max_grad_norm
         from models.training import TrainingStartRequest
 
-        self.assertEqual(_resolve_mlx_max_grad_norm(None), 1.0)
+        self.assertEqual(_resolve_mlx_max_grad_norm(None), 0.0)
         self.assertEqual(_resolve_mlx_max_grad_norm(0), 0.0)
+        self.assertEqual(_resolve_mlx_max_grad_norm(1.0), 1.0)
         self.assertEqual(_resolve_mlx_max_grad_norm(0.3), 0.3)
         with self.assertRaises(ValueError):
             _resolve_mlx_max_grad_norm(-1)
@@ -189,14 +192,27 @@ class TestTrainingRawSupport(unittest.TestCase):
 
         with self.assertRaises(ValidationError):
             request(max_grad_norm = float("inf"))
-        # Unset must survive to the resolver; a schema default of 0.0 would turn
-        # global-norm clipping off first.
+        # Unset must survive to the resolver rather than being coerced en route,
+        # so "no opinion" stays distinguishable from an explicit 0.
         self.assertIsNone(request().max_grad_norm)
         source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
         self.assertIn(
             'max_grad_norm = _resolve_mlx_max_grad_norm(config.get("max_grad_norm"))',
             source,
         )
+
+    def test_mlx_worker_asks_the_trainer_to_report_the_gradient_norm(self):
+        # What refills Studio's Gradient Norm chart on Apple Silicon. MLX returns a
+        # norm for free only under global-norm clipping, so the worker opts in
+        # explicitly; switching clip modes to get it would change the loss
+        # trajectory and cost VLM runs their mx.compile eligibility.
+        source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
+        self.assertIn('if "report_grad_norm" in _supported_fields:', source)
+        self.assertIn('mlx_config_kwargs["report_grad_norm"] = True', source)
+        # Feature-detected like the other newer fields, so an older unsloth_zoo
+        # without the flag keeps working instead of raising on construction.
+        gated = source.split("_supported_fields = ")[1]
+        self.assertNotIn("report_grad_norm = True,", gated.split("MLXTrainer(")[0].split("dict(")[0])
 
     def test_start_training_leaves_unset_max_grad_norm_for_worker_default(self):
         # None is what lets the worker apply the default; a coerced 0.0 would drop

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -161,7 +161,7 @@ class TestTrainingRawSupport(unittest.TestCase):
         self.assertNotIn("lora_random_state", config)
 
     def test_mlx_max_grad_norm_defaults_to_the_cuda_threshold(self):
-        # Unset must reach the trainer as the CUDA text path's 1.0, the mode
+        # Unset must reach the trainer as 1.0 (the CUDA text default), the mode
         # that also makes MLX report the gradient norm the chart plots.
         from pydantic import ValidationError
 
@@ -189,8 +189,8 @@ class TestTrainingRawSupport(unittest.TestCase):
 
         with self.assertRaises(ValidationError):
             request(max_grad_norm = float("inf"))
-        # An unset request must stay unset all the way to the resolver: a
-        # schema default of 0.0 would turn global-norm clipping off first.
+        # Unset must survive to the resolver; a schema default of 0.0 would turn
+        # global-norm clipping off first.
         self.assertIsNone(request().max_grad_norm)
         source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
         self.assertIn(
@@ -199,9 +199,8 @@ class TestTrainingRawSupport(unittest.TestCase):
         )
 
     def test_start_training_leaves_unset_max_grad_norm_for_worker_default(self):
-        # A None here is what lets the worker apply the CUDA-matching default;
-        # a coerced 0.0 would silently drop every UI run back off global-norm
-        # clipping, which is what emptied the gradient-norm chart.
+        # None is what lets the worker apply the default; a coerced 0.0 would drop
+        # every UI run back off global-norm clipping and re-empty the chart.
         backend = TrainingBackend()
 
         class DummyProcess:
@@ -293,13 +292,10 @@ class TestTrainingRawSupport(unittest.TestCase):
         )
 
     def test_training_backend_normalizes_explicit_none_seed_and_dtypes(self):
-        # Raw / backend callers can pass `random_seed=None` and
-        # `cast_norm_output_to_input_dtype=None` (or omit them), and those must
-        # NOT leak the `None` past `TrainingBackend.start_training`. Otherwise
-        # transformers.set_seed(None) raises, PEFT init becomes
-        # nondeterministic, and the MLX norm-output cast silently flips. The
-        # MLX clip knobs are the exception: None survives, so each one's owner
-        # (the MLX trainer, or the worker for max_grad_norm) picks the default.
+        # `random_seed=None` and `cast_norm_output_to_input_dtype=None` must not
+        # leak past `TrainingBackend.start_training`: set_seed(None) raises, PEFT
+        # init goes nondeterministic, and the MLX norm-output cast flips. The MLX
+        # clip knobs are the exception, where None means "owner picks the default".
         from core.training.training import (
             _coerce_seed,
             _coerce_optional_bool,
@@ -328,16 +324,14 @@ class TestTrainingRawSupport(unittest.TestCase):
         with self.assertRaises(ValueError):
             _coerce_optional_nonneg_float("max_grad_leaf_norm", -1)
 
-        # inf clears >= 0 but never binds, so it would train unclipped while
-        # the config reports a threshold. Same hazard on all three knobs.
+        # inf clears >= 0 but never binds, on all three knobs alike.
         for name in ("max_grad_norm", "max_grad_value", "max_grad_leaf_norm"):
             for bad in (float("inf"), float("-inf"), float("nan")):
                 with self.assertRaises(ValueError):
                     _coerce_optional_nonneg_float(name, bad)
 
     def test_mlx_clip_knobs_reject_non_finite_at_every_layer(self):
-        # The schema, the normalizer and the worker each guard the three clip
-        # knobs, because raw worker callers reach none of the layers above them.
+        # All three layers guard, since raw worker callers reach none above them.
         import math
 
         from pydantic import ValidationError

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -217,8 +217,8 @@ class TestTrainingRawSupport(unittest.TestCase):
         )
 
     def test_start_training_leaves_unset_max_grad_norm_for_worker_default(self):
-        # None is what lets the worker apply the default; a coerced 0.0 would drop
-        # every UI run back off global-norm clipping and re-empty the chart.
+        # None is what lets the worker apply the trainer's default; coercing it to
+        # 0.0 here would make "no opinion" indistinguishable from an explicit 0.
         backend = TrainingBackend()
 
         class DummyProcess:

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -163,7 +163,10 @@ class TestTrainingRawSupport(unittest.TestCase):
     def test_mlx_max_grad_norm_defaults_to_the_cuda_threshold(self):
         # Unset must reach the trainer as the CUDA text path's 1.0, the mode
         # that also makes MLX report the gradient norm the chart plots.
+        from pydantic import ValidationError
+
         from core.training.worker import _resolve_mlx_max_grad_norm
+        from models.training import TrainingStartRequest
 
         self.assertEqual(_resolve_mlx_max_grad_norm(None), 1.0)
         self.assertEqual(_resolve_mlx_max_grad_norm(0), 0.0)
@@ -172,18 +175,23 @@ class TestTrainingRawSupport(unittest.TestCase):
             _resolve_mlx_max_grad_norm(-1)
         with self.assertRaises(ValueError):
             _resolve_mlx_max_grad_norm("nope")
+        # inf clears a >= 0 check but never binds, so it would train unclipped.
+        with self.assertRaises(ValueError):
+            _resolve_mlx_max_grad_norm(float("inf"))
 
-        # An unset request must stay unset all the way to the resolver: a
-        # schema default of 0.0 would turn global-norm clipping off first.
-        from models.training import TrainingStartRequest
-
-        self.assertIsNone(
-            TrainingStartRequest(
+        def request(**overrides):
+            return TrainingStartRequest(
                 model_name = "unsloth/test",
                 training_type = "LoRA/QLoRA",
                 format_type = "auto",
-            ).max_grad_norm
-        )
+                **overrides,
+            )
+
+        with self.assertRaises(ValidationError):
+            request(max_grad_norm = float("inf"))
+        # An unset request must stay unset all the way to the resolver: a
+        # schema default of 0.0 would turn global-norm clipping off first.
+        self.assertIsNone(request().max_grad_norm)
         source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
         self.assertIn(
             'max_grad_norm = _resolve_mlx_max_grad_norm(config.get("max_grad_norm"))',

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -328,6 +328,41 @@ class TestTrainingRawSupport(unittest.TestCase):
         with self.assertRaises(ValueError):
             _coerce_optional_nonneg_float("max_grad_leaf_norm", -1)
 
+        # inf clears >= 0 but never binds, so it would train unclipped while
+        # the config reports a threshold. Same hazard on all three knobs.
+        for name in ("max_grad_norm", "max_grad_value", "max_grad_leaf_norm"):
+            for bad in (float("inf"), float("-inf"), float("nan")):
+                with self.assertRaises(ValueError):
+                    _coerce_optional_nonneg_float(name, bad)
+
+    def test_mlx_clip_knobs_reject_non_finite_at_every_layer(self):
+        # The schema, the normalizer and the worker each guard the three clip
+        # knobs, because raw worker callers reach none of the layers above them.
+        import math
+
+        from pydantic import ValidationError
+
+        from core.training.worker import _resolve_mlx_max_grad_norm
+        from models.training import TrainingStartRequest
+
+        for field in ("max_grad_norm", "max_grad_value", "max_grad_leaf_norm"):
+            for bad in (float("inf"), float("nan")):
+                with self.assertRaises(ValidationError):
+                    TrainingStartRequest(
+                        model_name = "unsloth/test",
+                        training_type = "LoRA/QLoRA",
+                        format_type = "auto",
+                        **{field: bad},
+                    )
+
+        with self.assertRaises(ValueError):
+            _resolve_mlx_max_grad_norm(float("inf"))
+
+        source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
+        for name in ("max_grad_value", "max_grad_leaf_norm"):
+            self.assertIn(f"if {name} < 0 or not math.isfinite({name}):", source)
+        self.assertTrue(math.isfinite(_resolve_mlx_max_grad_norm(None)))
+
     def test_mlx_worker_feature_detects_optional_mlx_config_fields(self):
         # `cast_norm_output_to_input_dtype`, `dataset_order`,
         # `max_grad_leaf_norm`, and `append_eos` ship in the paired

--- a/studio/frontend/src/features/training/api/mappers.ts
+++ b/studio/frontend/src/features/training/api/mappers.ts
@@ -113,9 +113,9 @@ export function buildTrainingStartPayload(
     save_steps: config.saveSteps,
     eval_steps: config.evalSteps,
     weight_decay: config.weightDecay,
-    // max_grad_norm is deliberately omitted: sending 0 turns global-norm
-    // clipping off, which silences the MLX gradient-norm chart. Leaving it
-    // unset lets the backend apply its default.
+    // max_grad_norm omitted on purpose: sending 0 turns global-norm clipping
+    // off and empties the MLX gradient-norm chart. Guarded by
+    // tests/training-start-payload-grad-norm.test.ts.
     max_grad_value: null,
     random_seed: config.randomSeed,
     packing: isEmbedding ? false : config.packing,

--- a/studio/frontend/src/features/training/api/mappers.ts
+++ b/studio/frontend/src/features/training/api/mappers.ts
@@ -113,9 +113,9 @@ export function buildTrainingStartPayload(
     save_steps: config.saveSteps,
     eval_steps: config.evalSteps,
     weight_decay: config.weightDecay,
-    // max_grad_norm omitted on purpose: sending 0 turns global-norm clipping
-    // off and empties the MLX gradient-norm chart. Guarded by
-    // tests/training-start-payload-grad-norm.test.ts.
+    // max_grad_norm omitted on purpose: the backend now honors an explicit value,
+    // so hardcoding 0 here would pin every UI run to "clipping off" and override
+    // that. Guarded by tests/training-start-payload-grad-norm.test.ts.
     max_grad_value: null,
     random_seed: config.randomSeed,
     packing: isEmbedding ? false : config.packing,

--- a/studio/frontend/src/features/training/api/mappers.ts
+++ b/studio/frontend/src/features/training/api/mappers.ts
@@ -113,7 +113,9 @@ export function buildTrainingStartPayload(
     save_steps: config.saveSteps,
     eval_steps: config.evalSteps,
     weight_decay: config.weightDecay,
-    max_grad_norm: 0.0,
+    // max_grad_norm is deliberately omitted: sending 0 turns global-norm
+    // clipping off, which silences the MLX gradient-norm chart. Leaving it
+    // unset lets the backend apply its default.
     max_grad_value: null,
     random_seed: config.randomSeed,
     packing: isEmbedding ? false : config.packing,

--- a/studio/frontend/src/features/training/types/api.ts
+++ b/studio/frontend/src/features/training/types/api.ts
@@ -40,7 +40,7 @@ export interface TrainingStartRequest {
   save_steps: number;
   eval_steps: number;
   weight_decay: number;
-  max_grad_norm: number;
+  max_grad_norm?: number | null;
   max_grad_value?: number | null;
   random_seed: number;
   packing: boolean;

--- a/studio/frontend/tests/training-start-payload-grad-norm.test.ts
+++ b/studio/frontend/tests/training-start-payload-grad-norm.test.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// The mapper used to send max_grad_norm: 0.0 on every run, which turns global-norm
-// clipping off on MLX and leaves the Gradient Norm chart with no samples to plot.
-// Omission is the whole fix, and nothing else fails if it is undone: the field is
-// optional in the request type, so restoring the literal would typecheck and pass
-// every other suite while silently emptying the chart again.
+// The mapper used to send max_grad_norm: 0.0 on every run. The backend now honors
+// an explicit threshold on MLX instead of discarding it, so that hardcoded 0 would
+// override the request for every UI run. Omitting the key is the fix, and nothing
+// else catches it if undone: the field is optional in the request type, so
+// restoring the literal would typecheck and pass every other suite.
 
 import assert from "node:assert/strict";
 import test from "node:test";

--- a/studio/frontend/tests/training-start-payload-grad-norm.test.ts
+++ b/studio/frontend/tests/training-start-payload-grad-norm.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The mapper used to send max_grad_norm: 0.0 on every run, which turns global-norm
+// clipping off on MLX and leaves the Gradient Norm chart with no samples to plot.
+// Omission is the whole fix, and nothing else fails if it is undone: the field is
+// optional in the request type, so restoring the literal would typecheck and pass
+// every other suite while silently emptying the chart again.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+import type { TrainingConfigState } from "../src/features/training/types/config.ts";
+
+registerBundlerResolver();
+const { buildTrainingStartPayload } = await import(
+  "../src/features/training/api/mappers.ts"
+);
+
+const CONFIG: TrainingConfigState = {
+  currentStep: 5,
+  modelType: "text",
+  selectedModel: "unsloth/gemma-3-270m-it",
+  projectName: "grad-norm",
+  trainingMethod: "lora",
+  hfToken: "",
+  datasetSource: "huggingface",
+  datasetFormat: "auto",
+  dataset: "unsloth/test",
+  datasetSubset: null,
+  datasetSplit: "train",
+  datasetEvalSplit: null,
+  datasetStreaming: false,
+  datasetManualMapping: {},
+  datasetSystemPrompt: "",
+  datasetUserTemplate: "",
+  datasetAssistantTemplate: "",
+  datasetLabelMapping: {},
+  datasetAdvisorNotification: null,
+  datasetSliceStart: null,
+  datasetSliceEnd: null,
+  uploadedFile: null,
+  uploadedEvalFile: null,
+  epochs: 1,
+  contextLength: 2048,
+  learningRate: 2e-4,
+  embeddingLearningRate: null,
+  optimizerType: "adamw_8bit",
+  lrSchedulerType: "linear",
+  loraRank: 16,
+  loraAlpha: 16,
+  loraDropout: 0,
+  loraVariant: "lora",
+  batchSize: 2,
+  gradientAccumulation: 4,
+  weightDecay: 0.001,
+  warmupSteps: 5,
+  maxSteps: 60,
+  saveSteps: 100,
+  evalSteps: 0,
+  packing: false,
+  trainOnCompletions: true,
+  gradientCheckpointing: "unsloth",
+  randomSeed: 3407,
+  enableWandb: false,
+  wandbToken: "",
+  wandbProject: "",
+  enableTensorboard: false,
+  tensorboardDir: "",
+  logFrequency: 1,
+  isCheckingVision: false,
+  isVisionModel: false,
+  isEmbeddingModel: false,
+  isAudioModel: false,
+  isLoadingModelDefaults: false,
+  modelDefaultsError: null,
+  modelDefaultsAppliedFor: null,
+  isCheckingDataset: false,
+  isDatasetImage: false,
+  isDatasetAudio: false,
+  trustRemoteCode: false,
+  approvedRemoteCodeFingerprint: null,
+  finetuneVisionLayers: false,
+  finetuneLanguageLayers: true,
+  finetuneAttentionModules: true,
+  finetuneMLPModules: true,
+  targetModules: ["q_proj", "v_proj"],
+  maxPositionEmbeddings: null,
+  visionImageSize: null,
+  s3Config: null,
+};
+
+test("the payload leaves max_grad_norm unset so the backend default governs", () => {
+  const payload = buildTrainingStartPayload(CONFIG);
+
+  assert.equal(
+    Object.hasOwn(payload, "max_grad_norm"),
+    false,
+    "max_grad_norm must be absent, not null and not 0",
+  );
+  // An explicit null would serialize and pin the backend to "no global clipping"
+  // just as 0.0 did, so check the wire form too.
+  assert.equal("max_grad_norm" in JSON.parse(JSON.stringify(payload)), false);
+});
+
+test("the sibling clip knobs keep their existing wire contract", () => {
+  const payload = buildTrainingStartPayload(CONFIG);
+
+  assert.equal(payload.max_grad_value, null);
+  assert.equal(payload.weight_decay, CONFIG.weightDecay);
+});


### PR DESCRIPTION
## Summary

MLX (Apple Silicon) training ran with global-norm gradient clipping disabled: the MLX worker hardcoded `max_grad_norm = 0.0` and discarded whatever the request carried, so the trainer fell back to its per-parameter clipping default. Two consequences:

1. **Cross-backend divergence.** The CUDA path trains text models at TRL's `SFTConfig` default of `1.0`, and Unsloth's own public MLX API applies that same `1.0` when no clipping knob is supplied. Studio and the CLI were the only two surfaces left on per-parameter clipping, so the same recipe trained differently on a Mac than on an NVIDIA box — and differently from an MLX notebook on that same Mac.
2. **An empty gradient-norm chart.** MLX reports a gradient norm whenever global-norm clipping is the resolved clip mode, so with clipping off, Studio's "Gradient Norm" chart received no samples and rendered as empty axes.

This makes the MLX default match the CUDA text path, which fixes both.

## Behavior changes (please read before reviewing)

- **MLX runs now clip to a global norm of 1.0 by default.** This applies to Studio and to `unsloth train`, which share the MLX worker. Loss curves on those two surfaces will shift slightly relative to previous runs, since global-norm clipping binds more often than per-parameter clipping. Runs on the public MLX API are unaffected — they already used `1.0`.
- **Peak memory rises on MLX.** Global-norm clipping adds a cross-tree gradient reduction. Measured on Qwen2.5-VL-3B (LoRA r=16, sequence lengths cycling 1024/1536/2048, batch 1, gradient accumulation 4): peak allocator memory goes from 10136 MiB with per-parameter clipping to 12332 MiB with global-norm clipping, about +21.7%. On unified memory this can turn a previously fitting large VLM run into an out-of-memory one.
- **Opting out.** API callers can send `max_grad_norm: 0` to turn global-norm clipping off, or set `max_grad_leaf_norm` to keep per-parameter clipping. Note that `0` alone turns *global-norm* clipping off and leaves MLX's per-parameter clipping in force; disabling clipping entirely also requires `max_grad_leaf_norm: 0`. The GUI and the CLI expose no clipping control, so those surfaces take the default.

## Why 1.0 and not CUDA's vision 0.3

CUDA's vision/audio-VLM branch overrides `max_grad_norm` to `0.3`, so "match CUDA" is ambiguous. This change uses a uniform `1.0` deliberately:

- The public MLX API already applies a uniform `1.0` with no modality branch, so mirroring CUDA's split would make Studio-on-MLX disagree with notebook-on-MLX for the same model on the same machine.
- The `0.3` has no documented vision rationale — it entered with the rest of the vision defaults block in a bulk commit, and the repository's own tests attribute `0.3` to the QLoRA paper, a text-LLM hyperparameter.
- The MLX and CUDA vision paths are not otherwise aligned: CUDA's vision branch also overrides the optimizer, the scheduler (cosine), and gradient checkpointing, while the MLX worker resolves those globally (linear). Mirroring only the clip constant would buy cosmetic parity on the least influential of them.
- Relative to today's per-parameter `1.0`, a global `0.3` would behave like a substantially smaller effective learning rate for MLX vision runs, with no UI control to notice or undo it.

Aligning the vision defaults as a whole is worth doing, but belongs in its own change alongside the scheduler and checkpointing.

## What changed

- The MLX worker resolves the threshold through a small helper instead of hardcoding `0.0`: unset selects `1.0`, and an explicit value is validated (non-negative, coercible) and passed through.
- `max_grad_norm` on the training request becomes `Optional[float] = None`, matching its sibling `max_grad_value` / `max_grad_leaf_norm` fields, so "unset" is distinguishable from "explicitly 0". Without that distinction the default could not be applied at all, because the UI previously sent a literal `0.0` on every request.
- The request normalizer runs `max_grad_norm` through the same non-negative coercion its sibling clip knobs already use.
- The frontend stops sending the hardcoded `max_grad_norm: 0.0` and lets the backend default govern. No UI control was added.
- A shared validator message that told callers "use 0 or None to disable" was corrected; neither disables clipping outright for any of the three clip knobs it serves.

## Validation

```bash
# backend, from studio/backend
python -m pytest tests/test_training_raw_support.py -q          # 14 passed
python -m pytest tests/ -q -k "training or grad or mlx_worker or preflight"

# frontend, from studio/frontend
npm run typecheck
npm test                                                        # 434 passed
```

New tests cover the resolver (unset selects 1.0; explicit 0, and other values, pass through; negative and non-numeric raise), that the request schema leaves `max_grad_norm` unset by default, and that the backend forwards `None` rather than coercing it to `0.0`. Both were mutation-checked: reverting the resolver default to `0.0` and restoring the old `values.get("max_grad_norm", 0.0)` each fail exactly the corresponding test.

The broad backend selection reports the same failures before and after this change (verified by comparing sorted failure lists against a clean checkout); they are pre-existing and environment-related.

## Known gap

The frontend omission has no regression test. Reintroducing `max_grad_norm: 0.0` in the request mapper would pass the test suites and the typecheck while silently restoring the empty chart; a comment at the omission site is the only in-repo signal.
