### PR TITLE
Fix the Windows-only snapshot path assertion in the diffusion prefetch test

### DIFF
--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -14,6 +14,7 @@ import contextlib
 import sys
 import threading
 import types
+from pathlib import Path
 
 import pytest
 
@@ -3448,7 +3449,9 @@ def test_prefetch_returns_snapshot_dir_for_manifest(monkeypatch):
     root = backend._prefetch_files(
         "base/repo", None, "base/repo", ["model_index.json", "vae/x.safetensors"], None
     )
-    assert root == "/cache/snap"
+    # str(Path(...).parent), so the separator is the platform's: '/cache/snap' on POSIX and
+    # '\cache\snap' on Windows. Comparing against the literal passed everywhere but Windows.
+    assert root == str(Path("/cache/snap"))
     assert (
         backend._prefetch_files("base/repo", None, "base/repo", ["vae/x.safetensors"], None) is None
     )

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -3449,8 +3449,7 @@ def test_prefetch_returns_snapshot_dir_for_manifest(monkeypatch):
     root = backend._prefetch_files(
         "base/repo", None, "base/repo", ["model_index.json", "vae/x.safetensors"], None
     )
-    # str(Path(...).parent), so the separator is the platform's: '/cache/snap' on POSIX and
-    # '\cache\snap' on Windows. Comparing against the literal passed everywhere but Windows.
+    # str(Path(...).parent) uses the platform separator, so the bare literal failed on Windows.
     assert root == str(Path("/cache/snap"))
     assert (
         backend._prefetch_files("base/repo", None, "base/repo", ["vae/x.safetensors"], None) is None


### PR DESCRIPTION
`test_prefetch_returns_snapshot_dir_for_manifest` fails on Windows, on `main`:

```
studio\backend\tests\test_diffusion_backend.py:3754: in test_prefetch_returns_snapshot_dir_for_manifest
    assert root == "/cache/snap"
E   AssertionError: assert '\\cache\\snap' == '/cache/snap'
```

`_prefetch_files` returns `str(Path(local).parent)`, so the separator is whatever the platform uses. The assertion compared against a hardcoded POSIX literal, which holds everywhere except Windows:

```python
>>> str(PureWindowsPath("/cache/snap/model_index.json").parent)
'\\cache\\snap'
```

The line under test is unchanged, so this is pre-existing rather than a regression. It had not been reported because these tests `importorskip` on torch and the Windows CI job was skipping them; a staging run that installed torch made them execute and the assertion surfaced immediately.

Comparing against `str(Path("/cache/snap"))` is correct on every platform: identical on POSIX, and the Windows form on Windows.

Test-only change, one file.
