### PR TITLE
Studio: bound Deep Research first output waits

### DIFF
--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1654,9 +1654,7 @@ class ResearchSupervisor:
         except (asyncio.CancelledError, StopAsyncIteration):
             pass
         except Exception:
-            logger.warning(
-                "research.%s_cleanup_failed run_id=%s", what, run_id, exc_info = True
-            )
+            logger.warning("research.%s_cleanup_failed run_id=%s", what, run_id, exc_info = True)
 
     async def _iter_stream_lines(
         self,

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1682,10 +1682,14 @@ class ResearchSupervisor:
                 await self._check_active(run_id)
             timeout = wait_timeout()
             line_task = asyncio.create_task(anext(iterator))
+            discarded = False
             try:
                 while not line_task.done():
                     await asyncio.wait({line_task}, timeout = timeout)
                     if self._cancel_event(run_id).is_set():
+                        # Set first: an iterator that outlasts the bound leaves the task
+                        # pending, and the finally must not spend the bound on it again.
+                        discarded = True
                         await self._discard_task(run_id, line_task, "stream_iterator")
                         await self._check_active(run_id)
                     # A line that arrived during the wait is earned; recomputing the
@@ -1698,7 +1702,7 @@ class ResearchSupervisor:
                 except StopAsyncIteration:
                     return
             finally:
-                if not line_task.done():
+                if not discarded and not line_task.done():
                     await self._discard_task(run_id, line_task, "stream_iterator")
             yield line
 
@@ -1755,6 +1759,7 @@ class ResearchSupervisor:
         last_progress_flush = asyncio.get_running_loop().time()
         finish_reason: str | None = None
         semantic_output_at: float | None = None
+        saw_data_frame = False
         first_output_deadline: float | None = None
 
         async def flush_progress() -> None:
@@ -1895,14 +1900,17 @@ class ResearchSupervisor:
                         if self._cancel_event(run["id"]).is_set():
                             await self._check_active(run["id"])
                         if not line.startswith("data:"):
-                            # Studio emits ": keep-alive" while it queues for a slot and
-                            # while it waits on llama-server's headers. Both are live waits,
-                            # not a stalled model, so re-arm; only silence spends the budget.
-                            if line.startswith(":") and semantic_output_at is None:
+                            # Before any frame, ": keep-alive" means Studio is queued for a
+                            # slot or waiting on the backend's headers, so re-arm. After one,
+                            # generation has started and the same comment is only stall filler
+                            # (routes/inference.py sends it every 15 s), which must not renew
+                            # the budget or a wedged model would never time out.
+                            if line.startswith(":") and not saw_data_frame:
                                 first_output_deadline = (
                                     loop.time() + _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
                                 )
                             continue
+                        saw_data_frame = True
                         data = line[5:].strip()
                         if data == "[DONE]":
                             break

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -164,8 +164,12 @@ def _first_output_budget() -> float:
     perfectly healthy queued run before it could ever speak. The wall clock still caps
     the total either way.
     """
-    interval = llama_admission_config_from_env().keepalive_interval_s
-    return max(_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS, 2.0 * interval)
+    config = llama_admission_config_from_env()
+    if not config.enabled:
+        # reserve() hands back a lease outright, so no heartbeat is ever sent and
+        # raising the budget would only delay catching a genuinely stalled request.
+        return _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
+    return max(_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS, 2.0 * config.keepalive_interval_s)
 
 
 def _auto_scrape_default() -> int:
@@ -1658,6 +1662,13 @@ class ResearchSupervisor:
                 "research.%s_late_cleanup_failed run_id=%s", what, run_id, exc_info = error
             )
 
+    def _absorb_when_done(self, run_id: str, task: asyncio.Task, what: str) -> None:
+        """Arrange for a task still running past cleanup to have its outcome retrieved."""
+        if task.done():
+            self._absorb_late_task(run_id, what, task)
+            return
+        task.add_done_callback(lambda finished: self._absorb_late_task(run_id, what, finished))
+
     async def _discard_task(self, run_id: str, task: asyncio.Task, what: str) -> None:
         """Cancel a pending task and absorb its outcome, without waiting forever.
 
@@ -1669,12 +1680,15 @@ class ResearchSupervisor:
         try:
             await asyncio.wait({task}, timeout = _STREAM_CLEANUP_TIMEOUT_SECONDS)
         except asyncio.CancelledError:
-            raise  # an outer cancellation (wall clock, shutdown) must keep propagating
+            # An outer cancellation (wall clock, shutdown) must keep propagating, but the
+            # child outlives this frame either way, so hand its outcome over before leaving.
+            self._absorb_when_done(run_id, task, what)
+            raise
         if not task.done():
             logger.warning("research.%s_cleanup_timed_out run_id=%s", what, run_id)
             # The bound expired but the task lives on, so keep the promise above by
             # absorbing its outcome whenever it finally cooperates.
-            task.add_done_callback(lambda finished: self._absorb_late_task(run_id, what, finished))
+            self._absorb_when_done(run_id, task, what)
             return
         try:
             task.result()

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -20,7 +20,6 @@ from typing import Any, AsyncIterator, Callable
 import httpx
 
 from auth import storage as auth_storage
-from core.inference.llama_admission import llama_admission_config_from_env
 from core.inference.message_content import content_to_text
 from core.inference.tool_loop_controller import is_tool_error, strip_result_for_model
 from core.inference.tools import RAG_SOURCES_SENTINEL, execute_tool
@@ -154,22 +153,9 @@ _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS = 120.0
 # Cancellation is cooperative, so bound the wait for a cancelled iterator to unwind;
 # otherwise a stuck one holds a timed-out call open for the rest of the wall clock.
 _STREAM_CLEANUP_TIMEOUT_SECONDS = 5.0
-
-
-def _first_output_budget() -> float:
-    """How long to wait for a first frame, never less than two admission heartbeats.
-
-    UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL has no upper bound and the queue sends
-    nothing until one full interval has passed, so a fixed budget below it would fail a
-    perfectly healthy queued run before it could ever speak. The wall clock still caps
-    the total either way.
-    """
-    config = llama_admission_config_from_env()
-    if not config.enabled:
-        # reserve() hands back a lease outright, so no heartbeat is ever sent and
-        # raising the budget would only delay catching a genuinely stalled request.
-        return _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
-    return max(_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS, 2.0 * config.keepalive_interval_s)
+# routes/inference.py marks an admission wait with this SSE comment, distinct from the
+# plain keepalive it sends whenever the backend itself is silent.
+_ADMISSION_WAIT_COMMENT = ": admission-wait"
 
 
 def _auto_scrape_default() -> int:
@@ -1800,7 +1786,6 @@ class ResearchSupervisor:
         last_progress_flush = asyncio.get_running_loop().time()
         finish_reason: str | None = None
         semantic_output_at: float | None = None
-        saw_data_frame = False
         first_output_deadline: float | None = None
 
         async def flush_progress() -> None:
@@ -1862,6 +1847,16 @@ class ResearchSupervisor:
 
         try:
             model_timeout = float(config["budgets"]["modelTimeoutSeconds"])
+            # Configurable, and never longer than the run's own budget. Legacy runs predate
+            # the key and fall back to the default.
+            first_output_budget = min(
+                float(
+                    config["budgets"].get(
+                        "firstOutputTimeoutSeconds", _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
+                    )
+                ),
+                model_timeout,
+            )
             timeout = httpx.Timeout(model_timeout)
             loop = asyncio.get_running_loop()
 
@@ -1906,7 +1901,7 @@ class ResearchSupervisor:
                                     await self._check_active(run["id"])
                             response = await send_task
                             response.raise_for_status()
-                            first_output_deadline = loop.time() + _first_output_budget()
+                            first_output_deadline = loop.time() + first_output_budget
                             break
                         except (httpx.TransportError, httpx.HTTPStatusError) as exc:
                             # Only reachable before a body byte is touched (the stream is consumed
@@ -1945,15 +1940,13 @@ class ResearchSupervisor:
                         if self._cancel_event(run["id"]).is_set():
                             await self._check_active(run["id"])
                         if not line.startswith("data:"):
-                            # Before any frame, ": keep-alive" means Studio is queued for a
-                            # slot or waiting on the backend's headers, so re-arm. After one,
-                            # generation has started and the same comment is only stall filler
-                            # (routes/inference.py sends it every 15 s), which must not renew
-                            # the budget or a wedged model would never time out.
-                            if line.startswith(":") and not saw_data_frame:
-                                first_output_deadline = loop.time() + _first_output_budget()
+                            # Only the admission marker defers the budget: queueing for a slot
+                            # is not the model's fault and has no timeout of its own. A plain
+                            # ": keep-alive" means the backend itself is silent, whether that
+                            # is prefill or a wedged model, and that is what the budget bounds.
+                            if line.startswith(_ADMISSION_WAIT_COMMENT):
+                                first_output_deadline = loop.time() + first_output_budget
                             continue
-                        saw_data_frame = True
                         data = line[5:].strip()
                         if data == "[DONE]":
                             break

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -156,6 +156,7 @@ _STREAM_CLEANUP_TIMEOUT_SECONDS = 5.0
 # routes/inference.py marks an admission wait with this SSE comment, distinct from the
 # plain keepalive it sends whenever the backend itself is silent.
 _ADMISSION_WAIT_COMMENT = ": admission-wait"
+_ADMISSION_DONE_COMMENT = ": admission-done"
 
 
 def _auto_scrape_default() -> int:
@@ -1940,11 +1941,14 @@ class ResearchSupervisor:
                         if self._cancel_event(run["id"]).is_set():
                             await self._check_active(run["id"])
                         if not line.startswith("data:"):
-                            # Only the admission marker defers the budget: queueing for a slot
-                            # is not the model's fault and has no timeout of its own. A plain
-                            # ": keep-alive" means the backend itself is silent, whether that
-                            # is prefill or a wedged model, and that is what the budget bounds.
+                            # Queueing for a slot has no timeout by design, so it is not
+                            # charged at all: suspend while it lasts and start the model's
+                            # budget the moment the queue says the slot is ours. A plain
+                            # ": keep-alive" means the backend itself is silent, whether in
+                            # prefill or wedged, and that is what the budget bounds.
                             if line.startswith(_ADMISSION_WAIT_COMMENT):
+                                first_output_deadline = None
+                            elif line.startswith(_ADMISSION_DONE_COMMENT):
                                 first_output_deadline = loop.time() + first_output_budget
                             continue
                         data = line[5:].strip()

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1867,6 +1867,7 @@ class ResearchSupervisor:
             ):
                 response: httpx.Response | None = None
                 send_task: asyncio.Task | None = None
