### PR TITLE
Studio: stop two backend tests from asking the host what the answer is

### DIFF
--- a/studio/backend/tests/test_hf_xet_fallback.py
+++ b/studio/backend/tests/test_hf_xet_fallback.py
@@ -478,6 +478,9 @@ def test_a_worker_spawned_during_the_gpu_init_retry_does_not_inherit_the_overrid
     sys.meta_path.insert(0, finder)
     try:
         shim = importlib.import_module("utils.hf_xet_fallback")
+        # There is only a retry to spawn into on a host with no accelerator (see _gpu_present),
+        # so pin that rather than letting the runner's hardware decide the assertion.
+        monkeypatch.setattr(shim, "_gpu_present", lambda: False)
         shim.DownloadStallError  # drives the load: plain attempt, then the retry
         assert len(child_envs) == 2, child_envs
         # The retry is the attempt that sets it; neither child may see it.

--- a/studio/backend/tests/test_text_io_encoding.py
+++ b/studio/backend/tests/test_text_io_encoding.py
@@ -601,6 +601,10 @@ def test_a_corrupt_pid_file_does_not_abort_shutdown(tmp_path: Path, monkeypatch)
     pid_file = tmp_path / "studio.pid"
     pid_file.write_bytes(b"\x80\xff")
     monkeypatch.setattr(studio_run, "_PID_FILE", pid_file)
+    # _legacy_heir scans the real Studio root, so without this the last assertion asks whether
+    # a server happens to be running on the machine: with one, the record is handed over rather
+    # than unlinked. The handoff has its own test below.
+    monkeypatch.setattr(studio_run, "_legacy_heir", lambda: None)
     studio_run._remove_pid_file()
     # Not this process's PID, so the file stays; the point is that it returned.
     assert pid_file.exists()
@@ -608,6 +612,26 @@ def test_a_corrupt_pid_file_does_not_abort_shutdown(tmp_path: Path, monkeypatch)
     pid_file.write_text(str(os.getpid()), encoding = "utf-8")
     studio_run._remove_pid_file()
     assert not pid_file.exists()
+
+
+def test_the_legacy_pid_record_is_handed_to_a_live_sibling(tmp_path: Path, monkeypatch) -> None:
+    """Only one server owns studio.pid, so deleting it while a sibling still serves would leave
+    that sibling unstoppable from an older CLI that reads no other file."""
+    import sys
+
+    backend = str(Path(__file__).resolve().parent.parent)
+    if backend not in sys.path:
+        sys.path.insert(0, backend)
+    import run as studio_run
+
+    pid_file = tmp_path / "studio.pid"
+    pid_file.write_text(str(os.getpid()), encoding = "utf-8")
+    monkeypatch.setattr(studio_run, "_PID_FILE", pid_file)
+    monkeypatch.setattr(studio_run, "_legacy_heir", lambda: 4242)
+
+    studio_run._remove_pid_file()
+
+    assert pid_file.read_text(encoding = "utf-8") == "4242"
 
 
 def test_the_kwargs_guard_only_judges_dicts_that_reach_a_call(tmp_path: Path) -> None:


### PR DESCRIPTION
Two tests in `studio/backend/tests/` pass on a GPU-less CI runner with no Studio running and fail on a developer box that has either. Neither is testing the machine.

### `test_hf_xet_fallback.py::test_a_worker_spawned_during_the_gpu_init_retry_does_not_inherit_the_override`

It asserts the shim makes two `unsloth_zoo` import attempts, the second under `UNSLOTH_ZOO_DISABLE_GPU_INIT`, and that neither spawned child inherits the flag.

`df5f139ba` gated that retry on `_gpu_present()`: the flag makes `unsloth_zoo` take its MLX/CPU path and stub triton and bitsandbytes for the whole process, which would turn a healthy GPU into 500s. On a machine with an accelerator there is therefore one attempt, not two, and the test fails with `assert 1 == 2`.

The two neighbouring tests in the same file already pin `_gpu_present` for exactly this reason (`monkeypatch.setattr(degraded, "_gpu_present", lambda: False)`, with the comment "The retry only applies to a host with no accelerator"). This one was missed. Same idiom applied.

### `test_text_io_encoding.py::test_a_corrupt_pid_file_does_not_abort_shutdown`

Its last assertion is that `_remove_pid_file()` unlinks a record holding this process's own PID. `_legacy_heir()` scans the real Studio root and hands `studio.pid` to a live sibling rather than deleting it, so with any Studio server running on the machine the file is rewritten and `assert not pid_file.exists()` fails:

```
pre-fix assertion "not pid_file.exists()" would see exists = True
file now holds: 4242
```

Pinned to "no heir", which is the case that assertion is about.

`test_the_legacy_pid_record_is_handed_to_a_live_sibling` pins the branch that broke the test above, rather than only working around it. Correction to the commit message, which claims the handoff had no coverage: `tests/test_studio_pid_files.py::test_the_legacy_pointer_moves_to_a_live_sibling` already covers it against the real `_legacy_heir` under an isolated root. I found that only after pushing -- my search was for the symbol name, and that test exercises the behaviour through `_remove_pid_file` without naming it. The new test is narrower (it stubs `_legacy_heir`, so it covers the two-line branch in `_remove_pid_file`) and is kept because it is what makes the stub in the test above self-evidently safe.

### Verification

```
tests/test_hf_xet_fallback.py     17 passed, 2 skipped   (was 1 failed, 16 passed, 2 skipped)
tests/test_text_io_encoding.py    381 passed             (380 before, +1 new test)
```

Run on a 8x B200 host with a Studio server up, i.e. the environment that reproduced both failures. No production code changes.
