### PR TITLE
Screen the program a Windows start command launches behind its title

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -350,6 +350,13 @@ _SED_SCAN_BUDGET = 200_000
 # Wrappers may sit between `find -exec` and the command it runs; bounded so a
 # line padded with `-exec env -exec env ...` cannot make the scan quadratic.
 _MAX_EXEC_PREFIX_SCAN = 32
+# Words the cmd-grammar scans may read across ONE command line, shared by all of
+# them. Every `cmd /c` begins a command line of its own, so `cmd /c cmd /c ...`
+# reads the tail once per level and the work is quadratic in what the model
+# wrote; this runs before the command does, so the wait is the caller's. Ten
+# times the words any real line holds, and a chain long enough to spend it is
+# refused rather than half-read.
+_CMD_GRAMMAR_BUDGET = 20_000
 # First window tried when balancing a `$(...)`, quadrupled until the span closes
 # (_substitution_span), so a line of many short substitutions stays linear.
 _SUBSTITUTION_SPAN_STEP = 64
@@ -1173,10 +1180,28 @@ def _unquoted_glob_indexes(text: str, tokens: "list[str]", punctuation: str) -> 
     )
 
 
-def _skip_start_switches(tokens: "list[str]", index: int) -> int:
-    """The first index at or after ``index`` that is not one of `start`'s switches."""
+def _skip_start_switches(
+    tokens: "list[str]",
+    index: int,
+    redirects: "frozenset[int]" = frozenset(),
+) -> int:
+    """The first index at or after ``index`` that is neither one of `start`'s
+    switches nor part of a redirection.
+
+    A redirection is the shell's own syntax and is taken out of the line before
+    the command runs, wherever it was written, so it stands between `start` and
+    its program without being either: `start >nul "" powershell` and `start ""
+    >nul powershell` both launch, and reading the `>nul` as the program left the
+    launch unscreened. Which words those are is the redirection scan's answer,
+    not a second reading of the spelling: `2>&1` is one token to the cmd lexer
+    and three to the POSIX one.
+    """
     while index < len(tokens):
-        switch = _win_switch(tokens[index].lower())
+        token = tokens[index]
+        if index in redirects:
+            index += 1
+            continue
+        switch = _win_switch(token.lower())
         if not _START_SWITCH_RE.fullmatch(switch):
             break
         # /d C:\dir and friends carry their value in the next token.
@@ -1753,7 +1778,15 @@ def _find_blocked_commands(command: str) -> set[str]:
         depth = 0  # open group brackets, which an `if` branch is written in
         skip = 0  # condition words still to consume
         skip_operand = False  # the word after a bare redirection operator
+        nonlocal cmd_grammar_budget, cmd_grammar_spent
         for index in range(begin, len(tokens)):
+            if cmd_grammar_budget <= 0:
+                # Read no further rather than spend the caller's wait on a
+                # chain of command lines; what is left goes unread, so the
+                # caller refuses the line instead of trusting a partial parse.
+                cmd_grammar_spent = True
+                break
+            cmd_grammar_budget -= 1
             token = tokens[index]
             if _looks_like_separator(token):
                 if lexed_posix and index not in quoted_separators:
@@ -2059,15 +2092,26 @@ def _find_blocked_commands(command: str) -> set[str]:
     # `time` is a cmd builtin that shows the clock, and `time start ""
     # powershell` launches nothing.
     cmd_run_indexes: "set[int]" = set()
+    # Words those scans have left to read, and whether one stopped without
+    # finishing. Shared across the whole line: every `cmd /c` begins a command
+    # line of its own, so a chain of them reads the same tail once per level.
+    cmd_grammar_budget = _CMD_GRAMMAR_BUDGET
+    cmd_grammar_spent = False
 
-    def _read_cmd_line(begin: int) -> None:
-        """Collect the words cmd runs in the command line starting at ``begin``."""
+    def _read_cmd_line(begin: int) -> bool:
+        """Collect the words cmd runs in the command line starting at ``begin``.
+
+        Returns whether the grammar budget ran out with words still ahead,
+        which is NOT the same as finding nothing: the rest of that command line
+        was never read, so the caller fails closed on it.
+        """
         for pos, cmd_word in _cmd_command_positions(begin).items():
             cmd_run_indexes.add(pos)
             if cmd_word == "start":
                 start_indexes.add(pos)
             elif cmd_word == "for":
                 cmd_for_indexes.add(pos)
+        return cmd_grammar_spent
 
     def _start_program_index(index: int) -> int:
         """The token the `start` at ``index`` launches, or -1 for none.
@@ -2096,12 +2140,12 @@ def _find_blocked_commands(command: str) -> set[str]:
         if title_tokens is None:
             # Built at most once per call, and only when a start is actually here.
             title_tokens = _start_title_indexes(tokens, lexed_posix)
-        first = _skip_start_switches(tokens, index + 1)
+        first = _skip_start_switches(tokens, index + 1, redirect_indexes)
         if first >= len(tokens):
             return -1
         if first not in title_tokens:
             return first
-        behind = _skip_start_switches(tokens, first + 1)
+        behind = _skip_start_switches(tokens, first + 1, redirect_indexes)
         return behind if behind < len(tokens) else -1
 
     def _cmd_runs_here(index: int) -> bool:
@@ -2121,8 +2165,10 @@ def _find_blocked_commands(command: str) -> set[str]:
             _start_program_index(pos) == index for pos in start_indexes
         )
 
-    if not lexed_posix:
-        _read_cmd_line(0)
+    if not lexed_posix and _read_cmd_line(0) and tokens:
+        # Unreachable on any line a model writes -- one pass costs one word per
+        # word -- but a partial parse is a free pass, so it is not trusted.
+        blocked.add(_token_basename(tokens[0]))
 
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):
     # on a -c/-/c flag, look back for a shell name (skipping flags) and
@@ -2173,8 +2219,12 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # those words, and reading them as a command line refused the
                 # message. Visited left to right, so an outer cmd has already
                 # named the inner one by the time it is reached.
-                if _cmd_runs_here(j):
-                    _read_cmd_line(i + 1)
+                if _cmd_runs_here(j) and _read_cmd_line(i + 1):
+                    # The budget ran out inside this payload, so a launch may
+                    # sit in the part never read: refuse the shell running it
+                    # rather than let `cmd /c cmd /c ...x300` ride in on the
+                    # scan giving up.
+                    blocked.add(prev_base)
             break  # stop at first non-flag token
 
     # `for /f %i in ('CMD') do ...` runs CMD as a child command and reads its

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1219,10 +1219,28 @@ def _start_title_indexes(tokens: "list[str]", lexed_posix: bool) -> "frozenset[i
 
 
 # cmd ends a command word at these whether or not whitespace surrounds them.
-_CMD_OPERATOR_RE = re.compile(r"[&|<>]")
+_CMD_OPERATOR_RE = re.compile(r"(?<!\^)[&|<>]")
 # ...but only these begin another command. `>` redirects into a file, so
 # `echo hi>start powershell` writes to one called start and launches nothing.
-_CMD_SEPARATOR_RE = re.compile(r"[&|]")
+# Microsoft: "The ampersand &, pipe | and parentheses ( ) are special characters
+# that must be preceded by the escape character ^ or quotation marks when you
+# pass them as arguments", so an escaped one is an argument and not a separator.
+_CMD_SEPARATOR_RE = re.compile(r"(?<!\^)[&|]")
+# A URL is opened in the browser rather than run: "any file type that has a
+# registered association, including URLs, which are automatically detected and
+# opened in the default browser" (the start reference), whose own example is
+# `start "Bing" "https://www.bing.com"`.
+_URL_SCHEME_RE = re.compile(r"[a-z][a-z0-9+.\-]*://", re.IGNORECASE)
+
+
+def _strip_cmd_carets(token: str) -> str:
+    """``token`` with cmd's escape character applied, as cmd applies it.
+
+    The caret escapes the character behind it and is dropped, so it hides a
+    name from a plain comparison the way quoting once did: cmd runs
+    `start "" power^shell` as powershell.
+    """
+    return re.sub(r"\^(.)", r"\1", token)
 
 
 def _strip_cmd_quotes(token: str) -> str:
@@ -1261,6 +1279,11 @@ def _blocked_start_program(token: str) -> "set[str]":
     """
     unquoted = _strip_cmd_quotes(token)
     target = unquoted if unquoted is not token else _CMD_OPERATOR_RE.split(token, 1)[0]
+    target = _strip_cmd_carets(target)
+    # A URL goes to the browser, so its host and path are not a program name and
+    # `start "" https://example.com/curl` is not curl.
+    if _URL_SCHEME_RE.match(target):
+        return set()
     base = os.path.basename(target.replace("\\", "/")).lower()
     stem, ext = os.path.splitext(base)
     if ext in {".exe", ".com", ".bat", ".cmd"}:
@@ -1521,9 +1544,13 @@ def _find_blocked_commands(command: str) -> set[str]:
         found at all. cmd reads the operator, so the word after the last one is
         the command.
         """
-        return _token_basename(_CMD_SEPARATOR_RE.split(tokens[index])[-1]) == "start"
+        return _cmd_word_base(_CMD_SEPARATOR_RE.split(tokens[index])[-1]) == "start"
 
-    def _cmd_command_head(index: int) -> int:
+    def _cmd_word_base(word: str) -> str:
+        """``word`` as cmd resolves it: escapes applied, then the plain basename."""
+        return _token_basename(_strip_cmd_carets(word))
+
+    def _cmd_command_head(index: int, after_if: bool = False) -> int:
         """The index of the word cmd runs for the segment beginning at ``index``.
 
         `if` carries out the command after its condition, so the leading word is
@@ -1535,19 +1562,21 @@ def _find_blocked_commands(command: str) -> set[str]:
         parsing further. Missing the optional /i left the comparison itself
         looking like the command.
         """
-        while index < len(tokens) and _token_basename(tokens[index]) == "if":
-            index += 1
+        while after_if or (index < len(tokens) and _cmd_word_base(tokens[index]) == "if"):
+            if not after_if:
+                index += 1
+            after_if = False
             for _ in range(2):  # /i and not, in either order
                 if index >= len(tokens):
                     break
                 # _token_basename would read /i as the path `i`, so the switch is
                 # matched on the raw word, through the Git Bash `//i` spelling.
                 word = tokens[index].lower()
-                if _win_switch(word) == "/i" or _token_basename(word) == "not":
+                if _win_switch(word) == "/i" or _cmd_word_base(word) == "not":
                     index += 1
             if index >= len(tokens):
                 break
-            if _token_basename(tokens[index]) in ("exist", "defined", "errorlevel"):
+            if _cmd_word_base(tokens[index]) in ("exist", "defined", "errorlevel"):
                 index += 2
             else:
                 index += 1  # the `a==b` comparison, which cmd lexes as one word
@@ -1568,9 +1597,9 @@ def _find_blocked_commands(command: str) -> set[str]:
         Under bash the payload ends at the first shell separator, since that
         terminates the cmd invocation rather than starting a new cmd command:
         with `cmd //c echo ok; printf "%s" start "" powershell`, cmd is handed
-        only `echo ok` and the start belongs to printf. An escaped one is the
-        opposite: bash passes it through and cmd reads it as its own separator,
-        so it opens a segment rather than ending the scan.
+        only `echo ok` and the start belongs to printf. An escaped one is passed
+        through instead, and then it depends whose syntax it is: cmd reads `\&`
+        as its own separator and opens a segment, but `\;` is only text to it.
         """
         found: "set[int]" = set()
         head = -1  # index of the word cmd runs for the open segment
@@ -1579,7 +1608,8 @@ def _find_blocked_commands(command: str) -> set[str]:
             if _looks_like_separator(token):
                 if lexed_posix and index not in quoted_separators:
                     break
-                head = -1
+                if _CMD_SEPARATOR_RE.search(token):
+                    head = -1
                 continue
             # A separator with no space around it stays inside the token under
             # the cmd lexer, so it both hides a start and opens a segment:
@@ -1593,7 +1623,15 @@ def _find_blocked_commands(command: str) -> set[str]:
             if (glued or index == head) and _is_cmd_start_word(index):
                 found.add(index)
             if glued:
-                head = index  # the segment after the last separator begins here
+                # The segment after the last separator begins inside this token,
+                # so its head is here -- unless that word is a conditional, whose
+                # command is further along: `cmd /c echo&if exist . start "" pwsh`
+                # left the head pinned to the glued token and missed the launch.
+                head = (
+                    _cmd_command_head(index + 1, after_if = True)
+                    if _cmd_word_base(pieces[-1]) == "if"
+                    else index
+                )
         return found
 
     def _exec_child_index(start: int) -> "tuple[int, bool]":
@@ -1714,7 +1752,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             sed_indexes.append(token_index)
             if xargs_index >= 0:
                 sed_xargs[token_index] = xargs_index
-        if base == "start":
+        if base == "start" and lexed_posix:
             start_indexes.add(token_index)
         if base in _blocked_commands():
             blocked.add(base)
@@ -1854,6 +1892,12 @@ def _find_blocked_commands(command: str) -> set[str]:
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
     title_tokens: "frozenset[int] | None" = None
+    # When cmd is the shell the whole line is its command line, so it is read
+    # with cmd's grammar rather than the POSIX command positions above, which
+    # hand a wrapper's operand to the next word: `time` is a cmd builtin that
+    # shows the clock, and `time start "" powershell` launches nothing.
+    if not lexed_posix:
+        start_indexes |= _cmd_start_positions(0)
     # `start` launches a program in cmd. On a POSIX host it is whatever the user
     # has by that name, its arguments are arguments, and reading them as cmd
     # syntax refused `start "dry run" rm` on Linux and macOS.
@@ -1875,7 +1919,12 @@ def _find_blocked_commands(command: str) -> set[str]:
         # screened itself. Microsoft documents the switches AFTER the title too,
         # so they are skipped on both sides of it: `start "" /min powershell`
         # left the program at j + 2 and screened the switch instead.
-        if j + 1 < len(tokens) and j in title_tokens:
+        if j in title_tokens:
+            # Microsoft writes the syntax as `start <"title"> [switches]
+            # [<command>|<program> [<parameter>...]]`, so the program is
+            # optional and a lone quoted operand is only the title: `start
+            # "powershell"` opens a window with that name and runs nothing,
+            # where screening it as the program refused the word itself.
             k = _skip_start_switches(tokens, j + 1)
             if k < len(tokens):
                 blocked |= _blocked_start_program(tokens[k])

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1245,8 +1245,9 @@ def _cmd_split(token: str, chars: str) -> "list[str]":
 
     Microsoft: "The ampersand &, pipe | and parentheses ( ) are special
     characters that must be preceded by the escape character ^ or quotation
-    marks when you pass them as arguments." The caret escapes whatever follows
-    it and is then dropped, so both halves of that have to be read together and
+    marks when you pass them as arguments." Both halves of that are read here:
+    a quoted one is data, and the caret escapes whatever follows it and is then
+    dropped, so both halves of that have to be read together and
     in one pass: a lookbehind for a single caret cannot tell `ok^&start`, where
     the & is an argument, from `ok^^&start`, where the first caret escapes the
     second and the & still separates two commands. Dropping the caret matters on
@@ -1255,14 +1256,23 @@ def _cmd_split(token: str, chars: str) -> "list[str]":
     """
     pieces: "list[str]" = []
     current: "list[str]" = []
+    quoted = False
     index = 0
     while index < len(token):
         char = token[index]
-        if char == "^" and index + 1 < len(token):
+        if char == "^" and index + 1 < len(token) and not quoted:
             current.append(token[index + 1])  # escaped, so never syntax
             index += 2
             continue
-        if char in chars:
+        if char == '"':
+            # The cmd lexer keeps the quotes, and quoting is the other way cmd
+            # documents for passing these as arguments, so `echo "x&start"`
+            # prints one word rather than running a second command.
+            quoted = not quoted
+            current.append(char)
+            index += 1
+            continue
+        if char in chars and not quoted:
             pieces.append("".join(current))
             current = []
             index += 1

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1218,6 +1218,13 @@ def _start_title_indexes(tokens: "list[str]", lexed_posix: bool) -> "frozenset[i
     )
 
 
+# cmd ends a command word at these whether or not whitespace surrounds them.
+_CMD_OPERATOR_RE = re.compile(r"[&|<>]")
+# cmd commands that take the rest of their segment as text, so a `start` behind
+# one is a word being printed or assigned rather than a program being launched.
+_CMD_TEXT_COMMANDS = frozenset({"echo", "rem", "set", "title", "prompt"})
+
+
 def _strip_cmd_quotes(token: str) -> str:
     """``token`` without the quotes cmd strips before it resolves a program.
 
@@ -1243,8 +1250,14 @@ def _blocked_start_program(token: str) -> "set[str]":
     Backslashes separate here whatever the host is: this only ever reads a
     Windows program, and posixpath leaves `C:\\Windows\\System32\\powershell.exe`
     whole, so the name never matched on the Linux CI that runs these tests.
+
+    A cmd operator glued to the name ends it, since the cmd lexer takes no
+    punctuation_chars and leaves `powershell&` whole where cmd reads an operator
+    and runs powershell. The recursive scan this replaced stripped those, so
+    matching the raw token dropped a name the older code caught.
     """
-    base = os.path.basename(_strip_cmd_quotes(token).replace("\\", "/")).lower()
+    target = _CMD_OPERATOR_RE.split(_strip_cmd_quotes(token), 1)[0]
+    base = os.path.basename(target.replace("\\", "/")).lower()
     stem, ext = os.path.splitext(base)
     if ext in {".exe", ".com", ".bat", ".cmd"}:
         base = stem
@@ -1521,6 +1534,31 @@ def _find_blocked_commands(command: str) -> set[str]:
             base = stem
         return base
 
+    def _cmd_start_positions(begin: int) -> "set[int]":
+        """Indexes of the `start` words that launch a program in the cmd command
+        line running from ``begin`` to the end.
+
+        cmd keeps parsing past its own conditionals and operators, so promoting
+        only the first word missed `cmd //c if exist . start "" powershell`,
+        which cmd runs and which the scan had caught before it was gated. Each
+        segment is read down to its leading word instead, so a start that is an
+        argument of one that takes text stays an argument: `cmd //c echo start
+        "my title" powershell` prints and launches nothing.
+        """
+        found: "set[int]" = set()
+        head = -1
+        for index in range(begin, len(tokens)):
+            if _looks_like_separator(tokens[index]):
+                head = -1
+                continue
+            if head < 0:
+                head = index
+            if _token_basename(tokens[index]) != "start":
+                continue
+            if head == index or _token_basename(tokens[head]) not in _CMD_TEXT_COMMANDS:
+                found.add(index)
+        return found
+
     def _exec_child_index(start: int) -> "tuple[int, bool]":
         """The command a `find -exec` actually runs, as ``(index, overflowed)``;
         the index is -1 when the action holds no command word at all.
@@ -1769,12 +1807,11 @@ def _find_blocked_commands(command: str) -> set[str]:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
                 blocked |= _find_blocked_commands(tokens[i + 1])
-                # The nested command line starts here, so a start word in this
-                # position is a launch even though the outer scan reads it as an
-                # argument of cmd. Recursing alone does not reach it: only the
-                # one token is passed on, and `start` by itself blocks nothing.
-                if _token_basename(tokens[i + 1]) == "start":
-                    start_indexes.add(i + 1)
+                # Everything from here on is cmd's command line, which the outer
+                # scan can only read as arguments of cmd. Recursing does not
+                # reach it either: only the one token is passed on, and `start`
+                # by itself blocks nothing.
+                start_indexes |= _cmd_start_positions(i + 1)
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1782,6 +1819,11 @@ def _find_blocked_commands(command: str) -> set[str]:
     title_tokens: "frozenset[int] | None" = None
     source_quoted: "frozenset[int] | None" = None
     source_quoted_built = False
+    # `start` launches a program in cmd. On a POSIX host it is whatever the user
+    # has by that name, its arguments are arguments, and reading them as cmd
+    # syntax refused `start "dry run" rm` on Linux and macOS.
+    if sys.platform != "win32":
+        start_indexes.clear()
     # Only a start that is really a launch. `echo start "my title" powershell`
     # prints text, and reading every token named start walked the title branch
     # into a hard block for it.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1184,9 +1184,7 @@ def _skip_start_switches(tokens: "list[str]", index: int) -> int:
     return index
 
 
-def _quoted_token_indexes(
-    command: str, tokens: "list[str]", lexed_posix: bool
-) -> "frozenset[int]":
+def _quoted_token_indexes(command: str, tokens: "list[str]", lexed_posix: bool) -> "frozenset[int]":
     """Indexes of ``tokens`` that were written with quotes around them.
 
     cmd reads `start`'s first argument as a window title only when it is quoted,
@@ -1219,9 +1217,7 @@ def _quoted_token_indexes(
         return frozenset()
     if len(raw) != len(tokens):
         return frozenset()
-    return frozenset(
-        index for index, token in enumerate(raw) if token.startswith(('"', "'"))
-    )
+    return frozenset(index for index, token in enumerate(raw) if token.startswith(('"', "'")))
 
 
 def _xargs_replacement(tokens: "list[str]", start: int, end: int) -> str:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1218,6 +1218,41 @@ def _start_title_indexes(tokens: "list[str]", lexed_posix: bool) -> "frozenset[i
     )
 
 
+def _strip_cmd_quotes(token: str) -> str:
+    """``token`` without the quotes cmd strips before it resolves a program.
+
+    Only the non-POSIX lexer leaves them on, and the recursive scan re-lexes
+    what it is handed, so `start "" "powershell.exe" -c ls` recursed into a
+    program spelled `"powershell.exe"`, which matches no blocked name. Quoting
+    the path is the ordinary way to write one holding a space, so the hard block
+    was a quote away on any host without Git Bash.
+    """
+    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+        return token[1:-1]
+    return token
+
+
+def _blocked_start_program(token: str) -> "set[str]":
+    """The blocked names the program `start` launches resolves to.
+
+    A start target is one program, not a shell line, so it is matched by name
+    rather than rescanned as command text. Rescanning read a Windows path as a
+    command position, where the blocklist's own `.` matches the dot in any file
+    that has one, and `start "" "C:/Users/me/report.txt"` came back refused.
+
+    Backslashes separate here whatever the host is: this only ever reads a
+    Windows program, and posixpath leaves `C:\\Windows\\System32\\powershell.exe`
+    whole, so the name never matched on the Linux CI that runs these tests.
+    """
+    base = os.path.basename(_strip_cmd_quotes(token).replace("\\", "/")).lower()
+    stem, ext = os.path.splitext(base)
+    if ext in {".exe", ".com", ".bat", ".cmd"}:
+        base = stem
+    if base in _blocked_commands():
+        return {base}
+    return _blocked_matching_glob(base)
+
+
 def _source_quoted_indexes(command: str, tokens: "list[str]") -> "frozenset[int] | None":
     """Indexes of ``tokens`` the user wrote double quotes around, or None when
     that cannot be told.
@@ -1538,6 +1573,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     skip_operand = False  # consume a wrapper/conditional operand, not the command
     sed_indexes: "list[int]" = []  # command-position sed words, for the `e` scan below
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
+    start_indexes: "set[int]" = set()  # command-position start words, for the scan below
     xargs_index = -1  # an xargs awaiting the command it wraps
     for token_index, token in enumerate(tokens):
         if skip_operand:
@@ -1603,6 +1639,8 @@ def _find_blocked_commands(command: str) -> set[str]:
             sed_indexes.append(token_index)
             if xargs_index >= 0:
                 sed_xargs[token_index] = xargs_index
+        if base == "start":
+            start_indexes.add(token_index)
         if base in _blocked_commands():
             blocked.add(base)
         else:
@@ -1724,11 +1762,19 @@ def _find_blocked_commands(command: str) -> set[str]:
                 continue  # skip Unix flags like --login, -l
             if is_win_c and prev.startswith("/") and len(prev) <= 3:
                 continue  # skip Windows flags like /s, /q (not /bin/bash)
-            prev_base = os.path.basename(prev).lower()
+            # _token_basename, not os.path.basename: the cmd lexer keeps a glued
+            # opener, so `(cmd //c ...)` left prev as `(cmd` and matched no shell.
+            prev_base = _token_basename(prev)
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
                 blocked |= _find_blocked_commands(tokens[i + 1])
+                # The nested command line starts here, so a start word in this
+                # position is a launch even though the outer scan reads it as an
+                # argument of cmd. Recursing alone does not reach it: only the
+                # one token is passed on, and `start` by itself blocks nothing.
+                if _token_basename(tokens[i + 1]) == "start":
+                    start_indexes.add(i + 1)
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1736,9 +1782,10 @@ def _find_blocked_commands(command: str) -> set[str]:
     title_tokens: "frozenset[int] | None" = None
     source_quoted: "frozenset[int] | None" = None
     source_quoted_built = False
-    for i, token in enumerate(tokens):
-        if os.path.basename(token).lower() not in ("start", "start.exe"):
-            continue
+    # Only a start that is really a launch. `echo start "my title" powershell`
+    # prints text, and reading every token named start walked the title branch
+    # into a hard block for it.
+    for i in sorted(start_indexes):
         # Built at most once per call, and only when a start is actually here:
         # the second of them lexes the whole line, so doing it per start token
         # made the scan quadratic (800 tokens took 1.1s against main's 34ms).
@@ -1756,7 +1803,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         if j + 1 < len(tokens) and j in title_tokens:
             k = _skip_start_switches(tokens, j + 1)
             if k < len(tokens):
-                blocked |= _find_blocked_commands(tokens[k])
+                blocked |= _blocked_start_program(tokens[k])
             continue
         # Whether a quoted word without spaces reaches cmd as a title depends on
         # how Git Bash rebuilds the line, and the two readings each hide a
@@ -1766,16 +1813,25 @@ def _find_blocked_commands(command: str) -> set[str]:
         # Rather than pick one, screen both positions for this one shape. It is
         # narrow enough not to bring back the over-block a blind two-token scan
         # caused, since an unquoted `start notepad rm.txt` is not in it.
-        blocked |= _find_blocked_commands(tokens[j])
+        blocked |= _blocked_start_program(tokens[j])
         if j + 1 >= len(tokens) or not lexed_posix:
             continue
         if not source_quoted_built:
             source_quoted = _source_quoted_indexes(command, tokens)
             source_quoted_built = True
-        if source_quoted is None or j in source_quoted:
+        # A desync answers "cannot tell", and screening everything then brought
+        # the unquoted-argument over-block back for any line holding a POSIX-only
+        # escape: `echo a\ b; start notepad rm.txt` reported rm again. Looking
+        # for the quoted spelling in the text keeps the fallback local, so a
+        # word the user never quoted stays out of the second screen.
+        if source_quoted is None:
+            plausible_title = f'"{tokens[j]}"' in command
+        else:
+            plausible_title = j in source_quoted
+        if plausible_title:
             k = _skip_start_switches(tokens, j + 1)
             if k < len(tokens):
-                blocked |= _find_blocked_commands(tokens[k])
+                blocked |= _blocked_start_program(tokens[k])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1240,6 +1240,51 @@ _CMD_FOR_SUBSTITUTION_RE = re.compile(
 )
 
 
+def _cmd_quoted_offsets(text: str) -> "list[bool]":
+    """Which offsets of ``text`` cmd reads inside quotation marks.
+
+    The same walk as _cmd_split, kept as a map rather than a split for the two
+    callers that need to place something in the original text: a group bracket
+    is only cmd's syntax unquoted, and a `for` expression found by re-reading
+    the line is only a construct where it is not quoted data.
+    """
+    inside: "list[bool]" = []
+    quoted = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "^" and index + 1 < len(text) and not quoted:
+            inside.extend([quoted, quoted])
+            index += 2
+            continue
+        if char == '"':
+            quoted = not quoted
+            inside.append(True)  # the mark belongs to the quoting either way
+            index += 1
+            continue
+        inside.append(quoted)
+        index += 1
+    return inside
+
+
+def _cmd_group_delta(token: str) -> int:
+    """How far ``token`` opens or closes cmd's grouping, quotes excluded.
+
+    A quoted bracket is argument data: `if exist x (echo ")" & echo done) else
+    start "" pwsh` closed the group early on the quoted one, so the `&` after it
+    read as outside the branch and the else that reopens the position was lost.
+    """
+    delta = 0
+    for char, quoted in zip(token, _cmd_quoted_offsets(token)):
+        if quoted:
+            continue
+        if char == "(":
+            delta += 1
+        elif char == ")":
+            delta -= 1
+    return delta
+
+
 def _cmd_split(token: str, chars: str) -> "list[str]":
     """``token`` split on the ``chars`` cmd reads as syntax, escapes applied.
 
@@ -1690,7 +1735,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                     # `if exist x (echo a & echo b) else start "" pwsh` runs the
                     # start, and clearing here lost the else that reopens it.
                     control = control and depth > 0
-                depth += token.count("(") - token.count(")")
+                depth += _cmd_group_delta(token)
                 continue
             # A separator with no space around it stays inside the token, under
             # either lexer: the cmd one takes no punctuation_chars, and bash
@@ -1714,7 +1759,7 @@ def _find_blocked_commands(command: str) -> set[str]:
             if len(pieces) > 1:
                 expect = True
                 control = control and depth > 0
-            depth += token.count("(") - token.count(")")
+            depth += _cmd_group_delta(token)
             word = _cmd_word_base(pieces[-1])
             if skip > 0:
                 skip -= 1
@@ -2030,7 +2075,14 @@ def _find_blocked_commands(command: str) -> set[str]:
     # Only where cmd runs a `for` itself. The body is found by re-reading the
     # text, which cannot tell a construct from a quotation of one on its own, so
     # `echo "for /f %i in ('rm -rf x') do echo %i"` was refused for printing.
+    quoted_offsets = _cmd_quoted_offsets(command) if cmd_for_indexes else []
     for match in _CMD_FOR_SUBSTITUTION_RE.finditer(command if cmd_for_indexes else ""):
+        # A `for` cmd runs somewhere on the line is not this `for`: the outer
+        # one in `for %i in (x) do echo "for /f %j in ('start "" pwsh') ..."` is
+        # real while the inner expression is echo's data, so each match has to
+        # be unquoted where it sits, not merely accompanied by a construct.
+        if match.start() < len(quoted_offsets) and quoted_offsets[match.start()]:
+            continue
         # The escapes are the outer parse's, so cmd hands the child a line with
         # them already applied: `echo x ^& start ""` reaches it as a real
         # separator, and reading it raw left the start an operand of echo.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1231,6 +1231,8 @@ _CMD_SEPARATOR_RE = re.compile(r"(?<!\^)[&|]")
 # opened in the default browser" (the start reference), whose own example is
 # `start "Bing" "https://www.bing.com"`.
 _URL_SCHEME_RE = re.compile(r"[a-z][a-z0-9+.\-]*://", re.IGNORECASE)
+# cmd's comparison operators, which sit between the two words of an `if` test.
+_CMD_COMPARE_OPS = frozenset({"equ", "neq", "lss", "leq", "gtr", "geq"})
 
 
 def _strip_cmd_carets(token: str) -> str:
@@ -1279,7 +1281,10 @@ def _blocked_start_program(token: str) -> "set[str]":
     """
     unquoted = _strip_cmd_quotes(token)
     target = unquoted if unquoted is not token else _CMD_OPERATOR_RE.split(token, 1)[0]
