### PR TITLE
Studio: fix training stuck at 100% when the worker will not exit

### DIFF
--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1117,6 +1117,11 @@ class TrainingBackend:
             with self._lock:
                 if self.current_job_id != run_id:
                     return False
+                # The pump can finish the run between the route's terminal check and this
+                # lock; it publishes under the same lock, so re-test here. Latching
+                # _should_stop after the fact reports a saved run as stopped for good.
+                if save and self._run_finished_locked():
+                    return False
                 if save or not run_id:
                     self._should_stop = True
                 if not save and not run_id:
@@ -1594,6 +1599,13 @@ class TrainingBackend:
             new_pump.start()
         return True
 
+    def _run_finished_locked(self) -> bool:
+        """is_run_finished()'s terminal test, for callers already holding _lock."""
+        if self._start_in_progress:
+            return False
+        p = self._progress
+        return bool(self._complete_seen.is_set() or p.is_completed or p.error)
+
     def is_run_finished(self) -> bool:
         """Whether the current run reached its own terminal state (saved and finalized).
 
@@ -1605,10 +1617,7 @@ class TrainingBackend:
         if getattr(self, "_spawn_in_progress", False):
             return False  # a new run is spawning; _progress is still the old run's
         with self._lock:
-            if self._start_in_progress:
-                return False
-            p = self._progress
-            return bool(self._complete_seen.is_set() or p.is_completed or p.error)
+            return self._run_finished_locked()
 
     def is_training_active(self) -> bool:
         """Check if training is currently active."""

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -54,9 +54,9 @@ def _env_int(name: str, default: int) -> int:
 _STOP_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S", 15)
 _STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 600)
 _CANCEL_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_CANCEL_TIMEOUT_S", 120)
-# Backstop for a run that ended on its own: reclaim the GPU from a worker wedged in
-# teardown. Not what unwedges the UI (is_run_finished does, at once), so it is generous --
-# a post-run wandb sync can legitimately take a while and must not be cut short.
+# Backstop to reclaim the GPU from a worker wedged in teardown after a run ended on its
+# own. is_run_finished already unwedges the UI, so this stays generous: a post-run wandb
+# sync can legitimately take a while and must not be cut short.
 _COMPLETE_EXIT_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_COMPLETE_EXIT_GRACE_S", 120)
 
 # Watchdog DB finalize: a few short retries so a transient SQLite lock doesn't lose the
@@ -1275,8 +1275,8 @@ class TrainingBackend:
                 self._progress.status_message = self._progress.error = error_message
             elif status != "completed":
                 self._progress.status_message = "Training stopped."
-            # A completed run keeps its own message: reaping a worker wedged in
-            # teardown after the save must not report the finished run as stopped.
+            # A completed run keeps its message: reaping a wedged worker after the save
+            # must not report the finished run as stopped.
         # Create the row if a start-time create failed (no-op otherwise; skips when the pump
         # is mid-create, in which case its create-then-finalize records the run instead).
         self._ensure_db_run_created()
@@ -1752,9 +1752,8 @@ class TrainingBackend:
                 self._safe_handle_event(event)
                 continue
 
-            # Snapshot: the watchdog drops _proc as its last step, so reading the
-            # attribute twice can hit None and kill this thread. A dropped handle
-            # means the watchdog already finalized the run.
+            # Snapshot: the watchdog drops _proc as its last step, so a second read can
+            # hit None and kill this thread. A dropped handle means it already finalized.
             proc = self._proc
             if proc is None:
                 self._pump_running = False
@@ -2102,10 +2101,10 @@ class TrainingBackend:
         elif db_action == "finalize":
             self._finalize_run_in_db(**db_action_kwargs)
 
-        # Bound how long a worker that will not exit can hold the UI: until _proc dies
-        # is_training_active() stays true, so /status reports "training" and the SSE
-        # never sends its final "complete" (bar stuck at 100%). No-ops on the normal
-        # prompt exit. Outside the lock: _start_stop_watchdog takes it, not reentrant.
+        # Bound how long a worker that will not exit can hold the UI: is_training_active()
+        # stays true until _proc dies, so the SSE never sends its final "complete" (bar
+        # stuck at 100%). No-ops on a prompt exit. Outside the lock: _start_stop_watchdog
+        # takes it, not reentrant.
         if etype in ("complete", "error"):
             self._start_stop_watchdog(
                 cancel = False,

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -54,6 +54,10 @@ def _env_int(name: str, default: int) -> int:
 _STOP_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S", 15)
 _STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 600)
 _CANCEL_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_CANCEL_TIMEOUT_S", 120)
+# Same escalation for a run that ends on its own. The terminal event is the worker's last
+# act (model already on disk), so everything after it is teardown and killing loses
+# nothing. Longer than the stop grace: nobody is waiting on a cancel here.
+_COMPLETE_EXIT_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_COMPLETE_EXIT_GRACE_S", 60)
 
 # Watchdog DB finalize: a few short retries so a transient SQLite lock doesn't lose the
 # terminal state, since the watchdog is the sole finalizer once _proc is dropped.
@@ -1136,10 +1140,15 @@ class TrainingBackend:
         self,
         cancel: bool,
         expected_job_id: Optional[str] = None,
+        grace_s: Optional[float] = None,
+        terminal_seen: bool = False,
     ) -> None:
-        """Start a daemon that force-terminates the worker if a requested stop does not
-        exit on its own. No-op if no worker is alive or a live watchdog already watches
-        this proc (a stale watchdog on an old proc never blocks a new run's watcher)."""
+        """Start a daemon that force-terminates the worker if it does not exit on its own.
+        Armed by a requested stop and by a run reaching its own terminal event, since a
+        worker wedged in teardown strands the UI either way. No-op if no worker is alive or
+        a live watchdog already watches this proc (a stale watchdog on an old proc never
+        blocks a new run's watcher). ``grace_s`` overrides the post-terminal grace;
+        ``terminal_seen`` starts it now, for an ending that never sets ``_complete_seen``."""
         with self._lock:
             if expected_job_id is not None and self.current_job_id != expected_job_id:
                 return
@@ -1155,6 +1164,7 @@ class TrainingBackend:
             watchdog = threading.Thread(
                 target = self._stop_watchdog_loop,
                 args = (proc, cancel, self.current_job_id),
+                kwargs = {"grace_s": grace_s, "terminal_seen": terminal_seen},
                 name = f"stop-watchdog-{self.current_job_id or 'unknown'}",
                 daemon = True,
             )
@@ -1167,12 +1177,16 @@ class TrainingBackend:
         target_proc: "mp.Process",
         cancel: bool,
         watched_job_id: Optional[str] = None,
+        grace_s: Optional[float] = None,
+        terminal_seen: bool = False,
     ) -> None:
-        """Escalate a stuck stop to force_terminate(): grace after "complete", else the
-        absolute backstop (see the module timeouts). No-ops on a clean exit; exits
-        silently if a new run replaces the worker."""
+        """Escalate a worker that will not exit to force_terminate(): grace after
+        "complete", else the absolute backstop (see the module timeouts). No-ops on a clean
+        exit; exits silently if a new run replaces the worker. ``grace_s`` overrides
+        ``_STOP_GRACE_S``; ``terminal_seen`` starts the grace at entry so an ending that
+        never sets ``_complete_seen`` (an error) does not sit out the whole backstop."""
         started = time.monotonic()
-        complete_at: Optional[float] = None
+        complete_at: Optional[float] = started if terminal_seen else None
         reason = ""
         while True:
             with self._lock:
@@ -1184,9 +1198,10 @@ class TrainingBackend:
                 return
             now = time.monotonic()
             abs_timeout = _CANCEL_TIMEOUT_S if cancelling else _STOP_TIMEOUT_S
+            grace = _STOP_GRACE_S if grace_s is None else grace_s
             if complete_at is None and self._complete_seen.is_set():
                 complete_at = now
-            if complete_at is not None and now - complete_at >= _STOP_GRACE_S:
+            if complete_at is not None and now - complete_at >= grace:
                 reason = "worker still alive after save"
                 break
             if now - started >= abs_timeout:
@@ -1254,9 +1269,12 @@ class TrainingBackend:
         with self._lock:
             if self.current_job_id != run_id:
                 return
-            self._progress.status_message = error_message or "Training stopped."
             if error_message:
-                self._progress.error = error_message
+                self._progress.status_message = self._progress.error = error_message
+            elif status != "completed":
+                self._progress.status_message = "Training stopped."
+            # A completed run keeps its own message: reaping a worker wedged in
+            # teardown after the save must not report the finished run as stopped.
         # Create the row if a start-time create failed (no-op otherwise; skips when the pump
         # is mid-create, in which case its create-then-finalize records the run instead).
         self._ensure_db_run_created()
@@ -1716,7 +1734,14 @@ class TrainingBackend:
                 self._safe_handle_event(event)
                 continue
 
-            if self._proc.is_alive():
+            # Snapshot: the watchdog drops _proc as its last step, so reading the
+            # attribute twice can hit None and kill this thread. A dropped handle
+            # means the watchdog already finalized the run.
+            proc = self._proc
+            if proc is None:
+                self._pump_running = False
+                return
+            if proc.is_alive():
                 continue
 
             # Worker exited. Drain the backlog and finalize, guarded so a slow or
@@ -2058,6 +2083,18 @@ class TrainingBackend:
             self._flush_metrics_to_db()
         elif db_action == "finalize":
             self._finalize_run_in_db(**db_action_kwargs)
+
+        # Bound how long a worker that will not exit can hold the UI: until _proc dies
+        # is_training_active() stays true, so /status reports "training" and the SSE
+        # never sends its final "complete" (bar stuck at 100%). No-ops on the normal
+        # prompt exit. Outside the lock: _start_stop_watchdog takes it, not reentrant.
+        if etype in ("complete", "error"):
+            self._start_stop_watchdog(
+                cancel = False,
+                expected_job_id = db_action_kwargs.get("expected_job_id"),
+                grace_s = _COMPLETE_EXIT_GRACE_S,
+                terminal_seen = True,
+            )
 
         if etype == "progress":
             self._log_training_progress()

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1444,6 +1444,9 @@ class TrainingBackend:
             # Terminal, so is_run_finished() is already true and the UI has stopped
             # waiting. terminate() is only a request: arm the same backstop as the other
             # terminal paths so a worker that ignores it cannot hold the GPU for good.
