### PR TITLE
Studio: stop model rows staying lit after the dots menu closes

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3415,9 +3415,12 @@ export function HubModelPicker({
 
   const downloadedRowButtonClassName =
     "bg-transparent pr-1 hover:bg-transparent focus-visible:bg-transparent dark:bg-transparent dark:hover:bg-transparent dark:focus-visible:bg-transparent";
+  // Not focus-within: the dots menu returns focus to its trigger on close, so
+  // the row stayed lit after the pointer left. Keyboard focus and an open menu
+  // still light it.
   const downloadedRowShellClassName = (selected: boolean) =>
     cn(
-      "group flex items-center rounded-full transition-colors hover:bg-[#ececec] focus-within:bg-[#ececec] dark:hover:bg-[var(--sidebar-accent)] dark:focus-within:bg-[var(--sidebar-accent)]",
+      "group flex items-center rounded-full transition-colors hover:bg-[#ececec] has-[:focus-visible]:bg-[#ececec] has-[[data-state=open]]:bg-[#ececec] dark:hover:bg-[var(--sidebar-accent)] dark:has-[:focus-visible]:bg-[var(--sidebar-accent)] dark:has-[[data-state=open]]:bg-[var(--sidebar-accent)]",
       selected && "bg-[#ececec] dark:bg-[var(--sidebar-accent)]",
     );
 


### PR DESCRIPTION
## Problem

Open a model row's dots menu, dismiss it, move the pointer away, and the row stays highlighted.

It is not a stuck hover, it is focus. The row shell lit on `focus-within`:

```
hover:bg-[#ececec] focus-within:bg-[#ececec] ...
```

Clicking the dots trigger gives it DOM focus, and Radix returns focus to the trigger when the menu closes. The trigger sits inside the row, so `:focus-within` keeps matching long after the pointer has left.

That also explains two rows appearing lit at once: one holding focus from a dots click, another genuinely hovered. Real `:hover` can only ever light one.

## Fix

Replace `focus-within` with two narrower conditions:

- `has-[:focus-visible]` for keyboard focus. Browsers do not match `:focus-visible` on a mouse click, so clicking the dots no longer lights the row, while tabbing to it still does.
- `has-[[data-state=open]]` so the row stays lit while its own menu is open, which `focus-within` was incidentally providing.

Both in light and dark. `has-[[data-state=open]]` is already the pattern used a few lines above for the row's icon strip.

## Notes

One line plus a comment. `tsc -b` is clean and the 463 frontend tests pass.
