### PR TITLE
studio: persist the settings dialog picks that reset on every tab switch

### DIFF
--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -31,6 +31,7 @@ import { Streamdown } from "streamdown";
 import { loadCodingAgents } from "../api/coding-agents";
 import { loadOpenAIAutoSwitchSettings } from "../api/openai-auto-switch";
 import { type OpenAIModel, listOpenAIModels } from "../api/openai-models";
+import { useSettingsPanelPrefsStore } from "../stores/settings-panel-prefs-store";
 import { buildAgentCommand, isLoopbackHost, normalizeHost } from "./agent-command";
 
 type ExampleType =
@@ -57,6 +58,9 @@ const TYPE_TABS: { id: ExampleType; label: string }[] = [
   { id: "pythonAdvanced", label: "Python + advanced" },
   { id: "javascriptAdvanced", label: "JavaScript + advanced" },
 ];
+
+// guards a restored tab against a snippet type dropped in a later release.
+const EXAMPLE_TYPE_IDS = new Set<string>(TYPE_TABS.map((tab) => tab.id));
 
 const TYPE_LABEL_KEY: Partial<Record<ExampleType, TranslationKey>> = {
   curlTools: "settings.apiKeys.exampleCurlTools",
@@ -509,20 +513,41 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   const cloudflareUrl = usePlatformStore((s) => s.cloudflareUrl);
   const serverUrl = usePlatformStore((s) => s.serverUrl);
   const secure = usePlatformStore((s) => s.secure);
-  const [lang, setLang] = useState<ExampleType>("curl");
+  const setStoredLang = useSettingsPanelPrefsStore((s) => s.setApiExampleLang);
+  const setStoredOs = useSettingsPanelPrefsStore((s) => s.setApiExampleOs);
+  const setStoredAgent = useSettingsPanelPrefsStore(
+    (s) => s.setApiExampleAgent,
+  );
+  // read once: these seed the controls, which write back through the handlers.
+  const [storedPrefs] = useState(() => useSettingsPanelPrefsStore.getState());
+  const [lang, setLang] = useState<ExampleType>(
+    storedPrefs.apiExampleLang && EXAMPLE_TYPE_IDS.has(storedPrefs.apiExampleLang)
+      ? (storedPrefs.apiExampleLang as ExampleType)
+      : "curl",
+  );
+  // an explicit pick wins, since the snippet may target another machine.
   const [os, setOs] = useState<Os>(
-    deviceType === "windows" ? "windows" : "unix",
+    storedPrefs.apiExampleOs === "windows" ||
+      storedPrefs.apiExampleOs === "unix"
+      ? storedPrefs.apiExampleOs
+      : deviceType === "windows"
+        ? "windows"
+        : "unix",
   );
   const [copied, setCopied] = useState(false);
   const [copiedUrl, setCopiedUrl] = useState(false);
   const [copiedAgent, setCopiedAgent] = useState(false);
-  const [agent, setAgent] = useState<string>(DEFAULT_AGENT);
+  const [agent, setAgent] = useState<string>(
+    storedPrefs.apiExampleAgent ?? DEFAULT_AGENT,
+  );
   const [availableAgents, setAvailableAgents] =
     useState<string[]>(DEFAULT_AGENTS);
   const [detectedAgents, setDetectedAgents] = useState<string[]>([]);
+  // set on answer, so a restored agent never validates against the defaults.
+  const [agentsLoaded, setAgentsLoaded] = useState(false);
   // True once the user has picked an agent themselves; guards the detection
   // effect below from clobbering that choice if it resolves afterward.
-  const agentPickedByUserRef = useRef(false);
+  const agentPickedByUserRef = useRef(storedPrefs.apiExampleAgent != null);
   const [useTunnel, setUseTunnel] = useState<boolean>(readUseTunnelPref);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   const base =
@@ -561,11 +586,24 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
       })
       .catch(() => {
         // Best-effort: keep the default agent list and let the user pick manually.
+      })
+      .finally(() => {
+        if (!cancelled) setAgentsLoaded(true);
       });
     return () => {
       cancelled = true;
     };
   }, [localAgentDetection]);
+
+  // a restored agent this build no longer offers cannot build a command.
+  useEffect(() => {
+    if (!agentPickedByUserRef.current) return;
+    if (localAgentDetection && !agentsLoaded) return;
+    if (availableAgents.includes(agent)) return;
+    agentPickedByUserRef.current = false;
+    setStoredAgent(null);
+    setAgent(DEFAULT_AGENT);
+  }, [agent, agentsLoaded, availableAgents, localAgentDetection, setStoredAgent]);
 
   // Single source of truth for the auto-picked agent, re-derived whenever
   // the detected list or the loaded model's GGUF-ness changes -- in either
@@ -726,7 +764,10 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
                 <button
                   key={tab.id}
                   type="button"
