### PR TITLE
Stop the health watchdog bypassing the backend startup grace period

### DIFF
--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -850,7 +850,7 @@ async fn health_watchdog(
         }
 
         let should_count_failure =
-            port.is_some() || should_count_watchdog_failure(has_seen_healthy, started_at.elapsed());
+            should_count_watchdog_failure(has_seen_healthy, started_at.elapsed());
 
         let Some(port) = port else {
             if has_adopted {


### PR DESCRIPTION
The watchdog was killing backends that were slow to start, not broken.

`should_count_failure` was `port.is_some() || should_count_watchdog_failure(...)`. The health-check branch only runs when the port is Some, so the left side was always true and the 5-minute startup grace period never applied. The "before grace period elapsed" log line it guards has never once printed.

A cold torch import stalls /api/health for 30-45s on Apple Silicon  three failed probes so the backend got SIGTERM'd at ~t+66s instead of the ~t+330s the code documents.