### PR TITLE
fix(studio): screen `start ""` under the cmd lexer, and give the new Windows bash a userland

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1376,6 +1376,8 @@ _START_SWITCHES = _START_SWITCHES_WITH_VALUE | {
 _CMD_CONTROL_FLOW = frozenset({"if", "else", "do", "for"})
 # cmd builtins that re-execute what follows, so their child is a command.
 _CMD_FORWARDING_COMMANDS = frozenset({"call", "start", "start.exe"})
+# cmd's own switches: a bare letter, or a letter carrying a value (`/v:on`).
+_CMD_SWITCH_RE = re.compile(r"/[a-zA-Z](?::[\w.]+)?$")
 # Shell binaries whose -c/\c argument is a command line rather than data.
 _SHELLS = frozenset({"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"})
 _SHELLS_WIN = frozenset({"cmd", "cmd.exe"})
@@ -1398,7 +1400,7 @@ _STARTS_A_NEW_PATH_RE = re.compile(r"(?:[a-zA-Z]:[/\\]|[/\\])")
 # reads the payload, not any later quoted argument.
 _CMD_DOUBLED_QUOTE_RE = re.compile(
     r"(?i)(?:^|[\s;&|(])(?:[^\s;&|(]*[\\/])?cmd(?:\.exe)?\s+"
-    r'(?:/[a-z]\s+|//[a-z]\s+)*//?[ck]\s+(".*")\s*$'
+    r'(?:/[a-z]\s+|//[a-z]\s+)*//?[ck]\s+(".*?")\s*(?:$|[&|;])'
 )
 
 
@@ -1547,6 +1549,13 @@ def _find_blocked_commands(command: str) -> set[str]:
             position += 1
             while position < len(argv):
                 word = argv[position]
+                if candidate == "env":
+                    # env's own -S nests: `env -S 'env --split-string=rm -rf x'`
+                    # really runs rm, and the generic flag skip swallowed it.
+                    following = argv[position + 1] if position + 1 < len(argv) else ""
+                    nested = _env_split_string_payload(word, following)
+                    if nested:
+                        return _screen_env_split_string(nested)
                 if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(candidate, frozenset()):
                     position += 2
                     continue
@@ -2003,6 +2012,11 @@ def _find_blocked_commands(command: str) -> set[str]:
                         k += 3  # `a EQU b`
                     else:
                         k += 1  # `string1==string2`, one token
+                        # ...unless the quoting split it: shlex yields `"x"`
+                        # and `=="x"`, and stopping after the first left the
+                        # operator fragment standing in for the body command.
+                        while k < len(tokens) and _cmd_unquote(tokens[k]).startswith("=="):
+                            k += 1
             # `else` / `do`: the command is simply the next word.
         return indexes
 
@@ -2055,10 +2069,16 @@ def _find_blocked_commands(command: str) -> set[str]:
             # an invocation hard blocked the payload behind it.
             prev_runs = _runnable_index(j)
             prev = _cmd_unquote(tokens[j]) if prev_runs else tokens[j]
+            if prev_runs and prev.startswith("("):
+                # A FOR /F command set keeps its opener and delimiter glued on
+                # (`('cmd`), so the shell name behind them was never matched.
+                prev = prev.lstrip("(").lstrip("'\"`")
             if prev.startswith("-"):
                 continue  # skip Unix flags like --login, -l
-            if is_win_c and prev.startswith("/") and len(prev) <= 3:
-                continue  # skip Windows flags like /s, /q (not /bin/bash)
+            if is_win_c and _CMD_SWITCH_RE.fullmatch(prev):
+                # /s, /q, and the value-style /v:on, /e:off, /t:0a. Anchored so
+                # a POSIX program path (/bin/bash) is never mistaken for one.
+                continue
             prev_base = os.path.basename(prev).lower()
             # Same for the payload: the cmd lexer makes `cmd /c "rm -rf x"` one
             # quoted token, which re-lexes to no command while still quoted.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1694,9 +1694,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             # `start 'My Window' prog` therefore still reads as a title, and
             # the raw double-quoted spelling is kept as it was.
             titled = (
-                head == ""
-                or any(char in head for char in ' \t\n\r"')
-                or '"%s"' % head in command
+                head == "" or any(char in head for char in ' \t\n\r"') or '"%s"' % head in command
             )
         # The head is screened WHATEVER `titled` says. It is a heuristic under
         # the posix lexer, and a false positive there must cost an over-block,

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1729,9 +1729,13 @@ def _find_blocked_commands(command: str) -> set[str]:
             # `if (len != 0 && !strpbrk (a, " \t\n\r\""))` emits it bare).
             # `start 'My Window' prog` therefore still reads as a title, and
             # the raw double-quoted spelling is kept as it was.
-            titled = (
-                head == "" or any(char in head for char in ' \t\n\r"') or '"%s"' % head in command
-            )
+            # Purely by CONTENT: bash removes the quoting before exec, so what
+            # the user wrote is gone by then and only what MSYS re-quotes for
+            # CreateProcess can read as a title. `start "explorer" .` reaches
+            # cmd as a bare `start explorer .`, where explorer is the program
+            # and `.` merely its argument, so consulting the raw double-quoted
+            # spelling hard-blocked that launch on the `.` source builtin.
+            titled = head == "" or any(char in head for char in ' \t\n\r"')
         # The head is screened WHATEVER `titled` says. It is a heuristic under
         # the posix lexer, and a false positive there must cost an over-block,
         # never an under-block: `echo "powershell" && cmd //c start powershell
@@ -1743,10 +1747,13 @@ def _find_blocked_commands(command: str) -> set[str]:
         # a find -exec child. `echo start "title" powershell` and
         # `grep -rn start "src/my dir" curl` run neither the title nor the word
         # behind it, and were hard-refused on a program that never starts.
+        # _exec_child_index, not flag + 1: a prefix forwards to its target, so
+        # `find . -exec env start "" powershell \;` really runs start and the
+        # direct-word test read `env` and stopped.
         runnable = (
             i in command_positions
             or i in win_c_payloads
-            or any(i == flag + 1 for flag in exec_flag_indexes)
+            or any(_exec_child_index(flag + 1)[0] == i for flag in exec_flag_indexes)
         )
         if titled and runnable and j + 1 < len(tokens):
             blocked |= _scan_cmd_payload(_cmd_unquote(tokens[j + 1]))

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1637,7 +1637,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
     _SHELLS_WIN = {"cmd", "cmd.exe"}
     for i, token in enumerate(tokens):
-        tok_lower = token.lower()
+        tok_lower = _cmd_unquote(token).lower()
         # Match -c exactly, or combined flags ending in c (e.g. -lc, -xc)
         is_unix_c = tok_lower == "-c" or (
             tok_lower.startswith("-") and tok_lower.endswith("c") and not tok_lower.startswith("--")
@@ -1650,16 +1650,19 @@ def _find_blocked_commands(command: str) -> set[str]:
         # Look back past flags for the shell binary. Windows flags and absolute
         # paths both start with /, so only skip short /X flags (not /bin/bash).
         for j in range(i - 1, -1, -1):
-            prev = tokens[j]
+            prev = _cmd_unquote(tokens[j])
             if prev.startswith("-"):
                 continue  # skip Unix flags like --login, -l
             if is_win_c and prev.startswith("/") and len(prev) <= 3:
                 continue  # skip Windows flags like /s, /q (not /bin/bash)
             prev_base = os.path.basename(prev).lower()
+            # The payload is unquoted for the same reason: under the cmd lexer
+            # `cmd /c "rm -rf x"` arrives as one quoted token, and re-lexing it
+            # with the quotes still attached finds no command at all.
             if is_unix_c and prev_base in _SHELLS:
-                blocked |= _find_blocked_commands(tokens[i + 1])
+                blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
             elif is_win_c and prev_base in _SHELLS_WIN:
-                blocked |= _find_blocked_commands(tokens[i + 1])
+                blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1674,11 +1677,24 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-        # `start ""` is the idiom for "no title"; anything else is the program.
-        if j < len(tokens) and _cmd_unquote(tokens[j]) == "":
-            j += 1
-        if j < len(tokens):
-            blocked |= _find_blocked_commands(_cmd_unquote(tokens[j]))
+        if j >= len(tokens):
+            continue
+        # `start ["title"] prog`: cmd reads the first argument as a window title
+        # ONLY when it is quoted, so an unquoted token here is the program
+        # itself and the one after it is just an argument. Both `start ""` and
+        # `start "MyWindow"` hide the program one token further on, and only the
+        # empty spelling was screened before. The cmd lexer keeps the quotes on
+        # the token; the posix lexer has already dropped them, so the raw text
+        # is consulted there. Guessing instead (screening both positions
+        # unconditionally) blocks `start explorer .` on the `.` source builtin.
+        head = tokens[j]
+        if not lexed_posix:
+            titled = head.startswith('"')
+        else:
+            titled = head == "" or '"%s"' % head in command or "'%s'" % head in command
+        blocked |= _find_blocked_commands(_cmd_unquote(head))
+        if titled and j + 1 < len(tokens):
+            blocked |= _find_blocked_commands(_cmd_unquote(tokens[j + 1]))
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1349,6 +1349,8 @@ def _cmd_unquote(token: str) -> str:
 # `start` launches its argument as a program, so that argument is a command
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
+# cmd keywords whose command word does not follow immediately, or at all.
+_CMD_CONTROL_FLOW = frozenset({"if", "else", "do", "for"})
 
 # Tells one quoted executable path apart from an argument list mentioning one.
 _EXECUTABLE_PATH_RE = re.compile(r"\.(?:exe|com|bat|cmd)(?=\s|$)", re.IGNORECASE)
@@ -1652,6 +1654,39 @@ def _find_blocked_commands(command: str) -> set[str]:
         )
         blocked.update(re.findall(pattern, lowered))
 
+    def _cmd_payload_commands(start: int) -> "list[int]":
+        """Command positions inside a `cmd /c` payload.
+
+        cmd runs control flow of its own, so the program is not always the first
+        word: `if exist FILE start "" prog` puts it behind a condition that bash
+        grammar reads as plain arguments. But the words after a command really
+        are its arguments, so marking the whole payload made
+        `cmd /c echo start "title" prog` read the echoed text as a launcher.
+        """
+        indexes: "list[int]" = []
+        k, expect = start, True
+        while k < len(tokens):
+            token = tokens[k]
+            if token in _SHELL_SEPARATORS:
+                k, expect = k + 1, True
+                continue
+            if not expect:
+                k += 1
+                continue
+            indexes.append(k)
+            if _token_basename(_cmd_unquote(token)) not in _CMD_CONTROL_FLOW:
+                k, expect = k + 1, False
+                continue
+            # `if [/i] [not] exist FILE prog`, and the else/do/for forms whose
+            # command is simply the next word.
+            k += 1
+            while k < len(tokens) and _cmd_unquote(tokens[k]).lower() in ("/i", "not"):
+                k += 1
+            if k < len(tokens):
+                condition = _cmd_unquote(tokens[k]).lower()
+                k += 2 if condition in ("exist", "defined", "errorlevel") else 1
+        return indexes
+
     def _runnable_index(idx: int) -> bool:
         """True where the shell would execute the word at ``idx``: command
         position, inside a `cmd /c` payload (cmd runs control flow of its own),
@@ -1696,14 +1731,8 @@ def _find_blocked_commands(command: str) -> set[str]:
             if is_unix_c and prev_runs and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
             elif is_win_c and prev_runs and prev_base in _SHELLS_WIN:
-                # Tell the start scan below where cmd hands control over. The
-                # WHOLE payload counts: cmd runs control flow of its own, so
-                # `cmd /c if exist C:\Windows start "" powershell` hides start
-                # behind an `if` that bash grammar reads as plain arguments.
-                for payload_index in range(i + 1, len(tokens)):
-                    if tokens[payload_index] in _SHELL_SEPARATORS:
-                        break
-                    win_c_payloads.add(payload_index)
+                # Tell the start scan below where cmd hands control over.
+                win_c_payloads.update(_cmd_payload_commands(i + 1))
                 blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
             break  # stop at first non-flag token
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1784,6 +1784,12 @@ def _find_blocked_commands(command: str) -> set[str]:
             # `else` / `do`: the command is simply the next word.
         return indexes
 
+    # Resolved once: testing every -exec flag on every lookup made the whole
+    # scan quadratic (800 exec clauses and 800 start words, 21 kB, spent 1.4s
+    # against 0.05s before). The children do not depend on what the sweep
+    # discovers, so there is nothing to recompute.
+    exec_children = {_exec_child_index(flag + 1)[0] for flag in exec_flag_indexes}
+
     def _runnable_index(idx: int) -> bool:
         """True where the shell would execute the word at ``idx``: command
         position, inside a `cmd /c` payload (cmd runs control flow of its own),
@@ -1792,7 +1798,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             idx in command_positions
             or idx in win_c_payloads
             or idx in start_children
-            or any(_exec_child_index(flag + 1)[0] == idx for flag in exec_flag_indexes)
+            or idx in exec_children
         )
 
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):
@@ -1902,18 +1908,16 @@ def _find_blocked_commands(command: str) -> set[str]:
             # bare, explorer being the program and `.` only its argument, while
             # `start 'My Window' prog` still reads as a title.
             titled = head == "" or any(char in head for char in ' \t\n\r"')
-        # The head is screened WHATEVER `titled` says: it is a heuristic, and a
-        # false positive must cost an over-block, never an under-block.
-        # `echo "powershell" && cmd //c start powershell -Command ls` reads as
-        # titled from the echo, so skipping the head would let it through.
-        blocked |= _scan_cmd_payload(_cmd_unquote(head))
-        # Stepping PAST the head only makes sense where the shell really runs
-        # this start: `echo start "title" powershell` launches nothing and was
-        # hard-refused. _runnable_index follows an -exec through its prefix, so
+        # Both the head and what follows it only matter where the shell really
+        # runs this start: `echo start "powershell"` launches nothing and was
+        # hard-refused. The bypass this once guarded against is still covered,
+        # because `echo "powershell" && cmd //c start powershell` puts its start
+        # after a separator and inside a cmd payload, both runnable positions.
+        # _runnable_index follows an -exec through its prefix too, so
         # `find . -exec env start "" powershell \;` still resolves to start
         # where testing the word right after the flag read `env` and stopped.
-        runnable = _runnable_index(i)
-        if runnable:
+        if _runnable_index(i):
+            blocked |= _scan_cmd_payload(_cmd_unquote(head))
             k = j + 1 if titled else j
             # Switches may also FOLLOW the title: the documented shape is
             # `START ["title"] [switches] command`, so `start "" /b powershell`
@@ -1934,6 +1938,27 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # _bash_exec runs this synchronously before the timeout.
                 # It runs untitled too: only the FIRST operand is a title.
                 start_children.add(k)
+                # A wrapper forwards to whatever it execs, and the Git userland
+                # this branch adds to PATH makes env/nice resolvable here, so
+                # `start "" env rm -rf victim` really deletes. Walk the chain:
+                # a wrapper can wrap a wrapper.
+                while k < len(tokens):
+                    child = _token_basename(_cmd_unquote(tokens[k]))
+                    if child not in _COMMAND_PREFIXES:
+                        break
+                    k += 1
+                    while k < len(tokens):
+                        word = _cmd_unquote(tokens[k])
+                        if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(child, frozenset()):
+                            k += 2  # the flag takes a separate value
+                            continue
+                        if word.startswith("-") or "=" in word:
+                            k += 1  # its own flags, and VAR=VALUE
+                            continue
+                        break
+                    if k < len(tokens):
+                        blocked |= _scan_cmd_payload(_cmd_unquote(tokens[k]))
+                        start_children.add(k)
 
 
     # start can launch a shell and a shell can run a start, so the two feed each

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1373,6 +1373,9 @@ _START_SWITCHES = _START_SWITCHES_WITH_VALUE | {
 _CMD_CONTROL_FLOW = frozenset({"if", "else", "do", "for"})
 # cmd builtins that re-execute what follows, so their child is a command.
 _CMD_FORWARDING_COMMANDS = frozenset({"call", "start", "start.exe"})
+# Shell binaries whose -c/\c argument is a command line rather than data.
+_SHELLS = frozenset({"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"})
+_SHELLS_WIN = frozenset({"cmd", "cmd.exe"})
 # A payload may lead with its redirection. Bare operators take the next token
 # as the target; the attached spellings and `2>&1` carry their own.
 _CMD_REDIRECT_BARE_RE = re.compile(r"\d?(?:>>|>|<)$")
@@ -1419,7 +1422,16 @@ def _env_split_string_payload(word: str, following: str = "") -> str:
     elif bare in ("-S", "--split-string"):
         payload = following
     # The cmd lexer keeps the marks, and they are the shell's, not the payload's.
-    return _cmd_unquote(payload.strip()).strip('"')
+    # Only a BALANCED surrounding pair is the shell's: stripping stray quotes as
+    # well truncated `bash -c "rm -rf x"` to an unbalanced string that then
+    # failed to split at all.
+    payload = _cmd_unquote(payload.strip())
+    if payload.count('"') % 2:
+        # An ODD count is the cmd lexer having ended the token mid-quote, as it
+        # does for the attached `-S"rm -rf x"`; drop the orphan so the rest can
+        # still be split.
+        payload = payload.strip('"')
+    return payload
 
 
 def _cmd_quoted_program(payload: str) -> str:
@@ -1505,6 +1517,38 @@ def _find_blocked_commands(command: str) -> set[str]:
         if ext in {".exe", ".com", ".bat", ".cmd"}:
             base = stem
         return base
+
+    def _screen_env_split_string(payload: str) -> "set[str]":
+        """Screen an `env -S` payload as ARGV, which is what env makes of it.
+
+        -S splits the string into arguments and execs argv[0] directly; it does
+        not hand the result to a shell, so `env -S 'printf %s ; rm'` passes `;`
+        and `rm` to printf as data (verified against GNU coreutils 9.4, which
+        prints `;rm`). Reading it with shell grammar invented an operator there
+        and refused a harmless command. A shell reached this way is still a
+        shell, so its own -c payload is screened with the full grammar.
+        """
+        try:
+            argv = shlex.split(payload, posix = True)
+        except ValueError:
+            argv = payload.split()
+        if not argv:
+            return set()
+        found: "set[str]" = set()
+        base = _token_basename(argv[0])
+        if base in _BLOCKED_COMMANDS:
+            found.add(base)
+        else:
+            found |= _blocked_matching_glob(base)
+        if base in _SHELLS or base in _SHELLS_WIN:
+            # `env -S 'bash -c "rm -rf x"'` really does reach a shell.
+            for position, word in enumerate(argv[1:], start = 1):
+                flag = word.lower()
+                is_c = flag == "-c" or _win_switch(flag) in ("/c", "/k")
+                if is_c and position + 1 < len(argv):
+                    found |= _find_blocked_commands(argv[position + 1])
+                    break
+        return found
 
     def _scan_cmd_payload(payload: str) -> "set[str]":
         """A cmd payload, read as a command line AND as one quoted program path.
@@ -1640,7 +1684,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                 )
                 payload = _env_split_string_payload(token, following)
                 if payload:
-                    blocked |= _find_blocked_commands(payload)
+                    blocked |= _screen_env_split_string(payload)
             # A wrapper option whose value is a SEPARATE token precedes that
             # value, not the wrapped command. Without consuming it the value is
             # read as the command word and the real command behind it is never
@@ -1785,11 +1829,11 @@ def _find_blocked_commands(command: str) -> set[str]:
         """
         nonlocal blocked
         indexes: "list[int]" = []
-        k, expect = start, True
+        k, expect, in_if = start, True, False
         while k < len(tokens):
             token = tokens[k]
             if token in _SHELL_SEPARATORS:
-                k, expect = k + 1, True
+                k, expect, in_if = k + 1, True, False
                 continue
             bare = _cmd_unquote(token)
             # A payload may lead with its redirection (`cmd /c >out.txt start`),
@@ -1802,8 +1846,11 @@ def _find_blocked_commands(command: str) -> set[str]:
                 k += 1  # `>out.txt`, `2>&1`: self-contained
                 continue
             # cmd resumes at ELSE, so the else-branch is a command position:
-            # `if 1==2 echo no else start "" prog` really launches prog.
-            if _token_basename(bare) == "else":
+            # `if 1==2 echo no else start "" prog` really launches prog. Only
+            # while an IF is open, though: `echo no else powershell` merely
+            # prints the word and `findstr else powershell file` searches for it.
+            if in_if and _token_basename(bare) == "else":
+                in_if = False
                 k, expect = k + 1, True
                 continue
             if not expect:
@@ -1828,7 +1875,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                         following = _cmd_unquote(tokens[k + 1]) if k + 1 < len(tokens) else ""
                         split = _env_split_string_payload(tokens[k], following)
                         if split:
-                            blocked |= _find_blocked_commands(split)
+                            blocked |= _screen_env_split_string(split)
                     if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(base, frozenset()):
                         k += 2  # `env -u FOO prog`: the flag eats its value
                         continue
@@ -1851,6 +1898,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                     if is_do:
                         break
             elif base == "if":
+                in_if = True
                 # `if [/i] [not] <condition> CMD`. Every condition form has its
                 # own width, and assuming one token left the body of the
                 # comparison forms (`if 1 EQU 1 rm -rf x`) unscreened.
@@ -1902,8 +1950,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):
     # on a -c/-/c flag, look back for a shell name (skipping flags) and
     # recursively scan the nested command string.
-    _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
-    _SHELLS_WIN = {"cmd", "cmd.exe"}
+
 
     def _nested_shell_at(i: int) -> None:
         nonlocal blocked
@@ -2050,6 +2097,13 @@ def _find_blocked_commands(command: str) -> set[str]:
                     k += 1
                     while k < len(tokens):
                         word = _cmd_unquote(tokens[k])
+                        if child == "env":
+                            following = (
+                                _cmd_unquote(tokens[k + 1]) if k + 1 < len(tokens) else ""
+                            )
+                            split = _env_split_string_payload(tokens[k], following)
+                            if split:
+                                blocked |= _screen_env_split_string(split)
                         if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(child, frozenset()):
                             k += 2  # the flag takes a separate value
                             continue
@@ -2073,6 +2127,22 @@ def _find_blocked_commands(command: str) -> set[str]:
     # what it depends on is final. Alternating whole passes instead needed one
     # round per layer, and a bounded number of rounds left the deeper ones
     # unscreened.
+    if not lexed_posix:
+        # _get_shell_cmd hands the whole string to `cmd /c`, so the top level is
+        # itself a cmd payload. Only an explicit inner `cmd /c` was parsed with
+        # that grammar, which left `call start powershell` unscreened on the
+        # very host the cmd lexer is chosen for.
+        for payload_index in _cmd_payload_commands(0):
+            win_c_payloads.add(payload_index)
+            payload_word = _cmd_unquote(tokens[payload_index])
+            if any(char in payload_word for char in " \t"):
+                continue  # a whole command line in one token; _scan_cmd_payload owns it
+            payload_base = _token_basename(payload_word)
+            if payload_base in _BLOCKED_COMMANDS:
+                blocked.add(payload_base)
+            else:
+                blocked |= _blocked_matching_glob(payload_base)
+
     for index in range(len(tokens)):
         _nested_shell_at(index)
         _start_at(index)

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1341,13 +1341,8 @@ def _win_switch(token: str) -> str:
 def _cmd_unquote(token: str) -> str:
     """Strip the double quotes the non-posix lexer leaves on a token.
 
-    shlex.split(posix = False) keeps quote marks inside the token, so the
-    `start ""` no-title idiom arrives as the two-character string `""` and a
-    quoted program name never matches a blocked one. cmd.exe itself strips
-    double quotes, so honouring them here is what the shell does; single quotes
-    are left alone because cmd does not treat them as quoting (`'rm'` really is
-    a literal unknown program there, which _token_basename relies on). Identity
-    under posix lexing, where the lexer has already removed them.
+    cmd.exe strips them itself, so the `start ""` no-title idiom and quoted
+    program names match. Single quotes stay: cmd does not treat them as quoting.
     """
     while len(token) >= 2 and token.startswith('"') and token.endswith('"'):
         token = token[1:-1]
@@ -1656,9 +1651,8 @@ def _find_blocked_commands(command: str) -> set[str]:
             if is_win_c and prev.startswith("/") and len(prev) <= 3:
                 continue  # skip Windows flags like /s, /q (not /bin/bash)
             prev_base = os.path.basename(prev).lower()
-            # The payload is unquoted for the same reason: under the cmd lexer
-            # `cmd /c "rm -rf x"` arrives as one quoted token, and re-lexing it
-            # with the quotes still attached finds no command at all.
+            # Same for the payload: under the cmd lexer `cmd /c "rm -rf x"` is
+            # one quoted token, and re-lexing it quoted finds no command.
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
             elif is_win_c and prev_base in _SHELLS_WIN:
@@ -1680,13 +1674,10 @@ def _find_blocked_commands(command: str) -> set[str]:
         if j >= len(tokens):
             continue
         # `start ["title"] prog`: cmd reads the first argument as a window title
-        # ONLY when it is quoted, so an unquoted token here is the program
-        # itself and the one after it is just an argument. Both `start ""` and
-        # `start "MyWindow"` hide the program one token further on, and only the
-        # empty spelling was screened before. The cmd lexer keeps the quotes on
-        # the token; the posix lexer has already dropped them, so the raw text
-        # is consulted there. Guessing instead (screening both positions
-        # unconditionally) blocks `start explorer .` on the `.` source builtin.
+        # ONLY when quoted, so an unquoted token here is the program and the
+        # next one just its argument. Screening both would block
+        # `start explorer .` on the `.` source builtin. The cmd lexer keeps the
+        # quotes; the posix one drops them, so the raw text is consulted there.
         head = tokens[j]
         if not lexed_posix:
             titled = head.startswith('"')
@@ -6631,9 +6622,8 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
         _trusted_git_dir, git_ext = _resolve_trusted_windows_git()
         if _trusted_git_dir:
             path_entries.append(_trusted_git_dir)
-        # The shell's own userland, on the same trust boundary. Appended last so
-        # a Git-shipped python.exe/git.exe cannot shadow the interpreter this
-        # server runs in, which the first PATH entry deliberately pins.
+        # The shell's own userland, same trust boundary. Last, so a Git-shipped
+        # python.exe/git.exe cannot shadow the interpreter pinned first.
         path_entries.extend(_windows_bash_userland_dirs())
 
     # Deduplicate, preserving order.
@@ -6657,10 +6647,8 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Windows needs SystemRoot for Python/subprocess to work.
     if sys.platform == "win32":
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
-        # Windows tempfile / SDKs honour TEMP/TMP, not TMPDIR, so a native
-        # program run from the shell would otherwise fall back to GetTempPath
-        # and write outside the per-session sandbox dir. Matches
-        # _build_bypass_env, which already repoints all three.
+        # Windows honours TEMP/TMP, not TMPDIR, so a native program would
+        # otherwise fall back to GetTempPath and write outside the sandbox.
         env["TEMP"] = workdir
         env["TMP"] = workdir
         # Restrict PATHEXT so cwd .BAT/.CMD cannot hijack bare names (#7317).
