### PR TITLE
Studio: simplify desktop setup progress UI

### DIFF
--- a/studio/frontend/src/components/tauri/startup-messages.ts
+++ b/studio/frontend/src/components/tauri/startup-messages.ts
@@ -3,6 +3,38 @@ export const MODELS_STARTUP_MESSAGE = "Loading models...";
 export const SERVER_STARTUP_MESSAGE = "Starting server...";
 export const SERVER_START_FALLBACK_MS = 3_000;
 
+export interface InstallProgressMessage {
+  title: string;
+  subtitle: string;
+}
+
+const GETTING_READY_MESSAGE: InstallProgressMessage = {
+  title: "Getting things ready...",
+  subtitle: "This won’t take long.",
+};
+
+export function installProgressMessage(
+  currentStepIndex: number,
+): InstallProgressMessage {
+  if (currentStepIndex < 2) return GETTING_READY_MESSAGE;
+  if (currentStepIndex < 4) {
+    return {
+      title: "Preparing your workspace...",
+      subtitle: "Setting up everything Unsloth needs.",
+    };
+  }
+  if (currentStepIndex < 6) {
+    return {
+      title: "Installing Unsloth...",
+      subtitle: "Your private AI workspace is taking shape.",
+    };
+  }
+  return {
+    title: "Nearly done...",
+    subtitle: "Finishing setup.",
+  };
+}
+
 export type StartupMessage =
   | typeof INITIAL_STARTUP_MESSAGE
   | typeof MODELS_STARTUP_MESSAGE