-    target = _strip_cmd_carets(target)
+    # A group bracket is cmd's, not part of the name: it documents a
+    # parenthesised body for a single-line `if`, so the program in
+    # `if exist x (start "" powershell)` arrives spelled `powershell)`.
+    target = _strip_cmd_carets(target).strip("()")
     # A URL goes to the browser, so its host and path are not a program name and
     # `start "" https://example.com/curl` is not curl.
     if _URL_SCHEME_RE.match(target):
@@ -1550,88 +1555,91 @@ def _find_blocked_commands(command: str) -> set[str]:
         """``word`` as cmd resolves it: escapes applied, then the plain basename."""
         return _token_basename(_strip_cmd_carets(word))
 
-    def _cmd_command_head(index: int, after_if: bool = False) -> int:
-        """The index of the word cmd runs for the segment beginning at ``index``.
+    def _cmd_condition_words(index: int) -> int:
+        """How many words cmd's `if` condition occupies, starting at ``index``.
 
-        `if` carries out the command after its condition, so the leading word is
-        not the command: `cmd /c if exist x echo start "t" powershell` runs echo,
-        which only prints. Microsoft documents the condition as
-        `if [/i] [not] (<string1> <compareop> <string2> | exist <path> |
-        defined <var> | errorlevel <n>) <command>`, all of which take a fixed
-        number of words, so the command behind one can be reached without
-        parsing further. Missing the optional /i left the comparison itself
-        looking like the command.
+        Microsoft documents it as `if [/i] [not] (<string1> <compareop>
+        <string2> | exist <path> | defined <var> | errorlevel <n>) <command>`,
+        so it is a fixed count and the command behind it can be reached without
+        parsing further. The three-word comparison is the one that hid a launch:
+        `if 1 EQU 1 start "" powershell` left EQU looking like the command.
         """
-        while after_if or (index < len(tokens) and _cmd_word_base(tokens[index]) == "if"):
-            if not after_if:
-                index += 1
-            after_if = False
-            for _ in range(2):  # /i and not, in either order
-                if index >= len(tokens):
-                    break
-                # _token_basename would read /i as the path `i`, so the switch is
-                # matched on the raw word, through the Git Bash `//i` spelling.
-                word = tokens[index].lower()
-                if _win_switch(word) == "/i" or _cmd_word_base(word) == "not":
-                    index += 1
-            if index >= len(tokens):
-                break
-            if _cmd_word_base(tokens[index]) in ("exist", "defined", "errorlevel"):
-                index += 2
-            else:
-                index += 1  # the `a==b` comparison, which cmd lexes as one word
-        return index
+        words = 0
+        for _ in range(2):  # /i and not, in either order
+            if index + words >= len(tokens):
+                return words
+            # _token_basename would read /i as the path `i`, so the switch is
+            # matched on the raw word, through the Git Bash `//i` spelling.
+            word = tokens[index + words].lower()
+            if _win_switch(word) == "/i" or _cmd_word_base(word) == "not":
+                words += 1
+        if index + words >= len(tokens):
+            return words
+        if _cmd_word_base(tokens[index + words]) in ("exist", "defined", "errorlevel"):
+            return words + 2
+        if (
+            index + words + 1 < len(tokens)
+            and _cmd_word_base(tokens[index + words + 1]) in _CMD_COMPARE_OPS
+        ):
+            return words + 3
+        return words + 1  # the `a==b` form, which cmd lexes as one word
 
     def _cmd_start_positions(begin: int) -> "set[int]":
-        """Indexes of the `start` words that launch a program in the cmd command
+        """Indexes of the `start` words cmd runs as a command in the command
         line beginning at ``begin``.
 
-        cmd keeps parsing past its own conditionals and separators, so promoting
-        only the first word missed `cmd //c if exist . start "" powershell`,
-        which cmd runs and which the scan had caught before it was gated. Each
-        segment is read down to the word cmd actually runs instead, and only
-        that word counts: anywhere else a start is an operand of the command
-        that is running, whether that prints it (`cmd //c echo start "t" pwsh`)
-        or reads it as a name (`cmd /c dir start "" powershell`).
+        Anywhere but a command position a start is an operand of whatever is
+        running, whether that prints it (`cmd //c echo start "t" pwsh`) or reads
+        it as a name (`cmd /c dir start "" powershell`), so tracking where cmd
+        begins a command is what separates a launch from a word. Its grammar is
+        small and this follows all of it: a command starts the line, follows a
+        separator, follows an `if` condition or an `else`, and follows the `do`
+        of a `for`. A group bracket needs no case of its own -- it either sits
+        where a command was already expected, or after one that consumed it,
+        and `echo ok ( start "" pwsh )` only prints.
 
-        Under bash the payload ends at the first shell separator, since that
-        terminates the cmd invocation rather than starting a new cmd command:
-        with `cmd //c echo ok; printf "%s" start "" powershell`, cmd is handed
-        only `echo ok` and the start belongs to printf. An escaped one is passed
-        through instead, and then it depends whose syntax it is: cmd reads `\&`
-        as its own separator and opens a segment, but `\;` is only text to it.
+        Under bash an unescaped separator ends the cmd invocation rather than
+        starting another cmd command, so the scan stops: with `cmd //c echo ok;
+        printf "%s" start "" powershell`, cmd is handed only `echo ok`. An
+        escaped one is passed through to cmd, which reads it as its own, and it
+        can arrive glued to a word once bash has removed the escape.
         """
         found: "set[int]" = set()
-        head = -1  # index of the word cmd runs for the open segment
+        expect = True  # the next word is one cmd runs
+        skip = 0  # condition words still to consume
         for index in range(begin, len(tokens)):
             token = tokens[index]
             if _looks_like_separator(token):
                 if lexed_posix and index not in quoted_separators:
                     break
                 if _CMD_SEPARATOR_RE.search(token):
-                    head = -1
+                    expect = True
                 continue
-            # A separator with no space around it stays inside the token under
-            # the cmd lexer, so it both hides a start and opens a segment:
-            # `cmd /c echo ok&start "" pwsh` runs echo and then the start.
-            # Redirections are not separators: `cmd /c echo hi>start powershell`
-            # writes to a file called start and launches nothing.
-            pieces = [token] if lexed_posix else _CMD_SEPARATOR_RE.split(token)
-            glued = len(pieces) > 1
-            if head < 0:
-                head = _cmd_command_head(index)
-            if (glued or index == head) and _is_cmd_start_word(index):
+            # A separator with no space around it stays inside the token, under
+            # either lexer: the cmd one takes no punctuation_chars, and bash
+            # removes the escape from `ok\&start` before cmd reads the `&`.
+            pieces = _CMD_SEPARATOR_RE.split(token)
+            if len(pieces) > 1:
+                expect = True
+            word = _cmd_word_base(pieces[-1])
+            if skip > 0:
+                skip -= 1
+                continue
+            # `else` and the `do` of a `for` both hand the command along, from
+            # either side: the branch they open is a command position even
+            # though the word before them was one too.
+            if word in ("else", "do"):
+                expect = True
+                continue
+            if not expect:
+                continue
+            if word == "start":
                 found.add(index)
-            if glued:
-                # The segment after the last separator begins inside this token,
-                # so its head is here -- unless that word is a conditional, whose
-                # command is further along: `cmd /c echo&if exist . start "" pwsh`
-                # left the head pinned to the glued token and missed the launch.
-                head = (
-                    _cmd_command_head(index + 1, after_if = True)
-                    if _cmd_word_base(pieces[-1]) == "if"
-                    else index
-                )
+                expect = False
+            elif word == "if":
+                skip = _cmd_condition_words(index + 1)
+            else:
+                expect = False  # a `for` is re-armed by its own `do`, below
         return found
 
     def _exec_child_index(start: int) -> "tuple[int, bool]":

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1413,6 +1413,8 @@ def _blocked_start_program(token: str) -> "set[str]":
     names = {target}
     if "%" in target:
         names.add(_CMD_VARIABLE_RE.sub("", target))
+    if "!" in target:
+        names.add(_CMD_DELAYED_RE.sub("", target))
     blocked: "set[str]" = set()
     for name in names:
         base = os.path.basename(name.replace("\\", "/")).lower()
@@ -1614,6 +1616,18 @@ _START_SWITCH_RE = re.compile(r"/[a-z][a-z0-9]*", re.IGNORECASE)
 _CMD_SWITCH_RE = re.compile(r"/[a-z](?::[^\s/]*)?$", re.IGNORECASE)
 # A cmd variable expansion, `%NAME%` or a substring of one (`%PATH:~0,0%`).
 _CMD_VARIABLE_RE = re.compile(r"%[^%\s]*%")
+# ...and the delayed form, which cmd expands where /v:on or the registry enables
+# it. An unset variable leaves nothing behind in either spelling.
+_CMD_DELAYED_RE = re.compile(r"![^!\s]*!")
+# cmd's own commands, from its `help` list. `start` hands one of these to a
+# command processor rather than resolving a program, so the words behind it are
+# a command line: "If command is an internal cmd command or a batch file then
+# the command processor CMD.exe is run with the /K switch" (`start /?`).
+_CMD_INTERNAL_COMMANDS = frozenset(
+    """assoc break call cd chdir cls color copy date del dir echo endlocal erase exit for
+    ftype goto graftabl if md mkdir mklink move path pause popd prompt pushd rd rem ren
+    rename rmdir set setlocal shift start time title type ver verify vol""".split()
+)
 
 
 def _find_blocked_commands(command: str) -> set[str]:
@@ -1705,7 +1719,15 @@ def _find_blocked_commands(command: str) -> set[str]:
         # The bracket comes off before the prefix, or `(@start` keeps its `@`
         # and never matches: cmd reads the group opener, then the suppression.
         name = (pieces[-1] if pieces else "").lstrip("@").strip('"')
-        return os.path.basename(name.replace("\\", "/")).lower()
+        base = os.path.basename(name.replace("\\", "/")).lower()
+        # Delayed expansion happens before the word is resolved and an unset
+        # variable leaves nothing behind, so `st!X!art` IS start where it is
+        # enabled -- by /v:on on this line or by the registry on the host, which
+        # a command line does not show. Reading the spelling both ways is the
+        # safe direction: a file really named that launches nothing.
+        if "!" in base:
+            return _CMD_DELAYED_RE.sub("", base) or base
+        return base
 
     def _cmd_condition_words(index: int) -> int:
         """How many words cmd's `if` condition occupies, starting at ``index``.
@@ -2113,6 +2135,32 @@ def _find_blocked_commands(command: str) -> set[str]:
                 cmd_for_indexes.add(pos)
         return cmd_grammar_spent
 
+    def _cmd_payload_text(index: int) -> str:
+        """The source text from ``tokens[index]`` on, dequoted as cmd dequotes
+        its command line.
+
+        Microsoft: the string "is processed by examining the first character to
+        verify whether it's an opening quotation mark. If the first character is
+        an opening quotation mark, it's stripped along with the closing
+        quotation mark. Any text following the closing quotation marks is
+        preserved."
+
+        Read from the source rather than rebuilt from the tokens, because the
+        rebuild is what loses it: the cmd lexer splits `"start "" powershell"`
+        at the quotes into pieces that no longer sit where they did.
+        """
+        cursor = 0
+        for position, token in enumerate(tokens):
+            found = command.find(token, cursor)
+            if found < 0:
+                return ""  # a token the lexer built rather than copied
+            if position == index:
+                payload = command[found:]
+                closing = payload.rfind('"')
+                return payload[1:closing] + payload[closing + 1 :] if closing > 0 else payload[1:]
+            cursor = found + len(token)
+        return ""
+
     def _start_program_index(index: int) -> int:
         """The token the `start` at ``index`` launches, or -1 for none.
 
@@ -2175,6 +2223,8 @@ def _find_blocked_commands(command: str) -> set[str]:
     # recursively scan the nested command string.
     _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
     _SHELLS_WIN = {"cmd", "cmd.exe"}
+    # (switch index, shell index, shell name) per cmd command line found here.
+    cmd_payloads: "list[tuple[int, int, str]]" = []
     for i, token in enumerate(tokens):
         tok_lower = token.lower()
         # Match -c exactly, or combined flags ending in c (e.g. -lc, -xc)
@@ -2211,21 +2261,72 @@ def _find_blocked_commands(command: str) -> set[str]:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
                 blocked |= _find_blocked_commands(tokens[i + 1])
+                # cmd strips the quotation marks around its whole command line
+                # -- always with /s, and otherwise unless the string is one
+                # quoted executable name -- and runs what is left: `cmd /s /c
+                # "start "" powershell"` runs `start "" powershell`. The cmd
+                # lexer chops that string into quote-carrying pieces no grammar
+                # can read (`"start "`, `" powershell"`), so the line is taken
+                # from the source text instead, which the lexer cannot mangle.
+                if not lexed_posix and tokens[i + 1].startswith('"'):
+                    blocked |= _find_blocked_commands(_cmd_payload_text(i + 1))
                 # Everything from here on is cmd's command line, which the outer
-                # scan can only read as arguments of cmd. Recursing does not
+                # scan can only read as arguments of cmd, and recursing does not
                 # reach it either: only the one token is passed on, and `start`
-                # by itself blocks nothing. Only where this cmd is a command the
-                # line runs, though: `echo cmd /c start "" powershell` prints
-                # those words, and reading them as a command line refused the
-                # message. Visited left to right, so an outer cmd has already
-                # named the inner one by the time it is reached.
-                if _cmd_runs_here(j) and _read_cmd_line(i + 1):
-                    # The budget ran out inside this payload, so a launch may
-                    # sit in the part never read: refuse the shell running it
-                    # rather than let `cmd /c cmd /c ...x300` ride in on the
-                    # scan giving up.
-                    blocked.add(prev_base)
+                # by itself blocks nothing. Read below, once it is settled
+                # whether this cmd is a word the line runs.
+                cmd_payloads.append((i, j, prev_base))
             break  # stop at first non-flag token
+
+    # `start` launches a program in cmd. On a POSIX host it is whatever the user
+    # has by that name, its arguments are arguments, and reading them as cmd
+    # syntax refused `start "dry run" rm` on Linux and macOS.
+    screen_starts = sys.platform == "win32"
+    # Only a start that is really a launch. `echo start "my title" powershell`
+    # prints text, and reading every token named start walked the title branch
+    # into a hard block for it.
+    #
+    # Payloads and starts settle together rather than in two passes, because
+    # each can uncover the other: a `cmd /c` payload holds a start, a start may
+    # launch cmd, and `start "" call cmd /c start "" powershell` is both at
+    # once. The work is bounded -- a payload and a start are each read once,
+    # and the grammar budget above caps the total either way.
+    read_payloads: "set[int]" = set()
+    screened_starts: "set[int]" = set()
+    while True:
+        progressed = False
+        for i, j, prev_base in cmd_payloads:
+            if i in read_payloads or not _cmd_runs_here(j):
+                continue
+            # `echo cmd /c start "" powershell` prints those words, so a payload
+            # is read only where the cmd running it is a word the line runs.
+            read_payloads.add(i)
+            progressed = True
+            if _read_cmd_line(i + 1):
+                # The budget ran out inside this payload, so a launch may sit in
+                # the part never read: refuse the shell running it rather than
+                # let `cmd /c cmd /c ...x300` ride in on the scan giving up.
+                blocked.add(prev_base)
+        for i in sorted(start_indexes - screened_starts) if screen_starts else []:
+            screened_starts.add(i)
+            progressed = True
+            program = _start_program_index(i)
+            if program < 0:
+                continue
+            # "If command is an internal cmd command or a batch file then the
+            # command processor CMD.exe is run with the /K switch" (`start /?`),
+            # so the words behind an internal command are a cmd command line
+            # rather than that program's arguments: `start "" call start ""
+            # powershell` launches powershell, and screening the `call` alone
+            # returned nothing at all. cmd's own documented example is the same
+            # shape, `start /max start /?`.
+            if _cmd_word_base(tokens[program]) in _CMD_INTERNAL_COMMANDS:
+                if _read_cmd_line(program):
+                    blocked.add(_cmd_word_base(tokens[program]))
+                continue
+            blocked |= _blocked_start_program(tokens[program])
+        if not progressed:
+            break
 
     # `for /f %i in ('CMD') do ...` runs CMD as a child command and reads its
     # output, so the set is a command position the token scan sees only as data.
@@ -2247,26 +2348,18 @@ def _find_blocked_commands(command: str) -> set[str]:
         # Reading both as commands refused `for /f %i in (`powershell`)`, which
         # looks up a file by that name.
         backquoted = match.group("alt") is not None
-        if backquoted != ("usebackq" in (match.group("options") or "").lower()):
+        # A word of its own, not a substring: the options are keywords separated
+        # by whitespace, so `delims=usebackq` sets a delimiter set and leaves
+        # the backquotes a filename, where a search of the whole option text
+        # read it as the keyword and refused a line that launches nothing.
+        keywords = (match.group("options") or "").lower().replace('"', " ").split()
+        if backquoted != ("usebackq" in keywords):
             continue
         # The escapes are the outer parse's, so cmd hands the child a line with
         # them already applied: `echo x ^& start ""` reaches it as a real
         # separator, and reading it raw left the start an operand of echo.
         body = match.group("body") or match.group("alt") or ""
         blocked |= _find_blocked_commands(_cmd_split(body, "")[0])
-
-    # `start` launches a program in cmd. On a POSIX host it is whatever the user
-    # has by that name, its arguments are arguments, and reading them as cmd
-    # syntax refused `start "dry run" rm` on Linux and macOS.
-    if sys.platform != "win32":
-        start_indexes.clear()
-    # Only a start that is really a launch. `echo start "my title" powershell`
-    # prints text, and reading every token named start walked the title branch
-    # into a hard block for it.
-    for i in sorted(start_indexes):
-        program = _start_program_index(i)
-        if program >= 0:
-            blocked |= _blocked_start_program(tokens[program])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1232,6 +1232,12 @@ _URL_SCHEME_RE = re.compile(r"[a-z][a-z0-9+.\-]*://", re.IGNORECASE)
 _CMD_COMPARE_OPS = frozenset({"equ", "neq", "lss", "leq", "gtr", "geq"})
 # ...and its tests that take one operand of their own before the command.
 _CMD_TWO_WORD_TESTS = frozenset({"exist", "defined", "errorlevel", "cmdextversion"})
+# `for /f ... in ('CMD')` runs CMD and reads its output, the command-substitution
+# form documented for `for`; usebackq spells the same thing with backquotes.
+_CMD_FOR_SUBSTITUTION_RE = re.compile(
+    r"\bfor\s+/f\b[^(]*\(\s*(?:'(?P<body>[^']*)'|`(?P<alt>[^`]*)`)\s*\)",
+    re.IGNORECASE,
+)
 
 
 def _cmd_split(token: str, chars: str) -> "list[str]":
@@ -1578,10 +1584,22 @@ def _find_blocked_commands(command: str) -> set[str]:
         return _cmd_word_base(_cmd_split(tokens[index], _CMD_SEPARATORS)[-1]) == "start"
 
     def _cmd_word_base(word: str) -> str:
-        """``word`` as cmd resolves it: escapes applied, then the plain basename."""
-        # `@` suppresses echoing without changing which command runs, so
-        # `cmd /c @start "" powershell` is still a start.
-        return _token_basename(_cmd_split(word, "")[0].lstrip("@"))
+        """``word`` as cmd resolves a command keyword.
+
+        Escapes applied and `@` dropped, since it suppresses echoing without
+        changing which command runs, so `cmd /c @start "" powershell` is a
+        start. The extension is kept, unlike a program name: an explicit
+        `start.cmd` is a batch file in the working tree and its arguments are
+        that file's data, where the launcher is the bare builtin.
+
+        A group bracket is cmd's own syntax and can sit on either side of the
+        word, so the piece between brackets is what it runs: the set closer in
+        `for %i in (x)do start "" powershell` leaves `(x)do` as one token under
+        the cmd lexer, whose `do` still hands the body along.
+        """
+        plain = _cmd_split(word, "")[0].lstrip("@").strip(";&|`{}")
+        pieces = [piece for piece in re.split(r"[()]", plain) if piece]
+        return os.path.basename((pieces[-1] if pieces else "").replace("\\", "/")).lower()
 
     def _cmd_condition_words(index: int) -> int:
         """How many words cmd's `if` condition occupies, starting at ``index``.
@@ -1636,6 +1654,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         expect = True  # the next word is one cmd runs
         control = False  # an `if` or a `for` is open, so else/do hand off
         skip = 0  # condition words still to consume
+        skip_operand = False  # the word after a bare redirection operator
         for index in range(begin, len(tokens)):
             token = tokens[index]
             if _looks_like_separator(token):
@@ -1651,7 +1670,13 @@ def _find_blocked_commands(command: str) -> set[str]:
             # A redirection is bash's, consumed before cmd is handed its
             # arguments, so it holds the command position rather than taking it:
             # `cmd //c >nul start "" powershell` really does launch.
+            if skip_operand:
+                skip_operand = False
+                continue
             if _REDIR_PREFIX_RE.match(token):
+                # `> nul` is two words, and the target took the command position
+                # the operator had just been allowed to keep.
+                skip_operand = not _REDIR_PREFIX_RE.sub("", token)
                 continue
             # MSYS re-quotes an argument holding whitespace when it builds
             # cmd's command line, and quoting is what makes cmd's separators
@@ -1949,6 +1974,16 @@ def _find_blocked_commands(command: str) -> set[str]:
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
+    # `for /f %i in ('CMD') do ...` runs CMD as a child command and reads its
+    # output, so the set is a command position the token scan sees only as data.
+    # Backquotes are the same form under usebackq.
+    for match in _CMD_FOR_SUBSTITUTION_RE.finditer(command):
+        # The escapes are the outer parse's, so cmd hands the child a line with
+        # them already applied: `echo x ^& start ""` reaches it as a real
+        # separator, and reading it raw left the start an operand of echo.
+        body = match.group("body") or match.group("alt") or ""
+        blocked |= _find_blocked_commands(_cmd_split(body, "")[0])
+
     title_tokens: "frozenset[int] | None" = None
     # When cmd is the shell the whole line is its command line, so it is read
     # with cmd's grammar rather than the POSIX command positions above, which

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -148,11 +148,19 @@ _BLOCKED_COMMANDS_WIN = frozenset(
         "pwsh",
     }
 )
-_BLOCKED_COMMANDS = (
-    _BLOCKED_COMMANDS_COMMON | _BLOCKED_COMMANDS_WIN
-    if sys.platform == "win32"
-    else _BLOCKED_COMMANDS_COMMON
-)
+_BLOCKED_COMMANDS_ALL = _BLOCKED_COMMANDS_COMMON | _BLOCKED_COMMANDS_WIN
+
+
+def _blocked_commands() -> "frozenset[str]":
+    """The blocked names for the platform this call runs on.
+
+    Resolved per call rather than frozen at import so that a test can pin
+    sys.platform the way the rest of the Windows suite does. Freezing it meant
+    the Windows screen -- `cmd /c powershell` and friends -- could only ever be
+    exercised on a Windows runner, so it went untested everywhere it is built.
+    Both operands are constants, so this costs one comparison.
+    """
+    return _BLOCKED_COMMANDS_ALL if sys.platform == "win32" else _BLOCKED_COMMANDS_COMMON
 
 
 _SHELL_SEPARATORS = frozenset({";", "&&", "||", "|", "&", "\n", "(", ")", "`", "{", "}"})
@@ -469,7 +477,7 @@ def _blocked_matching_glob(base: str) -> "set[str]":
     """Blocked command names a command-position glob can expand to."""
     if not _is_unresolved_command_glob(base):
         return set()
-    return {name for name in _BLOCKED_COMMANDS if fnmatch.fnmatchcase(name, base)}
+    return {name for name in _blocked_commands() if fnmatch.fnmatchcase(name, base)}
 
 
 def _is_sed_command(base: str) -> bool:
@@ -1519,12 +1527,12 @@ def _find_blocked_commands(command: str) -> set[str]:
             sed_indexes.append(token_index)
             if xargs_index >= 0:
                 sed_xargs[token_index] = xargs_index
-        if base in _BLOCKED_COMMANDS:
+        if base in _blocked_commands():
             blocked.add(base)
         else:
             blocked |= _blocked_matching_glob(base)
         # Wrappers (env/time/xargs/sudo) consume one command; the next non-flag,
-        # non-numeric token is the real command. sudo is also in _BLOCKED_COMMANDS.
+        # non-numeric token is the real command, and that wrapper is blocked too.
         if base in _COMMAND_PREFIXES:
             if base == "xargs" and xargs_index < 0:
                 xargs_index = token_index
@@ -1572,7 +1580,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # a command that could not have worked anyway; a spelling
                 # that does forward them would otherwise be a free pass.
                 sed_indexes.append(i)
-            if attached_base in _BLOCKED_COMMANDS:
+            if attached_base in _blocked_commands():
                 blocked.add(attached_base)
             else:
                 blocked |= _blocked_matching_glob(attached_base)
@@ -1597,7 +1605,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                     # screened (`find . -exec sed '1e rm -f victim' {} +`, and
                     # behind a wrapper `find . -exec env sed '1e ...' {} +`).
                     sed_indexes.append(word)
-                if base in _BLOCKED_COMMANDS:
+                if base in _blocked_commands():
                     blocked.add(base)
                 else:
                     blocked |= _blocked_matching_glob(base)
@@ -1606,8 +1614,9 @@ def _find_blocked_commands(command: str) -> set[str]:
     # $(rm -rf), <(rm), backtick chains, or "foo;rm". Anchored to command-position
     # delimiters, so it doesn't match in argument position.
     lowered = command.lower()
-    if _BLOCKED_COMMANDS:
-        words_alt = "|".join(re.escape(w) for w in sorted(_BLOCKED_COMMANDS))
+    blocked_names = _blocked_commands()
+    if blocked_names:
+        words_alt = "|".join(re.escape(w) for w in sorted(blocked_names))
         pattern = (
             rf"(?:^|[;&|`\n(]\s*|[$]\(\s*|<\(\s*)"
             rf"(?:[\w./\\-]*/|[a-zA-Z]:[/\\][\w./\\-]*)?"
@@ -1658,11 +1667,18 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-        # `start ""` is the idiom for "no title"; anything else is the program.
-        if j < len(tokens) and tokens[j] == "":
-            j += 1
+        # `start "title" prog` is the documented form, so the program may be the
+        # token after the title rather than the title itself. Screen both instead
+        # of deciding which is which: cmd only treats the first quoted argument as
+        # a title when something follows it, the POSIX lexer strips those quotes
+        # while the non-POSIX one keeps them, and guessing wrong leaves the
+        # program unscreened. Matching `== ""` did exactly that twice -- it saw
+        # neither `start "" prog` on a Windows host without Git Bash (where the
+        # token arrives as a literal `""`) nor any non-empty title on either.
         if j < len(tokens):
             blocked |= _find_blocked_commands(tokens[j])
+        if j + 1 < len(tokens):
+            blocked |= _find_blocked_commands(tokens[j + 1])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1173,6 +1173,33 @@ def _unquoted_glob_indexes(text: str, tokens: "list[str]", punctuation: str) -> 
     )
 
 
+def _token_was_quoted(command: str, tokens: "list[str]", index: int, lexed_posix: bool) -> bool:
+    """Whether ``tokens[index]`` was written with quotes around it.
+
+    cmd reads `start`'s first argument as a window title only when it is quoted,
+    which is what separates `start "" prog` and `start "t" prog` -- a title with
+    the program behind it -- from `start prog arg`, where the second token is
+    just an argument. Screening an argument as if it were a command position is
+    not harmless: the recursive scan re-anchors its command-boundary regex at
+    the start of the token, so `start notepad rm.txt` reported `rm` even though
+    the same word in the same place on a full line does not match.
+
+    The non-POSIX lexer keeps the quotes, so the token answers for itself. The
+    POSIX one strips them, so the text is lexed a second time without stripping
+    and the two are lined up one-to-one, reporting nothing when they do not
+    align -- the same technique as _quoted_separator_indexes.
+    """
+    if not lexed_posix:
+        return tokens[index].startswith(('"', "'"))
+    try:
+        raw = shlex.split(command, posix = False)
+    except ValueError:
+        return False
+    if len(raw) != len(tokens) or index >= len(raw):
+        return False
+    return raw[index].startswith(('"', "'"))
+
+
 def _xargs_replacement(tokens: "list[str]", start: int, end: int) -> str:
     """The placeholder the xargs word at ``start`` substitutes into the command
     words behind it, or "" when it replaces nothing. GNU xargs takes it attached
