### PR TITLE
Fix Windows PowerShell resource path authorization

### DIFF
--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -147,3 +147,47 @@ jobs:
           # frontend dist rather than failing the upload itself.
           if-no-files-found: warn
           retention-days: 1
+
+  # install.rs carries a Windows-only path normalizer for PowerShell 5.1. The
+  # job above is Linux, and `cfg(windows)` items are stripped before type
+  # checking, so nothing there compiles that code, let alone runs its tests.
+  # That is how the RemoteSigned regression in #7819 reached two draft bundles.
+  windows-unit-tests:
+    name: Rust unit tests (windows)
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable @ 2026-03-27
+
+      - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
+        with:
+          workspaces: studio/src-tauri -> target
+
+      # Windows runners expose `python`, not `python3`, so pin an interpreter
+      # the way every other windows job here does.
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Lockfile supply-chain audit (pre-install scan)
+        run: python scripts/lockfile_supply_chain_audit.py
+
+      # tauri-build resolves frontendDist at compile time, so dist/ must exist
+      # before cargo test, exactly as in the Linux job.
+      - name: Frontend build (npm ci, vite)
+        working-directory: studio/frontend
+        run: |
+          npm ci --no-fund --no-audit
+          npm run build
+
+      - name: Rust unit tests (studio/src-tauri)
+        working-directory: studio/src-tauri
+        run: cargo test --no-fail-fast

--- a/studio/src-tauri/src/install.rs
+++ b/studio/src-tauri/src/install.rs
@@ -235,8 +235,9 @@ fn powershell_script_path(path: &Path) -> PathBuf {
     };
 
     // Only the verbatim form addresses a path past MAX_PATH; stripping it there
-    // would trade an authorization error for a "path too long" one.
-    if normalized.len() > 260 {
+    // would trade an authorization error for a "path too long" one. MAX_PATH
+    // counts the terminating NUL, so 259 units is the longest legacy path.
+    if normalized.len() >= 260 {
         return path.to_path_buf();
     }
 
@@ -1179,12 +1180,23 @@ mod tests {
                 "{unchanged} should be passed through untouched"
             );
         }
-        // Only the verbatim form reaches past MAX_PATH.
-        let long = format!(r"\\?\C:\{}\install.ps1", "a".repeat(300));
+        // MAX_PATH counts the terminating NUL, so 259 units still fits but 260 does not.
+        let fits = format!(r"C:\{}\install.ps1", "a".repeat(244));
+        assert_eq!(fits.len(), 259);
         assert_eq!(
-            powershell_script_path(Path::new(&long)),
-            PathBuf::from(&long)
+            powershell_script_path(Path::new(&format!(r"\\?\{fits}"))),
+            PathBuf::from(&fits)
         );
+        for over in [
+            format!(r"\\?\C:\{}\install.ps1", "a".repeat(245)),
+            format!(r"\\?\C:\{}\install.ps1", "a".repeat(300)),
+        ] {
+            assert_eq!(
+                powershell_script_path(Path::new(&over)),
+                PathBuf::from(&over),
+                "a path past MAX_PATH must stay verbatim"
+            );
+        }
     }
 
     #[cfg(windows)]

