### PR TITLE
Diffusion: replace the attention perf claims with re-measured numbers

### DIFF
--- a/scripts/sdpa_mask_backend_probe.py
+++ b/scripts/sdpa_mask_backend_probe.py
@@ -37,6 +37,24 @@ def timed(fn, iters = 20):
         return f"UNSUPPORTED ({type(e).__name__})"
 
 
+def _identity(run, reference):
+    """Whether ``run``'s dense output is bitwise-identical to the default dispatch's.
+
+    "yes" on exactly one backend names the kernel the dispatcher selected. A backend that cannot
+    run the dense mask at all reports why instead, so the column never silently reads as a
+    mismatch when nothing ran."""
+    if reference is None:
+        return "n/a"
+    try:
+        out = run()
+    except torch.OutOfMemoryError:
+        torch.cuda.empty_cache()
+        return "OOM"
+    except Exception:  # noqa: BLE001
+        return "unsupported"
+    return "yes" if torch.equal(reference, out) else f"no ({(reference - out).abs().max():.1e})"
+
+
 q, k, v = mk(), mk(), mk()
 dense = torch.ones(B, 1, N, N, dtype = torch.bool, device = dev)
 
@@ -48,8 +66,17 @@ backends = {
     "CUDNN": [SDPBackend.CUDNN_ATTENTION],
 }
 
+# The default dispatch's own dense output, so each forced backend can be checked against it.
+# Timings alone cannot say WHICH backend the dispatcher picked, because forcing one adds
+# sdpa_kernel overhead and two different kernels can land at similar times. Bitwise identity can:
+# the forced backend that reproduces this tensor exactly is the one the dispatcher chose.
+try:
+    reference = F.scaled_dot_product_attention(q, k, v, attn_mask = dense)
+except Exception:  # noqa: BLE001 -- no reference: the identity column just reports n/a
+    reference = None
+
 print(f"shape B={B} H={H} N={N} D={D} {dt}\n")
-print(f"{'backend':<20}{'mask=dense(ms)':>18}{'mask=None(ms)':>18}")
+print(f"{'backend':<20}{'mask=dense(ms)':>18}{'mask=None(ms)':>18}{'==default(dense)':>19}")
 for name, bk in backends.items():
 
     def run_dense():
@@ -68,4 +95,4 @@ for name, bk in backends.items():
     nms = timed(run_none)
     d_s = f"{dms:.2f}" if isinstance(dms, float) else dms
     n_s = f"{nms:.2f}" if isinstance(nms, float) else nms
-    print(f"{name:<20}{d_s:>18}{n_s:>18}")
+    print(f"{name:<20}{d_s:>18}{n_s:>18}{_identity(run_dense, reference):>19}")

--- a/studio/backend/core/inference/diffusion_attention.py
+++ b/studio/backend/core/inference/diffusion_attention.py
@@ -9,9 +9,15 @@ Attention is bandwidth-bound, so a better kernel is a real win orthogonal to wei
 (it speeds the QK/PV matmuls torchao never touches) and composes with torch.compile.
 
   auto  - the best *exact* backend for the device. On NVIDIA CUDA that is cuDNN fused attention
-          (``_native_cudnn``), ~1.18x end-to-end on B200, LPIPS ~0.004 (below the noise floor).
-          Elsewhere stays ``native``. Only upgrades when a speed profile is active, so
-          ``speed_mode=off`` stays bit-identical.
+          (``_native_cudnn``). Torch's SDPA dispatch is a HEURISTIC, not a guarantee, and that is
+          the reason to pin it: re-measured on torch 2.12 / B200 at Qwen-Image's 1024px shape
+          (B=1 H=24 N=4352 D=128 bf16) the default ALREADY lands on cuDNN, so pinning is
+          bitwise-identical and near free (compiled 1.599s -> 1.572s, 1.02x; eager 0.93x, the
+          per-call sdpa_kernel wrapper cost, which compile folds away) -- but FLASH and EFFICIENT
+          at that same shape run 3.9x and 9.0x slower. Pinning is insurance against the heuristic
+          picking one of those on another card, head_dim or torch build. Elsewhere stays
+          ``native``. Only upgrades when a speed profile is active, so ``speed_mode=off`` stays
+          bit-identical.
   native - force the default SDPA (bit-identical reference).
   cudnn  - cuDNN fused attention (exact; NVIDIA).
   flash / flash3 / flash4 - FlashAttention 2 / 3 (Hopper) / 4 (SM100); exact, kernel-gated.