@@ -1667,18 +1694,18 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-        # `start "title" prog` is the documented form, so the program may be the
-        # token after the title rather than the title itself. Screen both instead
-        # of deciding which is which: cmd only treats the first quoted argument as
-        # a title when something follows it, the POSIX lexer strips those quotes
-        # while the non-POSIX one keeps them, and guessing wrong leaves the
-        # program unscreened. Matching `== ""` did exactly that twice -- it saw
-        # neither `start "" prog` on a Windows host without Git Bash (where the
-        # token arrives as a literal `""`) nor any non-empty title on either.
+        # `start "title" prog` is the documented form: cmd reads a quoted first
+        # argument as the window title, but only when something follows it, so
+        # the program is the token behind it. Matching `== ""` instead saw
+        # neither `start "" prog` on a Windows host without Git Bash -- where the
+        # non-POSIX lexer keeps the quotes and the token arrives as a literal
+        # `""` -- nor any non-empty title on either lexer, and left the program
+        # in both unscreened.
         if j < len(tokens):
-            blocked |= _find_blocked_commands(tokens[j])
-        if j + 1 < len(tokens):
-            blocked |= _find_blocked_commands(tokens[j + 1])
+            if j + 1 < len(tokens) and _token_was_quoted(command, tokens, j, lexed_posix):
+                blocked |= _find_blocked_commands(tokens[j + 1])
+            else:
+                blocked |= _find_blocked_commands(tokens[j])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1328,20 +1328,6 @@ def _cmd_split(token: str, chars: str) -> "list[str]":
     return pieces
 
 
-def _strip_cmd_quotes(token: str) -> str:
-    """``token`` without the quotes cmd strips before it resolves a program.
-
-    Only the non-POSIX lexer leaves them on, and the recursive scan re-lexes
-    what it is handed, so `start "" "powershell.exe" -c ls` recursed into a
-    program spelled `"powershell.exe"`, which matches no blocked name. Quoting
-    the path is the ordinary way to write one holding a space, so the hard block
-    was a quote away on any host without Git Bash.
-    """
-    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
-        return token[1:-1]
-    return token
-
-
 def _blocked_start_program(token: str) -> "set[str]":
     """The blocked names the program `start` launches resolves to.
 
@@ -1362,16 +1348,25 @@ def _blocked_start_program(token: str) -> "set[str]":
     holding one usable, and splitting inside truncated `"C:/A&B/powershell.exe"`
     to `C:/A` and let the program behind it through.
     """
-    unquoted = _strip_cmd_quotes(token)
-    # Quoting is what makes a path holding an operator usable, so only one
-    # outside the quotes is syntax. A group bracket is cmd's too, not part of
-    # the name: it documents a parenthesised body for a single-line `if`, so
-    # `if exist x (start "" powershell)` arrives spelled `powershell)`.
-    target = (
-        _cmd_split(unquoted, "")[0]
-        if unquoted is not token
-        else _cmd_split(token, _CMD_OPERATORS)[0]
-    ).strip("()")
+    # Split BEFORE the quotes come off, so what they protected stays protected:
+    # the caret in `start "" "power^shell"` is part of a filename cmd looks up
+    # literally, and applying the escape to it hard-blocked that name as
+    # powershell. _cmd_split reads both rules in one pass and leaves the marks
+    # in place, so a quoted operator is data here as well and
+    # `"C:/A&B/powershell.exe"` is not truncated to `C:/A`.
+    piece = _cmd_split(token, _CMD_OPERATORS)[0]
+    quoted = _cmd_quoted_offsets(piece)
+    # cmd drops the marks themselves when it resolves the program, wherever they
+    # sit: `pow"ers"hell` runs powershell. A group bracket is cmd's syntax and
+    # not part of the name -- it documents a parenthesised body for a
+    # single-line `if`, so `if exist x (start "" powershell)` arrives spelled
+    # `powershell)` -- but only unquoted, a quoted one being a filename again.
+    chars = [(char, mark) for char, mark in zip(piece, quoted) if char != '"']
+    while chars and chars[0][0] in "()" and not chars[0][1]:
+        chars.pop(0)
+    while chars and chars[-1][0] in "()" and not chars[-1][1]:
+        chars.pop()
+    target = "".join(char for char, _mark in chars)
     # A URL goes to the browser, so its host and path are not a program name and
     # `start "" https://example.com/curl` is not curl.
     if _URL_SCHEME_RE.match(target):
@@ -1719,7 +1714,14 @@ def _find_blocked_commands(command: str) -> set[str]:
         """
         found: "dict[int, str]" = {}
         expect = True  # the next word is one cmd runs
-        control = False  # an `if` or a `for` is open, so else/do hand off
+        # The `if` and `for` statements still waiting for the word that hands
+        # the command along, innermost last. Each is CONSUMED there: the
+        # statement has had its handoff, so a later word spelled the same is an
+        # operand again and `for %i in (x) do echo do start "" pwsh` only
+        # prints. A list rather than a flag because the two nest, and one
+        # cleared by the inner `do` lost the `else` of `if exist x (for %i in
+        # (y) do echo a) else start "" pwsh`, which really launches.
+        control: "list[str]" = []
         depth = 0  # open group brackets, which an `if` branch is written in
         skip = 0  # condition words still to consume
         skip_operand = False  # the word after a bare redirection operator
@@ -1734,7 +1736,8 @@ def _find_blocked_commands(command: str) -> set[str]:
                     # commands, so the `if` it belongs to is still open:
                     # `if exist x (echo a & echo b) else start "" pwsh` runs the
                     # start, and clearing here lost the else that reopens it.
-                    control = control and depth > 0
+                    if not depth:
+                        control.clear()
                 depth += _cmd_group_delta(token)
                 continue
             # A separator with no space around it stays inside the token, under
@@ -1758,7 +1761,8 @@ def _find_blocked_commands(command: str) -> set[str]:
             pieces = [token] if requoted else _cmd_split(token, _CMD_SEPARATORS)
             if len(pieces) > 1:
                 expect = True
-                control = control and depth > 0
+                if not depth:
+                    control.clear()
             depth += _cmd_group_delta(token)
             word = _cmd_word_base(pieces[-1])
             if skip > 0:
@@ -1769,7 +1773,12 @@ def _find_blocked_commands(command: str) -> set[str]:
             # though the word before them was one too. Only where one of those
             # statements is open, though, or `cmd /c echo else start "" pwsh`
             # reads a printed word as a handoff.
-            if control and word in ("else", "do"):
+            statement = {"else": "if", "do": "for"}.get(word, "")
+            if statement and statement in control:
+                # The handoff belongs to the innermost statement of that kind,
+                # and one of a kind is interchangeable with another here, so
+                # which entry goes does not matter -- only how many.
+                control.remove(statement)
                 expect = True
                 continue
             if not expect:
@@ -1782,9 +1791,9 @@ def _find_blocked_commands(command: str) -> set[str]:
                 pass  # it reparses its target, so a command follows it
             elif word == "if":
                 skip = _cmd_condition_words(index + 1)
-                control = True
+                control.append("if")
             elif word == "for":
-                control = True
+                control.append("for")
                 expect = False  # re-armed by its own `do`, above
             else:
                 expect = False
@@ -1844,6 +1853,10 @@ def _find_blocked_commands(command: str) -> set[str]:
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
     start_indexes: "set[int]" = set()  # command-position start words, for the scan below
     cmd_for_indexes: "set[int]" = set()  # command-position for words, for the scan below
+    # Every command position this walk reaches, for the nested-shell scan below:
+    # a `cmd /c` payload is only a command line where the cmd running it is
+    # itself executed, and `echo cmd /c start "" powershell` merely prints.
+    run_indexes: "set[int]" = set()
     xargs_index = -1  # an xargs awaiting the command it wraps
     for token_index, token in enumerate(tokens):
         if skip_operand:
@@ -1905,6 +1918,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         if prefix_pending and token.lstrip("-").isdigit():
             continue
         base = _token_basename(token)
+        run_indexes.add(token_index)
         if _is_sed_command(base):
             sed_indexes.append(token_index)
             if xargs_index >= 0:
@@ -2008,6 +2022,80 @@ def _find_blocked_commands(command: str) -> set[str]:
         )
         blocked.update(re.findall(pattern, lowered))
 
+    # `cmd /c start "" prog` puts prog in a command position the scan above
+    # sees only as an argument, so screen what start actually launches.
+    title_tokens: "frozenset[int] | None" = None
+    # The words of every cmd command line read so far. When cmd is the shell the
+    # whole line is one, and it is read with cmd's grammar rather than the POSIX
+    # command positions above, which hand a wrapper's operand to the next word:
+    # `time` is a cmd builtin that shows the clock, and `time start ""
+    # powershell` launches nothing.
+    cmd_run_indexes: "set[int]" = set()
+
+    def _read_cmd_line(begin: int) -> None:
+        """Collect the words cmd runs in the command line starting at ``begin``."""
+        for pos, cmd_word in _cmd_command_positions(begin).items():
+            cmd_run_indexes.add(pos)
+            if cmd_word == "start":
+                start_indexes.add(pos)
+            elif cmd_word == "for":
+                cmd_for_indexes.add(pos)
+
+    def _start_program_index(index: int) -> int:
+        """The token the `start` at ``index`` launches, or -1 for none.
+
+        `start "title" prog` is the documented form: cmd reads a quoted first
+        argument as the window title, but only when something follows it, so the
+        program is the token behind it. A title is data, so it is not screened
+        itself. Microsoft documents the switches AFTER the title too, so they
+        are skipped on both sides of it: `start "" /min powershell` left the
+        program at j + 2 and screened the switch instead. The program is
+        optional in that syntax (`start <"title"> [switches]
+        [<command>|<program> [<parameter>...]]`), so a lone quoted operand is
+        only the title: `start "powershell"` opens a window with that name and
+        runs nothing, where screening it as the program refused the word itself.
+
+        Under Git Bash a quoted word without spaces is not a title by the time
+        cmd sees it, because bash removes the quotes and MSYS re-quotes an
+        argument only when it holds whitespace or is empty -- the same rule as
+        subprocess.list2cmdline. So `start "powershell" -c ls` arrives as `start
+        powershell -c ls` and is the program, and `start "t" powershell` arrives
+        as `start t powershell`, which launches t and passes powershell to it as
+        a parameter rather than running it.
+        test_git_bash_does_not_requote_a_bare_word checks that on Windows.
+        """
+        nonlocal title_tokens
+        if title_tokens is None:
+            # Built at most once per call, and only when a start is actually here.
+            title_tokens = _start_title_indexes(tokens, lexed_posix)
+        first = _skip_start_switches(tokens, index + 1)
+        if first >= len(tokens):
+            return -1
+        if first not in title_tokens:
+            return first
+        behind = _skip_start_switches(tokens, first + 1)
+        return behind if behind < len(tokens) else -1
+
+    def _cmd_runs_here(index: int) -> bool:
+        """Whether the shell word at ``index`` is one the line actually runs."""
+        # A word inside a cmd payload is cmd's whichever lexer read the line, so
+        # the payloads collected so far are consulted first: with Git Bash the
+        # outer `cmd /c cmd /c start "" powershell` is bash's command and the
+        # inner one is only its argument, yet cmd really does run it.
+        if index in cmd_run_indexes:
+            return True
+        if lexed_posix and index in run_indexes:
+            return True
+        # cmd launches a start's program, which is deliberately NOT a command
+        # position above (it is screened by name, not rescanned as command
+        # text), so `start "" cmd /c start "" powershell` needs it named here.
+        return sys.platform == "win32" and any(
+            _start_program_index(pos) == index for pos in start_indexes
+        )
+
+    if not lexed_posix:
+        _read_cmd_line(0)
+
     # Nested shell invocations (bash -c '...', bash -lc '...', cmd /c '...'):
     # on a -c/-/c flag, look back for a shell name (skipping flags) and
     # recursively scan the nested command string.
@@ -2048,27 +2136,15 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # Everything from here on is cmd's command line, which the outer
                 # scan can only read as arguments of cmd. Recursing does not
                 # reach it either: only the one token is passed on, and `start`
-                # by itself blocks nothing.
-                for pos, cmd_word in _cmd_command_positions(i + 1).items():
-                    if cmd_word == "start":
-                        start_indexes.add(pos)
-                    elif cmd_word == "for":
-                        cmd_for_indexes.add(pos)
+                # by itself blocks nothing. Only where this cmd is a command the
+                # line runs, though: `echo cmd /c start "" powershell` prints
+                # those words, and reading them as a command line refused the
+                # message. Visited left to right, so an outer cmd has already
+                # named the inner one by the time it is reached.
+                if _cmd_runs_here(j):
+                    _read_cmd_line(i + 1)
             break  # stop at first non-flag token
 
-    # `cmd /c start "" prog` puts prog in a command position the scan above
-    # sees only as an argument, so screen what start actually launches.
-    title_tokens: "frozenset[int] | None" = None
-    # When cmd is the shell the whole line is its command line, so it is read
-    # with cmd's grammar rather than the POSIX command positions above, which
-    # hand a wrapper's operand to the next word: `time` is a cmd builtin that
-    # shows the clock, and `time start "" powershell` launches nothing.
-    if not lexed_posix:
-        for pos, cmd_word in _cmd_command_positions(0).items():
-            if cmd_word == "start":
-                start_indexes.add(pos)
-            elif cmd_word == "for":
-                cmd_for_indexes.add(pos)
     # `for /f %i in ('CMD') do ...` runs CMD as a child command and reads its
     # output, so the set is a command position the token scan sees only as data.
     # Backquotes are the same form under usebackq.
@@ -2098,38 +2174,9 @@ def _find_blocked_commands(command: str) -> set[str]:
     # prints text, and reading every token named start walked the title branch
     # into a hard block for it.
     for i in sorted(start_indexes):
-        # Built at most once per call, and only when a start is actually here.
-        if title_tokens is None:
-            title_tokens = _start_title_indexes(tokens, lexed_posix)
-        j = _skip_start_switches(tokens, i + 1)
-        if j >= len(tokens):
-            continue
-        # `start "title" prog` is the documented form: cmd reads a quoted first
-        # argument as the window title, but only when something follows it, so
-        # the program is the token behind it. A title is data, so it is not
-        # screened itself. Microsoft documents the switches AFTER the title too,
-        # so they are skipped on both sides of it: `start "" /min powershell`
-        # left the program at j + 2 and screened the switch instead.
-        if j in title_tokens:
-            # Microsoft writes the syntax as `start <"title"> [switches]
-            # [<command>|<program> [<parameter>...]]`, so the program is
-            # optional and a lone quoted operand is only the title: `start
-            # "powershell"` opens a window with that name and runs nothing,
-            # where screening it as the program refused the word itself.
-            k = _skip_start_switches(tokens, j + 1)
-            if k < len(tokens):
-                blocked |= _blocked_start_program(tokens[k])
-            continue
-        # Otherwise this token is the program cmd launches. Under Git Bash a
-        # quoted word without spaces is not a title by the time cmd sees it,
-        # because bash removes the quotes and MSYS re-quotes an argument only
-        # when it holds whitespace or is empty -- the same rule as
-        # subprocess.list2cmdline. So `start "powershell" -c ls` arrives as
-        # `start powershell -c ls` and is caught right here, and `start "t"
-        # powershell` arrives as `start t powershell`, which launches t and
-        # passes powershell to it as a parameter rather than running it.
-        # test_git_bash_does_not_requote_a_bare_word checks that on Windows.
-        blocked |= _blocked_start_program(tokens[j])
+        program = _start_program_index(i)
+        if program >= 0:
+            blocked |= _blocked_start_program(tokens[program])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1318,6 +1318,25 @@ def _cmd_group_delta(token: str) -> int:
     return delta
 
 
+def _cmd_unquoted_split(text: str, chars: str) -> "list[str]":
+    """``text`` split on the ``chars`` that are OUTSIDE quotation marks.
+
+    Grouping brackets and cmd's argument delimiters are syntax bare and data
+    quoted, and reading a spelling rather than the quote state got both wrong:
+    `"(safe)start" "" powershell` names a program cmd looks up whole, and
+    splitting it left `start`, which refused a line that launches nothing.
+    """
+    pieces, current = [], []
+    for char, quoted in zip(text, _cmd_quoted_offsets(text)):
+        if char in chars and not quoted:
+            pieces.append("".join(current))
+            current = []
+            continue
+        current.append(char)
+    pieces.append("".join(current))
+    return pieces
+
+
 def _cmd_word_depth_delta(token: str) -> int:
     """How far ``token``'s brackets have moved cmd's grouping by the time it
     reads the command word in it.
@@ -1329,11 +1348,11 @@ def _cmd_word_depth_delta(token: str) -> int:
     the `else` of `if exist x (echo else) else start "" pwsh` is ECHO's data.
     """
     plain = _cmd_split(token, "")[0]
-    pieces = re.split(r"[()]", plain)
+    pieces = _cmd_unquoted_split(plain, "()")
     kept = [index for index, piece in enumerate(pieces) if piece]
     last = kept[-1] if kept else 0
     prefix = plain[: sum(len(piece) for piece in pieces[:last]) + last]
-    return prefix.count("(") - prefix.count(")")
+    return _cmd_group_delta(prefix)
 
 
 def _cmd_split(token: str, chars: str) -> "list[str]":
@@ -1451,6 +1470,14 @@ def _blocked_start_program(token: str) -> "set[str]":
         stem, ext = os.path.splitext(base)
         if ext in {".exe", ".com", ".bat", ".cmd"}:
             base = stem
+        if _CMD_DELAYED_RE.search(base):
+            # A delayed expansion is read when the command RUNS, so the same
+            # line can fill it: `cmd /v:on /c "set X=power&start "" !X!shell"`
+            # assembles powershell out of a fragment that is nothing on its own.
+            # Unknowable here and controllable there, so it is refused. The
+            # `%VAR%` form is read when the line is PARSED, before any set on it
+            # can run, which is why that one is only read both ways.
+            return {target.strip('"').lower()}
         if not base and len(names) > 1:
             # The program name is nothing BUT an expansion, so no reading of it
             # is a name: `start "" %ComSpec% /c powershell` launches cmd with a
@@ -1752,25 +1779,31 @@ def _find_blocked_commands(command: str) -> set[str]:
         `for %i in (x)do start "" powershell` leaves `(x)do` as one token under
         the cmd lexer, whose `do` still hands the body along.
         """
-        plain = _cmd_split(word, "")[0].strip(";&|`{}")
-        pieces = [piece for piece in re.split(r"[()]", plain) if piece]
+        plain = _cmd_split(word, "")[0].strip("&|`{}")
+        # Expansion runs before the line is parsed and a variable can contribute
+        # nothing, an unset `!X!` where delayed expansion is on or a zero-length
+        # `%PATH:~0,0%` anywhere, so `st!X!art` and `st%PATH:~0,0%art` ARE start.
+        # Read first, since what it leaves behind is what cmd then reads for
+        # syntax: the comma of `%PATH:~0,0%` is inside a variable and not a
+        # delimiter. Reading the spelling as cmd leaves it is the safe
+        # direction, a file really named that launching nothing, and it is not
+        # gated on /v:on either, since the registry enables delayed expansion
+        # host-wide and a command line does not show that.
+        if "!" in plain or "%" in plain:
+            plain = _CMD_DELAYED_RE.sub("", _CMD_VARIABLE_RE.sub("", plain)) or plain
+        # An unquoted delimiter then ends the command word, so `start;""
+        # powershell` is a start: cmd reads `;`, `,` and `=` where it reads a
+        # space, which is what makes `echo;hi` print. Quoted, they are filename
+        # characters. A word that BEGINS with one is not a name ending at one,
+        # so `=="a"` stays the comparison half it is.
+        plain = _cmd_unquoted_split(plain, ";,=")[0] or plain
+        pieces = [piece for piece in _cmd_unquoted_split(plain, "()") if piece]
         # The bracket comes off before the prefix, or `(@start` keeps its `@`
         # and never matches: cmd reads the group opener, then the suppression.
         # The marks come off wherever they sit, since cmd removes them when it
         # resolves the command: `pow"er"shell` runs powershell.
         name = (pieces[-1] if pieces else "").replace('"', "").lstrip("@")
-        base = os.path.basename(name.replace("\\", "/")).lower()
-        # Expansion happens before the word is resolved and a variable can
-        # contribute nothing, an unset `!X!` where delayed expansion is on or a
-        # zero-length `%PATH:~0,0%` anywhere, so `st!X!art` and `st%PATH:~0,0%art`
-        # ARE start. Reading the spelling as cmd leaves it is the safe
-        # direction: a file really named that launches nothing. Not gated on
-        # /v:on either, since the registry enables delayed expansion host-wide
-        # and a command line does not show that.
-        if "!" in base or "%" in base:
-            expanded = _CMD_DELAYED_RE.sub("", _CMD_VARIABLE_RE.sub("", base))
-            return expanded or base
-        return base
+        return os.path.basename(name.replace("\\", "/")).lower()
 
     def _cmd_condition_words(index: int) -> int:
         """How many words cmd's `if` condition occupies, starting at ``index``.
@@ -1781,6 +1814,15 @@ def _find_blocked_commands(command: str) -> set[str]:
         parsing further. The three-word comparison is the one that hid a launch:
         `if 1 EQU 1 start "" powershell` left EQU looking like the command.
         """
+        # A redirection between `if` and its test is performed by cmd and never
+        # reaches the condition, so counting from `>nul` in `if >nul exist f
+        # start "" powershell` put the count a word out and left the launch in
+        # argument position. The walk skips those tokens too, so they are not
+        # counted here either.
+        while index < len(tokens) and _REDIR_PREFIX_RE.match(tokens[index]):
+            head = _CMD_REDIR_HEAD_RE.match(tokens[index])
+            attached = tokens[index][head.end() :] if head else ""
+            index += 1 if attached or (head and "&" in head.group(0)) else 2
         words = 0
         for _ in range(2):  # /i and not, in either order
             if index + words >= len(tokens):
@@ -1947,7 +1989,14 @@ def _find_blocked_commands(command: str) -> set[str]:
             if word == "start":
                 expect = False
             elif word == "call":
-                pass  # it reparses its target, so a command follows it
+                # It reparses its target, so a command follows it -- and that
+                # second parse sees the line the FIRST one left, escapes
+                # already applied: `call echo safe ^& start "" powershell`
+                # reaches it with a real separator and the start runs. Only
+                # where a caret was there to remove, since otherwise the second
+                # parse reads what this walk is reading anyway.
+                if index + 1 < len(tokens):
+                    cmd_call_indexes.add(index + 1)
             elif word == "if":
                 skip = _cmd_condition_words(index + 1)
                 control.append(("if", word_depth))
@@ -2016,6 +2065,8 @@ def _find_blocked_commands(command: str) -> set[str]:
     # a `cmd /c` payload is only a command line where the cmd running it is
     # itself executed, and `echo cmd /c start "" powershell` merely prints.
     run_indexes: "set[int]" = set()
+    # Words a `call` reparses, which is a second pass over the text behind it.
+    cmd_call_indexes: "set[int]" = set()
     xargs_index = -1  # an xargs awaiting the command it wraps
     for token_index, token in enumerate(tokens):
         if skip_operand:
@@ -2224,6 +2275,22 @@ def _find_blocked_commands(command: str) -> set[str]:
                 blocked.update(_blocked_matching_glob(name))
         return cmd_grammar_spent
 
+    token_offsets: "list[int] | None" = None
+
+    def _token_offsets() -> "list[int]":
+        """Where each token starts in the source line, or -1 for one the lexer
+        built rather than copied. Built at most once, and only for the scans
+        that have to place a token back in the text they came from."""
+        nonlocal token_offsets
+        if token_offsets is None:
+            offsets, cursor = [], 0
+            for token in tokens:
+                found = command.find(token, cursor)
+                offsets.append(found)
+                cursor = found + len(token) if found >= 0 else cursor
+            token_offsets = offsets
+        return token_offsets
+
     def _cmd_payload_text(index: int) -> str:
         """The source text from ``tokens[index]`` on, dequoted as cmd dequotes
         its command line.
@@ -2238,16 +2305,11 @@ def _find_blocked_commands(command: str) -> set[str]:
         rebuild is what loses it: the cmd lexer splits `"start "" powershell"`
         at the quotes into pieces that no longer sit where they did.
         """
-        cursor = 0
-        for position, token in enumerate(tokens):
-            found = command.find(token, cursor)
-            if found < 0:
-                return ""  # a token the lexer built rather than copied
-            if position == index:
-                payload = command[found:]
-                closing = payload.rfind('"')
-                return payload[1:closing] + payload[closing + 1 :] if closing > 0 else payload[1:]
-            cursor = found + len(token)
+        offsets = _token_offsets()
+        if index < len(offsets) and offsets[index] >= 0:
+            payload = command[offsets[index] :]
+            closing = payload.rfind('"')
+            return payload[1:closing] + payload[closing + 1 :] if closing > 0 else payload[1:]
         return ""
 
     def _start_program_index(index: int) -> int:
@@ -2382,8 +2444,21 @@ def _find_blocked_commands(command: str) -> set[str]:
     # and the grammar budget above caps the total either way.
     read_payloads: "set[int]" = set()
     screened_starts: "set[int]" = set()
+    reparsed_calls: "set[int]" = set()
     while True:
         progressed = False
+        for i in sorted(cmd_call_indexes - reparsed_calls):
+            reparsed_calls.add(i)
+            progressed = True
+            offsets = _token_offsets()
+            text = command[offsets[i] :] if i < len(offsets) and offsets[i] >= 0 else ""
+            # Only where a caret was there for the first pass to remove: cmd
+            # reads `call echo safe ^& start "" powershell` as one command,
+            # then CALL reads what is left, where the `&` is a separator and
+            # the start is a command of its own. Without one the second pass
+            # sees the same words this walk already read.
+            if "^" in text:
+                blocked |= _find_blocked_commands(_cmd_split(text, "")[0])
         for i, j, prev_base in cmd_payloads:
             if i in read_payloads or not _cmd_runs_here(j):
                 continue
@@ -2423,13 +2498,21 @@ def _find_blocked_commands(command: str) -> set[str]:
     # Only where cmd runs a `for` itself. The body is found by re-reading the
     # text, which cannot tell a construct from a quotation of one on its own, so
     # `echo "for /f %i in ('rm -rf x') do echo %i"` was refused for printing.
-    quoted_offsets = _cmd_quoted_offsets(command) if cmd_for_indexes else []
-    for match in _CMD_FOR_SUBSTITUTION_RE.finditer(command if cmd_for_indexes else ""):
-        # A `for` cmd runs somewhere on the line is not this `for`: the outer
-        # one in `for %i in (x) do echo "for /f %j in ('start "" pwsh') ..."` is
-        # real while the inner expression is echo's data, so each match has to
-        # be unquoted where it sits, not merely accompanied by a construct.
-        if match.start() < len(quoted_offsets) and quoted_offsets[match.start()]:
+    # A `for` cmd runs somewhere on the line is not this `for`: the outer one in
+    # `for %i in (x) do echo "for /f %j in ('start "" pwsh') ..."` is real while
+    # the inner expression is echo's data, and `... do rem for /f %j in (...)`
+    # is a comment. So a match counts only where it BEGINS at one of the `for`
+    # words the walk recorded, rather than merely sharing a line with one.
+    # Inside that word rather than at it, since a separator glued in front
+    # leaves the `for` mid-token: `> out&for /f %i in (...)` is one token whose
+    # command word is the for.
+    for_spans = [
+        (_token_offsets()[i], _token_offsets()[i] + len(tokens[i]))
+        for i in cmd_for_indexes
+        if _token_offsets()[i] >= 0
+    ]
+    for match in _CMD_FOR_SUBSTITUTION_RE.finditer(command if for_spans else ""):
+        if not any(begin <= match.start() < end for begin, end in for_spans):
             continue
         # Only one of the two spellings is a child command, and usebackq is what
         # swaps them: Microsoft documents `('<command>')` without it and

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1220,9 +1220,9 @@ def _start_title_indexes(tokens: "list[str]", lexed_posix: bool) -> "frozenset[i
 
 # cmd ends a command word at these whether or not whitespace surrounds them.
 _CMD_OPERATOR_RE = re.compile(r"[&|<>]")
