### PR TITLE
CI: run the three Windows inference smokes as phases of one job

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -143,69 +143,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Phase 1 environment (API + auth)
-        run: |
-          echo "GGUF_REPO=unsloth/gemma-3-270m-it-GGUF" >> "$GITHUB_ENV"
-          echo "GGUF_VARIANT=UD-Q4_K_XL" >> "$GITHUB_ENV"
-          echo "GGUF_FILE=gemma-3-270m-it-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
-          echo "STUDIO_PORT=18888" >> "$GITHUB_ENV"
-          echo "HF_HOME=${{ github.workspace }}/hf-cache" >> "$GITHUB_ENV"
-
-      # Split restore + save (rather than the one-step actions/cache) so a
-      # transient restore-side failure does not kill the whole job. v5 has a
-      # known flake where it logs "Cache hit for: <key>" and then exits
-      # non-zero without actually extracting the archive (see
-      # actions/cache#1621 and github community discussion #163260).
-      # continue-on-error on restore masks that failure so the Prime step
-      # below can re-download from HF and the job keeps running. Save then
-      # populates the cache key on a real miss only; cache keys are
-      # immutable, so a corrupted cached entry persists until the -v1
-      # suffix below is bumped.
-      - name: Restore HF_HOME cache for unsloth/gemma-3-270m-it-GGUF
-        id: cache-hf
-        timeout-minutes: 15
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        continue-on-error: true
-        with:
-          path: hf-cache
-          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
-
-      - name: Prime HF_HOME with the GGUF
-        id: prime-hf
-        timeout-minutes: 15
-        # Run on a real cache miss AND on the silent-restore-failure mode
-        # described above (outcome != success).
-        if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
-        env:
-          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          python -m pip install --upgrade huggingface_hub
-          mkdir -p hf-cache
-          bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE"
-          bash .github/scripts/hf-download-with-retry.sh ggml-org/models tinyllamas/stories260K.gguf
-
-      - name: Save HF_HOME cache for unsloth/gemma-3-270m-it-GGUF
-        timeout-minutes: 15
-        # Only write a fresh cache entry when we actually rebuilt the
-        # directory (Prime ran and succeeded). Skipping when Prime is
-        # skipped avoids "already exists" save warnings on the happy path.
-        # Save on main only. Caches created on a PR ref are scoped to that
-        # merge ref -- per GitHub's docs they "can only be restored by re-runs
-        # of the pull request" -- while every PR *can* restore from the default
-        # branch. So a PR-scoped save helps almost nothing and competes for the
-        # 10GB per-repo budget, and when that budget is exceeded GitHub evicts
-        # by least-recently-used, which deletes main's copies that all PRs share.
-        # This repo was measured at 33.3GB across 30 caches, 3.3x over, with the
-        # same 4.6GB model held four times on four different PR refs and no copy
-        # on main at all. That is the thrash loop: PR misses -> downloads ->
-        # saves its own copy -> evicts main's -> next PR misses.
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: hf-cache
-          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
-
       - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
         shell: pwsh
         # See studio-windows-update-smoke.yml for the full rationale.
@@ -286,7 +223,13 @@ jobs:
           echo "install.ps1 installed the Windows prebuilt llama.cpp:"
           cat "$INFO"
 
+      # The last shared prerequisite every phase needs, so the phase gates below
+      # key on THIS step rather than on assert-prebuilt. shim only runs when
+      # assert-prebuilt succeeded, so `steps.shim.outcome == 'success'` implies
+      # the assertion passed and additionally catches a missing shim, which
+      # would otherwise let all three phases boot a Studio that is not on PATH.
       - name: Add Unsloth shim to GITHUB_PATH
+        id: shim
         if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         run: |
           SHIM_DIR=~/.unsloth/studio/bin
@@ -297,10 +240,84 @@ jobs:
           fi
           cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
 
+      # Needed by phases 1 and 3 only; the tool-calling phase drives the API with
+      # curl and never imports them, which is why phase 2 does not gate on this.
       - name: Install OpenAI + Anthropic Python SDKs
+        id: sdks
         if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         timeout-minutes: 10
         run: python -m pip install 'openai>=1.50' 'anthropic>=0.40'
+
+      # Phase 1's environment and model cache sit HERE, after the shared
+      # preamble, not before it. They used to run before the installer, which is
+      # where they sat when phase 1 was its own job -- harmless then, because a
+      # priming failure only killed that one job. Once the installer is shared,
+      # the same failure skips it under the implicit success(), assert-prebuilt
+      # skips with it, and every phase-2 and phase-3 gate evaluates false. A
+      # transient HF download would take the whole workflow down. Ordering the
+      # shared setup first keeps a phase-1 resource failure phase-local.
+      - name: Phase 1 environment (API + auth)
+        run: |
+          echo "GGUF_REPO=unsloth/gemma-3-270m-it-GGUF" >> "$GITHUB_ENV"
+          echo "GGUF_VARIANT=UD-Q4_K_XL" >> "$GITHUB_ENV"
+          echo "GGUF_FILE=gemma-3-270m-it-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
+          echo "STUDIO_PORT=18888" >> "$GITHUB_ENV"
+          echo "HF_HOME=${{ github.workspace }}/hf-cache" >> "$GITHUB_ENV"
+
+      # Split restore + save (rather than the one-step actions/cache) so a
+      # transient restore-side failure does not kill the whole job. v5 has a
+      # known flake where it logs "Cache hit for: <key>" and then exits
+      # non-zero without actually extracting the archive (see
+      # actions/cache#1621 and github community discussion #163260).
+      # continue-on-error on restore masks that failure so the Prime step
+      # below can re-download from HF and the job keeps running. Save then
+      # populates the cache key on a real miss only; cache keys are
+      # immutable, so a corrupted cached entry persists until the -v1
+      # suffix below is bumped.
+      - name: Restore HF_HOME cache for unsloth/gemma-3-270m-it-GGUF
+        id: cache-hf
+        timeout-minutes: 15
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        continue-on-error: true
+        with:
+          path: hf-cache
+          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
+
+      - name: Prime HF_HOME with the GGUF
+        id: prime-hf
+        timeout-minutes: 15
+        # Run on a real cache miss AND on the silent-restore-failure mode
+        # described above (outcome != success).
+        if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
+        env:
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
+        run: |
+          python -m pip install --upgrade huggingface_hub
+          mkdir -p hf-cache
+          bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE"
+          bash .github/scripts/hf-download-with-retry.sh ggml-org/models tinyllamas/stories260K.gguf
+
+      - name: Save HF_HOME cache for unsloth/gemma-3-270m-it-GGUF
+        timeout-minutes: 15
+        # Only write a fresh cache entry when we actually rebuilt the
+        # directory (Prime ran and succeeded). Skipping when Prime is
+        # skipped avoids "already exists" save warnings on the happy path.
+        # Save on main only. Caches created on a PR ref are scoped to that
+        # merge ref -- per GitHub's docs they "can only be restored by re-runs
+        # of the pull request" -- while every PR *can* restore from the default
+        # branch. So a PR-scoped save helps almost nothing and competes for the
+        # 10GB per-repo budget, and when that budget is exceeded GitHub evicts
+        # by least-recently-used, which deletes main's copies that all PRs share.
+        # This repo was measured at 33.3GB across 30 caches, 3.3x over, with the
+        # same 4.6GB model held four times on four different PR refs and no copy
+        # on main at all. That is the thrash loop: PR misses -> downloads ->
+        # saves its own copy -> evicts main's -> next PR misses.
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: hf-cache
+          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
 
       - name: Reset auth + boot Unsloth (API-only)
         timeout-minutes: 2
