### PR TITLE
Studio: link the Train page across to image training

### DIFF
--- a/studio/frontend/src/components/media-page-link.tsx
+++ b/studio/frontend/src/components/media-page-link.tsx
@@ -12,17 +12,20 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-/** The link between the two media pages (Images and Video). Kept out of either page's mode
- *  strip, which switches modes within a page, and parked at the far right past a divider so
- *  it reads as leaving rather than as another mode. */
+/** The link out to another page's workspace (Images, Video, image training). Kept out of the
+ *  page's mode strip, which switches modes within a page, and parked at the far right past a
+ *  divider so it reads as leaving rather than as another mode. */
 export function MediaPageLink({
   to,
   label,
   icon,
+  onNavigate,
 }: {
   to: "/images" | "/video";
   label: string;
   icon: IconSvgElement;
+  /** Runs before the route change, for a destination whose mode lives in a store. */
+  onNavigate?: () => void;
 }) {
   const navigate = useNavigate();
   return (
@@ -38,6 +41,7 @@ export function MediaPageLink({
           <button
             type="button"
             onClick={() => {
+              onNavigate?.();
               navigate({ to });
             }}
             className="flex h-[34px] shrink-0 items-center gap-1.5 rounded-full pl-2.5 pr-2 text-ui-13 font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/studio/frontend/src/components/media-page-link.tsx
+++ b/studio/frontend/src/components/media-page-link.tsx
@@ -19,11 +19,14 @@ export function MediaPageLink({
   to,
   label,
   icon,
+  tooltip,
   onNavigate,
 }: {
   to: "/images" | "/video";
   label: string;
   icon: IconSvgElement;
+  /** Needed on a translated page: the default prefix below is English. */
+  tooltip?: string;
   /** Runs before the route change, for a destination whose mode lives in a store. */
   onNavigate?: () => void;
 }) {
@@ -54,7 +57,7 @@ export function MediaPageLink({
             />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Go to {label}</TooltipContent>
+        <TooltipContent>{tooltip ?? `Go to ${label}`}</TooltipContent>
       </Tooltip>
     </>
   );

--- a/studio/frontend/src/features/studio/studio-page.tsx
+++ b/studio/frontend/src/features/studio/studio-page.tsx
@@ -208,6 +208,7 @@ export function StudioPage(): ReactElement {
                 <MediaPageLink
                   to="/images"
                   label={t("studio.imageTraining")}
+                  tooltip={t("studio.goToImageTraining")}
                   icon={Image03Icon}
                   onNavigate={() =>
                     useImageWorkflowStore.getState().setPageMode("train")

--- a/studio/frontend/src/features/studio/studio-page.tsx
+++ b/studio/frontend/src/features/studio/studio-page.tsx
@@ -12,8 +12,10 @@ import { GuidedTour, useGuidedTourController } from "@/features/tour";
 import { studioTourSteps, studioTrainingTourSteps } from "./tour";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
+import { ArrowLeft01Icon, Image03Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { MediaPageLink } from "@/components/media-page-link";
+import { useImageWorkflowStore } from "@/features/images/stores/image-workflow-store";
 import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import { useSidebar } from "@/components/ui/sidebar";
 import { DatasetPreviewDialog } from "./sections/dataset-preview-dialog";
@@ -198,6 +200,18 @@ export function StudioPage(): ReactElement {
                 </TabsTrigger>
                 <TabsTrigger value="history">{t("studio.tabs.history")}</TabsTrigger>
               </TabsList>
+              {/* Image training is a mode of the Images page, so it sits out
+                  here rather than in the tab strip. */}
+              <div className="ml-auto flex items-center gap-2">
+                <MediaPageLink
+                  to="/images"
+                  label={t("studio.imageTraining")}
+                  icon={Image03Icon}
+                  onNavigate={() =>
+                    useImageWorkflowStore.getState().setPageMode("train")
+                  }
+                />
+              </div>
             </div>
 
             <TabsContent value="configure">

--- a/studio/frontend/src/features/studio/studio-page.tsx
+++ b/studio/frontend/src/features/studio/studio-page.tsx
@@ -179,7 +179,9 @@ export function StudioPage(): ReactElement {
           </div>
         ) : (
           <Tabs value={activeTab} onValueChange={handleTabChange}>
-            <div className="flex items-center gap-3 pb-3">
+            {/* Wraps: TabsList is w-fit and the link is shrink-0, so a narrow
+                window would otherwise push the row past the viewport. */}
+            <div className="flex flex-wrap items-center gap-3 pb-3">
               {selectedHistoryRunId && activeTab === "history" && (
                 <Button
                   variant="ghost"

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -1102,6 +1102,7 @@ export const ar = {
   },
   studio: {
     imageTraining: "تدريب الصور",
+    goToImageTraining: "الانتقال إلى تدريب الصور",
     routeTitle: "تدريب",
     title: "استوديو الضبط الدقيق",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -1101,6 +1101,7 @@ export const ar = {
     },
   },
   studio: {
+    imageTraining: "تدريب الصور",
     routeTitle: "تدريب",
     title: "استوديو الضبط الدقيق",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -1140,6 +1140,7 @@ export const de = {
   },
   studio: {
     imageTraining: "Bildtraining",
+    goToImageTraining: "Zum Bildtraining",
     routeTitle: "Trainieren",
     title: "Fine-Tuning-Studio",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -1139,6 +1139,7 @@ export const de = {
     },
   },
   studio: {
+    imageTraining: "Bildtraining",
     routeTitle: "Trainieren",
     title: "Fine-Tuning-Studio",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -1109,6 +1109,7 @@ export const en = {
       history: "History",
     },
     imageTraining: "Image training",
+    goToImageTraining: "Go to image training",
     loadingRuntime: "Loading training runtime...",
     backToHistory: "Back to history",
     sections: {

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -1108,6 +1108,7 @@ export const en = {
       currentRun: "Current Run",
       history: "History",
     },
+    imageTraining: "Image training",
     loadingRuntime: "Loading training runtime...",
     backToHistory: "Back to history",
     sections: {

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -1134,6 +1134,7 @@ export const es = {
   },
   studio: {
     imageTraining: "Entrenamiento de imágenes",
+    goToImageTraining: "Ir al entrenamiento de imágenes",
     routeTitle: "Entrenar",
     title: "Studio de fine-tuning",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -1133,6 +1133,7 @@ export const es = {
     },
   },
   studio: {
+    imageTraining: "Entrenamiento de imágenes",
     routeTitle: "Entrenar",
     title: "Studio de fine-tuning",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -1140,6 +1140,7 @@ export const fr = {
   },
   studio: {
     imageTraining: "Entraînement d'images",
+    goToImageTraining: "Aller à l'entraînement d'images",
     routeTitle: "Entraîner",
     title: "Studio de fine-tuning",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -1139,6 +1139,7 @@ export const fr = {
     },
   },
   studio: {
+    imageTraining: "Entraînement d'images",
     routeTitle: "Entraîner",
     title: "Studio de fine-tuning",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -1107,6 +1107,7 @@ export const hi = {
   },
   studio: {
     imageTraining: "इमेज ट्रेनिंग",
+    goToImageTraining: "इमेज ट्रेनिंग पर जाएं",
     routeTitle: "ट्रेनिंग",
     title: "फ़ाइन-ट्यूनिंग Studio",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -1106,6 +1106,7 @@ export const hi = {
     },
   },
   studio: {
+    imageTraining: "इमेज ट्रेनिंग",
     routeTitle: "ट्रेनिंग",
     title: "फ़ाइन-ट्यूनिंग Studio",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -1139,6 +1139,7 @@ export const it = {
     },
   },
   studio: {
+    imageTraining: "Addestramento immagini",
     routeTitle: "Addestra",
     title: "Studio di fine-tuning",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -1140,6 +1140,7 @@ export const it = {
   },
   studio: {
     imageTraining: "Addestramento immagini",
+    goToImageTraining: "Vai all'addestramento immagini",
     routeTitle: "Addestra",
     title: "Studio di fine-tuning",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -1074,6 +1074,7 @@ export const ja = {
     },
   },
   studio: {
+    imageTraining: "画像トレーニング",
     routeTitle: "トレーニング",
     title: "Fine-tuning Studio",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -1075,6 +1075,7 @@ export const ja = {
   },
   studio: {
     imageTraining: "画像トレーニング",
+    goToImageTraining: "画像トレーニングへ移動",
     routeTitle: "トレーニング",
     title: "Fine-tuning Studio",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -1101,6 +1101,7 @@ export const ko = {
   },
   studio: {
     imageTraining: "이미지 학습",
+    goToImageTraining: "이미지 학습으로 이동",
     routeTitle: "학습",
     title: "파인튜닝 스튜디오",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -1100,6 +1100,7 @@ export const ko = {
     },
   },
   studio: {
+    imageTraining: "이미지 학습",
     routeTitle: "학습",
     title: "파인튜닝 스튜디오",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -1114,6 +1114,7 @@ export const ptBR = {
     },
   },
   studio: {
+    imageTraining: "Treinamento de imagens",
     routeTitle: "Treinar",
     title: "Estúdio de Fine-tuning",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -1115,6 +1115,7 @@ export const ptBR = {
   },
   studio: {
     imageTraining: "Treinamento de imagens",
+    goToImageTraining: "Ir para o treinamento de imagens",
     routeTitle: "Treinar",
     title: "Estúdio de Fine-tuning",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -1116,6 +1116,7 @@ export const ru = {
   },
   studio: {
     imageTraining: "Обучение изображений",
+    goToImageTraining: "Перейти к обучению изображений",
     routeTitle: "Обучение",
     title: "Студия дообучения",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -1115,6 +1115,7 @@ export const ru = {
     },
   },
   studio: {
+    imageTraining: "Обучение изображений",
     routeTitle: "Обучение",
     title: "Студия дообучения",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -1067,6 +1067,7 @@ export const zhCN = {
   },
   studio: {
     imageTraining: "图像训练",
+    goToImageTraining: "前往图像训练",
     routeTitle: "训练",
     title: "微调工作台",
     subtitles: {

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -1066,6 +1066,7 @@ export const zhCN = {
     },
   },
   studio: {
+    imageTraining: "图像训练",
     routeTitle: "训练",
     title: "微调工作台",
     subtitles: {


### PR DESCRIPTION
## What this does

The Images page already carries a link out to Video at the far right of its mode strip. This gives the Fine-tuning Studio the same affordance across to image training, at the right of its tab row.

## Note on the destination

Image training is not its own route. It is a mode of the Images page, held in `useImageWorkflowStore` as `pageMode`, so navigating to `/images` alone lands on Create.

`MediaPageLink` therefore takes an optional `onNavigate`, run before the route change, and the Studio page passes `setPageMode("train")` through it. The prop is optional and the two existing call sites are unchanged. The component's doc comment claimed it was only ever the Images/Video link, so that is updated.

Because the mode is not in the URL, a reload on `/images` falls back to Create. That is existing behaviour for Train mode generally, not something this link introduces, but it does mean the link is not shareable as a deep link.

## i18n

`studio.imageTraining` is added to `en.ts` only. The parity check passes and lists it as a fallback key for the other 11 locales, which is the normal path for a new string. The Images and Video pages hardcode their own link labels because those pages are not translated; the Studio page is, so this uses `t()`.

## Notes

Three files. `tsc -b` is clean, the 463 frontend tests pass, and i18n parity passes.
