### PR TITLE
Order the Mac inference phases so the gates stop fighting each other

### DIFF
--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -106,6 +106,45 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+
+      # Shared preamble, but it sits below phase 1's model priming because the
+      # install probe (stories260K) rides along in that same step. `!cancelled()`
+      # Deliberately NO `if:`, so this rides the implicit success(). Nothing
+      # phase-local runs before it any more, so the only thing the implicit check
+      # can see is a genuine shared-preamble failure -- checkout, setup-node or
+      # setup-python -- and those SHOULD stop the job rather than install onto a
+      # runner that never got its pinned toolchain.
+      - name: Install Unsloth (--local, --no-torch)
+        id: install
+        timeout-minutes: 20
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
+
+      # Last step of the shared preamble. Phases 2 and 3 gate on its outcome:
+      # once checkout, install and this check have passed, a failure inside one
+      # phase says nothing about the others, so the others should still run.
+      # Gates on `install` explicitly rather than on the implicit `success()` so
+      # that it keeps holding if a phase-local step is ever moved back above it.
+      # A broken install still skips this step, so its outcome stays non-success
+      # and the phases below correctly stay out.
+      - name: Assert llama.cpp loads on this macOS
+        id: assert-llama
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        timeout-minutes: 5
+        run: bash .github/scripts/assert-llama-loads.sh
+
+      # Phase 1's environment and model cache sit HERE, after the shared preamble,
+      # not before it. Ordering them first was what forced the installer onto an
+      # explicit `!cancelled()`: a phase-1 GGUF download failure would otherwise
+      # skip the install under the implicit success() and take phases 2 and 3
+      # down with it. That gate bought phase independence at the cost of running
+      # the installer on a runner whose setup-node or setup-python had failed.
+      # Moving the block is strictly better than either gate, because it makes
+      # the two failure classes structural: everything above is genuinely
+      # shared, everything from here down is phase 1's own.
       - name: Phase 1 environment
         run: |
           echo "GGUF_REPO=unsloth/gemma-3-270m-it-GGUF" >> "$GITHUB_ENV"
@@ -154,39 +193,6 @@ jobs:
         with:
           path: hf-cache
           key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
-
-      # Shared preamble, but it sits below phase 1's model priming because the
-      # install probe (stories260K) rides along in that same step. `!cancelled()`
-      # keeps it out of the implicit `success()` chain: a phase-1 GGUF download
-      # failure or 15-minute timeout is a phase-1 resource problem, and skipping
-      # the shared install because of it would take the assert-llama gate --
-      # and with it phases 2 and 3 -- down as well. A step timeout sets the step
-      # to failed, not cancelled (actions/runner StepsRunner.cs), so `!cancelled()`
-      # is true here; a real run cancellation still skips.
-      - name: Install Unsloth (--local, --no-torch)
-        id: install
-        if: ${{ !cancelled() }}
-        timeout-minutes: 20
-        uses: ./.github/actions/install-unsloth-local
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-
-      # Last step of the shared preamble. Phases 2 and 3 gate on its outcome:
-      # once checkout, install and this check have passed, a failure inside one
-      # phase says nothing about the others, so the others should still run.
-      # Gates on `install` explicitly rather than on the implicit `success()`,
-      # for the same reason as the step above: the implicit check is job-wide, so
-      # a phase-1 download failure would skip it and silently take phases 2 and 3
-      # with it. A broken install still skips this step, so its outcome stays
-      # non-success and the phases below correctly stay out.
-      - name: Assert llama.cpp loads on this macOS
-        id: assert-llama
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
-        timeout-minutes: 5
-        run: bash .github/scripts/assert-llama-loads.sh
-
       - name: Install OpenAI + Anthropic Python SDKs
         timeout-minutes: 5
         run: pip install 'openai>=1.50' 'anthropic>=0.40'
@@ -443,7 +449,14 @@ jobs:
           key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v2
 
       - name: Reset auth + boot Unsloth (API-only, default tool policy)
-        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}
+        id: boot-tools
+        # Phase-local prerequisite on top of the shared gate. The phase stays
+        # independent of EARLIER phases, which is what the shared assert-llama
+        # gate buys, but it is not independent of its own download: without this
+        # clause a failed download still boots a server with no model and runs
+        # the test against it. `!= 'failure'` and not `== 'success'`, because a
+        # cache hit skips the download.
+        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' && steps.download-gguf-tools.outcome != 'failure' }}
         timeout-minutes: 2
         # We deliberately use the API-only mode rather than
         # `unsloth studio run` because the latter calls
@@ -461,7 +474,8 @@ jobs:
           echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for /api/health, log in, change password, load model
-        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}
+        id: ready-tools
+        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' && steps.boot-tools.outcome == 'success' }}
         # 180s health wait + curl's own --max-time 600, with headroom.
         timeout-minutes: 15
         run: |
