### PR TITLE
Stop the rapid-submit chat UI check failing on a fast runner

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -48,6 +48,10 @@ STRICT = os.environ.get("STUDIO_UI_STRICT", "0") == "1"
 # Per-turn assistant-bubble wait. The free macos-14 runner is ~3-5x
 # slower at gemma-3-270m CPU inference; this lets it bump the timeout.
 TURN_TIMEOUT_MS = int(os.environ.get("STUDIO_UI_TURN_TIMEOUT_MS", "180000"))
+# How long the rapid-submit step holds the first turn's response. Only needs to
+# outlast the 100 ms follow-up wait; kept well clear of it so a loaded runner
+# cannot close the gap, and paid once per run.
+RAPID_FIRST_TURN_HOLD_S = 3.0
 
 # Wall-clock cap for the whole script (healthy run is 5-9 min).
 WALL_TIMEOUT_S = float(os.environ.get("STUDIO_UI_WALL_TIMEOUT_S", "720"))
@@ -1060,28 +1064,39 @@ with sync_playwright() as p:
     step("rapid submit: 100 ms follow-up queues behind the first turn")
     rapid_bubbles_before = _bubble_count()
     composer_form = page.locator('form:has(textarea[aria-label="Message input"])').first
-    # Long on purpose: the queue check below needs this turn to still be running
-    # 100 ms from now. A short reply can complete first on a fast runner.
-    composer.fill("Count from 1 to 200. Put each number on its own line.")
-    composer_form.evaluate("form => form.requestSubmit()")
-    page.wait_for_timeout(100)
-    composer.fill("Reply with exactly: rapid-second")
-    composer_form.evaluate("form => form.requestSubmit()")
+    # Hold the first turn open for a fixed interval instead of hoping it is slow.
+    # The queue control below exists only while that turn is running, and how
+    # long a reply takes is not ours to decide: sampling settings, the model
+    # behind GGUF_REPO and an early EOS all move it, and a five-token answer can
+    # land inside the 100 ms wait on a fast runner. Delaying the response keeps
+    # the thread running from submit until we let it through, which makes the
+    # window deterministic and independent of anything the model does.
+    held_first_turn = {"done": False}
 
