### PR TITLE
Fake the Windows blocklist in the mangled-switch test so it runs off Windows

### DIFF
--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -284,10 +284,17 @@ def test_notes_say_where_commands_run(monkeypatch):
         r'cmd //c start /d C:/tmp "" powershell -Command ls',
     ],
 )
-def test_cmd_shellout_is_screened_through_mangled_switches(command):
+def test_cmd_shellout_is_screened_through_mangled_switches(monkeypatch, command):
     # Git Bash turns a lone /c into a path, so a model writes //c. That spelling
     # skipped the nested scan, making `cmd //c powershell` reachable where
     # `cmd /c powershell` was blocked, and `start` launches its argument too.
+    # _BLOCKED_COMMANDS resolves the Windows names at import, so patching
+    # sys.platform is too late; fake the resolved set instead.
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
     assert tools._find_blocked_commands(command)
 
 


### PR DESCRIPTION
`test_cmd_shellout_is_screened_through_mangled_switches` fails on every non-Windows host, so Backend CI has been red on main since `a36bf3f6`. All four Python jobs fail with seven cases like:

```
FAILED studio/backend/tests/test_windows_bash_shell.py::test_cmd_shellout_is_screened_through_mangled_switches[cmd //c powershell -Command ls]
AssertionError: assert set()
```

The screening logic is correct. `_BLOCKED_COMMANDS` folds in `_BLOCKED_COMMANDS_WIN` (which holds `powershell` and `pwsh`) only when `sys.platform == "win32"`, and that is resolved at import:

```python
_BLOCKED_COMMANDS = (
    _BLOCKED_COMMANDS_COMMON | _BLOCKED_COMMANDS_WIN
    if sys.platform == "win32"
    else _BLOCKED_COMMANDS_COMMON
)
```

So off Windows the payload in every case is simply not a blocked name and `_find_blocked_commands` correctly returns an empty set. The switch parsing itself is platform independent: with a payload blocked everywhere, all seven spellings are caught on Linux today.

```
{'curl'} cmd /c curl x
{'curl'} cmd //c curl x
{'curl'} cmd //k curl x
{'curl'} cmd //c start "" curl x
{'curl'} cmd //c start /b "" curl x
{'curl'} cmd //c start //min "" curl x
{'curl'} cmd //c start /d C:/tmp "" curl x
```

This file's docstring already says its tests "run on every OS by faking the platform, because studio-backend-ci is Linux-only", and its siblings do exactly that. This one could not, because patching `sys.platform` is too late for a constant resolved at import, so it fakes the resolved set instead.

The test keeps its teeth: it still requires the `//c`, `//k` and `start` screening to find the payload, and reverting the fake makes all seven fail again.

Checked: `test_windows_bash_shell.py` 37 passed, 1 skipped.
