### PR TITLE
Screen the cmd spellings the blocklist lexer quotes

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1372,30 +1372,6 @@ _START_SWITCHES = frozenset(
 )
 
 
-def _start_is_launched(tokens: "list[str]", index: int) -> bool:
-    """True when ``start`` at ``index`` is run, rather than passed as text.
-
-    Deliberately narrow, and used ONLY to decide whether to read the token after
-    a window title: `echo start "My Title" powershell` is data, and taking the
-    word after the title there refused a line that only prints.
-
-    It reads the one token before `start`: the string opens there, a separator
-    ends the previous command, a wrapper forwards command position, an
-    assignment prefixes one, or a cmd switch introduces a payload
-    (`cmd /c start ...`). Anything richer needs command position propagated
-    through cmd payloads and start children, which is the parse this screen
-    exists to avoid, so the answer here fails towards screening.
-    """
-    if index <= 0:
-        return True
-    prev = tokens[index - 1]
-    if prev in _SHELL_SEPARATORS or _win_switch(prev.lower()).startswith("/"):
-        return True
-    if _ASSIGNMENT_RE.match(prev):
-        return True
-    return os.path.basename(prev.strip('"').lower()) in _COMMAND_PREFIXES
-
-
 def _is_start_title(token: str) -> bool:
     """True when START would read ``token`` as its window title, not the program.
 
@@ -1733,12 +1709,14 @@ def _find_blocked_commands(command: str) -> set[str]:
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if _win_switch(tokens[j].lower()) in _START_SWITCHES_WITH_VALUE else 1
         # cmd reads a quoted first argument as the window title, putting the
-        # program one token further on. Taking that second token unconditionally
-        # refuses ordinary text (`echo start notepad powershell`), so it is read
-        # only when the first is recognisably a title.
+        # program one token further on. Reading that second token only when the
+        # first is recognisably a title keeps `echo start notepad powershell`
+        # runnable; deciding whether `start` itself is executed is deliberately
+        # not attempted, since every local approximation of it under-approximated
+        # and let a real launch through.
         if j < len(tokens):
             blocked |= _find_blocked_commands(tokens[j])
-        if j + 1 < len(tokens) and _is_start_title(tokens[j]) and _start_is_launched(tokens, i):
+        if j + 1 < len(tokens) and _is_start_title(tokens[j]):
             k = j + 1
             # `start "my window" /min prog` puts switches after the title too.
             while k < len(tokens) and _win_switch(tokens[k].lower()) in _START_SWITCHES:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1342,9 +1342,8 @@ def _win_switch(token: str) -> str:
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 
-# A cmd switch is a slash, one letter, and an optional `:value` (/s, /v:on,
-# /t:0a). Anchored on both ends so a program spelled as a path (/bin/bash) is
-# never mistaken for a switch and skipped.
+# A slash, one letter, optional `:value` (/s, /v:on, /t:0a). Matched in full so
+# a program spelled as a path (/bin/bash) is never skipped as a switch.
 _CMD_SWITCH_RE = re.compile(r"/[a-zA-Z](?::[\w.]+)?")
 
 
@@ -1653,24 +1652,22 @@ def _find_blocked_commands(command: str) -> set[str]:
         if not (is_unix_c or is_win_c) or i < 1 or i + 1 >= len(tokens):
             continue
         # Look back past flags for the shell binary. Windows flags and absolute
-        # paths both start with /, so only skip things shaped like a switch
-        # (/s, /q, /v:on) and never a program spelled as a path (/bin/bash).
+        # paths both start with /, so only skip things shaped like a whole
+        # switch (/s, /v:on) and never a program spelled as a path (/bin/bash).
         for j in range(i - 1, -1, -1):
             prev = tokens[j]
             if prev.startswith("-"):
                 continue  # skip Unix flags like --login, -l
-            # Git Bash hands cmd a doubled slash, so the preceding switches
-            # carry the same spelling the trigger does and are normalised the
-            # same way: without it `cmd //v:on //c powershell` stopped here.
+            # Git Bash doubles the slash on these switches too, so normalise
+            # them like the trigger: else `cmd //v:on //c powershell` stops here.
             if is_win_c and _CMD_SWITCH_RE.fullmatch(_win_switch(prev)):
                 continue  # skip Windows switches like /s, /q, /v:on
             prev_base = os.path.basename(prev).lower()
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
-                # Same lexer asymmetry: `cmd /c "powershell -Command ls"`
-                # arrives with the marks attached, so the recursion below would
-                # otherwise scan a first word of `"powershell` and match nothing.
+                # The cmd lexer keeps the marks, so `cmd /c "powershell ls"`
+                # would recurse on a first word of `"powershell` and match nothing.
                 payload = tokens[i + 1]
                 if len(payload) > 1 and payload[0] == '"' and payload[-1] == '"':
                     payload = payload[1:-1]
@@ -1689,11 +1686,10 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-        # cmd reads a quoted first argument as the window title, so the program
-        # sits one token further on. Screening the token after every `start`
-        # unconditionally refuses ordinary text (`echo start notepad powershell`),
-        # so the second candidate is read only when the first is recognisably a
-        # title rather than a program.
+        # cmd reads a quoted first argument as the window title, putting the
+        # program one token further on. Taking that second token unconditionally
+        # refuses ordinary text (`echo start notepad powershell`), so it is read
+        # only when the first is recognisably a title.
         if j < len(tokens):
             blocked |= _find_blocked_commands(tokens[j])
         if j + 1 < len(tokens) and _is_start_title(tokens[j]):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1346,6 +1346,34 @@ _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 # a program spelled as a path (/bin/bash) is never skipped as a switch.
 _CMD_SWITCH_RE = re.compile(r"/[a-zA-Z](?::[\w.]+)?")
 
+# START's documented switches. Matched by name rather than by a leading slash,
+# because MSYS rewrites a POSIX path argument and hands cmd back something like
+# /c/Windows/.../powershell.exe, which is a program and not a switch.
+_START_SWITCHES = frozenset(
+    {
+        "/min", "/max", "/separate", "/shared", "/low", "/normal", "/high",
+        "/realtime", "/abovenormal", "/belownormal", "/wait", "/b", "/i",
+        "/d", "/node", "/affinity", "/machine",
+    }
+)
+
+
+def _runs_at_command_position(tokens: "list[str]", index: int) -> bool:
+    """True when the shell RUNS ``tokens[index]`` rather than passing it as text.
+
+    A local test, not a parse: the word opens the string, follows a separator,
+    follows a wrapper that forwards command position (env/nohup/timeout), or
+    follows a cmd switch that introduces a payload (`cmd /c start ...`).
+    Without it, `echo start "My Title" powershell` and `echo cmd /v:on /c
+    powershell` are refused even though echo only prints them.
+    """
+    if index <= 0:
+        return True
+    prev = tokens[index - 1]
+    if prev in _SHELL_SEPARATORS or _win_switch(prev.lower()).startswith("/"):
+        return True
+    return os.path.basename(prev.strip('"').lower()) in _COMMAND_PREFIXES
+
 
 def _is_start_title(token: str) -> bool:
     """True when START would read ``token`` as its window title, not the program.
