### PR TITLE
Desktop: fix the mobile-layout fallout of Windows text scaling

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -60,9 +60,8 @@ const MINIMUM_APP_WINDOW_SIZE: LogicalWindowSize = {
 // Keep in step with MOBILE_BREAKPOINT in hooks/use-mobile.ts.
 const MIN_DESKTOP_LAYOUT_WIDTH = 768;
 
-// Logical px needed per CSS px. devicePixelRatio already includes the display
-// scale, so anything left over is webview zoom, which Windows text scaling
-// adds. 1 when there is none.
+// Logical px per CSS px: webview zoom above the display scale (Windows text
+// scaling); 1 if none.
 function logicalPerCssPx(monitorScale: number): number {
   if (typeof window === "undefined" || !(monitorScale > 0)) return 1;
   const ratio = window.devicePixelRatio / monitorScale;
@@ -168,10 +167,9 @@ async function applyAppWindowLayout(
       finalW = Math.max(
         MIN_WINDOW_WIDTH,
         Math.round(screenW * 0.75),
-        // Windows text scaling zooms the webview on top of the display scale,
-        // so logical px buy fewer CSS px and the window opens under the
-        // sidebar's mobile breakpoint. Ratio is 1 without it, so this is a
-        // no-op elsewhere. Never exceed the screen.
+        // Windows text scaling shrinks CSS px, so the window would open under
+        // the sidebar's mobile breakpoint. No-op elsewhere; never exceed the
+        // screen.
         Math.min(
           Math.round(MIN_DESKTOP_LAYOUT_WIDTH * logicalPerCssPx(scale)),
           Math.round(screenW),

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -57,6 +57,17 @@ const MINIMUM_APP_WINDOW_SIZE: LogicalWindowSize = {
   width: MIN_WINDOW_WIDTH,
   height: MIN_WINDOW_HEIGHT,
 };
+// Keep in step with MOBILE_BREAKPOINT in hooks/use-mobile.ts.
+const MIN_DESKTOP_LAYOUT_WIDTH = 768;
+
+// Logical px needed per CSS px. devicePixelRatio already includes the display
+// scale, so anything left over is webview zoom, which Windows text scaling
+// adds. 1 when there is none.
+function logicalPerCssPx(monitorScale: number): number {
+  if (typeof window === "undefined" || !(monitorScale > 0)) return 1;
+  const ratio = window.devicePixelRatio / monitorScale;
+  return Number.isFinite(ratio) && ratio > 1 ? ratio : 1;
+}
 
 async function showSetupWindow(isCurrent: WindowLayoutGuard): Promise<void> {
   const { getCurrentWindow, LogicalSize } = await import(
@@ -154,7 +165,18 @@ async function applyAppWindowLayout(
       const scale = monitor.scaleFactor;
       const screenW = monitor.size.width / scale;
       const screenH = monitor.size.height / scale;
-      finalW = Math.max(MIN_WINDOW_WIDTH, Math.round(screenW * 0.75));
+      finalW = Math.max(
+        MIN_WINDOW_WIDTH,
+        Math.round(screenW * 0.75),
+        // Windows text scaling zooms the webview on top of the display scale,
+        // so logical px buy fewer CSS px and the window opens under the
+        // sidebar's mobile breakpoint. Ratio is 1 without it, so this is a
+        // no-op elsewhere. Never exceed the screen.
+        Math.min(
+          Math.round(MIN_DESKTOP_LAYOUT_WIDTH * logicalPerCssPx(scale)),
+          Math.round(screenW),
+        ),
+      );
       const targetH = Math.max(MIN_WINDOW_HEIGHT, Math.round(finalW / 1.618));
       finalH = Math.min(targetH, Math.round(screenH * 0.85));
     }

--- a/studio/frontend/src/components/navbar.tsx
+++ b/studio/frontend/src/components/navbar.tsx
@@ -3,14 +3,17 @@
 
 import {
   DesktopTitlebarNavigation,
+  shouldUseCustomWindowTitlebar,
   shouldUseNativeMacWindowTitlebar,
 } from "@/components/tauri/window-titlebar";
 import { SidebarTrigger, useSidebar } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
 import { useState } from "react";
 
 export function Navbar() {
   const { isMobile, pinned, togglePinned } = useSidebar();
   const [usesNativeMacTitlebar] = useState(shouldUseNativeMacWindowTitlebar);
+  const [usesCustomTitlebar] = useState(shouldUseCustomWindowTitlebar);
 
   if (!isMobile) {
     return (
@@ -35,9 +38,25 @@ export function Navbar() {
       </>
     );
   }
+  // Windows text scaling shrinks the CSS viewport, so a desktop window can land
+  // here; sit inside the custom titlebar band instead of buried under its z-[70].
   return (
-    <header className="absolute top-0 inset-x-0 z-[45] h-[48px] pointer-events-none">
-      <div className="flex h-full items-start pt-[11px] pl-2">
+    <header
+      className={cn(
+        "absolute top-0 inset-x-0 pointer-events-none",
+        usesCustomTitlebar
+          ? "z-[80] h-[var(--studio-custom-titlebar-height,34px)]"
+          : "z-[45] h-[48px]",
+      )}
+    >
+      <div
+        className={cn(
+          "flex h-full",
+          usesCustomTitlebar
+            ? "items-center pl-3"
+            : "items-start pt-[11px] pl-2",
+        )}
+      >
         <SidebarTrigger className="pointer-events-auto !size-[34px]" />
       </div>
     </header>

--- a/studio/frontend/src/components/navbar.tsx
+++ b/studio/frontend/src/components/navbar.tsx
@@ -38,8 +38,8 @@ export function Navbar() {
       </>
     );
   }
-  // Windows text scaling shrinks the CSS viewport, so a desktop window can land
-  // here; sit inside the custom titlebar band instead of buried under its z-[70].
+  // Desktop windows can land here under Windows text scaling, so sit inside the
+  // custom titlebar band instead of under its z-[70].
   return (
     <header
       className={cn(

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { useIsMobile } from "@/hooks/use-mobile";
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { useSidebarWidth } from "@/hooks/use-sidebar-width";
 import { isTauri } from "@/lib/api-base";
@@ -109,10 +110,17 @@ export function DesktopTitlebarNavigation({
   expanded,
   onToggleSidebar,
   className,
+  showSidebarToggle = true,
 }: {
   expanded: boolean;
   onToggleSidebar: () => void;
   className?: string;
+  /**
+   * Off in the mobile layout, where the sidebar is a sheet keyed off
+   * `openMobile` and pinning does nothing. Navbar's SidebarTrigger takes the
+   * slot, which an inert spacer holds open so back/forward stay put.
+   */
+  showSidebarToggle?: boolean;
 }): ReactElement {
   const stopTitlebarDrag = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -129,24 +137,28 @@ export function DesktopTitlebarNavigation({
       role="toolbar"
       aria-label="Sidebar and page navigation"
     >
-      <button
-        type="button"
-        title={expanded ? "Collapse sidebar" : "Expand sidebar"}
-        aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
-        onMouseDown={stopTitlebarDrag}
-        onDoubleClick={stopTitlebarDrag}
-        onClick={(event) => {
-          event.stopPropagation();
-          onToggleSidebar();
-        }}
-        className={buttonClass}
-      >
-        <HugeiconsIcon
-          icon={LayoutAlignLeftIcon}
-          strokeWidth={1.75}
-          className="size-icon"
-        />
-      </button>
+      {showSidebarToggle ? (
+        <button
+          type="button"
+          title={expanded ? "Collapse sidebar" : "Expand sidebar"}
+          aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
+          onMouseDown={stopTitlebarDrag}
+          onDoubleClick={stopTitlebarDrag}
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggleSidebar();
+          }}
+          className={buttonClass}
+        >
+          <HugeiconsIcon
+            icon={LayoutAlignLeftIcon}
+            strokeWidth={1.75}
+            className="size-icon"
+          />
+        </button>
+      ) : (
+        <div aria-hidden="true" className="size-[33px] shrink-0" />
+      )}
       <button
         type="button"
         title="Go back"
@@ -195,6 +207,8 @@ export function WindowTitlebar({
   const [enabled] = useState(shouldUseCustomWindowTitlebar);
   const [maximized, setMaximized] = useState(false);
   const { pinned, togglePinned } = useSidebarPin();
+  // Outside SidebarProvider, so read the same media query the provider does.
+  const isMobile = useIsMobile();
 
   const maximizeRefreshSequence = useRef(0);
   const maximizeRefreshTimer = useRef<number | null>(null);
@@ -381,6 +395,7 @@ export function WindowTitlebar({
             <DesktopTitlebarNavigation
               expanded={pinned}
               onToggleSidebar={togglePinned}
+              showSidebarToggle={!isMobile}
             />
           </div>
         )}

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -115,11 +115,7 @@ export function DesktopTitlebarNavigation({
   expanded: boolean;
   onToggleSidebar: () => void;
   className?: string;
-  /**
-   * Off in the mobile layout, where the sidebar is a sheet keyed off
-   * `openMobile` and pinning does nothing. Navbar's SidebarTrigger takes the
-   * slot, which an inert spacer holds open so back/forward stay put.
-   */
+  /** Off in mobile, where Navbar's SidebarTrigger owns the slot; a spacer holds it open. */
   showSidebarToggle?: boolean;
 }): ReactElement {
   const stopTitlebarDrag = (event: MouseEvent<HTMLButtonElement>) => {

--- a/studio/frontend/src/features/settings/components/settings-row.tsx
+++ b/studio/frontend/src/features/settings/components/settings-row.tsx
@@ -26,7 +26,11 @@ export function SettingsRow({
     <div
       data-settings-label={label}
       className={cn(
-        "flex justify-between gap-6 py-3",
+        // The controls are fixed-width and shrink-0, so an unwrapped row starves
+        // the label to one word per line once the content column gets narrow.
+        // justify-end keeps the control right on its own line; an auto margin
+        // would instead defeat items-stretch for the flex-col callers.
+        "flex flex-wrap justify-end gap-x-6 gap-y-2 py-3",
         alignTop ? "items-start" : "items-center",
         destructive && "border-t border-border/60 mt-2 pt-4",
         className,
@@ -34,7 +38,9 @@ export function SettingsRow({
     >
       <div
         className={cn(
-          "flex min-w-0 gap-2.5",
+          // 11rem is the widest floor that leaves every row's geometry
+          // unchanged at the widths that already fit.
+          "flex min-w-[11rem] flex-1 basis-0 gap-2.5",
           alignTop ? "items-start" : "items-center",
         )}
       >
@@ -55,7 +61,7 @@ export function SettingsRow({
       {children ? (
         <div
           className={cn(
-            "flex shrink-0",
+            "flex max-w-full shrink-0",
             // Drop the control past the label row so it lines up with the first
             // description line instead of the label.
             alignTop ? "items-start pt-[21px]" : "items-center",

--- a/studio/frontend/src/features/settings/components/settings-row.tsx
+++ b/studio/frontend/src/features/settings/components/settings-row.tsx
@@ -26,10 +26,9 @@ export function SettingsRow({
     <div
       data-settings-label={label}
       className={cn(
-        // The controls are fixed-width and shrink-0, so an unwrapped row starves
-        // the label to one word per line once the content column gets narrow.
-        // justify-end keeps the control right on its own line; an auto margin
-        // would instead defeat items-stretch for the flex-col callers.
+        // Controls are fixed-width and shrink-0, so an unwrapped row starves the
+        // label. justify-end right-aligns a wrapped control without breaking
+        // items-stretch for flex-col callers.
         "flex flex-wrap justify-end gap-x-6 gap-y-2 py-3",
         alignTop ? "items-start" : "items-center",
         destructive && "border-t border-border/60 mt-2 pt-4",
@@ -38,8 +37,7 @@ export function SettingsRow({
     >
       <div
         className={cn(
-          // 11rem is the widest floor that leaves every row's geometry
-          // unchanged at the widths that already fit.
+          // Widest floor that leaves already-fitting rows unchanged.
           "flex min-w-[11rem] flex-1 basis-0 gap-2.5",
           alignTop ? "items-start" : "items-center",
         )}
@@ -62,8 +60,7 @@ export function SettingsRow({
         <div
           className={cn(
             "flex max-w-full shrink-0",
-            // Drop the control past the label row so it lines up with the first
-            // description line instead of the label.
+            // Line the control up with the first description line, not the label.
             alignTop ? "items-start pt-[21px]" : "items-center",
           )}
         >


### PR DESCRIPTION
## Problem

Reported on Windows 11: the sidebar toggle in the titlebar does nothing in a normal window (a second control lower down works), and the Settings rows for Hugging Face token and Embedding model are badly misaligned. Maximizing the window fixes both.

Both are the same root cause, and it is not a Windows-only concern in principle.

**Windows text scaling multiplies the webview's device scale factor.** On the reporting machine, a 2880x1800 panel at 250% display scaling with `HKCU:\Software\Microsoft\Accessibility\TextScaleFactor = 125` gives an effective CSS device pixel ratio of **3.125**, not 2.5. Measured, not assumed: the sidebar is `17.5rem` = 280 CSS px and renders 873 physical px.

So the app's 900 logical px minimum window is only about **722 CSS px**, which is under `MOBILE_BREAKPOINT = 768` in `hooks/use-mobile.ts`. The desktop app renders its **mobile layout in an ordinary window**. Maximized gives 1152 logical, about 924 CSS px, which is why maximizing appears to fix it.

Two controls break there:

1. The titlebar's sidebar toggle calls `togglePinned`. In mobile mode the sidebar is a sheet keyed off `openMobile` and pin state does nothing, so the button focuses, shows its tooltip, and has no effect.
2. Navbar's `SidebarTrigger`, the control that does work, sits at `z-[45]` under the custom titlebar's `z-[70]` header. Only about 11px of it is clickable, which is the sliver users find by accident.

Confirmed by driving the shipped app: clicking that sliver opens the mobile sheet.

## Changes

**`components/tauri/window-titlebar.tsx`** - new `showSidebarToggle` prop, default `true`. In the mobile layout an inert same-size spacer holds the slot so back/forward keep their position, instead of rendering a toggle that cannot work.

**`components/navbar.tsx`** - when the custom titlebar is in use, the mobile `SidebarTrigger` moves into the titlebar band at `z-[80]`, where the desktop toggle would have been. One control, in the expected place, that works.

**`app/provider.tsx`** - first launch clamps the window width up to whatever buys 768 CSS px, bounded by the screen. The old `max(900, screenW * 0.75)` rule lands on 864 logical = 691 CSS px on the reporting machine, so the app opened in the mobile layout by construction. `devicePixelRatio` already includes the display scale, so the ratio is 1 and this is a no-op wherever there is no extra webview zoom.

This is deliberately first launch only. An existing install takes the `restoreStateCurrent` path, so a window already saved under the breakpoint stays there. Clamping that path too would override a size the user chose on purpose, and would have to fight the plugin's maximized-state restore. The two changes above are what make that case usable, and maximizing or widening still escapes it.

**`features/settings/components/settings-row.tsx`** - the row wraps instead of crushing the label. Controls are fixed-width and `shrink-0`, so a narrow content column starved the label. The settings dialog reserves 248px of nav plus 48px of padding, so this is reachable well before any viewport-width breakpoint fires.

Note `justify-end` rather than an auto margin on the control. Three callers (`appearance-tab.tsx:76`, `resources-tab.tsx:579`, `general-tab.tsx:642`) override the row to `flex-col items-stretch`. On a column axis an auto cross-axis margin suppresses `align-self: stretch` per CSS Flexbox 9.4/9.6, which would have shrink-to-fit the folder input and the embedding-model combobox instead of letting their `w-full` span the row. `resources-tab`'s override is `max-[840px]`, so that branch is live exactly at the reporting width.

## Verification

Measured with real rendering, comparing `origin/main` against this branch in a harness that reproduces the settings dialog shell (`min(960px, 100vw-2rem)` dialog, 248px nav, `p-6` main).

Label column width and line count for the two rows in the bug report:

| viewport | row | origin/main | this branch |
|---|---|---|---|
| 722 | Hugging Face token | 43px, 3 lines | 394px, 1 line |
| 722 | Embedding model | 26px, 2 lines | 394px, 1 line |
| 924 | Hugging Face token | 245px, 1 line | 245px, 1 line |
| 924 | Embedding model | 228px, 1 line | 228px, 1 line |
| 1400 | Hugging Face token | 245px, 1 line | 245px, 1 line |

43px for a label reading "Hugging Face token" is the reported bug.

No regression above the bug width: at 924 and 1400 every measured row is geometrically identical to `origin/main`, including `wrapped` state and the stretch probe on the `flex-col` callers. The label floor is `11rem` specifically because it is the widest value that keeps that true. `12rem` and `13rem` both made the Models folder row wrap at 924, which is the maximized width on the reporting machine.

`tsc -b` clean. `npm run build` clean. Biome against `origin/main` on these four files: one added `useBlockStatements`, from a braceless early return matching the 23 already in `provider.tsx`. Biome is non-blocking in this repo by design.

## Cross-platform

Every branch is guarded or width-driven.

- `navbar.tsx`: the non-custom-titlebar path keeps `z-[45] h-[48px] items-start pt-[11px] pl-2` verbatim. `shouldUseCustomWindowTitlebar()` is false when not in Tauri and false on macOS, so plain web and macOS are untouched.
- `window-titlebar.tsx`: `showSidebarToggle` defaults to true and the macOS caller in `app-sidebar.tsx:1729` does not pass it. The only site passing `false` is inside `WindowTitlebar`, itself gated on `shouldUseCustomWindowTitlebar()`, and then only when mobile.
- `provider.tsx`: ratio is 1 without extra webview zoom, so the computed width is unchanged elsewhere.
- `settings-row.tsx`: the only unguarded file, hence the measurement table above.

## Not verified

The titlebar and window-sizing changes need a desktop build to confirm end to end; only the settings-row geometry could be measured directly. The Tauri Linux debug build in CI covers compilation.

