### PR TITLE
Studio: lead the Context Length note with the automatic fit

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -1192,8 +1192,8 @@ export function ModelConfigPage({
                 />
               ) : null}
               <p className="text-ui-11 leading-relaxed text-muted-foreground">
-                By default, Unsloth uses the model's full context, lowering it
-                only if it will not fit your device's memory.
+                Unsloth automatically fits the context to your device, using the
+                full context when memory allows.
               </p>
               {isActiveModel &&
                 loadedMaxContextLength != null &&


### PR DESCRIPTION
## What this does

Rewords the Context Length note under the model's run settings.

Before:

> By default, Unsloth uses the model's full context, lowering it only if it will not fit your device's memory.

After:

> Unsloth automatically fits the context to your device, using the full context when memory allows.

The old wording led with "By default", which frames the behaviour as a setting you might have to correct rather than as something Unsloth handles. The new line leads with the automatic fit and is shorter, roughly three rendered lines down to two.

The described behaviour is unchanged, so it still matches the `Auto` badge above it and the VRAM warning below, which already covers the case where the context does not fit.

## Notes

One string. `tsc -b` is clean and the 463 frontend tests pass.
