### PR TITLE
Studio: center sheet header close buttons

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -334,6 +334,36 @@ const CUSTOM_CHROME_STYLE = {
   "--studio-window-control-inset": "112px",
 } as CSSProperties;
 
+/**
+ * Mirrors the titlebar heights onto <html>. The chrome styles above sit on a
+ * wrapper div, so anything Radix portals into document.body reads them as
+ * empty; overlays that must clear the window controls need them at the root.
+ */
+function DesktopChromeVarsEffect({
+  usesCustomTitlebar,
+  usesNativeMacTitlebar,
+}: {
+  usesCustomTitlebar: boolean;
+  usesNativeMacTitlebar: boolean;
+}) {
+  useEffect(() => {
+    const el = document.documentElement;
+    const set = (name: string, value: string | null) =>
+      value === null
+        ? el.style.removeProperty(name)
+        : el.style.setProperty(name, value);
+    set("--studio-custom-titlebar-height", usesCustomTitlebar ? "34px" : null);
+    set("--studio-mac-titlebar-height", usesNativeMacTitlebar ? "34px" : null);
+    set("--studio-window-control-inset", usesCustomTitlebar ? "112px" : null);
+    return () => {
+      set("--studio-custom-titlebar-height", null);
+      set("--studio-mac-titlebar-height", null);
+      set("--studio-window-control-inset", null);
+    };
+  }, [usesCustomTitlebar, usesNativeMacTitlebar]);
+  return null;
+}
+
 function TauriWrapper({ children }: { children: ReactNode }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const {
@@ -498,6 +528,13 @@ function TauriWrapper({ children }: { children: ReactNode }) {
     />
   );
 
+  const chromeVars = (
+    <DesktopChromeVarsEffect
+      usesCustomTitlebar={usesCustomTitlebar}
+      usesNativeMacTitlebar={usesNativeMacTitlebar}
+    />
+  );
+
   if (!usesCustomTitlebar) {
     // macOS desktop uses the native titlebar and returns here before the
     // custom-titlebar branch, so mount the updater banner on this path too.
@@ -518,12 +555,18 @@ function TauriWrapper({ children }: { children: ReactNode }) {
               className="pointer-events-auto fixed inset-x-0 top-0 z-50 h-[var(--studio-mac-titlebar-height,34px)] select-none"
             />
           ) : null}
+          {chromeVars}
           {content}
         </div>
       );
     }
 
-    return <>{content}</>;
+    return (
+      <>
+        {chromeVars}
+        {content}
+      </>
+    );
   }
 
   const showSidebarSurface = showApp && !hidesTitlebarSidebar;
@@ -533,6 +576,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
       className="relative h-dvh min-h-0 overflow-hidden bg-background"
       style={CUSTOM_CHROME_STYLE}
     >
+      {chromeVars}
       <WindowTitlebar showSidebarSurface={showSidebarSurface} />
       <div className="h-full min-h-0 overflow-hidden">{content}</div>
     </div>

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -334,11 +334,8 @@ const CUSTOM_CHROME_STYLE = {
   "--studio-window-control-inset": "112px",
 } as CSSProperties;
 