@@ -480,6 +497,13 @@ jobs:
         # bash's `$!`, which is an MSYS pid that taskkill/Stop-Process cannot
         # resolve to the real Windows process. pwsh keeps us off Git Bash, and
         # every failure is swallowed so teardown can never fail the job.
+        #
+        # The command-line sweep after it is not redundant. A Studio that hangs
+        # during startup never binds the port -- the health wait exists for
+        # exactly that case -- so the port lookup finds no owner and would leave
+        # the process alive to collide with the next phase. The match is scoped
+        # to a command line naming both `unsloth` and `studio`, so it cannot
+        # reach the runner's own python from actions/setup-python.
         shell: pwsh
         run: |
           $ErrorActionPreference = 'SilentlyContinue'
@@ -494,6 +518,14 @@ jobs:
             } catch {
               Write-Host "pid $owner already gone"
             }
+          }
+          $stragglers = Get-CimInstance Win32_Process |
+                        Where-Object { $_.CommandLine -match 'unsloth' -and
+                                       $_.CommandLine -match 'studio' -and
+                                       $_.ProcessId -notin $owners }
+          foreach ($s in $stragglers) {
+            Write-Host "stopping unbound pid $($s.ProcessId): $($s.CommandLine)"
+            Stop-Process -Id $s.ProcessId -Force
           }
           Start-Sleep -Seconds 2
           if ((Get-NetTCPConnection -LocalPort $port -State Listen)) {
@@ -540,7 +572,7 @@ jobs:
         # implicit success(), so a phase 1 TEST failure would skip it while the
         # gated steps below still ran -- and they would then inherit the previous
         # phase's model, port and HF_HOME.
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' }}
         run: |
           echo "GGUF_REPO=unsloth/Qwen3.5-2B-GGUF" >> "$GITHUB_ENV"
           echo "GGUF_FILE=Qwen3.5-2B-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
@@ -556,7 +588,7 @@ jobs:
       # cache". Measured on staging during the Mac consolidation: two consecutive
       # runs both logged "Cache not found for input keys" and both failed to save.
       - name: Restore GGUF model cache
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' }}
         id: cache-gguf-tools
         timeout-minutes: 15
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -567,7 +599,7 @@ jobs:
 
       - name: Download GGUF if cache miss
         id: download-gguf-tools
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && (steps.cache-gguf-tools.outputs.cache-hit != 'true' || steps.cache-gguf-tools.outcome != 'success') }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && (steps.cache-gguf-tools.outputs.cache-hit != 'true' || steps.cache-gguf-tools.outcome != 'success') }}
         timeout-minutes: 15
         env:
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
@@ -593,7 +625,7 @@ jobs:
         # clause a failed download still boots a server with no model and runs
         # the test against it, burning Windows runner minutes and burying the
         # real error under a pile of connection failures.
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.download-gguf-tools.outcome != 'failure' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.download-gguf-tools.outcome != 'failure' }}
         timeout-minutes: 2
         run: |
           rm -rf ~/.unsloth/studio/auth
@@ -604,7 +636,7 @@ jobs:
 
       - name: Wait for /api/health, log in, change password, load model
         id: ready-tools
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.boot-tools.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.boot-tools.outcome == 'success' }}
         timeout-minutes: 25
         run: |
           for i in $(seq 1 180); do
@@ -654,7 +686,7 @@ jobs:
           jq '{status, display_name}' /tmp/load.json
 
       - name: Tool calling, server-side tools, thinking on/off
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.ready-tools.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.ready-tools.outcome == 'success' }}
         timeout-minutes: 15
         env:
           BASE_URL: http://127.0.0.1:18898
@@ -927,6 +959,13 @@ jobs:
         # bash's `$!`, which is an MSYS pid that taskkill/Stop-Process cannot
         # resolve to the real Windows process. pwsh keeps us off Git Bash, and
         # every failure is swallowed so teardown can never fail the job.
+        #
+        # The command-line sweep after it is not redundant. A Studio that hangs
+        # during startup never binds the port -- the health wait exists for
+        # exactly that case -- so the port lookup finds no owner and would leave
+        # the process alive to collide with the next phase. The match is scoped
+        # to a command line naming both `unsloth` and `studio`, so it cannot
+        # reach the runner's own python from actions/setup-python.
         shell: pwsh
         run: |
           $ErrorActionPreference = 'SilentlyContinue'
@@ -941,6 +980,14 @@ jobs:
             } catch {
               Write-Host "pid $owner already gone"
             }
+          }
+          $stragglers = Get-CimInstance Win32_Process |
+                        Where-Object { $_.CommandLine -match 'unsloth' -and
+                                       $_.CommandLine -match 'studio' -and
+                                       $_.ProcessId -notin $owners }
+          foreach ($s in $stragglers) {
+            Write-Host "stopping unbound pid $($s.ProcessId): $($s.CommandLine)"
+            Stop-Process -Id $s.ProcessId -Force
           }
           Start-Sleep -Seconds 2
           if ((Get-NetTCPConnection -LocalPort $port -State Listen)) {
@@ -987,7 +1034,7 @@ jobs:
         # implicit success(), so a phase 1 TEST failure would skip it while the
         # gated steps below still ran -- and they would then inherit the previous
         # phase's model, port and HF_HOME.
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.sdks.outcome == 'success' }}
         run: |
           echo "GGUF_REPO=unsloth/Qwen3-VL-2B-Instruct-GGUF" >> "$GITHUB_ENV"
           echo "GGUF_VARIANT=UD-IQ2_XXS" >> "$GITHUB_ENV"
@@ -1000,7 +1047,7 @@ jobs:
       # for the same reason as the tool-phase cache above: same key + different
       # `path` means a permanent restore miss and a refused save.
       - name: Restore HF_HOME cache for unsloth/Qwen3-VL-2B-Instruct-GGUF (model + mmproj)
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.sdks.outcome == 'success' }}
         id: cache-hf-vision
         timeout-minutes: 20
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1011,7 +1058,7 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF + mmproj
         id: prime-hf-vision
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && (steps.cache-hf-vision.outputs.cache-hit != 'true' || steps.cache-hf-vision.outcome != 'success') }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.sdks.outcome == 'success' && (steps.cache-hf-vision.outputs.cache-hit != 'true' || steps.cache-hf-vision.outcome != 'success') }}
         timeout-minutes: 20
         env:
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
@@ -1034,7 +1081,7 @@ jobs:
       - name: Reset auth + boot Unsloth (API-only)
         id: boot-vision
         # Same phase-local prerequisite as phase 2, for the same reason.
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.prime-hf-vision.outcome != 'failure' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.sdks.outcome == 'success' && steps.prime-hf-vision.outcome != 'failure' }}
         timeout-minutes: 2
         run: |
           rm -rf ~/.unsloth/studio/auth
@@ -1045,7 +1092,7 @@ jobs:
 
       - name: Wait for /api/health, log in, change password, load model
         id: ready-vision
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.boot-vision.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.sdks.outcome == 'success' && steps.boot-vision.outcome == 'success' }}
         timeout-minutes: 25
         run: |
           for i in $(seq 1 180); do
@@ -1086,7 +1133,7 @@ jobs:
           jq '{status, display_name, is_vision}' /tmp/load.json
 
       - name: JSON schema decoding + image input
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.ready-vision.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.sdks.outcome == 'success' && steps.ready-vision.outcome == 'success' }}
         timeout-minutes: 15
         env:
           BASE_URL: http://127.0.0.1:18899
