### PR TITLE
Fix the Chat UI test locator for the reworded STT model search box

### DIFF
--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -575,9 +575,7 @@ with sync_playwright() as p:
                 # "Search models" boxes the pattern would otherwise match page-wide.
                 page.locator('[data-testid="stt-model-results"]').locator(
                     "xpath=.."
-                ).get_by_placeholder(re.compile(r"search\b.*\bmodel", re.I)).fill(
-                    "whisper"
-                )
+                ).get_by_placeholder(re.compile(r"search\b.*\bmodel", re.I)).fill("whisper")
                 results = page.get_by_test_id("stt-model-results")
                 page.wait_for_function(
                     """() => {

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -568,11 +568,9 @@ with sync_playwright() as p:
                 page.get_by_label("Dictation engine").click()
                 page.get_by_role("option", name = "Local transcription").click()
                 page.get_by_label("Speech recognition model").click()
-                # Matched on the literal "Search model" until #7835 reworded it to "Search any
-                # model on HF"; get_by_placeholder is substring, not fuzzy, so the locator stopped
-                # resolving and this step failed on every run. A pattern spans both wordings, and
-                # scoping it to the popover that holds the results list keeps it off the other
-                # "Search models" boxes the pattern would otherwise match page-wide.
+                # #7835 reworded this placeholder to "Search any model on HF", and
+                # get_by_placeholder is substring, so the old literal stopped resolving. Scoped to
+                # the results popover: page-wide the pattern also hits the other search boxes.
                 page.locator('[data-testid="stt-model-results"]').locator(
                     "xpath=.."
                 ).get_by_placeholder(re.compile(r"search\b.*\bmodel", re.I)).fill("whisper")

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -568,7 +568,16 @@ with sync_playwright() as p:
                 page.get_by_label("Dictation engine").click()
                 page.get_by_role("option", name = "Local transcription").click()
                 page.get_by_label("Speech recognition model").click()
-                page.get_by_placeholder("Search model").fill("whisper")
+                # Matched on the literal "Search model" until #7835 reworded it to "Search any
+                # model on HF"; get_by_placeholder is substring, not fuzzy, so the locator stopped
+                # resolving and this step failed on every run. A pattern spans both wordings, and
+                # scoping it to the popover that holds the results list keeps it off the other
+                # "Search models" boxes the pattern would otherwise match page-wide.
+                page.locator('[data-testid="stt-model-results"]').locator(
+                    "xpath=.."
+                ).get_by_placeholder(re.compile(r"search\b.*\bmodel", re.I)).fill(
+                    "whisper"
+                )
                 results = page.get_by_test_id("stt-model-results")
                 page.wait_for_function(
                     """() => {


### PR DESCRIPTION
`Chat UI Tests` has been failing on `main` for every PR since #7835, on Linux and Windows alike:

```
[ui-extra] FAIL: Voice model picker did not wheel-scroll:
  TimeoutError('Locator.fill: Timeout 60000ms exceeded.
  Call log:
    - waiting for get_by_placeholder("Search model")')
```

#7835 reworded the dictation search box from `Search model` to `Search any model on HF`:

```
- sttModelSearchPlaceholder: "Search model",
+ sttModelSearchPlaceholder: "Search any model on HF",
```

`get_by_placeholder` matches on substring, not fuzzily, and `Search any model on HF` does not contain `Search model`, so the locator stopped resolving and the step began timing out at 60s on every run. Nothing is wrong with the product; the test simply stopped pointing at the box.

This matches a pattern that spans both wordings, scoped to the popover that holds the results list so it cannot collide with the other model search boxes on the page (`Search models` in the model picker, `Search model, endpoint, preview or error` in the API monitor), which an unscoped pattern would match under Playwright strict mode.

Verified against a live Studio rather than by reading. With the dictation dropdown open, the DOM holds `['Preset name', 'Search settings…', 'Search any model on HF']`, and:

| locator | elements matched |
|---|---:|
| old literal `"Search model"` | 0 |
| new pattern, scoped to the popover | 1 |

The scoped locator then fills successfully, which is the step that has been failing.

Test-only change, one file.