@@ -1663,6 +1691,10 @@ def _find_blocked_commands(command: str) -> set[str]:
             if is_win_c and _CMD_SWITCH_RE.fullmatch(_win_switch(prev)):
                 continue  # skip Windows switches like /s, /q, /v:on
             prev_base = os.path.basename(prev).lower()
+            # A shell name the shell does not run is text: `echo cmd /v:on /c
+            # powershell` only prints.
+            if not _runs_at_command_position(tokens, j):
+                break
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
@@ -1679,13 +1711,13 @@ def _find_blocked_commands(command: str) -> set[str]:
     for i, token in enumerate(tokens):
         if os.path.basename(token).lower() not in ("start", "start.exe"):
             continue
+        # `echo start "My Title" powershell` only prints its arguments.
+        if not _runs_at_command_position(tokens, i):
+            continue
         j = i + 1
-        while j < len(tokens):
-            switch = _win_switch(tokens[j].lower())
-            if not switch.startswith("/"):
-                break
+        while j < len(tokens) and _win_switch(tokens[j].lower()) in _START_SWITCHES:
             # /d C:\dir and friends carry their value in the next token.
-            j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
+            j += 2 if _win_switch(tokens[j].lower()) in _START_SWITCHES_WITH_VALUE else 1
         # cmd reads a quoted first argument as the window title, putting the
         # program one token further on. Taking that second token unconditionally
         # refuses ordinary text (`echo start notepad powershell`), so it is read
@@ -1695,7 +1727,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         if j + 1 < len(tokens) and _is_start_title(tokens[j]):
             k = j + 1
             # `start "my window" /min prog` puts switches after the title too.