@@ -403,13 +409,24 @@ def _warn(logger: Any, what: str, exc: Exception) -> None:
 # and step, materialises a dense [B,1,N,N] boolean mask so the video never attends to padded text.
 # But a dense bool attn_mask DISABLES every fused SDPA kernel (flash rejects it; cuDNN/efficient
 # fall back) and forces the slow math path: on a B200 at the production shape (N~=50k, 121 frames
-# 480p) the SAME attention is 421 ms WITH the dense mask vs 19 ms with attn_mask=None -- a ~22x tax
+# 480p) the SAME attention is 296 ms WITH the dense mask vs 15 ms with attn_mask=None -- a ~20x tax
+# (torch 2.12; scripts/sdpa_mask_backend_probe.py re-measures it, and also shows MATH OOMing on the
+# 75.5 GiB score matrix and FLASH refusing a dense mask outright). END TO END that is 10.4x: a full
+# 121-frame 832x480 10-step render goes 353.8s -> 33.9s, medians of 3, reproduced across two runs
 # purely to mask padding. And the text is ~99.5% padding: a t2v prompt fills only ~9 of ~1985 slots
 # (image 729 + byt5 256 + mllm 1000, almost all zero-padded).
 #
 # The fix is exact: the model already masks the padded text and DISCARDS its attention output (only
 # the video split feeds proj_out), so removing the padded tokens before attention changes nothing
-# for the video. Done in an eager forward pre-hook (outside the compiled blocks): drop the all-zero
+# for the video. "Exact" here means no information is discarded, NOT bit-reproducible: swapping
+# masked for fused SDPA perturbs each step at bf16 rounding scale (one DiT forward on identical
+# inputs differs by 6.6e-3 relative, cosine 0.99998) and 10 denoising steps amplify that
+# chaotically, so the finished video is visibly a different sample. That is intrinsic to the kernel
+# change, not to the trim: rendering the SAME dense-mask path under two different exact SDPA kernels
+# diverges MORE (LPIPS 0.303 vs the trim's 0.285, SSIM 0.744 vs 0.767, over 13 sampled frames).
+# Whole-video LPIPS cannot judge a kernel change at this step count; the single-forward relative
+# error is the metric that can.
+# Done in an eager forward pre-hook (outside the compiled blocks): drop the all-zero
 # image stream (t2v), trim the mllm/byt5 streams to their globally-valid columns, and -- when
 # nothing partially-padded remains (the common batch-1 / per-branch call) -- flag the DiT so the
 # processor skips the dense mask and runs the fused path. The only numeric change is the SDPA kernel

--- a/studio/backend/core/inference/diffusion_attention.py
+++ b/studio/backend/core/inference/diffusion_attention.py
@@ -407,9 +407,14 @@ def _warn(logger: Any, what: str, exc: Exception) -> None:
 #
 # HunyuanVideo15AttnProcessor2_0 runs a JOINT [video ; text] self-attention and, on EVERY block
 # and step, materialises a dense [B,1,N,N] boolean mask so the video never attends to padded text.
-# But a dense bool attn_mask DISABLES every fused SDPA kernel (flash rejects it; cuDNN/efficient
-# fall back) and forces the slow math path: on a B200 at the production shape (N~=50k, 121 frames
-# 480p) the SAME attention is 296 ms WITH the dense mask vs 15 ms with attn_mask=None -- a ~20x tax
+# But a dense bool attn_mask costs most of what the fused kernels are for. Established by output
+# identity, not by timing, since dispatch overhead makes timings alone ambiguous: FLASH refuses a
+# non-null mask outright, MATH OOMs on the 75.5 GiB [1,16,N,N] score matrix, and the default
+# dispatch is BITWISE-equal to forced cuDNN (296.11 vs 296.00 ms), so cuDNN is what runs -- on a
+# masked path 20x slower than its own unmasked one. On a B200 at the production shape (N~=50k, 121
+# frames 480p) the SAME attention is 296 ms WITH the dense mask vs 15 ms with attn_mask=None. (An
+# aside worth knowing before optimising here: forced EFFICIENT does the masked attention in 168 ms,
+# so the dispatcher's masked pick is not even the fastest available one.)
 # (torch 2.12; scripts/sdpa_mask_backend_probe.py re-measures it, and also shows MATH OOMing on the
 # 75.5 GiB score matrix and FLASH refusing a dense mask outright). END TO END that is 10.4x: a full
 # 121-frame 832x480 10-step render goes 353.8s -> 33.9s, medians of 3, reproduced across two runs


