### PR TITLE
Give the Windows sandbox bash a userland, and honour TEMP/TMP

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -6582,10 +6582,9 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
 
     if sys.platform == "win32":
         sysroot = os.environ.get("SystemRoot", r"C:\Windows")
-        # AHEAD of System32, which ships DOS twins of POSIX names: behind it a
-        # bare `find . -name '*.py'` resolves to FIND.EXE, not GNU find. Still
-        # behind the interpreter dirs above, so a Git-shipped python.exe cannot
-        # shadow the environment this server runs in.
+        # Ahead of System32 and its DOS twins (bare `find` would hit FIND.EXE,
+        # not GNU find), behind the interpreter dirs so a Git-shipped
+        # python.exe cannot shadow the environment this server runs in.
         path_entries.extend(_windows_bash_userland_dirs())
         path_entries.extend([os.path.join(sysroot, "System32"), sysroot])
     else:
@@ -6626,9 +6625,8 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Windows needs SystemRoot for Python/subprocess to work.
     if sys.platform == "win32":
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
-        # Windows tempfile / native SDKs honour TEMP/TMP, not TMPDIR, so without
-        # these a program launched from the sandbox falls back to GetTempPath and
-        # writes outside the workdir. _build_bypass_env already sets all three.
+        # Windows tempfile / native SDKs honour TEMP/TMP, not TMPDIR; without
+        # these a child falls back to GetTempPath and writes outside the workdir.
         env["TEMP"] = workdir
         env["TMP"] = workdir
         # Restrict PATHEXT so cwd .BAT/.CMD cannot hijack bare names (#7317).
@@ -6994,9 +6992,9 @@ def _windows_bash_userland_dirs() -> list[str]:
 
     ``bash -c`` is non-login, so /etc/profile never runs and Git for Windows'
     ``usr\\bin`` stays off PATH, leaving ls / cat / grep "command not found".
