### PR TITLE
Improve desktop startup status

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -321,6 +321,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
     isExternalServer,
     currentStepIndex,
     progressDetail,
+    startupMessage,
     elevationPackages,
     startInstall,
     retry,
@@ -464,6 +465,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
       error={error}
       currentStepIndex={currentStepIndex}
       progressDetail={startupProgressDetail}
+      startupMessage={startupMessage}
       elevationPackages={elevationPackages}
       onInstall={startInstall}
       onRetry={retry}

--- a/studio/frontend/src/components/tauri/startup-messages.ts
+++ b/studio/frontend/src/components/tauri/startup-messages.ts
@@ -1,0 +1,26 @@
+export const INITIAL_STARTUP_MESSAGE = "Loading Unsloth...";
+export const MODELS_STARTUP_MESSAGE = "Loading models...";
+export const SERVER_STARTUP_MESSAGE = "Starting server...";
+export const SERVER_START_FALLBACK_MS = 3_000;
+
+export type StartupMessage =
+  | typeof INITIAL_STARTUP_MESSAGE
+  | typeof MODELS_STARTUP_MESSAGE
+  | typeof SERVER_STARTUP_MESSAGE;
+
+export function startupMessageFromLog(
+  current: StartupMessage,
+  line: string,
+): StartupMessage {
+  const normalized = line.trim();
+  if (normalized === "- Starting server...") {
+    return SERVER_STARTUP_MESSAGE;
+  }
+  if (
+    current === INITIAL_STARTUP_MESSAGE &&
+    normalized === "- loading PyTorch, Unsloth and Transformers..."
+  ) {
+    return MODELS_STARTUP_MESSAGE;
+  }
+  return current;
+}

--- a/studio/frontend/src/components/tauri/startup-screen.tsx
+++ b/studio/frontend/src/components/tauri/startup-screen.tsx
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import {
+  INITIAL_STARTUP_MESSAGE,
+  SERVER_STARTUP_MESSAGE,
+  SERVER_START_FALLBACK_MS,
+  type StartupMessage,
+} from "@/components/tauri/startup-messages";
 import { ShimmerButton } from "@/components/ui/shimmer-button";
 import { Spinner } from "@/components/ui/spinner";
 import type { BackendStatus } from "@/hooks/use-tauri-backend";
 import type { CopySupportDiagnosticsResult } from "@/lib/tauri-diagnostics";
 import { AnimatePresence, motion } from "motion/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface StartupScreenProps {
   status: BackendStatus;
