### PR TITLE
Studio: screen the detached-window test against the Windows blocklist too

### DIFF
--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -7,7 +7,8 @@ Models write bash for a shell tool, and every other platform runs bash. ``cmd /c
 executes only the first line of a multi-line command, leaves single quotes in
 the argument, and does not understand bash quoting, so a correct script
 half-executes and reports success. These run on every OS by faking the platform,
-because studio-backend-ci is Linux-only.
+and for the screening tests the Windows blocklist, because studio-backend-ci is
+Linux-only.
 """
 
 import os
@@ -37,11 +38,10 @@ def _clear_bash_cache():
 def _windows_blocklist(monkeypatch):
     """Screen against the Windows blocklist whatever the host is.
 
-    `_BLOCKED_COMMANDS` is built at import time from `sys.platform`, so on the
-    Linux-only studio-backend-ci runner powershell/pwsh are simply not in it.
-    Faking `sys.platform` the way the rest of this file does cannot help here:
-    the set was already bound when the module was imported. Patch the set that
-    `_find_blocked_commands` actually reads on every call instead.
+    `_BLOCKED_COMMANDS` is bound at import from `sys.platform`, so powershell
+    and pwsh are absent on the Linux-only runner, and faking `sys.platform` the
+    way the rest of this file does would be too late. Patch the set that
+    `_find_blocked_commands` reads on every call instead.
     """
     monkeypatch.setattr(
         tools,

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -33,6 +33,23 @@ def _clear_bash_cache():
     cached.cache_clear()
 
 
+@pytest.fixture
+def _windows_blocklist(monkeypatch):
+    """Screen against the Windows blocklist whatever the host is.
+
+    `_BLOCKED_COMMANDS` is built at import time from `sys.platform`, so on the
+    Linux-only studio-backend-ci runner powershell/pwsh are simply not in it.
+    Faking `sys.platform` the way the rest of this file does cannot help here:
+    the set was already bound when the module was imported. Patch the set that
+    `_find_blocked_commands` actually reads on every call instead.
+    """
+    monkeypatch.setattr(
+        tools,
+        "_BLOCKED_COMMANDS",
+        tools._BLOCKED_COMMANDS_COMMON | tools._BLOCKED_COMMANDS_WIN,
+    )
+
+
 def _fake_trusted_root(monkeypatch, root):
     """Point the Program Files trust check at ``root``.
 
@@ -284,7 +301,7 @@ def test_notes_say_where_commands_run(monkeypatch):
         r'cmd //c start /d C:/tmp "" powershell -Command ls',
     ],
 )
-def test_cmd_shellout_is_screened_through_mangled_switches(command):
+def test_cmd_shellout_is_screened_through_mangled_switches(command, _windows_blocklist):
     # Git Bash turns a lone /c into a path, so a model writes //c. That spelling
     # skipped the nested scan, making `cmd //c powershell` reachable where
     # `cmd /c powershell` was blocked, and `start` launches its argument too.
@@ -300,7 +317,7 @@ def test_cmd_shellout_is_screened_through_mangled_switches(command):
         "start notepad",
     ],
 )
-def test_detached_windows_stay_launchable(command):
+def test_detached_windows_stay_launchable(command, _windows_blocklist):
     # `start` is the only route to a window on the user's desktop, which the
     # terminal description promises, so screening must not blanket-block cmd.
     assert not tools._find_blocked_commands(command)


### PR DESCRIPTION
## Problem

`studio/backend/tests/test_windows_bash_shell.py` builds its blocklist at **import** time:

```python
_BLOCKED_COMMANDS = (
    _BLOCKED_COMMANDS_COMMON | _BLOCKED_COMMANDS_WIN
    if sys.platform == "win32"
    else _BLOCKED_COMMANDS_COMMON
)
```

`powershell` and `pwsh` live in `_BLOCKED_COMMANDS_WIN`, so on the Linux-only `studio-backend-ci` runner they are simply not in the set, and faking `sys.platform` inside the test is too late: the frozenset is already bound.

This PR originally fixed the resulting red CI in `test_cmd_shellout_is_screened_through_mangled_switches`. **#7934 has since landed the same platform fix inline**, so that part is done and `main` is green (37 passed, 1 skipped locally).

What #7934 does not cover is the sibling. `test_detached_windows_stay_launchable` asserts commands are **not** blocked, which passes vacuously on Linux when the Windows names were never in the set: it cannot see a blanket block of `cmd` or `start`, which is the exact regression it exists to catch.

## Fix

Lift #7934's inline patch into a small `_windows_blocklist` fixture and apply it to both tests, so the negative assertion screens against a set that actually contains `powershell` and `pwsh`. The fixture patches the set `_find_blocked_commands` reads on each call; every other reference to `_BLOCKED_COMMANDS` is inside a function body, so that is sufficient.

Net effect versus `main`: 15 insertions, 9 deletions, one file, tests only.

## Verification

`python -m pytest tests/test_windows_bash_shell.py` in `studio/backend`: **37 passed, 1 skipped**, both before and after, since the point of the change is to strengthen an assertion rather than flip one.

The fixture is self-gating: `test_cmd_shellout_is_screened_through_mangled_switches` fails on Linux the moment the fixture stops applying, so a broken fixture cannot pass unnoticed.