-    bash.exe ships under ``Git\\bin`` and ``Git\\usr\\bin``, so both parents are
-    probed. Every candidate clears the same Program Files trust boundary as the
-    git entry (#7317) and is canonicalised against junctions. Fails closed: no
+    bash.exe ships under ``Git\\bin`` or ``Git\\usr\\bin``, so both parents are
+    probed. Candidates clear the same Program Files trust boundary as the git
+    entry (#7317) and are canonicalised against junctions. Fails closed: no
     trusted bash, no entries, PATH unchanged.
     """
     bash = _windows_bash()

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -6582,6 +6582,11 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
 
     if sys.platform == "win32":
         sysroot = os.environ.get("SystemRoot", r"C:\Windows")
+        # AHEAD of System32, which ships DOS twins of POSIX names: behind it a
+        # bare `find . -name '*.py'` resolves to FIND.EXE, not GNU find. Still
+        # behind the interpreter dirs above, so a Git-shipped python.exe cannot
+        # shadow the environment this server runs in.
+        path_entries.extend(_windows_bash_userland_dirs())
         path_entries.extend([os.path.join(sysroot, "System32"), sysroot])
     else:
         path_entries.extend(["/usr/local/bin", "/usr/bin", "/bin"])
@@ -6621,6 +6626,11 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Windows needs SystemRoot for Python/subprocess to work.
     if sys.platform == "win32":
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
+        # Windows tempfile / native SDKs honour TEMP/TMP, not TMPDIR, so without
+        # these a program launched from the sandbox falls back to GetTempPath and
+        # writes outside the workdir. _build_bypass_env already sets all three.
+        env["TEMP"] = workdir
+        env["TMP"] = workdir
         # Restrict PATHEXT so cwd .BAT/.CMD cannot hijack bare names (#7317).
         pathext = ".EXE;.COM"
         if git_ext and git_ext not in (".EXE", ".COM"):
@@ -6977,6 +6987,34 @@ def _windows_bash() -> "str | None":
         if os.path.isfile(candidate) and _is_trusted_windows_bash(candidate):
             return candidate
     return None
+
+
+def _windows_bash_userland_dirs() -> list[str]:
+    """Trusted dirs holding the resolved bash and the POSIX tools beside it.
+
+    ``bash -c`` is non-login, so /etc/profile never runs and Git for Windows'
+    ``usr\\bin`` stays off PATH, leaving ls / cat / grep "command not found".
+    bash.exe ships under ``Git\\bin`` and ``Git\\usr\\bin``, so both parents are
+    probed. Every candidate clears the same Program Files trust boundary as the
+    git entry (#7317) and is canonicalised against junctions. Fails closed: no
+    trusted bash, no entries, PATH unchanged.
+    """
+    bash = _windows_bash()
+    if not bash:
+        return []
+    bin_dir = os.path.dirname(bash)
+    candidates = [bin_dir]
+    for root in (os.path.dirname(bin_dir), os.path.dirname(os.path.dirname(bin_dir))):
+        if root:
+            candidates.append(os.path.join(root, "usr", "bin"))
+    dirs: list[str] = []
+    for candidate in candidates:
+        if not os.path.isdir(candidate) or not _is_trusted_windows_program_dir(candidate):
+            continue
+        real = os.path.realpath(candidate)
+        if real not in dirs:
+            dirs.append(real)
+    return dirs
 
 
 def _shell_is_posix() -> bool:

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -311,7 +311,13 @@ class TestSandboxEnvIsolation:
         assert env["PYTHONPATH"].endswith("sandbox_site")
         assert "leak-me" not in env["PYTHONPATH"]
 
-    def _trusted_git_bash(self, monkeypatch, tmp_path, *, usr_bin = True):
+    def _trusted_git_bash(
+        self,
+        monkeypatch,
+        tmp_path,
+        *,
+        usr_bin = True,
+    ):
         """Lay out a Program Files Git install and point the resolvers at it."""
         import core.inference.tools as tools_mod
 
@@ -350,7 +356,9 @@ class TestSandboxEnvIsolation:
         from core.inference.tools import _build_safe_env, _windows_bash_userland_dirs
 
         monkeypatch.setattr(sys, "platform", "win32")
-        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(tmp_path / "Program Files")])
+        monkeypatch.setattr(
+            tools_mod, "_windows_program_roots", lambda: [str(tmp_path / "Program Files")]
+        )
         shim = tmp_path / "scoop" / "shims"
         shim.mkdir(parents = True)
         monkeypatch.setattr(tools_mod, "_windows_bash", lambda: str(shim / "bash.exe"))

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -300,6 +300,8 @@ class TestSandboxEnvIsolation:
             "SystemRoot",
             "PATHEXT",  # Windows only; minimal list so cwd scripts cannot hijack
             "NoDefaultCurrentDirectoryInExePath",  # Windows only; no cwd-first lookup
+            "TEMP",  # Windows only; native programs honour these, not TMPDIR
+            "TMP",  # Windows only; native programs honour these, not TMPDIR
         }
         extras = set(env.keys()) - allowed
         assert not extras, f"sandbox env added unexpected keys: {extras}"
@@ -308,6 +310,86 @@ class TestSandboxEnvIsolation:
         # sitecustomize shim dir (code-interpreter path remap).
         assert env["PYTHONPATH"].endswith("sandbox_site")
         assert "leak-me" not in env["PYTHONPATH"]
+
+    def _trusted_git_bash(self, monkeypatch, tmp_path, *, usr_bin = True):
+        """Lay out a Program Files Git install and point the resolvers at it."""
+        import core.inference.tools as tools_mod
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        prog = tmp_path / "Program Files"
+        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(prog)])
+        bin_dir = prog / "Git" / "bin"
+        bin_dir.mkdir(parents = True)
+        if usr_bin:
+            (prog / "Git" / "usr" / "bin").mkdir(parents = True)
+        monkeypatch.setattr(tools_mod, "_windows_bash", lambda: str(bin_dir / "bash.exe"))
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: None)
+        return prog, bin_dir
+
+    def test_bash_userland_dirs_precede_system32(self, monkeypatch, tmp_path):
+        # `bash -c` is non-login, so /etc/profile never adds Git's usr\bin and
+        # `ls`/`cat`/`grep` are "command not found". They must also sort AHEAD of
+        # System32, which ships DOS twins (FIND.EXE, SORT.EXE) of POSIX names.
+        from core.inference.tools import _build_safe_env
+
+        prog, bin_dir = self._trusted_git_bash(monkeypatch, tmp_path)
+        usr_bin = prog / "Git" / "usr" / "bin"
+        env = _build_safe_env(str(tmp_path))
+        parts = env["PATH"].split(os.pathsep)
+        assert os.path.realpath(str(bin_dir)) in parts
+        assert os.path.realpath(str(usr_bin)) in parts
+        system32 = [p for p in parts if p.lower().endswith("system32")]
+        assert system32, parts
+        assert parts.index(os.path.realpath(str(usr_bin))) < parts.index(system32[0])
+        # Still behind the interpreter dir, so a Git python.exe cannot shadow
+        # the environment this server runs in.
+        assert parts.index(os.path.realpath(str(bin_dir))) > 0
+
+    def test_untrusted_bash_contributes_no_userland(self, monkeypatch, tmp_path):
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env, _windows_bash_userland_dirs
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(tmp_path / "Program Files")])
+        shim = tmp_path / "scoop" / "shims"
+        shim.mkdir(parents = True)
+        monkeypatch.setattr(tools_mod, "_windows_bash", lambda: str(shim / "bash.exe"))
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: None)
+        assert _windows_bash_userland_dirs() == []
+        assert str(shim) not in _build_safe_env(str(tmp_path))["PATH"].split(os.pathsep)
+
+    def test_no_bash_leaves_path_unchanged(self, monkeypatch, tmp_path):
+        # Fails closed: the cmd fallback host keeps exactly today's PATH.
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env, _windows_bash_userland_dirs
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [])
+        monkeypatch.setattr(tools_mod, "_windows_bash", lambda: None)
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: None)
+        assert _windows_bash_userland_dirs() == []
+        before = _build_safe_env(str(tmp_path))["PATH"]
+        monkeypatch.setattr(tools_mod, "_windows_bash_userland_dirs", lambda: [])
+        assert _build_safe_env(str(tmp_path))["PATH"] == before
+
+    def test_temp_and_tmp_point_at_the_workdir_on_windows(self, monkeypatch, tmp_path):
+        # Windows tempfile / native SDKs read TEMP/TMP, not TMPDIR, so without
+        # these a child writes outside the sandbox workdir.
+        from core.inference.tools import _build_safe_env
+
+        self._trusted_git_bash(monkeypatch, tmp_path)
+        env = _build_safe_env(str(tmp_path))
+        assert env["TEMP"] == str(tmp_path)
+        assert env["TMP"] == str(tmp_path)
+
+    def test_temp_and_tmp_absent_on_posix(self, monkeypatch, tmp_path):
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "linux")
+        env = _build_safe_env(str(tmp_path))
+        assert "TEMP" not in env
+        assert "TMP" not in env
+        assert env["TMPDIR"] == str(tmp_path)
 
     def test_host_git_dir_appended_after_curated(self, monkeypatch, tmp_path):
         # #7317: Windows Git lives under Program Files, not System32. Sandbox

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -582,10 +582,20 @@ class TestSandboxEnvIsolation:
         """When the known-folder API is unavailable, no roots are trusted: env
         vars (even %SystemDrive%) are caller-overrideable, so we never derive a
         trusted root from them."""
+        import ctypes
+
         import core.inference.tools as tools_mod
 
-        # ctypes fails on this Linux host, so the API path raises and we fail
-        # closed. Any attacker override of these env vars must be irrelevant.
+        # Make the API unavailable explicitly. Relying on ctypes.windll being
+        # absent only holds on a non-Windows host, so on Windows this asserted
+        # nothing and failed; the property it names has to be tested on the
+        # platform that has the API.
+        class _NoKnownFolderApi:
+            def __getattr__(self, name):
+                raise OSError("known-folder API unavailable")
+
+        monkeypatch.setattr(ctypes, "windll", _NoKnownFolderApi(), raising = False)
+        # Any attacker override of these env vars must be irrelevant.
         monkeypatch.setenv("ProgramFiles", r"D:\attacker-writable")
         monkeypatch.setenv("ProgramW6432", r"D:\attacker-writable")
         monkeypatch.setenv("SystemDrive", "D:")

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -586,10 +586,9 @@ class TestSandboxEnvIsolation:
 
         import core.inference.tools as tools_mod
 
-        # Make the API unavailable explicitly. Relying on ctypes.windll being
-        # absent only holds on a non-Windows host, so on Windows this asserted
-        # nothing and failed; the property it names has to be tested on the
-        # platform that has the API.
+        # Make the API unavailable explicitly: relying on ctypes.windll being
+        # absent only holds off Windows, where the API exists and this asserted
+        # nothing.
         class _NoKnownFolderApi:
             def __getattr__(self, name):
                 raise OSError("known-folder API unavailable")

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -301,7 +301,7 @@ class TestSandboxEnvIsolation:
             "PATHEXT",  # Windows only; minimal list so cwd scripts cannot hijack
             "NoDefaultCurrentDirectoryInExePath",  # Windows only; no cwd-first lookup
             "TEMP",  # Windows only; native programs honour these, not TMPDIR
-            "TMP",  # Windows only; native programs honour these, not TMPDIR
+            "TMP",
         }
         extras = set(env.keys()) - allowed
         assert not extras, f"sandbox env added unexpected keys: {extras}"
@@ -333,9 +333,8 @@ class TestSandboxEnvIsolation:
         return prog, bin_dir
 
     def test_bash_userland_dirs_precede_system32(self, monkeypatch, tmp_path):
-        # `bash -c` is non-login, so /etc/profile never adds Git's usr\bin and
-        # `ls`/`cat`/`grep` are "command not found". They must also sort AHEAD of
-        # System32, which ships DOS twins (FIND.EXE, SORT.EXE) of POSIX names.
+        # `bash -c` is non-login, so Git's usr\bin never joins PATH (ls/cat/grep
+        # missing) and must sort ahead of System32's DOS twins (FIND.EXE).
         from core.inference.tools import _build_safe_env
 
         prog, bin_dir = self._trusted_git_bash(monkeypatch, tmp_path)
@@ -347,8 +346,7 @@ class TestSandboxEnvIsolation:
         system32 = [p for p in parts if p.lower().endswith("system32")]
         assert system32, parts
         assert parts.index(os.path.realpath(str(usr_bin))) < parts.index(system32[0])
-        # Still behind the interpreter dir, so a Git python.exe cannot shadow
-        # the environment this server runs in.
+        # Still behind the interpreter dir, so a Git python.exe cannot shadow it.
         assert parts.index(os.path.realpath(str(bin_dir))) > 0
 
     def test_untrusted_bash_contributes_no_userland(self, monkeypatch, tmp_path):
@@ -381,8 +379,8 @@ class TestSandboxEnvIsolation:
         assert _build_safe_env(str(tmp_path))["PATH"] == before
 
     def test_temp_and_tmp_point_at_the_workdir_on_windows(self, monkeypatch, tmp_path):
-        # Windows tempfile / native SDKs read TEMP/TMP, not TMPDIR, so without
-        # these a child writes outside the sandbox workdir.
+        # Windows reads TEMP/TMP, not TMPDIR; without them a child writes
+        # outside the sandbox workdir.
         from core.inference.tools import _build_safe_env
 
         self._trusted_git_bash(monkeypatch, tmp_path)


### PR DESCRIPTION
## The gap

#7885 made the terminal resolve a trusted Git-for-Windows `bash.exe`, and the tool description now tells the model "The shell is bash (Git for Windows)". But `bash -c` is non-login, so `/etc/profile` never runs and Git's `usr\bin` never reaches PATH.

`_build_safe_env` builds the win32 PATH from the interpreter dir, `VIRTUAL_ENV\Scripts`, `System32`, `%SystemRoot%` and the trusted git dir. That git dir is `C:\Program Files\Git\cmd` on a stock install, which holds `git.exe`, `git-gui.exe`, `gitk.exe` and nothing else.

So the model writes `ls -la` and gets:

```
bash: ls: command not found
```

Same for `cat`, `grep`, `sed`, `awk`, `head`, `tail`, `cp`, `mv`, `mkdir`, `touch`, `tar`. Only bash builtins, System32, python and git resolve.

#7885's own end-to-end test uses `echo` and a `for` loop, both builtins, so it passes without a userland and cannot see this.

## The change

`_windows_bash_userland_dirs()` resolves the trusted bash and returns its own dir plus the sibling `usr\bin` (bash.exe ships under both `Git\bin` and `Git\usr\bin`, so both parents are probed).

It reuses the existing trust model rather than adding one: every candidate clears the same Program Files boundary as the git entry via `_is_trusted_windows_program_dir` (#7317), and is `os.path.realpath`'d so a junction cannot retarget it after the check. It fails closed -- no trusted bash, no entries, PATH byte-identical to today.

Ordering is deliberate. The entries sort **ahead of System32**, which ships DOS twins of POSIX names: behind it a bare `find . -name '*.py'` resolves to `FIND.EXE`, not GNU find. They sort **behind the interpreter dirs**, so a Git-shipped `python.exe` cannot shadow the environment this server runs in.

Separately, `TEMP`/`TMP` are now set to the workdir on win32. Windows tempfile and native SDKs read those, not `TMPDIR`, so a child would otherwise fall back to `GetTempPath` and write outside the sandbox. `_build_bypass_env` already sets all three; this brings the two into line.

## Verification

- `tests/test_sandbox_tools.py`: 201 passed, from 196. Four of the five new tests fail against `main`; the fifth (`test_temp_and_tmp_absent_on_posix`) passes there on purpose, pinning that POSIX is untouched.
- New coverage: userland dirs precede System32 and follow the interpreter dir; an untrusted (Scoop-shim) bash contributes nothing; no bash leaves PATH unchanged; `TEMP`/`TMP` set on win32 and absent on POSIX.
- `TEMP`/`TMP` added to the whitelist in `test_sandbox_env_is_minimal_whitelist`, which would otherwise fail on a Windows runner.
- POSIX is a measured no-op: `_find_blocked_commands` verdicts are identical to `main` across 24 ordinary commands, and `_build_safe_env` takes no new branch off win32.
- `ruff check` clean, `scripts/run_ruff_format.py` no drift, pre-push gate PASS.

## Needs a Windows host to confirm end to end

The PATH behaviour cannot be fully exercised from Linux. The tests pin the resolution logic with a faked platform and a faked Program Files root. On a real Windows host with Git for Windows, `ls -la` in the terminal is the one-line check.