### PR TITLE
Studio: test the Windows launcher shape, not just the path normalizer

### DIFF
--- a/studio/src-tauri/src/install.rs
+++ b/studio/src-tauri/src/install.rs
@@ -244,6 +244,36 @@ fn powershell_script_path(path: &Path) -> PathBuf {
     PathBuf::from(OsString::from_wide(&normalized))
 }
 
+/// Everything passed to `powershell.exe` before the script's own arguments.
+///
+/// Separate from `spawn_script` so a test can assert the property that matters:
+/// that this flag set authorizes this path spelling. #7819 broke first-run
+/// install by editing only the flags, which no test over `powershell_script_path`
+/// can see.
+#[cfg(windows)]
+fn powershell_launch_args(script: &Path) -> Vec<std::ffi::OsString> {
+    use std::ffi::OsString;
+
+    // No -WindowStyle Hidden / -ExecutionPolicy Bypass: that pair is a Microsoft
+    // detection signature, CREATE_NO_WINDOW hides the console, and NSIS writes
+    // resources without a mark-of-the-web so RemoteSigned loads them.
+    let mut launch: Vec<OsString> = [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "RemoteSigned",
+        "-File",
+    ]
+    .iter()
+    .map(OsString::from)
+    .collect();
+
+    // Load-bearing: RemoteSigned rejects the `\\?\` spelling Tauri resolves to.
+    launch.push(powershell_script_path(script).into_os_string());
+    launch
+}
+
 /// `Command::new` searches the running executable's own directory before the
 /// system one, and a `currentUser` install puts that directory somewhere the
 /// user can write, so resolve the interpreter absolutely.
@@ -389,23 +419,12 @@ fn spawn_script(
 
     #[cfg(windows)]
     let mut cmd = Command::new(powershell_exe());
-    // No -WindowStyle Hidden / -ExecutionPolicy Bypass: that pair is a Microsoft
-    // detection signature, CREATE_NO_WINDOW below already hides the console, and
-    // NSIS writes resources without a mark-of-the-web so RemoteSigned loads them.
     #[cfg(windows)]
-    cmd.args([
-        "-NoLogo",
-        "-NoProfile",
-        "-NonInteractive",
-        "-ExecutionPolicy",
-        "RemoteSigned",
-        "-File",
-    ])
-    .arg(powershell_script_path(script))
-    .args(args)
-    .current_dir(&work_dir)
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped());
+    cmd.args(powershell_launch_args(script))
+        .args(args)
+        .current_dir(&work_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
     // AppImage sets LD_LIBRARY_PATH to its bundled libs, which breaks Python
     // spawned by the install script. Only clear inside AppImage — native installs
@@ -1197,6 +1216,78 @@ mod tests {
                 "a path past MAX_PATH must stay verbatim"
             );
         }
