### PR TITLE
Bump install.sh / install.ps1 pins to unsloth>=2026.8.5, unsloth-zoo>=2026.8.4

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -3087,7 +3087,7 @@ exit 0
         if ($SkipTorch) {
             # No-torch: install unsloth + unsloth-zoo with --no-deps, then
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (migrated no-torch)" { uv pip install --python $VenvPython --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.8.4" "unsloth-zoo>=2026.8.3" }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (migrated no-torch)" { uv pip install --python $VenvPython --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.8.5" "unsloth-zoo>=2026.8.4" }
             if ($baseInstallExit -eq 0) {
                 # Resolve pydantic WITH deps so pip pins pydantic-core
                 # to the matching version (no-torch-runtime.txt below
@@ -3101,7 +3101,7 @@ exit 0
                 }
             }
         } else {
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (migrated)" { uv pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.8.4" "unsloth-zoo>=2026.8.3" }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (migrated)" { uv pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.8.5" "unsloth-zoo>=2026.8.4" }
         }
         if ($baseInstallExit -ne 0) {
             Write-Host "[ERROR] Failed to install unsloth (exit code $baseInstallExit)" -ForegroundColor Red
@@ -3228,7 +3228,7 @@ exit 0
         if ($SkipTorch) {
             # No-torch: install unsloth + unsloth-zoo with --no-deps, then
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (no-torch)" { uv pip install --python $VenvPython --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.8.4" "unsloth-zoo>=2026.8.3" }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (no-torch)" { uv pip install --python $VenvPython --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.8.5" "unsloth-zoo>=2026.8.4" }
             if ($baseInstallExit -eq 0) {
                 # Same pydantic-with-deps trick as the migrated branch.
                 $baseInstallExit = Invoke-InstallCommandRetry -Label "install pydantic" { uv pip install --python $VenvPython pydantic }
@@ -3240,7 +3240,7 @@ exit 0
                 }
             }
         } elseif ($StudioLocalInstall) {
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (local)" { uv pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.8.4" "unsloth-zoo>=2026.8.3" }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (local)" { uv pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.8.5" "unsloth-zoo>=2026.8.4" }
         } else {
             $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth" { uv pip install --python $VenvPython --upgrade-package unsloth -- "$PackageName" }
         }