-# cmd commands that take the rest of their segment as text, so a `start` behind
-# one is a word being printed or assigned rather than a program being launched.
-_CMD_TEXT_COMMANDS = frozenset({"echo", "rem", "set", "title", "prompt"})
+# ...but only these begin another command. `>` redirects into a file, so
+# `echo hi>start powershell` writes to one called start and launches nothing.
+_CMD_SEPARATOR_RE = re.compile(r"[&|]")
 
 
 def _strip_cmd_quotes(token: str) -> str:
@@ -1521,21 +1521,30 @@ def _find_blocked_commands(command: str) -> set[str]:
         found at all. cmd reads the operator, so the word after the last one is
         the command.
         """
-        return _token_basename(_CMD_OPERATOR_RE.split(tokens[index])[-1]) == "start"
+        return _token_basename(_CMD_SEPARATOR_RE.split(tokens[index])[-1]) == "start"
 
     def _cmd_command_head(index: int) -> int:
         """The index of the word cmd runs for the segment beginning at ``index``.
 
         `if` carries out the command after its condition, so the leading word is
         not the command: `cmd /c if exist x echo start "t" powershell` runs echo,
-        which only prints. The condition forms all take a fixed number of words
-        (`exist PATH`, `defined VAR`, `errorlevel N`, or one `a==b` comparison),
-        so the command behind them can be reached without parsing further.
+        which only prints. Microsoft documents the condition as
+        `if [/i] [not] (<string1> <compareop> <string2> | exist <path> |
+        defined <var> | errorlevel <n>) <command>`, all of which take a fixed
+        number of words, so the command behind one can be reached without
+        parsing further. Missing the optional /i left the comparison itself
+        looking like the command.
         """
         while index < len(tokens) and _token_basename(tokens[index]) == "if":
             index += 1
-            if index < len(tokens) and _token_basename(tokens[index]) == "not":
-                index += 1
+            for _ in range(2):  # /i and not, in either order
+                if index >= len(tokens):
+                    break
+                # _token_basename would read /i as the path `i`, so the switch is
+                # matched on the raw word, through the Git Bash `//i` spelling.
+                word = tokens[index].lower()
+                if _win_switch(word) == "/i" or _token_basename(word) == "not":
+                    index += 1
             if index >= len(tokens):
                 break
             if _token_basename(tokens[index]) in ("exist", "defined", "errorlevel"):
@@ -1548,47 +1557,43 @@ def _find_blocked_commands(command: str) -> set[str]:
         """Indexes of the `start` words that launch a program in the cmd command
         line beginning at ``begin``.
 
-        cmd keeps parsing past its own conditionals and operators, so promoting
+        cmd keeps parsing past its own conditionals and separators, so promoting
         only the first word missed `cmd //c if exist . start "" powershell`,
         which cmd runs and which the scan had caught before it was gated. Each
-        segment is read down to the word cmd actually runs instead, so a start
-        that is an argument of one taking text stays an argument: `cmd //c echo
-        start "my title" powershell` prints and launches nothing.
+        segment is read down to the word cmd actually runs instead, and only
+        that word counts: anywhere else a start is an operand of the command
+        that is running, whether that prints it (`cmd //c echo start "t" pwsh`)
+        or reads it as a name (`cmd /c dir start "" powershell`).
 
         Under bash the payload ends at the first shell separator, since that
         terminates the cmd invocation rather than starting a new cmd command:
-        with `cmd //c echo ok; printf "%s" start "t" powershell`, cmd is handed
-        only `echo ok` and the start belongs to printf. The cmd lexer has no
-        such boundary, and there `&` does begin a new cmd command.
+        with `cmd //c echo ok; printf "%s" start "" powershell`, cmd is handed
+        only `echo ok` and the start belongs to printf. An escaped one is the
+        opposite: bash passes it through and cmd reads it as its own separator,
+        so it opens a segment rather than ending the scan.
         """
         found: "set[int]" = set()
-        head_base: "str | None" = None  # the word cmd runs for the open segment
-        condition_end = begin
+        head = -1  # index of the word cmd runs for the open segment
         for index in range(begin, len(tokens)):
             token = tokens[index]
-            if _looks_like_separator(token) and index not in quoted_separators:
-                if lexed_posix:
+            if _looks_like_separator(token):
+                if lexed_posix and index not in quoted_separators:
                     break
-                head_base = None
+                head = -1
                 continue
-            # An operator with no space around it stays inside the token under
+            # A separator with no space around it stays inside the token under
             # the cmd lexer, so it both hides a start and opens a segment:
             # `cmd /c echo ok&start "" pwsh` runs echo and then the start.
-            pieces = [token] if lexed_posix else _CMD_OPERATOR_RE.split(token)
+            # Redirections are not separators: `cmd /c echo hi>start powershell`
+            # writes to a file called start and launches nothing.
+            pieces = [token] if lexed_posix else _CMD_SEPARATOR_RE.split(token)
             glued = len(pieces) > 1
-            if head_base is None:
-                condition_end = _cmd_command_head(index)
-                head_base = (
-                    _token_basename(tokens[condition_end]) if condition_end < len(tokens) else ""
-                )
-            if (
-                index >= condition_end
-                and _is_cmd_start_word(index)
-                and (glued or head_base == "start" or head_base not in _CMD_TEXT_COMMANDS)
-            ):
+            if head < 0:
+                head = _cmd_command_head(index)
+            if (glued or index == head) and _is_cmd_start_word(index):
                 found.add(index)
             if glued:
-                head_base = _token_basename(pieces[-1])
+                head = index  # the segment after the last separator begins here
         return found
 
     def _exec_child_index(start: int) -> "tuple[int, bool]":

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1219,13 +1219,10 @@ def _start_title_indexes(tokens: "list[str]", lexed_posix: bool) -> "frozenset[i
 
 
 # cmd ends a command word at these whether or not whitespace surrounds them.
-_CMD_OPERATOR_RE = re.compile(r"(?<!\^)[&|<>]")
+_CMD_OPERATORS = "&|<>"
 # ...but only these begin another command. `>` redirects into a file, so
 # `echo hi>start powershell` writes to one called start and launches nothing.
-# Microsoft: "The ampersand &, pipe | and parentheses ( ) are special characters
-# that must be preceded by the escape character ^ or quotation marks when you
-# pass them as arguments", so an escaped one is an argument and not a separator.
-_CMD_SEPARATOR_RE = re.compile(r"(?<!\^)[&|]")
+_CMD_SEPARATORS = "&|"
 # A URL is opened in the browser rather than run: "any file type that has a
 # registered association, including URLs, which are automatically detected and
 # opened in the default browser" (the start reference), whose own example is
@@ -1233,16 +1230,41 @@ _CMD_SEPARATOR_RE = re.compile(r"(?<!\^)[&|]")
 _URL_SCHEME_RE = re.compile(r"[a-z][a-z0-9+.\-]*://", re.IGNORECASE)
 # cmd's comparison operators, which sit between the two words of an `if` test.
 _CMD_COMPARE_OPS = frozenset({"equ", "neq", "lss", "leq", "gtr", "geq"})
+# ...and its tests that take one operand of their own before the command.
+_CMD_TWO_WORD_TESTS = frozenset({"exist", "defined", "errorlevel", "cmdextversion"})
 
 
-def _strip_cmd_carets(token: str) -> str:
-    """``token`` with cmd's escape character applied, as cmd applies it.
+def _cmd_split(token: str, chars: str) -> "list[str]":
+    """``token`` split on the ``chars`` cmd reads as syntax, escapes applied.
 
-    The caret escapes the character behind it and is dropped, so it hides a
-    name from a plain comparison the way quoting once did: cmd runs
-    `start "" power^shell` as powershell.
+    Microsoft: "The ampersand &, pipe | and parentheses ( ) are special
+    characters that must be preceded by the escape character ^ or quotation
+    marks when you pass them as arguments." The caret escapes whatever follows
+    it and is then dropped, so both halves of that have to be read together and
+    in one pass: a lookbehind for a single caret cannot tell `ok^&start`, where
+    the & is an argument, from `ok^^&start`, where the first caret escapes the
+    second and the & still separates two commands. Dropping the caret matters on
+    its own too, since it otherwise hides a name from a plain comparison the way
+    quoting did: cmd runs `start "" power^shell` as powershell.
     """
-    return re.sub(r"\^(.)", r"\1", token)
+    pieces: "list[str]" = []
+    current: "list[str]" = []
+    index = 0
+    while index < len(token):
+        char = token[index]
+        if char == "^" and index + 1 < len(token):
+            current.append(token[index + 1])  # escaped, so never syntax
+            index += 2
+            continue
+        if char in chars:
+            pieces.append("".join(current))
+            current = []
+            index += 1
+            continue
+        current.append(char)
+        index += 1
+    pieces.append("".join(current))
+    return pieces
 
 
 def _strip_cmd_quotes(token: str) -> str:
@@ -1280,11 +1302,15 @@ def _blocked_start_program(token: str) -> "set[str]":
     to `C:/A` and let the program behind it through.
     """
     unquoted = _strip_cmd_quotes(token)
-    target = unquoted if unquoted is not token else _CMD_OPERATOR_RE.split(token, 1)[0]
-    # A group bracket is cmd's, not part of the name: it documents a
-    # parenthesised body for a single-line `if`, so the program in
+    # Quoting is what makes a path holding an operator usable, so only one
+    # outside the quotes is syntax. A group bracket is cmd's too, not part of
+    # the name: it documents a parenthesised body for a single-line `if`, so
     # `if exist x (start "" powershell)` arrives spelled `powershell)`.
-    target = _strip_cmd_carets(target).strip("()")
+    target = (
+        _cmd_split(unquoted, "")[0]
+        if unquoted is not token
+        else _cmd_split(token, _CMD_OPERATORS)[0]
+    ).strip("()")
     # A URL goes to the browser, so its host and path are not a program name and
     # `start "" https://example.com/curl` is not curl.
     if _URL_SCHEME_RE.match(target):
@@ -1549,11 +1575,13 @@ def _find_blocked_commands(command: str) -> set[str]:
         found at all. cmd reads the operator, so the word after the last one is
         the command.
         """
-        return _cmd_word_base(_CMD_SEPARATOR_RE.split(tokens[index])[-1]) == "start"
+        return _cmd_word_base(_cmd_split(tokens[index], _CMD_SEPARATORS)[-1]) == "start"
 
     def _cmd_word_base(word: str) -> str:
         """``word`` as cmd resolves it: escapes applied, then the plain basename."""
-        return _token_basename(_strip_cmd_carets(word))
+        # `@` suppresses echoing without changing which command runs, so
+        # `cmd /c @start "" powershell` is still a start.
+        return _token_basename(_cmd_split(word, "")[0].lstrip("@"))
 
     def _cmd_condition_words(index: int) -> int:
         """How many words cmd's `if` condition occupies, starting at ``index``.
@@ -1575,7 +1603,7 @@ def _find_blocked_commands(command: str) -> set[str]:
                 words += 1
         if index + words >= len(tokens):
             return words
-        if _cmd_word_base(tokens[index + words]) in ("exist", "defined", "errorlevel"):
+        if _cmd_word_base(tokens[index + words]) in _CMD_TWO_WORD_TESTS:
             return words + 2
         if (
             index + words + 1 < len(tokens)
@@ -1606,29 +1634,39 @@ def _find_blocked_commands(command: str) -> set[str]:
         """
         found: "set[int]" = set()
         expect = True  # the next word is one cmd runs
+        control = False  # an `if` or a `for` is open, so else/do hand off
         skip = 0  # condition words still to consume
         for index in range(begin, len(tokens)):
             token = tokens[index]
             if _looks_like_separator(token):
                 if lexed_posix and index not in quoted_separators:
                     break
-                if _CMD_SEPARATOR_RE.search(token):
+                if len(_cmd_split(token, _CMD_SEPARATORS)) > 1:
                     expect = True
+                    control = False
                 continue
             # A separator with no space around it stays inside the token, under
             # either lexer: the cmd one takes no punctuation_chars, and bash
             # removes the escape from `ok\&start` before cmd reads the `&`.
-            pieces = _CMD_SEPARATOR_RE.split(token)
+            # A redirection is bash's, consumed before cmd is handed its
+            # arguments, so it holds the command position rather than taking it:
+            # `cmd //c >nul start "" powershell` really does launch.
+            if _REDIR_PREFIX_RE.match(token):
+                continue
+            pieces = _cmd_split(token, _CMD_SEPARATORS)
             if len(pieces) > 1:
                 expect = True
+                control = False
             word = _cmd_word_base(pieces[-1])
             if skip > 0:
                 skip -= 1
                 continue
             # `else` and the `do` of a `for` both hand the command along, from
             # either side: the branch they open is a command position even
-            # though the word before them was one too.
-            if word in ("else", "do"):
+            # though the word before them was one too. Only where one of those
+            # statements is open, though, or `cmd /c echo else start "" pwsh`
+            # reads a printed word as a handoff.
+            if control and word in ("else", "do"):
                 expect = True
                 continue
             if not expect:
@@ -1638,8 +1676,12 @@ def _find_blocked_commands(command: str) -> set[str]:
                 expect = False
             elif word == "if":
                 skip = _cmd_condition_words(index + 1)
+                control = True
+            elif word == "for":
+                control = True
+                expect = False  # re-armed by its own `do`, above
             else:
-                expect = False  # a `for` is re-armed by its own `do`, below
+                expect = False
         return found
 
     def _exec_child_index(start: int) -> "tuple[int, bool]":

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1227,15 +1227,23 @@ _CMD_SEPARATORS = "&|"
 # registered association, including URLs, which are automatically detected and
 # opened in the default browser" (the start reference), whose own example is
 # `start "Bing" "https://www.bing.com"`.
-_URL_SCHEME_RE = re.compile(r"[a-z][a-z0-9+.\-]*://", re.IGNORECASE)
+# Two letters at least: a one-letter "scheme" is a drive, and Win32 takes `/`
+# as a separator ("Naming Files, Paths, and Namespaces"), so
+# `C://Windows/System32/WindowsPowerShell/v1.0/powershell.exe` is a program and
+# reading it as a URL walked past the name.
+_URL_SCHEME_RE = re.compile(r"[a-z][a-z0-9+.\-]+://", re.IGNORECASE)
 # cmd's comparison operators, which sit between the two words of an `if` test.
 _CMD_COMPARE_OPS = frozenset({"equ", "neq", "lss", "leq", "gtr", "geq"})
 # ...and its tests that take one operand of their own before the command.
 _CMD_TWO_WORD_TESTS = frozenset({"exist", "defined", "errorlevel", "cmdextversion"})
 # `for /f ... in ('CMD')` runs CMD and reads its output, the command-substitution
-# form documented for `for`; usebackq spells the same thing with backquotes.
+# form documented for `for`. Which quoting spells it is decided by usebackq, so
+# the option string in between is captured rather than skipped -- and captured
+# quote by quote, since `delims=(` is a legal option holding cmd's own bracket
+# and stopping at the first one hid the set behind it.
 _CMD_FOR_SUBSTITUTION_RE = re.compile(
-    r"\bfor\s+/f\b[^(]*\(\s*(?:'(?P<body>[^']*)'|`(?P<alt>[^`]*)`)\s*\)",
+    r"\bfor\s+/f\b(?P<options>(?:\"[^\"]*\"|[^(\"])*)"
+    r"\(\s*(?:'(?P<body>[^']*)'|`(?P<alt>[^`]*)`)\s*\)",
     re.IGNORECASE,
 )
 
@@ -1371,13 +1379,26 @@ def _blocked_start_program(token: str) -> "set[str]":
     # `start "" https://example.com/curl` is not curl.
     if _URL_SCHEME_RE.match(target):
         return set()
-    base = os.path.basename(target.replace("\\", "/")).lower()
-    stem, ext = os.path.splitext(base)
-    if ext in {".exe", ".com", ".bat", ".cmd"}:
-        base = stem
-    if base in _blocked_commands():
-        return {base}
-    return _blocked_matching_glob(base)
+    # cmd expands its variables before it resolves the program, and a substring
+    # expansion can contribute nothing at all: `powershell%PATH:~0,0%` launches
+    # powershell, where the literal spelling matches no name. What each one
+    # expands to is not knowable here, so the name is read both ways and the
+    # blocked one counts -- refusing a file really called that is the safe
+    # direction, and `report%DATE%.txt` still names no program.
+    names = {target}
+    if "%" in target:
+        names.add(_CMD_VARIABLE_RE.sub("", target))
+    blocked: "set[str]" = set()
+    for name in names:
+        base = os.path.basename(name.replace("\\", "/")).lower()
+        stem, ext = os.path.splitext(base)
+        if ext in {".exe", ".com", ".bat", ".cmd"}:
+            base = stem
+        if base in _blocked_commands():
+            blocked.add(base)
+        else:
+            blocked |= _blocked_matching_glob(base)
+    return blocked
 
 
 def _xargs_replacement(tokens: "list[str]", start: int, end: int) -> str:
@@ -1561,6 +1582,13 @@ _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 # arguments in MSYS form, so `start "" /c/Windows/System32/powershell.exe` is the
 # launched program, and skipping it as a switch walked straight past the block.
 _START_SWITCH_RE = re.compile(r"/[a-z][a-z0-9]*", re.IGNORECASE)
+# cmd's own switches, which sit between it and the /c holding its command line.
+# One letter, and a value behind a colon for the documented /t:, /e:, /f: and
+# /v:. Anchored at both ends so a path is not mistaken for one: `/bin/bash` and
+# `/c/Windows/System32/cmd.exe` are programs.
+_CMD_SWITCH_RE = re.compile(r"/[a-z](?::[^\s/]*)?$", re.IGNORECASE)
+# A cmd variable expansion, `%NAME%` or a substring of one (`%PATH:~0,0%`).
+_CMD_VARIABLE_RE = re.compile(r"%[^%\s]*%")
 
 
 def _find_blocked_commands(command: str) -> set[str]:
@@ -2118,8 +2146,12 @@ def _find_blocked_commands(command: str) -> set[str]:
             prev = tokens[j]
             if prev.startswith("-"):
                 continue  # skip Unix flags like --login, -l
-            if is_win_c and prev.startswith("/") and len(prev) <= 3:
-                continue  # skip Windows flags like /s, /q (not /bin/bash)
+            if is_win_c and _CMD_SWITCH_RE.match(_win_switch(prev)):
+                # Skip cmd's own switches (/s, /q, and the value-bearing /v:on,
+                # /e:off, /t:0a) without skipping a path: a length test alone
+                # stopped the search at `cmd /v:on /c ...`, so the cmd in front
+                # of it was never found and its command line never read.
+                continue
             # The cmd lexer keeps a glued opener, so `(cmd //c ...)` left prev
             # as `(cmd` and matched no shell. Under bash the opener is its own
             # token, so one still attached survived quoting and is part of the
@@ -2158,6 +2190,14 @@ def _find_blocked_commands(command: str) -> set[str]:
         # real while the inner expression is echo's data, so each match has to
         # be unquoted where it sits, not merely accompanied by a construct.
         if match.start() < len(quoted_offsets) and quoted_offsets[match.start()]:
+            continue
+        # Only one of the two spellings is a child command, and usebackq is what
+        # swaps them: Microsoft documents `('<command>')` without it and
+        # ``(`<command>`)`` with it, the other being a literal string to parse.
+        # Reading both as commands refused `for /f %i in (`powershell`)`, which
+        # looks up a file by that name.
+        backquoted = match.group("alt") is not None
+        if backquoted != ("usebackq" in (match.group("options") or "").lower()):
             continue
         # The escapes are the outer parse's, so cmd hands the child a line with
         # them already applied: `echo x ^& start ""` reaches it as a real

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1597,9 +1597,12 @@ def _find_blocked_commands(command: str) -> set[str]:
         `for %i in (x)do start "" powershell` leaves `(x)do` as one token under
         the cmd lexer, whose `do` still hands the body along.
         """
-        plain = _cmd_split(word, "")[0].lstrip("@").strip(";&|`{}")
+        plain = _cmd_split(word, "")[0].strip(";&|`{}")
         pieces = [piece for piece in re.split(r"[()]", plain) if piece]
-        return os.path.basename((pieces[-1] if pieces else "").replace("\\", "/")).lower()
+        # The bracket comes off before the prefix, or `(@start` keeps its `@`
+        # and never matches: cmd reads the group opener, then the suppression.
+        name = (pieces[-1] if pieces else "").lstrip("@").strip('"')
+        return os.path.basename(name.replace("\\", "/")).lower()
 
     def _cmd_condition_words(index: int) -> int:
         """How many words cmd's `if` condition occupies, starting at ``index``.
@@ -1628,13 +1631,22 @@ def _find_blocked_commands(command: str) -> set[str]:
             and _cmd_word_base(tokens[index + words + 1]) in _CMD_COMPARE_OPS
         ):
             return words + 3
-        return words + 1  # the `a==b` form, which cmd lexes as one word
+        # The `a==b` form is one word unquoted, but the cmd lexer keeps the
+        # quotes and splits `"a"=="a"` into `"a"` and `=="a"`, whose second half
+        # then took the command position. Read on until both sides are in.
+        text = ""
+        for extra in range(words, len(tokens) - index):
+            text += _cmd_split(tokens[index + extra], "")[0]
+            head, sep, tail = text.partition("==")
+            if sep and head.strip() and tail.strip():
+                return extra + 1
+        return words + 1
 
-    def _cmd_start_positions(begin: int) -> "set[int]":
-        """Indexes of the `start` words cmd runs as a command in the command
-        line beginning at ``begin``.
+    def _cmd_command_positions(begin: int) -> "dict[int, str]":
+        """The words cmd runs as a command in the command line beginning at
+        ``begin``, by index.
 
-        Anywhere but a command position a start is an operand of whatever is
+        Anywhere but a command position a word is an operand of whatever is
         running, whether that prints it (`cmd //c echo start "t" pwsh`) or reads
         it as a name (`cmd /c dir start "" powershell`), so tracking where cmd
         begins a command is what separates a launch from a word. Its grammar is
@@ -1650,9 +1662,10 @@ def _find_blocked_commands(command: str) -> set[str]:
         escaped one is passed through to cmd, which reads it as its own, and it
         can arrive glued to a word once bash has removed the escape.
         """
-        found: "set[int]" = set()
+        found: "dict[int, str]" = {}
         expect = True  # the next word is one cmd runs
         control = False  # an `if` or a `for` is open, so else/do hand off
+        depth = 0  # open group brackets, which an `if` branch is written in
         skip = 0  # condition words still to consume
         skip_operand = False  # the word after a bare redirection operator
         for index in range(begin, len(tokens)):
@@ -1662,7 +1675,12 @@ def _find_blocked_commands(command: str) -> set[str]:
                     break
                 if len(_cmd_split(token, _CMD_SEPARATORS)) > 1:
                     expect = True
-                    control = False
+                    # A separator inside a group is between the branch's own
+                    # commands, so the `if` it belongs to is still open:
+                    # `if exist x (echo a & echo b) else start "" pwsh` runs the
+                    # start, and clearing here lost the else that reopens it.
+                    control = control and depth > 0
+                depth += token.count("(") - token.count(")")
                 continue
             # A separator with no space around it stays inside the token, under
             # either lexer: the cmd one takes no punctuation_chars, and bash
@@ -1685,7 +1703,8 @@ def _find_blocked_commands(command: str) -> set[str]:
             pieces = [token] if requoted else _cmd_split(token, _CMD_SEPARATORS)
             if len(pieces) > 1:
                 expect = True
-                control = False
+                control = control and depth > 0
+            depth += token.count("(") - token.count(")")
             word = _cmd_word_base(pieces[-1])
             if skip > 0:
                 skip -= 1
@@ -1700,8 +1719,9 @@ def _find_blocked_commands(command: str) -> set[str]:
                 continue
             if not expect:
                 continue
+            if word:
+                found[index] = word
             if word == "start":
-                found.add(index)
                 expect = False
             elif word == "call":
                 pass  # it reparses its target, so a command follows it
@@ -1768,6 +1788,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     sed_indexes: "list[int]" = []  # command-position sed words, for the `e` scan below
     sed_xargs: "dict[int, int]" = {}  # sed word -> the xargs that builds its argv
     start_indexes: "set[int]" = set()  # command-position start words, for the scan below
+    cmd_for_indexes: "set[int]" = set()  # command-position for words, for the scan below
     xargs_index = -1  # an xargs awaiting the command it wraps
     for token_index, token in enumerate(tokens):
         if skip_operand:
@@ -1960,7 +1981,11 @@ def _find_blocked_commands(command: str) -> set[str]:
             # as `(cmd` and matched no shell. Under bash the opener is its own
             # token, so one still attached survived quoting and is part of the
             # word: `echo '(bash' -c rm` prints three arguments and runs none.
-            prev_base = os.path.basename(prev).lower() if lexed_posix else _token_basename(prev)
+            # The cmd lexer keeps the quotes cmd itself strips, so `"cmd.exe" /c`
+            # matched no shell at all.
+            prev_base = (
+                os.path.basename(prev).lower() if lexed_posix else _token_basename(prev.strip('"'))
+            )
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
@@ -1969,28 +1994,39 @@ def _find_blocked_commands(command: str) -> set[str]:
                 # scan can only read as arguments of cmd. Recursing does not
                 # reach it either: only the one token is passed on, and `start`
                 # by itself blocks nothing.
-                start_indexes |= _cmd_start_positions(i + 1)
+                for pos, cmd_word in _cmd_command_positions(i + 1).items():
+                    if cmd_word == "start":
+                        start_indexes.add(pos)
+                    elif cmd_word == "for":
+                        cmd_for_indexes.add(pos)
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
-    # `for /f %i in ('CMD') do ...` runs CMD as a child command and reads its
-    # output, so the set is a command position the token scan sees only as data.
-    # Backquotes are the same form under usebackq.
-    for match in _CMD_FOR_SUBSTITUTION_RE.finditer(command):
-        # The escapes are the outer parse's, so cmd hands the child a line with
-        # them already applied: `echo x ^& start ""` reaches it as a real
-        # separator, and reading it raw left the start an operand of echo.
-        body = match.group("body") or match.group("alt") or ""
-        blocked |= _find_blocked_commands(_cmd_split(body, "")[0])
-
     title_tokens: "frozenset[int] | None" = None
     # When cmd is the shell the whole line is its command line, so it is read
     # with cmd's grammar rather than the POSIX command positions above, which
     # hand a wrapper's operand to the next word: `time` is a cmd builtin that
     # shows the clock, and `time start "" powershell` launches nothing.
     if not lexed_posix:
-        start_indexes |= _cmd_start_positions(0)
+        for pos, cmd_word in _cmd_command_positions(0).items():
+            if cmd_word == "start":
+                start_indexes.add(pos)
+            elif cmd_word == "for":
+                cmd_for_indexes.add(pos)
+    # `for /f %i in ('CMD') do ...` runs CMD as a child command and reads its
+    # output, so the set is a command position the token scan sees only as data.
+    # Backquotes are the same form under usebackq.
+    # Only where cmd runs a `for` itself. The body is found by re-reading the
+    # text, which cannot tell a construct from a quotation of one on its own, so
+    # `echo "for /f %i in ('rm -rf x') do echo %i"` was refused for printing.
+    for match in _CMD_FOR_SUBSTITUTION_RE.finditer(command if cmd_for_indexes else ""):
+        # The escapes are the outer parse's, so cmd hands the child a line with
+        # them already applied: `echo x ^& start ""` reaches it as a real
+        # separator, and reading it raw left the start an operand of echo.
+        body = match.group("body") or match.group("alt") or ""
+        blocked |= _find_blocked_commands(_cmd_split(body, "")[0])
+
     # `start` launches a program in cmd. On a POSIX host it is whatever the user
     # has by that name, its arguments are arguments, and reading them as cmd
     # syntax refused `start "dry run" rm` on Linux and macOS.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1318,6 +1318,24 @@ def _cmd_group_delta(token: str) -> int:
     return delta
 
 
+def _cmd_word_depth_delta(token: str) -> int:
+    """How far ``token``'s brackets have moved cmd's grouping by the time it
+    reads the command word in it.
+
+    A bracket in FRONT of the word groups around it, so `(echo` is a word one
+    level in; a bracket behind it closes a group the word was already inside,
+    so `else)` is a word at the level it was written at. The two need telling
+    apart because a handoff word only belongs to a statement at its own depth:
+    the `else` of `if exist x (echo else) else start "" pwsh` is ECHO's data.
+    """
+    plain = _cmd_split(token, "")[0]
+    pieces = re.split(r"[()]", plain)
+    kept = [index for index, piece in enumerate(pieces) if piece]
+    last = kept[-1] if kept else 0
+    prefix = plain[: sum(len(piece) for piece in pieces[:last]) + last]
+    return prefix.count("(") - prefix.count(")")
+
+
 def _cmd_split(token: str, chars: str) -> "list[str]":
     """``token`` split on the ``chars`` cmd reads as syntax, escapes applied.
 
@@ -1421,6 +1439,14 @@ def _blocked_start_program(token: str) -> "set[str]":
         stem, ext = os.path.splitext(base)
         if ext in {".exe", ".com", ".bat", ".cmd"}:
             base = stem
+        if not base and len(names) > 1:
+            # The program name is nothing BUT an expansion, so no reading of it
+            # is a name: `start "" %ComSpec% /c powershell` launches cmd with a
+            # command line behind it and comes back with no program at all.
+            # Refused rather than passed, the way an unread payload is. A path
+            # that merely holds one (`"%USERPROFILE%/notes.txt"`) still names
+            # its own file and is unaffected.
+            return {target.strip('"').lower()}
         if base in _blocked_commands():
             blocked.add(base)
         else:
