### PR TITLE
Studio: do not let the default tool policy reject every plain Anthropic message

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15618,10 +15618,19 @@ async def anthropic_messages(
     # chat. It must not steal an explicit Anthropic client-tool catalog (Claude
     # Code's Write/Edit/Bash tools) and turn it into Unsloth's local tool loop.
     # An explicit per-request server-tool ask was rejected as mixed mode above.
-    _enable_pre = False if _has_client_tool else _effective_enable_tools(payload)
+    # That default must not count as *this request* selecting server tools either:
+    # `unsloth studio run` resolves the policy to on unless --disable-tools, so
+    # reading it as a selection rejected every plain Messages request on a default
+    # server, the catalog holding terminal/python and permission_mode being omitted.
+    # Only an explicit ask reaches the gate; --disable-tools still vetoes both forms.
+    _policy_pre = _effective_enable_tools(payload)
+    _asked_pre = payload.enable_tools is True or bool(getattr(payload, "mcp_enabled", False))
     _server_tools_requested_pre = (
-        _enable_pre or (_enable_pre is None and bool(requested_studio_tools))
-    ) and not _anthropic_request_has_image(payload)
+        not _has_client_tool
+        and _policy_pre is not False
+        and (_asked_pre or bool(requested_studio_tools))
+        and not _anthropic_request_has_image(payload)
+    )
     if _server_tools_requested_pre:
         from core.inference.tools import ALL_TOOLS as _ALL_TOOLS_PRE
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15130,6 +15130,24 @@ _STUDIO_ANTHROPIC_TOOL_ALIASES = {
 _ANTHROPIC_UNPROMPTED_SAFE_TOOLS = frozenset({"web_search", "search_knowledge_base"})
 
 
+def _anthropic_selects_server_tools(
+    payload, requested_studio_tools: set[str], has_client_tool: bool
+) -> bool:
+    """Whether THIS request asked Unsloth to run its own tools on the Messages channel.
+
+    A process-wide ``--enable-tools`` is a default for ordinary chat, not a selection: reading
+    it as one made the permission gate reject every plain request on a default server, and
+    routing on it entered the local tool loop with terminal/python and nothing to confirm
+    them. So only an explicit ask counts -- ``enable_tools``/``mcp_enabled``, or an Anthropic
+    server-tool type in ``tools`` -- while ``--disable-tools`` and an explicit
+    ``enable_tools: false`` still veto both, and a client-tool catalog is never stolen.
+    """
+    if has_client_tool or _effective_enable_tools(payload) is False:
+        return False
+    asked = payload.enable_tools is True or bool(getattr(payload, "mcp_enabled", False))
+    return asked or bool(requested_studio_tools)
+
+
 def _anthropic_requested_studio_tools(tools: Optional[list]) -> set[str]:
     requested: set[str] = set()
     for tool in tools or []:
@@ -15618,18 +15636,11 @@ async def anthropic_messages(
     # chat. It must not steal an explicit Anthropic client-tool catalog (Claude
     # Code's Write/Edit/Bash tools) and turn it into Unsloth's local tool loop.
     # An explicit per-request server-tool ask was rejected as mixed mode above.
-    # That default must not count as *this request* selecting server tools either:
-    # `unsloth studio run` resolves the policy to on unless --disable-tools, so
-    # reading it as a selection rejected every plain Messages request on a default
-    # server, the catalog holding terminal/python and permission_mode being omitted.
-    # Only an explicit ask reaches the gate; --disable-tools still vetoes both forms.
-    _policy_pre = _effective_enable_tools(payload)
-    _asked_pre = payload.enable_tools is True or bool(getattr(payload, "mcp_enabled", False))
-    _server_tools_requested_pre = (
-        not _has_client_tool
-        and _policy_pre is not False
-        and (_asked_pre or bool(requested_studio_tools))
-        and not _anthropic_request_has_image(payload)
+    _selects_server_tools = _anthropic_selects_server_tools(
+        payload, requested_studio_tools, _has_client_tool
+    )
+    _server_tools_requested_pre = _selects_server_tools and not _anthropic_request_has_image(
+        payload
     )
     if _server_tools_requested_pre:
         from core.inference.tools import ALL_TOOLS as _ALL_TOOLS_PRE
@@ -15755,13 +15766,10 @@ async def anthropic_messages(
 
     # An Anthropic server-tool declaration implies server-tool mode, but only
     # when tools aren't explicitly disabled (CLI --disable-tools or per-request
-    # enable_tools=false). Explicit False always wins.
-    _enable = False if _has_client_tool else _effective_enable_tools(payload)
-    server_tools = (
-        (_enable or (_enable is None and bool(requested_studio_tools)))
-        and llama_backend.supports_tools
-        and not _has_image
-    )
+    # enable_tools=false). Explicit False always wins. Same predicate as the
+    # permission gate above: deciding "did this request select server tools"
+    # twice is what let the gate reject requests the router then served.
+    server_tools = _selects_server_tools and llama_backend.supports_tools and not _has_image
     client_tools = (
         not server_tools
         and len(openai_client_tools) > 0

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15144,8 +15144,10 @@ def _anthropic_selects_server_tools(
     """
     if has_client_tool or _effective_enable_tools(payload) is False:
         return False
-    asked = payload.enable_tools is True or bool(getattr(payload, "mcp_enabled", False))
-    return asked or bool(requested_studio_tools)
+    # enable_tools only, not the OpenAI path's mcp_enabled: this model is extra="allow", so
+    # that key does arrive, but nothing here loads MCP schemas. Treating it as intent would
+    # answer an MCP-only request with ALL_TOOLS' built-ins, or reject it for holding terminal.
+    return payload.enable_tools is True or bool(requested_studio_tools)
 
 
 def _anthropic_requested_studio_tools(tools: Optional[list]) -> set[str]:

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2266,7 +2266,9 @@ def _build_arg_parser():
         action = "store_true",
         default = None,
         help = "Force server-side tools (web search, code execution) on for "
-        "every request. Default: on for every bind, per-request setting honored.",
+        "every request. Default: on for every bind, per-request setting honored. "
+        "/v1/messages takes the on direction per request (enable_tools) because it has "
+        "no confirmation channel; the off direction still applies everywhere.",
     )
     parser.add_argument(
         "--disable-tools",

--- a/studio/backend/state/tool_policy.py
+++ b/studio/backend/state/tool_policy.py
@@ -6,8 +6,10 @@
 Set by `unsloth run` at startup; consulted by the inference route gates.
 
   None  -> no CLI override (default). Per-request `enable_tools` is honored.
-  True  -> CLI forced tools on for every request.
-  False -> CLI forced tools off for every request.
+  True  -> CLI forced tools on for every request. Not on /v1/messages: that channel
+           cannot present a confirmation prompt, so it takes the on direction from the
+           request itself (see _anthropic_selects_server_tools).
+  False -> CLI forced tools off for every request, /v1/messages included.
 """
 
 import contextvars

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2065,6 +2065,41 @@ class TestAnthropicMessagesToolRouting:
             _drive(anthropic_messages(payload, request = None, current_subject = "t"))
             assert backend.calls[0][0] == "tools"
 
+    def test_the_process_tool_default_alone_does_not_trip_the_permission_gate(self, monkeypatch):
+        """`unsloth studio run` resolves the policy to on unless --disable-tools, so reading it
+        as "this request selected server tools" rejected every plain Messages request on a
+        default server: the catalog holds terminal, and permission_mode is omitted."""
+        import routes.inference as inf_mod
+        from fastapi.responses import JSONResponse
+
+        backend = _mock_backend(monkeypatch)
+        passthrough_calls = []
+
+        async def _passthrough(*args, **kwargs):
+            passthrough_calls.append(args)
+            return JSONResponse({"type": "message", "content": []})
+
+        monkeypatch.setattr(inf_mod, "_anthropic_passthrough_non_streaming", _passthrough)
+        set_tool_policy(True)
+
+        _drive(anthropic_messages(_basic_payload(), request = None, current_subject = "t"))
+        assert passthrough_calls or backend.calls, "a plain chat request must still be served"
+
+        # The same default must not stop gating a request that does ask for server tools.
+        for fields in (
+            {"enable_tools": True},
+            {"enable_tools": True, "permission_mode": "ask"},
+            {"tools": [{"type": "terminal", "name": "terminal"}]},
+        ):
+            with pytest.raises(HTTPException) as exc:
+                _drive(
+                    anthropic_messages(
+                        _basic_payload(**fields), request = None, current_subject = "t"
+                    )
+                )
+            assert exc.value.status_code == 400
+            assert "no confirmation channel" in exc.value.detail["error"]["message"]
+
     def test_render_html_gated_for_server_tools(self, monkeypatch):
         # render_html is no longer unconditionally safe: a networked canvas prompts
         # in auto and this channel cannot present that gate, so selecting it under

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2101,6 +2101,21 @@ class TestAnthropicMessagesToolRouting:
         )
         assert backend.calls[0][0] == "tools"
 
+        # mcp_enabled is an ask on the OpenAI routes, which wire MCP discovery. This one does
+        # not, and the request model is extra="allow" so the key does arrive: honouring it
+        # would answer an MCP-only request with ALL_TOOLS' terminal/python under an MCP name.
+        reset_tool_policy()
+        backend = _mock_backend(monkeypatch)
+        _drive(
+            anthropic_messages(
+                _basic_payload(mcp_enabled = True, permission_mode = "off"),
+                request = None,
+                current_subject = "t",
+            )
+        )
+        assert backend.calls[0][0] == "plain"
+        assert not backend.calls[0][1].get("tools")
+
         # The same default must not stop gating a request that does ask for server tools.
         for fields in (
             {"enable_tools": True},

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2065,25 +2065,41 @@ class TestAnthropicMessagesToolRouting:
             _drive(anthropic_messages(payload, request = None, current_subject = "t"))
             assert backend.calls[0][0] == "tools"
 
-    def test_the_process_tool_default_alone_does_not_trip_the_permission_gate(self, monkeypatch):
-        """`unsloth studio run` resolves the policy to on unless --disable-tools, so reading it
+    def test_the_process_tool_default_alone_is_not_a_server_tool_selection(self, monkeypatch):
+        """`unsloth studio run` resolves the policy to on unless --disable-tools. Reading that
         as "this request selected server tools" rejected every plain Messages request on a
-        default server: the catalog holds terminal, and permission_mode is omitted."""
+        default server, and routing on it ran the local tool loop with terminal/python and no
+        way to confirm them. A default is not a selection, in either direction."""
         import routes.inference as inf_mod
         from fastapi.responses import JSONResponse
 
         backend = _mock_backend(monkeypatch)
-        passthrough_calls = []
 
         async def _passthrough(*args, **kwargs):
-            passthrough_calls.append(args)
             return JSONResponse({"type": "message", "content": []})
 
         monkeypatch.setattr(inf_mod, "_anthropic_passthrough_non_streaming", _passthrough)
         set_tool_policy(True)
 
         _drive(anthropic_messages(_basic_payload(), request = None, current_subject = "t"))
-        assert passthrough_calls or backend.calls, "a plain chat request must still be served"
+        assert backend.calls, "a plain chat request must still be served"
+        path, kwargs = backend.calls[0]
+        assert path == "plain", (
+            "a tool-free request took the server-tool loop on the process default alone, so "
+            "the model can call terminal/python with no confirmation channel"
+        )
+        assert not kwargs.get("tools")
+
+        # An explicit ask still routes to the loop, with the mode that permits it.
+        backend = _mock_backend(monkeypatch)
+        _drive(
+            anthropic_messages(
+                _basic_payload(enable_tools = True, permission_mode = "off"),
+                request = None,
+                current_subject = "t",
+            )
+        )
+        assert backend.calls[0][0] == "tools"
 
         # The same default must not stop gating a request that does ask for server tools.
         for fields in (

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2093,9 +2093,7 @@ class TestAnthropicMessagesToolRouting:
         ):
             with pytest.raises(HTTPException) as exc:
                 _drive(
-                    anthropic_messages(
-                        _basic_payload(**fields), request = None, current_subject = "t"
-                    )
+                    anthropic_messages(_basic_payload(**fields), request = None, current_subject = "t")
                 )
             assert exc.value.status_code == 400
             assert "no confirmation channel" in exc.value.detail["error"]["message"]

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1351,7 +1351,9 @@ def studio_default(
         None,
         "--enable-tools/--disable-tools",
         help = "Force server-side tools (web search, code execution) on or off for "
-        "every request. Default: on for every bind, with the per-chat UI toggle honored.",
+        "every request. Default: on for every bind, with the per-chat UI toggle honored. "
+        "/v1/messages takes the on direction per request (enable_tools) because it has no "
+        "confirmation channel; the off direction still applies everywhere.",
     ),
     disable_dns_pinning: bool = typer.Option(
         False,
@@ -1844,7 +1846,9 @@ def run(
         rich_help_panel = _RUN_PANEL_TOOLS,
         help = (
             "Force server-side tools (web search, code execution) on or off for "
-            "every request. Default: on for every bind."
+            "every request. Default: on for every bind. /v1/messages takes the on "
+            "direction per request (enable_tools) because it has no confirmation "
+            "channel; the off direction still applies everywhere."
         ),
     ),
     disable_dns_pinning: bool = typer.Option(


### PR DESCRIPTION
On a default `unsloth studio run` server, every ordinary `POST /v1/messages` answers 400:

```
permission_mode 'ask' has no confirmation channel for Anthropic Messages server tools,
and 'auto' (or the omitted default) cannot gate a local 'terminal'/'python' tool here;
set 'off' or 'full'.
```

Two changes met:

- `ce193c243` made the server-side tool policy default to on for every bind (`resolve_tool_policy`: `return True if flag is None else flag`), so `unsloth studio run` calls `set_tool_policy(True)` unless `--disable-tools` is passed.
- `#7079` added a pre-switch permission gate that reads the *resolved policy* as "this request selected server tools". For a tool-free request it therefore collected the whole catalog, found `terminal` in it, saw no `permission_mode`, and rejected.

A process-wide default is not a per-request selection. The gate now fires on an explicit ask only: `enable_tools` / `mcp_enabled`, or an Anthropic server-tool type in `tools`. `--disable-tools` still vetoes both forms.

### What still rejects

Verified by driving the real route with `set_tool_policy(True)`, the default a server actually runs with:

| request | before | after |
|---|---|---|
| plain chat, no tools, no mode | **400** | 200 |
| `enable_tools: true`, mode omitted | 400 | 400 |
| `enable_tools: true`, `permission_mode: ask` | 400 | 400 |
| `{"type": "terminal"}`, mode omitted or `auto` | 400 | 400 |
| `{"type": "terminal"}`, `permission_mode: full` | runs | runs |
| `web_search` only, `permission_mode: ask` | 400 | 400 |
| `{"type": "terminal"}` under `--disable-tools` | runs | runs |
| `render_html` under ask/auto/omitted | 400 | 400 |

### Why CI never saw it

The four end-to-end cases that cover this path (`test_anthropic_basic`, `test_anthropic_streaming`, `test_anthropic_with_tools`, `test_anthropic_tool_choice_any`) live in `tests/test_studio_api.py`, which `studio-backend-ci.yml` ignores because it needs a live model and a ~2 GB GGUF download. `test_the_process_tool_default_alone_is_not_a_server_tool_selection` now pins the case in the unit suite, where it fails before this change and passes after.

```
tests/test_anthropic_messages.py  tests/test_openai_tool_passthrough.py
tests/test_tool_policy_gates.py   tests/test_tool_policy_state.py
tests/test_secure_tools_execute.py tests/test_sf_client_tools_passthrough.py
tests/test_mcp_stdio_pr5863.py
-> 510 passed
```

### What this removes

Two behaviours change beyond the rejection, both deliberate:

- **`--enable-tools` no longer *enables* server tools on `/v1/messages`.** The policy is veto-only on that channel now: the off direction still applies everywhere, the on direction has to come from the request. This is not a state the flag could reach anyway, because `resolve_tool_policy` is `return True if flag is None else flag`, so the explicit flag and the bare default store the same `True`. `/v1/chat/completions` is untouched and still forces the loop on. The CLI help and the `tool_policy` docstring have been corrected to say so.
- **A policy-only default no longer routes into the server-tool loop.** Lifting the gate off the default fixed the rejection but left the execution it existed to stop: a tool-free request took the `tools` path with `python`/`terminal`/`render_html` and `confirm_tool_calls` unset. Both the gate and the router now call one predicate, `_anthropic_selects_server_tools`, since deciding "did this request select server tools" twice is what let them disagree.

`mcp_enabled` is deliberately not an ask here. It is one on the OpenAI routes because those consult `get_enabled_mcp_tools`; this route has no MCP discovery, so honouring it would answer an MCP-only request with the built-in `terminal`/`python`. The request model is `extra = "allow"`, so the key does arrive and this is not theoretical.

### Still reachable, unchanged from main

`{"enable_tools": true, "permission_mode": "off"}` hands the full catalog to the loop, and `anthropic_messages` never passes `confirm_tool_calls`, whose callee defaults it to `False` -- so `needs_confirm` is False on this channel in every mode. The sandbox stays on unless `full` or `bypass_permissions`. That is pre-existing and out of scope here, but it is the reason the on direction is per-request rather than a server default.
