### PR TITLE
Make chat titles use available sidebar width

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1514,7 +1514,7 @@ export function AppSidebar() {
           {isPinned && variant !== "project" && (
             <HugeiconsIcon icon={BubbleChatIcon} strokeWidth={1.75} className="size-icon! shrink-0" />
           )}
-          <span className="truncate">
+          <span className="min-w-0 flex-1 truncate">
             {pendingRename?.id === item.id ? pendingRename.title : item.title}
           </span>
           {showWorkSpinner && (

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -104,6 +104,7 @@ import { chatHistoryClearBoundary } from "./utils/chat-history-clear-boundary";
 import { syncExportedRepositoryToBackend } from "./utils/delete-thread-message";
 import { getImageInputUnavailableReason } from "./utils/image-input-support";
 import { isAssistantLocalThreadId } from "./utils/thread-ids";
+import { fallbackTitleFromUserText } from "./utils/fallback-chat-title";
 
 const pendingHistoryAppendByMessageId = new Map<string, Promise<void>>();
 // Resolves to the thread id assigned when this message's chat was first persisted.
@@ -579,14 +580,6 @@ async function generateTitleWithModel(payload: {
 }
 
 const inflightTitleByKey = new Set<string>();
-
-function fallbackTitleFromUserText(userText: string): string {
-  const firstLine = (userText || "").split(/\r?\n/, 1)[0] ?? "";
-  const cleaned = firstLine.replace(/\s+/g, " ").trim();
-  const max = 48;
-  if (!cleaned) return "New Chat";
-  return cleaned.slice(0, max) + (cleaned.length > max ? "..." : "");
-}
 
 function cloneContent(
   content: ThreadMessage["content"],

--- a/studio/frontend/src/features/chat/utils/fallback-chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/fallback-chat-title.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** Match the existing inline-rename limit; CSS owns visual truncation. */
+export const FALLBACK_CHAT_TITLE_MAX_LENGTH = 120;
+
+const FIRST_LINE_PATTERN = /\r?\n/;
+const WHITESPACE_PATTERN = /\s+/g;
+
+function cleanFirstLine(userText: string): string {
+  const firstLine = (userText || "").split(FIRST_LINE_PATTERN, 1)[0] ?? "";
+  return firstLine.replace(WHITESPACE_PATTERN, " ").trim();
+}
+
+export function fallbackTitleFromUserText(userText: string): string {
+  const cleaned = cleanFirstLine(userText);
+  return cleaned
+    ? cleaned.slice(0, FALLBACK_CHAT_TITLE_MAX_LENGTH)
+    : "New Chat";
+}

--- a/studio/frontend/tests/fallback-chat-title.test.ts
+++ b/studio/frontend/tests/fallback-chat-title.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  FALLBACK_CHAT_TITLE_MAX_LENGTH,
+  fallbackTitleFromUserText,
+} from "../src/features/chat/utils/fallback-chat-title.ts";
+
+test("fallback titles retain text for responsive CSS ellipsis", () => {
+  const title =
+    "Use Python to generate and plot a Mandelbrot set with a custom colour palette";
+
+  assert.equal(fallbackTitleFromUserText(title), title);
+  assert.equal(fallbackTitleFromUserText(`${title}\nSecond line`), title);
+  assert.equal(
+    fallbackTitleFromUserText("  words    keep   spacing  "),
+    "words keep spacing",
+  );
+  assert.equal(fallbackTitleFromUserText(""), "New Chat");
+});
+
+test("fallback titles remain bounded without storing a literal ellipsis", () => {
+  const title = fallbackTitleFromUserText(
+    "x".repeat(FALLBACK_CHAT_TITLE_MAX_LENGTH + 20),
+  );
+
+  assert.equal(title, "x".repeat(FALLBACK_CHAT_TITLE_MAX_LENGTH));
+  assert.equal(title.endsWith("..."), false);
+});


### PR DESCRIPTION
## Summary

- let recent-chat titles grow into the sidebar's available row width before CSS applies an ellipsis
- retain up to the existing 120-character rename limit for newly generated fallback titles
- keep visual truncation in CSS instead of persisting a literal ellipsis
- add focused coverage for fallback-title normalization and bounds

## Root cause

Fallback titles were permanently truncated to 48 characters and saved with a literal `...`. The recent-chat title span also did not explicitly grow as a flex child, so widening the sidebar could not consistently expose more text.

## Compatibility

This is intentionally forward-looking: existing conversations whose titles were already persisted in truncated form remain unchanged. The PR does not migrate or rewrite chat-history data, avoiding database risk and additional sidebar loading work.

## Validation

- `npm run typecheck`
- `npm test` — 438 passed
- `git diff --check`
- focused Biome check for the new fallback-title utility

Targeted ESLint is currently blocked by pre-existing unrelated errors in `app-sidebar.tsx`.