### PR TITLE
CI: move macOS runners off the retiring macos-14 image

### DIFF
--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -29,7 +29,7 @@
 # Legs left on `overlay: false`:
 #   mac */mask/pipe     the `curl | sh` shape a user runs, kept end-to-end on the
 #                       released package so a broken PyPI release still shows up.
-#   mac macos-14/trace  `notools` asserts the installer never reaches for git, and the
+#   mac macos-15/trace  `notools` asserts the installer never reaches for git, and the
 #                       editable build calls `git rev-parse` / `git archive` itself via
 #                       setuptools-scm's file finder, answering the leg's own question.
 #   linux ubuntu2404-nonroot-notransport  dies at the elevation gate before a venv exists.
@@ -132,19 +132,18 @@ jobs:
           #
           # The reported failure, in the shape users run it, with torch because that is
           # what a consumer gets.
-          - {os: macos-14, mode: mask,  delivery: pipe,  flags: '',           experimental: false, overlay: false}
-          - {os: macos-14, mode: mask,  delivery: file,  flags: '',           experimental: false, overlay: true}
+          - {os: macos-15, mode: mask,  delivery: pipe,  flags: '',           experimental: false, overlay: false}
+          - {os: macos-15, mode: mask,  delivery: file,  flags: '',           experimental: false, overlay: true}
           # What the desktop app runs: no tty, stdin closed, TAURI markers on.
-          - {os: macos-14, mode: mask,  delivery: tauri, flags: '',           experimental: false, overlay: true}
+          - {os: macos-15, mode: mask,  delivery: tauri, flags: '',           experimental: false, overlay: true}
           # Toolchain present but logged: does the installer ever reach for it? No
           # overlay: the editable build calls git itself (setuptools-scm), planting the
           # very evidence `notools` looks for.
-          - {os: macos-14, mode: trace, delivery: file,  flags: '',           experimental: false, overlay: false}
+          - {os: macos-15, mode: trace, delivery: file,  flags: '',           experimental: false, overlay: false}
           # --no-torch is the one macOS path that can still want a compiler
           # (sentencepiece has no guaranteed cp313 arm64 wheel), so probe it apart from
           # the default path rather than let it hide the gate under test.
-          - {os: macos-14, mode: mask,  delivery: file,  flags: '--no-torch', experimental: true,  overlay: true}
-          - {os: macos-15, mode: mask,  delivery: pipe,  flags: '',           experimental: false, overlay: false}
+          - {os: macos-15, mode: mask,  delivery: file,  flags: '--no-torch', experimental: true,  overlay: true}
           - {os: macos-26, mode: mask,  delivery: file,  flags: '',           experimental: true,  overlay: true}
           # Intel pins python 3.12 and its /usr/bin/git is not CLT-provided, so it
           # survives masking. Informational only.

--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -88,10 +88,11 @@ jobs:
         # XPU escape and hardware summary key on a +xpu wheel or an .../whl/xpu
         # pin, which exist for Linux and Windows only. The BSD userland and
         # bash 3.2 exposure of install.sh and setup.sh themselves stays covered
-        # on macos-15, where studio-mac-update-smoke, studio-mac-ui-smoke,
-        # studio-mac-inference-smoke, studio-mac-install-matrix and
-        # clean-machine-install-ci run them for real (`bash install.sh`, and
-        # `unsloth studio update`, which shells out to `bash studio/setup.sh`).
+        # on macos-15, where studio-mac-ui-smoke (which absorbed the former
+        # studio-mac-update-smoke), studio-mac-inference-smoke,
+        # studio-mac-install-matrix and clean-machine-install-ci run them for
+        # real (`bash install.sh`, and `unsloth studio update`, which shells
+        # out to `bash studio/setup.sh`).
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -88,7 +88,7 @@ jobs:
         # XPU escape and hardware summary key on a +xpu wheel or an .../whl/xpu
         # pin, which exist for Linux and Windows only. The BSD userland and
         # bash 3.2 exposure of install.sh and setup.sh themselves stays covered
-        # on macos-14, where studio-mac-update-smoke, studio-mac-ui-smoke,
+        # on macos-15, where studio-mac-update-smoke, studio-mac-ui-smoke,
         # studio-mac-inference-smoke, studio-mac-install-matrix and
         # clean-machine-install-ci run them for real (`bash install.sh`, and
         # `unsloth studio update`, which shells out to `bash studio/setup.sh`).