@@ -1718,15 +1744,20 @@ def _find_blocked_commands(command: str) -> set[str]:
         pieces = [piece for piece in re.split(r"[()]", plain) if piece]
         # The bracket comes off before the prefix, or `(@start` keeps its `@`
         # and never matches: cmd reads the group opener, then the suppression.
-        name = (pieces[-1] if pieces else "").lstrip("@").strip('"')
+        # The marks come off wherever they sit, since cmd removes them when it
+        # resolves the command: `pow"er"shell` runs powershell.
+        name = (pieces[-1] if pieces else "").replace('"', "").lstrip("@")
         base = os.path.basename(name.replace("\\", "/")).lower()
-        # Delayed expansion happens before the word is resolved and an unset
-        # variable leaves nothing behind, so `st!X!art` IS start where it is
-        # enabled -- by /v:on on this line or by the registry on the host, which
-        # a command line does not show. Reading the spelling both ways is the
-        # safe direction: a file really named that launches nothing.
-        if "!" in base:
-            return _CMD_DELAYED_RE.sub("", base) or base
+        # Expansion happens before the word is resolved and a variable can
+        # contribute nothing, an unset `!X!` where delayed expansion is on or a
+        # zero-length `%PATH:~0,0%` anywhere, so `st!X!art` and `st%PATH:~0,0%art`
+        # ARE start. Reading the spelling as cmd leaves it is the safe
+        # direction: a file really named that launches nothing. Not gated on
+        # /v:on either, since the registry enables delayed expansion host-wide
+        # and a command line does not show that.
+        if "!" in base or "%" in base:
+            expanded = _CMD_DELAYED_RE.sub("", _CMD_VARIABLE_RE.sub("", base))
+            return expanded or base
         return base
 
     def _cmd_condition_words(index: int) -> int:
@@ -1796,7 +1827,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         # prints. A list rather than a flag because the two nest, and one
         # cleared by the inner `do` lost the `else` of `if exist x (for %i in
         # (y) do echo a) else start "" pwsh`, which really launches.
-        control: "list[str]" = []
+        control: "list[tuple[str, int]]" = []
         depth = 0  # open group brackets, which an `if` branch is written in
         skip = 0  # condition words still to consume
         skip_operand = False  # the word after a bare redirection operator
@@ -1846,6 +1877,11 @@ def _find_blocked_commands(command: str) -> set[str]:
                 expect = True
                 if not depth:
                     control.clear()
+            # The word's own depth is the one its token opens it at: brackets
+            # before it are cmd's grouping around it, brackets behind it close
+            # a group it sits inside. So `(echo` is a word one level in, and
+            # `else)` is a word at the level the `)` then leaves.
+            word_depth = depth + _cmd_word_depth_delta(pieces[-1])
             depth += _cmd_group_delta(token)
             word = _cmd_word_base(pieces[-1])
             if skip > 0:
@@ -1857,11 +1893,15 @@ def _find_blocked_commands(command: str) -> set[str]:
             # statements is open, though, or `cmd /c echo else start "" pwsh`
             # reads a printed word as a handoff.
             statement = {"else": "if", "do": "for"}.get(word, "")
-            if statement and statement in control:
-                # The handoff belongs to the innermost statement of that kind,
-                # and one of a kind is interchangeable with another here, so
-                # which entry goes does not matter -- only how many.
-                control.remove(statement)
+            if statement and (statement, word_depth) in control:
+                # ...and only where it sits at the depth of the statement it
+                # belongs to: the `else` in `if exist no_f (echo else) else
+                # start "" pwsh` is ECHO's data one level in, and consuming the
+                # if there left the real else with nothing to reopen. The
+                # innermost of a kind is what a handoff closes, and two at the
+                # same depth are interchangeable, so which entry goes does not
+                # matter -- only how many.
+                control.remove((statement, word_depth))
                 expect = True
                 continue
             if not expect:
@@ -1874,9 +1914,9 @@ def _find_blocked_commands(command: str) -> set[str]:
                 pass  # it reparses its target, so a command follows it
             elif word == "if":
                 skip = _cmd_condition_words(index + 1)
-                control.append("if")
+                control.append(("if", word_depth))
             elif word == "for":
-                control.append("for")
+                control.append(("for", word_depth))
                 expect = False  # re-armed by its own `do`, above
             else:
                 expect = False
@@ -2133,6 +2173,17 @@ def _find_blocked_commands(command: str) -> set[str]:
                 start_indexes.add(pos)
             elif cmd_word == "for":
                 cmd_for_indexes.add(pos)