### PR DESCRIPTION
Follow-up to #8006, which is merged, so this goes on its own branch off main.

The three performance claims in `diffusion_attention.py` came over verbatim from the stale #7021 and were measured on an older torch/torchao stack. I re-measured all three on torch 2.12.1+cu130 / B200. One does not reproduce, one is off by a third, and the third turns out to understate the win badly. Comments and docstrings only; `comment_tools.py check --strip-docstrings` passes, so no code changes.

### 1. The cuDNN claim does not reproduce, and cannot

Claimed: `~1.18x end-to-end on B200, LPIPS ~0.004`.

At Qwen-Image's 1024px shape (B=1 H=24 N=4352 D=128 bf16), torch 2.12's default SDPA dispatch **already selects cuDNN**:

| backend | time | vs default |
| --- | --- | --- |
| default (dispatch) | 0.166 ms | — |
| CUDNN (forced) | 0.165 ms | bitwise-identical |
| FLASH | 0.643 ms | differs, 3.9x slower |
| EFFICIENT | 1.501 ms | differs, 9.0x slower |

So pinning selects the kernel that was going to run anyway. End to end the two renders come out bit-identical (`LPIPS 0.000000`, `np.array_equal` True, max abs diff 0), at 1.02x compiled (1.599s to 1.572s) and 0.93x eager, the latter being per-call `sdpa_kernel` wrapper cost that `torch.compile` folds away.

I verified the switch genuinely applies before concluding this: after `set_attention_backend("_native_cudnn")` the processor carries `AttentionBackendName._NATIVE_CUDNN` and the registry routes to `_native_cudnn_attention`. It is applied; it has nothing left to change. The original claim is self-consistent with an older torch where the default was *not* cuDNN, since a nonzero LPIPS means the output changed, which cannot happen when you select the kernel already in use.

**Pinning stays**, for a better reason than a speedup: torch's dispatch is a heuristic, and FLASH or EFFICIENT at that shape would cost 3.9x or 9.0x. The comment now says that instead of quoting a number that does not hold.

### 2. The dense-mask tax is ~20x, not ~22x

`296 ms` with the dense mask vs `15 ms` with `attn_mask=None`, re-measured with `scripts/sdpa_mask_backend_probe.py` which ships in #8006. Every structural claim reproduces: FLASH refuses a dense bool mask outright, cuDNN silently falls back, MATH OOMs on the 75.5 GiB score matrix.

### 3. The end-to-end win was never stated, and it is 10.4x

A full 121-frame 832x480 10-step HunyuanVideo-1.5 render:

| | run 1 | run 2 |
| --- | --- | --- |
| stock dense mask | 353.83 s | 354.19 s |
| attention trim | 33.88 s | 34.02 s |
| | 10.44x | 10.41x |

Medians of 3 timed renders after a warmup, tight variance on both.

### 4. "Exact" needed qualifying

The comment said the trim is *"Exact for the video output"*. No information is discarded, but the render is **not** bit-reproducible, and the finished video is visibly a different sample. That is worth stating plainly rather than leaving a reader to discover it.

It is the kernel change, not the trim. One DiT forward on identical inputs differs by **6.6e-3 relative at cosine 0.99998**, which is bf16 accumulation noise (bf16's relative epsilon is about 3.9e-3), and 10 denoising steps amplify it chaotically.

The control that establishes this: render the **same** dense-mask path twice under two different exact SDPA kernels, so the maths is identical and only the kernel differs.

| over 13 sampled frames | pure kernel swap (control) | the trim |
| --- | --- | --- |
| LPIPS mean / max | 0.3031 / 0.3710 | 0.2849 / 0.3354 |
| SSIM mean / min | 0.7443 / 0.6558 | 0.7669 / 0.6999 |

The control diverges **more** than the trim. So whole-video LPIPS cannot judge a kernel change at this step count, and the single-forward relative error is the metric that can. The comment now records both the qualification and that reasoning, so the next person does not re-run this to find out.

### Tests

`tests/test_diffusion_attention.py tests/test_diffusion_attention_trim.py` 59 passed. `ruff check` clean. AST comment gate 1/1 OK.
