### PR TITLE
Desktop: pin the shipped backend package version so a shared venv gets upgraded

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -371,9 +371,8 @@ jobs:
       STUDIO_VERSION: ${{ needs.prepare-version.outputs.studio_version }}
       DESKTOP_RELEASE_TAG: ${{ needs.prepare-version.outputs.desktop_release_tag }}
       DESKTOP_PRERELEASE: ${{ needs.prepare-version.outputs.prerelease }}
-      # Compiled into the binary by preflight/version.rs. Without it the app only
-      # knows the floor, so a shared ~/.unsloth/studio venv left by the CLI
-      # installer clears it once and is then never upgraded again.
+      # Compiled in by preflight/version.rs. Without it the app only knows the
+      # floor, so a shared venv left by the CLI installer is never upgraded again.
       UNSLOTH_DESKTOP_BACKEND_VERSION: ${{ needs.prepare-version.outputs.pypi_version }}
 
     steps:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -371,6 +371,10 @@ jobs:
       STUDIO_VERSION: ${{ needs.prepare-version.outputs.studio_version }}
       DESKTOP_RELEASE_TAG: ${{ needs.prepare-version.outputs.desktop_release_tag }}
       DESKTOP_PRERELEASE: ${{ needs.prepare-version.outputs.prerelease }}
