### PR TITLE
Fix the desktop clean-machine CI: asset patterns and the retired #7547 pins

### DIFF
--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -30,9 +30,13 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag in the desktop release repo'
+        description: 'Release tag in the desktop release repo (empty resolves the newest)'
         type: string
-        default: 'desktop-v0.1.50-beta'
+        # Empty, not a pinned tag. desktop-v0.1.50-beta predates #7547, so with the
+        # outcome pins retired a dispatch that took this default would fail all four
+        # POSIX legs at the installer step -- on a bundle nobody meant to test. Empty
+        # falls through to the same newest-desktop-v* resolution the schedule uses.
+        default: ''
       release_repo:
         description: 'owner/name hosting the desktop release'
         type: string
@@ -241,14 +245,29 @@ jobs:
             grep -E "disposition=|can_auto_repair=|Xcode Command Line|ModuleNotFoundError" "$f" || true
             found=1
             if grep -qE "desktop_preflight completed disposition=" "$f"; then disposition=1; fi
+            dispositions="${dispositions:-} $(grep -oE 'desktop_preflight completed disposition=[A-Za-z]+' "$f" | sed 's/.*disposition=//' | tr '\n' ' ')"
           done
-          # Everything above is `|| true`, so without these two lines the step could not
+          # Everything above is `|| true`, so without these lines the step could not
           # fail while the header sells the disposition as an acceptance criterion.
           # setup_logging (src-tauri/src/main.rs:50-67) opens tauri.log unconditionally at
           # process start, so no log means the binary never got that far, and a process
           # that hangs before preflight must not pass.
           [ "${found:-0}" = "1" ] || { echo "::error::the app wrote no tauri.log; it never reached setup_logging"; exit 1; }
           [ "${disposition:-0}" = "1" ] || { echo "::error::tauri.log records no desktop_preflight disposition; the app never completed preflight"; exit 1; }
+          # A recorded disposition is not enough. A post-#7547 bundle can install a
+          # working venv and still have preflight regress to NotInstalled, and the app
+          # then sits happily on the Install screen: alive, log written, disposition
+          # present, nothing built recognised. Windows has always required a READY
+          # disposition; the reason given for keeping that Windows-only was the install
+          # root, and the source says otherwise -- preflight/managed.rs env_removes
+          # UNSLOTH_STUDIO_HOME and STUDIO_HOME on every platform, not under a
+          # cfg(windows), so all three read the same legacy root.
+          echo "dispositions recorded: ${dispositions:-<none>}"
+          case "${dispositions:-}" in
+            *ManagedReady*|*OwnedReady*|*AttachedReady*) ;;
+            *) echo "::error::preflight never reported a ready disposition (saw: ${dispositions:-<none>}); the app did not recognise the environment the bundled installer just built"
+               exit 1 ;;
+          esac
 
       - name: Restore the runner
         if: always()
@@ -441,11 +460,26 @@ jobs:
             grep -E "disposition=|can_auto_repair=|ModuleNotFoundError" "$f" || true
             found=1
             if grep -qE "desktop_preflight completed disposition=" "$f"; then disposition=1; fi
+            dispositions="${dispositions:-} $(grep -oE 'desktop_preflight completed disposition=[A-Za-z]+' "$f" | sed 's/.*disposition=//' | tr '\n' ' ')"
           done
           # Same criterion the macOS rows enforce, same reason: everything above is
           # `|| true` and the loop skips a missing log, so the step could not fail.
           [ "${found:-0}" = "1" ] || { echo "::error::the app wrote no tauri.log; it never reached setup_logging"; exit 1; }
           [ "${disposition:-0}" = "1" ] || { echo "::error::tauri.log records no desktop_preflight disposition; the app never completed preflight"; exit 1; }
+          # A recorded disposition is not enough. A post-#7547 bundle can install a
+          # working venv and still have preflight regress to NotInstalled, and the app
+          # then sits happily on the Install screen: alive, log written, disposition
+          # present, nothing built recognised. Windows has always required a READY
+          # disposition; the reason given for keeping that Windows-only was the install
+          # root, and the source says otherwise -- preflight/managed.rs env_removes
+          # UNSLOTH_STUDIO_HOME and STUDIO_HOME on every platform, not under a
+          # cfg(windows), so all three read the same legacy root.
+          echo "dispositions recorded: ${dispositions:-<none>}"
+          case "${dispositions:-}" in
+            *ManagedReady*|*OwnedReady*|*AttachedReady*) ;;
+            *) echo "::error::preflight never reported a ready disposition (saw: ${dispositions:-<none>}); the app did not recognise the environment the bundled installer just built"
+               exit 1 ;;
+          esac
 
       - name: Restore the runner
         if: always()