@@ -7024,18 +7012,13 @@ def _windows_bash() -> "str | None":
 def _windows_bash_userland_dirs() -> list[str]:
     """Trusted dirs holding the resolved bash and the POSIX tools beside it.
 
-    `bash -c` is non-login, so it never sources /etc/profile, which is what
-    normally puts Git for Windows' usr\\bin on PATH. _build_safe_env builds PATH
-    from scratch, so without these the terminal description promises bash while
-    ls / cat / grep / sed / head all come back as "command not found" and only
-    builtins work. Both install layouts are covered: bash.exe under Git\\bin and
-    under Git\\usr\\bin put the install root one and two levels up respectively,
-    so both parents are probed and the one that exists wins.
-
-    Every candidate clears _is_trusted_windows_program_dir, the same Program
-    Files boundary as the git entry (#7317), and is canonicalised before use so
-    a junction cannot retarget it after the check. Fails closed: no trusted
-    bash, no entries, and PATH is exactly what it was before.
+    `bash -c` is non-login, so it never sources /etc/profile, which is what puts
+    Git for Windows' usr\\bin on PATH; without these, ls / cat / grep are all
+    "command not found". bash.exe ships under Git\\bin and Git\\usr\\bin, so the
+    install root is one or two levels up and both parents are probed. Every
+    candidate clears _is_trusted_windows_program_dir, the same Program Files
+    boundary as the git entry (#7317), and is canonicalised so a junction cannot
+    retarget it. Fails closed: no trusted bash, no entries, PATH unchanged.
     """
     bash = _windows_bash()
     if not bash:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1371,6 +1371,12 @@ _START_SWITCHES = _START_SWITCHES_WITH_VALUE | {
 }
 # cmd keywords whose command word does not follow immediately, or at all.
 _CMD_CONTROL_FLOW = frozenset({"if", "else", "do", "for"})
+# cmd builtins that re-execute what follows, so their child is a command.
+_CMD_FORWARDING_COMMANDS = frozenset({"call", "start", "start.exe"})
+# A payload may lead with its redirection. Bare operators take the next token
+# as the target; the attached spellings and `2>&1` carry their own.
+_CMD_REDIRECT_BARE_RE = re.compile(r"\d?(?:>>|>|<)$")
+_CMD_REDIRECT_ATTACHED_RE = re.compile(r"\d?(?:>>|>|<)")
 # cmd IF conditions, by how many tokens they occupy before the body command.
 _CMD_IF_UNARY = frozenset({"exist", "defined", "errorlevel", "cmdextversion"})
 _CMD_IF_COMPARISONS = frozenset({"equ", "neq", "lss", "leq", "gtr", "geq"})
@@ -1473,6 +1479,18 @@ def _find_blocked_commands(command: str) -> set[str]:
     quoted_redirects = (
         _quoted_redirection_indexes(command, tokens, ";&|()`") if lexed_posix else frozenset()
     )
+    # Tokens whose leading `(` came from QUOTING. The posix lexer drops the
+    # marks, so `echo "(start" powershell` is byte-identical to a real group
+    # opener by then; the cmd lexer keeps them and needs no help.
+    quoted_group_openers: "frozenset[int]" = frozenset()
+    if lexed_posix:
+        _marked = _masked_tokens(command, tokens, ";&|()`", frozenset("("), _QUOTED_SEPARATOR_MARK)
+        if _marked is not None:
+            quoted_group_openers = frozenset(
+                index
+                for index, marked_token in enumerate(_marked)
+                if marked_token.startswith(_QUOTED_SEPARATOR_MARK)
+            )
     exec_flag_indexes, invocation_stops, redirect_indexes = _exec_scan_layout(
         tokens, quoted_separators, quoted_redirects
     )
@@ -1773,11 +1791,31 @@ def _find_blocked_commands(command: str) -> set[str]:
             if token in _SHELL_SEPARATORS:
                 k, expect = k + 1, True
                 continue
+            bare = _cmd_unquote(token)
+            # A payload may lead with its redirection (`cmd /c >out.txt start`),
+            # and recording the redirection as the command stopped the walk
+            # before what cmd actually runs.
+            if _CMD_REDIRECT_BARE_RE.fullmatch(bare):
+                k += 2  # `> out.txt`, `2> err.txt`: the operand follows
+                continue
+            if _CMD_REDIRECT_ATTACHED_RE.match(bare):
+                k += 1  # `>out.txt`, `2>&1`: self-contained
+                continue
+            # cmd resumes at ELSE, so the else-branch is a command position:
+            # `if 1==2 echo no else start "" prog` really launches prog.
+            if _token_basename(bare) == "else":
+                k, expect = k + 1, True
+                continue
             if not expect:
                 k += 1
                 continue
             indexes.append(k)
-            base = _token_basename(_cmd_unquote(token))
+            base = _token_basename(bare)
+            if base in _CMD_FORWARDING_COMMANDS:
+                # `call` re-executes what follows, so its child is a command
+                # position rather than an argument.
+                k, expect = k + 1, True
+                continue
             if base in _COMMAND_PREFIXES:
                 # `env`/`nice` and friends exec their operand, and this branch
                 # now puts the Git userland on PATH, so they resolve inside a
@@ -1794,8 +1832,12 @@ def _find_blocked_commands(command: str) -> set[str]:
                     if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(base, frozenset()):
                         k += 2  # `env -u FOO prog`: the flag eats its value
                         continue
-                    if word.startswith("-") or "=" in word:
-                        k += 1  # the wrapper's own flags, and VAR=VALUE
+                    if (
+                        word.startswith("-")
+                        or "=" in word
+                        or _WRAPPER_DURATION_RE.fullmatch(word)
+                    ):
+                        k += 1  # its own flags, VAR=VALUE, `timeout 5 prog`
                         continue
                     break
                 continue
@@ -1850,7 +1892,15 @@ def _find_blocked_commands(command: str) -> set[str]:
             # `if 1==1 (start "" cmd /c powershell)` lexes the group opener onto
             # the command word, so it never reached command_positions even
             # though both grammars run whatever follows a `(`.
-            or (0 <= idx < len(tokens) and tokens[idx].startswith("("))
+            or (
+                0 <= idx < len(tokens)
+                and tokens[idx].startswith("(")
+                # A QUOTED `(` is data the command receives. The posix lexer
+                # drops the marks, so `echo "(start" powershell` looked exactly
+                # like a group opener; quoted_separators is what tells them
+                # apart, and the separator test above already relies on it.
+                and idx not in quoted_group_openers
+            )
         )
 
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1349,6 +1349,13 @@ def _cmd_unquote(token: str) -> str:
 # `start` launches its argument as a program, so that argument is a command
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
+# Only these are switches. Skipping ANY slash-prefixed word walked straight past
+# the program under Git Bash, where a POSIX path is how one is written:
+# `start "" /c/Program Files/PowerShell/7/pwsh.exe` read the path as a switch.
+_START_SWITCHES = _START_SWITCHES_WITH_VALUE | {
+    "/min", "/max", "/wait", "/b", "/i", "/low", "/normal", "/high",
+    "/realtime", "/abovenormal", "/belownormal", "/separate", "/shared",
+}
 # cmd keywords whose command word does not follow immediately, or at all.
 _CMD_CONTROL_FLOW = frozenset({"if", "else", "do", "for"})
 
@@ -1649,7 +1656,11 @@ def _find_blocked_commands(command: str) -> set[str]:
         words_alt = "|".join(re.escape(w) for w in sorted(_BLOCKED_COMMANDS))
         pattern = (
             rf"(?:^|[;&|`\n(]\s*|[$]\(\s*|<\(\s*)"
-            rf"(?:[\w./\\-]*/|[a-zA-Z]:[/\\][\w./\\-]*)?"
+            # The path prefix has to END on a separator. Letting it stop
+            # mid-name left the extension's dot to match the `.` builtin, so
+            # every `C:\dir\prog.exe` at the start of a scanned string reported
+            # `.` as a blocked command.
+            rf"(?:[\w./\\-]*/|[a-zA-Z]:[/\\](?:[\w.-]*[/\\])*)?"
             rf"({words_alt})(?:\.(?:exe|com|bat|cmd))?\b"
         )
         blocked.update(re.findall(pattern, lowered))
@@ -1675,6 +1686,17 @@ def _find_blocked_commands(command: str) -> set[str]:
                 continue
             indexes.append(k)
             base = _token_basename(_cmd_unquote(token))
+            if base in _COMMAND_PREFIXES:
+                # `env`/`nice` and friends exec their operand, and this branch
+                # now puts the Git userland on PATH, so they resolve inside a
+                # cmd payload too: `cmd /c env powershell` recorded only env and
+                # left the shell it runs sitting in argument position.
+                k += 1
+                while k < len(tokens) and (
+                    tokens[k].startswith("-") or "=" in _cmd_unquote(tokens[k])
+                ):
+                    k += 1  # env's own flags and VAR=VALUE assignments
+                continue
             if base not in _CMD_CONTROL_FLOW:
                 k, expect = k + 1, False
                 continue
@@ -1786,7 +1808,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         j = i + 1
         while j < len(tokens):
             switch = _win_switch(_cmd_unquote(tokens[j]).lower())
-            if not switch.startswith("/"):
+            if switch not in _START_SWITCHES:
                 break
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
@@ -1819,23 +1841,25 @@ def _find_blocked_commands(command: str) -> set[str]:
         # `find . -exec env start "" powershell \;` still resolves to start
         # where testing the word right after the flag read `env` and stopped.
         runnable = _runnable_index(i)
-        if titled and runnable and j + 1 < len(tokens):
-            k = j + 1
+        if runnable:
+            k = j + 1 if titled else j
             # Switches may also FOLLOW the title: the documented shape is
             # `START ["title"] [switches] command`, so `start "" /b powershell`
             # put /b where the program was expected and the scan stopped there.
             while k < len(tokens):
                 switch = _win_switch(_cmd_unquote(tokens[k]).lower())
-                if not switch.startswith("/"):
+                if switch not in _START_SWITCHES:
                     break
                 k += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
             if k < len(tokens):
                 blocked |= _scan_cmd_payload(_cmd_unquote(tokens[k]))
                 # start launches a COMMAND LINE, not just a program, so the
-                # child may be a shell of its own: `start "" cmd /c powershell`
+                # child may be a shell of its own: `start cmd /c powershell`
                 # reaches powershell through a nested cmd that this pass had
                 # already walked past. Re-scanning the remainder re-runs every
-                # pass over it, which screens that nesting to any depth.
+                # pass over it, which screens that nesting to any depth. It runs
+                # untitled too: only the FIRST operand is the title, so the
+                # nesting is identical either way.
                 blocked |= _find_blocked_commands(" ".join(tokens[k:]))
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1674,15 +1674,35 @@ def _find_blocked_commands(command: str) -> set[str]:
         if j >= len(tokens):
             continue
         # `start ["title"] prog`: cmd reads the first argument as a window title
-        # ONLY when quoted, so an unquoted token here is the program and the
-        # next one just its argument. Screening both would block
+        # ONLY when DOUBLE quoted, so an unquoted token here is the program and
+        # the next one just its argument. Screening both would block
         # `start explorer .` on the `.` source builtin. The cmd lexer keeps the
         # quotes; the posix one drops them, so the raw text is consulted there.
         head = tokens[j]
         if not lexed_posix:
             titled = head.startswith('"')
         else:
-            titled = head == "" or '"%s"' % head in command or "'%s'" % head in command
+            # Single quotes are NOT title quotes: cmd has no single-quote
+            # syntax, and bash strips them before cmd ever sees the word, so
+            # `start 'explorer' .` reaches cmd as the bare `start explorer .`
+            # and hard-blocked a legitimate command on the `.` behind it.
+            # What survives the hand-off is decided by CONTENT, not by the
+            # quote style written: the MSYS runtime Git Bash uses re-quotes an
+            # argument for CreateProcess exactly when it is empty or holds a
+            # space/tab/newline/quote (cygwin winf.cc, linebuf::fromargv:
+            # `if (len != 0 && !strpbrk (a, " \t\n\r\""))` emits it bare).
+            # `start 'My Window' prog` therefore still reads as a title, and
+            # the raw double-quoted spelling is kept as it was.
+            titled = (
+                head == ""
+                or any(char in head for char in ' \t\n\r"')
+                or '"%s"' % head in command
+            )
+        # The head is screened WHATEVER `titled` says. It is a heuristic under
+        # the posix lexer, and a false positive there must cost an over-block,
+        # never an under-block: `echo "powershell" && cmd //c start powershell
+        # -Command ls` reports titled from the echo, so skipping the head on a
+        # title would let the powershell start launches through unscreened.
         blocked |= _find_blocked_commands(_cmd_unquote(head))
         if titled and j + 1 < len(tokens):
             blocked |= _find_blocked_commands(_cmd_unquote(tokens[j + 1]))
@@ -6585,9 +6605,10 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     operator's cached creds. PYTHONPATH carries only the sandbox sitecustomize
     shim directory.
 
