### PR TITLE
CI: extract the POSIX local install into a composite action

### DIFF
--- a/.github/actions/install-unsloth-local/action.yml
+++ b/.github/actions/install-unsloth-local/action.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# The POSIX `install.sh --local --no-torch` bootstrap, which 13 jobs across 8
+# workflows ran with a byte-identical body. Extracted so the invocation has one
+# definition: the `set -o pipefail` + `tee` idiom is easy to get subtly wrong
+# (without pipefail the step reports the exit status of `tee`, not of
+# install.sh, and a failed install passes), and a flag or log-path change
+# previously had to be applied to 13 places consistently.
+#
+# Deliberately NOT parameterised beyond the two tokens. This action is "the
+# standard local no-torch install", not a general installer wrapper: giving it
+# an `args` input would let call sites drift apart again, which is the thing it
+# exists to prevent. The Windows `install.ps1` path is a different script with a
+# different body and stays separate.
+#
+# Composite actions cannot read the `secrets` context, so both tokens are
+# explicit inputs that each caller passes. That is not boilerplate for its own
+# sake: it keeps the PR-withholding decision visible at the call site, where it
+# belongs, rather than hidden behind a default.
+#
+# Keep `id`, `if`, `timeout-minutes` and `continue-on-error` on the CALLER's
+# step. They are step-level keys on the `uses:` step, so `steps.<id>.outcome`
+# gating in the caller keeps working unchanged; the caller sees this action as a
+# single step and cannot inspect the steps inside it.
+
+name: Install Unsloth (--local, --no-torch)
+description: >-
+  Run the checked-out install.sh in --local --no-torch mode, teeing the
+  installer output to logs/install.log. Requires actions/checkout to have run.
+
+inputs:
+  gh-token:
+    description: >-
+      Token for installer calls that hit the GitHub API (release lookups for the
+      llama.cpp prebuilt). Normally secrets.GITHUB_TOKEN.
+    required: true
+  hf-token:
+    description: >-
+      Hugging Face token, or the empty string to run unauthenticated. Callers
+      that reach this step on a `pull_request` event should withhold it with
+      `${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}`,
+      because this step executes checked-out PR code; public models still
+      download without it. Callers whose job cannot run on `pull_request` (for
+      example a `workflow_dispatch`-only job) may pass it unconditionally.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install Unsloth (--local, --no-torch)
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        HF_TOKEN: ${{ inputs.hf-token }}
+      run: |
+        mkdir -p logs
+        set -o pipefail
+        bash install.sh --local --no-torch 2>&1 | tee logs/install.log

--- a/.github/actions/install-unsloth-local/action.yml
+++ b/.github/actions/install-unsloth-local/action.yml
@@ -38,11 +38,19 @@ inputs:
   hf-token:
     description: >-
       Hugging Face token, or the empty string to run unauthenticated. Callers
-      that reach this step on a `pull_request` event should withhold it with
-      `${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}`,
+      that can reach this step on a pull_request event should withhold it,
       because this step executes checked-out PR code; public models still
-      download without it. Callers whose job cannot run on `pull_request` (for
-      example a `workflow_dispatch`-only job) may pass it unconditionally.
+      download without it. The idiom every such caller uses is a conditional on
+      github.event_name that yields secrets.HF_TOKEN off pull_request and an
+      empty string on it (see any call site). Callers whose job cannot run on
+      pull_request, such as a workflow_dispatch-only job, may pass it
+      unconditionally.
+
+      Do not write that conditional out as a literal template expression here.
+      GitHub evaluates expression syntax inside an action manifest, including
+      inside these description strings, and neither the github nor the secrets
+      context exists at manifest-parse time, so an example written out in full
+      fails the whole action with "Unrecognized named-value: 'github'".
     required: false
     default: ''
 

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -189,14 +189,11 @@ jobs:
           key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Gated off PR (see note above); public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       # ── boot the server under test (factored helper) ──────────────────
       - name: Serve unsloth run --disable-tools (gemma-4-E4B)
@@ -403,14 +400,11 @@ jobs:
           key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Gated off PR (see note above); public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Serve unsloth run --disable-tools (gemma-4-E4B)
         run: |
@@ -587,13 +581,10 @@ jobs:
           key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          hf-token: ${{ secrets.HF_TOKEN }}
 
       - name: Serve unsloth run --disable-tools (gemma-4-E4B)
         run: |