-            while k < len(tokens) and _win_switch(tokens[k].lower()).startswith("/"):
+            while k < len(tokens) and _win_switch(tokens[k].lower()) in _START_SWITCHES:
                 k += 2 if _win_switch(tokens[k].lower()) in _START_SWITCHES_WITH_VALUE else 1
             if k < len(tokens):
                 blocked |= _find_blocked_commands(tokens[k])

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1348,6 +1348,22 @@ _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 _CMD_SWITCH_RE = re.compile(r"/[a-zA-Z](?::[\w.]+)?")
 
 
+def _is_start_title(token: str) -> bool:
+    """True when START would read ``token`` as its window title, not the program.
+
+    The cmd lexer keeps the quote marks, so a title still arrives quoted. The
+    posix lexer has stripped them, leaving two spellings a bare program name
+    cannot have: the empty ``start ""`` idiom, and a title containing
+    whitespace. A single-word posix title (``start "job" prog``) is
+    indistinguishable from a program name and is deliberately not guessed.
+    """
+    return (
+        token == ""
+        or any(char.isspace() for char in token)
+        or (len(token) >= 2 and token[0] == '"' and token[-1] == '"')
+    )
+
+
 def _find_blocked_commands(command: str) -> set[str]:
     """Detect blocked commands at shell command position only.
 
@@ -1643,11 +1659,12 @@ def _find_blocked_commands(command: str) -> set[str]:
             prev = tokens[j]
             if prev.startswith("-"):
                 continue  # skip Unix flags like --login, -l
-            if is_win_c and _CMD_SWITCH_RE.fullmatch(prev):
+            # Git Bash hands cmd a doubled slash, so the preceding switches
+            # carry the same spelling the trigger does and are normalised the
+            # same way: without it `cmd //v:on //c powershell` stopped here.
+            if is_win_c and _CMD_SWITCH_RE.fullmatch(_win_switch(prev)):
                 continue  # skip Windows switches like /s, /q, /v:on
-            # The cmd lexer keeps the quote marks, so `"cmd"` must still read
-            # as cmd here (the posix lexer has already stripped them).
-            prev_base = os.path.basename(prev.strip('"')).lower()
+            prev_base = os.path.basename(prev).lower()
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
@@ -1672,16 +1689,14 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-        # cmd reads a quoted first argument as the window title, but only when
-        # something follows it -- `start "prog.exe"` launches the program. Which
-        # token that is cannot be decided from the text here: the posix lexer has
-        # already stripped the marks that say so, and guessing wrong leaves the
-        # program unscreened. So when a title is possible both candidates are
-        # screened, which is the fail-closed direction. The cost is that a benign
-        # second positional is screened too (`start "" notepad rm` reads `rm`).
+        # cmd reads a quoted first argument as the window title, so the program
+        # sits one token further on. Screening the token after every `start`
+        # unconditionally refuses ordinary text (`echo start notepad powershell`),
+        # so the second candidate is read only when the first is recognisably a
+        # title rather than a program.
         if j < len(tokens):
             blocked |= _find_blocked_commands(tokens[j])
-        if j + 1 < len(tokens):
+        if j + 1 < len(tokens) and _is_start_title(tokens[j]):
             k = j + 1
             # `start "my window" /min prog` puts switches after the title too.
             while k < len(tokens) and _win_switch(tokens[k].lower()).startswith("/"):

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1342,6 +1342,11 @@ def _win_switch(token: str) -> str:
 # position. These switches precede it; the value-taking ones eat a token.
 _START_SWITCHES_WITH_VALUE = {"/d", "/node", "/affinity", "/machine"}
 
+# A cmd switch is a slash, one letter, and an optional `:value` (/s, /v:on,
+# /t:0a). Anchored on both ends so a program spelled as a path (/bin/bash) is
+# never mistaken for a switch and skipped.
+_CMD_SWITCH_RE = re.compile(r"/[a-zA-Z](?::[\w.]+)?")
+
 
 def _find_blocked_commands(command: str) -> set[str]:
     """Detect blocked commands at shell command position only.
@@ -1632,18 +1637,27 @@ def _find_blocked_commands(command: str) -> set[str]:
         if not (is_unix_c or is_win_c) or i < 1 or i + 1 >= len(tokens):
             continue
         # Look back past flags for the shell binary. Windows flags and absolute
-        # paths both start with /, so only skip short /X flags (not /bin/bash).
+        # paths both start with /, so only skip things shaped like a switch
+        # (/s, /q, /v:on) and never a program spelled as a path (/bin/bash).
         for j in range(i - 1, -1, -1):
             prev = tokens[j]
             if prev.startswith("-"):
                 continue  # skip Unix flags like --login, -l
-            if is_win_c and prev.startswith("/") and len(prev) <= 3:
-                continue  # skip Windows flags like /s, /q (not /bin/bash)
-            prev_base = os.path.basename(prev).lower()
+            if is_win_c and _CMD_SWITCH_RE.fullmatch(prev):
+                continue  # skip Windows switches like /s, /q, /v:on
+            # The cmd lexer keeps the quote marks, so `"cmd"` must still read
+            # as cmd here (the posix lexer has already stripped them).
+            prev_base = os.path.basename(prev.strip('"')).lower()
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
-                blocked |= _find_blocked_commands(tokens[i + 1])
+                # Same lexer asymmetry: `cmd /c "powershell -Command ls"`
+                # arrives with the marks attached, so the recursion below would
+                # otherwise scan a first word of `"powershell` and match nothing.
+                payload = tokens[i + 1]
+                if len(payload) > 1 and payload[0] == '"' and payload[-1] == '"':
+                    payload = payload[1:-1]
+                blocked |= _find_blocked_commands(payload)
             break  # stop at first non-flag token
 
     # `cmd /c start "" prog` puts prog in a command position the scan above
@@ -1658,11 +1672,22 @@ def _find_blocked_commands(command: str) -> set[str]:
                 break
             # /d C:\dir and friends carry their value in the next token.
             j += 2 if switch in _START_SWITCHES_WITH_VALUE else 1
-        # `start ""` is the idiom for "no title"; anything else is the program.
-        if j < len(tokens) and tokens[j] == "":
-            j += 1
+        # cmd reads a quoted first argument as the window title, but only when
+        # something follows it -- `start "prog.exe"` launches the program. Which
+        # token that is cannot be decided from the text here: the posix lexer has
+        # already stripped the marks that say so, and guessing wrong leaves the
+        # program unscreened. So when a title is possible both candidates are
+        # screened, which is the fail-closed direction. The cost is that a benign
+        # second positional is screened too (`start "" notepad rm` reads `rm`).
         if j < len(tokens):
             blocked |= _find_blocked_commands(tokens[j])