@@ -722,9 +756,9 @@ jobs:
             exit 1
           }
           # All three legs now require the installer to exit 0, create the venv and import
-          # torch -- the #7547 outcome pins that let macOS and Linux accept a non-zero exit
-          # are gone. This extra assertion is still Windows-only because the app reads the
-          # same default root it wrote there
+          # torch, AND a ready disposition -- the #7547 outcome pins are gone and the
+          # POSIX legs carry the same case check. Kept spelled out here because the app
+          # reads the same default root it wrote
           # (%USERPROFILE%\.unsloth\studio; it ignores UNSLOTH_STUDIO_HOME, which is why
           # the log is found at the second path). So anything but a ready disposition means
           # the app cannot boot what was just installed -- the reported failure, on the very

--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -217,7 +217,13 @@ jobs:
             echo "app still running after 90s (pid $APP_PID)"
             kill -TERM "$APP_PID" 2>/dev/null || true
           else
-            wait "$APP_PID" 2>/dev/null; rc=$?
+            # `|| rc=$?`, not a bare `wait`: the step runs under `bash -e`, so a
+            # non-zero `wait` aborted the step right here and the two diagnostic lines
+            # below never printed. The failure showed up as a bare "Process completed
+            # with exit code 1" with no annotation and no app output -- which is exactly
+            # the information this branch exists to produce.
+            rc=0
+            wait "$APP_PID" 2>/dev/null || rc=$?
             echo "::error::desktop app exited early with rc=$rc"
             tail -50 logs/app-stdout.log || true
             exit 1
@@ -414,7 +420,13 @@ jobs:
             echo "app still running after 90s"
             kill -TERM "$APP_PID" 2>/dev/null || true
           else
-            wait "$APP_PID" 2>/dev/null; rc=$?
+            # `|| rc=$?`, not a bare `wait`: the step runs under `bash -e`, so a
+            # non-zero `wait` aborted the step right here and the two diagnostic lines
+            # below never printed. The failure showed up as a bare "Process completed
+            # with exit code 1" with no annotation and no app output -- which is exactly
+            # the information this branch exists to produce.
+            rc=0
+            wait "$APP_PID" 2>/dev/null || rc=$?
             echo "::error::desktop app exited early with rc=$rc"
             tail -60 logs/app-stdout.log || true
             exit 1

--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -111,8 +111,14 @@ jobs:
             echo "resolved release tag: $REL_TAG"
             echo "REL_TAG=$REL_TAG" >> "$GITHUB_ENV"
           fi
+          # Match on the extension, not on a filename fragment. The old '*aarch64.dmg'
+          # was the Tauri default bundle name, and the release pipeline moved to its own
+          # scheme at desktop-v0.1.512-beta (Unsloth-Desktop-<ver>-MacOS.dmg), which
+          # silently turned every run red at this line with "no assets match the file
+          # pattern". A release ships exactly one .dmg, and the arm64 assertion below is
+          # what actually checks the architecture, so the fragment bought nothing.
           gh release download "$REL_TAG" --repo "$REL_REPO" \
-            --pattern '*aarch64.dmg' --dir dl
+            --pattern '*.dmg' --dir dl
           ls -la dl
 
       - name: Strip the developer toolchain
@@ -178,27 +184,14 @@ jobs:
           # for the button, so launching alone sits for 90s without running the bundled
           # installer. Invoke it as src-tauri/src/install.rs does: --tauri, stdin closed,
           # no tty. --tauri rejects a custom studio home (install.sh:102-114).
-          # KNOWN OUTCOME PIN, retire when the desktop release catches up to #7547: REL_TAG
-          # predates it, so the bundle's own install.sh still hard-exits on the Xcode CLT
-          # gate #7547 turned into a warning. Only a new release moves that, not this PR.
-          # _check_macos_deps is the function #7547 added, so finding it retires the pin.
           SH="$APP/Contents/Resources/install.sh"