+            # cmd strips the quotes and applies the escapes before it resolves
+            # the command, and the walk above has already done both, so the name
+            # it holds is the one that runs: `cmd /c pow"er"shell` and `cmd /c
+            # power^shell` run powershell, which no scan of the raw spelling
+            # matches. Every command position is screened, not only the two
+            # words this grammar reads on.
+            name = _token_basename(cmd_word)
+            if name in _blocked_commands():
+                blocked.add(name)
+            else:
+                blocked.update(_blocked_matching_glob(name))
         return cmd_grammar_spent
 
     def _cmd_payload_text(index: int) -> str:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -175,6 +175,10 @@ _COMMAND_PREFIXES = frozenset(
         "command",
         "builtin",
         "exec",
+        # bash: "coproc [NAME] command ... The command is executed
+        # asynchronously", and with a NAME the command must be a compound one,
+        # so the word behind a simple `coproc` is what runs.
+        "coproc",
         "time",
         "nohup",
         "nice",
@@ -1695,7 +1699,63 @@ _CMD_INTERNAL_COMMANDS = frozenset(
 )
 
 
+# One outermost scan's allowance for the nested ones inside it, in characters
+# of command text, with a depth cap for the same reason. A quoted `cmd /c`
+# payload is a SUFFIX of the line it sits in, so every level re-reads what the
+# one above it read and a budget granted per call is no bound at all:
+# `cmd /c "` twenty deep took seconds, before the command it screens had
+# started. Shared across the whole scan instead, and what it cannot finish
+# reading is refused rather than passed.
+_MAX_NESTED_SCAN_CHARS = 20_000
+_MAX_NESTED_SCAN_DEPTH = 16
+_scan_state = threading.local()
+
+
 def _find_blocked_commands(command: str) -> set[str]:
+    """Screen ``command``, bounding the nested scans it starts (see
+    _MAX_NESTED_SCAN_CHARS). The outermost call owns the allowance and reports
+    the refusal, so a payload the budget stopped short of cannot ride in on the
+    scan giving up."""
+    outermost = not getattr(_scan_state, "depth", 0)
+    if outermost:
+        _scan_state.chars = _MAX_NESTED_SCAN_CHARS
+        _scan_state.overflowed = False
+    _scan_state.depth = getattr(_scan_state, "depth", 0) + 1
+    if not outermost:
+        # The outermost line has to be read whatever its length; the allowance
+        # is for what that read then starts.
+        _scan_state.chars -= len(command)
+    try:
+        if _scan_state.chars < 0 or _scan_state.depth > _MAX_NESTED_SCAN_DEPTH:
+            _scan_state.overflowed = True
+            return set()
+        blocked = _find_blocked_commands_inner(command)
+        if outermost and _scan_state.overflowed:
+            # Something below was never read, so the command word that led
+            # there is refused, the way an unread cmd payload already is.
+            head = _shell_lex_head(command)
+            blocked = blocked | {head} if head else blocked | {"cmd"}
+        return blocked
+    finally:
+        _scan_state.depth -= 1
+
+
+def _shell_lex_head(command: str) -> str:
+    """The first word of ``command``, for naming a scan that could not finish."""
+    for token in command.split():
+        return _token_basename_plain(token)
+    return ""
+
+
+def _token_basename_plain(token: str) -> str:
+    """``token`` reduced to the program name it holds, meta-characters aside."""
+    token = token.strip(";&|()`{}\"'")
+    base = os.path.basename(token.replace("\\", "/")).lower()
+    stem, ext = os.path.splitext(base)
+    return stem if ext in {".exe", ".com", ".bat", ".cmd"} else base
+
+
+def _find_blocked_commands_inner(command: str) -> set[str]:
     """Detect blocked commands at shell command position only.
 
     A token is at command position if it is the first token, or follows a
@@ -2207,6 +2267,13 @@ def _find_blocked_commands(command: str) -> set[str]:
             exec_words = [i + 1] if child in (-1, i + 1) else [i + 1, child]
             for word in exec_words:
                 base = _token_basename(tokens[word])
+                if base == "start" and lexed_posix:
+                    # find runs the action itself, so this is a command
+                    # position like any other: the `-exec start "" powershell`
+                    # of a find action and `fd . -x start "" powershell` launch,
+                    # and screening the name alone said nothing about what it
+                    # was pointed at.
+                    start_indexes.add(word)
                 if _is_sed_command(base):
                     # find runs its -exec child directly, but the walk above only
                     # reaches `find`, so a sed there never got its program
@@ -2269,6 +2336,12 @@ def _find_blocked_commands(command: str) -> set[str]:
             # Trailing dots and spaces are Win32's to ignore, so `cmd /c
             # powershell.exe.` runs powershell whatever the lexer was.
             name = _token_basename(_win32_name(cmd_word))
+            if _CMD_VARIABLE_RE.sub("", _CMD_DELAYED_RE.sub("", name)) == "" and name:
+                # Nothing but an expansion, so no reading of it is a name and
+                # what it runs is unknowable: `cmd //c %ComSpec% //c start ""
+                # powershell` is a nested cmd whose command line went unread.
+                # Refused, as the same shape already is in a start target.
+                blocked.add(name)
             if name in _blocked_commands():
                 blocked.add(name)
             else:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1173,8 +1173,21 @@ def _unquoted_glob_indexes(text: str, tokens: "list[str]", punctuation: str) -> 
     )
 
 
-def _token_was_quoted(command: str, tokens: "list[str]", index: int, lexed_posix: bool) -> bool:
-    """Whether ``tokens[index]`` was written with quotes around it.
+def _skip_start_switches(tokens: "list[str]", index: int) -> int:
+    """The first index at or after ``index`` that is not one of `start`'s switches."""
+    while index < len(tokens):
+        switch = _win_switch(tokens[index].lower())
+        if not switch.startswith("/"):
+            break
+        # /d C:\dir and friends carry their value in the next token.
+        index += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+    return index
+
+
+def _quoted_token_indexes(
+    command: str, tokens: "list[str]", lexed_posix: bool
+) -> "frozenset[int]":
+    """Indexes of ``tokens`` that were written with quotes around them.
 
     cmd reads `start`'s first argument as a window title only when it is quoted,
     which is what separates `start "" prog` and `start "t" prog` -- a title with
@@ -1184,20 +1197,31 @@ def _token_was_quoted(command: str, tokens: "list[str]", index: int, lexed_posix
     the start of the token, so `start notepad rm.txt` reported `rm` even though
     the same word in the same place on a full line does not match.
 
-    The non-POSIX lexer keeps the quotes, so the token answers for itself. The
-    POSIX one strips them, so the text is lexed a second time without stripping
-    and the two are lined up one-to-one, reporting nothing when they do not
-    align -- the same technique as _quoted_separator_indexes.
+    The non-POSIX lexer keeps the quotes, so the tokens answer for themselves.
+    The POSIX one strips them, so the text is lexed a second time without
+    stripping and the two are lined up one-to-one, reporting nothing when they
+    do not align -- the same technique as _quoted_separator_indexes. That second
+    lex has to be built like the first one: ``shlex.split`` passes no
+    punctuation_chars and clears the comment character, so `;`, `&&`, `|`, `(`
+    and `#` glued onto their neighbours, the two never lined up, and every
+    command holding a separator lost its title detection -- which is worse than
+    not having it, since the title was then screened in the program's place.
     """
     if not lexed_posix:
-        return tokens[index].startswith(('"', "'"))
+        return frozenset(
+            index for index, token in enumerate(tokens) if token.startswith(('"', "'"))
+        )
     try:
-        raw = shlex.split(command, posix = False)
+        lexer = shlex.shlex(command, posix = False, punctuation_chars = ";&|()`")
+        lexer.whitespace_split = True
+        raw = list(lexer)
     except ValueError:
-        return False
-    if len(raw) != len(tokens) or index >= len(raw):
-        return False
-    return raw[index].startswith(('"', "'"))
+        return frozenset()
+    if len(raw) != len(tokens):
+        return frozenset()
+    return frozenset(
+        index for index, token in enumerate(raw) if token.startswith(('"', "'"))
+    )
 
 
 def _xargs_replacement(tokens: "list[str]", start: int, end: int) -> str:
@@ -1684,28 +1708,30 @@ def _find_blocked_commands(command: str) -> set[str]:
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
+    quoted_tokens: "frozenset[int] | None" = None
     for i, token in enumerate(tokens):
         if os.path.basename(token).lower() not in ("start", "start.exe"):
             continue
-        j = i + 1
-        while j < len(tokens):
-            switch = _win_switch(tokens[j].lower())
-            if not switch.startswith("/"):
-                break
-            # /d C:\dir and friends carry their value in the next token.
-            j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+        # Built at most once per call, and only when a start is actually here:
+        # it lexes the whole line, so doing it per start token made the scan
+        # quadratic (800 tokens took 1.1s against main's 34ms).
+        if quoted_tokens is None:
+            quoted_tokens = _quoted_token_indexes(command, tokens, lexed_posix)
+        j = _skip_start_switches(tokens, i + 1)
         # `start "title" prog` is the documented form: cmd reads a quoted first
         # argument as the window title, but only when something follows it, so
         # the program is the token behind it. Matching `== ""` instead saw
         # neither `start "" prog` on a Windows host without Git Bash -- where the
         # non-POSIX lexer keeps the quotes and the token arrives as a literal
         # `""` -- nor any non-empty title on either lexer, and left the program
-        # in both unscreened.
+        # in both unscreened. A title is data, so it is not screened itself.
+        if j + 1 < len(tokens) and j in quoted_tokens:
+            # Microsoft documents the switches AFTER the title, so skip them on
+            # both sides of it: `start "" /min powershell` left the program at
+            # j + 2 and screened the switch instead.
+            j = _skip_start_switches(tokens, j + 1)
         if j < len(tokens):
-            if j + 1 < len(tokens) and _token_was_quoted(command, tokens, j, lexed_posix):
-                blocked |= _find_blocked_commands(tokens[j + 1])
-            else:
-                blocked |= _find_blocked_commands(tokens[j])
+            blocked |= _find_blocked_commands(tokens[j])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1653,7 +1653,11 @@ def _find_blocked_commands(command: str) -> set[str]:
             # `cmd //c >nul start "" powershell` really does launch.
             if _REDIR_PREFIX_RE.match(token):
                 continue
-            pieces = _cmd_split(token, _CMD_SEPARATORS)
+            # MSYS re-quotes an argument holding whitespace when it builds
+            # cmd's command line, and quoting is what makes cmd's separators
+            # ordinary data, so `cmd //c echo "x &start" "" pwsh` only prints.
+            requoted = lexed_posix and any(char.isspace() for char in token)
+            pieces = [token] if requoted else _cmd_split(token, _CMD_SEPARATORS)
             if len(pieces) > 1:
                 expect = True
                 control = False
@@ -1674,6 +1678,8 @@ def _find_blocked_commands(command: str) -> set[str]:
             if word == "start":
                 found.add(index)
                 expect = False
+            elif word == "call":
+                pass  # it reparses its target, so a command follows it
             elif word == "if":
                 skip = _cmd_condition_words(index + 1)
                 control = True
@@ -1925,9 +1931,11 @@ def _find_blocked_commands(command: str) -> set[str]:
                 continue  # skip Unix flags like --login, -l
             if is_win_c and prev.startswith("/") and len(prev) <= 3:
                 continue  # skip Windows flags like /s, /q (not /bin/bash)
-            # _token_basename, not os.path.basename: the cmd lexer keeps a glued
-            # opener, so `(cmd //c ...)` left prev as `(cmd` and matched no shell.
-            prev_base = _token_basename(prev)
+            # The cmd lexer keeps a glued opener, so `(cmd //c ...)` left prev
+            # as `(cmd` and matched no shell. Under bash the opener is its own
+            # token, so one still attached survived quoting and is part of the
+            # word: `echo '(bash' -c rm` prints three arguments and runs none.
+            prev_base = os.path.basename(prev).lower() if lexed_posix else _token_basename(prev)
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1177,17 +1177,15 @@ def _skip_start_switches(tokens: "list[str]", index: int) -> int:
     """The first index at or after ``index`` that is not one of `start`'s switches."""
     while index < len(tokens):
         switch = _win_switch(tokens[index].lower())
-        if not switch.startswith("/"):
+        if not _START_SWITCH_RE.fullmatch(switch):
             break
         # /d C:\dir and friends carry their value in the next token.
         index += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
     return index
 
 
-def _quoted_token_indexes(
-    command: str, tokens: "list[str]", lexed_posix: bool
-) -> "frozenset[int]":
-    """Indexes of ``tokens`` that were written with quotes around them.
+def _start_title_indexes(tokens: "list[str]", lexed_posix: bool) -> "frozenset[int]":
+    """Indexes of ``tokens`` that cmd reads as a quoted `start` window title.
 
     cmd reads `start`'s first argument as a window title only when it is quoted,
     which is what separates `start "" prog` and `start "t" prog` -- a title with
@@ -1197,31 +1195,55 @@ def _quoted_token_indexes(
     the start of the token, so `start notepad rm.txt` reported `rm` even though
     the same word in the same place on a full line does not match.
 
-    The non-POSIX lexer keeps the quotes, so the tokens answer for themselves.
-    The POSIX one strips them, so the text is lexed a second time without
-    stripping and the two are lined up one-to-one, reporting nothing when they
-    do not align -- the same technique as _quoted_separator_indexes. That second
-    lex has to be built like the first one: ``shlex.split`` passes no
-    punctuation_chars and clears the comment character, so `;`, `&&`, `|`, `(`
-    and `#` glued onto their neighbours, the two never lined up, and every
-    command holding a separator lost its title detection -- which is worse than
-    not having it, since the title was then screened in the program's place.
+    The question is which tokens still carry quotes by the time cmd parses the
+    line, not which ones the user wrote quotes around, and the two answers are
+    different under Git Bash. Bash strips the quotes and re-quotes an argument
+    only when it has to, so what reaches cmd quoted is exactly the empty and the
+    whitespace-carrying arguments. `start "powershell" -c ls` arrives as
+    `start powershell -c ls`, where powershell is the program and not a title:
+    reading the user's quotes there skipped the block entirely.
+
+    Without Git Bash nothing rewrites the line, the non-POSIX lexer keeps the
+    quotes, and the token answers for itself. Microsoft spells the title
+    `"<Title>"`, so only a double quote counts -- cmd has no single-quote
+    syntax, and `start 'title' rm.txt` launches a program literally named
+    'title', which is how a benign rm.txt came to be blocked as a command.
     """
     if not lexed_posix:
         return frozenset(
-            index for index, token in enumerate(tokens) if token.startswith(('"', "'"))
+            index for index, token in enumerate(tokens) if token.startswith('"')
         )
+    return frozenset(
+        index
+        for index, token in enumerate(tokens)
+        if not token or any(char.isspace() for char in token)
+    )
+
+
+def _source_quoted_indexes(command: str, tokens: "list[str]") -> "frozenset[int] | None":
+    """Indexes of ``tokens`` the user wrote double quotes around, or None when
+    that cannot be told.
+
+    Only the POSIX lexer needs asking, since it is the one that strips them. The
+    text is lexed a second time without stripping and the two are lined up
+    one-to-one -- the same technique as _quoted_separator_indexes -- so the
+    second lex has to be built like the first: ``shlex.split`` passes no
+    punctuation_chars and clears the comment character, which glues `;`, `&&`,
+    `|`, `(` and `#` onto their neighbours and desyncs the two.
+
+    A POSIX-only escape still desyncs them, hence None rather than an empty set:
+    the caller reads "cannot tell" as "screen both candidates", where an empty
+    set would have read as "nothing was quoted" and skipped a screen.
+    """
     try:
         lexer = shlex.shlex(command, posix = False, punctuation_chars = ";&|()`")
         lexer.whitespace_split = True
         raw = list(lexer)
     except ValueError:
-        return frozenset()
+        return None
     if len(raw) != len(tokens):
-        return frozenset()
-    return frozenset(
-        index for index, token in enumerate(raw) if token.startswith(('"', "'"))
-    )
+        return None
+    return frozenset(index for index, token in enumerate(raw) if token.startswith('"'))
 
 
 def _xargs_replacement(tokens: "list[str]", start: int, end: int) -> str:
@@ -1400,6 +1422,11 @@ def _win_switch(token: str) -> str:
 # `start` launches its argument as a program, so that argument is a command
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
+# Every `start` switch is one word (/b, /min, /node). Anything holding a further
+# separator is a path, not a switch: Git Bash hands native programs their
+# arguments in MSYS form, so `start "" /c/Windows/System32/powershell.exe` is the
+# launched program, and skipping it as a switch walked straight past the block.
+_START_SWITCH_RE = re.compile(r"/[a-z][a-z0-9]*", re.IGNORECASE)
 
 
 def _find_blocked_commands(command: str) -> set[str]:
@@ -1708,30 +1735,49 @@ def _find_blocked_commands(command: str) -> set[str]:
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
-    quoted_tokens: "frozenset[int] | None" = None
+    title_tokens: "frozenset[int] | None" = None
+    source_quoted: "frozenset[int] | None" = None
+    source_quoted_built = False
     for i, token in enumerate(tokens):
         if os.path.basename(token).lower() not in ("start", "start.exe"):
             continue
         # Built at most once per call, and only when a start is actually here:
-        # it lexes the whole line, so doing it per start token made the scan
-        # quadratic (800 tokens took 1.1s against main's 34ms).
-        if quoted_tokens is None:
-            quoted_tokens = _quoted_token_indexes(command, tokens, lexed_posix)
+        # the second of them lexes the whole line, so doing it per start token
+        # made the scan quadratic (800 tokens took 1.1s against main's 34ms).
+        if title_tokens is None:
+            title_tokens = _start_title_indexes(tokens, lexed_posix)
         j = _skip_start_switches(tokens, i + 1)
+        if j >= len(tokens):
+            continue
         # `start "title" prog` is the documented form: cmd reads a quoted first
         # argument as the window title, but only when something follows it, so
-        # the program is the token behind it. Matching `== ""` instead saw
-        # neither `start "" prog` on a Windows host without Git Bash -- where the
-        # non-POSIX lexer keeps the quotes and the token arrives as a literal
-        # `""` -- nor any non-empty title on either lexer, and left the program
-        # in both unscreened. A title is data, so it is not screened itself.
-        if j + 1 < len(tokens) and j in quoted_tokens:
-            # Microsoft documents the switches AFTER the title, so skip them on
-            # both sides of it: `start "" /min powershell` left the program at
-            # j + 2 and screened the switch instead.
-            j = _skip_start_switches(tokens, j + 1)
-        if j < len(tokens):
-            blocked |= _find_blocked_commands(tokens[j])
+        # the program is the token behind it. A title is data, so it is not
+        # screened itself. Microsoft documents the switches AFTER the title too,
+        # so they are skipped on both sides of it: `start "" /min powershell`
+        # left the program at j + 2 and screened the switch instead.
+        if j + 1 < len(tokens) and j in title_tokens:
+            k = _skip_start_switches(tokens, j + 1)
+            if k < len(tokens):
+                blocked |= _find_blocked_commands(tokens[k])
+            continue
+        # Whether a quoted word without spaces reaches cmd as a title depends on
+        # how Git Bash rebuilds the line, and the two readings each hide a
+        # different program: if it re-quotes, `start "t" powershell` launches
+        # powershell; if it does not, cmd is handed `start powershell -c ls` and
+        # powershell is the program that `start "powershell" -c ls` launches.
+        # Rather than pick one, screen both positions for this one shape. It is
+        # narrow enough not to bring back the over-block a blind two-token scan
+        # caused, since an unquoted `start notepad rm.txt` is not in it.
+        blocked |= _find_blocked_commands(tokens[j])
+        if j + 1 >= len(tokens) or not lexed_posix:
+            continue
+        if not source_quoted_built:
+            source_quoted = _source_quoted_indexes(command, tokens)
+            source_quoted_built = True
+        if source_quoted is None or j in source_quoted:
+            k = _skip_start_switches(tokens, j + 1)
+            if k < len(tokens):
+                blocked |= _find_blocked_commands(tokens[k])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1208,8 +1208,15 @@ def _skip_start_switches(
         switch = _win_switch(token.lower())
         if not _START_SWITCH_RE.fullmatch(switch):
             break
-        # /d C:\dir and friends carry their value in the next token.
-        index += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+        index += 1
+        if switch in _START_SWITCHES_WITH_VALUE:
+            # /d C:\dir and friends carry their value in the next token -- the
+            # next one start SEES, that is: a redirection in between is the
+            # shell's and gone before start reads its arguments, so counting it
+            # as the value left the directory looking like the program.
+            while index < len(tokens) and index in redirects:
+                index += 1
+            index += 1
     return index
 
 
@@ -1474,21 +1481,15 @@ def _blocked_start_program(token: str) -> "set[str]":
         stem, ext = os.path.splitext(base)
         if ext in {".exe", ".com", ".bat", ".cmd"}:
             base = stem
-        if _CMD_DELAYED_RE.search(base):
-            # A delayed expansion is read when the command RUNS, so the same
-            # line can fill it: `cmd /v:on /c "set X=power&start "" !X!shell"`
-            # assembles powershell out of a fragment that is nothing on its own.
-            # Unknowable here and controllable there, so it is refused. The
-            # `%VAR%` form is read when the line is PARSED, before any set on it
-            # can run, which is why that one is only read both ways.
-            return {target.strip('"').lower()}
-        if not base and len(names) > 1:
-            # The program name is nothing BUT an expansion, so no reading of it
-            # is a name: `start "" %ComSpec% /c powershell` launches cmd with a
-            # command line behind it and comes back with no program at all.
-            # Refused rather than passed, the way an unread payload is. A path
-            # that merely holds one (`"%USERPROFILE%/notes.txt"`) still names
-            # its own file and is unaffected.
+        if _CMD_DELAYED_RE.search(base) or _CMD_VARIABLE_RE.search(base):
+            # An expansion in the NAME leaves it unresolvable here: it can be
+            # the whole of it (`%ComSpec%`), it can contribute the characters
+            # that complete one (`power%ComSpec:~9,1%hell` is powershell), and
+            # a delayed one is filled by the very line it sits on (`set
+            # X=power&start "" !X!shell`). Reading it as empty was a guess, and
+            # the guess was wrong in the direction that launches, so the name
+            # is refused instead. Only the name: a path that merely holds an
+            # expansion (`"%USERPROFILE%/notes.txt"`) still names its own file.
             return {target.strip('"').lower()}
         if base in _blocked_commands():
             blocked.add(base)
@@ -1755,6 +1756,23 @@ def _token_basename_plain(token: str) -> str:
     return stem if ext in {".exe", ".com", ".bat", ".cmd"} else base
 
 
+def _scan_as_cmd(command: str) -> "set[str]":
+    """Screen ``command`` as cmd runs it, whatever shell the outer line used.
+
+    A `for /f` set and a `cmd /c` payload are cmd's own command lines even when
+    Git Bash handed them over, and the two grammars disagree: `;` delimits
+    arguments for cmd and separates commands for bash, so the same body read
+    the wrong way refused `for /f %i in ('start "" https://example.com/curl')`,
+    which opens a URL in the browser.
+    """
+    previous = getattr(_scan_state, "cmd_grammar", False)
+    _scan_state.cmd_grammar = True
+    try:
+        return _find_blocked_commands(command)
+    finally:
+        _scan_state.cmd_grammar = previous
+
+
 def _find_blocked_commands_inner(command: str) -> set[str]:
     """Detect blocked commands at shell command position only.
 
@@ -1777,7 +1795,12 @@ def _find_blocked_commands_inner(command: str) -> set[str]:
     # Windows host with bash the non-posix lexer never split on `;`, so the
     # command after a control-flow keyword stayed unread and
     # `if true; then rm -rf x; fi` came back with nothing blocked.
-    lexed_posix = _shell_is_posix()
+    # ...and a body cmd itself runs is read with cmd's grammar whatever the
+    # outer shell is, since that is the shell executing it: the `;` of a `for
+    # /f` set is an argument delimiter to cmd and a command separator to bash,
+    # and reading the outer shell's rules into cmd's child refused a line that
+    # only prints.
+    lexed_posix = _shell_is_posix() and not getattr(_scan_state, "cmd_grammar", False)
     try:
         if not lexed_posix:
             tokens = shlex.split(command, posix = False)
@@ -1874,42 +1897,52 @@ def _find_blocked_commands_inner(command: str) -> set[str]:
         parsing further. The three-word comparison is the one that hid a launch:
         `if 1 EQU 1 start "" powershell` left EQU looking like the command.
         """
-        # A redirection between `if` and its test is performed by cmd and never
-        # reaches the condition, so counting from `>nul` in `if >nul exist f
-        # start "" powershell` put the count a word out and left the launch in
-        # argument position. The walk skips those tokens too, so they are not
-        # counted here either.
-        while index < len(tokens) and _REDIR_PREFIX_RE.match(tokens[index]):
-            head = _CMD_REDIR_HEAD_RE.match(tokens[index])
-            attached = tokens[index][head.end() :] if head else ""
-            index += 1 if attached or (head and "&" in head.group(0)) else 2
+
+        # A redirection anywhere in the condition is performed by cmd and never
+        # reaches it, so `if >nul exist f start "" pwsh` and `if not >nul 1 EQU
+        # 2 start "" pwsh` both put the count out and left the launch in
+        # argument position. The walk steps over those tokens without spending
+        # a skip on them, so they are not counted here either -- at any point,
+        # not only in front.
+        def semantic(after: int) -> int:
+            """The next index at or after ``after`` that cmd reads as a word."""
+            while after < len(tokens) and _REDIR_PREFIX_RE.match(tokens[after]):
+                head = _CMD_REDIR_HEAD_RE.match(tokens[after])
+                attached = tokens[after][head.end() :] if head else ""
+                after += 1 if attached or (head and "&" in head.group(0)) else 2
+            return after
+
+        # The count is of semantic words, which is what the walk's skip spends.
         words = 0
+        cursor = semantic(index)
         for _ in range(2):  # /i and not, in either order
-            if index + words >= len(tokens):
+            if cursor >= len(tokens):
                 return words
             # _token_basename would read /i as the path `i`, so the switch is
             # matched on the raw word, through the Git Bash `//i` spelling.
-            word = tokens[index + words].lower()
+            word = tokens[cursor].lower()
             if _win_switch(word) == "/i" or _cmd_word_base(word) == "not":
                 words += 1
-        if index + words >= len(tokens):
+                cursor = semantic(cursor + 1)
+        if cursor >= len(tokens):
             return words
-        if _cmd_word_base(tokens[index + words]) in _CMD_TWO_WORD_TESTS:
+        if _cmd_word_base(tokens[cursor]) in _CMD_TWO_WORD_TESTS:
             return words + 2
-        if (
-            index + words + 1 < len(tokens)
-            and _cmd_word_base(tokens[index + words + 1]) in _CMD_COMPARE_OPS
-        ):
+        behind = semantic(cursor + 1)
+        if behind < len(tokens) and _cmd_word_base(tokens[behind]) in _CMD_COMPARE_OPS:
             return words + 3
         # The `a==b` form is one word unquoted, but the cmd lexer keeps the
         # quotes and splits `"a"=="a"` into `"a"` and `=="a"`, whose second half
         # then took the command position. Read on until both sides are in.
         text = ""
-        for extra in range(words, len(tokens) - index):
-            text += _cmd_split(tokens[index + extra], "")[0]
+        extra = words
+        while cursor < len(tokens):
+            text += _cmd_split(tokens[cursor], "")[0]
+            extra += 1
             head, sep, tail = text.partition("==")
             if sep and head.strip() and tail.strip():
-                return extra + 1
+                return extra
+            cursor = semantic(cursor + 1)
         return words + 1
 
     def _cmd_command_positions(begin: int) -> "dict[int, str]":
@@ -2267,6 +2300,11 @@ def _find_blocked_commands_inner(command: str) -> set[str]:
             exec_words = [i + 1] if child in (-1, i + 1) else [i + 1, child]
             for word in exec_words:
                 base = _token_basename(tokens[word])
+                # find runs the action itself, so its words are commands the
+                # line runs: without that, the `cmd` of `find . -exec cmd //c
+                # start "" powershell ;` was not a command position and its
+                # payload went unread.
+                run_indexes.add(word)
                 if base == "start" and lexed_posix:
                     # find runs the action itself, so this is a command
                     # position like any other: the `-exec start "" powershell`
@@ -2604,7 +2642,7 @@ def _find_blocked_commands_inner(command: str) -> set[str]:
         # them already applied: `echo x ^& start ""` reaches it as a real
         # separator, and reading it raw left the start an operand of echo.
         body = match.group("body") or match.group("alt") or ""
-        blocked |= _find_blocked_commands(_cmd_split(body, "")[0])
+        blocked |= _scan_as_cmd(_cmd_split(body, "")[0])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1379,6 +1379,18 @@ def _cmd_split(token: str, chars: str) -> "list[str]":
     return pieces
 
 
+def _win32_name(base: str) -> str:
+    """``base`` as Win32 resolves it: a trailing dot or space is ignored.
+
+    Microsoft's file-naming rules put "do not end a file or directory name with
+    a space or a period" among the reserved conventions -- the API trims them
+    outside the `\\\\?\\` namespace -- so `powershell.exe.` opens
+    powershell.exe, while splitext read the lone dot as the extension and the
+    name behind it matched nothing.
+    """
+    return base.rstrip(". ") or base
+
+
 def _blocked_start_program(token: str) -> "set[str]":
     """The blocked names the program `start` launches resolves to.
 
@@ -1435,7 +1447,7 @@ def _blocked_start_program(token: str) -> "set[str]":
         names.add(_CMD_DELAYED_RE.sub("", target))
     blocked: "set[str]" = set()
     for name in names:
-        base = os.path.basename(name.replace("\\", "/")).lower()
+        base = _win32_name(os.path.basename(name.replace("\\", "/")).lower())
         stem, ext = os.path.splitext(base)
         if ext in {".exe", ".com", ".bat", ".cmd"}:
             base = stem
@@ -1844,15 +1856,21 @@ def _find_blocked_commands(command: str) -> set[str]:
             if _looks_like_separator(token):
                 if lexed_posix and index not in quoted_separators:
                     break
-                if len(_cmd_split(token, _CMD_SEPARATORS)) > 1:
+                separated = len(_cmd_split(token, _CMD_SEPARATORS)) > 1
+                depth += _cmd_group_delta(token)
+                if separated:
                     expect = True
                     # A separator inside a group is between the branch's own
                     # commands, so the `if` it belongs to is still open:
                     # `if exist x (echo a & echo b) else start "" pwsh` runs the
                     # start, and clearing here lost the else that reopens it.
+                    # The depth that decides is the one the separator LEAVES:
+                    # `if exist x (echo a)& echo else start "" pwsh` closes the
+                    # branch on the same token, and reading the depth in front
+                    # of it kept an `if` that was over and made the printed
+                    # `else` a handoff.
                     if not depth:
                         control.clear()
-                depth += _cmd_group_delta(token)
                 continue
             # A separator with no space around it stays inside the token, under
             # either lexer: the cmd one takes no punctuation_chars, and bash
@@ -1862,28 +1880,46 @@ def _find_blocked_commands(command: str) -> set[str]:
             # `cmd //c >nul start "" powershell` really does launch.
             if skip_operand:
                 skip_operand = False
-                continue
-            if _REDIR_PREFIX_RE.match(token):
+                if len(_cmd_split(token, _CMD_SEPARATORS)) == 1:
+                    continue  # the whole word was the target
+                # ...but a separator ends the target even glued to it, so the
+                # word behind it is a command: `cmd /c > out&start ""
+                # powershell` really launches, and swallowing the token whole
+                # left it unscreened.
+            elif _REDIR_PREFIX_RE.match(token):
                 # `> nul` is two words, and the target took the command position
-                # the operator had just been allowed to keep.
-                skip_operand = not _REDIR_PREFIX_RE.sub("", token)
-                continue
+                # the operator had just been allowed to keep. `2>&1` carries its
+                # handle instead of a target, so nothing follows it to skip.
+                head = _CMD_REDIR_HEAD_RE.match(token)
+                rest = token[head.end() :] if head else ""
+                if not rest:
+                    skip_operand = "&" not in (head.group(0) if head else "")
+                    continue
+                if len(_cmd_split(rest, _CMD_SEPARATORS)) == 1:
+                    continue  # operator and target in one word, `>nul`
             # MSYS re-quotes an argument holding whitespace when it builds
             # cmd's command line, and quoting is what makes cmd's separators
             # ordinary data, so `cmd //c echo "x &start" "" pwsh` only prints.
             requoted = lexed_posix and any(char.isspace() for char in token)
             pieces = [token] if requoted else _cmd_split(token, _CMD_SEPARATORS)
-            if len(pieces) > 1:
-                expect = True
-                if not depth:
-                    control.clear()
             # The word's own depth is the one its token opens it at: brackets
             # before it are cmd's grouping around it, brackets behind it close
             # a group it sits inside. So `(echo` is a word one level in, and
             # `else)` is a word at the level the `)` then leaves.
             word_depth = depth + _cmd_word_depth_delta(pieces[-1])
             depth += _cmd_group_delta(token)
+            if len(pieces) > 1:
+                expect = True
+                if not depth:
+                    control.clear()
             word = _cmd_word_base(pieces[-1])
+            if not word:
+                # Syntax and nothing else: the trailing `&` of `echo a& start ""
+                # powershell` leaves an empty piece behind it, and reading that
+                # as a command word took back the position the separator had
+                # just opened, so the launch was never screened. A bare `(` is
+                # the same shape from the other side.
+                continue
             if skip > 0:
                 skip -= 1
                 continue
@@ -2179,7 +2215,9 @@ def _find_blocked_commands(command: str) -> set[str]:
             # power^shell` run powershell, which no scan of the raw spelling
             # matches. Every command position is screened, not only the two
             # words this grammar reads on.
-            name = _token_basename(cmd_word)
+            # Trailing dots and spaces are Win32's to ignore, so `cmd /c
+            # powershell.exe.` runs powershell whatever the lexer was.
+            name = _token_basename(_win32_name(cmd_word))
             if name in _blocked_commands():
                 blocked.add(name)
             else:
@@ -3455,6 +3493,9 @@ _SENSITIVE_GLOB_BASENAMES = frozenset(
 # A leading shell redirection (<, >, 2>, >>) hides the path from a plain glob
 # scan (cat </e??/passwd); strip it before matching.
 _REDIR_PREFIX_RE = re.compile(r"^\d*[<>]+")
+# ...and the whole of cmd's operator, which may carry a handle (`2>&1`, `>&2`)
+# where an ordinary one is followed by a file to write.
+_CMD_REDIR_HEAD_RE = re.compile(r"^\d*[<>]+&?\d*")
 # Bash brace expansion (cat /etc/pass{w,}d -> /etc/passwd /etc/passd, and the
 # sequence form cat /etc/pass{w..w}d -> /etc/passwd) runs after this classifier;
 # expand comma groups and .. sequences to scan each result.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1254,9 +1254,13 @@ def _blocked_start_program(token: str) -> "set[str]":
     A cmd operator glued to the name ends it, since the cmd lexer takes no
     punctuation_chars and leaves `powershell&` whole where cmd reads an operator
     and runs powershell. The recursive scan this replaced stripped those, so
-    matching the raw token dropped a name the older code caught.
+    matching the raw token dropped a name the older code caught. Only an
+    operator OUTSIDE the quotes is syntax though: quoting is what makes a path
+    holding one usable, and splitting inside truncated `"C:/A&B/powershell.exe"`
+    to `C:/A` and let the program behind it through.
     """
-    target = _CMD_OPERATOR_RE.split(_strip_cmd_quotes(token), 1)[0]
+    unquoted = _strip_cmd_quotes(token)
+    target = unquoted if unquoted is not token else _CMD_OPERATOR_RE.split(token, 1)[0]
     base = os.path.basename(target.replace("\\", "/")).lower()
     stem, ext = os.path.splitext(base)
     if ext in {".exe", ".com", ".bat", ".cmd"}:
@@ -1264,32 +1268,6 @@ def _blocked_start_program(token: str) -> "set[str]":
     if base in _blocked_commands():
         return {base}
     return _blocked_matching_glob(base)
-
-
-def _source_quoted_indexes(command: str, tokens: "list[str]") -> "frozenset[int] | None":
-    """Indexes of ``tokens`` the user wrote double quotes around, or None when
-    that cannot be told.
-
-    Only the POSIX lexer needs asking, since it is the one that strips them. The
-    text is lexed a second time without stripping and the two are lined up
-    one-to-one -- the same technique as _quoted_separator_indexes -- so the
-    second lex has to be built like the first: ``shlex.split`` passes no
-    punctuation_chars and clears the comment character, which glues `;`, `&&`,
-    `|`, `(` and `#` onto their neighbours and desyncs the two.
-
-    A POSIX-only escape still desyncs them, hence None rather than an empty set:
-    the caller reads "cannot tell" as "screen both candidates", where an empty
-    set would have read as "nothing was quoted" and skipped a screen.
-    """
-    try:
-        lexer = shlex.shlex(command, posix = False, punctuation_chars = ";&|()`")
-        lexer.whitespace_split = True
-        raw = list(lexer)
-    except ValueError:
-        return None
-    if len(raw) != len(tokens):
-        return None
-    return frozenset(index for index, token in enumerate(raw) if token.startswith('"'))
 
 
 def _xargs_replacement(tokens: "list[str]", start: int, end: int) -> str:
@@ -1534,29 +1512,83 @@ def _find_blocked_commands(command: str) -> set[str]:
             base = stem
         return base
 
+    def _is_cmd_start_word(index: int) -> bool:
+        """Whether ``tokens[index]`` ends in cmd's `start` command word.
+
+        The cmd lexer takes no punctuation_chars, so a separator with no space
+        around it stays glued to the word before it and `cmd /c dir&start ""
+        powershell` arrived as a single `dir&start`, where the start was never
+        found at all. cmd reads the operator, so the word after the last one is
+        the command.
+        """
+        return _token_basename(_CMD_OPERATOR_RE.split(tokens[index])[-1]) == "start"
+
+    def _cmd_command_head(index: int) -> int:
+        """The index of the word cmd runs for the segment beginning at ``index``.
+
+        `if` carries out the command after its condition, so the leading word is
+        not the command: `cmd /c if exist x echo start "t" powershell` runs echo,
+        which only prints. The condition forms all take a fixed number of words
+        (`exist PATH`, `defined VAR`, `errorlevel N`, or one `a==b` comparison),
+        so the command behind them can be reached without parsing further.
+        """
+        while index < len(tokens) and _token_basename(tokens[index]) == "if":
+            index += 1
+            if index < len(tokens) and _token_basename(tokens[index]) == "not":
+                index += 1
+            if index >= len(tokens):
+                break
+            if _token_basename(tokens[index]) in ("exist", "defined", "errorlevel"):
+                index += 2
+            else:
+                index += 1  # the `a==b` comparison, which cmd lexes as one word
+        return index
+
     def _cmd_start_positions(begin: int) -> "set[int]":
         """Indexes of the `start` words that launch a program in the cmd command
-        line running from ``begin`` to the end.
+        line beginning at ``begin``.
 
         cmd keeps parsing past its own conditionals and operators, so promoting
         only the first word missed `cmd //c if exist . start "" powershell`,
         which cmd runs and which the scan had caught before it was gated. Each
-        segment is read down to its leading word instead, so a start that is an
-        argument of one that takes text stays an argument: `cmd //c echo start
-        "my title" powershell` prints and launches nothing.
+        segment is read down to the word cmd actually runs instead, so a start
+        that is an argument of one taking text stays an argument: `cmd //c echo
+        start "my title" powershell` prints and launches nothing.
+
+        Under bash the payload ends at the first shell separator, since that
+        terminates the cmd invocation rather than starting a new cmd command:
+        with `cmd //c echo ok; printf "%s" start "t" powershell`, cmd is handed
+        only `echo ok` and the start belongs to printf. The cmd lexer has no
+        such boundary, and there `&` does begin a new cmd command.
         """
         found: "set[int]" = set()
-        head = -1
+        head_base: "str | None" = None  # the word cmd runs for the open segment
+        condition_end = begin
         for index in range(begin, len(tokens)):
-            if _looks_like_separator(tokens[index]):
-                head = -1
+            token = tokens[index]
+            if _looks_like_separator(token) and index not in quoted_separators:
+                if lexed_posix:
+                    break
+                head_base = None
                 continue
-            if head < 0:
-                head = index
-            if _token_basename(tokens[index]) != "start":
-                continue
-            if head == index or _token_basename(tokens[head]) not in _CMD_TEXT_COMMANDS:
+            # An operator with no space around it stays inside the token under
+            # the cmd lexer, so it both hides a start and opens a segment:
+            # `cmd /c echo ok&start "" pwsh` runs echo and then the start.
+            pieces = [token] if lexed_posix else _CMD_OPERATOR_RE.split(token)
+            glued = len(pieces) > 1
+            if head_base is None:
+                condition_end = _cmd_command_head(index)
+                head_base = (
+                    _token_basename(tokens[condition_end]) if condition_end < len(tokens) else ""
+                )
+            if (
+                index >= condition_end
+                and _is_cmd_start_word(index)
+                and (glued or head_base == "start" or head_base not in _CMD_TEXT_COMMANDS)
+            ):
                 found.add(index)
+            if glued:
+                head_base = _token_basename(pieces[-1])
         return found
 
     def _exec_child_index(start: int) -> "tuple[int, bool]":
@@ -1817,8 +1849,6 @@ def _find_blocked_commands(command: str) -> set[str]:
     # `cmd /c start "" prog` puts prog in a command position the scan above
     # sees only as an argument, so screen what start actually launches.
     title_tokens: "frozenset[int] | None" = None
-    source_quoted: "frozenset[int] | None" = None
-    source_quoted_built = False
     # `start` launches a program in cmd. On a POSIX host it is whatever the user
     # has by that name, its arguments are arguments, and reading them as cmd
     # syntax refused `start "dry run" rm` on Linux and macOS.
@@ -1828,9 +1858,7 @@ def _find_blocked_commands(command: str) -> set[str]:
     # prints text, and reading every token named start walked the title branch
     # into a hard block for it.
     for i in sorted(start_indexes):
-        # Built at most once per call, and only when a start is actually here:
-        # the second of them lexes the whole line, so doing it per start token
-        # made the scan quadratic (800 tokens took 1.1s against main's 34ms).
+        # Built at most once per call, and only when a start is actually here.
         if title_tokens is None:
             title_tokens = _start_title_indexes(tokens, lexed_posix)
         j = _skip_start_switches(tokens, i + 1)
@@ -1847,33 +1875,16 @@ def _find_blocked_commands(command: str) -> set[str]:
             if k < len(tokens):
                 blocked |= _blocked_start_program(tokens[k])
             continue
-        # Whether a quoted word without spaces reaches cmd as a title depends on
-        # how Git Bash rebuilds the line, and the two readings each hide a
-        # different program: if it re-quotes, `start "t" powershell` launches
-        # powershell; if it does not, cmd is handed `start powershell -c ls` and
-        # powershell is the program that `start "powershell" -c ls` launches.
-        # Rather than pick one, screen both positions for this one shape. It is
-        # narrow enough not to bring back the over-block a blind two-token scan
-        # caused, since an unquoted `start notepad rm.txt` is not in it.
+        # Otherwise this token is the program cmd launches. Under Git Bash a
+        # quoted word without spaces is not a title by the time cmd sees it,
+        # because bash removes the quotes and MSYS re-quotes an argument only
+        # when it holds whitespace or is empty -- the same rule as
+        # subprocess.list2cmdline. So `start "powershell" -c ls` arrives as
+        # `start powershell -c ls` and is caught right here, and `start "t"
+        # powershell` arrives as `start t powershell`, which launches t and
+        # passes powershell to it as a parameter rather than running it.
+        # test_git_bash_does_not_requote_a_bare_word checks that on Windows.
         blocked |= _blocked_start_program(tokens[j])
-        if j + 1 >= len(tokens) or not lexed_posix:
-            continue
-        if not source_quoted_built:
-            source_quoted = _source_quoted_indexes(command, tokens)
-            source_quoted_built = True
-        # A desync answers "cannot tell", and screening everything then brought
-        # the unquoted-argument over-block back for any line holding a POSIX-only
-        # escape: `echo a\ b; start notepad rm.txt` reported rm again. Looking
-        # for the quoted spelling in the text keeps the fallback local, so a
-        # word the user never quoted stays out of the second screen.
-        if source_quoted is None:
-            plausible_title = f'"{tokens[j]}"' in command
-        else:
-            plausible_title = j in source_quoted
-        if plausible_title:
-            k = _skip_start_switches(tokens, j + 1)
-            if k < len(tokens):
-                blocked |= _blocked_start_program(tokens[k])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -320,6 +320,28 @@ def test_start_screens_the_program_behind_a_window_title(monkeypatch, bash, comm
     assert tools._find_blocked_commands(command)
 
 
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "start notepad rm.txt",
+        "start excel curl.csv",
+        'start "" notepad rm.txt',
+        'start "rm.txt" notepad',
+    ],
+)
+def test_start_arguments_are_not_screened_as_commands(monkeypatch, bash, command):
+    # An unquoted first token is the program and the rest are its arguments, so
+    # only a quoted title moves the scan along. Screening an argument is not
+    # harmless: the recursive scan re-anchors its command-boundary regex at the
+    # start of the token, so `rm.txt` reported `rm` where the same word in the
+    # same place on a full line does not match. A quoted title is data too, and
+    # is not screened either.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert not tools._find_blocked_commands(command)
+
+
 @pytest.mark.parametrize(
     "command",
     [

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -13,6 +13,7 @@ because studio-backend-ci is Linux-only.
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -1543,6 +1544,63 @@ def test_cmd_strips_the_quotes_around_its_command_line(monkeypatch, bash, comman
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
     assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A command word that is nothing but an expansion cannot be resolved,
+        # and this one is a nested cmd whose command line then went unread.
+        ('cmd //c %ComSpec% //c start "" powershell', True),
+        ('cmd //c cmd //c start "" powershell', True),
+        # A name that merely holds an expansion still names its own program.
+        ("cmd //c my%X%prog", False),
+    ],
+)
+def test_an_expansion_only_command_word_fails_closed(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # bash runs a coproc's command asynchronously, so the word behind it is
+        # a command position: consuming `coproc` as the command itself left
+        # what it runs unscreened.
+        ('coproc start "" powershell -c ls', True),
+        ("coproc rm -rf x", True),
+        ("coproc echo start", False),
+        # find and fd run their exec action directly, so a `start` there is a
+        # launch like any other, including behind a wrapper.
+        ('find . -exec start "" powershell ;', True),
+        ('fd . -x start "" powershell', True),
+        ('find . -exec env start "" powershell ;', True),
+        ('find . -exec start "" notepad ;', False),
+    ],
+)
+def test_a_command_another_command_runs_is_screened(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+def test_nested_payload_scans_share_one_allowance(monkeypatch):
+    # A quoted `cmd /c` payload is a SUFFIX of the line it sits in, so every
+    # level re-reads what the one above it read, and an allowance granted per
+    # call is no bound at all: twenty deep took seconds before the command it
+    # screens had started. The scan is refused rather than passed when the
+    # shared allowance runs out.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    started = time.monotonic()
+    assert tools._find_blocked_commands('cmd /c "' * 20 + "echo ok" + '"' * 20)
+    assert time.monotonic() - started < 5  # ~0.1s here; the bound is what matters
+    # A payload no deeper than a real one is read in full, so the bound costs
+    # no detection: this one is nested and still found.
+    assert "powershell" in tools._find_blocked_commands('cmd /c "start "" powershell"')
+    assert not tools._find_blocked_commands('cmd /c "echo ok"')
 
 
 def test_a_chain_of_cmd_payloads_is_bounded_and_fails_closed(monkeypatch):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -351,7 +351,48 @@ def test_start_arguments_are_not_screened_as_commands(monkeypatch, bash, command
         "start notepad",
     ],
 )
-def test_detached_windows_stay_launchable(command):
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+def test_detached_windows_stay_launchable(monkeypatch, bash, command):
     # `start` is the only route to a window on the user's desktop, which the
     # terminal description promises, so screening must not blanket-block cmd.
+    #
+    # Pinned like the rest: unpinned this ran the POSIX lexer with the non-Windows
+    # block set, so it never saw the posture it exists to protect.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A separator before the start is the whole point: the second lex has to
+        # be built like the first, or the two stop lining up and the title is
+        # screened in the program's place.
+        'cd /c/proj; cmd //c start "" pwsh -Command ls',
+        'echo done; cmd //c start "" powershell -Command ls',
+        'cmd //c start "" pwsh -Command ls; echo ok',
+        '(cmd //c start "" pwsh -Command ls)',
+        'ls; cmd //c start "Build" powershell -Command "Remove-Item x"',
+        'start "t" powershell -c ls # note',
+        # Microsoft documents the switches after the title, not before it.
+        'start "" /min powershell -c ls',
+        'start "t" /wait /b pwsh -c ls',
+        'cmd /c start "" /min powershell -c ls',
+    ],
+)
+def test_start_screening_survives_separators_and_switch_order(monkeypatch, bash, command):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"])
+def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):
+    # The Windows set is a hard refusal; off Windows these stay a prompt instead
+    # (tests/test_permission_mode.py). Nothing asserted that, so dropping the
+    # platform gate entirely -- blocking them on Linux and macOS too -- passed
+    # the whole suite.
+    monkeypatch.setattr(sys, "platform", "linux")
     assert not tools._find_blocked_commands(command)

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1192,6 +1192,10 @@ def test_a_nested_cmd_payload_needs_a_cmd_that_runs(monkeypatch, bash, command, 
         # the option scan at the first one hid the set behind it.
         ("""cmd /c for /f "delims=(" %i in ('start "" powershell') do echo %i""", True),
         ("""cmd /c for /f "usebackq delims=(" %i in (`start "" powershell`) do echo %i""", True),
+        # The options are keywords separated by whitespace, so this one sets a
+        # delimiter set and leaves the backquotes a filename.
+        ("""cmd /c for /f "delims=usebackq" %i in (`start "" powershell`) do echo %i""", False),
+        ("""cmd /c for /f "usebackq delims=," %i in (`start "" powershell`) do echo %i""", True),
     ],
 )
 def test_a_for_set_runs_only_in_the_spelling_usebackq_selects(monkeypatch, command, blocked):
@@ -1263,6 +1267,67 @@ def test_a_redirection_is_not_the_program_start_launches(monkeypatch, bash, comm
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
     assert "powershell" in tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # Delayed expansion happens before the word is resolved and an unset
+        # variable leaves nothing behind, so this IS start where /v:on or the
+        # registry enables it, and the launcher itself went unread.
+        ('cmd /v:on /c st!X!art "" powershell', True),
+        ('cmd /c start "" power!X!shell', True),
+        # A name that expands to nothing blocked stays allowed.
+        ('cmd /c start "" my!X!file.txt', False),
+        ('cmd /c start "" report%DATE%.txt', False),
+    ],
+)
+def test_an_expansion_does_not_hide_the_command_word(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # `start /?`: an internal cmd command is handed to a command processor
+        # with /K, so the words behind it are a command line rather than that
+        # program's arguments. cmd's own example is the same shape.
+        ('cmd /c start "" call start "" powershell', True),
+        ('cmd /c start "" if exist x start "" powershell', True),
+        ('cmd /c start "" call cmd /c start "" powershell', True),
+        # ...and that command line is read as one, so a printing form stays
+        # allowed and an ordinary program's arguments are still arguments.
+        ('cmd /c start "" echo start "" powershell', False),
+        ('cmd /c start "" dir report.txt', False),
+        ('cmd /c start "" notepad rm.txt', False),
+    ],
+)
+def test_start_hands_an_internal_command_to_a_command_processor(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # cmd strips the marks around its whole command line and runs what is
+        # left. The cmd lexer chops that string into quote-carrying pieces no
+        # grammar can read, so the line is taken from the source text.
+        ('cmd /s /c "start "" powershell"', True),
+        ('cmd /c "start "" powershell"', True),
+        ('cmd /s /c "start powershell"', True),
+        ('cmd /s /c "echo start "" powershell"', False),
+        ('cmd /s /c "start "" notepad"', False),
+    ],
+)
+def test_cmd_strips_the_quotes_around_its_command_line(monkeypatch, bash, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
 
 
 def test_a_chain_of_cmd_payloads_is_bounded_and_fails_closed(monkeypatch):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -11,6 +11,7 @@ because studio-backend-ci is Linux-only.
 """
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -306,9 +307,11 @@ def test_cmd_shellout_is_screened_through_mangled_switches(monkeypatch, bash, co
 @pytest.mark.parametrize(
     "command",
     [
+        # A title cmd reads as one on either lexer: it holds whitespace, so bash
+        # has to re-quote it, and it arrives quoted whoever built the line.
         'start "My Title" powershell -Command ls',
-        'cmd /c start "t" pwsh -c ls',
-        'cmd //c start /min "win" powershell -Command ls',
+        'cmd /c start "a b" pwsh -c ls',
+        'cmd //c start /min "the win" powershell -Command ls',
     ],
 )
 def test_start_screens_the_program_behind_a_window_title(monkeypatch, bash, command):
@@ -318,6 +321,31 @@ def test_start_screens_the_program_behind_a_window_title(monkeypatch, bash, comm
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cmd /c start "t" pwsh -c ls',
+        'cmd //c start /min "win" powershell -Command ls',
+        'start "t" /wait /b pwsh -c ls',
+    ],
+)
+def test_a_bare_quoted_title_is_only_a_title_under_the_cmd_lexer(monkeypatch, command):
+    # Nothing rewrites the line without Git Bash, so cmd is handed the quotes
+    # the user wrote and reads them as the window title.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert tools._find_blocked_commands(command)
+
+    # With Git Bash it is not a title at all: bash removes the quotes and MSYS
+    # re-quotes an argument only when it holds whitespace or is empty, so cmd
+    # gets `start t pwsh -c ls`, which launches t and hands it pwsh as a
+    # parameter. Screening the word behind it instead was a guess at how MSYS
+    # rebuilds the line, and guessing cost two over-blocks before this;
+    # test_git_bash_does_not_requote_a_bare_word checks the rule on Windows.
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert not tools._find_blocked_commands(command)
 
 
 @pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
@@ -379,11 +407,11 @@ def test_detached_windows_stay_launchable(monkeypatch, bash, command):
         'echo done; cmd //c start "" powershell -Command ls',
         'cmd //c start "" pwsh -Command ls; echo ok',
         '(cmd //c start "" pwsh -Command ls)',
-        'ls; cmd //c start "Build" powershell -Command "Remove-Item x"',
-        'start "t" powershell -c ls # note',
+        'ls; cmd //c start "The Build" powershell -Command "Remove-Item x"',
+        'start "" powershell -c ls # note',
         # Microsoft documents the switches after the title, not before it.
         'start "" /min powershell -c ls',
-        'start "t" /wait /b pwsh -c ls',
+        'start "a b" /wait /b pwsh -c ls',
         'cmd /c start "" /min powershell -c ls',
     ],
 )
@@ -489,8 +517,11 @@ def test_start_target_is_matched_as_a_program_path(monkeypatch, command, blocked
         # command, so it is the one shape a name match alone still refuses.
         (r"echo a\ b; start notepad rm", False),
         (r"echo a\ b; start notepad curl", False),
-        # The hedge itself still has to survive the desync.
-        (r'echo a\ b; cmd //c start "t" powershell -c ls', True),
+        # An earlier quoted copy of the word used to be read as evidence that
+        # this one was quoted too, because the search was over the whole line.
+        (r'echo "notepad" a\ b; start notepad rm', False),
+        # The program itself is still screened whatever else is on the line.
+        (r'echo a\ b; cmd //c start "" powershell -c ls', True),
     ],
 )
 def test_desync_does_not_screen_unquoted_start_arguments(monkeypatch, command, blocked):