@@ -1292,6 +1339,13 @@ jobs:
         # bash's `$!`, which is an MSYS pid that taskkill/Stop-Process cannot
         # resolve to the real Windows process. pwsh keeps us off Git Bash, and
         # every failure is swallowed so teardown can never fail the job.
+        #
+        # The command-line sweep after it is not redundant. A Studio that hangs
+        # during startup never binds the port -- the health wait exists for
+        # exactly that case -- so the port lookup finds no owner and would leave
+        # the process alive to collide with the next phase. The match is scoped
+        # to a command line naming both `unsloth` and `studio`, so it cannot
+        # reach the runner's own python from actions/setup-python.
         shell: pwsh
         run: |
           $ErrorActionPreference = 'SilentlyContinue'
@@ -1306,6 +1360,14 @@ jobs:
             } catch {
               Write-Host "pid $owner already gone"
             }
+          }
+          $stragglers = Get-CimInstance Win32_Process |
+                        Where-Object { $_.CommandLine -match 'unsloth' -and
+                                       $_.CommandLine -match 'studio' -and
+                                       $_.ProcessId -notin $owners }
+          foreach ($s in $stragglers) {
+            Write-Host "stopping unbound pid $($s.ProcessId): $($s.CommandLine)"
+            Stop-Process -Id $s.ProcessId -Force
           }
           Start-Sleep -Seconds 2
           if ((Get-NetTCPConnection -LocalPort $port -State Listen)) {

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1,20 +1,23 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# Three end-to-end smoke jobs that boot a freshly-installed Unsloth and
-# exercise the surfaces real users hit through the OpenAI / Anthropic
-# SDKs and curl, on the FREE windows-latest runner. Each job picks the
-# smallest model that exercises the behaviour under test, primes
-# HF_HOME via actions/cache, and shares the install.ps1 --local
-# --no-torch bootstrap.
+# One end-to-end smoke job, three phases, that boots a freshly-installed
+# Unsloth and exercises the surfaces real users hit through the OpenAI /
+# Anthropic SDKs and curl, on the FREE windows-latest runner. Each phase
+# picks the smallest model that exercises the behaviour under test and
+# primes its own model cache; all three share a single install.ps1
+# --local --no-torch bootstrap.
 #
 #   1. OpenAI, Anthropic API tests
-#        gemma-3-270m-it UD-Q4_K_XL (~254 MiB).
+#        gemma-3-270m-it UD-Q4_K_XL (~254 MiB), port 18888.
 #   2. Tool calling Tests
-#        Qwen3.5-2B UD-Q4_K_XL (~890 MiB).
+#        Qwen3.5-2B UD-Q4_K_XL (~890 MiB), port 18898.
 #   3. JSON, images
-#        Qwen3-VL-2B-Instruct UD-IQ2_XXS + mmproj-F16 (~1.4 GiB total).
-#        Within the 14 GB windows-latest SSD budget.
+#        Qwen3-VL-2B-Instruct UD-IQ2_XXS + mmproj-F16 (~1.4 GiB total),
+#        port 18899. Within the 14 GB windows-latest SSD budget.
+#
+# The phases run in sequence on one runner. They used to be three parallel
+# jobs, each repeating a ~7 min Windows install to run ~4 min of tests.
 
 name: Windows Unsloth GGUF CI
 
@@ -45,25 +48,47 @@ permissions:
   contents: read
 
 jobs:
-  # ─────────────────────────────────────────────────────────────────────
-  # Job 1: OpenAI, Anthropic API tests
-  # ─────────────────────────────────────────────────────────────────────
-  openai-anthropic:
-    name: OpenAI, Anthropic API tests
+  # One job, three phases. These were three separate windows-latest jobs that
+  # differed only in model, port and test body: the checkout, setup-node,
+  # setup-python, npm/Defender tweaks, `install.ps1 --local --no-torch` and
+  # prebuilt assertion were identical in all three, so every triggering PR ran
+  # the same Windows install three times over.
+  #
+  # Windows is the platform where that actually costs something. Measured over
+  # recent runs, setup is ~7.0 min per job (install.ps1 alone is ~6.4) against
+  # ~3.8 min of tests, so setup dominates and sharing it once saves ~14
+  # runner-minutes and 2 of the 60 concurrent-job slots. The same trade is NOT
+  # worth making on ubuntu (studio-inference-smoke.yml), where setup is ~1.9 min
+  # against ~3.0 min of tests: there the added sequential wall time costs more
+  # feedback latency than the slots are worth.
+  #
+  # Each phase keeps its own model cache directory, HF_HOME, server port, server
+  # log, uploaded artifact and step timeouts, and each is gated on the SHARED
+  # preamble rather than on the phase before it, so a failure still points at one
+  # phase, earlier phases' logs survive it, and later phases still run -- the
+  # same independence the three jobs had.
+  inference-smoke:
+    name: GGUF inference smoke (API, tools, vision)
     runs-on: windows-latest
-    timeout-minutes: 30
+    # Was 30 + 30 + 35 across three runners. Sequentially they share one install,
+    # so the sum is well under 95, but a cold model cache on the vision phase is
+    # the slow case. 90 covers it while still bounding a hang. Every step that can
+    # block also carries its own `timeout-minutes`: the job cap alone is not a
+    # substitute, because hf-download-with-retry.sh retries forever by design and
+    # named the job timeout as its bound.
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash
     env:
-      GGUF_REPO: unsloth/gemma-3-270m-it-GGUF
-      GGUF_VARIANT: UD-Q4_K_XL
-      GGUF_FILE: gemma-3-270m-it-UD-Q4_K_XL.gguf
-      STUDIO_PORT: '18888'
-      HF_HOME: ${{ github.workspace }}/hf-cache
-      # Force UTF-8 for stdio (Windows defaults to cp1252; hf
-      # download / Unsloth CLI print "✓" checkmarks and crash
-      # otherwise).
+      # Only what every phase shares. Model, GGUF file, port and HF_HOME are set
+      # per phase via $GITHUB_ENV instead of here: if a phase-specific key were
+      # also declared at job level, whether the later $GITHUB_ENV write wins is
+      # not something the Actions docs pin down, and a phase quietly talking to
+      # the previous phase's port would be a nasty way to find out.
+      #
+      # Force UTF-8 for stdio (Windows defaults to cp1252; hf download / the
+      # Unsloth CLI print "✓" checkmarks and crash otherwise).
       PYTHONIOENCODING: utf-8
       PYTHONUTF8: '1'
     steps:
@@ -118,6 +143,14 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Phase 1 environment (API + auth)
+        run: |
+          echo "GGUF_REPO=unsloth/gemma-3-270m-it-GGUF" >> "$GITHUB_ENV"
+          echo "GGUF_VARIANT=UD-Q4_K_XL" >> "$GITHUB_ENV"
+          echo "GGUF_FILE=gemma-3-270m-it-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
+          echo "STUDIO_PORT=18888" >> "$GITHUB_ENV"
+          echo "HF_HOME=${{ github.workspace }}/hf-cache" >> "$GITHUB_ENV"
+
       # Split restore + save (rather than the one-step actions/cache) so a
       # transient restore-side failure does not kill the whole job. v5 has a
       # known flake where it logs "Cache hit for: <key>" and then exits
@@ -128,16 +161,18 @@ jobs:
       # populates the cache key on a real miss only; cache keys are
       # immutable, so a corrupted cached entry persists until the -v1
       # suffix below is bumped.
-      - name: Restore HF_HOME cache for ${{ env.GGUF_REPO }}
+      - name: Restore HF_HOME cache for unsloth/gemma-3-270m-it-GGUF
         id: cache-hf
+        timeout-minutes: 15
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
+        timeout-minutes: 15
         # Run on a real cache miss AND on the silent-restore-failure mode
         # described above (outcome != success).
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
@@ -150,7 +185,8 @@ jobs:
           bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE"
           bash .github/scripts/hf-download-with-retry.sh ggml-org/models tinyllamas/stories260K.gguf
 
-      - name: Save HF_HOME cache for ${{ env.GGUF_REPO }}
+      - name: Save HF_HOME cache for unsloth/gemma-3-270m-it-GGUF
+        timeout-minutes: 15
         # Only write a fresh cache entry when we actually rebuilt the
         # directory (Prime ran and succeeded). Skipping when Prime is
         # skipped avoids "already exists" save warnings on the happy path.
@@ -168,7 +204,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
 
       - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
         shell: pwsh
@@ -202,6 +238,9 @@ jobs:
           }
 
       - name: Install Unsloth (--local, --no-torch)