-          if grep -q '_check_macos_deps' "$SH"; then
-            echo "::error::the bundled install.sh now carries #7547; delete this pin block and let the venv + torch assertions below run unconditionally"
-            exit 1
-          fi
           rc=0
           env -u UNSLOTH_STUDIO_HOME \
             bash "$SH" --tauri \
             < /dev/null 2>&1 | tee logs/bundled-install.log || rc=$?
           echo "bundled installer exit code: $rc"
-          # Exit code AND the exact gate line, so any other non-zero exit still fails.
-          if [ "$rc" -eq 1 ] && grep -qE '^==> Xcode Command Line Tools are required\.[[:space:]]*$' logs/bundled-install.log; then
-            echo "::notice::known pre-#7547 outcome: the shipped bundle's install.sh stopped on the Xcode CLT gate and exited 1. Not a regression here; the next desktop release retires this pin."
-            exit 0
-          fi
           [ "$rc" -eq 0 ] || {
-            echo "::error::bundled installer exited $rc, which is neither success nor the pinned pre-#7547 outcome (exit 1 plus '==> Xcode Command Line Tools are required.')"
+            echo "::error::bundled installer exited $rc"
             exit 1
           }
           PY="$HOME/.unsloth/studio/unsloth_studio/bin/python"
@@ -389,29 +382,14 @@ jobs:
           fi
           [ -n "$SH" ] && [ -f "$SH" ] || { echo "::error::the bundle ships no install.sh resource"; exit 1; }
           echo "bundled installer: $SH"
-          # KNOWN OUTCOME PIN, retire when the desktop release catches up to #7547: the
-          # bundle carries its own install.sh and REL_TAG predates it, so on a stripped
-          # runner it still exits 2 at the NEED_SUDO handshake for the optional set rather
-          # than falling through to prebuilt llama.cpp. Only a new release moves that.
-          # _SMART_APT_OPTIONAL is the guard #7547 added, so finding it retires the pin.
-          if grep -q '_SMART_APT_OPTIONAL' "$SH"; then
-            echo "::error::the bundled install.sh now carries #7547; delete this pin block and let the venv + torch assertions below run unconditionally"
-            exit 1
-          fi
           # --tauri rejects a custom studio home (install.sh:102-114), so drop the
           # workspace-scoped override; close stdin as install.rs does.
           rc=0
           env -u UNSLOTH_STUDIO_HOME \
             bash "$SH" --tauri < /dev/null 2>&1 | tee logs/bundled-install.log || rc=$?
           echo "bundled installer exit code: $rc"
-          # Exit code AND the exact optional set, so a different NEED_SUDO list or any other
-          # non-zero exit is still a failure.
-          if [ "$rc" -eq 2 ] && grep -qE '^\[TAURI:NEED_SUDO\] cmake git build-essential libcurl4-openssl-dev[[:space:]]*$' logs/bundled-install.log; then
-            echo "::notice::known pre-#7547 outcome: the shipped bundle's install.sh asked to elevate for the optional set and exited 2. Not a regression here; the next desktop release retires this pin."
-            exit 0
-          fi
           [ "$rc" -eq 0 ] || {
-            echo "::error::bundled installer exited $rc, which is neither success nor the pinned pre-#7547 outcome (exit 2 plus exactly '[TAURI:NEED_SUDO] cmake git build-essential libcurl4-openssl-dev')"
+            echo "::error::bundled installer exited $rc"
             exit 1
           }
           PY="$HOME/.unsloth/studio/unsloth_studio/bin/python"
@@ -509,7 +487,10 @@ jobs:
             echo "resolved release tag: $REL_TAG"
             echo "REL_TAG=$REL_TAG" >> "$GITHUB_ENV"
           fi
-          gh release download "$REL_TAG" --repo "$REL_REPO" --pattern '*setup.exe' --dir dl
+          # Extension, not fragment: see the macOS leg. '*setup.exe' was the Tauri NSIS
+          # default; the current asset is Unsloth-Desktop-<ver>-Windows.exe, and a release
+          # ships exactly one .exe.
+          gh release download "$REL_TAG" --repo "$REL_REPO" --pattern '*.exe' --dir dl
           ls -la dl
 
       - name: Strip the developer toolchain
