### PR TITLE
Extract the API-only Studio boot into one script

### DIFF
--- a/.github/scripts/boot-studio-api-only.sh
+++ b/.github/scripts/boot-studio-api-only.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+#
+# Wipe Studio's auth state and boot `unsloth studio` in API-only mode in the
+# background, exporting the pid so a later step can stop it.
+#
+# Usage:
+#   boot-studio-api-only.sh --port 18888 [--log logs/studio.log] [--pid-var STUDIO_PID]
+#
+# Twenty steps across eight workflows ran this same five-line body, varying only
+# in those three values. Extracted so the three easy-to-get-wrong parts have one
+# definition:
+#
+#  * `rm -rf`, not `unsloth studio reset-password`. The boot below has to re-seed
+#    a fresh `.bootstrap_password`, and it only does that when the auth directory
+#    is absent. A caller that "resets" instead silently keeps the old password and
+#    the test then authenticates against stale state.
+#  * The pid has to reach `$GITHUB_ENV`, because the step that stops the server is
+#    a different step with a different shell. `$!` alone dies with the step.
+#  * stdout AND stderr go to the log. The server writes its startup diagnostics to
+#    stderr, so a `>` without `2>&1` produces an empty log on exactly the failure
+#    a reader needs it for.
+#
+# NOT for `unsloth run`: that is serve-unsloth-run.sh, which boots a different
+# command with a different contract (banner API key, /v1/models resolution) and
+# has nothing to share with this beyond the word "boot".
+#
+# Deliberately does not wait for health. The callers' waits differ -- some poll
+# /api/health and stop, others go on to rotate the bootstrap password and load a
+# model in the same step -- and folding the simple case in here would leave the
+# rest calling a script that does half their work.
+
+set -uo pipefail
+
+PORT=""
+LOG="logs/studio.log"
+PID_VAR="STUDIO_PID"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --port)    PORT="$2"; shift 2 ;;
+    --log)     LOG="$2"; shift 2 ;;
+    --pid-var) PID_VAR="$2"; shift 2 ;;
+    *) echo "boot-studio-api-only.sh: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$PORT" ] || { echo "boot-studio-api-only.sh: --port is required" >&2; exit 2; }
+
+# Wipe rather than reset: the boot below re-seeds .bootstrap_password only when
+# the directory is gone. See the header.
+rm -rf ~/.unsloth/studio/auth
+mkdir -p "$(dirname "$LOG")"
+
+UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$PORT" > "$LOG" 2>&1 &
+SERVER_PID=$!
+
+echo "[boot] unsloth studio --api-only on 127.0.0.1:${PORT}, pid ${SERVER_PID}, log ${LOG}"
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "${PID_VAR}=${SERVER_PID}" >> "$GITHUB_ENV"
+else
+  echo "${PID_VAR}=${SERVER_PID}"
+fi

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -27,6 +27,9 @@ on:
       - 'pyproject.toml'
       - 'tests/studio/**'
       - '.github/workflows/studio-api-smoke.yml'
+      # Every server boot in this workflow shells out to that script, so an edit
+      # to it changes what this workflow actually runs.
+      - '.github/scripts/boot-studio-api-only.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -124,11 +127,7 @@ jobs:
       - name: Reset auth + boot Unsloth (API-only)
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
         run: |

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -38,6 +38,9 @@ on:
       - 'install.sh'
       - 'pyproject.toml'
       - '.github/workflows/studio-inference-smoke.yml'
+      # Every server boot in this workflow shells out to that script, so an edit
+      # to it changes what this workflow actually runs.
+      - '.github/scripts/boot-studio-api-only.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -138,11 +141,7 @@ jobs:
       - name: Reset auth + boot Unsloth (API-only)
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
         run: |
@@ -408,11 +407,7 @@ jobs:
         # tool_policy=None so each request's `enable_tools` field is
         # honoured.
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health, log in, change password, load model
         run: |
@@ -983,11 +978,7 @@ jobs:
         # response_format requests aren't routed through the agentic
         # tool loop.
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health, log in, change password, load model
         run: |

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -40,6 +40,9 @@ on:
       - 'install.sh'
       - 'pyproject.toml'
       - '.github/workflows/studio-mac-inference-smoke.yml'
+      # Every server boot in this workflow shells out to that script, so an edit
+      # to it changes what this workflow actually runs.
+      - '.github/scripts/boot-studio-api-only.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -195,11 +198,7 @@ jobs:
         timeout-minutes: 2
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
         timeout-minutes: 5
@@ -454,11 +453,8 @@ jobs:
         # tool_policy=None so each request's `enable_tools` field is
         # honoured.
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio_tools.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port "$STUDIO_PORT" --log logs/studio_tools.log
 
       - name: Wait for /api/health, log in, change password, load model
         if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}
@@ -883,11 +879,8 @@ jobs:
         # response_format requests aren't routed through the agentic
         # tool loop.
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio_vision.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port "$STUDIO_PORT" --log logs/studio_vision.log
 
       - name: Wait for /api/health, log in, change password, load model
         if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -35,6 +35,9 @@ on:
       - 'tests/studio/**'
       - '.github/scripts/run-studio-permission-browser.sh'
       - '.github/workflows/studio-mac-ui-smoke.yml'
