### PR TITLE
Desktop: make the close button quit outside macOS

### DIFF
--- a/studio/frontend/src/features/hub/download-manager/download-manager-state.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-state.ts
@@ -256,15 +256,14 @@ export const setState = useDownloadManagerStore.setState;
 export const getState = useDownloadManagerStore.getState;
 
 /**
- * Downloads run in the backend, which the desktop quit path reaps, but only this store
- * knows they are in flight. A Tauri quit never fires beforeunload, so mirror the state
- * to Rust exactly as training runs are mirrored, and let it ask before killing them.
+ * Downloads run in the backend, which the quit path reaps, but only this store knows they
+ * are in flight. A Tauri quit never fires beforeunload, so mirror it to Rust to ask first.
  */
 export function hasActiveDownloadJob(
   jobs: Record<string, ManagedDownload>,
 ): boolean {
-  // External jobs count too, unlike in `partialize`: the STT sidecars that own them
-  // are reached through the backend, so a quit kills those transfers as well.
+  // External jobs count too, unlike in `partialize`: their STT sidecars are reached
+  // through the backend, so a quit kills those transfers as well.
   return Object.values(jobs).some((job) => ACTIVE_STATES.has(job.state));
 }
 
@@ -277,8 +276,7 @@ function publishDownloadsActive(active: boolean): void {
     .catch(() => {});
 }
 
