### PR TITLE
Unsloth Studio: keep the Images and Video headers clear of the custom titlebar

### DIFF
--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2454,7 +2454,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   );
 
   return (
-    <div className="diffusion-surface flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+    // The chat-style layout gives this page no outer top inset, so clear the custom
+    // titlebar here (34px on win/linux, 0 under macOS's native one) as chat does.
+    <div className="diffusion-surface flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-[var(--studio-content-top-inset,0px)]">
       {/* Top: the model selector, sitting clear of the sidebar and level with the settings column below. Load progress shows in a toast. */}
       <div className="relative flex h-[48px] shrink-0 items-start justify-between pl-6 pr-2 pt-[11px]">
         <div className="flex items-center gap-2">

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1505,7 +1505,9 @@ export function VideoPage({ active = true }: { active?: boolean }) {
   );
 
   return (
-    <div className="diffusion-surface flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+    // The chat-style layout gives this page no outer top inset, so clear the custom
+    // titlebar here (34px on win/linux, 0 under macOS's native one) as chat does.
+    <div className="diffusion-surface flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-[var(--studio-content-top-inset,0px)]">
       {/* Top: the model selector, sitting clear of the sidebar and level with the controls column below. Load progress shows in a toast. */}
       <div className="flex h-[48px] shrink-0 items-start justify-between pl-6 pr-2 pt-[11px]">
         <div className="flex items-center gap-3">

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -35,6 +35,7 @@ DESKTOP_UPDATE_POLICY = REPO / "studio/src-tauri/src/desktop_update_policy.rs"
 APP_PROVIDER = FRONTEND / "app/provider.tsx"
 ROOT_ROUTE = FRONTEND / "app/routes/__root.tsx"
 IMAGES_PAGE = FRONTEND / "features/images/images-page.tsx"
+VIDEO_PAGE = FRONTEND / "features/video/video-page.tsx"
 
 CLIPBOARD_FILES = FRONTEND / "features/chat/utils/clipboard-files.ts"
 TAURI_CAPABILITIES = REPO / "studio/src-tauri/capabilities/default.json"
@@ -514,11 +515,11 @@ def test_chat_sidebar_row_actions_visible_on_coarse_pointers():
     assert ".sidebar-row-action.sidebar-touch-reveal" in coarse_block
 
 
-def test_images_page_clears_the_custom_titlebar():
-    """The chat-style layout gives Images no outer inset, so it must apply its own."""
+def test_media_pages_clear_the_custom_titlebar():
+    """The chat-style layout gives the media pages no outer inset, so each applies its own."""
     root = ROOT_ROUTE.read_text(encoding = "utf-8")
-    images = IMAGES_PAGE.read_text(encoding = "utf-8")
 
     assert "const isChatLike = isChatRoute || isImagesRoute || isVideoRoute;" in root
-    shell = images.split('"diffusion-surface', 1)[1].split(">", 1)[0]
-    assert "pt-[var(--studio-content-top-inset,0px)]" in shell
+    for page in (IMAGES_PAGE, VIDEO_PAGE):
+        shell = page.read_text(encoding = "utf-8").split('"diffusion-surface', 1)[1].split(">", 1)[0]
+        assert "pt-[var(--studio-content-top-inset,0px)]" in shell, page.name

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -33,6 +33,8 @@ DESKTOP_UPDATE_POLICY = REPO / "studio/src-tauri/src/desktop_update_policy.rs"
 
 
 APP_PROVIDER = FRONTEND / "app/provider.tsx"
+ROOT_ROUTE = FRONTEND / "app/routes/__root.tsx"
+IMAGES_PAGE = FRONTEND / "features/images/images-page.tsx"
 
 CLIPBOARD_FILES = FRONTEND / "features/chat/utils/clipboard-files.ts"
 TAURI_CAPABILITIES = REPO / "studio/src-tauri/capabilities/default.json"
@@ -510,3 +512,13 @@ def test_chat_sidebar_row_actions_visible_on_coarse_pointers():
     # Must not reveal every sidebar-row-action (project/run/nav rows lack padding).
     assert ".sidebar-row-action {\n\t\t\t@apply opacity-100" not in coarse_block
     assert ".sidebar-row-action.sidebar-touch-reveal" in coarse_block
+
+
+def test_images_page_clears_the_custom_titlebar():
+    """The chat-style layout gives Images no outer inset, so it must apply its own."""
+    root = ROOT_ROUTE.read_text(encoding = "utf-8")
+    images = IMAGES_PAGE.read_text(encoding = "utf-8")
+
+    assert "const isChatLike = isChatRoute || isImagesRoute || isVideoRoute;" in root
+    shell = images.split('"diffusion-surface', 1)[1].split(">", 1)[0]
+    assert "pt-[var(--studio-content-top-inset,0px)]" in shell


### PR DESCRIPTION
## What

On Windows and Linux the Images and Video page headers render underneath the 34px custom titlebar. The model selector, the Create | Train pills and the Video link are all clipped, and the pills are the only part you can even partly see.

## Why

`__root.tsx` treats Chat, Images and Video as chat-like, which deliberately drops the outer top inset because each page renders its own full-height shell. Chat re-applies the inset itself. Images and Video, added in #6763, never did, so their 48px header row starts at content-y 0 and sits under the titlebar.

## Fix

Apply `pt-[var(--studio-content-top-inset,0px)]` on both page shells, the same variable Chat uses. It resolves to 34px under the custom titlebar and 0px under the native macOS one, so the macOS path is unchanged.

All the image workflows (Create, Transform, Inpaint, Extend, Upscale, Reference, Edit) go through the one `ImagesPage` shell, so they are all covered by the single change.

## Tests

Added `test_media_pages_clear_the_custom_titlebar` to `tests/studio/test_desktop_reliability_frontend_contract.py`. It asserts the chat-like grouping in `__root.tsx` and the inset on both shells. Verified it fails against both files before the fix. 24 tests pass in that file.

Verified live in the desktop app via HMR.

## Before / after

Screenshots to follow.

## Note

#7859 touches the same two header rows for left inset and padding, but does not address the overlap. Whichever lands second will need a small conflict fixup.