-    PATH starts with the Studio interpreter / venv and OS system dirs so
-    ``python``/``pip`` stay pinned. On Windows only, Git-for-Windows install
-    dirs from the host PATH are appended so bare ``git`` resolves (#7317).
+    PATH starts with the Studio interpreter / venv so ``python``/``pip`` stay
+    pinned, then the OS system dirs. On Windows only, Git-for-Windows install
+    dirs are inserted between the two so bare ``git`` resolves (#7317) and the
+    userland beats the System32 DOS twins of POSIX names (``find``, ``sort``).
     User-writable host PATH entries (venv, ``node_modules/.bin``, etc.) are
     never inherited — they could shadow auto-safe terminal commands.
     """
@@ -6603,28 +6624,35 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
         if venv_bin not in path_entries:
             path_entries.append(venv_bin)
 
-    if sys.platform == "win32":
-        sysroot = os.environ.get("SystemRoot", r"C:\Windows")
-        path_entries.extend([os.path.join(sysroot, "System32"), sysroot])
-    else:
-        path_entries.extend(["/usr/local/bin", "/usr/bin", "/bin"])
-
     # Windows Git installs live outside System32; inherit the dir of the git
     # the HOST shell resolves, but ONLY when it sits under a system install
     # root (Program Files, windir). A user-writable dir (Scoop/Choco shims)
     # is refused: it would let an attacker drop rg.exe/jq.exe beside git and
     # have an auto-approved bare command execute it (#7317).
     git_ext = ""
+    win_git_entries: list[str] = []
     if sys.platform == "win32":
-        # Append the CANONICAL (realpath) trusted git dir, scanning past any
-        # untrusted user shim that sorts first on PATH; the canonical path
-        # cannot be retargeted via a junction after the trust check.
+        # The CANONICAL (realpath) trusted git dir, scanning past any untrusted
+        # user shim that sorts first on PATH; the canonical path cannot be
+        # retargeted via a junction after the trust check.
         _trusted_git_dir, git_ext = _resolve_trusted_windows_git()
         if _trusted_git_dir:
-            path_entries.append(_trusted_git_dir)
-        # The shell's own userland, same trust boundary. Last, so a Git-shipped
-        # python.exe/git.exe cannot shadow the interpreter pinned first.
-        path_entries.extend(_windows_bash_userland_dirs())
+            win_git_entries.append(_trusted_git_dir)
+        # The shell's own userland, same trust boundary.
+        win_git_entries.extend(_windows_bash_userland_dirs())
+
+    if sys.platform == "win32":
+        sysroot = os.environ.get("SystemRoot", r"C:\Windows")
+        # AHEAD of System32, because System32 ships DOS twins of POSIX names:
+        # find.exe and sort.exe are there, so a bare `find . -name '*.py'` in
+        # the bash this tool advertises resolved to the DOS FIND and answered
+        # "FIND: Parameter format not correct" instead of running GNU find.
+        # Still behind the interpreter dirs above, so a Git-shipped python.exe
+        # cannot shadow the interpreter this server runs in.
+        path_entries.extend(win_git_entries)
+        path_entries.extend([os.path.join(sysroot, "System32"), sysroot])
+    else:
+        path_entries.extend(["/usr/local/bin", "/usr/bin", "/bin"])
 
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1618,9 +1618,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             # is written: attached, `=`-joined, or in the following token.
             if prefix_pending and prefix_command == "env":
                 following = (
-                    _cmd_unquote(tokens[token_index + 1])
-                    if token_index + 1 < len(tokens)
-                    else ""
+                    _cmd_unquote(tokens[token_index + 1]) if token_index + 1 < len(tokens) else ""
                 )
                 payload = _env_split_string_payload(token, following)
                 if payload:
@@ -1789,9 +1787,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                 while k < len(tokens):
                     word = _cmd_unquote(tokens[k])
                     if base == "env":
-                        following = (
-                            _cmd_unquote(tokens[k + 1]) if k + 1 < len(tokens) else ""
-                        )
+                        following = _cmd_unquote(tokens[k + 1]) if k + 1 < len(tokens) else ""
                         split = _env_split_string_payload(tokens[k], following)
                         if split:
                             blocked |= _find_blocked_commands(split)

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1763,6 +1763,18 @@ def _find_blocked_commands(command: str) -> set[str]:
                     else:
                         blocked |= _blocked_matching_glob(payload_base)
                 blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
+                if not _cmd_unquote(tokens[i + 1]):
+                    # `cmd /c ""prog" args"` is the documented way to quote a
+                    # program path holding spaces, and cmd strips the outer
+                    # pair and runs the rest as one string. The cmd lexer ends
+                    # the first token at the doubled quote, so the payload read
+                    # as EMPTY and prog was never screened.
+                    # cmd drops the outer pair and leaves the inner quoting to
+                    # the program, and the lexer already ended a token on every
+                    # one of those marks, so drop them all rather than re-pair
+                    # them: over-quoting here would cost a missed screen.
+                    blocked |= _find_blocked_commands(
+                        " ".join(word.replace('"', "") for word in tokens[i + 1:]))
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1807,7 +1819,23 @@ def _find_blocked_commands(command: str) -> set[str]:
         # where testing the word right after the flag read `env` and stopped.
         runnable = _runnable_index(i)
         if titled and runnable and j + 1 < len(tokens):
-            blocked |= _scan_cmd_payload(_cmd_unquote(tokens[j + 1]))
+            k = j + 1
+            # Switches may also FOLLOW the title: the documented shape is
+            # `START ["title"] [switches] command`, so `start "" /b powershell`
+            # put /b where the program was expected and the scan stopped there.
+            while k < len(tokens):
+                switch = _win_switch(_cmd_unquote(tokens[k]).lower())
+                if not switch.startswith("/"):
+                    break
+                k += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+            if k < len(tokens):
+                blocked |= _scan_cmd_payload(_cmd_unquote(tokens[k]))
+                # start launches a COMMAND LINE, not just a program, so the
+                # child may be a shell of its own: `start "" cmd /c powershell`
+                # reaches powershell through a nested cmd that this pass had
+                # already walked past. Re-scanning the remainder re-runs every
+                # pass over it, which screens that nesting to any depth.
+                blocked |= _find_blocked_commands(" ".join(tokens[k:]))
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -186,8 +186,10 @@ _COMMAND_PREFIXES = frozenset(
 # Unconsumed, the value is mistaken for the wrapped command: `env -u FOO rm -rf x`
 # reads as command `FOO`. Shared by the auto gate and the blocklist walk.
 _WRAPPER_VALUE_FLAGS_BY_CMD = {
-    # env -i/--ignore-environment is VALUELESS; only -u/--unset takes a name.
-    "env": frozenset({"-u", "--unset"}),
+    # env -i/--ignore-environment is VALUELESS. -u/--unset takes a name and
+    # -C/--chdir a directory, and reading that directory as the child left the
+    # shell behind it (`env -C /tmp bash -c ...`) unscreened.
+    "env": frozenset({"-u", "--unset", "-C", "--chdir"}),
     "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
     "timeout": frozenset({"-s", "--signal", "-k", "--kill-after"}),
     "nice": frozenset({"-n", "--adjustment"}),
@@ -1364,6 +1366,9 @@ _CMD_IF_COMPARISONS = frozenset({"equ", "neq", "lss", "leq", "gtr", "geq"})
 
 # Tells one quoted executable path apart from an argument list mentioning one.
 _EXECUTABLE_PATH_RE = re.compile(r"\.(?:exe|com|bat|cmd)(?=\s|$)", re.IGNORECASE)
+# A drive root or a rooted path: where a SECOND one of these begins, the string
+# is an argument list, not one program path carrying spaces.
+_STARTS_A_NEW_PATH_RE = re.compile(r"(?:[a-zA-Z]:[/\\]|[/\\])")
 
 # `cmd /c ""C:\Program Files\...\prog.exe" args"`: cmd removes the first and
 # last quote of the payload and runs what is left. Anchored to the flag so it
@@ -1474,8 +1479,17 @@ def _find_blocked_commands(command: str) -> set[str]:
             (".exe", ".com", ".bat", ".cmd")
         ):
             return found
-        if not any(char in payload.split()[0] for char in ":/\\"):
+        words = payload.split()
+        if not any(char in words[0] for char in ":/\\"):
             return found  # starts on a command word (`echo C:/tools/curl.exe`)
+        # One path split on ITS OWN spaces continues the same chain, so a later
+        # word starting a fresh absolute path means these are separate operands:
+        # `C:/Windows/System32/findstr curl C:/logs/curl.exe` greps a file whose
+        # name happens to be a blocked one, and reading the LAST word as the
+        # program hard-refused it. The first word is the command there, and the
+        # re-lex above has already screened it.
+        if any(_STARTS_A_NEW_PATH_RE.match(word) for word in words[1:]):
+            return found
         base = _token_basename(payload)
         return found | ({base} if base in _BLOCKED_COMMANDS else _blocked_matching_glob(base))
 
@@ -1533,8 +1547,6 @@ def _find_blocked_commands(command: str) -> set[str]:
     command_positions: "set[int]" = set()  # command-position words, for the start scan
     win_c_payloads: "set[int]" = set()  # the word a `cmd /c` hands over, same
     start_children: set[int] = set()  # what a `start` launches
-    seen_nested: set[int] = set()  # -c/\c flags already resolved to a shell
-    seen_start: set[int] = set()  # `start` words whose child is already known
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
     xargs_index = -1  # an xargs awaiting the command it wraps
     for token_index, token in enumerate(tokens):
@@ -1788,159 +1800,153 @@ def _find_blocked_commands(command: str) -> set[str]:
     # recursively scan the nested command string.
     _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
     _SHELLS_WIN = {"cmd", "cmd.exe"}
-    def _nested_shell_pass() -> None:
+    def _nested_shell_at(i: int) -> None:
         nonlocal blocked
-        for i, token in enumerate(tokens):
-            if i in seen_nested:
-                continue
-            tok_lower = _cmd_unquote(token).lower()
-            # Match -c exactly, or combined flags ending in c (e.g. -lc, -xc)
-            is_unix_c = tok_lower == "-c" or (
-                tok_lower.startswith("-") and tok_lower.endswith("c") and not tok_lower.startswith("--")
-            )
-            # Git Bash mangles a lone /c into a path, so models write //c and MSYS
-            # hands cmd back a single slash; /k runs the payload the same way.
-            is_win_c = _win_switch(tok_lower) in ("/c", "/k")
-            if not (is_unix_c or is_win_c) or i < 1 or i + 1 >= len(tokens):
-                continue
-            # Look back past flags for the shell binary. Windows flags and absolute
-            # paths both start with /, so only skip short /X flags (not /bin/bash).
-            for j in range(i - 1, -1, -1):
-                # A shell name only invokes a shell where the shell would run it:
-                # `echo "cmd" /c powershell` merely prints it, and reading that as
-                # an invocation hard blocked the payload behind it.
-                prev_runs = _runnable_index(j)
-                prev = _cmd_unquote(tokens[j]) if prev_runs else tokens[j]
-                if prev.startswith("-"):
-                    continue  # skip Unix flags like --login, -l
-                if is_win_c and prev.startswith("/") and len(prev) <= 3:
-                    continue  # skip Windows flags like /s, /q (not /bin/bash)
-                prev_base = os.path.basename(prev).lower()
-                # Same for the payload: the cmd lexer makes `cmd /c "rm -rf x"` one
-                # quoted token, which re-lexes to no command while still quoted.
-                if is_unix_c and prev_runs and prev_base in _SHELLS:
-                    seen_nested.add(i)
-                    blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
-                elif is_win_c and prev_runs and prev_base in _SHELLS_WIN:
-                    seen_nested.add(i)
-                    # Tell the start scan below where cmd hands control over, and
-                    # screen those words here: the walk above reads the payload with
-                    # bash grammar, so a program cmd runs from its own control flow
-                    # (`cmd /c if exist FILE powershell`) sat in argument position
-                    # and no pass ever looked at it.
-                    payload_commands = _cmd_payload_commands(i + 1)
-                    win_c_payloads.update(payload_commands)
-                    for payload_index in payload_commands:
-                        payload_word = _cmd_unquote(tokens[payload_index])
-                        if any(char in payload_word for char in " \t"):
-                            # A whole command line in one quoted token, which
-                            # _scan_cmd_payload already reads with its own rules;
-                            # a basename here would read `type C:/logs/curl` as curl.
-                            continue
-                        payload_base = _token_basename(payload_word)
-                        if payload_base in _BLOCKED_COMMANDS:
-                            blocked.add(payload_base)
+        token = tokens[i]
+        tok_lower = _cmd_unquote(token).lower()
+        # Match -c exactly, or combined flags ending in c (e.g. -lc, -xc)
+        is_unix_c = tok_lower == "-c" or (
+            tok_lower.startswith("-") and tok_lower.endswith("c") and not tok_lower.startswith("--")
+        )
+        # Git Bash mangles a lone /c into a path, so models write //c and MSYS
+        # hands cmd back a single slash; /k runs the payload the same way.
+        is_win_c = _win_switch(tok_lower) in ("/c", "/k")
+        if not (is_unix_c or is_win_c) or i < 1 or i + 1 >= len(tokens):
+            return
+        # Look back past flags for the shell binary. Windows flags and absolute
+        # paths both start with /, so only skip short /X flags (not /bin/bash).
+        for j in range(i - 1, -1, -1):
+            # A shell name only invokes a shell where the shell would run it:
+            # `echo "cmd" /c powershell` merely prints it, and reading that as
+            # an invocation hard blocked the payload behind it.
+            prev_runs = _runnable_index(j)
+            prev = _cmd_unquote(tokens[j]) if prev_runs else tokens[j]
+            if prev.startswith("-"):
+                continue  # skip Unix flags like --login, -l
+            if is_win_c and prev.startswith("/") and len(prev) <= 3:
+                continue  # skip Windows flags like /s, /q (not /bin/bash)
+            prev_base = os.path.basename(prev).lower()
+            # Same for the payload: the cmd lexer makes `cmd /c "rm -rf x"` one
+            # quoted token, which re-lexes to no command while still quoted.
+            if is_unix_c and prev_runs and prev_base in _SHELLS:
+                blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
+            elif is_win_c and prev_runs and prev_base in _SHELLS_WIN:
+                # Tell the start scan below where cmd hands control over, and
+                # screen those words here: the walk above reads the payload with
+                # bash grammar, so a program cmd runs from its own control flow
+                # (`cmd /c if exist FILE powershell`) sat in argument position
+                # and no pass ever looked at it.
+                payload_commands = _cmd_payload_commands(i + 1)
+                win_c_payloads.update(payload_commands)
+                for payload_index in payload_commands:
+                    payload_word = _cmd_unquote(tokens[payload_index])
+                    if any(char in payload_word for char in " \t"):
+                        # A whole command line in one quoted token, which
+                        # _scan_cmd_payload already reads with its own rules;
+                        # a basename here would read `type C:/logs/curl` as curl.
+                        continue
+                    payload_base = _token_basename(payload_word)
+                    if payload_base in _BLOCKED_COMMANDS:
+                        blocked.add(payload_base)
+                    else:
+                        blocked |= _blocked_matching_glob(payload_base)
+                blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
+                if not _cmd_unquote(tokens[i + 1]):
+                    # `cmd /c ""prog" args"` is the documented way to quote a
+                    # program path holding spaces: cmd strips the OUTER pair and
+                    # runs the rest as one string. The cmd lexer ends the first
+                    # token at the doubled quote, so the payload read as EMPTY.
+                    # Rebuild it from the raw command rather than from the
+                    # tokens, which have lost both the adjacency and the inner
+                    # quotes that hold a spaced path together.
+                    payload = _cmd_outer_quoted_payload(command)
+                    blocked |= _find_blocked_commands(payload)
+                    program = _cmd_quoted_program(payload)
+                    if program:
+                        program_base = _token_basename(program)
+                        if program_base in _BLOCKED_COMMANDS:
+                            blocked.add(program_base)
                         else:
-                            blocked |= _blocked_matching_glob(payload_base)
-                    blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
-                    if not _cmd_unquote(tokens[i + 1]):
-                        # `cmd /c ""prog" args"` is the documented way to quote a
-                        # program path holding spaces: cmd strips the OUTER pair and
-                        # runs the rest as one string. The cmd lexer ends the first
-                        # token at the doubled quote, so the payload read as EMPTY.
-                        # Rebuild it from the raw command rather than from the
-                        # tokens, which have lost both the adjacency and the inner
-                        # quotes that hold a spaced path together.
-                        payload = _cmd_outer_quoted_payload(command)
-                        blocked |= _find_blocked_commands(payload)
-                        program = _cmd_quoted_program(payload)
-                        if program:
-                            program_base = _token_basename(program)
-                            if program_base in _BLOCKED_COMMANDS:
-                                blocked.add(program_base)
-                            else:
-                                blocked |= _blocked_matching_glob(program_base)
-                break  # stop at first non-flag token
+                            blocked |= _blocked_matching_glob(program_base)
+            break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
-    def _start_pass() -> None:
+    def _start_at(i: int) -> None:
         nonlocal blocked
-        for i, token in enumerate(tokens):
-            if i in seen_start:
-                continue
-            if os.path.basename(_cmd_unquote(token)).lower() not in ("start", "start.exe"):
-                continue
-            j = i + 1
-            while j < len(tokens):
-                switch = _win_switch(_cmd_unquote(tokens[j]).lower())
+        token = tokens[i]
+        if os.path.basename(_cmd_unquote(token)).lower() not in ("start", "start.exe"):
+            return
+        j = i + 1
+        while j < len(tokens):
+            switch = _win_switch(_cmd_unquote(tokens[j]).lower())
+            if switch not in _START_SWITCHES:
+                break
+            # /d C:\dir and friends carry their value in the next token.
+            j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+        if j >= len(tokens):
+            return
+        # `start ["title"] prog`: cmd reads the first argument as a window title
+        # ONLY when it arrives DOUBLE quoted, so an unquoted token here is the
+        # program and the next one merely its argument; screening both blocked
+        # `start explorer .` on the `.` source builtin.
+        head = tokens[j]
+        if not lexed_posix:
+            titled = head.startswith('"')  # the cmd lexer keeps the quote marks
+        else:
+            # The posix lexer drops them, and bash strips the quoting before
+            # exec anyway, so what arrives quoted is decided by CONTENT: the
+            # MSYS runtime re-quotes for CreateProcess only an empty argument
+            # or one holding a space/tab/newline/quote (cygwin winf.cc,
+            # linebuf::fromargv). `start "explorer" .` therefore reaches cmd
+            # bare, explorer being the program and `.` only its argument, while
+            # `start 'My Window' prog` still reads as a title.
+            titled = head == "" or any(char in head for char in ' \t\n\r"')
+        # The head is screened WHATEVER `titled` says: it is a heuristic, and a
+        # false positive must cost an over-block, never an under-block.
+        # `echo "powershell" && cmd //c start powershell -Command ls` reads as
+        # titled from the echo, so skipping the head would let it through.
+        blocked |= _scan_cmd_payload(_cmd_unquote(head))
+        # Stepping PAST the head only makes sense where the shell really runs
+        # this start: `echo start "title" powershell` launches nothing and was
+        # hard-refused. _runnable_index follows an -exec through its prefix, so
+        # `find . -exec env start "" powershell \;` still resolves to start
+        # where testing the word right after the flag read `env` and stopped.
+        runnable = _runnable_index(i)
+        if runnable:
+            k = j + 1 if titled else j
+            # Switches may also FOLLOW the title: the documented shape is
+            # `START ["title"] [switches] command`, so `start "" /b powershell`
+            # put /b where the program was expected and the scan stopped there.
+            while k < len(tokens):
+                switch = _win_switch(_cmd_unquote(tokens[k]).lower())
                 if switch not in _START_SWITCHES:
                     break
-                # /d C:\dir and friends carry their value in the next token.
-                j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-            if j >= len(tokens):
-                continue
-            # `start ["title"] prog`: cmd reads the first argument as a window title
-            # ONLY when it arrives DOUBLE quoted, so an unquoted token here is the
-            # program and the next one merely its argument; screening both blocked
-            # `start explorer .` on the `.` source builtin.
-            head = tokens[j]
-            if not lexed_posix:
-                titled = head.startswith('"')  # the cmd lexer keeps the quote marks
-            else:
-                # The posix lexer drops them, and bash strips the quoting before
-                # exec anyway, so what arrives quoted is decided by CONTENT: the
-                # MSYS runtime re-quotes for CreateProcess only an empty argument
-                # or one holding a space/tab/newline/quote (cygwin winf.cc,
-                # linebuf::fromargv). `start "explorer" .` therefore reaches cmd
-                # bare, explorer being the program and `.` only its argument, while
-                # `start 'My Window' prog` still reads as a title.
-                titled = head == "" or any(char in head for char in ' \t\n\r"')
-            # The head is screened WHATEVER `titled` says: it is a heuristic, and a
-            # false positive must cost an over-block, never an under-block.
-            # `echo "powershell" && cmd //c start powershell -Command ls` reads as
-            # titled from the echo, so skipping the head would let it through.
-            blocked |= _scan_cmd_payload(_cmd_unquote(head))
-            # Stepping PAST the head only makes sense where the shell really runs
-            # this start: `echo start "title" powershell` launches nothing and was
-            # hard-refused. _runnable_index follows an -exec through its prefix, so
-            # `find . -exec env start "" powershell \;` still resolves to start
-            # where testing the word right after the flag read `env` and stopped.
-            runnable = _runnable_index(i)
-            if runnable:
-                k = j + 1 if titled else j
-                # Switches may also FOLLOW the title: the documented shape is
-                # `START ["title"] [switches] command`, so `start "" /b powershell`
-                # put /b where the program was expected and the scan stopped there.
-                while k < len(tokens):
-                    switch = _win_switch(_cmd_unquote(tokens[k]).lower())
-                    if switch not in _START_SWITCHES:
-                        break
-                    k += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-                if k < len(tokens):
-                    blocked |= _scan_cmd_payload(_cmd_unquote(tokens[k]))
-                    # start launches a COMMAND LINE, not just a program, so the
-                    # child may be a shell of its own: `start cmd /c powershell`
-                    # reaches powershell through a nested cmd. Marking the child
-                    # RUNNABLE and running the nested pass again screens that,
-                    # where re-scanning the joined remainder made the whole scan
-                    # QUADRATIC in the input: a few kB stalled the request, and
-                    # _bash_exec runs this synchronously before the timeout.
-                    # It runs untitled too: only the FIRST operand is a title.
-                    start_children.add(k)
-                    seen_start.add(i)
+                k += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+            if k < len(tokens):
+                blocked |= _scan_cmd_payload(_cmd_unquote(tokens[k]))
+                # start launches a COMMAND LINE, not just a program, so the
+                # child may be a shell of its own: `start cmd /c powershell`
+                # reaches powershell through a nested cmd. Marking the child
+                # RUNNABLE and running the nested pass again screens that,
+                # where re-scanning the joined remainder made the whole scan
+                # QUADRATIC in the input: a few kB stalled the request, and
+                # _bash_exec runs this synchronously before the timeout.
+                # It runs untitled too: only the FIRST operand is a title.
+                start_children.add(k)
 
 
-    # start can launch a shell and a shell can run a start, so the two passes
-    # feed each other. Alternating them to a fixed point resolves that nesting;
-    # each word is handled once, which keeps the whole scan linear. The cap is
-    # a backstop -- every extra level needs another literal `cmd /c start ""`.
-    for _ in range(4):
-        discovered = (len(win_c_payloads), len(start_children))
-        _nested_shell_pass()
-        _start_pass()
-        if (len(win_c_payloads), len(start_children)) == discovered:
-            break
+    # start can launch a shell and a shell can run a start, so the two feed each
+    # other. Every dependency points BACKWARD (a -c flag reads the shell name
+    # before it, a start reads its own position) and every discovery points
+    # FORWARD (the payload and the launched child both follow), so one sweep in
+    # index order resolves a chain of ANY depth: by the time a word is reached,
+    # what it depends on is final. Alternating whole passes instead needed one
+    # round per layer, and a bounded number of rounds left the deeper ones
+    # unscreened.
+    for index in range(len(tokens)):
+        _nested_shell_at(index)
+        _start_at(index)
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The
@@ -5878,6 +5884,11 @@ def _terminal_is_high_risk(command: str, _depth: int = 0) -> bool:
                 if current_command == "setpriv" and flag in _SETPRIV_PRIVILEGE_FLAGS:
                     # Ahead of the wrapper-value skip below, which would otherwise
                     # swallow `--reuid 0` before it is judged.
+                    return True
+                if current_command == "env" and flag in ("-C", "--chdir"):
+                    # Also ahead of the skip: -C now carries a separate value,
+                    # so the skip would swallow it before the branch below,
+                    # which asks because the chdir enables a relative read.
                     return True
                 # A wrapper option taking a SEPARATE value (env -u NAME): the next
                 # token is that value, not the wrapped command.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1338,6 +1338,22 @@ def _win_switch(token: str) -> str:
     return token[1:] if token.startswith("//") else token
 
 
+def _cmd_unquote(token: str) -> str:
+    """Strip the double quotes the non-posix lexer leaves on a token.
+
+    shlex.split(posix = False) keeps quote marks inside the token, so the
+    `start ""` no-title idiom arrives as the two-character string `""` and a
+    quoted program name never matches a blocked one. cmd.exe itself strips
+    double quotes, so honouring them here is what the shell does; single quotes
+    are left alone because cmd does not treat them as quoting (`'rm'` really is
+    a literal unknown program there, which _token_basename relies on). Identity
+    under posix lexing, where the lexer has already removed them.
+    """
+    while len(token) >= 2 and token.startswith('"') and token.endswith('"'):
+        token = token[1:-1]
+    return token
+
+
 # `start` launches its argument as a program, so that argument is a command
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
@@ -1649,20 +1665,20 @@ def _find_blocked_commands(command: str) -> set[str]:
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
     for i, token in enumerate(tokens):
-        if os.path.basename(token).lower() not in ("start", "start.exe"):
+        if os.path.basename(_cmd_unquote(token)).lower() not in ("start", "start.exe"):
             continue
         j = i + 1
         while j < len(tokens):
-            switch = _win_switch(tokens[j].lower())
+            switch = _win_switch(_cmd_unquote(tokens[j]).lower())
             if not switch.startswith("/"):
                 break
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
         # `start ""` is the idiom for "no title"; anything else is the program.
-        if j < len(tokens) and tokens[j] == "":
+        if j < len(tokens) and _cmd_unquote(tokens[j]) == "":
             j += 1
         if j < len(tokens):
-            blocked |= _find_blocked_commands(tokens[j])
+            blocked |= _find_blocked_commands(_cmd_unquote(tokens[j]))
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The
@@ -6599,6 +6615,10 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
         _trusted_git_dir, git_ext = _resolve_trusted_windows_git()
         if _trusted_git_dir:
             path_entries.append(_trusted_git_dir)
+        # The shell's own userland, on the same trust boundary. Appended last so
+        # a Git-shipped python.exe/git.exe cannot shadow the interpreter this
+        # server runs in, which the first PATH entry deliberately pins.
+        path_entries.extend(_windows_bash_userland_dirs())
 
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))
@@ -6621,6 +6641,12 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Windows needs SystemRoot for Python/subprocess to work.
     if sys.platform == "win32":
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
+        # Windows tempfile / SDKs honour TEMP/TMP, not TMPDIR, so a native
+        # program run from the shell would otherwise fall back to GetTempPath
+        # and write outside the per-session sandbox dir. Matches
+        # _build_bypass_env, which already repoints all three.
+        env["TEMP"] = workdir
+        env["TMP"] = workdir
         # Restrict PATHEXT so cwd .BAT/.CMD cannot hijack bare names (#7317).
         pathext = ".EXE;.COM"
         if git_ext and git_ext not in (".EXE", ".COM"):
@@ -6977,6 +7003,40 @@ def _windows_bash() -> "str | None":
         if os.path.isfile(candidate) and _is_trusted_windows_bash(candidate):
             return candidate
     return None
+
+
+def _windows_bash_userland_dirs() -> list[str]:
+    """Trusted dirs holding the resolved bash and the POSIX tools beside it.
+
+    `bash -c` is non-login, so it never sources /etc/profile, which is what
+    normally puts Git for Windows' usr\\bin on PATH. _build_safe_env builds PATH
+    from scratch, so without these the terminal description promises bash while
+    ls / cat / grep / sed / head all come back as "command not found" and only
+    builtins work. Both install layouts are covered: bash.exe under Git\\bin and
+    under Git\\usr\\bin put the install root one and two levels up respectively,
+    so both parents are probed and the one that exists wins.
+
+    Every candidate clears _is_trusted_windows_program_dir, the same Program
+    Files boundary as the git entry (#7317), and is canonicalised before use so
+    a junction cannot retarget it after the check. Fails closed: no trusted
+    bash, no entries, and PATH is exactly what it was before.
+    """
+    bash = _windows_bash()
+    if not bash:
+        return []
+    bin_dir = os.path.dirname(bash)
+    candidates = [bin_dir]
+    for root in (os.path.dirname(bin_dir), os.path.dirname(os.path.dirname(bin_dir))):
+        if root:
+            candidates.append(os.path.join(root, "usr", "bin"))
+    dirs: list[str] = []
+    for candidate in candidates:
+        if not os.path.isdir(candidate) or not _is_trusted_windows_program_dir(candidate):
+            continue
+        real = os.path.realpath(candidate)
+        if real not in dirs:
+            dirs.append(real)
+    return dirs
 
 
 def _shell_is_posix() -> bool:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1674,17 +1674,29 @@ def _find_blocked_commands(command: str) -> set[str]:
                 k += 1
                 continue
             indexes.append(k)
-            if _token_basename(_cmd_unquote(token)) not in _CMD_CONTROL_FLOW:
+            base = _token_basename(_cmd_unquote(token))
+            if base not in _CMD_CONTROL_FLOW:
                 k, expect = k + 1, False
                 continue
-            # `if [/i] [not] exist FILE prog`, and the else/do/for forms whose
-            # command is simply the next word.
             k += 1
-            while k < len(tokens) and _cmd_unquote(tokens[k]).lower() in ("/i", "not"):
-                k += 1
-            if k < len(tokens):
-                condition = _cmd_unquote(tokens[k]).lower()
-                k += 2 if condition in ("exist", "defined", "errorlevel") else 1
+            if base == "for":
+                # `for %i in (set) do CMD`: the body is whatever follows `do`,
+                # not a short condition, so stepping a fixed width recorded the
+                # loop variable and left the body unscreened.
+                while k < len(tokens) and tokens[k] not in _SHELL_SEPARATORS:
+                    is_do = _cmd_unquote(tokens[k]).lower() == "do"
+                    k += 1
+                    if is_do:
+                        break
+            elif base == "if":
+                # `if [/i] [not] exist|defined|errorlevel OPERAND CMD`, else the
+                # comparison is one token.
+                while k < len(tokens) and _cmd_unquote(tokens[k]).lower() in ("/i", "not"):
+                    k += 1
+                if k < len(tokens):
+                    condition = _cmd_unquote(tokens[k]).lower()
+                    k += 2 if condition in ("exist", "defined", "errorlevel") else 1
+            # `else` / `do`: the command is simply the next word.
         return indexes
 
     def _runnable_index(idx: int) -> bool:
@@ -1731,8 +1743,25 @@ def _find_blocked_commands(command: str) -> set[str]:
             if is_unix_c and prev_runs and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
             elif is_win_c and prev_runs and prev_base in _SHELLS_WIN:
-                # Tell the start scan below where cmd hands control over.
-                win_c_payloads.update(_cmd_payload_commands(i + 1))
+                # Tell the start scan below where cmd hands control over, and
+                # screen those words here: the walk above reads the payload with
+                # bash grammar, so a program cmd runs from its own control flow
+                # (`cmd /c if exist FILE powershell`) sat in argument position
+                # and no pass ever looked at it.
+                payload_commands = _cmd_payload_commands(i + 1)
+                win_c_payloads.update(payload_commands)
+                for payload_index in payload_commands:
+                    payload_word = _cmd_unquote(tokens[payload_index])
+                    if any(char in payload_word for char in " \t"):
+                        # A whole command line in one quoted token, which
+                        # _scan_cmd_payload already reads with its own rules;
+                        # a basename here would read `type C:/logs/curl` as curl.
+                        continue
+                    payload_base = _token_basename(payload_word)
+                    if payload_base in _BLOCKED_COMMANDS:
+                        blocked.add(payload_base)
+                    else:
+                        blocked |= _blocked_matching_glob(payload_base)
                 blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
             break  # stop at first non-flag token
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1398,6 +1398,24 @@ def _cmd_outer_quoted_payload(command: str) -> str:
     return match.group(1)[1:-1]
 
 
+def _env_split_string_payload(word: str, following: str = "") -> str:
+    """The command line an `env -S` runs, in any of its three spellings.
+
+    -S/--split-string splits the string into arguments and executes them, so
+    the payload is a command line rather than data.
+    """
+    bare = _cmd_unquote(word)
+    payload = ""
+    if bare.startswith("-S") and bare != "-S":
+        payload = bare[2:]
+    elif bare.startswith("--split-string="):
+        payload = bare.split("=", 1)[1]
+    elif bare in ("-S", "--split-string"):
+        payload = following
+    # The cmd lexer keeps the marks, and they are the shell's, not the payload's.
+    return _cmd_unquote(payload.strip()).strip('"')
+
+
 def _cmd_quoted_program(payload: str) -> str:
     """The program of a payload that opens with a quoted path.
 
@@ -1499,6 +1517,11 @@ def _find_blocked_commands(command: str) -> set[str]:
         # re-lex above has already screened it.
         if any(_STARTS_A_NEW_PATH_RE.match(word) for word in words[1:]):
             return found
+        # A continuation carries the rest of the path, so only the LAST word may
+        # lack a separator. A bare word before it ends the path and starts an
+        # operand list: `.../findstr curl logs/powershell.exe` searches a file.
+        if any(not any(ch in word for ch in "/\\") for word in words[1:-1]):
+            return found
         base = _token_basename(payload)
         return found | ({base} if base in _BLOCKED_COMMANDS else _blocked_matching_glob(base))
 
@@ -1590,6 +1613,18 @@ def _find_blocked_commands(command: str) -> set[str]:
             xargs_index = -1
             continue
         if token.startswith("-"):
+            # `env -S "rm -rf x"` splits the string into arguments and RUNS it,
+            # so the payload is a command line of its own. Screen it wherever it
+            # is written: attached, `=`-joined, or in the following token.
+            if prefix_pending and prefix_command == "env":
+                following = (
+                    _cmd_unquote(tokens[token_index + 1])
+                    if token_index + 1 < len(tokens)
+                    else ""
+                )
+                payload = _env_split_string_payload(token, following)
+                if payload:
+                    blocked |= _find_blocked_commands(payload)
             # A wrapper option whose value is a SEPARATE token precedes that
             # value, not the wrapped command. Without consuming it the value is
             # read as the command word and the real command behind it is never
@@ -1732,6 +1767,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         are its arguments, so marking the whole payload made
         `cmd /c echo start "title" prog` read the echoed text as a launcher.
         """
+        nonlocal blocked
         indexes: "list[int]" = []
         k, expect = start, True
         while k < len(tokens):
@@ -1752,6 +1788,13 @@ def _find_blocked_commands(command: str) -> set[str]:
                 k += 1
                 while k < len(tokens):
                     word = _cmd_unquote(tokens[k])
+                    if base == "env":
+                        following = (
+                            _cmd_unquote(tokens[k + 1]) if k + 1 < len(tokens) else ""
+                        )
+                        split = _env_split_string_payload(tokens[k], following)
+                        if split:
+                            blocked |= _find_blocked_commands(split)
                     if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(base, frozenset()):
                         k += 2  # `env -u FOO prog`: the flag eats its value
                         continue
@@ -1808,6 +1851,10 @@ def _find_blocked_commands(command: str) -> set[str]:
             or idx in win_c_payloads
             or idx in start_children
             or idx in exec_children
+            # `if 1==1 (start "" cmd /c powershell)` lexes the group opener onto
+            # the command word, so it never reached command_positions even
+            # though both grammars run whatever follows a `(`.
+            or (0 <= idx < len(tokens) and tokens[idx].startswith("("))
         )
 
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):
@@ -1891,7 +1938,9 @@ def _find_blocked_commands(command: str) -> set[str]:
     def _start_at(i: int) -> None:
         nonlocal blocked
         token = tokens[i]
-        if os.path.basename(_cmd_unquote(token)).lower() not in ("start", "start.exe"):
+        # _token_basename, not os.path.basename: it strips the glued-on shell
+        # meta-chars, so the `(start` of a grouped branch is still a start.
+        if _token_basename(_cmd_unquote(token)) not in ("start", "start.exe"):
             return
         j = i + 1
         while j < len(tokens):
@@ -1962,8 +2011,12 @@ def _find_blocked_commands(command: str) -> set[str]:
                         if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(child, frozenset()):
                             k += 2  # the flag takes a separate value
                             continue
-                        if word.startswith("-") or "=" in word:
-                            k += 1  # its own flags, and VAR=VALUE
+                        if (
+                            word.startswith("-")
+                            or "=" in word
+                            or _WRAPPER_DURATION_RE.fullmatch(word)
+                        ):
+                            k += 1  # its own flags, VAR=VALUE, `timeout 5 prog`
                             continue
                         break
                     if k < len(tokens):
@@ -5919,7 +5972,13 @@ def _terminal_is_high_risk(command: str, _depth: int = 0) -> bool:
                     # Ahead of the wrapper-value skip below, which would otherwise
                     # swallow `--reuid 0` before it is judged.
                     return True
-                if current_command == "env" and flag in ("-C", "--chdir"):
+                if current_command == "env" and (
+                    flag in ("-C", "--chdir")
+                    # Attached short form: `env -C.. cat other/secret` chdirs
+                    # just as `env -C ..` does, and reached the generic option
+                    # skip below without ever being judged.
+                    or (token.startswith("-C") and token != "-C")
+                ):
                     # Also ahead of the skip: -C now carries a separate value,
                     # so the skip would swallow it before the branch below,
                     # which asks because the chdir enables a relative read.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1774,7 +1774,8 @@ def _find_blocked_commands(command: str) -> set[str]:
                     # one of those marks, so drop them all rather than re-pair
                     # them: over-quoting here would cost a missed screen.
                     blocked |= _find_blocked_commands(
-                        " ".join(word.replace('"', "") for word in tokens[i + 1:]))
+                        " ".join(word.replace('"', "") for word in tokens[i + 1 :])
+                    )
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1358,9 +1358,43 @@ _START_SWITCHES = _START_SWITCHES_WITH_VALUE | {
 }
 # cmd keywords whose command word does not follow immediately, or at all.
 _CMD_CONTROL_FLOW = frozenset({"if", "else", "do", "for"})
+# cmd IF conditions, by how many tokens they occupy before the body command.
+_CMD_IF_UNARY = frozenset({"exist", "defined", "errorlevel", "cmdextversion"})
+_CMD_IF_COMPARISONS = frozenset({"equ", "neq", "lss", "leq", "gtr", "geq"})
 
 # Tells one quoted executable path apart from an argument list mentioning one.
 _EXECUTABLE_PATH_RE = re.compile(r"\.(?:exe|com|bat|cmd)(?=\s|$)", re.IGNORECASE)
+
+# `cmd /c ""C:\Program Files\...\prog.exe" args"`: cmd removes the first and
+# last quote of the payload and runs what is left. Anchored to the flag so it
+# reads the payload, not any later quoted argument.
+_CMD_DOUBLED_QUOTE_RE = re.compile(
+    r"(?i)(?:^|[\s;&|(])(?:[^\s;&|(]*[\\/])?cmd(?:\.exe)?\s+"
+    r'(?:/[a-z]\s+|//[a-z]\s+)*//?[ck]\s+(".*")\s*$'
+)
+
+
+def _cmd_outer_quoted_payload(command: str) -> str:
+    """The payload of a doubled-quote `cmd /c` line, outer pair removed."""
+    match = _CMD_DOUBLED_QUOTE_RE.search(command)
+    if not match:
+        return ""
+    return match.group(1)[1:-1]
+
+
+def _cmd_quoted_program(payload: str) -> str:
+    """The program of a payload that opens with a quoted path.
+
+    Re-lexing keeps such a path in one token but leaves the quote marks glued
+    on, so the basename reads `pwsh.exe"` and matches nothing. This is the
+    whole point of the doubled-quote form, so read the program off it directly.
+    """
+    if not payload.startswith('"'):
+        return ""
+    end = payload.find('"', 1)
+    return payload[1:end] if end > 1 else ""
+
+
 
 
 def _find_blocked_commands(command: str) -> set[str]:
@@ -1498,6 +1532,9 @@ def _find_blocked_commands(command: str) -> set[str]:
     sed_indexes: "list[int]" = []  # command-position sed words, for the `e` scan below
     command_positions: "set[int]" = set()  # command-position words, for the start scan
     win_c_payloads: "set[int]" = set()  # the word a `cmd /c` hands over, same
+    start_children: set[int] = set()  # what a `start` launches
+    seen_nested: set[int] = set()  # -c/\c flags already resolved to a shell
+    seen_start: set[int] = set()  # `start` words whose child is already known
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
     xargs_index = -1  # an xargs awaiting the command it wraps
     for token_index, token in enumerate(tokens):
@@ -1692,10 +1729,15 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # cmd payload too: `cmd /c env powershell` recorded only env and
                 # left the shell it runs sitting in argument position.
                 k += 1
-                while k < len(tokens) and (
-                    tokens[k].startswith("-") or "=" in _cmd_unquote(tokens[k])
-                ):
-                    k += 1  # env's own flags and VAR=VALUE assignments
+                while k < len(tokens):
+                    word = _cmd_unquote(tokens[k])
+                    if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(base, frozenset()):
+                        k += 2  # `env -u FOO prog`: the flag eats its value
+                        continue
+                    if word.startswith("-") or "=" in word:
+                        k += 1  # the wrapper's own flags, and VAR=VALUE
+                        continue
+                    break
                 continue
             if base not in _CMD_CONTROL_FLOW:
                 k, expect = k + 1, False
@@ -1711,13 +1753,22 @@ def _find_blocked_commands(command: str) -> set[str]:
                     if is_do:
                         break
             elif base == "if":
-                # `if [/i] [not] exist|defined|errorlevel OPERAND CMD`, else the
-                # comparison is one token.
+                # `if [/i] [not] <condition> CMD`. Every condition form has its
+                # own width, and assuming one token left the body of the
+                # comparison forms (`if 1 EQU 1 rm -rf x`) unscreened.
                 while k < len(tokens) and _cmd_unquote(tokens[k]).lower() in ("/i", "not"):
                     k += 1
                 if k < len(tokens):
                     condition = _cmd_unquote(tokens[k]).lower()
-                    k += 2 if condition in ("exist", "defined", "errorlevel") else 1
+                    if condition in _CMD_IF_UNARY:
+                        k += 2  # `exist FILE`, `defined VAR`, `errorlevel N`
+                    elif (
+                        k + 2 < len(tokens)
+                        and _cmd_unquote(tokens[k + 1]).lower() in _CMD_IF_COMPARISONS
+                    ):
+                        k += 3  # `a EQU b`
+                    else:
+                        k += 1  # `string1==string2`, one token
             # `else` / `do`: the command is simply the next word.
         return indexes
 
@@ -1728,6 +1779,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         return (
             idx in command_positions
             or idx in win_c_payloads
+            or idx in start_children
             or any(_exec_child_index(flag + 1)[0] == idx for flag in exec_flag_indexes)
         )
 
@@ -1736,131 +1788,159 @@ def _find_blocked_commands(command: str) -> set[str]:
     # recursively scan the nested command string.
     _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
     _SHELLS_WIN = {"cmd", "cmd.exe"}
-    for i, token in enumerate(tokens):
-        tok_lower = _cmd_unquote(token).lower()
-        # Match -c exactly, or combined flags ending in c (e.g. -lc, -xc)
-        is_unix_c = tok_lower == "-c" or (
-            tok_lower.startswith("-") and tok_lower.endswith("c") and not tok_lower.startswith("--")
-        )
-        # Git Bash mangles a lone /c into a path, so models write //c and MSYS
-        # hands cmd back a single slash; /k runs the payload the same way.
-        is_win_c = _win_switch(tok_lower) in ("/c", "/k")
-        if not (is_unix_c or is_win_c) or i < 1 or i + 1 >= len(tokens):
-            continue
-        # Look back past flags for the shell binary. Windows flags and absolute
-        # paths both start with /, so only skip short /X flags (not /bin/bash).
-        for j in range(i - 1, -1, -1):
-            # A shell name only invokes a shell where the shell would run it:
-            # `echo "cmd" /c powershell` merely prints it, and reading that as
-            # an invocation hard blocked the payload behind it.
-            prev_runs = _runnable_index(j)
-            prev = _cmd_unquote(tokens[j]) if prev_runs else tokens[j]
-            if prev.startswith("-"):
-                continue  # skip Unix flags like --login, -l
-            if is_win_c and prev.startswith("/") and len(prev) <= 3:
-                continue  # skip Windows flags like /s, /q (not /bin/bash)
-            prev_base = os.path.basename(prev).lower()
-            # Same for the payload: the cmd lexer makes `cmd /c "rm -rf x"` one
-            # quoted token, which re-lexes to no command while still quoted.
-            if is_unix_c and prev_runs and prev_base in _SHELLS:
-                blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
-            elif is_win_c and prev_runs and prev_base in _SHELLS_WIN:
-                # Tell the start scan below where cmd hands control over, and
-                # screen those words here: the walk above reads the payload with
-                # bash grammar, so a program cmd runs from its own control flow
-                # (`cmd /c if exist FILE powershell`) sat in argument position
-                # and no pass ever looked at it.
-                payload_commands = _cmd_payload_commands(i + 1)
-                win_c_payloads.update(payload_commands)
-                for payload_index in payload_commands:
-                    payload_word = _cmd_unquote(tokens[payload_index])
-                    if any(char in payload_word for char in " \t"):
-                        # A whole command line in one quoted token, which
-                        # _scan_cmd_payload already reads with its own rules;
-                        # a basename here would read `type C:/logs/curl` as curl.
-                        continue
-                    payload_base = _token_basename(payload_word)
-                    if payload_base in _BLOCKED_COMMANDS:
-                        blocked.add(payload_base)
-                    else:
-                        blocked |= _blocked_matching_glob(payload_base)
-                blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
-                if not _cmd_unquote(tokens[i + 1]):
-                    # `cmd /c ""prog" args"` is the documented way to quote a
-                    # program path holding spaces, and cmd strips the outer
-                    # pair and runs the rest as one string. The cmd lexer ends
-                    # the first token at the doubled quote, so the payload read
-                    # as EMPTY and prog was never screened.
-                    # cmd drops the outer pair and leaves the inner quoting to
-                    # the program, and the lexer already ended a token on every
-                    # one of those marks, so drop them all rather than re-pair
-                    # them: over-quoting here would cost a missed screen.
-                    blocked |= _find_blocked_commands(
-                        " ".join(word.replace('"', "") for word in tokens[i + 1 :])
-                    )
-            break  # stop at first non-flag token
+    def _nested_shell_pass() -> None:
+        nonlocal blocked
+        for i, token in enumerate(tokens):
+            if i in seen_nested:
+                continue
+            tok_lower = _cmd_unquote(token).lower()
+            # Match -c exactly, or combined flags ending in c (e.g. -lc, -xc)
+            is_unix_c = tok_lower == "-c" or (
+                tok_lower.startswith("-") and tok_lower.endswith("c") and not tok_lower.startswith("--")
+            )
+            # Git Bash mangles a lone /c into a path, so models write //c and MSYS
+            # hands cmd back a single slash; /k runs the payload the same way.
+            is_win_c = _win_switch(tok_lower) in ("/c", "/k")
+            if not (is_unix_c or is_win_c) or i < 1 or i + 1 >= len(tokens):
+                continue
+            # Look back past flags for the shell binary. Windows flags and absolute
+            # paths both start with /, so only skip short /X flags (not /bin/bash).
+            for j in range(i - 1, -1, -1):
+                # A shell name only invokes a shell where the shell would run it:
+                # `echo "cmd" /c powershell` merely prints it, and reading that as
+                # an invocation hard blocked the payload behind it.
+                prev_runs = _runnable_index(j)
+                prev = _cmd_unquote(tokens[j]) if prev_runs else tokens[j]
+                if prev.startswith("-"):
+                    continue  # skip Unix flags like --login, -l
+                if is_win_c and prev.startswith("/") and len(prev) <= 3:
+                    continue  # skip Windows flags like /s, /q (not /bin/bash)
+                prev_base = os.path.basename(prev).lower()
+                # Same for the payload: the cmd lexer makes `cmd /c "rm -rf x"` one
+                # quoted token, which re-lexes to no command while still quoted.
+                if is_unix_c and prev_runs and prev_base in _SHELLS:
+                    seen_nested.add(i)
+                    blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
+                elif is_win_c and prev_runs and prev_base in _SHELLS_WIN:
+                    seen_nested.add(i)
+                    # Tell the start scan below where cmd hands control over, and
+                    # screen those words here: the walk above reads the payload with
+                    # bash grammar, so a program cmd runs from its own control flow
+                    # (`cmd /c if exist FILE powershell`) sat in argument position
+                    # and no pass ever looked at it.
+                    payload_commands = _cmd_payload_commands(i + 1)
+                    win_c_payloads.update(payload_commands)
+                    for payload_index in payload_commands:
+                        payload_word = _cmd_unquote(tokens[payload_index])
+                        if any(char in payload_word for char in " \t"):
+                            # A whole command line in one quoted token, which
+                            # _scan_cmd_payload already reads with its own rules;
+                            # a basename here would read `type C:/logs/curl` as curl.
+                            continue
+                        payload_base = _token_basename(payload_word)
+                        if payload_base in _BLOCKED_COMMANDS:
+                            blocked.add(payload_base)
+                        else:
+                            blocked |= _blocked_matching_glob(payload_base)
+                    blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
+                    if not _cmd_unquote(tokens[i + 1]):
+                        # `cmd /c ""prog" args"` is the documented way to quote a
+                        # program path holding spaces: cmd strips the OUTER pair and
+                        # runs the rest as one string. The cmd lexer ends the first
+                        # token at the doubled quote, so the payload read as EMPTY.
+                        # Rebuild it from the raw command rather than from the
+                        # tokens, which have lost both the adjacency and the inner
+                        # quotes that hold a spaced path together.
+                        payload = _cmd_outer_quoted_payload(command)
+                        blocked |= _find_blocked_commands(payload)
+                        program = _cmd_quoted_program(payload)
+                        if program:
+                            program_base = _token_basename(program)
+                            if program_base in _BLOCKED_COMMANDS:
+                                blocked.add(program_base)
+                            else:
+                                blocked |= _blocked_matching_glob(program_base)
+                break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
-    for i, token in enumerate(tokens):
-        if os.path.basename(_cmd_unquote(token)).lower() not in ("start", "start.exe"):
-            continue
-        j = i + 1
-        while j < len(tokens):
-            switch = _win_switch(_cmd_unquote(tokens[j]).lower())
-            if switch not in _START_SWITCHES:
-                break
-            # /d C:\dir and friends carry their value in the next token.
-            j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-        if j >= len(tokens):
-            continue
-        # `start ["title"] prog`: cmd reads the first argument as a window title
-        # ONLY when it arrives DOUBLE quoted, so an unquoted token here is the
-        # program and the next one merely its argument; screening both blocked
-        # `start explorer .` on the `.` source builtin.
-        head = tokens[j]
-        if not lexed_posix:
-            titled = head.startswith('"')  # the cmd lexer keeps the quote marks
-        else:
-            # The posix lexer drops them, and bash strips the quoting before
-            # exec anyway, so what arrives quoted is decided by CONTENT: the
-            # MSYS runtime re-quotes for CreateProcess only an empty argument
-            # or one holding a space/tab/newline/quote (cygwin winf.cc,
-            # linebuf::fromargv). `start "explorer" .` therefore reaches cmd
-            # bare, explorer being the program and `.` only its argument, while
-            # `start 'My Window' prog` still reads as a title.
-            titled = head == "" or any(char in head for char in ' \t\n\r"')
-        # The head is screened WHATEVER `titled` says: it is a heuristic, and a
-        # false positive must cost an over-block, never an under-block.
-        # `echo "powershell" && cmd //c start powershell -Command ls` reads as
-        # titled from the echo, so skipping the head would let it through.
-        blocked |= _scan_cmd_payload(_cmd_unquote(head))
-        # Stepping PAST the head only makes sense where the shell really runs
-        # this start: `echo start "title" powershell` launches nothing and was
-        # hard-refused. _runnable_index follows an -exec through its prefix, so
-        # `find . -exec env start "" powershell \;` still resolves to start
-        # where testing the word right after the flag read `env` and stopped.
-        runnable = _runnable_index(i)
-        if runnable:
-            k = j + 1 if titled else j
-            # Switches may also FOLLOW the title: the documented shape is
-            # `START ["title"] [switches] command`, so `start "" /b powershell`
-            # put /b where the program was expected and the scan stopped there.
-            while k < len(tokens):
-                switch = _win_switch(_cmd_unquote(tokens[k]).lower())
+    def _start_pass() -> None:
+        nonlocal blocked
+        for i, token in enumerate(tokens):
+            if i in seen_start:
+                continue
+            if os.path.basename(_cmd_unquote(token)).lower() not in ("start", "start.exe"):
+                continue
+            j = i + 1
+            while j < len(tokens):
+                switch = _win_switch(_cmd_unquote(tokens[j]).lower())
                 if switch not in _START_SWITCHES:
                     break
-                k += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-            if k < len(tokens):
-                blocked |= _scan_cmd_payload(_cmd_unquote(tokens[k]))
-                # start launches a COMMAND LINE, not just a program, so the
-                # child may be a shell of its own: `start cmd /c powershell`
-                # reaches powershell through a nested cmd that this pass had
-                # already walked past. Re-scanning the remainder re-runs every
-                # pass over it, which screens that nesting to any depth. It runs
-                # untitled too: only the FIRST operand is the title, so the
-                # nesting is identical either way.
-                blocked |= _find_blocked_commands(" ".join(tokens[k:]))
+                # /d C:\dir and friends carry their value in the next token.
+                j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+            if j >= len(tokens):
+                continue
+            # `start ["title"] prog`: cmd reads the first argument as a window title
+            # ONLY when it arrives DOUBLE quoted, so an unquoted token here is the
+            # program and the next one merely its argument; screening both blocked
+            # `start explorer .` on the `.` source builtin.
+            head = tokens[j]
+            if not lexed_posix:
+                titled = head.startswith('"')  # the cmd lexer keeps the quote marks
+            else:
+                # The posix lexer drops them, and bash strips the quoting before
+                # exec anyway, so what arrives quoted is decided by CONTENT: the
+                # MSYS runtime re-quotes for CreateProcess only an empty argument
+                # or one holding a space/tab/newline/quote (cygwin winf.cc,
+                # linebuf::fromargv). `start "explorer" .` therefore reaches cmd
+                # bare, explorer being the program and `.` only its argument, while
+                # `start 'My Window' prog` still reads as a title.
+                titled = head == "" or any(char in head for char in ' \t\n\r"')
+            # The head is screened WHATEVER `titled` says: it is a heuristic, and a
+            # false positive must cost an over-block, never an under-block.
+            # `echo "powershell" && cmd //c start powershell -Command ls` reads as
+            # titled from the echo, so skipping the head would let it through.
+            blocked |= _scan_cmd_payload(_cmd_unquote(head))
+            # Stepping PAST the head only makes sense where the shell really runs
+            # this start: `echo start "title" powershell` launches nothing and was
+            # hard-refused. _runnable_index follows an -exec through its prefix, so
+            # `find . -exec env start "" powershell \;` still resolves to start
+            # where testing the word right after the flag read `env` and stopped.
+            runnable = _runnable_index(i)
+            if runnable:
+                k = j + 1 if titled else j
+                # Switches may also FOLLOW the title: the documented shape is
+                # `START ["title"] [switches] command`, so `start "" /b powershell`
+                # put /b where the program was expected and the scan stopped there.
+                while k < len(tokens):
+                    switch = _win_switch(_cmd_unquote(tokens[k]).lower())
+                    if switch not in _START_SWITCHES:
+                        break
+                    k += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+                if k < len(tokens):
+                    blocked |= _scan_cmd_payload(_cmd_unquote(tokens[k]))
+                    # start launches a COMMAND LINE, not just a program, so the
+                    # child may be a shell of its own: `start cmd /c powershell`
+                    # reaches powershell through a nested cmd. Marking the child
+                    # RUNNABLE and running the nested pass again screens that,
+                    # where re-scanning the joined remainder made the whole scan
+                    # QUADRATIC in the input: a few kB stalled the request, and
+                    # _bash_exec runs this synchronously before the timeout.
+                    # It runs untitled too: only the FIRST operand is a title.
+                    start_children.add(k)
+                    seen_start.add(i)
+
+
+    # start can launch a shell and a shell can run a start, so the two passes
+    # feed each other. Alternating them to a fixed point resolves that nesting;
+    # each word is handled once, which keeps the whole scan linear. The cap is
+    # a backstop -- every extra level needs another literal `cmd /c start ""`.
+    for _ in range(4):
+        discovered = (len(win_c_payloads), len(start_children))
+        _nested_shell_pass()
+        _start_pass()
+        if (len(win_c_payloads), len(start_children)) == discovered:
+            break
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1353,6 +1353,10 @@ def _cmd_unquote(token: str) -> str:
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 
+# A word ending in a program extension, used to tell one quoted executable path
+# apart from an argument list that merely mentions one.
+_EXECUTABLE_PATH_RE = re.compile(r"\.(?:exe|com|bat|cmd)(?=\s|$)", re.IGNORECASE)
+
 
 def _find_blocked_commands(command: str) -> set[str]:
     """Detect blocked commands at shell command position only.
@@ -1413,6 +1417,31 @@ def _find_blocked_commands(command: str) -> set[str]:
             base = stem
         return base
 
+    def _scan_cmd_payload(payload: str) -> "set[str]":
+        """A cmd payload, read as a command line AND as one quoted program path.
+
+        `cmd /?` keeps the quotes around the string after /c when it "is the
+        name of an executable file", and a quoted command token is never split
+        on its spaces, so `cmd /c "C:/Program Files/PowerShell/7/pwsh.exe" -c ls`
+        really runs pwsh; start's program argument reads the same way. Only
+        re-lexing the payload splits it into `C:/Program` and `Files/...`, so
+        the program launched was never screened at all.
+        """
+        found = _find_blocked_commands(payload)
+        if not any(char in payload for char in " \t"):
+            return found  # no spaces: the re-lex above already read the program
+        # Anything but ONE whole executable path is an argument list cmd splits
+        # itself, so `cmd /c "type C:/logs/curl"` and a second program in
+        # `cmd /c "C:/bin/copy.exe build/curl.exe"` are left to the re-lex.
+        if len(_EXECUTABLE_PATH_RE.findall(payload)) != 1 or not payload.lower().endswith(
+            (".exe", ".com", ".bat", ".cmd")
+        ):
+            return found
+        if not any(char in payload.split()[0] for char in ":/\\"):
+            return found  # starts on a command word (`echo C:/tools/curl.exe`)
+        base = _token_basename(payload)
+        return found | ({base} if base in _BLOCKED_COMMANDS else _blocked_matching_glob(base))
+
     def _exec_child_index(start: int) -> "tuple[int, bool]":
         """The command a `find -exec` actually runs, as ``(index, overflowed)``;
         the index is -1 when the action holds no command word at all.
@@ -1464,6 +1493,8 @@ def _find_blocked_commands(command: str) -> set[str]:
     prefix_command = ""  # which wrapper that was, for its own value-taking options
     skip_operand = False  # consume a wrapper/conditional operand, not the command
     sed_indexes: "list[int]" = []  # command-position sed words, for the `e` scan below
+    command_positions: "set[int]" = set()  # command-position words, for the start scan
+    win_c_payloads: "set[int]" = set()  # the word a `cmd /c` hands over, same
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
     xargs_index = -1  # an xargs awaiting the command it wraps
     for token_index, token in enumerate(tokens):
@@ -1525,6 +1556,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         # Numeric wrapper arg: `timeout 1 cmd` / `nice -n 5 cmd`.
         if prefix_pending and token.lstrip("-").isdigit():
             continue
+        command_positions.add(token_index)
         base = _token_basename(token)
         if _is_sed_command(base):
             sed_indexes.append(token_index)
@@ -1656,7 +1688,11 @@ def _find_blocked_commands(command: str) -> set[str]:
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
             elif is_win_c and prev_base in _SHELLS_WIN:
-                blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
+                # `cmd //c start ...` puts start one token past a switch, which
+                # is no command position at all, so the start scan below is told
+                # where cmd hands control over.
+                win_c_payloads.add(i + 1)
+                blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1701,9 +1737,19 @@ def _find_blocked_commands(command: str) -> set[str]:
         # never an under-block: `echo "powershell" && cmd //c start powershell
         # -Command ls` reports titled from the echo, so skipping the head on a
         # title would let the powershell start launches through unscreened.
-        blocked |= _find_blocked_commands(_cmd_unquote(head))
-        if titled and j + 1 < len(tokens):
-            blocked |= _find_blocked_commands(_cmd_unquote(tokens[j + 1]))
+        blocked |= _scan_cmd_payload(_cmd_unquote(head))
+        # Stepping PAST the head only makes sense where this start is a command
+        # the shell runs: at command position, one token past a `cmd /c`, or as
+        # a find -exec child. `echo start "title" powershell` and
+        # `grep -rn start "src/my dir" curl` run neither the title nor the word
+        # behind it, and were hard-refused on a program that never starts.
+        runnable = (
+            i in command_positions
+            or i in win_c_payloads
+            or any(i == flag + 1 for flag in exec_flag_indexes)
+        )
+        if titled and runnable and j + 1 < len(tokens):
+            blocked |= _scan_cmd_payload(_cmd_unquote(tokens[j + 1]))
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1832,11 +1832,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                     if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(base, frozenset()):
                         k += 2  # `env -u FOO prog`: the flag eats its value
                         continue
-                    if (
-                        word.startswith("-")
-                        or "=" in word
-                        or _WRAPPER_DURATION_RE.fullmatch(word)
-                    ):
+                    if word.startswith("-") or "=" in word or _WRAPPER_DURATION_RE.fullmatch(word):
                         k += 1  # its own flags, VAR=VALUE, `timeout 5 prog`
                         continue
                     break

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1339,11 +1339,8 @@ def _win_switch(token: str) -> str:
 
 
 def _cmd_unquote(token: str) -> str:
-    """Strip the double quotes the non-posix lexer leaves on a token.
-
-    cmd.exe strips them itself, so the `start ""` no-title idiom and quoted
-    program names match. Single quotes stay: cmd does not treat them as quoting.
-    """
+    """Strip the double quotes the cmd lexer leaves on a token; cmd.exe strips
+    them itself. Single quotes stay: cmd has no single-quote syntax."""
     while len(token) >= 2 and token.startswith('"') and token.endswith('"'):
         token = token[1:-1]
     return token
@@ -1353,8 +1350,7 @@ def _cmd_unquote(token: str) -> str:
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 
-# A word ending in a program extension, used to tell one quoted executable path
-# apart from an argument list that merely mentions one.
+# Tells one quoted executable path apart from an argument list mentioning one.
 _EXECUTABLE_PATH_RE = re.compile(r"\.(?:exe|com|bat|cmd)(?=\s|$)", re.IGNORECASE)
 
 
@@ -1420,19 +1416,17 @@ def _find_blocked_commands(command: str) -> set[str]:
     def _scan_cmd_payload(payload: str) -> "set[str]":
         """A cmd payload, read as a command line AND as one quoted program path.
 
-        `cmd /?` keeps the quotes around the string after /c when it "is the
-        name of an executable file", and a quoted command token is never split
-        on its spaces, so `cmd /c "C:/Program Files/PowerShell/7/pwsh.exe" -c ls`
-        really runs pwsh; start's program argument reads the same way. Only
-        re-lexing the payload splits it into `C:/Program` and `Files/...`, so
-        the program launched was never screened at all.
+        cmd keeps the quotes when the string after /c names an executable file
+        and never splits a quoted token on its spaces (start's program argument
+        reads the same), so `cmd /c "C:/Program Files/PowerShell/7/pwsh.exe" -c
+        ls` really runs pwsh. Re-lexing alone splits that into `C:/Program` and
+        `Files/...`, leaving the program launched unscreened.
         """
         found = _find_blocked_commands(payload)
         if not any(char in payload for char in " \t"):
             return found  # no spaces: the re-lex above already read the program
         # Anything but ONE whole executable path is an argument list cmd splits
-        # itself, so `cmd /c "type C:/logs/curl"` and a second program in
-        # `cmd /c "C:/bin/copy.exe build/curl.exe"` are left to the re-lex.
+        # itself (`cmd /c "type C:/logs/curl"`), so leave it to the re-lex.
         if len(_EXECUTABLE_PATH_RE.findall(payload)) != 1 or not payload.lower().endswith(
             (".exe", ".com", ".bat", ".cmd")
         ):
@@ -1659,12 +1653,9 @@ def _find_blocked_commands(command: str) -> set[str]:
         blocked.update(re.findall(pattern, lowered))
 
     def _runnable_index(idx: int) -> bool:
-        """True where the shell would execute the word at ``idx``.
-
-        Command position, anywhere inside a `cmd /c` payload (cmd runs control
-        flow of its own), or the child a `find -exec` resolves to. Everything
-        else is data a program merely prints or searches.
-        """
+        """True where the shell would execute the word at ``idx``: command
+        position, inside a `cmd /c` payload (cmd runs control flow of its own),
+        or a `find -exec` child. Anything else is data, not an invocation."""
         return (
             idx in command_positions
             or idx in win_c_payloads
@@ -1690,10 +1681,9 @@ def _find_blocked_commands(command: str) -> set[str]:
         # Look back past flags for the shell binary. Windows flags and absolute
         # paths both start with /, so only skip short /X flags (not /bin/bash).
         for j in range(i - 1, -1, -1):
-            # A shell name only invokes a shell where the shell would run it.
-            # `echo "cmd" /c powershell` and `printf "%s" bash -c "rm -rf x"`
-            # merely print the name, and reading it as a real invocation hard
-            # blocked the payload behind it.
+            # A shell name only invokes a shell where the shell would run it:
+            # `echo "cmd" /c powershell` merely prints it, and reading that as
+            # an invocation hard blocked the payload behind it.
             prev_runs = _runnable_index(j)
             prev = _cmd_unquote(tokens[j]) if prev_runs else tokens[j]
             if prev.startswith("-"):
@@ -1701,17 +1691,15 @@ def _find_blocked_commands(command: str) -> set[str]:
             if is_win_c and prev.startswith("/") and len(prev) <= 3:
                 continue  # skip Windows flags like /s, /q (not /bin/bash)
             prev_base = os.path.basename(prev).lower()
-            # Same for the payload: under the cmd lexer `cmd /c "rm -rf x"` is
-            # one quoted token, and re-lexing it quoted finds no command.
+            # Same for the payload: the cmd lexer makes `cmd /c "rm -rf x"` one
+            # quoted token, which re-lexes to no command while still quoted.
             if is_unix_c and prev_runs and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
             elif is_win_c and prev_runs and prev_base in _SHELLS_WIN:
-                # `cmd //c start ...` puts start one token past a switch, which
-                # is no command position at all, so the start scan below is told
-                # where cmd hands control over. The whole payload counts, not
-                # just its first word: cmd runs control flow of its own, and
-                # `cmd /c if exist C:\Windows start "" powershell` puts start
-                # behind an `if` condition that bash grammar reads as arguments.
+                # Tell the start scan below where cmd hands control over. The
+                # WHOLE payload counts: cmd runs control flow of its own, so
+                # `cmd /c if exist C:\Windows start "" powershell` hides start
+                # behind an `if` that bash grammar reads as plain arguments.
                 for payload_index in range(i + 1, len(tokens)):
                     if tokens[payload_index] in _SHELL_SEPARATORS:
                         break
@@ -1734,46 +1722,31 @@ def _find_blocked_commands(command: str) -> set[str]:
         if j >= len(tokens):
             continue
         # `start ["title"] prog`: cmd reads the first argument as a window title
-        # ONLY when DOUBLE quoted, so an unquoted token here is the program and
-        # the next one just its argument. Screening both would block
-        # `start explorer .` on the `.` source builtin. The cmd lexer keeps the
-        # quotes; the posix one drops them, so the raw text is consulted there.
+        # ONLY when it arrives DOUBLE quoted, so an unquoted token here is the
+        # program and the next one merely its argument; screening both blocked
+        # `start explorer .` on the `.` source builtin.
         head = tokens[j]
         if not lexed_posix:
-            titled = head.startswith('"')
+            titled = head.startswith('"')  # the cmd lexer keeps the quote marks
         else:
-            # Single quotes are NOT title quotes: cmd has no single-quote
-            # syntax, and bash strips them before cmd ever sees the word, so
-            # `start 'explorer' .` reaches cmd as the bare `start explorer .`
-            # and hard-blocked a legitimate command on the `.` behind it.
-            # What survives the hand-off is decided by CONTENT, not by the
-            # quote style written: the MSYS runtime Git Bash uses re-quotes an
-            # argument for CreateProcess exactly when it is empty or holds a
-            # space/tab/newline/quote (cygwin winf.cc, linebuf::fromargv:
-            # `if (len != 0 && !strpbrk (a, " \t\n\r\""))` emits it bare).
-            # `start 'My Window' prog` therefore still reads as a title, and
-            # the raw double-quoted spelling is kept as it was.
-            # Purely by CONTENT: bash removes the quoting before exec, so what
-            # the user wrote is gone by then and only what MSYS re-quotes for
-            # CreateProcess can read as a title. `start "explorer" .` reaches
-            # cmd as a bare `start explorer .`, where explorer is the program
-            # and `.` merely its argument, so consulting the raw double-quoted
-            # spelling hard-blocked that launch on the `.` source builtin.
+            # The posix lexer drops them, and bash strips the quoting before
+            # exec anyway, so what arrives quoted is decided by CONTENT: the
+            # MSYS runtime re-quotes for CreateProcess only an empty argument
+            # or one holding a space/tab/newline/quote (cygwin winf.cc,
+            # linebuf::fromargv). `start "explorer" .` therefore reaches cmd
+            # bare, explorer being the program and `.` only its argument, while
+            # `start 'My Window' prog` still reads as a title.
             titled = head == "" or any(char in head for char in ' \t\n\r"')
-        # The head is screened WHATEVER `titled` says. It is a heuristic under
-        # the posix lexer, and a false positive there must cost an over-block,
-        # never an under-block: `echo "powershell" && cmd //c start powershell
-        # -Command ls` reports titled from the echo, so skipping the head on a
-        # title would let the powershell start launches through unscreened.
+        # The head is screened WHATEVER `titled` says: it is a heuristic, and a
+        # false positive must cost an over-block, never an under-block.
+        # `echo "powershell" && cmd //c start powershell -Command ls` reads as
+        # titled from the echo, so skipping the head would let it through.
         blocked |= _scan_cmd_payload(_cmd_unquote(head))
-        # Stepping PAST the head only makes sense where this start is a command
-        # the shell runs: at command position, one token past a `cmd /c`, or as
-        # a find -exec child. `echo start "title" powershell` and
-        # `grep -rn start "src/my dir" curl` run neither the title nor the word
-        # behind it, and were hard-refused on a program that never starts.
-        # _exec_child_index, not flag + 1: a prefix forwards to its target, so
-        # `find . -exec env start "" powershell \;` really runs start and the
-        # direct-word test read `env` and stopped.
+        # Stepping PAST the head only makes sense where the shell really runs
+        # this start: `echo start "title" powershell` launches nothing and was
+        # hard-refused. _runnable_index follows an -exec through its prefix, so
+        # `find . -exec env start "" powershell \;` still resolves to start
+        # where testing the word right after the flag read `env` and stopped.
         runnable = _runnable_index(i)
         if titled and runnable and j + 1 < len(tokens):
             blocked |= _scan_cmd_payload(_cmd_unquote(tokens[j + 1]))
@@ -6704,8 +6677,8 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     win_git_entries: list[str] = []
     if sys.platform == "win32":
         # The CANONICAL (realpath) trusted git dir, scanning past any untrusted
-        # user shim that sorts first on PATH; the canonical path cannot be
-        # retargeted via a junction after the trust check.
+        # user shim earlier on PATH; a junction cannot retarget it after the
+        # trust check.
         _trusted_git_dir, git_ext = _resolve_trusted_windows_git()
         if _trusted_git_dir:
             win_git_entries.append(_trusted_git_dir)
@@ -6714,12 +6687,10 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
 
     if sys.platform == "win32":
         sysroot = os.environ.get("SystemRoot", r"C:\Windows")
-        # AHEAD of System32, because System32 ships DOS twins of POSIX names:
-        # find.exe and sort.exe are there, so a bare `find . -name '*.py'` in
-        # the bash this tool advertises resolved to the DOS FIND and answered
-        # "FIND: Parameter format not correct" instead of running GNU find.
-        # Still behind the interpreter dirs above, so a Git-shipped python.exe
-        # cannot shadow the interpreter this server runs in.
+        # AHEAD of System32, which ships DOS twins of POSIX names: behind it a
+        # bare `find . -name '*.py'` resolved to FIND.EXE, not GNU find. Still
+        # behind the interpreter dirs above, so a Git-shipped python.exe cannot
+        # shadow the interpreter this server runs in.
         path_entries.extend(win_git_entries)
         path_entries.extend([os.path.join(sysroot, "System32"), sysroot])
     else:
@@ -6746,8 +6717,8 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Windows needs SystemRoot for Python/subprocess to work.
     if sys.platform == "win32":
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
-        # Windows honours TEMP/TMP, not TMPDIR, so a native program would
-        # otherwise fall back to GetTempPath and write outside the sandbox.
+        # Windows honours TEMP/TMP, not TMPDIR; without them a native program
+        # falls back to GetTempPath and writes outside the sandbox.
         env["TEMP"] = workdir
         env["TMP"] = workdir
         # Restrict PATHEXT so cwd .BAT/.CMD cannot hijack bare names (#7317).
@@ -7111,13 +7082,12 @@ def _windows_bash() -> "str | None":
 def _windows_bash_userland_dirs() -> list[str]:
     """Trusted dirs holding the resolved bash and the POSIX tools beside it.
 
-    `bash -c` is non-login, so it never sources /etc/profile, which is what puts
-    Git for Windows' usr\\bin on PATH; without these, ls / cat / grep are all
-    "command not found". bash.exe ships under Git\\bin and Git\\usr\\bin, so the
-    install root is one or two levels up and both parents are probed. Every
-    candidate clears _is_trusted_windows_program_dir, the same Program Files
-    boundary as the git entry (#7317), and is canonicalised so a junction cannot
-    retarget it. Fails closed: no trusted bash, no entries, PATH unchanged.
+    `bash -c` is non-login, so /etc/profile never runs and Git for Windows'
+    usr\\bin stays off PATH, leaving ls / cat / grep "command not found".
+    bash.exe ships under Git\\bin and Git\\usr\\bin, so both parents are probed.
+    Every candidate clears the same Program Files trust boundary as the git
+    entry (#7317) and is canonicalised against junctions. Fails closed: no
+    trusted bash, no entries, PATH unchanged.
     """
     bash = _windows_bash()
     if not bash:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1355,8 +1355,19 @@ _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 # the program under Git Bash, where a POSIX path is how one is written:
 # `start "" /c/Program Files/PowerShell/7/pwsh.exe` read the path as a switch.
 _START_SWITCHES = _START_SWITCHES_WITH_VALUE | {
-    "/min", "/max", "/wait", "/b", "/i", "/low", "/normal", "/high",
-    "/realtime", "/abovenormal", "/belownormal", "/separate", "/shared",
+    "/min",
+    "/max",
+    "/wait",
+    "/b",
+    "/i",
+    "/low",
+    "/normal",
+    "/high",
+    "/realtime",
+    "/abovenormal",
+    "/belownormal",
+    "/separate",
+    "/shared",
 }
 # cmd keywords whose command word does not follow immediately, or at all.
 _CMD_CONTROL_FLOW = frozenset({"if", "else", "do", "for"})
@@ -1398,8 +1409,6 @@ def _cmd_quoted_program(payload: str) -> str:
         return ""
     end = payload.find('"', 1)
     return payload[1:end] if end > 1 else ""
-
-
 
 
 def _find_blocked_commands(command: str) -> set[str]:
@@ -1806,6 +1815,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     # recursively scan the nested command string.
     _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
     _SHELLS_WIN = {"cmd", "cmd.exe"}
+
     def _nested_shell_at(i: int) -> None:
         nonlocal blocked
         token = tokens[i]
@@ -1959,7 +1969,6 @@ def _find_blocked_commands(command: str) -> set[str]:
                     if k < len(tokens):
                         blocked |= _scan_cmd_payload(_cmd_unquote(tokens[k]))
                         start_children.add(k)
-
 
     # start can launch a shell and a shell can run a start, so the two feed each
     # other. Every dependency points BACKWARD (a -c flag reads the shell name

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -193,6 +193,9 @@ _WRAPPER_VALUE_FLAGS_BY_CMD = {
     "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
     "timeout": frozenset({"-s", "--signal", "-k", "--kill-after"}),
     "nice": frozenset({"-n", "--adjustment"}),
+    # GNU time -f/--format takes a FORMAT and -o/--output a file, and reading
+    # either as the wrapped command hid the shell behind it.
+    "time": frozenset({"-f", "--format", "-o", "--output"}),
     "ionice": frozenset({"-c", "--class", "-n", "--classdata", "-p", "--pid"}),
     "xargs": frozenset(
         {"-I", "-L", "-P", "-d", "--delimiter", "-a", "--arg-file", "-n", "-s", "-E"}
@@ -1570,7 +1573,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                     break
         return found
 
-    def _scan_cmd_payload(payload: str) -> "set[str]":
+    def _scan_cmd_payload(payload: str, program_position: bool = True) -> "set[str]":
         """A cmd payload, read as a command line AND as one quoted program path.
 
         cmd keeps the quotes when the string after /c names an executable file
@@ -1591,6 +1594,16 @@ def _find_blocked_commands(command: str) -> set[str]:
         words = payload.split()
         if not any(char in words[0] for char in ":/\\"):
             return found  # starts on a command word (`echo C:/tools/curl.exe`)
+        if not program_position:
+            # Two path-like words are ambiguous at the string level:
+            # `C:/Program Files/PowerShell/7/pwsh.exe` is one spaced path, and
+            # `C:/Windows/System32/findstr logs/powershell.exe` is a command
+            # with an operand, and nothing in the text separates them. cmd's
+            # launcher spelling puts the arguments OUTSIDE the quotes, so the
+            # caller passes program_position only where a program is what it
+            # is reading. `cmd /c "PATH"` alone is left to the re-lex rather
+            # than refusing an ordinary file inspection.
+            return found
         # One path split on ITS OWN spaces continues the same chain, so a later
         # word starting a fresh absolute path means these are separate operands:
         # `C:/Windows/System32/findstr curl C:/logs/curl.exe` greps a file whose
@@ -1927,9 +1940,17 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # `for /f %i in ('CMD') do ...` RUNS the quoted set as a child
                 # command, so the first word inside that group is a command
                 # position rather than iterable data.
+                head_window = range(k, min(k + 4, len(tokens)))
+                # `for /f %i in (set)`: the set is a COMMAND only with the
+                # command delimiter -- single quotes, or backticks under
+                # usebackq. Unquoted it names a FILE whose contents are parsed,
+                # so `for /f %i in (powershell) do ...` launches nothing.
+                usebackq = any(
+                    "usebackq" in _cmd_unquote(tokens[j]).lower() for j in head_window
+                )
+                delimiters = "`" if usebackq else "'"
                 substitutes = any(
-                    _win_switch(_cmd_unquote(tokens[j]).lower()) == "/f"
-                    for j in range(k, min(k + 3, len(tokens)))
+                    _win_switch(_cmd_unquote(tokens[j]).lower()) == "/f" for j in head_window
                 )
                 opened = False
                 while k < len(tokens) and tokens[k] not in _SHELL_SEPARATORS:
@@ -1938,7 +1959,13 @@ def _find_blocked_commands(command: str) -> set[str]:
                     # value. Only the one AFTER the group closes is the body.
                     was_outside = depth <= 0
                     depth += word.count("(") - word.count(")")
-                    if substitutes and was_outside and depth > 0:
+                    opener_body = word[word.find("(") + 1 :] if "(" in word else ""
+                    quoted_set = opener_body.startswith(tuple(delimiters)) or (
+                        not opener_body
+                        and k + 1 < len(tokens)
+                        and tokens[k + 1].startswith(tuple(delimiters))
+                    )
+                    if substitutes and quoted_set and was_outside and depth > 0:
                         # The group just opened. Its command word is either glued
                         # to the opener (`('cmd`) or the token after it.
                         stripped = word.lstrip("(").lstrip("'\"`")
@@ -2059,7 +2086,9 @@ def _find_blocked_commands(command: str) -> set[str]:
                         blocked.add(payload_base)
                     else:
                         blocked |= _blocked_matching_glob(payload_base)
-                blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
+                blocked |= _scan_cmd_payload(
+                    _cmd_unquote(tokens[i + 1]), program_position = i + 2 < len(tokens)
+                )
                 if not _cmd_unquote(tokens[i + 1]):
                     # `cmd /c ""prog" args"` is the documented way to quote a
                     # program path holding spaces: cmd strips the OUTER pair and

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1951,7 +1951,6 @@ def _find_blocked_commands(command: str) -> set[str]:
     # on a -c/-/c flag, look back for a shell name (skipping flags) and
     # recursively scan the nested command string.
 
-
     def _nested_shell_at(i: int) -> None:
         nonlocal blocked
         token = tokens[i]
@@ -2098,9 +2097,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                     while k < len(tokens):
                         word = _cmd_unquote(tokens[k])
                         if child == "env":
-                            following = (
-                                _cmd_unquote(tokens[k + 1]) if k + 1 < len(tokens) else ""
-                            )
+                            following = _cmd_unquote(tokens[k + 1]) if k + 1 < len(tokens) else ""
                             split = _env_split_string_payload(tokens[k], following)
                             if split:
                                 blocked |= _screen_env_split_string(split)

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1534,6 +1534,26 @@ def _find_blocked_commands(command: str) -> set[str]:
             argv = payload.split()
         if not argv:
             return set()
+        # A wrapper in the split argv forwards to what it execs, so
+        # `env -S 'env powershell'` reaches powershell through the inner env.
+        position = 0
+        while position < len(argv):
+            candidate = _token_basename(argv[position])
+            if candidate not in _COMMAND_PREFIXES:
+                break
+            position += 1
+            while position < len(argv):
+                word = argv[position]
+                if word in _WRAPPER_VALUE_FLAGS_BY_CMD.get(candidate, frozenset()):
+                    position += 2
+                    continue
+                if word.startswith("-") or "=" in word or _WRAPPER_DURATION_RE.fullmatch(word):
+                    position += 1
+                    continue
+                break
+        if position >= len(argv):
+            return set()
+        argv = argv[position:]
         found: "set[str]" = set()
         base = _token_basename(argv[0])
         if base in _BLOCKED_COMMANDS:
@@ -1818,6 +1838,8 @@ def _find_blocked_commands(command: str) -> set[str]:
         )
         blocked.update(re.findall(pattern, lowered))
 
+    walked_payload_states: "set[tuple[int, bool, bool]]" = set()
+
     def _cmd_payload_commands(start: int) -> "list[int]":
         """Command positions inside a `cmd /c` payload.
 
@@ -1831,6 +1853,15 @@ def _find_blocked_commands(command: str) -> set[str]:
         indexes: "list[int]" = []
         k, expect, in_if = start, True, False
         while k < len(tokens):
+            # Every `/c` walked the whole remaining suffix, so a chain of them
+            # made screening quadratic (1500 prefixes, ~10 kB, took 0.89s
+            # against 0.06s before). A (position, expect) state reached once
+            # yields the same positions every later time, and the callers only
+            # ever union the results, so stopping there costs nothing and makes
+            # the total work linear in the token count.
+            if (k, expect, in_if) in walked_payload_states:
+                break
+            walked_payload_states.add((k, expect, in_if))
             token = tokens[k]
             if token in _SHELL_SEPARATORS:
                 k, expect, in_if = k + 1, True, False
@@ -1892,8 +1923,40 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # `for %i in (set) do CMD`: the body is whatever follows `do`,
                 # not a short condition, so stepping a fixed width recorded the
                 # loop variable and left the body unscreened.
+                depth = 0
+                # `for /f %i in ('CMD') do ...` RUNS the quoted set as a child
+                # command, so the first word inside that group is a command
+                # position rather than iterable data.
+                substitutes = any(
+                    _win_switch(_cmd_unquote(tokens[j]).lower()) == "/f"
+                    for j in range(k, min(k + 3, len(tokens)))
+                )
+                opened = False
                 while k < len(tokens) and tokens[k] not in _SHELL_SEPARATORS:
-                    is_do = _cmd_unquote(tokens[k]).lower() == "do"
+                    word = _cmd_unquote(tokens[k])
+                    # `for %i in (x do y) do CMD`: the first `do` is an iterable
+                    # value. Only the one AFTER the group closes is the body.
+                    was_outside = depth <= 0
+                    depth += word.count("(") - word.count(")")
+                    if substitutes and was_outside and depth > 0:
+                        # The group just opened. Its command word is either glued
+                        # to the opener (`('cmd`) or the token after it.
+                        stripped = word.lstrip("(").lstrip("'\"`")
+                        if stripped:
+                            # Glued to the opener (`('powershell`), so the index
+                            # alone will not read as the command: the quote is
+                            # left on deliberately elsewhere, cmd having no
+                            # single-quote syntax. Screen the word here instead.
+                            glued = _token_basename(stripped)
+                            if glued in _BLOCKED_COMMANDS:
+                                blocked.add(glued)
+                            else:
+                                blocked |= _blocked_matching_glob(glued)
+                            indexes.append(k)
+                        elif k + 1 < len(tokens):
+                            indexes.append(k + 1)
+                        opened = True
+                    is_do = depth <= 0 and word.lower() == "do" and not (opened and depth > 0)
                     k += 1
                     if is_do:
                         break
@@ -1936,15 +1999,10 @@ def _find_blocked_commands(command: str) -> set[str]:
             # `if 1==1 (start "" cmd /c powershell)` lexes the group opener onto
             # the command word, so it never reached command_positions even
             # though both grammars run whatever follows a `(`.
-            or (
-                0 <= idx < len(tokens)
-                and tokens[idx].startswith("(")
-                # A QUOTED `(` is data the command receives. The posix lexer
-                # drops the marks, so `echo "(start" powershell` looked exactly
-                # like a group opener; quoted_separators is what tells them
-                # apart, and the separator test above already relies on it.
-                and idx not in quoted_group_openers
-            )
+            # A `(` glued to the command word is NOT runnable on its own: the
+            # cmd payload walk decides that, because only it knows where the
+            # grammar expects a command. Testing startswith("(") alone made
+            # `echo (start powershell` a launcher of its echoed argument.
         )
 
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1945,9 +1945,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # command delimiter -- single quotes, or backticks under
                 # usebackq. Unquoted it names a FILE whose contents are parsed,
                 # so `for /f %i in (powershell) do ...` launches nothing.
-                usebackq = any(
-                    "usebackq" in _cmd_unquote(tokens[j]).lower() for j in head_window
-                )
+                usebackq = any("usebackq" in _cmd_unquote(tokens[j]).lower() for j in head_window)
                 delimiters = "`" if usebackq else "'"
                 substitutes = any(
                     _win_switch(_cmd_unquote(tokens[j]).lower()) == "/f" for j in head_window

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1658,6 +1658,19 @@ def _find_blocked_commands(command: str) -> set[str]:
         )
         blocked.update(re.findall(pattern, lowered))
 
+    def _runnable_index(idx: int) -> bool:
+        """True where the shell would execute the word at ``idx``.
+
+        Command position, anywhere inside a `cmd /c` payload (cmd runs control
+        flow of its own), or the child a `find -exec` resolves to. Everything
+        else is data a program merely prints or searches.
+        """
+        return (
+            idx in command_positions
+            or idx in win_c_payloads
+            or any(_exec_child_index(flag + 1)[0] == idx for flag in exec_flag_indexes)
+        )
+
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):
     # on a -c/-/c flag, look back for a shell name (skipping flags) and
     # recursively scan the nested command string.
@@ -1677,7 +1690,12 @@ def _find_blocked_commands(command: str) -> set[str]:
         # Look back past flags for the shell binary. Windows flags and absolute
         # paths both start with /, so only skip short /X flags (not /bin/bash).
         for j in range(i - 1, -1, -1):
-            prev = _cmd_unquote(tokens[j])
+            # A shell name only invokes a shell where the shell would run it.
+            # `echo "cmd" /c powershell` and `printf "%s" bash -c "rm -rf x"`
+            # merely print the name, and reading it as a real invocation hard
+            # blocked the payload behind it.
+            prev_runs = _runnable_index(j)
+            prev = _cmd_unquote(tokens[j]) if prev_runs else tokens[j]
             if prev.startswith("-"):
                 continue  # skip Unix flags like --login, -l
             if is_win_c and prev.startswith("/") and len(prev) <= 3:
@@ -1685,13 +1703,19 @@ def _find_blocked_commands(command: str) -> set[str]:
             prev_base = os.path.basename(prev).lower()
             # Same for the payload: under the cmd lexer `cmd /c "rm -rf x"` is
             # one quoted token, and re-lexing it quoted finds no command.
-            if is_unix_c and prev_base in _SHELLS:
+            if is_unix_c and prev_runs and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(_cmd_unquote(tokens[i + 1]))
-            elif is_win_c and prev_base in _SHELLS_WIN:
+            elif is_win_c and prev_runs and prev_base in _SHELLS_WIN:
                 # `cmd //c start ...` puts start one token past a switch, which
                 # is no command position at all, so the start scan below is told
-                # where cmd hands control over.
-                win_c_payloads.add(i + 1)
+                # where cmd hands control over. The whole payload counts, not
+                # just its first word: cmd runs control flow of its own, and
+                # `cmd /c if exist C:\Windows start "" powershell` puts start
+                # behind an `if` condition that bash grammar reads as arguments.
+                for payload_index in range(i + 1, len(tokens)):
+                    if tokens[payload_index] in _SHELL_SEPARATORS:
+                        break
+                    win_c_payloads.add(payload_index)
                 blocked |= _scan_cmd_payload(_cmd_unquote(tokens[i + 1]))
             break  # stop at first non-flag token
 
@@ -1750,11 +1774,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         # _exec_child_index, not flag + 1: a prefix forwards to its target, so
         # `find . -exec env start "" powershell \;` really runs start and the
         # direct-word test read `env` and stopped.
-        runnable = (
-            i in command_positions
-            or i in win_c_payloads
-            or any(_exec_child_index(flag + 1)[0] == i for flag in exec_flag_indexes)
-        )
+        runnable = _runnable_index(i)
         if titled and runnable and j + 1 < len(tokens):
             blocked |= _scan_cmd_payload(_cmd_unquote(tokens[j + 1]))
 

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -300,6 +300,8 @@ class TestSandboxEnvIsolation:
             "SystemRoot",
             "PATHEXT",  # Windows only; minimal list so cwd scripts cannot hijack
             "NoDefaultCurrentDirectoryInExePath",  # Windows only; no cwd-first lookup
+            "TEMP",  # Windows only; native programs honour these, not TMPDIR
+            "TMP",  # Windows only; kept pointing inside the sandbox workdir
         }
         extras = set(env.keys()) - allowed
         assert not extras, f"sandbox env added unexpected keys: {extras}"

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -496,10 +496,19 @@ class TestSandboxEnvIsolation:
         """When the known-folder API is unavailable, no roots are trusted: env
         vars (even %SystemDrive%) are caller-overrideable, so we never derive a
         trusted root from them."""
+        import ctypes
+
         import core.inference.tools as tools_mod
 
-        # ctypes fails on this Linux host, so the API path raises and we fail
-        # closed. Any attacker override of these env vars must be irrelevant.
+        # Make the API unavailable explicitly. Relying on ctypes.windll being
+        # absent only held off Windows, so on a real Windows runner the call
+        # succeeded and returned the true roots: this asserted nothing where it
+        # matters most. Any attacker override of these env vars stays irrelevant.
+        class _NoKnownFolderApi:
+            def __getattr__(self, name):
+                raise OSError("known-folder API unavailable")
+
+        monkeypatch.setattr(ctypes, "windll", _NoKnownFolderApi(), raising = False)
         monkeypatch.setenv("ProgramFiles", r"D:\attacker-writable")
         monkeypatch.setenv("ProgramW6432", r"D:\attacker-writable")
         monkeypatch.setenv("SystemDrive", "D:")

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1347,9 +1347,7 @@ def test_a_for_f_set_running_a_shell_is_followed(monkeypatch):
     # name behind them was never matched by the nested lookup.
     _fake_windows_screening(monkeypatch, bash = None)
     assert tools._find_blocked_commands("for /f %i in ('cmd /c powershell') do echo %i")
-    assert tools._find_blocked_commands(
-        'cmd /c "for /f %i in (\'cmd /c powershell\') do echo %i"'
-    )
+    assert tools._find_blocked_commands("cmd /c \"for /f %i in ('cmd /c powershell') do echo %i\"")
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1090,3 +1090,72 @@ def test_quoted_cmd_grammar_words_launch_nothing(monkeypatch, command, bash):
 def test_a_real_group_opener_is_still_a_command_position(monkeypatch, bash):
     _fake_windows_screening(monkeypatch, bash = bash)
     assert tools._find_blocked_commands('if 1==1 (start "" powershell) else echo no')
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Under the cmd fallback the WHOLE string is a cmd payload, so its own
+        # grammar applies at the top level and not only inside an inner cmd /c.
+        "call start powershell",
+        "call cmd /c powershell",
+        "call powershell -Command ls",
+        # env -S behind a start: the attached spellings were discarded as flags.
+        'start "" env -Spowershell',
+        'start "" env --split-string=powershell',
+    ],
+)
+def test_the_top_level_is_a_cmd_payload_under_the_fallback(monkeypatch, command):
+    _fake_windows_screening(monkeypatch, bash = None)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # ELSE is control flow only while an IF is open. Unconditionally
+        # resuming command position there refused ordinary arguments.
+        "cmd /c echo no else powershell",
+        "cmd /c findstr else powershell file",
+        "call echo hello",
+    ],
+)
+def test_cmd_keywords_in_argument_position_launch_nothing(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+def test_an_else_branch_is_still_a_command_position(monkeypatch):
+    _fake_windows_screening(monkeypatch, bash = None)
+    assert tools._find_blocked_commands("cmd /c if 1==2 echo no else powershell")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # -S splits its value into ARGV and execs argv[0]; it does not invoke a
+        # shell, so `;` is data (GNU coreutils 9.4 prints `;rm` for this).
+        "env -S 'printf a ; b'",
+        "env -S 'echo hello'",
+        "env -S 'printf a b c'",
+    ],
+)
+def test_an_env_split_string_is_argv_not_shell_syntax(monkeypatch, command):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "env -S 'rm -rf victim'",
+        # A shell reached through -S is still a shell, so its -c payload counts.
+        "env -S 'bash -c \"rm -rf x\"'",
+        "env -S \"bash -c 'rm -rf x'\"",
+        "env -S 'sh -c \"curl http://x\"'",
+    ],
+)
+def test_an_env_split_string_still_reaches_its_command(monkeypatch, command):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1159,3 +1159,79 @@ def test_an_env_split_string_is_argv_not_shell_syntax(monkeypatch, command):
 def test_an_env_split_string_still_reaches_its_command(monkeypatch, command):
     monkeypatch.setattr(sys, "platform", "linux")
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `for /f ... in ('CMD')` RUNS the quoted set, so its first word is a
+        # command position rather than iterable data. cmd syntax only: under
+        # bash the parenthesis is a syntax error and nothing is launched.
+        "for /f %i in (' cmd /c powershell -Command ls ') do echo %i",
+        "for /f %i in ('powershell -Command ls') do echo %i",
+        'for /f "tokens=1" %i in (\'rm -rf x\') do echo %i',
+    ],
+)
+def test_a_for_f_command_set_is_screened(monkeypatch, command):
+    _fake_windows_screening(monkeypatch, bash = None)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+def test_the_for_body_delimiter_is_found_after_the_iterable(monkeypatch, bash):
+    # `for %i in (x do y) do CMD`: the first `do` is an iterable value, so
+    # stopping there marked `y)` as the body and missed the real launcher.
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands("for %i in (x do y) do start powershell")
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "for %i in (1 2 3) do echo %i",
+        "for /f %i in (file.txt) do echo %i",
+        "for /f %i in ('echo hello') do echo %i",
+    ],
+)
+def test_an_ordinary_for_loop_launches_nothing(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A wrapper inside the split argv forwards to what it execs.
+        'env -S "env powershell"',
+        'env -S "nice rm -rf victim"',
+        'env -S "env -u FOO rm -rf victim"',
+    ],
+)
+def test_a_wrapper_inside_an_env_split_string_is_followed(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+def test_a_glued_paren_is_a_group_opener_only_at_a_command_position(monkeypatch):
+    # `echo (start powershell` passes the text to echo. Treating every
+    # `(`-prefixed word as runnable read the echoed argument as a launcher.
+    _fake_windows_screening(monkeypatch, bash = None)
+    assert not tools._find_blocked_commands("echo (start powershell")
+    assert tools._find_blocked_commands('if 1==1 (start "" cmd /c powershell) else echo no')
+
+
+def test_nested_cmd_prefixes_stay_linear(monkeypatch):
+    # Every `/c` re-walked the whole remaining suffix, so a chain of them made
+    # screening quadratic (1500 prefixes, ~10 kB, 0.89s against 0.06s before).
+    import time
+
+    _fake_windows_screening(monkeypatch, bash = None)
+    elapsed = []
+    for count in (750, 3000):
+        began = time.perf_counter()
+        assert tools._find_blocked_commands("cmd /c " * count + "powershell")
+        elapsed.append(time.perf_counter() - began)
+    assert elapsed[1] < 8 * elapsed[0] + 0.5, elapsed  # linear, not quadratic
+    assert elapsed[1] < 2.0, elapsed

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -652,3 +652,56 @@ def test_posix_env_is_unchanged(monkeypatch, tmp_path):
     assert "TEMP" not in env
     assert "TMP" not in env
     assert env["PATH"].split(os.pathsep)[-3:] == ["/usr/local/bin", "/usr/bin", "/bin"]
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # cmd runs control flow of its own, so the program start launches can
+        # sit behind a condition that bash grammar reads as plain arguments.
+        r'cmd /c if exist C:\Windows start "" powershell -Command ls',
+        r'cmd //c if exist C:\Windows start "" pwsh -Command ls',
+        r'cmd /c if not exist C:\nope start "" powershell -Command ls',
+    ],
+)
+def test_start_behind_cmd_control_flow_is_still_screened(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A shell name a program merely prints or searches for is data. Reading
+        # it as a real invocation hard-blocked the payload behind it.
+        'echo "cmd" /c powershell',
+        "echo cmd /c powershell",
+        'printf "%s" "bash" -c "rm -rf x"',
+        'grep -rn cmd /c "src/my dir"',
+    ],
+)
+def test_a_shell_name_in_argument_position_invokes_nothing(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Double-quoted: cmd has no single-quote syntax, so the single-quoted
+        # spelling is only a real invocation on the host that has bash, and it
+        # is covered by the bash-lexer cases elsewhere in this file.
+        'bash -c "rm -rf x"',
+        'env FOO=1 bash -c "rm -rf x"',
+        r'find . -exec bash -c "rm -rf x" \;',
+        '"cmd" /c powershell -Command ls',
+        "cmd /c powershell -Command ls",
+    ],
+)
+def test_a_shell_the_shell_runs_still_screens_its_payload(monkeypatch, command, bash):
+    # The guard above must not cost the nested-shell scan its real cases.
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -437,6 +437,83 @@ def test_a_quote_elsewhere_cannot_hide_the_start_program(monkeypatch, command, b
     assert tools._find_blocked_commands(command)
 
 
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # cmd keeps the quotes around the string after /c when it names an
+        # executable file (`cmd /?` rule 1) and never splits a quoted command
+        # token on its spaces, and start reads its program argument the same
+        # way, so all three really launch pwsh. Only re-lexing the payload split
+        # it into `C:/Program` and `Files/...` and the program went unscreened.
+        # The sandbox PATH carries System32 but not Program Files, so the full
+        # path is the spelling left once the bare `pwsh` is not found.
+        'cmd //c "C:/Program Files/PowerShell/7/pwsh.exe" -Command ls',
+        'cmd //c start "" "C:/Program Files/PowerShell/7/pwsh.exe"',
+        'cmd //c start "My Window" "C:/Program Files/PowerShell/7/pwsh.exe"',
+    ],
+)
+def test_quoted_program_paths_with_spaces_are_screened(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Only a payload that is ENTIRELY one executable path reads as a
+        # program, so an ordinary argument list that merely mentions one keeps
+        # working: cmd splits these itself and runs the word in front.
+        'cmd //c "C:/Program Files/Git/bin/git.exe" status',
+        'cmd //c "C:/Program Files/Microsoft VS Code/Code.exe"',
+        'cmd //c "type C:/logs/curl"',
+        'cmd //c "echo C:/tools/curl.exe"',
+        'cmd //c "copy build/curl.exe dist"',
+    ],
+)
+def test_quoted_payloads_are_not_read_as_programs_by_mistake(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A `start` the shell never runs launches nothing, so the quoted word
+        # behind it is not a title and the word behind THAT is not a program.
+        # Reading them as one hard-refused a grep and an echo on a program that
+        # never starts. The head is still screened, whatever position it is in.
+        'echo start "title" powershell',
+        'printf "%s" start "title" powershell',
+        'grep -rn start "src/my dir" curl',
+    ],
+)
+def test_a_start_in_argument_position_launches_nothing(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Every route by which the shell really reaches a start: `cmd /c` hands
+        # control one token past a switch, which is no command position of its
+        # own, and find/xargs run their child directly.
+        'cmd //c start "My Window" pwsh -Command ls',
+        'cmd /c start "" powershell -Command ls',
+        r'find . -exec start "" powershell \;',
+        'xargs start "" powershell',
+        'start "" powershell',
+    ],
+)
+def test_a_start_the_shell_runs_still_steps_past_its_title(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
 def _fake_git_for_windows(monkeypatch, tmp_path):
     """A trusted Git for Windows layout under a faked Program Files root."""
     program_files = tmp_path / "Program Files"

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -476,9 +476,7 @@ def test_bash_userland_outranks_the_system32_dos_twins(monkeypatch, tmp_path):
     assert path.index(os.path.realpath(usr_bin)) < path.index(system32)
     # ...and the interpreter still outranks the userland, so a Git-shipped
     # python.exe cannot shadow the environment this server runs in.
-    assert path.index(os.path.dirname(sys.executable)) < path.index(
-        os.path.realpath(usr_bin)
-    )
+    assert path.index(os.path.dirname(sys.executable)) < path.index(os.path.realpath(usr_bin))
 
 
 def test_usr_bin_is_found_from_either_install_layout(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -985,3 +985,60 @@ def test_exec_children_do_not_make_screening_quadratic(monkeypatch):
     began = time.perf_counter()
     tools._find_blocked_commands(command)
     assert time.perf_counter() - began < 1.0
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The lexer glues a group opener onto the command word, so the launcher
+        # never reached a command position even though cmd runs the branch.
+        'if 1==1 (start "" cmd /c powershell) else echo no',
+        'if 1==1 (start "" powershell) else echo no',
+        # env -S splits its string into arguments and RUNS them.
+        'cmd //c env -S "rm -rf victim"',
+        'env -S "rm -rf victim"',
+        'env -S"rm -rf victim"',
+        'env --split-string="rm -rf victim"',
+        'cmd //c start "" env -S "powershell -Command ls"',
+        # `timeout DURATION COMMAND`: the duration is not the launched child.
+        'cmd //c start "" timeout 1 powershell',
+        'cmd //c start "" timeout 1.5s pwsh',
+    ],
+)
+def test_a_launcher_behind_cmd_grammar_is_screened(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A bare word before the last one ends the path and starts an operand
+        # list, so this greps a RELATIVE file that happens to be named after a
+        # blocked command. Only absolute later operands were caught before.
+        'cmd /c "C:/Windows/System32/findstr curl logs/powershell.exe"',
+        'cmd /c "C:/Windows/System32/findstr rm build/rm.exe"',
+        'env -S "echo hello"',
+        'echo "env -S rm"',
+        "grep -rn env-S src/",
+    ],
+)
+def test_cmd_grammar_does_not_over_block(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "env -C.. cat other-session/secret",  # attached short form
+        "env -C .. cat other-session/secret",
+        "env --chdir=.. cat other-session/secret",
+    ],
+)
+def test_an_env_chdir_asks_in_every_spelling(monkeypatch, command):
+    # The chdir enables a relative read outside the session workdir, so it must
+    # prompt. The attached spelling reached the generic option skip unjudged.
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert tools._terminal_is_high_risk(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -730,3 +730,23 @@ def test_a_start_cmd_really_runs_is_still_screened(monkeypatch, command, bash):
     # The guard above must not cost the cmd control-flow cases their coverage.
     _fake_windows_screening(monkeypatch, bash = bash)
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # cmd runs the FOR body after `do`, not a word a fixed width along.
+        "cmd /c for %i in (1) do powershell -Command ls",
+        "cmd /c for %i in (1) do rm -rf x",
+        r'cmd /c for /f %i in (list.txt) do start "" powershell',
+        # ...and the IF body is a command in its own right, which no pass
+        # looked at while these indexes were only recorded for later scans.
+        r"cmd /c if exist C:\Windows powershell -Command ls",
+        "cmd /c if defined FOO rm -rf x",
+        r"cmd /c if not exist C:\nope pwsh -Command ls",
+    ],
+)
+def test_a_cmd_control_flow_body_is_screened(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1044,6 +1044,7 @@ def test_an_env_chdir_asks_in_every_spelling(monkeypatch, command):
     monkeypatch.setattr(sys, "platform", "linux")
     assert tools._terminal_is_high_risk(command)
 
+
 _WIN_PS = "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
 
 

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1301,3 +1301,68 @@ def test_a_bare_quoted_cmd_payload_is_read_as_a_command_line(monkeypatch, comman
 def test_a_spaced_program_path_still_resolves(monkeypatch, command, bash):
     _fake_windows_screening(monkeypatch, bash = bash)
     assert "pwsh" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # cmd's own value-style switches sit between it and the /c payload.
+        "cmd /v:on /c powershell -Command ls",
+        "cmd /e:off /t:0a /c powershell",
+        # The quoting splits the comparison, so the operator fragment stood in
+        # for the body command.
+        'cmd /c if "x"=="x" powershell',
+        "cmd /c if x==x powershell",
+    ],
+)
+def test_cmd_switches_and_quoted_comparisons_reach_the_body(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+def test_a_posix_shell_path_is_not_read_as_a_cmd_switch(monkeypatch, bash):
+    # The switch skip is anchored, so /bin/bash is still the shell it names.
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert "rm" in tools._find_blocked_commands('/bin/bash -c "rm -rf x"')
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+def test_a_false_comparison_branch_launches_nothing(monkeypatch, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands('cmd /c if "x"=="y" echo no')
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+def test_a_doubled_quote_payload_before_a_separator(monkeypatch, bash):
+    # The capture was anchored to the end of the whole string, so a payload
+    # with another command after it was never extracted.
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands('cmd /c ""powershell" -Command ls" & echo done')
+
+
+def test_a_for_f_set_running_a_shell_is_followed(monkeypatch):
+    # The set keeps its opener and delimiter glued on (`('cmd`), so the shell
+    # name behind them was never matched by the nested lookup.
+    _fake_windows_screening(monkeypatch, bash = None)
+    assert tools._find_blocked_commands("for /f %i in ('cmd /c powershell') do echo %i")
+    assert tools._find_blocked_commands(
+        'cmd /c "for /f %i in (\'cmd /c powershell\') do echo %i"'
+    )
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        # env's own -S nests, and the generic flag skip swallowed it.
+        ("env -S 'env --split-string=rm -rf victim'", True),
+        ("env -S 'env -S rm -rf victim'", True),
+        ("env -S 'env rm -rf victim'", True),
+        ("env -S 'env nice rm -rf x'", True),
+        ("env -S 'env echo hello'", False),
+    ],
+)
+def test_a_nested_env_split_string_is_followed(monkeypatch, command, expected):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert bool(tools._find_blocked_commands(command)) is expected

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1235,3 +1235,69 @@ def test_nested_cmd_prefixes_stay_linear(monkeypatch):
         elapsed.append(time.perf_counter() - began)
     assert elapsed[1] < 8 * elapsed[0] + 0.5, elapsed  # linear, not quadratic
     assert elapsed[1] < 2.0, elapsed
+
+
+def test_only_a_quoted_for_f_set_is_a_command(monkeypatch):
+    # `for /f %i in (set)` runs the set only with the command delimiter. An
+    # unquoted set names a FILE whose contents are parsed, so nothing launches.
+    _fake_windows_screening(monkeypatch, bash = None)
+    assert tools._find_blocked_commands("for /f %i in ('powershell -Command ls') do echo %i")
+    assert tools._find_blocked_commands(
+        'for /f "usebackq" %i in (`powershell -Command ls`) do echo %i'
+    )
+    assert not tools._find_blocked_commands("for /f %i in (file.txt) do echo %i")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # GNU time -f takes a FORMAT, so reading it as the wrapped command hid
+        # the shell behind it.
+        "env time -f '%E' bash -c 'rm -rf victim'",
+        "time -f '%E' bash -c 'rm -rf x'",
+        "time --format '%E' bash -c 'rm -rf x'",
+        "time -o out.txt bash -c 'rm -rf x'",
+    ],
+)
+def test_a_time_format_operand_is_not_the_wrapped_command(monkeypatch, command):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert "rm" in tools._find_blocked_commands(command)
+
+
+def test_a_time_wrapper_over_a_safe_command_is_clean(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert not tools._find_blocked_commands("time -f '%E' ls -la")
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Two path-like words are ambiguous: one spaced program path, or a
+        # command with an operand. cmd's launcher spelling puts the arguments
+        # OUTSIDE the quotes, so a bare quoted payload is read as a command
+        # line rather than refusing an ordinary file inspection.
+        'cmd /c "C:/Windows/System32/findstr logs/powershell.exe"',
+        'cmd /c "C:/Windows/System32/findstr curl C:/logs/curl.exe"',
+        'cmd /c "C:/tools/findstr rm build/rm.exe"',
+    ],
+)
+def test_a_bare_quoted_cmd_payload_is_read_as_a_command_line(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # ...while every spelling that really launches a spaced path still does.
+        'cmd //c "C:/Program Files/PowerShell/7/pwsh.exe" -Command ls',
+        'cmd /c "C:/Program Files/PowerShell/7/pwsh.exe" -c ls',
+        'cmd //c start "" "C:/Program Files/PowerShell/7/pwsh.exe"',
+        'cmd //c start "My Window" "C:/Program Files/PowerShell/7/pwsh.exe"',
+    ],
+)
+def test_a_spaced_program_path_still_resolves(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert "pwsh" in tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -685,6 +685,57 @@ def test_a_shell_name_in_argument_position_invokes_nothing(monkeypatch, command,
 @pytest.mark.parametrize(
     "command",
     [
+        # start launches a command LINE, so its child can be a shell in turn.
+        'cmd //c start "" cmd /c powershell -Command ls',
+        'cmd //c start "" cmd //c powershell -Command ls',
+        "start \"\" cmd /c rm -rf x",
+        # `START ["title"] [switches] command`: switches follow the title too,
+        # and reading only the word after it stopped on /b or /d.
+        'cmd //c start "" /b powershell -Command ls',
+        'start "" /min /b pwsh -c ls',
+    ],
+)
+def test_a_start_child_is_screened_past_its_title_and_switches(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The documented way to quote a program path holding spaces. The cmd
+        # lexer ends the first token on the doubled quote, so the payload read
+        # as empty and what cmd actually runs went unscreened.
+        'cmd /c ""powershell" -Command ls"',
+        'cmd //c ""powershell" -Command ls"',
+    ],
+)
+def test_a_doubled_quote_cmd_payload_is_screened(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Reaching past the title must not read an argument as the program.
+        'start "" notepad "my file.txt"',
+        'start "" /b wt -d .',
+        'cmd //c start "" explorer .',
+        'cmd //c start "" bash -c "bash /c/x.sh"',
+    ],
+)
+def test_reaching_past_a_start_title_still_launches_nothing(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
         # Double-quoted: cmd has no single-quote syntax, so that spelling is a
         # real invocation only on the bash host, covered elsewhere here.
         'bash -c "rm -rf x"',

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -688,7 +688,7 @@ def test_a_shell_name_in_argument_position_invokes_nothing(monkeypatch, command,
         # start launches a command LINE, so its child can be a shell in turn.
         'cmd //c start "" cmd /c powershell -Command ls',
         'cmd //c start "" cmd //c powershell -Command ls',
-        "start \"\" cmd /c rm -rf x",
+        'start "" cmd /c rm -rf x',
         # `START ["title"] [switches] command`: switches follow the title too,
         # and reading only the word after it stopped on /b or /d.
         'cmd //c start "" /b powershell -Command ls',

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -43,6 +43,27 @@ def _fake_trusted_root(monkeypatch, root):
     monkeypatch.setattr(tools, "_windows_program_roots", lambda: [str(root)])
 
 
+_WIN_BASH = r"C:\Program Files\Git\bin\bash.exe"
+
+
+def _fake_windows_screening(monkeypatch, bash = _WIN_BASH):
+    """Screen a command the way a Windows host would, on any runner.
+
+    Faking sys.platform is not enough for the blocklist: _BLOCKED_COMMANDS is
+    derived from the real platform at import, so powershell/pwsh are absent off
+    Windows and an assertion that a nested shell-out is caught passes on nothing.
+    The win32 union is patched in explicitly, and the resolver with it, since the
+    lexer branch is keyed to the shell that will run the command.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+
+
 def test_posix_shell_is_unchanged(monkeypatch):
     monkeypatch.setattr(sys, "platform", "linux")
     assert tools._get_shell_cmd("echo hi") == ["bash", "-c", "echo hi"]
@@ -272,6 +293,18 @@ def test_notes_say_where_commands_run(monkeypatch):
     assert "opens a window on the user's desktop" in tools._build_terminal_shell_note()
 
 
+def test_windows_only_names_are_not_blocked_off_windows():
+    # Why the two tests below have to fake the blocklist as well as the platform:
+    # _BLOCKED_COMMANDS is derived at import, so on the Linux runner powershell
+    # is not a blocked name and `assert _find_blocked_commands(...)` asserts the
+    # empty set. Delete _fake_windows_screening and they go green on nothing.
+    if sys.platform == "win32":
+        pytest.skip("the win32 union is already live on this host")
+    assert "powershell" in tools._BLOCKED_COMMANDS_WIN
+    assert "powershell" not in tools._BLOCKED_COMMANDS
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
 @pytest.mark.parametrize(
     "command",
     [
@@ -284,13 +317,17 @@ def test_notes_say_where_commands_run(monkeypatch):
         r'cmd //c start /d C:/tmp "" powershell -Command ls',
     ],
 )
-def test_cmd_shellout_is_screened_through_mangled_switches(command):
+def test_cmd_shellout_is_screened_through_mangled_switches(monkeypatch, command, bash):
     # Git Bash turns a lone /c into a path, so a model writes //c. That spelling
     # skipped the nested scan, making `cmd //c powershell` reachable where
     # `cmd /c powershell` was blocked, and `start` launches its argument too.
+    # Screened under both shells: the lexer differs between them, the verdict
+    # must not.
+    _fake_windows_screening(monkeypatch, bash = bash)
     assert tools._find_blocked_commands(command)
 
 
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
 @pytest.mark.parametrize(
     "command",
     [
@@ -300,7 +337,94 @@ def test_cmd_shellout_is_screened_through_mangled_switches(command):
         "start notepad",
     ],
 )
-def test_detached_windows_stay_launchable(command):
+def test_detached_windows_stay_launchable(monkeypatch, command, bash):
     # `start` is the only route to a window on the user's desktop, which the
     # terminal description promises, so screening must not blanket-block cmd.
+    # Faked as Windows so this really guards over-blocking: off Windows none of
+    # these names are blocked anyway and the assertion proves nothing.
+    _fake_windows_screening(monkeypatch, bash = bash)
     assert not tools._find_blocked_commands(command)
+
+
+def _fake_git_for_windows(monkeypatch, tmp_path):
+    """A trusted Git for Windows layout under a faked Program Files root."""
+    program_files = tmp_path / "Program Files"
+    bin_dir = program_files / "Git" / "bin"
+    usr_bin = program_files / "Git" / "usr" / "bin"
+    bin_dir.mkdir(parents = True)
+    usr_bin.mkdir(parents = True)
+    (bin_dir / "bash.exe").write_text("")
+    monkeypatch.setattr(sys, "platform", "win32")
+    _fake_trusted_root(monkeypatch, program_files)
+    monkeypatch.setattr(os, "environ", {})
+    monkeypatch.setattr(tools.shutil, "which", lambda _name: None)
+    return bin_dir, usr_bin
+
+
+def test_bash_userland_is_on_the_sandbox_path(monkeypatch, tmp_path):
+    # _build_safe_env builds PATH from scratch and bash -c is non-login, so
+    # nothing sources /etc/profile: without this the description says bash while
+    # ls / cat / grep are all "command not found" and only builtins work.
+    bin_dir, usr_bin = _fake_git_for_windows(monkeypatch, tmp_path)
+    entries = tools._build_safe_env(str(tmp_path / "work"))["PATH"].split(os.pathsep)
+    assert os.path.realpath(bin_dir) in entries
+    assert os.path.realpath(usr_bin) in entries
+    # The interpreter this server runs in stays pinned ahead of a Git-shipped one.
+    assert entries[0] == os.path.dirname(sys.executable)
+
+
+def test_usr_bin_is_found_from_either_install_layout(monkeypatch, tmp_path):
+    # bash.exe ships at Git\bin and at Git\usr\bin, which put the install root
+    # one and two levels up, so both parents have to be probed.
+    _, usr_bin = _fake_git_for_windows(monkeypatch, tmp_path)
+    (usr_bin / "bash.exe").write_text("")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: str(usr_bin / "bash.exe"))
+    assert os.path.realpath(usr_bin) in tools._windows_bash_userland_dirs()
+
+
+def test_untrusted_bash_contributes_no_path_entries(monkeypatch, tmp_path):
+    # Same boundary as the git PATH entry: a user-writable dir would let an
+    # attacker drop ls.exe/grep.exe beside bash and have a bare name run it.
+    shims = tmp_path / "scoop" / "shims"
+    shims.mkdir(parents = True)
+    (shims / "bash.exe").write_text("")
+    monkeypatch.setattr(sys, "platform", "win32")
+    _fake_trusted_root(monkeypatch, tmp_path / "Program Files")
+    monkeypatch.setattr(os, "environ", {"PATH": str(shims)})
+    monkeypatch.setattr(tools.shutil, "which", lambda _name: str(shims / "bash.exe"))
+    assert tools._windows_bash_userland_dirs() == []
+    entries = tools._build_safe_env(str(tmp_path / "work"))["PATH"].split(os.pathsep)
+    assert str(shims) not in entries
+
+
+def test_no_bash_leaves_the_windows_path_exactly_as_it_was(monkeypatch, tmp_path):
+    # The cmd fallback host must see the pre-existing PATH, byte for byte.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    monkeypatch.setattr(os, "environ", {})
+    monkeypatch.setattr(tools.shutil, "which", lambda _name: None)
+    env = tools._build_safe_env(str(tmp_path / "work"))
+    # os.path.join, so the separator is the host's and this reads the same on
+    # the Linux runner as it does on Windows.
+    sysroot = r"C:\Windows"
+    assert env["PATH"] == os.pathsep.join(
+        [os.path.dirname(sys.executable), os.path.join(sysroot, "System32"), sysroot]
+    )
+
+
+def test_windows_repoints_temp_and_tmp_at_the_workdir(monkeypatch, tmp_path):
+    # Windows tempfile / SDKs read TEMP/TMP, not TMPDIR, so a native program run
+    # from the shell fell back to GetTempPath and wrote outside the sandbox.
+    _fake_git_for_windows(monkeypatch, tmp_path)
+    workdir = str(tmp_path / "work")
+    env = tools._build_safe_env(workdir)
+    assert env["TMPDIR"] == env["TEMP"] == env["TMP"] == workdir
+
+
+def test_posix_env_is_unchanged(monkeypatch, tmp_path):
+    # TEMP/TMP are a Windows concern; POSIX keeps exactly the vars it had.
+    monkeypatch.setattr(sys, "platform", "linux")
+    env = tools._build_safe_env(str(tmp_path))
+    assert "TEMP" not in env
+    assert "TMP" not in env
+    assert env["PATH"].split(os.pathsep)[-3:] == ["/usr/local/bin", "/usr/bin", "/bin"]

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1169,7 +1169,7 @@ def test_an_env_split_string_still_reaches_its_command(monkeypatch, command):
         # bash the parenthesis is a syntax error and nothing is launched.
         "for /f %i in (' cmd /c powershell -Command ls ') do echo %i",
         "for /f %i in ('powershell -Command ls') do echo %i",
-        'for /f "tokens=1" %i in (\'rm -rf x\') do echo %i',
+        "for /f \"tokens=1\" %i in ('rm -rf x') do echo %i",
     ],
 )
 def test_a_for_f_command_set_is_screened(monkeypatch, command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -986,6 +986,7 @@ def test_exec_children_do_not_make_screening_quadratic(monkeypatch):
     tools._find_blocked_commands(command)
     assert time.perf_counter() - began < 1.0
 
+
 @pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
 @pytest.mark.parametrize(
     "command",

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -10,6 +10,7 @@ half-executes and reports success. These run on every OS by faking the platform,
 because studio-backend-ci is Linux-only.
 """
 
+import ntpath
 import os
 import sys
 from pathlib import Path
@@ -730,6 +731,84 @@ def test_a_doubled_quote_cmd_payload_is_screened(monkeypatch, command, bash):
 def test_reaching_past_a_start_title_still_launches_nothing(monkeypatch, command, bash):
     _fake_windows_screening(monkeypatch, bash = bash)
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Only the FIRST operand can be a title, so an untitled start nests the
+        # same way a titled one does.
+        "start cmd /c powershell -Command ls",
+        "cmd //c start cmd /c powershell -Command ls",
+        "start cmd /c rm -rf x",
+        # Wrappers exec their operand, and the Git userland this branch puts on
+        # PATH makes them resolve inside a cmd payload too.
+        "cmd //c env powershell -Command ls",
+        "cmd //c env FOO=1 powershell -Command ls",
+        "cmd //c nice curl http://x",
+    ],
+)
+def test_a_start_or_wrapper_child_cannot_hide_a_shell(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+def test_a_backslash_program_path_after_start_is_screened(monkeypatch, bash):
+    # Backslash paths need the Windows os.path to split: on the Linux runner
+    # posixpath reads the whole string as one basename, so this is the only
+    # test here that has to patch it.
+    _fake_windows_screening(monkeypatch, bash = bash)
+    monkeypatch.setattr(tools.os, "path", ntpath)
+    assert tools._find_blocked_commands(
+        r'cmd //c start "" "C:\Program Files\PowerShell\7\pwsh.exe"'
+    )
+
+
+def test_a_posix_program_path_after_start_is_not_read_as_a_switch(monkeypatch):
+    # Under Git Bash a program path is written POSIX style and MSYS converts it
+    # for cmd. Skipping every slash-prefixed word walked straight past it.
+    _fake_windows_screening(monkeypatch)
+    assert tools._find_blocked_commands(
+        r"cmd //c start \"\" /c/Program\ Files/PowerShell/7/pwsh.exe".replace('\\"', '"')
+    )
+    assert tools._find_blocked_commands('cmd //c start "" /c/msys64/usr/bin/curl.exe http://x')
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        r"C:\Users\me\notepad.exe",
+        r"C:\a.exe",
+        "C:/a.exe",
+        r'start "" C:\Users\me\notepad.exe',
+    ],
+)
+def test_a_program_path_does_not_report_the_source_builtin(monkeypatch, command, bash):
+    # The regex sweep's path prefix stopped mid-name, leaving the extension's
+    # dot to match the `.` builtin, so any drive-qualified program path at the
+    # start of a scanned string reported `.` as blocked.
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert "." not in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (r"C:\tools\rm -rf x", "rm"),
+        ("/usr/bin/rm -rf x", "rm"),
+        ("echo hi; /usr/bin/curl http://x", "curl"),
+        (r"$(C:\w\rm -rf x)", "rm"),
+        (". ./script.sh", "."),
+    ],
+)
+def test_path_qualified_names_are_still_caught(monkeypatch, command, expected):
+    # The counterpart to the test above: tightening that prefix must not cost
+    # any real detection, and a genuine `.` still resolves through the tokens.
+    _fake_windows_screening(monkeypatch)
+    assert expected in tools._find_blocked_commands(command)
 
 
 @pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -49,11 +49,9 @@ _WIN_BASH = r"C:\Program Files\Git\bin\bash.exe"
 def _fake_windows_screening(monkeypatch, bash = _WIN_BASH):
     """Screen a command the way a Windows host would, on any runner.
 
-    Faking sys.platform is not enough for the blocklist: _BLOCKED_COMMANDS is
-    derived from the real platform at import, so powershell/pwsh are absent off
-    Windows and an assertion that a nested shell-out is caught passes on nothing.
-    The win32 union is patched in explicitly, and the resolver with it, since the
-    lexer branch is keyed to the shell that will run the command.
+    Faking sys.platform is not enough: _BLOCKED_COMMANDS is derived at import,
+    so powershell/pwsh are absent off Windows and the assertions pass on nothing.
+    The bash resolver is patched too, since the lexer branch keys off it.
     """
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
@@ -294,10 +292,9 @@ def test_notes_say_where_commands_run(monkeypatch):
 
 
 def test_windows_only_names_are_not_blocked_off_windows():
-    # Why the two tests below have to fake the blocklist as well as the platform:
-    # _BLOCKED_COMMANDS is derived at import, so on the Linux runner powershell
-    # is not a blocked name and `assert _find_blocked_commands(...)` asserts the
-    # empty set. Delete _fake_windows_screening and they go green on nothing.
+    # Why the tests below fake the blocklist as well as the platform:
+    # _BLOCKED_COMMANDS is derived at import, so off Windows powershell is not
+    # blocked and `assert _find_blocked_commands(...)` asserts the empty set.
     if sys.platform == "win32":
         pytest.skip("the win32 union is already live on this host")
     assert "powershell" in tools._BLOCKED_COMMANDS_WIN
@@ -321,8 +318,7 @@ def test_cmd_shellout_is_screened_through_mangled_switches(monkeypatch, command,
     # Git Bash turns a lone /c into a path, so a model writes //c. That spelling
     # skipped the nested scan, making `cmd //c powershell` reachable where
     # `cmd /c powershell` was blocked, and `start` launches its argument too.
-    # Screened under both shells: the lexer differs between them, the verdict
-    # must not.
+    # Screened under both shells: the lexer differs, the verdict must not.
     _fake_windows_screening(monkeypatch, bash = bash)
     assert tools._find_blocked_commands(command)
 
@@ -340,8 +336,7 @@ def test_cmd_shellout_is_screened_through_mangled_switches(monkeypatch, command,
 def test_detached_windows_stay_launchable(monkeypatch, command, bash):
     # `start` is the only route to a window on the user's desktop, which the
     # terminal description promises, so screening must not blanket-block cmd.
-    # Faked as Windows so this really guards over-blocking: off Windows none of
-    # these names are blocked anyway and the assertion proves nothing.
+    # Faked as Windows; off it none of these names are blocked anyway.
     _fake_windows_screening(monkeypatch, bash = bash)
     assert not tools._find_blocked_commands(command)
 
@@ -350,12 +345,11 @@ def test_detached_windows_stay_launchable(monkeypatch, command, bash):
 @pytest.mark.parametrize(
     "command",
     [
-        # A window title is the other spelling that puts the program one token
-        # further on, and only the empty one used to be screened.
+        # A title is the other spelling that puts the program one token later.
         'cmd //c start "MyWindow" powershell -Command ls',
         'cmd //c start /b "Build" pwsh -Command ls',
-        # The cmd lexer keeps quote marks, so a quoted shell name or payload
-        # never matched the nested-shell scan.
+        # The cmd lexer keeps quote marks, so quoted names and payloads never
+        # matched the nested-shell scan.
         '"cmd" /c powershell -Command ls',
         'cmd /c "powershell -Command ls"',
         'cmd /c "rm -rf x"',
@@ -371,9 +365,8 @@ def test_quoted_shellouts_are_screened(monkeypatch, command, bash):
 @pytest.mark.parametrize(
     "command",
     [
-        # An UNQUOTED first argument is the program, not a title, so the token
-        # after it is an argument. Screening it anyway blocks `.` (the POSIX
-        # source builtin) on a plain "open this folder".
+        # An UNQUOTED first argument is the program, so the token after it is
+        # just an argument; screening it blocks `.` on `start explorer .`.
         "cmd //c start explorer .",
         "cmd //c start code .",
         r"cmd //c start explorer C:\Users\me\project",
@@ -388,8 +381,7 @@ def test_start_arguments_are_not_read_as_commands(monkeypatch, command, bash):
 
 
 def test_posix_start_scan_is_unaffected():
-    # The start scan runs on every platform, so an over-block there would land
-    # on Linux and macOS, where none of this applies.
+    # The start scan runs everywhere, so an over-block lands on Linux and macOS.
     assert not tools._find_blocked_commands("start code .")
     assert not tools._find_blocked_commands("start explorer .")
 
@@ -411,19 +403,17 @@ def _fake_git_for_windows(monkeypatch, tmp_path):
 
 def test_bash_userland_is_on_the_sandbox_path(monkeypatch, tmp_path):
     # _build_safe_env builds PATH from scratch and bash -c is non-login, so
-    # nothing sources /etc/profile: without this the description says bash while
-    # ls / cat / grep are all "command not found" and only builtins work.
+    # nothing sources /etc/profile: without this ls / cat / grep are missing.
     bin_dir, usr_bin = _fake_git_for_windows(monkeypatch, tmp_path)
     entries = tools._build_safe_env(str(tmp_path / "work"))["PATH"].split(os.pathsep)
     assert os.path.realpath(bin_dir) in entries
     assert os.path.realpath(usr_bin) in entries
-    # The interpreter this server runs in stays pinned ahead of a Git-shipped one.
+    # This server's interpreter stays pinned ahead of a Git-shipped one.
     assert entries[0] == os.path.dirname(sys.executable)
 
 
 def test_usr_bin_is_found_from_either_install_layout(monkeypatch, tmp_path):
-    # bash.exe ships at Git\bin and at Git\usr\bin, which put the install root
-    # one and two levels up, so both parents have to be probed.
+    # bash.exe ships at Git\bin and Git\usr\bin, so both parents must be probed.
     _, usr_bin = _fake_git_for_windows(monkeypatch, tmp_path)
     (usr_bin / "bash.exe").write_text("")
     monkeypatch.setattr(tools, "_windows_bash", lambda: str(usr_bin / "bash.exe"))
@@ -432,7 +422,7 @@ def test_usr_bin_is_found_from_either_install_layout(monkeypatch, tmp_path):
 
 def test_untrusted_bash_contributes_no_path_entries(monkeypatch, tmp_path):
     # Same boundary as the git PATH entry: a user-writable dir would let an
-    # attacker drop ls.exe/grep.exe beside bash and have a bare name run it.
+    # attacker drop ls.exe beside bash and have a bare name run it.
     shims = tmp_path / "scoop" / "shims"
     shims.mkdir(parents = True)
     (shims / "bash.exe").write_text("")
@@ -452,8 +442,7 @@ def test_no_bash_leaves_the_windows_path_exactly_as_it_was(monkeypatch, tmp_path
     monkeypatch.setattr(os, "environ", {})
     monkeypatch.setattr(tools.shutil, "which", lambda _name: None)
     env = tools._build_safe_env(str(tmp_path / "work"))
-    # os.path.join, so the separator is the host's and this reads the same on
-    # the Linux runner as it does on Windows.
+    # os.path.join, so this reads the same on a Linux runner as on Windows.
     sysroot = r"C:\Windows"
     assert env["PATH"] == os.pathsep.join(
         [os.path.dirname(sys.executable), os.path.join(sysroot, "System32"), sysroot]
@@ -461,8 +450,8 @@ def test_no_bash_leaves_the_windows_path_exactly_as_it_was(monkeypatch, tmp_path
 
 
 def test_windows_repoints_temp_and_tmp_at_the_workdir(monkeypatch, tmp_path):
-    # Windows tempfile / SDKs read TEMP/TMP, not TMPDIR, so a native program run
-    # from the shell fell back to GetTempPath and wrote outside the sandbox.
+    # Windows reads TEMP/TMP, not TMPDIR, so a native program fell back to
+    # GetTempPath and wrote outside the sandbox.
     _fake_git_for_windows(monkeypatch, tmp_path)
     workdir = str(tmp_path / "work")
     env = tools._build_safe_env(workdir)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -880,3 +880,42 @@ def test_a_start_cmd_really_runs_is_still_screened(monkeypatch, command, bash):
 def test_a_cmd_control_flow_body_is_screened(monkeypatch, command, bash):
     _fake_windows_screening(monkeypatch, bash = bash)
     assert tools._find_blocked_commands(command)
+
+@pytest.mark.parametrize("depth", [1, 2, 5, 8])
+def test_a_launcher_chain_is_screened_at_any_depth(monkeypatch, depth):
+    # Alternating whole passes needed one round per layer, so a bounded number
+    # of rounds left the deeper chains unscreened. Every dependency points
+    # backward and every discovery forward, so one sweep resolves them all.
+    _fake_windows_screening(monkeypatch, bash = None)
+    command = "cmd //c " + 'start "" cmd /c ' * depth + "powershell -Command ls"
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+def test_a_wrapper_option_value_is_not_read_as_its_child(monkeypatch):
+    # POSIX too: `env -C DIR` takes a separate operand, and reading DIR as the
+    # child made the shell behind it fail the runnable check.
+    monkeypatch.setattr(sys, "platform", "linux")
+    for command in (
+        "env -C /tmp bash -c 'rm -rf victim'",
+        "env --chdir=/tmp bash -c 'rm -rf victim'",
+        "env -u FOO bash -c 'rm -rf victim'",
+    ):
+        assert "rm" in tools._find_blocked_commands(command), command
+    assert not tools._find_blocked_commands("env -C /tmp ls -la")
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+def test_inspecting_a_file_named_after_a_blocked_command_is_allowed(monkeypatch, bash):
+    # One path split on its own spaces continues the same chain; a later word
+    # starting a fresh absolute path means these are separate operands. Reading
+    # the LAST word as the program refused a plain grep over a log file.
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(
+        'cmd /c "C:/Windows/System32/findstr curl C:/logs/curl.exe"'
+    )
+    assert not tools._find_blocked_commands('cmd /c "C:/tools/findstr rm C:/logs/rm.exe"')
+    # ...but a real program path with spaces, and a real command, still resolve.
+    assert "pwsh" in tools._find_blocked_commands(
+        'cmd /c "C:/Program Files/PowerShell/7/pwsh.exe" -c ls'
+    )
+    assert "rm" in tools._find_blocked_commands('cmd /c "C:/tools/rm C:/logs/x.exe"')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -49,9 +49,9 @@ _WIN_BASH = r"C:\Program Files\Git\bin\bash.exe"
 def _fake_windows_screening(monkeypatch, bash = _WIN_BASH):
     """Screen a command the way a Windows host would, on any runner.
 
-    Faking sys.platform is not enough: _BLOCKED_COMMANDS is derived at import,
-    so powershell/pwsh are absent off Windows and the assertions pass on nothing.
-    The bash resolver is patched too, since the lexer branch keys off it.
+    _BLOCKED_COMMANDS is derived at import, so faking sys.platform alone leaves
+    powershell/pwsh absent and the assertions pass on nothing. The bash resolver
+    is patched too, since the lexer branch keys off it.
     """
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
@@ -292,9 +292,7 @@ def test_notes_say_where_commands_run(monkeypatch):
 
 
 def test_windows_only_names_are_not_blocked_off_windows():
-    # Why the tests below fake the blocklist as well as the platform:
-    # _BLOCKED_COMMANDS is derived at import, so off Windows powershell is not
-    # blocked and `assert _find_blocked_commands(...)` asserts the empty set.
+    # Why the tests below fake the blocklist as well as the platform.
     if sys.platform == "win32":
         pytest.skip("the win32 union is already live on this host")
     assert "powershell" in tools._BLOCKED_COMMANDS_WIN
@@ -345,9 +343,8 @@ def test_detached_windows_stay_launchable(monkeypatch, command, bash):
 @pytest.mark.parametrize(
     "command",
     [
-        # A SPACED title is the other spelling that puts the program one token
-        # later, and it reads that way under either shell (see below for why a
-        # title without spaces does not).
+        # A SPACED title puts the program one token later under either shell
+        # (see below for why a title without spaces does not).
         'cmd //c start "My Window" powershell -Command ls',
         'cmd //c start /b "Build Step" pwsh -Command ls',
         # The cmd lexer keeps quote marks, so quoted names and payloads never
@@ -375,12 +372,11 @@ def test_a_title_without_spaces_reads_differently_per_shell(
     monkeypatch, command, blocked_under_cmd
 ):
     # Same text, opposite correct answers. Under cmd the quotes survive on the
-    # token, so the word really is a title and the NEXT one is the program.
-    # Under bash the quotes are gone before exec and the MSYS runtime re-emits
-    # a word with no space bare (cygwin winf.cc, linebuf::fromargv), so cmd
-    # receives `start explorer .`, the word itself is the program, and the token
-    # behind it is only an argument. Screening it there hard-blocked a
-    # legitimate launch on the `.` source builtin.
+    # token, so the word is a title and the NEXT one is the program. Under bash
+    # they are gone before exec and the MSYS runtime re-emits a space-free word
+    # bare (cygwin winf.cc, linebuf::fromargv), so cmd receives
+    # `start explorer .`: the word itself is the program and the token behind it
+    # is only an argument, whose `.` source builtin hard-blocked the launch.
     _fake_windows_screening(monkeypatch, bash = None)
     assert tools._find_blocked_commands(command) == {blocked_under_cmd}
     _fake_windows_screening(monkeypatch, bash = _WIN_BASH)
@@ -397,9 +393,9 @@ def test_a_title_without_spaces_reads_differently_per_shell(
     ],
 )
 def test_a_wrapped_find_exec_start_is_still_reachable(monkeypatch, command, bash):
-    # A command prefix forwards to its target, so the child of the -exec is
-    # `start`, not the wrapper. Testing the word directly after the flag read
-    # `env` and stopped, leaving the program start launches unscreened.
+    # A prefix forwards to its target, so the -exec child is `start`, not the
+    # wrapper. Testing the word right after the flag read `env` and stopped,
+    # leaving the program start launches unscreened.
     _fake_windows_screening(monkeypatch, bash = bash)
     assert tools._find_blocked_commands(command)
 
@@ -433,11 +429,10 @@ def test_posix_start_scan_is_unaffected():
 @pytest.mark.parametrize(
     "command",
     [
-        # cmd.exe has no single-quote syntax, and bash strips them before cmd
-        # sees the word, so these reach it as the bare `start explorer .` the
-        # test above already keeps launchable. Reading the quotes as a title
-        # moved the program one token right and hard-blocked the `.` behind it
-        # as the POSIX source builtin.
+        # cmd has no single-quote syntax and bash strips them before cmd sees
+        # the word, so these arrive as the bare `start explorer .` kept
+        # launchable above. Reading the quotes as a title moved the program one
+        # token right and hard-blocked the `.` source builtin behind it.
         "cmd //c start 'explorer' .",
         "cmd //c start 'code' .",
         # The same false title from a quote that belongs to another command.
@@ -456,10 +451,10 @@ def test_double_quoted_start_titles_still_move_the_program_along(monkeypatch, ba
 
 
 def test_a_spaced_single_quoted_start_title_moves_the_program_under_bash(monkeypatch):
-    # A title reaches cmd quoted when its CONTENT forces the MSYS runtime to
-    # re-quote it, which a space does whichever quote style bash was handed; the
-    # program is then the token behind it. cmd itself has no single-quote
-    # syntax, so this spelling only reads as a title on the bash host.
+    # A title reaches cmd quoted when its CONTENT makes the MSYS runtime
+    # re-quote it, which a space does whichever quote style bash was handed, so
+    # the program is the token behind it. cmd has no single-quote syntax, so
+    # this spelling reads as a title only on the bash host.
     _fake_windows_screening(monkeypatch, bash = _WIN_BASH)
     assert tools._find_blocked_commands("cmd //c start 'My Window' powershell -Command ls")
 
@@ -468,9 +463,9 @@ def test_a_spaced_single_quoted_start_title_moves_the_program_under_bash(monkeyp
 @pytest.mark.parametrize(
     "command",
     [
-        # The quoted word belongs to the echo, not to start, so the head after
-        # `start` is the program. Screening only the token behind a title would
-        # read this as titled and let the program through unscreened.
+        # The quoted word belongs to the echo, not to start, so the head is the
+        # program. Screening only the token behind a title reads this as titled
+        # and lets the program through unscreened.
         'echo "powershell" && cmd //c start powershell -Command ls',
         "echo 'rm' && cmd //c start rm -rf /",
     ],
@@ -484,13 +479,13 @@ def test_a_quote_elsewhere_cannot_hide_the_start_program(monkeypatch, command, b
 @pytest.mark.parametrize(
     "command",
     [
-        # cmd keeps the quotes around the string after /c when it names an
-        # executable file (`cmd /?` rule 1) and never splits a quoted command
-        # token on its spaces, and start reads its program argument the same
-        # way, so all three really launch pwsh. Only re-lexing the payload split
-        # it into `C:/Program` and `Files/...` and the program went unscreened.
-        # The sandbox PATH carries System32 but not Program Files, so the full
-        # path is the spelling left once the bare `pwsh` is not found.
+        # cmd keeps the quotes when the string after /c names an executable
+        # file and never splits a quoted token on its spaces, and start reads
+        # its program argument the same way, so all three launch pwsh.
+        # Re-lexing alone split it into `C:/Program` and `Files/...` and the
+        # program went unscreened. The sandbox PATH carries System32 but not
+        # Program Files, so the full path is what is left once bare `pwsh`
+        # is not found.
         'cmd //c "C:/Program Files/PowerShell/7/pwsh.exe" -Command ls',
         'cmd //c start "" "C:/Program Files/PowerShell/7/pwsh.exe"',
         'cmd //c start "My Window" "C:/Program Files/PowerShell/7/pwsh.exe"',
@@ -506,8 +501,7 @@ def test_quoted_program_paths_with_spaces_are_screened(monkeypatch, command, bas
     "command",
     [
         # Only a payload that is ENTIRELY one executable path reads as a
-        # program, so an ordinary argument list that merely mentions one keeps
-        # working: cmd splits these itself and runs the word in front.
+        # program; cmd splits these itself and runs the word in front.
         'cmd //c "C:/Program Files/Git/bin/git.exe" status',
         'cmd //c "C:/Program Files/Microsoft VS Code/Code.exe"',
         'cmd //c "type C:/logs/curl"',
@@ -525,9 +519,9 @@ def test_quoted_payloads_are_not_read_as_programs_by_mistake(monkeypatch, comman
     "command",
     [
         # A `start` the shell never runs launches nothing, so the quoted word
-        # behind it is not a title and the word behind THAT is not a program.
-        # Reading them as one hard-refused a grep and an echo on a program that
-        # never starts. The head is still screened, whatever position it is in.
+        # behind it is no title and the word behind THAT no program; reading
+        # them as such hard-refused a grep and an echo. The head is screened
+        # whatever position it is in.
         'echo start "title" powershell',
         'printf "%s" start "title" powershell',
         'grep -rn start "src/my dir" curl',
@@ -544,7 +538,7 @@ def test_a_start_in_argument_position_launches_nothing(monkeypatch, command, bas
     [
         # Every route by which the shell really reaches a start: `cmd /c` hands
         # control one token past a switch, which is no command position of its
-        # own, and find/xargs run their child directly.
+        # own; find/xargs run their child directly.
         'cmd //c start "My Window" pwsh -Command ls',
         'cmd /c start "" powershell -Command ls',
         r'find . -exec start "" powershell \;',
@@ -573,8 +567,8 @@ def _fake_git_for_windows(monkeypatch, tmp_path):
 
 
 def test_bash_userland_is_on_the_sandbox_path(monkeypatch, tmp_path):
-    # _build_safe_env builds PATH from scratch and bash -c is non-login, so
-    # nothing sources /etc/profile: without this ls / cat / grep are missing.
+    # PATH is built from scratch and `bash -c` is non-login, so nothing sources
+    # /etc/profile: without this, ls / cat / grep are all missing.
     bin_dir, usr_bin = _fake_git_for_windows(monkeypatch, tmp_path)
     entries = tools._build_safe_env(str(tmp_path / "work"))["PATH"].split(os.pathsep)
     assert os.path.realpath(bin_dir) in entries
@@ -584,18 +578,18 @@ def test_bash_userland_is_on_the_sandbox_path(monkeypatch, tmp_path):
 
 
 def test_bash_userland_outranks_the_system32_dos_twins(monkeypatch, tmp_path):
-    # System32 ships find.exe and sort.exe, which are the DOS commands, not the
-    # POSIX ones. Behind them a bare `find . -name '*.py'` in the bash this tool
-    # advertises answered "FIND: Parameter format not correct".
+    # System32's find.exe and sort.exe are the DOS commands, not the POSIX ones:
+    # behind them a bare `find . -name '*.py'` in the bash this tool advertises
+    # answered "FIND: Parameter format not correct".
     _, usr_bin = _fake_git_for_windows(monkeypatch, tmp_path)
-    # Read as one string: os.pathsep is ':' on a Linux runner, which would split
-    # the faked C:\Windows drive letter off into its own entry.
+    # One string, not split entries: os.pathsep is ':' on a Linux runner and
+    # would cut the faked C:\Windows drive letter off into its own entry.
     path = tools._build_safe_env(str(tmp_path / "work"))["PATH"]
     system32 = os.path.join(r"C:\Windows", "System32")
     assert system32 in path
     assert path.index(os.path.realpath(usr_bin)) < path.index(system32)
     # ...and the interpreter still outranks the userland, so a Git-shipped
-    # python.exe cannot shadow the environment this server runs in.
+    # python.exe cannot shadow this server's own.
     assert path.index(os.path.dirname(sys.executable)) < path.index(os.path.realpath(usr_bin))
 
 
@@ -637,7 +631,7 @@ def test_no_bash_leaves_the_windows_path_exactly_as_it_was(monkeypatch, tmp_path
 
 
 def test_windows_repoints_temp_and_tmp_at_the_workdir(monkeypatch, tmp_path):
-    # Windows reads TEMP/TMP, not TMPDIR, so a native program fell back to
+    # Windows reads TEMP/TMP, not TMPDIR: a native program fell back to
     # GetTempPath and wrote outside the sandbox.
     _fake_git_for_windows(monkeypatch, tmp_path)
     workdir = str(tmp_path / "work")
@@ -674,7 +668,7 @@ def test_start_behind_cmd_control_flow_is_still_screened(monkeypatch, command, b
 @pytest.mark.parametrize(
     "command",
     [
-        # A shell name a program merely prints or searches for is data. Reading
+        # A shell name a program merely prints or searches for is data; reading
         # it as a real invocation hard-blocked the payload behind it.
         'echo "cmd" /c powershell',
         "echo cmd /c powershell",
@@ -691,9 +685,8 @@ def test_a_shell_name_in_argument_position_invokes_nothing(monkeypatch, command,
 @pytest.mark.parametrize(
     "command",
     [
-        # Double-quoted: cmd has no single-quote syntax, so the single-quoted
-        # spelling is only a real invocation on the host that has bash, and it
-        # is covered by the bash-lexer cases elsewhere in this file.
+        # Double-quoted: cmd has no single-quote syntax, so that spelling is a
+        # real invocation only on the bash host, covered elsewhere here.
         'bash -c "rm -rf x"',
         'env FOO=1 bash -c "rm -rf x"',
         r'find . -exec bash -c "rm -rf x" \;',

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -346,6 +346,54 @@ def test_detached_windows_stay_launchable(monkeypatch, command, bash):
     assert not tools._find_blocked_commands(command)
 
 
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A window title is the other spelling that puts the program one token
+        # further on, and only the empty one used to be screened.
+        'cmd //c start "MyWindow" powershell -Command ls',
+        'cmd //c start /b "Build" pwsh -Command ls',
+        # The cmd lexer keeps quote marks, so a quoted shell name or payload
+        # never matched the nested-shell scan.
+        '"cmd" /c powershell -Command ls',
+        'cmd /c "powershell -Command ls"',
+        'cmd /c "rm -rf x"',
+        '"bash" -c "rm -rf x"',
+    ],
+)
+def test_quoted_shellouts_are_screened(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # An UNQUOTED first argument is the program, not a title, so the token
+        # after it is an argument. Screening it anyway blocks `.` (the POSIX
+        # source builtin) on a plain "open this folder".
+        "cmd //c start explorer .",
+        "cmd //c start code .",
+        r"cmd //c start explorer C:\Users\me\project",
+        'cmd //c start "" wt -d .',
+        "cmd //c start https://example.com",
+        'cmd //c start /min "" myapp.exe --flag',
+    ],
+)
+def test_start_arguments_are_not_read_as_commands(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+def test_posix_start_scan_is_unaffected():
+    # The start scan runs on every platform, so an over-block there would land
+    # on Linux and macOS, where none of this applies.
+    assert not tools._find_blocked_commands("start code .")
+    assert not tools._find_blocked_commands("start explorer .")
+
+
 def _fake_git_for_windows(monkeypatch, tmp_path):
     """A trusted Git for Windows layout under a faked Program Files root."""
     program_files = tmp_path / "Program Files"

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -345,9 +345,11 @@ def test_detached_windows_stay_launchable(monkeypatch, command, bash):
 @pytest.mark.parametrize(
     "command",
     [
-        # A title is the other spelling that puts the program one token later.
-        'cmd //c start "MyWindow" powershell -Command ls',
-        'cmd //c start /b "Build" pwsh -Command ls',
+        # A SPACED title is the other spelling that puts the program one token
+        # later, and it reads that way under either shell (see below for why a
+        # title without spaces does not).
+        'cmd //c start "My Window" powershell -Command ls',
+        'cmd //c start /b "Build Step" pwsh -Command ls',
         # The cmd lexer keeps quote marks, so quoted names and payloads never
         # matched the nested-shell scan.
         '"cmd" /c powershell -Command ls',
@@ -357,6 +359,47 @@ def test_detached_windows_stay_launchable(monkeypatch, command, bash):
     ],
 )
 def test_quoted_shellouts_are_screened(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command,blocked_under_cmd",
+    [
+        ('cmd //c start "MyWindow" powershell -Command ls', "powershell"),
+        ('cmd //c start "explorer" .', "."),
+        ('cmd //c start "code" .', "."),
+    ],
+)
+def test_a_title_without_spaces_reads_differently_per_shell(
+    monkeypatch, command, blocked_under_cmd
+):
+    # Same text, opposite correct answers. Under cmd the quotes survive on the
+    # token, so the word really is a title and the NEXT one is the program.
+    # Under bash the quotes are gone before exec and the MSYS runtime re-emits
+    # a word with no space bare (cygwin winf.cc, linebuf::fromargv), so cmd
+    # receives `start explorer .`, the word itself is the program, and the token
+    # behind it is only an argument. Screening it there hard-blocked a
+    # legitimate launch on the `.` source builtin.
+    _fake_windows_screening(monkeypatch, bash = None)
+    assert tools._find_blocked_commands(command) == {blocked_under_cmd}
+    _fake_windows_screening(monkeypatch, bash = _WIN_BASH)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        r'find . -exec env start "" powershell \;',
+        r'find . -exec nice start "" powershell \;',
+        r'find . -exec env -u FOO start "" powershell \;',
+    ],
+)
+def test_a_wrapped_find_exec_start_is_still_reachable(monkeypatch, command, bash):
+    # A command prefix forwards to its target, so the child of the -exec is
+    # `start`, not the wrapper. Testing the word directly after the flag read
+    # `env` and stopped, leaving the program start launches unscreened.
     _fake_windows_screening(monkeypatch, bash = bash)
     assert tools._find_blocked_commands(command)
 

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -881,6 +881,7 @@ def test_a_cmd_control_flow_body_is_screened(monkeypatch, command, bash):
     _fake_windows_screening(monkeypatch, bash = bash)
     assert tools._find_blocked_commands(command)
 
+
 @pytest.mark.parametrize("depth", [1, 2, 5, 8])
 def test_a_launcher_chain_is_screened_at_any_depth(monkeypatch, depth):
     # Alternating whole passes needed one round per layer, so a bounded number
@@ -919,6 +920,7 @@ def test_inspecting_a_file_named_after_a_blocked_command_is_allowed(monkeypatch,
         'cmd /c "C:/Program Files/PowerShell/7/pwsh.exe" -c ls'
     )
     assert "rm" in tools._find_blocked_commands('cmd /c "C:/tools/rm C:/logs/x.exe"')
+
 
 @pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1043,3 +1043,49 @@ def test_an_env_chdir_asks_in_every_spelling(monkeypatch, command):
     # prompt. The attached spelling reached the generic option skip unjudged.
     monkeypatch.setattr(sys, "platform", "linux")
     assert tools._terminal_is_high_risk(command)
+
+_WIN_PS = "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `timeout DURATION COMMAND` in the payload walk, not just behind start.
+        "cmd /c timeout 1 rm -rf victim",
+        # cmd resumes at ELSE, so the else-branch is a command position.
+        'cmd /c if 1==2 echo no else start "" ' + _WIN_PS + " -Command ls",
+        # CALL re-executes what follows.
+        'cmd /c call start "" ' + _WIN_PS + " -Command ls",
+        "cmd /c call powershell -Command ls",
+        # A payload may lead with its redirection.
+        'cmd /c >out.txt start "" ' + _WIN_PS,
+        "cmd /c 2> err.txt rm -rf x",
+    ],
+)
+def test_cmd_payload_grammar_reaches_the_real_command(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A QUOTED `(` is data. The posix lexer drops the marks, so this was
+        # byte-identical to a group opener and got read as a launcher.
+        'echo "(start" "" powershell',
+        'echo "(start" powershell',
+        "cmd /c echo no else ok",
+        "cmd /c echo call powershell",
+    ],
+)
+def test_quoted_cmd_grammar_words_launch_nothing(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+def test_a_real_group_opener_is_still_a_command_position(monkeypatch, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands('if 1==1 (start "" powershell) else echo no')

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -919,3 +919,67 @@ def test_inspecting_a_file_named_after_a_blocked_command_is_allowed(monkeypatch,
         'cmd /c "C:/Program Files/PowerShell/7/pwsh.exe" -c ls'
     )
     assert "rm" in tools._find_blocked_commands('cmd /c "C:/tools/rm C:/logs/x.exe"')
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A wrapper forwards to whatever it execs, and the Git userland this
+        # branch adds to PATH makes these resolvable behind a start.
+        'cmd //c start "" env rm -rf victim',
+        'cmd //c start "" nice powershell -Command ls',
+        'start "" env -u FOO rm -rf victim',
+        'start "" env nice rm -rf victim',  # a wrapper wrapping a wrapper
+    ],
+)
+def test_a_wrapper_between_start_and_its_program_is_followed(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A start nothing runs launches nothing, quoted head or not.
+        "echo start powershell",
+        'echo start "powershell"',
+        "grep -rn start src/",
+        'start "" env FOO=1 ls -la',
+        'start "" nice notepad x.txt',
+    ],
+)
+def test_a_start_nothing_runs_is_not_screened(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # ...but a start the shell DOES run is, which is what gating the head
+        # on the runnable check had to preserve.
+        'echo "powershell" && cmd //c start powershell -Command ls',
+        "cmd //c start powershell -Command ls",
+        "start powershell -Command ls",
+        "echo hi & start powershell",
+        "echo hi && start powershell",
+        r'find . -exec env start "" powershell \;',
+    ],
+)
+def test_a_start_the_shell_runs_is_still_screened(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command.replace('\\"', '"'))
+
+
+def test_exec_children_do_not_make_screening_quadratic(monkeypatch):
+    # _runnable_index re-ran _exec_child_index over every -exec flag on every
+    # lookup, so many exec clauses plus many start words went quadratic.
+    import time
+
+    _fake_windows_screening(monkeypatch, bash = None)
+    command = " ".join([r"find . -exec ls {} \;"] * 800 + ["start"] * 800)
+    began = time.perf_counter()
+    tools._find_blocked_commands(command)
+    assert time.perf_counter() - began < 1.0

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -386,6 +386,57 @@ def test_posix_start_scan_is_unaffected():
     assert not tools._find_blocked_commands("start explorer .")
 
 
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # cmd.exe has no single-quote syntax, and bash strips them before cmd
+        # sees the word, so these reach it as the bare `start explorer .` the
+        # test above already keeps launchable. Reading the quotes as a title
+        # moved the program one token right and hard-blocked the `.` behind it
+        # as the POSIX source builtin.
+        "cmd //c start 'explorer' .",
+        "cmd //c start 'code' .",
+        # The same false title from a quote that belongs to another command.
+        "echo 'explorer' && cmd //c start explorer .",
+    ],
+)
+def test_single_quoted_start_targets_are_not_titles(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+def test_double_quoted_start_titles_still_move_the_program_along(monkeypatch, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands('cmd //c start "My Window" pwsh -Command ls')
+
+
+def test_a_spaced_single_quoted_start_title_moves_the_program_under_bash(monkeypatch):
+    # A title reaches cmd quoted when its CONTENT forces the MSYS runtime to
+    # re-quote it, which a space does whichever quote style bash was handed; the
+    # program is then the token behind it. cmd itself has no single-quote
+    # syntax, so this spelling only reads as a title on the bash host.
+    _fake_windows_screening(monkeypatch, bash = _WIN_BASH)
+    assert tools._find_blocked_commands("cmd //c start 'My Window' powershell -Command ls")
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The quoted word belongs to the echo, not to start, so the head after
+        # `start` is the program. Screening only the token behind a title would
+        # read this as titled and let the program through unscreened.
+        'echo "powershell" && cmd //c start powershell -Command ls',
+        "echo 'rm' && cmd //c start rm -rf /",
+    ],
+)
+def test_a_quote_elsewhere_cannot_hide_the_start_program(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)
+
+
 def _fake_git_for_windows(monkeypatch, tmp_path):
     """A trusted Git for Windows layout under a faked Program Files root."""
     program_files = tmp_path / "Program Files"
@@ -410,6 +461,24 @@ def test_bash_userland_is_on_the_sandbox_path(monkeypatch, tmp_path):
     assert os.path.realpath(usr_bin) in entries
     # This server's interpreter stays pinned ahead of a Git-shipped one.
     assert entries[0] == os.path.dirname(sys.executable)
+
+
+def test_bash_userland_outranks_the_system32_dos_twins(monkeypatch, tmp_path):
+    # System32 ships find.exe and sort.exe, which are the DOS commands, not the
+    # POSIX ones. Behind them a bare `find . -name '*.py'` in the bash this tool
+    # advertises answered "FIND: Parameter format not correct".
+    _, usr_bin = _fake_git_for_windows(monkeypatch, tmp_path)
+    # Read as one string: os.pathsep is ':' on a Linux runner, which would split
+    # the faked C:\Windows drive letter off into its own entry.
+    path = tools._build_safe_env(str(tmp_path / "work"))["PATH"]
+    system32 = os.path.join(r"C:\Windows", "System32")
+    assert system32 in path
+    assert path.index(os.path.realpath(usr_bin)) < path.index(system32)
+    # ...and the interpreter still outranks the userland, so a Git-shipped
+    # python.exe cannot shadow the environment this server runs in.
+    assert path.index(os.path.dirname(sys.executable)) < path.index(
+        os.path.realpath(usr_bin)
+    )
 
 
 def test_usr_bin_is_found_from_either_install_layout(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -698,3 +698,35 @@ def test_a_shell_the_shell_runs_still_screens_its_payload(monkeypatch, command, 
     # The guard above must not cost the nested-shell scan its real cases.
     _fake_windows_screening(monkeypatch, bash = bash)
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Inside a cmd payload the words after a command are its arguments, so
+        # an echoed or searched-for `start "title" ...` launches nothing.
+        'cmd /c echo start "title" powershell',
+        'cmd //c echo start "title" powershell',
+        'cmd /c findstr start "title" powershell',
+    ],
+)
+def test_a_start_echoed_inside_a_cmd_payload_launches_nothing(monkeypatch, command, bash):
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [_WIN_BASH, None], ids = ["bash", "cmd"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        r'cmd /c if exist C:\Windows start "" powershell -Command ls',
+        r'cmd /c if not exist C:\nope start "" powershell -Command ls',
+        'cmd /c if defined FOO start "" pwsh -Command ls',
+        'cmd /c dir & start "" powershell -Command ls',
+    ],
+)
+def test_a_start_cmd_really_runs_is_still_screened(monkeypatch, command, bash):
+    # The guard above must not cost the cmd control-flow cases their coverage.
+    _fake_windows_screening(monkeypatch, bash = bash)
+    assert tools._find_blocked_commands(command)


### PR DESCRIPTION
Follow-up to #7885, which now runs a trusted Git for Windows bash for the terminal tool instead of `cmd /c`. Three things, one of which is red on CI today.

### The new tests fail on the Linux runner

`test_cmd_shellout_is_screened_through_mangled_switches` asserts `cmd //c powershell -Command ls` is blocked, but never fakes the platform. `powershell` and `pwsh` live only in `_BLOCKED_COMMANDS_WIN`, and `_BLOCKED_COMMANDS` is derived at import:

```python
_BLOCKED_COMMANDS = (
    _BLOCKED_COMMANDS_COMMON | _BLOCKED_COMMANDS_WIN
    if sys.platform == "win32"
    else _BLOCKED_COMMANDS_COMMON
)
```

Every lookup in `_find_blocked_commands` goes through that constant, so on `ubuntu-latest` the recursion reaches `powershell`, matches nothing, and returns the empty set. `studio-backend-ci` is `ubuntu-latest` and its `-k` list does not deselect this file, so it is 7 failures on all four Python versions. Confirmed by running it, on the merge commit as it stands:

```
7 failed, 30 passed, 1 skipped
```

It went unnoticed because every CI run on the PR branch and on `main` is `cancelled`, so there is no signal to read.

Both nested-shell tests now fake the win32 blocklist through one helper and run under each shell, since the lexer differs between them and the verdict must not. `test_detached_windows_stay_launchable` had the mirror problem: off Windows none of its four commands contain a blocked name, so it passed without guarding against over-blocking at all. Added `test_windows_only_names_are_not_blocked_off_windows` so the next reader knows the helper is load-bearing.

### `start ""` is not screened under the cmd lexer

Running the fixed tests under both shells surfaced a real gap in the `start` scan. It compares the no-title token against the empty string:

```python
if j < len(tokens) and tokens[j] == "":
```

`shlex.split(posix = False)`, the branch taken on a host with no bash, keeps the quote marks, so that token is the two-character string `""`. The scan treats it as the program, recurses into nothing, and never reaches what `start` actually launches. On the cmd fallback:

| command | before | after |
|---|---|---|
| `cmd /c powershell -Command ls` | blocked | blocked |
| `cmd //c start "" powershell -Command ls` | **clean** | blocked |
| `cmd //c start /b "" pwsh -Command ls` | **clean** | blocked |
| `cmd //c start //min "" powershell -Command ls` | **clean** | blocked |
| `cmd //c start /d C:/tmp "" powershell -Command ls` | **clean** | blocked |

`cmd.exe` strips double quotes itself, so `_cmd_unquote` does the same at the three places the scan reads a token. Single quotes are deliberately left alone: cmd does not treat them as quoting, and `_token_basename` already relies on that.

Not a regression from #7885 (the `start` scan is new there), but the fix it added only worked under one of the two lexers.

### The new bash has no userland

`_build_safe_env` builds PATH from scratch, and `bash -c` is non-login so it never sources `/etc/profile`, which is what normally puts `Git\usr\bin` on PATH. The win32 PATH is:

```
dirname(sys.executable)  |  %VIRTUAL_ENV%\Scripts  |  %SystemRoot%\System32  |  %SystemRoot%  |  <trusted git dir>
```

and `_resolve_trusted_windows_git` returns the dir holding `git.exe`, which on a stock install is `C:\Program Files\Git\cmd` (git.exe, git-gui.exe, gitk.exe, nothing else). So the terminal description tells the model "The shell is bash (Git for Windows)" and `ls`, `cat`, `grep`, `sed`, `head`, `cp`, `mv`, `tar` are all `command not found`. Only builtins, System32, python and git resolve. The existing Windows end-to-end test uses `echo` and a `for` loop, both builtins, so it cannot catch this.

`_windows_bash_userland_dirs` appends the resolved bash's own dir and the sibling `usr\bin`, each cleared through `_is_trusted_windows_program_dir` and `realpath`ed first, the same Program Files boundary as the git entry from #7317. Both install layouts are handled: `bash.exe` ships under `Git\bin` and under `Git\usr\bin`, which put the install root one and two levels up, so both parents are probed. Appended last so a Git-shipped `python.exe` cannot shadow the interpreter the first entry pins. Fails closed: no trusted bash, no entries, PATH byte-identical to today.

Also repoints `TEMP` and `TMP` at the workdir on Windows. Windows tempfile and SDKs read those, not `TMPDIR`, so a native program run from the shell fell back to `GetTempPath` and wrote outside the per-session sandbox dir. `_build_bypass_env` already sets all three with that exact comment; the sandboxed builder did not.

### On `cmd` in `_BLOCKED_COMMANDS_WIN`

#7885 offered to add it and deferred to a maintainer. My read is to leave it out, and I have not added it here.

`_find_blocked_commands` already recurses through `cmd /c`, `cmd //c` and `cmd //k`, and through `start`, so a `cmd` payload is screened rather than waved past (more so with the `""` fix above). The destructive cmd builtins `del`, `erase`, `rd` and `taskkill` are already prompt-gated in `_HIGH_RISK_COMMANDS` via `_CMD_SHELLS`. Blocking `cmd` outright would remove the only route to the desktop window the new description promises, break `test_detached_windows_stay_launchable`, and break `test_notes_never_recommend_a_blocked_program` on every platform, since the no-bash note reads "The shell is cmd, not bash". The remaining `cmd //c start wt` case opens a window, which is the advertised capability rather than a bypass.

### POSIX

Untouched. `_windows_bash_userland_dirs` is only reached inside the existing win32 branch and `TEMP`/`TMP` are set in the win32 block; `test_posix_env_is_unchanged` pins it.

### Verification

`studio/backend` on Linux.

- `test_windows_bash_shell.py` before: 7 failed, 30 passed, 1 skipped. After: 55 passed, 1 skipped (the win32-only end-to-end test).
- `test_windows_bash_shell` + `test_bypass_permissions` + `test_tool_output_streaming` + `test_permission_mode` + `test_sandbox_tools` + `test_secure_tools_execute`: 2087 passed, 1 skipped, 1 failure, `test_web_search_tool_runs_with_mocked_fetch`, missing `ddgs` in my environment, which fails the same way on an unmodified tree.
- Full backend suite: the 97 failures and 62 errors are missing optional deps and a torch/torchao mismatch in my environment; the two that touch this area (`test_web_search_tool_runs_with_mocked_fetch`, `test_a_corrupt_pid_file_does_not_abort_shutdown`) both reproduce on an unmodified tree.

The PATH change cannot be fully verified from Linux. The tests pin the resolution and trust logic with a faked platform; `ls -la` in the terminal tool on a Windows host with Git for Windows is the end-to-end check.

### Out of scope, worth their own issues

Found while auditing, all pre-existing, but the shell change makes them more reachable.

1. The Windows kill path is single-pid. `_capture_process_group` returns `None` off POSIX and `_killpg_captured` is a no-op, so `_kill_process_tree` is just `proc.kill()`, and `TerminateProcess` does not walk children. Under `cmd /c` that was one command; a multi-line bash script, the thing #7885 enabled, is a process tree, so a timeout or a Stop leaves every grandchild running. `src-tauri/src/process.rs` already does this correctly with `CREATE_NEW_PROCESS_GROUP` plus a `KILL_ON_JOB_CLOSE` job object.
2. `_terminal_is_potentially_unsafe`, `_command_is_network_exec_or_exfil` and `_terminal_is_high_risk` lex POSIX unconditionally while the blocklist now branches on `_shell_is_posix()`, so on a cmd-fallback host the two gates tokenize the same string differently. #7885 shrank this asymmetry rather than creating it.
3. `_AUTO_SAFE_TERMINAL_COMMANDS` lists `sort`, and `_AUTO_UNSAFE_COMMAND_FLAGS` only knows `-`-prefixed spellings, so with System32 on PATH `sort /O <path> in.txt` is auto-approved and writes anywhere.

---

### Added during review

Codex reviewed this 13 times and the diff grew well past the three items above. Recording what changed, since most of it is not visible from the original description.

**Screening the cmd payload grammar.** The `start` and `cmd /c` scans now read the payload the way cmd does rather than with bash grammar: window titles and the switches that may follow one (`START ["title"] [switches] command`), the documented `cmd /c ""prog" args"` quoting for spaced paths, `IF` conditions at their real width (`exist`/`defined`/`errorlevel`/`cmdextversion` take an operand, `EQU`/`NEQ`/`LSS`/`LEQ`/`GTR`/`GEQ` consume three tokens), `FOR` bodies after `do`, and wrappers such as `env`/`nice` which forward to whatever they exec. Launcher chains resolve at any depth: every dependency in these passes points backward and every discovery forward, so a single sweep in index order handles `cmd /c start "" cmd /c start "" ... powershell`.

**A POSIX regression, introduced here and fixed here.** The `_runnable_index` guard added mid-review read `env -C`'s directory operand as its child, so `env -C /tmp bash -c 'rm -rf victim'` stopped being screened on Linux and macOS. It blocks on both baselines. `-C`/`--chdir` is now in `_WRAPPER_VALUE_FLAGS_BY_CMD`, and the `env -C` high-risk branch is judged ahead of the wrapper-value skip, as `setpriv --reuid` already was.

I had been reporting the POSIX side as untouched on the strength of a hand-written corpus that happened to contain no wrapper option taking a separate value. That evidence is now generated rather than chosen:

- every entry in `_WRAPPER_VALUE_FLAGS_BY_CMD` crossed with every one of its flags, both spellings, 74 cases: 0 regressions, 0 drift, 0 unscreened;
- a grammar-derived differential, 13 prefixes x 14 syntactic contexts x 12 bodies = 2184 cases on real Linux: 0 verdict differences against post-7885 **and** against pre-7885.

**Two quadratic blowups, both mine.** Re-scanning the remainder of every `start` made a few kB of input take seconds; so did re-deriving every `find -exec` child on every `_runnable_index` call. `_bash_exec` screens synchronously before the subprocess timeout applies, so these stalled a backend request rather than merely being slow.

| input | before | after |
| --- | --- | --- |
| 400 `start` words | 4.11s | 0.035s |
| 800 exec clauses + 800 `start` words (21 kB) | 1.36s | 0.04s |

Both shapes are now asserted in the suite rather than checked by hand.

**Over-blocks removed.** A drive-qualified program path reported the `.` builtin as blocked, because the regex sweep's path prefix could stop mid-name and match the extension's dot. `cmd /c "C:/Windows/System32/findstr curl C:/logs/curl.exe"` was refused, reading the last word as the program. And screening a `start` head regardless of position refused `echo start "powershell"`; the bypass that guarded against puts its `start` after a separator and inside a cmd payload, both runnable positions, so gating it loses nothing. All three are pinned in both directions.

**Windows CI.** Verified on the staging repo across `ubuntu-latest`, `macos-14` and `windows-latest`: 468 passed, 2 skipped on Windows. That run also caught `test_program_roots_fails_closed_without_known_folder_api` (from #7323, untouched here), which could only pass off Windows because it relied on `ctypes.windll` being absent; on a Windows host the API succeeds, so the property it protects was never exercised there. Fixed only because it was the sole blocker to a green Windows signal.

`test_multiline_script_runs_every_line_on_windows` is confirmed to have executed rather than skipped, so the original #7885 regression is verified on a real Windows host and not just against a faked platform.

Local: 2302 passed, 1 skipped.