@@ -627,7 +608,7 @@ jobs:
       - name: Silent install
         shell: pwsh
         run: |
-          $exe = (Get-ChildItem dl/*setup.exe | Select-Object -First 1).FullName
+          $exe = (Get-ChildItem dl/*.exe | Select-Object -First 1).FullName
           # /S is the NSIS silent switch: a user double-clicks, but an installer that cannot
           # run unattended cannot be scripted or MDM-deployed either.
           $p = Start-Process -FilePath $exe -ArgumentList '/S' -Wait -PassThru
@@ -728,10 +709,10 @@ jobs:
             Write-Host '::error::tauri.log records no desktop_preflight disposition; the app never completed preflight'
             exit 1
           }
-          # Windows only, and stricter than macOS/Linux: those two accept the bundled
-          # installer's pre-#7547 pinned exit, so no venv exists there and NotInstalled is
-          # the honest answer. Here the installer was required to exit 0, create the venv
-          # and import torch, and the app reads the same default root it wrote
+          # All three legs now require the installer to exit 0, create the venv and import
+          # torch -- the #7547 outcome pins that let macOS and Linux accept a non-zero exit
+          # are gone. This extra assertion is still Windows-only because the app reads the
+          # same default root it wrote there
           # (%USERPROFILE%\.unsloth\studio; it ignores UNSLOTH_STUDIO_HOME, which is why
           # the log is found at the second path). So anything but a ready disposition means
           # the app cannot boot what was just installed -- the reported failure, on the very


### PR DESCRIPTION
The nightly has been red on `main` since 2026-08-05, all six legs, for two unrelated reasons. Neither is a product regression.

## macOS and Windows: the download patterns went stale

Both legs died at `gh release download` with `no assets match the file pattern`. The patterns were Tauri's default bundle names, and the release pipeline moved to its own scheme at `desktop-v0.1.512-beta`:

| leg | pattern | last green release (`desktop-v0.1.50-beta`) | current (`desktop-v0.1.522-beta`) |
|---|---|---|---|
| macOS | `*aarch64.dmg` | `Unsloth.Studio.Desktop._0.1.50-beta_aarch64.dmg` | `Unsloth-Desktop-0_1_522_beta-MacOS.dmg` |
| Windows | `*setup.exe` | (no Windows asset yet) | `Unsloth-Desktop-0_1_522_beta-Windows.exe` |
| Linux deb | `*.deb` | `...-Linux.deb` | `...-Ubuntu.deb` |
| Linux AppImage | `*.AppImage` | `...-Ubuntu.AppImage` | `...-Linux.AppImage` |

The 2026-08-04 run was the last one to resolve a release built with the old names, which is exactly why it was the last green one. The two Linux patterns already matched on extension and kept working; the deb/AppImage OS labels swapped between the schemes, which a glob does not care about.

Matching on the extension drops the coupling to a naming scheme entirely. A release ships exactly one `.dmg` and one `.exe`, and the arm64 check further down the macOS leg is what actually verifies the architecture, so the `aarch64` fragment was never load-bearing.

## Linux: its own tripwire fired

The deb and AppImage legs got past the download and stopped on the guard they were built with:

```
::error::the bundled install.sh now carries #7547; delete this pin block and
let the venv + torch assertions below run unconditionally
```

That is the pin doing its job. It was added when the shipped bundle predated #7547, it detects `_SMART_APT_OPTIONAL` (Linux) and `_check_macos_deps` (macOS) as the marker that the shipped `install.sh` caught up, and it asks to be deleted at that point. The `desktop-v0.1.522-beta` bundle carries the fix, so both pins are retired here.

With them gone, all three platforms now hold the installer to the same bar Windows already did: exit 0, leave a venv at `~/.unsloth/studio/unsloth_studio/bin/python`, and import torch. macOS no longer accepts `exit 1` plus the Xcode CLT gate line, and Linux no longer accepts `exit 2` plus the exact NEED_SUDO optional set.

## Validation

Validated on a staging repo rather than by merging and waiting for the next nightly: the release assets are mirrored into the staging repo so the workflow resolves and downloads them the same way, and the job is dispatched there against the current bundle.