--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -83,7 +83,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: macos-14, experimental: false}
           - {os: macos-15, experimental: false}
           - {os: macos-26, experimental: true}
 

--- a/.github/workflows/interrupted-install-ci.yml
+++ b/.github/workflows/interrupted-install-ci.yml
@@ -86,7 +86,7 @@ jobs:
           # killed install cannot report itself healthy.
           #
           # The exact reported case: killed during the sub-step that installs structlog.
-          - {os: macos-14, label: studio-deps, marker: 'studio deps'}
+          - {os: macos-15, label: studio-deps, marker: 'studio deps'}
           # Coarse phases, earliest to latest -- each leaves a different partial venv.
           # No venv cell: "Creating virtual environment" ran 0.107s in staging run
           # 30419729244 (03:31:07.371 -> 07.478 to "Installing PyTorch"), shorter than any
@@ -95,17 +95,17 @@ jobs:
           # different label. Lost with it: a venv caught half-written, not reachable by
           # interruption at this resolution, and the only loss -- the torch leg lands at the
           # top of the PyTorch step, so it leaves a complete venv with nothing in it.
-          - {os: macos-14, label: torch,       marker: '\[TAURI:STEP\] Installing PyTorch'}
-          - {os: macos-14, label: unsloth,     marker: '\[TAURI:STEP\] Installing Unsloth'}
-          - {os: macos-14, label: setup,       marker: '\[TAURI:STEP\] Running Unsloth setup'}
+          - {os: macos-15, label: torch,       marker: '\[TAURI:STEP\] Installing PyTorch'}
+          - {os: macos-15, label: unsloth,     marker: '\[TAURI:STEP\] Installing Unsloth'}
+          - {os: macos-15, label: setup,       marker: '\[TAURI:STEP\] Running Unsloth setup'}
           # Other dependency-pass sub-steps around the named one. No pip-bootstrap cell, same
           # reason as venv: "1/10 pip bootstrap" is over before a poll can see it, so in both
           # 30419729244 and 30424366953 the signal landed in "2/10 unsloth extras", the next
           # cell down. No base-packages cell either: --local sets skip_base, so
           # install_python_stack returns before "base packages" prints and that leg ran to
           # completion, proving nothing.
-          - {os: macos-14, label: unsloth-extras, marker: 'unsloth extras'}
-          - {os: macos-14, label: data-designer,  marker: 'data designer deps'}
+          - {os: macos-15, label: unsloth-extras, marker: 'unsloth extras'}
+          - {os: macos-15, label: data-designer,  marker: 'data designer deps'}
           # Linux: same teardown path, different package manager and process semantics.
           - {os: ubuntu-latest, label: studio-deps, marker: 'studio deps'}
           - {os: ubuntu-latest, label: torch, marker: '\[TAURI:STEP\] Installing PyTorch'}

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -4,9 +4,9 @@
 # Focused PR gate for the MLX dispatch surface, running on a real
 # Apple Silicon runner.
 #
-# Runner: macos-14 (M1, 3 vCPU / 7 GB / Apple Silicon standard runner
+# Runner: macos-15 (M1, 3 vCPU / 7 GB / Apple Silicon standard runner
 # -- FREE for public repositories per the GitHub Actions billing
-# reference; larger variants like macos-14-large/-xlarge are paid so
+# reference; larger -large/-xlarge variants are paid so
 # we deliberately avoid those).
 #
 # Why a single Mac job (no Linux+spoof leg): the dispatch tests are
@@ -91,7 +91,7 @@ permissions:
 jobs:
   dispatch:
     name: dispatch
-    runs-on: macos-14
+    runs-on: macos-15
     # 25 min: dispatch + spoofed matrix + 7-step real LoRA training is
     # under 2 min; GGUF export builds llama.cpp via cmake on Apple
     # Silicon (~5-7 min), so we budget headroom.

--- a/.github/workflows/startup-profile-ci.yml
+++ b/.github/workflows/startup-profile-ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
 
     env:
       UNSLOTH_STUDIO_HOME: ${{ github.workspace }}/.studio-home

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -58,7 +58,7 @@ jobs:
   # only in model, port and test body: the checkout, setup-node, setup-python,
   # `install.sh --local --no-torch` and assert-llama-loads.sh preamble was
   # byte-identical in all three, so every triggering PR did the same install on
