### PR TITLE
Tighten remaining artifact uploads (follow-up to #7930)

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -172,13 +172,20 @@ jobs:
         run: npm run biome:check
 
       - name: Upload built dist
-        # Always upload so a green run is reviewable too -- the dist
-        # output catches "tests passed but bundle changed unexpectedly"
-        # regressions that would be invisible if we only kept artifacts
-        # on failure.
-        if: always()
+        # Failures only. This uploads a whole build directory (~35MB), and
+        # keeping it from green runs too made it the second-largest artifact
+        # family in the repo at ~3.5GB. Actions storage is not free on public
+        # repos, and exceeding the account allowance silently stops GitHub
+        # scheduling jobs org-wide, so a build tree retained purely for review
+        # is not worth that risk.
+        #
+        # The "bundle changed unexpectedly" check this previously enabled is
+        # better served by asserting on the build inside the job -- the size
+        # gate in build.sh is the existing precedent -- rather than by keeping
+        # every green run's output for inspection.
+        if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: studio-frontend-dist
           path: studio/frontend/dist
-          retention-days: 3
+          retention-days: 1

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -352,4 +352,7 @@ jobs:
             logs/playwright-permissions-*
             logs/playwright_extra
             logs/studio-permissions-*.log
-          retention-days: 7
+          # 1 day, matching the repository-wide cap. A larger value here is
+          # silently clamped to that cap today, so stating 7 only invites the
+          # artifacts to re-inflate if the cap is ever raised.
+          retention-days: 1

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -370,4 +370,7 @@ jobs:
             logs/playwright_modelcfg
             logs/playwright_ime
             logs/studio-permissions-*.log
-          retention-days: 7
+          # 1 day, matching the repository-wide cap. A larger value here is
+          # silently clamped to that cap today, so stating 7 only invites the
+          # artifacts to re-inflate if the cap is ever raised.
+          retention-days: 1

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -411,4 +411,7 @@ jobs:
             logs/playwright-permissions-*
             logs/playwright_extra
             logs/studio-permissions-*.log
-          retention-days: 7
+          # 1 day, matching the repository-wide cap. A larger value here is
+          # silently clamped to that cap today, so stating 7 only invites the
+          # artifacts to re-inflate if the cap is ever raised.
+          retention-days: 1


### PR DESCRIPTION
## Why

Follow-up to #7930. That PR fixed `tauri-debug-build`, which was 97% of the repo's Actions artifact storage (~350GB) and whose overflow silently halted GitHub Actions scheduling org-wide. This tightens the remaining upload steps that share the same shape.

I audited all 47 `upload-artifact` steps across the 37 workflows and cross-referenced them against measured artifact sizes rather than guessing from the YAML. Measured per-run averages before the cleanup:

| artifact | per run | total | verdict |
|---|---:|---:|---|
| tauri-debug-build | 1.33 GB | 350 GB | fixed in #7930 |
| desktop-release-linux-x64 | 160 MB | 0.32 GB | fine: manual dispatch only, retention 1 |
| **studio-frontend-dist** | **35 MB** | **3.55 GB** | **fixed here** |
| studio-ui-smoke-artifacts | 3.7 MB | 2.45 GB | retention made honest here |
| mac / windows ui-smoke | ~2.5 MB | 3.5 GB | retention made honest here |
| ~23,000 log artifacts | <10 KB | 0.03 GB | fine as-is |

Nothing else uploads a build tree on green runs. The ~20 steps that upload named `*.log` / SARIF files are a few KB each and are left alone.

## Changes

**`studio-frontend-ci.yml` -- `studio-frontend-dist`: `always()` -> `failure()`, retention 3 -> 1**

It uploaded the whole `studio/frontend/dist` directory on every run. The existing comment explained the green-run copy was kept so a reviewer could catch "tests passed but bundle changed unexpectedly". That is better served by asserting on the build inside the job -- the CSS size gate in `build.sh` is the existing precedent in this repo -- than by retaining every green run's output.

**`studio-ui-smoke.yml`, `studio-mac-ui-smoke.yml`, `studio-windows-ui-smoke.yml`: `retention-days: 7` -> `1`**

Not a behaviour change: the repository-wide retention cap already clamps these to 1 day. Verified against a live artifact:

```
windows-studio-ui-smoke-artifacts  created=2026-08-05T13:37  expires=2026-08-06T13:10
```

Requested 7, expires in 1. Stating 7 is misleading and lets these silently re-inflate if the cap is ever raised. These stay on `always()` -- Playwright traces are the point of a UI smoke test, and at ~3MB per run under a 1-day cap they are proportionate.

## Test plan

- [x] All 4 workflows parse; upload steps resolve to the intended `if:` and `retention-days`
- [x] Audit confirms no other step uploads a build tree on green runs
- [x] Retention clamping verified empirically against a live artifact's `expires_at`
- [ ] Confirm a failing frontend CI run still uploads `studio-frontend-dist`
- [ ] Confirm a green frontend CI run uploads nothing