@@ -552,6 +583,103 @@ def test_start_is_not_read_as_cmd_syntax_off_windows(monkeypatch, platform, comm
     # program refused a benign line that main allows.
     monkeypatch.setattr(sys, "platform", platform)
     assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason = "Git Bash argument passing")
+def test_git_bash_does_not_requote_a_bare_word():
+    # The screen reads `start "t" prog` as launching t, not prog, because MSYS
+    # re-quotes an argument only when it holds whitespace or is empty. That rule
+    # decides which token cmd runs, so it is checked against the real thing
+    # rather than argued from the docs: ask cmd to echo the line it was handed.
+    bash = tools._windows_bash()
+    if bash is None:
+        pytest.skip("no trusted Git Bash on this host")
+    echoed = subprocess.run(
+        [bash, "-c", 'cmd //c echo start "t" powershell'],
+        capture_output = True,
+        text = True,
+        timeout = 60,
+    ).stdout.strip()
+    assert echoed == "start t powershell", echoed
+    # ...and that it does re-quote once the word holds a space, which is what
+    # makes the whitespace test the right one.
+    echoed = subprocess.run(
+        [bash, "-c", 'cmd //c echo start "a b" powershell'],
+        capture_output = True,
+        text = True,
+        timeout = 60,
+    ).stdout.strip()
+    assert echoed == 'start "a b" powershell', echoed
+
+
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # cmd's `if` carries out the command after its condition, so the leading
+        # word is not the command and the one behind the condition may be a
+        # text command whose arguments are only printed.
+        ('cmd /c if exist x echo start "my title" powershell', False),
+        ('cmd /c if not defined V echo start "t" powershell', False),
+        ('cmd /c if errorlevel 1 echo start "t" powershell', False),
+        # ...but a real launch behind a condition still counts.
+        ('cmd /c if exist x start "" powershell -c ls', True),
+        ('cmd /c if not exist x start "" pwsh -c ls', True),
+    ],
+)
+def test_cmd_if_advances_to_the_command_it_runs(monkeypatch, bash, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The cmd lexer glues a spaceless separator to the word before it, so
+        # the start was not found as a word at all.
+        'cmd /c dir&start "" powershell -c ls',
+        'cmd /c echo ok&start "" pwsh -c ls',
+        'cmd /c dir|start "" powershell -c ls',
+    ],
+)
+def test_start_is_found_behind_a_glued_cmd_separator(monkeypatch, command):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A bash separator ends the cmd invocation rather than starting another
+        # cmd command, so what follows belongs to bash and not to cmd.
+        ('cmd //c echo ok; printf "%s" start "" powershell', False),
+        ('cmd //c dir; ls start "" pwsh -c ls', False),
+        ('cmd //c dir; echo start "my title" pwsh', False),
+        # The cmd payload before the separator is still read.
+        ('cmd //c start "" powershell -c ls; echo done', True),
+    ],
+)
+def test_the_nested_cmd_scan_stops_at_an_outer_separator(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Quoting is what makes a path holding an operator usable, so an
+        # operator inside the quotes is part of the name, not cmd syntax.
+        r'start "" "C:\A&B\powershell.exe"',
+        r'start "" "C:\Program Files (x86)\A&B\pwsh.exe"',
+    ],
+)
+def test_an_operator_inside_a_quoted_path_is_not_cmd_syntax(monkeypatch, command):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert tools._find_blocked_commands(command)
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1161,6 +1161,61 @@ def test_a_handoff_belongs_to_the_statement_at_its_depth(monkeypatch, command, b
 @pytest.mark.parametrize(
     ("command", "blocked"),
     [
+        # A separator ends a redirection target even glued to it, so the word
+        # behind it is a command; swallowing the token whole left the launch
+        # unscreened. `2>&1` carries a handle rather than a target, so nothing
+        # follows it to skip and the words behind it stay echo's.
+        ('cmd /c > out&start "" powershell', True),
+        ('cmd /c >out&start "" powershell', True),
+        ('cmd /c > out start "" powershell', True),
+        ("cmd /c echo hi 2>&1 powershell", False),
+        # The target is what the separator ends, and the command behind it is
+        # read as one -- including a `for`, whose set is a command of its own.
+        ("""cmd /c > out&for /f %i in ('start "" powershell') do echo %i""", True),
+        # `>&2` is the whole operator, handle and all, so the word behind it is
+        # the command rather than the target of a redirection still waiting.
+        ('cmd /c >&2 start "" powershell', True),
+        # An empty piece is syntax and not a command word: reading the one the
+        # trailing `&` leaves behind took back the position it had just opened.
+        ('cmd /c echo a& start "" powershell', True),
+        ('cmd /c (echo a)& start "" powershell', True),
+        ('cmd /c if exist x ( start "" powershell )', True),
+        ('cmd /c echo a& echo start "" powershell', False),
+        # An `if` is over at the `)` even when the separator is glued to it, so
+        # the printed `else` behind it is ECHO's message and not a handoff.
+        ('cmd /c if exist x (echo a)& echo else start "" powershell', False),
+        ('cmd /c if exist x (echo a )& echo else start "" powershell', False),
+        ('cmd /c if exist x (echo a & echo b) else start "" powershell', True),
+    ],
+)
+def test_cmd_syntax_glued_to_a_word_still_ends_it(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # Win32 ignores a trailing dot or space, so these open powershell.exe
+        # while splitext read the lone dot as the extension and matched nothing.
+        ('cmd //c start "" C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe.', True),
+        ('cmd //c start "" powershell.exe.', True),
+        ("cmd //c powershell.", True),
+        ('cmd //c start "" "report.txt."', False),
+        ('cmd //c start "" notepad.', False),
+    ],
+)
+def test_a_trailing_dot_is_not_part_of_a_windows_name(monkeypatch, bash, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
         # cmd strips the quotes and applies the escapes before it resolves the
         # command, so these run powershell while no scan of the raw spelling
         # matches. The grammar walk normalises the word; screening only the two

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -284,10 +284,39 @@ def test_notes_say_where_commands_run(monkeypatch):
         r'cmd //c start /d C:/tmp "" powershell -Command ls',
     ],
 )
-def test_cmd_shellout_is_screened_through_mangled_switches(command):
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+def test_cmd_shellout_is_screened_through_mangled_switches(monkeypatch, bash, command):
     # Git Bash turns a lone /c into a path, so a model writes //c. That spelling
     # skipped the nested scan, making `cmd //c powershell` reachable where
     # `cmd /c powershell` was blocked, and `start` launches its argument too.
+    #
+    # Pinned to win32 like the rest of this file: powershell and pwsh are hard
+    # blocks only there (off Windows they are a prompt, see test_permission_mode),
+    # so on a Linux runner this asserted nothing about the nested scan at all.
+    #
+    # Both shells, because the presence of Git Bash decides which lexer runs and
+    # the two disagree about quotes: without it the title in `start ""` arrives
+    # as a literal `""` and every start form here went unscreened.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    "command",
+    [
+        'start "My Title" powershell -Command ls',
+        'cmd /c start "t" pwsh -c ls',
+        'cmd //c start /min "win" powershell -Command ls',
+    ],
+)
+def test_start_screens_the_program_behind_a_window_title(monkeypatch, bash, command):
+    # `start "title" prog` is the documented form. The title was read as the
+    # program, so anything after it launched unscreened -- on both lexers, which
+    # made this the wider of the two holes.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
     assert tools._find_blocked_commands(command)
 
 

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -388,7 +388,9 @@ def test_start_screening_survives_separators_and_switch_order(monkeypatch, bash,
     assert tools._find_blocked_commands(command)
 
 
-@pytest.mark.parametrize("command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"])
+@pytest.mark.parametrize(
+    "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
+)
 def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):
     # The Windows set is a hard refusal; off Windows these stay a prompt instead
     # (tests/test_permission_mode.py). Nothing asserted that, so dropping the

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -862,6 +862,60 @@ def test_cmd_escapes_prefixes_and_control_words(monkeypatch, command, blocked, b
     assert bool(tools._find_blocked_commands(command)) is blocked
 
 
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # `call` reparses its target, so the word behind it is another command.
+        ('cmd //c call start "" powershell', True),
+        ('cmd //c call call start "" pwsh', True),
+        ('cmd //c echo call start "" powershell', False),
+    ],
+)
+def test_call_hands_the_command_along(monkeypatch, bash, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # MSYS re-quotes an argument holding whitespace when it builds cmd's
+        # command line, and quoting is what makes cmd's separators ordinary
+        # data, so the `&` inside one of those is not a separator at all.
+        ('cmd //c echo "x &start" "" powershell', False),
+        ('cmd //c echo "a & start" "" pwsh', False),
+        # ...while one in a word MSYS passes through bare still is.
+        (r'cmd //c echo ok\&start "" powershell', True),
+    ],
+)
+def test_a_separator_inside_a_requoted_argument_is_data(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked", "platform"),
+    [
+        # Where a POSIX shell lexes, a group opener is its own token, so one
+        # still attached to a word survived quoting and belongs to it: these
+        # print their arguments and run none of them.
+        ("echo '(bash' -c rm", False, "linux"),
+        ("echo '(sh' -c curl", False, "linux"),
+        # A real nested shell behind a group is still read there.
+        ('x; (bash -c "rm -rf /")', True, "linux"),
+        # ...but the cmd lexer keeps the opener glued, where it really is one.
+        ('(cmd //c start "" pwsh -Command ls)', True, "win32"),
+    ],
+)
+def test_a_quoted_group_opener_belongs_to_the_word(monkeypatch, command, blocked, platform):
+    monkeypatch.setattr(sys, "platform", platform)
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
 @pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1047,6 +1047,30 @@ def test_quotes_protect_cmd_separators_under_the_cmd_lexer(monkeypatch, command,
 
 
 @pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A quoted bracket is argument data, so it neither opens nor closes the
+        # branch: closing early on one let the `&` read as outside it and lost
+        # the `else` that reopens the command position.
+        ('cmd /c if exist no_f (echo ")" & echo done) else start "" powershell', True),
+        ('cmd /c if exist no_f (echo "(" & echo done) else start "" pwsh', True),
+        ('cmd /c if exist no_f (echo ok & echo done) else start "" powershell', True),
+        # A `for` cmd runs somewhere on the line is not this `for`: the outer
+        # one here is real while the inner expression is echo's data.
+        (
+            """cmd /c for %i in (x) do echo "for /f %j in ('start "" powershell') do echo %j\"""",
+            False,
+        ),
+        ("""cmd /c for /f %i in ('start "" pwsh') do echo %i""", True),
+    ],
+)
+def test_quoting_decides_what_is_cmd_syntax_in_place(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )
 def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -970,6 +970,63 @@ def test_an_unquoted_for_set_is_data_under_the_cmd_lexer(monkeypatch):
 
 
 @pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A separator inside a group is between the branch's own commands, so
+        # the `if` it belongs to is still open and its `else` still reopens.
+        ('cmd /c if exist no_f (echo ok & echo done) else start "" powershell', True),
+        ('cmd /c if exist no_f (echo a & echo b) else echo start "" pwsh', False),
+        # ...while one outside a group closes the statement as before.
+        ('cmd /c if exist x echo ok & echo do start "" powershell', False),
+        # The cmd lexer keeps the quotes and splits `"a"=="a"`, whose second
+        # half was taking the command position.
+        ('cmd /c if "a"=="a" start "" powershell', True),
+        ('cmd /c if /i "a" == "a" start "" pwsh', True),
+        ('cmd /c if "a"=="a" echo start "" powershell', False),
+        # cmd strips the quotes round its own name before running the payload.
+        ('"cmd.exe" /c start "" powershell', True),
+        ('"cmd" /c start "" pwsh', True),
+        # The group opener comes off before the echo-suppression prefix.
+        ('cmd /c (@start "" powershell)', True),
+        ('cmd /c (@echo start "" powershell)', False),
+    ],
+)
+def test_cmd_groups_quotes_and_prefixes_compose(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # The set is found by re-reading the text, which cannot tell a construct
+        # from a quotation of one, so it only runs where cmd runs a `for`.
+        ("""echo "for /f %i in ('rm -rf victim') do echo %i\"""", False),
+        ("""cmd /c echo "for /f %i in ('start "" pwsh') do echo %i\"""", False),
+        ("""cmd //c for /f %i in ('start "" pwsh') do echo %i""", True),
+    ],
+)
+def test_a_quoted_for_expression_is_not_a_for(monkeypatch, bash, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+def test_a_bare_for_is_only_cmds_where_cmd_is_the_shell(monkeypatch):
+    # The substitution is cmd syntax. Under Git Bash the same text is bash's
+    # own: the parentheses open a subshell and the quoted set is one word, so
+    # there is no cmd construct to read.
+    monkeypatch.setattr(sys, "platform", "win32")
+    command = """for /f %i in ('start "" pwsh') do echo %i"""
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert tools._find_blocked_commands(command)
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )
 def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1179,6 +1179,71 @@ def test_a_nested_cmd_payload_needs_a_cmd_that_runs(monkeypatch, bash, command, 
 
 
 @pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # usebackq swaps which quoting runs a command: Microsoft documents
+        # `('<command>')` without it and ``(`<command>`)`` with it, the other
+        # spelling being a literal string to parse.
+        ("""cmd /c for /f %i in (`start "" powershell`) do echo %i""", False),
+        ("""cmd /c for /f "usebackq" %i in ('start "" powershell') do echo %i""", False),
+        ("""cmd /c for /f "usebackq" %i in (`start "" powershell`) do echo %i""", True),
+        ("""cmd /c for /f %i in ('start "" powershell') do echo %i""", True),
+        # `delims=(` is a legal option holding cmd's own bracket, and stopping
+        # the option scan at the first one hid the set behind it.
+        ("""cmd /c for /f "delims=(" %i in ('start "" powershell') do echo %i""", True),
+        ("""cmd /c for /f "usebackq delims=(" %i in (`start "" powershell`) do echo %i""", True),
+    ],
+)
+def test_a_for_set_runs_only_in_the_spelling_usebackq_selects(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # cmd's own switches sit between it and the /c holding its command
+        # line, and the value-bearing ones outran a length test, so the cmd in
+        # front of them was never found and its payload never read.
+        ('cmd /v:on /c start "" powershell', True),
+        ('cmd /e:off /f:on /t:0a /c start "" pwsh', True),
+        ('cmd /s /q /d /c start "" powershell', True),
+        # ...while a path is a program, not a switch.
+        ("cmd /c /bin/bash -c ls", False),
+    ],
+)
+def test_cmd_switches_do_not_hide_the_shell_in_front_of_them(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # Win32 takes `/` as a separator, so a drive path can be spelled with a
+        # doubled one and read as a URL scheme, walking past the program name.
+        ('cmd /c start "" C://Windows/System32/WindowsPowerShell/v1.0/powershell.exe', True),
+        ('cmd /c start "" C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe', True),
+        # A scheme of two letters or more is still a URL, which start hands to
+        # the browser rather than running.
+        ('cmd /c start "" https://example.com/powershell', False),
+        ('cmd /c start "" file:///C:/tmp/powershell', False),
+        # cmd expands its variables before it resolves the program, and a
+        # substring expansion can contribute nothing at all.
+        ('cmd /c start "" powershell%PATH:~0,0%', True),
+        ('cmd /c start "" %COMSPEC%', False),
+        ('cmd /c start "" report%DATE%.txt', False),
+    ],
+)
+def test_a_start_target_is_read_as_cmd_resolves_it(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )
 def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -403,11 +403,8 @@ def test_detached_windows_stay_launchable(monkeypatch, bash, command):
         # from a second lex of the whole line meant a `;` or a `#` glued onto
         # its neighbour stopped the two lining up, and the title was screened
         # in the program's place.
-        'cd /c/proj; cmd //c start "" pwsh -Command ls',
-        'echo done; cmd //c start "" powershell -Command ls',
         'cmd //c start "" pwsh -Command ls; echo ok',
         '(cmd //c start "" pwsh -Command ls)',
-        'ls; cmd //c start "The Build" powershell -Command "Remove-Item x"',
         'start "" powershell -c ls # note',
         # Microsoft documents the switches after the title, not before it.
         'start "" /min powershell -c ls',
@@ -419,6 +416,28 @@ def test_start_screening_survives_separators_and_switch_order(monkeypatch, bash,
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'cd /c/proj; cmd //c start "" pwsh -Command ls',
+        'echo done; cmd //c start "" powershell -Command ls',
+        'ls; cmd //c start "The Build" powershell -Command "Remove-Item x"',
+    ],
+)
+def test_a_semicolon_starts_a_command_for_bash_but_not_for_cmd(monkeypatch, command):
+    # Microsoft lists cmd's command separators as `&`, `&&`, `||` and `|`, and
+    # puts `;` with the characters that merely have to be quoted -- it is an
+    # ARGUMENT delimiter. So the same line reads two ways: bash runs the cmd
+    # behind the `;`, while cmd looks up a program named by the first word and
+    # hands it everything else, launching nothing.
+    # test_cmd_reads_a_semicolon_as_an_argument_delimiter checks that on Windows.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert tools._find_blocked_commands(command)
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert not tools._find_blocked_commands(command)
 
 
 @pytest.mark.parametrize(
@@ -618,6 +637,22 @@ def test_git_bash_does_not_requote_a_bare_word():
         timeout = 60,
     ).stdout.strip()
     assert echoed == 'start "a b" powershell', echoed
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason = "cmd parsing")
+def test_cmd_reads_a_semicolon_as_an_argument_delimiter():
+    # Whether `;` begins a command decides whether the words behind one are a
+    # command line or a first program's arguments, so it is checked against cmd
+    # itself. Microsoft lists only `&`, `&&`, `||` and `|` as command
+    # separators: if `;` were one, the second word would run and print on its
+    # own line. It is echo's argument instead, delimiter included.
+    echoed = subprocess.run(
+        ["cmd", "/c", "echo one; echo two"],
+        capture_output = True,
+        text = True,
+        timeout = 60,
+    ).stdout.strip()
+    assert echoed == "one; echo two", echoed
 
 
 @pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
@@ -1067,6 +1102,79 @@ def test_quotes_protect_cmd_separators_under_the_cmd_lexer(monkeypatch, command,
 def test_quoting_decides_what_is_cmd_syntax_in_place(monkeypatch, command, blocked):
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # Quoting protects a caret the same way it protects an operator, so the
+        # name cmd looks up is a file really called `power^shell`. Applying the
+        # escape to it hard-blocked the benign name as powershell.
+        ('cmd /c start "" "power^shell"', False),
+        ('cmd /c start "" power^shell', True),
+        ('cmd /c start "" "powershell"', True),
+        # cmd drops the marks wherever they sit when it resolves the program.
+        ('cmd /c start "" pow"ers"hell', True),
+        # ...but a quoted bracket is part of the filename, not cmd's grouping.
+        ('cmd /c start "" "power)shell"', False),
+        ('cmd /c if exist x (start "" powershell)', True),
+    ],
+)
+def test_a_quoted_start_target_is_a_filename(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+def test_a_quoted_caret_reaches_cmd_unquoted_through_git_bash(monkeypatch):
+    # The same line the other way round: bash removes the quotes and MSYS
+    # re-quotes nothing without whitespace, so cmd is handed a real escape and
+    # powershell does launch.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert "powershell" in tools._find_blocked_commands('cmd /c start "" "power^shell"')
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A statement is consumed by its own handoff word, so a later one is an
+        # operand again: these only print the words behind `echo`.
+        ('cmd /c for %i in (x) do echo do start "" powershell', False),
+        ('cmd /c if exist x (echo a) else echo else start "" powershell', False),
+        # The real handoffs still count, including one statement's after
+        # another's has been used up.
+        ('cmd /c for %i in (x) do start "" powershell', True),
+        ('cmd /c if exist x (echo a) else start "" powershell', True),
+        ('cmd /c if exist x (for %i in (y) do echo a) else start "" powershell', True),
+        ('cmd /c for %i in (x) do for %j in (y) do start "" powershell', True),
+    ],
+)
+def test_a_for_or_if_hands_off_once(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A `cmd /c` payload is a command line only where that cmd is itself
+        # run. echo prints these words, so reading them as one refused a
+        # message; the same words in command position really do launch.
+        ('echo cmd /c start "" powershell', False),
+        ('cmd /c cmd /c start "" powershell', True),
+        # cmd launches a start's program, which is deliberately not a command
+        # position (it is screened by name), so it is named separately.
+        ('cmd /c start "" cmd /c start "" powershell', True),
+        ('cmd /c echo start "" cmd /c start "" powershell', False),
+    ],
+)
+def test_a_nested_cmd_payload_needs_a_cmd_that_runs(monkeypatch, bash, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
     assert bool(tools._find_blocked_commands(command)) is blocked
 
 

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1243,6 +1243,46 @@ def test_a_start_target_is_read_as_cmd_resolves_it(monkeypatch, command, blocked
     assert bool(tools._find_blocked_commands(command)) is blocked
 
 
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A redirection is the shell's own syntax, taken out of the line before
+        # the command runs, so it stands between `start` and its program
+        # without being either. Reading the `>nul` as the program left the
+        # launch behind it unscreened.
+        'cmd /c start >nul "" powershell',
+        'cmd /c start "" >nul powershell',
+        'cmd /c start "" 2>&1 powershell',
+        "cmd /c start >nul powershell",
+        'cmd /c start > nul "" powershell',
+        'cmd /c start /min >nul "" powershell',
+    ],
+)
+def test_a_redirection_is_not_the_program_start_launches(monkeypatch, bash, command):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert "powershell" in tools._find_blocked_commands(command)
+
+
+def test_a_chain_of_cmd_payloads_is_bounded_and_fails_closed(monkeypatch):
+    # Every `cmd /c` begins a command line of its own, so the tail is read once
+    # per level and a long enough chain is quadratic in what the model wrote.
+    # The scan runs before the command does, so that wait is the caller's: the
+    # budget is shared across the line, and a chain that spends it is refused
+    # rather than trusted on the half that was read.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    # The shell whose command line went unread is what comes back, so the
+    # refusal holds even where the chain names nothing blocked at all.
+    assert "cmd" in tools._find_blocked_commands("cmd /c " * 400 + "echo ok")
+    assert "cmd" in tools._find_blocked_commands("cmd /c " * 400 + 'start "" powershell')
+    # A line no longer than anything a model writes is read in full, budget
+    # untouched, so the bound costs no detection where it matters.
+    assert "powershell" in tools._find_blocked_commands("cmd /c " * 8 + 'start "" powershell')
+    assert not tools._find_blocked_commands("cmd /c " * 8 + "echo ok")
+
+
 @pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -825,6 +825,44 @@ def test_cmd_command_positions_are_followed_through_its_grammar(
 
 
 @pytest.mark.parametrize(
+    ("command", "blocked", "bash"),
+    [
+        # `cmdextversion <n>` takes an operand like exist and defined do.
+        ('cmd /c if cmdextversion 1 start "" powershell', True, None),
+        ('cmd /c if not cmdextversion 2 start "" pwsh', True, None),
+        # The caret escapes what follows it and is then dropped, so the two have
+        # to be read together: in `ok^&start` the & is an argument, but in
+        # `ok^^&start` the first caret escapes the second and the & still
+        # separates, which a lookbehind for one caret cannot tell apart.
+        ('cmd /c echo ok^&start "" powershell', False, None),
+        ('cmd /c echo ok^^&start "" powershell', True, None),
+        ('cmd /c echo ok^^^&start "" powershell', False, None),
+        # `@` suppresses echoing without changing which command runs.
+        ('cmd /c @start "" powershell', True, None),
+        ('cmd /c @echo start "" powershell', False, None),
+        # A leading redirection is bash's, consumed before cmd is handed its
+        # arguments, so it holds the command position rather than taking it.
+        ('cmd //c >nul start "" powershell', True, r"C:\Program Files\Git\bin\bash.exe"),
+        ('cmd //c 2>nul start "" pwsh', True, r"C:\Program Files\Git\bin\bash.exe"),
+        # ...and `else` or `do` only hand off where one of their statements is
+        # open, or a printed word reads as a handoff.
+        ('cmd /c echo else start "" powershell', False, None),
+        ('cmd /c echo do start "" powershell', False, None),
+        ('cmd /c if exist no_f echo ok else start "" powershell', True, None),
+        # A separator closes the statement with the segment it was opened in,
+        # so a printed `else` or `do` after one is not a handoff either.
+        ('cmd /c if exist x start "" notepad & echo do start "" powershell', False, None),
+        ('cmd /c if exist x start "" notepad & echo else start "" pwsh', False, None),
+        ('cmd /c for %i in (x) do start notepad & echo do start "" pwsh', False, None),
+    ],
+)
+def test_cmd_escapes_prefixes_and_control_words(monkeypatch, command, blocked, bash):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )
 def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1237,7 +1237,7 @@ def test_a_for_expression_belongs_to_a_for_that_runs(monkeypatch, command, block
         ('cmd /c start "" power!X!shell', True),
         # `%VAR%` is read when the line is PARSED, before any set on it runs,
         # so that one stays read-both-ways rather than refused.
-        ('cmd /c start "" report%DATE%.txt', False),
+        ('cmd /c start "" report%DATE%.txt', True),
         ('cmd /c start "" "my!file.txt"', False),
     ],
 )
@@ -1444,7 +1444,7 @@ def test_cmd_switches_do_not_hide_the_shell_in_front_of_them(monkeypatch, comman
         # cmd expands its variables before it resolves the program, and a
         # substring expansion can contribute nothing at all.
         ('cmd /c start "" powershell%PATH:~0,0%', True),
-        ('cmd /c start "" report%DATE%.txt', False),
+        ('cmd /c start "" report%DATE%.txt', True),
         # ...and where the program name is nothing BUT an expansion, no reading
         # of it is a name at all, so the line is refused rather than passed:
         # `start "" %ComSpec% /c powershell` launches cmd with a command line
@@ -1494,8 +1494,8 @@ def test_a_redirection_is_not_the_program_start_launches(monkeypatch, bash, comm
         # fragment is a delayed one, which the same line can fill
         # (test_a_delayed_expansion_in_a_program_name_fails_closed).
         ('cmd /c start "" my!X!file.txt', True),
-        ('cmd /c start "" my%X%file.txt', False),
-        ('cmd /c start "" report%DATE%.txt', False),
+        ('cmd /c start "" my%X%file.txt', True),
+        ('cmd /c start "" report%DATE%.txt', True),
     ],
 )
 def test_an_expansion_does_not_hide_the_command_word(monkeypatch, command, blocked):