--- a/studio/frontend/src/components/tauri/startup-screen.tsx
+++ b/studio/frontend/src/components/tauri/startup-screen.tsx
@@ -3,6 +3,7 @@
 
 import {
   INITIAL_STARTUP_MESSAGE,
+  installProgressMessage,
   SERVER_STARTUP_MESSAGE,
   SERVER_START_FALLBACK_MS,
   type StartupMessage,
@@ -90,15 +91,6 @@ function DiagnosticsCopyActions({
 // Constants
 // ---------------------------------------------------------------------------
 
-const INSTALL_STEPS = [
-  "Detecting your system",
-  "Checking dependencies",
-  "Setting up package manager",
-  "Creating Python environment",
-  "Installing ML framework",
-  "Installing Unsloth",
-  "Finalizing setup",
-] as const;
 
 const EASE_OUT_QUART: [number, number, number, number] = [0.165, 0.84, 0.44, 1];
 
@@ -191,34 +183,40 @@ function NotInstalledContent({ onInstall }: { onInstall: () => void }) {
 }
 
 function InstallingContent({
+  logs,
   currentStepIndex,
   progressDetail,
 }: {
+  logs: string[];
   currentStepIndex: number;
   progressDetail: string | null;
 }) {
-  const stepNum = Math.max(0, currentStepIndex) + 1;
-  const stepLabel = INSTALL_STEPS[Math.min(currentStepIndex, INSTALL_STEPS.length - 1)];
+  const message = installProgressMessage(currentStepIndex);
+  const detailLines = progressDetail
+    ? [...logs, progressDetail]
+    : logs;
 
   return (
-    <div className="flex h-full flex-col items-center">
+    <div className="flex h-full w-full flex-col items-center">
       <div className="flex flex-1 items-center">
         <Logo />
       </div>
-      <div className="mb-10 flex flex-col items-center gap-2">
+      <div className="mb-10 flex w-full flex-col items-center gap-2">
         <Spinner className="size-6 text-primary" />
-        <p className="text-sm font-bold text-foreground">Installing...</p>
-        <p className="text-sm font-bold text-muted-foreground">
-          Your AI workspace is taking shape. Chat with AI, build projects, and
-          train models, all on your computer.
+        <p className="text-sm font-bold text-foreground" aria-live="polite">
+          {message.title}
         </p>
-        {currentStepIndex >= 0 && (
-          <p className="mt-1 text-xs font-bold text-muted-foreground">
-            Step {stepNum} of {INSTALL_STEPS.length}: {stepLabel}
-          </p>
-        )}
-        {progressDetail && (
-          <p className="text-xs text-muted-foreground/70">{progressDetail}</p>
+        <p className="text-sm text-muted-foreground">{message.subtitle}</p>
+        {detailLines.length > 0 && (
+          <details className="group mt-2 w-full max-w-sm text-left">
+            <summary className="mx-auto w-fit cursor-pointer select-none rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+              <span className="group-open:hidden">Show installation details</span>
+              <span className="hidden group-open:inline">Hide installation details</span>
+            </summary>
+            <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
+              {detailLines.join("\n")}
+            </pre>
+          </details>
         )}
       </div>
     </div>
@@ -232,18 +230,29 @@ function RepairingContent({
   logs: string[];
   progressDetail: string | null;
 }) {
-  const latest = progressDetail ?? logs.at(-1);
+  const detailLines = progressDetail
+    ? [...logs, progressDetail]
+    : logs;
 
   return (
-    <div className="flex h-full flex-col items-center">
+    <div className="flex h-full w-full flex-col items-center">
       <div className="flex flex-1 items-center">
         <Logo />
       </div>
-      <div className="mb-10 flex flex-col items-center gap-2">
+      <div className="mb-10 flex w-full flex-col items-center gap-2">
         <Spinner className="size-6 text-primary" />
-        <p className="text-sm font-bold text-foreground">Updating existing Unsloth install...</p>
-        {latest && (
-          <p className="max-w-xs text-center text-xs text-muted-foreground">{latest}</p>
+        <p className="text-sm font-bold text-foreground">Getting things ready...</p>
+        <p className="text-sm text-muted-foreground">This won’t take long.</p>
+        {detailLines.length > 0 && (
+          <details className="group mt-2 w-full max-w-sm text-left">
+            <summary className="mx-auto w-fit cursor-pointer select-none rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+              <span className="group-open:hidden">Show setup details</span>
+              <span className="hidden group-open:inline">Hide setup details</span>
+            </summary>
+            <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
+              {detailLines.join("\n")}
+            </pre>
+          </details>
         )}
       </div>
     </div>
@@ -426,7 +435,13 @@ export function StartupScreen({
       case "not-installed":
         return <NotInstalledContent onInstall={onInstall} />;
       case "installing":
-        return <InstallingContent currentStepIndex={currentStepIndex} progressDetail={progressDetail} />;
+        return (
+          <InstallingContent
+            logs={logs}
+            currentStepIndex={currentStepIndex}
+            progressDetail={progressDetail}
+          />
+        );
       case "install-error":
         return (
           <InstallErrorContent

--- a/studio/frontend/tests/startup-messages.test.ts
+++ b/studio/frontend/tests/startup-messages.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   INITIAL_STARTUP_MESSAGE,
+  installProgressMessage,
   SERVER_START_FALLBACK_MS,
   startupMessageFromLog,
 } from "../src/components/tauri/startup-messages.ts";
@@ -25,6 +26,18 @@ test("startup messages follow backend phases without regressing", () => {
     server,
   );
 });
+
+test("installer progress uses friendly staged messages", () => {
+  assert.deepEqual(installProgressMessage(-1), {
+    title: "Getting things ready...",
+    subtitle: "This won’t take long.",
+  });
+  assert.equal(installProgressMessage(2).title, "Preparing your workspace...");
+  assert.equal(installProgressMessage(4).title, "Installing Unsloth...");
+  assert.equal(installProgressMessage(6).title, "Nearly done...");
+  assert.equal(installProgressMessage(999).title, "Nearly done...");
+});
+
 
 test("server fallback delay is three seconds", () => {
   assert.equal(SERVER_START_FALLBACK_MS, 3_000);


### PR DESCRIPTION
## Summary
- replace technical first-launch install steps with friendly staged setup messaging
- hide raw installer and automatic repair output behind closed-by-default details controls
- keep diagnostic output available for users who choose to expand it
- add focused coverage for installer progress message phases

## Verification
- `node --experimental-strip-types --test tests/startup-messages.test.ts` (3 passed)
- `git diff --check`

## Notes
- Full frontend typecheck was unavailable in the worktree because dependencies are not installed (`tsc` is missing).