+                send_discarded = False
                 model_waits = 0
                 attempt = 0
                 try:
@@ -1879,9 +1880,14 @@ class ResearchSupervisor:
                         )
                         try:
                             send_task = asyncio.create_task(client.send(request, stream = True))
+                            # A retry builds a fresh task, so the guard starts over with it.
+                            send_discarded = False
                             while not send_task.done():
                                 await asyncio.wait({send_task}, timeout = 0.2)
                                 if self._cancel_event(run["id"]).is_set():
+                                    # Set first, for the same reason as the iterator path:
+                                    # a send that outlasts the bound must not be waited on twice.
+                                    send_discarded = True
                                     await self._discard_task(run["id"], send_task, "send")
                                     await self._check_active(run["id"])
                             response = await send_task
@@ -1971,7 +1977,7 @@ class ResearchSupervisor:
                     if semantic_output_at is None:
                         raise ModelFirstOutputTimeout("Local model never produced output")
                 finally:
-                    if send_task is not None and not send_task.done():
+                    if send_task is not None and not send_discarded and not send_task.done():
                         await self._discard_task(run["id"], send_task, "send")
                     if (
                         response is None

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1895,6 +1895,13 @@ class ResearchSupervisor:
                         if self._cancel_event(run["id"]).is_set():
                             await self._check_active(run["id"])
                         if not line.startswith("data:"):
+                            # Studio emits ": keep-alive" while it queues for a slot and
+                            # while it waits on llama-server's headers. Both are live waits,
+                            # not a stalled model, so re-arm; only silence spends the budget.
+                            if line.startswith(":") and semantic_output_at is None:
+                                first_output_deadline = (
+                                    loop.time() + _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
+                                )
                             continue
                         data = line[5:].strip()
                         if data == "[DONE]":

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -150,6 +150,9 @@ _NO_MODEL_LOADED_DETAIL = "No model loaded"
 # Transport keepalives prevent HTTP read timeouts without proving that a model is progressing.
 _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS = 120.0
 _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS = 120.0
+# Cancellation is cooperative, so bound the wait for a cancelled iterator to unwind;
+# otherwise a stuck one holds a timed-out call open for the rest of the wall clock.
+_STREAM_CLEANUP_TIMEOUT_SECONDS = 5.0
 
 
 def _auto_scrape_default() -> int:
@@ -572,11 +575,14 @@ class LeaseLost(Exception):
 
 
 class ModelOutputIdleTimeout(httpx.ReadTimeout):
-    pass
+    # Default message: the stream reader raises the class the deadline names.
+    def __init__(self, message: str = "Local model stopped producing output"):
+        super().__init__(message)
 
 
 class ModelFirstOutputTimeout(httpx.ReadTimeout):
-    pass
+    def __init__(self, message: str = "Local model never produced output"):
+        super().__init__(message)
 
 
 class ModelWallClockTimeout(httpx.ReadTimeout):
@@ -1628,11 +1634,35 @@ class ResearchSupervisor:
                     "research.api_key_cleanup_failed run_id=%s", run["id"], exc_info = True
                 )
 
+    async def _discard_task(self, run_id: str, task: asyncio.Task, what: str) -> None:
+        """Cancel a pending task and absorb its outcome, without waiting forever.
+
+        Awaiting it keeps a late error from surfacing as an unretrieved task exception;
+        bounding the wait keeps an iterator that declines cancellation from pinning the
+        caller here, and swallowing only its own outcome keeps the real error intact.
+        """
+        task.cancel()
+        try:
+            await asyncio.wait({task}, timeout = _STREAM_CLEANUP_TIMEOUT_SECONDS)
+        except asyncio.CancelledError:
+            raise  # an outer cancellation (wall clock, shutdown) must keep propagating
+        if not task.done():
+            logger.warning("research.%s_cleanup_timed_out run_id=%s", what, run_id)
+            return
+        try:
+            task.result()
+        except (asyncio.CancelledError, StopAsyncIteration):
+            pass
+        except Exception:
+            logger.warning(
+                "research.%s_cleanup_failed run_id=%s", what, run_id, exc_info = True
+            )
+
     async def _iter_stream_lines(
         self,
         run_id: str,
         response: httpx.Response,
-        semantic_deadline: Callable[[], float | None] | None = None,
+        semantic_deadline: Callable[[], tuple[float, type[BaseException]] | None] | None = None,
     ) -> AsyncIterator[str]:
         iterator = response.aiter_lines().__aiter__()
 
@@ -1642,10 +1672,12 @@ class ResearchSupervisor:
             deadline = semantic_deadline()
             if deadline is None:
                 return 0.2
-            remaining = deadline - asyncio.get_running_loop().time()
+            at, expired = deadline
+            remaining = at - asyncio.get_running_loop().time()
             if remaining > 0:
                 return min(0.2, remaining)
-            raise ModelOutputIdleTimeout("Local model stopped producing output")
+            # Named by the caller, so a first-output deadline is never reported as a stall.
+            raise expired()
 
         while True:
             if self._cancel_event(run_id).is_set():
@@ -1656,18 +1688,12 @@ class ResearchSupervisor:
                 while not line_task.done():
                     await asyncio.wait({line_task}, timeout = timeout)
                     if self._cancel_event(run_id).is_set():
-                        line_task.cancel()
-                        try:
-                            await line_task
-                        except asyncio.CancelledError:
-                            pass
-                        except Exception:
-                            logger.warning(
-                                "research.stream_iterator_cleanup_failed run_id=%s",
-                                run_id,
-                                exc_info = True,
-                            )
+                        await self._discard_task(run_id, line_task, "stream_iterator")
                         await self._check_active(run_id)
+                    # A line that arrived during the wait is earned; recomputing the
+                    # deadline first would let an expiry in the same turn discard it.
+                    if line_task.done():
+                        break
                     timeout = wait_timeout()
                 try:
                     line = line_task.result()
@@ -1675,17 +1701,7 @@ class ResearchSupervisor:
                     return
             finally:
                 if not line_task.done():
