### PR TITLE
Clamp Deep Research max_tokens to loaded context window

### DIFF
--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -711,6 +711,92 @@ def _loaded_context_length() -> int | None:
     return None
 
 
+def _estimate_prompt_tokens(messages: list[dict]) -> int:
+    """Conservative prompt token estimate for max_tokens clamping.
+
+    Uses the same chars-per-token heuristic as synthesis evidence budgeting so
+    Deep Research sizes output against the same context window it already probes.
+    """
+    chars = 0
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, str):
+            chars += len(content)
+            continue
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict):
+                    text = part.get("text")
+                    if isinstance(text, str):
+                        chars += len(text)
+    return max(1, int(chars / _SYNTHESIS_EVIDENCE_CHARS_PER_TOKEN) + len(messages) * 4)
+
+
+def _clamp_max_tokens_for_context(
+    requested: int,
+    messages: list[dict],
+    *,
+    context_length: int | None = None,
+) -> int:
+    ctx = context_length if context_length is not None else _loaded_context_length()
+    if not ctx:
+        return requested
+    available = max(1, ctx - _estimate_prompt_tokens(messages))
+    return max(1, min(requested, available))
+
+
+def _resolve_max_tokens(
+    max_tokens: int | None,
+    inference: dict[str, Any],
+    messages: list[dict],
+) -> int:
+    requested = int(max_tokens or inference.get("maxTokens") or 4096)
+    ceiling = 16384 if max_tokens is not None else 8192
+    capped = min(requested, ceiling)
+    return _clamp_max_tokens_for_context(capped, messages)
+
+
+def _normalize_completion_usage(raw: Any) -> dict[str, int] | None:
+    if not isinstance(raw, dict):
+        return None
+    usage: dict[str, int] = {}
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        value = raw.get(key)
+        if isinstance(value, (int, float)):
+            usage[key] = int(value)
+    return usage or None
+
+
+def _completion_hit_context_wall(
+    usage: dict[str, int] | None,
+    *,
+    requested_max_tokens: int,
+    context_length: int | None = None,
+) -> bool:
+    if not usage:
+        return False
+    prompt_tokens = int(usage.get("prompt_tokens") or 0)
+    completion_tokens = int(usage.get("completion_tokens") or 0)
+    total_tokens = int(usage.get("total_tokens") or prompt_tokens + completion_tokens)
+    ctx = context_length if context_length is not None else _loaded_context_length()
+    if ctx is not None and total_tokens >= ctx:
+        return True
+    return completion_tokens < requested_max_tokens
+
+
+def _synthesis_length_limit_error(
+    usage: dict[str, int] | None,
+    *,
+    requested_max_tokens: int,
+) -> str:
+    if _completion_hit_context_wall(usage, requested_max_tokens = requested_max_tokens):
+        return (
+            "Local model report hit the loaded context window before completion. "
+            "Lower Context Length in chat settings or reduce the research evidence size."
+        )
+    return "Local model report reached its output limit before completion"
+
+
 async def _model_unloaded(response: httpx.Response) -> bool:
     """Whether the local endpoint refused because no model is loaded (routes.inference). That is
     transient for a durable run -- the model can be loaded again -- unlike any other 400."""
@@ -1547,12 +1633,13 @@ class ResearchSupervisor:
         )
         config = run["config"]
         inference = config.get("inferenceRequest") or {}
+        resolved_max_tokens = _resolve_max_tokens(None, inference, messages)
         payload: dict[str, Any] = {
             "model": inference.get("model") or config.get("model") or "",
             "messages": messages,
             "stream": False,
             "temperature": inference.get("temperature", 0.2),
-            "max_tokens": min(int(inference.get("maxTokens") or 4096), 8192),
+            "max_tokens": resolved_max_tokens,
         }
         if inference.get("topP") is not None:
             payload["top_p"] = inference["topP"]
@@ -1741,7 +1828,7 @@ class ResearchSupervisor:
         step_position: int | None = None,
         max_tokens: int | None = None,
         enable_thinking: bool | None = None,