+        id: install
+        if: ${{ !cancelled() }}
+        timeout-minutes: 25
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -216,6 +255,9 @@ jobs:
           & ./install.ps1 --local --no-torch *>&1 | Tee-Object -FilePath logs/install.log
 
       - name: Assert install.ps1 used the Windows llama.cpp prebuilt
+        id: assert-prebuilt
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        timeout-minutes: 5
         run: |
           # Filesystem check; setup.ps1's stream output isn't captured.
           LLAMA_DIR=~/.unsloth/llama.cpp
@@ -240,6 +282,7 @@ jobs:
           cat "$INFO"
 
       - name: Add Unsloth shim to GITHUB_PATH
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         run: |
           SHIM_DIR=~/.unsloth/studio/bin
           if [ ! -f "$SHIM_DIR/unsloth.exe" ]; then
@@ -250,6 +293,8 @@ jobs:
           cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
 
       - name: Install OpenAI + Anthropic Python SDKs
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        timeout-minutes: 10
         run: python -m pip install 'openai>=1.50' 'anthropic>=0.40'
 
       - name: Reset auth + boot Unsloth (API-only)
@@ -262,6 +307,7 @@ jobs:
           echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for /api/health
+        timeout-minutes: 10
         run: |
           for i in $(seq 1 180); do
             if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
@@ -450,162 +496,55 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   # Job 2: Tool calling Tests
   # ─────────────────────────────────────────────────────────────────────
-  tool-calling:
-    name: Tool calling Tests
-    runs-on: windows-latest
-    timeout-minutes: 30
-    defaults:
-      run:
-        shell: bash
-    env:
-      # Tool calling is the highest-volume GGUF in this workflow
-      # (Qwen3.5-2B at Q4_K_XL = ~1.28 GiB). The previous HF_HOME
-      # cache stored xet chunks + blobs + snapshots = ~4.7 GiB --
-      # 3.7x file-size inflation, dominating the post-step upload
-      # (211 s on first run; subsequent runs hit the cache, but the
-      # one-time cost recurs every time the cache key bumps). Use
-      # main's `--local-dir gguf-cache` pattern: cache the flat .gguf
-      # only, pass an absolute path to Unsloth's /api/inference/load.
-      # The OpenAI/Anth and JSON+images jobs still cover the
-      # gguf_variant resolution path.
-      GGUF_REPO: unsloth/Qwen3.5-2B-GGUF
-      GGUF_FILE: Qwen3.5-2B-UD-Q4_K_XL.gguf
-      STUDIO_PORT: '18898'
-      # Force UTF-8 for stdio (Windows defaults to cp1252; hf
-      # download / Unsloth CLI print "✓" checkmarks and crash
-      # otherwise).
-      PYTHONIOENCODING: utf-8
-      PYTHONUTF8: '1'
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
+      - name: Phase 2 environment (tool calling)
+        run: |
+          echo "GGUF_REPO=unsloth/Qwen3.5-2B-GGUF" >> "$GITHUB_ENV"
+          echo "GGUF_FILE=Qwen3.5-2B-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
+          echo "STUDIO_PORT=18898" >> "$GITHUB_ENV"
+          echo "HF_HOME=${{ github.workspace }}/hf-cache-tools" >> "$GITHUB_ENV"
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: '22'
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.12'
-
-      # Split restore + save so a transient restore-side failure does not
-      # kill the whole job. See the matching block in the tool-calling job
-      # above for the full rationale (actions/cache#1621).
       - name: Restore GGUF model cache
-        id: cache-gguf
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        id: cache-gguf-tools
+        timeout-minutes: 15
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
-          path: gguf-cache
-          key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
+          path: gguf-cache-tools
+          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v1
 
       - name: Download GGUF if cache miss
-        id: download-gguf
-        if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
+        id: download-gguf-tools
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && (steps.cache-gguf-tools.outputs.cache-hit != 'true' || steps.cache-gguf-tools.outcome != 'success') }}
+        timeout-minutes: 15
         env:
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
-          mkdir -p gguf-cache
-          bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE" gguf-cache
+          mkdir -p gguf-cache-tools
+          bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE" gguf-cache-tools
 
       - name: Save GGUF model cache
-        if: always() && github.ref == 'refs/heads/main' && steps.download-gguf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.download-gguf-tools.outcome == 'success'
+        timeout-minutes: 15
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: gguf-cache
-          key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
-
-      - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
-        shell: pwsh
-        # See studio-windows-update-smoke.yml for the full rationale.
-        # tl;dr: setup.ps1 needs npm >=11 to skip a 35 s winget Node
-        # reinstall, and Defender's real-time scan dominates the
-        # frontend / uv-pip-extract steps.
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Write-Host "npm version before upgrade: $(npm -v)"
-          npm install -g 'npm@^11' 2>&1 | Out-Host
-          Write-Host "npm version after upgrade: $(npm -v)"
-          # NOTE: do NOT pre-create these directories. See
-          # studio-windows-update-smoke.yml for the full rationale --
-          # creating an empty studio/frontend/dist trips setup.ps1's
-          # mtime-based staleness check into "frontend up to date, skip
-          # rebuild" and Unsloth boots with an empty dist directory.
-          # Add-MpPreference accepts paths that do not yet exist.
-          foreach ($p in @(
-            "$env:USERPROFILE\.unsloth",
-            "$env:USERPROFILE\AppData\Local\uv",
-            "$env:GITHUB_WORKSPACE\studio\frontend\node_modules",
-            "$env:GITHUB_WORKSPACE\studio\frontend\dist"
-          )) {
-            try {
-              Add-MpPreference -ExclusionPath $p -ErrorAction Stop
-              Write-Host "Defender exclusion added: $p"
-            } catch {
-              Write-Host "Defender exclusion skipped ($($_.Exception.Message)): $p"
-            }
-          }
-
-      - name: Install Unsloth (--local, --no-torch)
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          New-Item -ItemType Directory -Force -Path logs | Out-Null
-          # *>&1 captures Write-Host (Information stream) output;
-          # plain 2>&1 does not. setup.ps1 emits "prebuilt installed
-          # and validated" via Write-Host, and we grep for that.
-          $ProgressPreference = 'SilentlyContinue'
-          & ./install.ps1 --local --no-torch *>&1 | Tee-Object -FilePath logs/install.log
-
-      - name: Assert install.ps1 used the Windows llama.cpp prebuilt
-        run: |
-          # Filesystem check; setup.ps1's stream output isn't captured.
-          LLAMA_DIR=~/.unsloth/llama.cpp
-          INFO="$LLAMA_DIR/UNSLOTH_PREBUILT_INFO.json"
-          BIN="$LLAMA_DIR/build/bin/Release/llama-server.exe"
-          if grep -q "falling back to source build" logs/install.log; then
-            echo "::error::install.ps1 fell back to source-build llama.cpp on Windows."
-            grep -E "llama-prebuilt|llama.cpp" logs/install.log | tail -60
-            exit 1
-          fi
-          if [ ! -f "$INFO" ]; then
-            echo "::error::no UNSLOTH_PREBUILT_INFO.json at $INFO."
-            ls -la "$LLAMA_DIR" || true
-            exit 1
-          fi
-          if [ ! -f "$BIN" ]; then
-            echo "::error::no llama-server.exe at $BIN."
-            ls -la "$LLAMA_DIR/build/bin" || true
-            exit 1
-          fi
-          echo "install.ps1 installed the Windows prebuilt llama.cpp:"
-          cat "$INFO"
-
-      - name: Add Unsloth shim to GITHUB_PATH
-        run: |
-          SHIM_DIR=~/.unsloth/studio/bin
-          if [ ! -f "$SHIM_DIR/unsloth.exe" ]; then
-            echo "::error::unsloth.exe shim not found at $SHIM_DIR"
-            ls -la ~/.unsloth/studio/ || true
-            exit 1
-          fi
-          cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
+          path: gguf-cache-tools
+          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v1
 
       - name: Reset auth + boot Unsloth (API-only, default tool policy)
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         run: |
           rm -rf ~/.unsloth/studio/auth
           mkdir -p logs
           UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