-                    line_task.cancel()
-                    try:
-                        await line_task
-                    except asyncio.CancelledError:
-                        pass
-                    except Exception:
-                        logger.warning(
-                            "research.stream_iterator_cleanup_failed run_id=%s",
-                            run_id,
-                            exc_info = True,
-                        )
+                    await self._discard_task(run_id, line_task, "stream_iterator")
             yield line
 
     async def _stream_completion(
@@ -1805,14 +1821,15 @@ class ResearchSupervisor:
             timeout = httpx.Timeout(model_timeout)
             loop = asyncio.get_running_loop()
 
-            def semantic_deadline() -> float | None:
+            def semantic_deadline() -> tuple[float, type[BaseException]] | None:
                 if semantic_output_at is None:
                     if first_output_deadline is None:
                         return None
-                    if loop.time() >= first_output_deadline:
-                        raise ModelFirstOutputTimeout("Local model never produced output")
-                    return first_output_deadline
-                return semantic_output_at + _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS
+                    return first_output_deadline, ModelFirstOutputTimeout
+                return (
+                    semantic_output_at + _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS,
+                    ModelOutputIdleTimeout,
+                )
 
             async with (
                 _wall_clock_timeout(model_timeout),
@@ -1835,11 +1852,7 @@ class ResearchSupervisor:
                             while not send_task.done():
                                 await asyncio.wait({send_task}, timeout = 0.2)
                                 if self._cancel_event(run["id"]).is_set():
-                                    send_task.cancel()
-                                    try:
-                                        await send_task
-                                    except asyncio.CancelledError:
-                                        pass
+                                    await self._discard_task(run["id"], send_task, "send")
                                     await self._check_active(run["id"])
                             response = await send_task
                             response.raise_for_status()
@@ -1923,11 +1936,7 @@ class ResearchSupervisor:
                         raise ModelFirstOutputTimeout("Local model never produced output")
                 finally:
                     if send_task is not None and not send_task.done():
-                        send_task.cancel()
-                        try:
-                            await send_task
-                        except asyncio.CancelledError:
-                            pass
+                        await self._discard_task(run["id"], send_task, "send")
                     if (
                         response is None
                         and send_task is not None

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -20,6 +20,7 @@ from typing import Any, AsyncIterator, Callable
 import httpx
 
 from auth import storage as auth_storage
+from core.inference.llama_admission import llama_admission_config_from_env
 from core.inference.message_content import content_to_text
 from core.inference.tool_loop_controller import is_tool_error, strip_result_for_model
 from core.inference.tools import RAG_SOURCES_SENTINEL, execute_tool
@@ -153,6 +154,18 @@ _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS = 120.0
 # Cancellation is cooperative, so bound the wait for a cancelled iterator to unwind;
 # otherwise a stuck one holds a timed-out call open for the rest of the wall clock.
 _STREAM_CLEANUP_TIMEOUT_SECONDS = 5.0
+
+
+def _first_output_budget() -> float:
+    """How long to wait for a first frame, never less than two admission heartbeats.
+
+    UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL has no upper bound and the queue sends
+    nothing until one full interval has passed, so a fixed budget below it would fail a
+    perfectly healthy queued run before it could ever speak. The wall clock still caps
+    the total either way.
+    """
+    interval = llama_admission_config_from_env().keepalive_interval_s
+    return max(_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS, 2.0 * interval)
 
 
 def _auto_scrape_default() -> int:
@@ -1634,6 +1647,17 @@ class ResearchSupervisor:
                     "research.api_key_cleanup_failed run_id=%s", run["id"], exc_info = True
                 )
 
+    @staticmethod
+    def _absorb_late_task(run_id: str, what: str, task: asyncio.Task) -> None:
+        """Retrieve the outcome of a task that outlived the cleanup bound."""
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.warning(
+                "research.%s_late_cleanup_failed run_id=%s", what, run_id, exc_info = error
+            )
+
     async def _discard_task(self, run_id: str, task: asyncio.Task, what: str) -> None:
         """Cancel a pending task and absorb its outcome, without waiting forever.
 
@@ -1648,6 +1672,9 @@ class ResearchSupervisor:
             raise  # an outer cancellation (wall clock, shutdown) must keep propagating
         if not task.done():
             logger.warning("research.%s_cleanup_timed_out run_id=%s", what, run_id)
+            # The bound expired but the task lives on, so keep the promise above by
+            # absorbing its outcome whenever it finally cooperates.
+            task.add_done_callback(lambda finished: self._absorb_late_task(run_id, what, finished))
             return
         try:
             task.result()
@@ -1859,9 +1886,7 @@ class ResearchSupervisor:
                                     await self._check_active(run["id"])
                             response = await send_task
                             response.raise_for_status()
-                            first_output_deadline = (
-                                loop.time() + _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
-                            )
+                            first_output_deadline = loop.time() + _first_output_budget()
                             break
                         except (httpx.TransportError, httpx.HTTPStatusError) as exc:
                             # Only reachable before a body byte is touched (the stream is consumed
@@ -1906,9 +1931,7 @@ class ResearchSupervisor:
                             # (routes/inference.py sends it every 15 s), which must not renew
                             # the budget or a wedged model would never time out.
                             if line.startswith(":") and not saw_data_frame:
-                                first_output_deadline = (
-                                    loop.time() + _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
-                                )
+                                first_output_deadline = loop.time() + _first_output_budget()
                             continue
                         saw_data_frame = True
                         data = line[5:].strip()

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -153,8 +153,7 @@ _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS = 120.0
 # Cancellation is cooperative, so bound the wait for a cancelled iterator to unwind;
 # otherwise a stuck one holds a timed-out call open for the rest of the wall clock.
 _STREAM_CLEANUP_TIMEOUT_SECONDS = 5.0
-# routes/inference.py marks an admission wait with this SSE comment, distinct from the
-# plain keepalive it sends whenever the backend itself is silent.
+# The SSE comment routes/inference.py sends while queued, not while the backend is silent.
 _ADMISSION_WAIT_COMMENT = ": admission-wait"
 _ADMISSION_DONE_COMMENT = ": admission-done"
 
@@ -1667,14 +1666,12 @@ class ResearchSupervisor:
         try:
             await asyncio.wait({task}, timeout = _STREAM_CLEANUP_TIMEOUT_SECONDS)
         except asyncio.CancelledError:
-            # An outer cancellation (wall clock, shutdown) must keep propagating, but the
-            # child outlives this frame either way, so hand its outcome over before leaving.
+            # Must keep propagating, but the child outlives this frame, so hand it over first.
             self._absorb_when_done(run_id, task, what)
             raise
         if not task.done():
             logger.warning("research.%s_cleanup_timed_out run_id=%s", what, run_id)
-            # The bound expired but the task lives on, so keep the promise above by
-            # absorbing its outcome whenever it finally cooperates.
+            # Bound expired but the task lives on: absorb its outcome when it cooperates.
             self._absorb_when_done(run_id, task, what)
             return
         try:
@@ -1715,8 +1712,7 @@ class ResearchSupervisor:
                 while not line_task.done():
                     await asyncio.wait({line_task}, timeout = timeout)
                     if self._cancel_event(run_id).is_set():
-                        # Set first: an iterator that outlasts the bound leaves the task
-                        # pending, and the finally must not spend the bound on it again.
+                        # Set first: the finally must not spend the bound on it again.
                         discarded = True
                         await self._discard_task(run_id, line_task, "stream_iterator")
                         await self._check_active(run_id)
@@ -1848,8 +1844,7 @@ class ResearchSupervisor:
 
         try:
             model_timeout = float(config["budgets"]["modelTimeoutSeconds"])
-            # Configurable, and never longer than the run's own budget. Legacy runs predate
-            # the key and fall back to the default.
+            # Configurable, capped by the run's wall clock; legacy runs use the default.
             first_output_budget = min(
                 float(
                     config["budgets"].get(
@@ -1895,8 +1890,7 @@ class ResearchSupervisor:
                             while not send_task.done():
                                 await asyncio.wait({send_task}, timeout = 0.2)
                                 if self._cancel_event(run["id"]).is_set():
-                                    # Set first, for the same reason as the iterator path:
-                                    # a send that outlasts the bound must not be waited on twice.
+                                    # Set first: a send outlasting the bound is not waited on twice.
                                     send_discarded = True
                                     await self._discard_task(run["id"], send_task, "send")
                                     await self._check_active(run["id"])
@@ -1941,11 +1935,9 @@ class ResearchSupervisor:
                         if self._cancel_event(run["id"]).is_set():
                             await self._check_active(run["id"])
                         if not line.startswith("data:"):
-                            # Queueing for a slot has no timeout by design, so it is not
-                            # charged at all: suspend while it lasts and start the model's
-                            # budget the moment the queue says the slot is ours. A plain
-                            # ": keep-alive" means the backend itself is silent, whether in
-                            # prefill or wedged, and that is what the budget bounds.
+                            # Queueing has no timeout by design, so it is not charged: suspend
+                            # for it, and start the budget when the slot is granted. A plain
+                            # ": keep-alive" means a silent backend, which is what we bound.
                             if line.startswith(_ADMISSION_WAIT_COMMENT):
                                 first_output_deadline = None
                             elif line.startswith(_ADMISSION_DONE_COMMENT):

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -147,9 +147,8 @@ _MODEL_WAIT_POLL_SECONDS = 2.0
 # otherwise re-send forever, so cap how many times one call may wait.
 _MAX_MODEL_WAITS = 3
 _NO_MODEL_LOADED_DETAIL = "No model loaded"
-# Transport keepalives prevent HTTP read timeouts without proving that a model which already
-# started answering is still progressing. Prefill remains governed by modelTimeoutSeconds because
-# CPU and offloaded models can legitimately take many minutes to produce their first token.
+# Transport keepalives prevent HTTP read timeouts without proving that a model is progressing.
+_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS = 120.0
 _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS = 120.0
 
 
@@ -576,11 +575,17 @@ class ModelOutputIdleTimeout(httpx.ReadTimeout):
     pass
 
 
+class ModelFirstOutputTimeout(httpx.ReadTimeout):
+    pass
+
+
 class ModelWallClockTimeout(httpx.ReadTimeout):
     pass
 
 
 def _safe_error(exc: BaseException) -> str:
+    if isinstance(exc, ModelFirstOutputTimeout):
+        return "Local model never started producing output"
     if isinstance(exc, ModelOutputIdleTimeout):
         return "Local model stopped producing output before completion"
     if isinstance(exc, ModelWallClockTimeout):
@@ -1643,6 +1648,8 @@ class ResearchSupervisor:
             raise ModelOutputIdleTimeout("Local model stopped producing output")
 
         while True:
+            if self._cancel_event(run_id).is_set():
+                await self._check_active(run_id)
             timeout = wait_timeout()
             line_task = asyncio.create_task(anext(iterator))
             try:
@@ -1654,6 +1661,12 @@ class ResearchSupervisor:
                             await line_task
                         except asyncio.CancelledError:
                             pass
+                        except Exception:
+                            logger.warning(
+                                "research.stream_iterator_cleanup_failed run_id=%s",
+                                run_id,
+                                exc_info = True,
+                            )
                         await self._check_active(run_id)
                     timeout = wait_timeout()
                 try:
@@ -1667,6 +1680,12 @@ class ResearchSupervisor:
                         await line_task
                     except asyncio.CancelledError:
                         pass
+                    except Exception:
+                        logger.warning(
+                            "research.stream_iterator_cleanup_failed run_id=%s",
+                            run_id,
+                            exc_info = True,
+                        )
             yield line
 
     async def _stream_completion(
@@ -1722,6 +1741,7 @@ class ResearchSupervisor:
         last_progress_flush = asyncio.get_running_loop().time()
         finish_reason: str | None = None
         semantic_output_at: float | None = None
+        first_output_deadline: float | None = None
 
         async def flush_progress() -> None:
             nonlocal pending_report, pending_reasoning, pending_reasoning_offset
@@ -1787,7 +1807,11 @@ class ResearchSupervisor:
 
             def semantic_deadline() -> float | None:
                 if semantic_output_at is None:
-                    return None
+                    if first_output_deadline is None:
+                        return None
+                    if loop.time() >= first_output_deadline:
+                        raise ModelFirstOutputTimeout("Local model never produced output")
+                    return first_output_deadline
                 return semantic_output_at + _MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS
 
             async with (
@@ -1819,6 +1843,9 @@ class ResearchSupervisor:
                                     await self._check_active(run["id"])
                             response = await send_task
                             response.raise_for_status()
+                            first_output_deadline = (
+                                loop.time() + _MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
+                            )
                             break
                         except (httpx.TransportError, httpx.HTTPStatusError) as exc:
                             # Only reachable before a body byte is touched (the stream is consumed
@@ -1892,6 +1919,8 @@ class ResearchSupervisor:
                             and asyncio.get_running_loop().time() - last_progress_flush >= 0.25
                         ):
                             await flush_progress()
+                    if semantic_output_at is None:
+                        raise ModelFirstOutputTimeout("Local model never produced output")
                 finally:
                     if send_task is not None and not send_task.done():
                         send_task.cancel()

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1127,11 +1127,9 @@ _STREAM_DISCONNECT_POLL_TIMEOUT_S = 0.25
 _OPENAI_PASSTHROUGH_PREHEADER_STATUS_WINDOW_S = 0.1
 _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S = 5.0
 _OPENAI_PASSTHROUGH_SSE_KEEPALIVE = ": keep-alive\n\n"
-# Distinct from the keepalive above so a client can tell "queued for a slot" from
-# "the backend is silent". Both are SSE comments, so any conforming reader ignores them.
+# Lets a client tell "queued" from "backend silent"; SSE comments, so readers ignore both.
 _OPENAI_ADMISSION_SSE_WAIT = ": admission-wait\n\n"
-# Paired with the above: the slot is ours, so any clock a client suspended for the
-# queue starts now. Sent only when the caller actually waited.
+# Paired with the above: the slot is ours, so a suspended client clock starts now.
 _OPENAI_ADMISSION_SSE_DONE = ": admission-done\n\n"
 _OPENAI_LLAMA_ADMISSION_POLL_S = 0.25
 # Idle window before a local tool-loop stream emits an SSE keepalive comment
@@ -1365,8 +1363,7 @@ async def _openai_admission_wait_stream_chunks(
     )
     deadline = None if config.queue_timeout_s is None else time.monotonic() + config.queue_timeout_s
     keepalive_interval_s = max(0.001, config.keepalive_interval_s)
-    # Announce the wait at once rather than after a full interval: a caller that must not
-    # mistake queueing for a stalled backend cannot wait out an operator-set interval first.
+    # At once, not after a full interval: a caller must not wait one out to learn it queued.
     yield _OPENAI_ADMISSION_SSE_WAIT
     next_keepalive_at = time.monotonic() + keepalive_interval_s
     try:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1127,6 +1127,9 @@ _STREAM_DISCONNECT_POLL_TIMEOUT_S = 0.25
 _OPENAI_PASSTHROUGH_PREHEADER_STATUS_WINDOW_S = 0.1
 _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S = 5.0
 _OPENAI_PASSTHROUGH_SSE_KEEPALIVE = ": keep-alive\n\n"
+# Distinct from the keepalive above so a client can tell "queued for a slot" from
+# "the backend is silent". Both are SSE comments, so any conforming reader ignores them.
+_OPENAI_ADMISSION_SSE_WAIT = ": admission-wait\n\n"
 _OPENAI_LLAMA_ADMISSION_POLL_S = 0.25
 # Idle window before a local tool-loop stream emits an SSE keepalive comment
 # (e.g. prompt prefill between tool iterations). A second layer atop the
@@ -1359,6 +1362,9 @@ async def _openai_admission_wait_stream_chunks(
     )
     deadline = None if config.queue_timeout_s is None else time.monotonic() + config.queue_timeout_s
     keepalive_interval_s = max(0.001, config.keepalive_interval_s)
+    # Announce the wait at once rather than after a full interval: a caller that must not
+    # mistake queueing for a stalled backend cannot wait out an operator-set interval first.
+    yield _OPENAI_ADMISSION_SSE_WAIT
     next_keepalive_at = time.monotonic() + keepalive_interval_s
     try:
         while True:
@@ -1395,7 +1401,7 @@ async def _openai_admission_wait_stream_chunks(
             now = time.monotonic()
             if now >= next_keepalive_at:
                 next_keepalive_at = now + keepalive_interval_s
-                yield _OPENAI_PASSTHROUGH_SSE_KEEPALIVE
+                yield _OPENAI_ADMISSION_SSE_WAIT
     except asyncio.CancelledError:
         reservation.cancel()
         raise

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1130,6 +1130,9 @@ _OPENAI_PASSTHROUGH_SSE_KEEPALIVE = ": keep-alive\n\n"
 # Distinct from the keepalive above so a client can tell "queued for a slot" from
 # "the backend is silent". Both are SSE comments, so any conforming reader ignores them.
 _OPENAI_ADMISSION_SSE_WAIT = ": admission-wait\n\n"
+# Paired with the above: the slot is ours, so any clock a client suspended for the
+# queue starts now. Sent only when the caller actually waited.
+_OPENAI_ADMISSION_SSE_DONE = ": admission-done\n\n"
 _OPENAI_LLAMA_ADMISSION_POLL_S = 0.25
 # Idle window before a local tool-loop stream emits an SSE keepalive comment
 # (e.g. prompt prefill between tool iterations). A second layer atop the
@@ -1375,6 +1378,7 @@ async def _openai_admission_wait_stream_chunks(
             )
             lease = reservation.lease_nowait()
             if lease is not None:
+                yield _OPENAI_ADMISSION_SSE_DONE
                 yield lease
                 return
 
@@ -1391,6 +1395,7 @@ async def _openai_admission_wait_stream_chunks(
             except asyncio.TimeoutError:
                 lease = None
             if lease is not None:
+                yield _OPENAI_ADMISSION_SSE_DONE
                 yield lease
                 return
             await _raise_if_openai_admission_cancelled(

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -245,6 +245,7 @@ def _sanitize_config(payload: CreateResearchRun, thread: dict) -> dict:
         "maxSources": 40,
         "modelTimeoutSeconds": 900,
         "toolTimeoutSeconds": 120,
+        "firstOutputTimeoutSeconds": 120,
     }
     for key, value in (payload.budgets or {}).items():
         if key not in budgets:
@@ -255,6 +256,9 @@ def _sanitize_config(payload: CreateResearchRun, thread: dict) -> dict:
         "maxSources": (1, 100),
         "modelTimeoutSeconds": (10, 3600),
         "toolTimeoutSeconds": (5, 600),
+        # Same range as its parent: a slow CPU or offloaded model can legitimately spend
+        # minutes before its first token, and the run's own wall clock still caps it.
+        "firstOutputTimeoutSeconds": (10, 3600),
     }
     for key, (minimum, maximum) in limits.items():
         if not minimum <= budgets[key] <= maximum:

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -256,8 +256,7 @@ def _sanitize_config(payload: CreateResearchRun, thread: dict) -> dict:
         "maxSources": (1, 100),
         "modelTimeoutSeconds": (10, 3600),
         "toolTimeoutSeconds": (5, 600),
-        # Same range as its parent: a slow CPU or offloaded model can legitimately spend
-        # minutes before its first token, and the run's own wall clock still caps it.
+        # Same range as its parent: slow CPU and offloaded models need minutes to first token.
         "firstOutputTimeoutSeconds": (10, 3600),
     }
     for key, (minimum, maximum) in limits.items():

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -5172,6 +5172,12 @@ class TestApiMonitorProviderAndCompletionStreams:
                 assert cancel_id in inf_mod._CANCEL_REGISTRY
 
                 blocker.release()
+                # The lease is announced before it is handed over, so drain that marker
+                # first; the request only reaches upstream on the chunk after it.
+                assert (
+                    await asyncio.wait_for(iterator.__anext__(), timeout = 1.0)
+                    == ": admission-done\n\n"
+                )
                 pending = asyncio.create_task(iterator.__anext__())
                 for _ in range(100):
                     if "body" in body_holder:
@@ -5278,7 +5284,13 @@ class TestApiMonitorProviderAndCompletionStreams:
                 assert chunk == ": admission-wait\n\n"
 
                 blocker.release()
-                first = await asyncio.wait_for(iterator.__anext__(), timeout = 0.2)
+                # The lease is announced before it is handed over, so the payload is the
+                # chunk after that marker.
+                assert (
+                    await asyncio.wait_for(iterator.__anext__(), timeout = 1.0)
+                    == ": admission-done\n\n"
+                )
+                first = await asyncio.wait_for(iterator.__anext__(), timeout = 1.0)
                 assert "hello" in first
 
                 pending = asyncio.create_task(iterator.__anext__())

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -2323,7 +2323,7 @@ class TestGgufVisionToolRouting:
             iterator = response.body_iterator
             try:
                 chunk = await asyncio.wait_for(iterator.__anext__(), timeout = 0.2)
-                assert chunk == ": keep-alive\n\n"
+                assert chunk == ": admission-wait\n\n"
                 snapshot = queue.snapshot()
                 assert snapshot.active == 1
                 assert snapshot.queued == 1
@@ -2512,7 +2512,7 @@ class TestGgufVisionToolRouting:
             iterator = response.body_iterator
             try:
                 chunk = await asyncio.wait_for(iterator.__anext__(), timeout = 0.2)
-                assert chunk == ": keep-alive\n\n"
+                assert chunk == ": admission-wait\n\n"
                 snapshot = queue.snapshot()
                 assert snapshot.active == 1
                 assert snapshot.queued == 1
@@ -5168,7 +5168,7 @@ class TestApiMonitorProviderAndCompletionStreams:
             iterator = response.body_iterator
             try:
                 chunk = await asyncio.wait_for(iterator.__anext__(), timeout = 0.2)
-                assert chunk == ": keep-alive\n\n"
+                assert chunk == ": admission-wait\n\n"
                 assert cancel_id in inf_mod._CANCEL_REGISTRY
 
                 blocker.release()
@@ -5275,7 +5275,7 @@ class TestApiMonitorProviderAndCompletionStreams:
             iterator = response.body_iterator
             try:
                 chunk = await asyncio.wait_for(iterator.__anext__(), timeout = 0.2)
-                assert chunk == ": keep-alive\n\n"
+                assert chunk == ": admission-wait\n\n"
 
                 blocker.release()
                 first = await asyncio.wait_for(iterator.__anext__(), timeout = 0.2)
@@ -5454,7 +5454,7 @@ class TestApiMonitorProviderAndCompletionStreams:
             iterator = response.body_iterator
             try:
                 chunk = await asyncio.wait_for(iterator.__anext__(), timeout = 0.2)
-                assert chunk == ": keep-alive\n\n"
+                assert chunk == ": admission-wait\n\n"
                 snapshot = queue.snapshot()
                 assert snapshot.active == 1
                 assert snapshot.queued == 1
@@ -6997,7 +6997,7 @@ class TestResponsesChatTemplateKwargs:
             iterator = response.body_iterator
             try:
                 chunk = await asyncio.wait_for(iterator.__anext__(), timeout = 0.2)
-                assert chunk == ": keep-alive\n\n"
+                assert chunk == ": admission-wait\n\n"
                 snapshot = queue.snapshot()
                 assert snapshot.active == 1
                 assert snapshot.queued == 1

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -5172,8 +5172,7 @@ class TestApiMonitorProviderAndCompletionStreams:
                 assert cancel_id in inf_mod._CANCEL_REGISTRY
 
                 blocker.release()
-                # The lease is announced before it is handed over, so drain that marker
-                # first; the request only reaches upstream on the chunk after it.
+                # The lease is announced before handover, so drain that marker first.
                 assert (
                     await asyncio.wait_for(iterator.__anext__(), timeout = 1.0)
                     == ": admission-done\n\n"
@@ -5284,8 +5283,7 @@ class TestApiMonitorProviderAndCompletionStreams:
                 assert chunk == ": admission-wait\n\n"
 
                 blocker.release()
-                # The lease is announced before it is handed over, so the payload is the
-                # chunk after that marker.
+                # The lease is announced before handover, so the payload is the next chunk.
                 assert (
                     await asyncio.wait_for(iterator.__anext__(), timeout = 1.0)
                     == ": admission-done\n\n"

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -27,6 +27,17 @@ from core.research_runs import (
 from routes.research_runs import CreateResearchRun, _is_sensitive_key, _sanitize_config
 
 
+@pytest.fixture(autouse = True)
+def _fast_admission_heartbeat(monkeypatch):
+    """Keep the admission heartbeat below the budgets these tests patch.
+
+    The first-output budget is floored at two admission heartbeats, so the shipped 5 s
+    interval would otherwise dominate every sub-second deadline asserted here. The floor
+    itself is covered by test_first_output_budget_never_undercuts_the_admission_heartbeat.
+    """
+    monkeypatch.setenv("UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL", "0.001")
+
+
 def test_sanitize_query_redacts_payment_card():
     cleaned = _sanitize_public_query("verify card 4111111111111111 statement")
     assert "4111111111111111" not in cleaned
@@ -966,6 +977,67 @@ def test_endless_keepalives_still_end_at_the_wall_clock(monkeypatch):
 
     with pytest.raises(research_runs.ModelWallClockTimeout):
         _run_stream(supervisor, timeout_seconds = 0.4)
+
+
+def test_a_task_outliving_cleanup_has_its_outcome_absorbed(monkeypatch):
+    """A task that ignores the cleanup bound must not later log an unretrieved exception."""
+    monkeypatch.setattr(research_runs, "_STREAM_CLEANUP_TIMEOUT_SECONDS", 0.05)
+    supervisor = _make_supervisor(_noop_check_active)
+
+    absorbed = []
+    real_absorb = research_runs.ResearchSupervisor._absorb_late_task
+
+    def _spy(run_id, what, task):
+        absorbed.append(what)
+        return real_absorb(run_id, what, task)
+
+    monkeypatch.setattr(research_runs.ResearchSupervisor, "_absorb_late_task", staticmethod(_spy))
+
+    async def _drive():
+        gate = asyncio.get_running_loop().create_future()
+
+        async def _stubborn():
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                pass  # declines cancellation, then keeps running on its own terms
+            await gate
+            raise RuntimeError("late failure")
+
+        task = asyncio.create_task(_stubborn())
+        await asyncio.sleep(0)
+        await supervisor._discard_task("run-1", task, "stream_iterator")
+        assert not task.done(), "the bound must have expired with the task still running"
+
+        gate.set_result(None)
+        await asyncio.sleep(0.05)
+        assert task.done()
+        # Retrieved by the callback; asyncio only warns for exceptions never retrieved.
+        assert absorbed == ["stream_iterator"], f"outcome was not absorbed: {absorbed}"
+        assert isinstance(task.exception(), RuntimeError)
+
+    asyncio.run(_drive())
+
+
+def test_first_output_budget_never_undercuts_the_admission_heartbeat(monkeypatch):
+    """A slow admission heartbeat must not fail a healthy queued run.
+
+    UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL has no upper bound and the queue stays
+    silent for a full interval, so a budget below it would expire before the queue could
+    prove it is alive.
+    """
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 120.0)
+
+    monkeypatch.setenv("UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL", "5")
+    assert research_runs._first_output_budget() == 120.0, "the default must be unchanged"
+
+    monkeypatch.setenv("UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL", "300")
+    assert research_runs._first_output_budget() == 600.0, "must clear two 300 s heartbeats"
+
+    # The legacy spelling feeds the same config, so it must lift the floor too.
+    monkeypatch.delenv("UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL")
+    monkeypatch.setenv("UNSLOTH_OPENAI_COMPAT_ADMISSION_KEEPALIVE_INTERVAL", "200")
+    assert research_runs._first_output_budget() == 400.0
 
 
 def test_stall_keepalives_after_the_first_frame_do_not_renew_the_budget(monkeypatch):

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -977,6 +977,67 @@ def test_plain_keepalives_mean_a_silent_backend_and_spend_the_budget(monkeypatch
     assert time.monotonic() - started < 5.0, "must end on the budget, not the wall clock"
 
 
+def test_the_queue_wait_is_not_charged_to_the_model_budget(monkeypatch):
+    """The tail of a queue wait must not eat into the model's own budget.
+
+    Markers are interval-spaced, so anchoring the deadline to the last one charges up to
+    a full interval of queueing against the model. The wait is suspended instead, and the
+    budget starts when the queue says the slot is ours.
+    """
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.3)
+
+    class _QueuedThenAdmitted:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            # One marker, then a queue wait far longer than the budget between markers.
+            yield ": admission-wait"
+            await asyncio.sleep(1.0)
+            yield ": admission-done"
+            yield 'data: {"choices":[{"delta":{"content":"report"}}]}'
+            yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'
+            yield "data: [DONE]"
+
+    _install_fake_client(monkeypatch, [_QueuedThenAdmitted()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    assert _run_stream(supervisor, timeout_seconds = 10.0) == ("report", "", "stop")
+
+
+def test_the_budget_starts_when_admission_ends(monkeypatch):
+    """Once the slot is granted, a silent model is on its own budget again."""
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.1)
+
+    class _AdmittedThenSilent:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            yield ": admission-wait"
+            yield ": admission-done"
+            await asyncio.sleep(30)
+            yield "data: [DONE]"
+
+    _install_fake_client(monkeypatch, [_AdmittedThenSilent()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    started = time.monotonic()
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        _run_stream(supervisor, timeout_seconds = 30.0)
+    assert time.monotonic() - started < 5.0, "the budget must run from admission end"
+
+
 def test_endless_admission_waits_still_end_at_the_wall_clock(monkeypatch):
     """Deferring on the admission marker must not make a stream unbounded."""
     monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -968,6 +968,96 @@ def test_endless_keepalives_still_end_at_the_wall_clock(monkeypatch):
         _run_stream(supervisor, timeout_seconds = 0.4)
 
 
+def test_stall_keepalives_after_the_first_frame_do_not_renew_the_budget(monkeypatch):
+    """A wedged local GGUF model must still time out.
+
+    routes/inference.py sends the role frame once generation starts and then a
+    ": keep-alive" every 15 s while next(gen) stays silent. A role-only delta is not
+    semantic output, so those comments must not keep renewing the first-output budget.
+    """
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.2)
+
+    class _RoleThenWedged:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            yield 'data: {"choices":[{"delta":{"role":"assistant"}}]}'
+            while True:
+                await asyncio.sleep(0.01)
+                yield ": keep-alive"
+
+    _install_fake_client(monkeypatch, [_RoleThenWedged()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    started = time.monotonic()
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        _run_stream(supervisor, timeout_seconds = 30.0)
+    assert time.monotonic() - started < 5.0, "must end on the budget, not the wall clock"
+
+
+def test_a_cancelled_stream_iterator_is_only_discarded_once(monkeypatch):
+    """Cancellation must stay inside one cleanup bound, not two.
+
+    An iterator that outlasts _STREAM_CLEANUP_TIMEOUT_SECONDS leaves the task pending,
+    and cleaning it up a second time in the finally would double the advertised wait.
+    """
+    monkeypatch.setattr(research_runs, "_STREAM_CLEANUP_TIMEOUT_SECONDS", 0.2)
+    discards = []
+    real_discard = research_runs.ResearchSupervisor._discard_task
+
+    async def _counting_discard(self, run_id, task, what):
+        discards.append(what)
+        return await real_discard(self, run_id, task, what)
+
+    monkeypatch.setattr(research_runs.ResearchSupervisor, "_discard_task", _counting_discard)
+
+    supervisor = _make_supervisor(_noop_check_active)
+    run = _waiting_run(30.0)
+
+    class _UncancellableStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            # Cancel only once the stream loop owns the task, so the send phase (which
+            # has its own cleanup) is not what gets exercised here.
+            supervisor._cancel_event(run["id"]).set()
+            while True:
+                try:
+                    await asyncio.sleep(30)
+                except asyncio.CancelledError:
+                    # Swallows cancellation: exactly what the cleanup bound exists for.
+                    await asyncio.sleep(30)
+                yield ": keep-alive"
+
+    _install_fake_client(monkeypatch, [_UncancellableStream()])
+
+    async def _cancelled(run_id):
+        if supervisor._cancel_event(run_id).is_set():
+            raise research_runs.RunCancelled()
+
+    supervisor._check_active = _cancelled
+
+    started = time.monotonic()
+    with pytest.raises(research_runs.RunCancelled):
+        asyncio.run(supervisor._stream_completion(run, [{"role": "user"}], report_progress = False))
+    elapsed = time.monotonic() - started
+    iterator_discards = [w for w in discards if w == "stream_iterator"]
+    assert len(iterator_discards) == 1, f"discarded {len(iterator_discards)} times: {discards}"
+    assert elapsed < 1.0, f"cancellation took {elapsed:.2f}s, more than one cleanup bound"
+
+
 def test_stream_completion_first_output_timeout_survives_iterator_cleanup(monkeypatch):
     monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.01)
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -886,6 +886,65 @@ def test_stream_completion_times_out_when_output_stalls(monkeypatch):
 
 
 def test_stream_completion_times_out_when_output_never_starts(monkeypatch):
+    """#7964: headers arrive, then the backend goes silent. Silence is the fault signal."""
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
+
+    class _SilentStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            await asyncio.sleep(30)
+            yield "data: [DONE]"
+
+    _install_fake_client(monkeypatch, [_SilentStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        _run_stream(supervisor, timeout_seconds = 1.0)
+
+
+def test_admission_keepalives_do_not_spend_the_first_output_budget(monkeypatch):
+    """A run queued behind another generation must still be served, not failed.
+
+    Studio's admission queue has no default timeout and emits ": keep-alive" while a
+    caller waits for a llama.cpp slot, so a queued Deep Research run outlives any fixed
+    first-output budget through no fault of the model.
+    """
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
+
+    class _QueuedThenServedStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            # Ten keepalive periods, each shorter than the budget but far longer than
+            # it in total: the wait is live, so none of them may end the run.
+            for _ in range(10):
+                await asyncio.sleep(0.02)
+                yield ": keep-alive"
+            yield 'data: {"choices":[{"delta":{"content":"report"}}]}'
+            yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'
+            yield "data: [DONE]"
+
+    _install_fake_client(monkeypatch, [_QueuedThenServedStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    assert _run_stream(supervisor, timeout_seconds = 5.0) == ("report", "", "stop")
+
+
+def test_endless_keepalives_still_end_at_the_wall_clock(monkeypatch):
+    """Re-arming on keepalives must not make a stream unbounded."""
     monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
 
     class _KeepaliveOnlyStream:
@@ -905,8 +964,8 @@ def test_stream_completion_times_out_when_output_never_starts(monkeypatch):
     _install_fake_client(monkeypatch, [_KeepaliveOnlyStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    with pytest.raises(research_runs.ModelFirstOutputTimeout):
-        _run_stream(supervisor, timeout_seconds = 1.0)
+    with pytest.raises(research_runs.ModelWallClockTimeout):
+        _run_stream(supervisor, timeout_seconds = 0.4)
 
 
 def test_stream_completion_first_output_timeout_survives_iterator_cleanup(monkeypatch):

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -928,8 +928,7 @@ def test_admission_keepalives_do_not_spend_the_first_output_budget(monkeypatch):
             return None
 
         async def aiter_lines(self):
-            # Ten keepalive periods, each shorter than the budget but far longer than
-            # it in total: the wait is live, so none of them may end the run.
+            # Ten periods, each under the budget but far over it in total; none may end the run.
             for _ in range(10):
                 await asyncio.sleep(0.02)
                 yield ": admission-wait"
@@ -1291,8 +1290,7 @@ def test_a_cancelled_stream_iterator_is_only_discarded_once(monkeypatch):
             return None
 
         async def aiter_lines(self):
-            # Cancel only once the stream loop owns the task, so the send phase (which
-            # has its own cleanup) is not what gets exercised here.
+            # Cancel once the stream loop owns the task, not the send phase.
             supervisor._cancel_event(run["id"]).set()
             while True:
                 try:
@@ -1431,8 +1429,7 @@ def test_stream_completion_semantic_output_resets_the_idle_timeout(monkeypatch):
 
 
 def test_stream_completion_allows_output_before_first_output_timeout(monkeypatch):
-    # Deadline well clear of the 0.10 s prefill: Windows rounds each sleep up to a
-    # 15.625 ms tick, which makes it 0.15625 s, and Backend CI is ubuntu-only.
+    # Clear of the 0.10 s prefill: a 15.625 ms tick would stretch it to 0.15625 s.
     monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 1.0)
     monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.03)
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -27,17 +27,6 @@ from core.research_runs import (
 from routes.research_runs import CreateResearchRun, _is_sensitive_key, _sanitize_config
 
 
-@pytest.fixture(autouse = True)
-def _fast_admission_heartbeat(monkeypatch):
-    """Keep the admission heartbeat below the budgets these tests patch.
-
-    The first-output budget is floored at two admission heartbeats, so the shipped 5 s
-    interval would otherwise dominate every sub-second deadline asserted here. The floor
-    itself is covered by test_first_output_budget_never_undercuts_the_admission_heartbeat.
-    """
-    monkeypatch.setenv("UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL", "0.001")
-
-
 def test_sanitize_query_redacts_payment_card():
     cleaned = _sanitize_public_query("verify card 4111111111111111 statement")
     assert "4111111111111111" not in cleaned
@@ -923,9 +912,9 @@ def test_stream_completion_times_out_when_output_never_starts(monkeypatch):
 def test_admission_keepalives_do_not_spend_the_first_output_budget(monkeypatch):
     """A run queued behind another generation must still be served, not failed.
 
-    Studio's admission queue has no default timeout and emits ": keep-alive" while a
-    caller waits for a llama.cpp slot, so a queued Deep Research run outlives any fixed
-    first-output budget through no fault of the model.
+    The admission queue has no default timeout and marks the wait with its own SSE
+    comment, so a queued Deep Research run outlives any fixed first-output budget
+    through no fault of the model.
     """
     monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
 
@@ -943,7 +932,7 @@ def test_admission_keepalives_do_not_spend_the_first_output_budget(monkeypatch):
             # it in total: the wait is live, so none of them may end the run.
             for _ in range(10):
                 await asyncio.sleep(0.02)
-                yield ": keep-alive"
+                yield ": admission-wait"
             yield 'data: {"choices":[{"delta":{"content":"report"}}]}'
             yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'
             yield "data: [DONE]"
@@ -954,11 +943,8 @@ def test_admission_keepalives_do_not_spend_the_first_output_budget(monkeypatch):
     assert _run_stream(supervisor, timeout_seconds = 5.0) == ("report", "", "stop")
 
 
-def test_endless_keepalives_still_end_at_the_wall_clock(monkeypatch):
-    """Re-arming on keepalives must not make a stream unbounded."""
-    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
-
-    class _KeepaliveOnlyStream:
+def _comment_only_stream(comment: str):
+    class _CommentOnly:
         status_code = 200
 
         def raise_for_status(self):
@@ -970,9 +956,31 @@ def test_endless_keepalives_still_end_at_the_wall_clock(monkeypatch):
         async def aiter_lines(self):
             while True:
                 await asyncio.sleep(0.01)
-                yield ": keep-alive"
+                yield comment
 
-    _install_fake_client(monkeypatch, [_KeepaliveOnlyStream()])
+    return _CommentOnly()
+
+
+def test_plain_keepalives_mean_a_silent_backend_and_spend_the_budget(monkeypatch):
+    """A backend that only ever sends keepalives is stalled, whatever the phase.
+
+    routes/inference.py sends the plain comment while llama-server is silent, both
+    before its headers and mid-generation, so it must not defer the budget.
+    """
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
+    _install_fake_client(monkeypatch, [_comment_only_stream(": keep-alive")])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    started = time.monotonic()
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        _run_stream(supervisor, timeout_seconds = 30.0)
+    assert time.monotonic() - started < 5.0, "must end on the budget, not the wall clock"
+
+
+def test_endless_admission_waits_still_end_at_the_wall_clock(monkeypatch):
+    """Deferring on the admission marker must not make a stream unbounded."""
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
+    _install_fake_client(monkeypatch, [_comment_only_stream(": admission-wait")])
     supervisor = _make_supervisor(_noop_check_active)
 
     with pytest.raises(research_runs.ModelWallClockTimeout):
@@ -1019,30 +1027,43 @@ def test_a_task_outliving_cleanup_has_its_outcome_absorbed(monkeypatch):
     asyncio.run(_drive())
 
 
-def test_first_output_budget_never_undercuts_the_admission_heartbeat(monkeypatch):
-    """A slow admission heartbeat must not fail a healthy queued run.
+def test_first_output_budget_is_configurable_and_clamped(monkeypatch):
+    """The budget is a run budget, not a constant, and never outlives its own wall clock."""
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
 
-    UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL has no upper bound and the queue stays
-    silent for a full interval, so a budget below it would expire before the queue could
-    prove it is alive.
-    """
-    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 120.0)
+    def _budget(budgets):
+        model_timeout = float(budgets["modelTimeoutSeconds"])
+        return min(
+            float(
+                budgets.get(
+                    "firstOutputTimeoutSeconds",
+                    research_runs._MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS,
+                )
+            ),
+            model_timeout,
+        )
 
-    monkeypatch.setenv("UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL", "5")
-    assert research_runs._first_output_budget() == 120.0, "the default must be unchanged"
+    # A run created before this budget existed keeps the shipped default.
+    assert _budget({"modelTimeoutSeconds": 900}) == 0.05
+    # An explicit budget is honoured.
+    assert _budget({"modelTimeoutSeconds": 900, "firstOutputTimeoutSeconds": 600}) == 600.0
+    # And can never exceed the run's own wall clock.
+    assert _budget({"modelTimeoutSeconds": 30, "firstOutputTimeoutSeconds": 600}) == 30.0
 
-    monkeypatch.setenv("UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL", "300")
-    assert research_runs._first_output_budget() == 600.0, "must clear two 300 s heartbeats"
 
-    # The legacy spelling feeds the same config, so it must lift the floor too.
-    monkeypatch.delenv("UNSLOTH_LLAMA_ADMISSION_KEEPALIVE_INTERVAL")
-    monkeypatch.setenv("UNSLOTH_OPENAI_COMPAT_ADMISSION_KEEPALIVE_INTERVAL", "200")
-    assert research_runs._first_output_budget() == 400.0
+def test_a_configured_first_output_budget_reaches_the_stream(monkeypatch):
+    """The value in the run config, not the module constant, is what bounds the wait."""
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 30.0)
+    _install_fake_client(monkeypatch, [_comment_only_stream(": keep-alive")])
+    supervisor = _make_supervisor(_noop_check_active)
 
-    # With the queue switched off, reserve() leases outright and never sends a heartbeat,
-    # so the floor would only postpone catching a genuinely stalled request.
-    monkeypatch.setenv("UNSLOTH_LLAMA_ADMISSION_CONTROL", "0")
-    assert research_runs._first_output_budget() == 120.0
+    run = _waiting_run(30.0)
+    run["config"]["budgets"]["firstOutputTimeoutSeconds"] = 0.05
+
+    started = time.monotonic()
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        asyncio.run(supervisor._stream_completion(run, [{"role": "user"}], report_progress = False))
+    assert time.monotonic() - started < 5.0, "the configured budget must win over the constant"
 
 
 def test_stall_keepalives_after_the_first_frame_do_not_renew_the_budget(monkeypatch):

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -885,6 +885,88 @@ def test_stream_completion_times_out_when_output_stalls(monkeypatch):
         _run_stream(supervisor, timeout_seconds = 1.0)
 
 
+def test_stream_completion_times_out_when_output_never_starts(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.05)
+
+    class _KeepaliveOnlyStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            while True:
+                await asyncio.sleep(0.01)
+                yield ": keep-alive"
+
+    _install_fake_client(monkeypatch, [_KeepaliveOnlyStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        _run_stream(supervisor, timeout_seconds = 1.0)
+
+
+def test_stream_completion_first_output_timeout_survives_iterator_cleanup(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.01)
+
+    class _BrokenSilentStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            try:
+                await asyncio.Event().wait()
+                yield ""
+            except asyncio.CancelledError as exc:
+                raise httpx.ReadError("cleanup failed") from exc
+
+    _install_fake_client(monkeypatch, [_BrokenSilentStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        _run_stream(supervisor, timeout_seconds = 1.0)
+
+
+@pytest.mark.parametrize("body", ("data: [DONE]\n\n", ""))
+def test_stream_completion_rejects_zero_output_terminal_stream(monkeypatch, body):
+    _install_fake_client(monkeypatch, [_response(200, body = body)])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    with pytest.raises(research_runs.ModelFirstOutputTimeout):
+        _run_stream(supervisor, timeout_seconds = 1.0)
+
+
+def test_stream_cancellation_wins_at_first_output_deadline():
+    async def _cancelled(run_id: str) -> None:
+        raise RunCancelled()
+
+    async def run():
+        supervisor = _make_supervisor(_cancelled)
+        supervisor._cancel_event("run-1").set()
+        response = _response(200, body = "")
+
+        def expired_deadline() -> float:
+            raise research_runs.ModelFirstOutputTimeout()
+
+        iterator = supervisor._iter_stream_lines(
+            "run-1",
+            response,
+            expired_deadline,
+        )
+        await anext(iterator)
+
+    with pytest.raises(RunCancelled):
+        asyncio.run(run())
+
+
 def test_stream_cleanup_error_does_not_replace_output_stall(monkeypatch):
     monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.05)
 
@@ -938,7 +1020,8 @@ def test_stream_completion_semantic_output_resets_the_idle_timeout(monkeypatch):
     assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "thinking", "stop")
 
 
-def test_stream_completion_does_not_apply_idle_timeout_during_prefill(monkeypatch):
+def test_stream_completion_allows_output_before_first_output_timeout(monkeypatch):
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.15)
     monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.03)
 
     class _SlowPrefillStream:
@@ -1021,6 +1104,10 @@ def test_stream_completion_stops_at_done_even_if_socket_stays_open(monkeypatch):
 @pytest.mark.parametrize(
     ("exc", "message"),
     (
+        (
+            research_runs.ModelFirstOutputTimeout("first"),
+            "Local model never started producing output",
+        ),
         (
             research_runs.ModelOutputIdleTimeout("idle"),
             "Local model stopped producing output before completion",

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1073,6 +1073,62 @@ def test_stall_keepalives_after_the_first_frame_do_not_renew_the_budget(monkeypa
     assert time.monotonic() - started < 5.0, "must end on the budget, not the wall clock"
 
 
+def test_a_cancelled_send_is_only_discarded_once(monkeypatch):
+    """The pre-header send needs the same single-cleanup guarantee as the iterator.
+
+    A send that declines cancellation past the bound would otherwise be waited on again
+    by the enclosing finally, doubling how long a user cancellation takes.
+    """
+    monkeypatch.setattr(research_runs, "_STREAM_CLEANUP_TIMEOUT_SECONDS", 0.2)
+    discards = []
+    real_discard = research_runs.ResearchSupervisor._discard_task
+
+    async def _counting_discard(self, run_id, task, what):
+        discards.append(what)
+        return await real_discard(self, run_id, task, what)
+
+    monkeypatch.setattr(research_runs.ResearchSupervisor, "_discard_task", _counting_discard)
+
+    supervisor = _make_supervisor(_noop_check_active)
+    run = _waiting_run(30.0)
+
+    class _StubbornClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+        def build_request(self, *args, **kwargs):
+            return SimpleNamespace(headers = {})
+
+        async def send(
+            self,
+            request,
+            stream = False,
+        ):
+            supervisor._cancel_event(run["id"]).set()
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await asyncio.sleep(10)  # declines cancellation past the bound
+
+    monkeypatch.setattr(research_runs.httpx, "AsyncClient", lambda **kwargs: _StubbornClient())
+
+    async def _cancelled(run_id):
+        if supervisor._cancel_event(run_id).is_set():
+            raise research_runs.RunCancelled()
+
+    supervisor._check_active = _cancelled
+
+    started = time.monotonic()
+    with pytest.raises(research_runs.RunCancelled):
+        asyncio.run(supervisor._stream_completion(run, [{"role": "user"}], report_progress = False))
+    elapsed = time.monotonic() - started
+    assert [w for w in discards if w == "send"] == ["send"], f"discards: {discards}"
+    assert elapsed < 1.0, f"cancellation took {elapsed:.2f}s, more than one cleanup bound"
+
+
 def test_a_cancelled_stream_iterator_is_only_discarded_once(monkeypatch):
     """Cancellation must stay inside one cleanup bound, not two.
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1039,6 +1039,11 @@ def test_first_output_budget_never_undercuts_the_admission_heartbeat(monkeypatch
     monkeypatch.setenv("UNSLOTH_OPENAI_COMPAT_ADMISSION_KEEPALIVE_INTERVAL", "200")
     assert research_runs._first_output_budget() == 400.0
 
+    # With the queue switched off, reserve() leases outright and never sends a heartbeat,
+    # so the floor would only postpone catching a genuinely stalled request.
+    monkeypatch.setenv("UNSLOTH_LLAMA_ADMISSION_CONTROL", "0")
+    assert research_runs._first_output_budget() == 120.0
+
 
 def test_stall_keepalives_after_the_first_frame_do_not_renew_the_budget(monkeypatch):
     """A wedged local GGUF model must still time out.
@@ -1071,6 +1076,52 @@ def test_stall_keepalives_after_the_first_frame_do_not_renew_the_budget(monkeypa
     with pytest.raises(research_runs.ModelFirstOutputTimeout):
         _run_stream(supervisor, timeout_seconds = 30.0)
     assert time.monotonic() - started < 5.0, "must end on the budget, not the wall clock"
+
+
+def test_outer_cancellation_still_hands_off_the_child_task(monkeypatch):
+    """Shutdown or the wall clock must not strand the child with nobody reading it.
+
+    _discard_task re-raises an outer cancellation, but the child outlives the frame
+    either way, so its outcome still has to be claimed before the caller leaves.
+    """
+    monkeypatch.setattr(research_runs, "_STREAM_CLEANUP_TIMEOUT_SECONDS", 30.0)
+    absorbed = []
+    real_absorb = research_runs.ResearchSupervisor._absorb_late_task
+
+    def _spy(run_id, what, task):
+        absorbed.append(what)
+        return real_absorb(run_id, what, task)
+
+    monkeypatch.setattr(research_runs.ResearchSupervisor, "_absorb_late_task", staticmethod(_spy))
+    supervisor = _make_supervisor(_noop_check_active)
+
+    async def _drive():
+        gate = asyncio.get_running_loop().create_future()
+
+        async def _stubborn():
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                pass  # declines the first cancellation
+            await gate
+            raise RuntimeError("late failure")
+
+        child = asyncio.create_task(_stubborn())
+        await asyncio.sleep(0)
+        cleanup = asyncio.create_task(supervisor._discard_task("run-1", child, "stream_iterator"))
+        await asyncio.sleep(0.05)
+        # Cancel the cleanup itself, standing in for the wall clock or a shutdown.
+        cleanup.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cleanup
+
+        gate.set_result(None)
+        await asyncio.sleep(0.05)
+        assert child.done()
+        assert absorbed == ["stream_iterator"], f"child was stranded: {absorbed}"
+        assert isinstance(child.exception(), RuntimeError)
+
+    asyncio.run(_drive())
 
 
 def test_a_cancelled_send_is_only_discarded_once(monkeypatch):

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1021,7 +1021,9 @@ def test_stream_completion_semantic_output_resets_the_idle_timeout(monkeypatch):
 
 
 def test_stream_completion_allows_output_before_first_output_timeout(monkeypatch):
-    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.15)
+    # Deadline well clear of the 0.10 s prefill: Windows rounds each sleep up to a
+    # 15.625 ms tick, which makes it 0.15625 s, and Backend CI is ubuntu-only.
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 1.0)
     monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 0.03)
 
     class _SlowPrefillStream:
@@ -1045,6 +1047,81 @@ def test_stream_completion_allows_output_before_first_output_timeout(monkeypatch
     supervisor = _make_supervisor(_noop_check_active)
 
     assert _run_stream(supervisor, timeout_seconds = 1.0) == ("report", "", "stop")
+
+
+def test_first_output_deadline_disarms_once_output_starts(monkeypatch):
+    """The budget bounds the wait for the FIRST token, never total generation time."""
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.15)
+    monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 5.0)
+
+    class _LongGenerationStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            await asyncio.sleep(0.05)
+            yield 'data: {"choices":[{"delta":{"content":"start"}}]}'
+            for index in range(12):
+                await asyncio.sleep(0.05)
+                yield 'data: {"choices":[{"delta":{"content":" w%d"}}]}' % index
+            yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'
+            yield "data: [DONE]"
+
+    _install_fake_client(monkeypatch, [_LongGenerationStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    report, _reasoning, finish_reason = _run_stream(supervisor, timeout_seconds = 30.0)
+    assert finish_reason == "stop"
+    assert report.startswith("start w0 w1")
+    assert report.endswith("w11")
+
+
+def test_reasoning_only_prefix_disarms_the_first_output_deadline(monkeypatch):
+    """A thinking model may reason for longer than the budget before any content."""
+    monkeypatch.setattr(research_runs, "_MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS", 0.15)
+    monkeypatch.setattr(research_runs, "_MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS", 5.0)
+    # Reasoning deltas flush to storage whatever report_progress says.
+    monkeypatch.setattr(research_runs.db, "append_worker_event", lambda *args, **kwargs: 1)
+
+    class _LongThinkStream:
+        status_code = 200
+
+        def raise_for_status(self):
+            return self
+
+        async def aclose(self):
+            return None
+
+        async def aiter_lines(self):
+            await asyncio.sleep(0.05)
+            for index in range(10):
+                yield 'data: {"choices":[{"delta":{"reasoning_content":"t%d "}}]}' % index
+                await asyncio.sleep(0.05)
+            yield 'data: {"choices":[{"delta":{"content":"answer"}}]}'
+            yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'
+            yield "data: [DONE]"
+
+    _install_fake_client(monkeypatch, [_LongThinkStream()])
+    supervisor = _make_supervisor(_noop_check_active)
+
+    report, reasoning, _finish = _run_stream(supervisor, timeout_seconds = 30.0)
+    assert report == "answer"
+    assert reasoning.startswith("t0 ")
+
+
+def test_shipped_stream_deadline_constants_are_pinned():
+    """Every other test monkeypatches these, so nothing else would notice a change."""
+    assert research_runs._MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS == 120.0
+    assert research_runs._MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS == 120.0
+    assert (
+        research_runs._MODEL_FIRST_OUTPUT_TIMEOUT_SECONDS
+        >= research_runs._MODEL_OUTPUT_IDLE_TIMEOUT_SECONDS
+    )
 
 
 def test_stream_completion_counts_whitespace_tokens_as_output(monkeypatch):

--- a/studio/backend/tests/test_research_runs_storage.py
+++ b/studio/backend/tests/test_research_runs_storage.py
@@ -1313,6 +1313,7 @@ def test_research_budget_defaults_support_long_runs():
         "maxSources": 40,
         "modelTimeoutSeconds": 900,
         "toolTimeoutSeconds": 120,
+        "firstOutputTimeoutSeconds": 120,
     }
     assert config["instructions"] == "Answer in Spanish."
     ResearchPlan(
@@ -1334,6 +1335,7 @@ def test_research_budget_ceilings_allow_depth_but_remain_bounded():
             "maxSources": 100,
             "modelTimeoutSeconds": 3600,
             "toolTimeoutSeconds": 600,
+            "firstOutputTimeoutSeconds": 3600,
         },
     )
     assert _sanitize_config(payload, {"modelId": "local-model"})["budgets"] == payload.budgets

--- a/studio/frontend/src/features/chat/types/research.ts
+++ b/studio/frontend/src/features/chat/types/research.ts
@@ -88,6 +88,8 @@ export interface ResearchBudgets {
   maxSources: number;
   modelTimeoutSeconds: number;
   toolTimeoutSeconds: number;
+  // Optional: runs created before this budget existed do not carry it.
+  firstOutputTimeoutSeconds?: number;
 }
 
 export interface ResearchWebsitePolicy {


### PR DESCRIPTION
## Summary
- start a 120-second first-output deadline after Deep Research accepts a model stream
- switch to the existing inter-output deadline after the first content or reasoning delta
- report zero-output stalls and terminal streams as `Local model never started producing output`
- preserve cancellation priority and prevent iterator cleanup failures from masking the timeout

## Behavior
Model-load waits, pre-body transport retries, and the configured wall-clock budget remain unchanged. SSE keepalives and empty protocol frames do not count as model output.

Closes #7964

## Validation
- `python -m pytest studio/backend/tests/test_research_runs_hardening.py studio/backend/tests/test_research_runs_storage.py tests/studio/test_deep_research_frontend_contract.py -q` (225 passed)
- `python -m ruff check studio/backend/core/research_runs.py studio/backend/tests/test_research_runs_hardening.py`
- `python -m py_compile studio/backend/core/research_runs.py studio/backend/tests/test_research_runs_hardening.py`
- `git diff --check`