### PR TITLE
Studio: screen the cmd and START spellings the blocklist lexer quotes

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1645,6 +1645,14 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # `env -i`, `env A=b`, `timeout 5`: the wrapper's own argument.
                 i += 1
                 continue
+            if token and not token.strip('"'):
+                # A word of nothing but double quotes is not the child, for the
+                # reason the main walk gives: cmd collapses a doubled pair and
+                # runs what follows it. Only `"`, since cmd has no single-quote
+                # syntax and `start '' prog` really does look for a program
+                # literally named `''`.
+                i += 1
+                continue
             base = _token_basename(token)
             if base in _COMMAND_PREFIXES:
                 wrapper = base
@@ -1758,6 +1766,14 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # `cmd /c "C:\\...\\cmd.exe" /c powershell` really nests.
                 expect_command = False
                 continue
+        if token and not token.strip('"'):
+            # A word made only of double quotes is not a program. cmd collapses a
+            # doubled pair and runs what follows, so `""cmd /c powershell""`
+            # lexes to an empty word with the program behind it; spending command
+            # position on the empty word left that program in argument position.
+            # Only `"`: cmd has no single-quote syntax, so `''` really is a
+            # program name there and the word after it is its argument.
+            continue
         base = _token_basename(token)
         # Every word this loop reaches is one the shell would RUN, wrappers and
         # assignment prefixes already stepped over. The walks below decide the
@@ -1845,6 +1861,11 @@ def _find_blocked_commands(command: str) -> set[str]:
                 continue
             exec_words = [i + 1] if child in (-1, i + 1) else [i + 1, child]
             for word in exec_words:
+                # find runs these itself, so they are command positions the main
+                # walk never sees: it reaches `find` and stops. Published, or the
+                # nested-shell lookup declines to read the payload of
+                # `find . -exec bash -c 'rm -rf x' \;` and that really deletes.
+                command_indexes.add(word)
                 base = _token_basename(tokens[word])
                 if _is_sed_command(base):
                     # find runs its -exec child directly, but the walk above only
@@ -1873,7 +1894,10 @@ def _find_blocked_commands(command: str) -> set[str]:
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
     for i, token in enumerate(tokens):
-        if os.path.basename(token).lower() not in ("start", "start.exe"):
+        # _token_basename, not os.path.basename: the cmd lexer leaves an operator
+        # glued to the word it opens, so `(start cmd /c powershell` arrived as one
+        # token `(start`, matched nothing, and the group's launch went unread.
+        if _token_basename(token) != "start":
             continue
         # Only a START the shell RUNS. `echo start "job" powershell` prints
         # three words, and treating them as a launch hard-blocks text output.
@@ -1931,16 +1955,47 @@ def _find_blocked_commands(command: str) -> set[str]:
             continue
         if j < len(tokens):
             program = _unquote(tokens[j])
+            bare = _unwrap_quotes(program)
+            if bare != program:
+                # The same doubled-quote shape the /c payload already handles:
+                # `start "" ""cmd /c powershell""` reaches START as one quoted
+                # span it unquotes and runs. Scanned IN ADDITION to the quoted
+                # form, never instead of it, for the reason given at that site.
+                blocked |= _screen_cmd_payload(bare)
+                blocked |= _blocked_quoted_program(bare, _BLOCKED_COMMANDS)
             # What START launches is a command the shell runs, so it is published
             # for the lookups below: `start "" "cmd" /c powershell` reaches a real
             # cmd, and only the walk above can tell that from a quoted word an
             # earlier command was merely handed.
             command_indexes.add(j)
+            # A wrapper is a command in its own right AND a step on the way to
+            # one, exactly as under `-exec`, so the program it forwards to is
+            # published too. Without it `start "" env bash -c "rm -rf x"` named
+            # only `env` and the nested-shell lookup declined to read the payload.
+            forwarded, _overflowed = _exec_child_index(j)
+            if forwarded not in (-1, j):
+                command_indexes.add(forwarded)
+                # Screened the same way START's own target is, not merely looked
+                # up by name: quoting can hand the wrapper a whole command line,
+                # and `start "" env "cmd /c powershell"` reduced to a basename of
+                # `c powershell` and matched nothing.
+                blocked |= _screen_cmd_payload(_unquote(tokens[forwarded]))
+                blocked |= _blocked_quoted_program(
+                    _unquote(tokens[forwarded]), _BLOCKED_COMMANDS
+                )
             blocked |= _screen_cmd_payload(program)
             # Same split-path shape as the /c payload: START documents a title
             # followed by the program, and `start "" "C:\Program Files\...
             # \pwsh.exe"` is one quoted word until it is re-lexed.
             blocked |= _blocked_quoted_program(program, _BLOCKED_COMMANDS)
+            if not program and j + 1 < len(tokens):
+                # The empty-first-token shape the /c payload documents: a doubled
+                # pair lexes to a `""` of its own and the program sits behind it,
+                # each word still carrying a stray mark. `start "" ""cmd /c
+                # powershell""` reached START as the empty word and stopped.
+                tail = " ".join(word.strip('"') for word in tokens[j + 1 :])
+                blocked |= _find_blocked_commands(tail)
+                blocked |= _blocked_quoted_program(tail, _BLOCKED_COMMANDS)
 
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):
     # on a -c/-/c flag, look back for a shell name (skipping flags) and

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1365,6 +1365,20 @@ def _unwrap_quotes(token: str) -> str:
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 
 
+def _is_start_title(token: str, lexed_posix: bool) -> bool:
+    """Whether ``token`` is START's window title rather than the program it runs.
+
+    Documented as `start <"title"> ... [<command>]`: a quoted first argument is
+    always the title, which is why `start ""` is the idiom for launching a
+    quoted path. The posix lexer has already dropped the quote marks, so only
+    the empty-title spelling is still recognisable there and the caller screens
+    one token further on instead.
+    """
+    if lexed_posix:
+        return token == ""
+    return len(token) >= 2 and token[0] == '"' == token[-1]
+
+
 def _find_blocked_commands(command: str) -> set[str]:
     """Detect blocked commands at shell command position only.
 
@@ -1685,17 +1699,29 @@ def _find_blocked_commands(command: str) -> set[str]:
         if os.path.basename(token).lower() not in ("start", "start.exe"):
             continue
         j = i + 1
+        titled = False
         while j < len(tokens):
             switch = _win_switch(tokens[j].lower())
-            if not switch.startswith("/"):
+            if switch.startswith("/"):
+                # /d C:\dir and friends carry their value in the next token.
+                j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+            elif not titled and _is_start_title(tokens[j], lexed_posix):
+                # START takes its window title as a QUOTED first argument, so
+                # the program is the token behind it. Only the `""` idiom was
+                # stepped over, which read `start "job" powershell` as a program
+                # named job and left powershell in argument position.
+                titled = True
+                j += 1
+            else:
                 break
-            # /d C:\dir and friends carry their value in the next token.
-            j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-        # `start ""` is the idiom for "no title"; anything else is the program.
-        if j < len(tokens) and _unquote(tokens[j]) == "":
-            j += 1
         if j < len(tokens):
             blocked |= _find_blocked_commands(_unquote(tokens[j]))
+            if lexed_posix and not titled and j + 1 < len(tokens):
+                # Posix only: shlex dropped the quote marks, so a title cannot be
+                # told from a program and the word behind it is screened too.
+                # Under cmd the marks survive, and a token without them IS the
+                # program, so guessing there would block an ordinary argument.
+                blocked |= _find_blocked_commands(tokens[j + 1])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1128,8 +1128,9 @@ def _is_document_target(target: str) -> bool:
     # final chunk called a PowerShell launch a `.ps1` document and skipped every
     # other check on it.
     words = stripped.split()
+    carries = _path_continuations(words)
     for position, word in enumerate(words):
-        if position and not _continues_path(words, position):
+        if position and not _continues_path(words, position, carries):
             break
         if _path_suffix(word) in _WINDOWS_EXE_SUFFIXES:
             return False
@@ -1147,12 +1148,16 @@ def _has_bare_cmd_operator(text: str) -> bool:
     whole second command behind one. An odd run of carets in front of the
     operator hands it over as literal text instead.
     """
-    for index, char in enumerate(text):
-        if char not in "&|":
+    carets = 0
+    for char in text:
+        if char == "^":
+            carets += 1
             continue
-        carets = len(text[:index]) - len(text[:index].rstrip("^"))
-        if carets % 2 == 0:
+        if char in "&|" and carets % 2 == 0:
             return True
+        # Counted along the one walk rather than re-measured from the start of
+        # the text at every operator, which copied a longer prefix each time.
+        carets = 0
     return False
 
 
@@ -1593,7 +1598,25 @@ def _is_start_switch(token: str) -> bool:
     return switch.startswith("/") and "/" not in switch[1:]
 
 
-def _continues_path(words: "list[str]", position: int) -> bool:
+def _path_continuations(words: "list[str]") -> "list[bool]":
+    """For each position, whether a LATER word still carries a path separator.
+
+    One reverse pass answering the lookahead `_continues_path` needs. Asking it
+    per word rescanned the whole remaining list each time, so a quoted path made
+    of many separator-less fragments cost time in the square of its length.
+    """
+    carries = [False] * (len(words) + 1)
+    for position in range(len(words) - 1, -1, -1):
+        bare = words[position].strip('"')
+        if not bare or bare.startswith("-"):
+            continue
+        if _PATH_FRAGMENT_RE.match(bare) or _URL_SCHEME_RE.match(bare):
+            continue
+        carries[position] = "\\" in bare or "/" in bare or carries[position + 1]
+    return carries
+
+
+def _continues_path(words: "list[str]", position: int, carries: "list[bool] | None" = None) -> bool:
     """Whether ``words[position]`` is another chunk of the path in front of it.
 
     What continues a path holding spaces is a RELATIVE fragment. A word that
@@ -1612,15 +1635,9 @@ def _continues_path(words: "list[str]", position: int) -> bool:
         return False
     if "\\" in bare or "/" in bare:
         return True
-    for later in words[position + 1 :]:
-        following = later.strip('"')
-        if not following or following.startswith("-"):
-            break
-        if _PATH_FRAGMENT_RE.match(following) or _URL_SCHEME_RE.match(following):
-            break
-        if "\\" in following or "/" in following:
-            return True
-    return False
+    if carries is None:
+        carries = _path_continuations(words)
+    return carries[position + 1]
 
 
 def _quoted_program_word(payload: str) -> str:
@@ -1676,6 +1693,7 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
     # recovering a program from it would block a line cmd cannot run.
     if not words or not _PATH_FRAGMENT_RE.match(words[0].strip('"')):
         return set()
+    carries = _path_continuations(words)
     program: "list[str]" = []
     for position, word in enumerate(words):
         bare = word.strip('"')
@@ -1685,7 +1703,7 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
         # continues one is a RELATIVE fragment: `C:\Program Files\PowerShell\7\
         # pwsh` runs pwsh, while the `rm` of `C:\tools\notepad rm` is a file
         # notepad is being run on.
-        if program and not _continues_path(words, position):
+        if program and not _continues_path(words, position, carries):
             break
         program.append(bare)
         if os.path.splitext(bare)[1].lower() in _WINDOWS_EXE_SUFFIXES:
@@ -2009,6 +2027,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         return -1, steps >= _MAX_EXEC_PREFIX_SCAN and i < len(tokens)
 
     expect_command = True  # start of string is a command position
+    active_prefixes = command_prefixes  # narrowed once an external wrapper executes
     command_indexes: "set[int]" = set()  # words the shell runs, for the walks below
     win_shell_pending = False  # a cmd at command position, awaiting its /c or /k
     payload_pending = False  # the next word is what cmd's /c hands to a new shell
@@ -2071,6 +2090,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             win_shell_pending = False
             payload_pending = False
             xargs_index = -1
+            active_prefixes = command_prefixes
             continue
         if token.startswith("-"):
             # A wrapper option whose value is a SEPARATE token precedes that
@@ -2135,11 +2155,17 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             blocked |= _blocked_matching_glob(base)
         # Wrappers (env/time/xargs/sudo) consume one command; the next non-flag,
         # non-numeric token is the real command. sudo is also in _BLOCKED_COMMANDS.
-        if base in command_prefixes:
+        if base in active_prefixes:
             if base == "xargs" and xargs_index < 0:
                 xargs_index = token_index
             prefix_pending = True
             prefix_command = base
+            if base not in _CMD_ONLY_PREFIXES:
+                # An EXTERNAL wrapper runs its child itself rather than handing
+                # the rest of the line back to cmd, so cmd's own builtins stop
+                # applying behind one: `cmd //c "xargs call powershell"` looks
+                # for a program named call and never reaches PowerShell.
+                active_prefixes = command_prefixes - _CMD_ONLY_PREFIXES
             continue
         expect_command = False
         prefix_pending = False
@@ -2277,15 +2303,17 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # still glued to a word was quoted and is not an operator at all.
             return ""
         quotes = 0
+        carets = 0
         last = -1
         for position, char in enumerate(token):
+            if char == "^":
+                carets += 1
+                continue
             if char == '"':
                 quotes += 1
-            elif char in "&|(" and quotes % 2 == 0:
-                before = token[:position]
-                carets = len(before) - len(before.rstrip("^"))
-                if carets % 2 == 0:
-                    last = position
+            elif char in "&|(" and quotes % 2 == 0 and carets % 2 == 0:
+                last = position
+            carets = 0
         return token[last + 1 :] if last >= 0 else ""
 
     def _is_start_word(token: str) -> bool:
@@ -2472,6 +2500,10 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         # it means START had a title and a command, so the quoted word is the
         # window title. An option, a separator, or nothing at all means no
         # command followed, and the quoted word was the command line itself.
+        #
+        # START's own options are slash-prefixed, which is what `_is_start_switch`
+        # reads. A `-` opens no option there, so `-notepad.exe` is the program
+        # START runs and the quoted word in front of it really was the title.
         following_word = tokens[j] if j < len(tokens) else ""
         title_had_a_command = (
             bool(following_word)
@@ -2480,7 +2512,8 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # otherwise read as the program this title was given.
             and j not in newline_starts
             and not (
-                following_word.startswith("-") or following_word.strip('"') in _SHELL_SEPARATORS
+                _is_start_switch(following_word.strip('"'))
+                or following_word.strip('"') in _SHELL_SEPARATORS
             )
         )
         if titled and lexed_posix and not title_had_a_command:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1053,6 +1053,19 @@ def _quoted_separator_indexes(text: str, tokens: "list[str]", punctuation: str) 
     )
 
 
+def _is_program_path(target: str) -> bool:
+    """Whether ``target`` is a path to an executable rather than a command line.
+
+    Told apart by shape and suffix: a path opens with a drive, a separator or a
+    `%VAR%`, and ends in one of the extensions cmd runs. `rm -rf x` is neither,
+    so a real command line handed over in quotes is still lexed as one.
+    """
+    stripped = target.strip('"')
+    if not stripped or not _PATH_FRAGMENT_RE.match(stripped):
+        return False
+    return os.path.splitext(stripped)[1].lower() in _WINDOWS_EXE_SUFFIXES
+
+
 def _is_document_target(target: str) -> bool:
     """Whether START would OPEN ``target`` through its file association rather
     than execute it.
@@ -1617,6 +1630,12 @@ def _find_blocked_commands(command: str) -> set[str]:
         `cmd /c powershell&echo ok` runs powershell and read as one program named
         `powershell&echo`. That is a command line too, escaped carets aside.
         """
+        if _is_program_path(text):
+            # A program path holds spaces like any other, and re-lexing one reads
+            # its directory components as words: `C:\powershell scripts\
+            # notepad.exe` runs notepad and reported the folder it sits in. The
+            # recovery below reads the program off the path instead.
+            return _blocked_quoted_program(text, _BLOCKED_COMMANDS)
         if any(char.isspace() or char in "\"'" for char in text) or _has_bare_cmd_operator(text):
             return _find_blocked_commands(text)
         base = _token_basename(text)
@@ -2021,6 +2040,11 @@ def _find_blocked_commands(command: str) -> set[str]:
             # a command followed it.
             and (lexed_posix or not _ends_with_cmd_operator(previous))
         ):
+            continue
+        if not lexed_posix and previous.endswith(";"):
+            # cmd has no `;` separator, so the scan above opened a command
+            # position that shell never opens: `echo ; start "" powershell` and
+            # `echo hi; start ""...` both print their whole line there.
             continue
         j = i + 1
         titled = False

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2448,6 +2448,11 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 call_child_indexes.add(i + 1)
             elif (
                 not tail
+                # CALL is cmd's builtin, so this boundary only forwards where
+                # cmd is the one parsing. Under bash `( call rm` runs a program
+                # named call and never reaches rm, and the operator branch above
+                # is already lexer-gated the same way.
+                and (not lexed_posix or _cmd_payload)
                 and _ends_with_cmd_operator(token)
                 and i + 2 < len(tokens)
                 and _token_basename(_unwrap_quotes(tokens[i + 1])) in _CMD_ONLY_PREFIXES

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1398,11 +1398,14 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
     is arguments.
     """
     words = payload.split()
-    if not words or not _PATH_FRAGMENT_RE.match(words[0].strip("\"'")):
+    # Only `"`, matching _unwrap_quotes: cmd has no single-quote syntax, so
+    # `cmd /c 'C:\\...\\pwsh.exe'` looks for a literally single-quoted path and
+    # recovering a program from it would block a line cmd cannot run.
+    if not words or not _PATH_FRAGMENT_RE.match(words[0].strip('"')):
         return set()
     program: "list[str]" = []
     for word in words:
-        bare = word.strip("\"'")
+        bare = word.strip('"')
         if bare.startswith("-") or _is_start_switch(bare):
             break  # an option ends the path and starts the arguments
         program.append(bare)
@@ -1471,6 +1474,23 @@ def _find_blocked_commands(command: str) -> set[str]:
     # `';'` never looks like a separator there and nothing has to be recovered;
     # the split() fallback has no quoting model at all, so it reports nothing
     # either and both shells reach the same verdict.
+    def _screen_cmd_payload(text: str) -> "set[str]":
+        """Screen what cmd runs, as a command line or as one program name.
+
+        A token holding whitespace or a quote mark is lexed again: quoting can
+        hand the whole command line over at once, and an unbalanced quote drops
+        the scan onto split(), whose tokens keep their marks. A bare word is a
+        program name, and re-scanning it as a command line reads
+        `C:\\tmp\\image.png` as a path followed by the POSIX source builtin,
+        which hard-blocks a document launch.
+        """
+        if any(char.isspace() or char in "\"'" for char in text):
+            return _find_blocked_commands(text)
+        base = _token_basename(text)
+        if base in _BLOCKED_COMMANDS:
+            return {base}
+        return _blocked_matching_glob(base)
+
     def _unquote(tok: str) -> str:
         # Quote marks survive lexing only under cmd. On the posix path shlex has
         # already eaten the delimiters, so stripping another pair would turn a
@@ -1737,14 +1757,16 @@ def _find_blocked_commands(command: str) -> set[str]:
                 continue  # skip Unix flags like --login, -l
             if is_win_c and prev.startswith("/") and len(prev) <= 3:
                 continue  # skip Windows flags like /s, /q (not /bin/bash)
-            # `start "" "cmd" /c prog` quotes the shell name too, and a leading
-            # quote hid it from this lookup, so nothing recursed into prog.
-            prev_base = os.path.basename(_unquote(prev)).lower()
+            # `start "" "cmd" /c prog` quotes the shell name, and a full path
+            # spells it `C:\Windows\System32\cmd.exe`, which os.path.basename
+            # leaves whole off Windows. Either one hid the shell from this
+            # lookup, so the payload behind its /c was never scanned.
+            prev_base = _token_basename(_unquote(prev).replace("\\", "/"))
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(_unquote(tokens[i + 1]))
             elif is_win_c and prev_base in _SHELLS_WIN:
                 payload = _unquote(tokens[i + 1])
-                blocked |= _find_blocked_commands(payload)
+                blocked |= _screen_cmd_payload(payload)
                 bare = _unwrap_quotes(payload)
                 if bare != payload:
                     # Git Bash keeps cmd's own quotes: `cmd //c '"powershell
@@ -1790,22 +1812,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
         if j < len(tokens):
             program = _unquote(tokens[j])
-            if any(char.isspace() or char in "\"'" for char in program):
-                # Quoting can hand the whole command line over as one token,
-                # `start "" "powershell -Command ls"`, and an unbalanced quote
-                # drops the scan onto split(), whose tokens keep their marks.
-                # Both only read once lexed again.
-                blocked |= _find_blocked_commands(program)
-            else:
-                # A bare word is a program name, and re-scanning it as a command
-                # line reads `C:\tmp\image.png` as a path followed by the POSIX
-                # `.` builtin, hard-blocking a document launch the terminal note
-                # promises stays usable.
-                program_base = _token_basename(program)
-                if program_base in _BLOCKED_COMMANDS:
-                    blocked.add(program_base)
-                else:
-                    blocked |= _blocked_matching_glob(program_base)
+            blocked |= _screen_cmd_payload(program)
             # Same split-path shape as the /c payload: START documents a title
             # followed by the program, and `start "" "C:\Program Files\...
             # \pwsh.exe"` is one quoted word until it is re-lexed.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1955,7 +1955,9 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         # later `xargs "" rm`, which is a different command entirely.
         return chunk_of[index] == chunk_of[index + 1]
 
-    def _exec_child_index(start: int, prefixes: "frozenset[str] | set[str]" = ()) -> "tuple[int, bool]":
+    def _exec_child_index(
+        start: int, prefixes: "frozenset[str] | set[str]" = ()
+    ) -> "tuple[int, bool]":
         """The command a `find -exec` actually runs, as ``(index, overflowed)``;
         the index is -1 when the action holds no command word at all.
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1338,6 +1338,24 @@ def _win_switch(token: str) -> str:
     return token[1:] if token.startswith("//") else token
 
 
+def _unwrap_quotes(token: str) -> str:
+    """Drop one surrounding quote pair, which the cmd lexer keeps.
+
+    shlex(posix = False) hands back `"prog args"` with its quote marks attached
+    where the posix lexer strips them, and that is the lexer a Windows host with
+    no trusted bash uses. So `cmd /c "powershell -Command ls"` -- the ordinary
+    Windows spelling -- recursed into a payload whose first word was
+    `"powershell`, and `start ""` never matched the empty-title idiom, leaving
+    the program behind the title unscreened. Both are command positions.
+
+    Unquoting only ever widens what is screened, so the posix path, where there
+    is nothing left to unwrap, reaches the same verdict.
+    """
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in "\"'":
+        return token[1:-1]
+    return token
+
+
 # `start` launches its argument as a program, so that argument is a command
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
@@ -1641,9 +1659,9 @@ def _find_blocked_commands(command: str) -> set[str]:
                 continue  # skip Windows flags like /s, /q (not /bin/bash)
             prev_base = os.path.basename(prev).lower()
             if is_unix_c and prev_base in _SHELLS:
-                blocked |= _find_blocked_commands(tokens[i + 1])
+                blocked |= _find_blocked_commands(_unwrap_quotes(tokens[i + 1]))
             elif is_win_c and prev_base in _SHELLS_WIN:
-                blocked |= _find_blocked_commands(tokens[i + 1])
+                blocked |= _find_blocked_commands(_unwrap_quotes(tokens[i + 1]))
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1659,10 +1677,10 @@ def _find_blocked_commands(command: str) -> set[str]:
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
         # `start ""` is the idiom for "no title"; anything else is the program.
-        if j < len(tokens) and tokens[j] == "":
+        if j < len(tokens) and _unwrap_quotes(tokens[j]) == "":
             j += 1
         if j < len(tokens):
-            blocked |= _find_blocked_commands(tokens[j])
+            blocked |= _find_blocked_commands(_unwrap_quotes(tokens[j]))
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1183,7 +1183,10 @@ def _live_operator_segments(token: str, lexed_posix: bool) -> "list[str]":
     carets = 0
     start = 0
     for position, char in enumerate(token):
-        if char == "^":
+        # Only OUTSIDE a quoted span is the caret an escape. Within one it is
+        # the character it looks like, so `"a^"` closes its quote and the
+        # operator behind it is live. `_cmd_quote_states` reads it the same way.
+        if char == "^" and quotes % 2 == 0:
             carets += 1
             continue
         if char == '"' and carets % 2 == 0:
@@ -1215,7 +1218,8 @@ def _live_operator_tail(token: str, lexed_posix: bool) -> str:
     carets = 0
     last = -1
     for position, char in enumerate(token):
-        if char == "^":
+        # Only outside a quoted span, as in `_live_operator_segments`.
+        if char == "^" and quotes % 2 == 0:
             carets += 1
             continue
         # A caret escapes the quote mark itself, so `^"` is text cmd prints and
@@ -2227,6 +2231,28 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             skip_operand = skip_two
             skip_two = False
             continue
+        attached_payload = ""
+        if not expect_command and win_shell_pending:
+            switch = _win_switch(token.lower())
+            for spelling in ("/c", "/k"):
+                if not switch.startswith(spelling) or len(switch) == len(spelling):
+                    continue
+                # cmd takes its command string straight after the switch, with
+                # no space: `cmd /c"powershell -Command ls"` runs it. Read from
+                # the RAW line rather than the token, because a quote opening
+                # mid-token does not hold that lexer's word together.
+                width = len(spelling) + (1 if token.startswith("//") else 0)
+                offsets = _token_offsets()
+                if offsets and token_index < len(offsets):
+                    attached_payload = command[offsets[token_index] + width :]
+                else:
+                    attached_payload = _win_switch(token)[len(spelling) :]
+                break
+        if attached_payload:
+            blocked |= _screen_cmd_payload(_unwrap_quotes(attached_payload.strip()))
+            win_shell_pending = False
+            expect_command = False
+            continue
         if not expect_command and win_shell_pending and _win_switch(token.lower()) in ("/c", "/k"):
             # cmd runs the word after its own switch, a real command position the
             # outer shell sees only as an argument. Tied to a cmd this loop
@@ -2345,7 +2371,10 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # `call call powershell` of `echo&call call powershell`.
             prefix_pending = tail_base in (command_prefixes | _CMD_ONLY_PREFIXES)
             prefix_command = tail_base if prefix_pending else ""
-            expect_command = prefix_pending
+            # A keyword handed over by the operator opens what it always opens,
+            # IF's condition included: cmd runs `echo&if 1==1 powershell`.
+            if_pending = tail_base == "if"
+            expect_command = prefix_pending or tail_base in _SHELL_KEYWORDS_AS_SEP
             continue
         if not expect_command:
             continue
@@ -2545,6 +2574,12 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         if _token_basename(tokens[i]) != "start":
             # Reached only through the glued-operator spelling, where the live
             # operator in front of the word is itself the command boundary.
+            return True
+        if _live_operator_tail(tokens[i], lexed_posix):
+            # The token opens with, or carries, a live operator, and what
+            # follows one is a command by definition. That lexer splits
+            # `echo "a"&start ""` into `"a"` and `&start`, so the boundary is at
+            # the FRONT of this token rather than the end of the one before it.
             return True
         previous = tokens[i - 1] if i else ""
         if (

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1609,6 +1609,35 @@ def _find_blocked_commands(command: str) -> set[str]:
             base = stem
         return base
 
+    def _whitespace_chunks() -> "list[int] | None":
+        """For each token, the index of the whitespace-delimited word it came
+        from, or ``None`` when the two passes do not line up.
+
+        Lexing each word on its own and counting what it yields is enough to
+        recover the boundaries the token list threw away, and the total is
+        checked against the real lex so a word that lexes differently in
+        isolation reports nothing rather than a wrong answer.
+        """
+        owners: "list[int]" = []
+        for position, chunk in enumerate(command.split()):
+            try:
+                if lex_mode == "posix":
+                    lexer = shlex.shlex(chunk, posix = True, punctuation_chars = ";&|()`")
+                    lexer.whitespace_split = True
+                    produced = len(list(lexer))
+                elif lex_mode == "cmd":
+                    produced = len(shlex.split(chunk, posix = False))
+                else:
+                    produced = 1
+            except ValueError:
+                return None
+            owners.extend([position] * produced)
+        return owners if len(owners) == len(tokens) else None
+
+    # Built at most once, and only when a quote-only word actually asks: it costs
+    # a second lex of every word, and almost no command holds one.
+    chunk_cache: "list[list[int] | None]" = []
+
     def _glued_empty_quotes(index: int) -> bool:
         """Whether ``tokens[index]`` is an empty quoted pair the shell would have
         collapsed INTO the word after it.
@@ -1621,9 +1650,18 @@ def _find_blocked_commands(command: str) -> set[str]:
         whitespace between them, which only the raw text still has.
         """
         token = tokens[index]
-        if not token or token.strip('"'):
+        if not token or token.strip('"') or index + 1 >= len(tokens):
             return False
-        return index + 1 < len(tokens) and token + tokens[index + 1] in command
+        if not chunk_cache:
+            chunk_cache.append(_whitespace_chunks())
+        chunk_of = chunk_cache[0]
+        if chunk_of is None:
+            return False
+        # Same whitespace-delimited word means the shell never separated them.
+        # Asked positionally rather than by searching the line for the two
+        # spellings joined: an earlier `echo ""rm` would otherwise vouch for a
+        # later `xargs "" rm`, which is a different command entirely.
+        return chunk_of[index] == chunk_of[index + 1]
 
     def _exec_child_index(start: int) -> "tuple[int, bool]":
         """The command a `find -exec` actually runs, as ``(index, overflowed)``;

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -378,7 +378,10 @@ _SEPARATOR_CHARS = frozenset("".join(_SHELL_SEPARATORS))
 # non-whitespace, non-quote, non-punctuation_chars character serves, so the
 # masked text splits into the same words and the token lists line up.
 _QUOTED_SEPARATOR_MARK = "\x00"
-_NEWLINE_COMMAND_MARK = "\x01"
+# Stand-ins for a newline during the second lex. Several, because the command is
+# the caller's text: a literal \x01 in it used to disable newline recovery for
+# the whole line, which is a boundary an author could delete by including one.
+_NEWLINE_COMMAND_MARKS = ("\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x0e", "\x0f")
 # The characters bash expands a word against the filesystem for, and the
 # placeholder standing in for a QUOTED one during the same second lex.
 _GLOB_CHARS = frozenset("*?[")
@@ -1098,7 +1101,21 @@ def _is_document_target(target: str) -> bool:
     stripped = target.strip('"')
     if not stripped or not _PATH_FRAGMENT_RE.match(stripped):
         return False
-    suffix = _path_suffix(stripped)
+    # A target may carry its own arguments, so the path is walked first. An
+    # executable suffix anywhere along it means a PROGRAM was named and the rest
+    # are its arguments: reading `C:\tools\pwsh.exe scripts\job.ps1` by its
+    # final chunk called a PowerShell launch a `.ps1` document and skipped every
+    # other check on it.
+    words = stripped.split()
+    for position, word in enumerate(words):
+        if position and not _continues_path(words, position):
+            break
+        if _path_suffix(word) in _WINDOWS_EXE_SUFFIXES:
+            return False
+    # Nothing along the path is executable, so the whole target is a candidate
+    # FILE and its own suffix decides. A document's name may hold spaces, which
+    # is why `C:\tmp\rm report.docx` is one file rather than rm with an operand.
+    suffix = _path_suffix(words[-1])
     return bool(suffix) and suffix not in _WINDOWS_EXE_SUFFIXES
 
 
@@ -1157,7 +1174,10 @@ def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "froz
     marks alone; the recovered count is checked against the original and anything
     unexpected reports nothing.
     """
-    if "\n" not in text or _NEWLINE_COMMAND_MARK in text:
+    if "\n" not in text:
+        return frozenset()
+    mark = next((candidate for candidate in _NEWLINE_COMMAND_MARKS if candidate not in text), "")
+    if not mark:
         return frozenset()
     states = _shell_quote_states(text)
 
@@ -1174,10 +1194,10 @@ def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "froz
         return carets % 2 == 0
 
     marked = "".join(
-        f" {_NEWLINE_COMMAND_MARK} " if char == "\n" and _separates(index) else char
+        f" {mark} " if char == "\n" and _separates(index) else char
         for index, char in enumerate(text)
     )
-    if _NEWLINE_COMMAND_MARK not in marked:
+    if mark not in marked:
         return frozenset()  # every newline was quoted, so none of them separates
     try:
         if mode == "posix":
@@ -1196,7 +1216,7 @@ def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "froz
     starts: "set[int]" = set()
     index, opening = 0, False
     for token in relexed:
-        if token == _NEWLINE_COMMAND_MARK:
+        if token == mark:
             opening = True
             continue
         if opening:
@@ -1543,18 +1563,34 @@ def _is_start_switch(token: str) -> bool:
     return switch.startswith("/") and "/" not in switch[1:]
 
 
-def _continues_path(bare: str) -> bool:
-    """Whether ``bare`` is another chunk of the path in front of it.
+def _continues_path(words: "list[str]", position: int) -> bool:
+    """Whether ``words[position]`` is another chunk of the path in front of it.
 
     What continues a path holding spaces is a RELATIVE fragment. A word that
     opens a path of its own, names a URL, or is an option belongs to the
     arguments however many separators it carries.
+
+    A fragment need not carry a separator itself: `C:\\Program Files (x86)\\
+    PowerShell\\7\\pwsh.exe` has `Files` between two that do, and stopping there
+    left `Program` as the program and the shell behind it unreported. Such a
+    word continues the path when a LATER one still carries it.
     """
+    bare = words[position].strip('"')
     if not bare or bare.startswith("-"):
         return False
-    if "\\" not in bare and "/" not in bare:
+    if _PATH_FRAGMENT_RE.match(bare) or _URL_SCHEME_RE.match(bare):
         return False
-    return not _PATH_FRAGMENT_RE.match(bare) and not _URL_SCHEME_RE.match(bare)
+    if "\\" in bare or "/" in bare:
+        return True
+    for later in words[position + 1 :]:
+        following = later.strip('"')
+        if not following or following.startswith("-"):
+            break
+        if _PATH_FRAGMENT_RE.match(following) or _URL_SCHEME_RE.match(following):
+            break
+        if "\\" in following or "/" in following:
+            return True
+    return False
 
 
 def _quoted_program_word(payload: str) -> str:
@@ -1619,17 +1655,16 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
         # continues one is a RELATIVE fragment: `C:\Program Files\PowerShell\7\
         # pwsh` runs pwsh, while the `rm` of `C:\tools\notepad rm` is a file
         # notepad is being run on.
-        if program and not _continues_path(bare):
+        if program and not _continues_path(words, position):
             break
         program.append(bare)
         if os.path.splitext(bare)[1].lower() in _WINDOWS_EXE_SUFFIXES:
-            # An executable suffix ends the path, unless the NEXT word carries
-            # it on: a directory may be named `rm.exe dir`, and stopping at the
-            # chunk rather than the basename reported the folder as the program
-            # for a line that runs `C:\rm.exe dir\notepad`.
-            following = words[position + 1].strip('"') if position + 1 < len(words) else ""
-            if not _continues_path(following):
-                break
+            # An executable suffix ends the path. CreateProcess resolves an
+            # unquoted path by trying its space-separated prefixes SHORTEST
+            # first, so `C:\tools\pwsh.exe scripts\job.ps1` runs pwsh with a
+            # script argument; carrying the path on through that argument read
+            # `job.ps1` as the program and let the shell behind it through.
+            break
     if not program:
         return set()
     # cmd searches PATHEXT, so the suffix is optional: `...\PowerShell\7\pwsh`
@@ -2161,9 +2196,16 @@ def _find_blocked_commands(command: str) -> set[str]:
         gate already reads it off the previous token; the shell lookbacks did
         not, so `cmd /c echo hi& cmd /c powershell` left the second shell unread.
         """
+        previous = tokens[index - 1] if index else ""
+        if not lexed_posix and previous.endswith(";"):
+            # cmd has no `;` separator, so the scan above opened a command
+            # position that shell never opens. The START gate already refuses it
+            # and this one trusted the index, which read `echo ; cmd /c
+            # powershell` as a launch when cmd prints the whole line.
+            return False
         if index in command_indexes:
             return True
-        return bool(index) and not lexed_posix and _ends_with_cmd_operator(tokens[index - 1])
+        return bool(index) and not lexed_posix and _ends_with_cmd_operator(previous)
 
     def _is_start_word(token: str) -> bool:
         """Whether ``token`` is a START the shell will run.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1339,17 +1339,13 @@ def _win_switch(token: str) -> str:
 
 
 def _unwrap_quotes(token: str) -> str:
-    """Drop one surrounding quote pair, which the cmd lexer keeps.
+    """Drop one surrounding quote pair, which shlex(posix = False) keeps.
 
-    shlex(posix = False) hands back `"prog args"` with its quote marks attached
-    where the posix lexer strips them, and that is the lexer a Windows host with
-    no trusted bash uses. So `cmd /c "powershell -Command ls"` -- the ordinary
-    Windows spelling -- recursed into a payload whose first word was
-    `"powershell`, and `start ""` never matched the empty-title idiom, leaving
-    the program behind the title unscreened. Both are command positions.
-
-    Unquoting only ever widens what is screened, so the posix path, where there
-    is nothing left to unwrap, reaches the same verdict.
+    That non-posix lexer is the one a Windows host with no trusted bash uses, so
+    `cmd /c "powershell -Command ls"` recursed into `"powershell` and `start ""`
+    never matched the empty-title idiom, leaving both command positions
+    unscreened. Unwrapping only widens what is screened, so the posix path, with
+    no quotes left to drop, reaches the same verdict.
     """
     if len(token) >= 2 and token[0] == token[-1] and token[0] in "\"'":
         return token[1:-1]

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1053,6 +1053,23 @@ def _quoted_separator_indexes(text: str, tokens: "list[str]", punctuation: str) 
     )
 
 
+def _ends_with_cmd_operator(token: str) -> bool:
+    """Whether ``token`` ends in an operator that starts a new command IN CMD.
+
+    cmd's control operators are `&`, `&&`, `||`, `|` and parentheses; `;` is a
+    plain argument separator there, not a `;` as bash means it, so
+    `cmd /c echo hi; start "" prog` prints the lot. A caret escapes the operator
+    that follows it and hands it over as text, so `echo hi ^& start "" prog`
+    prints too, and neither may be read as a launch.
+    """
+    if not token or token[-1] not in "&|()":
+        return False
+    # Count the carets IMMEDIATELY before the operator: an odd run escapes it,
+    # an even one is escaped carets followed by a live operator.
+    carets = len(token[:-1]) - len(token[:-1].rstrip("^"))
+    return carets % 2 == 0
+
+
 def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "frozenset[int]":
     """Indexes of ``tokens`` that open a new physical line the shell will run.
 
@@ -1419,6 +1436,9 @@ _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 
 # What a word has to end in before a path is read as naming a program.
 _WINDOWS_EXE_SUFFIXES = frozenset({".exe", ".com", ".bat", ".cmd"})
+# `start "" https://example.com/powershell` hands the URL to the default browser.
+# Its last path segment is not a program, and reading it as one refused the link.
+_URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
 # A drive letter, a separator, or a %VAR% cmd expands before reading the path:
 # how a payload that OPENS with a program path is told from one whose command
 # word was lexed normally.
@@ -1870,21 +1890,15 @@ def _find_blocked_commands(command: str) -> set[str]:
         if (
             i
             and i not in command_indexes
-            # The cmd lexer never splits a separator off the word it is glued to,
-            # so `x;` keeps its `;` and the scan above stays in argument position
+            # The cmd lexer never splits an operator off the word it is glued to,
+            # so `hi&` keeps its `&` and the scan above stays in argument position
             # for the rest of the line. Read straight off the previous token
             # instead, which is what that lexer does leave to go on. Kept to that
-            # lexer: the posix one splits separators into tokens of their own and
-            # knows which were quoted, and second-guessing it there read a
-            # printed `';'` or `"then"` as though a command followed it.
-            and (
-                lexed_posix
-                or not (
-                    _looks_like_separator(previous)
-                    or previous.endswith((";", "&", "|", "(", "`"))
-                    or previous in _SHELL_KEYWORDS_AS_SEP
-                )
-            )
+            # lexer, and to the operators cmd actually has: the posix one splits
+            # separators into tokens of its own and knows which were quoted, and
+            # second-guessing it there read a printed `';'` or `"then"` as though
+            # a command followed it.
+            and (lexed_posix or not _ends_with_cmd_operator(previous))
         ):
             continue
         j = i + 1
@@ -1910,6 +1924,11 @@ def _find_blocked_commands(command: str) -> set[str]:
             # LINE looks the same: `start "ssh a@b"` has no program behind it
             # because that was the program. Screened as well as skipped.
             blocked |= _screen_cmd_payload(_unquote(tokens[title_at]))
+        if j < len(tokens) and _URL_SCHEME_RE.match(_unquote(tokens[j])):
+            # A URL is opened in the default browser, exactly like the document
+            # targets above: `start "" https://example.com/powershell` browses,
+            # it does not run the last path segment.
+            continue
         if j < len(tokens):
             program = _unquote(tokens[j])
             # What START launches is a command the shell runs, so it is published

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1679,10 +1679,19 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
     # %VAR% is expanded before the path is read, so the separator is normalised
     # rather than assumed.
     stem, ext = os.path.splitext(os.path.basename(program[-1].replace("\\", "/")))
-    if ext and ext.lower() not in _WINDOWS_EXE_SUFFIXES:
-        return set()
-    base = stem.lower()
-    return {base} if base in blocked_names else set()
+    candidates: "list[str]" = []
+    if not ext or ext.lower() in _WINDOWS_EXE_SUFFIXES:
+        candidates.append(stem.lower())
+    if not ext or ext.lower() not in _WINDOWS_EXE_SUFFIXES:
+        # Nothing along the path says where it ENDS, so the shortest prefix is a
+        # candidate too: CreateProcess tries those first, and `C:\tools\rm
+        # scripts\x` runs rm on a file rather than naming one long path. Only
+        # when the last component is suffixless, so a spaced directory ending in
+        # a real executable, `C:\powershell scripts\notepad.exe`, still reports
+        # the notepad it launches rather than the folder it sits in.
+        first = os.path.basename(program[0].replace("\\", "/"))
+        candidates.append(os.path.splitext(first)[0].lower())
+    return {base for base in candidates if base in blocked_names}
 
 
 def _is_start_title(token: str, lexed_posix: bool) -> bool:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1802,9 +1802,10 @@ def _quoted_program_word(payload: str) -> str:
         # a span whose opening mark sat on an earlier word survives it, and it
         # hid the suffix: `"C:\Program Files\cmd.exe"` walked past its own
         # `.exe` and reported the folder in front of it.
-        if os.path.splitext(os.path.basename(bare.replace("\\", "/").rstrip('"')))[
-            1
-        ].lower() in _WINDOWS_EXE_SUFFIXES:
+        if (
+            os.path.splitext(os.path.basename(bare.replace("\\", "/").rstrip('"')))[1].lower()
+            in _WINDOWS_EXE_SUFFIXES
+        ):
             return " ".join(program)
     # PATHEXT makes the suffix optional, so a path that never carries one is
     # still a program: `cmd /c "C:\\tools.v2\\notepad -x"` launches notepad.
@@ -2031,9 +2032,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 # The closing mark of the span belongs to the program, not to
                 # the arguments behind it.
                 consumed += 1
-            return found | _find_blocked_commands(
-                program_stem + text[consumed:], _cmd_payload = True
-            )
+            return found | _find_blocked_commands(program_stem + text[consumed:], _cmd_payload = True)
         if any(char.isspace() or char in "\"'" for char in text):
             return _find_blocked_commands(text, _cmd_payload = True)
         base = _token_basename(text)

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -180,12 +180,14 @@ _COMMAND_PREFIXES = frozenset(
         "doas",
         "su",
         "xargs",
-        # cmd's own prefix: CALL re-parses the rest of the line and runs it, so
-        # its target is a command position exactly as a wrapper's child is.
-        # https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/call
-        "call",
     }
 )
+# cmd's own prefix: CALL re-parses the rest of the line and runs it, so its
+# target is a command position exactly as a wrapper's child is. Kept apart from
+# the set above because bash has no such builtin, and applying it there blocked
+# the ARGUMENTS of a user program that happens to be named call.
+# https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/call
+_CMD_ONLY_PREFIXES = frozenset({"call"})
 # Wrapper options whose VALUE is a separate token (env -u NAME, nice -n 5).
 # Unconsumed, the value is mistaken for the wrapped command: `env -u FOO rm -rf x`
 # reads as command `FOO`. Shared by the auto gate and the blocklist walk.
@@ -1541,6 +1543,20 @@ def _is_start_switch(token: str) -> bool:
     return switch.startswith("/") and "/" not in switch[1:]
 
 
+def _continues_path(bare: str) -> bool:
+    """Whether ``bare`` is another chunk of the path in front of it.
+
+    What continues a path holding spaces is a RELATIVE fragment. A word that
+    opens a path of its own, names a URL, or is an option belongs to the
+    arguments however many separators it carries.
+    """
+    if not bare or bare.startswith("-"):
+        return False
+    if "\\" not in bare and "/" not in bare:
+        return False
+    return not _PATH_FRAGMENT_RE.match(bare) and not _URL_SCHEME_RE.match(bare)
+
+
 def _quoted_program_word(payload: str) -> str:
     """The executable ``_blocked_quoted_program`` would read out of ``payload``,
     or ``""`` when the payload is not that shape.
@@ -1595,26 +1611,25 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
     if not words or not _PATH_FRAGMENT_RE.match(words[0].strip('"')):
         return set()
     program: "list[str]" = []
-    for word in words:
+    for position, word in enumerate(words):
         bare = word.strip('"')
         if bare.startswith("-") or _is_start_switch(bare):
             break  # an option ends the path and starts the arguments
         # Joining words is how a path holding spaces is recovered, and what
         # continues one is a RELATIVE fragment: `C:\Program Files\PowerShell\7\
         # pwsh` runs pwsh, while the `rm` of `C:\tools\notepad rm` is a file
-        # notepad is being run on. A word that opens a path of its own, or names
-        # a URL, is an argument however many separators it carries, and reading
-        # those as continuations hid the program behind them: the basename of
-        # `cmd /c "C:\tmp\curl http://x"` came back as `x`.
-        if program and (
-            ("\\" not in bare and "/" not in bare)
-            or _PATH_FRAGMENT_RE.match(bare)
-            or _URL_SCHEME_RE.match(bare)
-        ):
+        # notepad is being run on.
+        if program and not _continues_path(bare):
             break
         program.append(bare)
         if os.path.splitext(bare)[1].lower() in _WINDOWS_EXE_SUFFIXES:
-            break  # the executable ends it too; the rest are arguments
+            # An executable suffix ends the path, unless the NEXT word carries
+            # it on: a directory may be named `rm.exe dir`, and stopping at the
+            # chunk rather than the basename reported the folder as the program
+            # for a line that runs `C:\rm.exe dir\notepad`.
+            following = words[position + 1].strip('"') if position + 1 < len(words) else ""
+            if not _continues_path(following):
+                break
     if not program:
         return set()
     # cmd searches PATHEXT, so the suffix is optional: `...\PowerShell\7\pwsh`
@@ -1677,6 +1692,10 @@ def _find_blocked_commands(command: str) -> set[str]:
     # `if true; then rm -rf x; fi` came back with nothing blocked.
     lexed_posix = _shell_is_posix()
     lex_mode = "posix" if lexed_posix else "cmd"
+    # cmd's CALL is a prefix only where cmd is doing the parsing. A payload
+    # behind a `/c` is cmd's even when the outer shell is bash, and that case is
+    # published by the fixpoint below rather than read from this set.
+    command_prefixes = _COMMAND_PREFIXES if lexed_posix else _COMMAND_PREFIXES | _CMD_ONLY_PREFIXES
     try:
         if not lexed_posix:
             tokens = shlex.split(command, posix = False)
@@ -1796,6 +1815,26 @@ def _find_blocked_commands(command: str) -> set[str]:
     # Built at most once, and only when a quote-only word actually asks: it costs
     # a second lex of every word, and almost no command holds one.
     chunk_cache: "list[list[int] | None]" = []
+    offsets_cache: "list[int] | None" = None
+
+    def _token_offsets() -> "list[int] | None":
+        """Where each token starts in the raw line, or ``None`` if it cannot be
+        told. Only meaningful under the cmd lexer, which preserves its tokens
+        verbatim; the posix one has already eaten delimiters by then.
+        """
+        nonlocal offsets_cache
+        if offsets_cache is None:
+            found: "list[int]" = []
+            position = 0
+            for token in tokens:
+                at = command.find(token, position)
+                if at < 0:
+                    offsets_cache = [-1]
+                    return None
+                found.append(at)
+                position = at + len(token)
+            offsets_cache = found
+        return None if offsets_cache == [-1] else offsets_cache
 
     def _glued_empty_quotes(index: int) -> bool:
         """Whether ``tokens[index]`` is an empty quoted pair the shell would have
@@ -1811,6 +1850,16 @@ def _find_blocked_commands(command: str) -> set[str]:
         token = tokens[index]
         if not token or token.strip('"') or index + 1 >= len(tokens):
             return False
+        if lex_mode == "cmd":
+            # That lexer hands back its tokens verbatim, quote marks and all, so
+            # where each one sits in the line can be read off directly. Splitting
+            # the line on whitespace instead gave up as soon as any EARLIER
+            # argument held quoted whitespace, and `echo "a b" && ""cmd /c
+            # powershell""` then lost the glue on a pair much further along.
+            offsets = _token_offsets()
+            if offsets is None:
+                return False
+            return offsets[index] + len(token) == offsets[index + 1]
         if not chunk_cache:
             chunk_cache.append(_whitespace_chunks())
         chunk_of = chunk_cache[0]
@@ -1864,7 +1913,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                 i += 1
                 continue
             base = _token_basename(token)
-            if base in _COMMAND_PREFIXES:
+            if base in command_prefixes:
                 wrapper = base
                 i += 1
                 continue
@@ -1996,7 +2045,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             blocked |= _blocked_matching_glob(base)
         # Wrappers (env/time/xargs/sudo) consume one command; the next non-flag,
         # non-numeric token is the real command. sudo is also in _BLOCKED_COMMANDS.
-        if base in _COMMAND_PREFIXES:
+        if base in command_prefixes:
             if base == "xargs" and xargs_index < 0:
                 xargs_index = token_index
             prefix_pending = True
@@ -2116,8 +2165,39 @@ def _find_blocked_commands(command: str) -> set[str]:
             return True
         return bool(index) and not lexed_posix and _ends_with_cmd_operator(tokens[index - 1])
 
+    def _is_start_word(token: str) -> bool:
+        """Whether ``token`` is a START the shell will run.
+
+        cmd needs no whitespace around its operators, so `echo ok&&start ""
+        powershell` really launches, and that lexer hands the whole thing back
+        as one token `ok&&start`. The operator is only live when it is neither
+        inside a quoted span nor escaped by an odd run of carets, which is what
+        keeps `echo "a&start b"` and `echo hi^&start ...` as text.
+        """
+        if _token_basename(token) == "start":
+            return True
+        if lexed_posix:
+            # The posix lexer splits its own separators into tokens, so a `&`
+            # still glued to a word was quoted and is not an operator at all.
+            return False
+        quotes = 0
+        last = -1
+        for position, char in enumerate(token):
+            if char == '"':
+                quotes += 1
+            elif char in "&|(" and quotes % 2 == 0:
+                before = token[:position]
+                carets = len(before) - len(before.rstrip("^"))
+                if carets % 2 == 0:
+                    last = position
+        return last >= 0 and _token_basename(token[last + 1 :]) == "start"
+
     def _start_is_run(i: int) -> bool:
         """Whether the START at ``tokens[i]`` is one the shell runs."""
+        if _token_basename(tokens[i]) != "start":
+            # Reached only through the glued-operator spelling, where the live
+            # operator in front of the word is itself the command boundary.
+            return True
         previous = tokens[i - 1] if i else ""
         if (
             i
@@ -2172,7 +2252,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     for _pass in range(len(tokens)):
         discovered = len(command_indexes)
         for i, token in enumerate(tokens):
-            if _token_basename(token) == "start" and _start_is_run(i):
+            if _is_start_word(token) and _start_is_run(i):
                 target, _title_at = _start_target(i)
                 if target < len(tokens):
                     command_indexes.add(target)
@@ -2216,6 +2296,18 @@ def _find_blocked_commands(command: str) -> set[str]:
                 prev_base = _token_basename(_unquote(prev).replace("\\", "/"))
                 if (is_unix_c and prev_base in _SHELLS) or (is_win_c and prev_base in _SHELLS_WIN):
                     command_indexes.add(i + 1)
+                    # What follows a `/c` is cmd's to parse even when the outer
+                    # shell is bash, so CALL forwards there too. Published here
+                    # rather than read from the prefix set, which is bash's on
+                    # that lexer: `cmd //c call start "" powershell` launches.
+                    payload = i + 1
+                    while (
+                        is_win_c
+                        and payload + 1 < len(tokens)
+                        and _token_basename(tokens[payload]) in _CMD_ONLY_PREFIXES
+                    ):
+                        payload += 1
+                        command_indexes.add(payload)
                 break
         if len(command_indexes) == discovered:
             break
@@ -2226,7 +2318,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         # _token_basename, not os.path.basename: the cmd lexer leaves an operator
         # glued to the word it opens, so `(start cmd /c powershell` arrived as one
         # token `(start`, matched nothing, and the group's launch went unread.
-        if _token_basename(token) != "start":
+        if not _is_start_word(token):
             continue
         # Only a START the shell RUNS. `echo start "job" powershell` prints
         # three words, and treating them as a launch hard-blocks text output.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1053,6 +1053,18 @@ def _quoted_separator_indexes(text: str, tokens: "list[str]", punctuation: str) 
     )
 
 
+def _path_suffix(path: str) -> str:
+    """The lowercased extension of ``path``, or ``""`` when it has none.
+
+    os.path.splitext splits at the last dot and keeps everything after it, so a
+    command line reads as one enormous suffix: `C:\\tools\\rm.exe -rf x` came
+    back as `.exe -rf x`. A real suffix carries no whitespace, and calling that
+    one a document meant START skipped the line rather than screening it.
+    """
+    suffix = os.path.splitext(path)[1].lower()
+    return "" if any(char.isspace() for char in suffix) else suffix
+
+
 def _is_program_path(target: str) -> bool:
     """Whether ``target`` is a path to an executable rather than a command line.
 
@@ -1063,7 +1075,7 @@ def _is_program_path(target: str) -> bool:
     stripped = target.strip('"')
     if not stripped or not _PATH_FRAGMENT_RE.match(stripped):
         return False
-    return os.path.splitext(stripped)[1].lower() in _WINDOWS_EXE_SUFFIXES
+    return _path_suffix(stripped) in _WINDOWS_EXE_SUFFIXES
 
 
 def _is_document_target(target: str) -> bool:
@@ -1077,7 +1089,7 @@ def _is_document_target(target: str) -> bool:
     stripped = target.strip('"')
     if not stripped or not _PATH_FRAGMENT_RE.match(stripped):
         return False
-    suffix = os.path.splitext(stripped)[1].lower()
+    suffix = _path_suffix(stripped)
     return bool(suffix) and suffix not in _WINDOWS_EXE_SUFFIXES
 
 
@@ -1630,13 +1642,23 @@ def _find_blocked_commands(command: str) -> set[str]:
         `cmd /c powershell&echo ok` runs powershell and read as one program named
         `powershell&echo`. That is a command line too, escaped carets aside.
         """
+        if _has_bare_cmd_operator(text):
+            # An operator means a second command follows, whatever the first one
+            # looks like, so the whole line is read.
+            return _find_blocked_commands(text)
         if _is_program_path(text):
             # A program path holds spaces like any other, and re-lexing one reads
             # its directory components as words: `C:\powershell scripts\
             # notepad.exe` runs notepad and reported the folder it sits in. The
             # recovery below reads the program off the path instead.
             return _blocked_quoted_program(text, _BLOCKED_COMMANDS)
-        if any(char.isspace() or char in "\"'" for char in text) or _has_bare_cmd_operator(text):
+        words = text.split()
+        if words and _is_program_path(words[0]):
+            # A path followed by its own arguments is still a program, not a
+            # command line: re-lexing `C:\tools\notepad.exe -x y` matched the
+            # POSIX source builtin on the extension dot and refused the launch.
+            return _blocked_quoted_program(words[0], _BLOCKED_COMMANDS)
+        if any(char.isspace() or char in "\"'" for char in text):
             return _find_blocked_commands(text)
         base = _token_basename(text)
         if base in _BLOCKED_COMMANDS:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1165,6 +1165,34 @@ def _is_win_comparison(tokens: "list[str]", index: int) -> bool:
     return index + 1 < len(tokens) and tokens[index + 1].lower() in _WIN_COMPARE_OPERATORS
 
 
+def _live_operator_segments(token: str, lexed_posix: bool) -> "list[str]":
+    """``token`` split at every live cmd operator inside it.
+
+    One token can carry a whole chain of commands, because cmd needs no
+    whitespace around its separators: `powershell&echo` is two. Reading only
+    what follows the LAST operator skipped every command before it.
+    """
+    if lexed_posix:
+        return [token]
+    segments: "list[str]" = []
+    quotes = 0
+    carets = 0
+    start = 0
+    for position, char in enumerate(token):
+        if char == "^":
+            carets += 1
+            continue
+        if char == '"':
+            quotes += 1
+        elif char in "&|(" and quotes % 2 == 0 and carets % 2 == 0:
+            if char != "(" or position == 0 or token[position - 1] in "&|()^":
+                segments.append(token[start:position])
+                start = position + 1
+        carets = 0
+    segments.append(token[start:])
+    return segments
+
+
 def _live_operator_tail(token: str, lexed_posix: bool) -> str:
     """What ``token`` starts a new command with, or ``""`` if it does not.
 
@@ -1907,14 +1935,31 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # notepad.exe` runs notepad and reported the folder it sits in. The
             # recovery below reads the program off the path instead.
             return _blocked_quoted_program(text, _BLOCKED_COMMANDS)
-        if _quoted_program_word(text):
+        program_word = _quoted_program_word(text)
+        if program_word:
             # A path followed by its own arguments is still a program, not a
             # command line: re-lexing `C:\tools\notepad.exe -x y` matched the
             # POSIX source builtin on the extension dot and refused the launch.
             # The recovery reads the whole payload rather than its first word,
             # because the path may hold spaces of its own and
             # `C:\powershell scripts\notepad.exe -x` runs notepad.
-            return _blocked_quoted_program(text, _BLOCKED_COMMANDS)
+            found = _blocked_quoted_program(text, _BLOCKED_COMMANDS)
+            program_base = _token_basename(program_word.replace("\\", "/"))
+            # PATHEXT makes the suffix optional, so the shell is named either
+            # way: `cmd.exe /c ...` and `cmd /c ...` open the same payload.
+            program_stem = os.path.splitext(program_base)[0]
+            if not {program_base, program_stem} & (_SHELLS | _SHELLS_WIN | _COMMAND_PREFIXES):
+                return found
+            # Unless the program is itself a shell or a wrapper, in which case
+            # its ARGUMENTS carry another command: `cmd //c "C:\Windows\
+            # System32\cmd.exe /c powershell"` reaches cmd as one string and
+            # runs PowerShell. Reporting only the path stopped at the wrapper.
+            # Spelled by its stem so the walk reads it as the shell it is: the
+            # path is what made it unrecognisable, and `cmd /c powershell` is
+            # what this line runs once the directory is off the front.
+            return found | _find_blocked_commands(
+                program_stem + text[len(program_word) :], _cmd_payload = True
+            )
         if any(char.isspace() or char in "\"'" for char in text):
             return _find_blocked_commands(text, _cmd_payload = True)
         base = _token_basename(text)
@@ -2213,8 +2258,22 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             if not prefix_pending:
                 expect_command = False
             continue
+        operator_segments = _live_operator_segments(token, lexed_posix)
         operator_tail = _live_operator_tail(token, lexed_posix)
         if operator_tail:
+            # Everything between the first operator and the last is a command of
+            # its own, and so is the leading segment when this token stood at a
+            # command position: `cmd /c echo&cmd /c powershell&echo` runs three.
+            for position, segment in enumerate(operator_segments[:-1]):
+                if position and not segment:
+                    continue
+                if position == 0 and not expect_command:
+                    continue
+                segment_base = _token_basename(_unquote(segment).replace("\\", "/"))
+                if segment_base in _BLOCKED_COMMANDS:
+                    blocked.add(segment_base)
+                else:
+                    blocked |= _blocked_matching_glob(segment_base)
             # A control operator INSIDE the token ends the command in front of
             # it and opens one behind it, so the word the operator hands over is
             # a command word: `cmd /c echo ok&cmd /c powershell` really nests,

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2099,6 +2099,19 @@ def _find_blocked_commands(command: str) -> set[str]:
     # `%COMSPEC% /c powershell` is a shell invocation spelled the long way.
     _SHELLS_WIN = {"cmd", "cmd.exe", "%comspec%"}
 
+    def _at_command(index: int) -> bool:
+        """Whether the shell runs ``tokens[index]``.
+
+        The main scan decides this, and the cmd lexer leaves one case it cannot:
+        an operator glued to the word in front, since `hi&` keeps its `&` and
+        that scan stays in argument position for the rest of the line. The START
+        gate already reads it off the previous token; the shell lookbacks did
+        not, so `cmd /c echo hi& cmd /c powershell` left the second shell unread.
+        """
+        if index in command_indexes:
+            return True
+        return bool(index) and not lexed_posix and _ends_with_cmd_operator(tokens[index - 1])
+
     def _start_is_run(i: int) -> bool:
         """Whether the START at ``tokens[i]`` is one the shell runs."""
         previous = tokens[i - 1] if i else ""
@@ -2194,7 +2207,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                     continue
                 if is_win_c and prev.startswith("/") and len(prev) <= 3:
                     continue
-                if j not in command_indexes:
+                if not _at_command(j):
                     break
                 prev_base = _token_basename(_unquote(prev).replace("\\", "/"))
                 if (is_unix_c and prev_base in _SHELLS) or (is_win_c and prev_base in _SHELLS_WIN):
@@ -2264,7 +2277,15 @@ def _find_blocked_commands(command: str) -> set[str]:
             # one, exactly as under `-exec`, so the program it forwards to is
             # published too. Without it `start "" env bash -c "rm -rf x"` named
             # only `env` and the nested-shell lookup declined to read the payload.
-            forwarded, _overflowed = _exec_child_index(j)
+            forwarded, prefix_overflowed = _exec_child_index(j)
+            if prefix_overflowed:
+                # The wrapper chain outran the hop budget, so the command START
+                # finally runs was never reached. Blocked by the chain's own
+                # first word rather than let `start "" env ...x40 rm -rf x` ride
+                # in behind the padding: the `-exec` path fails closed on the
+                # same overflow, and a launcher that fails open instead just
+                # tells an author how long to make the chain.
+                blocked.add(_token_basename(tokens[j]))
             if forwarded not in (-1, j):
                 command_indexes.add(forwarded)
                 # Screened the same way START's own target is, not merely looked
@@ -2314,7 +2335,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             # leaves whole off Windows. Either one hid the shell from this
             # lookup, so the payload behind its /c was never scanned.
             prev_base = _token_basename(_unquote(prev).replace("\\", "/"))
-            if j not in command_indexes:
+            if not _at_command(j):
                 # A shell NAMED in passing runs nothing. Unquoting and normalising
                 # the word made `echo "cmd" /c powershell` and a printed
                 # `C:\Windows\System32\cmd.exe /c powershell` resolve to a shell

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1691,6 +1691,14 @@ def _find_blocked_commands(command: str) -> set[str]:
                 blocked |= _find_blocked_commands(_unquote(tokens[i + 1]))
             elif is_win_c and prev_base in _SHELLS_WIN:
                 blocked |= _find_blocked_commands(_unquote(tokens[i + 1]))
+                if not _unquote(tokens[i + 1]) and i + 2 < len(tokens):
+                    # `cmd /s /c ""prog" args"`: /s strips the outer pair off the
+                    # WHOLE payload, so the lexer hands back that pair as an
+                    # empty first token and the program sits behind it, each
+                    # word still carrying a stray mark. Documented under cmd /s.
+                    blocked |= _find_blocked_commands(
+                        " ".join(word.strip('"') for word in tokens[i + 2 :])
+                    )
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1716,11 +1724,18 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
         if j < len(tokens):
             blocked |= _find_blocked_commands(_unquote(tokens[j]))
-            if lexed_posix and not titled and j + 1 < len(tokens):
-                # Posix only: shlex dropped the quote marks, so a title cannot be
-                # told from a program and the word behind it is screened too.
-                # Under cmd the marks survive, and a token without them IS the
-                # program, so guessing there would block an ordinary argument.
+            if (
+                lexed_posix
+                and not titled
+                and j + 1 < len(tokens)
+                and any(char.isspace() for char in tokens[j])
+            ):
+                # Posix dropped the quote marks, so a title is only still
+                # provable by the whitespace it holds: nothing else survives
+                # lexing as one token. A bare word is taken as the program,
+                # since `start notepad powershell.txt` is the ordinary shape and
+                # guessing there blocks the argument. Under cmd the marks
+                # survive and no guess is needed.
                 blocked |= _find_blocked_commands(tokens[j + 1])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2192,6 +2192,14 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         # the bound with words still ahead means the child is merely UNREAD.
         return -1, steps >= _MAX_EXEC_PREFIX_SCAN and i < len(tokens)
 
+    # Defined ahead of the walk below, which reaches _screen_cmd_payload and
+    # through it these sets. Left further down they were unassigned on the
+    # first pass and the screen raised NameError instead of answering.
+    _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
+    # cmd expands %COMSPEC% before it runs anything, and it names cmd.exe, so
+    # `%COMSPEC% /c powershell` is a shell invocation spelled the long way.
+    _SHELLS_WIN = {"cmd", "cmd.exe", "%comspec%"}
+
     expect_command = True  # start of string is a command position
     # What a `/c` hands over is cmd's command line whatever lexed the outer one,
     # so bash's own builtins stop being wrappers inside it.
@@ -2537,10 +2545,6 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         )
         blocked.update(re.findall(pattern, lowered))
 
-    _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
-    # cmd expands %COMSPEC% before it runs anything, and it names cmd.exe, so
-    # `%COMSPEC% /c powershell` is a shell invocation spelled the long way.
-    _SHELLS_WIN = {"cmd", "cmd.exe", "%comspec%"}
 
     def _at_command(index: int) -> bool:
         """Whether the shell runs ``tokens[index]``.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1123,6 +1123,14 @@ def _ends_with_cmd_operator(token: str) -> bool:
     """
     if not token or token[-1] not in "&|()":
         return False
+    if token[-1] == "(":
+        # cmd's `echo(` and `rem(` forms print what follows them, and no other
+        # word glued to a `(` opens a group either: real grouping is a `(` of its
+        # own, or one behind another operator. Reading `cmd /c echo( start ""
+        # powershell` as a launch refused a line that only prints it.
+        stem = token.rstrip("(")
+        if stem and stem[-1] not in "&|()^":
+            return False
     # Count the carets IMMEDIATELY before the operator: an odd run escapes it,
     # an even one is escaped carets followed by a live operator.
     carets = len(token[:-1]) - len(token[:-1].rstrip("^"))
@@ -1547,9 +1555,15 @@ def _quoted_program_word(payload: str) -> str:
         if bare.startswith("-") or _is_start_switch(bare):
             break
         program.append(bare)
-        if os.path.splitext(bare)[1].lower() in _WINDOWS_EXE_SUFFIXES:
+        if os.path.splitext(os.path.basename(bare.replace("\\", "/")))[1].lower() in (
+            _WINDOWS_EXE_SUFFIXES
+        ):
             return " ".join(program)
-    return ""
+    # PATHEXT makes the suffix optional, so a path that never carries one is
+    # still a program: `cmd /c "C:\\tools.v2\\notepad -x"` launches notepad.
+    # Without this the payload fell through to a full re-lex, which read the
+    # dotted directory as the POSIX source builtin and refused the launch.
+    return " ".join(program)
 
 
 def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "set[str]":

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1595,12 +1595,18 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
         bare = word.strip('"')
         if bare.startswith("-") or _is_start_switch(bare):
             break  # an option ends the path and starts the arguments
-        # Joining words is how a path holding spaces is recovered, and only a
-        # word carrying a SEPARATOR continues one: `C:\Program Files\PowerShell\
-        # 7\pwsh` runs pwsh, while the `rm` of `C:\tools\notepad rm` is a file
-        # notepad is being run on. The two are the same list of words otherwise,
-        # and joining both read the second as a program named rm.
-        if program and "\\" not in bare and "/" not in bare:
+        # Joining words is how a path holding spaces is recovered, and what
+        # continues one is a RELATIVE fragment: `C:\Program Files\PowerShell\7\
+        # pwsh` runs pwsh, while the `rm` of `C:\tools\notepad rm` is a file
+        # notepad is being run on. A word that opens a path of its own, or names
+        # a URL, is an argument however many separators it carries, and reading
+        # those as continuations hid the program behind them: the basename of
+        # `cmd /c "C:\tmp\curl http://x"` came back as `x`.
+        if program and (
+            ("\\" not in bare and "/" not in bare)
+            or _PATH_FRAGMENT_RE.match(bare)
+            or _URL_SCHEME_RE.match(bare)
+        ):
             break
         program.append(bare)
         if os.path.splitext(bare)[1].lower() in _WINDOWS_EXE_SUFFIXES:
@@ -2089,7 +2095,9 @@ def _find_blocked_commands(command: str) -> set[str]:
         blocked.update(re.findall(pattern, lowered))
 
     _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
-    _SHELLS_WIN = {"cmd", "cmd.exe"}
+    # cmd expands %COMSPEC% before it runs anything, and it names cmd.exe, so
+    # `%COMSPEC% /c powershell` is a shell invocation spelled the long way.
+    _SHELLS_WIN = {"cmd", "cmd.exe", "%comspec%"}
 
     def _start_is_run(i: int) -> bool:
         """Whether the START at ``tokens[i]`` is one the shell runs."""
@@ -2154,6 +2162,14 @@ def _find_blocked_commands(command: str) -> set[str]:
                     forwarded, _overflowed = _exec_child_index(target)
                     if forwarded not in (-1, target):
                         command_indexes.add(forwarded)
+                    for word in {target, forwarded} - {-1}:
+                        # The `e` scan reads its own list, built while the main
+                        # walk ran, so a sed START launches was never read as one:
+                        # `start "" sed '1e rm -f victim' input` runs that script
+                        # and shells out from it. Registered here for the same
+                        # reason `-exec` children are.
+                        if _is_sed_command(_token_basename(tokens[word])):
+                            sed_indexes.append(word)
                 continue
             # A shell runs the word behind its own -c or /c, which the outer
             # shell sees only as an argument. Gated on the shell itself being

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -206,6 +206,7 @@ def _selects_its_own_executable(token: str) -> bool:
     bare = token.strip("\"'")
     return "/" in bare or "\\" in bare
 
+
 # bash's source builtins. cmd has neither, so a PATH whose last segment happens
 # to spell one names a file rather than the builtin: `cd C:\dir\.` is an
 # ordinary directory walk and reading `.` out of it refused the line.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2135,7 +2135,9 @@ def _find_blocked_commands(command: str) -> set[str]:
             # passing still publishes nothing.
             tok_lower = token.lower()
             is_c = tok_lower == "-c" or (
-                tok_lower.startswith("-") and tok_lower.endswith("c") and not tok_lower.startswith("--")
+                tok_lower.startswith("-")
+                and tok_lower.endswith("c")
+                and not tok_lower.startswith("--")
             )
             is_c = is_c or _win_switch(tok_lower) in ("/c", "/k")
             if not is_c or i < 1 or i + 1 >= len(tokens):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1655,6 +1655,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             prefix_pending = False
             prefix_command = ""
             win_shell_pending = False
+            payload_pending = False
             xargs_index = -1
         if skip_operand:
             # `exec -a NAME cmd` and `if exist FILE cmd` both put an operand
@@ -1695,6 +1696,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             prefix_pending = False
             prefix_command = ""
             win_shell_pending = False
+            payload_pending = False
             xargs_index = -1
             continue
         if token.startswith("-"):
@@ -1762,7 +1764,11 @@ def _find_blocked_commands(command: str) -> set[str]:
         prefix_command = ""
         # Only a cmd the shell RUNS opens a payload behind /c, so this is set
         # here and nowhere else, and any separator or newline clears it again.
-        win_shell_pending = base in ("cmd", "cmd.exe")
+        # Normalised like the nested-shell lookup: a shell can be spelled as a
+        # full path, and os.path.basename leaves a backslash path whole off
+        # Windows, so `C:\Windows\System32\cmd.exe /c start "" powershell`
+        # matched no shell and its START was left in argument position.
+        win_shell_pending = _token_basename(_unquote(token).replace("\\", "/")) == "cmd"
         xargs_index = -1
 
     # `alias zap='rm -rf'` stores a command bash runs when the alias is invoked,

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1571,9 +1571,9 @@ def _find_blocked_commands(command: str) -> set[str]:
     )
     # Both lexers count a newline as plain whitespace, so neither leaves a token
     # behind to look back at; recovered with the lexer that produced `tokens`.
-    # Built only when a START is actually reached, since it costs a second lex
-    # and only that walk has to decide command position on its own.
-    newline_starts: "frozenset[int] | None" = None
+    # The helper returns at once unless the text really holds one, so the second
+    # lex is paid only by a multi-line command.
+    newline_starts = _newline_command_indexes(command, tokens, lex_mode)
     exec_flag_indexes, invocation_stops, redirect_indexes = _exec_scan_layout(
         tokens, quoted_separators, quoted_redirects
     )
@@ -1636,7 +1636,9 @@ def _find_blocked_commands(command: str) -> set[str]:
         return -1, steps >= _MAX_EXEC_PREFIX_SCAN and i < len(tokens)
 
     expect_command = True  # start of string is a command position
-    command_indexes: "set[int]" = set()  # words the shell runs, for the START walk
+    command_indexes: "set[int]" = set()  # words the shell runs, for the walks below
+    win_shell_pending = False  # a cmd at command position, awaiting its /c or /k
+    payload_pending = False  # the next word is what cmd's /c hands to a new shell
     prefix_pending = False  # last cmd-position token was a wrapper (env/time/xargs/...)
     prefix_command = ""  # which wrapper that was, for its own value-taking options
     skip_operand = False  # consume a wrapper/conditional operand, not the command
@@ -1644,10 +1646,30 @@ def _find_blocked_commands(command: str) -> set[str]:
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
     xargs_index = -1  # an xargs awaiting the command it wraps
     for token_index, token in enumerate(tokens):
+        if token_index in newline_starts:
+            # A newline ends the command as surely as `;` does, and it ends any
+            # operand or wrapper still waiting on one with it. Both lexers count
+            # it as whitespace, so it is recovered from the raw text instead.
+            expect_command = True
+            skip_operand = False
+            prefix_pending = False
+            prefix_command = ""
+            win_shell_pending = False
+            xargs_index = -1
         if skip_operand:
             # `exec -a NAME cmd` and `if exist FILE cmd` both put an operand
             # where the command word would otherwise be.
             skip_operand = False
+            continue
+        if not expect_command and win_shell_pending and _win_switch(token.lower()) in ("/c", "/k"):
+            # cmd runs the word after its own switch, a real command position the
+            # outer shell sees only as an argument. Tied to a cmd this loop
+            # actually reached at command position, so `echo /c start ""` stays
+            # the text it is; and left to the walk below rather than blessing one
+            # token, so `cmd //c env start ""` steps over its prefix as usual.
+            expect_command = True
+            win_shell_pending = False
+            payload_pending = True
             continue
         if expect_command and token.lower() in _WIN_CONDITIONAL_KEYWORDS:
             skip_operand = token.lower() != "not"
@@ -1672,6 +1694,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             expect_command = True
             prefix_pending = False
             prefix_command = ""
+            win_shell_pending = False
             xargs_index = -1
             continue
         if token.startswith("-"):
@@ -1702,10 +1725,21 @@ def _find_blocked_commands(command: str) -> set[str]:
         # Numeric wrapper arg: `timeout 1 cmd` / `nice -n 5 cmd`.
         if prefix_pending and token.lstrip("-").isdigit():
             continue
+        if payload_pending:
+            payload_pending = False
+            if any(char.isspace() for char in token):
+                # Quoting can hand cmd its whole command line as one word, and
+                # that word is not a program name: os.path.basename read the last
+                # segment of `cmd /c "ls /usr/bin/rm"` and refused the listing.
+                # The nested-shell lookup below re-lexes it properly. A quoted
+                # word with no space in it IS the program, so it is left alone:
+                # `cmd /c "C:\\...\\cmd.exe" /c powershell` really nests.
+                expect_command = False
+                continue
         base = _token_basename(token)
         # Every word this loop reaches is one the shell would RUN, wrappers and
-        # assignment prefixes already stepped over. The START walk below decides
-        # the same question and cannot redo it from the token list alone.
+        # assignment prefixes already stepped over. The walks below decide the
+        # same question and cannot redo it from the token list alone.
         command_indexes.add(token_index)
         if _is_sed_command(base):
             sed_indexes.append(token_index)
@@ -1726,6 +1760,9 @@ def _find_blocked_commands(command: str) -> set[str]:
         expect_command = False
         prefix_pending = False
         prefix_command = ""
+        # Only a cmd the shell RUNS opens a payload behind /c, so this is set
+        # here and nowhere else, and any separator or newline clears it again.
+        win_shell_pending = base in ("cmd", "cmd.exe")
         xargs_index = -1
 
     # `alias zap='rm -rf'` stores a command bash runs when the alias is invoked,
@@ -1807,6 +1844,79 @@ def _find_blocked_commands(command: str) -> set[str]:
         )
         blocked.update(re.findall(pattern, lowered))
 
+    # `cmd /c start "" prog` puts prog in a command position the scan above
+    # sees only as an argument, so screen what start actually launches.
+    for i, token in enumerate(tokens):
+        if os.path.basename(token).lower() not in ("start", "start.exe"):
+            continue
+        # Only a START the shell RUNS. `echo start "job" powershell` prints
+        # three words, and treating them as a launch hard-blocks text output.
+        # The main scan above already decided which words are run, wrappers and
+        # assignment prefixes and all, so that verdict is reused rather than
+        # re-derived: reading the previous token instead missed `time start ...`,
+        # `FOO=1 start ...` and `xargs start ...`, each of which really launches.
+        # It knows nothing of two cases, so both are added. A newline separates
+        # commands but lexes as whitespace, leaving no token to look back at; and
+        # cmd runs the word right after its own /c or /k, which the outer shell
+        # sees only as an argument -- `cmd //c start "" powershell` is the very
+        # command this walk exists for.
+        previous = tokens[i - 1] if i else ""
+        if (
+            i
+            and i not in command_indexes
+            # The cmd lexer never splits a separator off the word it is glued to,
+            # so `x;` keeps its `;` and the scan above stays in argument position
+            # for the rest of the line. Read straight off the previous token
+            # instead, which is what that lexer does leave to go on. Kept to that
+            # lexer: the posix one splits separators into tokens of their own and
+            # knows which were quoted, and second-guessing it there read a
+            # printed `';'` or `"then"` as though a command followed it.
+            and (
+                lexed_posix
+                or not (
+                    _looks_like_separator(previous)
+                    or previous.endswith((";", "&", "|", "(", "`"))
+                    or previous in _SHELL_KEYWORDS_AS_SEP
+                )
+            )
+        ):
+            continue
+        j = i + 1
+        titled = False
+        title_at = -1
+        while j < len(tokens):
+            switch = _win_switch(tokens[j].lower())
+            if _is_start_switch(tokens[j].lower()):
+                # /d C:\dir and friends carry their value in the next token.
+                j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+            elif not titled and _is_start_title(tokens[j], lexed_posix):
+                # START takes its window title as a QUOTED first argument, so
+                # the program is the token behind it. Only the `""` idiom was
+                # stepped over, which read `start "job" powershell` as a program
+                # named job and left powershell in argument position.
+                titled = True
+                title_at = j
+                j += 1
+            else:
+                break
+        if titled and lexed_posix:
+            # Posix proves a title only by its whitespace, and a quoted COMMAND
+            # LINE looks the same: `start "ssh a@b"` has no program behind it
+            # because that was the program. Screened as well as skipped.
+            blocked |= _screen_cmd_payload(_unquote(tokens[title_at]))
+        if j < len(tokens):
+            program = _unquote(tokens[j])
+            # What START launches is a command the shell runs, so it is published
+            # for the lookups below: `start "" "cmd" /c powershell` reaches a real
+            # cmd, and only the walk above can tell that from a quoted word an
+            # earlier command was merely handed.
+            command_indexes.add(j)
+            blocked |= _screen_cmd_payload(program)
+            # Same split-path shape as the /c payload: START documents a title
+            # followed by the program, and `start "" "C:\Program Files\...
+            # \pwsh.exe"` is one quoted word until it is re-lexed.
+            blocked |= _blocked_quoted_program(program, _BLOCKED_COMMANDS)
+
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):
     # on a -c/-/c flag, look back for a shell name (skipping flags) and
     # recursively scan the nested command string.
@@ -1836,6 +1946,12 @@ def _find_blocked_commands(command: str) -> set[str]:
             # leaves whole off Windows. Either one hid the shell from this
             # lookup, so the payload behind its /c was never scanned.
             prev_base = _token_basename(_unquote(prev).replace("\\", "/"))
+            if j not in command_indexes:
+                # A shell NAMED in passing runs nothing. Unquoting and normalising
+                # the word made `echo "cmd" /c powershell` and a printed
+                # `C:\Windows\System32\cmd.exe /c powershell` resolve to a shell
+                # and hard-block the text they only print.
+                break
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(_unquote(tokens[i + 1]))
             elif is_win_c and prev_base in _SHELLS_WIN:
@@ -1863,69 +1979,6 @@ def _find_blocked_commands(command: str) -> set[str]:
                     blocked |= _blocked_quoted_program(tail, _BLOCKED_COMMANDS)
             break  # stop at first non-flag token
 
-    # `cmd /c start "" prog` puts prog in a command position the scan above
-    # sees only as an argument, so screen what start actually launches.
-    for i, token in enumerate(tokens):
-        if os.path.basename(token).lower() not in ("start", "start.exe"):
-            continue
-        # Only a START the shell RUNS. `echo start "job" powershell` prints
-        # three words, and treating them as a launch hard-blocks text output.
-        # The main scan above already decided which words are run, wrappers and
-        # assignment prefixes and all, so that verdict is reused rather than
-        # re-derived: reading the previous token instead missed `time start ...`,
-        # `FOO=1 start ...` and `xargs start ...`, each of which really launches.
-        # It knows nothing of two cases, so both are added. A newline separates
-        # commands but lexes as whitespace, leaving no token to look back at; and
-        # cmd runs the word right after its own /c or /k, which the outer shell
-        # sees only as an argument -- `cmd //c start "" powershell` is the very
-        # command this walk exists for.
-        previous = tokens[i - 1] if i else ""
-        if newline_starts is None:
-            newline_starts = _newline_command_indexes(command, tokens, lex_mode)
-        if (
-            i
-            and i not in command_indexes
-            and i not in newline_starts
-            and _win_switch(previous.lower()) not in ("/c", "/k")
-            # The cmd lexer never splits a separator off the word it is glued to,
-            # so `x;` keeps its `;` and the scan above stays in argument position
-            # for the rest of the line. Read straight off the previous token
-            # instead, which is what that lexer does leave to go on.
-            and not _looks_like_separator(previous)
-            and not previous.endswith((";", "&", "|", "(", "`"))
-            and previous not in _SHELL_KEYWORDS_AS_SEP
-        ):
-            continue
-        j = i + 1
-        titled = False
-        title_at = -1
-        while j < len(tokens):
-            switch = _win_switch(tokens[j].lower())
-            if _is_start_switch(tokens[j].lower()):
-                # /d C:\dir and friends carry their value in the next token.
-                j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-            elif not titled and _is_start_title(tokens[j], lexed_posix):
-                # START takes its window title as a QUOTED first argument, so
-                # the program is the token behind it. Only the `""` idiom was
-                # stepped over, which read `start "job" powershell` as a program
-                # named job and left powershell in argument position.
-                titled = True
-                title_at = j
-                j += 1
-            else:
-                break
-        if titled and lexed_posix:
-            # Posix proves a title only by its whitespace, and a quoted COMMAND
-            # LINE looks the same: `start "ssh a@b"` has no program behind it
-            # because that was the program. Screened as well as skipped.
-            blocked |= _screen_cmd_payload(_unquote(tokens[title_at]))
-        if j < len(tokens):
-            program = _unquote(tokens[j])
-            blocked |= _screen_cmd_payload(program)
-            # Same split-path shape as the /c payload: START documents a title
-            # followed by the program, and `start "" "C:\Program Files\...
-            # \pwsh.exe"` is one quoted word until it is re-lexed.
-            blocked |= _blocked_quoted_program(program, _BLOCKED_COMMANDS)
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1159,9 +1159,7 @@ def _is_win_comparison(tokens: "list[str]", index: int) -> bool:
     token = tokens[index]
     if "==" in token and not token.startswith("=="):
         return True
-    return (
-        index + 1 < len(tokens) and tokens[index + 1].lower() in _WIN_COMPARE_OPERATORS
-    )
+    return index + 1 < len(tokens) and tokens[index + 1].lower() in _WIN_COMPARE_OPERATORS
 
 
 def _live_operator_tail(token: str, lexed_posix: bool) -> str:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1148,12 +1148,15 @@ def _is_document_target(target: str) -> bool:
             break
         if _path_suffix(word) in _WINDOWS_EXE_SUFFIXES:
             return False
-    if stopped < len(words) - 1:
-        # The path ended with more than one word behind it, so those words are
-        # ARGUMENTS and the whole string is a command line. Judging it by the
-        # last one read `C:\tools\powershell -Command script.ps1` as a `.ps1`
-        # document and skipped the shell in front of it. A single trailing word
-        # is still the document's own name, which may hold spaces.
+    if stopped < len(words) and any(
+        word.strip('"').startswith("-") or _is_start_switch(word.strip('"'))
+        for word in words[stopped:]
+    ):
+        # An OPTION behind the path is what makes the string a command line:
+        # `C:\tools\powershell -Command script.ps1` runs a shell and hands it a
+        # script. Without one the extra words belong to the file's own name,
+        # which may hold as many spaces as it likes, so
+        # `C:\tmp\curl notes report.pdf` is one document START opens.
         return False
     # Nothing along the path is executable, so the whole target is a candidate
     # FILE and its own suffix decides. A document's name may hold spaces, which
@@ -1795,9 +1798,13 @@ def _quoted_program_word(payload: str) -> str:
             # below already stops where the path really ends.
             break
         program.append(bare)
-        if os.path.splitext(os.path.basename(bare.replace("\\", "/")))[1].lower() in (
-            _WINDOWS_EXE_SUFFIXES
-        ):
+        # `strip` above drops a PAIR of marks; a closing one glued to the end of
+        # a span whose opening mark sat on an earlier word survives it, and it
+        # hid the suffix: `"C:\Program Files\cmd.exe"` walked past its own
+        # `.exe` and reported the folder in front of it.
+        if os.path.splitext(os.path.basename(bare.replace("\\", "/").rstrip('"')))[
+            1
+        ].lower() in _WINDOWS_EXE_SUFFIXES:
             return " ".join(program)
     # PATHEXT makes the suffix optional, so a path that never carries one is
     # still a program: `cmd /c "C:\\tools.v2\\notepad -x"` launches notepad.
@@ -1969,7 +1976,18 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         `cmd /c powershell&echo ok` runs powershell and read as one program named
         `powershell&echo`. That is a command line too, escaped carets aside.
         """
-        if _has_bare_cmd_operator(text):
+        if (
+            _has_bare_cmd_operator(text)
+            # Unless the whole payload is ONE program path. cmd treats a special
+            # character inside a quoted path as text, so `C:\rm&x\notepad.exe`
+            # names a directory called `rm&x` rather than chaining a command.
+            # A payload holding whitespace is not that shape and still chains.
+            and not (
+                not any(char.isspace() for char in text)
+                and _opens_a_path(text)
+                and _path_suffix(text.strip('"')) in _WINDOWS_EXE_SUFFIXES
+            )
+        ):
             # An operator means a second command follows, whatever the first one
             # looks like, so the whole line is read.
             return _find_blocked_commands(text, _cmd_payload = True)
@@ -2001,8 +2019,20 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # Spelled by its stem so the walk reads it as the shell it is: the
             # path is what made it unrecognisable, and `cmd /c powershell` is
             # what this line runs once the directory is off the front.
+            # Measured on the raw text: `_quoted_program_word` hands back the
+            # name with its quote marks removed, so slicing by its length landed
+            # inside `"C:\Program Files\cmd.exe"` and rebuilt a broken word.
+            consumed = len(program_word)
+            for extra in range(len(text) - consumed + 1):
+                if text[: consumed + extra].replace('"', "") == program_word:
+                    consumed += extra
+                    break
+            if consumed < len(text) and text[consumed] == '"':
+                # The closing mark of the span belongs to the program, not to
+                # the arguments behind it.
+                consumed += 1
             return found | _find_blocked_commands(
-                program_stem + text[len(program_word) :], _cmd_payload = True
+                program_stem + text[consumed:], _cmd_payload = True
             )
         if any(char.isspace() or char in "\"'" for char in text):
             return _find_blocked_commands(text, _cmd_payload = True)
@@ -2394,6 +2424,14 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             expect_command = prefix_pending or tail_base in _SHELL_KEYWORDS_AS_SEP
             continue
         if not expect_command:
+            if not lexed_posix and _ends_with_cmd_operator(token):
+                # A group closing on the same token as its last word still ends
+                # the command: `if 1==0 (echo no) else powershell` runs the ELSE
+                # clause, and treating `no)` as an ordinary argument left it
+                # unread.
+                expect_command = True
+                prefix_pending = False
+                prefix_command = ""
             continue
         # A redirection may precede the command word (`</dev/null rm -rf x`).
         if _REDIR_PREFIX_RE.match(token):
@@ -2424,10 +2462,12 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         # them before resolving the program, so `call "powershell" -Command ls`
         # and `"rm" -rf x` run the same thing their bare spellings do.
         base = _token_basename(_unquote(token))
-        if not lexed_posix:
+        if not lexed_posix or in_cmd_payload or _cmd_payload:
             # A backslash is cmd's path separator, not an escape, and
-            # os.path.basename leaves such a path whole off Windows. Only on
-            # this lexer: under bash those backslashes really are escapes.
+            # os.path.basename leaves such a path whole off Windows. True of a
+            # `/c` payload too, whatever lexed the line it came from: bash's
+            # quoting carries the backslashes through, so
+            # `cmd //c call 'C:\tmp\rm.cmd'` reaches cmd with the path intact.
             base = _cmd_path_basename(_unquote(token), base)
         screened_indexes.add(token_index)
         # Every word this loop reaches is one the shell would RUN, wrappers and
@@ -2796,9 +2836,13 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         # Normalised like every other program lookup: os.path.basename leaves a
         # backslash path whole off Windows, so `call C:\tmp\rm.cmd` reported
         # nothing while the forward-slash spelling of the same path was caught.
-        published = _token_basename(_unquote(tokens[index]))
-        if not lexed_posix:
-            published = _cmd_path_basename(_unquote(tokens[index]), published)
+        # CALL is cmd's builtin, so anything this list holds is a word cmd
+        # resolves, whatever lexed the line it came from. bash's quoting carries
+        # the backslashes through: `cmd //c call 'C:\tmp\rm.cmd'` reaches cmd
+        # with the path intact, and reading it as one word missed the batch file.
+        published = _cmd_path_basename(
+            _unquote(tokens[index]), _token_basename(_unquote(tokens[index]))
+        )
         if published in _BLOCKED_COMMANDS:
             blocked.add(published)
         else:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2091,6 +2091,19 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             return plain
         return split
 
+    def _reported_basename(tok: str) -> str:
+        """The name to REPORT for ``tok``, cmd's path separator honoured.
+
+        The passes that fail closed name their token outright rather than look
+        it up, so nothing else normalises it for them, and os.path.basename
+        leaves a backslash path whole off Windows: `C:\\tools\\sed -rf` came
+        back refused under its whole path instead of under `sed`.
+        """
+        plain = _token_basename(tok)
+        if not lexed_posix or _cmd_payload:
+            return _cmd_path_basename(_unquote(tok), plain)
+        return plain
+
     def _whitespace_chunks() -> "list[int] | None":
         """For each token, the index of the whitespace-delimited word it came
         from, or ``None`` when the two passes do not line up.
@@ -2559,7 +2572,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 # The wrapper chain outran the hop budget, so the command that
                 # finally runs was never reached: block the chain itself rather
                 # than let `-exec env ...x33 rm -f victim ;` ride in behind it.
-                blocked.add(_token_basename(tokens[i + 1]))
+                blocked.add(_reported_basename(tokens[i + 1]))
                 continue
             exec_words = [i + 1] if child in (-1, i + 1) else [i + 1, child]
             for word in exec_words:
@@ -2737,6 +2750,28 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                     child += 1
             if _is_start_word(token) and _start_is_run(i):
                 target, _title_at = _start_target(i)
+                if (
+                    target < len(tokens)
+                    # cmd's IF, so only where cmd is the one parsing, exactly as
+                    # the main walk gates its own condition scan.
+                    and (not lexed_posix or _cmd_payload)
+                    and _unquote(tokens[target]).lower() == "if"
+                ):
+                    # START does not launch an INTERNAL command itself: it runs
+                    # the command processor over the whole tail (documented as
+                    # `cmd.exe /K`), so IF's body is a command position and
+                    # `start if 1==1 powershell` really does launch one. Read
+                    # from the raw line, since the condition parser wants the
+                    # text rather than the single word behind START. Only the
+                    # bare keyword: `if.exe` and `C:\bin\if` name a program, and
+                    # START launches those directly.
+                    offsets = _token_offsets()
+                    tail_text = (
+                        command[offsets[target] :]
+                        if offsets and target < len(offsets)
+                        else " ".join(tokens[target:])
+                    )
+                    blocked |= _screen_cmd_payload(_unwrap_quotes(tail_text.strip()))
                 if target < len(tokens) and not (
                     _URL_SCHEME_RE.match(_unquote(tokens[target]))
                     or _is_document_target(_unquote(tokens[target]))
@@ -2939,7 +2974,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 # in behind the padding: the `-exec` path fails closed on the
                 # same overflow, and a launcher that fails open instead just
                 # tells an author how long to make the chain.
-                blocked.add(_token_basename(tokens[j]))
+                blocked.add(_reported_basename(tokens[j]))
             if forwarded not in (-1, j):
                 command_indexes.add(forwarded)
                 # Screened the same way START's own target is, not merely looked
@@ -3047,17 +3082,17 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # The script sits past the scan window, so an empty program here is
             # only ignorance: block the sed itself rather than let an
             # `e rm -rf ~` ride in behind enough padding options.
-            blocked.add(_token_basename(tokens[i]))
+            blocked.add(_reported_basename(tokens[i]))
             continue
         if _sed_program_is_a_placeholder(program):
             # find rewrites `{}` before the child starts, so this is not a
             # program that was read (see _sed_program_is_a_placeholder).
-            blocked.add(_token_basename(tokens[i]))
+            blocked.add(_reported_basename(tokens[i]))
             continue
         if i in sed_xargs and _xargs_hides_sed_program(tokens, sed_xargs[i], i, program):
             # The program comes off stdin or out of an -I placeholder, so it is
             # not in the text to read at all (see _xargs_hides_sed_program).
-            blocked.add(_token_basename(tokens[i]))
+            blocked.add(_reported_basename(tokens[i]))
             continue
         if "$" in program:
             # A program held in a variable (p='...e rm -f victim'; sed "$p" f)

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -380,7 +380,7 @@ _SEPARATOR_CHARS = frozenset("".join(_SHELL_SEPARATORS))
 _QUOTED_SEPARATOR_MARK = "\x00"
 # Characters a newline stand-in may not use: the lexers give these a meaning, so
 # a mark spelled with one would not survive the second lex as a word of its own.
-_NEWLINE_MARK_UNUSABLE = frozenset(' \t\r\n\x0b\x0c"\'\\^;&|()`#')
+_NEWLINE_MARK_UNUSABLE = frozenset(" \t\r\n\x0b\x0c\"'\\^;&|()`#")
 
 
 def _newline_mark(text: str) -> str:
@@ -400,6 +400,8 @@ def _newline_mark(text: str) -> str:
             code += 1
         return chr(code)
     return ""
+
+
 # The characters bash expands a word against the filesystem for, and the
 # placeholder standing in for a QUOTED one during the same second lex.
 _GLOB_CHARS = frozenset("*?[")

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2206,44 +2206,13 @@ def _find_blocked_commands(command: str) -> set[str]:
         # cmd runs the word right after its own /c or /k, which the outer shell
         # sees only as an argument -- `cmd //c start "" powershell` is the very
         # command this walk exists for.
-        previous = tokens[i - 1] if i else ""
-        if (
-            i
-            and i not in command_indexes
-            # The cmd lexer never splits an operator off the word it is glued to,
-            # so `hi&` keeps its `&` and the scan above stays in argument position
-            # for the rest of the line. Read straight off the previous token
-            # instead, which is what that lexer does leave to go on. Kept to that
-            # lexer, and to the operators cmd actually has: the posix one splits
-            # separators into tokens of its own and knows which were quoted, and
-            # second-guessing it there read a printed `';'` or `"then"` as though
-            # a command followed it.
-            and (lexed_posix or not _ends_with_cmd_operator(previous))
-        ):
+        if not _start_is_run(i):
             continue
-        if not lexed_posix and previous.endswith(";"):
-            # cmd has no `;` separator, so the scan above opened a command
-            # position that shell never opens: `echo ; start "" powershell` and
-            # `echo hi; start ""...` both print their whole line there.
-            continue
-        j = i + 1
-        titled = False
-        title_at = -1
-        while j < len(tokens):
-            switch = _win_switch(tokens[j].lower())
-            if _is_start_switch(tokens[j].lower()):
-                # /d C:\dir and friends carry their value in the next token.
-                j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-            elif not titled and _is_start_title(tokens[j], lexed_posix):
-                # START takes its window title as a QUOTED first argument, so
-                # the program is the token behind it. Only the `""` idiom was
-                # stepped over, which read `start "job" powershell` as a program
-                # named job and left powershell in argument position.
-                titled = True
-                title_at = j
-                j += 1
-            else:
-                break
+        # The same walk the fixpoint above used to publish this launch. Kept in
+        # one place: a second copy is a second thing to keep in step, and the
+        # position it publishes has to be the position screened here.
+        j, title_at = _start_target(i)
+        titled = title_at != -1
         if titled and lexed_posix:
             # Posix proves a title only by its whitespace, and a quoted COMMAND
             # LINE looks the same: `start "ssh a@b"` has no program behind it

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -401,6 +401,8 @@ def _newline_mark(text: str) -> str:
         if code > len(present) + len(_NEWLINE_MARK_UNUSABLE) + 1:
             return ""
     return chr(code)
+
+
 # The characters bash expands a word against the filesystem for, and the
 # placeholder standing in for a QUOTED one during the same second lex.
 _GLOB_CHARS = frozenset("*?[")

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1158,7 +1158,10 @@ def _is_win_comparison(tokens: "list[str]", index: int) -> bool:
     """
     token = tokens[index]
     if "==" in token and not token.startswith("=="):
-        return True
+        # Unless the word is a PATH that happens to hold one. cmd compares two
+        # operands, and neither carries a separator, so `C:/a==b/powershell.exe`
+        # is the program it looks like rather than a condition.
+        return not ("/" in token or "\\" in token)
     return index + 1 < len(tokens) and tokens[index + 1].lower() in _WIN_COMPARE_OPERATORS
 
 
@@ -2178,8 +2181,12 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             token in _SHELL_KEYWORDS_AS_SEP and expect_command
         ):
             # cmd's IF opens a condition, and only there is a `==` a comparison
-            # rather than an ordinary character in a word.
-            if_pending = token.lower() == "if"
+            # rather than an ordinary character in a word. Only cmd has that
+            # form at all: under bash `if` is its own keyword and the word
+            # behind it is a command, so `if C:/a==b/powershell.exe` runs one.
+            if_pending = token.lower() == "if" and (
+                not lexed_posix or _cmd_payload or in_cmd_payload
+            )
             expect_command = True
             prefix_pending = False
             prefix_command = ""

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1616,7 +1616,11 @@ def _path_continuations(words: "list[str]") -> "list[bool]":
     return carries
 
 
-def _continues_path(words: "list[str]", position: int, carries: "list[bool] | None" = None) -> bool:
+def _continues_path(
+    words: "list[str]",
+    position: int,
+    carries: "list[bool] | None" = None,
+) -> bool:
     """Whether ``words[position]`` is another chunk of the path in front of it.
 
     What continues a path holding spaces is a RELATIVE fragment. A word that

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -394,14 +394,13 @@ def _newline_mark(text: str) -> str:
     """
     present = set(text)
     code = 1
-    limit = len(present) + len(_NEWLINE_MARK_UNUSABLE) + 2
-    for _ in range(limit):
-        while chr(code) in _NEWLINE_MARK_UNUSABLE or chr(code) in present:
-            code += 1
-        return chr(code)
-    return ""
-
-
+    # Bounded by the text's own distinct characters plus the unusable ones, so
+    # this cannot run away even on input built to be awkward.
+    while chr(code) in _NEWLINE_MARK_UNUSABLE or chr(code) in present:
+        code += 1
+        if code > len(present) + len(_NEWLINE_MARK_UNUSABLE) + 1:
+            return ""
+    return chr(code)
 # The characters bash expands a word against the filesystem for, and the
 # placeholder standing in for a QUOTED one during the same second lex.
 _GLOB_CHARS = frozenset("*?[")

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1061,7 +1061,10 @@ def _path_suffix(path: str) -> str:
     back as `.exe -rf x`. A real suffix carries no whitespace, and calling that
     one a document meant START skipped the line rather than screening it.
     """
-    suffix = os.path.splitext(path)[1].lower()
+    # The basename first, and the separator normalised: os.path.splitext does
+    # not split a backslash off Windows, so a dotted DIRECTORY supplied the
+    # extension and `C:\tools.v2\pwsh` came back with `.v2\pwsh`.
+    suffix = os.path.splitext(os.path.basename(path.replace("\\", "/")))[1].lower()
     return "" if any(char.isspace() for char in suffix) else suffix
 
 
@@ -1526,6 +1529,29 @@ def _is_start_switch(token: str) -> bool:
     return switch.startswith("/") and "/" not in switch[1:]
 
 
+def _quoted_program_word(payload: str) -> str:
+    """The executable ``_blocked_quoted_program`` would read out of ``payload``,
+    or ``""`` when the payload is not that shape.
+
+    Same walk, reported rather than looked up, so a caller can tell "this is a
+    program path with arguments behind it" from "this is a command line" without
+    guessing from the first whitespace-delimited word: a directory name may carry
+    spaces, and `C:\\powershell scripts\\notepad.exe -x` is one program.
+    """
+    words = payload.split()
+    if not words or not _PATH_FRAGMENT_RE.match(words[0].strip('"')):
+        return ""
+    program: "list[str]" = []
+    for word in words:
+        bare = word.strip('"')
+        if bare.startswith("-") or _is_start_switch(bare):
+            break
+        program.append(bare)
+        if os.path.splitext(bare)[1].lower() in _WINDOWS_EXE_SUFFIXES:
+            return " ".join(program)
+    return ""
+
+
 def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "set[str]":
     """Blocked names spelled as an executable PATH that lexing split apart.
 
@@ -1559,12 +1585,17 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
     # launches the same program. Any OTHER suffix names a document opened
     # through its file association, so `My Documents\powershell.docx` is a file
     # that happens to be called powershell, not a shell.
-    stem, ext = os.path.splitext(program[-1])
+    #
+    # The basename comes FIRST. os.path.basename does not split a backslash off
+    # Windows, so splitting the extension off the whole path let a dotted
+    # DIRECTORY supply it: `C:\tools.v2\pwsh` came back with an extension of
+    # `.v2\pwsh`, which is no executable suffix, and the shell went unreported.
+    # %VAR% is expanded before the path is read, so the separator is normalised
+    # rather than assumed.
+    stem, ext = os.path.splitext(os.path.basename(program[-1].replace("\\", "/")))
     if ext and ext.lower() not in _WINDOWS_EXE_SUFFIXES:
         return set()
-    # os.path.basename does not split a backslash off Windows, and %VAR% is
-    # expanded before the path is read.
-    base = os.path.basename(stem.replace("\\", "/")).lower()
+    base = stem.lower()
     return {base} if base in blocked_names else set()
 
 
@@ -1652,12 +1683,14 @@ def _find_blocked_commands(command: str) -> set[str]:
             # notepad.exe` runs notepad and reported the folder it sits in. The
             # recovery below reads the program off the path instead.
             return _blocked_quoted_program(text, _BLOCKED_COMMANDS)
-        words = text.split()
-        if words and _is_program_path(words[0]):
+        if _quoted_program_word(text):
             # A path followed by its own arguments is still a program, not a
             # command line: re-lexing `C:\tools\notepad.exe -x y` matched the
             # POSIX source builtin on the extension dot and refused the launch.
-            return _blocked_quoted_program(words[0], _BLOCKED_COMMANDS)
+            # The recovery reads the whole payload rather than its first word,
+            # because the path may hold spaces of its own and
+            # `C:\powershell scripts\notepad.exe -x` runs notepad.
+            return _blocked_quoted_program(text, _BLOCKED_COMMANDS)
         if any(char.isspace() or char in "\"'" for char in text):
             return _find_blocked_commands(text)
         base = _token_basename(text)
@@ -1727,6 +1760,34 @@ def _find_blocked_commands(command: str) -> set[str]:
     # Built at most once, and only when a quote-only word actually asks: it costs
     # a second lex of every word, and almost no command holds one.
     chunk_cache: "list[list[int] | None]" = []
+
+    def _raw_text_from(index: int) -> str:
+        """The command line from ``tokens[index]`` onward, as the caller wrote it.
+
+        Rejoining the tokens instead would drop the quoting the lexer consumed,
+        turning `sed '1e rm -f victim'` into four bare words, and the sed scan
+        reads that script for an `e`. So the text is sliced, not reconstructed:
+        the word boundary is the shortest prefix that lexes to exactly ``index``
+        tokens. Empty when no prefix does, rather than a wrong guess.
+        """
+        words = command.split()
+        for count in range(len(words) + 1):
+            try:
+                if lex_mode == "posix":
+                    lexer = shlex.shlex(
+                        " ".join(words[:count]), posix = True, punctuation_chars = ";&|()`"
+                    )
+                    lexer.whitespace_split = True
+                    produced = len(list(lexer))
+                elif lex_mode == "cmd":
+                    produced = len(shlex.split(" ".join(words[:count]), posix = False))
+                else:
+                    produced = count
+            except ValueError:
+                continue  # a prefix that cuts a quoted span in half proves nothing
+            if produced == index:
+                return " ".join(words[count:])
+        return ""
 
     def _glued_empty_quotes(index: int) -> bool:
         """Whether ``tokens[index]`` is an empty quoted pair the shell would have
@@ -2121,6 +2182,14 @@ def _find_blocked_commands(command: str) -> set[str]:
             # one, exactly as under `-exec`, so the program it forwards to is
             # published too. Without it `start "" env bash -c "rm -rf x"` named
             # only `env` and the nested-shell lookup declined to read the payload.
+            # What START launches is a command line in its own right, and the
+            # scans keyed to their own token lists -- sed's `e`, find and fd's
+            # -exec -- only ever saw `find` or `sed` in ARGUMENT position here.
+            # Sliced from the raw text through the whitespace map so the quoting
+            # survives: `start "" sed '1e rm -f victim' input` really runs it.
+            tail = _raw_text_from(j)
+            if tail:
+                blocked |= _find_blocked_commands(tail)
             forwarded, _overflowed = _exec_child_index(j)
             if forwarded not in (-1, j):
                 command_indexes.add(forwarded)

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1979,7 +1979,6 @@ def _find_blocked_commands(command: str) -> set[str]:
                     blocked |= _blocked_quoted_program(tail, _BLOCKED_COMMANDS)
             break  # stop at first non-flag token
 
-
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The
     # pattern-space forms yield an empty payload; the auto gate prompts on those.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -363,7 +363,9 @@ _SUBSTITUTION_SPAN_STEP = 64
 # Distinct from the surrounding quoting because bash expands neither: the `$(` in
 # `sed "s/\$(CC)/gcc/" Makefile` opens no command substitution.
 _ESCAPED_CHAR_STATE = "\\"
-_WIN_CONDITIONAL_KEYWORDS = frozenset({"exist", "defined", "errorlevel", "not"})
+_WIN_CONDITIONAL_KEYWORDS = frozenset(
+    {"exist", "defined", "errorlevel", "cmdextversion", "not"}
+)
 # cmd's IF also takes a comparison, either glued (`if 1==1 cmd`) or spelled with
 # one of these operators (`if %a% equ 1 cmd`). The body behind it is a command
 # cmd runs, so the operands have to be stepped over to reach it.
@@ -1141,11 +1143,20 @@ def _is_document_target(target: str) -> bool:
     # other check on it.
     words = stripped.split()
     carries = _path_continuations(words)
+    stopped = len(words)
     for position, word in enumerate(words):
         if position and not _continues_path(words, position, carries):
+            stopped = position
             break
         if _path_suffix(word) in _WINDOWS_EXE_SUFFIXES:
             return False
+    if stopped < len(words) - 1:
+        # The path ended with more than one word behind it, so those words are
+        # ARGUMENTS and the whole string is a command line. Judging it by the
+        # last one read `C:\tools\powershell -Command script.ps1` as a `.ps1`
+        # document and skipped the shell in front of it. A single trailing word
+        # is still the document's own name, which may hold spaces.
+        return False
     # Nothing along the path is executable, so the whole target is a candidate
     # FILE and its own suffix decides. A document's name may hold spaces, which
     # is why `C:\tmp\rm report.docx` is one file rather than rm with an operand.
@@ -2745,6 +2756,19 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 prev_base = _token_basename(_unquote(prev_tail or prev).replace("\\", "/"))
                 if (is_unix_c and prev_base in _SHELLS) or (is_win_c and prev_base in _SHELLS_WIN):
                     command_indexes.add(i + 1)
+                    if is_win_c and i + 1 not in screened_indexes:
+                        # A shell the main walk never reached, published here by
+                        # a launcher pass. cmd runs the WHOLE remainder as one
+                        # command string, so `start "" cmd /c if 1==1 powershell`
+                        # needs the condition parser over `if 1==1 powershell`
+                        # rather than the single word behind the switch.
+                        offsets = _token_offsets()
+                        remainder = (
+                            command[offsets[i + 1] :]
+                            if offsets and i + 1 < len(offsets)
+                            else " ".join(tokens[i + 1 :])
+                        )
+                        blocked |= _screen_cmd_payload(_unwrap_quotes(remainder.strip()))
                     # What follows a `/c` is cmd's to parse even when the outer
                     # shell is bash, so CALL forwards there too. Published here
                     # rather than read from the prefix set, which is bash's on

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1609,6 +1609,22 @@ def _find_blocked_commands(command: str) -> set[str]:
             base = stem
         return base
 
+    def _glued_empty_quotes(index: int) -> bool:
+        """Whether ``tokens[index]`` is an empty quoted pair the shell would have
+        collapsed INTO the word after it.
+
+        `""cmd /c prog` reaches the program as `cmd`, because the marks close a
+        zero-length span glued to it and the shell drops them before anything
+        sees argv; the cmd lexer keeps them and hands back a word of its own.
+        `"" rm` is a different line: a genuine empty argument, and the wrapper in
+        front of it really does try to run nothing. The two are told apart by the
+        whitespace between them, which only the raw text still has.
+        """
+        token = tokens[index]
+        if not token or token.strip('"'):
+            return False
+        return index + 1 < len(tokens) and token + tokens[index + 1] in command
+
     def _exec_child_index(start: int) -> "tuple[int, bool]":
         """The command a `find -exec` actually runs, as ``(index, overflowed)``;
         the index is -1 when the action holds no command word at all.
@@ -1645,12 +1661,9 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # `env -i`, `env A=b`, `timeout 5`: the wrapper's own argument.
                 i += 1
                 continue
-            if token and not token.strip('"'):
-                # A word of nothing but double quotes is not the child, for the
-                # reason the main walk gives: cmd collapses a doubled pair and
-                # runs what follows it. Only `"`, since cmd has no single-quote
-                # syntax and `start '' prog` really does look for a program
-                # literally named `''`.
+            if _glued_empty_quotes(i):
+                # Not the child: the shell collapsed this pair into the word
+                # behind it, for the reason _glued_empty_quotes gives.
                 i += 1
                 continue
             base = _token_basename(token)
@@ -1766,13 +1779,10 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # `cmd /c "C:\\...\\cmd.exe" /c powershell` really nests.
                 expect_command = False
                 continue
-        if token and not token.strip('"'):
-            # A word made only of double quotes is not a program. cmd collapses a
-            # doubled pair and runs what follows, so `""cmd /c powershell""`
-            # lexes to an empty word with the program behind it; spending command
-            # position on the empty word left that program in argument position.
-            # Only `"`: cmd has no single-quote syntax, so `''` really is a
-            # program name there and the word after it is its argument.
+        if _glued_empty_quotes(token_index):
+            # Not a program: the shell collapsed this pair into the word behind
+            # it, so `""cmd /c powershell""` runs cmd. Spending command position
+            # on the empty word left that program in argument position.
             continue
         base = _token_basename(token)
         # Every word this loop reaches is one the shell would RUN, wrappers and

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -191,7 +191,7 @@ _CMD_ONLY_PREFIXES = frozenset({"call"})
 # The other direction: shell builtins cmd either lacks or means differently.
 # Windows `time` is `time [/t]`, which sets the clock rather than running the
 # word behind it, and `command`, `builtin` and `exec` are bash's own.
-_POSIX_ONLY_PREFIXES = frozenset({"time", "command", "builtin", "exec"})
+_POSIX_ONLY_PREFIXES = frozenset({"time", "timeout", "command", "builtin", "exec"})
 # Wrapper options whose VALUE is a separate token (env -u NAME, nice -n 5).
 # Unconsumed, the value is mistaken for the wrapped command: `env -u FOO rm -rf x`
 # reads as command `FOO`. Shared by the auto gate and the blocklist walk.
@@ -1182,7 +1182,7 @@ def _live_operator_segments(token: str, lexed_posix: bool) -> "list[str]":
         if char == "^":
             carets += 1
             continue
-        if char == '"':
+        if char == '"' and carets % 2 == 0:
             quotes += 1
         elif char in "&|(" and quotes % 2 == 0 and carets % 2 == 0:
             if char != "(" or position == 0 or token[position - 1] in "&|()^":
@@ -1214,7 +1214,9 @@ def _live_operator_tail(token: str, lexed_posix: bool) -> str:
         if char == "^":
             carets += 1
             continue
-        if char == '"':
+        # A caret escapes the quote mark itself, so `^"` is text cmd prints and
+        # leaves no span open: `echo ^"&start "" powershell` really launches.
+        if char == '"' and carets % 2 == 0:
             quotes += 1
         elif char in "&|(" and quotes % 2 == 0 and carets % 2 == 0:
             # Same distinction `_ends_with_cmd_operator` draws: a `(` glued
@@ -1271,7 +1273,9 @@ def _ends_with_cmd_operator(token: str) -> bool:
     return carets % 2 == 0
 
 
-def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "frozenset[int]":
+def _newline_command_indexes(
+    text: str, tokens: "list[str]", mode: str, cmd_quoting: bool = False
+) -> "frozenset[int]":
     """Indexes of ``tokens`` that open a new physical line the shell will run.
 
     A newline ends a command as surely as `;` does, but shlex counts it as
@@ -1290,7 +1294,10 @@ def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "froz
     mark = _newline_mark(text)
     if not mark:
         return frozenset()
-    states = _shell_quote_states(text)
+    # cmd's quoting is its own: one delimiter and a caret escape.
+    # Reading a cmd line with bash's rules let a lone `'` hide every
+    # boundary behind it.
+    states = _cmd_quote_states(text) if cmd_quoting else _shell_quote_states(text)
 
     def _separates(index: int) -> bool:
         if states[index]:
@@ -1671,6 +1678,23 @@ _URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
 _PATH_FRAGMENT_RE = re.compile(r"^(?:[A-Za-z]:|\.{0,2}[/\\]|%[^%]+%[/\\])")
 
 
+def _opens_a_path(word: str) -> bool:
+    """Whether ``word`` begins a program path cmd would resolve.
+
+    The drive-rooted, `./` and `%VAR%\\` spellings, plus the plain relative one:
+    `tools\\pwsh.exe` names a program as surely as `.\\tools\\pwsh.exe` does, and
+    only the leading `.\\` told them apart. Kept to a word whose last segment
+    carries an executable suffix, so an ordinary argument holding a separator is
+    not mistaken for a program.
+    """
+    bare = word.strip('"')
+    if _PATH_FRAGMENT_RE.match(bare):
+        return True
+    if "\\" not in bare and "/" not in bare:
+        return False
+    return _path_suffix(bare) in _WINDOWS_EXE_SUFFIXES
+
+
 def _is_start_switch(token: str) -> bool:
     """Whether ``token`` is a START option rather than the program it launches.
 
@@ -1739,7 +1763,7 @@ def _quoted_program_word(payload: str) -> str:
     spaces, and `C:\\powershell scripts\\notepad.exe -x` is one program.
     """
     words = payload.split()
-    if not words or not _PATH_FRAGMENT_RE.match(words[0].strip('"')):
+    if not words or not _opens_a_path(words[0]):
         return ""
     program: "list[str]" = []
     for word in words:
@@ -1784,7 +1808,7 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
     # Only `"`, matching _unwrap_quotes: cmd has no single-quote syntax, so
     # `cmd /c 'C:\\...\\pwsh.exe'` looks for a literally single-quoted path and
     # recovering a program from it would block a line cmd cannot run.
-    if not words or not _PATH_FRAGMENT_RE.match(words[0].strip('"')):
+    if not words or not _opens_a_path(words[0]):
         return set()
     carries = _path_continuations(words)
     program: "list[str]" = []
@@ -1985,7 +2009,11 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
     # behind to look back at; recovered with the lexer that produced `tokens`.
     # The helper returns at once unless the text really holds one, so the second
     # lex is paid only by a multi-line command.
-    newline_starts = _newline_command_indexes(command, tokens, lex_mode)
+    # Which quoting reads the line is the SHELL's, not the lexer's: an
+    # unbalanced quote drops both lexers onto split() and the text is still cmd's.
+    newline_starts = _newline_command_indexes(
+        command, tokens, lex_mode, cmd_quoting = not lexed_posix
+    )
     exec_flag_indexes, invocation_stops, redirect_indexes = _exec_scan_layout(
         tokens, quoted_separators, quoted_redirects
     )
@@ -2195,6 +2223,10 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             skip_operand = token.lower() != "not"
             if_pending = token.lower() == "not" and if_pending
             continue
+        if expect_command and if_pending and _win_switch(token.lower()) == "/i":
+            # IF's documented case-insensitive switch stands between the keyword
+            # and the comparison, so the condition is still open behind it.
+            continue
         if expect_command and if_pending and _is_win_comparison(tokens, token_index):
             # `if 1==1 cmd /c powershell` runs that shell when the condition
             # holds. Reading the comparison as the command word left the body in
@@ -2326,6 +2358,11 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         # them before resolving the program, so `call "powershell" -Command ls`
         # and `"rm" -rf x` run the same thing their bare spellings do.
         base = _token_basename(_unquote(token))
+        if not lexed_posix:
+            # A backslash is cmd's path separator, not an escape, and
+            # os.path.basename leaves such a path whole off Windows. Only on
+            # this lexer: under bash those backslashes really are escapes.
+            base = _token_basename(_unquote(token).replace("\\", "/"))
         screened_indexes.add(token_index)
         # Every word this loop reaches is one the shell would RUN, wrappers and
         # assignment prefixes already stepped over. The walks below decide the
@@ -2561,7 +2598,9 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 while child < len(tokens):
                     command_indexes.add(child)
                     call_child_indexes.add(child)
-                    if _token_basename(_unwrap_quotes(tokens[child])) not in _CMD_ONLY_PREFIXES:
+                    if _token_basename(
+                        _unwrap_quotes(tokens[child]).replace("\\", "/")
+                    ) not in _CMD_ONLY_PREFIXES:
                         break
                     child += 1
             elif (
@@ -2583,7 +2622,9 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 while child < len(tokens):
                     command_indexes.add(child)
                     call_child_indexes.add(child)
-                    if _token_basename(_unwrap_quotes(tokens[child])) not in _CMD_ONLY_PREFIXES:
+                    if _token_basename(
+                        _unwrap_quotes(tokens[child]).replace("\\", "/")
+                    ) not in _CMD_ONLY_PREFIXES:
                         break
                     child += 1
             if _is_start_word(token) and _start_is_run(i):
@@ -2670,7 +2711,10 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
     for index in sorted(call_child_indexes):
         if index >= len(tokens) or index in screened_indexes:
             continue
-        published = _token_basename(_unquote(tokens[index]))
+        # Normalised like every other program lookup: os.path.basename leaves a
+        # backslash path whole off Windows, so `call C:\tmp\rm.cmd` reported
+        # nothing while the forward-slash spelling of the same path was caught.
+        published = _token_basename(_unquote(tokens[index]).replace("\\", "/"))
         if published in _BLOCKED_COMMANDS:
             blocked.add(published)
         else:
@@ -6039,6 +6083,29 @@ def _short_flag_arg(token: str, letters: str) -> "str | None":
         if ch in letters:
             return body[i + 1 :]
     return None
+
+
+def _cmd_quote_states(command: str) -> "list[str]":
+    """The quote context of every character AS CMD READS IT.
+
+    cmd has one string delimiter, the double quote, and one escape, the caret.
+    A single quote is an ordinary character there, so borrowing bash's states
+    let `echo 'hi` swallow the rest of the script and hide every command
+    boundary behind it. A caret-escaped quote opens no span either.
+    """
+    states: "list[str]" = []
+    quote = ""
+    carets = 0
+    for char in command:
+        if char == "^" and not quote:
+            states.append(quote)
+            carets += 1
+            continue
+        states.append(quote)
+        if char == '"' and carets % 2 == 0:
+            quote = "" if quote else '"'
+        carets = 0
+    return states
 
 
 def _shell_quote_states(command: str) -> "list[str]":

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1742,7 +1742,7 @@ def _is_start_title(token: str, lexed_posix: bool) -> bool:
     return len(token) >= 2 and token[0] == '"' == token[-1]
 
 
-def _find_blocked_commands(command: str) -> set[str]:
+def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]:
     """Detect blocked commands at shell command position only.
 
     A token is at command position if it is the first token, or follows a
@@ -1769,7 +1769,15 @@ def _find_blocked_commands(command: str) -> set[str]:
     # cmd's CALL is a prefix only where cmd is doing the parsing. A payload
     # behind a `/c` is cmd's even when the outer shell is bash, and that case is
     # published by the fixpoint below rather than read from this set.
-    command_prefixes = _COMMAND_PREFIXES if lexed_posix else _COMMAND_PREFIXES | _CMD_ONLY_PREFIXES
+    # ``_cmd_payload`` says this text is one cmd will parse, whatever lexed the
+    # line it came from: `cmd //c "call powershell"` reaches cmd as a command
+    # string even where bash is the outer shell, and re-lexing it with the outer
+    # lexer left CALL unread there while the unquoted spelling was caught.
+    command_prefixes = (
+        _COMMAND_PREFIXES
+        if lexed_posix and not _cmd_payload
+        else _COMMAND_PREFIXES | _CMD_ONLY_PREFIXES
+    )
     try:
         if not lexed_posix:
             tokens = shlex.split(command, posix = False)
@@ -1805,7 +1813,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         if _has_bare_cmd_operator(text):
             # An operator means a second command follows, whatever the first one
             # looks like, so the whole line is read.
-            return _find_blocked_commands(text)
+            return _find_blocked_commands(text, _cmd_payload = True)
         if _is_program_path(text):
             # A program path holds spaces like any other, and re-lexing one reads
             # its directory components as words: `C:\powershell scripts\
@@ -1821,7 +1829,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             # `C:\powershell scripts\notepad.exe -x` runs notepad.
             return _blocked_quoted_program(text, _BLOCKED_COMMANDS)
         if any(char.isspace() or char in "\"'" for char in text):
-            return _find_blocked_commands(text)
+            return _find_blocked_commands(text, _cmd_payload = True)
         base = _token_basename(text)
         if base in _BLOCKED_COMMANDS:
             return {base}
@@ -1947,7 +1955,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         # later `xargs "" rm`, which is a different command entirely.
         return chunk_of[index] == chunk_of[index + 1]
 
-    def _exec_child_index(start: int) -> "tuple[int, bool]":
+    def _exec_child_index(start: int, prefixes: "frozenset[str] | set[str]" = ()) -> "tuple[int, bool]":
         """The command a `find -exec` actually runs, as ``(index, overflowed)``;
         the index is -1 when the action holds no command word at all.
 
@@ -1989,7 +1997,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                 i += 1
                 continue
             base = _token_basename(token)
-            if base in command_prefixes:
+            if base in (prefixes or command_prefixes):
                 wrapper = base
                 i += 1
                 continue
@@ -2188,7 +2196,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             # wrapper is a command in its own right (`-exec sudo ls`) as well as
             # a step on the way to another one (`-exec env rm -rf x`), so
             # dropping either half loses a real detection.
-            child, prefix_overflowed = _exec_child_index(i + 1)
+            child, prefix_overflowed = _exec_child_index(i + 1, _COMMAND_PREFIXES)
             if prefix_overflowed:
                 # The wrapper chain outran the hop budget, so the command that
                 # finally runs was never reached: block the chain itself rather
@@ -2458,10 +2466,28 @@ def _find_blocked_commands(command: str) -> set[str]:
         # position it publishes has to be the position screened here.
         j, title_at = _start_target(i)
         titled = title_at != -1
-        if titled and lexed_posix:
+        # What follows the title decides whether it WAS one. A program word after
+        # it means START had a title and a command, so the quoted word is the
+        # window title. An option, a separator, or nothing at all means no
+        # command followed, and the quoted word was the command line itself.
+        following_word = tokens[j] if j < len(tokens) else ""
+        title_had_a_command = (
+            bool(following_word)
+            # A newline ends the command as surely as a separator does, and it
+            # lexes as whitespace, so the first word of the NEXT line would
+            # otherwise read as the program this title was given.
+            and j not in newline_starts
+            and not (
+                following_word.startswith("-") or following_word.strip('"') in _SHELL_SEPARATORS
+            )
+        )
+        if titled and lexed_posix and not title_had_a_command:
             # Posix proves a title only by its whitespace, and a quoted COMMAND
             # LINE looks the same: `start "ssh a@b"` has no program behind it
-            # because that was the program. Screened as well as skipped.
+            # because that was the program. Only then: START documents the first
+            # quoted argument as the WINDOW TITLE and the command after it, so
+            # `start "C:\Program Files\PowerShell\7\pwsh.exe" notepad` runs
+            # notepad and screening the title refused it for the title's sake.
             blocked |= _screen_cmd_payload(_unquote(tokens[title_at]))
         if j < len(tokens) and _URL_SCHEME_RE.match(_unquote(tokens[j])):
             # A URL is opened in the default browser, exactly like the document

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1414,9 +1414,14 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
     if not program:
         return set()
     # cmd searches PATHEXT, so the suffix is optional: `...\PowerShell\7\pwsh`
-    # launches the same program. os.path.basename does not split a backslash off
-    # Windows, and %VAR% is expanded before the path is read.
-    stem = os.path.splitext(program[-1])[0]
+    # launches the same program. Any OTHER suffix names a document opened
+    # through its file association, so `My Documents\powershell.docx` is a file
+    # that happens to be called powershell, not a shell.
+    stem, ext = os.path.splitext(program[-1])
+    if ext and ext.lower() not in _WINDOWS_EXE_SUFFIXES:
+        return set()
+    # os.path.basename does not split a backslash off Windows, and %VAR% is
+    # expanded before the path is read.
     base = os.path.basename(stem.replace("\\", "/")).lower()
     return {base} if base in blocked_names else set()
 
@@ -1431,7 +1436,11 @@ def _is_start_title(token: str, lexed_posix: bool) -> bool:
     one token further on instead.
     """
     if lexed_posix:
-        return token == ""
+        # The marks are gone, so a title is provable only by the whitespace it
+        # holds: nothing else survives lexing as one token. A bare word is taken
+        # as the program, since `start notepad readme.txt` is the ordinary shape
+        # and guessing the other way blocks the argument.
+        return token == "" or any(char.isspace() for char in token)
     return len(token) >= 2 and token[0] == '"' == token[-1]
 
 
@@ -1794,8 +1803,25 @@ def _find_blocked_commands(command: str) -> set[str]:
     for i, token in enumerate(tokens):
         if os.path.basename(token).lower() not in ("start", "start.exe"):
             continue
+        # Only a START the shell RUNS. `echo start "job" powershell` prints
+        # three words, and treating them as a launch hard-blocks text output.
+        # Command position cannot be taken from the main scan here: the outer
+        # shell runs only token 0 of `cmd //c start "" powershell`, which is the
+        # very command this exists for. So: first word, after a separator, or
+        # handed to cmd by its own /c or /k.
+        previous = tokens[i - 1] if i else ""
+        if i and not (
+            # `echo hi; start x` keeps the `;` glued on under the cmd lexer,
+            # which never splits it off, so test the tail as well as the token.
+            _looks_like_separator(previous)
+            or previous.endswith((";", "&", "|", "(", "`"))
+            or previous in _SHELL_KEYWORDS_AS_SEP
+            or _win_switch(previous.lower()) in ("/c", "/k")
+        ):
+            continue
         j = i + 1
         titled = False
+        title_at = -1
         while j < len(tokens):
             switch = _win_switch(tokens[j].lower())
             if _is_start_switch(tokens[j].lower()):
@@ -1807,9 +1833,15 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # stepped over, which read `start "job" powershell` as a program
                 # named job and left powershell in argument position.
                 titled = True
+                title_at = j
                 j += 1
             else:
                 break
+        if titled and lexed_posix:
+            # Posix proves a title only by its whitespace, and a quoted COMMAND
+            # LINE looks the same: `start "ssh a@b"` has no program behind it
+            # because that was the program. Screened as well as skipped.
+            blocked |= _screen_cmd_payload(_unquote(tokens[title_at]))
         if j < len(tokens):
             program = _unquote(tokens[j])
             blocked |= _screen_cmd_payload(program)
@@ -1817,19 +1849,6 @@ def _find_blocked_commands(command: str) -> set[str]:
             # followed by the program, and `start "" "C:\Program Files\...
             # \pwsh.exe"` is one quoted word until it is re-lexed.
             blocked |= _blocked_quoted_program(program, _BLOCKED_COMMANDS)
-            if (
-                lexed_posix
-                and not titled
-                and j + 1 < len(tokens)
-                and any(char.isspace() for char in tokens[j])
-            ):
-                # Posix dropped the quote marks, so a title is only still
-                # provable by the whitespace it holds: nothing else survives
-                # lexing as one token. A bare word is taken as the program,
-                # since `start notepad powershell.txt` is the ordinary shape and
-                # guessing there blocks the argument. Under cmd the marks
-                # survive and no guess is needed.
-                blocked |= _find_blocked_commands(tokens[j + 1])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1761,34 +1761,6 @@ def _find_blocked_commands(command: str) -> set[str]:
     # a second lex of every word, and almost no command holds one.
     chunk_cache: "list[list[int] | None]" = []
 
-    def _raw_text_from(index: int) -> str:
-        """The command line from ``tokens[index]`` onward, as the caller wrote it.
-
-        Rejoining the tokens instead would drop the quoting the lexer consumed,
-        turning `sed '1e rm -f victim'` into four bare words, and the sed scan
-        reads that script for an `e`. So the text is sliced, not reconstructed:
-        the word boundary is the shortest prefix that lexes to exactly ``index``
-        tokens. Empty when no prefix does, rather than a wrong guess.
-        """
-        words = command.split()
-        for count in range(len(words) + 1):
-            try:
-                if lex_mode == "posix":
-                    lexer = shlex.shlex(
-                        " ".join(words[:count]), posix = True, punctuation_chars = ";&|()`"
-                    )
-                    lexer.whitespace_split = True
-                    produced = len(list(lexer))
-                elif lex_mode == "cmd":
-                    produced = len(shlex.split(" ".join(words[:count]), posix = False))
-                else:
-                    produced = count
-            except ValueError:
-                continue  # a prefix that cuts a quoted span in half proves nothing
-            if produced == index:
-                return " ".join(words[count:])
-        return ""
-
     def _glued_empty_quotes(index: int) -> bool:
         """Whether ``tokens[index]`` is an empty quoted pair the shell would have
         collapsed INTO the word after it.
@@ -2090,6 +2062,98 @@ def _find_blocked_commands(command: str) -> set[str]:
         )
         blocked.update(re.findall(pattern, lowered))
 
+    _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
+    _SHELLS_WIN = {"cmd", "cmd.exe"}
+
+    def _start_is_run(i: int) -> bool:
+        """Whether the START at ``tokens[i]`` is one the shell runs."""
+        previous = tokens[i - 1] if i else ""
+        if (
+            i
+            and i not in command_indexes
+            # The cmd lexer never splits an operator off the word it is glued to,
+            # so `hi&` keeps its `&` and the scan above stays in argument position
+            # for the rest of the line. Read straight off the previous token
+            # instead, which is what that lexer does leave to go on. Kept to that
+            # lexer, and to the operators cmd actually has: the posix one splits
+            # separators into tokens of its own and knows which were quoted, and
+            # second-guessing it there read a printed `';'` or `"then"` as though
+            # a command followed it.
+            and (lexed_posix or not _ends_with_cmd_operator(previous))
+        ):
+            return False
+        if not lexed_posix and previous.endswith(";"):
+            # cmd has no `;` separator, so the scan above opened a command
+            # position that shell never opens: `echo ; start "" powershell` and
+            # `echo hi; start ""...` both print their whole line there.
+            return False
+        return True
+
+    def _start_target(i: int) -> "tuple[int, int]":
+        """The index START launches, and the index of its title, from ``i``."""
+        j = i + 1
+        title_at = -1
+        while j < len(tokens):
+            switch = _win_switch(tokens[j].lower())
+            if _is_start_switch(tokens[j].lower()):
+                # /d C:\dir and friends carry their value in the next token.
+                j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+            elif title_at == -1 and _is_start_title(tokens[j], lexed_posix):
+                # START takes its window title as a QUOTED first argument, so
+                # the program is the token behind it. Only the `""` idiom was
+                # stepped over, which read `start "job" powershell` as a program
+                # named job and left powershell in argument position.
+                title_at = j
+                j += 1
+            else:
+                break
+        return j, title_at
+
+    # Which command positions each scan opens for the other. A launcher hands a
+    # command to a shell and a shell hands one back to a launcher, so reading
+    # each list once, in a fixed order, stopped at the first handover: the second
+    # `start` of `start "" cmd /c start "" cmd /c rm -rf x` sat in a payload the
+    # shell scan had not published yet, its own target was never published in
+    # turn, and the `rm` behind it went unread. Grown to a fixpoint instead. It
+    # only ever grows, and each pass adds at least one index or is the last, so
+    # it settles in as many passes as there are tokens and, for a real command,
+    # in two.
+    for _pass in range(len(tokens)):
+        discovered = len(command_indexes)
+        for i, token in enumerate(tokens):
+            if _token_basename(token) == "start" and _start_is_run(i):
+                target, _title_at = _start_target(i)
+                if target < len(tokens):
+                    command_indexes.add(target)
+                    forwarded, _overflowed = _exec_child_index(target)
+                    if forwarded not in (-1, target):
+                        command_indexes.add(forwarded)
+                continue
+            # A shell runs the word behind its own -c or /c, which the outer
+            # shell sees only as an argument. Gated on the shell itself being
+            # run, exactly as the payload scan below is, so a shell NAMED in
+            # passing still publishes nothing.
+            tok_lower = token.lower()
+            is_c = tok_lower == "-c" or (
+                tok_lower.startswith("-") and tok_lower.endswith("c") and not tok_lower.startswith("--")
+            )
+            is_c = is_c or _win_switch(tok_lower) in ("/c", "/k")
+            if not is_c or i < 1 or i + 1 >= len(tokens):
+                continue
+            for j in range(i - 1, -1, -1):
+                prev = tokens[j]
+                if prev.startswith("-"):
+                    continue
+                if prev.startswith("/") and len(prev) <= 3:
+                    continue
+                if j not in command_indexes:
+                    break
+                if _token_basename(_unquote(prev).replace("\\", "/")) in _SHELLS | _SHELLS_WIN:
+                    command_indexes.add(i + 1)
+                break
+        if len(command_indexes) == discovered:
+            break
+
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
     for i, token in enumerate(tokens):
@@ -2182,14 +2246,6 @@ def _find_blocked_commands(command: str) -> set[str]:
             # one, exactly as under `-exec`, so the program it forwards to is
             # published too. Without it `start "" env bash -c "rm -rf x"` named
             # only `env` and the nested-shell lookup declined to read the payload.
-            # What START launches is a command line in its own right, and the
-            # scans keyed to their own token lists -- sed's `e`, find and fd's
-            # -exec -- only ever saw `find` or `sed` in ARGUMENT position here.
-            # Sliced from the raw text through the whitespace map so the quoting
-            # survives: `start "" sed '1e rm -f victim' input` really runs it.
-            tail = _raw_text_from(j)
-            if tail:
-                blocked |= _find_blocked_commands(tail)
             forwarded, _overflowed = _exec_child_index(j)
             if forwarded not in (-1, j):
                 command_indexes.add(forwarded)
@@ -2216,8 +2272,6 @@ def _find_blocked_commands(command: str) -> set[str]:
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):
     # on a -c/-/c flag, look back for a shell name (skipping flags) and
     # recursively scan the nested command string.
-    _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
-    _SHELLS_WIN = {"cmd", "cmd.exe"}
     for i, token in enumerate(tokens):
         tok_lower = token.lower()
         # Match -c exactly, or combined flags ending in c (e.g. -lc, -xc)

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1366,9 +1366,10 @@ _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 
 # What a word has to end in before a path is read as naming a program.
 _WINDOWS_EXE_SUFFIXES = frozenset({".exe", ".com", ".bat", ".cmd"})
-# A drive letter or a separator: how a payload that OPENS with a program path
-# is told from one whose command word was lexed normally.
-_PATH_FRAGMENT_RE = re.compile(r"^(?:[A-Za-z]:|\.{0,2}[/\\])")
+# A drive letter, a separator, or a %VAR% cmd expands before reading the path:
+# how a payload that OPENS with a program path is told from one whose command
+# word was lexed normally.
+_PATH_FRAGMENT_RE = re.compile(r"^(?:[A-Za-z]:|\.{0,2}[/\\]|%[^%]+%[/\\])")
 
 
 def _is_start_switch(token: str) -> bool:
@@ -1399,13 +1400,22 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
     words = payload.split()
     if not words or not _PATH_FRAGMENT_RE.match(words[0].strip("\"'")):
         return set()
+    program: "list[str]" = []
     for word in words:
-        stem, ext = os.path.splitext(word.strip("\"'"))
-        if ext.lower() not in _WINDOWS_EXE_SUFFIXES:
-            continue
-        base = os.path.basename(stem.replace("\\", "/")).lower()
-        return {base} if base in blocked_names else set()
-    return set()
+        bare = word.strip("\"'")
+        if bare.startswith("-") or _is_start_switch(bare):
+            break  # an option ends the path and starts the arguments
+        program.append(bare)
+        if os.path.splitext(bare)[1].lower() in _WINDOWS_EXE_SUFFIXES:
+            break  # the executable ends it too; the rest are arguments
+    if not program:
+        return set()
+    # cmd searches PATHEXT, so the suffix is optional: `...\PowerShell\7\pwsh`
+    # launches the same program. os.path.basename does not split a backslash off
+    # Windows, and %VAR% is expanded before the path is read.
+    stem = os.path.splitext(program[-1])[0]
+    base = os.path.basename(stem.replace("\\", "/")).lower()
+    return {base} if base in blocked_names else set()
 
 
 def _is_start_title(token: str, lexed_posix: bool) -> bool:
@@ -1780,7 +1790,22 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
         if j < len(tokens):
             program = _unquote(tokens[j])
-            blocked |= _find_blocked_commands(program)
+            if any(char.isspace() or char in "\"'" for char in program):
+                # Quoting can hand the whole command line over as one token,
+                # `start "" "powershell -Command ls"`, and an unbalanced quote
+                # drops the scan onto split(), whose tokens keep their marks.
+                # Both only read once lexed again.
+                blocked |= _find_blocked_commands(program)
+            else:
+                # A bare word is a program name, and re-scanning it as a command
+                # line reads `C:\tmp\image.png` as a path followed by the POSIX
+                # `.` builtin, hard-blocking a document launch the terminal note
+                # promises stays usable.
+                program_base = _token_basename(program)
+                if program_base in _BLOCKED_COMMANDS:
+                    blocked.add(program_base)
+                else:
+                    blocked |= _blocked_matching_glob(program_base)
             # Same split-path shape as the /c payload: START documents a title
             # followed by the program, and `start "" "C:\Program Files\...
             # \pwsh.exe"` is one quoted word until it is re-lexed.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -180,6 +180,10 @@ _COMMAND_PREFIXES = frozenset(
         "doas",
         "su",
         "xargs",
+        # cmd's own prefix: CALL re-parses the rest of the line and runs it, so
+        # its target is a command position exactly as a wrapper's child is.
+        # https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/call
+        "call",
     }
 )
 # Wrapper options whose VALUE is a separate token (env -u NAME, nice -n 5).

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -360,6 +360,10 @@ _SUBSTITUTION_SPAN_STEP = 64
 # `sed "s/\$(CC)/gcc/" Makefile` opens no command substitution.
 _ESCAPED_CHAR_STATE = "\\"
 _WIN_CONDITIONAL_KEYWORDS = frozenset({"exist", "defined", "errorlevel", "not"})
+# cmd's IF also takes a comparison, either glued (`if 1==1 cmd`) or spelled with
+# one of these operators (`if %a% equ 1 cmd`). The body behind it is a command
+# cmd runs, so the operands have to be stepped over to reach it.
+_WIN_COMPARE_OPERATORS = frozenset({"equ", "neq", "lss", "leq", "gtr", "geq"})
 _FIND_EXEC_FLAGS = frozenset({"-exec", "-execdir", "-ok", "-okdir"})
 # A find action is COMPLETE at its terminator: words after it are find's next
 # predicate, not CMD's. Reading past it took a following `-exec grep -e safe {} +`
@@ -1145,6 +1149,21 @@ def _is_document_target(target: str) -> bool:
     return bool(suffix) and suffix not in _WINDOWS_EXE_SUFFIXES
 
 
+def _is_win_comparison(tokens: "list[str]", index: int) -> bool:
+    """Whether ``tokens[index]`` opens a cmd IF comparison rather than a command.
+
+    Either spelling: the glued `1==1`, or an operand whose NEXT word is one of
+    cmd's comparison operators. A leading `==` is not one, so `==x` stays the
+    ordinary word it is.
+    """
+    token = tokens[index]
+    if "==" in token and not token.startswith("=="):
+        return True
+    return (
+        index + 1 < len(tokens) and tokens[index + 1].lower() in _WIN_COMPARE_OPERATORS
+    )
+
+
 def _live_operator_tail(token: str, lexed_posix: bool) -> str:
     """What ``token`` starts a new command with, or ``""`` if it does not.
 
@@ -1169,7 +1188,11 @@ def _live_operator_tail(token: str, lexed_posix: bool) -> str:
         if char == '"':
             quotes += 1
         elif char in "&|(" and quotes % 2 == 0 and carets % 2 == 0:
-            last = position
+            # Same distinction `_ends_with_cmd_operator` draws: a `(` glued
+            # behind a plain word opens no group. `echo(text` and `rem(text` are
+            # the no-space forms of those commands and only print.
+            if char != "(" or position == 0 or token[position - 1] in "&|()^":
+                last = position
         carets = 0
     return token[last + 1 :] if last >= 0 else ""
 
@@ -2083,6 +2106,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
     prefix_pending = False  # last cmd-position token was a wrapper (env/time/xargs/...)
     prefix_command = ""  # which wrapper that was, for its own value-taking options
     skip_operand = False  # consume a wrapper/conditional operand, not the command
+    skip_two = False  # a spelled cmd comparison consumes its operator and operand
     sed_indexes: "list[int]" = []  # command-position sed words, for the `e` scan below
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
     xargs_index = -1  # an xargs awaiting the command it wraps
@@ -2093,6 +2117,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # it as whitespace, so it is recovered from the raw text instead.
             expect_command = True
             skip_operand = False
+            skip_two = False
             prefix_pending = False
             prefix_command = ""
             win_shell_pending = False
@@ -2103,7 +2128,8 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         if skip_operand:
             # `exec -a NAME cmd` and `if exist FILE cmd` both put an operand
             # where the command word would otherwise be.
-            skip_operand = False
+            skip_operand = skip_two
+            skip_two = False
             continue
         if not expect_command and win_shell_pending and _win_switch(token.lower()) in ("/c", "/k"):
             # cmd runs the word after its own switch, a real command position the
@@ -2119,6 +2145,13 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             continue
         if expect_command and token.lower() in _WIN_CONDITIONAL_KEYWORDS:
             skip_operand = token.lower() != "not"
+            continue
+        if expect_command and _is_win_comparison(tokens, token_index):
+            # `if 1==1 cmd /c powershell` runs that shell when the condition
+            # holds. Reading the comparison as the command word left the body in
+            # argument position and its payload unscreened.
+            skip_operand = tokens[token_index + 1].lower() in _WIN_COMPARE_OPERATORS
+            skip_two = skip_operand
             continue
         if prefix_pending and token == "-a":
             skip_operand = True
@@ -2174,14 +2207,17 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 blocked.add(tail_base)
             else:
                 blocked |= _blocked_matching_glob(tail_base)
-            expect_command = False
-            prefix_pending = False
-            prefix_command = ""
             payload_pending = False
             in_cmd_payload = False
             active_prefixes = command_prefixes
             xargs_index = -1
             win_shell_pending = tail_base == "cmd"
+            # The tail is a command word like any other, so a wrapper spelled
+            # there still forwards to the word behind it: cmd reparses the
+            # `call call powershell` of `echo&call call powershell`.
+            prefix_pending = tail_base in (command_prefixes | _CMD_ONLY_PREFIXES)
+            prefix_command = tail_base if prefix_pending else ""
+            expect_command = prefix_pending
             continue
         if not expect_command:
             continue
@@ -2443,9 +2479,15 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             ):
                 # The operator in front of it is the command boundary, so what
                 # CALL forwards to is a command position: cmd runs
-                # `echo hi&call powershell`.
-                command_indexes.add(i + 1)
-                call_child_indexes.add(i + 1)
+                # `echo hi&call powershell`. CALL may forward to another CALL,
+                # so the chain is followed rather than one link of it.
+                child = i + 1
+                while child < len(tokens):
+                    command_indexes.add(child)
+                    call_child_indexes.add(child)
+                    if _token_basename(_unwrap_quotes(tokens[child])) not in _CMD_ONLY_PREFIXES:
+                        break
+                    child += 1
             elif (
                 not tail
                 # CALL is cmd's builtin, so this boundary only forwards where
@@ -2461,8 +2503,13 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 # sitting inside it: `cmd /c echo hi& call powershell` runs
                 # PowerShell exactly as the glued spelling does.
                 command_indexes.add(i + 1)
-                command_indexes.add(i + 2)
-                call_child_indexes.add(i + 2)
+                child = i + 2
+                while child < len(tokens):
+                    command_indexes.add(child)
+                    call_child_indexes.add(child)
+                    if _token_basename(_unwrap_quotes(tokens[child])) not in _CMD_ONLY_PREFIXES:
+                        break
+                    child += 1
             if _is_start_word(token) and _start_is_run(i):
                 target, _title_at = _start_target(i)
                 if target < len(tokens):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1563,7 +1563,12 @@ def _quoted_program_word(payload: str) -> str:
     # still a program: `cmd /c "C:\\tools.v2\\notepad -x"` launches notepad.
     # Without this the payload fell through to a full re-lex, which read the
     # dotted directory as the POSIX source builtin and refused the launch.
-    return " ".join(program)
+    #
+    # Only the FIRST word, unlike the suffixed walk above. A suffix is what says
+    # where a path holding spaces ends, and with none there is nothing to say it:
+    # joining anyway read `C:\\tools\\notepad rm` as one program named rm and
+    # refused a line that runs notepad on a file called rm.
+    return program[0] if program else ""
 
 
 def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "set[str]":
@@ -1590,6 +1595,13 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
         bare = word.strip('"')
         if bare.startswith("-") or _is_start_switch(bare):
             break  # an option ends the path and starts the arguments
+        # Joining words is how a path holding spaces is recovered, and only a
+        # word carrying a SEPARATOR continues one: `C:\Program Files\PowerShell\
+        # 7\pwsh` runs pwsh, while the `rm` of `C:\tools\notepad rm` is a file
+        # notepad is being run on. The two are the same list of words otherwise,
+        # and joining both read the second as a program named rm.
+        if program and "\\" not in bare and "/" not in bare:
+            break
         program.append(bare)
         if os.path.splitext(bare)[1].lower() in _WINDOWS_EXE_SUFFIXES:
             break  # the executable ends it too; the rest are arguments

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1980,9 +1980,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # and `start "" env "cmd /c powershell"` reduced to a basename of
                 # `c powershell` and matched nothing.
                 blocked |= _screen_cmd_payload(_unquote(tokens[forwarded]))
-                blocked |= _blocked_quoted_program(
-                    _unquote(tokens[forwarded]), _BLOCKED_COMMANDS
-                )
+                blocked |= _blocked_quoted_program(_unquote(tokens[forwarded]), _BLOCKED_COMMANDS)
             blocked |= _screen_cmd_payload(program)
             # Same split-path shape as the /c payload: START documents a title
             # followed by the program, and `start "" "C:\Program Files\...

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1339,15 +1339,23 @@ def _win_switch(token: str) -> str:
 
 
 def _unwrap_quotes(token: str) -> str:
-    """Drop one surrounding quote pair, which shlex(posix = False) keeps.
+    """Drop one surrounding double-quote pair, which shlex(posix = False) keeps.
 
     That non-posix lexer is the one a Windows host with no trusted bash uses, so
     `cmd /c "powershell -Command ls"` recursed into `"powershell` and `start ""`
     never matched the empty-title idiom, leaving both command positions
-    unscreened. Unwrapping only widens what is screened, so the posix path, with
-    no quotes left to drop, reaches the same verdict.
+    unscreened.
+
+    Only `"`, because cmd has no other quoting: it runs `'powershell ...'` as a
+    program literally named `'powershell`, so stripping `'` here would block a
+    line cmd could never execute.
+
+    Callers must apply this ONLY on the non-posix path (see _unquote). The posix
+    lexer has already removed the delimiters, so a pair still attached is the
+    nested command's own syntax, and re-parsing without it reads a quoted word
+    as a command line.
     """
-    if len(token) >= 2 and token[0] == token[-1] and token[0] in "\"'":
+    if len(token) >= 2 and token[0] == '"' == token[-1]:
         return token[1:-1]
     return token
 
@@ -1390,11 +1398,20 @@ def _find_blocked_commands(command: str) -> set[str]:
     except ValueError:
         tokens = command.split()
         lexed_posix = False
+
     # Which separator tokens the shell only produced because the quoting was
     # stripped. The non-posix (cmd) lexer KEEPS the quote marks, so a quoted
     # `';'` never looks like a separator there and nothing has to be recovered;
     # the split() fallback has no quoting model at all, so it reports nothing
     # either and both shells reach the same verdict.
+    def _unquote(tok: str) -> str:
+        # Quote marks survive lexing only under cmd. On the posix path shlex has
+        # already eaten the delimiters, so stripping another pair would turn a
+        # quoted word into a command line: `bash -c '""rm -rf x""'` lexes to
+        # `rm -rf x` and is blocked, but unwrapped it becomes the single word
+        # `rm -rf x` and sails through. bash really runs that.
+        return tok if lexed_posix else _unwrap_quotes(tok)
+
     quoted_separators = (
         _quoted_separator_indexes(command, tokens, ";&|()`") if lexed_posix else frozenset()
     )
@@ -1653,11 +1670,13 @@ def _find_blocked_commands(command: str) -> set[str]:
                 continue  # skip Unix flags like --login, -l
             if is_win_c and prev.startswith("/") and len(prev) <= 3:
                 continue  # skip Windows flags like /s, /q (not /bin/bash)
-            prev_base = os.path.basename(prev).lower()
+            # `start "" "cmd" /c prog` quotes the shell name too, and a leading
+            # quote hid it from this lookup, so nothing recursed into prog.
+            prev_base = os.path.basename(_unquote(prev)).lower()
             if is_unix_c and prev_base in _SHELLS:
-                blocked |= _find_blocked_commands(_unwrap_quotes(tokens[i + 1]))
+                blocked |= _find_blocked_commands(_unquote(tokens[i + 1]))
             elif is_win_c and prev_base in _SHELLS_WIN:
-                blocked |= _find_blocked_commands(_unwrap_quotes(tokens[i + 1]))
+                blocked |= _find_blocked_commands(_unquote(tokens[i + 1]))
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1673,10 +1692,10 @@ def _find_blocked_commands(command: str) -> set[str]:
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
         # `start ""` is the idiom for "no title"; anything else is the program.
-        if j < len(tokens) and _unwrap_quotes(tokens[j]) == "":
+        if j < len(tokens) and _unquote(tokens[j]) == "":
             j += 1
         if j < len(tokens):
-            blocked |= _find_blocked_commands(_unwrap_quotes(tokens[j]))
+            blocked |= _find_blocked_commands(_unquote(tokens[j]))
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1053,6 +1053,37 @@ def _quoted_separator_indexes(text: str, tokens: "list[str]", punctuation: str) 
     )
 
 
+def _is_document_target(target: str) -> bool:
+    """Whether START would OPEN ``target`` through its file association rather
+    than execute it.
+
+    A path whose suffix is not one cmd runs is a document, and START is how a
+    shell opens one. Only a path: a bare word carrying a dot is still a program
+    to look up, and `rm -rf x.txt` is a command line rather than a file.
+    """
+    stripped = target.strip('"')
+    if not stripped or not _PATH_FRAGMENT_RE.match(stripped):
+        return False
+    suffix = os.path.splitext(stripped)[1].lower()
+    return bool(suffix) and suffix not in _WINDOWS_EXE_SUFFIXES
+
+
+def _has_bare_cmd_operator(text: str) -> bool:
+    """Whether ``text`` holds a cmd control operator the caret has not escaped.
+
+    cmd needs no whitespace around `&`, `&&`, `||` or `|`, so a word can carry a
+    whole second command behind one. An odd run of carets in front of the
+    operator hands it over as literal text instead.
+    """
+    for index, char in enumerate(text):
+        if char not in "&|":
+            continue
+        carets = len(text[:index]) - len(text[:index].rstrip("^"))
+        if carets % 2 == 0:
+            return True
+    return False
+
+
 def _ends_with_cmd_operator(token: str) -> bool:
     """Whether ``token`` ends in an operator that starts a new command IN CMD.
 
@@ -1087,8 +1118,21 @@ def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "froz
     if "\n" not in text or _NEWLINE_COMMAND_MARK in text:
         return frozenset()
     states = _shell_quote_states(text)
+
+    def _separates(index: int) -> bool:
+        if states[index]:
+            return False  # quoted: data the command receives, not a boundary
+        if mode == "posix":
+            return True
+        # A caret at the end of a cmd line continues it onto the next, the way a
+        # backslash does under bash, so `echo hi ^<newline>start "" prog` is one
+        # command that prints. An even run is escaped carets, which do not.
+        before = text[:index].rstrip(" \t\r")
+        carets = len(before) - len(before.rstrip("^"))
+        return carets % 2 == 0
+
     marked = "".join(
-        f" {_NEWLINE_COMMAND_MARK} " if char == "\n" and not states[index] else char
+        f" {_NEWLINE_COMMAND_MARK} " if char == "\n" and _separates(index) else char
         for index, char in enumerate(text)
     )
     if _NEWLINE_COMMAND_MARK not in marked:
@@ -1567,8 +1611,13 @@ def _find_blocked_commands(command: str) -> set[str]:
         program name, and re-scanning it as a command line reads
         `C:\\tmp\\image.png` as a path followed by the POSIX source builtin,
         which hard-blocks a document launch.
+
+        A cmd operator needs no whitespace around it, so a payload can hold a
+        whole second command with nothing to separate the words:
+        `cmd /c powershell&echo ok` runs powershell and read as one program named
+        `powershell&echo`. That is a command line too, escaped carets aside.
         """
-        if any(char.isspace() or char in "\"'" for char in text):
+        if any(char.isspace() or char in "\"'" for char in text) or _has_bare_cmd_operator(text):
             return _find_blocked_commands(text)
         base = _token_basename(text)
         if base in _BLOCKED_COMMANDS:
@@ -2000,6 +2049,12 @@ def _find_blocked_commands(command: str) -> set[str]:
             # A URL is opened in the default browser, exactly like the document
             # targets above: `start "" https://example.com/powershell` browses,
             # it does not run the last path segment.
+            continue
+        if j < len(tokens) and _is_document_target(_unquote(tokens[j])):
+            # A quoted document path holds spaces like any other, and re-lexing
+            # it as a command line read `C:\tmp\rm report.docx` as the rm builtin
+            # and refused the launch. Its suffix is not one cmd executes, so
+            # START opens it through its association, as it does the URLs above.
             continue
         if j < len(tokens):
             program = _unquote(tokens[j])

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -372,6 +372,7 @@ _SEPARATOR_CHARS = frozenset("".join(_SHELL_SEPARATORS))
 # non-whitespace, non-quote, non-punctuation_chars character serves, so the
 # masked text splits into the same words and the token lists line up.
 _QUOTED_SEPARATOR_MARK = "\x00"
+_NEWLINE_COMMAND_MARK = "\x01"
 # The characters bash expands a word against the filesystem for, and the
 # placeholder standing in for a QUOTED one during the same second lex.
 _GLOB_CHARS = frozenset("*?[")
@@ -1052,6 +1053,58 @@ def _quoted_separator_indexes(text: str, tokens: "list[str]", punctuation: str) 
     )
 
 
+def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "frozenset[int]":
+    """Indexes of ``tokens`` that open a new physical line the shell will run.
+
+    A newline ends a command as surely as `;` does, but shlex counts it as
+    whitespace and hands back nothing to show for it, so the first word of the
+    next line reads as one more argument of the command before it. The main scan
+    does not need this -- its regex pass already anchors on a bare newline -- but
+    a walk that has to decide command position from the token list alone does.
+
+    Found by marking every newline the quoting did NOT make literal and lexing a
+    second time. Only whitespace becomes a token, so the two lexes differ by the
+    marks alone; the recovered count is checked against the original and anything
+    unexpected reports nothing.
+    """
+    if "\n" not in text or _NEWLINE_COMMAND_MARK in text:
+        return frozenset()
+    states = _shell_quote_states(text)
+    marked = "".join(
+        f" {_NEWLINE_COMMAND_MARK} " if char == "\n" and not states[index] else char
+        for index, char in enumerate(text)
+    )
+    if _NEWLINE_COMMAND_MARK not in marked:
+        return frozenset()  # every newline was quoted, so none of them separates
+    try:
+        if mode == "posix":
+            lexer = shlex.shlex(marked, posix = True, punctuation_chars = ";&|()`")
+            lexer.whitespace_split = True
+            relexed = list(lexer)
+        elif mode == "cmd":
+            relexed = shlex.split(marked, posix = False)
+        else:
+            # The caller's own unbalanced-quote fallback. Mirrored rather than
+            # re-derived: guessing the lexer here lined the marks up against a
+            # different token list and reported nothing for the whole line.
+            relexed = marked.split()
+    except ValueError:
+        return frozenset()
+    starts: "set[int]" = set()
+    index, opening = 0, False
+    for token in relexed:
+        if token == _NEWLINE_COMMAND_MARK:
+            opening = True
+            continue
+        if opening:
+            starts.add(index)
+            opening = False
+        index += 1
+    if index != len(tokens):
+        return frozenset()  # the two lexes disagree; report nothing rather than guess
+    return frozenset(starts)
+
+
 def _masked_tokens(
     text: str, tokens: "list[str]", punctuation: str, chars: "frozenset[str]", mark: str
 ) -> "list[str] | None":
@@ -1467,6 +1520,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     # command after a control-flow keyword stayed unread and
     # `if true; then rm -rf x; fi` came back with nothing blocked.
     lexed_posix = _shell_is_posix()
+    lex_mode = "posix" if lexed_posix else "cmd"
     try:
         if not lexed_posix:
             tokens = shlex.split(command, posix = False)
@@ -1477,6 +1531,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     except ValueError:
         tokens = command.split()
         lexed_posix = False
+        lex_mode = "split"
 
     # Which separator tokens the shell only produced because the quoting was
     # stripped. The non-posix (cmd) lexer KEEPS the quote marks, so a quoted
@@ -1514,6 +1569,9 @@ def _find_blocked_commands(command: str) -> set[str]:
     quoted_redirects = (
         _quoted_redirection_indexes(command, tokens, ";&|()`") if lexed_posix else frozenset()
     )
+    # Both lexers count a newline as plain whitespace, so neither leaves a token
+    # behind to look back at; recovered with the lexer that produced `tokens`.
+    newline_starts = _newline_command_indexes(command, tokens, lex_mode)
     exec_flag_indexes, invocation_stops, redirect_indexes = _exec_scan_layout(
         tokens, quoted_separators, quoted_redirects
     )
@@ -1576,6 +1634,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         return -1, steps >= _MAX_EXEC_PREFIX_SCAN and i < len(tokens)
 
     expect_command = True  # start of string is a command position
+    command_indexes: "set[int]" = set()  # words the shell runs, for the START walk
     prefix_pending = False  # last cmd-position token was a wrapper (env/time/xargs/...)
     prefix_command = ""  # which wrapper that was, for its own value-taking options
     skip_operand = False  # consume a wrapper/conditional operand, not the command
@@ -1642,6 +1701,10 @@ def _find_blocked_commands(command: str) -> set[str]:
         if prefix_pending and token.lstrip("-").isdigit():
             continue
         base = _token_basename(token)
+        # Every word this loop reaches is one the shell would RUN, wrappers and
+        # assignment prefixes already stepped over. The START walk below decides
+        # the same question and cannot redo it from the token list alone.
+        command_indexes.add(token_index)
         if _is_sed_command(base):
             sed_indexes.append(token_index)
             if xargs_index >= 0:
@@ -1805,18 +1868,28 @@ def _find_blocked_commands(command: str) -> set[str]:
             continue
         # Only a START the shell RUNS. `echo start "job" powershell` prints
         # three words, and treating them as a launch hard-blocks text output.
-        # Command position cannot be taken from the main scan here: the outer
-        # shell runs only token 0 of `cmd //c start "" powershell`, which is the
-        # very command this exists for. So: first word, after a separator, or
-        # handed to cmd by its own /c or /k.
+        # The main scan above already decided which words are run, wrappers and
+        # assignment prefixes and all, so that verdict is reused rather than
+        # re-derived: reading the previous token instead missed `time start ...`,
+        # `FOO=1 start ...` and `xargs start ...`, each of which really launches.
+        # It knows nothing of two cases, so both are added. A newline separates
+        # commands but lexes as whitespace, leaving no token to look back at; and
+        # cmd runs the word right after its own /c or /k, which the outer shell
+        # sees only as an argument -- `cmd //c start "" powershell` is the very
+        # command this walk exists for.
         previous = tokens[i - 1] if i else ""
-        if i and not (
-            # `echo hi; start x` keeps the `;` glued on under the cmd lexer,
-            # which never splits it off, so test the tail as well as the token.
-            _looks_like_separator(previous)
-            or previous.endswith((";", "&", "|", "(", "`"))
-            or previous in _SHELL_KEYWORDS_AS_SEP
-            or _win_switch(previous.lower()) in ("/c", "/k")
+        if (
+            i
+            and i not in command_indexes
+            and i not in newline_starts
+            and _win_switch(previous.lower()) not in ("/c", "/k")
+            # The cmd lexer never splits a separator off the word it is glued to,
+            # so `x;` keeps its `;` and the scan above stays in argument position
+            # for the rest of the line. Read straight off the previous token
+            # instead, which is what that lexer does leave to go on.
+            and not _looks_like_separator(previous)
+            and not previous.endswith((";", "&", "|", "(", "`"))
+            and previous not in _SHELL_KEYWORDS_AS_SEP
         ):
             continue
         j = i + 1

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2159,24 +2159,29 @@ def _find_blocked_commands(command: str) -> set[str]:
             # shell sees only as an argument. Gated on the shell itself being
             # run, exactly as the payload scan below is, so a shell NAMED in
             # passing still publishes nothing.
+            # Read exactly as the payload scan reads it: a unix -c belongs to a
+            # unix shell, a windows /c to cmd, and only /c steps over a short
+            # /x flag. Publishing a position that scan would not read is a
+            # command position nothing justifies.
             tok_lower = token.lower()
-            is_c = tok_lower == "-c" or (
+            is_unix_c = tok_lower == "-c" or (
                 tok_lower.startswith("-")
                 and tok_lower.endswith("c")
                 and not tok_lower.startswith("--")
             )
-            is_c = is_c or _win_switch(tok_lower) in ("/c", "/k")
-            if not is_c or i < 1 or i + 1 >= len(tokens):
+            is_win_c = _win_switch(tok_lower) in ("/c", "/k")
+            if not (is_unix_c or is_win_c) or i < 1 or i + 1 >= len(tokens):
                 continue
             for j in range(i - 1, -1, -1):
                 prev = tokens[j]
                 if prev.startswith("-"):
                     continue
-                if prev.startswith("/") and len(prev) <= 3:
+                if is_win_c and prev.startswith("/") and len(prev) <= 3:
                     continue
                 if j not in command_indexes:
                     break
-                if _token_basename(_unquote(prev).replace("\\", "/")) in _SHELLS | _SHELLS_WIN:
+                prev_base = _token_basename(_unquote(prev).replace("\\", "/"))
+                if (is_unix_c and prev_base in _SHELLS) or (is_win_c and prev_base in _SHELLS_WIN):
                     command_indexes.add(i + 1)
                 break
         if len(command_indexes) == discovered:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2549,8 +2549,13 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             attached = tok[2:].strip("\"'")
         elif "=" in tok and tok.split("=", 1)[0] in _ATTACHED_EXEC_FLAGS:
             attached = tok.split("=", 1)[1].strip("\"'")
-        if attached:
-            attached_base = _token_basename(attached.split()[0])
+        # Whitespace is not a program. bash's backslash escapes the space behind
+        # it and joins the words, so `fd . -x\ ;` reaches this as the token
+        # `-x `, whose attached value is one blank: reading a first word out of
+        # it raised IndexError, and a screen that raises decides nothing.
+        attached_words = attached.split()
+        if attached_words:
+            attached_base = _token_basename(attached_words[0])
             if _is_sed_command(attached_base):
                 # The words after the flag are that sed's arguments, so its
                 # program is screened from the FLAG. fd 9 actually takes them

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -363,9 +363,7 @@ _SUBSTITUTION_SPAN_STEP = 64
 # Distinct from the surrounding quoting because bash expands neither: the `$(` in
 # `sed "s/\$(CC)/gcc/" Makefile` opens no command substitution.
 _ESCAPED_CHAR_STATE = "\\"
-_WIN_CONDITIONAL_KEYWORDS = frozenset(
-    {"exist", "defined", "errorlevel", "cmdextversion", "not"}
-)
+_WIN_CONDITIONAL_KEYWORDS = frozenset({"exist", "defined", "errorlevel", "cmdextversion", "not"})
 # cmd's IF also takes a comparison, either glued (`if 1==1 cmd`) or spelled with
 # one of these operators (`if %a% equ 1 cmd`). The body behind it is a command
 # cmd runs, so the operands have to be stepped over to reach it.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -192,6 +192,20 @@ _CMD_ONLY_PREFIXES = frozenset({"call"})
 # Windows `time` is `time [/t]`, which sets the clock rather than running the
 # word behind it, and `command`, `builtin` and `exec` are bash's own.
 _POSIX_ONLY_PREFIXES = frozenset({"time", "timeout", "command", "builtin", "exec"})
+
+
+def _selects_its_own_executable(token: str) -> bool:
+    """Whether ``token`` names a program by PATH rather than by bare name.
+
+    A bare `timeout` is whatever the system resolves, and on Windows that is
+    the one taking a delay. A path picks a specific executable instead, so the
+    reasons for reading the bare Windows spelling as a non-wrapper do not carry
+    over to it. Quote marks are cmd's to strip, and either separator counts:
+    cmd accepts both.
+    """
+    bare = token.strip("\"'")
+    return "/" in bare or "\\" in bare
+
 # bash's source builtins. cmd has neither, so a PATH whose last segment happens
 # to spell one names a file rather than the builtin: `cd C:\dir\.` is an
 # ordinary directory walk and reading `.` out of it refused the line.
@@ -2032,7 +2046,15 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 # The closing mark of the span belongs to the program, not to
                 # the arguments behind it.
                 consumed += 1
-            return found | _find_blocked_commands(program_stem + text[consumed:], _cmd_payload = True)
+            respelled = program_stem
+            if program_stem in _POSIX_ONLY_PREFIXES and _selects_its_own_executable(program_word):
+                # ...except where the DIRECTORY is the thing that matters. cmd's
+                # own `timeout` takes a delay, so the cmd lane reads the bare
+                # name as no wrapper at all; dropping the path in front of it
+                # turned `C:/tools/timeout 5 powershell` into that bare name and
+                # lost the launch. Only the suffix comes off here.
+                respelled = os.path.splitext(program_word.strip('"'))[0]
+            return found | _find_blocked_commands(respelled + text[consumed:], _cmd_payload = True)
         if any(char.isspace() or char in "\"'" for char in text):
             return _find_blocked_commands(text, _cmd_payload = True)
         base = _token_basename(text)
@@ -2233,8 +2255,17 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 # behind it, for the reason _glued_empty_quotes gives.
                 i += 1
                 continue
-            base = _token_basename(token)
-            if base in (prefixes or command_prefixes):
+            # Read the way the main walk reads a program: wherever cmd is the
+            # one parsing, a backslash is its path separator, and leaving it
+            # whole meant `start "" C:\tools\timeout 5 powershell` named no
+            # wrapper at all while its forward-slash spelling did.
+            base = _reported_basename(token)
+            # A path picks a specific executable, so cmd's reasons for reading
+            # the bare `timeout` as no wrapper do not reach it. Same rule the
+            # main walk applies, and START's target comes through here.
+            if base in (prefixes or command_prefixes) or (
+                base in _POSIX_ONLY_PREFIXES and _selects_its_own_executable(token)
+            ):
                 wrapper = base
                 i += 1
                 continue
@@ -2496,7 +2527,14 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             blocked |= _blocked_matching_glob(base)
         # Wrappers (env/time/xargs/sudo) consume one command; the next non-flag,
         # non-numeric token is the real command. sudo is also in _BLOCKED_COMMANDS.
-        if base in active_prefixes:
+        # cmd's own `time` and `timeout` take a clock reading or a delay rather
+        # than a command, which is why the cmd lane subtracts them. A PATH picks
+        # a DIFFERENT executable: `C:/tools/timeout 5 powershell` selects the one
+        # documented as `timeout DURATION COMMAND [ARG]...`, which really does
+        # launch its child, so the wrapper reading has to survive for it.
+        if base in active_prefixes or (
+            base in _POSIX_ONLY_PREFIXES and _selects_its_own_executable(token)
+        ):
             if base == "xargs" and xargs_index < 0:
                 xargs_index = token_index
             prefix_pending = True

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1571,7 +1571,9 @@ def _find_blocked_commands(command: str) -> set[str]:
     )
     # Both lexers count a newline as plain whitespace, so neither leaves a token
     # behind to look back at; recovered with the lexer that produced `tokens`.
-    newline_starts = _newline_command_indexes(command, tokens, lex_mode)
+    # Built only when a START is actually reached, since it costs a second lex
+    # and only that walk has to decide command position on its own.
+    newline_starts: "frozenset[int] | None" = None
     exec_flag_indexes, invocation_stops, redirect_indexes = _exec_scan_layout(
         tokens, quoted_separators, quoted_redirects
     )
@@ -1878,6 +1880,8 @@ def _find_blocked_commands(command: str) -> set[str]:
         # sees only as an argument -- `cmd //c start "" powershell` is the very
         # command this walk exists for.
         previous = tokens[i - 1] if i else ""
+        if newline_starts is None:
+            newline_starts = _newline_command_indexes(command, tokens, lex_mode)
         if (
             i
             and i not in command_indexes

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -378,10 +378,28 @@ _SEPARATOR_CHARS = frozenset("".join(_SHELL_SEPARATORS))
 # non-whitespace, non-quote, non-punctuation_chars character serves, so the
 # masked text splits into the same words and the token lists line up.
 _QUOTED_SEPARATOR_MARK = "\x00"
-# Stand-ins for a newline during the second lex. Several, because the command is
-# the caller's text: a literal \x01 in it used to disable newline recovery for
-# the whole line, which is a boundary an author could delete by including one.
-_NEWLINE_COMMAND_MARKS = ("\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x0e", "\x0f")
+# Characters a newline stand-in may not use: the lexers give these a meaning, so
+# a mark spelled with one would not survive the second lex as a word of its own.
+_NEWLINE_MARK_UNUSABLE = frozenset(' \t\r\n\x0b\x0c"\'\\^;&|()`#')
+
+
+def _newline_mark(text: str) -> str:
+    """A character to stand in for a newline during the second lex.
+
+    Searched rather than chosen from a fixed set: the command is the caller's
+    text, so any finite list of marks is one an author can include in full, and
+    doing that used to disable newline recovery for the whole line. A text of
+    length n holds at most n distinct characters, so a search bounded by its own
+    length always finds one it does not contain.
+    """
+    present = set(text)
+    code = 1
+    limit = len(present) + len(_NEWLINE_MARK_UNUSABLE) + 2
+    for _ in range(limit):
+        while chr(code) in _NEWLINE_MARK_UNUSABLE or chr(code) in present:
+            code += 1
+        return chr(code)
+    return ""
 # The characters bash expands a word against the filesystem for, and the
 # placeholder standing in for a QUOTED one during the same second lex.
 _GLOB_CHARS = frozenset("*?[")
@@ -1176,7 +1194,7 @@ def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "froz
     """
     if "\n" not in text:
         return frozenset()
-    mark = next((candidate for candidate in _NEWLINE_COMMAND_MARKS if candidate not in text), "")
+    mark = _newline_mark(text)
     if not mark:
         return frozenset()
     states = _shell_quote_states(text)
@@ -1189,8 +1207,17 @@ def _newline_command_indexes(text: str, tokens: "list[str]", mode: str) -> "froz
         # A caret at the end of a cmd line continues it onto the next, the way a
         # backslash does under bash, so `echo hi ^<newline>start "" prog` is one
         # command that prints. An even run is escaped carets, which do not.
-        before = text[:index].rstrip(" \t\r")
-        carets = len(before) - len(before.rstrip("^"))
+        #
+        # Walked backwards from the newline rather than by copying the prefix and
+        # stripping it: doing that per newline re-read the whole line each time,
+        # which is quadratic in the command and cost a second on a 280 KB script.
+        position = index - 1
+        while position >= 0 and text[position] in " \t\r":
+            position -= 1
+        carets = 0
+        while position >= 0 and text[position] == "^":
+            carets += 1
+            position -= 1
         return carets % 2 == 0
 
     marked = "".join(
@@ -1858,6 +1885,8 @@ def _find_blocked_commands(command: str) -> set[str]:
 
     # Built at most once, and only when a quote-only word actually asks: it costs
     # a second lex of every word, and almost no command holds one.
+    screened_indexes: "set[int]" = set()
+    call_child_indexes: "set[int]" = set()
     chunk_cache: "list[list[int] | None]" = []
     offsets_cache: "list[int] | None" = None
 
@@ -2074,7 +2103,11 @@ def _find_blocked_commands(command: str) -> set[str]:
             # it, so `""cmd /c powershell""` runs cmd. Spending command position
             # on the empty word left that program in argument position.
             continue
-        base = _token_basename(token)
+        # Unquoted first under the cmd lexer, which keeps the marks: cmd strips
+        # them before resolving the program, so `call "powershell" -Command ls`
+        # and `"rm" -rf x` run the same thing their bare spellings do.
+        base = _token_basename(_unquote(token))
+        screened_indexes.add(token_index)
         # Every word this loop reaches is one the shell would RUN, wrappers and
         # assignment prefixes already stepped over. The walks below decide the
         # same question and cannot redo it from the token list alone.
@@ -2216,21 +2249,20 @@ def _find_blocked_commands(command: str) -> set[str]:
             return True
         return bool(index) and not lexed_posix and _ends_with_cmd_operator(previous)
 
-    def _is_start_word(token: str) -> bool:
-        """Whether ``token`` is a START the shell will run.
+    def _live_operator_tail(token: str) -> str:
+        """What ``token`` starts a new command with, or ``""`` if it does not.
 
         cmd needs no whitespace around its operators, so `echo ok&&start ""
-        powershell` really launches, and that lexer hands the whole thing back
-        as one token `ok&&start`. The operator is only live when it is neither
-        inside a quoted span nor escaped by an odd run of carets, which is what
-        keeps `echo "a&start b"` and `echo hi^&start ...` as text.
+        powershell` really launches and `echo hi&call powershell` really calls,
+        while that lexer hands each back as one token. The operator is only live
+        when it is neither inside a quoted span nor escaped by an odd run of
+        carets, which is what keeps `echo "a&start b"` and `echo hi^&start ...`
+        as the text they print.
         """
-        if _token_basename(token) == "start":
-            return True
         if lexed_posix:
             # The posix lexer splits its own separators into tokens, so a `&`
             # still glued to a word was quoted and is not an operator at all.
-            return False
+            return ""
         quotes = 0
         last = -1
         for position, char in enumerate(token):
@@ -2241,7 +2273,14 @@ def _find_blocked_commands(command: str) -> set[str]:
                 carets = len(before) - len(before.rstrip("^"))
                 if carets % 2 == 0:
                     last = position
-        return last >= 0 and _token_basename(token[last + 1 :]) == "start"
+        return token[last + 1 :] if last >= 0 else ""
+
+    def _is_start_word(token: str) -> bool:
+        """Whether ``token`` is a START the shell will run."""
+        if _token_basename(token) == "start":
+            return True
+        tail = _live_operator_tail(token)
+        return bool(tail) and _token_basename(tail) == "start"
 
     def _start_is_run(i: int) -> bool:
         """Whether the START at ``tokens[i]`` is one the shell runs."""
@@ -2303,6 +2342,17 @@ def _find_blocked_commands(command: str) -> set[str]:
     for _pass in range(len(tokens)):
         discovered = len(command_indexes)
         for i, token in enumerate(tokens):
+            tail = _live_operator_tail(token)
+            if (
+                tail
+                and i + 1 < len(tokens)
+                and _token_basename(_unwrap_quotes(tail)) in _CMD_ONLY_PREFIXES
+            ):
+                # The operator in front of it is the command boundary, so what
+                # CALL forwards to is a command position: cmd runs
+                # `echo hi&call powershell`.
+                command_indexes.add(i + 1)
+                call_child_indexes.add(i + 1)
             if _is_start_word(token) and _start_is_run(i):
                 target, _title_at = _start_target(i)
                 if target < len(tokens):
@@ -2359,9 +2409,25 @@ def _find_blocked_commands(command: str) -> set[str]:
                     ):
                         payload += 1
                         command_indexes.add(payload)
+                        call_child_indexes.add(payload)
                 break
         if len(command_indexes) == discovered:
             break
+    # The walk that reads command names ran before this fixpoint, so what CALL
+    # forwards to has never been looked up: `cmd /c echo hi&call powershell`
+    # published the powershell and named nothing. Only CALL's children, because
+    # the other positions published here are ones the walks below screen on their
+    # own terms, and a URL or document target is deliberately not a program.
+    # Quotes are dropped first: cmd keeps them and resolves what is behind them,
+    # so `call "powershell" -Command ls` runs the same shell.
+    for index in sorted(call_child_indexes):
+        if index >= len(tokens) or index in screened_indexes:
+            continue
+        published = _token_basename(_unquote(tokens[index]))
+        if published in _BLOCKED_COMMANDS:
+            blocked.add(published)
+        else:
+            blocked |= _blocked_matching_glob(published)
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1274,7 +1274,10 @@ def _ends_with_cmd_operator(token: str) -> bool:
 
 
 def _newline_command_indexes(
-    text: str, tokens: "list[str]", mode: str, cmd_quoting: bool = False
+    text: str,
+    tokens: "list[str]",
+    mode: str,
+    cmd_quoting: bool = False,
 ) -> "frozenset[int]":
     """Indexes of ``tokens`` that open a new physical line the shell will run.
 
@@ -2598,9 +2601,10 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 while child < len(tokens):
                     command_indexes.add(child)
                     call_child_indexes.add(child)
-                    if _token_basename(
-                        _unwrap_quotes(tokens[child]).replace("\\", "/")
-                    ) not in _CMD_ONLY_PREFIXES:
+                    if (
+                        _token_basename(_unwrap_quotes(tokens[child]).replace("\\", "/"))
+                        not in _CMD_ONLY_PREFIXES
+                    ):
                         break
                     child += 1
             elif (
@@ -2622,9 +2626,10 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 while child < len(tokens):
                     command_indexes.add(child)
                     call_child_indexes.add(child)
-                    if _token_basename(
-                        _unwrap_quotes(tokens[child]).replace("\\", "/")
-                    ) not in _CMD_ONLY_PREFIXES:
+                    if (
+                        _token_basename(_unwrap_quotes(tokens[child]).replace("\\", "/"))
+                        not in _CMD_ONLY_PREFIXES
+                    ):
                         break
                     child += 1
             if _is_start_word(token) and _start_is_run(i):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -188,6 +188,10 @@ _COMMAND_PREFIXES = frozenset(
 # the ARGUMENTS of a user program that happens to be named call.
 # https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/call
 _CMD_ONLY_PREFIXES = frozenset({"call"})
+# The other direction: shell builtins cmd either lacks or means differently.
+# Windows `time` is `time [/t]`, which sets the clock rather than running the
+# word behind it, and `command`, `builtin` and `exec` are bash's own.
+_POSIX_ONLY_PREFIXES = frozenset({"time", "command", "builtin", "exec"})
 # Wrapper options whose VALUE is a separate token (env -u NAME, nice -n 5).
 # Unconsumed, the value is mistaken for the wrapped command: `env -u FOO rm -rf x`
 # reads as command `FOO`. Shared by the auto gate and the blocklist walk.
@@ -1141,6 +1145,35 @@ def _is_document_target(target: str) -> bool:
     return bool(suffix) and suffix not in _WINDOWS_EXE_SUFFIXES
 
 
+def _live_operator_tail(token: str, lexed_posix: bool) -> str:
+    """What ``token`` starts a new command with, or ``""`` if it does not.
+
+    cmd needs no whitespace around its operators, so `echo ok&&start ""
+    powershell` really launches and `echo hi&call powershell` really calls, while
+    that lexer hands each back as one token. The operator is only live when it is
+    neither inside a quoted span nor escaped by an odd run of carets, which is
+    what keeps `echo "a&start b"` and `echo hi^&start ...` as the text they
+    print.
+    """
+    if lexed_posix:
+        # The posix lexer splits its own separators into tokens, so a `&` still
+        # glued to a word was quoted and is not an operator at all.
+        return ""
+    quotes = 0
+    carets = 0
+    last = -1
+    for position, char in enumerate(token):
+        if char == "^":
+            carets += 1
+            continue
+        if char == '"':
+            quotes += 1
+        elif char in "&|(" and quotes % 2 == 0 and carets % 2 == 0:
+            last = position
+        carets = 0
+    return token[last + 1 :] if last >= 0 else ""
+
+
 def _has_bare_cmd_operator(text: str) -> bool:
     """Whether ``text`` holds a cmd control operator the caret has not escaped.
 
@@ -1608,7 +1641,7 @@ def _path_continuations(words: "list[str]") -> "list[bool]":
     carries = [False] * (len(words) + 1)
     for position in range(len(words) - 1, -1, -1):
         bare = words[position].strip('"')
-        if not bare or bare.startswith("-"):
+        if not bare:
             continue
         if _PATH_FRAGMENT_RE.match(bare) or _URL_SCHEME_RE.match(bare):
             continue
@@ -1633,7 +1666,7 @@ def _continues_path(
     word continues the path when a LATER one still carries it.
     """
     bare = words[position].strip('"')
-    if not bare or bare.startswith("-"):
+    if not bare:
         return False
     if _PATH_FRAGMENT_RE.match(bare) or _URL_SCHEME_RE.match(bare):
         return False
@@ -1659,7 +1692,11 @@ def _quoted_program_word(payload: str) -> str:
     program: "list[str]" = []
     for word in words:
         bare = word.strip('"')
-        if bare.startswith("-") or _is_start_switch(bare):
+        if _is_start_switch(bare):
+            # START's own switches end the path. A `-word` does NOT: a directory
+            # name may open with a hyphen, which is what
+            # `C:\Program -Files\PowerShell\7\pwsh.exe` spells, and the walk
+            # below already stops where the path really ends.
             break
         program.append(bare)
         if os.path.splitext(os.path.basename(bare.replace("\\", "/")))[1].lower() in (
@@ -1701,7 +1738,11 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
     program: "list[str]" = []
     for position, word in enumerate(words):
         bare = word.strip('"')
-        if bare.startswith("-") or _is_start_switch(bare):
+        if _is_start_switch(bare):
+            # START's own switches end the path. A `-word` does NOT: a directory
+            # name may open with a hyphen, which is what
+            # `C:\Program -Files\PowerShell\7\pwsh.exe` spells, and the walk
+            # below already stops where the path really ends.
             break  # an option ends the path and starts the arguments
         # Joining words is how a path holding spaces is recovered, and what
         # continues one is a RELATIVE fragment: `C:\Program Files\PowerShell\7\
@@ -1798,7 +1839,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
     command_prefixes = (
         _COMMAND_PREFIXES
         if lexed_posix and not _cmd_payload
-        else _COMMAND_PREFIXES | _CMD_ONLY_PREFIXES
+        else (_COMMAND_PREFIXES | _CMD_ONLY_PREFIXES) - _POSIX_ONLY_PREFIXES
     )
     try:
         if not lexed_posix:
@@ -2031,6 +2072,10 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         return -1, steps >= _MAX_EXEC_PREFIX_SCAN and i < len(tokens)
 
     expect_command = True  # start of string is a command position
+    # What a `/c` hands over is cmd's command line whatever lexed the outer one,
+    # so bash's own builtins stop being wrappers inside it.
+    cmd_payload_prefixes = (command_prefixes | _CMD_ONLY_PREFIXES) - _POSIX_ONLY_PREFIXES
+    in_cmd_payload = False
     active_prefixes = command_prefixes  # narrowed once an external wrapper executes
     command_indexes: "set[int]" = set()  # words the shell runs, for the walks below
     win_shell_pending = False  # a cmd at command position, awaiting its /c or /k
@@ -2052,7 +2097,9 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             prefix_command = ""
             win_shell_pending = False
             payload_pending = False
+            in_cmd_payload = False
             xargs_index = -1
+            active_prefixes = command_prefixes
         if skip_operand:
             # `exec -a NAME cmd` and `if exist FILE cmd` both put an operand
             # where the command word would otherwise be.
@@ -2067,6 +2114,8 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             expect_command = True
             win_shell_pending = False
             payload_pending = True
+            in_cmd_payload = True
+            active_prefixes = cmd_payload_prefixes
             continue
         if expect_command and token.lower() in _WIN_CONDITIONAL_KEYWORDS:
             skip_operand = token.lower() != "not"
@@ -2094,6 +2143,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             win_shell_pending = False
             payload_pending = False
             xargs_index = -1
+            in_cmd_payload = False
             active_prefixes = command_prefixes
             continue
         if token.startswith("-"):
@@ -2112,6 +2162,26 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # wrapper prefix awaits its command (`stdbuf -oL cmd`, `xargs -- cmd`).
             if not prefix_pending:
                 expect_command = False
+            continue
+        operator_tail = _live_operator_tail(token, lexed_posix)
+        if operator_tail:
+            # A control operator INSIDE the token ends the command in front of
+            # it and opens one behind it, so the word the operator hands over is
+            # a command word: `cmd /c echo ok&cmd /c powershell` really nests,
+            # and reading the whole token left the second shell unrecognised.
+            tail_base = _token_basename(_unquote(operator_tail).replace("\\", "/"))
+            if tail_base in _BLOCKED_COMMANDS:
+                blocked.add(tail_base)
+            else:
+                blocked |= _blocked_matching_glob(tail_base)
+            expect_command = False
+            prefix_pending = False
+            prefix_command = ""
+            payload_pending = False
+            in_cmd_payload = False
+            active_prefixes = command_prefixes
+            xargs_index = -1
+            win_shell_pending = tail_base == "cmd"
             continue
         if not expect_command:
             continue
@@ -2169,7 +2239,9 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 # the rest of the line back to cmd, so cmd's own builtins stop
                 # applying behind one: `cmd //c "xargs call powershell"` looks
                 # for a program named call and never reaches PowerShell.
-                active_prefixes = command_prefixes - _CMD_ONLY_PREFIXES
+                active_prefixes = (
+                    cmd_payload_prefixes if in_cmd_payload else command_prefixes
+                ) - _CMD_ONLY_PREFIXES
             continue
         expect_command = False
         prefix_pending = False
@@ -2292,39 +2364,11 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             return True
         return bool(index) and not lexed_posix and _ends_with_cmd_operator(previous)
 
-    def _live_operator_tail(token: str) -> str:
-        """What ``token`` starts a new command with, or ``""`` if it does not.
-
-        cmd needs no whitespace around its operators, so `echo ok&&start ""
-        powershell` really launches and `echo hi&call powershell` really calls,
-        while that lexer hands each back as one token. The operator is only live
-        when it is neither inside a quoted span nor escaped by an odd run of
-        carets, which is what keeps `echo "a&start b"` and `echo hi^&start ...`
-        as the text they print.
-        """
-        if lexed_posix:
-            # The posix lexer splits its own separators into tokens, so a `&`
-            # still glued to a word was quoted and is not an operator at all.
-            return ""
-        quotes = 0
-        carets = 0
-        last = -1
-        for position, char in enumerate(token):
-            if char == "^":
-                carets += 1
-                continue
-            if char == '"':
-                quotes += 1
-            elif char in "&|(" and quotes % 2 == 0 and carets % 2 == 0:
-                last = position
-            carets = 0
-        return token[last + 1 :] if last >= 0 else ""
-
     def _is_start_word(token: str) -> bool:
         """Whether ``token`` is a START the shell will run."""
         if _token_basename(token) == "start":
             return True
-        tail = _live_operator_tail(token)
+        tail = _live_operator_tail(token, lexed_posix)
         return bool(tail) and _token_basename(tail) == "start"
 
     def _start_is_run(i: int) -> bool:
@@ -2361,6 +2405,10 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         title_at = -1
         while j < len(tokens):
             switch = _win_switch(tokens[j].lower())
+            if switch == "/?":
+                # `/?` displays START's help and returns. Nothing behind it is
+                # launched, so there is no target to report.
+                return len(tokens), title_at
             if _is_start_switch(tokens[j].lower()):
                 # /d C:\dir and friends carry their value in the next token.
                 j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
@@ -2387,7 +2435,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
     for _pass in range(len(tokens)):
         discovered = len(command_indexes)
         for i, token in enumerate(tokens):
-            tail = _live_operator_tail(token)
+            tail = _live_operator_tail(token, lexed_posix)
             if (
                 tail
                 and i + 1 < len(tokens)
@@ -2398,6 +2446,18 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 # `echo hi&call powershell`.
                 command_indexes.add(i + 1)
                 call_child_indexes.add(i + 1)
+            elif (
+                not tail
+                and _ends_with_cmd_operator(token)
+                and i + 2 < len(tokens)
+                and _token_basename(_unwrap_quotes(tokens[i + 1])) in _CMD_ONLY_PREFIXES
+            ):
+                # Same boundary with the operator ENDING the token instead of
+                # sitting inside it: `cmd /c echo hi& call powershell` runs
+                # PowerShell exactly as the glued spelling does.
+                command_indexes.add(i + 1)
+                command_indexes.add(i + 2)
+                call_child_indexes.add(i + 2)
             if _is_start_word(token) and _start_is_run(i):
                 target, _title_at = _start_target(i)
                 if target < len(tokens):
@@ -2437,9 +2497,15 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                     continue
                 if is_win_c and prev.startswith("/") and len(prev) <= 3:
                     continue
-                if not _at_command(j):
+                # A control operator glued to the word in front of the shell
+                # leaves the shell in that same token, so the name is read from
+                # what the operator hands over, and the operator IS the command
+                # boundary: cmd runs the second shell of
+                # `cmd /c echo ok&cmd /c powershell`.
+                prev_tail = _live_operator_tail(prev, lexed_posix)
+                if not prev_tail and not _at_command(j):
                     break
-                prev_base = _token_basename(_unquote(prev).replace("\\", "/"))
+                prev_base = _token_basename(_unquote(prev_tail or prev).replace("\\", "/"))
                 if (is_unix_c and prev_base in _SHELLS) or (is_win_c and prev_base in _SHELLS_WIN):
                     command_indexes.add(i + 1)
                     # What follows a `/c` is cmd's to parse even when the outer

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1364,6 +1364,41 @@ def _unwrap_quotes(token: str) -> str:
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 
+# What a word has to end in before a path is read as naming a program.
+_WINDOWS_EXE_SUFFIXES = frozenset({".exe", ".com", ".bat", ".cmd"})
+
+
+def _is_start_switch(token: str) -> bool:
+    """Whether ``token`` is a START option rather than the program it launches.
+
+    Every documented one is a single letter or word after the slash, so an MSYS
+    drive path keeps its own: Git Bash hands `/c/Windows/.../powershell.exe`
+    straight to cmd as a C: executable, and skipping it as an option walks the
+    scan past the program onto its arguments.
+    """
+    switch = _win_switch(token)
+    return switch.startswith("/") and "/" not in switch[1:]
+
+
+def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "set[str]":
+    """Blocked names spelled as an executable PATH inside a cmd payload.
+
+    `cmd /c "C:\\Program Files\\PowerShell\\7\\pwsh.exe" -Command ls` names one
+    program whose path holds spaces, so re-lexing the payload reads
+    `C:\\Program` as the command word and leaves pwsh in argument position.
+    Anchored on the executable suffix so a word that merely mentions a path,
+    `ls /usr/bin/rm`, is still an argument.
+    """
+    found: "set[str]" = set()
+    for word in payload.split():
+        stem, ext = os.path.splitext(word.strip("\"'"))
+        if ext.lower() not in _WINDOWS_EXE_SUFFIXES:
+            continue
+        base = os.path.basename(stem.replace("\\", "/")).lower()
+        if base in blocked_names:
+            found.add(base)
+    return found
+
 
 def _is_start_title(token: str, lexed_posix: bool) -> bool:
     """Whether ``token`` is START's window title rather than the program it runs.
@@ -1690,15 +1725,19 @@ def _find_blocked_commands(command: str) -> set[str]:
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(_unquote(tokens[i + 1]))
             elif is_win_c and prev_base in _SHELLS_WIN:
-                blocked |= _find_blocked_commands(_unquote(tokens[i + 1]))
-                if not _unquote(tokens[i + 1]) and i + 2 < len(tokens):
+                payload = _unquote(tokens[i + 1])
+                blocked |= _find_blocked_commands(payload)
+                # A program path holding spaces survives lexing as one quoted
+                # word, so re-lexing it reads only its first path segment.
+                blocked |= _blocked_quoted_program(payload, _BLOCKED_COMMANDS)
+                if not payload and i + 2 < len(tokens):
                     # `cmd /s /c ""prog" args"`: /s strips the outer pair off the
                     # WHOLE payload, so the lexer hands back that pair as an
                     # empty first token and the program sits behind it, each
                     # word still carrying a stray mark. Documented under cmd /s.
-                    blocked |= _find_blocked_commands(
-                        " ".join(word.strip('"') for word in tokens[i + 2 :])
-                    )
+                    tail = " ".join(word.strip('"') for word in tokens[i + 2 :])
+                    blocked |= _find_blocked_commands(tail)
+                    blocked |= _blocked_quoted_program(tail, _BLOCKED_COMMANDS)
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1710,7 +1749,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         titled = False
         while j < len(tokens):
             switch = _win_switch(tokens[j].lower())
-            if switch.startswith("/"):
+            if _is_start_switch(tokens[j].lower()):
                 # /d C:\dir and friends carry their value in the next token.
                 j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
             elif not titled and _is_start_title(tokens[j], lexed_posix):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1366,6 +1366,9 @@ _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 
 # What a word has to end in before a path is read as naming a program.
 _WINDOWS_EXE_SUFFIXES = frozenset({".exe", ".com", ".bat", ".cmd"})
+# A drive letter or a separator: how a payload that OPENS with a program path
+# is told from one whose command word was lexed normally.
+_PATH_FRAGMENT_RE = re.compile(r"^(?:[A-Za-z]:|\.{0,2}[/\\])")
 
 
 def _is_start_switch(token: str) -> bool:
@@ -1381,23 +1384,28 @@ def _is_start_switch(token: str) -> bool:
 
 
 def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "set[str]":
-    """Blocked names spelled as an executable PATH inside a cmd payload.
+    """Blocked names spelled as an executable PATH that lexing split apart.
 
     `cmd /c "C:\\Program Files\\PowerShell\\7\\pwsh.exe" -Command ls` names one
     program whose path holds spaces, so re-lexing the payload reads
     `C:\\Program` as the command word and leaves pwsh in argument position.
-    Anchored on the executable suffix so a word that merely mentions a path,
-    `ls /usr/bin/rm`, is still an argument.
+
+    Only a payload OPENING with a path fragment can be that shape. Anything else
+    already had its command word lexed normally, and reading further would take
+    `echo C:\\tmp\\pwsh.exe` for a launch when the path is only being printed.
+    The walk stops at the first executable for the same reason: what follows it
+    is arguments.
     """
-    found: "set[str]" = set()
-    for word in payload.split():
+    words = payload.split()
+    if not words or not _PATH_FRAGMENT_RE.match(words[0].strip("\"'")):
+        return set()
+    for word in words:
         stem, ext = os.path.splitext(word.strip("\"'"))
         if ext.lower() not in _WINDOWS_EXE_SUFFIXES:
             continue
         base = os.path.basename(stem.replace("\\", "/")).lower()
-        if base in blocked_names:
-            found.add(base)
-    return found
+        return {base} if base in blocked_names else set()
+    return set()
 
 
 def _is_start_title(token: str, lexed_posix: bool) -> bool:
@@ -1727,6 +1735,15 @@ def _find_blocked_commands(command: str) -> set[str]:
             elif is_win_c and prev_base in _SHELLS_WIN:
                 payload = _unquote(tokens[i + 1])
                 blocked |= _find_blocked_commands(payload)
+                bare = _unwrap_quotes(payload)
+                if bare != payload:
+                    # Git Bash keeps cmd's own quotes: `cmd //c '"powershell
+                    # -Command ls"'` reaches cmd as one quoted string, which cmd
+                    # unquotes and runs. Scanned IN ADDITION to the quoted form,
+                    # never instead of it, because the two spans of `""rm -rf
+                    # x""` are what stop that one collapsing into a single word.
+                    blocked |= _find_blocked_commands(bare)
+                    blocked |= _blocked_quoted_program(bare, _BLOCKED_COMMANDS)
                 # A program path holding spaces survives lexing as one quoted
                 # word, so re-lexing it reads only its first path segment.
                 blocked |= _blocked_quoted_program(payload, _BLOCKED_COMMANDS)
@@ -1762,7 +1779,12 @@ def _find_blocked_commands(command: str) -> set[str]:
             else:
                 break
         if j < len(tokens):
-            blocked |= _find_blocked_commands(_unquote(tokens[j]))
+            program = _unquote(tokens[j])
+            blocked |= _find_blocked_commands(program)
+            # Same split-path shape as the /c payload: START documents a title
+            # followed by the program, and `start "" "C:\Program Files\...
+            # \pwsh.exe"` is one quoted word until it is re-lexed.
+            blocked |= _blocked_quoted_program(program, _BLOCKED_COMMANDS)
             if (
                 lexed_posix
                 and not titled

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2545,7 +2545,6 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         )
         blocked.update(re.findall(pattern, lowered))
 
-
     def _at_command(index: int) -> bool:
         """Whether the shell runs ``tokens[index]``.
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2105,6 +2105,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
     prefix_command = ""  # which wrapper that was, for its own value-taking options
     skip_operand = False  # consume a wrapper/conditional operand, not the command
     skip_two = False  # a spelled cmd comparison consumes its operator and operand
+    if_pending = False  # a cmd IF opened a condition still awaiting its body
     sed_indexes: "list[int]" = []  # command-position sed words, for the `e` scan below
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
     xargs_index = -1  # an xargs awaiting the command it wraps
@@ -2116,6 +2117,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             expect_command = True
             skip_operand = False
             skip_two = False
+            if_pending = False
             prefix_pending = False
             prefix_command = ""
             win_shell_pending = False
@@ -2143,13 +2145,20 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             continue
         if expect_command and token.lower() in _WIN_CONDITIONAL_KEYWORDS:
             skip_operand = token.lower() != "not"
+            if_pending = token.lower() == "not" and if_pending
             continue
-        if expect_command and _is_win_comparison(tokens, token_index):
+        if expect_command and if_pending and _is_win_comparison(tokens, token_index):
             # `if 1==1 cmd /c powershell` runs that shell when the condition
             # holds. Reading the comparison as the command word left the body in
             # argument position and its payload unscreened.
-            skip_operand = tokens[token_index + 1].lower() in _WIN_COMPARE_OPERATORS
+            #
+            # Only inside a condition an IF really opened. A `==` may sit in a
+            # path (`C:/a==b/powershell.exe`), and skipping that word passed
+            # over the program it names.
+            next_token = tokens[token_index + 1].lower() if token_index + 1 < len(tokens) else ""
+            skip_operand = next_token in _WIN_COMPARE_OPERATORS
             skip_two = skip_operand
+            if_pending = False
             continue
         if prefix_pending and token == "-a":
             skip_operand = True
@@ -2168,6 +2177,9 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         if (_looks_like_separator(token) and token_index not in quoted_separators) or (
             token in _SHELL_KEYWORDS_AS_SEP and expect_command
         ):
+            # cmd's IF opens a condition, and only there is a `==` a comparison
+            # rather than an ordinary character in a word.
+            if_pending = token.lower() == "if"
             expect_command = True
             prefix_pending = False
             prefix_command = ""
@@ -2510,7 +2522,15 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                     child += 1
             if _is_start_word(token) and _start_is_run(i):
                 target, _title_at = _start_target(i)
-                if target < len(tokens):
+                if target < len(tokens) and not (
+                    _URL_SCHEME_RE.match(_unquote(tokens[target]))
+                    or _is_document_target(_unquote(tokens[target]))
+                ):
+                    # A URL opens in the browser and a document in whatever is
+                    # registered for it, so neither is a shell word. Publishing
+                    # them anyway let the nested-shell pass read the basename of
+                    # `https://example.com/cmd` as a shell and screen the `/c`
+                    # behind it, which the START scan below already refuses to do.
                     command_indexes.add(target)
                     forwarded, _overflowed = _exec_child_index(target)
                     if forwarded not in (-1, target):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -188,23 +188,13 @@ _COMMAND_PREFIXES = frozenset(
 # the ARGUMENTS of a user program that happens to be named call.
 # https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/call
 _CMD_ONLY_PREFIXES = frozenset({"call"})
-# The other direction: shell builtins cmd either lacks or means differently.
-# Windows `time` is `time [/t]`, which sets the clock rather than running the
-# word behind it, and `command`, `builtin` and `exec` are bash's own.
-_POSIX_ONLY_PREFIXES = frozenset({"time", "timeout", "command", "builtin", "exec"})
-
-
-def _selects_its_own_executable(token: str) -> bool:
-    """Whether ``token`` names a program by PATH rather than by bare name.
-
-    A bare `timeout` is whatever the system resolves, and on Windows that is
-    the one taking a delay. A path picks a specific executable instead, so the
-    reasons for reading the bare Windows spelling as a non-wrapper do not carry
-    over to it. Quote marks are cmd's to strip, and either separator counts:
-    cmd accepts both.
-    """
-    bare = token.strip("\"'")
-    return "/" in bare or "\\" in bare
+# Windows spells some of these differently -- `time [/t]` sets the clock and
+# TIMEOUT takes a delay rather than a command -- but which executable a BARE
+# name resolves to is not ours to assume: _build_safe_env puts the interpreter
+# directory and an active venv in front of System32, so a coreutils
+# `timeout.exe` dropped in either one wins the lookup and really does run
+# `timeout 5 powershell`. A screen that guessed the Windows spelling here would
+# fail open on exactly that. They are read as wrappers on both lanes.
 
 
 # bash's source builtins. cmd has neither, so a PATH whose last segment happens
@@ -1163,15 +1153,18 @@ def _is_document_target(target: str) -> bool:
             break
         if _path_suffix(word) in _WINDOWS_EXE_SUFFIXES:
             return False
-    if stopped < len(words) and any(
-        word.strip('"').startswith("-") or _is_start_switch(word.strip('"'))
-        for word in words[stopped:]
-    ):
-        # An OPTION behind the path is what makes the string a command line:
-        # `C:\tools\powershell -Command script.ps1` runs a shell and hands it a
-        # script. Without one the extra words belong to the file's own name,
-        # which may hold as many spaces as it likes, so
-        # `C:\tmp\curl notes report.pdf` is one document START opens.
+    if stopped < len(words):
+        # Words behind the path make the string a command line, whether they
+        # are options or positional. An unquoted name holding spaces is
+        # ambiguous and Windows resolves the ambiguity by trying successively
+        # LONGER prefixes with `.exe` appended, first one wins, so
+        # `C:\tools\powershell payload.ps1` runs `C:\tools\powershell.exe`
+        # before the whole string is ever tried as a filename.
+        # https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
+        # Requiring an option here was mine, and it read that first prefix as
+        # part of a document's name: a launch behind a positional argument went
+        # unscreened. A name whose first word is no program is untouched, since
+        # the walk only reaches here once one has been resolved.
         return False
     # Nothing along the path is executable, so the whole target is a candidate
     # FILE and its own suffix decides. A document's name may hold spaces, which
@@ -1281,6 +1274,30 @@ def _has_bare_cmd_operator(text: str) -> bool:
         # the text at every operator, which copied a longer prefix each time.
         carets = 0
     return False
+
+
+def _cmd_group_delta(token: str) -> int:
+    """How many cmd groups ``token`` opens, less how many it closes.
+
+    Only LIVE parentheses count, on the same terms as ``_live_operator_tail``:
+    one inside a quoted span or behind an odd run of carets is text, and a `(`
+    glued behind a plain word is `echo(`'s no-space form rather than a group.
+    """
+    quotes = 0
+    carets = 0
+    delta = 0
+    for position, char in enumerate(token):
+        if char == "^" and quotes % 2 == 0:
+            carets += 1
+            continue
+        if char == '"' and carets % 2 == 0:
+            quotes += 1
+        elif quotes % 2 == 0 and carets % 2 == 0:
+            if char == "(" and (position == 0 or token[position - 1] in "&|()^"):
+                delta += 1
+            elif char == ")":
+                delta -= 1
+    return delta
 
 
 def _ends_with_cmd_operator(token: str) -> bool:
@@ -1902,7 +1919,14 @@ def _blocked_quoted_program(payload: str, blocked_names: "frozenset[str]") -> "s
         # a real executable, `C:\powershell scripts\notepad.exe`, still reports
         # the notepad it launches rather than the folder it sits in.
         first = os.path.basename(program[0].replace("\\", "/"))
-        candidates.append(os.path.splitext(first)[0].lower())
+        first_stem, first_ext = os.path.splitext(first)
+        if not first_ext or first_ext.lower() in _WINDOWS_EXE_SUFFIXES:
+            # `.exe` is appended only to a name that carries NO extension, so a
+            # prefix that already has one is tried literally. cmd runs neither
+            # `C:\reports\curl.txt` nor `C:\tmp\powershell.docx` -- without
+            # START there is no association to open them through -- and reading
+            # the stem out of one reported a program that never launches.
+            candidates.append(first_stem.lower())
     return {base for base in candidates if base in blocked_names}
 
 
@@ -1958,7 +1982,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
     command_prefixes = (
         _COMMAND_PREFIXES
         if lexed_posix and not _cmd_payload
-        else (_COMMAND_PREFIXES | _CMD_ONLY_PREFIXES) - _POSIX_ONLY_PREFIXES
+        else _COMMAND_PREFIXES | _CMD_ONLY_PREFIXES
     )
     try:
         if not lexed_posix:
@@ -2047,15 +2071,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
                 # The closing mark of the span belongs to the program, not to
                 # the arguments behind it.
                 consumed += 1
-            respelled = program_stem
-            if program_stem in _POSIX_ONLY_PREFIXES and _selects_its_own_executable(program_word):
-                # ...except where the DIRECTORY is the thing that matters. cmd's
-                # own `timeout` takes a delay, so the cmd lane reads the bare
-                # name as no wrapper at all; dropping the path in front of it
-                # turned `C:/tools/timeout 5 powershell` into that bare name and
-                # lost the launch. Only the suffix comes off here.
-                respelled = os.path.splitext(program_word.strip('"'))[0]
-            return found | _find_blocked_commands(respelled + text[consumed:], _cmd_payload = True)
+            return found | _find_blocked_commands(program_stem + text[consumed:], _cmd_payload = True)
         if any(char.isspace() or char in "\"'" for char in text):
             return _find_blocked_commands(text, _cmd_payload = True)
         base = _token_basename(text)
@@ -2261,12 +2277,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # whole meant `start "" C:\tools\timeout 5 powershell` named no
             # wrapper at all while its forward-slash spelling did.
             base = _reported_basename(token)
-            # A path picks a specific executable, so cmd's reasons for reading
-            # the bare `timeout` as no wrapper do not reach it. Same rule the
-            # main walk applies, and START's target comes through here.
-            if base in (prefixes or command_prefixes) or (
-                base in _POSIX_ONLY_PREFIXES and _selects_its_own_executable(token)
-            ):
+            if base in (prefixes or command_prefixes):
                 wrapper = base
                 i += 1
                 continue
@@ -2286,7 +2297,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
     expect_command = True  # start of string is a command position
     # What a `/c` hands over is cmd's command line whatever lexed the outer one,
     # so bash's own builtins stop being wrappers inside it.
-    cmd_payload_prefixes = (command_prefixes | _CMD_ONLY_PREFIXES) - _POSIX_ONLY_PREFIXES
+    cmd_payload_prefixes = command_prefixes | _CMD_ONLY_PREFIXES
     in_cmd_payload = False
     active_prefixes = command_prefixes  # narrowed once an external wrapper executes
     command_indexes: "set[int]" = set()  # words the shell runs, for the walks below
@@ -2300,7 +2311,14 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
     sed_indexes: "list[int]" = []  # command-position sed words, for the `e` scan below
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
     xargs_index = -1  # an xargs awaiting the command it wraps
+    group_depth = 0  # cmd groups opened by a live `(` and not yet closed
     for token_index, token in enumerate(tokens):
+        # Counted before the token is read, so a `)` is judged against the
+        # groups standing in front of it. Never below zero: an unmatched `)` on
+        # a line cmd would refuse must not make a later one look matched.
+        opened_before = group_depth
+        if not lexed_posix:
+            group_depth = max(0, group_depth + _cmd_group_delta(token))
         if token_index in newline_starts:
             # A newline ends the command as surely as `;` does, and it ends any
             # operand or wrapper still waiting on one with it. Both lexers count
@@ -2356,7 +2374,12 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             in_cmd_payload = True
             active_prefixes = cmd_payload_prefixes
             continue
-        if expect_command and token.lower() in _WIN_CONDITIONAL_KEYWORDS:
+        if expect_command and if_pending and token.lower() in _WIN_CONDITIONAL_KEYWORDS:
+            # Only inside a condition. EXIST, DEFINED, ERRORLEVEL and
+            # CMDEXTVERSION are IF's operators, not commands: at a command
+            # position of their own they name a program and take their words as
+            # ordinary arguments, so consuming an operand there stepped over one
+            # and opened a command position cmd never opens.
             skip_operand = token.lower() != "not"
             if_pending = token.lower() == "not" and if_pending
             continue
@@ -2463,12 +2486,23 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             prefix_pending = tail_base in (command_prefixes | _CMD_ONLY_PREFIXES)
             prefix_command = tail_base if prefix_pending else ""
             # A keyword handed over by the operator opens what it always opens,
-            # IF's condition included: cmd runs `echo&if 1==1 powershell`.
-            if_pending = tail_base == "if"
+            # IF's condition included: cmd runs `echo&if 1==1 powershell`. Read
+            # from the RAW tail, since _token_basename drops an executable
+            # suffix and `echo&if.exe 1==1 powershell` launches a program named
+            # if.exe with those words as its arguments, evaluating nothing.
+            if_pending = _unquote(operator_tail).lower() == "if"
             expect_command = prefix_pending or tail_base in _SHELL_KEYWORDS_AS_SEP
             continue
         if not expect_command:
-            if not lexed_posix and _ends_with_cmd_operator(token):
+            if (
+                not lexed_posix
+                and _ends_with_cmd_operator(token)
+                # ...but a `)` ends a command only if a group was ever opened.
+                # cmd has nothing to close otherwise, so the parenthesis is
+                # ordinary text and the words behind it stay arguments:
+                # `cmd /c echo foo) powershell` prints the lot.
+                and (token[-1] != ")" or opened_before > 0)
+            ):
                 # A group closing on the same token as its last word still ends
                 # the command: `if 1==0 (echo no) else powershell` runs the ELSE
                 # clause, and treating `no)` as an ordinary argument left it
@@ -2528,14 +2562,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             blocked |= _blocked_matching_glob(base)
         # Wrappers (env/time/xargs/sudo) consume one command; the next non-flag,
         # non-numeric token is the real command. sudo is also in _BLOCKED_COMMANDS.
-        # cmd's own `time` and `timeout` take a clock reading or a delay rather
-        # than a command, which is why the cmd lane subtracts them. A PATH picks
-        # a DIFFERENT executable: `C:/tools/timeout 5 powershell` selects the one
-        # documented as `timeout DURATION COMMAND [ARG]...`, which really does
-        # launch its child, so the wrapper reading has to survive for it.
-        if base in active_prefixes or (
-            base in _POSIX_ONLY_PREFIXES and _selects_its_own_executable(token)
-        ):
+        if base in active_prefixes:
             if base == "xargs" and xargs_index < 0:
                 xargs_index = token_index
             prefix_pending = True

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -192,6 +192,10 @@ _CMD_ONLY_PREFIXES = frozenset({"call"})
 # Windows `time` is `time [/t]`, which sets the clock rather than running the
 # word behind it, and `command`, `builtin` and `exec` are bash's own.
 _POSIX_ONLY_PREFIXES = frozenset({"time", "timeout", "command", "builtin", "exec"})
+# bash's source builtins. cmd has neither, so a PATH whose last segment happens
+# to spell one names a file rather than the builtin: `cd C:\dir\.` is an
+# ordinary directory walk and reading `.` out of it refused the line.
+_POSIX_SOURCE_BUILTINS = frozenset({".", "source"})
 # Wrapper options whose VALUE is a separate token (env -u NAME, nice -n 5).
 # Unconsumed, the value is mistaken for the wrapped command: `env -u FOO rm -rf x`
 # reads as command `FOO`. Shared by the auto gate and the blocklist walk.
@@ -2032,6 +2036,19 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             base = stem
         return base
 
+    def _cmd_path_basename(tok: str, plain: str) -> str:
+        """``tok``'s program name once cmd's path separator is honoured.
+
+        Falls back to ``plain`` where splitting the path would produce one of
+        bash's source builtins, which cmd does not have: `\\.` and `C:\\dir\\.`
+        name a directory entry rather than a command, and reporting `.` out of
+        them refused ordinary lines.
+        """
+        split = _token_basename(tok.replace("\\", "/"))
+        if split != plain and split in _POSIX_SOURCE_BUILTINS:
+            return plain
+        return split
+
     def _whitespace_chunks() -> "list[int] | None":
         """For each token, the index of the whitespace-delimited word it came
         from, or ``None`` when the two passes do not line up.
@@ -2365,7 +2382,7 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
             # A backslash is cmd's path separator, not an escape, and
             # os.path.basename leaves such a path whole off Windows. Only on
             # this lexer: under bash those backslashes really are escapes.
-            base = _token_basename(_unquote(token).replace("\\", "/"))
+            base = _cmd_path_basename(_unquote(token), base)
         screened_indexes.add(token_index)
         # Every word this loop reaches is one the shell would RUN, wrappers and
         # assignment prefixes already stepped over. The walks below decide the
@@ -2719,7 +2736,9 @@ def _find_blocked_commands(command: str, _cmd_payload: bool = False) -> set[str]
         # Normalised like every other program lookup: os.path.basename leaves a
         # backslash path whole off Windows, so `call C:\tmp\rm.cmd` reported
         # nothing while the forward-slash spelling of the same path was caught.
-        published = _token_basename(_unquote(tokens[index]).replace("\\", "/"))
+        published = _token_basename(_unquote(tokens[index]))
+        if not lexed_posix:
+            published = _cmd_path_basename(_unquote(tokens[index]), published)
         if published in _BLOCKED_COMMANDS:
             blocked.add(published)
         else:

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1249,7 +1249,7 @@ def test_call_forwards_to_a_command(windows_terminal, command):
 
 @pytest.mark.parametrize(
     "command",
-    ['call build.bat', "call node app.js", "call :build", 'echo call start "" powershell'],
+    ["call build.bat", "call node app.js", "call :build", 'echo call start "" powershell'],
 )
 def test_call_does_not_invent_a_command(windows_terminal, command):
     assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -272,22 +272,55 @@ def test_notes_say_where_commands_run(monkeypatch):
     assert "opens a window on the user's desktop" in tools._build_terminal_shell_note()
 
 
+@pytest.fixture(params = ["git-bash", "cmd-fallback"])
+def windows_terminal(request, monkeypatch):
+    """A Windows host, in both shell configurations _get_shell_cmd produces.
+
+    Faking sys.platform, which is all the rest of this file needs, does not
+    reach _BLOCKED_COMMANDS: it folds in _BLOCKED_COMMANDS_WIN at import, so on
+    the Linux runner powershell/pwsh are simply not blocked names and every
+    assertion below passes or fails for the wrong reason. Patch the constant.
+
+    The shell matters as well. With no trusted bash, _shell_is_posix() is False
+    and the blocklist lexes with shlex(posix = False), which keeps quote marks
+    on `""` and on a quoted payload. That is the configuration cmd screening
+    exists for, so both are parameters rather than one representative host.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        tools,
+        "_windows_bash",
+        (lambda: r"C:\Program Files\Git\bin\bash.exe")
+        if request.param == "git-bash"
+        else (lambda: None),
+    )
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+
+
 @pytest.mark.parametrize(
     "command",
     [
         "cmd /c powershell -Command ls",
         "cmd //c powershell -Command ls",
         "cmd //k powershell -Command ls",
+        'cmd /c "powershell -Command ls"',
         'cmd //c start "" powershell -Command ls',
+        "cmd //c start '' powershell -Command ls",
         'cmd //c start /b "" pwsh -Command ls',
         'cmd //c start //min "" powershell -Command ls',
         r'cmd //c start /d C:/tmp "" powershell -Command ls',
     ],
 )
-def test_cmd_shellout_is_screened_through_mangled_switches(command):
+def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, command):
     # Git Bash turns a lone /c into a path, so a model writes //c. That spelling
     # skipped the nested scan, making `cmd //c powershell` reachable where
     # `cmd /c powershell` was blocked, and `start` launches its argument too.
+    # The quoted spellings are the ones the cmd lexer hands back with their
+    # quote marks still attached (see _unwrap_quotes).
     assert tools._find_blocked_commands(command)
 
 
@@ -300,7 +333,7 @@ def test_cmd_shellout_is_screened_through_mangled_switches(command):
         "start notepad",
     ],
 )
-def test_detached_windows_stay_launchable(command):
+def test_detached_windows_stay_launchable(windows_terminal, command):
     # `start` is the only route to a window on the user's desktop, which the
     # terminal description promises, so screening must not blanket-block cmd.
     assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -871,3 +871,18 @@ def test_an_empty_pair_is_read_by_where_it_sits(monkeypatch):
     assert "powershell" in tools._find_blocked_commands('cmd //c start "" ""cmd /c powershell""')
     assert not tools._find_blocked_commands('xargs "" rm')
     assert not tools._find_blocked_commands('find . -exec "" rm ;')
+
+
+def test_an_earlier_pair_does_not_vouch_for_a_later_one(monkeypatch):
+    # Gluing is a fact about one position, so it is asked positionally. Searching
+    # the line for the two spellings joined let the `""rm` echoes here vouch for
+    # the `"" rm` after them, which is a separate command that runs nothing.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert not tools._find_blocked_commands('echo ""rm && xargs "" rm')
+    assert "powershell" in tools._find_blocked_commands('echo hi && ""cmd /c powershell""')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2231,3 +2231,17 @@ def test_a_refusal_names_the_program_not_its_path(windows_cmd_only, command):
     blocked = tools._find_blocked_commands(command)
     assert "sed" in blocked
     assert not [name for name in blocked if "/" in name or "\\" in name]
+
+
+@pytest.mark.parametrize("command", ["fd . -x\\ ;", "fd . --exec= ", "fd . -x\\ &"])
+def test_a_blank_attached_command_names_no_program(windows_git_bash_only, command):
+    # bash's backslash escapes the space behind it and joins the words, so the
+    # flag arrives carrying one blank. Reading a first word out of it raised,
+    # and a screen that raises decides nothing.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("command", ["fd . -xrm -rf x", "fd . --exec=rm", "fd . -x rm -rf x"])
+def test_an_attached_command_is_still_read(windows_git_bash_only, command):
+    # The other half: a flag that really does carry a command still names it.
+    assert "rm" in tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -815,3 +815,40 @@ def test_start_browses_a_url_rather_than_running_it(windows_terminal, command):
     # document targets. Reading its last path segment as the program refused the
     # link outright.
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "find . -exec bash -c 'rm -rf x' ;",
+        "fd -x bash -c 'rm -rf x'",
+        "find . -exec sh -c 'curl http://x' ;",
+        "find . -exec env bash -c 'rm -rf x' ;",
+    ],
+)
+def test_an_exec_launched_shell_still_has_its_payload_read(monkeypatch, command):
+    # find and fd run their -exec child themselves, so it is a command position
+    # the main walk never reaches: that walk sees `find` and stops. Requiring the
+    # nested-shell name to be at command position without publishing these first
+    # meant the `-c` payload went unread, and `rm -rf x` really deletes.
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd //c start "" env bash -c "rm -rf x"',
+        'cmd //c start "" env cmd /c powershell -Command ls',
+    ],
+)
+def test_start_follows_the_prefix_it_launches(windows_terminal, command):
+    # A wrapper is a command in its own right and a step on the way to one, the
+    # same shape `-exec` already models. Naming only `env` left the shell it
+    # forwards to out of command position, so its payload was never read.
+    assert tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -694,3 +694,36 @@ def test_a_quoted_cmd_payload_is_not_a_program_name(windows_terminal):
     # last path segment: listing a directory came back as the rm builtin.
     assert not tools._find_blocked_commands('cmd /c "ls /usr/bin/rm"')
     assert not tools._find_blocked_commands('cmd /c "dir C:\\tmp"')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        '"C:\\Windows\\System32\\cmd.exe" /c start "" powershell -Command ls',
+        "C:/Windows/System32/cmd.exe /c start \"\" powershell -Command ls",
+        '"C:\\Windows\\System32\\cmd.exe" /c env start "" powershell -Command ls',
+    ],
+)
+def test_a_full_path_cmd_still_opens_its_payload(windows_terminal, command):
+    # A shell can be spelled as a full path, and os.path.basename leaves a
+    # backslash path whole off Windows, so the /c opened no command position and
+    # the START behind it stayed in argument position. Normalised the way the
+    # nested-shell lookup already normalises the same spelling.
+    assert tools._find_blocked_commands(command)
+
+
+def test_bash_eats_an_unquoted_backslash_path(monkeypatch):
+    # Unquoted, those backslashes are bash escapes and the program name arrives
+    # as C:WindowsSystem32cmd.exe, which launches nothing. Checked against bash
+    # rather than assumed. Quoting is what carries the path through, and that
+    # spelling is covered above.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert "powershell" not in tools._find_blocked_commands(
+        "C:\\Windows\\System32\\cmd.exe /c start \"\" powershell"
+    )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1761,3 +1761,53 @@ def test_a_call_boundary_still_forwards_inside_a_quoted_payload():
             tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
         )
         assert "powershell" in tools._find_blocked_commands('cmd //c "echo hi& call powershell"')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c echo&call call powershell",
+        "cmd /c echo & call call powershell",
+        "cmd /c echo&call powershell",
+    ],
+)
+def test_a_prefix_handed_over_by_an_operator_still_forwards(windows_cmd_only, command):
+    # A wrapper spelled behind a glued operator is a command word like any
+    # other, so it forwards to the word behind it, and CALL may forward to
+    # another CALL. Screening the tail but dropping the prefix state left
+    # PowerShell unread even though cmd reparses and runs it.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("command", ['cmd /c echo(start "" powershell', 'cmd /c rem(start "" powershell'])
+def test_a_glued_parenthesis_after_a_word_opens_no_group(windows_cmd_only, command):
+    # `echo(` and `rem(` are the no-space forms of those commands and print what
+    # follows. Only a `(` of its own, or one behind another operator, opens a
+    # group, which is the distinction `_ends_with_cmd_operator` already drew.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_real_group_still_opens_a_command(windows_cmd_only):
+    # The other half: a `(` that is not glued behind a word does open one.
+    assert "powershell" in tools._find_blocked_commands('cmd /c (start "" powershell')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c if 1==1 cmd /c powershell",
+        "cmd /c if not 1==1 cmd /c powershell",
+        "cmd /c if %a% equ 1 cmd /c powershell",
+        "cmd /c if not %a% neq 1 cmd /c powershell",
+    ],
+)
+def test_a_cmd_comparison_still_leaves_a_command_behind_it(windows_terminal, command):
+    # cmd's IF takes a comparison glued (`1==1`) or spelled with an operator
+    # (`%a% equ 1`), and runs the body when it holds. Reading the comparison as
+    # the command word left that body in argument position.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+def test_a_comparison_in_argument_position_is_not_a_condition(windows_terminal):
+    # And only where a command may begin: `echo a==b rm` prints its arguments.
+    assert not tools._find_blocked_commands("echo a==b rm")

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -524,3 +524,64 @@ def test_an_unquoted_start_program_keeps_its_arguments(monkeypatch):
     assert not tools._find_blocked_commands("cmd //c start notepad powershell -Command ls")
     # A space could only have come from quoting, so that one is still a title.
     assert tools._find_blocked_commands('cmd //c start "my window" pwsh -Command ls')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r'cmd //c start "" "C:\Users\me\My Documents\powershell.docx"',
+        r'start "" "C:\Users\me\My Reports\rm.docx"',
+        r'cmd /c start "" "C:\Users\me\My Notes\curl.pdf"',
+    ],
+)
+def test_a_document_named_after_a_shell_is_still_a_document(windows_terminal, command):
+    # Dropping the .exe requirement so PATHEXT spellings resolve also accepted
+    # every other suffix, so a file called powershell.docx read as the program.
+    # cmd hands a non-executable suffix to its file association, never runs it.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd //c start "my window" /min powershell -Command ls',
+        'cmd //c start "my window" /b ssh a@b',
+        'start "my window" /min pwsh -Command ls',
+    ],
+)
+def test_switches_may_follow_the_title(windows_terminal, command):
+    # START takes its title first and its switches after, so the walk has to
+    # keep alternating rather than stop at the title. Only the cmd lexer kept
+    # the marks that prove one, so this went unread under Git Bash.
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'echo start "" powershell',
+        'echo start "job" powershell -Command ls',
+        'cmd //c echo start "" powershell',
+    ],
+)
+def test_a_printed_start_is_not_a_launched_one(windows_terminal, command):
+    # The word has to sit where the shell would RUN it. Screening it anywhere
+    # turns printing the line into a hard block, and this scan cannot borrow the
+    # main loop's command position: the outer shell runs only token 0 of
+    # `cmd //c start "" powershell`, which is the case the walk exists for.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_quoted_command_line_is_not_only_a_title(monkeypatch):
+    # Under bash a title is provable only by its whitespace, and a quoted
+    # command line looks identical: `start "ssh a@b"` has no program after it
+    # because that WAS the program. Screened as well as skipped over.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert "ssh" in tools._find_blocked_commands('cmd //c start "ssh a@b"')
+    assert "rm" in tools._find_blocked_commands("cmd //c start 'sudo rm -rf /'")

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1476,3 +1476,62 @@ def test_newline_scanning_does_not_reread_the_line(windows_cmd_only):
     started = time.monotonic()
     tools._find_blocked_commands(script)
     assert time.monotonic() - started < 5
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['cmd //c "call powershell"', 'cmd /c "call rm -rf x"'],
+)
+def test_a_quoted_cmd_payload_is_parsed_as_cmd(windows_terminal, command):
+    # What follows a `/c` reaches cmd as a command string even where bash is the
+    # outer shell, so CALL forwards inside it. Re-lexing the payload with the
+    # outer lexer left it unread there while the unquoted spelling was caught.
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("command", ["find . -exec call powershell ;", "fd . -x call powershell"])
+def test_call_is_not_a_prefix_for_an_exec_child(windows_terminal, command):
+    # find and fd run their -exec child themselves; cmd never re-parses it, so
+    # CALL is not a prefix there and the word behind it is that child's argument.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_an_exec_child_still_steps_over_a_real_wrapper(windows_terminal):
+    assert "powershell" in tools._find_blocked_commands("find . -exec env powershell ;")
+
+
+def test_a_start_title_is_not_the_command(windows_terminal):
+    # START documents its first quoted argument as the WINDOW TITLE with the
+    # command after it, so this runs notepad and screening the title refused the
+    # line for the title's sake.
+    assert not tools._find_blocked_commands(
+        'cmd //c start "C:\\Program Files\\PowerShell\\7\\pwsh.exe" notepad'
+    )
+
+
+def test_a_quoted_command_line_with_nothing_behind_it_is_still_screened(windows_git_bash_only):
+    # The reason the title is screened at all: posix proves a title only by its
+    # whitespace, so a quoted COMMAND LINE looks the same when nothing follows.
+    # Only under bash. cmd really does take that first quoted word as the title
+    # and run nothing, which is why `start "" "path"` is the documented idiom.
+    assert "pwsh" in tools._find_blocked_commands(
+        'cmd //c start "C:\\Program Files\\PowerShell\\7\\pwsh.exe"'
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'start "powershell -Command ls"',
+        'start "powershell -Command ls" -x y',
+        'start /d C:\\dir "powershell -Command ls" ; rm -rf x',
+        'start "powershell -Command ls"\nrm -rf x',
+    ],
+)
+def test_a_quoted_command_line_is_screened_when_no_command_follows(
+    windows_git_bash_only, command
+):
+    # What follows the quoted word decides whether it WAS a title. An option, a
+    # separator, a newline, or nothing at all means no command came after it, so
+    # the quoted word is the command line START runs.
+    assert "powershell" in tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -585,3 +585,32 @@ def test_a_quoted_command_line_is_not_only_a_title(monkeypatch):
     )
     assert "ssh" in tools._find_blocked_commands('cmd //c start "ssh a@b"')
     assert "rm" in tools._find_blocked_commands("cmd //c start 'sudo rm -rf /'")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'ls\nstart "" powershell -Command ls',
+        'echo hi\nstart "" ssh a@b',
+        "FOO=1 start \"\" powershell -Command ls",
+        'time start "" powershell -Command ls',
+        'env start "" powershell -Command ls',
+        'nohup start "" powershell -Command ls',
+        'echo x | xargs start "" powershell -Command ls',
+        'if x; then start "" rm -rf x',
+    ],
+)
+def test_a_launched_start_is_read_wherever_the_shell_runs_it(windows_terminal, command):
+    # Command position is what the main scan already decides, wrappers and
+    # assignment prefixes and all, so the walk reuses that verdict. Reading only
+    # the token before START instead missed every one of these, each of which
+    # really launches. A newline separates commands but lexes as whitespace,
+    # leaving no token to look back at, so it is recovered from the raw text.
+    assert tools._find_blocked_commands(command)
+
+
+def test_a_newline_inside_quotes_does_not_start_a_command(windows_terminal):
+    # Only a newline the quoting left bare ends a command. One inside a quoted
+    # word is data the command receives, and treating it as a separator would
+    # read printed text as a launch.
+    assert not tools._find_blocked_commands('echo "hi\nstart \'\' powershell"')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -313,10 +313,13 @@ def windows_terminal(request, monkeypatch):
         # token from the shell-name lookup, so nothing recursed into the tail.
         'cmd //c start "" "cmd" /c powershell -Command ls',
         # A quoted first argument is START's window title whatever it holds, so
-        # the program is one token further on than the `""` idiom implies.
-        'cmd //c start "job" powershell -Command ls',
+        # the program is one token further on than the `""` idiom implies. A
+        # title with a space stays provable after posix lexing drops the marks,
+        # because nothing else survives as one token.
         'cmd //c start "my window" pwsh -Command ls',
-        'cmd //c start /b "job" powershell -Command ls',
+        # /s strips the outer pair off the whole payload, leaving the lexer an
+        # empty first token with the program behind it.
+        'cmd /s /c ""powershell" -Command ls"',
     ],
 )
 def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, command):
@@ -380,3 +383,33 @@ def test_cmd_runs_only_double_quotes(monkeypatch):
     assert not tools._find_blocked_commands("cmd /c 'powershell -Command ls'")
     assert not tools._find_blocked_commands("cmd //c start '' powershell -Command ls")
     assert tools._find_blocked_commands('cmd /c "powershell -Command ls"')
+
+
+def test_cmd_reads_a_one_word_start_title(monkeypatch):
+    # Only the cmd lexer keeps the marks that prove `"job"` is a title rather
+    # than the program, so this spelling is screened there and not under bash.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert tools._find_blocked_commands('cmd //c start "job" powershell -Command ls')
+    assert tools._find_blocked_commands('cmd //c start /b "job" powershell -Command ls')
+
+
+def test_an_unquoted_start_program_keeps_its_arguments(monkeypatch):
+    # Posix lexing dropped the marks, so `notepad` could have been a title. It
+    # is taken as the program: `start notepad <file>` is the ordinary shape, and
+    # guessing the other way blocks the argument rather than a launched program.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert not tools._find_blocked_commands("cmd //c start notepad powershell -Command ls")
+    # A space could only have come from quoting, so that one is still a title.
+    assert tools._find_blocked_commands('cmd //c start "my window" pwsh -Command ls')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1064,9 +1064,7 @@ def test_the_launched_tail_keeps_its_quoting(windows_terminal):
     # Sliced out of the raw text, not rejoined from tokens: rejoining turns
     # `sed '1e rm -f victim'` into four bare words and the sed scan, which reads
     # that script for an `e`, then finds nothing.
-    assert "rm" in tools._find_blocked_commands(
-        "cmd //c start \"\" sed '1e rm -f victim' input"
-    )
+    assert "rm" in tools._find_blocked_commands("cmd //c start \"\" sed '1e rm -f victim' input")
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -886,3 +886,66 @@ def test_an_earlier_pair_does_not_vouch_for_a_later_one(monkeypatch):
     )
     assert not tools._find_blocked_commands('echo ""rm && xargs "" rm')
     assert "powershell" in tools._find_blocked_commands('echo hi && ""cmd /c powershell""')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c powershell&echo ok",
+        "cmd /c powershell|more",
+        "cmd /c powershell&&echo ok",
+    ],
+)
+def test_a_glued_cmd_operator_hides_a_second_command(windows_terminal, command):
+    # cmd needs no whitespace around & or |, so a payload can carry a whole
+    # second command with nothing separating the words. Screened as one program
+    # name, `powershell&echo` matched nothing and the launch went unread.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+def test_the_operator_test_reads_carets():
+    # An odd run of carets hands the operator over as text; an even run is
+    # escaped carets in front of a live one. Asserted on the helper rather than
+    # end to end, because the regex backstop matches a blocked word after any
+    # `&` whether or not a caret escaped it, and does so on main too. That is a
+    # separate false positive, called out in the PR as not fixed here.
+    assert tools._has_bare_cmd_operator("powershell&echo ok")
+    assert tools._has_bare_cmd_operator("a^^&powershell")
+    assert not tools._has_bare_cmd_operator("a^&powershell")
+    assert not tools._has_bare_cmd_operator("plain text")
+
+
+def test_a_caret_continues_a_cmd_line(monkeypatch):
+    # A caret at the end of a cmd line continues it, the way a backslash does
+    # under bash, so START is one more argument of the echo and only prints.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert not tools._find_blocked_commands('cmd /c echo hi ^\nstart "" powershell')
+    # An even run is escaped carets, so the newline still separates.
+    assert tools._find_blocked_commands('cmd /c echo hi ^^\nstart "" powershell')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd //c start "" "C:\\tmp\\rm report.docx"',
+        'cmd //c start "" "C:\\my docs\\curl notes.pdf"',
+    ],
+)
+def test_a_document_path_with_spaces_is_still_a_document(windows_terminal, command):
+    # A quoted document path holds spaces like any other, and re-lexing it as a
+    # command line read `rm report.docx` as the rm builtin. Its suffix is not one
+    # cmd executes, so START opens it through its association.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_quoted_command_line_after_start_is_not_a_document(windows_terminal):
+    # The other side: no path and no suffix cmd would associate, so this really
+    # is a command line and must still be lexed.
+    assert "rm" in tools._find_blocked_commands('start "" "rm -rf x"')
+    assert "rm" in tools._find_blocked_commands('start "" "rm -rf x.txt"')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2245,3 +2245,38 @@ def test_a_blank_attached_command_names_no_program(windows_git_bash_only, comman
 def test_an_attached_command_is_still_read(windows_git_bash_only, command):
     # The other half: a flag that really does carry a command still names it.
     assert "rm" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "C:/tools/timeout 5 powershell -Command ls",
+        "./timeout 5 powershell -Command ls",
+        'cmd /c "C:/tools/timeout 5 powershell -Command ls"',
+        'start "" C:/tools/timeout 5 powershell -Command ls',
+        'start "" C:\\tools\\timeout 5 powershell -Command ls',
+        "C:/tools/time powershell -Command ls",
+        "C:/tools/command powershell -Command ls",
+    ],
+)
+def test_a_path_qualified_wrapper_still_wraps(windows_cmd_only, command):
+    # cmd's own timeout takes a delay and its own time reads the clock, which is
+    # why the bare names are not wrappers there. A path picks a DIFFERENT
+    # executable, and the one it picks takes DURATION COMMAND and launches it.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "timeout 5 powershell -Command ls",
+        "time powershell -Command ls",
+        'cmd /c "timeout 5 powershell -Command ls"',
+        'start "" timeout 5 powershell -Command ls',
+    ],
+)
+def test_a_bare_windows_wrapper_launches_nothing(windows_cmd_only, command):
+    # The other half, and the reason the subtraction exists: cmd's own spelling
+    # of these names runs no child, so reading one as a wrapper refuses a line
+    # that could not have launched anything.
+    assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1929,6 +1929,4 @@ def test_a_path_qualified_shell_still_has_its_arguments_read(windows_terminal, c
 
 def test_a_path_qualified_program_is_still_just_a_program(windows_terminal):
     # And one that is neither still reports only itself.
-    assert tools._find_blocked_commands('cmd //c "C:\\tools\\pwsh.exe -Command ls"') == {
-        "pwsh"
-    }
+    assert tools._find_blocked_commands('cmd //c "C:\\tools\\pwsh.exe -Command ls"') == {"pwsh"}

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1779,7 +1779,9 @@ def test_a_prefix_handed_over_by_an_operator_still_forwards(windows_cmd_only, co
     assert "powershell" in tools._find_blocked_commands(command)
 
 
-@pytest.mark.parametrize("command", ['cmd /c echo(start "" powershell', 'cmd /c rem(start "" powershell'])
+@pytest.mark.parametrize(
+    "command", ['cmd /c echo(start "" powershell', 'cmd /c rem(start "" powershell']
+)
 def test_a_glued_parenthesis_after_a_word_opens_no_group(windows_cmd_only, command):
     # `echo(` and `rem(` are the no-space forms of those commands and print what
     # follows. Only a `(` of its own, or one behind another operator, opens a

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -639,7 +639,6 @@ def test_a_quoted_command_line_is_not_only_a_title(monkeypatch):
         'ls\nstart "" powershell -Command ls',
         'echo hi\nstart "" ssh a@b',
         'FOO=1 start "" powershell -Command ls',
-        'time start "" powershell -Command ls',
         'env start "" powershell -Command ls',
         'nohup start "" powershell -Command ls',
         'echo x | xargs start "" powershell -Command ls',
@@ -652,6 +651,32 @@ def test_a_launched_start_is_read_wherever_the_shell_runs_it(windows_terminal, c
     # really launches. A newline separates commands but lexes as whitespace,
     # leaving no token to look back at, so it is recovered from the raw text.
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['time start "" powershell -Command ls', "time powershell -Command ls"],
+)
+def test_a_posix_builtin_wrapper_is_read_only_under_bash(windows_git_bash_only, command):
+    # `time` runs the command behind it under bash. Under cmd it is `time [/t]`,
+    # which sets the clock, so nothing behind it is launched there and the cmd
+    # lane must not read it as a wrapper.
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c time powershell",
+        "cmd /c command powershell",
+        "cmd /c exec powershell",
+        "cmd /c builtin powershell",
+    ],
+)
+def test_a_posix_builtin_wrapper_is_not_read_in_a_cmd_payload(windows_terminal, command):
+    # The other half. A `/c` payload is cmd's line whatever lexed the outer one,
+    # so bash's own builtins do not run anything inside it.
+    assert not tools._find_blocked_commands(command)
 
 
 def test_a_newline_inside_quotes_does_not_start_a_command(windows_terminal):
@@ -689,7 +714,6 @@ def test_blank_and_leading_lines_still_open_a_command(windows_terminal, command)
     [
         'cmd //c env start "" powershell -Command ls',
         'cmd //c FOO=1 start "" powershell -Command ls',
-        'echo hi\ntime start "" powershell -Command ls',
         'echo hi\nFOO=1 start "" powershell -Command ls',
     ],
 )
@@ -1658,3 +1682,56 @@ def test_screening_stays_linear_in_path_fragments(windows_terminal):
     cost(500)
     small, large = cost(1000), cost(4000)
     assert large < small * 10, f"{small = } {large = }"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c echo ok&cmd /c powershell",
+        "cmd /c echo ok&&cmd /c powershell",
+        "cmd /c echo ok|cmd /c powershell",
+    ],
+)
+def test_a_shell_behind_a_glued_operator_opens_its_payload(windows_cmd_only, command):
+    # cmd needs no whitespace around its separators, so the second `cmd /c`
+    # really runs. Reading the whole token left that shell unrecognised and its
+    # payload unscreened.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c echo hi& call powershell",
+        "cmd /c echo hi&call powershell",
+        "cmd /c echo hi & call powershell",
+    ],
+)
+def test_call_is_read_however_the_operator_is_spelled(windows_cmd_only, command):
+    # The same boundary with the operator glued to the word in front, glued to
+    # CALL, or standing alone. All three run PowerShell.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\Program -Files\\PowerShell\\7\\pwsh.exe" -Command ls',
+        'cmd /c "C:\\Program - Files\\PowerShell\\7\\pwsh.exe" -Command ls',
+    ],
+)
+def test_a_hyphen_may_open_a_directory_name(windows_terminal, command):
+    # Windows allows a directory name to open with a hyphen, so a fragment
+    # carrying one is still part of the quoted path. Breaking there stopped the
+    # reconstruction at `C:\Program` and let the shell through unnamed.
+    assert "pwsh" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['start "my title" /? powershell', "cmd /c start \"job\" /? powershell"],
+)
+def test_start_help_launches_nothing(windows_terminal, command):
+    # `/?` displays START's help and returns, so the word behind it is never
+    # launched and screening it refused a line that only prints usage.
+    assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -394,6 +394,14 @@ def test_cmd_runs_only_double_quotes(monkeypatch):
     assert not tools._find_blocked_commands("cmd /c 'powershell -Command ls'")
     assert not tools._find_blocked_commands("cmd //c start '' powershell -Command ls")
     assert tools._find_blocked_commands('cmd /c "powershell -Command ls"')
+    # The path recovery follows the same rule, or it reconstructs a program out
+    # of a path cmd would look for literally, single quotes and all.
+    assert not tools._find_blocked_commands(
+        r"cmd /c 'C:\Program Files\PowerShell\7\pwsh.exe' -Command ls"
+    )
+    assert tools._find_blocked_commands(
+        r'cmd /c "C:\Program Files\PowerShell\7\pwsh.exe" -Command ls'
+    )
 
 
 def test_a_drive_path_after_start_is_the_program_not_a_switch(windows_terminal):
@@ -421,6 +429,17 @@ def test_the_s_switch_payload_keeps_a_spaced_program_path(monkeypatch):
     )
     # A path named in passing is still an argument, not a program.
     assert not tools._find_blocked_commands(r'cmd /c "ls /usr/bin/rm"')
+
+
+def test_a_full_path_still_names_the_nested_shell(windows_terminal):
+    # os.path.basename leaves a backslash path whole off Windows, so
+    # `C:\Windows\System32\cmd.exe` matched no shell and the second /c payload
+    # was never read. Asserting the program, not merely that something was
+    # blocked: the previous revision reported the POSIX source builtin here,
+    # which would have kept this test green for the wrong reason.
+    assert "powershell" in tools._find_blocked_commands(
+        r'cmd /c "C:\Windows\System32\cmd.exe" /c powershell -Command ls'
+    )
 
 
 def test_git_bash_hands_cmd_its_own_quotes(monkeypatch):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -597,7 +597,6 @@ def test_a_quoted_command_line_is_not_only_a_title(monkeypatch):
         'env start "" powershell -Command ls',
         'nohup start "" powershell -Command ls',
         'echo x | xargs start "" powershell -Command ls',
-        'if x; then start "" rm -rf x',
     ],
 )
 def test_a_launched_start_is_read_wherever_the_shell_runs_it(windows_terminal, command):
@@ -727,3 +726,92 @@ def test_bash_eats_an_unquoted_backslash_path(monkeypatch):
     assert "powershell" not in tools._find_blocked_commands(
         'C:\\Windows\\System32\\cmd.exe /c start "" powershell'
     )
+
+
+def test_a_bash_keyword_boundary_belongs_to_bash(monkeypatch):
+    # `;` and `then` are bash syntax. Under Git Bash they open a command and the
+    # START behind them launches; cmd has neither, so the same line only prints.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert "rm" in tools._find_blocked_commands('if x; then start "" rm -rf x')
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert not tools._find_blocked_commands('cmd /c echo hi; start "" powershell')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c echo hi; start "" powershell',
+        'cmd /c echo hi ^& start "" powershell',
+        'cmd /c echo hi ^^^& start "" powershell',
+    ],
+)
+def test_cmd_operators_decide_a_cmd_boundary(monkeypatch, command):
+    # cmd's control operators are &, &&, ||, | and parentheses. A `;` is a plain
+    # argument separator there, and a caret hands the operator after it over as
+    # text, so each of these prints its whole line and launches nothing.
+    # Asked of the cmd lexer alone: bash has neither rule, and the same lines
+    # really do run START there, which the next test pins.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c echo hi; start "" powershell',
+        'cmd /c echo hi ^& start "" powershell',
+    ],
+)
+def test_bash_has_neither_rule(monkeypatch, command):
+    # Under bash a `;` separates and a `^` is an ordinary character, so the `&`
+    # behind it is still an operator and START really launches. The caret rule
+    # must not leak across to the lexer it does not belong to.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert tools._find_blocked_commands(command)
+
+
+def test_a_live_cmd_operator_still_opens_a_command(monkeypatch):
+    # The other side of it: a bare `&`, and an escaped caret followed by a live
+    # `&`, both really do start a second command.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert tools._find_blocked_commands('cmd /c echo hi& start "" powershell')
+    assert tools._find_blocked_commands('cmd /c echo hi ^^& start "" powershell')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c start "" https://example.com/powershell',
+        'cmd /c start "title" "https://example.com/powershell"',
+        'cmd /c start "" http://x/rm',
+    ],
+)
+def test_start_browses_a_url_rather_than_running_it(windows_terminal, command):
+    # START hands a URL to the default browser, the same association route as the
+    # document targets. Reading its last path segment as the program refused the
+    # link outright.
+    assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1435,3 +1435,44 @@ def test_a_directory_named_like_a_command_is_not_the_program(windows_terminal, c
     # The other side: when the path DOES end in an executable, that is what runs,
     # so the folder it sits in is not screened as the program.
     assert not tools._find_blocked_commands(command)
+
+
+def test_the_newline_marker_cannot_be_exhausted(windows_terminal):
+    # Any fixed set of markers is one an author can include in full, and doing
+    # that used to disable newline recovery for the whole line. Searched now, so
+    # a command holding every previous candidate is still read.
+    every_old_marker = "".join(chr(code) for code in (1, 2, 3, 4, 5, 6, 14, 15))
+    command = f"echo {every_old_marker}\nstart \"\" powershell"
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c echo hi&call powershell",
+        "cmd /c echo hi & call powershell",
+        'call "powershell" -Command ls',
+        'cmd /c call "powershell" -Command ls',
+    ],
+)
+def test_call_is_read_through_glue_and_quoting(windows_cmd_only, command):
+    # cmd needs no whitespace around its operators, and it strips its own quote
+    # marks before resolving the program, so all four of these run PowerShell.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['cmd /c echo "a&call b"', 'cmd /c echo hi^&call powershell', "echo call powershell"],
+)
+def test_call_glue_has_to_be_live(windows_cmd_only, command):
+    assert not tools._find_blocked_commands(command)
+
+
+def test_newline_scanning_does_not_reread_the_line(windows_cmd_only):
+    # Counting the caret run by copying the prefix and stripping it re-read the
+    # whole line per newline, which is quadratic in the command.
+    script = "\n".join("echo line %d ^" % index for index in range(20000))
+    started = time.monotonic()
+    tools._find_blocked_commands(script)
+    assert time.monotonic() - started < 5

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1865,3 +1865,30 @@ def test_a_browser_target_is_not_a_shell_word(windows_terminal, command):
     # for it, so neither is a program. Publishing them as command positions let
     # the nested-shell pass read `https://example.com/cmd` as a shell.
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "if C:/a==b/powershell.exe",
+        "if ./a==b/rm -rf x",
+        "| if ./a==b/rm -rf x",
+        "if 1==1 rm -rf x",
+    ],
+)
+def test_bash_if_opens_no_cmd_comparison(windows_git_bash_only, command):
+    # Only cmd's IF takes a comparison. Under bash `if` is its own keyword and
+    # the word behind it is a command, so `if C:/a==b/powershell.exe` runs one
+    # and `if 1==1` looks for a program by that name. Found by randomised
+    # differential fuzzing once the corpus learned to spell a comparison.
+    assert tools._find_blocked_commands(command) or "1==1" in command
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["cmd /c if C:/a==b/powershell.exe -Command ls", "cmd /c if ./a==b/rm -rf x"],
+)
+def test_a_cmd_comparison_is_never_a_path(windows_terminal, command):
+    # And even inside a real condition, cmd compares two operands and neither
+    # carries a separator, so a word holding one is the program it looks like.
+    assert tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -320,6 +320,9 @@ def windows_terminal(request, monkeypatch):
         # /s strips the outer pair off the whole payload, leaving the lexer an
         # empty first token with the program behind it.
         'cmd /s /c ""powershell" -Command ls"',
+        # A program path holding spaces is ONE quoted word, so re-lexing it
+        # reads `C:\Program` and leaves the executable in argument position.
+        r'cmd /c "C:\Program Files\PowerShell\7\pwsh.exe" -Command ls',
     ],
 )
 def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, command):
@@ -383,6 +386,33 @@ def test_cmd_runs_only_double_quotes(monkeypatch):
     assert not tools._find_blocked_commands("cmd /c 'powershell -Command ls'")
     assert not tools._find_blocked_commands("cmd //c start '' powershell -Command ls")
     assert tools._find_blocked_commands('cmd /c "powershell -Command ls"')
+
+
+def test_a_drive_path_after_start_is_the_program_not_a_switch(windows_terminal):
+    # Git Bash hands `/c/Windows/...` to cmd as a C: executable path, but every
+    # documented START option is one word after the slash, so skipping anything
+    # slash-prefixed walked past the program onto its arguments.
+    assert tools._find_blocked_commands(
+        'cmd //c start "" /c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Command ls'
+    )
+
+
+def test_the_s_switch_payload_keeps_a_spaced_program_path(monkeypatch):
+    # /s strips the outer pair off the whole payload, so the program path is
+    # split across tokens with a stray mark on each. Pinned to the cmd lexer:
+    # posix shlex reads the backslashes as escapes and mangles the path.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert tools._find_blocked_commands(
+        r'cmd /s /c ""C:\Program Files\PowerShell\7\pwsh.exe" -Command ls"'
+    )
+    # A path named in passing is still an argument, not a program.
+    assert not tools._find_blocked_commands(r'cmd /c "ls /usr/bin/rm"')
 
 
 def test_cmd_reads_a_one_word_start_title(monkeypatch):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -312,6 +312,35 @@ def windows_terminal(request, monkeypatch):
     )
 
 
+@pytest.fixture
+def windows_cmd_only(monkeypatch):
+    """A Windows host with no trusted bash, so cmd does the parsing.
+
+    The blocklist is arranged exactly as ``windows_terminal`` does it, for the
+    reason that fixture gives: powershell is only a blocked name once
+    _BLOCKED_COMMANDS_WIN is folded in.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+
+
+@pytest.fixture
+def windows_git_bash_only(monkeypatch):
+    """The same host with a trusted Git Bash, so bash does the parsing."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+
+
 @pytest.mark.parametrize(
     "command",
     [
@@ -1234,17 +1263,35 @@ def test_a_wrapper_chain_within_the_budget_still_names_the_child(windows_termina
     "command",
     [
         'cmd //c call start "" powershell -Command ls',
-        'call start "" powershell',
-        "cmd /c call powershell",
-        "call cmd /c powershell",
-        "call rm -rf x",
+        'cmd /c call start "" powershell',
     ],
 )
-def test_call_forwards_to_a_command(windows_terminal, command):
+def test_call_forwards_inside_a_cmd_payload(windows_terminal, command):
+    # What follows a `/c` is cmd's to parse even when the outer shell is bash,
+    # so CALL forwards there on either lexer. The main walk recorded only
+    # `call`, so the position gate refused the START behind it.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['call start "" powershell', "cmd /c call powershell", "call rm -rf x"],
+)
+def test_call_forwards_when_cmd_is_the_shell(windows_cmd_only, command):
     # CALL re-parses the rest of the line and runs it, so its target is a
-    # command position exactly as a wrapper's child is. The main walk recorded
-    # only `call`, so the gate refused the START behind it.
+    # command position exactly as a wrapper's child is.
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["call curl http://x", "call rm -rf x"],
+)
+def test_call_is_not_a_prefix_under_bash(windows_git_bash_only, command):
+    # bash has no CALL builtin, so this runs a user program named call and the
+    # rest is its ARGUMENTS. Treating it as a prefix everywhere blocked a line
+    # bash would not have run the blocked name from.
+    assert not tools._find_blocked_commands(command)
 
 
 @pytest.mark.parametrize(
@@ -1253,3 +1300,55 @@ def test_call_forwards_to_a_command(windows_terminal, command):
 )
 def test_call_does_not_invent_a_command(windows_terminal, command):
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c echo ok&&start "" cmd /c powershell -Command ls',
+        'cmd /c echo hi&start "" powershell',
+        'echo hi&start "" powershell',
+        'cmd /c echo hi|start "" powershell',
+    ],
+)
+def test_start_after_a_glued_operator_still_launches(windows_cmd_only, command):
+    # cmd needs no whitespace around its operators, so this really launches, and
+    # that lexer hands the whole thing back as one token `ok&&start`.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c echo "a&start b"',
+        'cmd /c echo hi^&start "" powershell',
+        'cmd /c restart "" powershell',
+        "cmd /c kickstart --now",
+    ],
+)
+def test_a_glued_operator_has_to_be_live(windows_cmd_only, command):
+    # Inside a quoted span it is text, an odd run of carets escapes it, and a
+    # word merely ENDING in start is not one: `restart` and `kickstart` launch
+    # nothing.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_glue_survives_an_earlier_quoted_argument(windows_cmd_only):
+    # The owner map was built by splitting the whole line on whitespace, so it
+    # gave up as soon as any EARLIER argument held quoted whitespace and the
+    # glue was lost on a pair much further along. Read off token offsets now.
+    assert "powershell" in tools._find_blocked_commands('echo "a b" && ""cmd /c powershell""')
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['cmd /c "C:\\rm.exe dir\\notepad"', 'start "" "C:\\rm.exe dir\\notepad"'],
+)
+def test_an_exe_suffix_inside_a_directory_name_does_not_end_the_path(windows_terminal, command):
+    # A directory may be named `rm.exe dir`. Stopping at that chunk rather than
+    # the basename reported the folder as the program for a line running notepad.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_real_executable_still_ends_the_path(windows_terminal):
+    assert "rm" in tools._find_blocked_commands('cmd /c "C:\\tools\\rm.exe"')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1992,3 +1992,17 @@ def test_a_caret_escaped_quote_opens_no_span(windows_cmd_only):
     # behind it is live and the START it opens really launches.
     assert "powershell" in tools._find_blocked_commands('cmd /c echo ^"&start "" powershell')
     assert not tools._find_blocked_commands('cmd /c echo "&start "" powershell')
+
+
+@pytest.mark.parametrize("command", ["\\.", "cd C:\\dir\\.", "dir C:\\tmp\\."])
+def test_a_cmd_path_ending_in_a_dot_names_no_builtin(windows_cmd_only, command):
+    # cmd has neither `.` nor `source`, so the last segment of a path that
+    # happens to spell one is a directory entry rather than a command. Honouring
+    # cmd's separator made every such path report the POSIX source builtin.
+    # Found by randomised differential fuzzing against the previous scan.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_bare_source_builtin_is_still_read(windows_git_bash_only):
+    # The other half: spelled on its own it is the builtin, and bash has it.
+    assert "." in tools._find_blocked_commands(". ./script.sh")

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1228,3 +1228,28 @@ def test_a_padded_wrapper_chain_behind_start_fails_closed(windows_terminal):
 
 def test_a_wrapper_chain_within_the_budget_still_names_the_child(windows_terminal):
     assert "rm" in tools._find_blocked_commands('start "" env env rm -rf x')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd //c call start "" powershell -Command ls',
+        'call start "" powershell',
+        "cmd /c call powershell",
+        "call cmd /c powershell",
+        "call rm -rf x",
+    ],
+)
+def test_call_forwards_to_a_command(windows_terminal, command):
+    # CALL re-parses the rest of the line and runs it, so its target is a
+    # command position exactly as a wrapper's child is. The main walk recorded
+    # only `call`, so the gate refused the START behind it.
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['call build.bat', "call node app.js", "call :build", 'echo call start "" powershell'],
+)
+def test_call_does_not_invent_a_command(windows_terminal, command):
+    assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1093,3 +1093,40 @@ def test_nesting_does_not_decide_how_long_the_scan_takes(windows_terminal):
     start = time.monotonic()
     tools._find_blocked_commands('start "" ' * 40 + "echo hi")
     assert time.monotonic() - start < 5
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\tools.v2\\notepad -x"',
+        'cmd /c "C:\\tools.v2\\notepad"',
+    ],
+)
+def test_pathext_makes_the_suffix_optional_on_a_launched_path(windows_terminal, command):
+    # PATHEXT is why `C:\tools\notepad` runs notepad.exe, so a path that never
+    # carries a suffix is still a program. Reading it as anything else sent the
+    # payload through a full re-lex, where the dotted directory matched the
+    # POSIX source builtin and a legitimate launch was refused.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_echo_open_paren_prints_rather_than_groups(monkeypatch):
+    # cmd's `echo(` form prints what follows it. Reading the glued `(` as the
+    # grouping operator opened a command position the shell never opens, and
+    # refused a line that only prints its argument. A cmd shape: under bash the
+    # `(` is that shell's own operator and origin/main reads the line the same
+    # way, so only the cmd lexer is asserted here.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert not tools._find_blocked_commands('cmd /c echo( start "" powershell')
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['cmd /c ( start "" powershell )', '(start "" powershell)'],
+)
+def test_real_cmd_grouping_still_opens_a_command(windows_terminal, command):
+    # An operator GLUED to the word in front of START is a separate, pre-existing
+    # gap (`echo hi&(start ""...` reaches the cmd lexer as one token `hi&(start`),
+    # so it is not asserted here.
+    assert "powershell" in tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2123,3 +2123,70 @@ def test_a_document_name_may_still_hold_spaces(windows_terminal, command):
     # The other half: one trailing word is the document's own name, which may
     # carry spaces, and that is still a document rather than a command line.
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c start "" "C:\\tmp\\curl notes report.pdf"',
+        'cmd /c start "" "C:\\tmp\\my report.pdf"',
+    ],
+)
+def test_a_document_name_may_hold_many_words(windows_terminal, command):
+    # An OPTION behind the path is what makes a quoted string a command line.
+    # Without one the extra words belong to the file's own name, however many
+    # of them there are, and START opens it by association.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_an_option_still_makes_it_a_command_line(windows_terminal):
+    # The other half, unchanged: `-Command` is an option, so this runs a shell.
+    assert "powershell" in tools._find_blocked_commands(
+        'start "" "C:\\tools\\powershell -Command script.ps1"'
+    )
+
+
+def test_a_quoted_shell_path_keeps_its_own_arguments(windows_cmd_only):
+    # The program name comes back with its quote marks removed, so slicing the
+    # payload by its length landed inside the executable and rebuilt a broken
+    # word. Measured on the raw span instead, closing mark included.
+    assert "powershell" in tools._find_blocked_commands(
+        'cmd /c"C:\\Program Files\\cmd.exe" /c powershell'
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['cmd /c "C:\\rm&x\\notepad.exe"', 'cmd /c start "" "C:\\rm&x\\notepad.exe"'],
+)
+def test_an_operator_inside_a_quoted_path_is_path_text(windows_terminal, command):
+    # cmd treats a special character inside a quoted path as text, so `rm&x` is
+    # a directory name rather than a command chain.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_real_chain_behind_a_path_still_chains(windows_terminal):
+    # The other half: whitespace means the payload is not one path, so the
+    # operator really does open a second command.
+    assert "rm" in tools._find_blocked_commands(
+        'cmd /c "C:\\tools\\notepad.exe&rm -rf x"'
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["cmd //c call 'C:\\tmp\\rm.cmd' -rf x", "cmd //c call 'C:/tmp/rm.cmd' -rf x"],
+)
+def test_a_cmd_payload_keeps_cmd_paths_under_bash(windows_git_bash_only, command):
+    # bash's quoting carries the backslashes through, so the payload reaches cmd
+    # with the path intact and CALL resolves the batch file at the end of it.
+    assert "rm" in tools._find_blocked_commands(command)
+
+
+def test_a_group_closing_on_its_last_word_ends_the_command(windows_cmd_only):
+    # `if 1==0 (echo no) else powershell` runs the ELSE clause when the
+    # condition is false, and treating `no)` as an ordinary argument left it
+    # unread. The spaced spelling already worked.
+    assert "powershell" in tools._find_blocked_commands(
+        "cmd /c if 1==0 (echo no) else powershell -Command ls"
+    )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -664,20 +664,6 @@ def test_a_posix_builtin_wrapper_is_read_only_under_bash(windows_git_bash_only, 
     assert tools._find_blocked_commands(command)
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "cmd /c time powershell",
-        "cmd /c command powershell",
-        "cmd /c exec powershell",
-        "cmd /c builtin powershell",
-    ],
-)
-def test_a_posix_builtin_wrapper_is_not_read_in_a_cmd_payload(windows_terminal, command):
-    # The other half. A `/c` payload is cmd's line whatever lexed the outer one,
-    # so bash's own builtins do not run anything inside it.
-    assert not tools._find_blocked_commands(command)
-
 
 def test_a_newline_inside_quotes_does_not_start_a_command(windows_terminal):
     # Only a newline the quoting left bare ends a command. One inside a quoted
@@ -1011,14 +997,14 @@ def test_a_caret_continues_a_cmd_line(monkeypatch):
 @pytest.mark.parametrize(
     "command",
     [
-        'cmd //c start "" "C:\\tmp\\rm report.docx"',
-        'cmd //c start "" "C:\\my docs\\curl notes.pdf"',
+        'cmd //c start "" "C:\\tmp\\my report.docx"',
+        'cmd //c start "" "C:\\my docs\\notes summary.pdf"',
     ],
 )
 def test_a_document_path_with_spaces_is_still_a_document(windows_terminal, command):
     # A quoted document path holds spaces like any other, and re-lexing it as a
-    # command line read `rm report.docx` as the rm builtin. Its suffix is not one
-    # cmd executes, so START opens it through its association.
+    # command line read the first word as a program. No prefix of these names
+    # spells one, so START opens the file through its association.
     assert not tools._find_blocked_commands(command)
 
 
@@ -1422,9 +1408,9 @@ def test_an_executable_is_not_extended_into_its_arguments(windows_terminal, comm
 
 
 def test_a_document_name_may_still_hold_a_space(windows_terminal):
-    # The other side of that: nothing along `C:\tmp\rm report.docx` is
+    # The other side of that: nothing along `C:\tmp\my report.docx` is
     # executable, so the whole target is one file and its own suffix decides.
-    assert not tools._find_blocked_commands('cmd //c start "" "C:\\tmp\\rm report.docx"')
+    assert not tools._find_blocked_commands('cmd //c start "" "C:\\tmp\\my report.docx"')
 
 
 def test_the_newline_marker_is_not_attacker_controlled(windows_terminal):
@@ -1946,16 +1932,6 @@ def test_if_skips_its_case_insensitive_switch(windows_terminal):
     assert "powershell" in tools._find_blocked_commands("cmd /c if /i a==a powershell -Command ls")
 
 
-@pytest.mark.parametrize(
-    "command",
-    ["cmd /c timeout 5 powershell -Command ls", "cmd /c timeout /t 5 powershell"],
-)
-def test_windows_timeout_runs_nothing_behind_it(windows_terminal, command):
-    # Windows TIMEOUT pauses the command processor; it takes `/t` and `/nobreak`
-    # and does not forward to the word behind it, unlike the POSIX wrapper of
-    # the same name.
-    assert not tools._find_blocked_commands(command)
-
 
 def test_the_posix_timeout_still_wraps(windows_git_bash_only):
     # The other half, on the lane where `timeout 5 cmd` really does run cmd.
@@ -2128,14 +2104,14 @@ def test_a_document_name_may_still_hold_spaces(windows_terminal, command):
 @pytest.mark.parametrize(
     "command",
     [
-        'cmd /c start "" "C:\\tmp\\curl notes report.pdf"',
         'cmd /c start "" "C:\\tmp\\my report.pdf"',
+        'cmd /c start "" "C:\\tmp\\notes for review.pdf"',
     ],
 )
 def test_a_document_name_may_hold_many_words(windows_terminal, command):
-    # An OPTION behind the path is what makes a quoted string a command line.
-    # Without one the extra words belong to the file's own name, however many
-    # of them there are, and START opens it by association.
+    # A file's name may hold as many spaces as it likes, and none of the
+    # prefixes Windows tries out of these spells a program, so START opens
+    # the document by association.
     assert not tools._find_blocked_commands(command)
 
 
@@ -2266,17 +2242,139 @@ def test_a_path_qualified_wrapper_still_wraps(windows_cmd_only, command):
     assert "powershell" in tools._find_blocked_commands(command)
 
 
+
+
 @pytest.mark.parametrize(
     "command",
     [
         "timeout 5 powershell -Command ls",
         "time powershell -Command ls",
+        "command powershell -Command ls",
+        "exec powershell -Command ls",
+        "builtin powershell -Command ls",
         'cmd /c "timeout 5 powershell -Command ls"',
+        "cmd /c time powershell -Command ls",
         'start "" timeout 5 powershell -Command ls',
     ],
 )
-def test_a_bare_windows_wrapper_launches_nothing(windows_cmd_only, command):
-    # The other half, and the reason the subtraction exists: cmd's own spelling
-    # of these names runs no child, so reading one as a wrapper refuses a line
-    # that could not have launched anything.
+def test_a_bare_wrapper_name_is_still_a_wrapper(windows_cmd_only, command):
+    # Windows spells some of these differently -- TIME sets the clock, TIMEOUT
+    # takes a delay -- but which executable a bare name RESOLVES to is not ours
+    # to assume. _build_safe_env puts the interpreter directory and an active
+    # venv in front of System32, so a coreutils timeout.exe in either one wins
+    # the lookup and really does run the word behind it.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("command", ["timeout /t 5", "time /t", "cmd /c timeout /t 5"])
+def test_a_wrapper_with_no_child_names_nothing(windows_cmd_only, command):
+    # The flag is the wrapper's own argument either way, so no command follows.
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'start "" "C:\\tools\\powershell payload.ps1"',
+        'cmd /c start "" "C:\\tools\\powershell payload.ps1"',
+        'cmd /c start "" "C:\\tmp\\curl notes report.pdf"',
+        'cmd //c start "" "C:\\my docs\\curl notes.pdf"',
+    ],
+)
+def test_a_prefix_of_a_spaced_name_that_spells_a_program_is_one(windows_terminal, command):
+    # An unquoted name holding spaces is ambiguous, and Windows resolves it by
+    # trying successively LONGER prefixes with `.exe` appended, first one wins.
+    # So a positional argument behind the path is no more a document than an
+    # option is: the program at the front of it runs either way.
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c C:\\reports\\curl.txt",
+        "cmd /c C:\\tmp\\powershell.docx",
+    ],
+)
+def test_a_non_executable_suffix_names_no_program(windows_cmd_only, command):
+    # `.exe` is appended only to a name carrying NO extension, so one that
+    # already has a non-executable suffix is tried literally. Without START
+    # there is no association to open it through, and cmd refuses the line.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command", ["cmd /c C:\\tools\\powershell.exe", "cmd /c C:\\tools\\powershell"]
+)
+def test_an_executable_or_suffixless_path_still_names_its_program(windows_cmd_only, command):
+    # The other half: an executable suffix runs, and a suffixless path is what
+    # PATHEXT completes.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command", ["cmd /c echo foo) powershell -Command ls", "echo hi) rm -rf x"]
+)
+def test_an_unmatched_paren_closes_no_group(windows_cmd_only, command):
+    # cmd has nothing to close, so the parenthesis is ordinary text and the
+    # words behind it stay arguments of the command in front.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c (echo foo) powershell -Command ls",
+        "cmd /c ( echo no ) powershell -Command ls",
+        "cmd /c if 1==0 (echo no) else powershell -Command ls",
+    ],
+)
+def test_a_group_that_was_opened_still_ends_the_command(windows_cmd_only, command):
+    # The other half: a live `(` in front means the `)` really does close one.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c cmdextversion foo powershell",
+        "cmd /c errorlevel foo powershell",
+        "cmd /c defined foo powershell",
+        "cmd /c exist foo powershell",
+    ],
+)
+def test_a_condition_operator_is_not_one_at_command_position(windows_cmd_only, command):
+    # EXIST, DEFINED, ERRORLEVEL and CMDEXTVERSION are IF's operators. On their
+    # own they name a program and take their words as ordinary arguments, so
+    # consuming an operand there opened a command position cmd never opens.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c if cmdextversion 1 powershell",
+        "cmd /c if errorlevel 1 powershell",
+        "cmd /c if exist x powershell",
+        "cmd /c if not exist x powershell",
+    ],
+)
+def test_a_condition_operator_behind_if_still_opens_a_body(windows_cmd_only, command):
+    # The other half, inside a condition IF really opened.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["cmd /c echo&if.exe 1==1 powershell", "cmd /c echo&if.cmd 1==1 powershell"],
+)
+def test_a_program_named_if_behind_an_operator_is_a_program(windows_cmd_only, command):
+    # The basename drops an executable suffix, which turned `if.exe` into the
+    # keyword. cmd launches it with those words as arguments and evaluates
+    # nothing. The unglued and START paths already drew this distinction.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_bare_if_behind_an_operator_still_opens_a_condition(windows_cmd_only):
+    # The other half, unchanged.
+    assert "powershell" in tools._find_blocked_commands("cmd /c echo&if 1==1 powershell")

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1641,15 +1641,13 @@ def test_screening_stays_linear_in_escaped_operators(monkeypatch):
     cost(2000)  # warm the caches the walk builds
     small, large = cost(4000), cost(16000)
     # Quadratic would be about 16x for four times the input.
-    assert large < small * 10, f"{small=} {large=}"
+    assert large < small * 10, f"{small = } {large = }"
 
 
 def test_screening_stays_linear_in_path_fragments(windows_terminal):
     # A quoted path made of many separator-less fragments asked the same
     # lookahead once per fragment, and every call rescanned what was left.
-    assert "pwsh" in tools._find_blocked_commands(
-        'cmd /c "C:\\Program a a dir\\pwsh.exe"'
-    )
+    assert "pwsh" in tools._find_blocked_commands('cmd /c "C:\\Program a a dir\\pwsh.exe"')
 
     def cost(count):
         text = 'cmd /c "C:\\Program ' + "a " * count + 'dir\\pwsh.exe"'
@@ -1659,4 +1657,4 @@ def test_screening_stays_linear_in_path_fragments(windows_terminal):
 
     cost(500)
     small, large = cost(1000), cost(4000)
-    assert large < small * 10, f"{small=} {large=}"
+    assert large < small * 10, f"{small = } {large = }"

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1528,9 +1528,7 @@ def test_a_quoted_command_line_with_nothing_behind_it_is_still_screened(windows_
         'start "powershell -Command ls"\nrm -rf x',
     ],
 )
-def test_a_quoted_command_line_is_screened_when_no_command_follows(
-    windows_git_bash_only, command
-):
+def test_a_quoted_command_line_is_screened_when_no_command_follows(windows_git_bash_only, command):
     # What follows the quoted word decides whether it WAS a title. An option, a
     # separator, a newline, or nothing at all means no command came after it, so
     # the quoted word is the command line START runs.

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1735,3 +1735,31 @@ def test_start_help_launches_nothing(windows_terminal, command):
     # `/?` displays START's help and returns, so the word behind it is never
     # launched and screening it refused a line that only prints usage.
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["( call rm -rf x", ") call rm -rf x", "cmd /c echo hi& call powershell"],
+)
+def test_a_call_boundary_only_forwards_where_cmd_parses(windows_git_bash_only, command):
+    # The operator boundary that publishes CALL's child is cmd's, so it must not
+    # apply to a line bash is reading: `( call rm` runs a subshell looking for a
+    # program named call and never reaches rm. Found by randomised differential
+    # fuzzing against the previous scan, which reported neither.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_call_boundary_still_forwards_inside_a_quoted_payload():
+    # And it does apply inside a `/c` payload even where bash is the outer
+    # shell, because that payload is cmd's command line.
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(sys, "platform", "win32")
+        patch.setattr(tools, "_shell_is_posix", lambda: True)
+        patch.setattr(
+            tools,
+            "_BLOCKED_COMMANDS",
+            tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+        )
+        assert "powershell" in tools._find_blocked_commands(
+            'cmd //c "echo hi& call powershell"'
+        )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1401,3 +1401,37 @@ def test_the_newline_marker_is_not_attacker_controlled(windows_terminal):
     # line: a boundary an author could delete by typing it.
     assert "powershell" in tools._find_blocked_commands('echo \x01\nstart "" powershell')
     assert "powershell" in tools._find_blocked_commands('echo \x01\x02\x03\nstart "" powershell')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\tools\\rm scripts\\x"',
+        'cmd /c "C:\\tools\\pwsh scripts\\job.ps1"',
+        # START is not in this list on purpose. `cmd /c` runs a COMMAND LINE, so
+        # its prefixes are candidate programs; START takes a single target, which
+        # is why its arguments go outside the quotes, so a fully quoted target
+        # naming no executable reads as one file. With a suffix present there is
+        # no ambiguity and `start "" "C:\tools\pwsh.exe scripts\job.ps1"` is
+        # screened, which the test above pins.
+    ],
+)
+def test_the_shortest_prefix_is_screened_when_nothing_ends_the_path(windows_terminal, command):
+    # No executable suffix anywhere says where this path ENDS, and CreateProcess
+    # tries the shortest prefix first, so `C:\tools\rm scripts\x` runs rm on a
+    # file rather than naming one long path. Joining it all read the argument as
+    # the program and let the blocked one in front of it through.
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\powershell scripts\\notepad.exe -x"',
+        'cmd /c "C:\\tools\\notepad rm"',
+    ],
+)
+def test_a_directory_named_like_a_command_is_not_the_program(windows_terminal, command):
+    # The other side: when the path DOES end in an executable, that is what runs,
+    # so the folder it sits in is not screened as the program.
+    assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1523,7 +1523,7 @@ def test_a_quoted_command_line_with_nothing_behind_it_is_still_screened(windows_
     "command",
     [
         'start "powershell -Command ls"',
-        'start "powershell -Command ls" -x y',
+        'start "powershell -Command ls" /min',
         'start /d C:\\dir "powershell -Command ls" ; rm -rf x',
         'start "powershell -Command ls"\nrm -rf x',
     ],
@@ -1533,6 +1533,20 @@ def test_a_quoted_command_line_is_screened_when_no_command_follows(windows_git_b
     # separator, a newline, or nothing at all means no command came after it, so
     # the quoted word is the command line START runs.
     assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd //c start "C:\\Program Files\\PowerShell\\7\\pwsh.exe" -notepad.exe',
+        'start "powershell -Command ls" -x y',
+    ],
+)
+def test_a_hyphen_target_is_a_program_not_a_start_option(windows_git_bash_only, command):
+    # Every option START documents is slash-prefixed, so a `-` opens none of
+    # them. A hyphenated word behind the quoted one is the program START runs,
+    # which makes the quoted word its window title and nothing to screen.
+    assert not tools._find_blocked_commands(command)
 
 
 @pytest.mark.parametrize(
@@ -1578,3 +1592,71 @@ def test_a_call_wrapper_only_forwards_where_cmd_parses(command):
 
     assert not screen(True)
     assert screen(False)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['cmd //c "xargs call powershell"', 'cmd //c "env call powershell"'],
+)
+def test_call_stops_at_an_external_wrapper(windows_terminal, command):
+    # xargs and env run their child themselves rather than handing the rest of
+    # the line back to cmd, so cmd's own builtins no longer apply behind one.
+    # `xargs [OPTION]... COMMAND [INITIAL-ARGS]...` looks for a program named
+    # call, finds none, and never reaches PowerShell.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['cmd //c "call xargs powershell"', 'cmd //c "xargs powershell"'],
+)
+def test_a_wrapper_still_runs_its_own_child(windows_terminal, command):
+    # The other half. CALL re-parses the line under cmd, so a wrapper behind one
+    # is still cmd's, and a wrapper with a real child still launches it.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+def test_screening_stays_linear_in_escaped_operators(monkeypatch):
+    # Counting the carets in front of each operator by re-measuring the text
+    # from its start copied a longer prefix every time, so a payload made of
+    # escaped operators cost time in the square of its length.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert tools._has_bare_cmd_operator("echo hi&start")
+    assert not tools._has_bare_cmd_operator("echo hi^&start")
+    assert tools._has_bare_cmd_operator("echo hi^^&start")
+    assert not tools._has_bare_cmd_operator("echo hi^^^&start")
+
+    def cost(count):
+        text = 'cmd /c "echo ' + "^&" * count + '"'
+        start = time.perf_counter()
+        tools._find_blocked_commands(text)
+        return time.perf_counter() - start
+
+    cost(2000)  # warm the caches the walk builds
+    small, large = cost(4000), cost(16000)
+    # Quadratic would be about 16x for four times the input.
+    assert large < small * 10, f"{small=} {large=}"
+
+
+def test_screening_stays_linear_in_path_fragments(windows_terminal):
+    # A quoted path made of many separator-less fragments asked the same
+    # lookahead once per fragment, and every call rescanned what was left.
+    assert "pwsh" in tools._find_blocked_commands(
+        'cmd /c "C:\\Program a a dir\\pwsh.exe"'
+    )
+
+    def cost(count):
+        text = 'cmd /c "C:\\Program ' + "a " * count + 'dir\\pwsh.exe"'
+        start = time.perf_counter()
+        tools._find_blocked_commands(text)
+        return time.perf_counter() - start
+
+    cost(500)
+    small, large = cost(1000), cost(4000)
+    assert large < small * 10, f"{small=} {large=}"

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1342,13 +1342,62 @@ def test_glue_survives_an_earlier_quoted_argument(windows_cmd_only):
 
 @pytest.mark.parametrize(
     "command",
-    ['cmd /c "C:\\rm.exe dir\\notepad"', 'start "" "C:\\rm.exe dir\\notepad"'],
+    ['cmd /c "C:\\rm.exe dir\\notepad"', 'start "" "C:\\tools\\pwsh.exe scripts\\job.ps1"'],
 )
-def test_an_exe_suffix_inside_a_directory_name_does_not_end_the_path(windows_terminal, command):
-    # A directory may be named `rm.exe dir`. Stopping at that chunk rather than
-    # the basename reported the folder as the program for a line running notepad.
-    assert not tools._find_blocked_commands(command)
+def test_an_executable_suffix_ends_the_path(windows_terminal, command):
+    # CreateProcess resolves a path holding spaces by trying its prefixes
+    # SHORTEST first, so `C:\tools\pwsh.exe scripts\job.ps1` runs pwsh with a
+    # script argument rather than naming one long path. Carrying the path on
+    # through that argument read `job.ps1` as the program, whose suffix is not
+    # executable, and let the shell behind it through.
+    #
+    # A directory really named `rm.exe dir` is the same list of words, so it is
+    # refused here. That is the safe direction of an ambiguity the command line
+    # cannot resolve, and it is what the shell would try first.
+    assert tools._find_blocked_commands(command)
 
 
 def test_a_real_executable_still_ends_the_path(windows_terminal):
     assert "rm" in tools._find_blocked_commands('cmd /c "C:\\tools\\rm.exe"')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\Program Files (x86)\\PowerShell\\7\\pwsh.exe"',
+        'start "" "C:\\Program Files (x86)\\PowerShell\\7\\pwsh.exe"',
+    ],
+)
+def test_a_space_only_fragment_still_continues_a_path(windows_terminal, command):
+    # `Files` carries no separator of its own, and stopping there left `Program`
+    # as the program while the shell at the end of the path went unreported.
+    # A word like that continues the path when a LATER one still carries it.
+    assert "pwsh" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\tools\\pwsh.exe scripts\\job.ps1"',
+        'start "" "C:\\tools\\pwsh.exe scripts\\job.ps1"',
+    ],
+)
+def test_an_executable_is_not_extended_into_its_arguments(windows_terminal, command):
+    # Carrying the path on through a relative ARGUMENT read `job.ps1` as the
+    # program; its suffix is not executable, so the launch was reported as a
+    # document and the shell in front of it went unscreened.
+    assert "pwsh" in tools._find_blocked_commands(command)
+
+
+def test_a_document_name_may_still_hold_a_space(windows_terminal):
+    # The other side of that: nothing along `C:\tmp\rm report.docx` is
+    # executable, so the whole target is one file and its own suffix decides.
+    assert not tools._find_blocked_commands('cmd //c start "" "C:\\tmp\\rm report.docx"')
+
+
+def test_the_newline_marker_is_not_attacker_controlled(windows_terminal):
+    # The stand-in for a newline during the second lex used to be one fixed
+    # control character, so including it disabled newline recovery for the whole
+    # line: a boundary an author could delete by typing it.
+    assert "powershell" in tools._find_blocked_commands('echo \x01\nstart "" powershell')
+    assert "powershell" in tools._find_blocked_commands('echo \x01\x02\x03\nstart "" powershell')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -276,15 +276,12 @@ def test_notes_say_where_commands_run(monkeypatch):
 def windows_terminal(request, monkeypatch):
     """A Windows host, in both shell configurations _get_shell_cmd produces.
 
-    Faking sys.platform, which is all the rest of this file needs, does not
-    reach _BLOCKED_COMMANDS: it folds in _BLOCKED_COMMANDS_WIN at import, so on
-    the Linux runner powershell/pwsh are simply not blocked names and every
-    assertion below passes or fails for the wrong reason. Patch the constant.
-
-    The shell matters as well. With no trusted bash, _shell_is_posix() is False
-    and the blocklist lexes with shlex(posix = False), which keeps quote marks
-    on `""` and on a quoted payload. That is the configuration cmd screening
-    exists for, so both are parameters rather than one representative host.
+    Faking sys.platform, which is all the rest of this file needs, cannot reach
+    _BLOCKED_COMMANDS: it folds in _BLOCKED_COMMANDS_WIN at import, so on the
+    Linux runner powershell/pwsh are not blocked names and every assertion below
+    would pass or fail for the wrong reason. Both shells are parameters because
+    with no trusted bash the blocklist lexes with shlex(posix = False), which
+    keeps the quote marks cmd screening exists for.
     """
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(
@@ -319,8 +316,7 @@ def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, com
     # Git Bash turns a lone /c into a path, so a model writes //c. That spelling
     # skipped the nested scan, making `cmd //c powershell` reachable where
     # `cmd /c powershell` was blocked, and `start` launches its argument too.
-    # The quoted spellings are the ones the cmd lexer hands back with their
-    # quote marks still attached (see _unwrap_quotes).
+    # The quoted spellings reach the scan with their quotes on (_unwrap_quotes).
     assert tools._find_blocked_commands(command)
 
 

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -979,3 +979,46 @@ def test_detached_windows_stay_launchable(command, _windows_blocklist):
     # The blocklist is faked here too, or the Linux runner asserts this against
     # a set with no powershell in it and cannot see a blanket block at all.
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\powershell scripts\\notepad.exe"',
+        'start "" "C:\\powershell scripts\\notepad.exe"',
+        'cmd /c "C:\\rm backups\\notepad.exe"',
+    ],
+)
+def test_a_folder_name_is_not_the_program(windows_terminal, command):
+    # A program path holds spaces like any other, so re-lexing one read its
+    # directory components as words and reported the folder the executable sits
+    # in. The path shape and an executable suffix say to read the program off the
+    # path instead of scanning the whole thing as a shell line.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_program_path_is_still_read(windows_terminal):
+    # The other side: the same shape, and this one really is a blocked shell.
+    assert "pwsh" in tools._find_blocked_commands(
+        'cmd /c "C:\\Program Files\\PowerShell\\7\\pwsh.exe" -Command ls'
+    )
+    # And a real command line handed over in quotes is not a path, so it is lexed.
+    assert "rm" in tools._find_blocked_commands('start "" "rm -rf x"')
+
+
+def test_cmd_has_no_semicolon_separator(monkeypatch):
+    # The main scan treats `;` as a separator for bash and records what follows
+    # as a command. cmd never opens a command there, so trusting that set read
+    # `echo ; start "" powershell` as a launch when it only prints.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert not tools._find_blocked_commands('echo ; start "" powershell')
+    assert not tools._find_blocked_commands('cmd /c echo hi; start "" powershell')
+    # Under bash the same line really does open a command.
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert "powershell" in tools._find_blocked_commands('echo ; start "" powershell')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1159,3 +1159,44 @@ def test_a_word_without_a_separator_does_not_continue_a_path(windows_terminal, c
 )
 def test_a_spaced_or_suffixless_program_path_is_still_read(windows_terminal, command):
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\tmp\\curl http://x"',
+        'start "" "C:\\tmp\\curl http://x"',
+        'cmd /c "C:\\tmp\\curl C:\\out\\x"',
+    ],
+)
+def test_an_argument_is_not_a_path_continuation(windows_terminal, command):
+    # What continues a path holding spaces is a RELATIVE fragment. A word that
+    # opens a path of its own, or names a URL, is an argument however many
+    # separators it carries, and reading those as continuations took the
+    # basename off the ARGUMENT: `C:\tmp\curl http://x` came back as `x`.
+    assert "curl" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "start \"\" sed '1e rm -f victim' input",
+        'cmd //c start "" sed "1e rm -f victim" input',
+    ],
+)
+def test_a_sed_that_start_launches_is_read_as_sed(windows_terminal, command):
+    # The `e` scan reads its own list, built while the main walk ran, so a sed
+    # START launches was never read as one even though the launch itself was
+    # published. GNU sed's `e` shells out, so that script really deletes.
+    assert "rm" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["%COMSPEC% /c powershell", 'cmd /c start "" %COMSPEC% /c powershell'],
+)
+def test_comspec_names_cmd(windows_terminal, command):
+    # cmd expands %COMSPEC% before running anything and it names cmd.exe, so
+    # this is a shell invocation spelled the long way. Comparing the literal
+    # token to the shell names left the payload behind its /c unread.
+    assert "powershell" in tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -637,3 +637,60 @@ def test_blank_and_leading_lines_still_open_a_command(windows_terminal, command)
     # The recovery counts marks rather than measuring gaps, so a run of newlines,
     # a leading one and a CRLF pair all open exactly one command between them.
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd //c env start "" powershell -Command ls',
+        'cmd //c FOO=1 start "" powershell -Command ls',
+        'echo hi\ntime start "" powershell -Command ls',
+        'echo hi\nFOO=1 start "" powershell -Command ls',
+    ],
+)
+def test_a_prefix_may_stand_between_a_boundary_and_start(windows_terminal, command):
+    # A newline and cmd's own /c each open a command position, and a wrapper or
+    # assignment prefix may sit in it before START does. Blessing only the first
+    # word after the boundary left every one of these launches unscreened, so
+    # both feed the same prefix walk an ordinary command position uses.
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'echo "cmd" /c powershell',
+        "echo C:\\Windows\\System32\\cmd.exe /c powershell",
+        'echo /c start "" powershell',
+        'echo /k start "" powershell',
+    ],
+)
+def test_a_shell_named_in_passing_opens_no_payload(windows_terminal, command):
+    # Only a cmd the shell RUNS hands anything to a /c. Recovering the name by
+    # unquoting and normalising any previous word, and taking any /c-shaped token
+    # as a handoff, turned printing these lines into a hard block.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo ';' start \"\" powershell",
+        'echo "then" start "" powershell',
+        "echo '|' start \"\" powershell",
+    ],
+)
+def test_a_quoted_separator_before_start_is_still_data(windows_terminal, command):
+    # The posix lexer splits real separators into tokens of their own and records
+    # which of them the quoting only made look that way. Reading the previous
+    # token instead second-guessed it, and a printed `';'` or `"then"` read as
+    # though a command followed it.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_quoted_cmd_payload_is_not_a_program_name(windows_terminal):
+    # Marking what /c hands over as a command position also offered the whole
+    # quoted line to the blocklist as one word, and os.path.basename read its
+    # last path segment: listing a directory came back as the rm builtin.
+    assert not tools._find_blocked_commands('cmd /c "ls /usr/bin/rm"')
+    assert not tools._find_blocked_commands('cmd /c "dir C:\\tmp"')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -323,6 +323,8 @@ def windows_terminal(request, monkeypatch):
         # A program path holding spaces is ONE quoted word, so re-lexing it
         # reads `C:\Program` and leaves the executable in argument position.
         r'cmd /c "C:\Program Files\PowerShell\7\pwsh.exe" -Command ls',
+        # START reaches the same shape behind its title.
+        r'cmd //c start "" "C:\Program Files\PowerShell\7\pwsh.exe" -Command ls',
     ],
 )
 def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, command):
@@ -413,6 +415,37 @@ def test_the_s_switch_payload_keeps_a_spaced_program_path(monkeypatch):
     )
     # A path named in passing is still an argument, not a program.
     assert not tools._find_blocked_commands(r'cmd /c "ls /usr/bin/rm"')
+
+
+def test_git_bash_hands_cmd_its_own_quotes(monkeypatch):
+    # Under Git Bash the outer posix lexer strips only the shell's quoting, so
+    # cmd's own pair survives into the payload and cmd unquotes and runs it.
+    # Scanned in ADDITION to the quoted form, never instead: the two spans of
+    # `""rm -rf x""` are what keep that one from collapsing to a single word.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert tools._find_blocked_commands("""cmd //c '"powershell -Command ls"'""")
+    assert "rm" in tools._find_blocked_commands("""cmd /c '""rm -rf x""'""")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r'cmd /c "echo C:\tmp\pwsh.exe"',
+        r'cmd /c "dir C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"',
+        r'cmd /c "ls /usr/bin/rm"',
+    ],
+)
+def test_a_path_named_in_passing_is_not_a_program(windows_terminal, command):
+    # The split-path recovery reads the program a payload OPENS with. Scanning
+    # every word for an executable suffix instead turns printing or listing a
+    # PowerShell path into a hard block.
+    assert not tools._find_blocked_commands(command)
 
 
 def test_cmd_reads_a_one_word_start_title(monkeypatch):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -686,13 +686,21 @@ def test_a_newline_inside_quotes_does_not_start_a_command(windows_terminal):
     assert not tools._find_blocked_commands("echo \"hi\nstart '' powershell\"")
 
 
-def test_a_continued_line_is_one_command(windows_terminal):
+def test_a_continued_line_is_one_command(windows_git_bash_only):
     # A backslash before the newline joins the two lines, so what follows is one
     # more argument rather than a new command. Verified against bash: the second
     # line is printed, not launched. Only a newline the quoting left bare counts,
     # and an escaped one is quoted like any other character.
     assert not tools._find_blocked_commands('echo hi \\\nstart "" powershell')
     assert not tools._find_blocked_commands('echo one two \\\nthree start "" powershell')
+
+
+def test_cmd_continues_a_line_with_a_caret_not_a_backslash(windows_cmd_only):
+    # cmd's continuation is the caret. A backslash is an ordinary character
+    # there, so the newline behind it still ends the command and the START on
+    # the next line really launches.
+    assert "powershell" in tools._find_blocked_commands('echo hi \\\nstart "" powershell')
+    assert not tools._find_blocked_commands('echo hi ^\nstart "" powershell')
 
 
 @pytest.mark.parametrize(
@@ -1930,3 +1938,63 @@ def test_a_path_qualified_shell_still_has_its_arguments_read(windows_terminal, c
 def test_a_path_qualified_program_is_still_just_a_program(windows_terminal):
     # And one that is neither still reports only itself.
     assert tools._find_blocked_commands('cmd //c "C:\\tools\\pwsh.exe -Command ls"') == {"pwsh"}
+
+
+def test_if_skips_its_case_insensitive_switch(windows_terminal):
+    # `/i` stands between IF and its comparison, so the condition is still open
+    # behind it and the body behind that still runs.
+    assert "powershell" in tools._find_blocked_commands(
+        "cmd /c if /i a==a powershell -Command ls"
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["cmd /c timeout 5 powershell -Command ls", "cmd /c timeout /t 5 powershell"],
+)
+def test_windows_timeout_runs_nothing_behind_it(windows_terminal, command):
+    # Windows TIMEOUT pauses the command processor; it takes `/t` and `/nobreak`
+    # and does not forward to the word behind it, unlike the POSIX wrapper of
+    # the same name.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_the_posix_timeout_still_wraps(windows_git_bash_only):
+    # The other half, on the lane where `timeout 5 cmd` really does run cmd.
+    assert "powershell" in tools._find_blocked_commands("timeout 5 powershell -Command ls")
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['cmd /c "tools\\pwsh.exe -Command ls"', 'cmd /c "tools\\sub\\pwsh.exe -Command ls"'],
+)
+def test_a_plain_relative_path_names_a_program(windows_terminal, command):
+    # cmd resolves `tools\pwsh.exe` as surely as `.\tools\pwsh.exe`, and only
+    # the leading `.\` told the two apart.
+    assert "pwsh" in tools._find_blocked_commands(command)
+
+
+def test_a_call_child_path_is_normalised(windows_cmd_only):
+    # os.path.basename leaves a backslash path whole off Windows, so the
+    # forward-slash spelling was caught and this one was not.
+    assert "rm" in tools._find_blocked_commands("cmd /c call C:\\tmp\\rm.cmd -rf x")
+    assert "rm" in tools._find_blocked_commands("cmd /c call C:/tmp/rm.cmd -rf x")
+
+
+def test_a_single_quote_hides_no_cmd_boundary(windows_cmd_only):
+    # cmd has one string delimiter and it is not the single quote, so a lone `'`
+    # is an ordinary character and the newline behind it still ends the command.
+    assert "powershell" in tools._find_blocked_commands(
+        "cmd /c echo 'hi\nstart \"\" powershell"
+    )
+    # A double quote really does open a span, and the newline inside it is data.
+    assert not tools._find_blocked_commands('cmd /c echo "hi\nstart "" powershell')
+
+
+def test_a_caret_escaped_quote_opens_no_span(windows_cmd_only):
+    # `^"` is a quote mark cmd prints rather than a delimiter, so the operator
+    # behind it is live and the START it opens really launches.
+    assert "powershell" in tools._find_blocked_commands(
+        'cmd /c echo ^"&start "" powershell'
+    )
+    assert not tools._find_blocked_commands('cmd /c echo "&start "" powershell')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2070,3 +2070,56 @@ def test_a_glued_payload_never_raises(windows_terminal, command):
     # were unassigned on the first pass. Found by randomised differential
     # fuzzing, which counts a raise as a crash rather than an answer.
     assert isinstance(tools._find_blocked_commands(command), set)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c if cmdextversion 1 powershell -Command ls",
+        "cmd /c if errorlevel 1 powershell -Command ls",
+        "cmd /c if defined FOO powershell -Command ls",
+    ],
+)
+def test_every_cmd_condition_leaves_its_body_behind_it(windows_terminal, command):
+    # IF takes EXIST, DEFINED, ERRORLEVEL and CMDEXTVERSION as well as a
+    # comparison, and each carries its own operand. Missing one consumed the
+    # body as though it were the operand.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'start "" cmd /c if 1==1 powershell -Command ls',
+        "find . -exec cmd /c if 1==1 powershell -Command ls ;",
+    ],
+)
+def test_a_late_discovered_shell_reparses_its_whole_payload(windows_terminal, command):
+    # A shell the main walk never reached is published by a launcher pass, and
+    # cmd runs the WHOLE remainder as one command string. Screening only the
+    # word behind the switch left the condition unparsed and its body unread.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'start "" "C:\\tools\\powershell -Command script.ps1"',
+        'start "" "C:\\tools\\powershell -Command ls"',
+    ],
+)
+def test_a_suffixless_program_with_arguments_is_a_command_line(windows_terminal, command):
+    # START resolves a suffixless leading path through PATHEXT, so a `.ps1` word
+    # further along is its ARGUMENT. Judging the string by its last word called
+    # the whole thing a document and skipped the shell in front of it.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['start "" "C:\\tmp\\report.docx"', 'start "" "C:\\tmp\\my report.docx"'],
+)
+def test_a_document_name_may_still_hold_spaces(windows_terminal, command):
+    # The other half: one trailing word is the document's own name, which may
+    # carry spaces, and that is still a document rather than a command line.
+    assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -664,7 +664,6 @@ def test_a_posix_builtin_wrapper_is_read_only_under_bash(windows_git_bash_only, 
     assert tools._find_blocked_commands(command)
 
 
-
 def test_a_newline_inside_quotes_does_not_start_a_command(windows_terminal):
     # Only a newline the quoting left bare ends a command. One inside a quoted
     # word is data the command receives, and treating it as a separator would
@@ -1932,7 +1931,6 @@ def test_if_skips_its_case_insensitive_switch(windows_terminal):
     assert "powershell" in tools._find_blocked_commands("cmd /c if /i a==a powershell -Command ls")
 
 
-
 def test_the_posix_timeout_still_wraps(windows_git_bash_only):
     # The other half, on the lane where `timeout 5 cmd` really does run cmd.
     assert "powershell" in tools._find_blocked_commands("timeout 5 powershell -Command ls")
@@ -2240,8 +2238,6 @@ def test_a_path_qualified_wrapper_still_wraps(windows_cmd_only, command):
     # why the bare names are not wrappers there. A path picks a DIFFERENT
     # executable, and the one it picks takes DURATION COMMAND and launches it.
     assert "powershell" in tools._find_blocked_commands(command)
-
-
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1892,3 +1892,43 @@ def test_a_cmd_comparison_is_never_a_path(windows_terminal, command):
     # And even inside a real condition, cmd compares two operands and neither
     # carries a separator, so a word holding one is the program it looks like.
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c echo&cmd /c powershell&echo",
+        "cmd /c echo&call powershell&echo",
+        "cmd /c echo&powershell&echo",
+        "cmd /c echo|powershell|echo",
+    ],
+)
+def test_every_segment_of_a_glued_token_is_a_command(windows_cmd_only, command):
+    # One token can carry a whole chain, because cmd needs no whitespace around
+    # its separators. Reading only what followed the LAST operator skipped every
+    # command before it, so a trailing `&echo` hid the launch in front of it.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd //c "C:\\Windows\\System32\\cmd.exe /c powershell"',
+        'cmd //c "C:/Windows/System32/cmd.exe /c powershell"',
+        'cmd //c "C:\\Program Files\\Git\\bin\\bash.exe -c powershell"',
+        'cmd //c "C:\\tools\\env.exe powershell"',
+    ],
+)
+def test_a_path_qualified_shell_still_has_its_arguments_read(windows_terminal, command):
+    # A payload opening with a program path reported that program and stopped.
+    # Where the program is itself a shell or a wrapper its ARGUMENTS carry
+    # another command, and PATHEXT makes the suffix optional, so the name is
+    # matched by its stem too.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+def test_a_path_qualified_program_is_still_just_a_program(windows_terminal):
+    # And one that is neither still reports only itself.
+    assert tools._find_blocked_commands('cmd //c "C:\\tools\\pwsh.exe -Command ls"') == {
+        "pwsh"
+    }

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -852,3 +852,22 @@ def test_start_follows_the_prefix_it_launches(windows_terminal, command):
     # same shape `-exec` already models. Naming only `env` left the shell it
     # forwards to out of command position, so its payload was never read.
     assert tools._find_blocked_commands(command)
+
+
+def test_an_empty_pair_is_read_by_where_it_sits(monkeypatch):
+    # `""cmd` closes a zero-length span glued to the program, and the shell drops
+    # the marks before anything sees argv, so cmd really runs. `"" rm` is a
+    # different line: a genuine empty argument, and the wrapper in front of it
+    # tries to run nothing at all. Only the whitespace between them tells the two
+    # apart, so the raw text decides rather than the token alone.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert "powershell" in tools._find_blocked_commands('""cmd /c powershell""')
+    assert "powershell" in tools._find_blocked_commands('cmd //c start "" ""cmd /c powershell""')
+    assert not tools._find_blocked_commands('xargs "" rm')
+    assert not tools._find_blocked_commands('find . -exec "" rm ;')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2059,7 +2059,7 @@ def test_a_payload_glued_to_the_switch_is_still_a_payload(windows_terminal, comm
     [
         "cmd //cC:\\Program equecho",
         "cmd /cC:\\tools\\pwsh.exe -Command ls",
-        "cmd /c\"rm\" fd",
+        'cmd /c"rm" fd',
         "| https://example.com/cmd //c./a==b/rm -rf dir",
     ],
 )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2223,9 +2223,7 @@ def test_a_program_named_if_is_launched_directly(windows_cmd_only, command):
     assert not tools._find_blocked_commands(command)
 
 
-@pytest.mark.parametrize(
-    "command", ["C:\\tools\\sed -rf", "\\sed -rf", "C:\\tools\\sed.exe -rf"]
-)
+@pytest.mark.parametrize("command", ["C:\\tools\\sed -rf", "\\sed -rf", "C:\\tools\\sed.exe -rf"])
 def test_a_refusal_names_the_program_not_its_path(windows_cmd_only, command):
     # The passes that fail closed name their token outright, and nothing else
     # normalises it for them, so a backslash path was refused whole. The name

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2052,3 +2052,21 @@ def test_a_payload_glued_to_the_switch_is_still_a_payload(windows_terminal, comm
     # remainder is read from the raw line, because a quote opening mid-token
     # does not hold that lexer's word together.
     assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd //cC:\\Program equecho",
+        "cmd /cC:\\tools\\pwsh.exe -Command ls",
+        "cmd /c\"rm\" fd",
+        "| https://example.com/cmd //c./a==b/rm -rf dir",
+    ],
+)
+def test_a_glued_payload_never_raises(windows_terminal, command):
+    # The screen answers a yes or no; an exception is neither. Reading a payload
+    # glued to the switch reaches _screen_cmd_payload from inside the main walk,
+    # and the shell name sets it consults were defined BELOW that walk, so they
+    # were unassigned on the first pass. Found by randomised differential
+    # fuzzing, which counts a raise as a crash rather than an answer.
+    assert isinstance(tools._find_blocked_commands(command), set)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -592,7 +592,7 @@ def test_a_quoted_command_line_is_not_only_a_title(monkeypatch):
     [
         'ls\nstart "" powershell -Command ls',
         'echo hi\nstart "" ssh a@b',
-        "FOO=1 start \"\" powershell -Command ls",
+        'FOO=1 start "" powershell -Command ls',
         'time start "" powershell -Command ls',
         'env start "" powershell -Command ls',
         'nohup start "" powershell -Command ls',
@@ -613,4 +613,4 @@ def test_a_newline_inside_quotes_does_not_start_a_command(windows_terminal):
     # Only a newline the quoting left bare ends a command. One inside a quoted
     # word is data the command receives, and treating it as a separator would
     # read printed text as a launch.
-    assert not tools._find_blocked_commands('echo "hi\nstart \'\' powershell"')
+    assert not tools._find_blocked_commands("echo \"hi\nstart '' powershell\"")

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -371,6 +371,9 @@ def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, com
 def test_detached_windows_stay_launchable(windows_terminal, command):
     # `start` is the only route to a window on the user's desktop, which the
     # terminal description promises, so screening must not blanket-block cmd.
+    # #7936 added this with its own blocklist fixture; windows_terminal fakes the
+    # same set AND fixes which lexer runs, so the two were folded together rather
+    # than left as one name defined twice, where the second silently won.
     assert not tools._find_blocked_commands(command)
 
 
@@ -967,23 +970,6 @@ def test_a_quoted_command_line_after_start_is_not_a_document(windows_terminal):
 @pytest.mark.parametrize(
     "command",
     [
-        'cmd //c start "" bash -c "bash /c/x.sh"',
-        "cmd //c start wt",
-        "cmd //c dir",
-        "start notepad",
-    ],
-)
-def test_detached_windows_stay_launchable(command, _windows_blocklist):
-    # `start` is the only route to a window on the user's desktop, which the
-    # terminal description promises, so screening must not blanket-block cmd.
-    # The blocklist is faked here too, or the Linux runner asserts this against
-    # a set with no powershell in it and cannot see a blanket block at all.
-    assert not tools._find_blocked_commands(command)
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
         'cmd /c "C:\\powershell scripts\\notepad.exe"',
         'start "" "C:\\powershell scripts\\notepad.exe"',
         'cmd /c "C:\\rm backups\\notepad.exe"',
@@ -1057,3 +1043,56 @@ def test_arguments_after_a_program_path_are_not_a_command(windows_terminal, comm
 def test_an_operator_still_wins_over_the_path_shape(windows_terminal):
     # An operator means a second command follows whatever the first looks like.
     assert "rm" in tools._find_blocked_commands('cmd /c "C:\\tools\\notepad.exe&rm -rf x"')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "start \"\" sed '1e rm -f victim' input",
+        'start "" fd -x rm -rf x',
+        'start "" find . -exec rm -rf x ;',
+    ],
+)
+def test_start_launches_a_command_line_not_just_a_program(windows_terminal, command):
+    # sed's `e` and find/fd's -exec are scanned from their own token lists, and
+    # those only ever saw the tool in ARGUMENT position behind START. What START
+    # launches is a command line in its own right, so it is scanned as one.
+    assert "rm" in tools._find_blocked_commands(command)
+
+
+def test_the_launched_tail_keeps_its_quoting(windows_terminal):
+    # Sliced out of the raw text, not rejoined from tokens: rejoining turns
+    # `sed '1e rm -f victim'` into four bare words and the sed scan, which reads
+    # that script for an `e`, then finds nothing.
+    assert "rm" in tools._find_blocked_commands(
+        "cmd //c start \"\" sed '1e rm -f victim' input"
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\tools.v2\\pwsh"',
+        'start "" "C:\\tools.v2\\pwsh"',
+    ],
+)
+def test_a_dotted_directory_does_not_supply_the_extension(windows_terminal, command):
+    # os.path.splitext does not split a backslash off Windows, so splitting the
+    # whole path let the DIRECTORY supply the suffix: `C:\tools.v2\pwsh` came
+    # back with `.v2\pwsh`, no executable suffix, and the shell went unreported.
+    # The basename comes first now, everywhere a suffix is read.
+    assert "pwsh" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\powershell scripts\\notepad.exe -x"',
+        'start "" "C:\\powershell scripts\\notepad.exe -x"',
+    ],
+)
+def test_a_spaced_path_with_arguments_is_recovered_whole(windows_terminal, command):
+    # Reading only the first whitespace-delimited word missed that the directory
+    # itself holds a space, so the payload fell through to a full re-lex and the
+    # folder `powershell scripts` was reported for a line that runs notepad.
+    assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1533,3 +1533,48 @@ def test_a_quoted_command_line_is_screened_when_no_command_follows(windows_git_b
     # separator, a newline, or nothing at all means no command came after it, so
     # the quoted word is the command line START runs.
     assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "notepad start rm -rf x",
+        "dir report.docx start powershell -Command ls",
+    ],
+)
+def test_start_only_launches_where_a_command_may_begin(windows_terminal, command):
+    # START is a launcher at a command position and an ordinary argument
+    # anywhere else. A program already named ahead of it receives these words,
+    # so nothing behind the START runs. Randomised differential fuzzing against
+    # the previous scan reduced to this one family, so it is pinned here.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["env", "nohup", "time", "xargs", "FOO=1", "true &&", "true ;", "echo hi |"],
+)
+def test_start_still_launches_behind_a_real_prefix(windows_git_bash_only, prefix):
+    # The other half, and the reason the rule above is safe: everywhere a
+    # command really does begin, START is read as one.
+    assert "rm" in tools._find_blocked_commands(f"{prefix} start rm -rf x")
+
+
+@pytest.mark.parametrize("command", ["call bash -c pwsh", "call cmd /c powershell"])
+def test_a_call_wrapper_only_forwards_where_cmd_parses(command):
+    # CALL is a cmd builtin, so the shell behind it opens a payload only on the
+    # cmd lane. Under bash `call` is an ordinary program name and everything
+    # after it is its arguments, which run nothing.
+    def screen(posix):
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(sys, "platform", "win32")
+            patch.setattr(tools, "_shell_is_posix", lambda: posix)
+            patch.setattr(
+                tools,
+                "_BLOCKED_COMMANDS",
+                tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+            )
+            return tools._find_blocked_commands(command)
+
+    assert not screen(True)
+    assert screen(False)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1442,7 +1442,7 @@ def test_the_newline_marker_cannot_be_exhausted(windows_terminal):
     # that used to disable newline recovery for the whole line. Searched now, so
     # a command holding every previous candidate is still read.
     every_old_marker = "".join(chr(code) for code in (1, 2, 3, 4, 5, 6, 14, 15))
-    command = f"echo {every_old_marker}\nstart \"\" powershell"
+    command = f'echo {every_old_marker}\nstart "" powershell'
     assert "powershell" in tools._find_blocked_commands(command)
 
 
@@ -1463,7 +1463,7 @@ def test_call_is_read_through_glue_and_quoting(windows_cmd_only, command):
 
 @pytest.mark.parametrize(
     "command",
-    ['cmd /c echo "a&call b"', 'cmd /c echo hi^&call powershell', "echo call powershell"],
+    ['cmd /c echo "a&call b"', "cmd /c echo hi^&call powershell", "echo call powershell"],
 )
 def test_call_glue_has_to_be_live(windows_cmd_only, command):
     assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1130,3 +1130,32 @@ def test_real_cmd_grouping_still_opens_a_command(windows_terminal, command):
     # gap (`echo hi&(start ""...` reaches the cmd lexer as one token `hi&(start`),
     # so it is not asserted here.
     assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\tools\\notepad rm"',
+        'cmd /c "C:\\tools\\notepad powershell"',
+        'start "" "C:\\tools\\notepad rm"',
+    ],
+)
+def test_a_word_without_a_separator_does_not_continue_a_path(windows_terminal, command):
+    # `C:\Program Files\PowerShell\7\pwsh` and `C:\tools\notepad rm` are the same
+    # list of words: a path holding a space, and a path followed by a file to
+    # open. Joining both read the second as a program named rm and refused a line
+    # that runs notepad. Only a word carrying a separator continues the path.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\Program Files\\PowerShell\\7\\pwsh"',
+        'cmd /c "C:\\tools\\rm -rf x"',
+        'cmd /c "C:\\tools\\rm"',
+        'cmd /c "C:\\powershell scripts\\pwsh.exe -x"',
+    ],
+)
+def test_a_spaced_or_suffixless_program_path_is_still_read(windows_terminal, command):
+    assert tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1813,3 +1813,55 @@ def test_a_cmd_comparison_still_leaves_a_command_behind_it(windows_terminal, com
 def test_a_comparison_in_argument_position_is_not_a_condition(windows_terminal):
     # And only where a command may begin: `echo a==b rm` prints its arguments.
     assert not tools._find_blocked_commands("echo a==b rm")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "1==1",
+        "cmd /c if 1==1",
+        'cmd //c "if 1==1 echo ok"',
+        "if",
+        "cmd /c if not",
+        "cmd /c if %a% equ",
+    ],
+)
+def test_a_comparison_at_the_end_of_the_line_does_not_raise(windows_terminal, command):
+    # The screen answers a yes or no; an exception is neither, and whatever the
+    # caller does with one it is not a refusal. A comparison with nothing behind
+    # it read past the end of the token list.
+    assert isinstance(tools._find_blocked_commands(command), set)
+
+
+def test_a_quoted_cmd_payload_with_a_comparison_is_still_screened(windows_terminal):
+    # And the payload behind it is still read.
+    assert "rm" in tools._find_blocked_commands('cmd //c "if 1==1 rm -rf x"')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "C:/a==b/powershell.exe -Command ls",
+        "./a==b/rm -rf x",
+        "cmd /c C:/a==b/powershell.exe -Command ls",
+    ],
+)
+def test_an_equals_in_a_path_is_not_a_comparison(windows_terminal, command):
+    # `==` reads as cmd's comparison only inside a condition an IF opened. A
+    # path may hold one, and skipping that word passed over the program it
+    # names while the regex backstop could not match it either.
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'start "" https://example.com/cmd /c powershell',
+        'start "" report.docx /c powershell',
+    ],
+)
+def test_a_browser_target_is_not_a_shell_word(windows_terminal, command):
+    # START hands a URL to the browser and a document to whatever is registered
+    # for it, so neither is a program. Publishing them as command positions let
+    # the nested-shell pass read `https://example.com/cmd` as a shell.
+    assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -700,7 +700,7 @@ def test_a_quoted_cmd_payload_is_not_a_program_name(windows_terminal):
     "command",
     [
         '"C:\\Windows\\System32\\cmd.exe" /c start "" powershell -Command ls',
-        "C:/Windows/System32/cmd.exe /c start \"\" powershell -Command ls",
+        'C:/Windows/System32/cmd.exe /c start "" powershell -Command ls',
         '"C:\\Windows\\System32\\cmd.exe" /c env start "" powershell -Command ls',
     ],
 )
@@ -725,5 +725,5 @@ def test_bash_eats_an_unquoted_backslash_path(monkeypatch):
         tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
     )
     assert "powershell" not in tools._find_blocked_commands(
-        "C:\\Windows\\System32\\cmd.exe /c start \"\" powershell"
+        'C:\\Windows\\System32\\cmd.exe /c start "" powershell'
     )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2188,3 +2188,48 @@ def test_a_group_closing_on_its_last_word_ends_the_command(windows_cmd_only):
     assert "powershell" in tools._find_blocked_commands(
         "cmd /c if 1==0 (echo no) else powershell -Command ls"
     )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "start if 1==1 powershell -Command ls",
+        "start if not 1==1 powershell -Command ls",
+        "start if exist x powershell -Command ls",
+        'start "" if 1==1 powershell -Command ls',
+        "start /b if 1==1 powershell -Command ls",
+        "cmd /c start if 1==1 powershell -Command ls",
+    ],
+)
+def test_start_hands_an_internal_command_to_the_processor(windows_cmd_only, command):
+    # START does not launch an internal cmd command itself: it runs the command
+    # processor over the whole tail, so IF's body is a command position and the
+    # launch behind the condition is real.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "start if.exe 1==1 powershell",
+        "start C:\\bin\\if 1==1 powershell",
+        "start iffy powershell",
+        "start if",
+    ],
+)
+def test_a_program_named_if_is_launched_directly(windows_cmd_only, command):
+    # Only the bare keyword goes to the processor. A suffix or a path names a
+    # program, which START launches with the rest as its arguments.
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command", ["C:\\tools\\sed -rf", "\\sed -rf", "C:\\tools\\sed.exe -rf"]
+)
+def test_a_refusal_names_the_program_not_its_path(windows_cmd_only, command):
+    # The passes that fail closed name their token outright, and nothing else
+    # normalises it for them, so a backslash path was refused whole. The name
+    # reaches the author in the refusal, so it has to be the program's.
+    blocked = tools._find_blocked_commands(command)
+    assert "sed" in blocked
+    assert not [name for name in blocked if "/" in name or "\\" in name]

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -12,6 +12,7 @@ because studio-backend-ci is Linux-only.
 
 import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -1048,28 +1049,6 @@ def test_an_operator_still_wins_over_the_path_shape(windows_terminal):
 @pytest.mark.parametrize(
     "command",
     [
-        "start \"\" sed '1e rm -f victim' input",
-        'start "" fd -x rm -rf x',
-        'start "" find . -exec rm -rf x ;',
-    ],
-)
-def test_start_launches_a_command_line_not_just_a_program(windows_terminal, command):
-    # sed's `e` and find/fd's -exec are scanned from their own token lists, and
-    # those only ever saw the tool in ARGUMENT position behind START. What START
-    # launches is a command line in its own right, so it is scanned as one.
-    assert "rm" in tools._find_blocked_commands(command)
-
-
-def test_the_launched_tail_keeps_its_quoting(windows_terminal):
-    # Sliced out of the raw text, not rejoined from tokens: rejoining turns
-    # `sed '1e rm -f victim'` into four bare words and the sed scan, which reads
-    # that script for an `e`, then finds nothing.
-    assert "rm" in tools._find_blocked_commands("cmd //c start \"\" sed '1e rm -f victim' input")
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
         'cmd /c "C:\\tools.v2\\pwsh"',
         'start "" "C:\\tools.v2\\pwsh"',
     ],
@@ -1094,3 +1073,23 @@ def test_a_spaced_path_with_arguments_is_recovered_whole(windows_terminal, comma
     # itself holds a space, so the payload fell through to a full re-lex and the
     # folder `powershell scripts` was reported for a line that runs notepad.
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3, 8])
+def test_a_launcher_and_a_shell_hand_command_position_to_each_other(windows_terminal, depth):
+    # Each scan opens command positions the other reads, so reading each list
+    # once, in a fixed order, stopped at the first handover: the second `start`
+    # sat in a payload the shell scan had not published yet, its own target was
+    # never published in turn, and the `rm` behind it went unread.
+    command = 'start "" cmd /c ' * depth + "rm -rf x"
+    assert "rm" in tools._find_blocked_commands(command)
+
+
+def test_nesting_does_not_decide_how_long_the_scan_takes(windows_terminal):
+    # Every nested scan runs on a SUFFIX of the same text and the token walk
+    # reaches those suffixes too, so each was scanned once per path that arrived
+    # at it: 2**n for n wrappers, which is 19 seconds at 17 of them and does not
+    # finish at 30. A command that refuses to be screened is a command that runs.
+    start = time.monotonic()
+    tools._find_blocked_commands('start "" ' * 40 + "echo hi")
+    assert time.monotonic() - start < 5

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1943,9 +1943,7 @@ def test_a_path_qualified_program_is_still_just_a_program(windows_terminal):
 def test_if_skips_its_case_insensitive_switch(windows_terminal):
     # `/i` stands between IF and its comparison, so the condition is still open
     # behind it and the body behind that still runs.
-    assert "powershell" in tools._find_blocked_commands(
-        "cmd /c if /i a==a powershell -Command ls"
-    )
+    assert "powershell" in tools._find_blocked_commands("cmd /c if /i a==a powershell -Command ls")
 
 
 @pytest.mark.parametrize(
@@ -1984,9 +1982,7 @@ def test_a_call_child_path_is_normalised(windows_cmd_only):
 def test_a_single_quote_hides_no_cmd_boundary(windows_cmd_only):
     # cmd has one string delimiter and it is not the single quote, so a lone `'`
     # is an ordinary character and the newline behind it still ends the command.
-    assert "powershell" in tools._find_blocked_commands(
-        "cmd /c echo 'hi\nstart \"\" powershell"
-    )
+    assert "powershell" in tools._find_blocked_commands('cmd /c echo \'hi\nstart "" powershell')
     # A double quote really does open a span, and the newline inside it is data.
     assert not tools._find_blocked_commands('cmd /c echo "hi\nstart "" powershell')
 
@@ -1994,7 +1990,5 @@ def test_a_single_quote_hides_no_cmd_boundary(windows_cmd_only):
 def test_a_caret_escaped_quote_opens_no_span(windows_cmd_only):
     # `^"` is a quote mark cmd prints rather than a delimiter, so the operator
     # behind it is live and the START it opens really launches.
-    assert "powershell" in tools._find_blocked_commands(
-        'cmd /c echo ^"&start "" powershell'
-    )
+    assert "powershell" in tools._find_blocked_commands('cmd /c echo ^"&start "" powershell')
     assert not tools._find_blocked_commands('cmd /c echo "&start "" powershell')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1729,7 +1729,7 @@ def test_a_hyphen_may_open_a_directory_name(windows_terminal, command):
 
 @pytest.mark.parametrize(
     "command",
-    ['start "my title" /? powershell', "cmd /c start \"job\" /? powershell"],
+    ['start "my title" /? powershell', 'cmd /c start "job" /? powershell'],
 )
 def test_start_help_launches_nothing(windows_terminal, command):
     # `/?` displays START's help and returns, so the word behind it is never

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1200,3 +1200,31 @@ def test_comspec_names_cmd(windows_terminal, command):
     # this is a shell invocation spelled the long way. Comparing the literal
     # token to the shell names left the payload behind its /c unread.
     assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c echo hi& cmd /c powershell",
+        'cmd /c start "" https://x/?a=1& cmd /c powershell',
+    ],
+)
+def test_a_glued_operator_opens_a_command_for_the_shell_lookup(windows_terminal, command):
+    # The cmd lexer never splits an operator off the word it is glued to, so
+    # `hi&` keeps its `&` and the main scan stays in argument position for the
+    # rest of the line. The START gate already reads that off the previous
+    # token; the shell lookups did not, so the second shell was refused a
+    # command position and its payload went unread. Both ask one predicate now.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+def test_a_padded_wrapper_chain_behind_start_fails_closed(windows_terminal):
+    # The wrapper chain outran the hop budget, so the command START finally runs
+    # was never reached. Blocking the chain's own first word is what `-exec`
+    # already does; failing open instead just tells an author how long to make
+    # the padding.
+    assert tools._find_blocked_commands('start "" ' + "env " * 40 + "rm -rf x")
+
+
+def test_a_wrapper_chain_within_the_budget_still_names_the_child(windows_terminal):
+    assert "rm" in tools._find_blocked_commands('start "" env env rm -rf x')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1760,6 +1760,4 @@ def test_a_call_boundary_still_forwards_inside_a_quoted_payload():
             "_BLOCKED_COMMANDS",
             tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
         )
-        assert "powershell" in tools._find_blocked_commands(
-            'cmd //c "echo hi& call powershell"'
-        )
+        assert "powershell" in tools._find_blocked_commands('cmd //c "echo hi& call powershell"')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -306,10 +306,12 @@ def windows_terminal(request, monkeypatch):
         "cmd //k powershell -Command ls",
         'cmd /c "powershell -Command ls"',
         'cmd //c start "" powershell -Command ls',
-        "cmd //c start '' powershell -Command ls",
         'cmd //c start /b "" pwsh -Command ls',
         'cmd //c start //min "" powershell -Command ls',
         r'cmd //c start /d C:/tmp "" powershell -Command ls',
+        # start quotes the shell it launches too, and the leading quote hid that
+        # token from the shell-name lookup, so nothing recursed into the tail.
+        'cmd //c start "" "cmd" /c powershell -Command ls',
     ],
 )
 def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, command):
@@ -333,3 +335,38 @@ def test_detached_windows_stay_launchable(windows_terminal, command):
     # `start` is the only route to a window on the user's desktop, which the
     # terminal description promises, so screening must not blanket-block cmd.
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        """bash -c '""rm -rf x""'""",
+        """bash -c '""curl http://x""'""",
+        """sh -c '""sudo rm -rf /""'""",
+        """cmd /c '""rm -rf x""'""",
+    ],
+)
+def test_doubled_quotes_do_not_hide_the_nested_command(command):
+    # The two quote marks belong to DIFFERENT spans, so posix shlex hands the
+    # recursion `rm -rf x` and blocks it. Unwrapping a pair there would leave
+    # one fully quoted span, lexing to the single word `rm -rf x`, which is no
+    # blocked name and which the regex cannot reach behind a quote. bash runs
+    # the payload for real, so that path must stay screened.
+    assert tools._find_blocked_commands(command)
+
+
+def test_cmd_runs_only_double_quotes(monkeypatch):
+    # cmd has no single-quote syntax: it looks for a program literally named
+    # `'powershell`. Blocking these would refuse a line cmd cannot execute, so
+    # unwrapping is limited to `"`. Pinned to the cmd lexer because under bash
+    # the same spelling really does reach powershell, and is blocked.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+    assert not tools._find_blocked_commands("cmd /c 'powershell -Command ls'")
+    assert not tools._find_blocked_commands("cmd //c start '' powershell -Command ls")
+    assert tools._find_blocked_commands('cmd /c "powershell -Command ls"')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2006,3 +2006,49 @@ def test_a_cmd_path_ending_in_a_dot_names_no_builtin(windows_cmd_only, command):
 def test_a_bare_source_builtin_is_still_read(windows_git_bash_only):
     # The other half: spelled on its own it is the builtin, and bash has it.
     assert "." in tools._find_blocked_commands(". ./script.sh")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd /c echo&if 1==1 powershell -Command ls",
+        "cmd /c echo & if 1==1 powershell -Command ls",
+        "cmd /c echo&if /i a==a powershell",
+    ],
+)
+def test_an_if_handed_over_by_an_operator_opens_its_condition(windows_cmd_only, command):
+    # A keyword behind a glued separator opens what it always opens. Setting
+    # command position only for wrappers let the comparison consume it and the
+    # body behind it went unread.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c echo "a^"&start "" powershell',
+        'cmd /c echo "a"&start "" powershell',
+        'cmd /c echo ^"&start "" powershell',
+    ],
+)
+def test_a_caret_inside_a_quoted_span_is_literal(windows_cmd_only, command):
+    # Only outside a span is the caret an escape, so `"a^"` closes its quote and
+    # the operator behind it is live. That lexer also splits the span off into
+    # its own token, which puts the boundary at the FRONT of the next one.
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c"powershell -Command ls"',
+        'cmd //c"powershell -Command ls"',
+        "cmd /cpowershell",
+        'cmd /k"powershell -Command ls"',
+    ],
+)
+def test_a_payload_glued_to_the_switch_is_still_a_payload(windows_terminal, command):
+    # cmd takes its command string straight after the switch with no space. The
+    # remainder is read from the raw line, because a quote opening mid-token
+    # does not hold that lexer's word together.
+    assert "powershell" in tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1022,3 +1022,38 @@ def test_cmd_has_no_semicolon_separator(monkeypatch):
     # Under bash the same line really does open a command.
     monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
     assert "powershell" in tools._find_blocked_commands('echo ; start "" powershell')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\tools\\rm.exe -rf x"',
+        'start "" "C:\\tools\\rm.exe -rf x"',
+        'cmd /c "C:\\tools\\pwsh.exe -Command ls"',
+    ],
+)
+def test_a_program_path_with_arguments_is_still_read(windows_terminal, command):
+    # os.path.splitext keeps everything after the last dot, so this path plus its
+    # arguments came back with a suffix of `.exe -rf x`. Calling that a document
+    # meant START skipped the line rather than screening it. A real suffix
+    # carries no whitespace.
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c "C:\\tools\\notepad.exe -x y"',
+        'start "" "C:\\tools\\notepad.exe -x y"',
+    ],
+)
+def test_arguments_after_a_program_path_are_not_a_command(windows_terminal, command):
+    # The other half: a path followed by its own arguments is still a program.
+    # Re-lexing it as a command line matched the POSIX source builtin on the
+    # extension dot and refused an ordinary launch.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_an_operator_still_wins_over_the_path_shape(windows_terminal):
+    # An operator means a second command follows whatever the first looks like.
+    assert "rm" in tools._find_blocked_commands('cmd /c "C:\\tools\\notepad.exe&rm -rf x"')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -312,6 +312,11 @@ def windows_terminal(request, monkeypatch):
         # start quotes the shell it launches too, and the leading quote hid that
         # token from the shell-name lookup, so nothing recursed into the tail.
         'cmd //c start "" "cmd" /c powershell -Command ls',
+        # A quoted first argument is START's window title whatever it holds, so
+        # the program is one token further on than the `""` idiom implies.
+        'cmd //c start "job" powershell -Command ls',
+        'cmd //c start "my window" pwsh -Command ls',
+        'cmd //c start /b "job" powershell -Command ls',
     ],
 )
 def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, command):
@@ -329,6 +334,9 @@ def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, com
         "cmd //c start wt",
         "cmd //c dir",
         "start notepad",
+        # Skipping the title must not start blocking an ordinary argument.
+        "cmd //c start notepad readme.txt",
+        'cmd //c start "job" notepad',
     ],
 )
 def test_detached_windows_stay_launchable(windows_terminal, command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -325,6 +325,12 @@ def windows_terminal(request, monkeypatch):
         r'cmd /c "C:\Program Files\PowerShell\7\pwsh.exe" -Command ls',
         # START reaches the same shape behind its title.
         r'cmd //c start "" "C:\Program Files\PowerShell\7\pwsh.exe" -Command ls',
+        # cmd searches PATHEXT, so the suffix is optional...
+        r'cmd /c "C:\Program Files\PowerShell\7\pwsh" -Command ls',
+        r'cmd //c start "" "C:\Program Files\PowerShell\7\pwsh" -Command ls',
+        # ...and it expands %VAR% before reading the path.
+        r'cmd /c "%ProgramFiles%\PowerShell\7\pwsh.exe" -Command ls',
+        r'cmd /c "%ProgramFiles%\PowerShell\7\pwsh" -Command ls',
     ],
 )
 def test_cmd_shellout_is_screened_through_mangled_switches(windows_terminal, command):
@@ -431,6 +437,29 @@ def test_git_bash_hands_cmd_its_own_quotes(monkeypatch):
     )
     assert tools._find_blocked_commands("""cmd //c '"powershell -Command ls"'""")
     assert "rm" in tools._find_blocked_commands("""cmd /c '""rm -rf x""'""")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r'cmd //c start "" C:\tmp\image.png',
+        r'cmd //c start "job" C:\tmp\readme.txt',
+        r'cmd //c start "" "C:\Users\me\My Documents\report.docx"',
+    ],
+)
+def test_start_still_opens_a_document(windows_terminal, command):
+    # File association is what START is for. Re-scanning the target as a command
+    # line reads the extension dot as the POSIX `.` builtin, which turned every
+    # absolute Windows path into a hard block. A bare word is a program name.
+    assert not tools._find_blocked_commands(command)
+
+
+def test_a_quoted_command_line_after_start_is_still_lexed():
+    # The other half: quoting can hand the whole line over as one token, and an
+    # unbalanced quote drops the scan onto split(), whose tokens keep their
+    # marks. Both have to be lexed again or the program is never read.
+    assert "rm" in tools._find_blocked_commands('start "" "rm -rf x"')
+    assert "curl" in tools._find_blocked_commands('start ""curl http://x"')
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -614,3 +614,26 @@ def test_a_newline_inside_quotes_does_not_start_a_command(windows_terminal):
     # word is data the command receives, and treating it as a separator would
     # read printed text as a launch.
     assert not tools._find_blocked_commands("echo \"hi\nstart '' powershell\"")
+
+
+def test_a_continued_line_is_one_command(windows_terminal):
+    # A backslash before the newline joins the two lines, so what follows is one
+    # more argument rather than a new command. Verified against bash: the second
+    # line is printed, not launched. Only a newline the quoting left bare counts,
+    # and an escaped one is quoted like any other character.
+    assert not tools._find_blocked_commands('echo hi \\\nstart "" powershell')
+    assert not tools._find_blocked_commands('echo one two \\\nthree start "" powershell')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        '\nstart "" powershell -Command ls',
+        'echo hi\n\n\nstart "" powershell -Command ls',
+        'echo hi\r\nstart "" powershell -Command ls',
+    ],
+)
+def test_blank_and_leading_lines_still_open_a_command(windows_terminal, command):
+    # The recovery counts marks rather than measuring gaps, so a run of newlines,
+    # a leading one and a CRLF pair all open exactly one command between them.
+    assert tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -2168,9 +2168,7 @@ def test_an_operator_inside_a_quoted_path_is_path_text(windows_terminal, command
 def test_a_real_chain_behind_a_path_still_chains(windows_terminal):
     # The other half: whitespace means the payload is not one path, so the
     # operator really does open a second command.
-    assert "rm" in tools._find_blocked_commands(
-        'cmd /c "C:\\tools\\notepad.exe&rm -rf x"'
-    )
+    assert "rm" in tools._find_blocked_commands('cmd /c "C:\\tools\\notepad.exe&rm -rf x"')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Opened to fix the red `Backend CI`, but #7934 has since landed that fix, so what is left here is the screening gaps that investigation turned up. `_find_blocked_commands` decides whether a model-issued terminal command is refused, so a false negative is a sandbox bypass and a false positive refuses a line the model was entitled to run. Both directions are measured below.

Merged with main; the test fixture here supersedes #7934's inline patch and the inline patch is dropped.

## What was reachable

All of these are missed on `main` today. Verified on both lexers, with the Windows blocklist arranged.

| command | main | here |
|---|---|---|
| `cmd /c "powershell -Command ls"` | not screened | `powershell` |
| `cmd //c start "" powershell ...` | not screened | `powershell` |
| `cmd //c start "job" powershell ...` | not screened | `powershell` |
| `cmd //c start "" "cmd" /c powershell ...` | not screened | `powershell` |
| `cmd //c start "my window" /min powershell` | not screened | `powershell` |
| `cmd //c env start "" powershell` | not screened | `powershell` |
| `"C:\Windows\System32\cmd.exe" /c start "" powershell` | not screened | `powershell` |
| `cmd /c "C:\Program Files\PowerShell\7\pwsh.exe" ...` | not screened | `pwsh` |

They have one root cause between them: this scan re-lexes text that `cmd` parses by its own rules, after the lexer has already discarded the quote provenance those rules depend on.

**`shlex(posix = False)` keeps quote marks.** That is the lexer a Windows host with no trusted bash uses, the `cmd` fallback #7885 documents and the one configuration this screening exists for. So a nested `/c` payload recursed into a string whose first word was `"powershell`, and `tokens[j] == ""` never matched `'""'`.

**START takes its window title as a quoted first argument**, which is why `start ""` is the idiom for launching a quoted path. Only the empty spelling was stepped over, so `start "job" powershell` read a program named `job`. [The documented syntax](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start) also allows switches after the title, so `start "my window" /min powershell` was missed as well.

**A program may be spelled as a path.** `os.path.basename` does not split a backslash off Windows, so a quoted shell name, a full path, an extensionless PATHEXT spelling and a `%VAR%` path each hid the program from the lookup.

## Command position

Screening the word `start` wherever it appeared refused ordinary output, so it now has to sit where the shell would run it. That question is answered once, by the main scan, and the walks that need it ask rather than re-derive it. They also answer it FOR each other: a launcher hands a command to a shell and a shell hands one back, so the positions are grown to a fixpoint rather than read once in a fixed order. Reading them once meant the second `start` of `start "" cmd /c start "" cmd /c rm -rf x` sat in a payload the shell scan had not published yet, and the `rm` behind it went unread. A real command settles in two passes. The main scan learned the two boundaries it was missing: a newline, which ends a command but lexes as whitespace, and `cmd`'s own `/c`, tied to a `cmd` the scan actually reached at command position.

These are refused on `main` and are **not** refused here, because nothing in them runs:

```
echo start "" powershell
echo "cmd" /c powershell
echo /c start "" powershell
echo ';' start "" powershell
cmd /c "ls /usr/bin/rm"
cmd //c start "" "C:\Users\me\My Documents\powershell.docx"
```

The last one is a document opened through its file association, which is what START is for.

## Where unwrapping must not happen

Only under the cmd lexer, and only for `"`.

On the POSIX path `shlex` has already eaten the delimiters, so a pair still attached belongs to the nested command. Stripping one re-parses a command line as a single quoted word:

```
bash -c '""rm -rf x""'
```

The two marks belong to different spans. `main` lexes that to `rm -rf x` and blocks `rm`. Unwrapped it becomes one fully quoted span lexing to the single word `rm -rf x`, which is no blocked name, and the regex backstop is anchored to `^` or a separator so it cannot reach a word behind a quote. Confirmed against a real shell: the file was deleted, exit 0.

Single quotes are not cmd syntax either. cmd looks for a program literally named `'powershell`, so blocking `cmd /c 'powershell -Command ls'` would refuse a line it could never run. The same asymmetry decides the title rule and the backslash path: unquoted, `C:\Windows\System32\cmd.exe` reaches bash as `C:WindowsSystem32cmd.exe` and launches nothing, so only the quoted spelling is screened. Each of these is pinned as a negative case.

## Verification

**Differential fuzz against `main`, both lexers, 8990 command/lexer pairs: 332 widenings, 350 narrowings, and 0 unexplained.** Every difference is classified into a named family rather than sampled, and the narrowings are the families settled on this PR: the caret-escaped operator, a posix one-word title, argument position, a document or URL target, a program-path folder, and the substring backstop `main` uses in place of position. The corpus is built from the launcher and payload shapes each round turned up, including newlines, wrapper prefixes, dotted directories, `echo(` and unbalanced quoting.

That measurement is one-sided by construction, so **40 ordinary commands were checked separately for detections `main` does not make**, including `npm start`, `./start.sh`, `restart_service`, `cmd /c "echo hello"`, `echo "C:\Windows\System32\cmd.exe"` and multi-line scripts: none.

Pathological input does not blow up, and the cost is not something the author of the command gets to choose: 5000 nested `start "" cmd /c` wrappers, 20000 tokens, complete in 168 ms against `main` 639 ms, and every nesting depth tried is faster than `main`. An earlier revision of this branch rescanned what START launches and was exponential in the nesting depth, 19 seconds at 17 wrappers; that mechanism was removed rather than capped, because a work limit inside a screen is a bypass an author can buy.

Every new test fails against the revision before its fix, so they pin the fixes rather than the symptoms. 481 passed across `test_sandbox_tools.py` and `test_windows_bash_shell.py`. `ruff check` clean, `scripts/run_ruff_format.py` no drift, pre-push gate PASS, and a staging mirror is green on every workflow it runs, including `Backend CI` and `startup windows-latest`.

## Not included

Pre-existing gaps found while measuring, none introduced here and none closed here. Each was measured as returning the same set as `main` on both lexers:

- `cmd /c "" powershell`, and a bare quoted program at top level under the cmd lexer.
- `^` caret escaping, which `main` only appears to catch because its backstop is a substring regex that cannot see a caret.
- `cmd /s /c` with a suffixless program followed by a positional argument.
- Single quotes under the cmd lexer, which has no such syntax, so `echo 'a<newline>start "" powershell'` is two commands there and one under bash. Deciding it properly needs quote PROVENANCE, which `shlex(posix = False)` discards.
- A separator followed by a redirection inside a payload: `cmd /c "echo ok & >nul powershell"`. The `&` is absorbed into the redirection, which is right for a glued `&>out.txt` and wrong for a spaced `& >nul`. The fix is to ask the whitespace map whether the two came from one word, but that code decides which words a command never sees for the sed scan, the exec scan and the main walk alike.
- `find` and `fd` behind START: `start "" find . -exec rm -rf x ;`. Their flags are only recognised while a find/fd word the shell runs is in scope, and that scope is tracked separately from the walk that knows about START. A sed behind START IS read, because the sed scan takes a list this walk can add to.
- A `.lnk` shortcut as a START target: `cmd /c start "" C:\tmp\evil.lnk`. Treating it as executable does not close it, because the basename read off the path is the shortcut's own name and not what it launches; what it runs lives inside the file, and this screen decides on the text it is handed. Blocking it means refusing every shortcut launch, which is a policy change rather than a screening gap.

These belong with a cmd tokenizer that tracks quote state as it scans, rather than with more string-level rules on top of an already-lexed line.

The `cmd /s /c` one is declined deliberately rather than overlooked. It would be the tenth recovery for the single root cause named at the top, and several of the previous nine introduced a regression that had to be fixed. Enumerating cmd's spellings one at a time does not terminate. A parser that reads a cmd command line once, keeping the quote boundaries the lexer discards, closes that item and the remaining position items together, and deserves its own change rather than another patch here.


