### PR TITLE
Fix desktop window chrome

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -450,8 +450,9 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         .catch(() => undefined);
     };
     const handleResize = () => {
-      setNativeMacControlsHidden(false);
-      refresh();
+      setNativeMacControlsHidden(
+        window.innerHeight >= window.screen.height - 1,
+      );
     };
     refresh();
     window.addEventListener("resize", handleResize);

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -440,28 +440,21 @@ function TauriWrapper({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!usesNativeMacTitlebar) return;
-    let disposed = false;
-    let unlistenResize: (() => void) | undefined;
-    let unlistenFocus: (() => void) | undefined;
-
-    void import("@tauri-apps/api/window")
-      .then(async ({ getCurrentWindow }) => {
-        const appWindow = getCurrentWindow();
-        const refresh = async () => {
-          const fullscreen = await appWindow.isFullscreen();
-          if (!disposed) setNativeMacControlsHidden(fullscreen);
-        };
-        await refresh();
-        if (disposed) return;
-        unlistenResize = await appWindow.onResized(() => void refresh());
-        unlistenFocus = await appWindow.onFocusChanged(() => void refresh());
-      })
-      .catch(() => undefined);
+    let active = true;
+    const refresh = () => {
+      void import("@tauri-apps/api/window")
+        .then(({ getCurrentWindow }) => getCurrentWindow().isFullscreen())
+        .then((fullscreen) => {
+          if (active) setNativeMacControlsHidden(fullscreen);
+        })
+        .catch(() => undefined);
+    };
+    refresh();
+    window.addEventListener("resize", refresh);
 
     return () => {
-      disposed = true;
-      unlistenResize?.();
-      unlistenFocus?.();
+      active = false;
+      window.removeEventListener("resize", refresh);
     };
   }, [usesNativeMacTitlebar]);
 

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -449,12 +449,16 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         })
         .catch(() => undefined);
     };
+    const handleResize = () => {
+      setNativeMacControlsHidden(false);
+      refresh();
+    };
     refresh();
