### PR TITLE
Move the titlebar size contract to 30px, where the components already are

### DIFF
--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -401,7 +401,9 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert navigation.count('aria-label="Go back"') == 1
     assert navigation.count('aria-label="Go forward"') == 1
 
-    assert "inline-flex size-[33px] shrink-0" in navigation
+    # 30px, not 33: #7970 resized the nav icon buttons for consistent rounded
+    # hover boxes and this source-string contract was not moved with it.
+    assert "inline-flex size-[30px] shrink-0" in navigation
 
     assert navigation.count("onDoubleClick={stopTitlebarDrag}") == 3
     assert "maximized" not in navigation
@@ -417,7 +419,7 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert '"--studio-collapsed-chat-controls-inset": "188px"' in APP_PROVIDER.read_text(
         encoding = "utf-8"
     )
-    assert 'className="!size-[33px] rounded-[10px] text-muted-foreground"' in chat_page
+    assert 'className="!size-[30px] rounded-[10px] text-muted-foreground"' in chat_page
     assert 'aria-label="New chat"' in chat_page
     new_chat_click = chat_page.index("onClick={handleDesktopNewChat}")
     assert new_chat_click < chat_page.index("<ModelSelector", new_chat_click)

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -401,8 +401,7 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert navigation.count('aria-label="Go back"') == 1
     assert navigation.count('aria-label="Go forward"') == 1
 
-    # 30px, not 33: #7970 resized the nav icon buttons for consistent rounded
-    # hover boxes and this source-string contract was not moved with it.
+    # 30px, not 33: #7970 resized the nav icon buttons but missed this contract.
     assert "inline-flex size-[30px] shrink-0" in navigation
 
     assert navigation.count("onDoubleClick={stopTitlebarDrag}") == 3


### PR DESCRIPTION
### The red

`Repo tests (CPU)` is failing on `main` and every open PR inherits it:

```
FAILED tests/studio/test_desktop_reliability_frontend_contract.py::test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker
assert 'inline-flex size-[33px] shrink-0' in '({\n  expanded,\n  onToggleSidebar,\n ...'
1 failed, 4443 passed, 97 skipped
```

Reproduced on pristine `origin/main` at `bf7bb5a99`, so it is not any PR's doing:

```
pytest tests/studio/test_desktop_reliability_frontend_contract.py -q
1 failed, 24 passed
```

### Cause

`c4144da5b` (#7970, consistent rounded hover boxes for nav icon buttons) resized those buttons to `size-[30px]`:

```
studio/frontend/src/components/tauri/window-titlebar.tsx:125
  "inline-flex size-[30px] shrink-0 items-center justify-center rounded-[10px] ..."
studio/frontend/src/features/chat/chat-page.tsx:3289
  className="!size-[30px] rounded-[10px] text-muted-foreground"
```

The source-string assertions added by `640f8586c` (#7837) still expect `size-[33px]`. These are contract tests that read the `.tsx` as text, so a deliberate style change moves the component without moving the assertion.

### The change

Both assertions move to 30px, matching the components. The second one had not been reported yet only because the first fails earlier in the same test.

The components are right and the test is stale, not the other way round: `window-titlebar.tsx:100` uses `size-[30px]` too, and `chat-page.tsx` uses it at three call sites, so 30 is the consistent value #7970 intended.

`tests/studio/test_desktop_reliability_frontend_contract.py` on `origin/main` at `bf7bb5a99`: 1 failed / 24 passed before, **25 passed** after.