@@ -3268,7 +3268,7 @@ exit 0
         Write-TauriLog "STEP" "Installing unsloth"
         substep "installing unsloth (this may take a few minutes)..."
         if ($StudioLocalInstall) {
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (auto torch backend)" { uv pip install --python $VenvPython "unsloth-zoo>=2026.8.3" "unsloth>=2026.8.4" --torch-backend=auto }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (auto torch backend)" { uv pip install --python $VenvPython "unsloth-zoo>=2026.8.4" "unsloth>=2026.8.5" --torch-backend=auto }
             if ($baseInstallExit -ne 0) {
                 Write-Host "[ERROR] Failed to install unsloth (exit code $baseInstallExit)" -ForegroundColor Red
                 return (Exit-InstallFailure "Failed to install unsloth (exit code $baseInstallExit)" $baseInstallExit)

--- a/install.sh
+++ b/install.sh
@@ -4108,7 +4108,7 @@ if [ "$_MIGRATED" = true ]; then
         # to prevent transitive torch resolution.
         run_install_cmd_retry "install unsloth (migrated no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --reinstall-package unsloth --reinstall-package unsloth-zoo \
-            "unsloth>=2026.8.4" "unsloth-zoo>=2026.8.3"
+            "unsloth>=2026.8.5" "unsloth-zoo>=2026.8.4"
         # Resolve pydantic WITH deps so pip pins pydantic-core to the
         # matching version (no-torch-runtime.txt below is --no-deps).
         # All transitive deps are torch-free.
@@ -4125,7 +4125,7 @@ if [ "$_MIGRATED" = true ]; then
         run_install_cmd_retry "install unsloth (migrated)" uv pip install --python "$_VENV_PY" \
             ${_UNSLOTH_TORCH_OVERRIDES:+--overrides "$_UNSLOTH_TORCH_OVERRIDES"} \
             --reinstall-package unsloth --reinstall-package unsloth-zoo \
-            "unsloth>=2026.8.4" "unsloth-zoo>=2026.8.3" ${_MLX_LM_EXCLUDE_ARG:-}
+            "unsloth>=2026.8.5" "unsloth-zoo>=2026.8.4" ${_MLX_LM_EXCLUDE_ARG:-}
         [ -n "$_UNSLOTH_TORCH_OVERRIDES" ] && rm -f "$_UNSLOTH_TORCH_OVERRIDES"
         _UNSLOTH_TORCH_OVERRIDES=""
     fi
@@ -4359,7 +4359,7 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
         # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
         run_install_cmd_retry "install unsloth (no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --upgrade-package unsloth --upgrade-package unsloth-zoo \
-            "unsloth>=2026.8.4" "unsloth-zoo>=2026.8.3"
+            "unsloth>=2026.8.5" "unsloth-zoo>=2026.8.4"
         # Same pydantic-with-deps trick as the migrated branch.
         run_install_cmd_retry "install pydantic (with deps for compatible core)" \
             uv pip install --python "$_VENV_PY" pydantic
@@ -4378,7 +4378,7 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
     elif [ "$STUDIO_LOCAL_INSTALL" = true ]; then
         run_install_cmd_retry "install unsloth (local)" uv pip install --python "$_VENV_PY" \
             ${_UNSLOTH_TORCH_OVERRIDES:+--overrides "$_UNSLOTH_TORCH_OVERRIDES"} \
-            --upgrade-package unsloth "unsloth>=2026.8.4" "unsloth-zoo>=2026.8.3"
+            --upgrade-package unsloth "unsloth>=2026.8.5" "unsloth-zoo>=2026.8.4"
         substep "overlaying local repo (editable)..."
         run_install_cmd "overlay local repo" uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
         substep "overlaying unsloth-zoo from git main..."
@@ -4407,7 +4407,7 @@ else
     tauri_log "STEP" "Installing Unsloth"
     substep "installing unsloth (this may take a few minutes)..."
     if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
-        run_install_cmd_retry "install unsloth (auto torch backend)" uv pip install --python "$_VENV_PY" "unsloth-zoo>=2026.8.3" "unsloth>=2026.8.4" --torch-backend=auto
+        run_install_cmd_retry "install unsloth (auto torch backend)" uv pip install --python "$_VENV_PY" "unsloth-zoo>=2026.8.4" "unsloth>=2026.8.5" --torch-backend=auto
         substep "overlaying local repo (editable)..."
         run_install_cmd "overlay local repo" uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
         substep "overlaying unsloth-zoo from git main..."


### PR DESCRIPTION
## Summary

- PyPI release [unsloth 2026.8.5](https://pypi.org/project/unsloth/2026.8.5/) is now live.
- Bumps the pinned floor in `install.sh` and `install.ps1` from `unsloth>=2026.8.4` to `unsloth>=2026.8.5` so fresh installs resolve to the new wheel.
- Bumps the paired `unsloth-zoo` floor from `>=2026.8.3` to `>=2026.8.4`, since [unsloth-zoo 2026.8.4](https://pypi.org/project/unsloth-zoo/2026.8.4/) shipped alongside it. This matches `pyproject.toml`, which already declares `unsloth_zoo>=2026.8.4`.
- Updates all 5 install commands in each of `install.sh` and `install.ps1` (migrated / migrated no-torch / no-torch / local / auto torch backend paths).
- Tagged on main as `v0.1.522-beta`.

Follows the same pattern as #5716, and keeps the zoo floor explicit per #6440.

Unlike #7906, both floors move together here: that bump had to leave the zoo floor behind because no matching zoo release existed yet. The two are independent release lines, so they move in step only when both have actually shipped.

## Scope

- Version strings only: 10 lines changed across the two scripts.
- The `--reinstall-package` / `--upgrade-package` flags and the `unsloth-zoo @ git+...` git-main overlay lines are untouched.

## Test plan

- [x] `bash -n install.sh` passes
- [x] `install.ps1` parses cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`, 0 errors)
- [x] `uv pip compile` resolves the exact pinned pair against PyPI: `unsloth==2026.8.5`, `unsloth-zoo==2026.8.4`
- [x] No stale `2026.8.4` / `2026.8.3` pins left in either script
- [ ] Sanity-run `install.sh` on a clean Linux host
- [ ] Sanity-run `install.ps1` on a clean Windows host