### PR TITLE
tests: extend the version-compat matrices to the current PyPI releases

### DIFF
--- a/tests/version_compat/test_transformers_pinned_symbols.py
+++ b/tests/version_compat/test_transformers_pinned_symbols.py
@@ -16,7 +16,7 @@ import pytest
 from tests.version_compat._fetch import fetch_text, first_match, has_def
 
 
-# 4.57.6 floor + every 5.x minor since 5.0.0 + main.
+# 4.57.6 floor + every 5.x minor since 5.0.0, up to the current PyPI latest, + main.
 TRANSFORMERS_TAGS = [
     "v4.57.6",  # anchor (must work)
     "v5.0.0",
@@ -29,6 +29,21 @@ TRANSFORMERS_TAGS = [
     "v5.6.2",
     "v5.7.0",
     "v5.8.0",
+    "v5.8.1",
+    "v5.9.0",
+    "v5.10.0",
+    "v5.10.1",
+    "v5.10.2",
+    # Upstream tagged PyPI 5.10.4 as v5.10.3 (the tag's __init__ says 5.10.4);
+    # there is no v5.10.4 tag and no 5.10.3 on PyPI, so fetch by the tag name.
+    "v5.10.3",
+    "v5.11.0",
+    "v5.12.0",
+    "v5.12.1",
+    "v5.13.0",
+    "v5.13.1",
+    "v5.14.0",
+    "v5.14.1",  # current PyPI latest
     "main",
 ]
 

--- a/tests/version_compat/test_trl_grpo_pinned_symbols.py
+++ b/tests/version_compat/test_trl_grpo_pinned_symbols.py
@@ -55,7 +55,11 @@ TRL_TAGS = [
     "v1.5.1",
     "v1.6.0",
     "v1.7.0",  # anchor: first release unsloth's TRL>=1.7.0 GRPO patch targets
-    "v1.7.1",  # current PyPI latest
+    "v1.7.1",
+    "v1.8.0",
+    "v1.9.0",
+    "v1.9.1",
+    "v1.9.2",  # current PyPI latest
     "main",
 ]
 


### PR DESCRIPTION
## Summary

`tests/version_compat/` pins the symbols unsloth reaches into upstream for, one case per release tag. Both matrices had fallen behind: transformers stopped at `v5.8.0` and TRL at `v1.7.1`, while PyPI is now at transformers 5.14.1 and TRL 1.9.2. Every release since then was unchecked, so a rename or a moved symbol in any of them would land in users' hands before CI noticed.

This extends both to the current latest.

- transformers: adds `v5.8.1` through `v5.14.1` (13 tags)
- TRL: adds `v1.8.0` through `v1.9.2` (4 tags)

`main` stays at the end of each list, and the `v4.57.6` and `v0.22.x` floors are untouched.

## Result

```
1297 passed, 177 skipped in 105.88s
```

The skips are the pre-existing per-tag guards for symbols that do not exist in a given release. The new tags do real work rather than skipping wholesale: `-k "5.14.1 or 5.12.0 or 5.10.3"` is `57 passed, 0 skipped`, and `-k "1.9.2 or 1.8.0"` is `50 passed, 4 skipped`.

## One tag needs a note

Upstream tagged the release PyPI calls 5.10.4 as `v5.10.3`; that tag's `__init__` reports `5.10.4`, and there is no `v5.10.4` tag and no 5.10.3 on PyPI. The entry follows the tag name, since that is what the fetch resolves against, and there is a comment in the file saying so.

## Not changed here, but worth flagging

`pyproject.toml` still caps `transformers ... <=5.5.0` and `trl>=0.18.2,!=0.19.0,<=0.24.0`. Those ceilings are nine transformers minors and a major behind what this matrix now checks. Raising them is a separate call that wants end-to-end validation rather than symbol presence, so I have left them alone and am only noting the gap.