@@ -750,14 +741,11 @@ jobs:
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Gated off PR (see note above); public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Serve unsloth run --disable-tools (gemma-3-270m)
         run: |

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -54,6 +54,9 @@ on:
       - 'studio/backend/models/**'
       - 'install.sh'
       - '.github/workflows/local-agent-guides-ci.yml'
+      # The install step in this workflow is `uses:` on that composite action,
+      # so an edit to the action changes what this workflow actually runs.
+      - '.github/actions/install-unsloth-local/action.yml'
       - '.github/scripts/serve-unsloth-run.sh'
       - '.github/scripts/assert-prompt-cache.sh'
       - '.github/scripts/agent-guides-install.sh'
@@ -72,6 +75,7 @@ on:
       - 'studio/backend/models/**'
       - 'install.sh'
       - '.github/workflows/local-agent-guides-ci.yml'
+      - '.github/actions/install-unsloth-local/action.yml'
       - '.github/scripts/serve-unsloth-run.sh'
       - '.github/scripts/assert-prompt-cache.sh'
       - '.github/scripts/agent-guides-install.sh'

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -109,14 +109,11 @@ jobs:
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Install pyjwt for the JWT-expiry forge test
         run: pip install 'pyjwt>=2.6'

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -27,6 +27,9 @@ on:
       - 'pyproject.toml'
       - 'tests/studio/**'
       - '.github/workflows/studio-api-smoke.yml'
+      # The install step in this workflow is `uses:` on that composite action,
+      # so an edit to the action changes what this workflow actually runs.
+      - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
   workflow_dispatch:

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -38,6 +38,9 @@ on:
       - 'install.sh'
       - 'pyproject.toml'
       - '.github/workflows/studio-inference-smoke.yml'
+      # The install step in this workflow is `uses:` on that composite action,
+      # so an edit to the action changes what this workflow actually runs.
+      - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
   # Manual trigger for pre-warming HF_HOME caches on main, or re-running

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -123,14 +123,11 @@ jobs:
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Install OpenAI + Anthropic Python SDKs
         run: pip install 'openai>=1.50' 'anthropic>=0.40'
@@ -392,14 +389,11 @@ jobs:
           key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Reset auth + boot Unsloth (API-only, default tool policy)
         # We deliberately use the API-only mode rather than
@@ -972,14 +966,11 @@ jobs:
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v2
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Install OpenAI + Anthropic Python SDKs
         run: pip install 'openai>=1.50' 'anthropic>=0.40'

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -40,6 +40,9 @@ on:
       - 'install.sh'
       - 'pyproject.toml'
       - '.github/workflows/studio-mac-inference-smoke.yml'
+      # The install step in this workflow is `uses:` on that composite action,
+      # so an edit to the action changes what this workflow actually runs.
+      - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
   # Manual trigger for pre-warming model caches on main, or re-running

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -164,14 +164,11 @@ jobs:
         id: install
         if: ${{ !cancelled() }}
         timeout-minutes: 20
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       # Last step of the shared preamble. Phases 2 and 3 gate on its outcome:
       # once checkout, install and this check have passed, a failure inside one

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -79,14 +79,11 @@ jobs:
           python-version: '3.12'
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Assert llama.cpp loads on this macOS
         run: bash .github/scripts/assert-llama-loads.sh

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -16,6 +16,9 @@ on:
       - 'install.sh'
       - '.github/scripts/assert-llama-loads.sh'
       - '.github/workflows/studio-mac-install-matrix.yml'
+      # The install step in this workflow is `uses:` on that composite action,
+      # so an edit to the action changes what this workflow actually runs.
+      - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
   workflow_dispatch:

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -35,6 +35,9 @@ on:
       - 'tests/studio/**'
       - '.github/scripts/run-studio-permission-browser.sh'
       - '.github/workflows/studio-mac-ui-smoke.yml'
+      # The install step in this workflow is `uses:` on that composite action,
+      # so an edit to the action changes what this workflow actually runs.
+      - '.github/actions/install-unsloth-local/action.yml'
       # The absorbed update phase round-trips scripts/uninstall.sh, which none
       # of the entries above cover.
       - 'scripts/uninstall.sh'

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -129,20 +129,12 @@ jobs:
 
       - name: Install Unsloth (--local, --no-torch)
         id: install_unsloth