-                  onClick={() => setLang(tab.id)}
+                  onClick={() => {
+                    setLang(tab.id);
+                    setStoredLang(tab.id);
+                  }}
                   aria-pressed={active}
                   className={cn(
                     "rounded-full px-2.5 py-1 text-ui-11 font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
@@ -745,7 +786,10 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
           <div className="flex min-w-0 items-center gap-0.5 border-b border-border px-2 py-1.5">
             <button
               type="button"
-              onClick={() => setOs("unix")}
+              onClick={() => {
+                setOs("unix");
+                setStoredOs("unix");
+              }}
               aria-pressed={os === "unix"}
               className={cn(
                 "rounded-full px-2.5 py-1 text-ui-11 font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
@@ -758,7 +802,10 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
             </button>
             <button
               type="button"
-              onClick={() => setOs("windows")}
+              onClick={() => {
+                setOs("windows");
+                setStoredOs("windows");
+              }}
               aria-pressed={os === "windows"}
               className={cn(
                 "rounded-full px-2.5 py-1 text-ui-11 font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
@@ -816,6 +863,7 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
                   onClick={() => {
                     agentPickedByUserRef.current = true;
                     setAgent(id);
+                    setStoredAgent(id);
                   }}
                   aria-pressed={active}
                   title={

--- a/studio/frontend/src/features/settings/stores/settings-panel-prefs-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-panel-prefs-store.ts
@@ -21,9 +21,6 @@ export interface SettingsPanelPrefsState {
   setAgentsAgent: (agent: string | null) => void;
   setAgentsModel: (model: string | null, variant: string | null) => void;
   setAgentsVariant: (model: string, variant: string) => void;
-  // Drops the quant without touching the model, for the case where the repo
-  // stops offering a remembered quant but the model itself is still valid.
-  clearAgentsVariant: () => void;
 
   // null os means "follow the detected device type".
   apiExampleLang: string | null;
@@ -101,8 +98,6 @@ export const useSettingsPanelPrefsStore = create<SettingsPanelPrefsState>()(
         set({ agentsModel, agentsVariant, agentsVariantModel: agentsModel }),
       setAgentsVariant: (agentsVariantModel, agentsVariant) =>
         set({ agentsVariant, agentsVariantModel }),
-      clearAgentsVariant: () =>
-        set({ agentsVariant: null, agentsVariantModel: null }),
 
       apiExampleLang: null,
       apiExampleOs: null,

--- a/studio/frontend/src/features/settings/stores/settings-panel-prefs-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-panel-prefs-store.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ExampleOs = "unix" | "windows";
+export type FineTuneAction = "train" | "recipes" | "export";
+
+export const SETTINGS_PANEL_PREFS_STORAGE_KEY = "unsloth_settings_panel_prefs";
+
+// settings dialog picks that renderTab() used to drop on every tab switch.
+export interface SettingsPanelPrefsState {
+  // null model means "follow whichever model the server has resident".
+  agentsAgent: string | null;
+  agentsModel: string | null;
+  agentsVariant: string | null;
+  setAgentsAgent: (agent: string | null) => void;
+  setAgentsModel: (model: string | null, variant: string | null) => void;
+  setAgentsVariant: (variant: string | null) => void;
+
+  // null os means "follow the detected device type".
+  apiExampleLang: string | null;
+  apiExampleOs: ExampleOs | null;
+  apiExampleAgent: string | null;
+  setApiExampleLang: (lang: string) => void;
+  setApiExampleOs: (os: ExampleOs) => void;
+  setApiExampleAgent: (agent: string | null) => void;
+
+  resourcesLiveUpdates: boolean;
+  setResourcesLiveUpdates: (enabled: boolean) => void;
+
+  fineTuneAction: FineTuneAction;
+  setFineTuneAction: (action: FineTuneAction) => void;
+}
+
+export const useSettingsPanelPrefsStore = create<SettingsPanelPrefsState>()(
+  persist(
+    (set) => ({
+      agentsAgent: null,
+      agentsModel: null,
+      agentsVariant: null,
+      setAgentsAgent: (agentsAgent) => set({ agentsAgent }),
+      // a quant belongs to its repo, so the two only ever move together.
+      setAgentsModel: (agentsModel, agentsVariant) =>
+        set({ agentsModel, agentsVariant }),
+      setAgentsVariant: (agentsVariant) => set({ agentsVariant }),
+
+      apiExampleLang: null,
+      apiExampleOs: null,
+      apiExampleAgent: null,
+      setApiExampleLang: (apiExampleLang) => set({ apiExampleLang }),
+      setApiExampleOs: (apiExampleOs) => set({ apiExampleOs }),
+      setApiExampleAgent: (apiExampleAgent) => set({ apiExampleAgent }),
+
+      resourcesLiveUpdates: true,
+      setResourcesLiveUpdates: (resourcesLiveUpdates) =>
+        set({ resourcesLiveUpdates }),
+
+      fineTuneAction: "train",
+      setFineTuneAction: (fineTuneAction) => set({ fineTuneAction }),
+    }),
+    { name: SETTINGS_PANEL_PREFS_STORAGE_KEY },
+  ),
+);

--- a/studio/frontend/src/features/settings/stores/settings-panel-prefs-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-panel-prefs-store.ts
@@ -14,10 +14,13 @@ export interface SettingsPanelPrefsState {
   // null model means "follow whichever model the server has resident".
   agentsAgent: string | null;
   agentsModel: string | null;
+  // the quant carries the model it was picked for, so remembering a quant alone
+  // never pins a model the tab would otherwise keep following.
   agentsVariant: string | null;
+  agentsVariantModel: string | null;
   setAgentsAgent: (agent: string | null) => void;
   setAgentsModel: (model: string | null, variant: string | null) => void;
-  setAgentsVariant: (variant: string | null) => void;
+  setAgentsVariant: (model: string, variant: string) => void;
 
   // null os means "follow the detected device type".
   apiExampleLang: string | null;
@@ -40,11 +43,13 @@ export const useSettingsPanelPrefsStore = create<SettingsPanelPrefsState>()(
       agentsAgent: null,
       agentsModel: null,
       agentsVariant: null,
+      agentsVariantModel: null,
       setAgentsAgent: (agentsAgent) => set({ agentsAgent }),
-      // a quant belongs to its repo, so the two only ever move together.
+      // picking a model carries its quant, and clearing it clears that quant.
       setAgentsModel: (agentsModel, agentsVariant) =>
-        set({ agentsModel, agentsVariant }),
-      setAgentsVariant: (agentsVariant) => set({ agentsVariant }),
+        set({ agentsModel, agentsVariant, agentsVariantModel: agentsModel }),
+      setAgentsVariant: (agentsVariantModel, agentsVariant) =>
+        set({ agentsVariant, agentsVariantModel }),
 
       apiExampleLang: null,
       apiExampleOs: null,

--- a/studio/frontend/src/features/settings/stores/settings-panel-prefs-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-panel-prefs-store.ts
@@ -21,6 +21,9 @@ export interface SettingsPanelPrefsState {
   setAgentsAgent: (agent: string | null) => void;
   setAgentsModel: (model: string | null, variant: string | null) => void;
   setAgentsVariant: (model: string, variant: string) => void;
+  // Drops the quant without touching the model, for the case where the repo
+  // stops offering a remembered quant but the model itself is still valid.
+  clearAgentsVariant: () => void;
 
   // null os means "follow the detected device type".
   apiExampleLang: string | null;
@@ -37,6 +40,54 @@ export interface SettingsPanelPrefsState {
   setFineTuneAction: (action: FineTuneAction) => void;
 }
 
+const EXAMPLE_OS_VALUES: ExampleOs[] = ["unix", "windows"];
+const FINE_TUNE_VALUES: FineTuneAction[] = ["train", "recipes", "export"];
+
+// localStorage is untyped at runtime and these reach `.toLowerCase()` and the
+// path checks in agents-tab, so a bad record would take the app down. The
+// default merge also spreads the blob over the actions themselves. Whitelist.
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function oneOf<T extends string>(value: unknown, allowed: T[], fallback: T): T {
+  return typeof value === "string" && (allowed as string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+function sanitize(
+  persisted: unknown,
+  current: SettingsPanelPrefsState,
+): SettingsPanelPrefsState {
+  const raw = (
+    persisted && typeof persisted === "object" ? persisted : {}
+  ) as Record<string, unknown>;
+  const agentsModel = text(raw.agentsModel);
+  const agentsVariantModel = text(raw.agentsVariantModel);
+  const agentsVariant = text(raw.agentsVariant);
+  return {
+    ...current,
+    agentsAgent: text(raw.agentsAgent),
+    agentsModel,
+    // A quant with no model to scope it to can never be applied.
+    agentsVariant: agentsVariantModel ? agentsVariant : null,
+    agentsVariantModel: agentsVariant ? agentsVariantModel : null,
+    apiExampleLang: text(raw.apiExampleLang),
+    apiExampleOs:
+      typeof raw.apiExampleOs === "string" &&
+      (EXAMPLE_OS_VALUES as string[]).includes(raw.apiExampleOs)
+        ? (raw.apiExampleOs as ExampleOs)
+        : null,
+    apiExampleAgent: text(raw.apiExampleAgent),
+    resourcesLiveUpdates:
+      typeof raw.resourcesLiveUpdates === "boolean"
+        ? raw.resourcesLiveUpdates
+        : true,
+    fineTuneAction: oneOf(raw.fineTuneAction, FINE_TUNE_VALUES, "train"),
+  };
+}
+
 export const useSettingsPanelPrefsStore = create<SettingsPanelPrefsState>()(
   persist(
     (set) => ({
@@ -50,6 +101,8 @@ export const useSettingsPanelPrefsStore = create<SettingsPanelPrefsState>()(
         set({ agentsModel, agentsVariant, agentsVariantModel: agentsModel }),
       setAgentsVariant: (agentsVariantModel, agentsVariant) =>
         set({ agentsVariant, agentsVariantModel }),
+      clearAgentsVariant: () =>
+        set({ agentsVariant: null, agentsVariantModel: null }),
 
       apiExampleLang: null,
       apiExampleOs: null,
@@ -65,6 +118,15 @@ export const useSettingsPanelPrefsStore = create<SettingsPanelPrefsState>()(
       fineTuneAction: "train",
       setFineTuneAction: (fineTuneAction) => set({ fineTuneAction }),
     }),
-    { name: SETTINGS_PANEL_PREFS_STORAGE_KEY },
+    {
+      name: SETTINGS_PANEL_PREFS_STORAGE_KEY,
+      // Pinned so a later shape change has somewhere to migrate from.
+      version: 1,
+      // Older records share these field names, so the sanitiser is enough. A
+      // newer one is dropped: it may reuse the names with different meaning.
+      migrate: (persisted, version) =>
+        (version < 1 ? persisted : {}) as SettingsPanelPrefsState,
+      merge: (persisted, current) => sanitize(persisted, current),
+    },
   ),
 );

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -714,7 +714,8 @@ export function AgentsTab() {
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [variants, setVariants] = useState<GgufVariantDetail[]>([]);
   const [selectedVariant, setSelectedVariant] = useState<string | null>(
-    chosenVariant.current?.model === initialModel
+    chosenVariant.current &&
+    modelKey(chosenVariant.current.model) === modelKey(initialModel)
       ? chosenVariant.current.variant
       : initialModel === EXAMPLE_MODEL_REPO
         ? EXAMPLE_MODEL_VARIANT
@@ -930,6 +931,16 @@ export function AgentsTab() {
     };
   }, []);
 
+  // The remembered quant for `model`, matched through modelKey: the catalog,
+  // cache and status endpoints can disagree on repo-id casing, and an exact
+  // compare would silently drop the user's quant.
+  const rememberedVariant = useCallback((model: string): string | null => {
+    const chosen = chosenVariant.current;
+    return chosen && modelKey(chosen.model) === modelKey(model)
+      ? chosen.variant
+      : null;
+  }, []);
+
   // List the resident model and follow it, unless the user picked one explicitly.
   const adoptActiveModel = useCallback(
     (active: { model: string; variant: string | null }) => {
@@ -946,14 +957,10 @@ export function AgentsTab() {
         setSelectedModel(active.model);
         // a remembered quant for this model wins, since it may be adopted here
         // before the variants fetch below has had a chance to apply it.
-        setSelectedVariant(
-          chosenVariant.current?.model === active.model
-            ? chosenVariant.current.variant
-            : active.variant,
-        );
+        setSelectedVariant(rememberedVariant(active.model) ?? active.variant);
       }
     },
-    [],
+    [rememberedVariant],
   );
 
   // A native-grant label only stands for whatever was resident at the time, so once
@@ -1149,20 +1156,19 @@ export function AgentsTab() {
         );
         // Authoritative for this repo: drop a remembered quant it no longer
         // offers, or adoptActiveModel re-imposes it on the next poll.
-        if (
-          chosenVariant.current?.model === selectedModel &&
-          !available.has(chosenVariant.current.variant)
-        ) {
+        const remembered = rememberedVariant(selectedModel);
+        if (remembered && !available.has(remembered)) {
           chosenVariant.current = null;
-          if (storedVariantModel === selectedModel) {
+          if (
+            storedVariantModel &&
+            modelKey(storedVariantModel) === modelKey(selectedModel)
+          ) {
             clearStoredVariant();
           }
         }
         const nextVariant =
           pickVariant(available, [
-            chosenVariant.current?.model === selectedModel
-              ? chosenVariant.current.variant
-              : null,
+            rememberedVariant(selectedModel),
             preferredVariant,
             info.default_variant,
           ]) ??
@@ -1205,6 +1211,7 @@ export function AgentsTab() {
     clearStoredVariant,
     hfToken,
     preferredVariant,
+    rememberedVariant,
     selectedModel,
   ]);
 

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -644,12 +644,6 @@ export function AgentsTab() {
   const setStoredVariant = useSettingsPanelPrefsStore(
     (s) => s.setAgentsVariant,
   );
-  const clearStoredVariant = useSettingsPanelPrefsStore(
-    (s) => s.clearAgentsVariant,
-  );
-  const storedVariantModel = useSettingsPanelPrefsStore(
-    (s) => s.agentsVariantModel,
-  );
   // read once: these seed the controls, which write back through the handlers.
   const [storedPrefs] = useState(() => useSettingsPanelPrefsStore.getState());
   const [agents, setAgents] = useState<string[]>(
@@ -1073,7 +1067,11 @@ export function AgentsTab() {
     restoredModel.current = null;
     // modelKey both sides: discovery folds repo-id case, so an exact match
     // would retire a valid pick just for a different spelling.
+    // A path is never in discoveredKeys (the catalog drops path ids and a scan
+    // root may not cover it), but `unsloth start --model <path>` is valid, so
+    // absence there is not evidence.
     if (
+      looksLikePath(restored) ||
       discoveredKeys.has(modelKey(restored)) ||
       (active && modelKey(active.model) === modelKey(restored))
     ) {
@@ -1156,15 +1154,13 @@ export function AgentsTab() {
         );
         // Authoritative for this repo: drop a remembered quant it no longer
         // offers, or adoptActiveModel re-imposes it on the next poll.
+        // Stop adoptActiveModel re-imposing a quant this repo will not serve.
+        // In-memory only: `partial` here means "still downloading", and an
+        // offline reply lists just the cache, so neither is grounds to delete
+        // the user's saved quant. Dropping the ref re-runs this next mount.
         const remembered = rememberedVariant(selectedModel);
         if (remembered && !available.has(remembered)) {
           chosenVariant.current = null;
-          if (
-            storedVariantModel &&
-            modelKey(storedVariantModel) === modelKey(selectedModel)
-          ) {
-            clearStoredVariant();
-          }
         }
         const nextVariant =
           pickVariant(available, [
@@ -1203,12 +1199,8 @@ export function AgentsTab() {
     return () => {
       cancelled = true;
     };
-    // storedVariantModel is read inside but is not a dep: this effect changes
-    // it, and re-running would refetch the variants.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     cachedLoadId,
-    clearStoredVariant,
     hfToken,
     preferredVariant,
     rememberedVariant,
@@ -1410,7 +1402,8 @@ export function AgentsTab() {
                           onSelect={() => {
                             modelSelectionChanged.current = true;
                             restoredModel.current = null;
-                            const variant = knownVariants[model] ?? null;
+                            const variant =
+                              rememberedVariant(model) ?? knownVariants[model] ?? null;
                             setSelectedModel(model);
                             setSelectedVariant(variant);
                             // a native-grant label names no path to reuse.

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -644,6 +644,12 @@ export function AgentsTab() {
   const setStoredVariant = useSettingsPanelPrefsStore(
     (s) => s.setAgentsVariant,
   );
+  const clearStoredVariant = useSettingsPanelPrefsStore(
+    (s) => s.clearAgentsVariant,
+  );
+  const storedVariantModel = useSettingsPanelPrefsStore(
+    (s) => s.agentsVariantModel,
+  );
   // read once: these seed the controls, which write back through the handlers.
   const [storedPrefs] = useState(() => useSettingsPanelPrefsStore.getState());
   const [agents, setAgents] = useState<string[]>(
@@ -860,10 +866,17 @@ export function AgentsTab() {
 
   useEffect(() => {
     let cancelled = false;
+    // An endpoint that could not answer has not proved a model absent, and the
+    // retire treats discoveredKeys as exactly that proof.
+    let discoveryComplete = true;
+    const note = <T,>(fallback: T) => (): T => {
+      discoveryComplete = false;
+      return fallback;
+    };
     Promise.all([
-      listModels().catch(() => null),
-      listCachedGguf().catch(() => []),
-      listLocalModels().catch(() => null),
+      listModels().catch(note(null)),
+      listCachedGguf().catch(note([])),
+      listLocalModels().catch(note(null)),
     ])
       .then(([info, cachedGgufs, local]) => {
         if (cancelled) {
@@ -890,7 +903,10 @@ export function AgentsTab() {
             labels[entry.id] = entry.label;
           }
         }
-        setDiscoveredKeys(new Set(discovered.models.map(modelKey)));
+        // Left null when a source failed; null already means "cannot retire".
+        if (discoveryComplete) {
+          setDiscoveredKeys(new Set(discovered.models.map(modelKey)));
+        }
         // Status is applied on its own schedule now, so keep whatever model it has
         // already adopted rather than dropping it when this slower scan lands.
         setModels(() => {
@@ -1023,13 +1039,14 @@ export function AgentsTab() {
         .then((status) => {
           if (!cancelled && seq === statusSeq.current) {
             applyStatus(status);
+            // Only a current, answered poll is evidence: settling a superseded
+            // one would let the retire run with activeModelRef unset.
+            setStatusSettled(true);
           }
         })
         .catch(() => {
-          // A failed poll just leaves the last known selection in place.
-        })
-        .finally(() => {
-          if (!cancelled) setStatusSettled(true);
+          // Not settled: a request that never answered proves nothing about
+          // what is resident, so the retire below must keep waiting.
         });
     };
     sync();
@@ -1047,7 +1064,12 @@ export function AgentsTab() {
     if (!(restored && discoveredKeys && statusSettled)) return;
     const active = activeModelRef.current;
     restoredModel.current = null;
-    if (discoveredKeys.has(modelKey(restored)) || active?.model === restored) {
+    // modelKey both sides: discovery folds repo-id case, so an exact match
+    // would retire a valid pick just for a different spelling.
+    if (
+      discoveredKeys.has(modelKey(restored)) ||
+      (active && modelKey(active.model) === modelKey(restored))
+    ) {
       return;
     }
     // an uncached pick would pin the builder to a model the CLI cannot load.
@@ -1125,6 +1147,17 @@ export function AgentsTab() {
         const available = new Set(
           uniqueVariants.map((variant) => variant.quant),
         );
+        // Authoritative for this repo: drop a remembered quant it no longer
+        // offers, or adoptActiveModel re-imposes it on the next poll.
+        if (
+          chosenVariant.current?.model === selectedModel &&
+          !available.has(chosenVariant.current.variant)
+        ) {
+          chosenVariant.current = null;
+          if (storedVariantModel === selectedModel) {
+            clearStoredVariant();
+          }
+        }
         const nextVariant =
           pickVariant(available, [
             chosenVariant.current?.model === selectedModel
@@ -1164,7 +1197,16 @@ export function AgentsTab() {
     return () => {
       cancelled = true;
     };
-  }, [cachedLoadId, hfToken, preferredVariant, selectedModel]);
+    // storedVariantModel is read inside but is not a dep: this effect changes
+    // it, and re-running would refetch the variants.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    cachedLoadId,
+    clearStoredVariant,
+    hfToken,
+    preferredVariant,
+    selectedModel,
+  ]);
 
   // No GGUF warning for `codex` (unsloth_cli's _require_gguf_for_codex): the
   // picker only ever offers GGUF models.

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -677,9 +677,8 @@ export function AgentsTab() {
   const [knownVariants, setKnownVariants] = useState<Record<string, string>>({
     [EXAMPLE_MODEL_REPO]: EXAMPLE_MODEL_VARIANT,
   });
-  const [selectedModel, setSelectedModel] = useState(
-    storedPrefs.agentsModel ?? EXAMPLE_MODEL_REPO,
-  );
+  const initialModel = storedPrefs.agentsModel ?? EXAMPLE_MODEL_REPO;
+  const [selectedModel, setSelectedModel] = useState(initialModel);
   const modelSelectionChanged = useRef(storedPrefs.agentsModel != null);
   // held until discovery and the first status can confirm the restored model.
   const restoredModel = useRef<string | null>(storedPrefs.agentsModel);
@@ -688,22 +687,32 @@ export function AgentsTab() {
   );
   const [statusSettled, setStatusSettled] = useState(false);
   // The model status last reported, for the discovery scan to preserve.
-  const activeModelRef = useRef<string | null>(null);
+  const activeModelRef = useRef<{
+    model: string;
+    variant: string | null;
+  } | null>(null);
   // Only the newest status request may apply; a slow earlier one must not win.
   const statusSeq = useRef(0);
   // A quant picked by hand, scoped to its repo: polling and refetches must not
   // overwrite it, but it must not follow the selection onto a different repo.
-  // seeding a restored quant here puts it through the same fetch a fresh one is.
+  // a restored quant is scoped the same way, so it applies when its model does.
   const chosenVariant = useRef<{ model: string; variant: string } | null>(
-    storedPrefs.agentsModel && storedPrefs.agentsVariant
-      ? { model: storedPrefs.agentsModel, variant: storedPrefs.agentsVariant }
+    storedPrefs.agentsVariantModel && storedPrefs.agentsVariant
+      ? {
+          model: storedPrefs.agentsVariantModel,
+          variant: storedPrefs.agentsVariant,
+        }
       : null,
   );
   const [modelSearch, setModelSearch] = useState("");
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [variants, setVariants] = useState<GgufVariantDetail[]>([]);
   const [selectedVariant, setSelectedVariant] = useState<string | null>(
-    storedPrefs.agentsModel ? storedPrefs.agentsVariant : EXAMPLE_MODEL_VARIANT,
+    chosenVariant.current?.model === initialModel
+      ? chosenVariant.current.variant
+      : initialModel === EXAMPLE_MODEL_REPO
+        ? EXAMPLE_MODEL_VARIANT
+        : null,
   );
   const [variantsLoading, setVariantsLoading] = useState(true);
   const [variantsFailed, setVariantsFailed] = useState(false);
@@ -885,7 +894,7 @@ export function AgentsTab() {
         // Status is applied on its own schedule now, so keep whatever model it has
         // already adopted rather than dropping it when this slower scan lands.
         setModels(() => {
-          const active = activeModelRef.current;
+          const active = activeModelRef.current?.model;
           return active && !discovered.models.includes(active)
             ? [active, ...discovered.models]
             : discovered.models;
@@ -919,9 +928,13 @@ export function AgentsTab() {
       }
       if (!modelSelectionChanged.current) {
         setSelectedModel(active.model);
-        if (chosenVariant.current?.model !== active.model) {
-          setSelectedVariant(active.variant);
-        }
+        // a remembered quant for this model wins, since it may be adopted here
+        // before the variants fetch below has had a chance to apply it.
+        setSelectedVariant(
+          chosenVariant.current?.model === active.model
+            ? chosenVariant.current.variant
+            : active.variant,
+        );
       }
     },
     [],
@@ -974,7 +987,9 @@ export function AgentsTab() {
   const applyStatus = useCallback(
     (status: InferenceStatusResponse) => {
       const active = activeGgufSelection(status);
-      activeModelRef.current = active?.model ?? null;
+      activeModelRef.current = active
+        ? { model: active.model, variant: active.variant }
+        : null;
       const wasAttachOnly = attachOnlyModel;
       setActiveStatusModel(active?.model ?? null);
       setAttachOnlyModel(active && !active.named ? active.model : null);
@@ -1030,20 +1045,25 @@ export function AgentsTab() {
   useEffect(() => {
     const restored = restoredModel.current;
     if (!(restored && discoveredKeys && statusSettled)) return;
+    const active = activeModelRef.current;
     restoredModel.current = null;
-    if (
-      discoveredKeys.has(modelKey(restored)) ||
-      activeModelRef.current === restored
-    ) {
+    if (discoveredKeys.has(modelKey(restored)) || active?.model === restored) {
       return;
     }
     // an uncached pick would pin the builder to a model the CLI cannot load.
     modelSelectionChanged.current = false;
     chosenVariant.current = null;
     setStoredModel(null, null);
+    // adopt straight away rather than parking on the example model: the next
+    // poll is STATUS_POLL_MS away, and a command copied meanwhile would switch
+    // a shared server off whatever is loaded.
+    if (active) {
+      adoptActiveModel(active);
+      return;
+    }
     setSelectedModel(EXAMPLE_MODEL_REPO);
     setSelectedVariant(EXAMPLE_MODEL_VARIANT);
-  }, [discoveredKeys, statusSettled, setStoredModel]);
+  }, [adoptActiveModel, discoveredKeys, statusSettled, setStoredModel]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1391,12 +1411,10 @@ export function AgentsTab() {
                 onValueChange={(variant) => {
                   chosenVariant.current = { model: selectedModel, variant };
                   setSelectedVariant(variant);
-                  // a quant picked while following the resident model is its own.
-                  if (
-                    useSettingsPanelPrefsStore.getState().agentsModel ===
-                    selectedModel
-                  ) {
-                    setStoredVariant(variant);
+                  // stored against its model, so a quant picked while following
+                  // the resident model is remembered without pinning it.
+                  if (selectedModel !== attachOnlyModel) {
+                    setStoredVariant(selectedModel, variant);
                   }
                   resetCopied();
                 }}

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -53,6 +53,7 @@ import {
 } from "../components/agent-command";
 import { SettingsSection } from "../components/settings-section";
 import { psSingle, shSingle } from "../components/usage-examples";
+import { useSettingsPanelPrefsStore } from "../stores/settings-panel-prefs-store";
 
 const DOCS_URL = "https://unsloth.ai/docs/integrations/unsloth-start";
 const EXAMPLE_MODEL_REPO = "unsloth/gemma-4-E4B-it-GGUF";
@@ -214,6 +215,11 @@ function looksLikePath(value: string): boolean {
   );
 }
 
+// hugging face ids fold case; a path does not, since Linux paths are sensitive.
+function modelKey(model: string): string {
+  return looksLikePath(model) ? model : model.toLowerCase();
+}
+
 function isHuggingFaceRepo(model: string): boolean {
   return HUGGING_FACE_REPO_PATTERN.test(model);
 }
@@ -242,11 +248,9 @@ function discoverGgufModels(
   const variants: Record<string, string> = {};
   // Hugging Face ids are case-insensitive, and the catalog and cache endpoints can
   // disagree on spelling; two rows for one repo would leave the load id on only one.
-  const seen = new Set(models.map((model) => model.toLowerCase()));
+  const seen = new Set(models.map(modelKey));
   const add = (model: string) => {
-    // Local entries arrive here as absolute paths, and a path is case-sensitive on
-    // Linux: folding those would collapse two distinct models into one.
-    const key = looksLikePath(model) ? model : model.toLowerCase();
+    const key = modelKey(model);
     if (seen.has(key)) {
       return;
     }
@@ -635,14 +639,29 @@ export function AgentsTab() {
     ? deviceType === "windows"
     : isWindowsClient;
   const localDetection = canUseLocalAgentDetection(serverUrl ?? origin);
+  const setStoredAgent = useSettingsPanelPrefsStore((s) => s.setAgentsAgent);
+  const setStoredModel = useSettingsPanelPrefsStore((s) => s.setAgentsModel);
+  const setStoredVariant = useSettingsPanelPrefsStore(
+    (s) => s.setAgentsVariant,
+  );
+  // read once: these seed the controls, which write back through the handlers.
+  const [storedPrefs] = useState(() => useSettingsPanelPrefsStore.getState());
   const [agents, setAgents] = useState<string[]>(
     SUPPORTED_AGENTS.map((agent) => agent.id),
   );
-  const [selectedAgent, setSelectedAgent] = useState(FALLBACK_AGENT.id);
-  const agentSelectionChanged = useRef(false);
+  const [selectedAgent, setSelectedAgent] = useState(
+    storedPrefs.agentsAgent ?? FALLBACK_AGENT.id,
+  );
+  // a restored pick counts as explicit, or detection would overwrite it.
+  const agentSelectionChanged = useRef(storedPrefs.agentsAgent != null);
   const [detectedAgents, setDetectedAgents] = useState<Set<string>>(new Set());
   const [loaded, setLoaded] = useState(false);
-  const [models, setModels] = useState<string[]>([EXAMPLE_MODEL_REPO]);
+  // list the restored model until the discovery scan confirms or retires it.
+  const [models, setModels] = useState<string[]>(
+    storedPrefs.agentsModel && storedPrefs.agentsModel !== EXAMPLE_MODEL_REPO
+      ? [storedPrefs.agentsModel, EXAMPLE_MODEL_REPO]
+      : [EXAMPLE_MODEL_REPO],
+  );
   const [cachedLoadIds, setCachedLoadIds] = useState<Record<string, string>>(
     {},
   );
@@ -658,20 +677,33 @@ export function AgentsTab() {
   const [knownVariants, setKnownVariants] = useState<Record<string, string>>({
     [EXAMPLE_MODEL_REPO]: EXAMPLE_MODEL_VARIANT,
   });
-  const [selectedModel, setSelectedModel] = useState(EXAMPLE_MODEL_REPO);
-  const modelSelectionChanged = useRef(false);
+  const [selectedModel, setSelectedModel] = useState(
+    storedPrefs.agentsModel ?? EXAMPLE_MODEL_REPO,
+  );
+  const modelSelectionChanged = useRef(storedPrefs.agentsModel != null);
+  // held until discovery and the first status can confirm the restored model.
+  const restoredModel = useRef<string | null>(storedPrefs.agentsModel);
+  const [discoveredKeys, setDiscoveredKeys] = useState<Set<string> | null>(
+    null,
+  );
+  const [statusSettled, setStatusSettled] = useState(false);
   // The model status last reported, for the discovery scan to preserve.
   const activeModelRef = useRef<string | null>(null);
   // Only the newest status request may apply; a slow earlier one must not win.
   const statusSeq = useRef(0);
   // A quant picked by hand, scoped to its repo: polling and refetches must not
   // overwrite it, but it must not follow the selection onto a different repo.
-  const chosenVariant = useRef<{ model: string; variant: string } | null>(null);
+  // seeding a restored quant here puts it through the same fetch a fresh one is.
+  const chosenVariant = useRef<{ model: string; variant: string } | null>(
+    storedPrefs.agentsModel && storedPrefs.agentsVariant
+      ? { model: storedPrefs.agentsModel, variant: storedPrefs.agentsVariant }
+      : null,
+  );
   const [modelSearch, setModelSearch] = useState("");
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [variants, setVariants] = useState<GgufVariantDetail[]>([]);
   const [selectedVariant, setSelectedVariant] = useState<string | null>(
-    EXAMPLE_MODEL_VARIANT,
+    storedPrefs.agentsModel ? storedPrefs.agentsVariant : EXAMPLE_MODEL_VARIANT,
   );
   const [variantsLoading, setVariantsLoading] = useState(true);
   const [variantsFailed, setVariantsFailed] = useState(false);
@@ -796,6 +828,27 @@ export function AgentsTab() {
     };
   }, [localDetection]);
 
+  // a restored agent the backend no longer lists cannot build a command.
+  useEffect(() => {
+    if (!agentSelectionChanged.current) return;
+    if (localDetection && !loaded) return;
+    if (agents.includes(selectedAgent)) return;
+    agentSelectionChanged.current = false;
+    setStoredAgent(null);
+    setSelectedAgent(
+      agents.find((agent) => detectedAgents.has(agent)) ??
+        agents[0] ??
+        FALLBACK_AGENT.id,
+    );
+  }, [
+    agents,
+    detectedAgents,
+    loaded,
+    localDetection,
+    selectedAgent,
+    setStoredAgent,
+  ]);
+
   useEffect(() => {
     let cancelled = false;
     Promise.all([
@@ -828,6 +881,7 @@ export function AgentsTab() {
             labels[entry.id] = entry.label;
           }
         }
+        setDiscoveredKeys(new Set(discovered.models.map(modelKey)));
         // Status is applied on its own schedule now, so keep whatever model it has
         // already adopted rather than dropping it when this slower scan lands.
         setModels(() => {
@@ -958,6 +1012,9 @@ export function AgentsTab() {
         })
         .catch(() => {
           // A failed poll just leaves the last known selection in place.
+        })
+        .finally(() => {
+          if (!cancelled) setStatusSettled(true);
         });
     };
     sync();
@@ -967,6 +1024,26 @@ export function AgentsTab() {
       window.clearInterval(timer);
     };
   }, [applyStatus]);
+
+  // retiring a restored pick needs both reads: either alone can miss a model
+  // the other knows about, and a wrong retire drops the user's choice.
+  useEffect(() => {
+    const restored = restoredModel.current;
+    if (!(restored && discoveredKeys && statusSettled)) return;
+    restoredModel.current = null;
+    if (
+      discoveredKeys.has(modelKey(restored)) ||
+      activeModelRef.current === restored
+    ) {
+      return;
+    }
+    // an uncached pick would pin the builder to a model the CLI cannot load.
+    modelSelectionChanged.current = false;
+    chosenVariant.current = null;
+    setStoredModel(null, null);
+    setSelectedModel(EXAMPLE_MODEL_REPO);
+    setSelectedVariant(EXAMPLE_MODEL_VARIANT);
+  }, [discoveredKeys, statusSettled, setStoredModel]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1146,6 +1223,7 @@ export function AgentsTab() {
                 onValueChange={(agent) => {
                   agentSelectionChanged.current = true;
                   setSelectedAgent(agent);
+                  setStoredAgent(agent);
                   resetCopied();
                 }}
               >
@@ -1262,8 +1340,15 @@ export function AgentsTab() {
                           data-checked={model === selectedModel}
                           onSelect={() => {
                             modelSelectionChanged.current = true;
+                            restoredModel.current = null;
+                            const variant = knownVariants[model] ?? null;
                             setSelectedModel(model);
-                            setSelectedVariant(knownVariants[model] ?? null);
+                            setSelectedVariant(variant);
+                            // a native-grant label names no path to reuse.
+                            setStoredModel(
+                              model === attachOnlyModel ? null : model,
+                              model === attachOnlyModel ? null : variant,
+                            );
                             setVariants([]);
                             setVariantsFailed(false);
                             setVariantsLoading(isHuggingFaceRepo(model));
@@ -1306,6 +1391,13 @@ export function AgentsTab() {
                 onValueChange={(variant) => {
                   chosenVariant.current = { model: selectedModel, variant };
                   setSelectedVariant(variant);
+                  // a quant picked while following the resident model is its own.
+                  if (
+                    useSettingsPanelPrefsStore.getState().agentsModel ===
+                    selectedModel
+                  ) {
+                    setStoredVariant(variant);
+                  }
                   resetCopied();
                 }}
                 disabled={variantsLoading || variants.length === 0}

--- a/studio/frontend/src/features/settings/tabs/data-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/data-tab.tsx
@@ -67,6 +67,13 @@ import { SettingsRow } from "../components/settings-row";
 import { SettingsSection } from "../components/settings-section";
 import { UploadedFilesView } from "../components/uploaded-files-dialog";
 import { useSettingsDialogStore } from "../stores/settings-dialog-store";
+import {
+  type FineTuneAction,
+  useSettingsPanelPrefsStore,
+} from "../stores/settings-panel-prefs-store";
+
+// display order, and the guard against a persisted action this build dropped.
+const FINE_TUNE_ACTIONS: FineTuneAction[] = ["export", "train", "recipes"];
 
 export function DataTab() {
   const t = useT();
@@ -97,18 +104,20 @@ export function DataTab() {
   // the Train tab would upload it and then strand the user; gate the action
   // the same way the sidebar gates Train.
   const chatOnly = usePlatformStore((s) => s.isChatOnly());
-  const [fineTuneAction, setFineTuneAction] = useState<
-    "train" | "recipes" | "export"
-  >(chatOnly ? "export" : "train");
+  const storedFineTuneAction = useSettingsPanelPrefsStore(
+    (s) => s.fineTuneAction,
+  );
+  const setFineTuneAction = useSettingsPanelPrefsStore(
+    (s) => s.setFineTuneAction,
+  );
+  const restoredAction = FINE_TUNE_ACTIONS.includes(storedFineTuneAction)
+    ? storedFineTuneAction
+    : "export";
+  // derived, not corrected: a stored "train" returns when chat-only flips off.
+  const fineTuneAction =
+    chatOnly && restoredAction === "train" ? "export" : restoredAction;
   // Chat Completions (OpenAI messages) is the only export format we ship.
   const fineTuneFormat: FineTuneFormat = "openai";
-
-  // The MLX self-heal can flip chat-only while the dialog is open.
-  useEffect(() => {
-    if (chatOnly) {
-      setFineTuneAction((a) => (a === "train" ? "export" : a));
-    }
-  }, [chatOnly]);
   // Requests can arrive after Data is already mounted (for example from the
   // archive-all toast), so always switch before consuming the flag.
   useEffect(() => {
@@ -480,7 +489,7 @@ export function DataTab() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56">
-                {(["export", "train", "recipes"] as const).map((action) => (
+                {FINE_TUNE_ACTIONS.map((action) => (
                   <DropdownMenuItem
                     key={action}
                     disabled={action === "train" && chatOnly}

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -64,6 +64,7 @@ import { SettingsRow } from "../components/settings-row";
 import { SettingsSection } from "../components/settings-section";
 import { StudioVersionSection } from "../components/studio-version-section";
 import { useSettingsDialogStore } from "../stores/settings-dialog-store";
+import { SETTINGS_PANEL_PREFS_STORAGE_KEY } from "../stores/settings-panel-prefs-store";
 
 // Keys cleared by "Reset all local preferences".
 // NEVER include auth/session keys here — clearing them would log the user out
@@ -82,6 +83,7 @@ const PREFS_KEYS: string[] = [
   "chat_settings_width",
   "unsloth_sidebar_navigate_open",
   "unsloth_settings_active_tab",
+  SETTINGS_PANEL_PREFS_STORAGE_KEY,
   // Chat runtime prefs
   "unsloth_chat_auto_title",
   "unsloth_chat_permission_mode",

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -29,6 +29,7 @@ import {
 import { SettingsRow } from "../components/settings-row";
 import { SettingsSection } from "../components/settings-section";
 import { useMonitorOverlayStore } from "../stores/monitor-overlay-store";
+import { useSettingsPanelPrefsStore } from "../stores/settings-panel-prefs-store";
 import { CopyIcon, FolderOpenIcon, LayersIcon } from "lucide-react";
 
 const POLL_MS = 3000;
@@ -183,7 +184,10 @@ function deviceOrdinal(device: GpuDevice): number | undefined {
 
 export function ResourcesTab() {
   const t = useT();
-  const [liveUpdates, setLiveUpdates] = useState(true);
+  const liveUpdates = useSettingsPanelPrefsStore((s) => s.resourcesLiveUpdates);
+  const setLiveUpdates = useSettingsPanelPrefsStore(
+    (s) => s.setResourcesLiveUpdates,
+  );
   const { isOpen, setIsOpen } = useMonitorOverlayStore();
   const systemInfo = useSystemInfo({
     enabled: liveUpdates,

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -189,8 +189,9 @@ export function ResourcesTab() {
     (s) => s.setResourcesLiveUpdates,
   );
   const { isOpen, setIsOpen } = useMonitorOverlayStore();
+  // always fetch once: the switch is persisted now, so gating the hook on it
+  // would leave a session that opens with it off reading zeros forever.
   const systemInfo = useSystemInfo({
-    enabled: liveUpdates,
     pollMs: liveUpdates ? POLL_MS : undefined,
   });
   const [hfCache, setHfCache] = useState<HuggingFaceCacheSettings | null>(null);

--- a/studio/frontend/tests/settings-panel-prefs.test.ts
+++ b/studio/frontend/tests/settings-panel-prefs.test.ts
@@ -96,6 +96,65 @@ test("a persisted blob cannot replace the store actions", () => {
   assert.equal(typeof out.setFineTuneAction, "function");
 });
 
+// The case agentsVariantModel exists for: the tab keeps following the resident
+// model, but the quant picked against it still survives the unmount.
+test("a quant picked while following the resident model does not pin a model", () => {
+  const s = useSettingsPanelPrefsStore.getState();
+  s.setAgentsModel(null, null);
+  s.setAgentsVariant("unsloth/Qux-GGUF", "Q6_K");
+  const next = useSettingsPanelPrefsStore.getState();
+  assert.equal(next.agentsModel, null);
+  assert.equal(next.agentsVariant, "Q6_K");
+  assert.equal(next.agentsVariantModel, "unsloth/Qux-GGUF");
+});
+
+// Half a pair is unusable: a quant with no model can never be scoped to one.
+test("a quant with no model to scope it to is dropped", () => {
+  const merged = useSettingsPanelPrefsStore.persist.getOptions().merge;
+  assert.ok(merged);
+  const out = merged(
+    { agentsVariant: "Q6_K" },
+    useSettingsPanelPrefsStore.getState(),
+  ) as { agentsVariant: unknown; agentsVariantModel: unknown };
+  assert.equal(out.agentsVariant, null);
+  assert.equal(out.agentsVariantModel, null);
+});
+
+// A downgrade must not read a newer record: the field names may have been
+// reused with different meaning.
+test("a record from a newer build falls back to defaults", () => {
+  const { migrate, version } = useSettingsPanelPrefsStore.persist.getOptions();
+  assert.ok(migrate);
+  assert.equal(version, 1);
+  assert.deepEqual(migrate({ agentsModel: "unsloth/Foo-GGUF" }, 2), {});
+  assert.deepEqual(migrate({ agentsModel: "unsloth/Foo-GGUF" }, 0), {
+    agentsModel: "unsloth/Foo-GGUF",
+  });
+});
+
+// Settling in a .finally let a superseded or failed poll release the retire
+// with no resident model recorded, which erased the saved model and quant.
+test("the status poll settles only on the read that applied", async () => {
+  const source = await readFile(
+    new URL("../src/features/settings/tabs/agents-tab.tsx", import.meta.url),
+    "utf8",
+  );
+  const sync = source.slice(
+    source.indexOf("const sync = ()"),
+    source.indexOf("const timer = window.setInterval"),
+  );
+  assert.ok(sync, "the status poll moved; this contract needs updating");
+  assert.ok(
+    !sync.includes(".finally("),
+    "a stale or failed poll must not settle",
+  );
+  const applied = sync.slice(
+    sync.indexOf("seq === statusSeq.current"),
+    sync.indexOf(".catch("),
+  );
+  assert.match(applied, /setStatusSettled\(true\)/);
+});
+
 // Reset-all is the only in-app escape hatch from a bad pinned model.
 test("Reset all local preferences clears this key", async () => {
   const source = await readFile(
@@ -133,5 +192,29 @@ test("the remembered quant is scoped through modelKey, not an exact compare", as
     exact,
     [],
     "an exact repo-id compare on chosenVariant drops the quant on a casing difference",
+  );
+});
+
+// An unreadable record leaves the pre-PR defaults, so a mangled blob never
+// changes how the tabs behave.
+test("an unreadable record leaves the defaults", () => {
+  const merged = useSettingsPanelPrefsStore.persist.getOptions().merge;
+  assert.ok(merged);
+  const out = merged(null, useSettingsPanelPrefsStore.getState());
+  assert.equal(out.agentsModel, null);
+  assert.equal(out.agentsVariant, null);
+  assert.equal(out.resourcesLiveUpdates, true);
+  assert.equal(out.fineTuneAction, "train");
+});
+
+// Last: it rehydrates the store. Corrupt JSON must not take settings down.
+test("corrupt JSON does not break the store", async () => {
+  store.set(KEY, "{not json");
+  await assert.doesNotReject(async () => {
+    await useSettingsPanelPrefsStore.persist.rehydrate();
+  });
+  assert.equal(
+    typeof useSettingsPanelPrefsStore.getState().setAgentsModel,
+    "function",
   );
 });

--- a/studio/frontend/tests/settings-panel-prefs.test.ts
+++ b/studio/frontend/tests/settings-panel-prefs.test.ts
@@ -112,3 +112,26 @@ test("Reset all local preferences clears this key", async () => {
     `${SETTINGS_PANEL_PREFS_STORAGE_KEY} missing from PREFS_KEYS`,
   );
 });
+
+// A quant is scoped to the repo it was picked for, and the catalog, cache and
+// status endpoints can disagree on repo-id casing, so that scope check has to
+// normalize or the user's quant is dropped when the spelling differs.
+test("the remembered quant is scoped through modelKey, not an exact compare", async () => {
+  const source = await readFile(
+    new URL("../src/features/settings/tabs/agents-tab.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /modelKey\(chosen\.model\) === modelKey\(model\)/,
+    "rememberedVariant must compare through modelKey",
+  );
+  const exact = source
+    .split("\n")
+    .filter((line) => line.includes("chosenVariant.current?.model ==="));
+  assert.deepEqual(
+    exact,
+    [],
+    "an exact repo-id compare on chosenVariant drops the quant on a casing difference",
+  );
+});

--- a/studio/frontend/tests/settings-panel-prefs.test.ts
+++ b/studio/frontend/tests/settings-panel-prefs.test.ts
@@ -56,14 +56,13 @@ test("picking a model carries its quant, and clearing it clears the quant", () =
   assert.equal(next.agentsVariantModel, null);
 });
 
-test("a quant can be dropped without disturbing the model", () => {
+test("a quant remembered for one model does not follow onto another", () => {
   const s = useSettingsPanelPrefsStore.getState();
-  s.setAgentsModel("unsloth/Baz-GGUF", "Q4_K_M");
-  useSettingsPanelPrefsStore.getState().clearAgentsVariant();
+  s.setAgentsVariant("unsloth/Baz-GGUF", "Q4_K_M");
   const next = useSettingsPanelPrefsStore.getState();
-  assert.equal(next.agentsModel, "unsloth/Baz-GGUF");
-  assert.equal(next.agentsVariant, null);
-  assert.equal(next.agentsVariantModel, null);
+  assert.equal(next.agentsVariant, "Q4_K_M");
+  assert.equal(next.agentsVariantModel, "unsloth/Baz-GGUF");
+  assert.equal(next.agentsModel, null, "a quant pick must not pin the model");
 });
 
 test("a setter write round-trips through localStorage", () => {

--- a/studio/frontend/tests/settings-panel-prefs.test.ts
+++ b/studio/frontend/tests/settings-panel-prefs.test.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { installLocalStorageFake, registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+const { store } = installLocalStorageFake();
+
+const KEY = "unsloth_settings_panel_prefs";
+
+// A record written before the sanitiser existed, holding every field.
+store.set(
+  KEY,
+  JSON.stringify({
+    state: {
+      agentsAgent: "codex",
+      agentsModel: "unsloth/Foo-GGUF",
+      agentsVariant: "UD-Q4_K_XL",
+      agentsVariantModel: "unsloth/Foo-GGUF",
+      apiExampleLang: "pythonTools",
+      apiExampleOs: "windows",
+      apiExampleAgent: "codex",
+      resourcesLiveUpdates: false,
+      fineTuneAction: "recipes",
+    },
+    version: 0,
+  }),
+);
+
+const { useSettingsPanelPrefsStore, SETTINGS_PANEL_PREFS_STORAGE_KEY } =
+  await import("../src/features/settings/stores/settings-panel-prefs-store.ts");
+
+test("a version 0 record hydrates every field", () => {
+  const s = useSettingsPanelPrefsStore.getState();
+  assert.equal(s.agentsAgent, "codex");
+  assert.equal(s.agentsModel, "unsloth/Foo-GGUF");
+  assert.equal(s.agentsVariant, "UD-Q4_K_XL");
+  assert.equal(s.apiExampleOs, "windows");
+  assert.equal(s.resourcesLiveUpdates, false);
+  assert.equal(s.fineTuneAction, "recipes");
+});
+
+test("picking a model carries its quant, and clearing it clears the quant", () => {
+  const s = useSettingsPanelPrefsStore.getState();
+  s.setAgentsModel("unsloth/Bar-GGUF", "Q4_K_M");
+  let next = useSettingsPanelPrefsStore.getState();
+  assert.equal(next.agentsModel, "unsloth/Bar-GGUF");
+  assert.equal(next.agentsVariantModel, "unsloth/Bar-GGUF");
+  next.setAgentsModel(null, null);
+  next = useSettingsPanelPrefsStore.getState();
+  assert.equal(next.agentsModel, null);
+  assert.equal(next.agentsVariant, null);
+  assert.equal(next.agentsVariantModel, null);
+});
+
+test("a quant can be dropped without disturbing the model", () => {
+  const s = useSettingsPanelPrefsStore.getState();
+  s.setAgentsModel("unsloth/Baz-GGUF", "Q4_K_M");
+  useSettingsPanelPrefsStore.getState().clearAgentsVariant();
+  const next = useSettingsPanelPrefsStore.getState();
+  assert.equal(next.agentsModel, "unsloth/Baz-GGUF");
+  assert.equal(next.agentsVariant, null);
+  assert.equal(next.agentsVariantModel, null);
+});
+
+test("a setter write round-trips through localStorage", () => {
+  useSettingsPanelPrefsStore.getState().setFineTuneAction("export");
+  const raw = store.get(KEY);
+  assert.ok(raw, "nothing was written");
+  assert.equal(JSON.parse(raw as string).state.fineTuneAction, "export");
+});
+
+// The reason the sanitiser exists: agentsModel reaches `.toLowerCase()` and the
+// path checks in agents-tab, so a non-string takes the whole app down.
+test("a non-string model is refused rather than handed to the tab", () => {
+  const merged = useSettingsPanelPrefsStore.persist.getOptions().merge;
+  assert.ok(merged, "merge must be supplied, or untrusted JSON reaches the UI");
+  const out = merged(
+    { agentsModel: 42, agentsVariant: [], fineTuneAction: "obliterate" },
+    useSettingsPanelPrefsStore.getState(),
+  ) as { agentsModel: unknown; fineTuneAction: string };
+  assert.equal(out.agentsModel, null);
+  assert.equal(out.fineTuneAction, "train");
+});
+
+test("a persisted blob cannot replace the store actions", () => {
+  const merged = useSettingsPanelPrefsStore.persist.getOptions().merge;
+  assert.ok(merged);
+  const out = merged(
+    { setFineTuneAction: 5 },
+    useSettingsPanelPrefsStore.getState(),
+  ) as { setFineTuneAction: unknown };
+  assert.equal(typeof out.setFineTuneAction, "function");
+});
+
+// Reset-all is the only in-app escape hatch from a bad pinned model.
+test("Reset all local preferences clears this key", async () => {
+  const source = await readFile(
+    new URL("../src/features/settings/tabs/general-tab.tsx", import.meta.url),
+    "utf8",
+  );
+  const keys = source.slice(
+    source.indexOf("const PREFS_KEYS"),
+    source.indexOf("];", source.indexOf("const PREFS_KEYS")),
+  );
+  assert.ok(
+    keys.includes("SETTINGS_PANEL_PREFS_STORAGE_KEY") ||
+      keys.includes(`"${SETTINGS_PANEL_PREFS_STORAGE_KEY}"`),
+    `${SETTINGS_PANEL_PREFS_STORAGE_KEY} missing from PREFS_KEYS`,
+  );
+});


### PR DESCRIPTION
`settings-dialog.tsx:463` renders only the active tab, and `<Dialog open={open}>` sets no `forceMount`, so every tab unmounts on a tab switch and again on close. Eight user picks lived in plain `useState` and went back to their defaults each time.

The Agents tab was the worst of it. Agent, model and quant all reset, so the generated `unsloth start` command reverted to Claude Code on `unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL` after a trip to any other tab.

## What persists now

New `stores/settings-panel-prefs-store.ts`, a single zustand `persist` store under `unsloth_settings_panel_prefs`, built in the same shape as `plus-menu-prefs-store.ts`.

- Agents tab: `selectedAgent`, `selectedModel`, `selectedVariant`
- API keys tab (`usage-examples.tsx`): snippet language, OS and coding agent. The `useTunnel` switch beside them already persisted under its own key, so these three were the odd ones out.
- Resources tab: the live updates switch
- Data tab: the fine-tune split button action

Subpage state in the Voice and Data tabs is deliberately left alone. Reopening settings should land on a tab's main view, not wherever the user last drilled into.

## Restoring safely

A stored name can go stale between sessions, so nothing is trusted on load.

The Agents tab follows whichever model the server reports as resident (`agents-tab.tsx:949`), and only an explicit pick overrides that. A restored model sets the same explicit-pick flag, so if the model had since left the cache it would pin the builder for good: the command would name a model the CLI cannot load, and on a shared server naming a model unloads the resident one for every attached session. `agents-tab.tsx:1030` retires a restored pick that neither the discovery scan nor `/api/inference/status` can account for, and following the resident model then resumes.

That check needs both reads. Discovery does not know what is loaded, status does not know what is cached, so the retire waits for both to land. The status poll marks itself settled in a `finally`, so a failing poll cannot pin the selection either.

- A restored quant seeds `chosenVariant`, which puts it through the existing `listGgufVariants` path and falls back when the repo no longer offers it.
- Native-grant labels are never stored. They stand for a path `/api/inference/status` withholds, so they cannot name anything in a later session.
- A restored agent the backend no longer lists falls back to a detected one, in both the Agents tab and the usage examples panel. The usage examples check waits for the real agent list rather than judging against the placeholder defaults.
- Snippet language, OS and fine-tune action are validated against their allowed values, the way `settings-dialog-store.ts:64` guards its persisted tab.

## Testing

`npm run typecheck`, `npm test` (463 pass), `npm run i18n:check` and `vite build` are clean. No new user-facing strings, so no locale work.

Checked by hand in the Tauri dev app on macOS: picked a non-default agent, model and quant, switched to Data and back, closed and reopened the dialog, then reloaded. Same for the curl and Python tabs under API keys, the Resources live updates switch, and the fine-tune split button.

Frontend only. No backend, Tauri or platform API is touched, so Linux, Windows and macOS behave identically. Two platform-sensitive details are preserved: `modelKey` folds case for Hugging Face repo ids but never for paths, since Linux paths are case-sensitive, and the API examples OS toggle only stops following the detected device type once it is clicked.
