### PR TITLE
Skip a test module with a missing optional dep instead of exiting pytest

### DIFF
--- a/tests/test_missing_optional_dep_skips.py
+++ b/tests/test_missing_optional_dep_skips.py
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-only
-"""A missing optional dependency must skip one module, not kill the session.
-
-`require_package` / `require_python_package` run at import time, so their old
-`sys.exit(1)` aborted the whole pytest run instead of skipping four files.
-"""
+"""A missing optional dependency must skip one module, not kill the session."""
 
 import subprocess
 import sys
@@ -23,7 +19,6 @@ def _repo_root():
 
 
 def test_a_missing_package_skips_the_module_under_pytest():
-    # Anything other than Skipped here means the session-wide abort is back.
     with pytest.raises(pytest.skip.Exception):
         require_python_package(_ABSENT)
 
@@ -33,8 +28,7 @@ def test_an_installed_package_is_a_no_op():
 
 
 def test_the_standalone_script_path_still_exits():
-    # Direct runs must still exit(1), so use a subprocess with pytest genuinely
-    # absent from sys.modules rather than faking it.
+    # A subprocess, so pytest is genuinely absent from sys.modules, not faked.
     script = textwrap.dedent(f"""
         import sys
         sys.path.insert(0, {str(_repo_root())!r})

--- a/tests/test_missing_optional_dep_skips.py
+++ b/tests/test_missing_optional_dep_skips.py
@@ -1,11 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 """A missing optional dependency must skip one module, not kill the session.
 
-`require_package` / `require_python_package` are called at module import time by
-the four tests/saving/text_to_speech_models files. They used to `sys.exit(1)`
-when a package was absent, and under pytest that lands during collection: pytest
-turns SystemExit there into an INTERNALERROR and aborts the whole run. A host
-without xcodec2 therefore executed zero tests across the entire suite.
+`require_package` / `require_python_package` run at import time, so their old
+`sys.exit(1)` aborted the whole pytest run instead of skipping four files.
 """
 
 import subprocess
@@ -26,8 +23,7 @@ def _repo_root():
 
 
 def test_a_missing_package_skips_the_module_under_pytest():
-    # pytest.skip raises Skipped, which is what allows the rest of the session
-    # to carry on. Anything else here means the abort is back.
+    # Anything other than Skipped here means the session-wide abort is back.
     with pytest.raises(pytest.skip.Exception):
         require_python_package(_ABSENT)
 
@@ -37,9 +33,8 @@ def test_an_installed_package_is_a_no_op():
 
 
 def test_the_standalone_script_path_still_exits():
-    # These files are also meant to be runnable directly, so outside pytest the
-    # historical `sys.exit(1)` must survive. Run it in a subprocess with pytest
-    # genuinely absent from sys.modules rather than faking it.
+    # Direct runs must still exit(1), so use a subprocess with pytest genuinely
+    # absent from sys.modules rather than faking it.
     script = textwrap.dedent(f"""
         import sys
         sys.path.insert(0, {str(_repo_root())!r})

--- a/tests/test_missing_optional_dep_skips.py
+++ b/tests/test_missing_optional_dep_skips.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""A missing optional dependency must skip one module, not kill the session.
+
+`require_package` / `require_python_package` are called at module import time by
+the four tests/saving/text_to_speech_models files. They used to `sys.exit(1)`
+when a package was absent, and under pytest that lands during collection: pytest
+turns SystemExit there into an INTERNALERROR and aborts the whole run. A host
+without xcodec2 therefore executed zero tests across the entire suite.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from tests.utils.os_utils import require_python_package
+
+
+_ABSENT = "unsloth_definitely_not_a_real_package_xyz"
+
+
+def _repo_root():
+    import pathlib
+    return pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_a_missing_package_skips_the_module_under_pytest():
+    # pytest.skip raises Skipped, which is what allows the rest of the session
+    # to carry on. Anything else here means the abort is back.
+    with pytest.raises(pytest.skip.Exception):
+        require_python_package(_ABSENT)
+
+
+def test_an_installed_package_is_a_no_op():
+    require_python_package("sys", import_name = "sys")
+
+
+def test_the_standalone_script_path_still_exits():
+    # These files are also meant to be runnable directly, so outside pytest the
+    # historical `sys.exit(1)` must survive. Run it in a subprocess with pytest
+    # genuinely absent from sys.modules rather than faking it.
+    script = textwrap.dedent(f"""
+        import sys
+        sys.path.insert(0, {str(_repo_root())!r})
+        for name in list(sys.modules):
+            if name == "pytest" or name.startswith("pytest."):
+                del sys.modules[name]
+        from tests.utils.os_utils import require_python_package
+        require_python_package({_ABSENT!r})
+        print("NO EXIT")
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output = True,
+        text = True,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "NO EXIT" not in result.stdout

--- a/tests/utils/os_utils.py
+++ b/tests/utils/os_utils.py
@@ -6,14 +6,10 @@ import importlib
 
 
 def _missing_dependency(message):
-    """Skip under pytest, exit when run as a standalone script.
+    """Skip under pytest, exit as a standalone script.
 
-    These helpers are called at module import time, so under pytest the
-    `sys.exit(1)` below lands during collection. pytest turns a SystemExit
-    there into an INTERNALERROR and aborts the whole session, so one absent
-    optional package (xcodec2, snac, soundfile, ffmpeg) means the entire suite
-    runs zero tests rather than skipping four files. The files are also meant
-    to be runnable directly, hence the exit is kept for that path.
+    Callers run at import time, so a SystemExit during collection would become an
+    INTERNALERROR and abort the whole session instead of skipping one module.
     """
     if "pytest" in sys.modules:
         import pytest

--- a/tests/utils/os_utils.py
+++ b/tests/utils/os_utils.py
@@ -5,6 +5,22 @@ import shutil
 import importlib
 
 
+def _missing_dependency(message):
+    """Skip under pytest, exit when run as a standalone script.
+
+    These helpers are called at module import time, so under pytest the
+    `sys.exit(1)` below lands during collection. pytest turns a SystemExit
+    there into an INTERNALERROR and aborts the whole session, so one absent
+    optional package (xcodec2, snac, soundfile, ffmpeg) means the entire suite
+    runs zero tests rather than skipping four files. The files are also meant
+    to be runnable directly, hence the exit is kept for that path.
+    """
+    if "pytest" in sys.modules:
+        import pytest
+        pytest.skip(message, allow_module_level = True)
+    sys.exit(1)
+
+
 def detect_package_manager():
     """Detect the available package manager"""
     package_managers = {
@@ -56,7 +72,7 @@ def check_package_installed(package_name, package_manager = None):
 
 
 def require_package(package_name, executable_name = None):
-    """Require a package to be installed, exit if not found"""
+    """Require a package to be installed; skip the module under pytest if not."""
 
     # Executable in PATH is the most reliable signal
     if executable_name:
@@ -92,7 +108,7 @@ def require_package(package_name, executable_name = None):
     print(f"  conda install -c conda-forge {package_name}")
 
     print(f"\nPlease install the required package and run the script again.")
-    sys.exit(1)
+    _missing_dependency(f"{package_name} is not installed")
 
 
 # Usage
@@ -104,7 +120,7 @@ def require_python_package(
     import_name = None,
     pip_name = None,
 ):
-    """Require a Python package to be installed, exit if not found"""
+    """Require a Python package to be installed; skip the module under pytest if not."""
     if import_name is None:
         import_name = package_name
     if pip_name is None:
@@ -117,6 +133,6 @@ def require_python_package(
         print(f"  # or with conda:")
         print(f"  conda install {pip_name}")
         print(f"\nAfter installation, run this script again.")
-        sys.exit(1)
+        _missing_dependency(f"Python package '{package_name}' is not installed")
     else:
         print(f"✓ Python package '{package_name}' is installed")

--- a/tests/utils/os_utils.py
+++ b/tests/utils/os_utils.py
@@ -6,11 +6,7 @@ import importlib
 
 
 def _missing_dependency(message):
-    """Skip under pytest, exit as a standalone script.
-
-    Callers run at import time, so a SystemExit during collection would become an
-    INTERNALERROR and abort the whole session instead of skipping one module.
-    """
+    """Skip under pytest, since exiting at import time aborts the whole session."""
     if "pytest" in sys.modules:
         import pytest
         pytest.skip(message, allow_module_level = True)


### PR DESCRIPTION
### The problem

`tests/utils/os_utils.py` exposes `require_package` and `require_python_package`, and both end in `sys.exit(1)` when the dependency is absent. The four `tests/saving/text_to_speech_models/` files call them at **module import time**:

```python
require_package("ffmpeg", "ffmpeg")
require_python_package("soundfile")
require_python_package("xcodec2")
```

Under pytest that `sys.exit(1)` lands during collection. pytest turns a `SystemExit` there into an `INTERNALERROR` and aborts the entire session:

```
❌ Error: Python package 'xcodec2' is not installed
INTERNALERROR> ...
INTERNALERROR>   File "tests/utils/os_utils.py", line 120, in require_python_package
INTERNALERROR>     sys.exit(1)
INTERNALERROR> SystemExit: 1
mainloop: caught unexpected SystemExit!
1812 warnings, 12 errors in 222.56s
```

So on any host without `xcodec2`, `snac` or `soundfile`, `pytest tests/` runs **zero tests** and reports no failures. Nothing is red, and it is easy to read that as a clean run.

Removing the offending file does not help. `--ignore=tests/saving/text_to_speech_models/test_lasa.py` just moves the abort to the next one:

```
INTERNALERROR>   File "tests/saving/text_to_speech_models/test_orpheus.py", line 20, in <module>
INTERNALERROR>     require_python_package("snac")
INTERNALERROR> SystemExit: 1
```

### The fix

Route both helpers through a single place that skips at module level when pytest is running, and keeps the historical exit otherwise. These files are also meant to be runnable directly as scripts (their own message says "run this script again"), so that path is preserved.

```python
def _missing_dependency(message):
    if "pytest" in sys.modules:
        import pytest
        pytest.skip(message, allow_module_level = True)
    sys.exit(1)
```

Both helpers are internal to `tests/`; a repo-wide search shows no other callers.

### Before and after

`pytest tests/saving/text_to_speech_models/test_lasa.py` on a host without `xcodec2`:

| | result |
| --- | --- |
| before | `mainloop: caught unexpected SystemExit!`, no tests collected |
| after | `1 skipped in 0.02s` |

Whole tree, same host: before, collection aborts and nothing runs. After, the four TTS modules skip and collection proceeds.

### Tests

`tests/test_missing_optional_dep_skips.py`, 3 tests: a missing package raises `Skipped` under pytest, an installed one is a no-op, and the standalone path still exits 1. The last runs in a subprocess with pytest genuinely absent from `sys.modules` rather than faking it.

### Scope note

CI is unaffected either way. Every workflow runs targeted paths (`pytest tests/security`, `pytest tests/vllm_compat/...`, `pytest tests/studio/load_freeze/`) rather than the whole `tests/` tree, which is why this was only reachable when running the suite locally.

Worth flagging separately, and deliberately **not** addressed here: once the abort is gone, collection reaches 17 pre-existing errors under `tests/saving/` and `tests/utils/test_packing.py` that the `SystemExit` was hiding. They are heavyweight integration modules that download and merge real models at import time, so they need HF access, disk and VRAM rather than a code fix. This PR does not make them worse; it makes them visible.
