### PR TITLE
Tauri smoke: stop uploading the whole target/debug tree (350GB of artifacts)

### DIFF
--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -127,12 +127,23 @@ jobs:
           du -h "$BIN"
 
       - name: Upload Tauri debug build
-        # Always upload so a green run leaves the binary inspectable too.
-        if: always()
+        # Failures only, and only the binary -- never the whole target/debug
+        # tree. That directory is ~1.3GB per run: the 405MB unstripped binary
+        # plus deps/, build/ and incremental/ intermediates that are useless
+        # without the exact toolchain that produced them. Uploading it on every
+        # run accumulated ~350GB of live artifacts, which is two orders of
+        # magnitude past the org allowance. Actions storage is the one resource
+        # that is NOT free on public repos, and exceeding it silently stops
+        # GitHub scheduling jobs across the whole account -- no error, nothing
+        # runs. A green run does not need its binary kept; a red one does.
+        if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: tauri-debug-build
           path: |
-            studio/src-tauri/target/debug
+            studio/src-tauri/target/debug/unsloth-studio
             studio/frontend/dist
-          retention-days: 3
+          # The build can fail before the binary exists; still upload the
+          # frontend dist rather than failing the upload itself.
+          if-no-files-found: warn
+          retention-days: 1


### PR DESCRIPTION
## Why

Actions scheduling stalled org-wide today: `unslothai/unsloth` and `unslothai/unsloth-zoo` accepted workflow runs, queued them, and never scheduled a single job. No error surfaced, GitHub's status page stayed green, and the queue was repeatedly emptied without effect.

The cause is Actions **artifact storage**, not compute. Storage is the one Actions resource that is not free on public repositories, and exceeding the account allowance silently halts job scheduling.

Measured across `unslothai/unsloth` (25,672 unexpired artifacts, ~360 GB live):

| artifact | count | GB |
|---|---:|---:|
| **tauri-debug-build** | **264** | **349.96** |
| studio-frontend-dist | 100 | 3.55 |
| studio-ui-smoke-artifacts | 668 | 2.45 |
| mac-studio-ui-smoke-artifacts | 699 | 1.80 |
| windows-studio-ui-smoke-artifacts | 686 | 1.71 |
| desktop-release-* | 6 | 0.56 |
| everything else (~23,000) | | 0.03 |

`tauri-debug-build` alone is 97% of it, at ~1.3 GB per run.

## What was wrong

The upload took the entire Cargo debug target directory:

```yaml
path: |
  studio/src-tauri/target/debug     # whole tree
  studio/frontend/dist
```

`studio/src-tauri/target/debug` is not just the binary. From a recent run's own `du -h`, the binary is **405 MB** (unstripped, with debug_info); the remaining ~925 MB is `deps/`, `build/`, `incremental/` and `.fingerprint/` — intermediates that are unusable without the exact toolchain that produced them.

Combined with `if: always()`, every green run also persisted 1.3 GB. `retention-days: 3` did not bound this: at this workflow's trigger rate (`pull_request` on `studio/**` plus `push` to main/pip), three days of successful runs is enough to accumulate hundreds of GB.

## Change

- Upload only `studio/src-tauri/target/debug/unsloth-studio` (the binary named in `Cargo.toml`), not the tree.
- `if: always()` -> `if: failure()`. A green run does not need its binary retained; a failing one does, which is the diagnostic case the step exists for.
- `if-no-files-found: warn` so the upload still succeeds when the build failed before producing a binary.
- `retention-days: 3` -> `1`.

Steady-state storage from this workflow goes from ~1.3 GB per run to zero, with ~440 MB retained for one day only when the job actually fails.

## Scope

One file, one step. The build, the Rust unit tests, and the "Inspect produced binary" check are untouched, so the workflow's actual coverage is unchanged. `studio-tauri-smoke.yml` is the only workflow in the repo that uploads a `target/` directory (verified by grep across `.github/workflows/`).

## Test plan

- [x] YAML parses; job `linux-debug-build` intact
- [x] Upload step resolves to `if: failure()`, `retention-days: 1`, `if-no-files-found: warn`
- [x] Binary path matches `name = "unsloth-studio"` in `studio/src-tauri/Cargo.toml`, and the path a real run reported (`studio/src-tauri/target/debug/unsloth-studio`)
- [ ] Confirm on a failing run that the artifact still contains the binary
- [ ] Confirm a green run uploads nothing

## Follow-up (not in this PR)

The existing ~350 GB of `tauri-debug-build` artifacts still has to be deleted; retention changes are not retroactive, so nothing frees on its own. The four `*-ui-smoke-artifacts` / `studio-frontend-dist` families (~9.5 GB) are worth a similar look, since they are also CI scratch retained from green runs.