-/**
- * Mirrors the titlebar heights onto <html>. The chrome styles above sit on a
- * wrapper div, so anything Radix portals into document.body reads them as
- * empty; overlays that must clear the window controls need them at the root.
- */
+// Mirror the titlebar heights onto <html>: the styles above sit on a wrapper
+// div, so overlays portalled into document.body would read them as empty.
 function DesktopChromeVarsEffect({
   usesCustomTitlebar,
   usesNativeMacTitlebar,

--- a/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
@@ -5,6 +5,7 @@
 
 import {
   Sheet,
+  SheetCloseButton,
   SheetContent,
   SheetDescription,
   SheetHeader,
@@ -18,9 +19,9 @@ import {
   useExternalProvidersStore,
 } from "@/features/chat";
 import { cn } from "@/lib/utils";
+import { useMessage, useMessageTiming } from "@assistant-ui/react";
 import { HelpCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useMessage, useMessageTiming } from "@assistant-ui/react";
 import type { FC, ReactNode } from "react";
 
 type ResponseDetailsMetadata = {
@@ -337,16 +338,20 @@ export const MessageResponseDetailsSheet: FC<{
       <SheetContent
         side="right"
         className="w-[min(28rem,100vw)] p-0 sm:max-w-[28rem]"
+        showCloseButton={false}
       >
         <SheetHeader className="border-b p-4">
-          <SheetTitle className="flex items-center gap-2 pr-10 font-heading text-base">
-            <HugeiconsIcon
-              icon={HelpCircleIcon}
-              strokeWidth={1.75}
-              className="size-icon text-chat-icon-fg"
-            />
-            Response details
-          </SheetTitle>
+          <div className="relative">
+            <SheetTitle className="flex items-center gap-2 pr-10 font-heading text-base">
+              <HugeiconsIcon
+                icon={HelpCircleIcon}
+                strokeWidth={1.75}
+                className="size-icon text-chat-icon-fg"
+              />
+              Response details
+            </SheetTitle>
+            <SheetCloseButton className="absolute top-1/2 right-0 -translate-y-1/2" />
+          </div>
           <SheetDescription className="sr-only">
             Timing, model, token, and tool details for this response.
           </SheetDescription>

--- a/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
@@ -339,6 +339,11 @@ export const MessageResponseDetailsSheet: FC<{
         side="right"
         className="w-[min(28rem,100vw)] p-0 sm:max-w-[28rem]"
         showCloseButton={false}
+        // Clear the desktop window controls; 0px in the browser and on macOS.
+        style={{
+          height: "calc(100% - var(--studio-custom-titlebar-height, 0px))",
+          marginTop: "var(--studio-custom-titlebar-height, 0px)",
+        }}
       >
         <SheetHeader className="border-b p-4">
           <div className="relative">

--- a/studio/frontend/src/components/ui/sheet.tsx
+++ b/studio/frontend/src/components/ui/sheet.tsx
@@ -27,6 +27,17 @@ function SheetClose({
   return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
+function SheetCloseButton({ className }: { className?: string }) {
+  return (
+    <SheetPrimitive.Close data-slot="sheet-close" asChild={true}>
+      <Button variant="ghost" className={className} size="icon-sm">
+        <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
+        <span className="sr-only">Close</span>
+      </Button>
+    </SheetPrimitive.Close>
+  );
+}
+
 function SheetPortal({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
@@ -93,16 +104,7 @@ function SheetContent({
           {children}
         </DialogPortalContainerContext.Provider>
         {showCloseButton && (
-          <SheetPrimitive.Close data-slot="sheet-close" asChild>
-            <Button
-              variant="ghost"
-              className="absolute top-4 right-4"
-              size="icon-sm"
-            >
-              <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
-              <span className="sr-only">Close</span>
-            </Button>
-          </SheetPrimitive.Close>
+          <SheetCloseButton className="absolute top-4 right-4" />
         )}
       </SheetPrimitive.Content>
     </SheetPortal>
@@ -159,6 +161,7 @@ export {
   Sheet,
   SheetTrigger,
   SheetClose,
+  SheetCloseButton,
   SheetContent,
   SheetHeader,
   SheetFooter,

--- a/studio/frontend/src/features/rag/components/document-preview-sheet.tsx
+++ b/studio/frontend/src/features/rag/components/document-preview-sheet.tsx
@@ -408,7 +408,13 @@ export function DocumentPreviewSheet() {
     <Sheet open={open} onOpenChange={(o) => !o && closePreview()}>
       <SheetContent
         side="right"
-        style={{ width: previewWidth, maxWidth: "95vw" }}
+        // Clear the desktop window controls; 0px in the browser and on macOS.
+        style={{
+          width: previewWidth,
+          maxWidth: "95vw",
+          height: "calc(100% - var(--studio-custom-titlebar-height, 0px))",
+          marginTop: "var(--studio-custom-titlebar-height, 0px)",
+        }}
         className={cn(
           "flex w-full flex-col gap-0 p-0",
           resizing && "select-none",

--- a/studio/frontend/src/features/rag/components/document-preview-sheet.tsx
+++ b/studio/frontend/src/features/rag/components/document-preview-sheet.tsx
@@ -16,6 +16,7 @@ import { Spinner } from "@/components/ui/spinner";
 
 import {
   Sheet,
+  SheetCloseButton,
   SheetContent,
   SheetHeader,
   SheetTitle,
@@ -412,6 +413,7 @@ export function DocumentPreviewSheet() {
           "flex w-full flex-col gap-0 p-0",
           resizing && "select-none",
         )}
+        showCloseButton={false}
       >
         {/* Drag the left edge to widen the preview; double-click to reset. */}
         <div
@@ -429,16 +431,18 @@ export function DocumentPreviewSheet() {
           )}
         />
         <SheetHeader className="gap-1 border-b p-4">
-          {/* pr-10 reserves room for the absolute close button. */}
-          <SheetTitle className="flex items-center gap-2 pr-10 text-sm">
-            <FileTextIcon className="size-4 shrink-0" />
-            <span className="min-w-0 truncate">{headerName}</span>
-            {headerPage != null && (
-              <span className="shrink-0 text-muted-foreground">
-                · page {headerPage}
-              </span>
-            )}
-          </SheetTitle>
+          <div className="relative">
+            <SheetTitle className="flex items-center gap-2 pr-10 text-sm">
+              <FileTextIcon className="size-4 shrink-0" />
+              <span className="min-w-0 truncate">{headerName}</span>
+              {headerPage != null && (
+                <span className="shrink-0 text-muted-foreground">
+                  · page {headerPage}
+                </span>
+              )}
+            </SheetTitle>
+            <SheetCloseButton className="absolute top-1/2 right-0 -translate-y-1/2" />
+          </div>
         </SheetHeader>
 
         <div className="min-h-0 flex-1">

--- a/tests/studio/test_chat_response_details_ui_contract.py
+++ b/tests/studio/test_chat_response_details_ui_contract.py
@@ -13,6 +13,10 @@ THREAD_TSX = REPO / "studio/frontend/src/components/assistant-ui/thread.tsx"
 DETAILS_TSX = (
     REPO / "studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx"
 )
+DOCUMENT_PREVIEW_TSX = (
+    REPO / "studio/frontend/src/features/rag/components/document-preview-sheet.tsx"
+)
+SHEET_TSX = REPO / "studio/frontend/src/components/ui/sheet.tsx"
 REASONING_TSX = REPO / "studio/frontend/src/components/assistant-ui/reasoning.tsx"
 ADAPTER_TS = REPO / "studio/frontend/src/features/chat/api/chat-adapter.ts"
 CHAT_PREFS_TS = REPO / "studio/frontend/src/features/chat/stores/chat-preferences-store.ts"
@@ -43,6 +47,44 @@ def test_response_details_sheet_uses_unsloth_sheet_and_key_sections():
         assert f'title="{section}"' in src
     for field in ["Model", "Provider", "Total", "Cache hits", "Enabled", "Called"]:
         assert f'label="{field}"' in src
+
+
+def assert_sheet_close_button_tracks_title_center(src: str) -> None:
+    content_start = src.index("<SheetContent")
+    content_tail = src[content_start:]
+    content_end = re.search(r"(?m)^\s*>\s*$", content_tail)
+    assert content_end is not None
+    content_open = content_tail[: content_end.end()]
+    header = src[src.index("<SheetHeader") : src.index("</SheetHeader>")]
+    close_start = header.index("<SheetCloseButton")
+    close = header[close_start : header.index("/>", close_start)]
+    class_name = re.search(r'className="([^"]+)"', close)
+
+    assert "showCloseButton={false}" in content_open
+    assert '<div className="relative">' in header
+    assert class_name is not None
+    class_tokens = class_name.group(1).split()
+    for token in ["absolute", "top-1/2", "right-0", "-translate-y-1/2"]:
+        assert token in class_tokens
+
+
+def test_sheet_headers_center_the_shared_close_button_on_the_title():
+    assert_sheet_close_button_tracks_title_center(
+        DETAILS_TSX.read_text(encoding = "utf-8"),
+    )
+    assert_sheet_close_button_tracks_title_center(
+        DOCUMENT_PREVIEW_TSX.read_text(encoding = "utf-8"),
+    )
+
+    sheet_src = SHEET_TSX.read_text(encoding = "utf-8")
+    close_button = sheet_src[
+        sheet_src.index("function SheetCloseButton") : sheet_src.index("function SheetPortal")
+    ]
+    assert 'variant="ghost"' in close_button
+    assert 'size="icon-sm"' in close_button
+    assert "Cancel01Icon" in close_button
+    assert '<span className="sr-only">Close</span>' in close_button
+    assert '<SheetCloseButton className="absolute top-4 right-4" />' in sheet_src
 
 
 def test_response_model_badge_is_user_configurable_and_rendered_once_per_message():


### PR DESCRIPTION
## Summary

The close buttons in Response details and Document preview are not vertically aligned with their titles. The shared default uses a fixed 16px top offset for a 32px button, while the title lines follow Studio's adjustable UI font size.

This PR keeps both close buttons centered on their titles across the full 12px to 20px UI font-size range.

## What changed

- Add a shared `SheetCloseButton` that preserves the existing icon, size, style, and accessible label.
- Position it against the title line in Response details and Document preview instead of using the sheet's fixed top offset.
- Keep the default close-button behavior for every other sheet unchanged.
- Add focused contract coverage for both headers and the shared control.

The header height, title position, button size, and horizontal position are unchanged.

## Screenshots

### Before
<img width="448" height="72" alt="response-details-alignment-before" src="https://github.com/user-attachments/assets/a7887121-c48f-466d-a292-526726ab1cd8" />



### After

<img width="448" height="72" alt="response-details-alignment-after" src="https://github.com/user-attachments/assets/8e3697b3-80d1-4f6f-8172-eacab55fceca" />

## Testing

- `npm run typecheck`
- `npm run build`
- `npm exec eslint src/components/ui/sheet.tsx src/components/assistant-ui/message-response-details-sheet.tsx`
- `python -m pytest tests/studio/test_chat_response_details_ui_contract.py -q` (7 passed)
- `git diff --check`

## Runtime validation

Built and served Studio from this branch, then measured both rendered header structures with Playwright against the compiled application stylesheet.

At the default 15px UI font size, the old fixed offset put the Response details close button 4.750px below its title center and the Document preview close button 6.625px below its title center. Both differences are 0.000px after the change.

The centers also match exactly at the 12px, 16px, and 20px UI font sizes. The Response details sheet was additionally exercised in a live chat.
