### PR TITLE
Studio: make the fp8 smoke probe catch a missing activation scale floor

### DIFF
--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -271,16 +271,17 @@ def _smoke_probe(scheme: str, device: str) -> bool:
     prototype kernel: it fails here and the ladder moves on, rather than crashing at the first
     real denoise step.
 
-    Half the probe input is all-zero rows, and the result is checked for finiteness, because a
-    kernel that runs is not the same as a kernel that is usable. Per-row dynamic activation
-    scaling divides by each row's amax, so an all-zero row yields scale 0 and NaN qdata unless
-    the config floors it (fp8's ``activation_value_lb``). That floor is applied only when the
-    installed torchao exposes the kwarg, and a build without it degrades SILENTLY: random probe
-    input has no zero row, so the probe passed and fp8 engaged. Padded text streams then hit it
-    for real -- Wan pads every prompt to 512 tokens, so the trailing rows entering
-    ``condition_embedder`` are exactly zero and every frame renders black. Measured on B200,
-    4096-wide Linear, 412 of 512 rows non-finite with the floor removed and 0 of 512 with it.
-    Failing here instead costs one ladder step down to int8."""
+    Half the input is all-zero rows and the output is checked for finiteness, because a kernel
+    that runs is not the same as one that is usable. torchao's ``_choose_scale_float8`` has no
+    eps clamp, so a zero row yields scale 0 and NaN qdata; that is the root cause behind
+    qwen-image's fp8 black frames (its txt stream emits all-zero token rows through a set of
+    ``txt_mlp.net.2`` linears that changes run to run, which is why keeping a fixed subset bf16
+    does not fix it). ``_make_quant_config`` floors it with ``activation_value_lb``, but only
+    when the installed torchao exposes that kwarg, and without a zero row the probe passed on a
+    build lacking it. Zero rows are not exotic: every Wan pipeline pads prompt embeddings with
+    ``new_zeros`` out to 226 or 512, so the tail rows reaching the DiT are exactly zero.
+    Measured on B200, 4096-wide Linear: 412 of 512 rows non-finite without the floor, 0 of 512
+    with it. Failing here costs one ladder step down to int8 instead."""
     key = (scheme, device)
     if key in _SMOKE_CACHE:
         return _SMOKE_CACHE[key]

--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -266,9 +266,21 @@ def _scheme_supported(scheme: str, device: str) -> bool:
 
 
 def _smoke_probe(scheme: str, device: str) -> bool:
-    """True iff a tiny Linear quantised with ``scheme`` runs one M=32 forward. Cached per
-    (scheme, device). Makes ``auto`` robust to a build lacking a prototype kernel: it fails
-    here and the ladder moves on, rather than crashing at the first real denoise step."""
+    """True iff a tiny Linear quantised with ``scheme`` runs one M=32 forward and returns
+    finite values. Cached per (scheme, device). Makes ``auto`` robust to a build lacking a
+    prototype kernel: it fails here and the ladder moves on, rather than crashing at the first
+    real denoise step.
+
+    Half the probe input is all-zero rows, and the result is checked for finiteness, because a
+    kernel that runs is not the same as a kernel that is usable. Per-row dynamic activation
+    scaling divides by each row's amax, so an all-zero row yields scale 0 and NaN qdata unless
+    the config floors it (fp8's ``activation_value_lb``). That floor is applied only when the
+    installed torchao exposes the kwarg, and a build without it degrades SILENTLY: random probe
+    input has no zero row, so the probe passed and fp8 engaged. Padded text streams then hit it
+    for real -- Wan pads every prompt to 512 tokens, so the trailing rows entering
+    ``condition_embedder`` are exactly zero and every frame renders black. Measured on B200,
+    4096-wide Linear, 412 of 512 rows non-finite with the floor removed and 0 of 512 with it.
+    Failing here instead costs one ladder step down to int8."""
     key = (scheme, device)
     if key in _SMOKE_CACHE:
         return _SMOKE_CACHE[key]
@@ -279,11 +291,13 @@ def _smoke_probe(scheme: str, device: str) -> bool:
 
         lin = torch.nn.Linear(512, 512, bias = False).to(device = device, dtype = torch.bfloat16)
         quantize_(lin, _make_quant_config(scheme), filter_fn = make_filter_fn(0))
+        # M stays 32 (scaled_mm wants 16-aligned dims); the zero rows go inside it, not after it.
         x = torch.randn(32, 512, device = device, dtype = torch.bfloat16)
+        x[16:] = 0
         with torch.no_grad():
-            lin(x)
+            out = lin(x)
         torch.cuda.synchronize()
-        ok = True
+        ok = bool(torch.isfinite(out).all().item())
     except Exception:
         ok = False
     _SMOKE_CACHE[key] = ok

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -268,11 +268,10 @@ def test_smoke_probe_caches_and_tolerates_failure(monkeypatch):
     tqz.quantize_ = _quantize_boom
     assert tq._smoke_probe(TQ_FP8, "cuda") is False
 
-    # A kernel that RUNS but returns non-finite values probes False too. That is the whole point
-    # of checking finiteness: fp8's per-row activation scale divides by the row amax, so an
-    # all-zero row gives scale 0 and NaN qdata unless the config floors it, and the floor is
-    # applied only on a torchao exposing activation_value_lb. Without this the probe passed on
-    # such a build and every padded text stream (Wan pads prompts to 512 tokens) rendered black.
+    # A kernel that RUNS but returns non-finite values probes False too. torchao's fp8 scale
+    # chooser has no eps clamp, so a zero activation row gives scale 0 and NaN qdata unless the
+    # config floors it, and the floor is applied only on a torchao exposing activation_value_lb.
+    # Without this the probe passed on such a build and every zero-padded text stream went black.
     # int8, not fp8: _make_quant_config(fp8) imports PerRow, which this stub module does not
     # carry, so an fp8 probe here would return False from the ImportError and prove nothing.
     tq._SMOKE_CACHE.clear()

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -193,9 +193,31 @@ def test_scheme_supported_shortcircuits(monkeypatch):
     assert tq._scheme_supported(TQ_FP8, "cuda") is False
 
 
+class _FakeTensor:
+    """Records the probe's zero-row write so the assertion below can check it happened."""
+
+    def __init__(self):
+        self.zeroed = []
+
+    def __setitem__(self, key, value):
+        self.zeroed.append((key, value))
+
+
+class _FakeBool:
+    def __init__(self, value):
+        self.value = value
+
+    def all(self):
+        return self
+
+    def item(self):
+        return self.value
+
+
 def test_smoke_probe_caches_and_tolerates_failure(monkeypatch):
     tq._SMOKE_CACHE.clear()
     calls = {"n": 0}
+    finite = {"ok": True}
 
     class _Lin:
         def __init__(self, *a, **k):
@@ -207,7 +229,8 @@ def test_smoke_probe_caches_and_tolerates_failure(monkeypatch):
     torch = types.ModuleType("torch")
     torch.bfloat16 = "bfloat16"
     torch.nn = types.SimpleNamespace(Linear = _Lin)
-    torch.randn = lambda *a, **k: object()
+    torch.randn = lambda *a, **k: _FakeTensor()
+    torch.isfinite = lambda t: _FakeBool(finite["ok"])
     torch.no_grad = lambda: __import__("contextlib").nullcontext()
     torch.cuda = types.SimpleNamespace(is_available = lambda: True, synchronize = lambda: None)
     monkeypatch.setitem(sys.modules, "torch", torch)
@@ -244,6 +267,55 @@ def test_smoke_probe_caches_and_tolerates_failure(monkeypatch):
 
     tqz.quantize_ = _quantize_boom
     assert tq._smoke_probe(TQ_FP8, "cuda") is False
+
+    # A kernel that RUNS but returns non-finite values probes False too. That is the whole point
+    # of checking finiteness: fp8's per-row activation scale divides by the row amax, so an
+    # all-zero row gives scale 0 and NaN qdata unless the config floors it, and the floor is
+    # applied only on a torchao exposing activation_value_lb. Without this the probe passed on
+    # such a build and every padded text stream (Wan pads prompts to 512 tokens) rendered black.
+    # int8, not fp8: _make_quant_config(fp8) imports PerRow, which this stub module does not
+    # carry, so an fp8 probe here would return False from the ImportError and prove nothing.
+    tq._SMOKE_CACHE.clear()
+    tqz.quantize_ = _quantize_ok
+    finite["ok"] = False
+    assert tq._smoke_probe(TQ_INT8, "cuda") is False
+
+
+def test_the_smoke_probe_feeds_zero_rows_not_only_noise(monkeypatch):
+    # The finiteness check above is only meaningful if the input actually contains a zero row:
+    # torch.randn alone never produces one, which is exactly how the silent degradation survived.
+    tq._SMOKE_CACHE.clear()
+    seen = {}
+
+    class _Lin:
+        def __init__(self, *a, **k):
+            pass
+
+        def to(self, **k):
+            return self
+
+        def __call__(self, x):
+            seen["x"] = x
+            return x
+
+    torch = types.ModuleType("torch")
+    torch.bfloat16 = "bfloat16"
+    torch.nn = types.SimpleNamespace(Linear = _Lin)
+    torch.randn = lambda *a, **k: _FakeTensor()
+    torch.isfinite = lambda t: _FakeBool(True)
+    torch.no_grad = lambda: __import__("contextlib").nullcontext()
+    torch.cuda = types.SimpleNamespace(is_available = lambda: True, synchronize = lambda: None)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    tqz = types.ModuleType("torchao.quantization")
+    tqz.quantize_ = lambda module, config, filter_fn = None: None
+    tqz.Int8DynamicActivationInt8WeightConfig = lambda: "int8cfg"
+    tqz.Float8DynamicActivationFloat8WeightConfig = lambda: "fp8cfg"
+    monkeypatch.setitem(sys.modules, "torchao.quantization", tqz)
+
+    assert tq._smoke_probe(TQ_INT8, "cuda") is True
+    assert seen["x"].zeroed, "probe input was never zeroed anywhere"
+    assert all(value == 0 for _, value in seen["x"].zeroed)
 
 
 # ── consumer-vs-datacenter detection (fp8 fast-accumulate gate) ──────────────────


### PR DESCRIPTION
### The gap

`_smoke_probe` in `diffusion_transformer_quant.py` is what decides whether `auto` engages fp8 or steps down the ladder to int8, and whether an explicit `transformer_quant: fp8` is honored or falls back to GGUF. It fed the probe Linear only `torch.randn`, so it never saw an all-zero activation row.

torchao's `_choose_scale_float8` has no eps clamp, so a zero activation row yields scale 0 and NaN qdata. That is the root cause behind qwen-image's fp8 black frames: its text stream emits all-zero token rows through a set of `txt_mlp.net.2` linears that changes run to run, which is also why keeping a fixed subset in bf16 does not fix it. `_make_quant_config` floors it:

```python
if "activation_value_lb" in config_params:
    fp8_kwargs["activation_value_lb"] = 1e-12
```

but only when the installed torchao exposes the kwarg. A build without it degrades in silence: random probe input has no zero row, the probe passes, fp8 engages, and the failure surfaces at the first real denoise instead.

Zero rows are not exotic. Every Wan pipeline pads prompt embeddings with `new_zeros` out to `max_sequence_length` (226 in `WanPipeline` / `WanVACEPipeline` / `WanVideoToVideoPipeline`, 512 in `WanImageToVideoPipeline` / `WanAnimatePipeline`), so the tail rows reaching the DiT are exactly zero.

### Measured

The floor's effect on real renders, qwen-image at 512px, seed 1234, 20 steps, LPIPS against dense bf16:

| config | first non-finite | black | LPIPS |
| --- | --- | --- | --- |
| plain fp8 | `blocks.5.txt_mlp.net.2` | yes | 0.712 / 0.652 |
| `activation_value_lb = 1e-12` | none | no | 0.062 / 0.048 |
| keep 35 observed zero-row linears bf16 | `blocks.27.txt_mlp.net.2` | yes | 0.712 / 0.652 |
| keep top-32 by absmax bf16 | `blocks.5.txt_mlp.net.2` | yes | 0.712 / 0.652 |

And the isolated mechanism this PR probes for, on a B200, 4096-wide bf16 Linear, 512 rows with 412 of them zeroed, quantised through `_make_quant_config("fp8")`:

| config | non-finite output rows |
| --- | --- |
| `activation_value_lb = 1e-12` (as shipped) | 0 / 512 |
| floor removed | 412 / 512 |

### The change

The probe now zeroes half its input and checks `torch.isfinite` on the result. M stays 32, since `scaled_mm` wants 16-aligned dims, so the zero rows go inside the batch rather than extending it. A config that cannot survive a zero row now fails where the existing machinery already knows what to do with a failure: `auto` moves one step down to int8, an explicit request returns `None` and loads GGUF.

The check is deliberately generic rather than a version test on torchao. It catches any scale-floor failure, not only this one kwarg going missing.

On torchao 0.17.0 (which does carry `activation_value_lb`) int8, fp8, mxfp8 and nvfp4 all still probe `True`; fp8 probes `False` once the floor is stripped.

### Tests

- `test_smoke_probe_caches_and_tolerates_failure` extended: a kernel that runs but returns non-finite values now probes `False`.
- `test_the_smoke_probe_feeds_zero_rows_not_only_noise` added, because the finiteness check is only worth anything if the input actually contains a zero row. `torch.randn` alone never produces one, which is exactly how the silent degradation survived.
- `studio/backend/tests/test_diffusion_transformer_quant.py` 49 passed.
- `tests/ -k "quant or video or diffusion"` 1764 passed, 1 failed. The failure is `test_openai_auto_download.py::test_a_quant_request_is_not_satisfied_by_transformers_weights`, which fails identically on a worktree without this change.
- `hub/tests/` 172 passed as a separate invocation.
- `ruff check` clean.
