### PR TITLE
CI: point rust-cache at the real v2.9.1 tag and label the unlabelled pins

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -64,7 +64,7 @@ jobs:
       pypi_version: ${{ steps.prepare.outputs.pypi_version }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -387,7 +387,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -400,7 +400,7 @@ jobs:
 
       # ── Node.js ──
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 24
 
@@ -607,7 +607,7 @@ jobs:
           git diff -- Cargo.toml Cargo.lock
 
       - name: Rust cache
-        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           workspaces: 'studio/src-tauri -> target'
 
@@ -696,7 +696,7 @@ jobs:
       - name: Build Linux app
         id: build_linux
         if: matrix.platform == 'ubuntu-22.04'
-        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5  # v0.6.2
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -710,7 +710,7 @@ jobs:
       - name: Build macOS app
         id: build_macos
         if: matrix.platform == 'macos-latest'
-        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5  # v0.6.2
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -868,7 +868,7 @@ jobs:
       - name: Build Windows app
         id: build_windows
         if: matrix.platform == 'windows-latest'
-        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5  # v0.6.2
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable @ 2026-03-27
 
-      - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
+      - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           # Save only on main. This action defaults to saving on every ref, and
           # a PR-scoped rust cache (550-840MB here) can only be restored by
@@ -172,7 +172,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable @ 2026-03-27
 
-      - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
+      - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           # Save only on main. This action defaults to saving on every ref, and
           # a PR-scoped rust cache (550-840MB here) can only be restored by


### PR DESCRIPTION
Three of the four `swatinem/rust-cache` pins were on `e18b497796c12c097a38f9edb9d0641fb99eee32` with the comment `# v2.9.1`.

**That commit is not v2.9.1.** It is an untagged commit pushed 17 seconds after the tag (`update changelog, not sure why npm suddenly does not commit this`). The real v2.9.1 is `c19371144df3bb44fab255c43d04cbc2ab54d1c4`, which `security-audit.yml` was already using.

To be clear about severity: **nothing was compromised.** It is a legitimate upstream commit and the two differ only by a changelog file. But a SHA pin whose comment names a version it is not defeats the point of the convention. The comment is the only human-readable part of the pin, so anyone auditing, reviewing, or bumping these reads it instead of resolving the hash. All four now agree.

## Also in this PR

Six pins in `release-desktop.yml` carried no version comment at all (`checkout` x2, `setup-node`, `tauri-action` x3). Added, so every SHA pin in the repo is labelled.

## How this was verified

Rather than eyeballing, I resolved **every** pinned SHA in every workflow against the upstream tag list via `gh api repos/<owner>/<repo>/tags`. Result: 13 actions checked, and no pin now claims a version that does not resolve to it.

The one pin still not backed by a tag is `dtolnay/rust-toolchain@29eef336d9`, commented `# stable @ 2026-03-27`. That is a branch pointer by design and is correctly documented as such, so it is left alone.

## Scope

**No version is upgraded here.** v2.9.2 exists; moving to it is a separate decision. Existing Rust caches are **not** invalidated. I checked the action source rather than assuming: the cache key is built from a hardcoded literal (`let key = core.getInput("prefix-key") || "v0-rust";`, `src/config.ts:74`), with no `CACHE_VERSION` constant and no reference to `package.json`. That line is byte-identical at both SHAs, and `git diff c1937114 e18b4977` is 4 added lines of `CHANGELOG.md` and nothing else, so the two commits are indistinguishable as an executable action.

Two other pin outliers were deliberately **not** changed:

- `lockfile-audit.yml` uses `checkout` v7.0.0 and `setup-python` v6.3.0 where the rest of the repo is on v6.0.2 / v6.2.0. Those are *newer*, not stale, so converging them on the majority would be a downgrade. Bumping the other 76 call sites to v7 is a real change with its own risk and belongs in its own PR.
- `ossf.yml` is the vendored upstream OpenSSF Scorecard starter workflow and tracks the pins that project ships. Diverging from it locally would make future upstream syncs noisier.
