### PR TITLE
Read the GGUF context length from the snapshot that answered, not the repo cache dir

### DIFF
--- a/studio/backend/hub/services/models/gguf_variants.py
+++ b/studio/backend/hub/services/models/gguf_variants.py
@@ -32,10 +32,10 @@ from hub.utils.gguf import (
     is_big_endian_gguf_path,
     list_empty_gguf_variant_dirs,
     list_gguf_variants,
-    list_gguf_variants_from_hf_cache,
     list_local_gguf_variants,
     list_partial_gguf_variants_from_state,
     pick_best_gguf,
+    select_gguf_cache_snapshot,
 )
 from hub.utils.paths import (
     is_local_path,
@@ -734,13 +734,12 @@ async def get_gguf_variants_answer(
             scoped_response = _scoped_local_response()
             if scoped_response is not None:
                 return scoped_response
-            cached = list_gguf_variants_from_hf_cache(repo_id, root = hub_cache)
+            cached = select_gguf_cache_snapshot(repo_id, root = hub_cache)
             if cached is not None:
-                variants, has_vision, complete = cached
-                # This listing is scoped to one cache, so name it: a repo-wide walk starts at
-                # the active cache and could read a different copy's context length.
-                if repo_cache_dir is not None and repo_cache_dir.is_dir():
-                    answered_from[0] = str(repo_cache_dir)
+                variants, has_vision, complete, snapshot = cached
+                # Name the answering snapshot: a repo-wide walk could read a different cache's
+                # context length, and a repo-dir walk a sibling revision's.
+                answered_from[0] = str(snapshot)
                 # The lister leaves torn quants in: they stay listed for management, but not ready.
                 return _with_state_partials(
                     _local_response(repo_id, variants, has_vision, complete)
@@ -779,11 +778,10 @@ async def get_gguf_variants_answer(
             scoped_response = _scoped_local_response()
             if scoped_response is not None:
                 return scoped_response
-            cached = list_gguf_variants_from_hf_cache(repo_id, root = hub_cache)
+            cached = select_gguf_cache_snapshot(repo_id, root = hub_cache)
             if cached is not None:
-                variants, has_vision, complete = cached
-                if repo_cache_dir is not None and repo_cache_dir.is_dir():
-                    answered_from[0] = str(repo_cache_dir)
+                variants, has_vision, complete, snapshot = cached
+                answered_from[0] = str(snapshot)
                 # Same reason as the local_only branch above, state partials included:
                 # an unreachable Hub is exactly when a resume has nowhere else to surface.
                 return _with_state_partials(

--- a/studio/backend/hub/tests/test_empty_variant_folder.py
+++ b/studio/backend/hub/tests/test_empty_variant_folder.py
@@ -121,7 +121,7 @@ def _force_compute_to_raise(monkeypatch):
     monkeypatch.setattr(gguf_variants, "list_gguf_variants", _boom, raising = False)
     monkeypatch.setattr(
         gguf_variants,
-        "list_gguf_variants_from_hf_cache",
+        "select_gguf_cache_snapshot",
         lambda repo_id, root = None: None,
         raising = False,
     )

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -347,9 +347,8 @@ def select_gguf_cache_snapshot(
 ) -> Optional[tuple[list[GgufVariantInfo], bool, set, Path]]:
     """``list_gguf_variants_from_hf_cache`` plus the snapshot it answered from.
 
-    A repo cache dir holds every revision, so a caller that goes on to read metadata off
-    "wherever this listing came from" needs the snapshot: given the repo dir it can read a
-    revision this listing skipped.
+    A repo dir holds every revision, so a caller that then reads metadata from wherever this
+    listing came from needs the snapshot, not the dir: the dir includes revisions it skipped.
     """
     # Local import: inventory_scan imports this module.
     from hub.utils.inventory_scan import complete_snapshot_variants

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -342,14 +342,14 @@ def list_empty_gguf_variant_dirs(repo_id: str, root: Optional[Path] = None) -> s
     return {label for key, label in empty.items() if key not in nonempty}
 
 
-def list_gguf_variants_from_hf_cache(
+def select_gguf_cache_snapshot(
     repo_id: str, root: Optional[Path] = None
-) -> Optional[tuple[list[GgufVariantInfo], bool, set]]:
-    """``(variants, has_vision, complete)`` for the snapshot a load would read.
+) -> Optional[tuple[list[GgufVariantInfo], bool, set, Path]]:
+    """``list_gguf_variants_from_hf_cache`` plus the snapshot it answered from.
 
-    Everything in that snapshot is listed, so a torn download stays visible to resume or delete;
-    *complete* is the subset whose shards are all present, so the caller marks the rest partial
-    rather than ready, as the snapshot-path form of this call does.
+    A repo cache dir holds every revision, so a caller that goes on to read metadata off
+    "wherever this listing came from" needs the snapshot: given the repo dir it can read a
+    revision this listing skipped.
     """
     # Local import: inventory_scan imports this module.
     from hub.utils.inventory_scan import complete_snapshot_variants
@@ -360,17 +360,30 @@ def list_gguf_variants_from_hf_cache(
         else iter_hf_cache_snapshots(repo_id)
     )
     # Pick the snapshot the inventory row does: newest holding a whole quant, else first non-empty.
-    fallback: Optional[tuple[list[GgufVariantInfo], bool, set]] = None
+    fallback: Optional[tuple[list[GgufVariantInfo], bool, set, Path]] = None
     for snapshot in snapshots:
         variants, has_vision = list_local_gguf_variants(str(snapshot))
         complete = complete_snapshot_variants(str(snapshot)) if variants else set()
         if variants:
             # Selection only: an unlabelled quant cannot be judged, so it counts as usable.
             if any(not v.quant or v.quant in complete for v in variants):
-                return variants, has_vision, complete
+                return variants, has_vision, complete, snapshot
         if fallback is None and (variants or has_vision):
-            fallback = (variants, has_vision, complete)
+            fallback = (variants, has_vision, complete, snapshot)
     return fallback
+
+
+def list_gguf_variants_from_hf_cache(
+    repo_id: str, root: Optional[Path] = None
+) -> Optional[tuple[list[GgufVariantInfo], bool, set]]:
+    """``(variants, has_vision, complete)`` for the snapshot a load would read.
+
+    Everything in that snapshot is listed, so a torn download stays visible to resume or delete;
+    *complete* is the subset whose shards are all present, so the caller marks the rest partial
+    rather than ready, as the snapshot-path form of this call does.
+    """
+    selected = select_gguf_cache_snapshot(repo_id, root = root)
+    return selected[:3] if selected is not None else None
 
 
 def list_partial_gguf_variants_from_state(

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -3834,8 +3834,7 @@ def test_another_caches_quant_is_offered_as_a_download_not_as_downloaded(monkeyp
 def test_context_follows_the_answering_revision_not_a_sibling(monkeypatch, tmp_path):
     """The context read is pinned to the snapshot that answered, not the repo dir.
 
-    One repo dir holds every revision and the read walks it whole, so naming the dir let a
-    revision the listing skipped supply the length for a quant it does not hold.
+    The read walks the whole dir, so naming the dir let a skipped revision supply the length.
     """
     hub_cache = tmp_path / "hub"
     hub_cache.mkdir(parents = True)
@@ -3871,8 +3870,8 @@ def test_context_follows_the_answering_revision_not_a_sibling(monkeypatch, tmp_p
 def test_a_case_variant_repo_dir_still_names_its_snapshot(monkeypatch, tmp_path):
     """Provenance survives a repo_id whose case differs from the cached dir's.
 
-    The lister matches case-insensitively but the repo dir was rebuilt from repo_id, so on a
-    case-sensitive filesystem it failed ``is_dir()`` and the length fell back to a repo-wide walk.
+    The lister folds case, but the repo dir was rebuilt from repo_id, so it failed ``is_dir()``
+    on a case-sensitive filesystem and the length fell back to a repo-wide walk.
     """
     hub_cache = tmp_path / "hub"
     hub_cache.mkdir(parents = True)

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -3843,9 +3843,7 @@ def test_context_follows_the_answering_revision_not_a_sibling(monkeypatch, tmp_p
     repo_dir = _write_cached_gguf(
         hub_cache, "org/repo", "m-Q4_K_M.gguf", mtime = 1_000_000_000, revision = "older"
     )
-    _write_cached_gguf(
-        hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer"
-    )
+    _write_cached_gguf(hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer")
 
     _pin_caches(monkeypatch, hub_cache, [hub_cache])
     _unreachable_hub(monkeypatch)

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -3492,11 +3492,13 @@ def test_offline_context_follows_the_hf_cache_when_it_answers(monkeypatch, tmp_p
     """The HF cache answers before local_path, so with both present the length must come
     from the cache. Picking local_path on the offline flag alone attached another copy's
     context to the cache's variants. Real service, no stub."""
+    cache_snapshot = tmp_path / "hub" / "models--org--repo" / "snapshots" / "rev"
+    cache_snapshot.mkdir(parents = True)
     context_calls = []
 
     monkeypatch.setattr(
         GV,
-        "list_gguf_variants_from_hf_cache",
+        "select_gguf_cache_snapshot",
         lambda repo_id, root = None: (
             [
                 SimpleNamespace(
@@ -3508,6 +3510,7 @@ def test_offline_context_follows_the_hf_cache_when_it_answers(monkeypatch, tmp_p
             ],
             False,
             {"q4_k_m"},
+            cache_snapshot,
         ),
     )
     monkeypatch.setattr(GV, "list_partial_gguf_variants_from_state", lambda *a, **k: None)
@@ -3526,7 +3529,7 @@ def test_offline_context_follows_the_hf_cache_when_it_answers(monkeypatch, tmp_p
             current_subject = "test-user",
         )
     )
-    assert context_calls == [("org/repo", False)]
+    assert context_calls == [(str(cache_snapshot), True)]
 
 
 def test_offline_context_follows_the_cache_the_variants_were_read_from(monkeypatch, tmp_path):
@@ -3534,12 +3537,13 @@ def test_offline_context_follows_the_cache_the_variants_were_read_from(monkeypat
     has to come from there too. Falling back to the repo id walks every cache, active one
     first, and can attach another copy's context to these variants. Real service, no stub."""
     legacy_repo = tmp_path / "legacy" / "hub" / "models--org--repo"
-    (legacy_repo / "snapshots" / "rev").mkdir(parents = True)
+    legacy_snapshot = legacy_repo / "snapshots" / "rev"
+    legacy_snapshot.mkdir(parents = True)
     context_calls = []
 
     monkeypatch.setattr(
         GV,
-        "list_gguf_variants_from_hf_cache",
+        "select_gguf_cache_snapshot",
         lambda repo_id, root = None: (
             [
                 SimpleNamespace(
@@ -3551,6 +3555,7 @@ def test_offline_context_follows_the_cache_the_variants_were_read_from(monkeypat
             ],
             False,
             {"q4_k_m"},
+            legacy_snapshot,
         ),
     )
     monkeypatch.setattr(GV, "list_partial_gguf_variants_from_state", lambda *a, **k: None)
@@ -3569,7 +3574,7 @@ def test_offline_context_follows_the_cache_the_variants_were_read_from(monkeypat
             current_subject = "test-user",
         )
     )
-    assert context_calls == [(str(legacy_repo), True)]
+    assert context_calls == [(str(legacy_snapshot), True)]
 
 
 def test_failed_hub_context_follows_the_cache_the_variants_were_read_from(monkeypatch, tmp_path):
@@ -3577,7 +3582,8 @@ def test_failed_hub_context_follows_the_cache_the_variants_were_read_from(monkey
     supply their context metadata. Otherwise the route searches by repo id and can read a
     different cache copy first."""
     legacy_repo = tmp_path / "legacy" / "hub" / "models--org--repo"
-    (legacy_repo / "snapshots" / "rev").mkdir(parents = True)
+    legacy_snapshot = legacy_repo / "snapshots" / "rev"
+    legacy_snapshot.mkdir(parents = True)
     context_calls = []
 
     def _unreachable(*args, **kwargs):
@@ -3586,7 +3592,7 @@ def test_failed_hub_context_follows_the_cache_the_variants_were_read_from(monkey
     monkeypatch.setattr(GV, "list_gguf_variants", _unreachable)
     monkeypatch.setattr(
         GV,
-        "list_gguf_variants_from_hf_cache",
+        "select_gguf_cache_snapshot",
         lambda repo_id, root = None: (
             [
                 SimpleNamespace(
@@ -3598,6 +3604,7 @@ def test_failed_hub_context_follows_the_cache_the_variants_were_read_from(monkey
             ],
             False,
             {"q4_k_m"},
+            legacy_snapshot,
         ),
     )
     monkeypatch.setattr(GV, "list_partial_gguf_variants_from_state", lambda *a, **k: None)
@@ -3615,7 +3622,7 @@ def test_failed_hub_context_follows_the_cache_the_variants_were_read_from(monkey
             current_subject = "test-user",
         )
     )
-    assert context_calls == [(str(legacy_repo), True)]
+    assert context_calls == [(str(legacy_snapshot), True)]
 
 
 def test_switching_cache_storage_does_not_join_a_stuck_scan(monkeypatch, tmp_path):
@@ -3644,7 +3651,7 @@ def test_switching_cache_storage_does_not_join_a_stuck_scan(monkeypatch, tmp_pat
             wedged.wait(5)
         return None
 
-    monkeypatch.setattr(GV, "list_gguf_variants_from_hf_cache", scan)
+    monkeypatch.setattr(GV, "select_gguf_cache_snapshot", scan)
     monkeypatch.setattr(GV, "list_partial_gguf_variants_from_state", lambda *a, **k: None)
     monkeypatch.setattr(GV, "list_local_gguf_variants", lambda _p: ([], False))
     monkeypatch.setattr(GV, "_snapshot_scope_for_request", lambda *a, **k: None)
@@ -3674,12 +3681,13 @@ def _write_cached_gguf(
     repo_id: str,
     filename: str,
     mtime: float | None = None,
+    revision: str = "rev",
 ) -> Path:
     """One real snapshot under *hub_cache*; *mtime* pins which one a repo-wide walk picks."""
     import os
 
     repo_dir = hub_cache / ("models--" + repo_id.replace("/", "--"))
-    snapshot = repo_dir / "snapshots" / "rev"
+    snapshot = repo_dir / "snapshots" / revision
     snapshot.mkdir(parents = True, exist_ok = True)
     (snapshot / filename).write_bytes(b"GGUF" + b"\0" * 32)
     if mtime is not None:
@@ -3748,8 +3756,8 @@ def test_failed_hub_lists_the_selected_cache_not_another_one(monkeypatch, tmp_pa
         )
     )
     assert sorted(v.quant for v in response.variants) == ["Q8_0"]
-    # The context length has to come off that same copy.
-    assert context_calls == [(str(selected_repo), True)]
+    # The context length has to come off that same copy, down to the snapshot.
+    assert context_calls == [(str(selected_repo / "snapshots" / "rev"), True)]
 
 
 def test_an_unreadable_cache_root_is_skipped_not_fatal(tmp_path):
@@ -3821,3 +3829,74 @@ def test_another_caches_quant_is_offered_as_a_download_not_as_downloaded(monkeyp
     )
     assert [v.quant for v in response.variants] == ["Q8_0"]
     assert [v.downloaded for v in response.variants] == [False]
+
+
+def test_context_follows_the_answering_revision_not_a_sibling(monkeypatch, tmp_path):
+    """The context read is pinned to the snapshot that answered, not the repo dir.
+
+    One repo dir holds every revision and the read walks it whole, so naming the dir let a
+    revision the listing skipped supply the length for a quant it does not hold.
+    """
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir(parents = True)
+    # Only the newer snapshot holds a whole quant, so it is the one that answers.
+    repo_dir = _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q4_K_M.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer"
+    )
+
+    _pin_caches(monkeypatch, hub_cache, [hub_cache])
+    _unreachable_hub(monkeypatch)
+    monkeypatch.setattr(GV, "list_partial_gguf_variants_from_state", lambda *a, **k: None)
+
+    context_calls = []
+    monkeypatch.setattr(
+        models_route,
+        "_read_native_context_length",
+        lambda model, *, is_local: context_calls.append((str(model), is_local)) or 4096,
+    )
+
+    response = asyncio.run(
+        models_route.get_gguf_variants(
+            repo_id = "org/repo",
+            local_path = str(repo_dir),
+            hf_token = None,
+            current_subject = "test-user",
+        )
+    )
+    assert [v.quant for v in response.variants] == ["Q8_0"]
+    assert context_calls == [(str(repo_dir / "snapshots" / "newer"), True)]
+
+
+def test_a_case_variant_repo_dir_still_names_its_snapshot(monkeypatch, tmp_path):
+    """Provenance survives a repo_id whose case differs from the cached dir's.
+
+    The lister matches case-insensitively but the repo dir was rebuilt from repo_id, so on a
+    case-sensitive filesystem it failed ``is_dir()`` and the length fell back to a repo-wide walk.
+    """
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir(parents = True)
+    repo_dir = _write_cached_gguf(hub_cache, "org/repo", "m-Q8_0.gguf")
+
+    _pin_caches(monkeypatch, hub_cache, [hub_cache])
+    _unreachable_hub(monkeypatch)
+    monkeypatch.setattr(GV, "list_partial_gguf_variants_from_state", lambda *a, **k: None)
+
+    context_calls = []
+    monkeypatch.setattr(
+        models_route,
+        "_read_native_context_length",
+        lambda model, *, is_local: context_calls.append((str(model), is_local)) or 4096,
+    )
+
+    response = asyncio.run(
+        models_route.get_gguf_variants(
+            repo_id = "org/Repo",  # on disk as models--org--repo
+            hf_token = None,
+            current_subject = "test-user",
+        )
+    )
+    assert [v.quant for v in response.variants] == ["Q8_0"]
+    assert context_calls == [(str(repo_dir / "snapshots" / "rev"), True)]


### PR DESCRIPTION
Follow-up to #7788 and #7857, which pinned the GGUF variant listing and its context length to the cache a request names. The pin stopped one level short of where it needed to be.

## The problem

`get_gguf_variants_answer` records the copy that supplied a cached listing in `answered_from`, and `routes/models.py` reads the native context length off that copy. It recorded the **repo cache dir**. A repo cache dir holds every revision, and `_read_native_context_length` walks whatever it is handed with `rglob`, taking the first parseable non-mmproj GGUF. So the length could be read off a revision the listing skipped.

The lister picks the newest snapshot holding a whole quant. Give one repo dir two revisions:

| | holds | mtime |
|---|---|---|
| `revA` | `Q4_K_M` | older |
| `revB` | `Q8_0` | newer |

The listing is `revB`'s `Q8_0`. Before this change the context length came from `revA`, a revision that does not hold the quant being offered:

```
listed variants      : ['Q8_0'] (from revB)
context read from rev: revA
VERDICT              : WRONG-REVISION LEAK
```

After:

```
listed variants      : ['Q8_0'] (from revB)
context read from rev: revB
VERDICT              : OK
```

This also drops provenance entirely on a case-variant repo dir. `repo_cache_dir` is rebuilt from `repo_id`, but the cache lister matches case-insensitively, so a request for `org/Repo` against an on-disk `models--org--repo` failed the `is_dir()` guard on a case-sensitive filesystem and fell all the way back to a walk over every cache root, keyed by repo id.

## The change

`hub/utils/gguf.py` gains `select_gguf_cache_snapshot`: the existing selection loop, returning the snapshot it picked alongside the listing. `list_gguf_variants_from_hf_cache` becomes a thin wrapper over it with an unchanged signature and contract, so `_ready_cached_variants` and every other caller are untouched.

Both cache-fallback sites in `gguf_variants.py` call the selector and record the snapshot. The `repo_cache_dir.is_dir()` guard goes away with it: the snapshot came out of a directory walk, so it exists by construction. That is what makes the case-variant path work again, since the snapshot is the directory that was actually read rather than a name rebuilt from the request.

One walk, one answer. Provenance and listing cannot disagree, because they are now the same return value.

## Tests

Two regression tests in `tests/test_cached_gguf_routes.py`, both driving the real service:

- `test_context_follows_the_answering_revision_not_a_sibling`
- `test_a_case_variant_repo_dir_still_names_its_snapshot`

Both fail with the production hunk reverted and the tests kept:

```
FAILED test_context_follows_the_answering_revision_not_a_sibling
FAILED test_a_case_variant_repo_dir_still_names_its_snapshot
```

with the case-variant one reverting to `[('org/Repo', False)]`, the repo-wide walk.

The three existing provenance tests were tightened from the repo dir to the snapshot, and the stubs of `list_gguf_variants_from_hf_cache` in the service module now stub the selector instead.