+      # Every server boot in this workflow shells out to that script, so an edit
+      # to it changes what this workflow actually runs.
+      - '.github/scripts/boot-studio-api-only.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -196,11 +199,7 @@ jobs:
       - name: Reset auth + boot Unsloth
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
         run: |
@@ -301,11 +300,8 @@ jobs:
 
       - name: Reset auth + boot Unsloth for extra UI tests (port 18897)
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p 18897 \
-            > logs/studio_extra.log 2>&1 &
-          echo "STUDIO_EXTRA_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port 18897 --log logs/studio_extra.log --pid-var STUDIO_EXTRA_PID
 
       - name: Wait for /api/health on 18897
         run: |
@@ -400,11 +396,8 @@ jobs:
       - name: Reset auth + boot Unsloth (API-only, port 18894)
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p 18894 \
-            > logs/studio_api.log 2>&1 &
-          echo "STUDIO_API_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port 18894 --log logs/studio_api.log --pid-var STUDIO_API_PID
 
       - name: Wait for /api/health on 18894
         run: |

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -29,6 +29,9 @@ on:
       - 'tests/studio/**'
       - '.github/scripts/run-studio-permission-browser.sh'
       - '.github/workflows/studio-ui-smoke.yml'
+      # Every server boot in this workflow shells out to that script, so an edit
+      # to it changes what this workflow actually runs.
+      - '.github/scripts/boot-studio-api-only.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -136,11 +139,7 @@ jobs:
       - name: Reset auth + boot Unsloth
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
         # 180 s -- a cold runner with venv warm-up + lazy imports has
@@ -214,11 +213,8 @@ jobs:
       # warm install we already did) so this adds little wall time.
       - name: Reset auth + boot Unsloth for extra UI tests (port 18894)
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p 18894 \
-            > logs/studio_extra.log 2>&1 &
-          echo "STUDIO_EXTRA_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port 18894 --log logs/studio_extra.log --pid-var STUDIO_EXTRA_PID
 
       - name: Wait for /api/health on 18894
         run: |
@@ -274,11 +270,8 @@ jobs:
       # (RAG embedder + llama.cpp probe) stay hidden from the picker.
       - name: Reset auth + boot Unsloth for model-config tests (port 18898)
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p 18898 \
-            > logs/studio_modelcfg.log 2>&1 &
-          echo "STUDIO_MODELCFG_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port 18898 --log logs/studio_modelcfg.log --pid-var STUDIO_MODELCFG_PID
 
       - name: Wait for /api/health on 18898
         run: |
@@ -320,11 +313,8 @@ jobs:
       # earlier UI tests. No GGUF -- the bug surface is the composer.
       - name: Reset auth + boot Unsloth for IME / i18n tests (port 18896)
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p 18896 \
-            > logs/studio_ime.log 2>&1 &
-          echo "STUDIO_IME_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port 18896 --log logs/studio_ime.log --pid-var STUDIO_IME_PID
 
       - name: Wait for /api/health on 18896
         run: |

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -22,6 +22,9 @@ on:
       - 'pyproject.toml'
       - 'tests/studio/**'
       - '.github/workflows/studio-windows-api-smoke.yml'
+      # Every server boot in this workflow shells out to that script, so an edit
+      # to it changes what this workflow actually runs.
+      - '.github/scripts/boot-studio-api-only.sh'
   push:
     branches: [main, pip]
   workflow_dispatch:
@@ -191,11 +194,7 @@ jobs:
       - name: Reset auth + boot Unsloth (API-only)
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
         run: |

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -36,6 +36,9 @@ on:
       # not pull in the GGUF smoke jobs.
       - 'tests/studio/*.ps1'
       - '.github/workflows/studio-windows-inference-smoke.yml'
+      # Every server boot in this workflow shells out to that script, so an edit
+      # to it changes what this workflow actually runs.
+      - '.github/scripts/boot-studio-api-only.sh'
   push:
     branches: [main, pip]
   workflow_dispatch:
@@ -323,11 +326,7 @@ jobs:
         timeout-minutes: 2
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
         timeout-minutes: 10
@@ -628,11 +627,8 @@ jobs:
         if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.download-gguf-tools.outcome != 'failure' }}
         timeout-minutes: 2
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio_tools.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port "$STUDIO_PORT" --log logs/studio_tools.log
 
       - name: Wait for /api/health, log in, change password, load model
         id: ready-tools
@@ -1084,11 +1080,8 @@ jobs:
         if: ${{ !cancelled() && steps.shim.outcome == 'success' && steps.sdks.outcome == 'success' && steps.prime-hf-vision.outcome != 'failure' }}
         timeout-minutes: 2
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio_vision.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port "$STUDIO_PORT" --log logs/studio_vision.log
 
       - name: Wait for /api/health, log in, change password, load model
         id: ready-vision
