### PR TITLE
Desktop: Fix "Copy path" failing in the desktop app

### DIFF
--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -45,39 +45,28 @@ function copyWithExecCommand(text: string): boolean {
   }
 }
 
-/**
- * Start the async Clipboard API write without awaiting it. The spec reads transient
- * activation when writeText is *called*, so arming it here keeps the result usable
- * after a later await. Null when the API is missing (insecure context).
- */
-function startWebClipboardWrite(text: string): Promise<boolean> | null {
-  if (typeof navigator?.clipboard?.writeText !== "function") return null;
-  return navigator.clipboard.writeText(text).then(
-    () => true,
-    (error) => {
-      console.warn("Async clipboard API failed, falling back to execCommand", error);
-      return false;
-    },
-  );
-}
-
 export async function copyToClipboard(text: string): Promise<boolean> {
   if (typeof text !== "string" || text.length === 0) {
     return false;
   }
 
-  // Armed before any await, so it still carries the click's activation even when the
-  // Tauri attempt below yields first and then fails.
-  const webWrite = startWebClipboardWrite(text);
-
-  // Native IPC has no activation requirement, which is the whole point: callers that
-  // await something before copying have already lost the gesture.
-  const nativeOk = isTauri ? await copyWithTauriClipboard(text) : false;
-  // Always settle the armed write, even once native has succeeded: returning with it
-  // still in flight would let it land after the user's next copy and clobber it.
-  const webOk = webWrite ? await webWrite : false;
-  if (nativeOk || webOk) {
+  // Exactly one writer runs per call. Pre-arming the web write would keep the click's
+  // activation for a native failure, but it also leaves a second write in flight that a
+  // rapid second copy can lose a race to, and a silently stale clipboard is worse than a
+  // visible failure. Gated synchronously, so a browser still writes inside the gesture.
+  if (isTauri && (await copyWithTauriClipboard(text))) {
     return true;
+  }
+
+  // Primary: async Clipboard API
+  if (typeof navigator?.clipboard?.writeText === "function") {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      console.warn("Async clipboard API failed, falling back to execCommand", error);
+      // Rejected (NotAllowedError, insecure context, etc.); fall through.
+    }
   }
 
   // Fallback: execCommand (works in Safari when called during user gesture)

--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -1,6 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { isTauri } from "@/lib/api-base";
+
+// Native IPC, so it works outside a user gesture (e.g. after an await).
+async function copyWithTauriClipboard(text: string): Promise<boolean> {
+  if (!isTauri) return false;
+  try {
+    const { writeText } = await import("@tauri-apps/plugin-clipboard-manager");
+    await writeText(text);
+    return true;
+  } catch (error) {
+    console.warn("Tauri clipboard-manager writeText failed", error);
+    return false;
+  }
+}
+
 /**
  * Synchronous textarea + execCommand copy so it runs in the same user gesture
  * as the click (required by Safari's clipboard security).
@@ -34,6 +49,10 @@ function copyWithExecCommand(text: string): boolean {
 export async function copyToClipboard(text: string): Promise<boolean> {
   if (typeof text !== "string" || text.length === 0) {
     return false;
+  }
+
+  if (await copyWithTauriClipboard(text)) {
+    return true;
   }
 
   // Primary: async Clipboard API

--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -72,11 +72,11 @@ export async function copyToClipboard(text: string): Promise<boolean> {
 
   // Native IPC has no activation requirement, which is the whole point: callers that
   // await something before copying have already lost the gesture.
-  if (isTauri && (await copyWithTauriClipboard(text))) {
-    return true;
-  }
-
-  if (webWrite && (await webWrite)) {
+  const nativeOk = isTauri ? await copyWithTauriClipboard(text) : false;
+  // Always settle the armed write, even once native has succeeded: returning with it
+  // still in flight would let it land after the user's next copy and clobber it.
+  const webOk = webWrite ? await webWrite : false;
+  if (nativeOk || webOk) {
     return true;
   }
 

--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -45,26 +45,39 @@ function copyWithExecCommand(text: string): boolean {
   }
 }
 
+/**
+ * Start the async Clipboard API write without awaiting it. The spec reads transient
+ * activation when writeText is *called*, so arming it here keeps the result usable
+ * after a later await. Null when the API is missing (insecure context).
+ */
+function startWebClipboardWrite(text: string): Promise<boolean> | null {
+  if (typeof navigator?.clipboard?.writeText !== "function") return null;
+  return navigator.clipboard.writeText(text).then(
+    () => true,
+    (error) => {
+      console.warn("Async clipboard API failed, falling back to execCommand", error);
+      return false;
+    },
+  );
+}
+
 export async function copyToClipboard(text: string): Promise<boolean> {
   if (typeof text !== "string" || text.length === 0) {
     return false;
   }
 
-  // Gate synchronously so non-Tauri browsers reach the web paths without
-  // yielding out of the user gesture.
+  // Armed before any await, so it still carries the click's activation even when the
+  // Tauri attempt below yields first and then fails.
+  const webWrite = startWebClipboardWrite(text);
+
+  // Native IPC has no activation requirement, which is the whole point: callers that
+  // await something before copying have already lost the gesture.
   if (isTauri && (await copyWithTauriClipboard(text))) {
     return true;
   }
 
-  // Primary: async Clipboard API
-  if (typeof navigator?.clipboard?.writeText === "function") {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch (error) {
-      console.warn("Async clipboard API failed, falling back to execCommand", error);
-      // Rejected (NotAllowedError, insecure context, etc.); fall through.
-    }
+  if (webWrite && (await webWrite)) {
+    return true;
   }
 
   // Fallback: execCommand (works in Safari when called during user gesture)

--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -5,7 +5,6 @@ import { isTauri } from "@/lib/api-base";
 
 // Native IPC, so it works outside a user gesture (e.g. after an await).
 async function copyWithTauriClipboard(text: string): Promise<boolean> {
-  if (!isTauri) return false;
   try {
     const { writeText } = await import("@tauri-apps/plugin-clipboard-manager");
     await writeText(text);
@@ -51,7 +50,9 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     return false;
   }
 
-  if (await copyWithTauriClipboard(text)) {
+  // Gate synchronously so non-Tauri browsers reach the web paths without
+  // yielding out of the user gesture.
+  if (isTauri && (await copyWithTauriClipboard(text))) {
     return true;
   }
 

--- a/studio/frontend/src/lib/tauri-diagnostics.ts
+++ b/studio/frontend/src/lib/tauri-diagnostics.ts
@@ -142,26 +142,10 @@ async function collectDiagnosticsReport(
   }
 }
 
-async function copyWithTauriClipboard(text: string): Promise<boolean> {
-  if (!isTauri) return false;
-  try {
-    const { writeText } = await import("@tauri-apps/plugin-clipboard-manager");
-    await writeText(text);
-    return true;
-  } catch (error) {
-    console.warn("Tauri clipboard-manager writeText failed", error);
-    return false;
-  }
-}
-
 export async function copySupportDiagnostics(
   snapshot: FrontendSupportSnapshot,
 ): Promise<CopySupportDiagnosticsResult> {
   const { report, source } = await collectDiagnosticsReport(snapshot);
-
-  if (await copyWithTauriClipboard(report)) {
-    return { ok: true, report, source };
-  }
 
   if (await copyToClipboard(report)) {
     return { ok: true, report, source };

--- a/studio/frontend/tests/copy-to-clipboard.test.ts
+++ b/studio/frontend/tests/copy-to-clipboard.test.ts
@@ -24,14 +24,19 @@ type Recorder = {
   appended: number;
   removed: number;
   nativeWrites: string[];
+  /** Resolves a "deferred" web write. */
+  settleWeb: () => void;
 };
 
 type EnvOptions = {
   tauri: boolean;
   /** How the stubbed Tauri plugin behaves once it is reached. */
   stub?: StubMode;
-  /** "absent" drops navigator.clipboard entirely, as an insecure context does. */
-  clipboard?: "ok" | "reject" | "absent";
+  /**
+   * "absent" drops navigator.clipboard entirely, as an insecure context does.
+   * "deferred" leaves the write pending until `settleWeb()` is called.
+   */
+  clipboard?: "ok" | "reject" | "absent" | "deferred";
   execCommandResult?: boolean;
 };
 
@@ -63,6 +68,7 @@ async function load(options: EnvOptions) {
     appended: 0,
     removed: 0,
     nativeWrites: [],
+    settleWeb: () => {},
   };
 
   const windowStub: Record<string, unknown> = {
@@ -105,9 +111,15 @@ async function load(options: EnvOptions) {
         : {
             writeText(text: string) {
               recorder.webWrites.push(text);
-              return clipboard === "reject"
-                ? Promise.reject(new Error("NotAllowedError"))
-                : Promise.resolve();
+              if (clipboard === "reject") {
+                return Promise.reject(new Error("NotAllowedError"));
+              }
+              if (clipboard === "deferred") {
+                return new Promise<void>((resolve) => {
+                  recorder.settleWeb = resolve;
+                });
+              }
+              return Promise.resolve();
             },
           },
   });
@@ -188,6 +200,32 @@ test("Tauri build lets the native write decide the result", async () => {
   assert.equal(await copyToClipboard("model/path.gguf"), true);
   assert.deepEqual(recorder.nativeWrites, ["model/path.gguf"]);
   assert.deepEqual(recorder.execCommands, [], "no need for the deprecated fallback");
+});
+
+test("Tauri build does not return with the armed web write still in flight", async () => {
+  const { copyToClipboard, recorder } = await load({
+    tauri: true,
+    clipboard: "deferred",
+  });
+
+  const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+  let settled = false;
+  const pending = copyToClipboard("model/path.gguf").then((ok) => {
+    settled = true;
+    return ok;
+  });
+
+  // Drain past the plugin's dynamic import, so "not settled" below means the call is
+  // genuinely waiting on the web write rather than still loading the native one.
+  for (let i = 0; i < 50 && recorder.nativeWrites.length === 0; i += 1) await tick();
+  assert.deepEqual(recorder.nativeWrites, ["model/path.gguf"], "native write ran");
+  for (let i = 0; i < 5; i += 1) await tick();
+
+  // Returning here would leave the armed write to land on whatever the user copies next.
+  assert.equal(settled, false, "must wait for the armed write to settle");
+
+  recorder.settleWeb();
+  assert.equal(await pending, true);
 });
 
 test("Tauri build arms the web write inside the gesture", async () => {

--- a/studio/frontend/tests/copy-to-clipboard.test.ts
+++ b/studio/frontend/tests/copy-to-clipboard.test.ts
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// lib/api-base derives `isTauri` once, at module evaluation, from globals that must
+// already be in place. clipboard-resolver.mjs copies a "?bust=N" key down the import
+// chain so each case gets its own evaluation of copy-to-clipboard + api-base, and
+// swaps @tauri-apps/plugin-clipboard-manager for a stub.
+register("./helpers/clipboard-resolver.mjs", import.meta.url);
+
+const MODULE = fileURLToPath(
+  new URL("../src/lib/copy-to-clipboard.ts", import.meta.url),
+);
+
+type StubMode = "ok" | "write-fails" | "module-missing";
+
+type Recorder = {
+  webWrites: string[];
+  execCommands: string[];
+  appended: number;
+  removed: number;
+  nativeWrites: string[];
+};
+
+type EnvOptions = {
+  tauri: boolean;
+  /** How the stubbed Tauri plugin behaves once it is reached. */
+  stub?: StubMode;
+  /** "absent" drops navigator.clipboard entirely, as an insecure context does. */
+  clipboard?: "ok" | "reject" | "absent";
+  execCommandResult?: boolean;
+};
+
+let generation = 0;
+
+function define(name: string, value: unknown) {
+  Object.defineProperty(globalThis, name, {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/**
+ * Install the globals copy-to-clipboard and api-base read, then import a fresh copy
+ * of the module under test. Returns the module plus a recorder of every writer.
+ */
+async function load(options: EnvOptions) {
+  const {
+    tauri,
+    stub = "ok",
+    clipboard = "ok",
+    execCommandResult = true,
+  } = options;
+
+  const recorder: Recorder = {
+    webWrites: [],
+    execCommands: [],
+    appended: 0,
+    removed: 0,
+    nativeWrites: [],
+  };
+
+  const windowStub: Record<string, unknown> = {
+    location: { protocol: tauri ? "tauri:" : "https:" },
+  };
+  if (tauri) {
+    windowStub.__TAURI_INTERNALS__ = {};
+  }
+  define("window", windowStub);
+
+  define("document", {
+    body: {
+      appendChild() {
+        recorder.appended += 1;
+      },
+      removeChild() {
+        recorder.removed += 1;
+      },
+    },
+    createElement() {
+      return {
+        value: "",
+        readOnly: false,
+        style: {} as Record<string, string>,
+        setAttribute() {},
+        focus() {},
+        select() {},
+      };
+    },
+    execCommand(command: string) {
+      recorder.execCommands.push(command);
+      return execCommandResult;
+    },
+  });
+
+  define("navigator", {
+    clipboard:
+      clipboard === "absent"
+        ? undefined
+        : {
+            writeText(text: string) {
+              recorder.webWrites.push(text);
+              return clipboard === "reject"
+                ? Promise.reject(new Error("NotAllowedError"))
+                : Promise.resolve();
+            },
+          },
+  });
+
+  // A fresh array per case, not a truncated shared one: the stub resolves
+  // `control.calls` at call time, so a late write cannot reach an earlier recorder.
+  generation += 1;
+  const control = ((globalThis as Record<string, unknown>).__TAURI_CLIPBOARD_STUB__ ??=
+    {}) as { calls: string[]; mode: StubMode };
+  control.calls = recorder.nativeWrites;
+  control.mode = stub;
+
+  const mod = (await import(`${MODULE}?bust=${generation}`)) as {
+    copyToClipboard: (text: string) => Promise<boolean>;
+  };
+  const api = (await import(
+    `${fileURLToPath(new URL("../src/lib/api-base.ts", import.meta.url))}?bust=${generation}`
+  )) as { isTauri: boolean };
+
+  assert.equal(api.isTauri, tauri, "isTauri did not match the staged environment");
+  return { copyToClipboard: mod.copyToClipboard, recorder };
+}
+
+// Silence the module's console.warn on the deliberate-failure cases.
+const realWarn = console.warn;
+test.before(() => {
+  console.warn = () => {};
+});
+test.after(() => {
+  console.warn = realWarn;
+});
+
+test("web build writes through navigator.clipboard before yielding", async () => {
+  const { copyToClipboard, recorder } = await load({ tauri: false });
+
+  // Not awaited yet: an async function runs synchronously up to its first await, so
+  // if the Tauri gate yielded, writeText would still be unreached at this point and
+  // the browser would have dropped transient activation by the time it ran. Snapshot
+  // before awaiting, and drain before asserting, so a failure cannot leave the
+  // continuation writing into the next case's recorder.
+  const pending = copyToClipboard("hello");
+  const writtenInGesture = [...recorder.webWrites];
+  const nativeInGesture = recorder.nativeWrites.length;
+  const result = await pending;
+
+  assert.deepEqual(
+    writtenInGesture,
+    ["hello"],
+    "navigator.clipboard.writeText must be called in the same tick as the click",
+  );
+  assert.equal(nativeInGesture, 0, "web build must not reach Tauri IPC");
+  assert.equal(result, true);
+  assert.deepEqual(recorder.execCommands, []);
+});
+
+test("web build reaches execCommand in the same tick when clipboard is absent", async () => {
+  const { copyToClipboard, recorder } = await load({
+    tauri: false,
+    clipboard: "absent",
+  });
+
+  const pending = copyToClipboard("hello");
+  const ranInGesture = [...recorder.execCommands];
+  const result = await pending;
+
+  assert.deepEqual(
+    ranInGesture,
+    ["copy"],
+    "the synchronous fallback must also run inside the gesture",
+  );
+  assert.equal(result, true);
+  assert.equal(recorder.removed, recorder.appended, "textarea must be cleaned up");
+});
+
+test("Tauri build copies natively and never touches navigator.clipboard", async () => {
+  const { copyToClipboard, recorder } = await load({ tauri: true });
+
+  assert.equal(await copyToClipboard("model/path.gguf"), true);
+  assert.deepEqual(recorder.nativeWrites, ["model/path.gguf"]);
+  assert.deepEqual(recorder.webWrites, []);
+  assert.deepEqual(recorder.execCommands, []);
+});
+
+test("Tauri build does not resolve the native writer before the first await", async () => {
+  const { copyToClipboard, recorder } = await load({ tauri: true });
+
+  const pending = copyToClipboard("model/path.gguf");
+  const nativeInGesture = [...recorder.nativeWrites];
+  const result = await pending;
+
+  assert.deepEqual(
+    nativeInGesture,
+    [],
+    "the dynamic import necessarily yields; native IPC is exempt from the gesture rule",
+  );
+  assert.equal(result, true);
+  assert.deepEqual(recorder.nativeWrites, ["model/path.gguf"]);
+});
+
+test("execCommand fallback runs when navigator.clipboard.writeText rejects", async () => {
+  const { copyToClipboard, recorder } = await load({
+    tauri: false,
+    clipboard: "reject",
+  });
+
+  assert.equal(await copyToClipboard("hello"), true);
+  assert.deepEqual(recorder.webWrites, ["hello"]);
+  assert.deepEqual(recorder.execCommands, ["copy"]);
+});
+
+test("copyToClipboard reports failure when every writer fails", async () => {
+  const { copyToClipboard, recorder } = await load({
+    tauri: false,
+    clipboard: "reject",
+    execCommandResult: false,
+  });
+
+  assert.equal(await copyToClipboard("hello"), false);
+  assert.deepEqual(recorder.execCommands, ["copy"]);
+  assert.equal(recorder.removed, recorder.appended);
+});
+
+test("a failed native write still falls through to the web writers", async () => {
+  const { copyToClipboard, recorder } = await load({
+    tauri: true,
+    stub: "write-fails",
+  });
+
+  assert.equal(await copyToClipboard("hello"), true);
+  assert.deepEqual(recorder.nativeWrites, ["hello"]);
+  assert.deepEqual(recorder.webWrites, ["hello"], "must degrade, not give up");
+});
+
+test("an install without the clipboard plugin falls through to the web writers", async () => {
+  const { copyToClipboard, recorder } = await load({
+    tauri: true,
+    stub: "module-missing",
+  });
+
+  assert.equal(await copyToClipboard("hello"), true);
+  assert.deepEqual(recorder.nativeWrites, [], "the import threw before writeText");
+  assert.deepEqual(recorder.webWrites, ["hello"]);
+});
+
+test("empty and non-string input returns false and touches no writer", async () => {
+  for (const tauri of [false, true]) {
+    const { copyToClipboard, recorder } = await load({ tauri });
+
+    assert.equal(await copyToClipboard(""), false);
+    assert.equal(await copyToClipboard(undefined as unknown as string), false);
+    assert.equal(await copyToClipboard(null as unknown as string), false);
+    assert.equal(await copyToClipboard(42 as unknown as string), false);
+
+    assert.deepEqual(recorder.nativeWrites, []);
+    assert.deepEqual(recorder.webWrites, []);
+    assert.deepEqual(recorder.execCommands, []);
+    assert.equal(recorder.appended, 0);
+  }
+});

--- a/studio/frontend/tests/copy-to-clipboard.test.ts
+++ b/studio/frontend/tests/copy-to-clipboard.test.ts
@@ -24,19 +24,14 @@ type Recorder = {
   appended: number;
   removed: number;
   nativeWrites: string[];
-  /** Resolves a "deferred" web write. */
-  settleWeb: () => void;
 };
 
 type EnvOptions = {
   tauri: boolean;
   /** How the stubbed Tauri plugin behaves once it is reached. */
   stub?: StubMode;
-  /**
-   * "absent" drops navigator.clipboard entirely, as an insecure context does.
-   * "deferred" leaves the write pending until `settleWeb()` is called.
-   */
-  clipboard?: "ok" | "reject" | "absent" | "deferred";
+  /** "absent" drops navigator.clipboard entirely, as an insecure context does. */
+  clipboard?: "ok" | "reject" | "absent";
   execCommandResult?: boolean;
 };
 
@@ -68,7 +63,6 @@ async function load(options: EnvOptions) {
     appended: 0,
     removed: 0,
     nativeWrites: [],
-    settleWeb: () => {},
   };
 
   const windowStub: Record<string, unknown> = {
@@ -113,11 +107,6 @@ async function load(options: EnvOptions) {
               recorder.webWrites.push(text);
               if (clipboard === "reject") {
                 return Promise.reject(new Error("NotAllowedError"));
-              }
-              if (clipboard === "deferred") {
-                return new Promise<void>((resolve) => {
-                  recorder.settleWeb = resolve;
-                });
               }
               return Promise.resolve();
             },
@@ -194,58 +183,14 @@ test("web build reaches execCommand in the same tick when clipboard is absent", 
   assert.equal(recorder.removed, recorder.appended, "textarea must be cleaned up");
 });
 
-test("Tauri build lets the native write decide the result", async () => {
+test("Tauri build copies natively and never touches navigator.clipboard", async () => {
   const { copyToClipboard, recorder } = await load({ tauri: true });
 
   assert.equal(await copyToClipboard("model/path.gguf"), true);
   assert.deepEqual(recorder.nativeWrites, ["model/path.gguf"]);
-  assert.deepEqual(recorder.execCommands, [], "no need for the deprecated fallback");
-});
-
-test("Tauri build does not return with the armed web write still in flight", async () => {
-  const { copyToClipboard, recorder } = await load({
-    tauri: true,
-    clipboard: "deferred",
-  });
-
-  const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
-  let settled = false;
-  const pending = copyToClipboard("model/path.gguf").then((ok) => {
-    settled = true;
-    return ok;
-  });
-
-  // Drain past the plugin's dynamic import, so "not settled" below means the call is
-  // genuinely waiting on the web write rather than still loading the native one.
-  for (let i = 0; i < 50 && recorder.nativeWrites.length === 0; i += 1) await tick();
-  assert.deepEqual(recorder.nativeWrites, ["model/path.gguf"], "native write ran");
-  for (let i = 0; i < 5; i += 1) await tick();
-
-  // Returning here would leave the armed write to land on whatever the user copies next.
-  assert.equal(settled, false, "must wait for the armed write to settle");
-
-  recorder.settleWeb();
-  assert.equal(await pending, true);
-});
-
-test("Tauri build arms the web write inside the gesture", async () => {
-  const { copyToClipboard, recorder } = await load({
-    tauri: true,
-    stub: "write-fails",
-  });
-
-  // The native attempt yields before it fails, so the only way its fallback can still
-  // hold the click's activation is if writeText was already called by this point.
-  const pending = copyToClipboard("model/path.gguf");
-  const armedInGesture = [...recorder.webWrites];
-  const result = await pending;
-
-  assert.deepEqual(
-    armedInGesture,
-    ["model/path.gguf"],
-    "the web write must be issued before the first await, not after the native failure",
-  );
-  assert.equal(result, true);
+  // Exactly one writer per call, so nothing is left in flight to clobber a later copy.
+  assert.deepEqual(recorder.webWrites, []);
+  assert.deepEqual(recorder.execCommands, []);
 });
 
 test("Tauri build does not resolve the native writer before the first await", async () => {

--- a/studio/frontend/tests/copy-to-clipboard.test.ts
+++ b/studio/frontend/tests/copy-to-clipboard.test.ts
@@ -182,13 +182,32 @@ test("web build reaches execCommand in the same tick when clipboard is absent", 
   assert.equal(recorder.removed, recorder.appended, "textarea must be cleaned up");
 });
 
-test("Tauri build copies natively and never touches navigator.clipboard", async () => {
+test("Tauri build lets the native write decide the result", async () => {
   const { copyToClipboard, recorder } = await load({ tauri: true });
 
   assert.equal(await copyToClipboard("model/path.gguf"), true);
   assert.deepEqual(recorder.nativeWrites, ["model/path.gguf"]);
-  assert.deepEqual(recorder.webWrites, []);
-  assert.deepEqual(recorder.execCommands, []);
+  assert.deepEqual(recorder.execCommands, [], "no need for the deprecated fallback");
+});
+
+test("Tauri build arms the web write inside the gesture", async () => {
+  const { copyToClipboard, recorder } = await load({
+    tauri: true,
+    stub: "write-fails",
+  });
+
+  // The native attempt yields before it fails, so the only way its fallback can still
+  // hold the click's activation is if writeText was already called by this point.
+  const pending = copyToClipboard("model/path.gguf");
+  const armedInGesture = [...recorder.webWrites];
+  const result = await pending;
+
+  assert.deepEqual(
+    armedInGesture,
+    ["model/path.gguf"],
+    "the web write must be issued before the first await, not after the native failure",
+  );
+  assert.equal(result, true);
 });
 
 test("Tauri build does not resolve the native writer before the first await", async () => {

--- a/studio/frontend/tests/helpers/clipboard-resolver.mjs
+++ b/studio/frontend/tests/helpers/clipboard-resolver.mjs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// bundler-resolver's two rules, plus the two this suite needs:
+//
+//   1. "@tauri-apps/plugin-clipboard-manager" -> a local stub, because the real
+//      package only resolves inside a Tauri webview.
+//   2. A "?bust=N" query on the importer is copied onto every src module it pulls
+//      in. lib/api-base computes `isTauri` once, at module evaluation, so the only
+//      way to exercise both branches in one process is to evaluate the whole
+//      subgraph again under a fresh key.
+import { existsSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SRC = fileURLToPath(new URL("../../src/", import.meta.url));
+const CLIPBOARD_STUB = new URL("./tauri-clipboard-stub.mjs", import.meta.url).href;
+
+function firstExisting(base) {
+  for (const candidate of [`${base}.ts`, `${base}/index.ts`, base]) {
+    if (existsSync(candidate)) return pathToFileURL(candidate).href;
+  }
+  return null;
+}
+
+function bustOf(parentURL) {
+  if (!parentURL) return "";
+  const bust = new URL(parentURL).searchParams.get("bust");
+  return bust ? `?bust=${bust}` : "";
+}
+
+export function resolve(specifier, context, next) {
+  const suffix = bustOf(context.parentURL);
+
+  if (specifier === "@tauri-apps/plugin-clipboard-manager") {
+    return next(CLIPBOARD_STUB + suffix, context);
+  }
+  if (specifier.startsWith("@/")) {
+    const resolved = firstExisting(SRC + specifier.slice(2));
+    return next(resolved ? resolved + suffix : specifier, context);
+  }
+  if (specifier.startsWith(".") && context.parentURL?.startsWith("file:")) {
+    const parent = new URL(context.parentURL);
+    parent.search = "";
+    const resolved = firstExisting(fileURLToPath(new URL(specifier, parent)));
+    if (resolved) return next(resolved + suffix, context);
+  }
+  return next(specifier, context);
+}

--- a/studio/frontend/tests/helpers/tauri-clipboard-stub.mjs
+++ b/studio/frontend/tests/helpers/tauri-clipboard-stub.mjs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Stands in for @tauri-apps/plugin-clipboard-manager, which only resolves inside a
+// Tauri webview. State lives on globalThis, not in module scope, so it survives the
+// re-evaluation clipboard-resolver.mjs forces with its "?bust=N" key.
+//
+//   mode "ok"             -> writeText resolves (native copy succeeded)
+//   mode "write-fails"    -> writeText rejects (capability missing / IPC error)
+//   mode "module-missing" -> the module itself throws on evaluation, which is what
+//                            `await import(...)` does on an install without the plugin
+
+const control = (globalThis.__TAURI_CLIPBOARD_STUB__ ??= { calls: [], mode: "ok" });
+
+if (control.mode === "module-missing") {
+  throw new Error("Cannot find module '@tauri-apps/plugin-clipboard-manager'");
+}
+
+export async function writeText(text) {
+  control.calls.push(text);
+  if (control.mode === "write-fails") {
+    throw new Error("clipboard-manager: forbidden, capability not granted");
+  }
+}


### PR DESCRIPTION
"Copy path" in the model options menu resolves the on-disk path with an HTTP request before copying, so by the time the copy runs, the click's user gesture has expired both navigator.clipboard.writeText and the execCommand fallback fail in the desktop webview, showing "Failed to copy". This makes copyToClipboard use the native Tauri clipboard-manager plugin first in the desktop app (no gesture required, capability already granted), falling back to the existing web paths in the browser, and removes the now-duplicate helper from tauri-diagnostics.ts.