### PR TITLE
CI: drop three macOS legs that assert nothing a Linux runner does not

### DIFF
--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -71,7 +71,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # No macOS leg on purpose. This matrix exists for Windows: the parity
+        # tests are pure `Path.read_text()` + regex assertions over install.sh /
+        # install.ps1 / setup.ps1, and the OS-specific risk they guard is the
+        # cp1252 default encoding on Windows. There is no `platform.`,
+        # `sys.platform`, `darwin` or `uname` reference anywhere in
+        # tests/python/test_cross_platform_parity.py, so the macOS row asserted
+        # exactly what the Linux row already asserts. macOS concurrency is
+        # capped at 5 account-wide; do not add it back without a Mac-specific
+        # assertion to justify it.
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -36,13 +36,17 @@
 #      only place in CI that exercises a real MLX backward pass +
 #      optimizer step + inference call.
 #
-# Three dispatch test files documented in tests/studio/README.md:
-#   - test_hardware_dispatch_matrix.py    parametrized 7-profile matrix
-#                                         + 2 dispatch-priority canaries
-#   - test_is_mlx_dispatch_gate.py        AST + runtime guard on
-#                                         unsloth._IS_MLX
+# Dispatch test files documented in tests/studio/README.md:
 #   - test_mlx_training_worker_behaviors.py  AST contract checks on
 #                                            studio/backend/core/training/worker.py
+#     Run here because no other workflow claims it.
+#
+# test_hardware_dispatch_matrix.py and test_is_mlx_dispatch_gate.py are NOT run
+# here. Both are fully spoofed (monkeypatched profiles plus a MetaPathFinder
+# that blocks `import mlx.core`), so they assert identically on any host, and
+# studio-backend-ci.yml runs both on ubuntu-latest. macOS concurrency is capped
+# at 5 jobs account-wide; re-running host-independent tests on that pool is the
+# most expensive way to learn nothing new.
 #
 # Surfaces a single PR check ("MLX CI on Mac M1 / dispatch").
 #
@@ -64,8 +68,12 @@ on:
       - 'studio/backend/utils/hardware/**'
       - 'studio/backend/core/training/worker.py'
       - 'studio/backend/core/inference/mlx_inference.py'
-      - 'tests/studio/test_hardware_dispatch_matrix.py'
-      - 'tests/studio/test_is_mlx_dispatch_gate.py'
+      # test_hardware_dispatch_matrix.py and test_is_mlx_dispatch_gate.py are
+      # deliberately absent: this workflow no longer runs them (see the AST
+      # contract step below), so booting a macOS runner when only those files
+      # change would burn a slot from the 5-job account-wide macOS cap to run
+      # nothing related. studio-backend-ci.yml covers both on ubuntu-latest and
+      # already triggers on them.
       - 'tests/studio/test_mlx_training_worker_behaviors.py'
       - 'tests/studio/run_real_mlx_smoke.py'
       - 'tests/conftest.py'
@@ -216,19 +224,24 @@ jobs:
           print('OK: FastMLXModel + MLXTrainer surface present')
           "
 
-      # Spoofed dispatch matrix. Runs on the real Mac too -- the
-      # test fixture installs a MetaPathFinder that blocks
-      # `import mlx.core` for "no-mlx" profiles, so the spoofs
-      # faithfully simulate every supported hardware combo regardless
-      # of whether mlx is installed for real.
-      - name: MLX dispatch tests (3 files, 36 tests)
+      # AST contract checks on worker.py. Pure `ast.parse`, no runtime and no
+      # mlx import, so it would run anywhere -- but this is the only workflow
+      # that runs it at all, so it stays here until something on Linux claims it.
+      #
+      # test_hardware_dispatch_matrix.py and test_is_mlx_dispatch_gate.py used
+      # to run here too. They are 100% spoofed monkeypatches (the fixture
+      # installs a MetaPathFinder that blocks `import mlx.core` for "no-mlx"
+      # profiles), so they assert the same thing on any host -- and
+      # studio-backend-ci.yml already runs both on ubuntu-latest in its
+      # "Hardware-spoof tests" step. Running them again on a macOS runner spent
+      # minutes from a pool capped at 5 concurrent jobs account-wide to
+      # re-derive a result Linux had already produced.
+      - name: MLX worker AST contract tests
         env:
           PYTHONPATH: ${{ github.workspace }}/studio
           UNSLOTH_COMPILE_DISABLE: '1'
         run: |
           python -m pytest -v --tb=short \