-// Transitions only: the poll loop patches progress several times a second, and every
-// one of those ticks lands here.
+// Transitions only: the poll loop patches progress several times a second.
 let lastPublishedDownloadsActive: boolean | null = null;
 
 function syncDownloadsActivity(state: DownloadManagerState): void {

--- a/studio/frontend/src/features/hub/download-manager/download-manager-state.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-state.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { isTauri } from "@/lib/api-base";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { INVENTORY_HINT_KIND } from "../inventory/constants";
@@ -253,6 +254,43 @@ export const useDownloadManagerStore = create<DownloadManagerState>()(
 
 export const setState = useDownloadManagerStore.setState;
 export const getState = useDownloadManagerStore.getState;
+
+/**
+ * Downloads run in the backend, which the desktop quit path reaps, but only this store
+ * knows they are in flight. A Tauri quit never fires beforeunload, so mirror the state
+ * to Rust exactly as training runs are mirrored, and let it ask before killing them.
+ */
+export function hasActiveDownloadJob(
+  jobs: Record<string, ManagedDownload>,
+): boolean {
+  // External jobs count too, unlike in `partialize`: the STT sidecars that own them
+  // are reached through the backend, so a quit kills those transfers as well.
+  return Object.values(jobs).some((job) => ACTIVE_STATES.has(job.state));
+}
+
+function publishDownloadsActive(active: boolean): void {
+  if (!isTauri) return;
+  void import("@tauri-apps/api/core")
+    .then(({ invoke }) =>
+      invoke("set_renderer_activity", { kind: "downloads", active }),
+    )
+    .catch(() => {});
+}
+
+// Transitions only: the poll loop patches progress several times a second, and every
+// one of those ticks lands here.
+let lastPublishedDownloadsActive: boolean | null = null;
+
+function syncDownloadsActivity(state: DownloadManagerState): void {
+  const active = hasActiveDownloadJob(state.jobs);
+  if (active === lastPublishedDownloadsActive) return;
+  lastPublishedDownloadsActive = active;
+  publishDownloadsActive(active);
+}
+
+// Once for whatever the persisted state restored, then on every change.
+syncDownloadsActivity(getState());
+useDownloadManagerStore.subscribe(syncDownloadsActivity);
 
 function withCompletedHintSignature(
   state: DownloadManagerState,

--- a/studio/frontend/src/features/training/hooks/use-training-unload-guard.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-unload-guard.ts
@@ -7,7 +7,8 @@ import { useTrainingRuntimeStore } from "../stores/training-runtime-store";
 
 let currentHandler: ((e: BeforeUnloadEvent) => void) | null = null;
 
-// Desktop quit never fires beforeunload; Rust asks from the tray instead.
+// Desktop quit never fires beforeunload; Rust asks instead, from the tray and
+// (outside macOS) from the window close button.
 function publishTrainingActive(active: boolean): void {
   if (!isTauri) return;
   void import("@tauri-apps/api/core")

--- a/studio/frontend/src/features/training/hooks/use-training-unload-guard.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-unload-guard.ts
@@ -7,8 +7,7 @@ import { useTrainingRuntimeStore } from "../stores/training-runtime-store";
 
 let currentHandler: ((e: BeforeUnloadEvent) => void) | null = null;
 
-// Desktop quit never fires beforeunload; Rust asks instead, from the tray and
-// (outside macOS) from the window close button.
+// Desktop quit never fires beforeunload; Rust asks instead, from the tray and (outside macOS) the close button.
 function publishTrainingActive(active: boolean): void {
   if (!isTauri) return;
   void import("@tauri-apps/api/core")

--- a/studio/frontend/src/hooks/use-tauri-update.ts
+++ b/studio/frontend/src/hooks/use-tauri-update.ts
@@ -69,8 +69,7 @@ const DEFAULT_UPDATE_POLICY: DesktopUpdatePolicy = {
   releaseTagPrefix: "desktop-v",
 };
 
-// Desktop quit never fires beforeunload; Rust asks instead, from the tray and (outside
-// macOS) the close button. The Tauri shell installer is the renderer's alone to report.
+// Desktop quit never fires beforeunload, and only the renderer sees the shell installer.
 function publishShellUpdateActive(active: boolean): void {
   if (!isTauri) return;
   void import("@tauri-apps/api/core")
@@ -359,8 +358,8 @@ export function useTauriUpdate(isExternalServer = false) {
 
       let downloaded = 0;
       let contentLength = 0;
-      // Past this point the Rust `update::is_update_running` flag is already false, so
-      // mirror the shell installer's own run: quitting through it leaves a half-updated app.
+      // `update::is_update_running` is already false here, and quitting mid-install
+      // leaves a half-updated app.
       publishShellUpdateActive(true);
       try {
         await update.downloadAndInstall((event) => {

--- a/studio/frontend/src/hooks/use-tauri-update.ts
+++ b/studio/frontend/src/hooks/use-tauri-update.ts
@@ -69,6 +69,17 @@ const DEFAULT_UPDATE_POLICY: DesktopUpdatePolicy = {
   releaseTagPrefix: "desktop-v",
 };
 
+// Desktop quit never fires beforeunload; Rust asks instead, from the tray and (outside
+// macOS) the close button. The Tauri shell installer is the renderer's alone to report.
+function publishShellUpdateActive(active: boolean): void {
+  if (!isTauri) return;
+  void import("@tauri-apps/api/core")
+    .then(({ invoke }) =>
+      invoke("set_renderer_activity", { kind: "shell_update", active }),
+    )
+    .catch(() => {});
+}
+
 const UPDATE_VERSION_RE = /^v?\d+\.\d+\.\d+(?:(?:[-+][0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)|(?:\.(?:post|dev|rc)\d*)|(?:(?:post|dev|rc|a|b)\d*))?$/;
 
 function normalizeUpdateVersion(version: string): string | null {
@@ -348,23 +359,33 @@ export function useTauriUpdate(isExternalServer = false) {
 
       let downloaded = 0;
       let contentLength = 0;
-      await update.downloadAndInstall((event) => {
-        switch (event.event) {
-          case "Started":
-            contentLength = event.data.contentLength ?? 0;
-            break;
-          case "Progress":
-            downloaded += event.data.chunkLength;
-            if (contentLength > 0) {
-              setUpdateProgress(Math.round((downloaded / contentLength) * 100));
-            }
-            break;
-          case "Finished":
-            setUpdatePhase("shell_install");
-            setStatus("installing");
-            break;
-        }
-      });
+      // Past this point the Rust `update::is_update_running` flag is already false, so
+      // mirror the shell installer's own run: quitting through it leaves a half-updated app.
+      publishShellUpdateActive(true);
+      try {
+        await update.downloadAndInstall((event) => {
+          switch (event.event) {
+            case "Started":
+              contentLength = event.data.contentLength ?? 0;
+              break;
+            case "Progress":
+              downloaded += event.data.chunkLength;
+              if (contentLength > 0) {
+                setUpdateProgress(
+                  Math.round((downloaded / contentLength) * 100),
+                );
+              }
+              break;
+            case "Finished":
+              setUpdatePhase("shell_install");
+              setStatus("installing");
+              break;
+          }
+        });
+      } finally {
+        // Success, failure and cancel alike: the installer is no longer running.
+        publishShellUpdateActive(false);
+      }
 
       const { relaunch } = await import("@tauri-apps/plugin-process");
       await relaunch();

--- a/studio/frontend/tests/download-transport-persistence.test.ts
+++ b/studio/frontend/tests/download-transport-persistence.test.ts
@@ -147,8 +147,7 @@ test("the cancel marker is written with the persisted job", () => {
 });
 
 test("a running job is the activity the desktop quit path asks about", () => {
-  // What set_renderer_activity mirrors into Rust, so the close button can warn
-  // before the backend is reaped out from under a multi-GB transfer.
+  // What set_renderer_activity mirrors into Rust, so the close button warns first.
   assert.equal(hasActiveDownloadJob(getState().jobs), true);
 });
 

--- a/studio/frontend/tests/download-transport-persistence.test.ts
+++ b/studio/frontend/tests/download-transport-persistence.test.ts
@@ -59,7 +59,7 @@ store.set(
   }),
 );
 
-const { getState, jobKeyOf, putJob } = await import(
+const { getState, hasActiveDownloadJob, jobKeyOf, putJob } = await import(
   "../src/features/hub/download-manager/download-manager-state.ts"
 );
 
@@ -144,4 +144,56 @@ test("the cancel marker is written with the persisted job", () => {
   const persisted = JSON.parse(store.get(PERSIST_KEY) ?? "null");
   assert.equal(persisted.state.jobs[key].transport, "http");
   assert.equal(persisted.state.jobs[key].cancelTransport, "xet");
+});
+
+test("a running job is the activity the desktop quit path asks about", () => {
+  // What set_renderer_activity mirrors into Rust, so the close button can warn
+  // before the backend is reaped out from under a multi-GB transfer.
+  assert.equal(hasActiveDownloadJob(getState().jobs), true);
+});
+
+test("an external job counts too, since a quit kills its transfer as well", () => {
+  assert.equal(hasActiveDownloadJob({}), false);
+  assert.equal(
+    hasActiveDownloadJob({
+      external: {
+        key: "model:org/external",
+        kind: "model",
+        repoId: "org/external",
+        variant: null,
+        state: "running",
+        downloadedBytes: 0,
+        completedBytes: 0,
+        completeOnDisk: false,
+        expectedBytes: 0,
+        fraction: 0,
+        bytesPerSec: 0,
+        error: null,
+        startedAt: 4,
+        external: true,
+      },
+    }),
+    true,
+  );
+  // A settled job is not activity, whoever owns it.
+  assert.equal(
+    hasActiveDownloadJob({
+      done: {
+        key: "model:org/done",
+        kind: "model",
+        repoId: "org/done",
+        variant: null,
+        state: "complete",
+        downloadedBytes: 0,
+        completedBytes: 0,
+        completeOnDisk: true,
+        expectedBytes: 0,
+        fraction: 1,
+        bytesPerSec: 0,
+        error: null,
+        startedAt: 4,
+      },
+    }),
+    false,
+  );
 });

--- a/studio/frontend/tests/helpers/kit.ts
+++ b/studio/frontend/tests/helpers/kit.ts
@@ -39,7 +39,9 @@ export function installLocalStorageFake(): {
     },
   };
   Object.assign(globalThis, {
-    window: { localStorage: storage },
+    // A location too: the desktop check in lib/api-base reads its protocol, and a
+    // module that only wants localStorage can still pull that in transitively.
+    window: { localStorage: storage, location: { protocol: "http:" } },
     localStorage: storage,
   });
   return { store, storage };

--- a/studio/frontend/tests/helpers/kit.ts
+++ b/studio/frontend/tests/helpers/kit.ts
@@ -39,8 +39,7 @@ export function installLocalStorageFake(): {
     },
   };
   Object.assign(globalThis, {
-    // A location too: the desktop check in lib/api-base reads its protocol, and a
-    // module that only wants localStorage can still pull that in transitively.
+    // A location too: lib/api-base reads its protocol, pulled in transitively.
     window: { localStorage: storage, location: { protocol: "http:" } },
     localStorage: storage,
   });

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -108,7 +108,7 @@ fn set_training_active(state: tauri::State<'_, TrainingActivityState>, active: b
     }
 }
 
-/// Ask before quitting mid-training (true to proceed). Tray Quit only, as below.
+/// Ask before quitting mid-training (true to proceed). request_quit only, as below.
 fn confirm_quit_during_training(app: &tauri::AppHandle) -> bool {
     use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
@@ -133,7 +133,7 @@ fn confirm_quit_during_training(app: &tauri::AppHandle) -> bool {
 }
 
 /// Ask before quitting mid-install (true to proceed): `cleanup_child_processes` SIGTERMs the
-/// installer, leaving a venv that looks healthy but cannot start. Tray Quit only, since
+/// installer, leaving a venv that looks healthy but cannot start. request_quit only, since
 /// RunEvent::Exit must never block on a dialog nobody can answer.
 fn confirm_quit_during_install(app: &tauri::AppHandle) -> bool {
     use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
@@ -285,6 +285,26 @@ fn show_main_window(app: &tauri::AppHandle) {
     }
 }
 
+/// Confirm, reap the backend, then exit. Always off the caller's thread: the
+/// confirmations block, and neither a tray callback nor the window event loop
+/// may. Exiting before the tree is reaped would orphan the backend.
+fn request_quit(app: &tauri::AppHandle) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        if !confirm_quit_during_install(&app) {
+            return;
+        }
+        if !confirm_quit_during_update(&app) {
+            return;
+        }
+        if !confirm_quit_during_training(&app) {
+            return;
+        }
+        cleanup_child_processes(&app);
+        app.exit(0);
+    });
+}
+
 fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let open = MenuItemBuilder::with_id("open", "Open Unsloth").build(app)?;
     let toggle = MenuItemBuilder::with_id("toggle", "Start/Stop Server").build(app)?;
@@ -302,26 +322,7 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             "toggle" => {
                 let _ = app.emit("tray-toggle-server", ());
             }
-            "quit" => {
-                // Run cleanup off the menu callback, but only exit after the
-                // backend tree has been reaped. Exiting first can terminate this
-                // process while a detached cleanup thread is still waiting,
-                // leaving the backend orphaned.
-                let app_handle = app.clone();
-                std::thread::spawn(move || {
-                    if !confirm_quit_during_install(&app_handle) {
-                        return;
-                    }
-                    if !confirm_quit_during_update(&app_handle) {
-                        return;
-                    }
-                    if !confirm_quit_during_training(&app_handle) {
-                        return;
-                    }
-                    cleanup_child_processes(&app_handle);
-                    app_handle.exit(0);
-                });
-            }
+            "quit" => request_quit(app),
             _ => {}
         })
         .on_tray_icon_event(|tray, event| {
@@ -436,14 +437,18 @@ fn main() {
                     .note_dropped_paths(paths);
             }
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                // Hide window instead of closing, because this is a tray app.
-                // Processes keep running so the backend stays available.
-                // Full cleanup happens via:
-                //   - Tray "Quit" menu item (explicit user action)
-                //   - The Unix termination signal listener (logout, kill, Ctrl-C)
-                //   - RunEvent::Exit, for framework-driven exits
-                let _ = window.hide();
+                // Never close directly: both paths below need the window alive,
+                // one to reopen from the tray, the other to parent a dialog.
                 api.prevent_close();
+                if cfg!(target_os = "macos") {
+                    // Closing a window leaves the app in the Dock; Reopen restores it.
+                    let _ = window.hide();
+                } else {
+                    // Elsewhere the close button means quit, so take the same
+                    // guarded path as the tray item rather than hiding a process
+                    // tree the user believes they just closed.
+                    request_quit(window.app_handle());
+                }
             }
         })
         .build(tauri::generate_context!())

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -32,11 +32,10 @@ use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent}
 use tauri::{Emitter, Manager};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
-/// Serializes the exit paths that must reap the backend: `request_quit` (the tray
-/// "Quit" item and, outside macOS, the window close button), the Unix termination
-/// signal listener, and `RunEvent::Exit`. Exactly one path
-/// runs cleanup; the others block until it is done, so the process never exits
-/// out from under a cleanup that is still killing the backend tree.
+/// Serializes the exit paths that must reap the backend: `request_quit` (tray "Quit"
+/// and, outside macOS, the close button), the Unix signal listener, and `RunEvent::Exit`.
+/// Exactly one runs cleanup; the others block until it is done, so the process never
+/// exits out from under a cleanup that is still killing the backend tree.
 static TERMINATION_CLEANUP: Once = Once::new();
 
 #[tauri::command]
@@ -287,14 +286,12 @@ fn show_main_window(app: &tauri::AppHandle) {
     }
 }
 
-/// One quit confirmation at a time. The dialogs are shown asynchronously and are
-/// not parented to the window, so the window stays clickable while one is up;
-/// without this, every further press of a close button that now means "quit"
-/// would stack another dialog on another thread.
+/// One quit confirmation at a time. The dialogs are async and not parented to the
+/// window, so without this every further close-button press would stack another one.
 static QUIT_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
-/// Clears the flag on cancel and on panic alike, so a quit that unwinds cannot
-/// leave the close button inert for the rest of the session.
+/// Clears the flag on cancel and on panic alike, so an unwinding quit cannot leave
+/// the close button inert for the rest of the session.
 struct QuitGuard;
 
 impl Drop for QuitGuard {
@@ -307,17 +304,16 @@ fn begin_quit() -> Option<QuitGuard> {
     (!QUIT_IN_PROGRESS.swap(true, Ordering::SeqCst)).then_some(QuitGuard)
 }
 
-/// Confirm, reap the backend, then exit. Always off the caller's thread: the
-/// confirmations block, and neither a tray callback nor the window event loop
-/// may. Exiting before the tree is reaped would orphan the backend.
+/// Confirm, reap the backend, then exit. Always off the caller's thread: the confirmations
+/// block, and neither a tray callback nor the window event loop may. Exiting before the
+/// tree is reaped would orphan the backend.
 fn request_quit(app: &tauri::AppHandle) {
     let Some(guard) = begin_quit() else {
         info!("Quit already awaiting confirmation, ignoring the repeat request");
         return;
     };
     let app = app.clone();
-    // The guard moves into the closure, so a failed spawn drops it and the next
-    // request retries rather than finding the quit path permanently closed.
+    // The guard moves into the closure, so a failed spawn drops it and the next request retries.
     let spawned = std::thread::Builder::new()
         .name("request-quit".to_string())
         .spawn(move || {
@@ -471,17 +467,15 @@ fn main() {
                     .note_dropped_paths(paths);
             }
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                // Never close directly. This is the only window, so closing it would
-                // drive the app to exit before the backend has been reaped; macOS
-                // additionally needs it alive to reopen from the tray or the Dock.
+                // Never close directly: this is the only window, so closing it would exit
+                // before the backend is reaped, and macOS needs it alive to reopen.
                 api.prevent_close();
                 if cfg!(target_os = "macos") {
                     // Closing a window leaves the app in the Dock; Reopen restores it.
                     let _ = window.hide();
                 } else {
-                    // Elsewhere the close button means quit, so take the same
-                    // guarded path as the tray item rather than hiding a process
-                    // tree the user believes they just closed.
+                    // Elsewhere the close button means quit: same guarded path as the tray
+                    // item, rather than hiding a tree the user believes they just closed.
                     request_quit(window.app_handle());
                 }
             }
@@ -509,8 +503,7 @@ fn main() {
 mod tests {
     use super::*;
 
-    // One test rather than three: `QUIT_IN_PROGRESS` is process-global and cargo
-    // runs tests on parallel threads.
+    // One test, not three: `QUIT_IN_PROGRESS` is process-global and cargo tests run in parallel.
     #[test]
     fn quit_guard_admits_one_quit_and_always_re_arms() {
         assert!(!QUIT_IN_PROGRESS.load(Ordering::SeqCst));

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -32,10 +32,9 @@ use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent}
 use tauri::{Emitter, Manager};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
-/// Serializes the exit paths that must reap the backend: `request_quit` (tray "Quit"
-/// and, outside macOS, the close button), the Unix signal listener, and `RunEvent::Exit`.
-/// Exactly one runs cleanup; the others block until it is done, so the process never
-/// exits out from under a cleanup that is still killing the backend tree.
+/// Serializes the exit paths that reap the backend: `request_quit` (tray "Quit" and,
+/// outside macOS, the close button), the Unix signal listener, and `RunEvent::Exit`.
+/// Exactly one runs cleanup; the others block, so the process never exits mid-reap.
 static TERMINATION_CLEANUP: Once = Once::new();
 
 #[tauri::command]
@@ -133,10 +132,9 @@ fn confirm_quit_during_training(app: &tauri::AppHandle) -> bool {
         .blocking_show()
 }
 
-/// Two more states only the renderer knows about, mirrored here for the same reason: Hub
-/// downloads, which the backend runs but only the frontend download manager tracks, and the
-/// Tauri shell self-update, which `update::is_update_running` stops covering the moment
-/// `downloadAndInstall` takes over from `start_backend_update`.
+/// Renderer-only activity, mirrored here for the same reason: Hub downloads, which the
+/// backend runs but only the frontend tracks, and the Tauri shell self-update, which
+/// `update::is_update_running` stops covering once `downloadAndInstall` takes over.
 #[derive(Default)]
 pub struct RendererActivity {
     pub downloads: bool,
@@ -149,7 +147,7 @@ fn new_renderer_activity_state() -> RendererActivityState {
     std::sync::Arc::new(std::sync::Mutex::new(RendererActivity::default()))
 }
 
-/// The command body, minus the `tauri::State` wrapper, so the tests can drive it directly.
+/// The command body without the `tauri::State` wrapper, so tests can drive it directly.
 fn apply_renderer_activity(state: &RendererActivityState, kind: &str, active: bool) {
     if let Ok(mut activity) = state.lock() {
         match kind {
@@ -375,12 +373,11 @@ fn show_main_window(app: &tauri::AppHandle) {
     }
 }
 
-/// One quit confirmation at a time. The dialogs are async and not parented to the
-/// window, so without this every further close-button press would stack another one.
+/// One quit confirmation at a time: the dialogs are unparented, so repeat close
+/// presses would stack another one.
 static QUIT_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
-/// Clears the flag on cancel and on panic alike, so an unwinding quit cannot leave
-/// the close button inert for the rest of the session.
+/// Clears the flag on cancel or panic, so a quit cannot leave the close button inert.
 struct QuitGuard;
 
 impl Drop for QuitGuard {
@@ -393,9 +390,8 @@ fn begin_quit() -> Option<QuitGuard> {
     (!QUIT_IN_PROGRESS.swap(true, Ordering::SeqCst)).then_some(QuitGuard)
 }
 
-/// Confirm, reap the backend, then exit. Always off the caller's thread: the confirmations
-/// block, and neither a tray callback nor the window event loop may. Exiting before the
-/// tree is reaped would orphan the backend.
+/// Confirm, reap the backend, then exit. Off the caller's thread because the confirmations
+/// block, and never exit first: that would orphan the backend tree.
 fn request_quit(app: &tauri::AppHandle) {
     let Some(guard) = begin_quit() else {
         info!("Quit already awaiting confirmation, ignoring the repeat request");
@@ -564,15 +560,14 @@ fn main() {
                     .note_dropped_paths(paths);
             }
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                // Never close directly: this is the only window, so closing it would exit
-                // before the backend is reaped, and macOS needs it alive to reopen.
+                // Never close directly: the only window, so closing exits before the reap.
                 api.prevent_close();
                 if cfg!(target_os = "macos") {
                     // Closing a window leaves the app in the Dock; Reopen restores it.
                     let _ = window.hide();
                 } else {
-                    // Elsewhere the close button means quit: same guarded path as the tray
-                    // item, rather than hiding a tree the user believes they just closed.
+                    // Elsewhere the close button means quit, not hiding what the user
+                    // believes they just closed.
                     request_quit(window.app_handle());
                 }
             }

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -25,14 +25,16 @@ use simplelog::{
     CombinedLogger, Config, LevelFilter, SharedLogger, TermLogger, TerminalMode, WriteLogger,
 };
 use std::fs;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Manager};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
-/// Serializes the exit paths that must reap the backend: the tray "Quit" item,
-/// the Unix termination signal listener, and `RunEvent::Exit`. Exactly one path
+/// Serializes the exit paths that must reap the backend: `request_quit` (the tray
+/// "Quit" item and, outside macOS, the window close button), the Unix termination
+/// signal listener, and `RunEvent::Exit`. Exactly one path
 /// runs cleanup; the others block until it is done, so the process never exits
 /// out from under a cleanup that is still killing the backend tree.
 static TERMINATION_CLEANUP: Once = Once::new();
@@ -285,24 +287,56 @@ fn show_main_window(app: &tauri::AppHandle) {
     }
 }
 
+/// One quit confirmation at a time. The dialogs are shown asynchronously and are
+/// not parented to the window, so the window stays clickable while one is up;
+/// without this, every further press of a close button that now means "quit"
+/// would stack another dialog on another thread.
+static QUIT_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Clears the flag on cancel and on panic alike, so a quit that unwinds cannot
+/// leave the close button inert for the rest of the session.
+struct QuitGuard;
+
+impl Drop for QuitGuard {
+    fn drop(&mut self) {
+        QUIT_IN_PROGRESS.store(false, Ordering::SeqCst);
+    }
+}
+
+fn begin_quit() -> Option<QuitGuard> {
+    (!QUIT_IN_PROGRESS.swap(true, Ordering::SeqCst)).then_some(QuitGuard)
+}
+
 /// Confirm, reap the backend, then exit. Always off the caller's thread: the
 /// confirmations block, and neither a tray callback nor the window event loop
 /// may. Exiting before the tree is reaped would orphan the backend.
 fn request_quit(app: &tauri::AppHandle) {
+    let Some(guard) = begin_quit() else {
+        info!("Quit already awaiting confirmation, ignoring the repeat request");
+        return;
+    };
     let app = app.clone();
-    std::thread::spawn(move || {
-        if !confirm_quit_during_install(&app) {
-            return;
-        }
-        if !confirm_quit_during_update(&app) {
-            return;
-        }
-        if !confirm_quit_during_training(&app) {
-            return;
-        }
-        cleanup_child_processes(&app);
-        app.exit(0);
-    });
+    // The guard moves into the closure, so a failed spawn drops it and the next
+    // request retries rather than finding the quit path permanently closed.
+    let spawned = std::thread::Builder::new()
+        .name("request-quit".to_string())
+        .spawn(move || {
+            let _guard = guard;
+            if !confirm_quit_during_install(&app) {
+                return;
+            }
+            if !confirm_quit_during_update(&app) {
+                return;
+            }
+            if !confirm_quit_during_training(&app) {
+                return;
+            }
+            cleanup_child_processes(&app);
+            app.exit(0);
+        });
+    if let Err(error) = spawned {
+        warn!("Could not spawn the quit thread: {error}");
+    }
 }
 
 fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
@@ -437,8 +471,9 @@ fn main() {
                     .note_dropped_paths(paths);
             }
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                // Never close directly: both paths below need the window alive,
-                // one to reopen from the tray, the other to parent a dialog.
+                // Never close directly. This is the only window, so closing it would
+                // drive the app to exit before the backend has been reaped; macOS
+                // additionally needs it alive to reopen from the tray or the Dock.
                 api.prevent_close();
                 if cfg!(target_os = "macos") {
                     // Closing a window leaves the app in the Dock; Reopen restores it.
@@ -468,4 +503,39 @@ fn main() {
             }
             _ => {}
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // One test rather than three: `QUIT_IN_PROGRESS` is process-global and cargo
+    // runs tests on parallel threads.
+    #[test]
+    fn quit_guard_admits_one_quit_and_always_re_arms() {
+        assert!(!QUIT_IN_PROGRESS.load(Ordering::SeqCst));
+
+        {
+            let _first = begin_quit().expect("the first quit must be admitted");
+            assert!(
+                begin_quit().is_none(),
+                "a repeat close must not stack a second confirmation"
+            );
+        }
+
+        // Cancelling drops the guard, which re-arms the close button.
+        {
+            let _second = begin_quit().expect("cancelling must re-arm the close button");
+        }
+
+        let unwound = std::panic::catch_unwind(|| {
+            let _guard = begin_quit().expect("admitted");
+            panic!("quit thread unwound");
+        });
+        assert!(unwound.is_err());
+        assert!(
+            begin_quit().is_some(),
+            "a panicking quit must release the guard"
+        );
+    }
 }

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -133,6 +133,95 @@ fn confirm_quit_during_training(app: &tauri::AppHandle) -> bool {
         .blocking_show()
 }
 
+/// Two more states only the renderer knows about, mirrored here for the same reason: Hub
+/// downloads, which the backend runs but only the frontend download manager tracks, and the
+/// Tauri shell self-update, which `update::is_update_running` stops covering the moment
+/// `downloadAndInstall` takes over from `start_backend_update`.
+#[derive(Default)]
+pub struct RendererActivity {
+    pub downloads: bool,
+    pub shell_update: bool,
+}
+
+pub type RendererActivityState = std::sync::Arc<std::sync::Mutex<RendererActivity>>;
+
+fn new_renderer_activity_state() -> RendererActivityState {
+    std::sync::Arc::new(std::sync::Mutex::new(RendererActivity::default()))
+}
+
+/// The command body, minus the `tauri::State` wrapper, so the tests can drive it directly.
+fn apply_renderer_activity(state: &RendererActivityState, kind: &str, active: bool) {
+    if let Ok(mut activity) = state.lock() {
+        match kind {
+            "downloads" => activity.downloads = active,
+            "shell_update" => activity.shell_update = active,
+            // An unknown kind is a renderer/Rust mismatch, never a reason to flip a flag.
+            _ => {}
+        }
+    }
+}
+
+#[tauri::command]
+fn set_renderer_activity(state: tauri::State<'_, RendererActivityState>, kind: &str, active: bool) {
+    apply_renderer_activity(state.inner(), kind, active);
+}
+
+/// Ask before quitting mid shell update (true to proceed). request_quit only, as below.
+fn confirm_quit_during_shell_update(app: &tauri::AppHandle) -> bool {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+
+    let Some(state) = app.try_state::<RendererActivityState>() else {
+        return true;
+    };
+    if !state
+        .lock()
+        .map(|activity| activity.shell_update)
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    app.dialog()
+        .message(
+            "The app update is still installing. Quitting now interrupts the \
+             installer part-way and can leave the app half-updated.",
+        )
+        .kind(MessageDialogKind::Warning)
+        .title("Update in progress")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Quit anyway".to_string(),
+            "Keep updating".to_string(),
+        ))
+        .blocking_show()
+}
+
+/// Ask before quitting mid-download (true to proceed). request_quit only, as below.
+fn confirm_quit_during_downloads(app: &tauri::AppHandle) -> bool {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+
+    let Some(state) = app.try_state::<RendererActivityState>() else {
+        return true;
+    };
+    if !state
+        .lock()
+        .map(|activity| activity.downloads)
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    app.dialog()
+        .message(
+            "Downloads are still running. Quitting now stops the backend and \
+             cancels the downloads in progress.",
+        )
+        .kind(MessageDialogKind::Warning)
+        .title("Downloads in progress")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Quit anyway".to_string(),
+            "Keep downloading".to_string(),
+        ))
+        .blocking_show()
+}
+
 /// Ask before quitting mid-install (true to proceed): `cleanup_child_processes` SIGTERMs the
 /// installer, leaving a venv that looks healthy but cannot start. request_quit only, since
 /// RunEvent::Exit must never block on a dialog nobody can answer.
@@ -324,7 +413,13 @@ fn request_quit(app: &tauri::AppHandle) {
             if !confirm_quit_during_update(&app) {
                 return;
             }
+            if !confirm_quit_during_shell_update(&app) {
+                return;
+            }
             if !confirm_quit_during_training(&app) {
+                return;
+            }
+            if !confirm_quit_during_downloads(&app) {
                 return;
             }
             cleanup_child_processes(&app);
@@ -400,12 +495,14 @@ fn main() {
         .manage(diagnostics::new_diagnostics_state())
         .manage(install::new_install_state())
         .manage(new_training_activity_state())
+        .manage(new_renderer_activity_state())
         .manage(native_intents::new_native_intake_state())
         .manage(new_backend_state())
         .manage(process::new_shutdown_flag())
         .manage(update::new_update_state())
         .invoke_handler(tauri::generate_handler![
             set_training_active,
+            set_renderer_activity,
             app_layout::has_initialized_app_window_layout,
             app_layout::mark_app_window_layout_initialized,
             app_layout::reset_app_window_layout_initialized,
@@ -530,5 +627,51 @@ mod tests {
             begin_quit().is_some(),
             "a panicking quit must release the guard"
         );
+    }
+
+    fn renderer_activity(state: &RendererActivityState) -> (bool, bool) {
+        let activity = state.lock().expect("the activity mutex must not be poisoned");
+        (activity.downloads, activity.shell_update)
+    }
+
+    #[test]
+    fn renderer_activity_starts_clear_and_round_trips_each_kind() {
+        let state = new_renderer_activity_state();
+        assert_eq!(renderer_activity(&state), (false, false));
+
+        apply_renderer_activity(&state, "downloads", true);
+        assert_eq!(renderer_activity(&state), (true, false));
+        apply_renderer_activity(&state, "downloads", false);
+        assert_eq!(renderer_activity(&state), (false, false));
+
+        apply_renderer_activity(&state, "shell_update", true);
+        assert_eq!(renderer_activity(&state), (false, true));
+        apply_renderer_activity(&state, "shell_update", false);
+        assert_eq!(renderer_activity(&state), (false, false));
+    }
+
+    #[test]
+    fn renderer_activity_kinds_are_independent() {
+        let state = new_renderer_activity_state();
+
+        apply_renderer_activity(&state, "downloads", true);
+        apply_renderer_activity(&state, "shell_update", true);
+        assert_eq!(renderer_activity(&state), (true, true));
+
+        // Downloads finishing must not clear an update that is still installing.
+        apply_renderer_activity(&state, "downloads", false);
+        assert_eq!(renderer_activity(&state), (false, true));
+    }
+
+    #[test]
+    fn renderer_activity_ignores_an_unknown_kind() {
+        let state = new_renderer_activity_state();
+        apply_renderer_activity(&state, "shell_update", true);
+
+        // A renderer/Rust mismatch must never flip a flag it did not name.
+        apply_renderer_activity(&state, "training", true);
+        apply_renderer_activity(&state, "", false);
+        apply_renderer_activity(&state, "Downloads", true);
+        assert_eq!(renderer_activity(&state), (false, true));
     }
 }


### PR DESCRIPTION
## Problem

`CloseRequested` in `main.rs` hid the window and prevented the close on **every** platform, with no `cfg` gate:

```rust
// Hide window instead of closing, because this is a tray app.
let _ = window.hide();
api.prevent_close();
```

That is the macOS convention. Closing a window there leaves the app in the Dock, and the `RunEvent::Reopen` handler right below already exists to bring it back.

On Windows and Linux the close button means quit. So the app silently turned into a tray process: the window vanished, `unsloth.exe`, `python.exe` and the WebView2 tree kept running, and Task Manager was the only thing that said so. This is what a "closing the app leaves processes running" report actually looks like from the user's side, and calling it a leak is fair.

## Fix

Keep hide-on-close for macOS. Everywhere else, quit.

The quit goes through the same guarded path as the tray "Quit" item, not a bare close, because that path asks first when something is in flight:

- `confirm_quit_during_install` - `cleanup_child_processes` SIGTERMs the installer, leaving a venv that looks healthy but cannot start
- `confirm_quit_during_update`
- `confirm_quit_during_training` - "Quitting now stops the run and the progress since the last checkpoint is lost"
- `confirm_quit_during_downloads` - Hub downloads run in the backend that cleanup reaps
- `confirm_quit_during_shell_update` - the Tauri shell installer, which takes over once `update::is_update_running` has already gone false

Without that, closing the window mid-training would have killed the run with no prompt, which would be a worse bug than the one being fixed.

The last two are state only the renderer has, so they are mirrored into Rust through `set_renderer_activity` the way training runs already are. Downloads count external jobs as well: the STT sidecars that own those are reached through the backend, so a quit stops those transfers too.

That sequence moved out of the tray callback into `request_quit`, since it now has two callers and both must keep the blocking confirmations off their own thread. The tray arm collapses to `"quit" => request_quit(app)`.

The close stays prevented in both branches. This is the only window, so letting it close would drive the app to exit before the backend has been reaped, which is exactly the orphan being fixed; macOS additionally needs it alive to reopen. `app.exit(0)` after cleanup drives the real exit, so `RunEvent::Exit` and the `TERMINATION_CLEANUP` `Once` are unchanged.

`request_quit` also takes a flag before it spawns, so only one confirmation can be up at a time. `tauri-plugin-dialog` shows these asynchronously and none of them is parented to the window, so the window stays clickable while a dialog is open; without the flag, pressing a close button that now means quit would stack another dialog on another thread. The flag is released from a `Drop` guard, so cancelling or panicking still re-arms the button, and the guard moves into the closure so a failed spawn re-arms it too.

## Behaviour change

On Windows and Linux, closing the window now stops the backend. Previously it kept serving, which is why the tray has a Start/Stop Server item. Anyone who wants the server to outlive the window can leave the window open, or run `unsloth studio` from the CLI, which is a separate process the desktop app does not own.

Worth deciding explicitly rather than inheriting: apps that do stay resident on Windows (Slack, Teams, Discord) either ask on first close or expose a "close to tray" preference, and they show a balloon so the user knows where the app went. Doing none of those and hiding silently is the one option that is clearly wrong. This PR takes the plain platform default; a preference could be layered on later if the resident-server workflow turns out to matter.

## Not verified

`cargo test` on Linux is green: 126 passed, 0 failed, including a new test that the quit flag admits one quit and always re-arms, on cancel and on panic, and three covering the renderer activity mirror. `cargo test` also runs on macOS and Windows on a staging replica of this branch. Frontend: `tsc -b` clean, 436 tests pass. No test or doc asserted the old hide-on-close behaviour.

What no CI here can reach is the real thing: that closing the window on real Windows takes the whole process tree with it. That needs a signed desktop build and a human.

Two known limits, both pre-existing and left alone. `cleanup_child_processes` discards the result of each stop, and `stop_adopted_backend` refuses to stop a backend whose ownership it cannot verify, so a backend the app adopted rather than spawned can survive a confirmed quit.

Two gaps stay open on purpose. An elevated Linux `apt` install never sets `install.child`, so it is not confirmed on, but it is also never reaped: `elevated_command` runs it outside everything cleanup touches, so the transaction completes and only the warning is missing. And the chat store persists settings on a 400ms trailing-edge debounce flushed from `beforeunload`, which a Tauri quit never fires; unlike the two above, closing that needs the quit path to signal the renderer and wait for a bounded acknowledgement, which belongs in its own change rather than inside a behaviour switch.