+            # Signal first: a stop watchdog already watching this proc makes the arming
+            # call a no-op, and only this tells it to use its grace over the save backstop.
+            self._complete_seen.set()
             self._start_stop_watchdog(
                 cancel = False,
                 expected_job_id = run_id,

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -2057,6 +2057,9 @@ class TrainingBackend:
             elif etype == "error":
                 self._progress.is_training = False
                 self._progress.error = event.get("error", "Unknown error")
+                # Terminal, so nothing is left to save: let a stop watchdog already
+                # watching this proc drop to its grace instead of the save backstop.
+                self._complete_seen.set()
                 if self._cancel_requested:
                     self._output_dir = self._progress.output_dir = None
                 logger.error("Training error: %s", event.get("error"))

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1422,6 +1422,7 @@ class TrainingBackend:
         with self._lock:
             recover = self._in_model_load and not self._xet_fallback_used
             proc = self._proc
+            run_id = self.current_job_id
             if recover:
                 self._xet_fallback_used = True
                 self._needs_xet_respawn = True
@@ -1439,6 +1440,16 @@ class TrainingBackend:
         # Terminate either way so the pump loop proceeds (respawn or finalize).
         if proc is not None and proc.is_alive():
             proc.terminate()
+        if not recover:
+            # Terminal, so is_run_finished() is already true and the UI has stopped
+            # waiting. terminate() is only a request: arm the same backstop as the other
+            # terminal paths so a worker that ignores it cannot hold the GPU for good.
+            self._start_stop_watchdog(
+                cancel = False,
+                expected_job_id = run_id,
+                grace_s = _COMPLETE_EXIT_GRACE_S,
+                terminal_seen = True,
+            )
 
     def _respawn_worker_disable_xet(self) -> None:
         """Respawn the worker once with HF_HUB_DISABLE_XET=1 after a model-load

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1221,7 +1221,9 @@ class TrainingBackend:
                 reason,
             )
         else:
-            logger.warning("Training watchdog force-terminating a worker that will not exit: %s", reason)
+            logger.warning(
+                "Training watchdog force-terminating a worker that will not exit: %s", reason
+            )
         # force_terminate can raise on a wedged child; finalize regardless.
         try:
             self.force_terminate(target_proc = target_proc)

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -54,9 +54,8 @@ def _env_int(name: str, default: int) -> int:
 _STOP_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S", 15)
 _STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 600)
 _CANCEL_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_CANCEL_TIMEOUT_S", 120)
-# Backstop to reclaim the GPU from a worker wedged in teardown after a run ended on its
-# own. is_run_finished already unwedges the UI, so this stays generous: a post-run wandb
-# sync can legitimately take a while and must not be cut short.
+# Backstop to reclaim the GPU from a worker wedged in teardown. Generous: is_run_finished
+# already unwedges the UI, and a post-run wandb sync can legitimately take a while.
 _COMPLETE_EXIT_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_COMPLETE_EXIT_GRACE_S", 120)
 
 # Watchdog DB finalize: a few short retries so a transient SQLite lock doesn't lose the
@@ -1118,8 +1117,8 @@ class TrainingBackend:
                 if self.current_job_id != run_id:
                     return False
                 # The pump can finish the run between the route's terminal check and this
-                # lock; it publishes under the same lock, so re-test here. Latching
-                # _should_stop after the fact reports a saved run as stopped for good.
+                # lock, so re-test: latching _should_stop after the fact would report a
+                # saved run as stopped for good.
                 if save and self._run_finished_locked():
                     return False
                 if save or not run_id:
@@ -1148,11 +1147,10 @@ class TrainingBackend:
         grace_s: Optional[float] = None,
         terminal_seen: bool = False,
     ) -> None:
-        """Start a daemon that force-terminates the worker if it does not exit on its own.
-        Armed by a requested stop and by a run reaching its own terminal event, since a
-        worker wedged in teardown strands the UI either way. No-op if no worker is alive or
-        a live watchdog already watches this proc (a stale watchdog on an old proc never
-        blocks a new run's watcher). ``grace_s`` overrides the post-terminal grace;
+        """Start a daemon that force-terminates a worker that will not exit. Armed by a stop
+        and by a run's own terminal event, since a wedged worker strands the UI either way.
+        No-op if no worker is alive or a live watchdog already watches this proc (a stale one
+        never blocks a new run). ``grace_s`` overrides the post-terminal grace;
         ``terminal_seen`` starts it now, for an ending that never sets ``_complete_seen``."""
         with self._lock:
             if expected_job_id is not None and self.current_job_id != expected_job_id:
@@ -1185,11 +1183,11 @@ class TrainingBackend:
         grace_s: Optional[float] = None,
         terminal_seen: bool = False,
     ) -> None:
-        """Escalate a worker that will not exit to force_terminate(): grace after
-        "complete", else the absolute backstop (see the module timeouts). No-ops on a clean
-        exit; exits silently if a new run replaces the worker. ``grace_s`` overrides
-        ``_STOP_GRACE_S``; ``terminal_seen`` starts the grace at entry so an ending that
-        never sets ``_complete_seen`` (an error) does not sit out the whole backstop."""
+        """Escalate a worker that will not exit to force_terminate(): grace after "complete",
+        else the absolute backstop (module timeouts). No-ops on a clean exit or once a new run
+        replaces the worker. ``grace_s`` overrides ``_STOP_GRACE_S``; ``terminal_seen`` starts
+        the grace at entry, so an ending that never sets ``_complete_seen`` (an error) does
+        not sit out the whole backstop."""
         started = time.monotonic()
         complete_at: Optional[float] = started if terminal_seen else None
         reason = ""
@@ -1280,8 +1278,7 @@ class TrainingBackend:
                 self._progress.status_message = self._progress.error = error_message
             elif status != "completed":
                 self._progress.status_message = "Training stopped."
-            # A completed run keeps its message: reaping a wedged worker after the save
-            # must not report the finished run as stopped.
+            # A completed run keeps its message; reaping a wedged worker must not relabel it.
         # Create the row if a start-time create failed (no-op otherwise; skips when the pump
         # is mid-create, in which case its create-then-finalize records the run instead).
         self._ensure_db_run_created()
@@ -1446,11 +1443,10 @@ class TrainingBackend:
         if proc is not None and proc.is_alive():
             proc.terminate()
         if not recover:
-            # Terminal, so is_run_finished() is already true and the UI has stopped
-            # waiting. terminate() is only a request: arm the same backstop as the other
-            # terminal paths so a worker that ignores it cannot hold the GPU for good.
-            # Signal first: a stop watchdog already watching this proc makes the arming
-            # call a no-op, and only this tells it to use its grace over the save backstop.
+            # terminate() is only a request: arm the same backstop as the other terminal
+            # paths so a worker that ignores it cannot hold the GPU for good. Signal first,
+            # since arming no-ops when a watchdog already watches this proc and only this
+            # drops it to the grace.
             self._complete_seen.set()
             self._start_stop_watchdog(
                 cancel = False,
@@ -1609,11 +1605,10 @@ class TrainingBackend:
     def is_run_finished(self) -> bool:
         """Whether the current run reached its own terminal state (saved and finalized).
 
-        is_training_active() is liveness-based, so it stays true until the worker exits --
-        which can lag by minutes behind a slow teardown (a wandb sync) or never happen at
-        all if the worker wedges, leaving the UI at 100%. Status and progress read this so
-        a finished run reports terminal at once; the GPU admission guards keep using
-        is_training_active(), since a lingering worker still holds its VRAM."""
+        is_training_active() is liveness-based, so it stays true until the worker exits, which
+        can lag minutes behind a slow teardown or never happen at all, leaving the UI at 100%.
+        Status and progress read this so a finished run reports terminal at once; the GPU
+        admission guards keep using is_training_active(), since a lingering worker holds VRAM."""
         if getattr(self, "_spawn_in_progress", False):
             return False  # a new run is spawning; _progress is still the old run's
         with self._lock:
@@ -1775,8 +1770,8 @@ class TrainingBackend:
                 self._safe_handle_event(event)
                 continue
 
-            # Snapshot: the watchdog drops _proc as its last step, so a second read can
-            # hit None and kill this thread. A dropped handle means it already finalized.
+            # Snapshot: the watchdog drops _proc last, so a re-read can hit None and kill
+            # this thread. A dropped handle means it already finalized.
             proc = self._proc
             if proc is None:
                 self._pump_running = False
@@ -2069,8 +2064,8 @@ class TrainingBackend:
             elif etype == "error":
                 self._progress.is_training = False
                 self._progress.error = event.get("error", "Unknown error")
-                # Terminal, so nothing is left to save: let a stop watchdog already
-                # watching this proc drop to its grace instead of the save backstop.
+                # Nothing left to save: drop an in-flight watchdog to its grace, not the
+                # save backstop.
                 self._complete_seen.set()
                 if self._cancel_requested:
                     self._output_dir = self._progress.output_dir = None
@@ -2127,10 +2122,8 @@ class TrainingBackend:
         elif db_action == "finalize":
             self._finalize_run_in_db(**db_action_kwargs)
 
-        # Bound how long a worker that will not exit can hold the UI: is_training_active()
-        # stays true until _proc dies, so the SSE never sends its final "complete" (bar
-        # stuck at 100%). No-ops on a prompt exit. Outside the lock: _start_stop_watchdog
-        # takes it, not reentrant.
+        # Bound how long a worker that will not exit can hold the UI at 100%. No-ops on a
+        # prompt exit. Outside the lock: _start_stop_watchdog takes it, not reentrant.
         if etype in ("complete", "error"):
             self._start_stop_watchdog(
                 cancel = False,

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -54,10 +54,10 @@ def _env_int(name: str, default: int) -> int:
 _STOP_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S", 15)
 _STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 600)
 _CANCEL_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_CANCEL_TIMEOUT_S", 120)
-# Same escalation for a run that ends on its own. The terminal event is the worker's last
-# act (model already on disk), so everything after it is teardown and killing loses
-# nothing. Longer than the stop grace: nobody is waiting on a cancel here.
-_COMPLETE_EXIT_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_COMPLETE_EXIT_GRACE_S", 60)
+# Backstop for a run that ended on its own: reclaim the GPU from a worker wedged in
+# teardown. Not what unwedges the UI (is_run_finished does, at once), so it is generous --
+# a post-run wandb sync can legitimately take a while and must not be cut short.
+_COMPLETE_EXIT_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_COMPLETE_EXIT_GRACE_S", 120)
 
 # Watchdog DB finalize: a few short retries so a transient SQLite lock doesn't lose the
 # terminal state, since the watchdog is the sole finalizer once _proc is dropped.
@@ -1221,7 +1221,7 @@ class TrainingBackend:
                 reason,
             )
         else:
-            logger.warning("Stop watchdog force-terminating stuck training worker: %s", reason)
+            logger.warning("Training watchdog force-terminating a worker that will not exit: %s", reason)
         # force_terminate can raise on a wedged child; finalize regardless.
         try:
             self.force_terminate(target_proc = target_proc)
@@ -1577,6 +1577,22 @@ class TrainingBackend:
             # this thread as not-yet-started and spawn yet another pump.
             new_pump.start()
         return True
+
+    def is_run_finished(self) -> bool:
+        """Whether the current run reached its own terminal state (saved and finalized).
+
+        is_training_active() is liveness-based, so it stays true until the worker exits --
+        which can lag by minutes behind a slow teardown (a wandb sync) or never happen at
+        all if the worker wedges, leaving the UI at 100%. Status and progress read this so
+        a finished run reports terminal at once; the GPU admission guards keep using
+        is_training_active(), since a lingering worker still holds its VRAM."""
+        if getattr(self, "_spawn_in_progress", False):
+            return False  # a new run is spawning; _progress is still the old run's
+        with self._lock:
+            if self._start_in_progress:
+                return False
+            p = self._progress
+            return bool(self._complete_seen.is_set() or p.is_completed or p.error)
 
     def is_training_active(self) -> bool:
         """Check if training is currently active."""

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2203,8 +2203,15 @@ def _run_mlx_training(event_queue, stop_queue, config):
         trainer.save_model = _save_model
 
     # ── 12. Save and finalize ──
+    _tracking_finished = [False]
+
     def _finish_tracking() -> None:
-        # Runs on every save/finalize exit so TB/W&B never leak on early return.
+        # Runs before every terminal send, and in the finally for early returns, so the
+        # parent never sees "complete" while a TB/W&B flush is still outstanding. Both
+        # closes are idempotent, and the flag keeps the trailing call a no-op.
+        if _tracking_finished[0]:
+            return
+        _tracking_finished[0] = True
         if tb_writer is not None:
             try:
                 tb_writer.close()
@@ -2236,6 +2243,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
         if trainer.stop_requested:
             if not _stop_save[0]:
                 # Cancel (save=False): skip saving.
+                _finish_tracking()
                 _send("complete", output_dir = None, status_message = "Training cancelled")
             else:
                 _send("status", status_message = "Saving stopped model...")
@@ -2244,6 +2252,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
                 # Stop-and-save promises a resumable checkpoint, not just model files.
                 if not _stop_checkpoint_ok():
                     return
+                _finish_tracking()
                 _send("complete", output_dir = output_dir, status_message = "Training stopped")
         else:
             _send("status", status_message = "Saving model...")
@@ -2252,6 +2261,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
             # A save-stop can race the natural final save; it made the same promise.
             if trainer.stop_requested and _stop_save[0] and not _stop_checkpoint_ok():
                 return
+            _finish_tracking()
             _send("complete", output_dir = output_dir, status_message = "Training completed")
     finally:
         _finish_tracking()

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2203,15 +2203,8 @@ def _run_mlx_training(event_queue, stop_queue, config):
         trainer.save_model = _save_model
 
     # ── 12. Save and finalize ──
-    _tracking_finished = [False]
-
     def _finish_tracking() -> None:
-        # Runs before every terminal send, and in the finally for early returns, so the
-        # parent never sees "complete" with a TB/W&B flush outstanding; the flag no-ops the
-        # repeat calls.
-        if _tracking_finished[0]:
-            return
-        _tracking_finished[0] = True
+        # Runs on every save/finalize exit so TB/W&B never leak on early return.
         if tb_writer is not None:
             try:
                 tb_writer.close()
@@ -2243,7 +2236,6 @@ def _run_mlx_training(event_queue, stop_queue, config):
         if trainer.stop_requested:
             if not _stop_save[0]:
                 # Cancel (save=False): skip saving.
-                _finish_tracking()
                 _send("complete", output_dir = None, status_message = "Training cancelled")
             else:
                 _send("status", status_message = "Saving stopped model...")
@@ -2252,7 +2244,6 @@ def _run_mlx_training(event_queue, stop_queue, config):
                 # Stop-and-save promises a resumable checkpoint, not just model files.
                 if not _stop_checkpoint_ok():
                     return
-                _finish_tracking()
                 _send("complete", output_dir = output_dir, status_message = "Training stopped")
         else:
             _send("status", status_message = "Saving model...")
@@ -2261,7 +2252,6 @@ def _run_mlx_training(event_queue, stop_queue, config):
             # A save-stop can race the natural final save; it made the same promise.
             if trainer.stop_requested and _stop_save[0] and not _stop_checkpoint_ok():
                 return
-            _finish_tracking()
             _send("complete", output_dir = output_dir, status_message = "Training completed")
     finally:
         _finish_tracking()

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2207,8 +2207,8 @@ def _run_mlx_training(event_queue, stop_queue, config):
 
     def _finish_tracking() -> None:
         # Runs before every terminal send, and in the finally for early returns, so the
-        # parent never sees "complete" while a TB/W&B flush is still outstanding. Both
-        # closes are idempotent, and the flag keeps the trailing call a no-op.
+        # parent never sees "complete" with a TB/W&B flush outstanding; the flag no-ops the
+        # repeat calls.
         if _tracking_finished[0]:
             return
         _tracking_finished[0] = True

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -113,6 +113,14 @@ def _is_finalizing(progress, msg_lower: str) -> bool:
     return total > 0 and step >= total
 
 
+def _run_finished(backend) -> bool:
+    """Whether the run reported terminal, so status/progress stop waiting on the worker
+    process to exit (see TrainingBackend.is_run_finished). getattr-guarded like the other
+    backend reads here: a stand-in without it keeps the old liveness-only behaviour."""
+    check = getattr(backend, "is_run_finished", None)
+    return bool(check()) if callable(check) else False
+
+
 def _validate_local_dataset_paths(paths: list[str], label: str = "Local dataset") -> list[str]:
     """Resolve and validate a list of local dataset paths. Returns validated absolute paths."""
     validated = []
@@ -664,7 +672,7 @@ async def reset_training(current_subject: str = Depends(get_current_subject)):
         is_active = backend.is_training_active()
 
         if is_active:
-            if backend._cancel_requested or backend.is_run_finished():
+            if backend._cancel_requested or _run_finished(backend):
                 # Cancel (save=False), or a finished run whose worker is still tearing
                 # down: nothing is left to save, so reap now instead of refusing the
                 # user's return to configuration until the watchdog gets there.
@@ -718,7 +726,7 @@ async def get_training_status(current_subject: str = Depends(get_current_subject
 
         # A finished run whose worker is still tearing down is not training: report the
         # terminal phase now rather than waiting on the process to exit.
-        is_active = backend.is_training_active() and not backend.is_run_finished()
+        is_active = backend.is_training_active() and not _run_finished(backend)
 
         try:
             progress = backend.trainer.get_training_progress()
@@ -871,7 +879,7 @@ async def stream_training_progress(
         def run_active() -> bool:
             """Live for streaming purposes: a run that already reported terminal is done,
             even while its worker is still tearing down (see is_run_finished)."""
-            return backend.is_training_active() and not backend.is_run_finished()
+            return backend.is_training_active() and not _run_finished(backend)
 
         def build_progress(
             step: int,

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -636,12 +636,10 @@ async def stop_training(
     """
     try:
         backend = get_training_backend()
-        # Terminal-aware like /status and the progress SSE: a run that already reported
-        # its own terminal event has saved and has nothing left to stop. Without this, a
-        # Stop landing in the poll window right after the run finished still latches
-        # _should_stop and overwrites the finished banner with "Stopping training and
-        # saving checkpoint...", which no later path clears -- /status then reports the
-        # saved run as "stopped" with that stale message for good.
+        # Terminal-aware like /status and the SSE: a run that already reported terminal has
+        # saved and has nothing left to stop. Otherwise a late Stop latches _should_stop and
+        # overwrites the finished banner with "Stopping training...", which nothing clears,
+        # so /status reports the saved run as "stopped" for good.
         is_active = backend.is_training_active() and not _run_finished(backend)
         logger.info("Stop requested: save=%s is_active=%s", body.save, is_active)
 
@@ -728,8 +726,7 @@ async def get_training_status(current_subject: str = Depends(get_current_subject
         backend = get_training_backend()
         job_id: str = getattr(backend, "current_job_id", "") or ""
 
-        # A finished run whose worker is still tearing down is not training: report the
-        # terminal phase now rather than waiting on the process to exit.
+        # A run still tearing down is not training: report terminal without waiting on exit.
         is_active = backend.is_training_active() and not _run_finished(backend)
 
         try:

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -636,7 +636,13 @@ async def stop_training(
     """
     try:
         backend = get_training_backend()
-        is_active = backend.is_training_active()
+        # Terminal-aware like /status and the progress SSE: a run that already reported
+        # its own terminal event has saved and has nothing left to stop. Without this, a
+        # Stop landing in the poll window right after the run finished still latches
+        # _should_stop and overwrites the finished banner with "Stopping training and
+        # saving checkpoint...", which no later path clears -- /status then reports the
+        # saved run as "stopped" with that stale message for good.
+        is_active = backend.is_training_active() and not _run_finished(backend)
         logger.info("Stop requested: save=%s is_active=%s", body.save, is_active)
 
         if not is_active:
@@ -672,11 +678,9 @@ async def reset_training(current_subject: str = Depends(get_current_subject)):
         is_active = backend.is_training_active()
 
         if is_active:
-            if backend._cancel_requested or _run_finished(backend):
-                # Cancel (save=False), or a finished run whose worker is still tearing
-                # down: nothing is left to save, so reap now instead of refusing the
-                # user's return to configuration until the watchdog gets there.
-                logger.info("Force-terminating subprocess for immediate reset")
+            if backend._cancel_requested:
+                # Cancel (save=False) requested -- force-terminate to reset immediately.
+                logger.info("Force-terminating subprocess for immediate reset (cancel path)")
                 backend.force_terminate()
             else:
                 logger.warning("Rejected reset while training active: is_active=%s", is_active)

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -101,10 +101,10 @@ _PROGRESS_STALL_TIMEOUT_POLLS = 1800  # ~30 min at 1 poll/sec
 def _is_finalizing(progress, msg_lower: str) -> bool:
     """Worker alive past the last step, `complete` not yet drained.
 
-    The post-training save emits no step updates, so the bar sat at 100% labelled
-    "training" for its whole duration, indistinguishable from a hang. Non-terminal
-    by design: the last step means the optimizer loop ended, not that the save
-    succeeded, so completion still comes solely from is_completed.
+    The save emits no step updates, so the bar sat at 100% labelled "training", which is
+    indistinguishable from a hang. Non-terminal by design: the last step means the optimizer
+    loop ended, not that the save succeeded, so completion still comes solely from
+    is_completed.
     """
     if any(k in msg_lower for k in ("saving", "merging")):
         return True
@@ -114,9 +114,9 @@ def _is_finalizing(progress, msg_lower: str) -> bool:
 
 
 def _run_finished(backend) -> bool:
-    """Whether the run reported terminal, so status/progress stop waiting on the worker
-    process to exit (see TrainingBackend.is_run_finished). getattr-guarded like the other
-    backend reads here: a stand-in without it keeps the old liveness-only behaviour."""
+    """Whether the run reported terminal (see TrainingBackend.is_run_finished), so status and
+    progress stop waiting on the worker to exit. getattr-guarded like the other backend reads
+    here: a stand-in without it keeps the old liveness-only behaviour."""
     check = getattr(backend, "is_run_finished", None)
     return bool(check()) if callable(check) else False
 
@@ -636,10 +636,9 @@ async def stop_training(
     """
     try:
         backend = get_training_backend()
-        # Terminal-aware like /status and the SSE: a run that already reported terminal has
-        # saved and has nothing left to stop. Otherwise a late Stop latches _should_stop and
-        # overwrites the finished banner with "Stopping training...", which nothing clears,
-        # so /status reports the saved run as "stopped" for good.
+        # Terminal-aware like /status and the SSE: otherwise a late Stop on a finished run
+        # latches _should_stop and overwrites the finished banner with "Stopping training...",
+        # which nothing clears, so /status reports the saved run as "stopped" for good.
         is_active = backend.is_training_active() and not _run_finished(backend)
         logger.info("Stop requested: save=%s is_active=%s", body.save, is_active)
 
@@ -878,8 +877,7 @@ async def stream_training_progress(
 
         # ── Helpers ──────────────────────────────────────────────
         def run_active() -> bool:
-            """Live for streaming purposes: a run that already reported terminal is done,
-            even while its worker is still tearing down (see is_run_finished)."""
+            """A run that reported terminal is done, even while its worker tears down."""
             return backend.is_training_active() and not _run_finished(backend)
 
         def build_progress(

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -664,9 +664,11 @@ async def reset_training(current_subject: str = Depends(get_current_subject)):
         is_active = backend.is_training_active()
 
         if is_active:
-            if backend._cancel_requested:
-                # Cancel (save=False) requested — force-terminate to reset immediately.
-                logger.info("Force-terminating subprocess for immediate reset (cancel path)")
+            if backend._cancel_requested or backend.is_run_finished():
+                # Cancel (save=False), or a finished run whose worker is still tearing
+                # down: nothing is left to save, so reap now instead of refusing the
+                # user's return to configuration until the watchdog gets there.
+                logger.info("Force-terminating subprocess for immediate reset")
                 backend.force_terminate()
             else:
                 logger.warning("Rejected reset while training active: is_active=%s", is_active)
@@ -714,7 +716,9 @@ async def get_training_status(current_subject: str = Depends(get_current_subject
         backend = get_training_backend()
         job_id: str = getattr(backend, "current_job_id", "") or ""
 
-        is_active = backend.is_training_active()
+        # A finished run whose worker is still tearing down is not training: report the
+        # terminal phase now rather than waiting on the process to exit.
+        is_active = backend.is_training_active() and not backend.is_run_finished()
 
         try:
             progress = backend.trainer.get_training_progress()
@@ -864,6 +868,11 @@ async def stream_training_progress(
         job_id: str = getattr(backend, "current_job_id", "") or ""
 
         # ── Helpers ──────────────────────────────────────────────
+        def run_active() -> bool:
+            """Live for streaming purposes: a run that already reported terminal is done,
+            even while its worker is still tearing down (see is_run_finished)."""
+            return backend.is_training_active() and not backend.is_run_finished()
+
         def build_progress(
             step: int,
             loss: Optional[float],
@@ -962,7 +971,7 @@ async def stream_training_progress(
 
         # ── Initial status (only on fresh connections) ───────────
         if resume_from_step is None:
-            is_active = backend.is_training_active()
+            is_active = run_active()
             tp = getattr(getattr(backend, "trainer", None), "training_progress", None)
             initial_total_steps = getattr(tp, "total_steps", 0) if tp else 0
             initial_epoch = getattr(tp, "epoch", None) if tp else None
@@ -1022,7 +1031,7 @@ async def stream_training_progress(
             backend.step_history
         )
 
-        while backend.is_training_active():
+        while run_active():
             # Client gone: end the generator without falling through to the final
             # "complete" frame, which a buffered/proxy consumer could otherwise read
             # as a finished run while training is still active.

--- a/studio/backend/tests/test_training_status_terminal.py
+++ b/studio/backend/tests/test_training_status_terminal.py
@@ -6,8 +6,8 @@
 /api/train/status and the /api/train/progress SSE both keyed off is_training_active(),
 which is liveness-based, so a worker wedged in post-save teardown kept the run reported as
 "training" forever. They now consult is_run_finished() as well. A live run must be
-unaffected, and /api/train/reset must reap a finished-but-lingering worker instead of
-refusing the user's return to configuration.
+unaffected, and /api/train/stop must be terminal-aware too: a Stop landing in the poll
+window after a run finished must not latch _should_stop over the finished banner.
 """
 
 from __future__ import annotations
@@ -16,7 +16,6 @@ import asyncio
 import sys
 from pathlib import Path
 
-import pytest
 
 _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
@@ -159,22 +158,40 @@ def test_progress_stream_stays_open_while_training(monkeypatch):
     assert "complete" in asyncio.run(_run())
 
 
-def test_reset_reaps_a_finished_but_lingering_worker(monkeypatch):
+def test_late_stop_does_not_unfinish_a_completed_run(monkeypatch):
+    """Stop clicked in the poll window after the run already finished.
+
+    The button greys out only once /api/train/status reports is_training_running=False
+    (3s poll, or the extra poll the SSE "complete" frame triggers), so a click can still
+    land on a run that has saved and emitted its terminal event. /stop is terminal-aware
+    like the other run-state surfaces, so it reports idle instead of latching
+    _should_stop and overwriting the finished banner with "Stopping training and saving
+    checkpoint..." -- which no later path clears, leaving the saved run reported as
+    "stopped" with a never-resolving message.
+    """
     b = _running(monkeypatch)
     b._handle_event(dict(_DONE))
-    asyncio.run(rt.reset_training(current_subject = "t"))
-    assert b._proc.is_alive() is False, "reset must reap instead of returning 409"
-    assert b.is_training_active() is False
+
+    resp = asyncio.run(rt.stop_training(rt.TrainingStopRequest(save = True), current_subject = "t"))
+    assert resp.status == "idle"
+    assert b._should_stop is False
+
+    st = asyncio.run(rt.get_training_status(current_subject = "t"))
+    assert st.phase == "completed"
+    assert st.message.startswith("Training completed!")
+
+    # ... and it survives the watchdog reaping the wedged worker.
+    b._finalize_stopped_after_escalation(target_proc = b._proc, watched_job_id = "job_1")
+    st = asyncio.run(rt.get_training_status(current_subject = "t"))
+    assert st.phase == "completed"
+    assert st.message.startswith("Training completed!")
 
 
-def test_reset_still_refused_mid_run(monkeypatch):
-    from fastapi import HTTPException
-
+def test_stop_mid_run_still_works(monkeypatch):
     b = _running(monkeypatch)
-    with pytest.raises(HTTPException) as exc:
-        asyncio.run(rt.reset_training(current_subject = "t"))
-    assert exc.value.status_code == 409
-    assert b._proc.is_alive() is True, "a live run must never be reaped by reset"
+    resp = asyncio.run(rt.stop_training(rt.TrainingStopRequest(save = True), current_subject = "t"))
+    assert resp.status == "stopped"
+    assert b._should_stop is True
 
 
 def test_surfaces_tolerate_a_backend_without_is_run_finished(monkeypatch):

--- a/studio/backend/tests/test_training_status_terminal.py
+++ b/studio/backend/tests/test_training_status_terminal.py
@@ -187,11 +187,54 @@ def test_late_stop_does_not_unfinish_a_completed_run(monkeypatch):
     assert st.message.startswith("Training completed!")
 
 
+def test_stop_and_save_losing_the_race_to_the_pump_keeps_the_run_completed(monkeypatch):
+    """The same late Stop, except the run finishes *after* the route's terminal check.
+
+    The route cannot close this gap by itself. The pump publishes the terminal state
+    under the backend lock, so the re-test has to sit inside stop_training() next to the
+    mutation it guards. Without it, /status derives "stopped" (it tests trainer_stopped
+    before is_completed) for a run the DB finalized as completed.
+    """
+    b = _running(monkeypatch)
+    b._db_run_created = True
+    real_stop, fired = b.stop_training, []
+
+    def stop_after_complete(save = True):
+        if not fired:
+            fired.append(True)
+            b._handle_event(dict(_DONE))  # the pump wins the gap
+        return real_stop(save = save)
+
+    b.stop_training = stop_after_complete
+
+    resp = asyncio.run(rt.stop_training(rt.TrainingStopRequest(save = True), current_subject = "t"))
+    assert resp.status == "idle"
+    assert b._should_stop is False, "a run that finished in the gap must not latch a stop"
+    assert (b._terminal_finalize_payload or {}).get("status") == "completed"
+
+    st = asyncio.run(rt.get_training_status(current_subject = "t"))
+    assert st.phase == "completed"
+    assert st.message.startswith("Training completed!")
+
+
 def test_stop_mid_run_still_works(monkeypatch):
     b = _running(monkeypatch)
     resp = asyncio.run(rt.stop_training(rt.TrainingStopRequest(save = True), current_subject = "t"))
     assert resp.status == "stopped"
     assert b._should_stop is True
+
+
+def test_cancel_mid_run_still_works(monkeypatch):
+    # save=False takes the other branch in stop_training; the new guard is scoped to the
+    # save path precisely because that branch has already mutated state by then.
+    b = _running(monkeypatch)
+    b._db_run_created = True
+    monkeypatch.setattr(
+        "storage.studio_db.mark_run_cancel_requested", lambda *a, **k: True, raising = False
+    )
+    resp = asyncio.run(rt.stop_training(rt.TrainingStopRequest(save = False), current_subject = "t"))
+    assert resp.status == "stopped"
+    assert b._cancel_requested is True
 
 
 def test_surfaces_tolerate_a_backend_without_is_run_finished(monkeypatch):

--- a/studio/backend/tests/test_training_status_terminal.py
+++ b/studio/backend/tests/test_training_status_terminal.py
@@ -195,8 +195,7 @@ def test_stop_mid_run_still_works(monkeypatch):
 
 
 def test_surfaces_tolerate_a_backend_without_is_run_finished(monkeypatch):
-    # These routes read the backend defensively (getattr) because stand-in backends are
-    # passed in. A backend lacking the new method must fall back to liveness, not raise.
+    # A stand-in backend lacking the new method must fall back to liveness, not raise.
     class _Minimal:
         current_job_id = "job_min"
         step_history: list = []

--- a/studio/backend/tests/test_training_status_terminal.py
+++ b/studio/backend/tests/test_training_status_terminal.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The two surfaces that hung at 100% when a finished worker would not exit (#7897).
+
+/api/train/status and the /api/train/progress SSE both keyed off is_training_active(),
+which is liveness-based, so a worker wedged in post-save teardown kept the run reported as
+"training" forever. They now consult is_run_finished() as well. A live run must be
+unaffected, and /api/train/reset must reap a finished-but-lingering worker instead of
+refusing the user's return to configuration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+import routes.training as rt
+from core.training.training import TrainingBackend, TrainingProgress
+
+
+class _WedgedProc:
+    """A worker that reported terminal and then never exits."""
+
+    pid = 999
+
+    def __init__(self):
+        self._alive = True
+
+    def is_alive(self):
+        return self._alive
+
+    def terminate(self):
+        self._alive = False
+
+    def kill(self):
+        self._alive = False
+
+    def join(self, timeout = None):
+        pass
+
+
+def _running(monkeypatch, job_id = "job_1"):
+    b = TrainingBackend()
+    b.current_job_id = job_id
+    b._proc = _WedgedProc()
+    b._progress = TrainingProgress(is_training = True, status_message = "Training in progress...")
+    b._finalize_run_in_db = lambda **kw: None
+    b._ensure_db_run_created = lambda: None
+    b._start_stop_watchdog = lambda **kw: None  # keep the worker wedged on purpose
+    monkeypatch.setattr(rt, "get_training_backend", lambda: b)
+    return b
+
+
+_DONE = {
+    "type": "complete",
+    "output_dir": "/tmp/out",
+    "status_message": "Training completed! Model saved to /tmp/out",
+}
+
+
+class _Req:
+    headers: dict = {}
+
+    async def is_disconnected(self):
+        return False
+
+
+async def _sse_events(timeout = 10.0):
+    """Event names the real SSE generator yields until it closes."""
+    resp = await rt.stream_training_progress(_Req(), current_subject = "t")
+    names: list[str] = []
+
+    async def pump():
+        async for chunk in resp.body_iterator:
+            for line in str(chunk).splitlines():
+                if line.startswith("event: "):
+                    names.append(line[7:].strip())
+            if names and names[-1] in ("complete", "error"):
+                return
+
+    try:
+        await asyncio.wait_for(pump(), timeout = timeout)
+    except asyncio.TimeoutError:
+        pass
+    return names
+
+
+def test_status_reports_completed_while_worker_still_wedged(monkeypatch):
+    b = _running(monkeypatch)
+    b._handle_event(dict(_DONE))
+    st = asyncio.run(rt.get_training_status(current_subject = "t"))
+    assert st.is_training_running is False
+    assert st.phase == "completed"
+    assert st.message.startswith("Training completed!")
+    assert b._proc.is_alive() is True
+
+
+def test_status_reports_error_while_worker_still_wedged(monkeypatch):
+    b = _running(monkeypatch)
+    b._handle_event({"type": "error", "error": "CUDA OOM", "stack": ""})
+    st = asyncio.run(rt.get_training_status(current_subject = "t"))
+    assert st.is_training_running is False
+    assert st.phase == "error"
+
+
+def test_status_unchanged_mid_run(monkeypatch):
+    _running(monkeypatch)
+    st = asyncio.run(rt.get_training_status(current_subject = "t"))
+    assert st.is_training_running is True
+    assert st.phase == "training"
+
+
+def test_progress_stream_completes_on_a_wedged_worker(monkeypatch):
+    b = _running(monkeypatch)
+    b.step_history.extend([1, 2])
+    b.loss_history.extend([1.0, 0.5])
+    b.lr_history.extend([1e-4, 9e-5])
+    b._handle_event(dict(_DONE))
+    names = asyncio.run(_sse_events())
+    assert "complete" in names, names
+    assert b._proc.is_alive() is True
+
+
+def test_progress_stream_stays_open_while_training(monkeypatch):
+    b = _running(monkeypatch)
+    b.step_history.append(1)
+    b.loss_history.append(1.0)
+    b.lr_history.append(1e-4)
+
+    async def _run():
+        resp = await rt.stream_training_progress(_Req(), current_subject = "t")
+        names: list[str] = []
+
+        async def pump():
+            async for chunk in resp.body_iterator:
+                for line in str(chunk).splitlines():
+                    if line.startswith("event: "):
+                        names.append(line[7:].strip())
+
+        task = asyncio.create_task(pump())
+        await asyncio.sleep(1.5)
+        assert "complete" not in names, names
+        b._handle_event(dict(_DONE))  # run ends; worker still lingers
+        for _ in range(100):
+            if "complete" in names:
+                break
+            await asyncio.sleep(0.05)
+        task.cancel()
+        return names
+
+    assert "complete" in asyncio.run(_run())
+
+
+def test_reset_reaps_a_finished_but_lingering_worker(monkeypatch):
+    b = _running(monkeypatch)
+    b._handle_event(dict(_DONE))
+    asyncio.run(rt.reset_training(current_subject = "t"))
+    assert b._proc.is_alive() is False, "reset must reap instead of returning 409"
+    assert b.is_training_active() is False
+
+
+def test_reset_still_refused_mid_run(monkeypatch):
+    from fastapi import HTTPException
+
+    b = _running(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(rt.reset_training(current_subject = "t"))
+    assert exc.value.status_code == 409
+    assert b._proc.is_alive() is True, "a live run must never be reaped by reset"

--- a/studio/backend/tests/test_training_status_terminal.py
+++ b/studio/backend/tests/test_training_status_terminal.py
@@ -175,3 +175,26 @@ def test_reset_still_refused_mid_run(monkeypatch):
         asyncio.run(rt.reset_training(current_subject = "t"))
     assert exc.value.status_code == 409
     assert b._proc.is_alive() is True, "a live run must never be reaped by reset"
+
+
+def test_surfaces_tolerate_a_backend_without_is_run_finished(monkeypatch):
+    # These routes read the backend defensively (getattr) because stand-in backends are
+    # passed in. A backend lacking the new method must fall back to liveness, not raise.
+    class _Minimal:
+        current_job_id = "job_min"
+        step_history: list = []
+        loss_history: list = []
+        lr_history: list = []
+        eval_loss_history: list = []
+        eval_step_history: list = []
+        eval_enabled = False
+        trainer = None
+        _should_stop = False
+
+        def is_training_active(self):
+            return False
+
+    monkeypatch.setattr(rt, "get_training_backend", lambda: _Minimal())
+    st = asyncio.run(rt.get_training_status(current_subject = "t"))
+    assert st.is_training_running is False
+    assert rt._run_finished(_Minimal()) is False

--- a/studio/backend/tests/test_training_status_terminal.py
+++ b/studio/backend/tests/test_training_status_terminal.py
@@ -3,11 +3,10 @@
 
 """The two surfaces that hung at 100% when a finished worker would not exit (#7897).
 
-/api/train/status and the /api/train/progress SSE both keyed off is_training_active(),
-which is liveness-based, so a worker wedged in post-save teardown kept the run reported as
-"training" forever. They now consult is_run_finished() as well. A live run must be
-unaffected, and /api/train/stop must be terminal-aware too: a Stop landing in the poll
-window after a run finished must not latch _should_stop over the finished banner.
+/api/train/status and the progress SSE keyed off liveness-based is_training_active(), so a
+worker wedged in post-save teardown kept reporting "training" forever; they now consult
+is_run_finished() too. A live run must be unaffected, and /api/train/stop must be
+terminal-aware too: a late Stop must not latch _should_stop over the finished banner.
 """
 
 from __future__ import annotations
@@ -161,13 +160,10 @@ def test_progress_stream_stays_open_while_training(monkeypatch):
 def test_late_stop_does_not_unfinish_a_completed_run(monkeypatch):
     """Stop clicked in the poll window after the run already finished.
 
-    The button greys out only once /api/train/status reports is_training_running=False
-    (3s poll, or the extra poll the SSE "complete" frame triggers), so a click can still
-    land on a run that has saved and emitted its terminal event. /stop is terminal-aware
-    like the other run-state surfaces, so it reports idle instead of latching
-    _should_stop and overwriting the finished banner with "Stopping training and saving
-    checkpoint..." -- which no later path clears, leaving the saved run reported as
-    "stopped" with a never-resolving message.
+    The button greys out only once /api/train/status reports is_training_running=False (3s
+    poll), so a click can still land on a run that has saved. /stop is terminal-aware, so it
+    reports idle instead of latching _should_stop and overwriting the finished banner with a
+    "Stopping..." message no later path clears.
     """
     b = _running(monkeypatch)
     b._handle_event(dict(_DONE))
@@ -190,10 +186,9 @@ def test_late_stop_does_not_unfinish_a_completed_run(monkeypatch):
 def test_stop_and_save_losing_the_race_to_the_pump_keeps_the_run_completed(monkeypatch):
     """The same late Stop, except the run finishes *after* the route's terminal check.
 
-    The route cannot close this gap by itself. The pump publishes the terminal state
-    under the backend lock, so the re-test has to sit inside stop_training() next to the
-    mutation it guards. Without it, /status derives "stopped" (it tests trainer_stopped
-    before is_completed) for a run the DB finalized as completed.
+    The pump publishes terminal state under the backend lock, so the re-test has to sit
+    inside stop_training() next to the mutation it guards. Without it, /status derives
+    "stopped" for a run the DB finalized as completed.
     """
     b = _running(monkeypatch)
     b._db_run_created = True
@@ -225,8 +220,7 @@ def test_stop_mid_run_still_works(monkeypatch):
 
 
 def test_cancel_mid_run_still_works(monkeypatch):
-    # save=False takes the other branch in stop_training; the new guard is scoped to the
-    # save path precisely because that branch has already mutated state by then.
+    # save=False takes the other branch, which the guard skips: it has already mutated state.
     b = _running(monkeypatch)
     b._db_run_created = True
     monkeypatch.setattr(

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -1185,10 +1185,11 @@ def test_is_run_finished_true_when_a_stall_is_unrecoverable():
 # ----------------------------------------------------------------------------
 
 
-def test_mlx_worker_flushes_tracking_before_every_terminal_send():
-    """The parent arms its exit watchdog on `complete`, so anything the worker still
-    does after that send races a force-terminate. The MLX path closes the TensorBoard
-    writer and calls wandb_run.finish() in a finally; both must be flushed first.
+def test_mlx_worker_never_withholds_a_terminal_send_behind_tracking_teardown():
+    """MLX teardown closes the TensorBoard writer and calls wandb_run.finish(), either of
+    which can block for many minutes. Putting that in front of `complete` would withhold
+    the event the UI waits on, which is the hang this whole change exists to end, so the
+    teardown stays in the finally and runs only after the send.
     """
     import ast
     from pathlib import Path as _P
@@ -1212,25 +1213,28 @@ def test_mlx_worker_flushes_tracking_before_every_terminal_send():
             and node.args[0].value == "complete"
         )
 
-    sends = sorted(n.lineno for n in ast.walk(fn) if _is_complete_send(n))
-    flushes = sorted(
-        n.lineno
+    def _teardown_lines(nodes):
+        return {
+            c.lineno
+            for n in nodes
+            for c in ast.walk(n)
+            if isinstance(c, ast.Call) and getattr(c.func, "id", "") == "_finish_tracking"
+        }
+
+    saves = [
+        n
         for n in ast.walk(fn)
-        if isinstance(n, ast.Call) and getattr(n.func, "id", "") == "_finish_tracking"
+        if isinstance(n, ast.Try)
+        and any(_is_complete_send(c) for stmt in n.body for c in ast.walk(stmt))
+    ]
+    assert len(saves) == 1, "expected one save/finalize try block with the terminal sends"
+    everywhere = _teardown_lines([fn])
+    assert everywhere, "expected the tracking teardown to still run"
+    assert everywhere == _teardown_lines(saves[0].finalbody), (
+        f"_finish_tracking() is called at worker.py:{sorted(everywhere)} but only "
+        f"{sorted(_teardown_lines(saves[0].finalbody))} is in the finally; a blocking "
+        "wandb_run.finish() ahead of _send('complete') strands the UI at 100%"
     )
-    # Only the sends after _finish_tracking is defined can be guarded by it.
-    defined_at = next(
-        n.lineno
-        for n in ast.walk(fn)
-        if isinstance(n, ast.FunctionDef) and n.name == "_finish_tracking"
-    )
-    guarded = [s for s in sends if s > defined_at]
-    assert guarded, "expected terminal sends after the tracking helper is defined"
-    for send in guarded:
-        assert any(send - 4 <= f < send for f in flushes), (
-            f"_send('complete') at worker.py:{send} is not preceded by _finish_tracking(); "
-            "the watchdog could force-terminate a pending TB/W&B flush"
-        )
 
 
 def test_terminal_stall_arms_the_exit_watchdog(monkeypatch):
@@ -1292,6 +1296,34 @@ def test_terminal_error_releases_an_in_flight_stop_watchdog(monkeypatch):
     b._handle_event({"type": "error", "error": "checkpoint failed", "stack": ""})
 
     assert b._complete_seen.is_set(), "a terminal error must signal the in-flight watchdog"
+    assert b._stop_watchdog is first, "the existing watcher stays; arming again is a no-op"
+    assert _wait_until(
+        lambda: calls == ["force", "final"]
+    ), "the in-flight watchdog must escalate on the grace, not the save backstop"
+    first.join(timeout = 5)
+
+
+def test_terminal_stall_releases_an_in_flight_stop_watchdog(monkeypatch):
+    # Same shape as the error path: Stop and Save, then the download stalls with no
+    # fallback left. The stop's watchdog already watches this proc, so arming again
+    # no-ops, and only the terminal signal keeps it off the 600s save backstop.
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 0.05)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
+    b = _running_backend()
+    b._start_stop_watchdog = TrainingBackend._start_stop_watchdog.__get__(b)
+    calls = _record_force_terminate(monkeypatch, b)
+    b._in_model_load = True
+    b._xet_fallback_used = True  # already on HTTP, so the stall is unrecoverable
+    b._proc.terminate = lambda: None  # worker ignores the terminate request
+
+    b._should_stop = True
+    b._start_stop_watchdog(cancel = False)  # the stop's own watchdog, now in flight
+    first = b._stop_watchdog
+    assert first is not None and first.is_alive()
+
+    b._handle_event({"type": "stall", "message": "no progress"})
+
+    assert b._complete_seen.is_set(), "a terminal stall must signal the in-flight watchdog"
     assert b._stop_watchdog is first, "the existing watcher stays; arming again is a no-op"
     assert _wait_until(
         lambda: calls == ["force", "final"]

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -1,13 +1,19 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Stop-watchdog escalation for a stuck training stop.
+"""Watchdog escalation for a training worker that will not exit.
 
 A save-stop signals the worker and waits for it to save and exit. On some platforms the
 worker saves but then wedges in post-save GPU/driver teardown and never exits, leaving the
 run stuck in "Stopping..." forever. These tests pin the bounded recovery: the watchdog
 escalates to force_terminate() a short grace after "complete" (save done) or after an
 absolute timeout (hang during save), and never force-kills a worker that exits cleanly.
+
+Section (d) covers the same wedge on a run that ends by itself: the model is on disk but
+the process lingers, and since is_training_active() is liveness-based the bar sits at 100%
+forever (issue #7897). The pump arms the same watchdog on a terminal event, and the
+escalation must not relabel a completed run as stopped.
+
 Fakes only; no GPU, network, or subprocess.
 """
 
@@ -48,6 +54,7 @@ _stub("matplotlib", _mpl)
 _stub("matplotlib.pyplot", _plt)
 _hw = _types.ModuleType("utils.hardware")
 _hw.prepare_gpu_selection = lambda *a, **k: (None, None)
+_hw.get_device = lambda *a, **k: None
 _stub("utils.hardware", _hw)
 _npl = _types.ModuleType("utils.native_path_leases")
 _npl.native_path_secret_removed_for_child_start = lambda: contextlib.nullcontext()
@@ -266,6 +273,8 @@ def test_new_run_gets_its_own_watchdog(monkeypatch):
         target_proc,
         cancel,
         watched_job_id = None,
+        grace_s = None,
+        terminal_seen = False,
     ):
         started.append(target_proc)
         # No timeout: the finally always releases this, so a superseded watchdog stays
@@ -905,3 +914,174 @@ def test_finish_stopped_run_error_leaves_new_run_untouched(monkeypatch):
     b._finish_stopped_run("job_old", None, [{"step": 1}], 1, None, None, [])
 
     assert b._run_finalized is True, "must not unclaim the new run's finalize"
+
+
+# ----------------------------------------------------------------------------
+# (d) A run that ends on its own and whose worker then wedges in teardown.
+# ----------------------------------------------------------------------------
+
+
+def _complete_event(output_dir = "/tmp/out"):
+    return {
+        "type": "complete",
+        "output_dir": output_dir,
+        "status_message": f"Training completed! Model saved to {output_dir}",
+    }
+
+
+def test_terminal_event_arms_watchdog_and_reaps_wedged_worker(monkeypatch):
+    # Saved, reported "complete", then never exited. Nothing used to reap it, so
+    # is_training_active() stayed true off _proc.is_alive() and the UI sat at 100%.
+    monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)  # ensure the grace fires, not the cap
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: None)
+
+    proc = _FakeProc(alive = True)
+    b._proc = proc
+    b.current_job_id = "job_1"
+
+    b._handle_event(_complete_event())
+
+    assert b._complete_seen.is_set()
+    assert b._stop_watchdog is not None, "a terminal event must arm the exit watchdog"
+    assert _wait_until(
+        lambda: calls == ["force", "final"]
+    ), "a worker still alive after the completion grace must be force-terminated"
+    b._stop_watchdog.join(timeout = 5)
+
+
+def test_terminal_error_event_also_arms_watchdog(monkeypatch):
+    # An error never sets _complete_seen, so terminal_seen starts the grace; without it
+    # the watchdog would wait out the full absolute backstop.
+    monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: None)
+
+    b._proc = _FakeProc(alive = True)
+    b.current_job_id = "job_1"
+
+    b._handle_event({"type": "error", "error": "boom", "stack": ""})
+
+    assert not b._complete_seen.is_set(), "an error is not a completed save"
+    assert _wait_until(lambda: calls == ["force", "final"])
+    b._stop_watchdog.join(timeout = 5)
+
+
+def test_normal_completion_never_force_terminates(monkeypatch):
+    # The common path: the worker exits a second or two after "complete". Arming on
+    # every run must stay invisible there.
+    monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 5.0)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 10.0)
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: None)
+
+    proc = _FakeProc(alive = True)
+    b._proc = proc
+    b.current_job_id = "job_1"
+
+    b._handle_event(_complete_event())
+    time.sleep(0.1)
+    proc._alive = False  # worker exits on its own, well inside the grace
+
+    b._stop_watchdog.join(timeout = 5)
+    assert calls == [], "a worker that exits on its own must never be force-terminated"
+
+
+def test_completion_watchdog_does_not_preempt_a_stop_watchdog(monkeypatch):
+    # A user stop already armed the tighter grace; the terminal event must not
+    # replace it with the longer completion grace.
+    b = TrainingBackend()
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: None)
+    monkeypatch.setattr(b, "_stop_watchdog_loop", lambda *a, **k: None)
+
+    b._proc = _FakeProc(alive = True)
+    b.current_job_id = "job_1"
+    b._start_stop_watchdog(cancel = False)
+    first = b._stop_watchdog
+    first.join(timeout = 5)
+
+    # Still the watcher of record for this proc while it is alive.
+    b._stop_watchdog = first
+    b._handle_event(_complete_event())
+    assert b._stop_watchdog is first or not first.is_alive()
+
+
+def test_escalation_finalize_keeps_completed_status_message(monkeypatch):
+    # Reaping a wedged worker after a successful save must not relabel the run: the
+    # message drives the UI banner.
+    b = TrainingBackend()
+    b.current_job_id = "job_1"
+    b._output_dir = "/tmp/out"
+    b._progress.is_completed = True
+    b._progress.status_message = "Training completed! Model saved to /tmp/out"
+    b._terminal_finalize_payload = {
+        "status": "completed",
+        "output_dir": "/tmp/out",
+        "clear_output_dir": False,
+        "expected_job_id": "job_1",
+    }
+    b._run_finalized = True  # the pump already recorded the terminal DB state
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+
+    proc = _FakeProc(alive = False)
+    b._proc = proc
+    b._finalize_stopped_after_escalation(target_proc = proc, watched_job_id = "job_1")
+
+    assert b._progress.status_message == "Training completed! Model saved to /tmp/out"
+    assert b._progress.error is None
+    assert b._progress.is_completed is True
+    assert b._progress.is_training is False
+    assert b._proc is None, "the handle must be dropped so is_training_active() goes false"
+
+
+def test_escalation_finalize_still_reports_a_stop_as_stopped(monkeypatch):
+    # The pre-existing stop path keeps its message.
+    b = TrainingBackend()
+    b.current_job_id = "job_1"
+    b._should_stop = True
+    b._output_dir = "/tmp/out"
+    b._terminal_finalize_payload = {
+        "status": "stopped",
+        "output_dir": "/tmp/out",
+        "clear_output_dir": False,
+        "expected_job_id": "job_1",
+    }
+    b._run_finalized = True
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+
+    proc = _FakeProc(alive = False)
+    b._proc = proc
+    b._finalize_stopped_after_escalation(target_proc = proc, watched_job_id = "job_1")
+
+    assert b._progress.status_message == "Training stopped."
+
+
+def test_pump_loop_exits_when_the_watchdog_drops_the_handle(monkeypatch):
+    # The watchdog drops _proc last. The pump read the attribute twice, so a drop
+    # between the two raised AttributeError and silently killed the pump.
+    b = TrainingBackend()
+    proc = _FakeProc(alive = True)
+    b._proc = proc
+    b._event_queue = queue.Queue()
+
+    def _read_queue(_q, timeout_sec = None):
+        b._proc = None  # watchdog finalizes concurrently
+        return None
+
+    monkeypatch.setattr(b, "_read_queue", _read_queue)
+
+    done = threading.Event()
+
+    def _run():
+        b._pump_loop()
+        done.set()
+
+    t = threading.Thread(target = _run, daemon = True)
+    t.start()
+    assert done.wait(timeout = 5), "pump must return cleanly, not die on a dropped handle"
+    assert b._pump_running is False

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -1198,7 +1198,8 @@ def test_mlx_worker_flushes_tracking_before_every_terminal_send():
     src = (_P(__file__).resolve().parent.parent / "core/training/worker.py").read_text()
     tree = ast.parse(src)
     fn = next(
-        n for n in ast.walk(tree)
+        n
+        for n in ast.walk(tree)
         if isinstance(n, ast.FunctionDef) and n.name == "_run_mlx_training"
     )
 
@@ -1213,12 +1214,14 @@ def test_mlx_worker_flushes_tracking_before_every_terminal_send():
 
     sends = sorted(n.lineno for n in ast.walk(fn) if _is_complete_send(n))
     flushes = sorted(
-        n.lineno for n in ast.walk(fn)
+        n.lineno
+        for n in ast.walk(fn)
         if isinstance(n, ast.Call) and getattr(n.func, "id", "") == "_finish_tracking"
     )
     # Only the sends after _finish_tracking is defined can be guarded by it.
     defined_at = next(
-        n.lineno for n in ast.walk(fn)
+        n.lineno
+        for n in ast.walk(fn)
         if isinstance(n, ast.FunctionDef) and n.name == "_finish_tracking"
     )
     guarded = [s for s in sends if s > defined_at]

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -1180,3 +1180,51 @@ def test_is_run_finished_true_when_a_stall_is_unrecoverable():
     b._handle_event({"type": "stall", "message": "no progress"})
     assert b._needs_xet_respawn is False
     assert b.is_run_finished() is True
+
+
+# ----------------------------------------------------------------------------
+# (f) The terminal event must be the worker's last act.
+# ----------------------------------------------------------------------------
+
+
+def test_mlx_worker_flushes_tracking_before_every_terminal_send():
+    """The parent arms its exit watchdog on `complete`, so anything the worker still
+    does after that send races a force-terminate. The MLX path closes the TensorBoard
+    writer and calls wandb_run.finish() in a finally; both must be flushed first.
+    """
+    import ast
+    from pathlib import Path as _P
+
+    src = (_P(__file__).resolve().parent.parent / "core/training/worker.py").read_text()
+    tree = ast.parse(src)
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_run_mlx_training"
+    )
+
+    def _is_complete_send(node):
+        return (
+            isinstance(node, ast.Call)
+            and getattr(node.func, "id", "") == "_send"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "complete"
+        )
+
+    sends = sorted(n.lineno for n in ast.walk(fn) if _is_complete_send(n))
+    flushes = sorted(
+        n.lineno for n in ast.walk(fn)
+        if isinstance(n, ast.Call) and getattr(n.func, "id", "") == "_finish_tracking"
+    )
+    # Only the sends after _finish_tracking is defined can be guarded by it.
+    defined_at = next(
+        n.lineno for n in ast.walk(fn)
+        if isinstance(n, ast.FunctionDef) and n.name == "_finish_tracking"
+    )
+    guarded = [s for s in sends if s > defined_at]
+    assert guarded, "expected terminal sends after the tracking helper is defined"
+    for send in guarded:
+        assert any(send - 4 <= f < send for f in flushes), (
+            f"_send('complete') at worker.py:{send} is not preceded by _finish_tracking(); "
+            "the watchdog could force-terminate a pending TB/W&B flush"
+        )

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -9,10 +9,9 @@ run stuck in "Stopping..." forever. These tests pin the bounded recovery: the wa
 escalates to force_terminate() a short grace after "complete" (save done) or after an
 absolute timeout (hang during save), and never force-kills a worker that exits cleanly.
 
-Section (d) covers the same wedge on a run that ends by itself: the model is on disk but
-the process lingers, and since is_training_active() is liveness-based the bar sits at 100%
-forever (issue #7897). The pump arms the same watchdog on a terminal event, and the
-escalation must not relabel a completed run as stopped.
+Section (d) covers the same wedge on a run that ends by itself: the model is on disk but the
+process lingers, so the liveness-based bar sits at 100% forever (#7897). The pump arms the
+same watchdog on a terminal event, and escalation must not relabel a completed run.
 
 Fakes only; no GPU, network, or subprocess.
 """
@@ -933,8 +932,7 @@ def _complete_event(output_dir = "/tmp/out"):
 
 
 def test_terminal_event_arms_watchdog_and_reaps_wedged_worker(monkeypatch):
-    # Saved, reported "complete", never exited: nothing reaped it, so is_training_active()
-    # stayed true off _proc.is_alive() and the UI sat at 100%.
+    # Saved, reported "complete", never exited: nothing reaped it, so the UI sat at 100%.
     monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)  # ensure the grace fires, not the cap
     b = TrainingBackend()
@@ -956,8 +954,7 @@ def test_terminal_event_arms_watchdog_and_reaps_wedged_worker(monkeypatch):
 
 
 def test_terminal_error_event_also_arms_watchdog(monkeypatch):
-    # A terminal error signals _complete_seen too (nothing is left to save); terminal_seen
-    # starts the grace for a freshly armed watchdog either way.
+    # A terminal error signals _complete_seen too, so the grace starts either way.
     monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = TrainingBackend()
@@ -1062,8 +1059,7 @@ def test_escalation_finalize_still_reports_a_stop_as_stopped(monkeypatch):
 
 
 def test_pump_loop_exits_when_the_watchdog_drops_the_handle(monkeypatch):
-    # The watchdog drops _proc last; the pump read it twice, so a drop in between raised
-    # AttributeError and silently killed the pump.
+    # The watchdog drops _proc last; a drop between the pump's two reads killed the pump.
     b = TrainingBackend()
     proc = _FakeProc(alive = True)
     b._proc = proc
@@ -1140,8 +1136,7 @@ def test_is_run_finished_does_not_leak_into_the_next_run():
 
 
 def test_is_run_finished_false_during_spawn_and_start_windows():
-    # _progress holds the previous run until start_training resets it, so these windows
-    # must not report the new run as already finished.
+    # _progress holds the previous run until start_training resets it.
     b = _running_backend()
     b._handle_event(_complete_event())
     b._spawn_in_progress = True
@@ -1187,15 +1182,13 @@ def test_is_run_finished_true_when_a_stall_is_unrecoverable():
 
 def test_mlx_worker_never_withholds_a_terminal_send_behind_tracking_teardown():
     """MLX teardown closes the TensorBoard writer and calls wandb_run.finish(), either of
-    which can block for many minutes. Putting that in front of `complete` would withhold
-    the event the UI waits on, which is the hang this whole change exists to end, so the
-    teardown stays in the finally and runs only after the send.
+    which can block for minutes. Ahead of `complete` that would withhold the event the UI
+    waits on, so the teardown stays in the finally and runs only after the send.
     """
     import ast
     from pathlib import Path as _P
 
-    # Beside the training module we actually imported, not relative to this file, so the
-    # test travels with the package rather than with its directory layout.
+    # Beside the training module we imported, so the test travels with the package.
     src = (_P(_TRAINING_MODULE_FILE).resolve().parent / "worker.py").read_text()
     tree = ast.parse(src)
     fn = next(
@@ -1238,9 +1231,8 @@ def test_mlx_worker_never_withholds_a_terminal_send_behind_tracking_teardown():
 
 
 def test_terminal_stall_arms_the_exit_watchdog(monkeypatch):
-    # An unrecoverable stall is terminal (is_run_finished() goes true), but terminate() is
-    # only a request. Without a backstop a worker that ignores it holds the GPU for good
-    # while the UI has already moved on, and every later start hits the live-_proc guard.
+    # An unrecoverable stall is terminal, but terminate() is only a request: without a
+    # backstop a worker that ignores it holds the GPU and blocks every later start.
     monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = _running_backend()
@@ -1278,10 +1270,9 @@ def test_recoverable_stall_does_not_arm_the_watchdog(monkeypatch):
 
 
 def test_terminal_error_releases_an_in_flight_stop_watchdog(monkeypatch):
-    # Stop and Save, then the worker fails its checkpoint and reports error instead of
-    # complete. The stop watchdog is already watching this proc, so arming again no-ops;
-    # without a terminal signal it would sit out the full save backstop (600s by default)
-    # with the GPU still blocked.
+    # Stop and Save, then the worker fails its checkpoint and reports error. The stop
+    # watchdog already watches this proc so arming no-ops; without a terminal signal it
+    # would sit out the full 600s save backstop with the GPU still blocked.
     monkeypatch.setitem(_G, "_STOP_GRACE_S", 0.05)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = _running_backend()
@@ -1304,9 +1295,8 @@ def test_terminal_error_releases_an_in_flight_stop_watchdog(monkeypatch):
 
 
 def test_terminal_stall_releases_an_in_flight_stop_watchdog(monkeypatch):
-    # Same shape as the error path: Stop and Save, then the download stalls with no
-    # fallback left. The stop's watchdog already watches this proc, so arming again
-    # no-ops, and only the terminal signal keeps it off the 600s save backstop.
+    # Same shape as the error path, via an unrecoverable stall: arming again no-ops, so only
+    # the terminal signal keeps the in-flight watchdog off the 600s save backstop.
     monkeypatch.setitem(_G, "_STOP_GRACE_S", 0.05)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = _running_backend()

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -956,8 +956,8 @@ def test_terminal_event_arms_watchdog_and_reaps_wedged_worker(monkeypatch):
 
 
 def test_terminal_error_event_also_arms_watchdog(monkeypatch):
-    # An error never sets _complete_seen, so terminal_seen starts the grace; without it the
-    # watchdog would wait out the full absolute backstop.
+    # A terminal error signals _complete_seen too (nothing is left to save); terminal_seen
+    # starts the grace for a freshly armed watchdog either way.
     monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = TrainingBackend()
@@ -969,7 +969,7 @@ def test_terminal_error_event_also_arms_watchdog(monkeypatch):
 
     b._handle_event({"type": "error", "error": "boom", "stack": ""})
 
-    assert not b._complete_seen.is_set(), "an error is not a completed save"
+    assert b._complete_seen.is_set(), "a terminal error leaves nothing to save"
     assert _wait_until(lambda: calls == ["force", "final"])
     b._stop_watchdog.join(timeout = 5)
 
@@ -1271,3 +1271,29 @@ def test_recoverable_stall_does_not_arm_the_watchdog(monkeypatch):
     assert b.is_run_finished() is False
     time.sleep(0.3)
     assert calls == [], "a respawning run must not be force-terminated"
+
+
+def test_terminal_error_releases_an_in_flight_stop_watchdog(monkeypatch):
+    # Stop and Save, then the worker fails its checkpoint and reports error instead of
+    # complete. The stop watchdog is already watching this proc, so arming again no-ops;
+    # without a terminal signal it would sit out the full save backstop (600s by default)
+    # with the GPU still blocked.
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 0.05)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
+    b = _running_backend()
+    b._start_stop_watchdog = TrainingBackend._start_stop_watchdog.__get__(b)
+    calls = _record_force_terminate(monkeypatch, b)
+
+    b._should_stop = True
+    b._start_stop_watchdog(cancel = False)      # the stop's own watchdog, now in flight
+    first = b._stop_watchdog
+    assert first is not None and first.is_alive()
+
+    b._handle_event({"type": "error", "error": "checkpoint failed", "stack": ""})
+
+    assert b._complete_seen.is_set(), "a terminal error must signal the in-flight watchdog"
+    assert b._stop_watchdog is first, "the existing watcher stays; arming again is a no-op"
+    assert _wait_until(
+        lambda: calls == ["force", "final"]
+    ), "the in-flight watchdog must escalate on the grace, not the save backstop"
+    first.join(timeout = 5)

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -68,7 +68,7 @@ _stub("utils.paths", _pth)
 # evict it below if we were the one to create the (stub-bound) module instance.
 _TRAINING_PRE_IMPORTED = "core.training.training" in sys.modules
 
-from core.training.training import TrainingBackend
+from core.training.training import TrainingBackend, TrainingProgress as _TP
 
 # Restore every stubbed module so this file never pollutes the shared session.
 for _name in (
@@ -1085,3 +1085,77 @@ def test_pump_loop_exits_when_the_watchdog_drops_the_handle(monkeypatch):
     t.start()
     assert done.wait(timeout = 5), "pump must return cleanly, not die on a dropped handle"
     assert b._pump_running is False
+
+
+# ----------------------------------------------------------------------------
+# (e) A finished run reports terminal at once, without waiting on the worker.
+# ----------------------------------------------------------------------------
+
+
+def _running_backend(job_id = "job_1"):
+    b = TrainingBackend()
+    b.current_job_id = job_id
+    b._proc = _FakeProc(alive = True)
+    b._progress = _TP(is_training = True, status_message = "Training in progress...")
+    b._finalize_run_in_db = lambda **kw: None
+    b._ensure_db_run_created = lambda: None
+    b._start_stop_watchdog = lambda **kw: None
+    return b
+
+
+def test_is_run_finished_false_while_training():
+    b = _running_backend()
+    assert b.is_run_finished() is False
+    assert b.is_training_active() is True
+
+
+def test_is_run_finished_true_once_terminal_even_though_worker_lives():
+    # The whole point: the UI must not wait on a worker wedged in teardown.
+    b = _running_backend()
+    b._handle_event(_complete_event())
+    assert b.is_run_finished() is True
+    assert b.is_training_active() is True, "admission guards still see the live worker"
+
+
+def test_is_run_finished_true_on_error():
+    b = _running_backend()
+    b._handle_event({"type": "error", "error": "boom", "stack": ""})
+    assert b.is_run_finished() is True
+
+
+def test_is_run_finished_untrue_for_a_fresh_backend():
+    assert TrainingBackend().is_run_finished() is False
+
+
+def test_is_run_finished_does_not_leak_into_the_next_run():
+    b = _running_backend()
+    b._handle_event(_complete_event())
+    assert b.is_run_finished() is True
+    # start_training's reset block.
+    b._complete_seen.clear()
+    b._progress = _TP(is_training = True, status_message = "Initializing training...")
+    b.current_job_id = "job_2"
+    b._proc = _FakeProc(alive = True)
+    assert b.is_run_finished() is False
+
+
+def test_is_run_finished_false_during_spawn_and_start_windows():
+    # _progress still holds the previous run until start_training resets it, so these
+    # windows must not report the new run as already finished.
+    b = _running_backend()
+    b._handle_event(_complete_event())
+    b._spawn_in_progress = True
+    assert b.is_run_finished() is False
+    b._spawn_in_progress = False
+    b._start_in_progress = True
+    assert b.is_run_finished() is False
+
+
+def test_is_training_active_still_liveness_only():
+    # Guards for inference/image/video/diffusion/install read this; a lingering worker
+    # still holds its VRAM, so it must keep reporting active.
+    b = _running_backend()
+    b._handle_event(_complete_event())
+    assert b.is_training_active() is True
+    b._proc._alive = False
+    assert b.is_training_active() is False

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -70,6 +70,9 @@ _TRAINING_PRE_IMPORTED = "core.training.training" in sys.modules
 
 from core.training.training import TrainingBackend, TrainingProgress as _TP
 
+# Captured before the eviction below, so it survives the sys.modules cleanup.
+_TRAINING_MODULE_FILE = sys.modules["core.training.training"].__file__
+
 # Restore every stubbed module so this file never pollutes the shared session.
 for _name in (
     "loggers",
@@ -1190,7 +1193,9 @@ def test_mlx_worker_flushes_tracking_before_every_terminal_send():
     import ast
     from pathlib import Path as _P
 
-    src = (_P(__file__).resolve().parent.parent / "core/training/worker.py").read_text()
+    # Beside the training module we actually imported, not relative to this file, so the
+    # test travels with the package rather than with its directory layout.
+    src = (_P(_TRAINING_MODULE_FILE).resolve().parent / "worker.py").read_text()
     tree = ast.parse(src)
     fn = next(
         n

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -1226,3 +1226,43 @@ def test_mlx_worker_flushes_tracking_before_every_terminal_send():
             f"_send('complete') at worker.py:{send} is not preceded by _finish_tracking(); "
             "the watchdog could force-terminate a pending TB/W&B flush"
         )
+
+
+def test_terminal_stall_arms_the_exit_watchdog(monkeypatch):
+    # An unrecoverable stall is terminal (is_run_finished() goes true), but terminate() is
+    # only a request. Without a backstop a worker that ignores it holds the GPU for good
+    # while the UI has already moved on, and every later start hits the live-_proc guard.
+    monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
+    b = _running_backend()
+    b._start_stop_watchdog = TrainingBackend._start_stop_watchdog.__get__(b)
+    calls = _record_force_terminate(monkeypatch, b)
+    b._in_model_load = True
+    b._xet_fallback_used = True  # already on HTTP, so the stall is unrecoverable
+
+    proc = b._proc
+    proc.terminate = lambda: None  # worker ignores the terminate request
+    b._handle_event({"type": "stall", "message": "no progress"})
+
+    assert b.is_run_finished() is True
+    assert _wait_until(lambda: calls == ["force", "final"]), (
+        "a wedged worker on the terminal stall path must still be reaped"
+    )
+    if b._stop_watchdog:
+        b._stop_watchdog.join(timeout = 5)
+
+
+def test_recoverable_stall_does_not_arm_the_watchdog(monkeypatch):
+    # The Xet fallback respawns the worker, so the run is not terminal and nothing may reap it.
+    monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
+    b = _running_backend()
+    b._start_stop_watchdog = TrainingBackend._start_stop_watchdog.__get__(b)
+    calls = _record_force_terminate(monkeypatch, b)
+    b._in_model_load = True
+
+    b._handle_event({"type": "stall", "message": "no progress"})
+
+    assert b._needs_xet_respawn is True
+    assert b.is_run_finished() is False
+    time.sleep(0.3)
+    assert calls == [], "a respawning run must not be force-terminated"

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -930,8 +930,8 @@ def _complete_event(output_dir = "/tmp/out"):
 
 
 def test_terminal_event_arms_watchdog_and_reaps_wedged_worker(monkeypatch):
-    # Saved, reported "complete", then never exited. Nothing used to reap it, so
-    # is_training_active() stayed true off _proc.is_alive() and the UI sat at 100%.
+    # Saved, reported "complete", never exited: nothing reaped it, so is_training_active()
+    # stayed true off _proc.is_alive() and the UI sat at 100%.
     monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)  # ensure the grace fires, not the cap
     b = TrainingBackend()
@@ -953,8 +953,8 @@ def test_terminal_event_arms_watchdog_and_reaps_wedged_worker(monkeypatch):
 
 
 def test_terminal_error_event_also_arms_watchdog(monkeypatch):
-    # An error never sets _complete_seen, so terminal_seen starts the grace; without it
-    # the watchdog would wait out the full absolute backstop.
+    # An error never sets _complete_seen, so terminal_seen starts the grace; without it the
+    # watchdog would wait out the full absolute backstop.
     monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 0.05)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = TrainingBackend()
@@ -972,8 +972,7 @@ def test_terminal_error_event_also_arms_watchdog(monkeypatch):
 
 
 def test_normal_completion_never_force_terminates(monkeypatch):
-    # The common path: the worker exits a second or two after "complete". Arming on
-    # every run must stay invisible there.
+    # The common path: the worker exits shortly after "complete", so arming stays invisible.
     monkeypatch.setitem(_G, "_COMPLETE_EXIT_GRACE_S", 5.0)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 10.0)
     b = TrainingBackend()
@@ -993,8 +992,7 @@ def test_normal_completion_never_force_terminates(monkeypatch):
 
 
 def test_completion_watchdog_does_not_preempt_a_stop_watchdog(monkeypatch):
-    # A user stop already armed the tighter grace; the terminal event must not
-    # replace it with the longer completion grace.
+    # A user stop armed the tighter grace; the terminal event must not replace it.
     b = TrainingBackend()
     monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: None)
     monkeypatch.setattr(b, "_stop_watchdog_loop", lambda *a, **k: None)
@@ -1012,8 +1010,7 @@ def test_completion_watchdog_does_not_preempt_a_stop_watchdog(monkeypatch):
 
 
 def test_escalation_finalize_keeps_completed_status_message(monkeypatch):
-    # Reaping a wedged worker after a successful save must not relabel the run: the
-    # message drives the UI banner.
+    # Reaping a wedged worker after a successful save must not relabel the run.
     b = TrainingBackend()
     b.current_job_id = "job_1"
     b._output_dir = "/tmp/out"
@@ -1062,8 +1059,8 @@ def test_escalation_finalize_still_reports_a_stop_as_stopped(monkeypatch):
 
 
 def test_pump_loop_exits_when_the_watchdog_drops_the_handle(monkeypatch):
-    # The watchdog drops _proc last. The pump read the attribute twice, so a drop
-    # between the two raised AttributeError and silently killed the pump.
+    # The watchdog drops _proc last; the pump read it twice, so a drop in between raised
+    # AttributeError and silently killed the pump.
     b = TrainingBackend()
     proc = _FakeProc(alive = True)
     b._proc = proc
@@ -1140,8 +1137,8 @@ def test_is_run_finished_does_not_leak_into_the_next_run():
 
 
 def test_is_run_finished_false_during_spawn_and_start_windows():
-    # _progress still holds the previous run until start_training resets it, so these
-    # windows must not report the new run as already finished.
+    # _progress holds the previous run until start_training resets it, so these windows
+    # must not report the new run as already finished.
     b = _running_backend()
     b._handle_event(_complete_event())
     b._spawn_in_progress = True
@@ -1152,8 +1149,7 @@ def test_is_run_finished_false_during_spawn_and_start_windows():
 
 
 def test_is_training_active_still_liveness_only():
-    # Guards for inference/image/video/diffusion/install read this; a lingering worker
-    # still holds its VRAM, so it must keep reporting active.
+    # A lingering worker still holds its VRAM, so the admission guards must see it active.
     b = _running_backend()
     b._handle_event(_complete_event())
     assert b.is_training_active() is True
@@ -1162,8 +1158,7 @@ def test_is_training_active_still_liveness_only():
 
 
 def test_is_run_finished_false_across_an_xet_respawn():
-    # A model-load stall terminates the worker and the pump respawns it over HTTP. The
-    # run is still going, so the UI must not flip to a terminal phase in that window.
+    # A stall respawns the worker over HTTP; the run is still going, so no terminal phase.
     b = _running_backend()
     b._in_model_load = True
     b._handle_event({"type": "stall", "message": "no progress"})

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -1245,9 +1245,9 @@ def test_terminal_stall_arms_the_exit_watchdog(monkeypatch):
     b._handle_event({"type": "stall", "message": "no progress"})
 
     assert b.is_run_finished() is True
-    assert _wait_until(lambda: calls == ["force", "final"]), (
-        "a wedged worker on the terminal stall path must still be reaped"
-    )
+    assert _wait_until(
+        lambda: calls == ["force", "final"]
+    ), "a wedged worker on the terminal stall path must still be reaped"
     if b._stop_watchdog:
         b._stop_watchdog.join(timeout = 5)
 

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -1159,3 +1159,24 @@ def test_is_training_active_still_liveness_only():
     assert b.is_training_active() is True
     b._proc._alive = False
     assert b.is_training_active() is False
+
+
+def test_is_run_finished_false_across_an_xet_respawn():
+    # A model-load stall terminates the worker and the pump respawns it over HTTP. The
+    # run is still going, so the UI must not flip to a terminal phase in that window.
+    b = _running_backend()
+    b._in_model_load = True
+    b._handle_event({"type": "stall", "message": "no progress"})
+    assert b._needs_xet_respawn is True
+    assert b._progress.error is None
+    assert b.is_run_finished() is False
+
+
+def test_is_run_finished_true_when_a_stall_is_unrecoverable():
+    # Already fell back to HTTP: the stall is terminal, so the UI should say so.
+    b = _running_backend()
+    b._in_model_load = True
+    b._xet_fallback_used = True
+    b._handle_event({"type": "stall", "message": "no progress"})
+    assert b._needs_xet_respawn is False
+    assert b.is_run_finished() is True

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -1285,7 +1285,7 @@ def test_terminal_error_releases_an_in_flight_stop_watchdog(monkeypatch):
     calls = _record_force_terminate(monkeypatch, b)
 
     b._should_stop = True
-    b._start_stop_watchdog(cancel = False)      # the stop's own watchdog, now in flight
+    b._start_stop_watchdog(cancel = False)  # the stop's own watchdog, now in flight
     first = b._stop_watchdog
     assert first is not None and first.is_alive()
 


### PR DESCRIPTION
Fixes #7897.

### The bug

A training run that finishes on its own has already done everything that matters by the time the worker emits its terminal event: the model, tokenizer and adapter config are on disk, `is_completed` is set and the DB row is finalized. But `is_training_active()` answers on worker liveness alone:

```python
if self._proc is not None and self._proc.is_alive():
    return True
```

That check runs before the `is_completed` / `_complete_seen` ones below it. So if the worker emits `complete` and then wedges in GPU or interpreter teardown, `/api/train/status` keeps returning `phase="training", is_training_running=true` and the `/api/train/progress` SSE never falls out of `while backend.is_training_active():`, so it never sends its final `complete` frame. The progress bar sits at 100% indefinitely.

Pressing "Stop and Save" was the only way out because `_start_stop_watchdog`, which force-terminates a stuck worker, had a single call site: `stop_training`. The exported model was valid afterwards because it had been saved before the hang; the stop only reaped the zombie.

Reported on Windows 10 with an RX 7900 XTX on ROCm, and intermittent, which fits a lingering process exit after GPU teardown.

### The fix

`is_training_active()` was answering two different questions with one number:

1. is a run in progress (status, progress stream, stop)
2. is the GPU still occupied by a training worker (admission guards for inference, image and video generation, diffusion start, transformers install, `/train/start`)

After a terminal event the answer to 1 is definitively no, while 2 stays yes until the process exits. So:

- **`is_training_active()` is unchanged**, still liveness-based, and every one of the 15 admission call sites keeps its exact previous answer. A lingering worker still holds its VRAM and must keep blocking new GPU work.
- **New `is_run_finished()`**, consulted by `/api/train/status`, the progress SSE and `/api/train/stop` through a getattr-guarded `_run_finished` helper. A run that reported terminal is reported terminal at once, with no grace and no kill involved.
- **The watchdog is now armed on any terminal event**, not just a user stop, purely as a backstop so a wedged worker cannot hold the GPU forever. Its grace is a generous 120s (`UNSLOTH_STUDIO_TRAINING_COMPLETE_EXIT_GRACE_S`) precisely because it no longer gates the UI.
- **The MLX path is deliberately left alone.** Its TensorBoard/W&B teardown stays in the trailing `finally`, after the terminal send. Flushing first looks tidier and an earlier revision of this PR did exactly that, but `wandb_run.finish()` routinely blocks for minutes and sometimes deadlocks, so putting it ahead of `complete` withholds the event the UI waits on and reproduces this same bug on Apple Silicon. The watchdog grace bounds the teardown instead.
- **`_finalize_stopped_after_escalation` keeps a completed run's status message** instead of overwriting it with "Training stopped.". That message drives the UI banner.
- **`_pump_loop` snapshots `_proc`.** The watchdog drops the handle as its last step, so reading the attribute twice could hit `None` and kill the pump thread with an `AttributeError`. Pre-existing, but arming on every run would have made it routine.
- **A terminal error or an unrecoverable download stall signals an in-flight stop watchdog.** Arming again is a no-op while a watchdog already watches that worker, so without the signal it sat out the 600s save backstop with the GPU still held.
- **`stop_training` re-tests terminal under its own lock.** The route's check and the backend's mutation are separate reads, so a run that finishes in between would latch `_should_stop` on a run that already saved. The status phase ladder tests that flag before `is_completed`, which reported a completed run as stopped for good.

### Verification

70 tests across `test_training_stop_watchdog.py` and a new `test_training_status_terminal.py`, which drives the real `/status`, `/progress` SSE and `/stop` handlers against a worker that never exits. Every new behaviour fails on the unpatched code, the pump one with exactly the `AttributeError: 'NoneType' object has no attribute 'is_alive'` it predicts.

Beyond the unit tests, the change was exercised by a simulation suite covering the lifecycle state machine, real spawn subprocesses (normal exit, wedged, slow teardown, crash, hard crash), the `[Linux, Windows, WSL, macOS] x [NVIDIA, AMD/ROCm, CPU-only]` matrix, and concurrency races between the pump, the watchdog and reset. Two results are worth calling out:

- With the watchdog disarmed entirely, the UI still unsticks. The fix does not depend on the kill.
- A worker with a slow but legitimate teardown exits on its own with exitcode 0 and is never force-killed.

Run on real `ubuntu-latest`, `windows-latest` and `macos-14` (Apple Silicon) runners, all green, with the UI unsticking in 0.07s to 0.12s on all three. The full backend suite was also run on this branch and on clean `main`: the failing-test set is identical, so nothing here regresses.

No frontend file is touched, so browser behaviour is unaffected. The `TrainingStatus` response shape is unchanged, the backend surface is additive (`is_run_finished`; the watchdog helpers only gained optional keyword arguments), and the new env var falls back to its default when absent, so existing installs are unaffected.

### Note

The log attached to the issue captures a successful session, so the hang itself is not in it. The root cause is from reading the code path the report describes, not a live repro of a wedged ROCm teardown.