+            > logs/studio_tools.log 2>&1 &
           echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for /api/health, log in, change password, load model
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        timeout-minutes: 25
         run: |
           for i in $(seq 1 180); do
             if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
@@ -635,7 +574,7 @@ jobs:
           # via bash parameter expansion -- pathlib.Path on Windows
           # accepts forward slashes natively, so Unsloth's loader sees
           # a normal path.
-          GGUF_PATH="${GITHUB_WORKSPACE//\\//}/gguf-cache/${GGUF_FILE}"
+          GGUF_PATH="${GITHUB_WORKSPACE//\\//}/gguf-cache-tools/${GGUF_FILE}"
           ls -lh "$GGUF_PATH"
           # Retry: same rationale as the OpenAI/Anthropic job.
           LOAD_OK=0
@@ -654,6 +593,7 @@ jobs:
           jq '{status, display_name}' /tmp/load.json
 
       - name: Tool calling, server-side tools, thinking on/off
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         env:
           BASE_URL: http://127.0.0.1:18898
         run: |
@@ -942,7 +882,7 @@ jobs:
         with:
           name: windows-tool-calling-log
           path: |
-            logs/studio.log
+            logs/studio_tools.log
             logs/install.log
             logs/llama-server/*.log
           retention-days: 7
@@ -950,163 +890,59 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   # Job 3: JSON, images
   # ─────────────────────────────────────────────────────────────────────
-  json-images:
-    name: JSON, images
-    runs-on: windows-latest
-    timeout-minutes: 35
-    defaults:
-      run:
-        shell: bash
-    env:
-      GGUF_REPO: unsloth/Qwen3-VL-2B-Instruct-GGUF
-      GGUF_VARIANT: UD-IQ2_XXS
-      GGUF_FILE: Qwen3-VL-2B-Instruct-UD-IQ2_XXS.gguf
-      MMPROJ_FILE: mmproj-F16.gguf
-      STUDIO_PORT: '18899'
-      HF_HOME: ${{ github.workspace }}/hf-cache
-      # Force UTF-8 for stdio (Windows defaults to cp1252; hf
-      # download / Unsloth CLI print "✓" checkmarks and crash
-      # otherwise).
-      PYTHONIOENCODING: utf-8
-      PYTHONUTF8: '1'
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
+      - name: Phase 3 environment (JSON + vision)
+        run: |
+          echo "GGUF_REPO=unsloth/Qwen3-VL-2B-Instruct-GGUF" >> "$GITHUB_ENV"
+          echo "GGUF_VARIANT=UD-IQ2_XXS" >> "$GITHUB_ENV"
+          echo "GGUF_FILE=Qwen3-VL-2B-Instruct-UD-IQ2_XXS.gguf" >> "$GITHUB_ENV"
+          echo "MMPROJ_FILE=mmproj-F16.gguf" >> "$GITHUB_ENV"
+          echo "STUDIO_PORT=18899" >> "$GITHUB_ENV"
+          echo "HF_HOME=${{ github.workspace }}/hf-cache-vision" >> "$GITHUB_ENV"
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: '22'
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.12'
-
-      # Split restore + save so a transient restore-side failure does not
-      # kill the whole job. See the matching block in the tool-calling job
-      # for the full rationale (actions/cache#1621). This is the block that
-      # actually broke in run 25713577488: "Cache hit for: <key>" was
-      # logged, the step exited non-zero in ~0.3 s without extracting the
-      # 3.4 GiB archive, and steps 6-15 were skipped.
-      - name: Restore HF_HOME cache for ${{ env.GGUF_REPO }} (model + mmproj)
-        id: cache-hf
+      - name: Restore HF_HOME cache for unsloth/Qwen3-VL-2B-Instruct-GGUF (model + mmproj)
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        id: cache-hf-vision
+        timeout-minutes: 20
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
-          path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v2
+          path: hf-cache-vision
+          key: ${{ runner.os }}-hf-unsloth/Qwen3-VL-2B-Instruct-GGUF-UD-IQ2_XXS-mmproj-F16.gguf-v2
 
       - name: Prime HF_HOME with the GGUF + mmproj
-        id: prime-hf
-        if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
+        id: prime-hf-vision
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && (steps.cache-hf-vision.outputs.cache-hit != 'true' || steps.cache-hf-vision.outcome != 'success') }}
+        timeout-minutes: 20
         env:
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
-          mkdir -p hf-cache
+          mkdir -p hf-cache-vision
           bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE"
           bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$MMPROJ_FILE"
           bash .github/scripts/hf-download-with-retry.sh ggml-org/models tinyllamas/stories260K.gguf
 
-      - name: Save HF_HOME cache for ${{ env.GGUF_REPO }} (model + mmproj)
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+      - name: Save HF_HOME cache for unsloth/Qwen3-VL-2B-Instruct-GGUF (model + mmproj)
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf-vision.outcome == 'success'
+        timeout-minutes: 20
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v2
-
-      - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
-        shell: pwsh
-        # See studio-windows-update-smoke.yml for the full rationale.
-        # tl;dr: setup.ps1 needs npm >=11 to skip a 35 s winget Node
-        # reinstall, and Defender's real-time scan dominates the
-        # frontend / uv-pip-extract steps.
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Write-Host "npm version before upgrade: $(npm -v)"
-          npm install -g 'npm@^11' 2>&1 | Out-Host
-          Write-Host "npm version after upgrade: $(npm -v)"
-          # NOTE: do NOT pre-create these directories. See
-          # studio-windows-update-smoke.yml for the full rationale --
-          # creating an empty studio/frontend/dist trips setup.ps1's
-          # mtime-based staleness check into "frontend up to date, skip
-          # rebuild" and Unsloth boots with an empty dist directory.
-          # Add-MpPreference accepts paths that do not yet exist.
-          foreach ($p in @(
-            "$env:USERPROFILE\.unsloth",
-            "$env:USERPROFILE\AppData\Local\uv",
-            "$env:GITHUB_WORKSPACE\studio\frontend\node_modules",
-            "$env:GITHUB_WORKSPACE\studio\frontend\dist"
-          )) {
-            try {
-              Add-MpPreference -ExclusionPath $p -ErrorAction Stop
-              Write-Host "Defender exclusion added: $p"
-            } catch {
-              Write-Host "Defender exclusion skipped ($($_.Exception.Message)): $p"
-            }
-          }
-
-      - name: Install Unsloth (--local, --no-torch)
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          New-Item -ItemType Directory -Force -Path logs | Out-Null
-          # *>&1 captures Write-Host (Information stream) output;
-          # plain 2>&1 does not. setup.ps1 emits "prebuilt installed
-          # and validated" via Write-Host, and we grep for that.
-          $ProgressPreference = 'SilentlyContinue'
-          & ./install.ps1 --local --no-torch *>&1 | Tee-Object -FilePath logs/install.log
-
-      - name: Assert install.ps1 used the Windows llama.cpp prebuilt
-        run: |
-          # Filesystem check; setup.ps1's stream output isn't captured.
-          LLAMA_DIR=~/.unsloth/llama.cpp
-          INFO="$LLAMA_DIR/UNSLOTH_PREBUILT_INFO.json"
-          BIN="$LLAMA_DIR/build/bin/Release/llama-server.exe"
-          if grep -q "falling back to source build" logs/install.log; then
-            echo "::error::install.ps1 fell back to source-build llama.cpp on Windows."
-            grep -E "llama-prebuilt|llama.cpp" logs/install.log | tail -60
-            exit 1
-          fi
-          if [ ! -f "$INFO" ]; then
-            echo "::error::no UNSLOTH_PREBUILT_INFO.json at $INFO."
-            ls -la "$LLAMA_DIR" || true
-            exit 1
-          fi
-          if [ ! -f "$BIN" ]; then
-            echo "::error::no llama-server.exe at $BIN."
-            ls -la "$LLAMA_DIR/build/bin" || true
-            exit 1
-          fi
-          echo "install.ps1 installed the Windows prebuilt llama.cpp:"
-          cat "$INFO"
-
-      - name: Add Unsloth shim to GITHUB_PATH
-        run: |
-          SHIM_DIR=~/.unsloth/studio/bin
-          if [ ! -f "$SHIM_DIR/unsloth.exe" ]; then
-            echo "::error::unsloth.exe shim not found at $SHIM_DIR"
-            ls -la ~/.unsloth/studio/ || true
-            exit 1
-          fi
-          cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
-
-      - name: Install OpenAI + Anthropic Python SDKs
-        run: python -m pip install 'openai>=1.50' 'anthropic>=0.40'
+          path: hf-cache-vision
+          key: ${{ runner.os }}-hf-unsloth/Qwen3-VL-2B-Instruct-GGUF-UD-IQ2_XXS-mmproj-F16.gguf-v2
 
       - name: Reset auth + boot Unsloth (API-only)
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         run: |
           rm -rf ~/.unsloth/studio/auth
           mkdir -p logs
           UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
+            > logs/studio_vision.log 2>&1 &
           echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for /api/health, log in, change password, load model
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        timeout-minutes: 25
         run: |
           for i in $(seq 1 180); do
             if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
@@ -1146,6 +982,7 @@ jobs:
           jq '{status, display_name, is_vision}' /tmp/load.json
 
       - name: JSON schema decoding + image input
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         env:
           BASE_URL: http://127.0.0.1:18899
         run: |
@@ -1367,7 +1204,7 @@ jobs:
         with:
           name: windows-json-images-log
           path: |
-            logs/studio.log
+            logs/studio_vision.log
             logs/install.log
             logs/llama-server/*.log
           retention-days: 7

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -237,9 +237,14 @@ jobs:
             }
           }
 
+      # Deliberately NO `if:`, so this rides the implicit success() and a failed
+      # preamble (installer unit tests, setup-node, setup-python, the Defender
+      # tweak) still stops the job here, exactly as it did when this was three
+      # jobs. Gating it on `!cancelled()` would install onto a runner whose
+      # pinned Python or Node never materialised, and every phase below gates on
+      # assert-prebuilt, which would then pass and hide the real failure.
       - name: Install Unsloth (--local, --no-torch)
         id: install
-        if: ${{ !cancelled() }}
         timeout-minutes: 25
         shell: pwsh
         env:
@@ -298,6 +303,7 @@ jobs:
         run: python -m pip install 'openai>=1.50' 'anthropic>=0.40'
 
       - name: Reset auth + boot Unsloth (API-only)
+        timeout-minutes: 2
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
           rm -rf ~/.unsloth/studio/auth
@@ -321,6 +327,7 @@ jobs:
           exit 1
 
       - name: Password rotation (old must fail, new must work)
+        timeout-minutes: 3
         run: |
           OLD=$(cat ~/.unsloth/studio/auth/.bootstrap_password)
           NEW="CIRotated-$(python -c 'import secrets; print(secrets.token_urlsafe(12))')"
@@ -349,6 +356,7 @@ jobs:
           echo "password rotation OK (old=401, new=200)"
 
       - name: Load the GGUF (HF repo + variant, served from HF_HOME cache)
+        timeout-minutes: 20
         run: |
           # Retry the load step a few times so a transient TCP RST during
           # llama-server warm-up (Windows runner image churn,
@@ -372,6 +380,7 @@ jobs:
           jq '{status, display_name, is_gguf, context_length}' /tmp/load.json
 
       - name: Multi-turn determinism via OpenAI + Anthropic SDKs
+        timeout-minutes: 12
         env:
           BASE_URL: http://127.0.0.1:18888
         run: |
@@ -538,6 +547,14 @@ jobs:
           echo "STUDIO_PORT=18898" >> "$GITHUB_ENV"
           echo "HF_HOME=${{ github.workspace }}/hf-cache-tools" >> "$GITHUB_ENV"
 
+      # Key suffix bumped v1 -> v2 with the directory rename, and this is not
+      # cosmetic. actions/cache identifies an entry by key AND a version hash
+      # derived from the `path` input, but key uniqueness is global per ref. The
+      # old gguf-cache entry still holds the -v1 key, so a restore into
+      # gguf-cache-tools misses on version while the save is refused with
+      # "Unable to reserve cache with key ... another job may be creating this
+      # cache". Measured on staging during the Mac consolidation: two consecutive
+      # runs both logged "Cache not found for input keys" and both failed to save.
       - name: Restore GGUF model cache
         if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         id: cache-gguf-tools
@@ -546,7 +563,7 @@ jobs:
         continue-on-error: true
         with:
           path: gguf-cache-tools
-          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v1
+          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v2
 
       - name: Download GGUF if cache miss
         id: download-gguf-tools
@@ -566,10 +583,18 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: gguf-cache-tools
-          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v1
+          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v2
 
       - name: Reset auth + boot Unsloth (API-only, default tool policy)
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        id: boot-tools
+        # Phase-local prerequisite on top of the shared gate. The phase stays
+        # independent of EARLIER phases, which is what the shared assert-prebuilt
+        # gate buys, but it is not independent of its own download: without this
+        # clause a failed download still boots a server with no model and runs
+        # the test against it, burning Windows runner minutes and burying the
+        # real error under a pile of connection failures.
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.download-gguf-tools.outcome != 'failure' }}
+        timeout-minutes: 2
         run: |
           rm -rf ~/.unsloth/studio/auth
           mkdir -p logs
@@ -578,7 +603,8 @@ jobs:
           echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for /api/health, log in, change password, load model
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        id: ready-tools
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.boot-tools.outcome == 'success' }}
         timeout-minutes: 25
         run: |
           for i in $(seq 1 180); do
@@ -628,7 +654,8 @@ jobs:
           jq '{status, display_name}' /tmp/load.json
 
       - name: Tool calling, server-side tools, thinking on/off
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.ready-tools.outcome == 'success' }}
+        timeout-minutes: 15
         env:
           BASE_URL: http://127.0.0.1:18898
         run: |
@@ -969,6 +996,9 @@ jobs:
           echo "STUDIO_PORT=18899" >> "$GITHUB_ENV"
           echo "HF_HOME=${{ github.workspace }}/hf-cache-vision" >> "$GITHUB_ENV"
 
+      # Key suffix bumped v2 -> v3 with the hf-cache -> hf-cache-vision rename,
+      # for the same reason as the tool-phase cache above: same key + different
+      # `path` means a permanent restore miss and a refused save.
       - name: Restore HF_HOME cache for unsloth/Qwen3-VL-2B-Instruct-GGUF (model + mmproj)
         if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         id: cache-hf-vision
@@ -977,7 +1007,7 @@ jobs:
         continue-on-error: true
         with:
           path: hf-cache-vision
-          key: ${{ runner.os }}-hf-unsloth/Qwen3-VL-2B-Instruct-GGUF-UD-IQ2_XXS-mmproj-F16.gguf-v2
+          key: ${{ runner.os }}-hf-unsloth/Qwen3-VL-2B-Instruct-GGUF-UD-IQ2_XXS-mmproj-F16.gguf-v3
 
       - name: Prime HF_HOME with the GGUF + mmproj
         id: prime-hf-vision
@@ -999,10 +1029,13 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache-vision
-          key: ${{ runner.os }}-hf-unsloth/Qwen3-VL-2B-Instruct-GGUF-UD-IQ2_XXS-mmproj-F16.gguf-v2
+          key: ${{ runner.os }}-hf-unsloth/Qwen3-VL-2B-Instruct-GGUF-UD-IQ2_XXS-mmproj-F16.gguf-v3
 
       - name: Reset auth + boot Unsloth (API-only)
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        id: boot-vision
+        # Same phase-local prerequisite as phase 2, for the same reason.
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.prime-hf-vision.outcome != 'failure' }}
+        timeout-minutes: 2
         run: |
           rm -rf ~/.unsloth/studio/auth
           mkdir -p logs
@@ -1011,7 +1044,8 @@ jobs:
           echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for /api/health, log in, change password, load model
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        id: ready-vision
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.boot-vision.outcome == 'success' }}
         timeout-minutes: 25
         run: |
           for i in $(seq 1 180); do
@@ -1052,7 +1086,8 @@ jobs:
           jq '{status, display_name, is_vision}' /tmp/load.json
 
       - name: JSON schema decoding + image input
-        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' && steps.ready-vision.outcome == 'success' }}
+        timeout-minutes: 15
         env:
           BASE_URL: http://127.0.0.1:18899
         run: |

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -456,13 +456,43 @@ jobs:
 
       - name: Stop Unsloth
         if: always()
-        # Run as cmd so we are not running through the Git Bash shell;
-        # Git Bash on windows-latest has been observed to exit 143
-        # (SIGTERM) from any inline kill/sleep block, masking a green
-        # test run. The runner reclaims the Unsloth child process at
-        # job end either way, so just emit a marker and exit 0.
-        shell: cmd
-        run: echo Stop Unsloth (no-op; runner reclaims STUDIO_PID=%STUDIO_PID% at job end)
+        # NOT via Git Bash: bash on windows-latest has been observed to exit
+        # 143 (SIGTERM) from any inline kill/sleep block, masking a green test
+        # run (#5460, #5462). That is why this used to be a cmd no-op relying
+        # on the runner to reclaim the process at job end.
+        #
+        # That reliance was only safe while each phase was its OWN job. In one
+        # job the phase 1 server would stay alive through phases 2 and 3,
+        # holding its model resident and, worse, still owning
+        # ~/.unsloth/studio/auth while the next phase wipes and re-seeds that
+        # directory to get a fresh bootstrap password.
+        #
+        # Kill by listening port rather than by PID: STUDIO_PID comes from
+        # bash's `$!`, which is an MSYS pid that taskkill/Stop-Process cannot
+        # resolve to the real Windows process. pwsh keeps us off Git Bash, and
+        # every failure is swallowed so teardown can never fail the job.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          $port = $env:STUDIO_PORT
+          $owners = (Get-NetTCPConnection -LocalPort $port -State Listen).OwningProcess |
+                    Sort-Object -Unique
+          foreach ($owner in $owners) {
+            try {
+              $p = Get-Process -Id $owner
+              Write-Host "stopping pid $owner ($($p.ProcessName)) on port $port"
+              Stop-Process -Id $owner -Force
+            } catch {
+              Write-Host "pid $owner already gone"
+            }
+          }
+          Start-Sleep -Seconds 2
+          if ((Get-NetTCPConnection -LocalPort $port -State Listen)) {
+            Write-Host "note: something is still listening on $port"
+          } else {
+            Write-Host "port $port is free"
+          }
+          exit 0
 
       - name: Collect llama-server logs
         if: always()
@@ -497,6 +527,11 @@ jobs:
   # Job 2: Tool calling Tests
   # ─────────────────────────────────────────────────────────────────────
       - name: Phase 2 environment (tool calling)
+        # Same gate as the rest of this phase. Without it the step rides the
+        # implicit success(), so a phase 1 TEST failure would skip it while the
+        # gated steps below still ran -- and they would then inherit the previous
+        # phase's model, port and HF_HOME.
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         run: |
           echo "GGUF_REPO=unsloth/Qwen3.5-2B-GGUF" >> "$GITHUB_ENV"
           echo "GGUF_FILE=Qwen3.5-2B-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
@@ -850,13 +885,43 @@ jobs:
 
       - name: Stop Unsloth
         if: always()
-        # Run as cmd so we are not running through the Git Bash shell;
-        # Git Bash on windows-latest has been observed to exit 143
-        # (SIGTERM) from any inline kill/sleep block, masking a green
-        # test run. The runner reclaims the Unsloth child process at
-        # job end either way, so just emit a marker and exit 0.
-        shell: cmd
-        run: echo Stop Unsloth (no-op; runner reclaims STUDIO_PID=%STUDIO_PID% at job end)
+        # NOT via Git Bash: bash on windows-latest has been observed to exit
+        # 143 (SIGTERM) from any inline kill/sleep block, masking a green test
+        # run (#5460, #5462). That is why this used to be a cmd no-op relying
+        # on the runner to reclaim the process at job end.
+        #
+        # That reliance was only safe while each phase was its OWN job. In one
+        # job the phase 1 server would stay alive through phases 2 and 3,
+        # holding its model resident and, worse, still owning
+        # ~/.unsloth/studio/auth while the next phase wipes and re-seeds that
+        # directory to get a fresh bootstrap password.
+        #
+        # Kill by listening port rather than by PID: STUDIO_PID comes from
+        # bash's `$!`, which is an MSYS pid that taskkill/Stop-Process cannot
+        # resolve to the real Windows process. pwsh keeps us off Git Bash, and
+        # every failure is swallowed so teardown can never fail the job.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          $port = $env:STUDIO_PORT
+          $owners = (Get-NetTCPConnection -LocalPort $port -State Listen).OwningProcess |
+                    Sort-Object -Unique
+          foreach ($owner in $owners) {
+            try {
+              $p = Get-Process -Id $owner
+              Write-Host "stopping pid $owner ($($p.ProcessName)) on port $port"
+              Stop-Process -Id $owner -Force
+            } catch {
+              Write-Host "pid $owner already gone"
+            }
+          }
+          Start-Sleep -Seconds 2
+          if ((Get-NetTCPConnection -LocalPort $port -State Listen)) {
+            Write-Host "note: something is still listening on $port"
+          } else {
+            Write-Host "port $port is free"
+          }
+          exit 0
 
       - name: Collect llama-server logs
         if: always()
@@ -891,6 +956,11 @@ jobs:
   # Job 3: JSON, images
   # ─────────────────────────────────────────────────────────────────────
       - name: Phase 3 environment (JSON + vision)
+        # Same gate as the rest of this phase. Without it the step rides the
+        # implicit success(), so a phase 1 TEST failure would skip it while the
+        # gated steps below still ran -- and they would then inherit the previous
+        # phase's model, port and HF_HOME.
+        if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         run: |
           echo "GGUF_REPO=unsloth/Qwen3-VL-2B-Instruct-GGUF" >> "$GITHUB_ENV"
           echo "GGUF_VARIANT=UD-IQ2_XXS" >> "$GITHUB_ENV"
@@ -1172,13 +1242,43 @@ jobs:
 
       - name: Stop Unsloth
         if: always()
-        # Run as cmd so we are not running through the Git Bash shell;
-        # Git Bash on windows-latest has been observed to exit 143
-        # (SIGTERM) from any inline kill/sleep block, masking a green
-        # test run. The runner reclaims the Unsloth child process at
-        # job end either way, so just emit a marker and exit 0.
-        shell: cmd
-        run: echo Stop Unsloth (no-op; runner reclaims STUDIO_PID=%STUDIO_PID% at job end)
+        # NOT via Git Bash: bash on windows-latest has been observed to exit
+        # 143 (SIGTERM) from any inline kill/sleep block, masking a green test
+        # run (#5460, #5462). That is why this used to be a cmd no-op relying
+        # on the runner to reclaim the process at job end.
+        #
+        # That reliance was only safe while each phase was its OWN job. In one
+        # job the phase 1 server would stay alive through phases 2 and 3,
+        # holding its model resident and, worse, still owning
+        # ~/.unsloth/studio/auth while the next phase wipes and re-seeds that
+        # directory to get a fresh bootstrap password.
+        #
+        # Kill by listening port rather than by PID: STUDIO_PID comes from
+        # bash's `$!`, which is an MSYS pid that taskkill/Stop-Process cannot
+        # resolve to the real Windows process. pwsh keeps us off Git Bash, and
+        # every failure is swallowed so teardown can never fail the job.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          $port = $env:STUDIO_PORT
+          $owners = (Get-NetTCPConnection -LocalPort $port -State Listen).OwningProcess |
+                    Sort-Object -Unique
+          foreach ($owner in $owners) {
+            try {
+              $p = Get-Process -Id $owner
+              Write-Host "stopping pid $owner ($($p.ProcessName)) on port $port"
+              Stop-Process -Id $owner -Force
+            } catch {
+              Write-Host "pid $owner already gone"
+            }
+          }
+          Start-Sleep -Seconds 2
+          if ((Get-NetTCPConnection -LocalPort $port -State Listen)) {
+            Write-Host "note: something is still listening on $port"
+          } else {
+            Write-Host "port $port is free"
+          }
+          exit 0
 
       - name: Collect llama-server logs
         if: always()


### PR DESCRIPTION
`openai-anthropic`, `tool-calling` and `json-images` differed only in model, port and test body. The checkout, setup-node, setup-python, npm/Defender tweaks, `install.ps1 --local --no-torch` and prebuilt assertion were identical in all three, so every triggering PR ran the same Windows install three times concurrently.

## Why Windows and not Linux

This is measured, not assumed. Consolidating trades wall time for concurrency slots, and that only pays when per-job setup `S` dominates test time `T` (the saving is `2S - C`). From recent successful runs:

| | setup `S` | tests `T` | verdict |
|---|---|---|---|
| **Windows** | **7.0 min** (`install.ps1` alone is 6.4) | 3.8 min | setup dominates, consolidate |
| Ubuntu | 1.9 min | 3.0 min | tests dominate, **leave parallel** |
| macOS | 2.1 min | 2.1 min | already done in #7978, forced by the hard 5-slot cap |

So this saves ~14 runner-minutes and **2 of the 60 concurrent-job slots**, at roughly +4 min of wall time on this workflow. I deliberately did **not** make the same change to `studio-inference-smoke.yml` (ubuntu): there it would add more feedback latency than the slots are worth, and minutes are free on public repos.

Windows jobs on this workflow: **10 to 8.**

## Collisions the merge had to resolve

All three jobs were written assuming they owned the runner, so merging them surfaced real conflicts rather than just concatenating:

| collision | resolution |
|---|---|
| `cache-hf` / `prime-hf` step ids in **both** phase 1 and phase 3 | phase-scoped: `cache-hf-vision`, `prime-hf-vision` |
| both used the `hf-cache` directory and the same `HF_HOME` | split into `hf-cache`, `gguf-cache-tools`, `hf-cache-vision` |
| all three wrote `logs/studio.log` | `studio.log` / `studio_tools.log` / `studio_vision.log` |

Model, GGUF file, port and `HF_HOME` move from job-level `env:` to per-phase `$GITHUB_ENV` writes, and the cache keys inline their values as literals. That follows #7978: if a phase-specific key were *also* declared at job level, whether the later `$GITHUB_ENV` write wins is not something the Actions docs pin down, and a phase quietly talking to the previous phase's port would be a nasty way to find out.

## Phase independence is preserved, not assumed

Each phase is gated on the **shared preamble** (`!cancelled() && steps.assert-prebuilt.outcome == 'success'`), not on the phase before it. One failing phase therefore does not swallow the next, and a failure still points at a single phase.

The nine `Stop Unsloth` / `Collect llama-server logs` / `Upload logs` steps keep their `always()` verbatim so logs survive a failure. Worth flagging that I got this wrong first time: a blanket "gate every step" pass added a *second* `if:` key to 10 steps that already had one, including those `always()` steps. YAML keeps the last, so it would have silently changed when logs get collected. Existing conditions are now ANDed with the gate rather than replaced.

Every step that can block carries its own `timeout-minutes`. The 90 min job cap is the outer guard only, because `hf-download-with-retry.sh` retries forever by design and named the job timeout as its bound (the gap #7978 had to close).

## Verification

- Workflow parses; no duplicate step ids, no duplicate `if:` keys, ports/log files/cache dirs/artifact names all distinct per phase.
- No dangling `needs:` or cross-references to the three removed job ids.
- **Assertion-preservation diff**: the set of test commands extracted from every workflow is **identical before and after, 121 commands**. All three phase bodies are intact (`Multi-turn determinism`, `Tool calling`, `JSON schema decoding + image input`).
- Staging CI to follow on this PR.