@@ -14,6 +20,7 @@ interface StartupScreenProps {
   error: string | null;
   currentStepIndex: number;
   progressDetail: string | null;
+  startupMessage: StartupMessage;
   elevationPackages: string[];
   onInstall: () => void;
   onRetry: () => void;
@@ -324,7 +331,23 @@ function NeedsElevationContent({
   );
 }
 
-function StartingContent() {
+function StartingContent({ message }: { message: StartupMessage }) {
+  const [showFallback, setShowFallback] = useState(false);
+
+  useEffect(() => {
+    if (message !== SERVER_STARTUP_MESSAGE) {
+      return;
+    }
+
+    const fallback = window.setTimeout(
+      () => setShowFallback(true),
+      SERVER_START_FALLBACK_MS,
+    );
+    return () => window.clearTimeout(fallback);
+  }, [message]);
+
+  const displayMessage = showFallback ? INITIAL_STARTUP_MESSAGE : message;
+
   return (
     <div className="flex h-full flex-col items-center">
       <div className="flex flex-1 items-center">
@@ -332,7 +355,7 @@ function StartingContent() {
       </div>
       <div className="mb-10 flex flex-col items-center gap-2">
         <Spinner className="size-6 text-primary" />
-        <p className="text-sm text-muted-foreground">Starting server...</p>
+        <p className="text-sm text-muted-foreground">{displayMessage}</p>
       </div>
     </div>
   );
@@ -387,6 +410,7 @@ export function StartupScreen({
   error,
   currentStepIndex,
   progressDetail,
+  startupMessage,
   elevationPackages,
   onInstall,
   onRetry,
@@ -430,7 +454,7 @@ export function StartupScreen({
           />
         );
       case "starting":
-        return <StartingContent />;
+        return <StartingContent key={startupMessage} message={startupMessage} />;
       case "running":
         return null;
       case "stopped":

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -11,6 +11,12 @@ import {
   clearTauriAuthFailure,
   getTauriAuthFailure,
 } from "@/features/auth";
+import {
+  INITIAL_STARTUP_MESSAGE,
+  SERVER_STARTUP_MESSAGE,
+  startupMessageFromLog,
+  type StartupMessage,
+} from "@/components/tauri/startup-messages";
 
 export type BackendStatus =
   | "checking"
@@ -114,6 +120,9 @@ export function useTauriBackend() {
   const [currentStepIndex, setCurrentStepIndex] = useState(-1);
   const [elevationPackages, setElevationPackages] = useState<string[]>([]);
   const [progressDetail, setProgressDetail] = useState<string | null>(null);
+  const [startupMessage, setStartupMessage] = useState<StartupMessage>(
+    INITIAL_STARTUP_MESSAGE,
+  );
   // Track seen step names to deduplicate (Strict Mode, event replay, etc.)
   const seenStepsRef = useRef(new Set<string>());
   // True when we attached to a server we didn't spawn (can't stop it)
@@ -215,6 +224,7 @@ export function useTauriBackend() {
           setApiBase(preflight.port);
           portRef.current = preflight.port;
           setIsExternalServer(true);
+          setStartupMessage(SERVER_STARTUP_MESSAGE);
           setRunningStatus();
           startExternalServerPoll(preflight.port);
           return;
@@ -228,6 +238,7 @@ export function useTauriBackend() {
           portRef.current = preflight.port;
           setIsExternalServer(false);
           stopExternalServerPoll();
+          setStartupMessage(SERVER_STARTUP_MESSAGE);
           setRunningStatus();
           return;
         case "managed_ready":
@@ -270,6 +281,7 @@ export function useTauriBackend() {
       return;
     }
     startingRef.current = true;
+    setStartupMessage(INITIAL_STARTUP_MESSAGE);
     portRef.current = null;
     startTimedOutRef.current = false;
 
@@ -581,6 +593,7 @@ export function useTauriBackend() {
 
       register<string>("server-log", (e) => {
         setLogs((prev) => [...prev.slice(-499), e.payload]);
+        setStartupMessage((current) => startupMessageFromLog(current, e.payload));
       });
 
       register<void>("tray-toggle-server", () => {
@@ -628,7 +641,7 @@ export function useTauriBackend() {
 
   return {
     status, logs, error, isExternalServer,
-    currentStepIndex, progressDetail, elevationPackages,
+    currentStepIndex, progressDetail, startupMessage, elevationPackages,
     startServer, stopServer, startInstall,
     retry, retryInstall, approveElevation, copyDiagnostics,
   };

--- a/studio/frontend/tests/startup-messages.test.ts
+++ b/studio/frontend/tests/startup-messages.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  INITIAL_STARTUP_MESSAGE,
+  SERVER_START_FALLBACK_MS,
+  startupMessageFromLog,
+} from "../src/components/tauri/startup-messages.ts";
+
+test("startup messages follow backend phases without regressing", () => {
+  const models = startupMessageFromLog(
+    INITIAL_STARTUP_MESSAGE,
+    "  - loading PyTorch, Unsloth and Transformers...",
+  );
+  assert.equal(models, "Loading models...");
+  assert.equal(startupMessageFromLog(models, "unrelated output"), models);
+
+  const server = startupMessageFromLog(models, "  - Starting server...");
+  assert.equal(server, "Starting server...");
+  assert.equal(
+    startupMessageFromLog(
+      server,
+      "  - loading PyTorch, Unsloth and Transformers...",
+    ),
+    server,
+  );
+});
+
+test("server fallback delay is three seconds", () => {
+  assert.equal(SERVER_START_FALLBACK_MS, 3_000);
+});


### PR DESCRIPTION
## Summary

- show desktop startup phases from backend logs
- fall back to Loading Unsloth after 3 seconds if startup continues
- keep app handoff immediate when backend becomes ready

## Checks

- `npm test --prefix studio/frontend` (436 passed)
- `npm run typecheck --prefix studio/frontend`
- targeted ESLint/Biome checks
- `git diff --check`