+      # Compiled into the binary by preflight/version.rs. Without it the app only
+      # knows the floor, so a shared ~/.unsloth/studio venv left by the CLI
+      # installer clears it once and is then never upgraded again.
+      UNSLOTH_DESKTOP_BACKEND_VERSION: ${{ needs.prepare-version.outputs.pypi_version }}
 
     steps:
       # harden-runner in audit mode: surfaces every egress destination in

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -680,7 +680,7 @@ mod tests {
             String::new()
         };
         format!(
-            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.3","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{ROOT_ID}"{owner}}}"#
+            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{ROOT_ID}"{owner}}}"#
         )
     }
 

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -1096,7 +1096,7 @@ mod tests {
     async fn authenticated_health_uses_login_bearer_and_accepts_ready_version() {
         let (port, seen, server) = http_sequence_server(vec![
             ("200 OK", r#"{"access_token":"test-access-token"}"#),
-            ("200 OK", r#"{"version":"2026.5.3"}"#),
+            ("200 OK", r#"{"version":"2026.8.4"}"#),
         ])
         .await;
 

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -466,8 +466,8 @@ mod tests {
 
     #[test]
     fn managed_venv_behind_the_shipped_backend_is_outdated() {
-        // Above the floor but below what this build shipped with: the exact case
-        // the standalone installer leaves behind in the shared venv.
+        // Above the floor but below what this build shipped: the exact case the
+        // standalone installer leaves behind in the shared venv.
         assert_eq!(
             backend_version_outdated_reason(Some("2026.8.4"), "2026.8.5").as_deref(),
             Some("desktop_backend_version_outdated")
@@ -490,8 +490,8 @@ mod tests {
                 Some(reason)
             );
         }
-        // Unstamped builds fall back to the floor, so dev and CI keep today's
-        // behaviour and the managed gate reduces to the shared one.
+        // Unstamped builds fall back to the floor, so the managed gate reduces
+        // to the shared one for dev and CI.
         assert_eq!(expected_backend_version(), MIN_DESKTOP_BACKEND_VERSION);
         assert_eq!(
             managed_backend_version_stale_reason(Some(MIN_DESKTOP_BACKEND_VERSION)),

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -23,7 +23,10 @@ use backend::{backend_desktop_auth_status, backend_health};
 #[cfg(test)]
 use managed::probe_managed_bin;
 #[cfg(test)]
-use version::{backend_version_compatible, MIN_DESKTOP_BACKEND_VERSION};
+use version::{
+    backend_version_compatible, backend_version_outdated_reason, expected_backend_version,
+    managed_backend_version_stale_reason, MIN_DESKTOP_BACKEND_VERSION,
+};
 
 fn release_auto_repair() -> bool {
     !cfg!(debug_assertions)
@@ -433,23 +436,22 @@ mod tests {
     fn backend_version_gate_classifies_core_cases() {
         for version in [
             MIN_DESKTOP_BACKEND_VERSION,
-            "2026.5.4",
+            "2026.8.5",
             "2027.1.0",
-            "2026.5.3.post1",
-            "2026.5.3+local",
-            "2026.5.3.post1",
+            "2026.8.4.post1",
+            "2026.8.4+local",
         ] {
             assert!(backend_version_compatible(Some(version)), "{version}");
         }
         for (version, reason) in [
             (None, "desktop_backend_version_missing"),
             (Some("not-a-version"), "desktop_backend_version_invalid"),
-            (Some("2026.5.3.1"), "desktop_backend_version_invalid"),
-            (Some("2026.5.3foo"), "desktop_backend_version_invalid"),
-            (Some("2026.5.3.devx"), "desktop_backend_version_invalid"),
+            (Some("2026.8.4.1"), "desktop_backend_version_invalid"),
+            (Some("2026.8.4foo"), "desktop_backend_version_invalid"),
+            (Some("2026.8.4.devx"), "desktop_backend_version_invalid"),
             (Some("2026.5.2"), "desktop_backend_version_too_old"),
-            (Some("2026.5.3rc1"), "desktop_backend_version_too_old"),
-            (Some("2026.5.3.dev1"), "desktop_backend_version_too_old"),
+            (Some("2026.8.4rc1"), "desktop_backend_version_too_old"),
+            (Some("2026.8.4.dev1"), "desktop_backend_version_too_old"),
         ] {
             assert_eq!(
                 backend_version_stale_reason(version).as_deref(),
@@ -459,6 +461,45 @@ mod tests {
         assert_eq!(
             backend_version_compatible(Some("dev")),
             cfg!(debug_assertions)
+        );
+    }
+
+    #[test]
+    fn managed_venv_behind_the_shipped_backend_is_outdated() {
+        // Above the floor but below what this build shipped with: the exact case
+        // the standalone installer leaves behind in the shared venv.
+        assert_eq!(
+            backend_version_outdated_reason(Some("2026.8.4"), "2026.8.5").as_deref(),
+            Some("desktop_backend_version_outdated")
+        );
+        for version in ["2026.8.5", "2026.8.6", "2027.1.0"] {
+            assert_eq!(
+                backend_version_outdated_reason(Some(version), "2026.8.5"),
+                None,
+                "{version}"
+            );
+        }
+        // The floor still speaks first, so its reasons keep reaching the UI.
+        for (version, reason) in [
+            (None, "desktop_backend_version_missing"),
+            (Some("not-a-version"), "desktop_backend_version_invalid"),
+            (Some("2026.5.2"), "desktop_backend_version_too_old"),
+        ] {
+            assert_eq!(
+                backend_version_outdated_reason(version, "2026.8.5").as_deref(),
+                Some(reason)
+            );
+        }
+        // Unstamped builds fall back to the floor, so dev and CI keep today's
+        // behaviour and the managed gate reduces to the shared one.
+        assert_eq!(expected_backend_version(), MIN_DESKTOP_BACKEND_VERSION);
+        assert_eq!(
+            managed_backend_version_stale_reason(Some(MIN_DESKTOP_BACKEND_VERSION)),
+            None
+        );
+        assert_eq!(
+            managed_backend_version_stale_reason(Some("2026.5.2")).as_deref(),
+            Some("desktop_backend_version_too_old")
         );
     }
 
@@ -578,7 +619,7 @@ exit 1
                 r#"#!/bin/sh
 if [ "$1" = "-h" ]; then exit 0; fi
 if [ "$1" = "studio" ] && [ "$2" = "desktop-capabilities" ] && [ "$3" = "--json" ]; then
-  printf '{"desktop_protocol_version":1,"desktop_manageability_version":2,"supports_api_only":true,"supports_provision_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_install_ok":true,"version":"2026.5.3"}'
+  printf '{"desktop_protocol_version":1,"desktop_manageability_version":2,"supports_api_only":true,"supports_provision_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_install_ok":true,"version":"2026.8.4"}'
   exit 0
 fi
 exit 1
@@ -590,7 +631,7 @@ exit 1
                 r#"#!/bin/sh
 if [ "$1" = "-h" ]; then exit 0; fi
 if [ "$1" = "studio" ] && [ "$2" = "desktop-capabilities" ] && [ "$3" = "--json" ]; then
-  printf '{"desktop_protocol_version":1,"desktop_manageability_version":2,"supports_api_only":true,"supports_provision_desktop_auth":false,"supports_desktop_backend_ownership":true,"desktop_auth_stale_reason":"cap_false","studio_install_ok":true,"version":"2026.5.3"}'
+  printf '{"desktop_protocol_version":1,"desktop_manageability_version":2,"supports_api_only":true,"supports_provision_desktop_auth":false,"supports_desktop_backend_ownership":true,"desktop_auth_stale_reason":"cap_false","studio_install_ok":true,"version":"2026.8.4"}'
   exit 0
 fi
 if [ "$1" = "studio" ] && [ "$2" = "provision-desktop-auth" ] && [ "$3" = "--help" ]; then exit 0; fi
@@ -643,7 +684,7 @@ if [ "$1" = "-h" ]; then
 fi
 if [ "$1" = "studio" ] && [ "$2" = "desktop-capabilities" ] && [ "$3" = "--json" ]; then
   if [ -f "$modecap" ]; then exit 42; fi
-  printf '{"desktop_protocol_version":1,"desktop_manageability_version":2,"supports_api_only":true,"supports_provision_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_install_ok":true,"version":"2026.5.3"}'
+  printf '{"desktop_protocol_version":1,"desktop_manageability_version":2,"supports_api_only":true,"supports_provision_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_install_ok":true,"version":"2026.8.4"}'
   exit 0
 fi
 exit 1
@@ -713,7 +754,7 @@ exit 1
     fn desktop_ready_health_with_owner(root_id: &str, include_owner: bool) -> String {
         let owner = desktop_owner_json(include_owner);
         format!(
-            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.3","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{root_id}"{owner}}}"#
+            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{root_id}"{owner}}}"#
         )
     }
 
@@ -773,7 +814,7 @@ exit 1
     async fn backend_with_auth_support_but_missing_protocol_is_old() {
         let probe = probe_test_backend(
             format!(
-                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.3","desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
                 desktop_owner_json(true)
             ),
             "401 Unauthorized",
@@ -799,7 +840,7 @@ exit 1
         // protocol-compatible backend into a conflict the user has to kill.
         let probe = probe_test_backend(
             format!(
-                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.3","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
                 desktop_owner_json(true)
             ),
             "401 Unauthorized",
@@ -813,7 +854,7 @@ exit 1
     async fn backend_without_any_manageability_field_is_old() {
         let probe = probe_test_backend(
             format!(
-                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.3","desktop_protocol_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
                 desktop_owner_json(true)
             ),
             "401 Unauthorized",
@@ -921,7 +962,7 @@ exit 1
     async fn backend_capability_false_is_old_even_when_route_401() {
         let probe = probe_test_backend(
             format!(
-                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.3","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":false,"supports_desktop_backend_ownership":true,"desktop_auth_stale_reason":"cap_false","studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":false,"supports_desktop_backend_ownership":true,"desktop_auth_stale_reason":"cap_false","studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
                 desktop_owner_json(true)
             ),
             "401 Unauthorized",

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -155,9 +155,8 @@ fn backend_capability_stale_reason(health: &BackendHealth) -> Option<String> {
     if health.supports_desktop_backend_ownership != Some(true) {
         return Some("desktop_backend_ownership_unsupported".to_string());
     }
-    // Unauthenticated /api/health gates `version` behind a bearer; capability bits
-    // (protocol/manageability/auth/ownership) above are only set by backends >=
-    // MIN_DESKTOP_BACKEND_VERSION, so missing version means "auth-gated", not "old".
+    // Unauthenticated /api/health gates `version` behind a bearer; the capability
+    // bits above predate the floor, so missing version means "auth-gated", not "old".
     match health.version.as_deref() {
         Some(version) if !version.is_empty() => backend_version_stale_reason(Some(version)),
         _ => None,

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -155,8 +155,8 @@ fn backend_capability_stale_reason(health: &BackendHealth) -> Option<String> {
     if health.supports_desktop_backend_ownership != Some(true) {
         return Some("desktop_backend_ownership_unsupported".to_string());
     }
-    // Unauthenticated /api/health gates `version` behind a bearer; the capability
-    // bits above predate the floor, so missing version means "auth-gated", not "old".
+    // Unauthenticated /api/health gates `version` behind a bearer, and the bits
+    // above predate the floor, so no version means "auth-gated", not "old".
     match health.version.as_deref() {
         Some(version) if !version.is_empty() => backend_version_stale_reason(Some(version)),
         _ => None,

--- a/studio/src-tauri/src/preflight/managed.rs
+++ b/studio/src-tauri/src/preflight/managed.rs
@@ -570,7 +570,7 @@ mod tests {
     #[test]
     fn a_venv_behind_the_desktop_backend_version_is_stale() {
         // The CLI installer shares this venv, so its package version is the only
-        // thing that pulls an old-but-launchable install forward through repair.
+        // thing that pulls an old-but-launchable install forward via repair.
         let mut capability = healthy_capability();
         capability.version = Some("2026.5.2".to_string());
         assert_eq!(

--- a/studio/src-tauri/src/preflight/managed.rs
+++ b/studio/src-tauri/src/preflight/managed.rs
@@ -1,6 +1,6 @@
 use super::types::ManagedProbe;
 use super::version::{
-    backend_version_stale_reason, DESKTOP_MANAGEABILITY_VERSION, DESKTOP_PROTOCOL_VERSION,
+    managed_backend_version_stale_reason, DESKTOP_MANAGEABILITY_VERSION, DESKTOP_PROTOCOL_VERSION,
 };
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
@@ -450,7 +450,7 @@ fn desktop_capability_stale_reason(capability: &DesktopCapability) -> Option<Str
                 .unwrap_or_else(|| "studio_install_incomplete".to_string()),
         );
     }
-    backend_version_stale_reason(capability.version.as_deref())
+    managed_backend_version_stale_reason(capability.version.as_deref())
 }
 
 fn desktop_capability_ready(capability: &DesktopCapability) -> bool {
@@ -544,6 +544,7 @@ pub async fn managed_install_ready() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::version::MIN_DESKTOP_BACKEND_VERSION;
     use super::*;
 
     fn healthy_capability() -> DesktopCapability {
@@ -556,7 +557,7 @@ mod tests {
             desktop_auth_stale_reason: None,
             studio_install_ok: Some(true),
             studio_install_reason: None,
-            version: Some("2026.7.5".to_string()),
+            version: Some(MIN_DESKTOP_BACKEND_VERSION.to_string()),
         }
     }
 
@@ -564,6 +565,19 @@ mod tests {
     fn complete_install_is_ready() {
         assert_eq!(desktop_capability_stale_reason(&healthy_capability()), None);
         assert!(desktop_capability_ready(&healthy_capability()));
+    }
+
+    #[test]
+    fn a_venv_behind_the_desktop_backend_version_is_stale() {
+        // The CLI installer shares this venv, so its package version is the only
+        // thing that pulls an old-but-launchable install forward through repair.
+        let mut capability = healthy_capability();
+        capability.version = Some("2026.5.2".to_string());
+        assert_eq!(
+            desktop_capability_stale_reason(&capability).as_deref(),
+            Some("desktop_backend_version_too_old")
+        );
+        assert!(!desktop_capability_ready(&capability));
     }
 
     #[test]

--- a/studio/src-tauri/src/preflight/version.rs
+++ b/studio/src-tauri/src/preflight/version.rs
@@ -12,7 +12,7 @@ pub(crate) const DESKTOP_MANAGEABILITY_VERSION: u16 = 2;
 pub(crate) const DESKTOP_BACKEND_MANAGEABILITY_VERSION: u16 = 1;
 // Explicit backend package minimum, not the desktop app Cargo version: backend
 // and app releases can diverge. When bumping, verify this package exists on PyPI.
-pub(super) const MIN_DESKTOP_BACKEND_VERSION: &str = "2026.5.3";
+pub(super) const MIN_DESKTOP_BACKEND_VERSION: &str = "2026.8.4";
 
 #[derive(Debug, Eq, PartialEq)]
 pub(super) struct ParsedVersion {
@@ -168,4 +168,34 @@ pub(crate) fn backend_version_stale_reason(version: Option<&str>) -> Option<Stri
         }
         Some(_) => Some("desktop_backend_version_too_old".to_string()),
     }
+}
+
+// The backend package this build was released against. The release workflow
+// stamps it from the same pypi_version the updater manifest carries; local and
+// CI builds leave it unset, so the floor above stays the only gate there.
+pub(super) fn expected_backend_version() -> &'static str {
+    option_env!("UNSLOTH_DESKTOP_BACKEND_VERSION").unwrap_or(MIN_DESKTOP_BACKEND_VERSION)
+}
+
+pub(super) fn backend_version_outdated_reason(
+    version: Option<&str>,
+    expected: &str,
+) -> Option<String> {
+    if let Some(reason) = backend_version_stale_reason(version) {
+        return Some(reason);
+    }
+    // Anything unparseable here already cleared the floor (`dev` in a debug
+    // build), so leave that judgement where it was made.
+    let actual = version.and_then(parse_version)?;
+    let expected = parse_version(expected)?;
+    (compare_versions(&actual, &expected) == Ordering::Less)
+        .then(|| "desktop_backend_version_outdated".to_string())
+}
+
+// Managed venv only. ~/.unsloth/studio is shared with the CLI installer, so a
+// venv can clear the floor and still predate this app forever; repairing it is
+// the only way forward. A running backend keeps the floor alone, so one that is
+// merely older stays adoptable and stoppable.
+pub(super) fn managed_backend_version_stale_reason(version: Option<&str>) -> Option<String> {
+    backend_version_outdated_reason(version, expected_backend_version())
 }

--- a/studio/src-tauri/src/preflight/version.rs
+++ b/studio/src-tauri/src/preflight/version.rs
@@ -170,9 +170,9 @@ pub(crate) fn backend_version_stale_reason(version: Option<&str>) -> Option<Stri
     }
 }
 
-// The backend package this build was released against. The release workflow
-// stamps it from the same pypi_version the updater manifest carries; local and
-// CI builds leave it unset, so the floor above stays the only gate there.
+// The backend package this build shipped with, stamped by the release workflow
+// from the same pypi_version as the updater manifest. Local and CI builds leave
+// it unset, so the floor above stays their only gate.
 pub(super) fn expected_backend_version() -> &'static str {
     option_env!("UNSLOTH_DESKTOP_BACKEND_VERSION").unwrap_or(MIN_DESKTOP_BACKEND_VERSION)
 }
@@ -184,18 +184,16 @@ pub(super) fn backend_version_outdated_reason(
     if let Some(reason) = backend_version_stale_reason(version) {
         return Some(reason);
     }
-    // Anything unparseable here already cleared the floor (`dev` in a debug
-    // build), so leave that judgement where it was made.
+    // Anything unparseable here already cleared the floor, so leave it there.
     let actual = version.and_then(parse_version)?;
     let expected = parse_version(expected)?;
     (compare_versions(&actual, &expected) == Ordering::Less)
         .then(|| "desktop_backend_version_outdated".to_string())
 }
 
-// Managed venv only. ~/.unsloth/studio is shared with the CLI installer, so a
-// venv can clear the floor and still predate this app forever; repairing it is
-// the only way forward. A running backend keeps the floor alone, so one that is
-// merely older stays adoptable and stoppable.
+// Managed venv only: ~/.unsloth/studio is shared with the CLI installer, so a
+// venv can clear the floor yet predate this app forever, and only repair moves
+// it. Running backends keep the floor alone, so an older one stays adoptable.
 pub(super) fn managed_backend_version_stale_reason(version: Option<&str>) -> Option<String> {
     backend_version_outdated_reason(version, expected_backend_version())
 }


### PR DESCRIPTION
## Problem

The desktop app never upgrades a pre-existing managed venv, so users keep running a stale backend indefinitely.

`preflight/version.rs` only knew `MIN_DESKTOP_BACKEND_VERSION`, which is a floor, not a pin. `~/.unsloth/studio` is shared with the standalone CLI installer (`irm https://unsloth.ai/install.ps1 | iex`), so whichever installer runs first owns the venv. If that venv holds an `unsloth` newer than the floor but older than the desktop release, it clears the gate, `probe_managed_bin` reports `ManagedProbe::Ready`, and the app adopts it forever.

Reproduced on Windows 11: the venv held `unsloth 2026.7.6` against a floor of `2026.5.3`, while PyPI was on `2026.8.4`. Settings showed `Package Version 2026.7.6` and nothing ever moved it.

## Fix

`release-desktop.yml` already computes the exact `pypi_version` for the updater manifest, but it was never compiled into the binary. Stamp it in as `UNSLOTH_DESKTOP_BACKEND_VERSION` and read it back with `option_env!`, falling back to the floor when unset so local builds and `cargo test` behave exactly as before.

The managed-CLI probe now reports `Stale { reason: "desktop_backend_version_outdated" }` for a venv below the stamped version, which routes into the existing `ManagedStale` disposition and the `start_managed_repair` path that already knows how to run `unsloth studio update`.

The capability cache is not a bypass: `cache_matches` re-evaluates `desktop_capability_ready` against the running binary's expected version, so a cache written by an older app build is rejected.

## Behaviour change worth reviewing

The floor moves from `2026.5.3` to `2026.8.4`, matching the `install.sh` / `install.ps1` pin so the CLI and desktop agree.

The running-backend paths (`preflight/backend.rs`, `desktop_backend_owner.rs`) deliberately keep comparing against the floor rather than the stamp, so they never demand a backend newer than one a previous app version could have spawned. The floor bump tightens them by that much for backends this app **owns or has adopted**: an authenticated health response below `2026.8.4` is now reported stale and repaired rather than adopted (`desktop_backend_owner.rs`).

It does **not** tighten the externally launched case, and an earlier draft of this description claimed it did. Unauthenticated `/api/health` omits `version` for every backend version, not just old ones (`main.py:1344` returns `base` unless a bearer validates; `version` is only added to the `authed` dict at `:1369`), and preflight has no bearer for an external backend by construction. So a CLI-launched `unsloth studio` is still adopted regardless of its version, exactly as it is on `main`. Making the missing-`version` case stale would reject a perfectly current terminal-launched backend as too old, which is why the comment at `backend.rs:158-159` is deliberate. The shared-venv problem is fixed through the managed-install probe instead, which reads `version` from `desktop-capabilities --json`.

Consequences to weigh:

- First launch after this ships will repair most existing installs once. That is the point, but it costs the user an upgrade on startup.
- Repair runs `unsloth studio update`, which resolves to whatever pip picks, not to the stamped version. If an environment cannot reach the stamped version (yanked release, Python or platform constraint, index lag) preflight stays stale and the user gets a `repair-failed` result rather than a loop. Visible failure, but a new way to fail.

## Tests

Added to the existing `#[cfg(test)]` modules:

- a venv below the expected version is stale with the right reason, and not ready
- equal and newer versions stay ready
- the `option_env!` fallback equals the floor when unset

Version fixtures across `src-tauri` were swept for the floor bump: fixtures meant to be current moved to `2026.8.4`, fixtures meant to be old were left at `2026.5.1` / `2026.5.2`, and the min-relative prerelease cases became `2026.8.4rc1` / `2026.8.4.dev1` to preserve their intent. `desktop_update_policy.rs` uses an unrelated comparator and was left alone.

`studio-tauri-smoke.yml` does not set `UNSLOTH_DESKTOP_BACKEND_VERSION`, so the fallback assertion holds in CI.

