### PR TITLE
Match the desktop titlebar contract to the 30px nav buttons

### DIFF
--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -401,7 +401,12 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert navigation.count('aria-label="Go back"') == 1
     assert navigation.count('aria-label="Go forward"') == 1
 
-    assert "inline-flex size-[33px] shrink-0" in navigation
+    # Nav buttons share one class constant since #7970 gave them consistent hover boxes, which
+    # also took them 33px -> 30px (the arrow spacer moved with them). What the contract pins is
+    # the shape: a fixed-size, non-shrinking inline-flex box, so the arrows cannot collapse or
+    # drift out of line with the picker.
+    assert "inline-flex size-[30px] shrink-0" in navigation
+    assert 'className="size-[30px] shrink-0"' in navigation  # the matching spacer
 
     assert navigation.count("onDoubleClick={stopTitlebarDrag}") == 3
     assert "maximized" not in navigation
@@ -417,7 +422,9 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert '"--studio-collapsed-chat-controls-inset": "188px"' in APP_PROVIDER.read_text(
         encoding = "utf-8"
     )
-    assert 'className="!size-[33px] rounded-[10px] text-muted-foreground"' in chat_page
+    # Same 33px -> 30px pass as the titlebar above: the collapsed chat controls have to match the
+    # nav buttons, so they moved together and the two sizes must stay equal.
+    assert 'className="!size-[30px] rounded-[10px] text-muted-foreground"' in chat_page
     assert 'aria-label="New chat"' in chat_page
     new_chat_click = chat_page.index("onClick={handleDesktopNewChat}")
     assert new_chat_click < chat_page.index("<ModelSelector", new_chat_click)

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -401,10 +401,8 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert navigation.count('aria-label="Go back"') == 1
     assert navigation.count('aria-label="Go forward"') == 1
 
-    # Nav buttons share one class constant since #7970 gave them consistent hover boxes, which
-    # also took them 33px -> 30px (the arrow spacer moved with them). What the contract pins is
-    # the shape: a fixed-size, non-shrinking inline-flex box, so the arrows cannot collapse or
-    # drift out of line with the picker.
+    # #7970 put the nav buttons on one class constant, 33px -> 30px, spacer included. What is
+    # pinned is the shape: a fixed-size, non-shrinking box the arrows cannot drift out of.
     assert "inline-flex size-[30px] shrink-0" in navigation
     assert 'className="size-[30px] shrink-0"' in navigation  # the matching spacer
 
@@ -422,8 +420,7 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert '"--studio-collapsed-chat-controls-inset": "188px"' in APP_PROVIDER.read_text(
         encoding = "utf-8"
     )
-    # Same 33px -> 30px pass as the titlebar above: the collapsed chat controls have to match the
-    # nav buttons, so they moved together and the two sizes must stay equal.
+    # Same #7970 pass: the collapsed chat controls must stay equal to the nav buttons.
     assert 'className="!size-[30px] rounded-[10px] text-muted-foreground"' in chat_page
     assert 'aria-label="New chat"' in chat_page
     new_chat_click = chat_page.index("onClick={handleDesktopNewChat}")


### PR DESCRIPTION
`tests/studio/test_desktop_reliability_frontend_contract.py::test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker` has been failing on `main` itself, so `Repo tests (CPU)` is red on main and every branch cut from it inherits the failure.

### Cause

#7970 gave the nav icon buttons consistent rounded hover boxes. That refactor moved them onto one shared class constant and took them from `size-[33px]` to `size-[30px]`, and the collapsed chat controls moved with them. The contract test still pinned the old `33px` strings in two places:

- the titlebar navigation block: `inline-flex size-[33px] shrink-0`
- the chat page controls: `className="!size-[33px] rounded-[10px] text-muted-foreground"`

Both are now `30px` in the components, and the arrow spacer is `size-[30px]` too, so the new size is deliberate and uniform rather than a regression.

### Change

Test-only. Pins the current size and keeps what the contract is actually there to protect: a fixed-size, non-shrinking box, so the history arrows cannot collapse or drift out of line with the model picker. Also asserts the arrow spacer matches, since the button and its spacer have to stay equal.

### Verification

- `tests/studio/test_desktop_reliability_frontend_contract.py`: 25 passed (was 1 failed / 24 passed on unmodified main).
- `tests/studio/`, the scope `Repo tests (CPU)` runs: 2546 passed, 3 skipped.
