### PR TITLE
Studio: rework the media pane headings and tidy the Create controls

### DIFF
--- a/studio/frontend/src/components/advanced-disclosure.tsx
+++ b/studio/frontend/src/components/advanced-disclosure.tsx
@@ -28,7 +28,7 @@ export function AdvancedDisclosure({
         type="button"
         onClick={() => onOpenChange(!open)}
         aria-expanded={open}
-        className="flex items-center gap-2 rounded-lg px-1 py-1.5 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {/* Icon and label sized to the slider rows above, so it reads as one of them. */}
         <HugeiconsIcon

--- a/studio/frontend/src/components/negative-prompt-field.tsx
+++ b/studio/frontend/src/components/negative-prompt-field.tsx
@@ -40,7 +40,7 @@ export function NegativePromptField({
           aria-hidden={true}
           tabIndex={-1}
           onClick={() => onOpenChange(!open)}
-          className="ml-auto inline-flex"
+          className="inline-flex"
         >
           <ChevronDown
             className={cn(

--- a/studio/frontend/src/components/negative-prompt-field.tsx
+++ b/studio/frontend/src/components/negative-prompt-field.tsx
@@ -33,7 +33,7 @@ export function NegativePromptField({
         >
           Negative prompt
         </button>
-        <InfoHint>{hint}</InfoHint>
+        {/* Chevron before the hint, so it stays next to the label it expands. */}
         <button
           type="button"
           // The labelled button above is the accessible toggle; this is decoration.
@@ -49,6 +49,7 @@ export function NegativePromptField({
             )}
           />
         </button>
+        <InfoHint>{hint}</InfoHint>
       </div>
       {open && (
         <Textarea

--- a/studio/frontend/src/components/negative-prompt-field.tsx
+++ b/studio/frontend/src/components/negative-prompt-field.tsx
@@ -7,10 +7,6 @@ import { InfoHint } from "@/components/ui/info-hint";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
-// The hint and chevron only appear with the row, so a rarely used field stays quiet.
-const REVEAL_ON_ROW_HOVER =
-  "pointer-events-none inline-flex opacity-0 transition-opacity group-hover/negative:pointer-events-auto group-hover/negative:opacity-100 group-focus-within/negative:pointer-events-auto group-focus-within/negative:opacity-100";
-
 /** Collapsible negative prompt, shared by the Images and Video Create panels. */
 export function NegativePromptField({
   value,
@@ -25,8 +21,9 @@ export function NegativePromptField({
   onOpenChange: (open: boolean) => void;
   hint: string;
 }) {
+  // Same shape as Field, so it keeps the panel's spacing.
   return (
-    <div className="group/negative -mt-1 flex flex-col gap-1.5 pb-2">
+    <div className="flex flex-col gap-1.5">
       <div className="flex items-center gap-1">
         <button
           type="button"
@@ -43,10 +40,7 @@ export function NegativePromptField({
           aria-hidden={true}
           tabIndex={-1}
           onClick={() => onOpenChange(!open)}
-          className={cn(
-            REVEAL_ON_ROW_HOVER,
-            open && "pointer-events-auto opacity-100",
-          )}
+          className="ml-auto inline-flex"
         >
           <ChevronDown
             className={cn(

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2558,13 +2558,13 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             {/* The sidebar submenu is the switcher, so name the active workflow over its controls. */}
             <div className="grid gap-1">
               {/* h-9 keeps this level with the Video page heading. */}
-              <h2 className="flex h-9 items-center gap-2 font-heading text-base font-medium text-foreground">
+              <h2 className="flex h-9 items-center gap-2 font-heading text-lg font-medium text-foreground">
                 {/* Same icon the sidebar submenu uses for this workflow. */}
                 <HugeiconsIcon
                   icon={activeWorkflowTab.icon}
                   className="size-4 shrink-0"
                 />
-                {activeWorkflowTab.label}
+                {activeWorkflowTab.heading ?? activeWorkflowTab.label}
               </h2>
               <p className="text-ui-11p5 leading-snug text-muted-foreground">
                 {activeWorkflowTab.hint}

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2563,7 +2563,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
                 {/* Same icon the sidebar submenu uses for this workflow. */}
                 <HugeiconsIcon
                   icon={activeWorkflowTab.icon}
-                  className="size-6 shrink-0"
+                  className="size-[22px] shrink-0"
                 />
                 {activeWorkflowTab.heading ?? activeWorkflowTab.label}
               </h2>

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2563,7 +2563,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
                 {/* Same icon the sidebar submenu uses for this workflow. */}
                 <HugeiconsIcon
                   icon={activeWorkflowTab.icon}
-                  className="size-[26px] shrink-0"
+                  className="size-6 shrink-0"
                 />
                 {activeWorkflowTab.heading ?? activeWorkflowTab.label}
               </h2>

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2558,15 +2558,15 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             {/* The sidebar submenu is the switcher, so name the active workflow over its controls. */}
             <div className="grid gap-1">
               {/* h-9 keeps this level with the Video page heading. */}
-              <h2 className="flex h-9 items-center gap-2 font-heading text-lg font-medium text-foreground">
+              <h2 className="flex h-9 items-center gap-2 font-heading text-xl font-medium text-foreground">
                 {/* Same icon the sidebar submenu uses for this workflow. */}
                 <HugeiconsIcon
                   icon={activeWorkflowTab.icon}
-                  className="size-4 shrink-0"
+                  className="size-[22px] shrink-0"
                 />
                 {activeWorkflowTab.heading ?? activeWorkflowTab.label}
               </h2>
-              <p className="text-ui-11p5 leading-snug text-muted-foreground">
+              <p className="text-ui-12p5 leading-snug text-muted-foreground">
                 {activeWorkflowTab.hint}
               </p>
             </div>

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2559,7 +2559,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             {/* Icon rides the heading; the line below runs the full width.
                 Same shape on the Video page, so the two stay level. */}
             <div className="mb-2 grid gap-1.5">
-              <h2 className="flex items-center gap-2.5 font-heading text-xl font-medium leading-none text-foreground">
+              <h2 className="flex items-center gap-2 font-heading text-xl font-medium leading-none text-foreground">
                 {/* Same icon the sidebar submenu uses for this workflow. */}
                 <HugeiconsIcon
                   icon={activeWorkflowTab.icon}

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2559,11 +2559,11 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             {/* Icon rides the heading; the line below runs the full width.
                 Same shape on the Video page, so the two stay level. */}
             <div className="mb-2 grid gap-1.5">
-              <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none text-foreground">
+              <h2 className="flex items-center gap-2.5 font-heading text-xl font-medium leading-none text-foreground">
                 {/* Same icon the sidebar submenu uses for this workflow. */}
                 <HugeiconsIcon
                   icon={activeWorkflowTab.icon}
-                  className="size-5 shrink-0"
+                  className="size-[18px] shrink-0"
                 />
                 {activeWorkflowTab.heading ?? activeWorkflowTab.label}
               </h2>

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2556,22 +2556,20 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             )}
           >
             {/* The sidebar submenu is the switcher, so name the active workflow over its controls. */}
-            {/* Icon centred on the heading and its line together. Same shape on
-                the Video page, so the two stay level. */}
-            <div className="mb-2 flex items-center gap-4">
-              {/* Same icon the sidebar submenu uses for this workflow. */}
-              <HugeiconsIcon
-                icon={activeWorkflowTab.icon}
-                className="size-[30px] shrink-0"
-              />
-              <div className="grid min-w-0 gap-0.5">
-                <h2 className="font-heading text-xl font-medium leading-none text-foreground">
-                  {activeWorkflowTab.heading ?? activeWorkflowTab.label}
-                </h2>
-                <p className="text-xs leading-snug text-muted-foreground">
-                  {activeWorkflowTab.hint}
-                </p>
-              </div>
+            {/* Icon rides the heading; the line below runs the full width.
+                Same shape on the Video page, so the two stay level. */}
+            <div className="mb-2 grid gap-1.5">
+              <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none text-foreground">
+                {/* Same icon the sidebar submenu uses for this workflow. */}
+                <HugeiconsIcon
+                  icon={activeWorkflowTab.icon}
+                  className="size-[26px] shrink-0"
+                />
+                {activeWorkflowTab.heading ?? activeWorkflowTab.label}
+              </h2>
+              <p className="text-xs leading-snug text-muted-foreground">
+                {activeWorkflowTab.hint}
+              </p>
             </div>
 
             {workflow === "transform" && (

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2556,19 +2556,22 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             )}
           >
             {/* The sidebar submenu is the switcher, so name the active workflow over its controls. */}
-            <div className="grid gap-1">
-              {/* h-9 keeps this level with the Video page heading. */}
-              <h2 className="flex h-9 items-center gap-2 font-heading text-xl font-medium text-foreground">
-                {/* Same icon the sidebar submenu uses for this workflow. */}
-                <HugeiconsIcon
-                  icon={activeWorkflowTab.icon}
-                  className="size-[22px] shrink-0"
-                />
-                {activeWorkflowTab.heading ?? activeWorkflowTab.label}
-              </h2>
-              <p className="text-ui-12p5 leading-snug text-muted-foreground">
-                {activeWorkflowTab.hint}
-              </p>
+            {/* Icon centred on the heading and its line together. Same shape on
+                the Video page, so the two stay level. */}
+            <div className="mb-2 flex items-center gap-4">
+              {/* Same icon the sidebar submenu uses for this workflow. */}
+              <HugeiconsIcon
+                icon={activeWorkflowTab.icon}
+                className="size-[30px] shrink-0"
+              />
+              <div className="grid min-w-0 gap-0.5">
+                <h2 className="font-heading text-xl font-medium leading-none text-foreground">
+                  {activeWorkflowTab.heading ?? activeWorkflowTab.label}
+                </h2>
+                <p className="text-xs leading-snug text-muted-foreground">
+                  {activeWorkflowTab.hint}
+                </p>
+              </div>
             </div>
 
             {workflow === "transform" && (

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2563,7 +2563,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
                 {/* Same icon the sidebar submenu uses for this workflow. */}
                 <HugeiconsIcon
                   icon={activeWorkflowTab.icon}
-                  className="size-[22px] shrink-0"
+                  className="size-5 shrink-0"
                 />
                 {activeWorkflowTab.heading ?? activeWorkflowTab.label}
               </h2>

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1133,7 +1133,7 @@ export function DiffusionTrainPanel({
             <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
               <HugeiconsIcon
                 icon={TestTubeOutlineIcon}
-                className="size-6 shrink-0"
+                className="size-[22px] shrink-0"
               />
               Train a LoRA
             </h2>
@@ -1494,7 +1494,7 @@ export function DiffusionTrainPanel({
                   <span className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
                     <HugeiconsIcon
                       icon={Settings02Icon}
-                      className="size-6 shrink-0"
+                      className="size-[22px] shrink-0"
                     />
                     Train settings
                   </span>

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1129,11 +1129,11 @@ export function DiffusionTrainPanel({
         >
           <div>
             {/* Matches "Training settings" across the rule, so the two headings read as one row. */}
-            <h2 className="font-heading flex items-center gap-1.5 text-base font-medium">
-              <HugeiconsIcon icon={TestTubeOutlineIcon} className="size-4" />
+            <h2 className="font-heading flex items-center gap-1.5 text-xl font-medium">
+              <HugeiconsIcon icon={TestTubeOutlineIcon} className="size-[22px]" />
               Train a LoRA
             </h2>
-            <p className="mt-1 text-ui-11 leading-snug text-muted-foreground">
+            <p className="mt-1 text-ui-12p5 leading-snug text-muted-foreground">
               Teach a model a style or subject from your own images.
             </p>
           </div>
@@ -1484,8 +1484,8 @@ export function DiffusionTrainPanel({
           <>
             <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between">
-                <span className="font-heading flex items-center gap-1.5 text-base font-medium">
-                  <HugeiconsIcon icon={Settings02Icon} className="size-4" />
+                <span className="font-heading flex items-center gap-1.5 text-xl font-medium">
+                  <HugeiconsIcon icon={Settings02Icon} className="size-[22px]" />
                   Training settings
                 </span>
                 <span className="text-xs text-muted-foreground">

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1130,7 +1130,7 @@ export function DiffusionTrainPanel({
           {/* Icon rides the heading; the line below runs the full width. */}
           <div className="mb-1 grid gap-1.5">
             {/* Matches "Train settings" across the rule, so the two headings read as one row. */}
-            <h2 className="flex items-center gap-2.5 font-heading text-xl font-medium leading-none">
+            <h2 className="flex items-center gap-2 font-heading text-xl font-medium leading-none">
               <HugeiconsIcon
                 icon={TestTubeOutlineIcon}
                 className="size-[18px] shrink-0"
@@ -1491,7 +1491,7 @@ export function DiffusionTrainPanel({
                   starts level with Model family. */}
               <div className="mb-2 flex items-center justify-between">
                 <div className="grid gap-1.5">
-                  <span className="flex items-center gap-2.5 font-heading text-xl font-medium leading-none">
+                  <span className="flex items-center gap-2 font-heading text-xl font-medium leading-none">
                     <HugeiconsIcon
                       icon={Settings02Icon}
                       className="size-[18px] shrink-0"

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1130,10 +1130,10 @@ export function DiffusionTrainPanel({
           {/* Icon rides the heading; the line below runs the full width. */}
           <div className="mb-1 grid gap-1.5">
             {/* Matches "Train settings" across the rule, so the two headings read as one row. */}
-            <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
+            <h2 className="flex items-center gap-2.5 font-heading text-xl font-medium leading-none">
               <HugeiconsIcon
                 icon={TestTubeOutlineIcon}
-                className="size-5 shrink-0"
+                className="size-[18px] shrink-0"
               />
               Train a LoRA
             </h2>
@@ -1491,10 +1491,10 @@ export function DiffusionTrainPanel({
                   starts level with Model family. */}
               <div className="mb-2 flex items-center justify-between">
                 <div className="grid gap-1.5">
-                  <span className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
+                  <span className="flex items-center gap-2.5 font-heading text-xl font-medium leading-none">
                     <HugeiconsIcon
                       icon={Settings02Icon}
-                      className="size-5 shrink-0"
+                      className="size-[18px] shrink-0"
                     />
                     Train settings
                   </span>

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1133,7 +1133,7 @@ export function DiffusionTrainPanel({
             <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
               <HugeiconsIcon
                 icon={TestTubeOutlineIcon}
-                className="size-[22px] shrink-0"
+                className="size-5 shrink-0"
               />
               Train a LoRA
             </h2>
@@ -1494,7 +1494,7 @@ export function DiffusionTrainPanel({
                   <span className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
                     <HugeiconsIcon
                       icon={Settings02Icon}
-                      className="size-[22px] shrink-0"
+                      className="size-5 shrink-0"
                     />
                     Train settings
                   </span>

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1127,16 +1127,19 @@ export function DiffusionTrainPanel({
             settingsFadeClass,
           )}
         >
-          {/* Icon centred on the heading and its line together. */}
-          <div className="mb-1 flex items-center gap-4">
-            <HugeiconsIcon icon={TestTubeOutlineIcon} className="size-[30px] shrink-0" />
-            <div className="min-w-0">
-              {/* Matches "Train settings" across the rule, so the two headings read as one row. */}
-              <h2 className="font-heading text-xl font-medium leading-none">Train a LoRA</h2>
-              <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
-                Teach a model a new style or subject.
-              </p>
-            </div>
+          {/* Icon rides the heading; the line below runs the full width. */}
+          <div className="mb-1 grid gap-1.5">
+            {/* Matches "Train settings" across the rule, so the two headings read as one row. */}
+            <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
+              <HugeiconsIcon
+                icon={TestTubeOutlineIcon}
+                className="size-[26px] shrink-0"
+              />
+              Train a LoRA
+            </h2>
+            <p className="text-xs leading-snug text-muted-foreground">
+              Teach a model a new style or subject.
+            </p>
           </div>
 
           {/* Family + base */}
@@ -1485,19 +1488,17 @@ export function DiffusionTrainPanel({
           <>
             <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                  <HugeiconsIcon
-                    icon={Settings02Icon}
-                    className="size-[30px] shrink-0"
-                  />
-                  <div className="min-w-0">
-                    <span className="font-heading block text-xl font-medium leading-none">
-                      Train settings
-                    </span>
-                    <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
-                      Hyperparameters for this run.
-                    </p>
-                  </div>
+                <div className="grid gap-1.5">
+                  <span className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
+                    <HugeiconsIcon
+                      icon={Settings02Icon}
+                      className="size-[26px] shrink-0"
+                    />
+                    Train settings
+                  </span>
+                  <p className="text-xs leading-snug text-muted-foreground">
+                    Hyperparameters for this run.
+                  </p>
                 </div>
                 <span className="text-xs text-muted-foreground">
                   Applied on Start training

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1127,15 +1127,16 @@ export function DiffusionTrainPanel({
             settingsFadeClass,
           )}
         >
-          <div>
-            {/* Matches "Training settings" across the rule, so the two headings read as one row. */}
-            <h2 className="font-heading flex items-center gap-1.5 text-xl font-medium">
-              <HugeiconsIcon icon={TestTubeOutlineIcon} className="size-[22px]" />
-              Train a LoRA
-            </h2>
-            <p className="mt-1 text-ui-12p5 leading-snug text-muted-foreground">
-              Teach a model a style or subject from your own images.
-            </p>
+          {/* Icon centred on the heading and its line together. */}
+          <div className="mb-1 flex items-center gap-4">
+            <HugeiconsIcon icon={TestTubeOutlineIcon} className="size-[30px] shrink-0" />
+            <div className="min-w-0">
+              {/* Matches "Training settings" across the rule, so the two headings read as one row. */}
+              <h2 className="font-heading text-xl font-medium leading-none">Train a LoRA</h2>
+              <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
+                Teach a model a style or subject from your own images.
+              </p>
+            </div>
           </div>
 
           {/* Family + base */}
@@ -1484,8 +1485,8 @@ export function DiffusionTrainPanel({
           <>
             <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between">
-                <span className="font-heading flex items-center gap-1.5 text-xl font-medium">
-                  <HugeiconsIcon icon={Settings02Icon} className="size-[22px]" />
+                <span className="font-heading flex items-center gap-4 text-xl font-medium">
+                  <HugeiconsIcon icon={Settings02Icon} className="size-7" />
                   Training settings
                 </span>
                 <span className="text-xs text-muted-foreground">

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1133,7 +1133,7 @@ export function DiffusionTrainPanel({
             <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
               <HugeiconsIcon
                 icon={TestTubeOutlineIcon}
-                className="size-[26px] shrink-0"
+                className="size-6 shrink-0"
               />
               Train a LoRA
             </h2>
@@ -1487,12 +1487,14 @@ export function DiffusionTrainPanel({
         ) : !hasRun ? (
           <>
             <div className="flex flex-col gap-4">
-              <div className="flex items-center justify-between">
+              {/* mb-2 + gap-4 matches the left column's mb-1 + gap-5, so Steps
+                  starts level with Model family. */}
+              <div className="mb-2 flex items-center justify-between">
                 <div className="grid gap-1.5">
                   <span className="flex items-center gap-3 font-heading text-xl font-medium leading-none">
                     <HugeiconsIcon
                       icon={Settings02Icon}
-                      className="size-[26px] shrink-0"
+                      className="size-6 shrink-0"
                     />
                     Train settings
                   </span>

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1131,10 +1131,10 @@ export function DiffusionTrainPanel({
           <div className="mb-1 flex items-center gap-4">
             <HugeiconsIcon icon={TestTubeOutlineIcon} className="size-[30px] shrink-0" />
             <div className="min-w-0">
-              {/* Matches "Training settings" across the rule, so the two headings read as one row. */}
+              {/* Matches "Train settings" across the rule, so the two headings read as one row. */}
               <h2 className="font-heading text-xl font-medium leading-none">Train a LoRA</h2>
               <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
-                Teach a model a style or subject from your own images.
+                Teach a model a new style or subject.
               </p>
             </div>
           </div>
@@ -1485,10 +1485,20 @@ export function DiffusionTrainPanel({
           <>
             <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between">
-                <span className="font-heading flex items-center gap-4 text-xl font-medium">
-                  <HugeiconsIcon icon={Settings02Icon} className="size-7" />
-                  Training settings
-                </span>
+                <div className="flex items-center gap-4">
+                  <HugeiconsIcon
+                    icon={Settings02Icon}
+                    className="size-[30px] shrink-0"
+                  />
+                  <div className="min-w-0">
+                    <span className="font-heading block text-xl font-medium leading-none">
+                      Train settings
+                    </span>
+                    <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
+                      Hyperparameters for this run.
+                    </p>
+                  </div>
+                </div>
                 <span className="text-xs text-muted-foreground">
                   Applied on Start training
                 </span>

--- a/studio/frontend/src/features/images/workflows.ts
+++ b/studio/frontend/src/features/images/workflows.ts
@@ -26,6 +26,9 @@ export type WorkflowId =
 export const WORKFLOW_TABS: Array<{
   id: WorkflowId;
   label: string;
+  /** Page heading, when the sidebar's short label would read oddly on its own.
+   *  Falls back to `label`. */
+  heading?: string;
   requires: string | null;
   icon: IconSvgElement;
   hint: string;
@@ -33,6 +36,8 @@ export const WORKFLOW_TABS: Array<{
   {
     id: "create",
     label: "Create",
+    // The sidebar nests this under Images, so "Create" alone is clear there.
+    heading: "Create images",
     requires: null,
     // Not the pencil: that is the sidebar's New chat icon.
     icon: SparklesIcon,

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1559,12 +1559,12 @@ export function VideoPage({ active = true }: { active?: boolean }) {
           >
           {/* Names the pane, as the Images column does. h-9 keeps both pages' headings level. */}
           <div className="grid gap-1">
-            <h2 className="flex h-9 items-center gap-2 font-heading text-lg font-medium text-foreground">
+            <h2 className="flex h-9 items-center gap-2 font-heading text-xl font-medium text-foreground">
               {/* The app's Video icon, same as the sidebar row. */}
-              <HugeiconsIcon icon={FlimSlateIcon} className="size-4 shrink-0" />
+              <HugeiconsIcon icon={FlimSlateIcon} className="size-[22px] shrink-0" />
               Create videos
             </h2>
-            <p className="text-ui-11p5 leading-snug text-muted-foreground">
+            <p className="text-ui-12p5 leading-snug text-muted-foreground">
               Generate a video from a prompt
             </p>
           </div>

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1562,7 +1562,7 @@ export function VideoPage({ active = true }: { active?: boolean }) {
           <div className="mb-2 grid gap-1.5">
             <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none text-foreground">
               {/* The app's Video icon, same as the sidebar row. */}
-              <HugeiconsIcon icon={FlimSlateIcon} className="size-[26px] shrink-0" />
+              <HugeiconsIcon icon={FlimSlateIcon} className="size-6 shrink-0" />
               Create videos
             </h2>
             <p className="text-xs leading-snug text-muted-foreground">

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1559,17 +1559,15 @@ export function VideoPage({ active = true }: { active?: boolean }) {
           >
           {/* Names the pane, as the Images column does. Same shape there, so
               the two pages stay level. */}
-          <div className="mb-2 flex items-center gap-4">
-            {/* The app's Video icon, same as the sidebar row. */}
-            <HugeiconsIcon icon={FlimSlateIcon} className="size-[30px] shrink-0" />
-            <div className="grid min-w-0 gap-0.5">
-              <h2 className="font-heading text-xl font-medium leading-none text-foreground">
-                Create videos
-              </h2>
-              <p className="text-xs leading-snug text-muted-foreground">
-                Generate a video from a prompt
-              </p>
-            </div>
+          <div className="mb-2 grid gap-1.5">
+            <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none text-foreground">
+              {/* The app's Video icon, same as the sidebar row. */}
+              <HugeiconsIcon icon={FlimSlateIcon} className="size-[26px] shrink-0" />
+              Create videos
+            </h2>
+            <p className="text-xs leading-snug text-muted-foreground">
+              Generate a video from a prompt
+            </p>
           </div>
 
           <Field label="Prompt">

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -8,7 +8,6 @@ import {
   FlimSlateIcon,
   Image03Icon,
   InformationCircleIcon,
-  SparklesIcon,
   VolumeHighIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -1560,10 +1559,10 @@ export function VideoPage({ active = true }: { active?: boolean }) {
           >
           {/* Names the pane, as the Images column does. h-9 keeps both pages' headings level. */}
           <div className="grid gap-1">
-            <h2 className="flex h-9 items-center gap-2 font-heading text-base font-medium text-foreground">
-              {/* The Images page's Create icon, so both headings read the same. */}
-              <HugeiconsIcon icon={SparklesIcon} className="size-4 shrink-0" />
-              Create
+            <h2 className="flex h-9 items-center gap-2 font-heading text-lg font-medium text-foreground">
+              {/* The app's Video icon, same as the sidebar row. */}
+              <HugeiconsIcon icon={FlimSlateIcon} className="size-4 shrink-0" />
+              Create videos
             </h2>
             <p className="text-ui-11p5 leading-snug text-muted-foreground">
               Generate a video from a prompt

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1560,9 +1560,9 @@ export function VideoPage({ active = true }: { active?: boolean }) {
           {/* Names the pane, as the Images column does. Same shape there, so
               the two pages stay level. */}
           <div className="mb-2 grid gap-1.5">
-            <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none text-foreground">
+            <h2 className="flex items-center gap-2.5 font-heading text-xl font-medium leading-none text-foreground">
               {/* The app's Video icon, same as the sidebar row. */}
-              <HugeiconsIcon icon={FlimSlateIcon} className="size-5 shrink-0" />
+              <HugeiconsIcon icon={FlimSlateIcon} className="size-[18px] shrink-0" />
               Create videos
             </h2>
             <p className="text-xs leading-snug text-muted-foreground">

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1562,7 +1562,7 @@ export function VideoPage({ active = true }: { active?: boolean }) {
           <div className="mb-2 grid gap-1.5">
             <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none text-foreground">
               {/* The app's Video icon, same as the sidebar row. */}
-              <HugeiconsIcon icon={FlimSlateIcon} className="size-[22px] shrink-0" />
+              <HugeiconsIcon icon={FlimSlateIcon} className="size-5 shrink-0" />
               Create videos
             </h2>
             <p className="text-xs leading-snug text-muted-foreground">

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1557,16 +1557,19 @@ export function VideoPage({ active = true }: { active?: boolean }) {
               settingsFadeClass,
             )}
           >
-          {/* Names the pane, as the Images column does. h-9 keeps both pages' headings level. */}
-          <div className="grid gap-1">
-            <h2 className="flex h-9 items-center gap-2 font-heading text-xl font-medium text-foreground">
-              {/* The app's Video icon, same as the sidebar row. */}
-              <HugeiconsIcon icon={FlimSlateIcon} className="size-[22px] shrink-0" />
-              Create videos
-            </h2>
-            <p className="text-ui-12p5 leading-snug text-muted-foreground">
-              Generate a video from a prompt
-            </p>
+          {/* Names the pane, as the Images column does. Same shape there, so
+              the two pages stay level. */}
+          <div className="mb-2 flex items-center gap-4">
+            {/* The app's Video icon, same as the sidebar row. */}
+            <HugeiconsIcon icon={FlimSlateIcon} className="size-[30px] shrink-0" />
+            <div className="grid min-w-0 gap-0.5">
+              <h2 className="font-heading text-xl font-medium leading-none text-foreground">
+                Create videos
+              </h2>
+              <p className="text-xs leading-snug text-muted-foreground">
+                Generate a video from a prompt
+              </p>
+            </div>
           </div>
 
           <Field label="Prompt">

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1562,7 +1562,7 @@ export function VideoPage({ active = true }: { active?: boolean }) {
           <div className="mb-2 grid gap-1.5">
             <h2 className="flex items-center gap-3 font-heading text-xl font-medium leading-none text-foreground">
               {/* The app's Video icon, same as the sidebar row. */}
-              <HugeiconsIcon icon={FlimSlateIcon} className="size-6 shrink-0" />
+              <HugeiconsIcon icon={FlimSlateIcon} className="size-[22px] shrink-0" />
               Create videos
             </h2>
             <p className="text-xs leading-snug text-muted-foreground">

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1560,7 +1560,7 @@ export function VideoPage({ active = true }: { active?: boolean }) {
           {/* Names the pane, as the Images column does. Same shape there, so
               the two pages stay level. */}
           <div className="mb-2 grid gap-1.5">
-            <h2 className="flex items-center gap-2.5 font-heading text-xl font-medium leading-none text-foreground">
+            <h2 className="flex items-center gap-2 font-heading text-xl font-medium leading-none text-foreground">
               {/* The app's Video icon, same as the sidebar row. */}
               <HugeiconsIcon icon={FlimSlateIcon} className="size-[18px] shrink-0" />
               Create videos


### PR DESCRIPTION
## What this does

Reworks the heading block on the Images Create, Video Create and Images Train panes, and tidies two controls under them.

### Naming

Both Create panes had a bare "Create" heading, which says nothing once you are already looking at the pane. They now read "Create images" and "Create videos".

For Images the string is shared with the sidebar submenu, which nests these rows under Images, so renaming it outright would have produced "Images > Create images". `WORKFLOW_TABS` gains an optional `heading` used only by the page; the submenu keeps the short label.

On the Train pane, "Training settings" becomes "Train settings" and gains a short line under it, so both headings across the rule read the same way. Its icon grows to 30px to match, now that it sits beside two rows rather than one. The "Train a LoRA" line wrapped to two lines in that column, so it is shortened to one.

### Video icon

The Video pane borrowed the Images pane's sparkles icon. It now uses `FlimSlateIcon`, the app's own video icon, already used by the sidebar Video row, the settings nav customizer, the Images page's link to Video, and this page's empty state.

### Heading layout

The heading blocks across all four media headings now share one treatment:

- heading `text-base` to `text-xl`, with `leading-none` so the line under it sits close
- icon stays on the heading line, `size-4` to 26px
- supporting line to `text-xs`, matching a field label like "Prompt", running the full width below
- 24px between the block and the first field, via a margin on the block rather than the container gap, so the other field gaps are unchanged

### Negative prompt

The chevron was hidden until you hovered the row, so nothing indicated the field expanded. It is always visible now and sits directly after the label, with the info hint moved out past it so it does not hold the chevron away from the words. The labelled button remains the accessible toggle; the chevron stays `aria-hidden` decoration, so the reorder does not change what a screen reader announces.

Its wrapper also carried `-mt-1` and `pb-2`, which no other field has, so it sat 12px below the prompt box and 24px above the next field. Both are 16px now, matching the rest of the panel. Its inner structure was already identical to `Field`.

### Advanced

`px-1` to `px-3`, so the hover pill has room around its icon and chevron.

## Notes

Six files, presentation and copy only. `tsc -b` is clean and the 463 frontend tests pass.

`NegativePromptField` and `AdvancedDisclosure` are shared by both Create panes, so those two changes land on Images and Video together.