@@ -495,7 +509,7 @@ jobs:
             | jq '{status, display_name}'
 
       - name: Tool calling, server-side tools, thinking on/off
-        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' && steps.ready-tools.outcome == 'success' }}
         timeout-minutes: 20
         env:
           BASE_URL: http://127.0.0.1:18898
@@ -872,12 +886,16 @@ jobs:
           key: ${{ runner.os }}-gguf-unsloth/gemma-4-E2B-it-GGUF-gemma-4-E2B-it-UD-Q4_K_XL.gguf-mmproj-F16.gguf-v3
 
       - name: Install OpenAI + Anthropic Python SDKs
+        id: sdks-vision
         if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}
         timeout-minutes: 5
         run: pip install 'openai>=1.50' 'anthropic>=0.40'
 
       - name: Reset auth + boot Unsloth (API-only)
-        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}
+        id: boot-vision
+        # Same phase-local prerequisite as phase 2. The SDK clause is here and
+        # not in phase 2 because only this phase imports openai/anthropic.
+        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' && steps.sdks-vision.outcome == 'success' && steps.download-gguf-vision.outcome != 'failure' }}
         timeout-minutes: 2
         # See phase 2's comment: API-only mode keeps tool_policy=None so
         # response_format requests aren't routed through the agentic
@@ -890,7 +908,8 @@ jobs:
           echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for /api/health, log in, change password, load model
-        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}
+        id: ready-vision
+        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' && steps.boot-vision.outcome == 'success' }}
         # 180s health wait + curl's own --max-time 900, with headroom.
         timeout-minutes: 20
         run: |
@@ -929,7 +948,7 @@ jobs:
             | jq '{status, display_name, is_vision}'
 
       - name: JSON schema decoding + image input
-        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' && steps.ready-vision.outcome == 'success' }}
         timeout-minutes: 20
         env:
           BASE_URL: http://127.0.0.1:18899


### PR DESCRIPTION
Follow-up to the Mac inference-smoke consolidation, applying the resolution that came out of reviewing the equivalent Windows change in #8013. Same three phases, same one-job shape, so the same two gating problems were present here.

## The installer gate

The step carried an explicit `if: ${{ !cancelled() }}`, and the comment above it explained the reasoning: phase 1's environment and model cache ran *before* the installer, so under the implicit `success()` a phase-1 GGUF download failure or 15-minute timeout would skip the install, skip `assert-llama` with it, and evaluate every phase-2 and phase-3 gate false. A transient HF download would take the whole workflow down.

The gate does buy that independence. What the comment did not weigh is the other side: `!cancelled()` is true after *any* non-cancellation failure, including a failed `setup-node` or `setup-python`. The installer then runs on a runner that never got its pinned toolchain, `assert-llama` passes, and all three phases run and fail somewhere unrelated to the real cause.

Reordering gets both properties at once, and needs no condition at all:

```
before   checkout  node  python  Phase 1 env  cache-hf  prime-hf  save  install(!cancelled)  assert-llama
after    checkout  node  python  install  assert-llama  Phase 1 env  cache-hf  prime-hf  save
```

Everything above phase 1's block is genuinely shared; everything from the block down is phase 1's own. The installer goes back to the implicit `success()`, where the only thing it can now see is a real shared-preamble failure, which *should* stop the job.

Checked that nothing in the preamble needed the moved environment: the installer takes `gh-token` and `hf-token`, not `HF_HOME`, and phase 2 already ran it with no `HF_HOME` set at all.

## Phase-local prerequisites

Phases 2 and 3 gated every step on `assert-llama` alone. That is right for cross-phase independence and wrong within a phase: a failed download still booted a server with no model, and the test then ran against it, so the job spent the phase's full budget cascading from an error already reported several steps earlier.

Each phase now chains on its own prerequisites, with `assert-llama` kept as the first term so nothing about cross-phase independence changes:

```
phase 2   boot-tools    <- download-gguf-tools.outcome  != 'failure'
          ready-tools   <- boot-tools.outcome           == 'success'
          test          <- ready-tools.outcome          == 'success'

phase 3   boot-vision   <- sdks-vision.outcome == 'success' && download-gguf-vision.outcome != 'failure'
          ready-vision  <- boot-vision.outcome  == 'success'
          test          <- ready-vision.outcome == 'success'
```

The download clause is `!= 'failure'` rather than `== 'success'` on purpose: a cache hit skips the download step, and `== 'success'` would make a warm cache skip the entire phase.

Phase 3 gates on the SDK install because it is the only phase that imports `openai` / `anthropic`; phase 2 drives the API with curl and deliberately does not, so a pip failure there cannot cost the tool-calling coverage.

## Verification

- Every `run:` body in the file is byte-identical across the change: 24 before, 24 after, 0 lost and 0 added. The diff moves steps and edits `if:` keys only.
- `actionlint` clean, and no step ends up with a duplicate `if:` key.
- No step gates on its own `id`.