@@ -1606,11 +1599,7 @@ jobs:
 
       - name: Reset auth + boot Unsloth (API-only)
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health, log in, load the GGUF
         run: |

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -21,6 +21,9 @@ on:
       - 'tests/studio/**'
       - '.github/scripts/run-studio-permission-browser.sh'
       - '.github/workflows/studio-windows-ui-smoke.yml'
+      # Every server boot in this workflow shells out to that script, so an edit
+      # to it changes what this workflow actually runs.
+      - '.github/scripts/boot-studio-api-only.sh'
   push:
     branches: [main, pip]
   workflow_dispatch:
@@ -308,11 +311,7 @@ jobs:
       - name: Reset auth + boot Unsloth
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
-            > logs/studio.log 2>&1 &
-          echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
         run: |
@@ -363,11 +362,8 @@ jobs:
 
       - name: Reset auth + boot Unsloth for extra UI tests (port 18897)
         run: |
-          rm -rf ~/.unsloth/studio/auth
-          mkdir -p logs
-          UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p 18897 \
-            > logs/studio_extra.log 2>&1 &
-          echo "STUDIO_EXTRA_PID=$!" >> "$GITHUB_ENV"
+          bash .github/scripts/boot-studio-api-only.sh \
+            --port 18897 --log logs/studio_extra.log --pid-var STUDIO_EXTRA_PID
 
       - name: Wait for /api/health on 18897
         run: |


### PR DESCRIPTION
Twenty-one steps across eight workflows ran the same five-line body, varying only in three values. `.github/scripts/boot-studio-api-only.sh` takes those as flags: `--port`, `--log`, `--pid-var`.

```yaml
- name: Reset auth + boot Unsloth (API-only)
  run: |
    rm -rf ~/.unsloth/studio/auth
    mkdir -p logs
    UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
      > logs/studio_tools.log 2>&1 &
    echo "STUDIO_PID=$!" >> "$GITHUB_ENV"
```

becomes

```yaml
- name: Reset auth + boot Unsloth (API-only)
  run: |
    bash .github/scripts/boot-studio-api-only.sh \
      --port "$STUDIO_PORT" --log logs/studio_tools.log
```

105 lines of duplicated YAML down to 31.

## Why this one is worth extracting

Three parts of that body are easy to get subtly wrong, and each failure is quiet:

- **`rm -rf`, not `unsloth studio reset-password`.** The boot re-seeds a fresh `.bootstrap_password` only when the auth directory is *absent*. A caller that "resets" instead keeps the old password, and the test then authenticates against stale state rather than the state it thinks it created.
- **The pid has to reach `$GITHUB_ENV`.** The step that stops the server is a different step with a different shell, so `$!` alone dies with the step that made it.
- **Both streams go to the log.** The server writes its startup diagnostics to stderr, so a redirect without `2>&1` produces an empty log on exactly the failure a reader needs it for.

## One departure from the plan

The plan said to extend `.github/scripts/serve-unsloth-run.sh`. That is the wrong home. It boots `unsloth run --disable-tools` and its entire body is banner API-key parsing and `/v1/models` resolution; these twenty-one boot `unsloth studio --api-only` with auth wiped and no banner at all. They share the word "boot" and nothing else. Each script's header now says which is which, so the next person does not have to work it out twice.

The script also deliberately does **not** wait for health. The callers' waits differ: some poll `/api/health` and stop, others go straight on to rotate the bootstrap password and load a model in the same step. Folding the simple case in would leave the rest calling a helper that does half their work.

## Not converted

- Three boots **inside Playwright retry loops**, which re-boot mid-loop and reassign the pid in the running shell.
- Three **boot-briefly-and-kill** steps that keep the pid in a local shell variable rather than `$GITHUB_ENV` and never wipe auth. Converting those would change the pid contract for no gain.

## Verification

**Every call site asks for exactly what its old inline body did.** A checker reconstructs `(port, log, pid-var)` from each pre-change body at `origin/main` and compares it to the arguments now passed: **21 call sites checked, 0 mismatches, 0 left unconverted.**

That check had to walk steps positionally. Keying on `(job, step name)` looked right and was not: the consolidated workflows have two steps with the *same* name in the *same* job (phase 1 and phase 3), so a dict kept only the last and silently compared phase 1's call against phase 3's body, reporting two mismatches that did not exist.

**The background process still outlives the step.** Moving the launch one shell level deeper is the one behavioural risk here, so it was tested rather than assumed, against a stub `unsloth` on `PATH` with `HOME` pointed at a scratch directory:

```
[boot] unsloth studio --api-only on 127.0.0.1:18999, pid 3240372, log logs/x.log
STUDIO_TEST_PID=3240372          <- pid reaches $GITHUB_ENV
fake unsloth args: studio -H 127.0.0.1 -p 18999
to stderr                        <- stdout AND stderr captured
orphan survives script exit: yes
auth wiped: good
```

`shellcheck` clean. `actionlint` reports nothing new across the eight workflows.

**Each caller's `paths:` filter gains the script**, so an edit to it re-runs the workflows that call it. That is the trap #8015 hit: centralising a body moves it out from under filters that only name the workflow file.