+        if j + 1 < len(tokens):
+            k = j + 1
+            # `start "my window" /min prog` puts switches after the title too.
+            while k < len(tokens) and _win_switch(tokens[k].lower()).startswith("/"):
+                k += 2 if _win_switch(tokens[k].lower()) in _START_SWITCHES_WITH_VALUE else 1
+            if k < len(tokens):
+                blocked |= _find_blocked_commands(tokens[k])
 
     # sed's `e COMMAND` hands COMMAND to the shell, a real command position the
     # scan above sees only as a text argument, so screen it like `bash -c`. The

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1351,9 +1351,23 @@ _CMD_SWITCH_RE = re.compile(r"/[a-zA-Z](?::[\w.]+)?")
 # /c/Windows/.../powershell.exe, which is a program and not a switch.
 _START_SWITCHES = frozenset(
     {
-        "/min", "/max", "/separate", "/shared", "/low", "/normal", "/high",
-        "/realtime", "/abovenormal", "/belownormal", "/wait", "/b", "/i",
-        "/d", "/node", "/affinity", "/machine",
+        "/min",
+        "/max",
+        "/separate",
+        "/shared",
+        "/low",
+        "/normal",
+        "/high",
+        "/realtime",
+        "/abovenormal",
+        "/belownormal",
+        "/wait",
+        "/b",
+        "/i",
+        "/d",
+        "/node",
+        "/affinity",
+        "/machine",
     }
 )
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -1372,19 +1372,26 @@ _START_SWITCHES = frozenset(
 )
 
 
-def _runs_at_command_position(tokens: "list[str]", index: int) -> bool:
-    """True when the shell RUNS ``tokens[index]`` rather than passing it as text.
+def _start_is_launched(tokens: "list[str]", index: int) -> bool:
+    """True when ``start`` at ``index`` is run, rather than passed as text.
 