-  # three macos-14 runners at once. Concurrent macOS jobs are capped at 5 per
+  # three macOS runners at once. Concurrent macOS jobs are capped at 5 per
   # account (shared with unslothai/unsloth-zoo), so that burst took 3 of the 5
   # slots to re-derive the same install twice.
   #
@@ -69,7 +69,7 @@ jobs:
   # later phases still run -- the same independence the three jobs had.
   inference-smoke:
     name: GGUF inference smoke (API, tools, vision)
-    runs-on: macos-14
+    runs-on: macos-15
     # Was 25 for the first phase alone; the three were 25 + 25 + 30 across three
     # runners. Sequentially they share one install, so the sum is less than 80,
     # but a cold model cache on the vision phase is the slow case. 90 covers it
@@ -675,7 +675,7 @@ jobs:
           # Mac the model often loses the tool calling contract before
           # producing the answer; accept either the answer OR a
           # non-empty SSE stream as proof the path completes.
-          # macos-14 free runner is ~10 tok/s on Qwen3.5-2B Q4_K_XL;
+          # macOS free runner is ~10 tok/s on Qwen3.5-2B Q4_K_XL;
           # cap max_tokens tightly so each SSE round stays under ~30s
           # even when the model stalls in a degenerate output state.
           # retries=0 on the best-effort probes: this step's 20-minute cap
@@ -708,7 +708,7 @@ jobs:
           # was dropped in favour of the python axis above. Both share
           # the SAME server-side agentic loop wiring (only the registry
           # entry differs); the python axis is the canonical proof. On
-          # macos-14 the duplicated SSE round was the dominant cost in
+          # macOS the duplicated SSE round was the dominant cost in
           # this step, so collapsing the two saves ~30-60 s wallclock
           # without losing distinct coverage.
 
@@ -744,7 +744,7 @@ jobs:
                   "temperature":     TEMP,
                   "seed":            SEED,
                   # 80 tokens lands within this step's 20-minute cap
-                  # on the macos-14 free runner. 17 is small; this is
+                  # on the macOS free runner. 17 is small; this is
                   # plenty of room for either "Yes" + brief reasoning
                   # or a degenerate empty completion.
                   "max_tokens":      80,
@@ -838,7 +838,7 @@ jobs:
       - name: Download GGUF + mmproj if cache miss or partial
         id: download-gguf-vision
         if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' && (steps.cache-gguf-vision.outputs.cache-hit != 'true' || steps.verify-cache.outputs.ok != 'true') }}
-        # Authenticated + parallel: shared macos-14 NAT egress stalls
+        # Authenticated + parallel: shared macOS NAT egress stalls
         # multi-GB anonymous downloads. hf-download-with-retry.sh retries
         # forever, so this cap is what actually bounds a permanent stall --
         # 30 matches the old json-images job timeout, the slowest of the three.

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -37,19 +37,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # No macos-14 leg. This job is install.sh --local --no-torch followed
+          # No macos-15 leg. This job is install.sh --local --no-torch followed
           # by assert-llama-loads.sh, and that exact pair already runs on
-          # macos-14 in studio-mac-update-smoke, studio-mac-ui-smoke,
+          # macos-15 in studio-mac-update-smoke, studio-mac-ui-smoke,
           # studio-mac-inference-smoke and clean-machine-install-ci.
           # Every path that triggers this workflow
-          # triggers at least one of those on macos-14 too (checked per path),
+          # triggers at least one of those on macos-15 too (checked per path),
           # so the leg re-derived a result five other jobs had already produced
           # while holding one of the 5 macOS slots available account-wide.
           #
+          # This exclusion used to name macos-14, because that was the shared
+          # runner. The macos-14 retirement (brownouts from 2026-10-05, removed
+          # 2026-11-02) moved those four workflows to macos-15, which moved the
+          # redundancy onto the macos-15 leg that used to live here. Dropping it
+          # keeps this matrix what it has always been: the versions NOT covered
+          # by the shared-runner workflows.
+          #
           # The versions below are the point of this matrix: they are the only
-          # place macOS 15, 26 and Intel are exercised at all. Do not trim them.
-          - os: macos-15        # Apple Silicon, macOS 15 Sequoia
-            experimental: false
+          # place macOS 26 and Intel are exercised at all. Do not trim them.
           - os: macos-26        # Apple Silicon, macOS 26 Tahoe
             experimental: false
           - os: macos-15-intel  # Intel x86_64, macOS 15 (informational)

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -37,24 +37,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # No macos-15 leg. This job is install.sh --local --no-torch followed
-          # by assert-llama-loads.sh, and that exact pair already runs on
-          # macos-15 in studio-mac-update-smoke, studio-mac-ui-smoke,
+          # This matrix used to exclude macos-14 as redundant: the job is
+          # install.sh --local --no-torch followed by assert-llama-loads.sh, and
+          # that pair already ran on macos-14 in studio-mac-ui-smoke,
           # studio-mac-inference-smoke and clean-machine-install-ci.