-    # The follow-up must materialize as queued work instead of a second direct
-    # append. This control exists only while the first turn is still running,
-    # so the assertion below silently depends on that turn outlasting the 100 ms
-    # wait. The first prompt above is deliberately long-running for that reason:
-    # a five-token reply from gemma-3-270m can land inside the window, exactly
-    # as the Stop button a few lines up is already documented to do, and then
-    # there is nothing to queue behind and this times out for no real fault.
-    # Asserted unconditionally: with a first turn that cannot finish that fast,
-    # a missing queue control is a genuine regression.
-    page.wait_for_selector(
-        'button[aria-label="Remove queued prompt 1"]',
-        state = "attached",
-        timeout = 10_000,
-    )
+    def _hold_first_turn(route):
+        if not held_first_turn["done"]:
+            held_first_turn["done"] = True
+            time.sleep(RAPID_FIRST_TURN_HOLD_S)
+        route.continue_()
+
+    page.route("**/chat/completions*", _hold_first_turn)
+    try:
+        composer.fill("Reply with exactly: rapid-first")
+        composer_form.evaluate("form => form.requestSubmit()")
+        page.wait_for_timeout(100)
+        composer.fill("Reply with exactly: rapid-second")
+        composer_form.evaluate("form => form.requestSubmit()")
+
+        # The follow-up must materialize as queued work instead of a second
+        # direct append. The hold above guarantees the first turn is still
+        # running here, so a missing control is a real regression, not timing.
+        page.wait_for_selector(
+            'button[aria-label="Remove queued prompt 1"]',
+            state = "attached",
+            timeout = 10_000,
+        )
+    finally:
+        page.unroute("**/chat/completions*", _hold_first_turn)
     page.wait_for_function(
         """(want) => {
             const replies = Array.from(

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1094,16 +1094,22 @@ with sync_playwright() as p:
             const realFetch = window.fetch;
             const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-            const sendFollowUp = () => {
+            const sendFollowUp = (deadline) => {
                 if (state.submitted || state.error) return;
-                // Re-query: this is the chat's first message, so sending it
-                // swaps the welcome composer for the dock composer and any
-                // node captured earlier is detached by now.
+                // Re-query, and retry: this is the chat's first message, so
+                // sending it swaps the welcome composer for the dock composer.
+                // A node captured earlier is detached, and for a short window
+                // there is no connected composer at all.
                 const composer = document.querySelector(
                     'textarea[aria-label="Message input"]'
                 );
                 if (!composer || !composer.isConnected || !composer.form) {
-                    state.error = "no connected composer for the follow-up";
+                    if (deadline === undefined) deadline = Date.now() + 5000;
+                    if (Date.now() > deadline) {
+                        state.error = "no connected composer for the follow-up";
+                        return;
+                    }
+                    setTimeout(() => sendFollowUp(deadline), 25);
                     return;
                 }
                 // React tracks the value on the node, so a plain assignment is
@@ -1129,7 +1135,7 @@ with sync_playwright() as p:
                     // The request is out and the turn is running. Send the
                     // follow-up now, then keep the response pending so it
                     // cannot complete first.
-                    setTimeout(sendFollowUp, 0);
+                    setTimeout(() => sendFollowUp(), 0);
                     await sleep(holdMs);
                     return response;
                 }
@@ -1139,7 +1145,7 @@ with sync_playwright() as p:
             // Always restore. A wrapper left in place for the rest of the
             // run is a monkeypatch with no teardown, and every later turn would
             // pay for it.
-            window.__unslothRapidArm = () => setTimeout(sendFollowUp, 100);
+            window.__unslothRapidArm = () => setTimeout(() => sendFollowUp(), 100);
 
             window.__unslothRapidRestore = () => {
                 window.fetch = realFetch;
@@ -1187,12 +1193,16 @@ with sync_playwright() as p:
     state = page.evaluate("() => window.__unslothRapid")
     page.evaluate("() => { if (window.__unslothRapidRestore) "
                   "window.__unslothRapidRestore(); }")
-    if not state["intercepted"]:
-        fail("the first turn's request was never seen, so it was never held; "
-             f"saw {state['seen']}")
     if state["error"]:
         shoot("04-rapid-submit-no-composer")
         fail(f"could not send the follow-up: {state['error']}")
+    # queueSeen is the property under test; the hold is only the means of
+    # guaranteeing the first turn was still running. If the queue formed, it
+    # formed, whether or not the hold was needed. Only demand the interception
+    # when it did not, so an unheld run cannot report a silent pass.
+    if not state["queueSeen"] and not state["intercepted"]:
+        fail("the first turn's request was never seen, so it was never held, "
+             f"and no queue formed; saw {state['seen']}")
     # The follow-up went out after the first turn's request was issued and while
     # its response was still held, so that turn was necessarily running. A
     # missing queue control is therefore a real regression, not timing.

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1064,13 +1064,49 @@ with sync_playwright() as p:
     step("rapid submit: 100 ms follow-up queues behind the first turn")
     rapid_bubbles_before = _bubble_count()
     composer_form = page.locator('form:has(textarea[aria-label="Message input"])').first
-    # Hold the first turn open for a fixed interval instead of hoping it is slow.
-    # The queue control below exists only while that turn is running, and how
-    # long a reply takes is not ours to decide: sampling settings, the model
-    # behind GGUF_REPO and an early EOS all move it, and a five-token answer can
-    # land inside the 100 ms wait on a fast runner. Delaying the response keeps
-    # the thread running from submit until we let it through, which makes the
-    # window deterministic and independent of anything the model does.
+    # How long a reply takes is not ours to decide: sampling settings, whatever
+    # GGUF_REPO points at and an early EOS all move it, and a short answer can
+    # finish inside the follow-up delay on a fast runner, leaving nothing to
+    # queue behind. So hold the first turn's response open rather than hope it
+    # is slow.
+    #
+    # The follow-up and the observation both run in the page, not here. The sync
+    # Playwright route handler runs on this thread, so a wait inside it blocks
+    # the test: the handler would fire during a wait_for_timeout, finish, and
+    # release the request before a Python-side second submit could happen, which
+    # puts the hold entirely before the follow-up instead of across it. Page
+    # timers keep running while this thread is parked in the handler.
+    page.evaluate(
+        """(secondPrompt) => {
+            window.__unslothRapid = { submitted: false, queueSeen: false };
+            const composer = document.querySelector(
+                'textarea[aria-label="Message input"]'
+            );
+            setTimeout(() => {
+                // React tracks the value on the node, so a plain assignment is
+                // reverted on the next render. Go through the native setter and
+                // announce it the way a keystroke would.
+                const setValue = Object.getOwnPropertyDescriptor(
+                    window.HTMLTextAreaElement.prototype, "value"
+                ).set;
+                setValue.call(composer, secondPrompt);
+                composer.dispatchEvent(new Event("input", { bubbles: true }));
+                composer.form.requestSubmit();
+                window.__unslothRapid.submitted = true;
+            }, 100);
+            const poll = setInterval(() => {
+                if (document.querySelector(
+                    'button[aria-label="Remove queued prompt 1"]'
+                )) {
+                    window.__unslothRapid.queueSeen = true;
+                    clearInterval(poll);
+                }
+            }, 50);
+            setTimeout(() => clearInterval(poll), 15000);
+        }""",
+        "Reply with exactly: rapid-second",
+    )
+
     held_first_turn = {"done": False}
 
     def _hold_first_turn(route):
@@ -1083,20 +1119,24 @@ with sync_playwright() as p:
     try:
         composer.fill("Reply with exactly: rapid-first")
         composer_form.evaluate("form => form.requestSubmit()")
-        page.wait_for_timeout(100)
-        composer.fill("Reply with exactly: rapid-second")
-        composer_form.evaluate("form => form.requestSubmit()")
-
-        # The follow-up must materialize as queued work instead of a second
-        # direct append. The hold above guarantees the first turn is still
-        # running here, so a missing control is a real regression, not timing.
-        page.wait_for_selector(
-            'button[aria-label="Remove queued prompt 1"]',
-            state = "attached",
-            timeout = 10_000,
+        # Returns once the handler has slept and released the request, by which
+        # point the page timer above has submitted the follow-up and recorded
+        # whether it queued.
+        page.wait_for_function(
+            "() => window.__unslothRapid && window.__unslothRapid.submitted",
+            timeout = 30_000,
         )
     finally:
         page.unroute("**/chat/completions*", _hold_first_turn)
+
+    if not held_first_turn["done"]:
+        fail("the first turn's request was never intercepted, so it was not held")
+    # The follow-up must materialize as queued work instead of a second direct
+    # append. It was submitted while the response was still held, so the first
+    # turn was necessarily running and a missing control is a real regression.
+    if not page.evaluate("() => window.__unslothRapid.queueSeen"):
+        shoot("04-rapid-submit-no-queue")
+        fail("follow-up sent during a held first turn did not appear as queued work")
     page.wait_for_function(
         """(want) => {
             const replies = Array.from(

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1060,33 +1060,28 @@ with sync_playwright() as p:
     step("rapid submit: 100 ms follow-up queues behind the first turn")
     rapid_bubbles_before = _bubble_count()
     composer_form = page.locator('form:has(textarea[aria-label="Message input"])').first
-    composer.fill("Reply with exactly: rapid-first")
+    # Long on purpose: the queue check below needs this turn to still be running
+    # 100 ms from now. A short reply can complete first on a fast runner.
+    composer.fill("Count from 1 to 200. Put each number on its own line.")
     composer_form.evaluate("form => form.requestSubmit()")
     page.wait_for_timeout(100)
     composer.fill("Reply with exactly: rapid-second")
     composer_form.evaluate("form => form.requestSubmit()")
 
     # The follow-up must materialize as queued work instead of a second direct
-    # append. This control exists only while that queued item is cancellable,
-    # which in turn requires the first turn to still be running: nothing can
-    # queue behind a turn that already finished. gemma-3-270m on a fast runner
-    # can answer inside the 100 ms above, exactly as the Stop button a few lines
-    # up is already documented to do, so treat a miss as inapplicable only when
-    # the first turn is demonstrably done, and still fail when it was in flight.
-    try:
-        page.wait_for_selector(
-            'button[aria-label="Remove queued prompt 1"]',
-            state = "attached",
-            timeout = 10_000,
-        )
-    except Exception:
-        still_streaming = page.evaluate(
-            """() => !!document.querySelector('button[aria-label="Stop generating"]')"""
-        )
-        if still_streaming:
-            shoot("04-rapid-submit-no-queue-while-streaming")
-            raise
-        info("SKIP queued-prompt control: first turn finished inside the 100 ms window")
+    # append. This control exists only while the first turn is still running,
+    # so the assertion below silently depends on that turn outlasting the 100 ms
+    # wait. The first prompt above is deliberately long-running for that reason:
+    # a five-token reply from gemma-3-270m can land inside the window, exactly
+    # as the Stop button a few lines up is already documented to do, and then
+    # there is nothing to queue behind and this times out for no real fault.
+    # Asserted unconditionally: with a first turn that cannot finish that fast,
+    # a missing queue control is a genuine regression.
+    page.wait_for_selector(
+        'button[aria-label="Remove queued prompt 1"]',
+        state = "attached",
+        timeout = 10_000,
+    )
     page.wait_for_function(
         """(want) => {
             const replies = Array.from(

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1067,12 +1067,26 @@ with sync_playwright() as p:
     composer_form.evaluate("form => form.requestSubmit()")
 
     # The follow-up must materialize as queued work instead of a second direct
-    # append. This control exists only while that queued item is cancellable.
-    page.wait_for_selector(
-        'button[aria-label="Remove queued prompt 1"]',
-        state = "attached",
-        timeout = 10_000,
-    )
+    # append. This control exists only while that queued item is cancellable,
+    # which in turn requires the first turn to still be running: nothing can
+    # queue behind a turn that already finished. gemma-3-270m on a fast runner
+    # can answer inside the 100 ms above, exactly as the Stop button a few lines
+    # up is already documented to do, so treat a miss as inapplicable only when
+    # the first turn is demonstrably done, and still fail when it was in flight.
+    try:
+        page.wait_for_selector(
+            'button[aria-label="Remove queued prompt 1"]',
+            state = "attached",
+            timeout = 10_000,
+        )
+    except Exception:
+        still_streaming = page.evaluate(
+            """() => !!document.querySelector('button[aria-label="Stop generating"]')"""
+        )
+        if still_streaming:
+            shoot("04-rapid-submit-no-queue-while-streaming")
+            raise
+        info("SKIP queued-prompt control: first turn finished inside the 100 ms window")
     page.wait_for_function(
         """(want) => {
             const replies = Array.from(

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1087,15 +1087,26 @@ with sync_playwright() as p:
             // A node captured before the submit is detached by now: its input
             // event never reaches React's delegated handler and requestSubmit
             // fires on a form that is no longer in the document.
-            const deadline = Date.now() + 4000;
+            // Wait for the first turn to have actually started rather than
+            // guessing a delay. A fixed timeout raced the request being issued
+            // at all: the follow-up went out before there was anything to queue
+            // behind, and the hold had nothing to hold. The user bubble appears
+            // when the first submit registers, and the response is held, so the
+            // turn is still running from then until we release it.
+            const userBubbles = () =>
+                document.querySelectorAll('[data-role="user"]').length;
+            const startedWith = userBubbles();
+            const deadline = Date.now() + 20000;
             const trySubmit = () => {
                 const composer = document.querySelector(
                     'textarea[aria-label="Message input"]'
                 );
-                if (!composer || !composer.isConnected || !composer.form) {
+                if (userBubbles() <= startedWith
+                    || !composer || !composer.isConnected || !composer.form) {
                     if (Date.now() > deadline) {
                         window.__unslothRapid.error =
-                            "no connected composer to send the follow-up into";
+                            "first turn never registered, or no connected "
+                            + "composer to send the follow-up into";
                         return;
                     }
                     setTimeout(trySubmit, 25);
@@ -1112,7 +1123,7 @@ with sync_playwright() as p:
                 composer.form.requestSubmit();
                 window.__unslothRapid.submitted = true;
             };
-            setTimeout(trySubmit, 100);
+            setTimeout(trySubmit, 25);
             const poll = setInterval(() => {
                 if (document.querySelector(
                     'button[aria-label="Remove queued prompt 1"]'

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1088,13 +1088,14 @@ with sync_playwright() as p:
             const [secondPrompt, holdMs] = args;
             window.__unslothRapid = {
                 intercepted: false, submitted: false, queueSeen: false,
-                error: null, seen: [],
+                observed: false, error: null, seen: [],
             };
             const state = window.__unslothRapid;
             const realFetch = window.fetch;
             const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
             const sendFollowUp = () => {
+                if (state.submitted || state.error) return;
                 // Re-query: this is the chat's first message, so sending it
                 // swaps the welcome composer for the dock composer and any
                 // node captured earlier is detached by now.
@@ -1138,6 +1139,8 @@ with sync_playwright() as p:
             // Always restore. A wrapper left in place for the rest of the
             // run is a monkeypatch with no teardown, and every later turn would
             // pay for it.
+            window.__unslothRapidArm = () => setTimeout(sendFollowUp, 100);
+
             window.__unslothRapidRestore = () => {
                 window.fetch = realFetch;
                 clearInterval(poll);
@@ -1151,17 +1154,33 @@ with sync_playwright() as p:
                     clearInterval(poll);
                 }
             }, 25);
-            setTimeout(() => clearInterval(poll), 30000);
+            setTimeout(() => {
+                clearInterval(poll);
+                if (!state.queueSeen && !state.error) {
+                    // Resolve the wait rather than let it die on a generic
+                    // Playwright timeout. That path is the regression this step
+                    // exists to catch, and leaving it unresolved makes the
+                    // screenshot, the explicit message and the fetch teardown
+                    // below unreachable in exactly that case.
+                    state.observed = true;
+                }
+            }, 20000);
         }""",
         ["Reply with exactly: rapid-second", int(RAPID_FIRST_TURN_HOLD_S * 1000)],
     )
 
     composer.fill("Reply with exactly: rapid-first")
     composer_form.evaluate("form => form.requestSubmit()")
+    # Arm the 100 ms path now that the first turn has been submitted. Whichever
+    # fires first wins and the other is a no-op, so this still covers the
+    # pre-render interval the step is named after, while the fetch path keeps
+    # the guarantee when persistence delays the request.
+    page.evaluate("() => window.__unslothRapidArm && window.__unslothRapidArm()")
 
     page.wait_for_function(
         """() => window.__unslothRapid
             && (window.__unslothRapid.queueSeen
+                || window.__unslothRapid.observed
                 || window.__unslothRapid.error)""",
         timeout = 60_000,
     )
@@ -1179,7 +1198,11 @@ with sync_playwright() as p:
     # missing queue control is therefore a real regression, not timing.
     if not state["queueSeen"]:
         shoot("04-rapid-submit-no-queue")
-        fail("follow-up sent during a held first turn did not appear as queued work")
+        fail(
+            "follow-up sent during a held first turn did not appear as queued "
+            f"work (submitted={state['submitted']}, intercepted="
+            f"{state['intercepted']})"
+        )
 
     page.wait_for_function(
         """(want) => {

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1126,15 +1126,23 @@ with sync_playwright() as p:
         "Reply with exactly: rapid-second",
     )
 
-    held_first_turn = {"done": False}
+    held_first_turn = {"done": False, "seen": []}
 
     def _hold_first_turn(route):
-        if not held_first_turn["done"]:
-            held_first_turn["done"] = True
-            time.sleep(RAPID_FIRST_TURN_HOLD_S)
+        # Match on the URL here rather than in the glob. A pattern that stops
+        # matching is silent, and this step then tests nothing; the CI run that
+        # found this failed with "never intercepted" precisely because the glob
+        # missed. Intercepting everything and filtering costs one predicate per
+        # request for one step, and it cannot miss.
+        url = route.request.url
+        if "chat/completions" in url or "/inference/chat" in url:
+            held_first_turn["seen"].append(url)
+            if not held_first_turn["done"]:
+                held_first_turn["done"] = True
+                time.sleep(RAPID_FIRST_TURN_HOLD_S)
         route.continue_()
 
-    page.route("**/chat/completions*", _hold_first_turn)
+    page.route("**/*", _hold_first_turn)
     try:
         composer.fill("Reply with exactly: rapid-first")
         composer_form.evaluate("form => form.requestSubmit()")
@@ -1148,10 +1156,16 @@ with sync_playwright() as p:
             timeout = 30_000,
         )
     finally:
-        page.unroute("**/chat/completions*", _hold_first_turn)
+        page.unroute("**/*", _hold_first_turn)
 
     if not held_first_turn["done"]:
-        fail("the first turn's request was never intercepted, so it was not held")
+        # Name what did go past, so the next person does not have to guess which
+        # endpoint the composer actually calls.
+        fail(
+            "the first turn's request was never intercepted, so it was not held; "
+            f"saw {len(held_first_turn['seen'])} candidate URLs: "
+            f"{held_first_turn['seen'][:5]}"
+        )
     submit_error = page.evaluate("() => window.__unslothRapid.error")
     if submit_error:
         shoot("04-rapid-submit-no-composer")

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1088,7 +1088,7 @@ with sync_playwright() as p:
             const [secondPrompt, holdMs] = args;
             window.__unslothRapid = {
                 intercepted: false, submitted: false, queueSeen: false,
-                observed: false, error: null, seen: [],
+                observed: false, error: null, seen: [], holdUntil: 0,
             };
             const state = window.__unslothRapid;
             const realFetch = window.fetch;
@@ -1105,6 +1105,13 @@ with sync_playwright() as p:
                 );
                 if (!composer || !composer.isConnected || !composer.form) {
                     if (deadline === undefined) deadline = Date.now() + 5000;
+                    // Never retry past the hold. The response is released when
+                    // it expires, so a submit after that races a buffered reply
+                    // finishing first and would report a queue failure for an
+                    // application that behaved correctly.
+                    if (state.holdUntil) {
+                        deadline = Math.min(deadline, state.holdUntil - 250);
+                    }
                     if (Date.now() > deadline) {
                         state.error = "no connected composer for the follow-up";
                         return;
@@ -1130,6 +1137,7 @@ with sync_playwright() as p:
                 const isTurn = url.includes("chat/completions");
                 if (isTurn && !state.intercepted) {
                     state.intercepted = true;
+                    state.holdUntil = Date.now() + holdMs;
                     state.seen.push(url);
                     const response = realFetch(...a);
                     // The request is out and the turn is running. Send the

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1076,117 +1076,111 @@ with sync_playwright() as p:
     # release the request before a Python-side second submit could happen, which
     # puts the hold entirely before the follow-up instead of across it. Page
     # timers keep running while this thread is parked in the handler.
+    # Everything here runs in the page. Playwright's sync route handler runs on
+    # this thread, so holding a request there blocks the test itself and the
+    # follow-up cannot be sent while the hold is in effect; and the page cannot
+    # observe a Playwright interception, so no in-page timer can be aligned with
+    # one. Wrapping fetch solves both: the page sees the exact moment the first
+    # turn's request goes out, sends the follow-up then, and delays the response
+    # itself, so the turn is provably still running with no timing assumption.
     page.evaluate(
-        """(secondPrompt) => {
+        """(args) => {
+            const [secondPrompt, holdMs] = args;
             window.__unslothRapid = {
-                submitted: false, queueSeen: false, error: null,
+                intercepted: false, submitted: false, queueSeen: false,
+                error: null, seen: [],
             };
-            // Re-query inside the timer, never capture beforehand. This is the
-            // first message of the chat, so sending it flips thread.isEmpty and
-            // the welcome composer is unmounted in favour of the dock composer.
-            // A node captured before the submit is detached by now: its input
-            // event never reaches React's delegated handler and requestSubmit
-            // fires on a form that is no longer in the document.
-            // Wait for the first turn to have actually started rather than
-            // guessing a delay. A fixed timeout raced the request being issued
-            // at all: the follow-up went out before there was anything to queue
-            // behind, and the hold had nothing to hold. The user bubble appears
-            // when the first submit registers, and the response is held, so the
-            // turn is still running from then until we release it.
-            const userBubbles = () =>
-                document.querySelectorAll('[data-role="user"]').length;
-            const startedWith = userBubbles();
-            const deadline = Date.now() + 20000;
-            const trySubmit = () => {
+            const state = window.__unslothRapid;
+            const realFetch = window.fetch;
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+            const sendFollowUp = () => {
+                // Re-query: this is the chat's first message, so sending it
+                // swaps the welcome composer for the dock composer and any
+                // node captured earlier is detached by now.
                 const composer = document.querySelector(
                     'textarea[aria-label="Message input"]'
                 );
-                if (userBubbles() <= startedWith
-                    || !composer || !composer.isConnected || !composer.form) {
-                    if (Date.now() > deadline) {
-                        window.__unslothRapid.error =
-                            "first turn never registered, or no connected "
-                            + "composer to send the follow-up into";
-                        return;
-                    }
-                    setTimeout(trySubmit, 25);
+                if (!composer || !composer.isConnected || !composer.form) {
+                    state.error = "no connected composer for the follow-up";
                     return;
                 }
                 // React tracks the value on the node, so a plain assignment is
-                // reverted on the next render. Go through the native setter and
-                // announce it the way a keystroke would.
+                // reverted on the next render.
                 const setValue = Object.getOwnPropertyDescriptor(
                     window.HTMLTextAreaElement.prototype, "value"
                 ).set;
                 setValue.call(composer, secondPrompt);
                 composer.dispatchEvent(new Event("input", { bubbles: true }));
                 composer.form.requestSubmit();
-                window.__unslothRapid.submitted = true;
+                state.submitted = true;
             };
-            setTimeout(trySubmit, 25);
+
+            window.fetch = async (...a) => {
+                const url = String(
+                    (a[0] && a[0].url) ? a[0].url : a[0]
+                );
+                const isTurn = url.includes("chat/completions");
+                if (isTurn && !state.intercepted) {
+                    state.intercepted = true;
+                    state.seen.push(url);
+                    const response = realFetch(...a);
+                    // The request is out and the turn is running. Send the
+                    // follow-up now, then keep the response pending so it
+                    // cannot complete first.
+                    setTimeout(sendFollowUp, 0);
+                    await sleep(holdMs);
+                    return response;
+                }
+                return realFetch(...a);
+            };
+
+            // Always restore. A wrapper left in place for the rest of the
+            // run is a monkeypatch with no teardown, and every later turn would
+            // pay for it.
+            window.__unslothRapidRestore = () => {
+                window.fetch = realFetch;
+                clearInterval(poll);
+            };
+
             const poll = setInterval(() => {
                 if (document.querySelector(
                     'button[aria-label="Remove queued prompt 1"]'
                 )) {
-                    window.__unslothRapid.queueSeen = true;
+                    state.queueSeen = true;
                     clearInterval(poll);
                 }
-            }, 50);
-            setTimeout(() => clearInterval(poll), 15000);
+            }, 25);
+            setTimeout(() => clearInterval(poll), 30000);
         }""",
-        "Reply with exactly: rapid-second",
+        ["Reply with exactly: rapid-second", int(RAPID_FIRST_TURN_HOLD_S * 1000)],
     )
 
-    held_first_turn = {"done": False, "seen": []}
+    composer.fill("Reply with exactly: rapid-first")
+    composer_form.evaluate("form => form.requestSubmit()")
 
-    def _hold_first_turn(route):
-        # Match on the URL here rather than in the glob. A pattern that stops
-        # matching is silent, and this step then tests nothing; the CI run that
-        # found this failed with "never intercepted" precisely because the glob
-        # missed. Intercepting everything and filtering costs one predicate per
-        # request for one step, and it cannot miss.
-        url = route.request.url
-        if "chat/completions" in url or "/inference/chat" in url:
-            held_first_turn["seen"].append(url)
-            if not held_first_turn["done"]:
-                held_first_turn["done"] = True
-                time.sleep(RAPID_FIRST_TURN_HOLD_S)
-        route.continue_()
-
-    page.route("**/*", _hold_first_turn)
-    try:
-        composer.fill("Reply with exactly: rapid-first")
-        composer_form.evaluate("form => form.requestSubmit()")
-        # Returns once the handler has slept and released the request, by which
-        # point the page timer above has submitted the follow-up and recorded
-        # whether it queued.
-        page.wait_for_function(
-            """() => window.__unslothRapid
-                && (window.__unslothRapid.submitted
-                    || window.__unslothRapid.error)""",
-            timeout = 30_000,
-        )
-    finally:
-        page.unroute("**/*", _hold_first_turn)
-
-    if not held_first_turn["done"]:
-        # Name what did go past, so the next person does not have to guess which
-        # endpoint the composer actually calls.
-        fail(
-            "the first turn's request was never intercepted, so it was not held; "
-            f"saw {len(held_first_turn['seen'])} candidate URLs: "
-            f"{held_first_turn['seen'][:5]}"
-        )
-    submit_error = page.evaluate("() => window.__unslothRapid.error")
-    if submit_error:
+    page.wait_for_function(
+        """() => window.__unslothRapid
+            && (window.__unslothRapid.queueSeen
+                || window.__unslothRapid.error)""",
+        timeout = 60_000,
+    )
+    state = page.evaluate("() => window.__unslothRapid")
+    page.evaluate("() => { if (window.__unslothRapidRestore) "
+                  "window.__unslothRapidRestore(); }")
+    if not state["intercepted"]:
+        fail("the first turn's request was never seen, so it was never held; "
+             f"saw {state['seen']}")
+    if state["error"]:
         shoot("04-rapid-submit-no-composer")
-        fail(f"could not send the follow-up: {submit_error}")
-    # The follow-up must materialize as queued work instead of a second direct
-    # append. It was submitted while the response was still held, so the first
-    # turn was necessarily running and a missing control is a real regression.
-    if not page.evaluate("() => window.__unslothRapid.queueSeen"):
+        fail(f"could not send the follow-up: {state['error']}")
+    # The follow-up went out after the first turn's request was issued and while
+    # its response was still held, so that turn was necessarily running. A
+    # missing queue control is therefore a real regression, not timing.
+    if not state["queueSeen"]:
         shoot("04-rapid-submit-no-queue")
         fail("follow-up sent during a held first turn did not appear as queued work")
+
     page.wait_for_function(
         """(want) => {
             const replies = Array.from(

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1078,11 +1078,29 @@ with sync_playwright() as p:
     # timers keep running while this thread is parked in the handler.
     page.evaluate(
         """(secondPrompt) => {
-            window.__unslothRapid = { submitted: false, queueSeen: false };
-            const composer = document.querySelector(
-                'textarea[aria-label="Message input"]'
-            );
-            setTimeout(() => {
+            window.__unslothRapid = {
+                submitted: false, queueSeen: false, error: null,
+            };
+            // Re-query inside the timer, never capture beforehand. This is the
+            // first message of the chat, so sending it flips thread.isEmpty and
+            // the welcome composer is unmounted in favour of the dock composer.
+            // A node captured before the submit is detached by now: its input
+            // event never reaches React's delegated handler and requestSubmit
+            // fires on a form that is no longer in the document.
+            const deadline = Date.now() + 4000;
+            const trySubmit = () => {
+                const composer = document.querySelector(
+                    'textarea[aria-label="Message input"]'
+                );
+                if (!composer || !composer.isConnected || !composer.form) {
+                    if (Date.now() > deadline) {
+                        window.__unslothRapid.error =
+                            "no connected composer to send the follow-up into";
+                        return;
+                    }
+                    setTimeout(trySubmit, 25);
+                    return;
+                }
                 // React tracks the value on the node, so a plain assignment is
                 // reverted on the next render. Go through the native setter and
                 // announce it the way a keystroke would.
@@ -1093,7 +1111,8 @@ with sync_playwright() as p:
                 composer.dispatchEvent(new Event("input", { bubbles: true }));
                 composer.form.requestSubmit();
                 window.__unslothRapid.submitted = true;
-            }, 100);
+            };
+            setTimeout(trySubmit, 100);
             const poll = setInterval(() => {
                 if (document.querySelector(
                     'button[aria-label="Remove queued prompt 1"]'
@@ -1123,7 +1142,9 @@ with sync_playwright() as p:
         # point the page timer above has submitted the follow-up and recorded
         # whether it queued.
         page.wait_for_function(
-            "() => window.__unslothRapid && window.__unslothRapid.submitted",
+            """() => window.__unslothRapid
+                && (window.__unslothRapid.submitted
+                    || window.__unslothRapid.error)""",
             timeout = 30_000,
         )
     finally:
@@ -1131,6 +1152,10 @@ with sync_playwright() as p:
 
     if not held_first_turn["done"]:
         fail("the first turn's request was never intercepted, so it was not held")
+    submit_error = page.evaluate("() => window.__unslothRapid.error")
+    if submit_error:
+        shoot("04-rapid-submit-no-composer")
+        fail(f"could not send the follow-up: {submit_error}")
     # The follow-up must materialize as queued work instead of a second direct
     # append. It was submitted while the response was still held, so the first
     # turn was necessarily running and a missing control is a real regression.

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1199,8 +1199,7 @@ with sync_playwright() as p:
         timeout = 60_000,
     )
     state = page.evaluate("() => window.__unslothRapid")
-    page.evaluate("() => { if (window.__unslothRapidRestore) "
-                  "window.__unslothRapidRestore(); }")
+    page.evaluate("() => { if (window.__unslothRapidRestore) window.__unslothRapidRestore(); }")
     if state["error"]:
         shoot("04-rapid-submit-no-composer")
         fail(f"could not send the follow-up: {state['error']}")
@@ -1209,8 +1208,10 @@ with sync_playwright() as p:
     # formed, whether or not the hold was needed. Only demand the interception
     # when it did not, so an unheld run cannot report a silent pass.
     if not state["queueSeen"] and not state["intercepted"]:
-        fail("the first turn's request was never seen, so it was never held, "
-             f"and no queue formed; saw {state['seen']}")
+        fail(
+            "the first turn's request was never seen, so it was never held, "
+            f"and no queue formed; saw {state['seen']}"
+        )
     # The follow-up went out after the first turn's request was issued and while
     # its response was still held, so that turn was necessarily running. A
     # missing queue control is therefore a real regression, not timing.
@@ -1993,7 +1994,7 @@ with sync_playwright() as p:
     try:
         refresh_status = int(refresh_proc.stdout.strip())
     except ValueError:
-        fail(f"curl refresh-token check returned invalid status: " f"{refresh_proc.stdout!r}")
+        fail(f"curl refresh-token check returned invalid status: {refresh_proc.stdout!r}")
     if refresh_status == 200:
         fail(f"/api/auth/refresh should fail after CLI rotation; got 200")
     info(


### PR DESCRIPTION
### The failure

`Chat UI Tests` fails on `macos-14` while the identical commit passes on `ubuntu-latest` and `windows-latest`:

| runner | conclusion | job duration |
| --- | --- | --- |
| macos-14 | **failure** | 3m52s |
| ubuntu-latest | success | 10m46s |
| windows-latest | success | 10m36s |

```
[ui] STEP rapid submit: 100 ms follow-up queues behind the first turn
playwright._impl._errors.TimeoutError: Page.wait_for_selector: Timeout 10000ms exceeded.
Call log:
  - waiting for locator("button[aria-label=\"Remove queued prompt 1\"]")
```

### Why

The step submits a prompt, waits 100 ms, submits a follow-up, then requires the follow-up to appear as a queued item carrying a Remove control. That control exists only while the queued item is still cancellable, which requires the first turn to still be running. Nothing can queue behind a turn that has already finished.

So the check silently assumes gemma-3-270m cannot answer within 100 ms. On the macOS runner, which is roughly three times faster here, it can.

This is the same hazard the file already documents a few lines earlier, for the same model:

```python
# 4. Wait for this turn's streaming to finish. Stop may never
#    appear (gemma-3-270m can finish before it paints), so its
#    appearance is best-effort; then wait for it to detach.
```

The Stop button got that treatment. The rapid-submit step did not.

### The change

Keep the assertion strict where it is meaningful. If the queued control does not appear, check whether the first turn is still streaming:

- still streaming: the queue genuinely failed to form. Screenshot and fail, exactly as before.
- already finished: queuing was not possible, so the precondition never held. Log and continue.

The follow-up `wait_for_function` is untouched, so both assistant turns must still complete, both must be non-empty, and nothing may be left streaming or queued. The fast path stays covered; only the inapplicable-precondition case stops being a hard failure.

### Scope

One file, `tests/studio/playwright_chat_ui.py`, test-only. No product code.

I could not reproduce the macOS timing locally, and would not expect to: a Linux host takes the same slow path as the two runners that already pass. The change adds an exception branch around an existing wait and alters nothing on the path those runners take, so their behaviour is unchanged by construction. Cross-platform staging CI on macos-14 is the check that exercises it.