-        # The install is the shared bootstrap for every phase below, and only
-        # the Playwright phases need the primed GGUF. Detaching it from the
-        # implicit success() keeps the update and uninstall phases reachable
-        # when priming times out, which is the one case where they would still
-        # have produced a real result.
         if: ${{ !cancelled() }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Assert llama.cpp loads on this macOS
         id: assert_llama

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -119,14 +119,11 @@ jobs:
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
 
       - name: Install Unsloth (--local, --no-torch)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Install Playwright browsers
         run: |

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -29,6 +29,9 @@ on:
       - 'tests/studio/**'
       - '.github/scripts/run-studio-permission-browser.sh'
       - '.github/workflows/studio-ui-smoke.yml'
+      # The install step in this workflow is `uses:` on that composite action,
+      # so an edit to the action changes what this workflow actually runs.
+      - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
   workflow_dispatch:

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -64,19 +64,11 @@ jobs:
           # retrieved for pip but doesn't exist on disk".
 
       - name: Install Unsloth (--local, --no-torch)
-        # Pass the workflow token so the llama.cpp prebuilt installer's
-        # GitHub-API call to list releases isn't rate-limited (60/hr
-        # unauthenticated). Without this, three consecutive install +
-        # update + update calls in this job exceed the limit and the
-        # prebuilt path falls back to source build.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-        run: |
-          mkdir -p logs
-          set -o pipefail
-          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: First update should be a no-op (prebuilt already validated)
         # `unsloth studio update --local` runs studio/setup.sh against

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -23,6 +23,9 @@ on:
       - 'unsloth_cli/commands/studio.py'
       - 'pyproject.toml'
       - '.github/workflows/studio-update-smoke.yml'
+      # The install step in this workflow is `uses:` on that composite action,
+      # so an edit to the action changes what this workflow actually runs.
+      - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
   workflow_dispatch:


### PR DESCRIPTION
13 jobs across 8 workflows ran `install.sh --local --no-torch` with a byte-identical body. They now call one composite action, `.github/actions/install-unsloth-local`.

## This is not a line-count win, and I want to be straight about that

Workflows lose 49 lines; the action adds about 60. The diff is roughly neutral. What changes is that **the invocation went from 13 definitions to 1**.

Two things make that worth doing:

- The `set -o pipefail` + `tee` idiom is easy to get subtly wrong. Without `pipefail` the step reports `tee`'s exit status rather than `install.sh`'s, so a **failed install passes green**. That is one line to get right in one place now, instead of 13 places that have to agree.
- Any change to the flags or the log path previously had to be applied 13 times consistently.

This is also the first composite action in the repo. The existing sharing idiom is `.github/scripts/*.sh` (19 helpers), which stays the right tool for pure shell. A composite action is used here specifically because this step's duplication includes non-`run:` keys — the `env:` block carrying secrets — which a shell script cannot absorb.

## Tokens are inputs, deliberately

Composite actions cannot read the `secrets` context, so both tokens are explicit inputs each caller passes. That is a design choice rather than unavoidable boilerplate: it keeps the PR-withholding decision **visible at the call site** instead of hidden behind a default.

## The one caller that differs is correct

Twelve callers withhold `HF_TOKEN` on `pull_request`, because the step runs checked-out PR code and a hostile PR could exfiltrate it. The thirteenth, `local-agent-guides-ci`'s `resume` job, passes it unconditionally.

I preserved that rather than normalising it, and checked why before deciding: `resume` is gated on `github.event_name == 'workflow_dispatch'`, so it **cannot run on a pull request** and the withholding expression would be a no-op there. Not a gap.

## Caller-side keys are untouched

`id`, `if` and `timeout-minutes` stay on the caller's step. They are step-level keys on the `uses:` step, so the four downstream gates keep working unchanged — they read the caller's step, not the action's internals:

```
studio-mac-inference-smoke.yml:183   steps.install.outcome == 'success'
studio-mac-ui-smoke.yml:143          steps.install_unsloth.outcome == 'success'
studio-mac-ui-smoke.yml:460          steps.install_unsloth.outcome == 'success' && steps.assert_llama.outcome == 'success'
studio-mac-ui-smoke.yml:529          steps.install_unsloth.outcome == 'success'
```

The Windows `install.ps1` path is a different script with a different body and stays separate.

## Verification

- **actionlint** on every workflow: no new findings. The ones that remain are pre-existing (`macos-26` / `macos-15-intel` / `windows-11-arm` custom runner labels, `publish-desktop-updater`'s `queue: max`, `security-audit`'s empty `needs: []`).
- Every call site has `actions/checkout` before it, which a local action requires. Checked mechanically, not by eye.
- **Assertion-preservation diff**: the set of test commands across all workflows is unchanged at 121.
- Staging CI to follow.
