### PR TITLE
Studio: keep the sidebar fade in sync on resize and centre the profile row

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -2415,7 +2415,7 @@ export function AppSidebar() {
           "relative pb-[11px] group-data-[collapsible=icon]:px-0",
           // Tighter top with the update card so the fade hugs it; fuller top
           // for the profile on its own.
-          showUpdateCard ? "pt-1" : "pt-1.5",
+          showUpdateCard ? "pt-0.5" : "pt-1",
         )}
       >
         {/* Fade above the profile box, shown only when there's more list below
@@ -2426,11 +2426,12 @@ export function AppSidebar() {
           className={cn(
             // The scroll area hard-clips at the fade's bottom edge, so a plain
             // ramp is still part-transparent there and slices the last row
-            // mid-glyph. from-[16px] holds it opaque across the clip.
-            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[16px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
+            // mid-glyph. from-[6px] holds it opaque just across the clip:
+            // enough to cover it, short enough not to read as a white band.
+            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[6px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
             // Shorter fade with the update card so the list reads closer to
             // it, but still tall enough to clear a row.
-            showUpdateCard ? "h-9" : "h-14",
+            showUpdateCard ? "h-7" : "h-10",
             canScrollDown ? "opacity-100" : "opacity-0",
           )}
         />

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -2413,9 +2413,9 @@ export function AppSidebar() {
       <SidebarFooter
         className={cn(
           "relative pb-[11px] group-data-[collapsible=icon]:px-0",
-          // Tighter top with the update card so the fade hugs it; fuller top
-          // for the profile on its own.
-          showUpdateCard ? "pt-0.5" : "pt-1",
+          // pt-[5px] + the 6px fade plateau matches the 11px below the
+          // profile, so it sits centred. Tighter with the update card above.
+          showUpdateCard ? "pt-1" : "pt-[5px]",
         )}
       >
         {/* Fade above the profile box, shown only when there's more list below

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -2413,9 +2413,10 @@ export function AppSidebar() {
       <SidebarFooter
         className={cn(
           "relative pb-[11px] group-data-[collapsible=icon]:px-0",
-          // pt-[5px] + the 6px fade plateau matches the 11px below the
-          // profile, so it sits centred. Tighter with the update card above.
-          showUpdateCard ? "pt-1" : "pt-[5px]",
+          // pt-[3px] cancels the profile button's -3px margin, so the 8px
+          // above it is whatever sits over the footer edge (the fade plateau,
+          // or the list's pb-2 once the fade is hidden) and 8px sits below.
+          showUpdateCard ? "pt-1" : "pt-[3px]",
         )}
       >
         {/* Fade above the profile box, shown only when there's more list below
@@ -2426,9 +2427,9 @@ export function AppSidebar() {
           className={cn(
             // The scroll area hard-clips at the fade's bottom edge, so a plain
             // ramp is still part-transparent there and slices the last row
-            // mid-glyph. from-[6px] holds it opaque just across the clip:
-            // enough to cover it, short enough not to read as a white band.
-            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[6px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
+            // mid-glyph. from-[8px] holds it opaque just across the clip, and
+            // matches the list's pb-2 so the gap is the same once it hides.
+            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[8px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
             // Shorter fade with the update card so the list reads closer to
             // it, but still tall enough to clear a row.
             showUpdateCard ? "h-7" : "h-10",

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -655,7 +655,7 @@ export function AppSidebar() {
   // Driven only from onScroll + a content-change effect below. No
   // ResizeObserver: its callback-driven setState caused a render loop (React
   // #185). Both setters bail out when unchanged, so neither path can loop.
-  const syncScrollState = (el: HTMLDivElement) => {
+  const syncScrollState = useCallback((el: HTMLDivElement) => {
     const nextScrolled = el.scrollTop > 0;
     setScrolled((prev) => (prev === nextScrolled ? prev : nextScrolled));
     const nextCanScrollDown =
@@ -663,7 +663,7 @@ export function AppSidebar() {
     setCanScrollDown((prev) =>
       prev === nextCanScrollDown ? prev : nextCanScrollDown,
     );
-  };
+  }, []);
 
   const isRecipesRoute = pathname.startsWith("/data-recipes");
   const isExportRoute = pathname === "/export" || pathname.startsWith("/export/");
@@ -904,7 +904,21 @@ export function AppSidebar() {
     runsOpen,
     pinnedOpen,
     isStudioRoute,
+    // The update card grows the footer, so the scroll area shrinks under it.
+    showUpdateCard,
   ]);
+
+  // Resizing changes clientHeight without firing onScroll, so the fade would
+  // stay hidden while rows are still clipped. Window events only: no element
+  // observer, so this can't feed back into the loop that caused React #185.
+  useEffect(() => {
+    const onResize = () => {
+      const el = scrollRef.current;
+      if (el) syncScrollState(el);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [syncScrollState]);
 
   const chatDisabled = trainingInProgress;
   const usesDesktopTitlebar = usesCustomTitlebar || usesNativeMacTitlebar;
@@ -2401,7 +2415,7 @@ export function AppSidebar() {
           "relative pb-[11px] group-data-[collapsible=icon]:px-0",
           // Tighter top with the update card so the fade hugs it; fuller top
           // for the profile on its own.
-          showUpdateCard ? "pt-1.5" : "pt-2.5",
+          showUpdateCard ? "pt-1" : "pt-1.5",
         )}
       >
         {/* Fade above the profile box, shown only when there's more list below


### PR DESCRIPTION
Follow-up to #7902.

## Problem

#7902 fixed the fade's gradient so it covers the scroll container's clip edge. Three things were still wrong.

### 1. The fade goes stale on resize, so it is not painted at all

`canScrollDown` gates the fade's opacity, and it was only recomputed on scroll, on the collapsible `onAnimationEnd`, and from a content-change effect keyed on list lengths. Resizing the window changes `clientHeight` without firing any of them. Shrink the window and rows start overflowing, but `canScrollDown` stays `false`, so the fade sits at `opacity-0` while content is being clipped. The result is a hard cut with no gradient at all, most visible on desktop where windows get resized constantly.

The update card has the same problem from the other direction: it grows the footer and shrinks the scroll area under it, but it was not in the effect's deps.

### 2. The fade left a white block on top of the profile row

The opaque plateau from #7902 only has to cover the clip edge, and 16px was far wider than that, so it read as a solid band rather than the tail of a fade.

### 3. The profile row was not centred in its footer

The space above the profile was the plateau plus the footer's top padding, which came to far more than the 11px below it.

## Fix

Staleness:

- Add a `window` resize listener that re-runs the existing measurement. Window events only, no element observer, so this cannot feed back into the loop that caused the React #185 the existing comment warns about. The setters already bail out when unchanged.
- Wrap `syncScrollState` in `useCallback` so the effect has a stable dependency.
- Add `showUpdateCard` to the content-change effect deps.

Spacing:

- Plateau `from-[16px]` to `from-[6px]`, still covering the clip edge without reading as a band.
- Fade height back to `h-10`, `h-7` with the update card, so the ramp above the plateau clears sooner.
- Footer top padding to `pt-[5px]`. With the profile button's `-my-[3px]`, that puts 8px above the row and 8px below it.

`pb-[11px]` is deliberately untouched: it comes from #7901 for Tauri sidebar alignment and is pinned by a test there.

## Notes

One file. `tsc -b` is clean and the 463 frontend tests pass, including the #7901 footer guard.