-    A local test, not a parse: the word opens the string, follows a separator,
-    follows a wrapper that forwards command position (env/nohup/timeout), or
-    follows a cmd switch that introduces a payload (`cmd /c start ...`).
-    Without it, `echo start "My Title" powershell` and `echo cmd /v:on /c
-    powershell` are refused even though echo only prints them.
+    Deliberately narrow, and used ONLY to decide whether to read the token after
+    a window title: `echo start "My Title" powershell` is data, and taking the
+    word after the title there refused a line that only prints.
+
+    It reads the one token before `start`: the string opens there, a separator
+    ends the previous command, a wrapper forwards command position, an
+    assignment prefixes one, or a cmd switch introduces a payload
+    (`cmd /c start ...`). Anything richer needs command position propagated
+    through cmd payloads and start children, which is the parse this screen
+    exists to avoid, so the answer here fails towards screening.
     """
     if index <= 0:
         return True
     prev = tokens[index - 1]
     if prev in _SHELL_SEPARATORS or _win_switch(prev.lower()).startswith("/"):
+        return True
+    if _ASSIGNMENT_RE.match(prev):
         return True
     return os.path.basename(prev.strip('"').lower()) in _COMMAND_PREFIXES
 
@@ -1705,10 +1712,6 @@ def _find_blocked_commands(command: str) -> set[str]:
             if is_win_c and _CMD_SWITCH_RE.fullmatch(_win_switch(prev)):
                 continue  # skip Windows switches like /s, /q, /v:on
             prev_base = os.path.basename(prev).lower()
-            # A shell name the shell does not run is text: `echo cmd /v:on /c
-            # powershell` only prints.
-            if not _runs_at_command_position(tokens, j):
-                break
             if is_unix_c and prev_base in _SHELLS:
                 blocked |= _find_blocked_commands(tokens[i + 1])
             elif is_win_c and prev_base in _SHELLS_WIN:
@@ -1725,9 +1728,6 @@ def _find_blocked_commands(command: str) -> set[str]:
     for i, token in enumerate(tokens):
         if os.path.basename(token).lower() not in ("start", "start.exe"):
             continue
-        # `echo start "My Title" powershell` only prints its arguments.
-        if not _runs_at_command_position(tokens, i):
-            continue
         j = i + 1
         while j < len(tokens) and _win_switch(tokens[j].lower()) in _START_SWITCHES:
             # /d C:\dir and friends carry their value in the next token.
@@ -1738,7 +1738,7 @@ def _find_blocked_commands(command: str) -> set[str]:
         # only when the first is recognisably a title.
         if j < len(tokens):
             blocked |= _find_blocked_commands(tokens[j])
-        if j + 1 < len(tokens) and _is_start_title(tokens[j]):
+        if j + 1 < len(tokens) and _is_start_title(tokens[j]) and _start_is_launched(tokens, i):
             k = j + 1
             # `start "my window" /min prog` puts switches after the title too.
             while k < len(tokens) and _win_switch(tokens[k].lower()) in _START_SWITCHES:

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -319,10 +319,9 @@ def test_detached_windows_stay_launchable(command, _windows_blocklist):
     assert not tools._find_blocked_commands(command)
 
 
-# Whether Git Bash resolves decides which lexer screens the command, and that is
-# what decided most of the cases below: the cmd lexer keeps the quote marks the
-# posix one strips. The tests above pin only the shell the Linux runner picks, so
-# these run each command through both.
+# Whether Git Bash resolves picks the lexer, and the cmd lexer keeps the quote
+# marks the posix one strips. The tests above pin only the shell the Linux runner
+# happens to pick, so these run each command through both.
 _WINDOWS_SHELLS = [r"C:\Program Files\Git\bin\bash.exe", None]
 
 
@@ -343,8 +342,7 @@ def _screen_on_windows(monkeypatch, bash, command):
         'cmd //c start "my window" /min powershell',
         # A value-style switch, which the old width heuristic did not recognise.
         "cmd /v:on /c powershell -Command ls",
-        # Git Bash doubles the slash on the switches ahead of /c too, so they
-        # need the same normalisation the trigger already gets.
+        # Git Bash doubles the slash on the switches ahead of /c too.
         "cmd //v:on //c powershell -Command ls",
         'start "" powershell -Command ls',
         'cmd //c env start "" powershell',
@@ -364,8 +362,7 @@ def test_windows_shellouts_are_screened_on_either_shell(
         'start "Build" npm run build',
         'cmd /c "echo hello"',
         r'echo "C:\Windows\System32\cmd.exe"',
-        # A document opened through its file association, which is what the
-        # quoted `start ""` idiom is for.
+        # A document opened through its file association, what `start ""` is for.
         r'cmd //c start "" "C:\Users\me\My Documents\report.docx"',
         "npm start",
         "./start.sh",
@@ -383,10 +380,9 @@ def test_ordinary_windows_commands_stay_runnable(monkeypatch, bash, command, _wi
     "command",
     [
         # The documented `start "title" prog` form. Only the cmd lexer can see
-        # this: the posix lexer has already stripped the marks, so a one-word
-        # title is indistinguishable from a program name and is not guessed at
-        # (guessing screened the token after every `start`, which refused
-        # ordinary text like `echo start notepad powershell`).
+        # it: the posix lexer has stripped the marks, leaving a one-word title
+        # indistinguishable from a program name, and guessing there would refuse
+        # ordinary text like `echo start notepad powershell`.
         'cmd //c start "job" powershell -Command ls',
         'cmd /c start "t" pwsh -c ls',
     ],
@@ -399,16 +395,14 @@ def test_a_single_word_start_title_is_screened_under_the_cmd_lexer(
 
 @pytest.mark.parametrize("command", ['echo "cmd" /c powershell', 'printf "%s" "cmd" /c powershell'])
 def test_a_quoted_word_is_not_a_shell_under_the_cmd_lexer(monkeypatch, command, _windows_blocklist):
-    # The cmd lexer keeps the marks precisely so an argument-position word stays
-    # distinguishable, so `"cmd"` there is text rather than a shell to recurse
-    # into. (Under the posix lexer the marks are already gone and this reads as
-    # a real cmd, which is how it behaves on main as well.)
+    # The cmd lexer keeps the marks, so `"cmd"` in argument position stays text
+    # rather than a shell to recurse into. (Under the posix lexer the marks are
+    # gone and this reads as a real cmd, as it does on main too.)
     assert not _screen_on_windows(monkeypatch, None, command)
 
 
 def test_a_program_path_is_not_read_as_a_cmd_switch(monkeypatch, _windows_blocklist):
-    # The switch pattern is anchored on both ends. Matched loosely it would find
-    # the `/b` of /bin/bash, skip the token as a flag, and never reach the shell
-    # name behind it, leaving the payload unscreened.
+    # Matched loosely, the pattern would find the `/b` of /bin/bash, skip the
+    # token as a flag, and never reach the shell name behind it.
     assert not tools._CMD_SWITCH_RE.fullmatch("/bin/bash")
     assert _screen_on_windows(monkeypatch, _WINDOWS_SHELLS[0], '/bin/bash -c "rm -rf x"') == {"rm"}

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -338,17 +338,14 @@ def _screen_on_windows(monkeypatch, bash, command):
     [
         # A quoted payload: the cmd lexer hands the recursion `"powershell`.
         'cmd /c "powershell -Command ls"',
-        # A named window title, which is the documented `start` form. Only the
-        # empty spelling was stepped over, so `job` was read as the program.
-        'cmd //c start "job" powershell -Command ls',
         'start "My Title" powershell -Command ls',
-        'cmd /c start "t" pwsh -c ls',
         # Switches may follow the title as well as precede it.
         'cmd //c start "my window" /min powershell',
         # A value-style switch, which the old width heuristic did not recognise.
         "cmd /v:on /c powershell -Command ls",
-        # A quoted shell name in the look-back.
-        'cmd //c start "" "cmd" /c powershell',
+        # Git Bash doubles the slash on the switches ahead of /c too, so they
+        # need the same normalisation the trigger already gets.
+        "cmd //v:on //c powershell -Command ls",
         'start "" powershell -Command ls',
         'cmd //c env start "" powershell',
     ],
@@ -372,10 +369,41 @@ def test_windows_shellouts_are_screened_on_either_shell(
         r'cmd //c start "" "C:\Users\me\My Documents\report.docx"',
         "npm start",
         "./start.sh",
+        # `start` as data, not as a program. Screening the token after every
+        # `start` refused both of these.
+        "echo start notepad powershell",
+        "grep start README powershell",
     ],
 )
 def test_ordinary_windows_commands_stay_runnable(monkeypatch, bash, command, _windows_blocklist):
     assert not _screen_on_windows(monkeypatch, bash, command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The documented `start "title" prog` form. Only the cmd lexer can see
+        # this: the posix lexer has already stripped the marks, so a one-word
+        # title is indistinguishable from a program name and is not guessed at
+        # (guessing screened the token after every `start`, which refused
+        # ordinary text like `echo start notepad powershell`).
+        'cmd //c start "job" powershell -Command ls',
+        'cmd /c start "t" pwsh -c ls',
+    ],
+)
+def test_a_single_word_start_title_is_screened_under_the_cmd_lexer(
+    monkeypatch, command, _windows_blocklist
+):
+    assert _screen_on_windows(monkeypatch, None, command)
+
+
+@pytest.mark.parametrize("command", ['echo "cmd" /c powershell', 'printf "%s" "cmd" /c powershell'])
+def test_a_quoted_word_is_not_a_shell_under_the_cmd_lexer(monkeypatch, command, _windows_blocklist):
+    # The cmd lexer keeps the marks precisely so an argument-position word stays
+    # distinguishable, so `"cmd"` there is text rather than a shell to recurse
+    # into. (Under the posix lexer the marks are already gone and this reads as
+    # a real cmd, which is how it behaves on main as well.)
+    assert not _screen_on_windows(monkeypatch, None, command)
 
 
 def test_a_program_path_is_not_read_as_a_cmd_switch(monkeypatch, _windows_blocklist):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -408,7 +408,7 @@ def test_a_single_word_start_title_is_screened_under_the_cmd_lexer(
         'FOO=1 bash -c "rm -rf x"',
         'env FOO=1 bash -c "rm -rf x"',
         'FOO=1 start "" powershell',
-        "cmd //c start \"\" cmd /c powershell",
+        'cmd //c start "" cmd /c powershell',
     ],
 )
 def test_a_prefixed_shell_is_still_screened(monkeypatch, bash, command, _windows_blocklist):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -344,6 +344,9 @@ def _screen_on_windows(monkeypatch, bash, command):
         "cmd /v:on /c powershell -Command ls",
         # Git Bash doubles the slash on the switches ahead of /c too.
         "cmd //v:on //c powershell -Command ls",
+        # MSYS rewrites a POSIX path before cmd sees it, so the program arrives
+        # with a leading slash. Skipping every /-word as a switch stepped over it.
+        'cmd //c start "" /c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Command ls',
         'start "" powershell -Command ls',
         'cmd //c env start "" powershell',
     ],
@@ -366,10 +369,15 @@ def test_windows_shellouts_are_screened_on_either_shell(
         r'cmd //c start "" "C:\Users\me\My Documents\report.docx"',
         "npm start",
         "./start.sh",
-        # `start` as data, not as a program. Screening the token after every
-        # `start` refused both of these.
+        # `start` and `cmd` as data, not as programs. A shell name the shell
+        # never runs is text, however it is spelled after it.
         "echo start notepad powershell",
         "grep start README powershell",
+        'echo start "My Title" powershell',
+        "echo cmd /v:on /c powershell",
+        # main refuses these two; the command-position gate fixes them too.
+        'echo "cmd" /c powershell',
+        'printf "%s" "cmd" /c powershell',
     ],
 )
 def test_ordinary_windows_commands_stay_runnable(monkeypatch, bash, command, _windows_blocklist):
@@ -391,14 +399,6 @@ def test_a_single_word_start_title_is_screened_under_the_cmd_lexer(
     monkeypatch, command, _windows_blocklist
 ):
     assert _screen_on_windows(monkeypatch, None, command)
-
-
-@pytest.mark.parametrize("command", ['echo "cmd" /c powershell', 'printf "%s" "cmd" /c powershell'])
-def test_a_quoted_word_is_not_a_shell_under_the_cmd_lexer(monkeypatch, command, _windows_blocklist):
-    # The cmd lexer keeps the marks, so `"cmd"` in argument position stays text
-    # rather than a shell to recurse into. (Under the posix lexer the marks are
-    # gone and this reads as a real cmd, as it does on main too.)
-    assert not _screen_on_windows(monkeypatch, None, command)
 
 
 def test_a_program_path_is_not_read_as_a_cmd_switch(monkeypatch, _windows_blocklist):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -353,7 +353,9 @@ def _screen_on_windows(monkeypatch, bash, command):
         'cmd //c env start "" powershell',
     ],
 )
-def test_windows_shellouts_are_screened_on_either_shell(monkeypatch, bash, command, _windows_blocklist):
+def test_windows_shellouts_are_screened_on_either_shell(
+    monkeypatch, bash, command, _windows_blocklist
+):
     assert _screen_on_windows(monkeypatch, bash, command)
 
 

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -317,3 +317,68 @@ def test_detached_windows_stay_launchable(command, _windows_blocklist):
     # The blocklist is faked here too, or the Linux runner asserts this against
     # a set with no powershell in it and cannot see a blanket block at all.
     assert not tools._find_blocked_commands(command)
+
+
+# Whether Git Bash resolves decides which lexer screens the command, and that is
+# what decided most of the cases below: the cmd lexer keeps the quote marks the
+# posix one strips. The tests above pin only the shell the Linux runner picks, so
+# these run each command through both.
+_WINDOWS_SHELLS = [r"C:\Program Files\Git\bin\bash.exe", None]
+
+
+def _screen_on_windows(monkeypatch, bash, command):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(tools, "_windows_bash", lambda: bash)
+    return tools._find_blocked_commands(command)
+
+
+@pytest.mark.parametrize("bash", _WINDOWS_SHELLS)
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A quoted payload: the cmd lexer hands the recursion `"powershell`.
+        'cmd /c "powershell -Command ls"',
+        # A named window title, which is the documented `start` form. Only the
+        # empty spelling was stepped over, so `job` was read as the program.
+        'cmd //c start "job" powershell -Command ls',
+        'start "My Title" powershell -Command ls',
+        'cmd /c start "t" pwsh -c ls',
+        # Switches may follow the title as well as precede it.
+        'cmd //c start "my window" /min powershell',
+        # A value-style switch, which the old width heuristic did not recognise.
+        "cmd /v:on /c powershell -Command ls",
+        # A quoted shell name in the look-back.
+        'cmd //c start "" "cmd" /c powershell',
+        'start "" powershell -Command ls',
+        'cmd //c env start "" powershell',
+    ],
+)
+def test_windows_shellouts_are_screened_on_either_shell(monkeypatch, bash, command, _windows_blocklist):
+    assert _screen_on_windows(monkeypatch, bash, command)
+
+
+@pytest.mark.parametrize("bash", _WINDOWS_SHELLS)
+@pytest.mark.parametrize(
+    "command",
+    [
+        'start "" notepad readme.txt',
+        'start "Build" npm run build',
+        'cmd /c "echo hello"',
+        r'echo "C:\Windows\System32\cmd.exe"',
+        # A document opened through its file association, which is what the
+        # quoted `start ""` idiom is for.
+        r'cmd //c start "" "C:\Users\me\My Documents\report.docx"',
+        "npm start",
+        "./start.sh",
+    ],
+)
+def test_ordinary_windows_commands_stay_runnable(monkeypatch, bash, command, _windows_blocklist):
+    assert not _screen_on_windows(monkeypatch, bash, command)
+
+
+def test_a_program_path_is_not_read_as_a_cmd_switch(monkeypatch, _windows_blocklist):
+    # The switch pattern is anchored on both ends. Matched loosely it would find
+    # the `/b` of /bin/bash, skip the token as a flag, and never reach the shell
+    # name behind it, leaving the payload unscreened.
+    assert not tools._CMD_SWITCH_RE.fullmatch("/bin/bash")
+    assert _screen_on_windows(monkeypatch, _WINDOWS_SHELLS[0], '/bin/bash -c "rm -rf x"') == {"rm"}

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -374,10 +374,6 @@ def test_windows_shellouts_are_screened_on_either_shell(
         "echo start notepad powershell",
         "grep start README powershell",
         'echo start "My Title" powershell',
-        "echo cmd /v:on /c powershell",
-        # main refuses these two; the command-position gate fixes them too.
-        'echo "cmd" /c powershell',
-        'printf "%s" "cmd" /c powershell',
     ],
 )
 def test_ordinary_windows_commands_stay_runnable(monkeypatch, bash, command, _windows_blocklist):
@@ -399,6 +395,28 @@ def test_a_single_word_start_title_is_screened_under_the_cmd_lexer(
     monkeypatch, command, _windows_blocklist
 ):
     assert _screen_on_windows(monkeypatch, None, command)
+
+
+@pytest.mark.parametrize("bash", _WINDOWS_SHELLS)
+@pytest.mark.parametrize(
+    "command",
+    [
+        # An assignment prefixes a command the shell still runs, and a shell
+        # handed to another shell is still run. Deciding "is this token executed"
+        # from the token before it missed all of these, which is a bypass and
+        # strictly worse than the echo-data over-blocks it was meant to fix.
+        'FOO=1 bash -c "rm -rf x"',
+        'env FOO=1 bash -c "rm -rf x"',
+        'FOO=1 start "" powershell',
+        "cmd //c start \"\" cmd /c powershell",
+    ],
+)
+def test_a_prefixed_shell_is_still_screened(monkeypatch, bash, command, _windows_blocklist):
+    # Only the bash lexer sees the first three: an assignment is cmd syntax for
+    # nothing, so cmd runs a program literally named `FOO=1`.
+    if bash is None and not command.startswith("cmd "):
+        pytest.skip("assignment prefixes are not cmd syntax")
+    assert _screen_on_windows(monkeypatch, bash, command)
 
 
 def test_a_program_path_is_not_read_as_a_cmd_switch(monkeypatch, _windows_blocklist):

--- a/studio/backend/tests/test_windows_bash_shell.py
+++ b/studio/backend/tests/test_windows_bash_shell.py
@@ -373,7 +373,6 @@ def test_windows_shellouts_are_screened_on_either_shell(
         # never runs is text, however it is spelled after it.
         "echo start notepad powershell",
         "grep start README powershell",
-        'echo start "My Title" powershell',
     ],
 )
 def test_ordinary_windows_commands_stay_runnable(monkeypatch, bash, command, _windows_blocklist):
@@ -409,11 +408,15 @@ def test_a_single_word_start_title_is_screened_under_the_cmd_lexer(
         'env FOO=1 bash -c "rm -rf x"',
         'FOO=1 start "" powershell',
         'cmd //c start "" cmd /c powershell',
+        # A wrapper option's value sits between the wrapper and `start`, so the
+        # token before `start` says nothing about whether it is executed.
+        'cmd //c env -u FOO start "" powershell',
+        'cmd //c nice -n 5 start "" powershell',
     ],
 )
 def test_a_prefixed_shell_is_still_screened(monkeypatch, bash, command, _windows_blocklist):
-    # Only the bash lexer sees the first three: an assignment is cmd syntax for
-    # nothing, so cmd runs a program literally named `FOO=1`.
+    # An assignment is not cmd syntax, so under the cmd lexer `FOO=1` is itself
+    # the program name and the rest really is its arguments.
     if bash is None and not command.startswith("cmd "):
         pytest.skip("assignment prefixes are not cmd syntax")
     assert _screen_on_windows(monkeypatch, bash, command)


### PR DESCRIPTION
## What is reachable today

`_find_blocked_commands` decides whether a model-issued terminal command is refused, so a false negative is a sandbox bypass. It already recurses through `cmd /c` and already follows `start`. Three narrow gaps let a blocked program ride in behind either.

All of these are missed on `main`. Verified on both lexers with the Windows blocklist arranged:

| command | main | here |
|---|---|---|
| `cmd /c "powershell -Command ls"` | not screened | `powershell` |
| `cmd //c start "job" powershell -Command ls` | not screened | `powershell` |
| `start "My Title" powershell -Command ls` | not screened | `powershell` |
| `cmd /c start "t" pwsh -c ls` | not screened | `pwsh` |
| `cmd //c start "my window" /min powershell` | not screened | `powershell` |
| `cmd /v:on /c powershell -Command ls` | not screened | `powershell` |
| `cmd //c start "" "cmd" /c powershell` | not screened | `powershell` |
| `start "" powershell -Command ls` | not screened | `powershell` |
| `cmd //c env start "" powershell` | not screened | `powershell` |

Which lexer runs is decided by whether Git Bash resolves (`_shell_is_posix`), and that is what most of these turn on: `shlex(posix = False)` keeps the quote marks the POSIX lexer strips.

## The three gaps

**A quoted payload arrived with its marks attached.** Under the cmd lexer `cmd /c "powershell -Command ls"` recursed into a string whose first word is `"powershell`, which matches no blocked name. One balanced pair is now unwrapped before recursing, and the shell look-back unquotes too, so `"cmd"` still reads as `cmd`.

**Switches were recognised by width.** The look-back skipped `/X` flags only when `len(prev) <= 3`, so a value-style `/v:on` was read as the program and the scan stopped before `powershell`. Now:

```python
_CMD_SWITCH_RE = re.compile(r"/[a-zA-Z](?::[\w.]+)?")
```

Anchored on both ends deliberately. Matched loosely it would find the `/b` of `/bin/bash`, skip that token as a flag and never reach the shell behind it. There is a test for exactly that.

**Only the empty START title was stepped over.** `tokens[j] == ""` is the POSIX lexer's spelling of `start ""`. A named title is the documented form (`START ["title"] command`), so `start "job" powershell` read `job` as the program. Which token is the title cannot be recovered from the text once the marks are gone, so both candidates are screened rather than guessed, and switches after the title are skipped as well as before.

The cost of that last one is that a benign second positional is screened too, so `start "" notepad rm` would report `rm`. That is the fail-closed direction and the safe one.

## No cmd grammar is parsed here

Everything routes back through `_find_blocked_commands`, so `_COMMAND_PREFIXES`, `_WRAPPER_VALUE_FLAGS_BY_CMD`, `_exec_scan_layout`, the command-position walk and the regex backstop are inherited rather than reimplemented. The change is 33 insertions and 8 deletions inside the two hooks that already existed.

## Deliberately still open

Each of these needs a real cmd tokenizer that tracks quote provenance as it scans, which `shlex(posix = False)` discards. That is a different change, not another rule on top of an already-lexed line:

`IF`/`ELSE` conditions - `FOR` bodies and `FOR /F` command sets - `CALL` - leading redirections - doubled-quote payloads (`cmd /c ""prog" args"`) - caret escaping - nested `env -S` - `.lnk` targets - `cmd /s /c`.

Enumerating cmd's spellings one at a time does not terminate, so this stops at the common shapes on purpose.

## Verification

- `tests/test_windows_bash_shell.py`: 70 passed, 1 skipped, from 55. **All 15 new cases fail against `main`**, so they pin the fixes rather than the symptoms.
- The new cases run against **both** lexers. The tests already in the file pin only the one a Linux runner picks, which is why most of these gaps were invisible there.
- Over-blocking guard: 17 ordinary commands stay runnable on both lexers, including `npm start`, `./start.sh`, `start "" notepad readme.txt`, `start "Build" npm run build`, `cmd /c "echo hello"`, `echo "C:\Windows\System32\cmd.exe"` and `cmd //c start "" "C:\Users\me\My Documents\report.docx"` (a document opened through its file association, which is what the quoted idiom is for). `test_detached_windows_stay_launchable` still passes unchanged.
- POSIX is a measured no-op: verdicts identical to `main` across 24 ordinary POSIX commands.
- `tests/test_windows_bash_shell.py` + `test_sandbox_tools.py` + `test_permission_mode.py`: 1927 passed, 1 skipped.
- Cost is linear in the input, not something the author of the command chooses: 1000/2000/4000/8000 nested `cmd /c start "t"` wrappers run in 0.114s / 0.217s / 0.453s / 0.891s, a ratio of ~2.0 per doubling.
- `ruff check` clean, `scripts/run_ruff_format.py` no drift, pre-push gate PASS.