-    ) -> tuple[str, str, str | None]:
+    ) -> tuple[str, str, str | None, dict[str, int] | None]:
         call_id = uuid.uuid4().hex
         expires = (datetime.now(timezone.utc) + timedelta(hours = 2)).isoformat()
         token, key = await asyncio.to_thread(
@@ -1753,15 +1840,13 @@ class ResearchSupervisor:
         )
         config = run["config"]
         inference = config.get("inferenceRequest") or {}
+        resolved_max_tokens = _resolve_max_tokens(max_tokens, inference, messages)
         payload: dict[str, Any] = {
             "model": inference.get("model") or config.get("model") or "",
             "messages": messages,
             "stream": True,
             "temperature": inference.get("temperature", 0.2),
-            "max_tokens": min(
-                int(max_tokens or inference.get("maxTokens") or 4096),
-                16384 if max_tokens is not None else 8192,
-            ),
+            "max_tokens": resolved_max_tokens,
         }
         if inference.get("topP") is not None:
             payload["top_p"] = inference["topP"]
@@ -1782,6 +1867,7 @@ class ResearchSupervisor:
         pending_reasoning_offset = 0
         last_progress_flush = asyncio.get_running_loop().time()
         finish_reason: str | None = None
+        usage: dict[str, int] | None = None
         semantic_output_at: float | None = None
         first_output_deadline: float | None = None
 
@@ -1952,6 +2038,11 @@ class ResearchSupervisor:
                             chunk = json.loads(data)
                             if isinstance(chunk, dict) and "error" in chunk:
                                 raise RuntimeError("Local model stream failed")
+                            normalized_usage = _normalize_completion_usage(
+                                chunk.get("usage") if isinstance(chunk, dict) else None
+                            )
+                            if normalized_usage is not None:
+                                usage = normalized_usage
                             choice = chunk.get("choices", [{}])[0]
                             delta = choice.get("delta", {})
                             if isinstance(choice.get("finish_reason"), str):
@@ -2004,7 +2095,7 @@ class ResearchSupervisor:
                                 exc_info = True,
                             )
             await flush_progress()
-            return report, reasoning, finish_reason
+            return report, reasoning, finish_reason, usage
         except (TimeoutError, asyncio.TimeoutError) as exc:
             raise ModelWallClockTimeout(
                 "Local model request exceeded its wall-clock timeout"
@@ -2139,7 +2230,7 @@ class ResearchSupervisor:
                 planning_total, len(planner_system) + len(planning_question), _MAX_CONTEXT_CHARS
             )
         ]