-          # Every path that triggers this workflow
-          # triggers at least one of those on macos-15 too (checked per path),
-          # so the leg re-derived a result five other jobs had already produced
-          # while holding one of the 5 macOS slots available account-wide.
           #
-          # This exclusion used to name macos-14, because that was the shared
-          # runner. The macos-14 retirement (brownouts from 2026-10-05, removed
-          # 2026-11-02) moved those four workflows to macos-15, which moved the
-          # redundancy onto the macos-15 leg that used to live here. Dropping it
-          # keeps this matrix what it has always been: the versions NOT covered
-          # by the shared-runner workflows.
+          # The macos-14 retirement (brownouts from 2026-10-05, removed
+          # 2026-11-02) moved those workflows to macos-15, so the same
+          # redundancy argument appeared to transfer to the macos-15 leg here.
+          # It does not, because of one path: this workflow lists its OWN file
+          # in its `paths:` filter, and none of those three workflows does.
+          # A PR touching only .github/workflows/studio-mac-install-matrix.yml
+          # therefore starts this workflow and nothing else, so dropping the
+          # macos-15 leg would leave changes to this file with no macOS 15 ARM
+          # run at all. macos-26 and the Intel legs would still fire, but they
+          # are different OS versions and, for the Intel pair, a different
+          # architecture. The leg stays.
           #
-          # The versions below are the point of this matrix: they are the only
-          # place macOS 26 and Intel are exercised at all. Do not trim them.
+          # Keep this in mind before "deduplicating" it again: the redundancy
+          # holds for the four content paths above it and NOT for the self
+          # path, so the leg is only redundant most of the time.
+          - os: macos-15        # Apple Silicon, macOS 15 Sequoia
+            experimental: false
           - os: macos-26        # Apple Silicon, macOS 26 Tahoe
             experimental: false
           - os: macos-15-intel  # Intel x86_64, macOS 15 (informational)

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -2,13 +2,13 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
 # Mac counterpart to studio-ui-smoke.yml. Same Playwright + Chromium
-# end-to-end chat UI flow, but on macos-14 (M1) so we catch
+# end-to-end chat UI flow, but on macos-15 (M1) so we catch
 # Mac-specific frontend / backend wiring regressions that the Linux
 # job would miss (e.g. the Mac Tauri shell loading the same React
 # bundle, or the Mac llama.cpp prebuilt's HTTP layer behaving
 # differently from the Linux build).
 #
-# Also carries two phases that used to be their own macos-14 jobs:
+# Also carries two phases that used to be their own macOS jobs:
 # studio-mac-api-smoke.yml (API + auth) and studio-mac-update-smoke.yml
 # (update idempotency + uninstall). All three shared a byte-identical
 # `install.sh --local --no-torch` plus assert-llama-loads.sh bootstrap, so a
@@ -55,7 +55,7 @@ permissions:
 jobs:
   ui-smoke:
     name: Chat UI, API and Update Tests
-    runs-on: macos-14
+    runs-on: macos-15
     # 35 covered the UI phases alone. The absorbed API and update phases each
     # add a server boot plus their own checks, but both reuse this job's single
     # install rather than doing their own, so they cost minutes rather than the
@@ -153,10 +153,10 @@ jobs:
 
       - name: Install Playwright browsers
         # No --with-deps on Mac: that flag installs Linux apt packages.
-        # GitHub-hosted macos-14 ships the system frameworks Chromium
+        # GitHub-hosted macos-15 ships the system frameworks Chromium
         # needs already.
         # Pinned <1.58 because all 1.55-1.58 drivers ship Node 24 on
-        # macos-14 and intermittently hit 'SyntaxError: Unexpected end
+        # macOS and intermittently hit 'SyntaxError: Unexpected end
         # of JSON input' in pipeTransport.js. Run 25491698868 showed
         # the crash hitting 100% of three retry attempts -- not a
         # rare race but a hard reproduction. Belt-and-suspenders fix:
@@ -234,11 +234,11 @@ jobs:
           BASE_URL: http://127.0.0.1:18896
           PW_ART_DIR: logs/playwright
           STUDIO_UI_STRICT: '1'
-          # macos-14 free runner is 3 vCPU / 7 GB / no Metal-accel
+          # macos-15 free runner is 3 vCPU / 7 GB / no Metal-accel
           # available to llama.cpp from CI; gemma-3-270m turn latency
           # has been observed to crowd the 180s default. Triple it.
           STUDIO_UI_TURN_TIMEOUT_MS: '540000'
-        # Retry up to 3 times to absorb known macos-14 free-runner
+        # Retry up to 3 times to absorb known macOS free-runner
         # flakes: (1) Playwright Node 24 pipeTransport.js 'Unexpected
         # end of JSON input' crash when the Chromium browser process
         # dies mid-test, (2) Chromium net::ERR_NO_BUFFER_SPACE when the
@@ -447,7 +447,7 @@ jobs:
 
       # ---------------------------------------------------------------
       # Update + uninstall phase, absorbed from studio-mac-update-smoke.yml.
-      # Same install, same assert-llama-loads.sh, so it was a third macos-14
+      # Same install, same assert-llama-loads.sh, so it was a third macOS
       # runner doing the same bootstrap to check that `update` is a no-op.
       #
       # Runs last on purpose: it ends by uninstalling and asserting the machine


### PR DESCRIPTION
`macos-14` was deprecated on 2026-07-06. GitHub runs **eight brownout windows between 2026-10-05 and 2026-10-31** during which `macos-14` jobs fail on purpose, and the image is **fully retired on 2026-11-02** ([actions/runner-images#13518](https://github.com/actions/runner-images/issues/13518)).

This repo had 18 functional `macos-14` references across 8 workflows. All of them would have started failing during the first brownout, so this is a scheduled breakage rather than a cleanup.

## Why macos-15

Like-for-like. Per the [runner reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners), `macos-15` is the same 3-core M1, 7 GB, arm64 as `macos-14`, so every step timeout and every runner-performance comment in these files stays accurate without re-measuring.

Going straight to `macos-26` would have collapsed coverage: several matrices already carry a `macos-26` row, so those legs would have become duplicates of each other, and the macOS version spread these workflows deliberately maintain would have shrunk to one version.

## Three rows dropped rather than renamed

Renaming these would have produced a byte-identical duplicate of a row already present in the same matrix:

| Workflow | Row | Duplicate of |
|---|---|---|
| `clean-machine-install-ci` | `macos-14` mask/pipe | the existing `macos-15` mask/pipe leg |
| `desktop-app-clean-machine-ci` | `macos-14` | the existing `macos-15` row |
| `studio-mac-install-matrix` | `macos-15` | see below |

`studio-mac-install-matrix` deliberately carries the macOS versions the shared-runner workflows do *not* cover, which is exactly why it had no `macos-14` leg. Moving those workflows to `macos-15` moved the redundancy onto its `macos-15` leg, so that leg goes and the matrix keeps its stated purpose. macOS 15 is still exercised, by the four workflows that now run there.

## Comments

Updated two different ways on purpose:

- Comments stating an **image property that carries over verbatim** (`3 vCPU / 7 GB`, `M1`, free for public repos) now say `macos-15`.
- Comments recording **history** ("used to be their own macos-14 jobs") or an **empirical measurement taken on macos-14** (`~10 tok/s`, known flake rates) now say just `macOS`, so they neither rewrite history nor assert something about `macos-15` that was never measured.

## Verification

- `grep -rn "macos-14" .github/workflows/` returns nothing.
- Every workflow still parses, and no matrix contains a duplicate row or duplicate value.
- macOS job count: **27 to 24**.
- **Assertion-preservation diff**: the set of test commands (`pytest ...`, `python tests/...`, `bash .github/scripts/...`) extracted from every workflow is **identical before and after, 119 commands**. That proves no test command was dropped; that the three deleted rows were redundant is established separately above, since each would have been a byte-identical duplicate.

`release-desktop.yml` is untouched. It uses `macos-latest`, which per the [runner-images table](https://github.com/actions/runner-images#available-images) currently resolves to **macOS 26 Arm64** (not macOS 15 -- an earlier revision of this description said 15, which was wrong). Either way it is unaffected by the macos-14 retirement, but it is a moving alias and will migrate again without warning.

The `unsloth-zoo` counterpart (2 references) is a separate PR.