+    }
+
+    /// Run the real interpreter with the real flags against a script addressed
+    /// the way Tauri addresses it. Fails if the execution policy is swapped as
+    /// in #7819, or if `powershell_script_path` is dropped from the call site;
+    /// both leave the assertions over the normalizer itself passing.
+    #[cfg(windows)]
+    #[test]
+    fn powershell_runs_a_script_addressed_the_way_tauri_addresses_it() {
+        use std::fs;
+
+        // A temp file has no Zone.Identifier, so RemoteSigned admits it unsigned.
+        // The path spelling and the flag set are what is under test, not signing.
+        let dir = std::env::temp_dir().join(format!(
+            "unsloth-launch-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let script = dir.join("install.ps1");
+        fs::write(&script, "Write-Output 'unsloth-launcher-ok'\r\n").expect("write script");
+
+        // Resource resolution bottoms out in `canonicalize`, documented to return
+        // extended-length syntax. Assert that, so the test cannot pass vacuously.
+        let resolved = fs::canonicalize(&script).expect("canonicalize");
+        assert!(
+            resolved.as_os_str().to_string_lossy().starts_with(r"\\?\"),
+            "expected a verbatim path to exercise, got {resolved:?}"
+        );
+
+        let output = Command::new(powershell_exe())
+            .args(powershell_launch_args(&resolved))
+            .output()
+            .expect("spawn powershell");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let _ = fs::remove_dir_all(&dir);
+
+        assert!(
+            output.status.success() && stdout.contains("unsloth-launcher-ok"),
+            "the launcher shape failed to authorize {resolved:?}\n\
+             status: {:?}\nstdout: {stdout}\nstderr: {stderr}",
+            output.status.code()
+        );
+    }
+
+    /// Pin the flag set, so a policy swap shows up as a diff. `-File` stays last
+    /// so the script path is never parsed as a flag.
+    #[cfg(windows)]
+    #[test]
+    fn powershell_launch_args_pin_the_defender_friendly_shape() {
+        let args = powershell_launch_args(Path::new(r"\\?\C:\Users\Owner\install.ps1"));
+        let args: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args,
+            vec![
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "RemoteSigned",
+                "-File",
+                r"C:\Users\Owner\install.ps1",
+            ]
+        );
+        // The pair Microsoft ships as a detection test must not come back.
+        assert!(!args.iter().any(|a| a == "Bypass" || a == "-WindowStyle"));
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## What is wrong

#7943 fixed the verbatim-path authorization failure and added a `windows-unit-tests` leg to `studio-tauri-smoke.yml` to keep it fixed. That leg runs, but the two tests it guards with are assertions over `powershell_script_path` as a pure function, and the regression that actually shipped is invisible to them.

#7819's entire `install.rs` diff was `Bypass` -> `RemoteSigned`. It never touched a path. So the failure mode is a change to the *flags* interacting with a path spelling that was already there, and neither a normalizer unit test nor any Linux job can see it.

Two mutations reintroduce a broken first-run install on every Windows bundle while leaving all of #7943's assertions green:

1. swap the execution policy back, or to anything else
2. delete the `powershell_script_path(script)` call from `spawn_script` and pass `script` raw

## The fix

Lift the argument vector out of `spawn_script` into `powershell_launch_args`, so the call site is a value a test can look at rather than something built inline and immediately spawned. Then two tests:

- `powershell_runs_a_script_addressed_the_way_tauri_addresses_it` runs the real `powershell.exe`, with the real flags, against a path from `fs::canonicalize`, which is what `resolve(Resource)` bottoms out in and which Rust documents as returning extended-length syntax. It asserts it actually got a `\\?\` path before using it, so it cannot pass vacuously if `canonicalize` ever stops emitting one. A temp script has no `Zone.Identifier`, so `RemoteSigned` admits it unsigned; the path spelling and the flag set are what is under test, not signing.
- `powershell_launch_args_pin_the_defender_friendly_shape` pins the flag vector, so a policy swap shows up as a diff rather than as silence, and asserts `-WindowStyle` / `Bypass` do not come back.

No behaviour change. The arguments `spawn_script` passes are byte for byte the ones it passed before.

## Verification

Both legs of `studio-tauri-smoke.yml` on a disposable staging runner, since the Windows-only code is exactly what no local Linux build compiles:

| | Rust unit tests (windows) | Tauri Linux debug build |
|---|---|---|
| this branch | success, 127 passed (was 125) | success |
| negative control | **failure, 125 passed / 2 failed** | success |

The negative control is the part worth reading. It drops `powershell_script_path` from the call site, the mutation no existing test can see, and the new test reproduces the exact reported failure inside CI:

```
the launcher shape failed to authorize
  "\\?\C:\Users\runneradmin\AppData\Local\Temp\unsloth-launch-1992-1243\install.ps1"
    + FullyQualifiedErrorId : UnauthorizedAccess
```

Both `powershell_script_path_*` tests passed on that mutated tree, which is the gap this closes. The only two failures are the two tests added here.

## Note

This is test coverage only, so it does not help anyone currently stuck. `desktop-v0.1.521-beta` targets `a6ad2152`, which predates #7943's merge by about four and a half hours, so all three current Windows betas (`0.1.512`, `0.1.52`, `0.1.521`) still fail on first run with `AuthorizationManager check failed`. A build cut from current `main` is the actual fix for users.
