### PR TITLE
Update the nav icon button size contract to the 30px box

### DIFF
--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -401,7 +401,7 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert navigation.count('aria-label="Go back"') == 1
     assert navigation.count('aria-label="Go forward"') == 1
 
-    assert "inline-flex size-[33px] shrink-0" in navigation
+    assert "inline-flex size-[30px] shrink-0" in navigation
 
     assert navigation.count("onDoubleClick={stopTitlebarDrag}") == 3
     assert "maximized" not in navigation
@@ -417,7 +417,7 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert '"--studio-collapsed-chat-controls-inset": "188px"' in APP_PROVIDER.read_text(
         encoding = "utf-8"
     )
-    assert 'className="!size-[33px] rounded-[10px] text-muted-foreground"' in chat_page
+    assert 'className="!size-[30px] rounded-[10px] text-muted-foreground"' in chat_page
     assert 'aria-label="New chat"' in chat_page
     new_chat_click = chat_page.index("onClick={handleDesktopNewChat}")
     assert new_chat_click < chat_page.index("<ModelSelector", new_chat_click)


### PR DESCRIPTION
`main` is currently red on `Repo tests (CPU)`, and every open PR inherits it because CI builds the merge with `main`.

`#7970` moved every nav icon button to a 30px `rounded-[10px]` box. `tests/studio/test_desktop_reliability_frontend_contract.py` still asserts the old 33px literals, so `test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker` fails.

Two assertions in that test:

- line 404, the titlebar navigation button class
- line 420, the chat page model picker button class

The second is currently masked by the first.

The behaviour the test guards is unchanged: the history arrows survive collapse and appear exactly once each. Only the hardcoded sizes were stale, so this updates the literals rather than touching any component.

### Attribution

Bisected the commits `main` gained since `b41b819a4`:

| commit | subject | result |
|---|---|---|
| `73d54964b` | Require every declared denoiser, and every shard of it | 25 passed |
| `b325dd9ad` | Fix the Windows-only snapshot path assertion | 25 passed |
| `de1d0f8f2` | Studio: paint the image and video pickers from the curated catalog | 25 passed |
| `9719692fe` | Update _utils.py | 25 passed |
| `8c79e81de` | Bump install.sh / install.ps1 pins | 25 passed |
| `c4144da5b` | Studio: consistent rounded hover boxes for nav icon buttons (#7970) | **1 failed, 24 passed** |

### Verification

Fails before, passes after:

```
$ git stash && pytest tests/studio/test_desktop_reliability_frontend_contract.py -q
1 failed, 24 passed

$ git stash pop && pytest tests/studio/test_desktop_reliability_frontend_contract.py -q
25 passed
```

`tests/studio` is otherwise unaffected: 2520 passed, 4 skipped.