### PR TITLE
Studio: drop the streaming animation wrappers once a message completes

### DIFF
--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -23,11 +23,12 @@ import { Copy01Icon, Download01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { createMathPlugin } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import {
   Block,
   type BlockProps,
   Streamdown,
+  StreamdownContext,
   type StreamdownProps,
 } from "streamdown";
 import { createCodePlugin } from "./code-plugin";
@@ -246,6 +247,12 @@ function CodeBlockActions({
 // Collapse a full-HTML answer in place into an artifact card. Diffusion keeps the
 // raw code visible instead (the trailing MessageHtmlArtifacts appends its card).
 function StreamdownBlock(props: BlockProps) {
+  // Streamdown memoises each block on its content, so a block that finished
+  // streaming is never re-parsed and keeps the per-word animation wrappers the
+  // animated path added. Keying the block on the animating flag re-parses each
+  // one once when the message completes, without remounting the whole message.
+  const { isAnimating } = useContext(StreamdownContext);
+  const blockKey = isAnimating ? "live" : "done";
   const shouldCollapseHtmlArtifacts = useChatRuntimeStore(
     (state) =>
       (state.artifactsEnabled || state.collapseHtmlArtifacts) &&
@@ -339,7 +346,7 @@ function StreamdownBlock(props: BlockProps) {
     );
   }
 
-  return <Block {...props} />;
+  return <Block {...props} key={blockKey} />;
 }
 const AUDIO_PLAYER_RE = /<audio-player\s+src="([^"]+)"\s*\/>/;
 

--- a/studio/frontend/tests/markdown-block-remount-on-complete.test.ts
+++ b/studio/frontend/tests/markdown-block-remount-on-complete.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import ts from "typescript";
+
+const MARKDOWN_TEXT_PATH = fileURLToPath(
+  new URL("../src/components/assistant-ui/markdown-text.tsx", import.meta.url),
+);
+const source = ts.createSourceFile(
+  MARKDOWN_TEXT_PATH,
+  readFileSync(MARKDOWN_TEXT_PATH, "utf8"),
+  ts.ScriptTarget.ESNext,
+  true,
+  ts.ScriptKind.TSX,
+);
+
+function findFunction(name: string): ts.FunctionDeclaration | null {
+  let found: ts.FunctionDeclaration | null = null;
+  const visit = (node: ts.Node): void => {
+    if (ts.isFunctionDeclaration(node) && node.name?.getText(source) === name) {
+      found = node;
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  return found;
+}
+
+function findJsx(
+  scope: ts.Node,
+  tagName: string,
+): ts.JsxOpeningLikeElement | null {
+  let found: ts.JsxOpeningLikeElement | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+      node.tagName.getText(source) === tagName &&
+      !found
+    ) {
+      found = node;
+    }
+    node.forEachChild(visit);
+  };
+  scope.forEachChild(visit);
+  return found;
+}
+
+function jsxAttribute(
+  opening: ts.JsxOpeningLikeElement,
+  name: string,
+): ts.JsxAttribute | null {
+  for (const attribute of opening.attributes.properties) {
+    if (
+      ts.isJsxAttribute(attribute) &&
+      attribute.name.getText(source) === name
+    ) {
+      return attribute;
+    }
+  }
+  return null;
+}
+
+test("StreamdownBlock reads the animating flag from Streamdown's context", () => {
+  const block = findFunction("StreamdownBlock");
+  assert.ok(block, "StreamdownBlock is missing");
+
+  const body = block.getText(source);
+  assert.match(
+    body,
+    /useContext\(\s*StreamdownContext\s*\)/,
+    "StreamdownBlock must read StreamdownContext to know when the message is still streaming",
+  );
+  assert.match(
+    body,
+    /isAnimating/,
+    "StreamdownBlock must derive its key from isAnimating",
+  );
+});
+
+test("the streamed block is re-keyed once the message completes", () => {
+  const block = findFunction("StreamdownBlock");
+  assert.ok(block, "StreamdownBlock is missing");
+
+  // The last <Block> in the function is the default (non-artifact) return; it is
+  // the one that renders ordinary prose, so it is the one that accumulates the
+  // per-word animation wrappers while streaming.
+  let last: ts.JsxOpeningLikeElement | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+      node.tagName.getText(source) === "Block"
+    ) {
+      last = node;
+    }
+    node.forEachChild(visit);
+  };
+  block.forEachChild(visit);
+  assert.ok(last, "the default <Block> return is missing");
+
+  const key = jsxAttribute(last, "key");
+  assert.ok(
+    key,
+    "the default <Block> must carry a key so completed blocks re-parse without the animation wrappers",
+  );
+
+  // The key is either isAnimating itself or a local declared from it.
+  const identifier = (key.initializer?.getText(source) ?? "")
+    .replace(/[{}]/g, "")
+    .trim();
+  assert.ok(identifier, "the key must not be empty");
+  assert.match(
+    block.getText(source),
+    new RegExp(`${identifier}\\s*=\\s*isAnimating`),
+    `the key ${identifier} must be derived from isAnimating`,
+  );
+});


### PR DESCRIPTION
Follow-up to #7892.

## What happens today

#7892 turns on Streamdown's animated path (`animated={{duration: 0, stagger: 0}}`) to bypass a React transition that starves under a continuous token stream. That fixed the stall, but it has a side effect the PR description did not cover.

While a message is streaming, Streamdown's animate plugin rewrites every text node into a per-word `<span data-sd-animate>` carrying an inline CSS animation. Streamdown memoises each block on its content, so a block that has finished streaming is never re-parsed. The wrappers therefore stay in the DOM for the life of the message.

Measured in Studio on a 13,996-character answer with 127 KaTeX equations, after the stream has ended and `isAnimating` is false:

| | before this PR | after |
|---|---|---|
| `[data-sd-animate]` left in the finished message | 2,150 | 0 |
| Live CSS animations on the page | 2,150 | 0 |
| Final message HTML | 532,535 B | 295,693 B |

I confirmed the mechanism directly: tagging the wrapper nodes mid-stream and re-checking after completion shows 100 percent of them are still the same DOM nodes. Only remounting clears them, and nothing remounts a completed message, so the cost accumulates across a chat.

The inflation is worst on ordinary prose, where every word becomes an element, not on equations.

## The change

Key each block on Streamdown's `isAnimating` flag, read from `StreamdownContext`. Every block re-parses exactly once when the message completes, which produces the same markup a non-streamed message produces. The streaming behaviour from #7892 is untouched.

## Verification

Two production builds off the same base, driven in a real Studio instance against a deterministic SSE provider replaying the same answer at 1,400 chars/s under 4x CPU throttling.

- Wrappers after completion: 2,150 -> 0.
- The #7892 fix still holds: 86 visible updates during the stream (main without #7892 managed 4), no run over the pre-#7892 stall.
- Final rendered text, KaTeX element count and equation bounding boxes are identical to main.

Cross-engine, 4 engines (Chromium, Chrome, Firefox, WebKit) x 12 content corpora (KaTeX, prose, code, CJK, RTL, emoji with ZWJ sequences, tables and lists, incomplete LaTeX, one huge paragraph, Mermaid, HTML/SVG artifact fences, a 2-character answer):

- 0 leftover wrappers in all 48 cells.
- Final element counts match main exactly.
- Rendered text, KaTeX geometry and selection text identical to main in every cell, once the render has settled. The only residual difference is Mermaid, which mints a random diagram id per render and so differs run to run on main as well.

No blank or partial frames at the completion boundary, and text selection is preserved.

## Tests

`npm run typecheck`, `npm test` (439 pass), `npm run build`.
