### PR TITLE
Studio: keep dictation status reads off the sidecar lock

### DIFF
--- a/studio/backend/core/inference/stt_ggml_sidecar.py
+++ b/studio/backend/core/inference/stt_ggml_sidecar.py
@@ -465,7 +465,7 @@ class _GgmlDownloadState:
                 pass
             # Out of process so cancel() can terminate it; a thread blocked in
             # hf_hub_download could not be interrupted.
-            from core.inference.stt_download_worker import spawn_download
+            from core.inference.stt_download_worker import reap_download, spawn_download
 
             process = spawn_download(
                 ["--repo-id", repo_id, "--filename", filename],
@@ -476,7 +476,10 @@ class _GgmlDownloadState:
                     # cancel() landed between start() and the spawn.
                     process.terminate()
                 self._process = process
-            _, stderr = process.communicate()
+            # reap_download(), not communicate(): only it drops the PID
+            # spawn_download() adopted, which could otherwise be reused and then
+            # signalled by terminate_all.
+            stderr = reap_download(process)
             if process.returncode == 0:
                 return
             with self._lock:

--- a/studio/backend/core/inference/stt_ggml_sidecar.py
+++ b/studio/backend/core/inference/stt_ggml_sidecar.py
@@ -476,9 +476,8 @@ class _GgmlDownloadState:
                     # cancel() landed between start() and the spawn.
                     process.terminate()
                 self._process = process
-            # reap_download(), not communicate(): only it drops the PID
-            # spawn_download() adopted, which could otherwise be reused and then
-            # signalled by terminate_all.
+            # reap_download(), not communicate(): only it drops the adopted PID,
+            # which could otherwise be reused and then signalled by terminate_all.
             stderr = reap_download(process)
             if process.returncode == 0:
                 return

--- a/studio/backend/core/inference/stt_mtmd_sidecar.py
+++ b/studio/backend/core/inference/stt_mtmd_sidecar.py
@@ -212,8 +212,36 @@ def _cached_model_paths(model_id: str) -> Optional[tuple[str, str]]:
     return model, mmproj
 
 
+# The status endpoint asks for every model and the panel polls it every 750ms.
+# Each answer is two hf_hub_download() calls, which resolve refs and stat the
+# snapshot even local-only, so memoise it briefly. Only the boolean: a load
+# resolves the real paths every time.
+_DOWNLOADED_PROBE_TTL_SECONDS = 2.0
+_downloaded_probe_lock = threading.Lock()
+_downloaded_probe: dict[str, tuple[float, bool]] = {}
+
+
+def _forget_downloaded_probe(model_id: Optional[str] = None) -> None:
+    """Drop memoised answers, for one model or all of them."""
+    with _downloaded_probe_lock:
+        if model_id is None:
+            _downloaded_probe.clear()
+        else:
+            _downloaded_probe.pop(model_id, None)
+
+
 def is_model_downloaded(model_id: str) -> bool:
-    return model_id in MTMD_STT_MODELS and _cached_model_paths(model_id) is not None
+    if model_id not in MTMD_STT_MODELS:
+        return False
+    now = time.monotonic()
+    with _downloaded_probe_lock:
+        cached = _downloaded_probe.get(model_id)
+        if cached is not None and now - cached[0] < _DOWNLOADED_PROBE_TTL_SECONDS:
+            return cached[1]
+    downloaded = _cached_model_paths(model_id) is not None
+    with _downloaded_probe_lock:
+        _downloaded_probe[model_id] = (now, downloaded)
+    return downloaded
 
 
 class _MtmdDownloadState:
@@ -231,14 +259,18 @@ class _MtmdDownloadState:
     def status(self) -> dict:
         with self._lock:
             downloading = self._thread is not None and self._thread.is_alive()
-            return {
+            model_id = self._model_id
+            snapshot = {
                 "downloading": downloading,
-                "model": self._model_id if downloading else None,
+                "model": model_id if downloading else None,
                 "error": self._error,
                 "cancelled": self._cancelled,
                 "bytes_total": self._total_bytes if downloading else None,
-                "bytes_done": self._cache_bytes() if downloading else None,
             }
+        # Outside the lock: _cache_bytes() walks the cache blobs, and a cancel
+        # should not queue behind that.
+        snapshot["bytes_done"] = self._cache_bytes(model_id) if downloading else None
+        return snapshot
 
     def cancel(self) -> bool:
         """Stop an in-flight download. False when none was running."""
@@ -251,12 +283,15 @@ class _MtmdDownloadState:
             process.terminate()
         return True
 
-    def _cache_bytes(self) -> Optional[int]:
-        """Best-effort progress: bytes in this repo's cache blobs."""
+    def _cache_bytes(self, model_id: Optional[str] = None) -> Optional[int]:
+        """Best-effort progress: bytes in this repo's cache blobs.
+
+        Takes the model id so status() can call it after dropping the lock.
+        """
         try:
             from core.inference.stt_sidecar import _repo_cache_dir
 
-            model_id = self._model_id
+            model_id = model_id or self._model_id
             if not model_id:
                 return None
             blobs = _repo_cache_dir(MTMD_STT_MODELS[model_id].repo) / "blobs"
@@ -342,6 +377,10 @@ class _MtmdDownloadState:
             logger.warning("mtmd STT download failed for %s: %s", model_id, exc)
             with self._lock:
                 self._error = f"Download failed for '{model_id}'."
+        finally:
+            # The memo is stale however this ended. Dropping it here is what
+            # lets the panel settle on its next poll, not a TTL later.
+            _forget_downloaded_probe(model_id)
 
 
 _download_state = _MtmdDownloadState()
@@ -387,16 +426,19 @@ class MtmdSttSidecar:
 
     @property
     def loaded_model(self) -> Optional[str]:
-        with self._lock:
-            return self._model_id if self._process_alive() else None
+        # Lock-free, like stt_ggml_sidecar.py: _lock is held across a reap and
+        # across a whole llama.cpp install, and the status route reads this on
+        # the event loop. _process_alive() snapshots _process before poll(), so
+        # a concurrent unload is safe.
+        return self._model_id if self._process_alive() else None
 
     @property
     def device(self) -> Optional[str]:
-        return "llama.cpp" if self.loaded_model else None
+        return "llama.cpp" if self._process_alive() else None
 
     def is_loading(self) -> bool:
-        with self._lock:
-            return self._loading
+        # Bare bool read, for the same reason as loaded_model.
+        return self._loading
 
     @property
     def keep_alive_seconds(self) -> float:
@@ -648,7 +690,10 @@ class MtmdSttSidecar:
                     if response.status == 200:
                         return True
             except Exception:
-                time.sleep(0.25)
+                pass
+            # Outside the except: a 2xx that is not 200 would spin this loop
+            # with no delay for the whole startup timeout.
+            time.sleep(0.25)
         return False
 
     def transcribe(

--- a/studio/backend/core/inference/stt_mtmd_sidecar.py
+++ b/studio/backend/core/inference/stt_mtmd_sidecar.py
@@ -212,15 +212,12 @@ def _cached_model_paths(model_id: str) -> Optional[tuple[str, str]]:
     return model, mmproj
 
 
-# The status endpoint asks for every model and the panel polls it every 750ms.
-# Each answer is two hf_hub_download() calls, which resolve refs and stat the
-# snapshot even local-only, so memoise it briefly. Only the boolean: a load
-# resolves the real paths every time.
+# The panel polls every model every 750ms, and each answer is two hf_hub_download()
+# calls that stat the snapshot even local-only, so memoise the boolean briefly.
 _DOWNLOADED_PROBE_TTL_SECONDS = 2.0
 _downloaded_probe_lock = threading.Lock()
 _downloaded_probe: dict[str, tuple[float, bool]] = {}
-# Bumped by every invalidation, so a probe that started earlier cannot write its
-# now-stale answer back over a cleared entry.
+# Bumped on every invalidation so an in-flight probe cannot overwrite a cleared entry.
 _downloaded_probe_generation = 0
 
 
@@ -245,8 +242,7 @@ def is_model_downloaded(model_id: str) -> bool:
         generation = _downloaded_probe_generation
     downloaded = _cached_model_paths(model_id) is not None
     with _downloaded_probe_lock:
-        # Timestamp now, not before the probe: a slow cache would otherwise
-        # store an entry that is already most of the way to expiry.
+        # Timestamp now, not before the probe: a slow cache would store a near-expired entry.
         if generation == _downloaded_probe_generation:
             _downloaded_probe[model_id] = (time.monotonic(), downloaded)
     return downloaded
@@ -275,8 +271,7 @@ class _MtmdDownloadState:
                 "cancelled": self._cancelled,
                 "bytes_total": self._total_bytes if downloading else None,
             }
-        # Outside the lock: _cache_bytes() walks the cache blobs, and a cancel
-        # should not queue behind that.
+        # Outside the lock: _cache_bytes() walks the cache blobs, and a cancel must not queue.
         snapshot["bytes_done"] = self._cache_bytes(model_id) if downloading else None
         return snapshot
 
@@ -292,10 +287,7 @@ class _MtmdDownloadState:
         return True
 
     def _cache_bytes(self, model_id: Optional[str] = None) -> Optional[int]:
-        """Best-effort progress: bytes in this repo's cache blobs.
-
-        Takes the model id so status() can call it after dropping the lock.
-        """
+        """Best-effort progress: cache blob bytes. model_id lets status() call it unlocked."""
         try:
             from core.inference.stt_sidecar import _repo_cache_dir
 
@@ -386,8 +378,7 @@ class _MtmdDownloadState:
             with self._lock:
                 self._error = f"Download failed for '{model_id}'."
         finally:
-            # The memo is stale however this ended. Dropping it here is what
-            # lets the panel settle on its next poll, not a TTL later.
+            # The memo is stale however this ended; dropping it now lets the next poll settle.
             _forget_downloaded_probe(model_id)
 
 
@@ -434,16 +425,15 @@ class MtmdSttSidecar:
 
     @property
     def loaded_model(self) -> Optional[str]:
-        # Lock-free, like stt_ggml_sidecar.py: _lock is held across a reap and
-        # across a whole llama.cpp install, and the status route reads this on
-        # the event loop. _process_alive() snapshots _process before poll(), so
-        # a concurrent unload is safe.
+        # Lock-free: _lock is held across reaps and llama.cpp installs, but the status
+        # route reads this on the event loop. _process_alive() snapshots _process before
+        # poll(), so a concurrent unload is safe.
         return self._model_id if self._process_alive() else None
 
     @property
     def device(self) -> Optional[str]:
-        # Derived, not a second probe: two _process_alive() calls can straddle
-        # the publish and report a device with a null model.
+        # Derived, not a second probe: two probes can straddle the publish and
+        # report a device with no model.
         return "llama.cpp" if self.loaded_model else None
 
     def is_loading(self) -> bool:
@@ -484,9 +474,8 @@ class MtmdSttSidecar:
         self._generation += 1
         process = self._process
         try:
-            # Reap before clearing, not after: a lock-free reader during the
-            # reap has to still see the model, or training admission starts
-            # while the dying llama-server holds its VRAM.
+            # Reap before clearing: a lock-free reader mid-reap must still see the
+            # model, or training starts while the dying server still holds its VRAM.
             _reap(process)
         finally:
             self._process = None
@@ -597,10 +586,9 @@ class MtmdSttSidecar:
                 if self._gpu_disabled == training or self._active_requests:
                     self._schedule_idle_unload_locked()
                     return
-            # Announced before the slow part: the probe and the reap below take
-            # seconds, and is_loading() is read lock-free, so a training start
-            # landing there would see False and wait out the startup in unload()
-            # rather than cancel this load.
+            # Announced before the slow probe and reap: is_loading() is read lock-free,
+            # so a training start would otherwise see False and wait out the startup in
+            # unload() instead of cancelling this load.
             cancel_event = threading.Event()
             self._load_cancel_event = cancel_event
             self._loading = True
@@ -619,8 +607,7 @@ class MtmdSttSidecar:
                 self._release_locked()
                 released = True
             finally:
-                # Nothing started, so take the announcement back. Past here the
-                # startup owns it and clears it in its own finally.
+                # Nothing started, so take the announcement back; past here the startup owns it.
                 if not released:
                     self._loading = False
                     self._load_cancel_event = None
@@ -719,8 +706,7 @@ class MtmdSttSidecar:
                         return True
             except Exception:
                 pass
-            # Outside the except: a 2xx that is not 200 would spin this loop
-            # with no delay for the whole startup timeout.
+            # Outside the except: a non-200 2xx would otherwise spin this loop with no delay.
             time.sleep(0.25)
         return False
 

--- a/studio/backend/core/inference/stt_mtmd_sidecar.py
+++ b/studio/backend/core/inference/stt_mtmd_sidecar.py
@@ -219,11 +219,16 @@ def _cached_model_paths(model_id: str) -> Optional[tuple[str, str]]:
 _DOWNLOADED_PROBE_TTL_SECONDS = 2.0
 _downloaded_probe_lock = threading.Lock()
 _downloaded_probe: dict[str, tuple[float, bool]] = {}
+# Bumped by every invalidation, so a probe that started earlier cannot write its
+# now-stale answer back over a cleared entry.
+_downloaded_probe_generation = 0
 
 
 def _forget_downloaded_probe(model_id: Optional[str] = None) -> None:
     """Drop memoised answers, for one model or all of them."""
+    global _downloaded_probe_generation
     with _downloaded_probe_lock:
+        _downloaded_probe_generation += 1
         if model_id is None:
             _downloaded_probe.clear()
         else:
@@ -233,14 +238,17 @@ def _forget_downloaded_probe(model_id: Optional[str] = None) -> None:
 def is_model_downloaded(model_id: str) -> bool:
     if model_id not in MTMD_STT_MODELS:
         return False
-    now = time.monotonic()
     with _downloaded_probe_lock:
         cached = _downloaded_probe.get(model_id)
-        if cached is not None and now - cached[0] < _DOWNLOADED_PROBE_TTL_SECONDS:
+        if cached is not None and time.monotonic() - cached[0] < _DOWNLOADED_PROBE_TTL_SECONDS:
             return cached[1]
+        generation = _downloaded_probe_generation
     downloaded = _cached_model_paths(model_id) is not None
     with _downloaded_probe_lock:
-        _downloaded_probe[model_id] = (now, downloaded)
+        # Timestamp now, not before the probe: a slow cache would otherwise
+        # store an entry that is already most of the way to expiry.
+        if generation == _downloaded_probe_generation:
+            _downloaded_probe[model_id] = (time.monotonic(), downloaded)
     return downloaded
 
 
@@ -473,10 +481,15 @@ class MtmdSttSidecar:
         self._cancel_idle_unload_locked()
         self._generation += 1
         process = self._process
-        self._process = None
-        self._port = None
-        self._model_id = None
-        _reap(process)
+        try:
+            # Reap before clearing, not after: a lock-free reader during the
+            # reap has to still see the model, or training admission starts
+            # while the dying llama-server holds its VRAM.
+            _reap(process)
+        finally:
+            self._process = None
+            self._port = None
+            self._model_id = None
 
     def unload(self) -> None:
         # A startup has not assigned _process yet, so releasing alone would let

--- a/studio/backend/core/inference/stt_mtmd_sidecar.py
+++ b/studio/backend/core/inference/stt_mtmd_sidecar.py
@@ -442,7 +442,9 @@ class MtmdSttSidecar:
 
     @property
     def device(self) -> Optional[str]:
-        return "llama.cpp" if self._process_alive() else None
+        # Derived, not a second probe: two _process_alive() calls can straddle
+        # the publish and report a device with a null model.
+        return "llama.cpp" if self.loaded_model else None
 
     def is_loading(self) -> bool:
         # Bare bool read, for the same reason as loaded_model.
@@ -595,20 +597,33 @@ class MtmdSttSidecar:
                 if self._gpu_disabled == training or self._active_requests:
                     self._schedule_idle_unload_locked()
                     return
-            # Before the release: a 409 for a model that is not downloaded
-            # must not cost the user the server they were already using.
-            model_path, mmproj_path = self._ensure_model_downloaded(model_id)
-            # Only when there is a live server to protect: a request against a
-            # server that already died must not block recovery.
-            if self._active_requests and self._process_alive():
-                raise SttModelBusyError(
-                    "A transcription is still running on the current dictation model. "
-                    "Try again in a moment."
-                )
-            self._release_locked()
+            # Announced before the slow part: the probe and the reap below take
+            # seconds, and is_loading() is read lock-free, so a training start
+            # landing there would see False and wait out the startup in unload()
+            # rather than cancel this load.
             cancel_event = threading.Event()
             self._load_cancel_event = cancel_event
             self._loading = True
+            released = False
+            try:
+                # Before the release: a 409 for a model that is not downloaded
+                # must not cost the user the server they were already using.
+                model_path, mmproj_path = self._ensure_model_downloaded(model_id)
+                # Only when there is a live server to protect: a request against
+                # a server that already died must not block recovery.
+                if self._active_requests and self._process_alive():
+                    raise SttModelBusyError(
+                        "A transcription is still running on the current dictation model. "
+                        "Try again in a moment."
+                    )
+                self._release_locked()
+                released = True
+            finally:
+                # Nothing started, so take the announcement back. Past here the
+                # startup owns it and clears it in its own finally.
+                if not released:
+                    self._loading = False
+                    self._load_cancel_event = None
             # Re-read last: _release_locked() reaps the old server, which can
             # take seconds, and training admission that already passed its own
             # check cannot come back to cancel this load. Publishing _loading

--- a/studio/backend/tests/test_stt_review_fixes_4.py
+++ b/studio/backend/tests/test_stt_review_fixes_4.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Fourth review pass: status reads that must never block, and the PID registry.
+
+The STT status route reads these sidecars on the event loop, so anything it
+touches has to answer while a lifecycle operation holds the sidecar's lock.
+"""
+
+import subprocess
+import threading
+import time
+
+import pytest
+
+from core.inference import stt_ggml_sidecar as ggml_mod
+from core.inference import stt_mtmd_sidecar as mtmd_mod
+from core.inference.stt_mtmd_sidecar import MtmdSttSidecar
+
+
+class _SlowlyDyingProcess:
+    """A child whose reap blocks, like a llama-server that is slow to exit."""
+
+    def __init__(self, release: threading.Event):
+        self.pid = 4242
+        self._release = release
+        self._returncode = None
+
+    def poll(self):
+        return self._returncode
+
+    def terminate(self):
+        pass
+
+    def wait(self, timeout = None):
+        # Blocks until the test lets go, standing in for a server that takes
+        # seconds to release its port and VRAM.
+        if not self._release.wait(timeout = timeout):
+            raise subprocess.TimeoutExpired("llama-server", timeout)
+        self._returncode = -15
+        return self._returncode
+
+    def kill(self):
+        self._returncode = -9
+
+
+def _resident(sidecar: MtmdSttSidecar, process) -> None:
+    """Publish `process` as the loaded server, as a finished load would."""
+    sidecar._process = process
+    sidecar._port = 12345
+    sidecar._model_id = "qwen3-asr-0.6b"
+
+
+def test_status_reads_do_not_block_behind_a_reap(monkeypatch):
+    """loaded_model/device/is_loading answer while unload() reaps under _lock.
+
+    The status route reads these on the event loop, and training admission
+    reads them too, so neither can wait on a dying server.
+    """
+    monkeypatch.setattr(mtmd_mod, "forget_pid", lambda pid: None)
+    sidecar = MtmdSttSidecar(keep_alive_seconds = 0)
+    release = threading.Event()
+    _resident(sidecar, _SlowlyDyingProcess(release))
+
+    unloading = threading.Thread(target = sidecar.unload, daemon = True)
+    unloading.start()
+    try:
+        # Give unload() time to take _lock and block inside _reap().
+        time.sleep(0.2)
+        answered = threading.Event()
+
+        def read_status():
+            sidecar.loaded_model
+            sidecar.device
+            sidecar.is_loading()
+            answered.set()
+
+        threading.Thread(target = read_status, daemon = True).start()
+        assert answered.wait(timeout = 5), (
+            "a status read blocked behind the reap; the event loop would stall with it"
+        )
+    finally:
+        release.set()
+        unloading.join(timeout = 10)
+
+
+def test_status_reads_do_not_block_during_a_llama_cpp_update():
+    """update_maintenance() holds _lock for the whole install; polls continue."""
+    sidecar = MtmdSttSidecar(keep_alive_seconds = 0)
+    with sidecar.update_maintenance():
+        answered = threading.Event()
+
+        def read_status():
+            sidecar.loaded_model
+            sidecar.is_loading()
+            answered.set()
+
+        threading.Thread(target = read_status, daemon = True).start()
+        assert answered.wait(timeout = 5), (
+            "a status read blocked for the length of the llama.cpp install"
+        )
+
+
+def test_ggml_download_drops_its_adopted_pid(monkeypatch):
+    """spawn_download() adopts a PID, so the ggml path must reap it properly.
+
+    A PID left adopted can be reused, and terminate_all would then signal
+    whatever inherited it.
+    """
+    forgotten = []
+
+    class _Finished:
+        pid = 7777
+        returncode = 0
+
+        def poll(self):
+            return 0
+
+    monkeypatch.setattr(
+        ggml_mod, "_cached_model_path", lambda model_id: None
+    )
+    import core.inference.stt_download_worker as worker_mod
+
+    monkeypatch.setattr(worker_mod, "spawn_download", lambda *a, **k: _Finished())
+    monkeypatch.setattr(
+        worker_mod, "reap_download", lambda process: forgotten.append(process.pid) or b""
+    )
+    state = ggml_mod._GgmlDownloadState()
+    state._run("tiny", None)
+
+    assert forgotten == [7777], "the GGUF download never dropped its adopted PID"
+
+
+def test_wait_for_server_sleeps_on_a_non_200_success(monkeypatch):
+    """A 2xx that is not 200 must not spin the readiness loop with no delay."""
+
+    class _Response:
+        status = 204
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    slept = []
+    monkeypatch.setattr(mtmd_mod.urllib.request, "urlopen", lambda *a, **k: _Response())
+    monkeypatch.setattr(mtmd_mod.time, "sleep", slept.append)
+    monkeypatch.setattr(mtmd_mod, "_SERVER_START_TIMEOUT_SECONDS", 0.5)
+
+    class _Alive:
+        def poll(self):
+            return None
+
+    assert MtmdSttSidecar._wait_for_server(_Alive(), 1234) is False
+    assert slept, "the readiness loop spun without sleeping on a non-200 response"
+
+
+def test_download_probe_is_memoised_then_dropped_when_a_download_ends(monkeypatch):
+    """The status poll asks four times a second; the cache walk runs once."""
+    mtmd_mod._forget_downloaded_probe()
+    calls = []
+
+    def fake_paths(model_id):
+        calls.append(model_id)
+        return ("m.gguf", "p.gguf")
+
+    monkeypatch.setattr(mtmd_mod, "_cached_model_paths", fake_paths)
+    assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is True
+    assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is True
+    assert len(calls) == 1, "the memo did not spare the second probe"
+
+    # A finished download changes what is on disk, so the answer is dropped
+    # rather than left to expire: the panel settles on its next poll.
+    mtmd_mod._forget_downloaded_probe("qwen3-asr-0.6b")
+    assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is True
+    assert len(calls) == 2
+
+    mtmd_mod._forget_downloaded_probe()
+
+
+def test_download_probe_expires(monkeypatch):
+    """A cache emptied outside Studio is noticed without a restart."""
+    mtmd_mod._forget_downloaded_probe()
+    monkeypatch.setattr(mtmd_mod, "_DOWNLOADED_PROBE_TTL_SECONDS", 0.0)
+    calls = []
+
+    def fake_paths(model_id):
+        calls.append(model_id)
+        return None
+
+    monkeypatch.setattr(mtmd_mod, "_cached_model_paths", fake_paths)
+    assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is False
+    assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is False
+    assert len(calls) == 2, "an expired entry was still served"
+
+    mtmd_mod._forget_downloaded_probe()
+
+
+def test_unknown_model_is_never_memoised(monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        mtmd_mod, "_cached_model_paths", lambda model_id: called.append(model_id)
+    )
+    assert mtmd_mod.is_model_downloaded("not-a-model") is False
+    assert called == []
+
+
+def test_download_status_reports_progress_without_holding_the_lock():
+    """_cache_bytes() walks the cache; a cancel must not queue behind it."""
+    state = mtmd_mod._MtmdDownloadState()
+    observed = []
+
+    def slow_cache_bytes(model_id = None):
+        # The lock is free while this runs, or the assert below deadlocks.
+        observed.append(state._lock.acquire(blocking = False))
+        if observed[-1]:
+            state._lock.release()
+        return 1
+
+    state._cache_bytes = slow_cache_bytes
+    state._model_id = "qwen3-asr-0.6b"
+    state._thread = threading.Thread(target = lambda: time.sleep(0.5), daemon = True)
+    state._thread.start()
+    try:
+        status = state.status()
+    finally:
+        state._thread.join(timeout = 5)
+
+    assert status["bytes_done"] == 1
+    assert observed == [True], "progress was computed while holding the download lock"
+
+
+@pytest.mark.parametrize("model_id", sorted(mtmd_mod.MTMD_STT_MODELS))
+def test_catalogue_probes_stay_answerable(model_id):
+    """is_model_downloaded() never raises for a curated id, cache or no cache."""
+    mtmd_mod._forget_downloaded_probe()
+    assert isinstance(mtmd_mod.is_model_downloaded(model_id), bool)
+    mtmd_mod._forget_downloaded_probe()

--- a/studio/backend/tests/test_stt_review_fixes_4.py
+++ b/studio/backend/tests/test_stt_review_fixes_4.py
@@ -3,8 +3,8 @@
 
 """Fourth review pass: status reads that must never block, and the PID registry.
 
-The STT status route reads these sidecars on the event loop, so anything it
-touches has to answer while a lifecycle operation holds the sidecar's lock.
+The status route reads these sidecars on the event loop, so everything it touches
+has to answer while a lifecycle operation holds the sidecar's lock.
 """
 
 import subprocess
@@ -33,8 +33,7 @@ class _SlowlyDyingProcess:
         pass
 
     def wait(self, timeout = None):
-        # Blocks until the test lets go, standing in for a server that takes
-        # seconds to release its port and VRAM.
+        # Blocks until the test lets go, like a server slow to release its port and VRAM.
         if not self._release.wait(timeout = timeout):
             raise subprocess.TimeoutExpired("llama-server", timeout)
         self._returncode = -15
@@ -54,8 +53,8 @@ def _resident(sidecar: MtmdSttSidecar, process) -> None:
 def test_status_reads_do_not_block_behind_a_reap(monkeypatch):
     """loaded_model/device/is_loading answer while unload() reaps under _lock.
 
-    The status route reads these on the event loop, and training admission
-    reads them too, so neither can wait on a dying server.
+    The event loop and training admission both read these, so neither can wait
+    on a dying server.
     """
     monkeypatch.setattr(mtmd_mod, "forget_pid", lambda pid: None)
     sidecar = MtmdSttSidecar(keep_alive_seconds = 0)
@@ -87,9 +86,8 @@ def test_status_reads_do_not_block_behind_a_reap(monkeypatch):
 def test_a_reaping_server_stays_visible_to_training_admission(monkeypatch):
     """A dying llama-server still holds VRAM, so it must still read as resident.
 
-    _release_locked() clears the fields, so clearing them before the reap would
-    let summarize_resident_stt() report nothing while the process is alive, and
-    training would start into memory it does not have.
+    Clearing the fields before the reap would let summarize_resident_stt() report
+    nothing while the process is alive, and training would start into its memory.
     """
     monkeypatch.setattr(mtmd_mod, "forget_pid", lambda pid: None)
     sidecar = MtmdSttSidecar(keep_alive_seconds = 0)
@@ -185,10 +183,8 @@ def test_status_reads_do_not_block_during_a_llama_cpp_update():
 
 
 def test_ggml_download_drops_its_adopted_pid(monkeypatch):
-    """spawn_download() adopts a PID, so the ggml path must reap it properly.
-
-    A PID left adopted can be reused, and terminate_all would then signal
-    whatever inherited it.
+    """spawn_download() adopts a PID; left adopted it can be reused, and
+    terminate_all would then signal whatever inherited it.
     """
     forgotten = []
 
@@ -251,8 +247,7 @@ def test_download_probe_is_memoised_then_dropped_when_a_download_ends(monkeypatc
     assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is True
     assert len(calls) == 1, "the memo did not spare the second probe"
 
-    # A finished download changes what is on disk, so the answer is dropped
-    # rather than left to expire: the panel settles on its next poll.
+    # A finished download changes the disk, so the answer is dropped, not left to expire.
     mtmd_mod._forget_downloaded_probe("qwen3-asr-0.6b")
     assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is True
     assert len(calls) == 2
@@ -281,14 +276,13 @@ def test_download_probe_expires(monkeypatch):
 def test_an_invalidation_mid_probe_discards_the_stale_answer(monkeypatch):
     """A download finishing under a probe must not be undone by that probe.
 
-    The probe runs outside the lock, so it can read an incomplete snapshot,
-    then write False back after the download's invalidation already cleared the
-    entry. The model would then read as missing for a whole TTL.
+    The probe runs outside the lock, so it can write a stale False back over the
+    download's invalidation, and the model then reads as missing for a whole TTL.
     """
     mtmd_mod._forget_downloaded_probe()
 
     def probe_then_invalidate(model_id):
-        # Stands in for the download completing while this probe is in flight.
+        # The download completing while this probe is in flight.
         mtmd_mod._forget_downloaded_probe(model_id)
         return None
 
@@ -344,7 +338,7 @@ def test_download_status_reports_progress_without_holding_the_lock():
     observed = []
 
     def slow_cache_bytes(model_id = None):
-        # The lock is free while this runs, or the assert below deadlocks.
+        # The lock must be free while this runs.
         observed.append(state._lock.acquire(blocking = False))
         if observed[-1]:
             state._lock.release()

--- a/studio/backend/tests/test_stt_review_fixes_4.py
+++ b/studio/backend/tests/test_stt_review_fixes_4.py
@@ -76,9 +76,9 @@ def test_status_reads_do_not_block_behind_a_reap(monkeypatch):
             answered.set()
 
         threading.Thread(target = read_status, daemon = True).start()
-        assert answered.wait(timeout = 5), (
-            "a status read blocked behind the reap; the event loop would stall with it"
-        )
+        assert answered.wait(
+            timeout = 5
+        ), "a status read blocked behind the reap; the event loop would stall with it"
     finally:
         release.set()
         unloading.join(timeout = 10)
@@ -96,9 +96,9 @@ def test_status_reads_do_not_block_during_a_llama_cpp_update():
             answered.set()
 
         threading.Thread(target = read_status, daemon = True).start()
-        assert answered.wait(timeout = 5), (
-            "a status read blocked for the length of the llama.cpp install"
-        )
+        assert answered.wait(
+            timeout = 5
+        ), "a status read blocked for the length of the llama.cpp install"
 
 
 def test_ggml_download_drops_its_adopted_pid(monkeypatch):
@@ -116,9 +116,7 @@ def test_ggml_download_drops_its_adopted_pid(monkeypatch):
         def poll(self):
             return 0
 
-    monkeypatch.setattr(
-        ggml_mod, "_cached_model_path", lambda model_id: None
-    )
+    monkeypatch.setattr(ggml_mod, "_cached_model_path", lambda model_id: None)
     import core.inference.stt_download_worker as worker_mod
 
     monkeypatch.setattr(worker_mod, "spawn_download", lambda *a, **k: _Finished())
@@ -199,9 +197,7 @@ def test_download_probe_expires(monkeypatch):
 
 def test_unknown_model_is_never_memoised(monkeypatch):
     called = []
-    monkeypatch.setattr(
-        mtmd_mod, "_cached_model_paths", lambda model_id: called.append(model_id)
-    )
+    monkeypatch.setattr(mtmd_mod, "_cached_model_paths", lambda model_id: called.append(model_id))
     assert mtmd_mod.is_model_downloaded("not-a-model") is False
     assert called == []
 

--- a/studio/backend/tests/test_stt_review_fixes_4.py
+++ b/studio/backend/tests/test_stt_review_fixes_4.py
@@ -120,6 +120,53 @@ def test_a_reaping_server_stays_visible_to_training_admission(monkeypatch):
     assert sidecar._process is None
 
 
+def test_a_starting_load_is_announced_before_the_probe_and_the_reap():
+    """is_loading() has to be true across the cache probe and the old reap.
+
+    Training admission reads it lock-free, so a False there sends it to unload(),
+    which waits out the whole startup instead of cancelling the load.
+    """
+    sidecar = MtmdSttSidecar(keep_alive_seconds = 0)
+    probing = threading.Event()
+    release = threading.Event()
+
+    def slow_probe(model_id):
+        probing.set()
+        release.wait(timeout = 10)
+        raise RuntimeError("the probe is where the test stops")
+
+    sidecar._ensure_model_downloaded = slow_probe
+
+    def load():
+        try:
+            sidecar._load_locked("qwen3-asr-0.6b", "llama-server")
+        except Exception:
+            pass
+
+    loading = threading.Thread(target = load, daemon = True)
+    loading.start()
+    try:
+        assert probing.wait(timeout = 5)
+        assert sidecar.is_loading() is True, "the load was not announced before the probe"
+        assert sidecar.cancel_pending_load() is True, "training could not cancel this load"
+    finally:
+        release.set()
+        loading.join(timeout = 10)
+    # The load never started a server, so it must not leave _loading set.
+    assert sidecar.is_loading() is False
+    assert sidecar._load_cancel_event is None
+
+
+def test_device_never_contradicts_the_loaded_model():
+    """Mid-publish _process is set and _model_id is not; the two must agree."""
+    sidecar = MtmdSttSidecar(keep_alive_seconds = 0)
+    sidecar._process = _SlowlyDyingProcess(threading.Event())
+    sidecar._port = 12345
+    sidecar._model_id = None
+    assert sidecar.loaded_model is None
+    assert sidecar.device is None, "the status route would ship a device with no model"
+
+
 def test_status_reads_do_not_block_during_a_llama_cpp_update():
     """update_maintenance() holds _lock for the whole install; polls continue."""
     sidecar = MtmdSttSidecar(keep_alive_seconds = 0)

--- a/studio/backend/tests/test_stt_review_fixes_4.py
+++ b/studio/backend/tests/test_stt_review_fixes_4.py
@@ -111,9 +111,9 @@ def test_a_reaping_server_stays_visible_to_training_admission(monkeypatch):
         release.set()
         unloading.join(timeout = 10)
 
-    assert seen["model"] == "qwen3-asr-0.6b", (
-        "the reaping server read as gone; training admission would miss its VRAM"
-    )
+    assert (
+        seen["model"] == "qwen3-asr-0.6b"
+    ), "the reaping server read as gone; training admission would miss its VRAM"
     assert seen["device"] == "llama.cpp"
     # Once the reap is done the fields are cleared, so it reads as gone.
     assert sidecar.loaded_model is None
@@ -248,9 +248,9 @@ def test_an_invalidation_mid_probe_discards_the_stale_answer(monkeypatch):
     monkeypatch.setattr(mtmd_mod, "_cached_model_paths", probe_then_invalidate)
     assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is False
     with mtmd_mod._downloaded_probe_lock:
-        assert "qwen3-asr-0.6b" not in mtmd_mod._downloaded_probe, (
-            "a stale answer was written back over the invalidation"
-        )
+        assert (
+            "qwen3-asr-0.6b" not in mtmd_mod._downloaded_probe
+        ), "a stale answer was written back over the invalidation"
 
     # The next poll sees the finished download rather than waiting out the TTL.
     monkeypatch.setattr(mtmd_mod, "_cached_model_paths", lambda mid: ("m.gguf", "p.gguf"))

--- a/studio/backend/tests/test_stt_review_fixes_4.py
+++ b/studio/backend/tests/test_stt_review_fixes_4.py
@@ -84,6 +84,42 @@ def test_status_reads_do_not_block_behind_a_reap(monkeypatch):
         unloading.join(timeout = 10)
 
 
+def test_a_reaping_server_stays_visible_to_training_admission(monkeypatch):
+    """A dying llama-server still holds VRAM, so it must still read as resident.
+
+    _release_locked() clears the fields, so clearing them before the reap would
+    let summarize_resident_stt() report nothing while the process is alive, and
+    training would start into memory it does not have.
+    """
+    monkeypatch.setattr(mtmd_mod, "forget_pid", lambda pid: None)
+    sidecar = MtmdSttSidecar(keep_alive_seconds = 0)
+    release = threading.Event()
+    _resident(sidecar, _SlowlyDyingProcess(release))
+
+    seen = {}
+
+    def unload():
+        sidecar.unload()
+
+    unloading = threading.Thread(target = unload, daemon = True)
+    unloading.start()
+    try:
+        time.sleep(0.2)  # inside the reap
+        seen["model"] = sidecar.loaded_model
+        seen["device"] = sidecar.device
+    finally:
+        release.set()
+        unloading.join(timeout = 10)
+
+    assert seen["model"] == "qwen3-asr-0.6b", (
+        "the reaping server read as gone; training admission would miss its VRAM"
+    )
+    assert seen["device"] == "llama.cpp"
+    # Once the reap is done the fields are cleared, so it reads as gone.
+    assert sidecar.loaded_model is None
+    assert sidecar._process is None
+
+
 def test_status_reads_do_not_block_during_a_llama_cpp_update():
     """update_maintenance() holds _lock for the whole install; polls continue."""
     sidecar = MtmdSttSidecar(keep_alive_seconds = 0)
@@ -192,6 +228,59 @@ def test_download_probe_expires(monkeypatch):
     assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is False
     assert len(calls) == 2, "an expired entry was still served"
 
+    mtmd_mod._forget_downloaded_probe()
+
+
+def test_an_invalidation_mid_probe_discards_the_stale_answer(monkeypatch):
+    """A download finishing under a probe must not be undone by that probe.
+
+    The probe runs outside the lock, so it can read an incomplete snapshot,
+    then write False back after the download's invalidation already cleared the
+    entry. The model would then read as missing for a whole TTL.
+    """
+    mtmd_mod._forget_downloaded_probe()
+
+    def probe_then_invalidate(model_id):
+        # Stands in for the download completing while this probe is in flight.
+        mtmd_mod._forget_downloaded_probe(model_id)
+        return None
+
+    monkeypatch.setattr(mtmd_mod, "_cached_model_paths", probe_then_invalidate)
+    assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is False
+    with mtmd_mod._downloaded_probe_lock:
+        assert "qwen3-asr-0.6b" not in mtmd_mod._downloaded_probe, (
+            "a stale answer was written back over the invalidation"
+        )
+
+    # The next poll sees the finished download rather than waiting out the TTL.
+    monkeypatch.setattr(mtmd_mod, "_cached_model_paths", lambda mid: ("m.gguf", "p.gguf"))
+    assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is True
+    mtmd_mod._forget_downloaded_probe()
+
+
+def test_the_entry_is_timestamped_after_the_probe(monkeypatch):
+    """A slow cache must not store an entry that is already near expiry."""
+    mtmd_mod._forget_downloaded_probe()
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(mtmd_mod.time, "monotonic", lambda: clock["t"])
+
+    def slow_probe(model_id):
+        clock["t"] += 1.5  # probe takes most of the TTL
+        return ("m.gguf", "p.gguf")
+
+    monkeypatch.setattr(mtmd_mod, "_cached_model_paths", slow_probe)
+    assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is True
+
+    with mtmd_mod._downloaded_probe_lock:
+        stored_at = mtmd_mod._downloaded_probe["qwen3-asr-0.6b"][0]
+    assert stored_at == 1001.5, "the entry was timestamped before the probe ran"
+
+    # The panel's next poll, 750ms later, is still served from the memo.
+    clock["t"] += 0.75
+    called = []
+    monkeypatch.setattr(mtmd_mod, "_cached_model_paths", lambda mid: called.append(mid))
+    assert mtmd_mod.is_model_downloaded("qwen3-asr-0.6b") is True
+    assert called == [], "the entry expired early and the probe ran again"
     mtmd_mod._forget_downloaded_probe()
 
 


### PR DESCRIPTION
Follow-up to #7835. Three fixes in the dictation sidecars, plus two things the STT status poll was paying for on every request.

## Status reads that could stall the backend

`MtmdSttSidecar.loaded_model`, `.device` and `.is_loading()` acquired `_lock`. That lock is held in two places for a long time:

- `_release_locked()` reaps the old `llama-server` while holding it, so a model switch or an idle unload holds it until the process is gone (`terminate`, `wait(10)`, `kill`, `wait(10)`).
- `update_maintenance()` yields to the installer while holding it, so it stays held for the length of a whole llama.cpp install.

`stt_status` is an `async def` that reads all three directly, with no `to_thread`. So a dictation model switch stalled the FastAPI event loop until the old server died, and a llama.cpp update stalled it for the length of the install. That is every request in Studio, not just dictation. `summarize_resident_stt` and `free_stt_model_for_training` read the same property on the training admission path.

`stt_ggml_sidecar` already reads lock-free and says why: "status polls plus training admission must not block behind it". The new sidecar just did not inherit it. It does now, with the same `_process_alive()` snapshot-then-poll that makes a concurrent unload safe.

## GGUF downloads left an adopted PID behind

`_GgmlDownloadState._run` reaped its worker with `process.communicate()`. `spawn_download()` calls `adopt_pid()`, and only `reap_download()` calls `forget_pid()`, which is what its own docstring asks for:

> Callers pair every spawn with this: an adopted PID that outlives the process can be reused by something unrelated, which terminate_all would then signal.

The mtmd and Transformers paths already use it. Every Whisper GGUF download left a stale PID in the registry, so on macOS and Windows a later shutdown could signal whatever inherited it.

## Readiness loop could spin

`_wait_for_server` had its `time.sleep(0.25)` inside the `except`. urllib raises on 4xx and 5xx so this is hard to hit today, but a 2xx that is not 200 would spin the loop with no delay for the full 180s startup window. The sleep moved out.

## Two things the status poll paid for

`is_model_downloaded()` is two `hf_hub_download()` calls per model, and `stt_status` asks for the whole catalogue on every request while the download panel polls at 750ms. Even `local_files_only` resolves refs and stats the snapshot tree. That answer is now memoised for 2s, and a finished download drops the entry so the panel still settles on its next poll rather than a TTL later. Only the boolean is memoised: a load resolves the real paths through `_cached_model_paths()` every time, so nothing starts `llama-server` against a cached answer.

Measured locally, 200 polls across both models:

| | time |
| --- | --- |
| before | 392.3 ms |
| after | 2.0 ms |

`_MtmdDownloadState.status()` also called `_cache_bytes()` while holding the download lock, so a cancel arriving mid-poll queued behind a walk of every blob in the repo cache. It now runs after the snapshot is taken.

## Not changed

- `stt_status` doing synchronous work in an `async def`. It predates #7835, it is in a shared route file, and with the lock contention gone the rest is sub-millisecond.
- The double cache probe per transcription (`transcribe()` checks, then `load()` checks again). `_ensure_model_downloaded` is the seam the suite stubs, and saving about a millisecond is not worth moving it.
- The port reservation race in `_reserve_free_port`, the one-mtmd-download-at-a-time limit, and the three near-identical download trackers. Each is a behaviour change or a real refactor rather than a contained fix.

## Testing

`tests/test_stt_review_fixes_4.py` adds 10 tests, including threads that assert a status read answers while `unload()` is mid-reap and while `update_maintenance()` holds the lock. All 10 pass here, and 9 of them fail against the current code (the tenth is a guard that holds either way).

Full backend suite run both ways on the same machine: 56 failures with these changes against 57 on main, with `comm` showing no new failures. The difference is a flaky live GPU temperature test that failed on the baseline run. Everything still failing is a pre-existing macOS or environment case (case-insensitive filesystem, Linux and Windows setup scripts). No STT, dictation, VRAM or registry test fails in either run.

Studio boots clean on the patched code and serves the status endpoint. Nothing outside `studio/backend/core/inference/stt_*` changed.