-        response, planning_reasoning, _finish_reason = await self._stream_completion(
+        response, planning_reasoning, _finish_reason, _usage = await self._stream_completion(
             run,
             [
                 {
@@ -2359,7 +2450,7 @@ class ResearchSupervisor:
                     decision_total, decision_scaffold + evidence_chars, _MAX_CONTEXT_CHARS
                 )
             ]
-            decision, decision_reasoning, _finish_reason = await self._stream_completion(
+            decision, decision_reasoning, _finish_reason, _usage = await self._stream_completion(
                 run,
                 [
                     {
@@ -2681,7 +2772,7 @@ class ResearchSupervisor:
                 _MAX_CONTEXT_CHARS,
             )
         ]
-        audit_response, audit_reasoning, _audit_finish_reason = await self._stream_completion(
+        audit_response, audit_reasoning, _audit_finish_reason, _audit_usage = await self._stream_completion(
             run,
             [
                 {
@@ -2787,11 +2878,13 @@ class ResearchSupervisor:
                 ),
             },
         ]
-        report, synthesis_reasoning, synthesis_finish_reason = await self._stream_completion(
-            run,
-            synthesis_messages,
-            phase = "synthesis",
-            max_tokens = 16384,
+        report, synthesis_reasoning, synthesis_finish_reason, synthesis_usage = (
+            await self._stream_completion(
+                run,
+                synthesis_messages,
+                phase = "synthesis",
+                max_tokens = 16384,
+            )
         )
         await self._check_active(run["id"])
         if synthesis_finish_reason == "length":
@@ -2807,10 +2900,16 @@ class ResearchSupervisor:
                 },
                 synthesis_messages[1],
             ]
+            recovery_max_tokens = _resolve_max_tokens(
+                16384,
+                run["config"].get("inferenceRequest") or {},
+                recovery_messages,
+            )
             (
                 recovered_report,
                 recovery_reasoning,
                 recovery_finish_reason,
+                recovery_usage,
             ) = await self._stream_completion(
                 run,
                 recovery_messages,
@@ -2821,9 +2920,15 @@ class ResearchSupervisor:
             synthesis_reasoning += recovery_reasoning
             report = recovered_report
             synthesis_finish_reason = recovery_finish_reason
+            synthesis_usage = recovery_usage
             await self._check_active(run["id"])
             if synthesis_finish_reason == "length":
-                raise ValueError("Local model report reached its output limit before completion")
+                raise ValueError(
+                    _synthesis_length_limit_error(
+                        synthesis_usage,
+                        requested_max_tokens = recovery_max_tokens,
+                    )
+                )
         if not report.strip():
             report = _recover_report_from_reasoning(synthesis_reasoning)
         if not report:

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -746,9 +746,7 @@ def _clamp_max_tokens_for_context(
 
 
 def _resolve_max_tokens(
-    max_tokens: int | None,
-    inference: dict[str, Any],
-    messages: list[dict],
+    max_tokens: int | None, inference: dict[str, Any], messages: list[dict]
 ) -> int:
     requested = int(max_tokens or inference.get("maxTokens") or 4096)
     ceiling = 16384 if max_tokens is not None else 8192
@@ -785,9 +783,7 @@ def _completion_hit_context_wall(
 
 
 def _synthesis_length_limit_error(
-    usage: dict[str, int] | None,
-    *,
-    requested_max_tokens: int,
+    usage: dict[str, int] | None, *, requested_max_tokens: int
 ) -> str:
     if _completion_hit_context_wall(usage, requested_max_tokens = requested_max_tokens):
         return (
@@ -2772,7 +2768,12 @@ class ResearchSupervisor:
                 _MAX_CONTEXT_CHARS,
             )
         ]
-        audit_response, audit_reasoning, _audit_finish_reason, _audit_usage = await self._stream_completion(
+        (
+            audit_response,
+            audit_reasoning,
+            _audit_finish_reason,
+            _audit_usage,
+        ) = await self._stream_completion(
             run,
             [
                 {
@@ -2878,13 +2879,16 @@ class ResearchSupervisor:
                 ),
             },
         ]
-        report, synthesis_reasoning, synthesis_finish_reason, synthesis_usage = (
-            await self._stream_completion(
-                run,
-                synthesis_messages,
-                phase = "synthesis",
-                max_tokens = 16384,
-            )
+        (
+            report,
+            synthesis_reasoning,
+            synthesis_finish_reason,
+            synthesis_usage,
+        ) = await self._stream_completion(
+            run,
+            synthesis_messages,
+            phase = "synthesis",
+            max_tokens = 16384,
         )
         await self._check_active(run["id"])
         if synthesis_finish_reason == "length":

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1629,13 +1629,11 @@ class ResearchSupervisor:
         )
         config = run["config"]
         inference = config.get("inferenceRequest") or {}
-        resolved_max_tokens = _resolve_max_tokens(None, inference, messages)
         payload: dict[str, Any] = {
             "model": inference.get("model") or config.get("model") or "",
             "messages": messages,
             "stream": False,
             "temperature": inference.get("temperature", 0.2),
-            "max_tokens": resolved_max_tokens,
         }
         if inference.get("topP") is not None:
             payload["top_p"] = inference["topP"]
@@ -1652,6 +1650,7 @@ class ResearchSupervisor:
                 model_waits = 0
                 while True:
                     await self._check_active(run["id"])
+                    payload["max_tokens"] = _resolve_max_tokens(None, inference, messages)
                     try:
                         post_task = asyncio.create_task(
                             client.post(
@@ -1684,11 +1683,6 @@ class ResearchSupervisor:
                             if model_waits <= _MAX_MODEL_WAITS and await self._wait_for_local_model(
                                 run
                             ):
-                                payload["max_tokens"] = _resolve_max_tokens(
-                                    None,
-                                    inference,
-                                    messages,
-                                )
                                 continue
                             raise
                         retryable = (
@@ -1841,14 +1835,12 @@ class ResearchSupervisor:
         )
         config = run["config"]
         inference = config.get("inferenceRequest") or {}
-        resolved_max_tokens = _resolve_max_tokens(max_tokens, inference, messages)
         payload: dict[str, Any] = {
             "model": inference.get("model") or config.get("model") or "",
             "messages": messages,
             "stream": True,
             "stream_options": {"include_usage": True},
             "temperature": inference.get("temperature", 0.2),
-            "max_tokens": resolved_max_tokens,
         }
         if inference.get("topP") is not None:
             payload["top_p"] = inference["topP"]
@@ -1965,6 +1957,11 @@ class ResearchSupervisor:
                 attempt = 0
                 try:
                     while True:
+                        payload["max_tokens"] = _resolve_max_tokens(
+                            max_tokens,
+                            inference,
+                            messages,
+                        )
                         request = client.build_request(
                             "POST",
                             self._endpoint(),
@@ -2011,11 +2008,6 @@ class ResearchSupervisor:
                                 # without spending a transport attempt.
                                 if not await self._wait_for_local_model(run):
                                     raise
-                                payload["max_tokens"] = _resolve_max_tokens(
-                                    max_tokens,
-                                    inference,
-                                    messages,
-                                )
                             else:
                                 # _completion's policy, so both paths agree; re-check the lease
                                 # and cancellation before re-sending.

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1684,6 +1684,11 @@ class ResearchSupervisor:
                             if model_waits <= _MAX_MODEL_WAITS and await self._wait_for_local_model(
                                 run
                             ):
+                                payload["max_tokens"] = _resolve_max_tokens(
+                                    None,
+                                    inference,
+                                    messages,
+                                )
                                 continue
                             raise
                         retryable = (
@@ -1841,6 +1846,7 @@ class ResearchSupervisor:
             "model": inference.get("model") or config.get("model") or "",
             "messages": messages,
             "stream": True,
+            "stream_options": {"include_usage": True},
             "temperature": inference.get("temperature", 0.2),
             "max_tokens": resolved_max_tokens,
         }
@@ -2005,6 +2011,11 @@ class ResearchSupervisor:
                                 # without spending a transport attempt.
                                 if not await self._wait_for_local_model(run):
                                     raise
+                                payload["max_tokens"] = _resolve_max_tokens(
+                                    max_tokens,
+                                    inference,
+                                    messages,
+                                )
                             else:
                                 # _completion's policy, so both paths agree; re-check the lease
                                 # and cancellation before re-sending.

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -788,7 +788,7 @@ def _synthesis_length_limit_error(
     if _completion_hit_context_wall(usage, requested_max_tokens = requested_max_tokens):
         return (
             "Local model report hit the loaded context window before completion. "
-            "Lower Context Length in chat settings or reduce the research evidence size."
+            "Increase Context Length in chat settings or reduce the research evidence size."
         )
     return "Local model report reached its output limit before completion"
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -18,7 +18,6 @@ from core.research_runs import (
     ResearchSupervisor,
     RunCancelled,
     _citation_title,
-    _clamp_max_tokens_for_context,
     _completion_hit_context_wall,
     _escape_link_destination,
     _estimate_prompt_tokens,

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -18,9 +18,14 @@ from core.research_runs import (
     ResearchSupervisor,
     RunCancelled,
     _citation_title,
+    _clamp_max_tokens_for_context,
+    _completion_hit_context_wall,
     _escape_link_destination,
+    _estimate_prompt_tokens,
+    _resolve_max_tokens,
     _sanitize_public_query,
     _shield_untrusted,
+    _synthesis_length_limit_error,
     _validate_report_document_sources,
     _validate_report_sources,
 )
@@ -228,6 +233,48 @@ def test_prompt_budget_counts_the_whole_prompt(monkeypatch):
     assert research_runs._trimmable_budget(total, 0, 1_000) == 1_000
     assert research_runs._trimmable_budget(total, total - 10, 1_000) == 10
     assert research_runs._trimmable_budget(total, total + 5_000, 1_000) == 0
+
+
+def test_resolve_max_tokens_clamps_to_loaded_context(monkeypatch):
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 12_288)
+    messages = [{"role": "user", "content": "x" * 33_000}]
+    prompt_tokens = _estimate_prompt_tokens(messages)
+    resolved = _resolve_max_tokens(16_384, {}, messages)
+    assert resolved == 12_288 - prompt_tokens
+    assert resolved < 16_384
+
+
+def test_completion_hit_context_wall_matches_live_probe():
+    usage = {
+        "prompt_tokens": 11_032,
+        "completion_tokens": 1_256,
+        "total_tokens": 12_288,
+    }
+    assert _completion_hit_context_wall(
+        usage,
+        requested_max_tokens = 16_384,
+        context_length = 12_288,
+    )
+    assert not _completion_hit_context_wall(
+        {
+            "prompt_tokens": 1_000,
+            "completion_tokens": 16_384,
+            "total_tokens": 17_384,
+        },
+        requested_max_tokens = 16_384,
+        context_length = 32_768,
+    )
+
+
+def test_synthesis_length_limit_error_names_context_window():
+    usage = {
+        "prompt_tokens": 11_032,
+        "completion_tokens": 1_256,
+        "total_tokens": 12_288,
+    }
+    message = _synthesis_length_limit_error(usage, requested_max_tokens = 16_384)
+    assert "context window" in message.lower()
+    assert "Context Length" in message
 
 
 def test_every_research_prompt_path_is_budgeted():
@@ -687,10 +734,10 @@ def test_stream_completion_retries_after_the_model_is_loaded_again(monkeypatch):
         return None
 
     supervisor = _make_supervisor(_check_active)
-    report, reasoning, finish_reason = asyncio.run(
+    report, reasoning, finish_reason, usage = asyncio.run(
         supervisor._stream_completion(_waiting_run(30.0), [{"role": "user"}], report_progress = False)
     )
-    assert (report, reasoning, finish_reason) == ("report", "", "stop")
+    assert (report, reasoning, finish_reason, usage) == ("report", "", "stop", None)
     assert len(sent) == 2
 
 
@@ -738,7 +785,7 @@ def test_stream_completion_retries_a_transport_error_before_any_bytes_stream(mon
         [httpx.ConnectError(_TRANSPORT_BLIP), _response(200, body = _stream_body())],
     )
     supervisor = _make_supervisor(_noop_check_active)
-    assert _run_stream(supervisor) == ("report", "", "stop")
+    assert _run_stream(supervisor) == ("report", "", "stop", None)
     assert len(sent) == 2
     assert delays == [1]
 
@@ -750,7 +797,7 @@ def test_stream_completion_retries_a_transient_server_error(monkeypatch):
         [_response(503, body = "overloaded"), _response(200, body = _stream_body())],
     )
     supervisor = _make_supervisor(_noop_check_active)
-    assert _run_stream(supervisor) == ("report", "", "stop")
+    assert _run_stream(supervisor) == ("report", "", "stop", None)
     assert len(sent) == 2
     assert delays == [1]
 
@@ -1425,7 +1472,7 @@ def test_stream_completion_semantic_output_resets_the_idle_timeout(monkeypatch):
     _install_fake_client(monkeypatch, [_ProgressStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "thinking", "stop")
+    assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "thinking", "stop", None)
 
 
 def test_stream_completion_allows_output_before_first_output_timeout(monkeypatch):
@@ -1453,7 +1500,7 @@ def test_stream_completion_allows_output_before_first_output_timeout(monkeypatch
     _install_fake_client(monkeypatch, [_SlowPrefillStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "", "stop")
+    assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "", "stop", None)
 
 
 def test_first_output_deadline_disarms_once_output_starts(monkeypatch):
@@ -1554,7 +1601,7 @@ def test_stream_completion_counts_whitespace_tokens_as_output(monkeypatch):
     _install_fake_client(monkeypatch, [_WhitespaceStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    assert _run_stream(supervisor, timeout_seconds = 1.0) == (" \n\treport", "", "stop")
+    assert _run_stream(supervisor, timeout_seconds = 1.0) == (" \n\treport", "", "stop", None)
 
 
 def test_stream_completion_stops_at_done_even_if_socket_stays_open(monkeypatch):
@@ -1581,7 +1628,7 @@ def test_stream_completion_stops_at_done_even_if_socket_stays_open(monkeypatch):
     _install_fake_client(monkeypatch, [_OpenSocketAfterDone()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "", "stop")
+    assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "", "stop", None)
     assert state == {"iteratorClosed": True, "responseClosed": True}
 
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -273,7 +273,7 @@ def test_synthesis_length_limit_error_names_context_window():
     }
     message = _synthesis_length_limit_error(usage, requested_max_tokens = 16_384)
     assert "context window" in message.lower()
-    assert "Context Length" in message
+    assert "Increase Context Length" in message
 
 
 def test_every_research_prompt_path_is_budgeted():

--- a/studio/backend/tests/test_research_runs_storage.py
+++ b/studio/backend/tests/test_research_runs_storage.py
@@ -1547,7 +1547,12 @@ def test_supervisor_planning_and_research_are_durable_with_mocked_io(research_ho
         if "rigorous web research plan" in system:
             return json.dumps(_plan()), "Planned several lines of inquiry.", "stop", None
         if "iterative research process" in system:
-            return next(decisions), "Evaluated the evidence and selected the next action.", "stop", None
+            return (
+                next(decisions),
+                "Evaluated the evidence and selected the next action.",
+                "stop",
+                None,
+            )
         assert "<document_source_catalog>" in prompt
         assert "private.pdf" in prompt
         if kwargs.get("phase") == "synthesis_audit":

--- a/studio/backend/tests/test_research_runs_storage.py
+++ b/studio/backend/tests/test_research_runs_storage.py
@@ -1433,7 +1433,7 @@ def test_planner_prompt_shields_untrusted_conversation(research_home, monkeypatc
         **kwargs,
     ):
         captured["planner"] = messages[1]["content"]
-        return json.dumps(_plan()), "Planned.", "stop"
+        return json.dumps(_plan()), "Planned.", "stop", None
 
     monkeypatch.setattr(supervisor, "_stream_completion", fake_stream_completion)
 
@@ -1545,9 +1545,9 @@ def test_supervisor_planning_and_research_are_durable_with_mocked_io(research_ho
         assert "We were discussing OpenAI." in prompt
         assert "Compare that with Anthropic." in prompt
         if "rigorous web research plan" in system:
-            return json.dumps(_plan()), "Planned several lines of inquiry.", "stop"
+            return json.dumps(_plan()), "Planned several lines of inquiry.", "stop", None
         if "iterative research process" in system:
-            return next(decisions), "Evaluated the evidence and selected the next action.", "stop"
+            return next(decisions), "Evaluated the evidence and selected the next action.", "stop", None
         assert "<document_source_catalog>" in prompt
         assert "private.pdf" in prompt
         if kwargs.get("phase") == "synthesis_audit":
@@ -1567,12 +1567,13 @@ def test_supervisor_planning_and_research_are_durable_with_mocked_io(research_ho
                 ),
                 "Audited document evidence.",
                 "stop",
+                None,
             )
         if kwargs.get("phase") == "synthesis":
-            return "", "Repeated a truncated source URL.", "length"
+            return "", "Repeated a truncated source URL.", "length", None
         report = report_response
         research_db.set_report_progress(run["id"], report)
-        return report, "Checked the available evidence.", "stop"
+        return report, "Checked the available evidence.", "stop", None
 
     tool_calls = []
 
@@ -1772,9 +1773,9 @@ def _run_search_then_finish(
     ):
         system = messages[0]["content"]
         if "rigorous web research plan" in system:
-            return json.dumps(_plan()), "planned", "stop"
+            return json.dumps(_plan()), "planned", "stop", None
         if "iterative research process" in system:
-            return next(decisions), "decided", "stop"
+            return next(decisions), "decided", "stop", None
         synthesis_prompts.append(messages[1]["content"])
         if "evidence-to-claim audit" in system:
             return (
@@ -1797,9 +1798,10 @@ def _run_search_then_finish(
                 ),
                 "audited",
                 "stop",
+                None,
             )
         research_db.set_report_progress(run["id"], report)
-        return report, "synthesized", "stop"
+        return report, "synthesized", "stop", None
 
     monkeypatch.setattr(supervisor, "_stream_completion", fake_stream_completion)
     monkeypatch.setattr(worker, "execute_tool", fake_tool)
@@ -2021,12 +2023,12 @@ def test_synthesis_pass_runs_at_synthesis_phase(research_home, monkeypatch):
     ):
         system = messages[0]["content"]
         if "rigorous web research plan" in system:
-            return json.dumps(_plan()), "p", "stop"
+            return json.dumps(_plan()), "p", "stop", None
         if "iterative research process" in system:
-            return next(decisions), "d", "stop"
+            return next(decisions), "d", "stop", None
         captured.update(kwargs)
         research_db.set_report_progress(run["id"], "# Report\n\nGrounded text.")
-        return "# Report\n\nGrounded text.", "s", "stop"
+        return "# Report\n\nGrounded text.", "s", "stop", None
 
     def fake_tool(name, arguments, *a, **k):
         return "page body" if arguments.get("url") else _two_source_search()
@@ -2258,6 +2260,7 @@ def test_recovered_running_research_resumes_durable_progress(research_home, monk
                 ),
                 "",
                 "stop",
+                None,
             )
         assert "Saved durable snippet" in prompt
         assert "Private durable evidence" in prompt
@@ -2268,6 +2271,7 @@ def test_recovered_running_research_resumes_durable_progress(research_home, monk
             "# Resumed report\n\nSaved finding [Saved source](https://saved.example/source).",
             "",
             "stop",
+            None,
         )
 
     def unexpected_tool(*args, **kwargs):
@@ -2316,12 +2320,12 @@ def test_knowledge_base_evidence_beyond_the_source_cap_is_not_synthesized(
     async def fake_stream_completion(run, messages, **kwargs):
         system = messages[0]["content"]
         if "rigorous web research plan" in system:
-            return json.dumps(_plan()), "planned", "stop"
+            return json.dumps(_plan()), "planned", "stop", None
         if "iterative research process" in system:
-            return next(decisions), "decided", "stop"
+            return next(decisions), "decided", "stop", None
         synthesis_prompts.append(messages[1]["content"])
         research_db.set_report_progress(run["id"], report)
-        return report, "synthesized", "stop"
+        return report, "synthesized", "stop", None
 
     labels = iter(("kept", "capped"))
 

--- a/studio/backend/tests/test_research_runs_storage.py
+++ b/studio/backend/tests/test_research_runs_storage.py
@@ -412,7 +412,7 @@ def test_streamed_reasoning_is_batched_before_database_writes(research_home, mon
     )
     supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
 
-    report, reasoning, finish_reason = asyncio.run(
+    report, reasoning, finish_reason, _usage = asyncio.run(
         supervisor._stream_completion(
             run,
             [{"role": "user", "content": "question"}],

--- a/studio/frontend/package-lock.json
+++ b/studio/frontend/package-lock.json
@@ -1708,6 +1708,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1728,6 +1729,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1748,6 +1750,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1768,6 +1771,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1788,6 +1792,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1808,6 +1813,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1828,6 +1834,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1848,6 +1855,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1868,6 +1876,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1888,6 +1897,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1908,6 +1918,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6491,7 +6502,6 @@
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-deep-link/-/plugin-deep-link-2.4.9.tgz",
       "integrity": "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==",
-      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
       }


### PR DESCRIPTION
Fixes #7965.

Deep Research clamped `max_tokens` against fixed 8k/16k ceilings while `_loaded_context_length()` already sized evidence and auto-scrape gates. Synthesis could request 16384 completion tokens on a 12288 context model; the server truncated at the wall, returned `finish_reason: length`, and the worker blamed a non-existent output cap.

## Fix

| area | change |
|---|---|
| `research_runs.py` | `_resolve_max_tokens()` clamps to `context_length - estimated_prompt_tokens` (same chars/token heuristic as synthesis budgeting) |
| `_stream_completion` / `_completion` | Use resolved budget; capture stream `usage` |
| Synthesis failure | `_synthesis_length_limit_error()` names Context Length when usage shows context exhaustion vs a true output-cap hit |

## Testing

```
pytest tests/test_research_runs_hardening.py -q
100 passed
```

New tests cover context clamping, live-probe usage shape, and the updated error message.

Not run here: end-to-end Deep Research on a large HF cache with a loaded local model.