### PR TITLE
Desktop: keep slide-in panels below the custom titlebar

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -10,6 +10,7 @@ import {
   shouldUseCustomWindowTitlebar,
   shouldUseNativeMacWindowTitlebar,
 } from "@/components/tauri/window-titlebar";
+import { SheetViewportInsetProvider } from "@/components/ui/sheet";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { WebUpdateBanner } from "@/components/web/update-banner";
@@ -53,6 +54,7 @@ const MIN_WINDOW_WIDTH = 900;
 const MIN_WINDOW_HEIGHT = 600;
 const SETUP_WINDOW_WIDTH = 760;
 const SETUP_WINDOW_HEIGHT = 560;
+const CUSTOM_TITLEBAR_HEIGHT = "34px";
 const MINIMUM_APP_WINDOW_SIZE: LogicalWindowSize = {
   width: MIN_WINDOW_WIDTH,
   height: MIN_WINDOW_HEIGHT,
@@ -318,7 +320,7 @@ const MAC_NATIVE_CHROME_STYLE = {
 
 const CUSTOM_CHROME_STYLE = {
   "--studio-titlebar-height": "0px",
-  "--studio-custom-titlebar-height": "34px",
+  "--studio-custom-titlebar-height": CUSTOM_TITLEBAR_HEIGHT,
   "--studio-desktop-titlebar-height": "34px",
   "--studio-sidebar-expanded-width": "17.5rem",
   "--studio-sidebar-collapsed-width": "3rem",
@@ -607,14 +609,16 @@ function TauriWrapper({ children }: { children: ReactNode }) {
   const showSidebarSurface = showApp && !hidesTitlebarSidebar;
 
   return (
-    <div
-      className="relative h-dvh min-h-0 overflow-hidden bg-background"
-      style={CUSTOM_CHROME_STYLE}
-    >
-      {chromeVars}
-      <WindowTitlebar showSidebarSurface={showSidebarSurface} />
-      <div className="h-full min-h-0 overflow-hidden">{content}</div>
-    </div>
+    <SheetViewportInsetProvider top={CUSTOM_TITLEBAR_HEIGHT}>
+      <div
+        className="relative h-dvh min-h-0 overflow-hidden bg-background"
+        style={CUSTOM_CHROME_STYLE}
+      >
+        {chromeVars}
+        <WindowTitlebar showSidebarSurface={showSidebarSurface} />
+        <div className="h-full min-h-0 overflow-hidden">{content}</div>
+      </div>
+    </SheetViewportInsetProvider>
   );
 }
 

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -10,7 +10,6 @@ import {
   shouldUseCustomWindowTitlebar,
   shouldUseNativeMacWindowTitlebar,
 } from "@/components/tauri/window-titlebar";
-import { SheetViewportInsetProvider } from "@/components/ui/sheet";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { WebUpdateBanner } from "@/components/web/update-banner";
@@ -54,7 +53,6 @@ const MIN_WINDOW_WIDTH = 900;
 const MIN_WINDOW_HEIGHT = 600;
 const SETUP_WINDOW_WIDTH = 760;
 const SETUP_WINDOW_HEIGHT = 560;
-const CUSTOM_TITLEBAR_HEIGHT = "34px";
 const MINIMUM_APP_WINDOW_SIZE: LogicalWindowSize = {
   width: MIN_WINDOW_WIDTH,
   height: MIN_WINDOW_HEIGHT,
@@ -320,7 +318,7 @@ const MAC_NATIVE_CHROME_STYLE = {
 
 const CUSTOM_CHROME_STYLE = {
   "--studio-titlebar-height": "0px",
-  "--studio-custom-titlebar-height": CUSTOM_TITLEBAR_HEIGHT,
+  "--studio-custom-titlebar-height": "34px",
   "--studio-desktop-titlebar-height": "34px",
   "--studio-sidebar-expanded-width": "17.5rem",
   "--studio-sidebar-collapsed-width": "3rem",
@@ -609,16 +607,14 @@ function TauriWrapper({ children }: { children: ReactNode }) {
   const showSidebarSurface = showApp && !hidesTitlebarSidebar;
 
   return (
-    <SheetViewportInsetProvider top={CUSTOM_TITLEBAR_HEIGHT}>
-      <div
-        className="relative h-dvh min-h-0 overflow-hidden bg-background"
-        style={CUSTOM_CHROME_STYLE}
-      >
-        {chromeVars}
-        <WindowTitlebar showSidebarSurface={showSidebarSurface} />
-        <div className="h-full min-h-0 overflow-hidden">{content}</div>
-      </div>
-    </SheetViewportInsetProvider>
+    <div
+      className="relative h-dvh min-h-0 overflow-hidden bg-background"
+      style={CUSTOM_CHROME_STYLE}
+    >
+      {chromeVars}
+      <WindowTitlebar showSidebarSurface={showSidebarSurface} />
+      <div className="h-full min-h-0 overflow-hidden">{content}</div>
+    </div>
   );
 }
 

--- a/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
@@ -339,11 +339,6 @@ export const MessageResponseDetailsSheet: FC<{
         side="right"
         className="w-[min(28rem,100vw)] p-0 sm:max-w-[28rem]"
         showCloseButton={false}
-        // Clear the desktop window controls; 0px in the browser and on macOS.
-        style={{
-          height: "calc(100% - var(--studio-custom-titlebar-height, 0px))",
-          marginTop: "var(--studio-custom-titlebar-height, 0px)",
-        }}
       >
         <SheetHeader className="border-b p-4">
           <div className="relative">

--- a/studio/frontend/src/components/ui/sheet.tsx
+++ b/studio/frontend/src/components/ui/sheet.tsx
@@ -103,7 +103,7 @@ function SheetContent({
 }) {
   const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
   const viewportTopInset = useContext(SheetViewportTopInsetContext);
-  // This inline top wins over any top-* utility passed through className.
+  // Inline top beats any top-* utility passed through className.
   const contentStyle =
     position === "fixed" && side !== "bottom"
       ? { top: viewportTopInset, ...style }

--- a/studio/frontend/src/components/ui/sheet.tsx
+++ b/studio/frontend/src/components/ui/sheet.tsx
@@ -11,16 +11,13 @@ import { cn } from "@/lib/utils";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
-// The Windows and Linux custom titlebar paints over the viewport at z-70, so a
-// viewport-fixed sheet anchored to the top opens underneath it. Start below it
-// instead. DesktopChromeVarsEffect mirrors the height onto <html> so sheets
-// portalled to document.body can read it; it is unset in the browser and on
-// macOS, where the 0px fallback applies.
+// Windows/Linux custom titlebar paints over the viewport at z-70, so a fixed
+// sheet must start below it. DesktopChromeVarsEffect mirrors the height onto
+// <html> since sheets portal to document.body; unset in browser/macOS (0px).
 const VIEWPORT_TOP_EDGE =
   "data-[side=left]:top-[var(--studio-custom-titlebar-height,0px)] data-[side=right]:top-[var(--studio-custom-titlebar-height,0px)] data-[side=top]:top-[var(--studio-custom-titlebar-height,0px)]";
 
-// A sheet positioned inside a container follows that container's top edge; no
-// window chrome sits over it.
+// A contained sheet follows its container's top edge; no chrome sits over it.
 const CONTAINED_TOP_EDGE =
   "data-[side=left]:top-0 data-[side=right]:top-0 data-[side=top]:top-0";
 

--- a/studio/frontend/src/components/ui/sheet.tsx
+++ b/studio/frontend/src/components/ui/sheet.tsx
@@ -3,7 +3,7 @@
 
 import { Dialog as SheetPrimitive } from "radix-ui";
 import type * as React from "react";
-import { createContext, useContext, useState } from "react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { DialogPortalContainerContext } from "@/components/ui/dialog";
@@ -11,23 +11,18 @@ import { cn } from "@/lib/utils";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
-const SheetViewportTopInsetContext = createContext<
-  React.CSSProperties["top"]
->(0);
+// The Windows and Linux custom titlebar paints over the viewport at z-70, so a
+// viewport-fixed sheet anchored to the top opens underneath it. Start below it
+// instead. DesktopChromeVarsEffect mirrors the height onto <html> so sheets
+// portalled to document.body can read it; it is unset in the browser and on
+// macOS, where the 0px fallback applies.
+const VIEWPORT_TOP_EDGE =
+  "data-[side=left]:top-[var(--studio-custom-titlebar-height,0px)] data-[side=right]:top-[var(--studio-custom-titlebar-height,0px)] data-[side=top]:top-[var(--studio-custom-titlebar-height,0px)]";
 
-function SheetViewportInsetProvider({
-  children,
-  top,
-}: {
-  children: React.ReactNode;
-  top: React.CSSProperties["top"];
-}) {
-  return (
-    <SheetViewportTopInsetContext.Provider value={top}>
-      {children}
-    </SheetViewportTopInsetContext.Provider>
-  );
-}
+// A sheet positioned inside a container follows that container's top edge; no
+// window chrome sits over it.
+const CONTAINED_TOP_EDGE =
+  "data-[side=left]:top-0 data-[side=right]:top-0 data-[side=top]:top-0";
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
@@ -85,7 +80,6 @@ function SheetOverlay({
 function SheetContent({
   className,
   children,
-  style,
   side = "right",
   showCloseButton = true,
   container,
@@ -102,12 +96,6 @@ function SheetContent({
   overlayPosition?: "fixed" | "absolute";
 }) {
   const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
-  const viewportTopInset = useContext(SheetViewportTopInsetContext);
-  // Inline top beats any top-* utility passed through className.
-  const contentStyle =
-    position === "fixed" && side !== "bottom"
-      ? { top: viewportTopInset, ...style }
-      : style;
   return (
     <SheetPortal container={container ?? undefined}>
       <SheetOverlay
@@ -119,11 +107,11 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 z-50 flex flex-col bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:top-0 data-[side=left]:left-0 data-[side=left]:bottom-0 data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:top-0 data-[side=right]:right-0 data-[side=right]:bottom-0 data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-[side=bottom]:max-h-[85dvh] data-[side=top]:max-h-[85dvh] data-[side=bottom]:overflow-y-auto data-[side=top]:overflow-y-auto",
+          "bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 z-50 flex flex-col bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:left-0 data-[side=left]:bottom-0 data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:right-0 data-[side=right]:bottom-0 data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-[side=bottom]:max-h-[85dvh] data-[side=top]:max-h-[85dvh] data-[side=bottom]:overflow-y-auto data-[side=top]:overflow-y-auto",
           position === "fixed" ? "fixed" : "absolute",
+          position === "fixed" ? VIEWPORT_TOP_EDGE : CONTAINED_TOP_EDGE,
           className,
         )}
-        style={contentStyle}
         {...props}
       >
         <DialogPortalContainerContext.Provider value={contentEl}>
@@ -189,7 +177,6 @@ export {
   SheetClose,
   SheetCloseButton,
   SheetContent,
-  SheetViewportInsetProvider,
   SheetHeader,
   SheetFooter,
   SheetTitle,

--- a/studio/frontend/src/components/ui/sheet.tsx
+++ b/studio/frontend/src/components/ui/sheet.tsx
@@ -3,13 +3,31 @@
 
 import { Dialog as SheetPrimitive } from "radix-ui";
 import type * as React from "react";
-import { useState } from "react";
+import { createContext, useContext, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { DialogPortalContainerContext } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+
+const SheetViewportTopInsetContext = createContext<
+  React.CSSProperties["top"]
+>(0);
+
+function SheetViewportInsetProvider({
+  children,
+  top,
+}: {
+  children: React.ReactNode;
+  top: React.CSSProperties["top"];
+}) {
+  return (
+    <SheetViewportTopInsetContext.Provider value={top}>
+      {children}
+    </SheetViewportTopInsetContext.Provider>
+  );
+}
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
@@ -67,6 +85,7 @@ function SheetOverlay({
 function SheetContent({
   className,
   children,
+  style,
   side = "right",
   showCloseButton = true,
   container,
@@ -83,6 +102,12 @@ function SheetContent({
   overlayPosition?: "fixed" | "absolute";
 }) {
   const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
+  const viewportTopInset = useContext(SheetViewportTopInsetContext);
+  // This inline top wins over any top-* utility passed through className.
+  const contentStyle =
+    position === "fixed" && side !== "bottom"
+      ? { top: viewportTopInset, ...style }
+      : style;
   return (
     <SheetPortal container={container ?? undefined}>
       <SheetOverlay
@@ -94,10 +119,11 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 z-50 flex flex-col bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-[side=bottom]:max-h-[85dvh] data-[side=top]:max-h-[85dvh] data-[side=bottom]:overflow-y-auto data-[side=top]:overflow-y-auto",
+          "bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 z-50 flex flex-col bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:top-0 data-[side=left]:left-0 data-[side=left]:bottom-0 data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:top-0 data-[side=right]:right-0 data-[side=right]:bottom-0 data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-[side=bottom]:max-h-[85dvh] data-[side=top]:max-h-[85dvh] data-[side=bottom]:overflow-y-auto data-[side=top]:overflow-y-auto",
           position === "fixed" ? "fixed" : "absolute",
           className,
         )}
+        style={contentStyle}
         {...props}
       >
         <DialogPortalContainerContext.Provider value={contentEl}>
@@ -163,6 +189,7 @@ export {
   SheetClose,
   SheetCloseButton,
   SheetContent,
+  SheetViewportInsetProvider,
   SheetHeader,
   SheetFooter,
   SheetTitle,

--- a/studio/frontend/src/features/chat/components/research-activity-panel.tsx
+++ b/studio/frontend/src/features/chat/components/research-activity-panel.tsx
@@ -816,7 +816,10 @@ export function ResearchActivityPanel({
   return (
     <aside
       aria-label="Research activity"
-      className="relative flex min-h-0 flex-col bg-background text-foreground"
+      className={cn(
+        "relative flex min-h-0 flex-col bg-background text-foreground",
+        variant === "sheet" && "h-full",
+      )}
       style={
         variant === "panel"
           ? {
@@ -825,11 +828,7 @@ export function ResearchActivityPanel({
               marginTop:
                 "calc(var(--studio-content-top-inset, 0px) + var(--studio-chat-header-height, 48px))",
             }
-          : {
-              height:
-                "calc(100% - var(--studio-custom-titlebar-height, 0px))",
-              marginTop: "var(--studio-custom-titlebar-height, 0px)",
-            }
+          : undefined
       }
     >
       <header className="shrink-0 border-b border-border/70 px-4 py-3.5">

--- a/studio/frontend/src/features/rag/components/document-preview-sheet.tsx
+++ b/studio/frontend/src/features/rag/components/document-preview-sheet.tsx
@@ -408,13 +408,7 @@ export function DocumentPreviewSheet() {
     <Sheet open={open} onOpenChange={(o) => !o && closePreview()}>
       <SheetContent
         side="right"
-        // Clear the desktop window controls; 0px in the browser and on macOS.
-        style={{
-          width: previewWidth,
-          maxWidth: "95vw",
-          height: "calc(100% - var(--studio-custom-titlebar-height, 0px))",
-          marginTop: "var(--studio-custom-titlebar-height, 0px)",
-        }}
+        style={{ width: previewWidth, maxWidth: "95vw" }}
         className={cn(
           "flex w-full flex-col gap-0 p-0",
           resizing && "select-none",

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -495,14 +495,23 @@ def test_fixed_sheets_start_below_the_custom_titlebar():
     provider = APP_PROVIDER.read_text(encoding = "utf-8")
     sheet = SHEET.read_text(encoding = "utf-8")
 
-    assert "<SheetViewportInsetProvider" in provider
-    assert 'position === "fixed" && side !== "bottom"' in sheet
-    for side in ("left", "right"):
+    # Portalled sheets read the height off <html>, so the mirror has to stay.
+    assert 'set("--studio-custom-titlebar-height", usesCustomTitlebar ? "34px" : null)' in provider
+
+    # Only viewport-fixed sheets clear the titlebar. The recipe block sheet is
+    # position="absolute" inside its own container and keeps a plain top edge.
+    assert 'position === "fixed" ? VIEWPORT_TOP_EDGE : CONTAINED_TOP_EDGE' in sheet
+    for side in ("left", "right", "top"):
+        assert f"data-[side={side}]:top-[var(--studio-custom-titlebar-height,0px)]" in sheet
         assert f"data-[side={side}]:top-0" in sheet
+
+    # Anchor both edges so the inset shrinks the sheet rather than pushing its
+    # bottom past the viewport, which a leftover h-full would also do.
+    for side in ("left", "right"):
         assert f"data-[side={side}]:bottom-0" in sheet
         assert f"data-[side={side}]:h-full" not in sheet
 
-    # The context is the only sheet offset; a local one too would double up.
+    # The shared class is the only sheet offset; a local one too would double up.
     # Dialogs still read --studio-window-chrome-top (DesktopChromeVarsEffect).
     for portalled in (
         RESEARCH_ACTIVITY_PANEL,

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -22,6 +22,8 @@ THREAD = FRONTEND / "components/assistant-ui/thread.tsx"
 THREAD_SIDEBAR = FRONTEND / "features/chat/thread-sidebar.tsx"
 SHARED_COMPOSER = FRONTEND / "features/chat/shared-composer.tsx"
 TITLEBAR = FRONTEND / "components/tauri/window-titlebar.tsx"
+SHEET = FRONTEND / "components/ui/sheet.tsx"
+RESEARCH_ACTIVITY_PANEL = FRONTEND / "features/chat/components/research-activity-panel.tsx"
 NATIVE_DIALOGS = REPO / "studio/src-tauri/src/native_file_dialogs.rs"
 NATIVE_CLIPBOARD = REPO / "studio/src-tauri/src/native_clipboard.rs"
 TAURI_MAIN = REPO / "studio/src-tauri/src/main.rs"
@@ -485,6 +487,20 @@ def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
     )
     assert "aria-hidden={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
     assert "inert={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
+
+
+def test_fixed_sheets_start_below_the_custom_titlebar():
+    provider = APP_PROVIDER.read_text(encoding = "utf-8")
+    sheet = SHEET.read_text(encoding = "utf-8")
+    research_activity_panel = RESEARCH_ACTIVITY_PANEL.read_text(encoding = "utf-8")
+
+    assert "<SheetViewportInsetProvider" in provider
+    assert 'position === "fixed" && side !== "bottom"' in sheet
+    for side in ("left", "right"):
+        assert f"data-[side={side}]:top-0" in sheet
+        assert f"data-[side={side}]:bottom-0" in sheet
+        assert f"data-[side={side}]:h-full" not in sheet
+    assert "studio-custom-titlebar-height" not in research_activity_panel
 
 
 def test_visible_mac_sidebar_header_is_a_drag_region():

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -24,6 +24,8 @@ SHARED_COMPOSER = FRONTEND / "features/chat/shared-composer.tsx"
 TITLEBAR = FRONTEND / "components/tauri/window-titlebar.tsx"
 SHEET = FRONTEND / "components/ui/sheet.tsx"
 RESEARCH_ACTIVITY_PANEL = FRONTEND / "features/chat/components/research-activity-panel.tsx"
+RESPONSE_DETAILS_SHEET = FRONTEND / "components/assistant-ui/message-response-details-sheet.tsx"
+DOCUMENT_PREVIEW_SHEET = FRONTEND / "features/rag/components/document-preview-sheet.tsx"
 NATIVE_DIALOGS = REPO / "studio/src-tauri/src/native_file_dialogs.rs"
 NATIVE_CLIPBOARD = REPO / "studio/src-tauri/src/native_clipboard.rs"
 TAURI_MAIN = REPO / "studio/src-tauri/src/main.rs"
@@ -492,7 +494,6 @@ def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
 def test_fixed_sheets_start_below_the_custom_titlebar():
     provider = APP_PROVIDER.read_text(encoding = "utf-8")
     sheet = SHEET.read_text(encoding = "utf-8")
-    research_activity_panel = RESEARCH_ACTIVITY_PANEL.read_text(encoding = "utf-8")
 
     assert "<SheetViewportInsetProvider" in provider
     assert 'position === "fixed" && side !== "bottom"' in sheet
@@ -500,7 +501,16 @@ def test_fixed_sheets_start_below_the_custom_titlebar():
         assert f"data-[side={side}]:top-0" in sheet
         assert f"data-[side={side}]:bottom-0" in sheet
         assert f"data-[side={side}]:h-full" not in sheet
-    assert "studio-custom-titlebar-height" not in research_activity_panel
+
+    # The context is the only titlebar offset for sheets: one that also
+    # compensated locally would be pushed down twice. Dialogs still read
+    # --studio-window-chrome-top, which DesktopChromeVarsEffect mirrors.
+    for portalled in (
+        RESEARCH_ACTIVITY_PANEL,
+        RESPONSE_DETAILS_SHEET,
+        DOCUMENT_PREVIEW_SHEET,
+    ):
+        assert "studio-custom-titlebar-height" not in portalled.read_text(encoding = "utf-8")
 
 
 def test_visible_mac_sidebar_header_is_a_drag_region():

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -502,9 +502,8 @@ def test_fixed_sheets_start_below_the_custom_titlebar():
         assert f"data-[side={side}]:bottom-0" in sheet
         assert f"data-[side={side}]:h-full" not in sheet
 
-    # The context is the only titlebar offset for sheets: one that also
-    # compensated locally would be pushed down twice. Dialogs still read
-    # --studio-window-chrome-top, which DesktopChromeVarsEffect mirrors.
+    # The context is the only sheet offset; a local one too would double up.
+    # Dialogs still read --studio-window-chrome-top (DesktopChromeVarsEffect).
     for portalled in (
         RESEARCH_ACTIVITY_PANEL,
         RESPONSE_DETAILS_SHEET,

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -498,20 +498,20 @@ def test_fixed_sheets_start_below_the_custom_titlebar():
     # Portalled sheets read the height off <html>, so the mirror has to stay.
     assert 'set("--studio-custom-titlebar-height", usesCustomTitlebar ? "34px" : null)' in provider
 
-    # Only viewport-fixed sheets clear the titlebar. The recipe block sheet is
-    # position="absolute" inside its own container and keeps a plain top edge.
+    # Only viewport-fixed sheets clear the titlebar; the absolute recipe block
+    # sheet sits in its own container and keeps a plain top edge.
     assert 'position === "fixed" ? VIEWPORT_TOP_EDGE : CONTAINED_TOP_EDGE' in sheet
     for side in ("left", "right", "top"):
         assert f"data-[side={side}]:top-[var(--studio-custom-titlebar-height,0px)]" in sheet
         assert f"data-[side={side}]:top-0" in sheet
 
-    # Anchor both edges so the inset shrinks the sheet rather than pushing its
-    # bottom past the viewport, which a leftover h-full would also do.
+    # Anchor both edges so the inset shrinks the sheet; h-full would instead
+    # push its bottom past the viewport.
     for side in ("left", "right"):
         assert f"data-[side={side}]:bottom-0" in sheet
         assert f"data-[side={side}]:h-full" not in sheet
 
-    # The shared class is the only sheet offset; a local one too would double up.
+    # The shared class is the only sheet offset; a local one would double up.
     # Dialogs still read --studio-window-chrome-top (DesktopChromeVarsEffect).
     for portalled in (
         RESEARCH_ACTIVITY_PANEL,


### PR DESCRIPTION
## Problem

In the packaged Studio desktop app on Windows and Linux, certain slide-in panels open partly behind the app's opaque custom titlebar. The top 34px of the panel is covered, leaving its title and close button partly hidden.

Still affected on main: chart settings, and the sidebar and run settings panels at mobile-layout widths. Response details, RAG document preview and deep research hit the same bug but each carries its own local offset, which this PR replaces. Browser mode and macOS are unaffected.

## Reproduction

1. Open the packaged Studio desktop app on Windows or Linux.
2. Open chart settings, or the sidebar or run settings panel at a width that uses the mobile layout (reachable on desktop under Windows text scaling, see #7927).
3. The panel starts at the top of the window instead of below the titlebar, leaving its header and close control clipped.

## Root cause

Studio implements these slide-in panels with a shared UI component called `SheetContent`. The custom titlebar is 34px tall and renders above the panels. Fixed panels still start at `top: 0` and fill the viewport, so the titlebar covers their upper edge.

Radix renders the panels under `document.body`, outside the desktop chrome wrapper, so they cannot inherit the titlebar height variable defined there. #7957 solved that by mirroring the variable onto `<html>`, then offset two panels individually. The remaining panels, and any panel added later, still start at `top: 0`.

## Fix

- Read the mirrored `--studio-custom-titlebar-height` in `SheetContent`, so one place offsets every fixed panel. It is unset in the browser and on macOS, where the `0px` fallback applies.
- Apply the inset to fixed panels that open from the top, left, or right.
- Anchor left and right panels with explicit top and bottom edges so they still end at the viewport bottom.
- Leave bottom panels and panels contained inside another element unchanged.
- Remove the now-redundant local compensation from deep research, Response details and RAG document preview.
- Add a focused desktop contract test.

Caller-provided inline styles still take precedence. The overlay remains full-viewport, and the docked chat settings panel keeps its existing in-tree offset.

## Screenshots

### Before

<img width="1134" height="520" alt="sheet-titlebar-overlap-before" src="https://github.com/user-attachments/assets/9aeb0673-2492-4937-b43f-f5070691b217" />

### After
<img width="1134" height="520" alt="sheet-titlebar-overlap-after" src="https://github.com/user-attachments/assets/a2f28120-c4cb-4282-86af-2530e2e2097b" />


## Testing

- `python3 -m pytest tests/studio/test_desktop_reliability_frontend_contract.py -q` (26 passed; `test_desktop_titlebar_separates_navigation_from_sidebar_brand` fails identically on main)
- `npm test` (724 passed)
- `npm run typecheck`
- `git diff --check`

## Runtime validation

Built and ran a Linux AppImage containing this change.

- On main before #7957 added its per-panel offsets, the Response details panel started at the top of the window, underneath the custom titlebar. Its title and close button were clipped.
- With this change, the panel starts immediately below the 34px titlebar and still ends at the bottom of the window. The complete header and close button are visible.

The regression test covers the `<html>` mirror, fixed-panel inset conditions, edge anchoring, and removal of the local offsets.