-            tests/studio/test_hardware_dispatch_matrix.py \
-            tests/studio/test_is_mlx_dispatch_gate.py \
             tests/studio/test_mlx_training_worker_behaviors.py
 
       # Real MLX training + inference smoke test. Trains

--- a/.github/workflows/studio-export-capability-ci.yml
+++ b/.github/workflows/studio-export-capability-ci.yml
@@ -44,7 +44,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # No macOS leg on purpose. The only command this job runs is
+        # `pytest tests/test_export_capability.py`, and every test in that file
+        # goes through `_patch()`, which monkeypatches `_has_torch`,
+        # `get_device` and `is_apple_silicon`. Nothing in it touches Metal, MLX
+        # or any Apple binary, so a real Mac proves nothing a Linux runner does
+        # not already prove -- and studio-backend-ci.yml runs the same file on
+        # ubuntu-latest as part of `pytest tests/`. macOS concurrency is capped
+        # at 5 account-wide, so a leg that buys no signal is worth reclaiming.
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     env:


### PR DESCRIPTION
## Summary

GitHub caps **concurrent macOS jobs at 5** per account, shared across every `macos-*` label and across `unslothai/unsloth` and `unslothai/unsloth-zoo`. Enterprise is the only plan that raises it.

That cap is the binding constraint on CI latency here. Measured during a busy period: **35 jobs running against a 60-job total cap** (19 linux, 13 windows, 3 macOS) while **15 macOS jobs sat queued behind 5 slots**. The total cap is nowhere near reached, so raising overall concurrency would change nothing; macOS is the one genuinely scarce resource, and it was the slow leg on the last two desktop releases.

This PR removes three macOS legs that cost a slot each and produce no signal a Linux leg does not already produce.

## The three legs

**`studio-export-capability-ci.yml`** runs exactly one command, `pytest tests/test_export_capability.py`. Every test in that file goes through `_patch()`, which monkeypatches `_has_torch`, `get_device` and `is_apple_silicon`. Nothing touches Metal, MLX or any Apple binary. `studio-backend-ci.yml` already runs the same file on `ubuntu-latest` as part of `pytest tests/`, and does not deselect it.

**`cross-platform-parity-ci.yml`** runs source-text assertions. `tests/python/test_cross_platform_parity.py` is `Path.read_text()` plus regex over `install.sh` / `install.ps1` / `setup.ps1`, with **zero** `platform.`, `sys.platform`, `darwin` or `uname` references. The matrix exists for the Windows cp1252 default encoding, which the workflow header states outright. The macOS row asserted what the Linux row already asserts.

**`mlx-ci.yml`** keeps every Metal-bound step and stops re-running two fully spoofed test files. `test_hardware_dispatch_matrix.py` and `test_is_mlx_dispatch_gate.py` use monkeypatched profiles plus a `MetaPathFinder` that blocks `import mlx.core`, so they assert identically on any host, and `studio-backend-ci.yml` runs both on `ubuntu-latest` in its "Hardware-spoof tests" step. Their `paths:` triggers are removed too, so a change touching only those files no longer boots a Mac to run nothing related.

`test_mlx_training_worker_behaviors.py` **stays** on the Mac. It is pure `ast.parse` and would run anywhere, but no Linux job currently claims it, so removing it would have been real coverage loss.

## What is unchanged

Every genuinely Apple-bound step is untouched: real `_IS_MLX` verification, the real `mlx` module imports, the real LoRA training round-trip, `assert-llama-loads.sh`, codesigning and notarization.

## Test plan

- [x] All four modified workflow files parse as valid YAML
- [x] macOS job census across the repo: **33 -> 31**
- [x] Assertion-preservation diff: extracted the test-command set from every `run:` body before and after. The sets are identical apart from the two spoofed files, which is the intended change
- [x] Confirmed `studio-backend-ci.yml` triggers on `tests/**`, so both moved files still run on `ubuntu-latest` when changed
- [ ] CI green on this PR

## Follow-up

A second PR will consolidate the duplicated macOS smoke preamble. A byte-identical 5-step block (checkout, setup-node, setup-python, `install.sh --local --no-torch`, `assert-llama-loads.sh`) currently repeats across 7 job definitions, so a `studio/**` PR runs the same install on `macos-14` up to 7 times concurrently. Keeping that restructure separate so these deletions can land and be judged on their own.