--- a/studio/src-tauri/src/install.rs
+++ b/studio/src-tauri/src/install.rs
@@ -195,39 +195,66 @@ fn is_elevation_request(code: i32, packages: &[String]) -> bool {
 
 /// Windows PowerShell 5.1 applies `RemoteSigned` authorization differently to
 /// Win32 verbatim paths (`\\?\C:\...`) than to their ordinary drive/UNC forms.
-/// Tauri may return a verbatim resource path, so convert only the two lossless
-/// filesystem forms PowerShell understands before passing a script to `-File`.
+/// Tauri resolves resources through `canonicalize`, which always returns the
+/// verbatim form, so convert only the two lossless filesystem forms PowerShell
+/// understands before passing a script to `-File`.
 #[cfg(windows)]
 fn powershell_script_path(path: &Path) -> PathBuf {
     use std::ffi::OsString;
     use std::os::windows::ffi::{OsStrExt, OsStringExt};
 
-    let wide: Vec<u16> = path.as_os_str().encode_wide().collect();
-    let verbatim_unc: Vec<u16> = r"\\?\UNC\".encode_utf16().collect();
-    let verbatim: Vec<u16> = r"\\?\".encode_utf16().collect();
+    // Everything after `\\?\` reaches the object manager, which is case insensitive.
+    fn is(unit: Option<&u16>, ascii: u8) -> bool {
+        unit.is_some_and(|value| *value < 128 && (*value as u8).eq_ignore_ascii_case(&ascii))
+    }
 
-    let normalized = if wide.starts_with(&verbatim_unc) {
+    let wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    let verbatim: Vec<u16> = r"\\?\".encode_utf16().collect();
+    if !wide.starts_with(&verbatim) {
+        return path.to_path_buf();
+    }
+    let rest = &wide[verbatim.len()..];
+
+    let is_drive = rest.first().is_some_and(|value| {
+        (b'A' as u16..=b'Z' as u16).contains(value) || (b'a' as u16..=b'z' as u16).contains(value)
+    }) && rest.get(1) == Some(&(b':' as u16))
+        && rest.get(2) == Some(&(b'\\' as u16));
+
+    let normalized = if is(rest.first(), b'U')
+        && is(rest.get(1), b'N')
+        && is(rest.get(2), b'C')
+        && rest.get(3) == Some(&(b'\\' as u16))
+    {
         let mut value: Vec<u16> = r"\\".encode_utf16().collect();
-        value.extend_from_slice(&wide[verbatim_unc.len()..]);
+        value.extend_from_slice(&rest[4..]);
         value
+    } else if is_drive {
+        rest.to_vec()
     } else {
-        let drive = wide.get(verbatim.len()).copied();
-        let is_ascii_drive = drive.is_some_and(|value| {
-            (b'A' as u16..=b'Z' as u16).contains(&value)
-                || (b'a' as u16..=b'z' as u16).contains(&value)
-        });
-        if wide.starts_with(&verbatim)
-            && is_ascii_drive
-            && wide.get(verbatim.len() + 1) == Some(&(b':' as u16))
-            && wide.get(verbatim.len() + 2) == Some(&(b'\\' as u16))
-        {
-            wide[verbatim.len()..].to_vec()
-        } else {
-            return path.to_path_buf();
-        }
+        return path.to_path_buf();
     };
 
+    // Only the verbatim form addresses a path past MAX_PATH; stripping it there
+    // would trade an authorization error for a "path too long" one.
+    if normalized.len() > 260 {
+        return path.to_path_buf();
+    }
+
     PathBuf::from(OsString::from_wide(&normalized))
+}
+
+/// `Command::new` searches the running executable's own directory before the
+/// system one, and a `currentUser` install puts that directory somewhere the
+/// user can write, so resolve the interpreter absolutely.
+#[cfg(windows)]
+fn powershell_exe() -> PathBuf {
+    let system_root = std::env::var_os("SystemRoot").unwrap_or_else(|| r"C:\Windows".into());
+    let absolute = Path::new(&system_root).join(r"System32\WindowsPowerShell\v1.0\powershell.exe");
+    if absolute.is_file() {
+        absolute
+    } else {
+        PathBuf::from("powershell.exe")
+    }
 }
 
 // ── Script Resolution ──
@@ -360,7 +387,7 @@ fn spawn_script(
         .stderr(Stdio::piped());
 
     #[cfg(windows)]
-    let mut cmd = Command::new("powershell.exe");
+    let mut cmd = Command::new(powershell_exe());
     // No -WindowStyle Hidden / -ExecutionPolicy Bypass: that pair is a Microsoft
     // detection signature, CREATE_NO_WINDOW below already hides the console, and
     // NSIS writes resources without a mark-of-the-web so RemoteSigned loads them.
@@ -1121,6 +1148,55 @@ mod tests {
         assert_eq!(
             powershell_script_path(Path::new(r"\\?\Volume{1234}\install.ps1")),
             PathBuf::from(r"\\?\Volume{1234}\install.ps1")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn powershell_script_path_leaves_unsupported_spellings_verbatim() {
+        // The object manager is case insensitive, so `unc` must normalize too.
+        assert_eq!(
+            powershell_script_path(Path::new(r"\\?\unc\server\share\install.ps1")),
+            PathBuf::from(r"\\server\share\install.ps1")
+        );
+        assert_eq!(
+            powershell_script_path(Path::new(r"\\?\c:\Users\Owner\install.ps1")),
+            PathBuf::from(r"c:\Users\Owner\install.ps1")
+        );
+        // A drive letter with no separator is drive-relative, not the same path.
+        for unchanged in [
+            r"\\?\C:",
+            r"\\?\",
+            r"\\?\1:\install.ps1",
+            r"\\?\GLOBALROOT\Device\HarddiskVolume1\install.ps1",
+            r"\\.\C:\install.ps1",
+            r"\\server\share\install.ps1",
+            r"install.ps1",
+        ] {
+            assert_eq!(
+                powershell_script_path(Path::new(unchanged)),
+                PathBuf::from(unchanged),
+                "{unchanged} should be passed through untouched"
+            );
+        }
+        // Only the verbatim form reaches past MAX_PATH.
+        let long = format!(r"\\?\C:\{}\install.ps1", "a".repeat(300));
+        assert_eq!(
+            powershell_script_path(Path::new(&long)),
+            PathBuf::from(&long)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn powershell_exe_resolves_under_the_system_directory() {
+        let resolved = powershell_exe();
+        assert!(resolved.is_absolute(), "{resolved:?} should be absolute");
+        assert!(resolved.is_file(), "{resolved:?} should exist");
+        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".into());
+        assert!(
+            resolved.starts_with(&system_root),
+            "{resolved:?} escaped {system_root}"
         );
     }
 

--- a/studio/src-tauri/src/install.rs
+++ b/studio/src-tauri/src/install.rs
@@ -193,6 +193,43 @@ fn is_elevation_request(code: i32, packages: &[String]) -> bool {
     code == 2 && !packages.is_empty()
 }
 
+/// Windows PowerShell 5.1 applies `RemoteSigned` authorization differently to
+/// Win32 verbatim paths (`\\?\C:\...`) than to their ordinary drive/UNC forms.
+/// Tauri may return a verbatim resource path, so convert only the two lossless
+/// filesystem forms PowerShell understands before passing a script to `-File`.
+#[cfg(windows)]
+fn powershell_script_path(path: &Path) -> PathBuf {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    let verbatim_unc: Vec<u16> = r"\\?\UNC\".encode_utf16().collect();
+    let verbatim: Vec<u16> = r"\\?\".encode_utf16().collect();
+
+    let normalized = if wide.starts_with(&verbatim_unc) {
+        let mut value: Vec<u16> = r"\\".encode_utf16().collect();
+        value.extend_from_slice(&wide[verbatim_unc.len()..]);
+        value
+    } else {
+        let drive = wide.get(verbatim.len()).copied();
+        let is_ascii_drive = drive.is_some_and(|value| {
+            (b'A' as u16..=b'Z' as u16).contains(&value)
+                || (b'a' as u16..=b'z' as u16).contains(&value)
+        });
+        if wide.starts_with(&verbatim)
+            && is_ascii_drive
+            && wide.get(verbatim.len() + 1) == Some(&(b':' as u16))
+            && wide.get(verbatim.len() + 2) == Some(&(b'\\' as u16))
+        {
+            wide[verbatim.len()..].to_vec()
+        } else {
+            return path.to_path_buf();
+        }
+    };
+
+    PathBuf::from(OsString::from_wide(&normalized))
+}
+
 // ── Script Resolution ──
 
 /// Returns (script_path, args) depending on dev vs production mode.
@@ -336,7 +373,7 @@ fn spawn_script(
         "RemoteSigned",
         "-File",
     ])
-    .arg(script)
+    .arg(powershell_script_path(script))
     .args(args)
     .current_dir(&work_dir)
     .stdout(Stdio::piped())
@@ -1065,6 +1102,27 @@ fn capped_output_text(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn powershell_script_path_normalizes_verbatim_filesystem_paths() {
+        assert_eq!(
+            powershell_script_path(Path::new(r"\\?\C:\Users\Owner\install.ps1")),
+            PathBuf::from(r"C:\Users\Owner\install.ps1")
+        );
+        assert_eq!(
+            powershell_script_path(Path::new(r"\\?\UNC\server\share\install.ps1")),
+            PathBuf::from(r"\\server\share\install.ps1")
+        );
+        assert_eq!(
+            powershell_script_path(Path::new(r"C:\Users\Owner\install.ps1")),
+            PathBuf::from(r"C:\Users\Owner\install.ps1")
+        );
+        assert_eq!(
+            powershell_script_path(Path::new(r"\\?\Volume{1234}\install.ps1")),
+            PathBuf::from(r"\\?\Volume{1234}\install.ps1")
+        );
+    }
 
     #[test]
     fn elevated_output_cap_is_utf8_boundary_safe() {


### PR DESCRIPTION
## Summary

- keep the Defender-friendly Windows launcher shape introduced in #7819 (`RemoteSigned` plus `CREATE_NO_WINDOW`)
- convert Tauri's Win32 verbatim resource paths to ordinary drive or UNC paths before passing `install.ps1` to Windows PowerShell 5.1
- leave ordinary paths and unsupported device namespace paths unchanged
- cover drive, UNC, ordinary, and unsupported verbatim paths with a Windows unit test

## Root cause

Tauri can resolve the bundled script as `\\?\C:\...\install.ps1`. Windows PowerShell 5.1's `RemoteSigned` authorization rejects that spelling with `AuthorizationManager check failed` / `UnauthorizedAccess`, even when the script's Authenticode signature is valid and it has no `Zone.Identifier`. The equivalent `C:\...\install.ps1` path authorizes successfully.

This keeps `RemoteSigned`; it does not restore the `-WindowStyle Hidden -ExecutionPolicy Bypass` command shape that was removed because it matched a Microsoft Defender detection signature.

## Validation

- `rustfmt --edition 2021 --check studio/src-tauri/src/install.rs`
- `npm ci --no-fund --no-audit && npm run build` in `studio/frontend`
- `cargo test powershell_script_path_normalizes_verbatim_filesystem_paths -- --nocapture` on Windows: 1 passed
- [disposable Windows runner using the exact signed 0.1.52-beta installer](https://github.com/Imagineer99/unsloth/actions/runs/31009748837):
  - verbatim path + `RemoteSigned` reproduced `AuthorizationManager` / `UnauthorizedAccess`
  - normalized path + `RemoteSigned` authorized the exact signed script
  - the Rust normalization implementation compiled and passed its behavioral check

The runner validates the authorization fix while retaining the Defender-friendly command shape. Absence of consumer Defender notifications still requires final testing with the fully signed release installer.