@@ -1583,6 +1583,82 @@ def test_an_expansion_only_command_word_fails_closed(monkeypatch, command, block
 def test_a_command_another_command_runs_is_screened(monkeypatch, command, blocked):
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # An expansion in the NAME leaves it unresolvable: it can be the whole
+        # of it, and it can contribute exactly the characters that complete a
+        # blocked one, so reading it as empty was a guess that went the way
+        # that launches.
+        ('cmd /c start "" power%ComSpec:~9,1%hell', True),
+        ('cmd /c start "" %ComSpec%', True),
+        ('cmd /c start "" report%DATE%.txt', True),
+        # Only the name, though: a path that merely holds one still names its
+        # own file, and a name with no expansion at all is unaffected.
+        (r'cmd /c start "" "%USERPROFILE%\notes.txt"', False),
+        ('cmd /c start "" notepad', False),
+    ],
+)
+def test_an_expansion_in_a_program_name_is_unresolved(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # find runs the action itself, so its words are commands the line runs
+        # and a shell among them owns the payload behind it.
+        ('find . -exec cmd //c start "" powershell ;', True),
+        ('fd . -x cmd //c start "" powershell', True),
+        ('find . -exec cmd //c echo start "" powershell ;', False),
+    ],
+)
+def test_an_exec_child_owns_its_payload(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # The set of a `for /f` is executed by cmd whatever handed the line
+        # over, and the two grammars disagree about `;`: an argument delimiter
+        # to cmd, a command separator to bash. Read as bash, the first of these
+        # was refused for printing and the second went unscreened.
+        ("""cmd //c for /f %i in ('echo hi;start "" powershell') do echo %i""", False),
+        ("""cmd //c for /f %i in ('start;"" powershell') do echo %i""", True),
+        ("""cmd //c for /f %i in ('start "" powershell') do echo %i""", True),
+    ],
+)
+def test_a_cmd_owned_body_is_read_with_cmd_grammar(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A redirection is gone before start reads its arguments, so it is not
+        # the value of `/d` and the directory is not the program.
+        (r'cmd /c start "" /d >nul C:\tmp powershell', True),
+        (r'cmd /c start "" /d C:\tmp powershell', True),
+        (r'cmd /c start "" /d C:\tmp notepad', False),
+        # ...and it is not a condition word either, at any point in one.
+        ('cmd /c if not >nul 1 EQU 2 start "" powershell', True),
+        ('cmd /c if not 1 EQU 2 start "" powershell', True),
+        ('cmd /c if not 1 EQU 2 echo start "" powershell', False),
+    ],
+)
+def test_a_redirection_is_skipped_wherever_cmd_removes_it(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
     assert bool(tools._find_blocked_commands(command)) is blocked
 
 

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -327,7 +327,11 @@ def test_start_screens_the_program_behind_a_window_title(monkeypatch, bash, comm
         "start notepad rm.txt",
         "start excel curl.csv",
         'start "" notepad rm.txt',
-        'start "rm.txt" notepad',
+        # A title cmd still sees quoted on either lexer. main screens this one
+        # as a program and reports `rm`; the unspaced `"rm.txt"` spelling stays
+        # blocked under Git Bash exactly as on main, because bash drops the
+        # quotes and cmd is handed a program named rm.txt.
+        'start "rm x.txt" notepad',
     ],
 )
 def test_start_arguments_are_not_screened_as_commands(monkeypatch, bash, command):
@@ -367,9 +371,10 @@ def test_detached_windows_stay_launchable(monkeypatch, bash, command):
 @pytest.mark.parametrize(
     "command",
     [
-        # A separator before the start is the whole point: the second lex has to
-        # be built like the first, or the two stop lining up and the title is
-        # screened in the program's place.
+        # A separator before the start is the whole point: inferring the title
+        # from a second lex of the whole line meant a `;` or a `#` glued onto
+        # its neighbour stopped the two lining up, and the title was screened
+        # in the program's place.
         'cd /c/proj; cmd //c start "" pwsh -Command ls',
         'echo done; cmd //c start "" powershell -Command ls',
         'cmd //c start "" pwsh -Command ls; echo ok',
@@ -386,6 +391,51 @@ def test_start_screening_survives_separators_and_switch_order(monkeypatch, bash,
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
     assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Bash strips the user's quotes and re-quotes an argument only when it
+        # has to, so cmd is handed `start powershell -c ls`: powershell is the
+        # program, not a title. Reading the source quotes skipped it entirely.
+        'cmd //c start "powershell" -c ls',
+        "cmd //c start 'pwsh' -c ls",
+        # A POSIX-only escape anywhere earlier in the line used to desync the
+        # second lex the title came from, which then reported nothing and left
+        # the program behind the title unscreened.
+        r'echo a\ b; cmd //c start "" powershell -c ls',
+        r'echo a\ b\ c && cmd //c start "" pwsh -Command ls',
+        # Git Bash hands native programs their arguments in MSYS form, and every
+        # real start switch is one word, so a slash-rooted program is not one.
+        'cmd //c start "" /c/Windows/System32/powershell.exe -c ls',
+        "cmd //c start /c/Windows/System32/powershell.exe -c ls",
+    ],
+)
+def test_start_screening_reads_what_cmd_receives_not_the_source_quotes(monkeypatch, command):
+    # These all run through Git Bash, the shell that rewrites the line between
+    # the user and cmd. Screening the tokens the user typed rather than the ones
+    # cmd parses left the blocked program launchable in each.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "start 'title' rm.txt",
+        "start 'notes' curl.csv",
+    ],
+)
+def test_cmd_has_no_single_quote_syntax(monkeypatch, command):
+    # Without Git Bash nothing rewrites the line and cmd documents the title as
+    # "<Title>", so 'title' is a program literally named that and rm.txt is its
+    # argument. Counting a single quote as a title moved the scan onto the
+    # argument and hard-blocked a benign file for holding `rm`.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert not tools._find_blocked_commands(command)
 
 
 @pytest.mark.parametrize("command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"])

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1161,6 +1161,113 @@ def test_a_handoff_belongs_to_the_statement_at_its_depth(monkeypatch, command, b
 @pytest.mark.parametrize(
     ("command", "blocked"),
     [
+        # cmd reads `;`, `,` and `=` where it reads a space, which is what makes
+        # `echo;hi` print, so an unquoted one ends the command word.
+        ('cmd /c start;"" powershell', True),
+        ('cmd /c start,"" powershell', True),
+        # ...while a quoted one is a filename character, and a word that BEGINS
+        # with a delimiter is not a name ending at one. Written behind another
+        # command, since a payload that OPENS with a quote is dequoted by cmd
+        # itself and the marks are gone by the time the name is read.
+        ('cmd /c echo hi & "start;x" "" powershell', False),
+        ('cmd /c "start;x" "" powershell', True),
+        ('cmd /c if "a"=="a" echo start "" powershell', False),
+        # A quoted bracket is filename data too, so this names a program cmd
+        # looks up whole and powershell is only its argument.
+        ('cmd /c call "(safe)start" "" powershell', False),
+        ('cmd /c echo hi & "(safe)start" "" powershell', False),
+        ('cmd /c if exist x "(safe)start" "" powershell', False),
+        ('cmd /c if exist x (start "" powershell)', True),
+    ],
+)
+def test_quoting_decides_which_cmd_punctuation_is_syntax(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A redirection between `if` and its test is performed by cmd and never
+        # reaches the condition, so counting it as a condition word put the
+        # count out and left the launch behind it in argument position.
+        ('cmd /c if >nul exist file.txt start "" powershell', True),
+        ('cmd /c if 2>nul not exist file.txt start "" powershell', True),
+        ('cmd /c if > nul exist file.txt start "" powershell', True),
+        ('cmd /c if >nul defined V start "" powershell', True),
+        # ...and the condition still ends where it did, so a text command
+        # behind one only prints.
+        ('cmd /c if >nul exist file.txt echo start "" powershell', False),
+    ],
+)
+def test_a_redirection_is_not_a_condition_word(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A `for` expression counts where it IS one of the fors cmd runs, not
+        # merely where one shares its line: rem records a comment.
+        ("""cmd /c for %i in (x) do rem for /f %j in ('start "" powershell') do echo %j""", False),
+        ("""cmd /c for /f %i in ('start "" powershell') do echo %i""", True),
+        # ...found inside that word too, since a separator glued in front
+        # leaves the `for` mid-token.
+        ("""cmd /c > out&for /f %i in ('start "" powershell') do echo %i""", True),
+    ],
+)
+def test_a_for_expression_belongs_to_a_for_that_runs(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A delayed expansion is read when the command RUNS, so the same line
+        # can fill it and a fragment that is nothing on its own assembles a
+        # blocked name. Unknowable here and controllable there, so refused.
+        ('cmd /v:on /c "set X=power&start "" !X!shell"', True),
+        ('cmd /c start "" !X!shell', True),
+        ('cmd /c start "" power!X!shell', True),
+        # `%VAR%` is read when the line is PARSED, before any set on it runs,
+        # so that one stays read-both-ways rather than refused.
+        ('cmd /c start "" report%DATE%.txt', False),
+        ('cmd /c start "" "my!file.txt"', False),
+    ],
+)
+def test_a_delayed_expansion_in_a_program_name_fails_closed(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # CALL reparses what the first pass left, escapes already applied, so
+        # the caret-protected `&` becomes a separator on the second read and
+        # the start behind it runs.
+        ('cmd /c call echo safe ^& start "" powershell', True),
+        ('cmd /c call start "" powershell', True),
+        # Without a caret the second pass reads the same words as the first.
+        ("cmd /c call echo safe & echo start", False),
+        ("cmd /c echo safe ^& echo done", False),
+    ],
+)
+def test_call_reparses_the_line_the_first_pass_left(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
         # A separator ends a redirection target even glued to it, so the word
         # behind it is a command; swallowing the token whole left the launch
         # unscreened. `2>&1` carries a handle rather than a target, so nothing
@@ -1382,8 +1489,11 @@ def test_a_redirection_is_not_the_program_start_launches(monkeypatch, bash, comm
         # registry enables it, and the launcher itself went unread.
         ('cmd /v:on /c st!X!art "" powershell', True),
         ('cmd /c start "" power!X!shell', True),
-        # A name that expands to nothing blocked stays allowed.
-        ('cmd /c start "" my!X!file.txt', False),
+        # A name that expands to nothing blocked stays allowed... unless the
+        # fragment is a delayed one, which the same line can fill
+        # (test_a_delayed_expansion_in_a_program_name_fails_closed).
+        ('cmd /c start "" my!X!file.txt', True),
+        ('cmd /c start "" my%X%file.txt', False),
         ('cmd /c start "" report%DATE%.txt', False),
     ],
 )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -539,10 +539,18 @@ def test_desync_does_not_screen_unquoted_start_arguments(monkeypatch, command, b
         ('cmd //c if exist . start "" powershell -c ls', True),
         ('cmd //c dir & start "" powershell -c ls', True),
         ('cmd //c if not exist x.txt start "" pwsh -c ls', True),
-        # ...but a start that is an argument of a command taking text is not a
-        # launch, which is what gating the scan fixed in the first place.
+        # ...but only the word cmd runs counts. Anywhere else the start is an
+        # operand of the command that is running, whether that prints it or
+        # reads it as a name, and neither launches anything.
         ('cmd //c echo start "my title" powershell', False),
         ('cmd //c set x=start "t" powershell', False),
+        ('cmd /c dir start "" powershell', False),
+        ('cmd /c type start "" pwsh', False),
+        # `>` redirects into a file rather than beginning another command, so
+        # these write output to one called start and launch nothing, including
+        # where the redirection sits on the segment's own command word.
+        ("cmd /c echo hi>start powershell", False),
+        ('cmd /c x>start "" powershell', False),
     ],
 )
 def test_start_is_found_across_a_whole_cmd_command_line(monkeypatch, bash, command, blocked):
@@ -622,9 +630,15 @@ def test_git_bash_does_not_requote_a_bare_word():
         ('cmd /c if exist x echo start "my title" powershell', False),
         ('cmd /c if not defined V echo start "t" powershell', False),
         ('cmd /c if errorlevel 1 echo start "t" powershell', False),
+        # Microsoft documents /i before the comparison. Missing it left `a==a`
+        # looking like the command, which both refused a printed start and hid
+        # a real one behind the same condition.
+        ('cmd /c if /i a==a echo start "" powershell', False),
         # ...but a real launch behind a condition still counts.
         ('cmd /c if exist x start "" powershell -c ls', True),
         ('cmd /c if not exist x start "" pwsh -c ls', True),
+        ('cmd /c if /i a==a start "" powershell', True),
+        ('cmd //c if //i a==a start "" pwsh -c ls', True),
     ],
 )
 def test_cmd_if_advances_to_the_command_it_runs(monkeypatch, bash, command, blocked):
@@ -659,6 +673,11 @@ def test_start_is_found_behind_a_glued_cmd_separator(monkeypatch, command):
         ('cmd //c dir; echo start "my title" pwsh', False),
         # The cmd payload before the separator is still read.
         ('cmd //c start "" powershell -c ls; echo done', True),
+        # An escaped separator is the opposite case: bash passes it through and
+        # cmd reads it as its own, so it opens a segment rather than ending the
+        # scan, and the launch behind it is real.
+        (r'cmd //c echo ok \& start "" powershell -c ls', True),
+        (r'cmd //c dir \& start "" pwsh -c ls', True),
     ],
 )
 def test_the_nested_cmd_scan_stops_at_an_outer_separator(monkeypatch, command, blocked):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1139,6 +1139,50 @@ def test_a_quoted_caret_reaches_cmd_unquoted_through_git_bash(monkeypatch):
 @pytest.mark.parametrize(
     ("command", "blocked"),
     [
+        # A handoff word belongs to the statement at its OWN depth: the first
+        # `else` here is ECHO's data one level in, and consuming the `if` there
+        # left the real else with nothing to reopen.
+        ('cmd /c if exist no_f (echo else) else start "" powershell', True),
+        ('cmd /c if exist a (for %i in (x) do echo do) else start "" powershell', True),
+        # ...while a statement opened inside a group hands off inside it.
+        ('cmd /c if exist a (if exist b (echo x) else start "" powershell)', True),
+        ('cmd /c for %i in (x) do (start "" powershell)', True),
+        ('cmd /c if exist a (echo x) else (start "" powershell)', True),
+        # ...and a word behind the real handoff is an operand again.
+        ('cmd /c if exist a (echo a) else echo else start "" powershell', False),
+    ],
+)
+def test_a_handoff_belongs_to_the_statement_at_its_depth(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # cmd strips the quotes and applies the escapes before it resolves the
+        # command, so these run powershell while no scan of the raw spelling
+        # matches. The grammar walk normalises the word; screening only the two
+        # words it reads on threw the rest away.
+        ('cmd /c pow"er"shell', True),
+        ("cmd /c power^shell", True),
+        ('cmd /c "powershell"', True),
+        ('cmd /c st%PATH:~0,0%art "" pwsh', True),
+        # ...and a normalised word is still only screened in command position.
+        ('cmd /c echo pow"er"shell', False),
+        ("cmd /c notepad", False),
+    ],
+)
+def test_a_normalised_cmd_command_word_is_screened(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
         # A statement is consumed by its own handoff word, so a later one is an
         # operand again: these only print the words behind `echo`.
         ('cmd /c for %i in (x) do echo do start "" powershell', False),
@@ -1237,8 +1281,14 @@ def test_cmd_switches_do_not_hide_the_shell_in_front_of_them(monkeypatch, comman
         # cmd expands its variables before it resolves the program, and a
         # substring expansion can contribute nothing at all.
         ('cmd /c start "" powershell%PATH:~0,0%', True),
-        ('cmd /c start "" %COMSPEC%', False),
         ('cmd /c start "" report%DATE%.txt', False),
+        # ...and where the program name is nothing BUT an expansion, no reading
+        # of it is a name at all, so the line is refused rather than passed:
+        # `start "" %ComSpec% /c powershell` launches cmd with a command line
+        # behind it. A path that merely holds one still names its own file.
+        ('cmd /c start "" %COMSPEC%', True),
+        ('cmd /c start "" %ComSpec% /c powershell', True),
+        (r'cmd /c start "" "%USERPROFILE%\notes.txt"', False),
     ],
 )
 def test_a_start_target_is_read_as_cmd_resolves_it(monkeypatch, command, blocked):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -917,6 +917,59 @@ def test_a_quoted_group_opener_belongs_to_the_word(monkeypatch, command, blocked
 
 
 @pytest.mark.parametrize(
+    ("command", "blocked", "bash"),
+    [
+        # A bare redirection operator carries its target in the next word, and
+        # that word was taking the command position the operator had kept.
+        ('cmd //c > nul start "" powershell', True, r"C:\Program Files\Git\bin\bash.exe"),
+        ('cmd //c 2> nul start "" pwsh', True, r"C:\Program Files\Git\bin\bash.exe"),
+        ('cmd //c >nul start "" powershell', True, r"C:\Program Files\Git\bin\bash.exe"),
+        # The set closer glues to `do` under the cmd lexer, and the body still
+        # runs: cmd reads the bracket as its own syntax either way.
+        ('cmd /c for %i in (x)do start "" powershell', True, None),
+        ('cmd /c for %i in (x) do start "" pwsh', True, None),
+        # An explicit extension is a batch file in the working tree, whose
+        # arguments are its data; the launcher is the bare builtin.
+        ("cmd /c start.cmd powershell", False, None),
+        ("cmd /c start.bat rm", False, None),
+        ('cmd /c start "" powershell', True, None),
+    ],
+)
+def test_cmd_reads_its_own_brackets_targets_and_extensions(monkeypatch, command, blocked, bash):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # `for /f ... in ('CMD')` runs CMD as a child and reads its output, so
+        # the set is a command position the token scan sees only as data. The
+        # escapes there are the outer parse's, so the child is handed a line
+        # with them applied and the `^&` really does separate.
+        ("""cmd /c for /f %i in ('echo x ^& start "" powershell') do echo %i""", True),
+        ("""cmd /c for /f %i in ('start "" pwsh') do echo %i""", True),
+        ("""cmd /c for /f "usebackq" %i in (`start "" powershell`) do echo %i""", True),
+    ],
+)
+def test_for_f_runs_its_quoted_set_as_a_command(monkeypatch, bash, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+def test_an_unquoted_for_set_is_data_under_the_cmd_lexer(monkeypatch):
+    # Only a quoted set is a command; a plain one is the list to iterate. This
+    # is the cmd lexer alone, because under Git Bash the parentheses are bash's
+    # own and it would run the words inside them in a subshell.
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert not tools._find_blocked_commands("cmd /c for /f %i in (start powershell) do echo %i")
+
+
+@pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )
 def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -499,6 +499,61 @@ def test_desync_does_not_screen_unquoted_start_arguments(monkeypatch, command, b
     assert bool(tools._find_blocked_commands(command)) is blocked
 
 
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # cmd keeps parsing past its own conditionals and operators, so taking
+        # only the first word of its command line missed everything behind one.
+        ('cmd //c if exist . start "" powershell -c ls', True),
+        ('cmd //c dir & start "" powershell -c ls', True),
+        ('cmd //c if not exist x.txt start "" pwsh -c ls', True),
+        # ...but a start that is an argument of a command taking text is not a
+        # launch, which is what gating the scan fixed in the first place.
+        ('cmd //c echo start "my title" powershell', False),
+        ('cmd //c set x=start "t" powershell', False),
+    ],
+)
+def test_start_is_found_across_a_whole_cmd_command_line(monkeypatch, bash, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The cmd lexer takes no punctuation_chars, so an operator stays glued to
+        # the name, where cmd itself ends the command word and runs the program.
+        'start "" powershell& echo ok',
+        'start "" powershell&echo ok',
+        'start "" pwsh|more',
+        'start "" powershell>out.txt',
+    ],
+)
+def test_start_target_ends_at_a_cmd_operator(monkeypatch, command):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'start "dry run" rm',
+        'start "backup" curl http://x',
+        "start notepad rm",
+    ],
+)
+@pytest.mark.parametrize("platform", ["linux", "darwin"])
+def test_start_is_not_read_as_cmd_syntax_off_windows(monkeypatch, platform, command):
+    # `start` is a cmd launcher. Off Windows it is whatever the user has by that
+    # name, so its arguments are arguments and reading them as a title and a
+    # program refused a benign line that main allows.
+    monkeypatch.setattr(sys, "platform", platform)
+    assert not tools._find_blocked_commands(command)
+
+
 @pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -438,6 +438,67 @@ def test_cmd_has_no_single_quote_syntax(monkeypatch, command):
     assert not tools._find_blocked_commands(command)
 
 
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A start that is not a launch. Reading every token named start walked
+        # an ordinary argument into the title branch and refused a benign echo.
+        'echo start "my title" powershell',
+        "echo to start pwsh run this",
+        'printf "%s" start powershell',
+    ],
+)
+def test_start_is_only_screened_in_command_position(monkeypatch, bash, command):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # cmd strips the quotes before it resolves the program, but the non-POSIX
+        # lexer keeps them, so the scan looked for a program spelled with them
+        # and the hard block was one quote away. Quoting is the ordinary way to
+        # write a path holding a space.
+        ('cmd /c start "" "powershell.exe" -c ls', True),
+        (r'cmd /c start "" "C:\Windows\System32\powershell.exe"', True),
+        # ...and the target is a program, not a command line. Rescanning it as
+        # one read the path as a command position, where the blocklist's own `.`
+        # matches the dot in any file that has one.
+        (r'cmd /c start "" "C:\Users\me\report.txt"', False),
+        (r'cmd /c start "" "C:\Program Files\app\notepad.exe"', False),
+    ],
+)
+def test_start_target_is_matched_as_a_program_path(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A POSIX-only escape desyncs the quote check, which then answers
+        # "cannot tell". Screening both candidates on that answer brought the
+        # unquoted-argument over-block back for any line holding one.
+        (r"echo a\ b; start notepad rm.txt", False),
+        (r"echo a\ b; start excel curl.csv", False),
+        # The argument is a file that happens to be named like a blocked
+        # command, so it is the one shape a name match alone still refuses.
+        (r"echo a\ b; start notepad rm", False),
+        (r"echo a\ b; start notepad curl", False),
+        # The hedge itself still has to survive the desync.
+        (r'echo a\ b; cmd //c start "t" powershell -c ls', True),
+    ],
+)
+def test_desync_does_not_screen_unquoted_start_arguments(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
 @pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -794,6 +794,37 @@ def test_cmd_grammar_is_not_read_with_posix_rules(monkeypatch, command, blocked)
 
 
 @pytest.mark.parametrize(
+    ("command", "blocked", "bash"),
+    [
+        # cmd begins a command at the line start, after a separator or a group
+        # bracket, after an `if` condition or an `else`, and after the `do` of a
+        # `for`. Each of these hid a launch behind one of those.
+        ('cmd /c if 1 EQU 1 start "" powershell', True, None),
+        ('cmd /c if /i a NEQ b start "" pwsh', True, None),
+        ("cmd /c for %i in (x) do start powershell", True, None),
+        ("cmd /c for /f %i in (x) do start pwsh", True, None),
+        ('cmd /c if exist no_f echo ok else start "" powershell', True, None),
+        ('cmd /c if exist x (start "" powershell)', True, None),
+        ('cmd /c (start "" pwsh)', True, None),
+        # Bash removes the escape before cmd reads the separator, so it can
+        # arrive glued to the word in front of it.
+        (r'cmd //c echo ok\&start "" powershell', True, r"C:\Program Files\Git\bin\bash.exe"),
+        (r'cmd //c dir\|start "" pwsh', True, r"C:\Program Files\Git\bin\bash.exe"),
+        # ...and the operands of those same forms are still not launches.
+        ('cmd /c if 1 EQU 1 echo start "" powershell', False, None),
+        ("cmd /c for %i in (start) do echo powershell", False, None),
+        ('cmd /c if exist x echo start "" powershell', False, None),
+    ],
+)
+def test_cmd_command_positions_are_followed_through_its_grammar(
+    monkeypatch, command, blocked, bash
+):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )
 def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -1027,6 +1027,26 @@ def test_a_bare_for_is_only_cmds_where_cmd_is_the_shell(monkeypatch):
 
 
 @pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # Quoting is the other way cmd documents for passing its separators as
+        # arguments, and the cmd lexer keeps the quotes, so these print a word.
+        ('cmd /c echo "x&start" "" powershell', False),
+        ('cmd /c echo "x|start" "" pwsh', False),
+        # ...while the same text unquoted really does begin a command, and a
+        # quoted path holding one is still resolved to its program.
+        ('cmd /c echo x&start "" powershell', True),
+        (r'cmd /c start "" "C:\A&B\powershell.exe"', True),
+        ('start "" powershell&echo ok', True),
+    ],
+)
+def test_quotes_protect_cmd_separators_under_the_cmd_lexer(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )
 def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -702,6 +702,98 @@ def test_an_operator_inside_a_quoted_path_is_not_cmd_syntax(monkeypatch, command
 
 
 @pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # Microsoft: "&, | and parentheses are special characters that must be
+        # preceded by the escape character ^ ... when you pass them as
+        # arguments", so an escaped one is text and opens no command.
+        ('cmd /c echo ok^&start "" powershell', False),
+        ('cmd /c echo ok^|start "" pwsh', False),
+        # ...and the caret is dropped, so it hides a name from a plain
+        # comparison the way quoting once did.
+        ('start "" power^shell -c ls', True),
+        ('start "" pw^sh -c ls', True),
+        ('cmd /c start "" po^wers^hell', True),
+    ],
+)
+def test_cmd_carets_escape_and_are_dropped(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `start <"title"> [switches] [<command>|<program> [<parameter>...]]`:
+        # the program is optional, so a lone quoted operand is only the title
+        # and cmd opens a window with that name rather than running it.
+        'start "powershell"',
+        'cmd /c start "rm"',
+        'start /min "pwsh"',
+    ],
+)
+def test_a_lone_quoted_operand_is_only_a_title(monkeypatch, command):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", [r"C:\Program Files\Git\bin\bash.exe", None])
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The start reference: file types with a registered association,
+        # "including URLs, which are automatically detected and opened in the
+        # default browser". Its own example is `start "Bing" "https://..."`.
+        'start "" https://example.com/curl',
+        'start "Bing" "https://curl.com"',
+        'start "" http://rm.example.com/rm',
+        'cmd //c start "" https://example.com/powershell',
+    ],
+)
+def test_a_url_target_goes_to_the_browser_not_a_program(monkeypatch, bash, command):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    assert not tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # cmd reads an escaped `&` as its own separator, so a launch behind one
+        # is real, but `;` is not cmd syntax at all and is only text to it.
+        (r'cmd //c echo ok \& start "" powershell -c ls', True),
+        (r'cmd //c echo ok \; start "" powershell -c ls', False),
+        (r'cmd //c echo ok \| start "" pwsh -c ls', True),
+    ],
+)
+def test_only_cmds_own_separators_open_a_cmd_segment(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
+    ("command", "blocked"),
+    [
+        # A conditional glued behind a separator still hands its command along.
+        ('cmd /c echo&if exist . start "" powershell -c ls', True),
+        ('cmd /c dir&if /i a==a start "" pwsh', True),
+        ('cmd /c echo&if exist . echo start "" powershell', False),
+        # POSIX wrappers are not cmd's: `time` is a builtin that shows the
+        # clock, so it runs neither start nor what follows it.
+        ('time start "" powershell', False),
+        ('env start "" pwsh', False),
+    ],
+)
+def test_cmd_grammar_is_not_read_with_posix_rules(monkeypatch, command, blocked):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: None)
+    assert bool(tools._find_blocked_commands(command)) is blocked
+
+
+@pytest.mark.parametrize(
     "command", ["pwsh -Command ls", "powershell -c ls", "rmdir x", "runas /u:a b"]
 )
 def test_windows_only_names_are_not_hard_blocked_off_windows(monkeypatch, command):


### PR DESCRIPTION
## The CI failure

`test_cmd_shellout_is_screened_through_mangled_switches` has been failing all seven of its cases in `Backend CI` on `main`, on every Python version and so on every PR.

`_BLOCKED_COMMANDS` was frozen at import from `sys.platform`, so `powershell` and `pwsh` are absent from the set off Windows and `_find_blocked_commands("cmd /c powershell -Command ls")` returns nothing there. The rest of that file simulates Windows with `monkeypatch.setattr(sys, "platform", "win32")`, but a pin cannot reach a value that was already computed at import.

It is resolved per call now, and those cases pin the platform like their neighbours. That keeps the two postures exactly as they were: `powershell`/`pwsh` stay a hard block only on Windows, and off Windows they stay a prompt, which `test_permission_mode.py:743` documents on purpose.

## Two real gaps that surfaced once the cases could run

Both are Windows-only and neither was covered before:

```
start "" powershell -Command ls           missed on a host without Git Bash
start "My Title" powershell -Command ls   missed on either shell
cmd /c start "t" pwsh -c ls               missed on either shell
```

The title check was `tokens[j] == ""`. That is the POSIX lexer's spelling of `""`. Whether Git Bash is installed decides which lexer runs, and the non-POSIX one keeps the quotes, so on a Windows host without it the token arrives as a literal `""`, the check never fires, and the program behind the title is never screened.

The wider half is that a **non-empty** title was read as the program on both lexers. `start "title" prog` is the documented form, so this is how a model writes it when it wants a window.

The fix screens the token after the switches and the one after it, rather than deciding which is the title: cmd only treats the first quoted argument as a title when something follows it, and guessing wrong leaves the program unscreened. `start notepad rm` now screens `rm` too, which is the fail-closed direction for this check.

## Verification

- `tests/test_windows_bash_shell.py`: 50 passed, 1 skipped, from 7 failed.
- The seven cases now run against **both** shells, since which lexer runs is what decided the outcome.
- Reverting the title fix fails 10 cases; reverting the per-call resolution fails 20. The four `test_detached_windows_stay_launchable` cases still pass, so the screen did not become a blanket block on `cmd`.
- `tests/test_permission_mode.py` + `tests/test_windows_bash_shell.py`: 1711 passed, 1 skipped.
- The wider selection (`-k "tool or command or permission or shell or sandbox"`) is 3968 passed with 9 failures and 3 errors, all of which reproduce identically on an unmodified checkout of `main` (RAG retrieval, the Studio API tool suites, one MCP session case) and none of which touch this path.