-    window.addEventListener("resize", refresh);
+    window.addEventListener("resize", handleResize);
 
     return () => {
       active = false;
-      window.removeEventListener("resize", refresh);
+      window.removeEventListener("resize", handleResize);
     };
   }, [usesNativeMacTitlebar]);
 

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -550,6 +550,12 @@ function AppearanceCustomizationEffect() {
   useEffect(() => {
     applyCustomizationToDocument(customization, resolved);
   }, [customization, resolved]);
+  useEffect(() => {
+    if (!isTauri) return;
+    void import("@tauri-apps/api/window")
+      .then(({ getCurrentWindow }) => getCurrentWindow().setTheme(resolved))
+      .catch(() => undefined);
+  }, [resolved]);
   return null;
 }
 

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -357,6 +357,10 @@ function TauriWrapper({ children }: { children: ReactNode }) {
   const windowLayoutGenerationRef = useRef(0);
   const [desktopAuthReady, setDesktopAuthReady] = useState(!isTauri);
   const [desktopAuthRetry, setDesktopAuthRetry] = useState(0);
+  const [nativeMacControlsHidden, setNativeMacControlsHidden] = useState(false);
+  const usesCustomTitlebar = shouldUseCustomWindowTitlebar();
+  const usesNativeMacTitlebar = shouldUseNativeMacWindowTitlebar();
+  const hidesTitlebarSidebar = HIDDEN_TITLEBAR_SIDEBAR_ROUTES.has(pathname);
 
   useEffect(() => {
     if (!isTauri) return;
@@ -434,6 +438,33 @@ function TauriWrapper({ children }: { children: ReactNode }) {
     void fetchDeviceType({ force: true }).catch(() => undefined);
   }, [status, desktopAuthReady]);
 
+  useEffect(() => {
+    if (!usesNativeMacTitlebar) return;
+    let disposed = false;
+    let unlistenResize: (() => void) | undefined;
+    let unlistenFocus: (() => void) | undefined;
+
+    void import("@tauri-apps/api/window")
+      .then(async ({ getCurrentWindow }) => {
+        const appWindow = getCurrentWindow();
+        const refresh = async () => {
+          const fullscreen = await appWindow.isFullscreen();
+          if (!disposed) setNativeMacControlsHidden(fullscreen);
+        };
+        await refresh();
+        if (disposed) return;
+        unlistenResize = await appWindow.onResized(() => void refresh());
+        unlistenFocus = await appWindow.onFocusChanged(() => void refresh());
+      })
+      .catch(() => undefined);
+
+    return () => {
+      disposed = true;
+      unlistenResize?.();
+      unlistenFocus?.();
+    };
+  }, [usesNativeMacTitlebar]);
+
   if (!isTauri) {
     return (
       <>
@@ -460,9 +491,6 @@ function TauriWrapper({ children }: { children: ReactNode }) {
   const showApp = status === "running" && desktopAuthReady;
   const startupStatus = status === "running" ? "starting" : status;
   const startupProgressDetail = progressDetail;
-  const usesCustomTitlebar = shouldUseCustomWindowTitlebar();
-  const usesNativeMacTitlebar = shouldUseNativeMacWindowTitlebar();
-  const hidesTitlebarSidebar = HIDDEN_TITLEBAR_SIDEBAR_ROUTES.has(pathname);
 
   const content = showApp ? (
     <TauriUpdateLayer
@@ -509,7 +537,14 @@ function TauriWrapper({ children }: { children: ReactNode }) {
               ? "relative h-dvh min-h-0 overflow-x-hidden overflow-y-auto bg-background"
               : "relative h-dvh min-h-0 overflow-hidden bg-background"
           }
-          style={MAC_NATIVE_CHROME_STYLE}
+          style={
+            nativeMacControlsHidden
+              ? {
+                  ...MAC_NATIVE_CHROME_STYLE,
+                  "--studio-mac-traffic-light-inset": "6px",
+                } as CSSProperties
+              : MAC_NATIVE_CHROME_STYLE
+          }
         >
           {!showApp || hidesTitlebarSidebar ? (
             <div

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -450,9 +450,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         .catch(() => undefined);
     };
     const handleResize = () => {
-      setNativeMacControlsHidden(
-        window.innerHeight >= window.screen.height - 1,
-      );
+      refresh();
     };
     refresh();
     window.addEventListener("resize", handleResize);
@@ -578,7 +576,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
  * whenever either the customization or the resolved theme changes.
  */
 function AppearanceCustomizationEffect() {
-  const { resolved } = useTheme();
+  const { theme, resolved } = useTheme();
   const customization = useAppearanceCustomStore((s) => s.customization);
   useEffect(() => {
     applyCustomizationToDocument(customization, resolved);
@@ -586,9 +584,11 @@ function AppearanceCustomizationEffect() {
   useEffect(() => {
     if (!isTauri) return;
     void import("@tauri-apps/api/window")
-      .then(({ getCurrentWindow }) => getCurrentWindow().setTheme(resolved))
+      .then(({ getCurrentWindow }) =>
+        getCurrentWindow().setTheme(theme === "system" ? null : theme),
+      )
       .catch(() => undefined);
-  }, [resolved]);
+  }, [theme]);
   return null;
 }
 

--- a/studio/frontend/src/components/tauri/update-screen.tsx
+++ b/studio/frontend/src/components/tauri/update-screen.tsx
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { Spinner } from "@/components/ui/spinner";
 import type { UpdateStatus } from "@/hooks/use-tauri-update";
 import type { CopySupportDiagnosticsResult } from "@/lib/tauri-diagnostics";
 import { AnimatePresence, motion } from "motion/react";
-import { Spinner } from "@/components/ui/spinner";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 
 interface UpdateScreenProps {
   status: UpdateStatus;
@@ -68,28 +68,21 @@ function statusSubtext(status: UpdateStatus, progress: number): string {
   }
 }
 
-function LogViewer({ logs }: { logs: string[] }) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [logs]);
-
-  if (logs.length === 0) return null;
+function UpdateDetails({ logs }: { logs: string[] }) {
+  if (logs.length === 0) {
+    return null;
+  }
 
   return (
-    <div
-      ref={scrollRef}
-      className="mt-4 h-[180px] w-full max-w-xl overflow-y-auto rounded-lg border border-border/40 bg-muted/30 p-3 font-mono text-ui-11 leading-relaxed text-muted-foreground"
-    >
-      {logs.map((line, i) => (
-        <div key={i} className="whitespace-pre-wrap break-all">
-          {line}
-        </div>
-      ))}
-    </div>
+    <details className="group mt-2 w-full max-w-sm text-left">
+      <summary className="mx-auto w-fit cursor-pointer select-none rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+        <span className="group-open:hidden">Show update details</span>
+        <span className="hidden group-open:inline">Hide update details</span>
+      </summary>
+      <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
+        {logs.join("\n")}
+      </pre>
+    </details>
   );
 }
 
@@ -116,7 +109,10 @@ export function UpdateScreen({
         setManualMessage(null);
       } else {
         setManualReport(result.report);
-        setManualMessage(result.error ?? "Clipboard copy failed. Select and copy the diagnostics below.");
+        setManualMessage(
+          result.error ??
+            "Clipboard copy failed. Select and copy the diagnostics below.",
+        );
       }
     } catch (copyError) {
       setManualReport(null);
@@ -127,93 +123,101 @@ export function UpdateScreen({
   }
 
   return (
-    <div className="box-border flex h-full w-full overflow-y-auto bg-background">
-      <motion.div
-        initial={{ opacity: 0, y: 8 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4, ease: EASE_OUT_QUART }}
-        className="mx-auto flex min-h-full w-full max-w-xl flex-col items-center justify-center px-6 pb-6 pt-[var(--studio-startup-top-inset,0px)]"
-      >
-        <Logo />
-
-        <div className="mt-8 flex flex-col items-center gap-2">
-          {!isError && <Spinner className="size-6 text-primary" />}
-          <p className="text-sm font-semibold text-foreground">
-            {statusLabel(status)}
-          </p>
-          <p className="text-xs text-muted-foreground">
-            {statusSubtext(status, progress)}
-          </p>
-        </div>
-
-        {/* Download progress bar */}
-        {status === "downloading" && (
-          <div className="mt-4 h-1.5 w-full max-w-xs overflow-hidden rounded-full bg-muted">
-            <motion.div
-              className="h-full rounded-full bg-primary"
-              initial={{ width: 0 }}
-              animate={{ width: `${progress}%` }}
-              transition={{ duration: 0.3 }}
-            />
+    <div className="box-border flex h-full w-full flex-col items-center overflow-y-auto bg-background pb-6 pt-[var(--studio-startup-top-inset,0px)]">
+      <div className="flex min-h-0 w-full max-w-md flex-1 items-center justify-center px-6">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.2, ease: EASE_OUT_QUART }}
+          className="flex h-full w-full flex-col items-center text-center"
+        >
+          <div className="flex flex-1 items-center">
+            <Logo />
           </div>
-        )}
 
-        {/* Error display */}
-        <AnimatePresence>
-          {isError && error && (
-            <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              className="mt-4 w-full max-w-xl rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3"
+          <div className="mb-10 flex w-full flex-col items-center gap-2">
+            {!isError && <Spinner className="size-6 text-primary" />}
+            <p
+              className={
+                isError
+                  ? "text-sm font-medium text-destructive"
+                  : "text-sm font-bold text-foreground"
+              }
             >
-              <p className="text-xs text-destructive">{error}</p>
-            </motion.div>
-          )}
-        </AnimatePresence>
+              {statusLabel(status)}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {statusSubtext(status, progress)}
+            </p>
 
-        {/* Error actions */}
-        {isError && (
-          <div className="mt-4 flex items-center gap-2">
-            <button
-              type="button"
-              className="rounded-lg bg-muted px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
-              onClick={() => void handleCopyDiagnostics()}
-            >
-              {copying ? "Copying..." : "Copy Diagnostics"}
-            </button>
-            <button
-              type="button"
-              className="rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
-              onClick={onRetry}
-            >
-              Retry
-            </button>
-            <button
-              type="button"
-              className="rounded-lg bg-muted px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
-              onClick={onSkipRestart}
-            >
-              Skip & Restart
-            </button>
+            {status === "downloading" && (
+              <div className="mt-2 h-1.5 w-full max-w-xs overflow-hidden rounded-full bg-muted">
+                <motion.div
+                  className="h-full rounded-full bg-primary"
+                  initial={{ width: 0 }}
+                  animate={{ width: `${progress}%` }}
+                  transition={{ duration: 0.3 }}
+                />
+              </div>
+            )}
+
+            <AnimatePresence>
+              {isError && error && (
+                <motion.p
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  className="max-w-md text-xs text-muted-foreground"
+                >
+                  {error}
+                </motion.p>
+              )}
+            </AnimatePresence>
+
+            {isError && (
+              <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
+                <button
+                  type="button"
+                  className="rounded-lg bg-muted px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
+                  onClick={() => void handleCopyDiagnostics()}
+                >
+                  {copying ? "Copying..." : "Copy Diagnostics"}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
+                  onClick={onRetry}
+                >
+                  Retry
+                </button>
+                <button
+                  type="button"
+                  className="rounded-lg bg-muted px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
+                  onClick={onSkipRestart}
+                >
+                  Skip & Restart
+                </button>
+              </div>
+            )}
+
+            {manualMessage && (
+              <p className="mt-1 max-w-md text-xs text-destructive">
+                {manualMessage}
+              </p>
+            )}
+            {manualReport && (
+              <textarea
+                readOnly
+                value={manualReport}
+                onFocus={(event) => event.currentTarget.select()}
+                className="mt-1 h-32 w-full max-w-md resize-none rounded-lg border border-border/50 bg-muted/30 p-2 text-left font-mono text-ui-10 text-muted-foreground"
+              />
+            )}
+
+            <UpdateDetails logs={logs} />
           </div>
-        )}
-
-        {manualMessage && (
-          <p className="mt-3 max-w-xl text-center text-xs text-destructive">{manualMessage}</p>
-        )}
-        {manualReport && (
-          <textarea
-            readOnly
-            value={manualReport}
-            onFocus={(event) => event.currentTarget.select()}
-            className="mt-2 h-32 w-full max-w-xl resize-none rounded-lg border border-border/50 bg-muted/30 p-2 font-mono text-ui-10 text-muted-foreground"
-          />
-        )}
-
-        {/* Log viewer */}
-        <LogViewer logs={logs} />
-      </motion.div>
+        </motion.div>
+      </div>
     </div>
   );
 }

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -6,16 +6,10 @@ import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { useSidebarWidth } from "@/hooks/use-sidebar-width";
 import { isTauri } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
-import {
-  Cancel01Icon,
-  LayoutAlignLeftIcon,
-  MinusSignIcon,
-  SquareIcon,
-  SquareSquareIcon,
-} from "@hugeicons/core-free-icons";
+import { LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ArrowLeft, ArrowRight } from "lucide-react";
 import type { Window as TauriWindow } from "@tauri-apps/api/window";
+import { ArrowLeft, ArrowRight, Copy, Minus, Square, X } from "lucide-react";
 import {
   type MouseEvent,
   type ReactElement,
@@ -122,7 +116,7 @@ export function DesktopTitlebarNavigation({
     event.stopPropagation();
   };
   const buttonClass =
-    "inline-flex size-[30px] shrink-0 items-center justify-center rounded-[10px] text-nav-icon-idle transition-colors hover:bg-nav-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+    "inline-flex size-[30px] shrink-0 items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
   return (
     <div
@@ -414,11 +408,7 @@ export function WindowTitlebar({
             label="Minimize window"
             onClick={() => runWindowAction((appWindow) => appWindow.minimize())}
           >
-            <HugeiconsIcon
-              icon={MinusSignIcon}
-              strokeWidth={1.75}
-              className="size-[15px]"
-            />
+            <Minus aria-hidden="true" strokeWidth={1.75} className="w-[18px]" />
           </WindowControlButton>
           <WindowControlButton
             label={maximized ? "Restore window" : "Maximize window"}
@@ -426,22 +416,26 @@ export function WindowTitlebar({
               runWindowAction((appWindow) => appWindow.toggleMaximize())
             }
           >
-            <HugeiconsIcon
-              icon={maximized ? SquareSquareIcon : SquareIcon}
-              strokeWidth={1.75}
-              className="size-[14px]"
-            />
+            {maximized ? (
+              <Copy
+                aria-hidden="true"
+                strokeWidth={1.75}
+                className="size-[17px]"
+              />
+            ) : (
+              <Square
+                aria-hidden="true"
+                strokeWidth={1.75}
+                className="size-[16px]"
+              />
+            )}
           </WindowControlButton>
           <WindowControlButton
             label="Close window"
             onClick={() => runWindowAction((appWindow) => appWindow.close())}
             className="hover:bg-destructive/10 hover:text-destructive focus-visible:ring-destructive/70 dark:hover:bg-destructive/20"
           >
-            <HugeiconsIcon
-              icon={Cancel01Icon}
-              strokeWidth={1.75}
-              className="size-[15px]"
-            />
+            <X aria-hidden="true" strokeWidth={1.75} className="size-[18px]" />
           </WindowControlButton>
         </div>
       </header>

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -6,10 +6,10 @@ import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { useSidebarWidth } from "@/hooks/use-sidebar-width";
 import { isTauri } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
-import { LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
+import { CopyIcon, LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Window as TauriWindow } from "@tauri-apps/api/window";
-import { ArrowLeft, ArrowRight, Copy, Minus, Square, X } from "lucide-react";
+import { ArrowLeft, ArrowRight, Minus, Square, X } from "lucide-react";
 import {
   type MouseEvent,
   type ReactElement,
@@ -417,10 +417,10 @@ export function WindowTitlebar({
             }
           >
             {maximized ? (
-              <Copy
-                aria-hidden="true"
+              <HugeiconsIcon
+                icon={CopyIcon}
                 strokeWidth={1.75}
-                className="size-[17px]"
+                className="size-[17px] rotate-180"
               />
             ) : (
               <Square

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 import { CopyIcon, LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Window as TauriWindow } from "@tauri-apps/api/window";
-import { ArrowLeft, ArrowRight, Minus, X } from "lucide-react";
+import { ArrowLeft, ArrowRight, Minus, Square, X } from "lucide-react";
 import {
   type MouseEvent,
   type ReactElement,
@@ -416,11 +416,19 @@ export function WindowTitlebar({
               runWindowAction((appWindow) => appWindow.toggleMaximize())
             }
           >
-            <HugeiconsIcon
-              icon={CopyIcon}
-              strokeWidth={1.75}
-              className="size-[17px] rotate-180"
-            />
+            {maximized ? (
+              <HugeiconsIcon
+                icon={CopyIcon}
+                strokeWidth={1.75}
+                className="size-[17px] rotate-180"
+              />
+            ) : (
+              <Square
+                aria-hidden="true"
+                strokeWidth={1.75}
+                className="size-[16px]"
+              />
+            )}
           </WindowControlButton>
           <WindowControlButton
             label="Close window"

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 import { CopyIcon, LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Window as TauriWindow } from "@tauri-apps/api/window";
-import { ArrowLeft, ArrowRight, Minus, Square, X } from "lucide-react";
+import { ArrowLeft, ArrowRight, Minus, X } from "lucide-react";
 import {
   type MouseEvent,
   type ReactElement,
@@ -416,19 +416,11 @@ export function WindowTitlebar({
               runWindowAction((appWindow) => appWindow.toggleMaximize())
             }
           >
-            {maximized ? (
-              <HugeiconsIcon
-                icon={CopyIcon}
-                strokeWidth={1.75}
-                className="size-[17px] rotate-180"
-              />
-            ) : (
-              <Square
-                aria-hidden="true"
-                strokeWidth={1.75}
-                className="size-[16px]"
-              />
-            )}
+            <HugeiconsIcon
+              icon={CopyIcon}
+              strokeWidth={1.75}
+              className="size-[17px] rotate-180"
+            />
           </WindowControlButton>
           <WindowControlButton
             label="Close window"

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -967,6 +967,16 @@ html[data-chat-font] .aui-root {
 		@apply h-full;
 	}
 
+	html.tauri {
+		overflow: hidden;
+		overscroll-behavior: none;
+	}
+
+	html.tauri body,
+	html.tauri #root {
+		overflow: hidden;
+	}
+
 	body[data-scroll-locked] {
 		margin-right: 0 !important;
 	}

--- a/studio/frontend/src/main.tsx
+++ b/studio/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import "./index.css";
 import { App } from "./app/app";
 import { fetchDeviceType } from "./config/env";
 import { initializeLocale } from "./i18n";
+import { isTauri } from "./lib/api-base";
 
 const globalCrypto = globalThis.crypto as Crypto | undefined;
 
@@ -35,6 +36,10 @@ if (!rootElement) {
 }
 
 initializeLocale();
+
+if (isTauri) {
+  document.documentElement.classList.add("tauri");
+}
 
 // Rasterization follows the browser OS, not the potentially remote server.
 // This adjustment is calibrated for desktop Linux, so exclude Android.

--- a/studio/src-tauri/capabilities/default.json
+++ b/studio/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
     "core:window:allow-unminimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
+    "core:window:allow-set-theme",
     "core:tray:default",
     "process:default",
     "deep-link:default",


### PR DESCRIPTION
## Summary

- lighten dark-mode titlebar navigation icons
- align Windows/Linux window controls with the reference chrome
- sync macOS native controls with the app theme
- prevent touchpad momentum from overscrolling the Tauri document shell

## Root cause

The Tauri shell allowed document overscroll and did not sync its native window theme with the app theme.

## Validation

- `npm run typecheck`
- `npm test` (681 passed)
- `npm run build`
