### PR TITLE
Studio: keep row actions clear of overlay scrollbars

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3877,8 +3877,7 @@ export function HubModelPicker({
         >
           <div
             className={cn(
-              // Keep row actions clear of overlay scrollbars without shifting
-              // them when the list starts or stops overflowing.
+              // Keep row actions clear of overlay scrollbars, overflowing or not.
               "overlay-scrollbar-gutter",
               // On Device pulls the heading block tight to the controls; Recommended
               // keeps a little more top room above its first row.

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3877,7 +3877,9 @@ export function HubModelPicker({
         >
           <div
             className={cn(
-              "pr-0",
+              // Keep row actions clear of overlay scrollbars without shifting
+              // them when the list starts or stops overflowing.
+              "overlay-scrollbar-gutter",
               // On Device pulls the heading block tight to the controls; Recommended
               // keeps a little more top room above its first row.
               showDownloaded ? "pt-0" : "pt-[4px]",

--- a/studio/frontend/src/features/rag/components/project-source-dropzone.tsx
+++ b/studio/frontend/src/features/rag/components/project-source-dropzone.tsx
@@ -249,7 +249,7 @@ export function ProjectSourceDropzone({
           </button>
         ) : (
           <div className="flex flex-col gap-1 p-2">
-            <ul className="max-h-52 space-y-0.5 overflow-y-auto">
+            <ul className="overlay-scrollbar-gutter max-h-52 space-y-0.5 overflow-y-auto">
               {staged.map((entry) => (
                 <li
                   key={entry.id}

--- a/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
@@ -161,9 +161,11 @@ export function ApiKeysTab() {
           </p>
         ) : (
           <div className="hover-scrollbar flex max-h-72 min-w-0 flex-col overflow-y-auto pr-1 [scrollbar-gutter:stable]">
-            {keys.map((k) => (
-              <ApiKeyRow key={k.id} apiKey={k} onRevoke={setRevokeTarget} />
-            ))}
+            <div className="overlay-scrollbar-gutter">
+              {keys.map((k) => (
+                <ApiKeyRow key={k.id} apiKey={k} onRevoke={setRevokeTarget} />
+              ))}
+            </div>
           </div>
         )}
       </section>

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2720,8 +2720,7 @@ html[data-chat-font] .aui-root {
 	scrollbar-gutter: stable;
 }
 
-/* Keep right-edge controls clear of the measured overlay scrollbar strip.
-   Classic scrollbars fall back to zero because they already take layout space. */
+/* Reserve the measured overlay strip; classic scrollbars already take space. */
 .overlay-scrollbar-gutter {
 	padding-right: var(--overlay-scrollbar-gutter, 0px);
 }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2720,6 +2720,12 @@ html[data-chat-font] .aui-root {
 	scrollbar-gutter: stable;
 }
 
+/* Keep right-edge controls clear of the measured overlay scrollbar strip.
+   Classic scrollbars fall back to zero because they already take layout space. */
+.overlay-scrollbar-gutter {
+	padding-right: var(--overlay-scrollbar-gutter, 0px);
+}
+
 /* Chat viewport: solid track matching sidebar so the scrollbar reads as a
    full-height rail flush to the right edge, without a separate decorative strip. */
 .aui-thread-viewport {

--- a/studio/frontend/src/lib/overlay-scrollbar.ts
+++ b/studio/frontend/src/lib/overlay-scrollbar.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Measures the pointer-active strip of an overlay scrollbar and publishes it
+ * for right-edge controls. Classic scrollbars already take layout space, so
+ * their gutter stays unset.
+ */
+
+export const OVERLAY_SCROLLBAR_GUTTER_VAR = "--overlay-scrollbar-gutter";
+
+/** Ignore widths too large to be a scrollbar. */
+const MAX_GUTTER_PX = 48;
+
+/** Re-measuring is a forced layout, so resize bursts are coalesced. */
+const RESIZE_SETTLE_MS = 200;
+
+/** Measures the scrollbar's pointer-active width, or 0 when none is reliable. */
+export function measureOverlayScrollbarGutter(doc: Document): number {
+  const body = doc.body;
+  if (!body) {
+    return 0;
+  }
+
+  const probe = doc.createElement("div");
+  // Keep the probe in the viewport and above dialogs. Explicit pointer events
+  // override the body setting used while a Radix modal is open.
+  probe.style.cssText =
+    "position:fixed;top:0;left:0;width:60px;height:60px;margin:0;border:0;padding:0;opacity:0;overflow-y:scroll;pointer-events:auto;z-index:2147483647";
+  const content = doc.createElement("div");
+  content.style.cssText = "width:100%;height:300px";
+  probe.appendChild(content);
+  body.appendChild(probe);
+
+  try {
+    if (probe.offsetWidth - probe.clientWidth > 0) {
+      return 0;
+    }
+
+    // Reveal scrollbars configured to appear only while scrolling.
+    probe.scrollTop = 1;
+
+    const rect = probe.getBoundingClientRect();
+    const right = Math.round(rect.right);
+    const y = Math.round(rect.top + rect.height / 2);
+
+    let gutter = 0;
+    for (let offset = 1; offset <= MAX_GUTTER_PX; offset++) {
+      if (doc.elementFromPoint(right - offset, y) === content) {
+        return gutter;
+      }
+      gutter = offset;
+    }
+    return 0;
+  } finally {
+    body.removeChild(probe);
+  }
+}
+
+/** Publishes a positive gutter on the root element. */
+export function applyOverlayScrollbarGutter(doc: Document): number {
+  const gutter = measureOverlayScrollbarGutter(doc);
+  const root = doc.documentElement;
+  if (gutter > 0) {
+    root.style.setProperty(OVERLAY_SCROLLBAR_GUTTER_VAR, `${gutter}px`);
+  } else {
+    root.style.removeProperty(OVERLAY_SCROLLBAR_GUTTER_VAR);
+  }
+  return gutter;
+}
+
+/** Re-measures after resizing, refocusing, or returning to the page. */
+export function watchOverlayScrollbarGutter(win: Window): () => void {
+  const doc = win.document;
+  let resizeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const remeasure = () => applyOverlayScrollbarGutter(doc);
+  const onResize = () => {
+    if (resizeTimer !== undefined) {
+      clearTimeout(resizeTimer);
+    }
+    resizeTimer = setTimeout(remeasure, RESIZE_SETTLE_MS);
+  };
+
+  remeasure();
+  win.addEventListener("resize", onResize);
+  win.addEventListener("focus", remeasure);
+  doc.addEventListener("visibilitychange", remeasure);
+
+  return () => {
+    if (resizeTimer !== undefined) {
+      clearTimeout(resizeTimer);
+    }
+    win.removeEventListener("resize", onResize);
+    win.removeEventListener("focus", remeasure);
+    doc.removeEventListener("visibilitychange", remeasure);
+  };
+}

--- a/studio/frontend/src/lib/overlay-scrollbar.ts
+++ b/studio/frontend/src/lib/overlay-scrollbar.ts
@@ -2,9 +2,8 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 /**
- * Measures the pointer-active strip of an overlay scrollbar and publishes it
- * for right-edge controls. Classic scrollbars already take layout space, so
- * their gutter stays unset.
+ * Publishes the pointer-active strip of an overlay scrollbar for right-edge
+ * controls. Classic scrollbars take layout space, so their gutter stays unset.
  */
 
 export const OVERLAY_SCROLLBAR_GUTTER_VAR = "--overlay-scrollbar-gutter";
@@ -12,10 +11,10 @@ export const OVERLAY_SCROLLBAR_GUTTER_VAR = "--overlay-scrollbar-gutter";
 /** Ignore widths too large to be a scrollbar. */
 const MAX_GUTTER_PX = 48;
 
-/** Re-measuring is a forced layout, so resize bursts are coalesced. */
+/** Re-measuring forces layout, so resize bursts are coalesced. */
 const RESIZE_SETTLE_MS = 200;
 
-/** A measured width, plus whether the sweep could read the DOM at all. */
+/** `reliable` is false when the sweep could not read the DOM at all. */
 type Measurement = { gutter: number; reliable: boolean };
 
 function measure(doc: Document): Measurement {
@@ -25,8 +24,7 @@ function measure(doc: Document): Measurement {
   }
 
   const probe = doc.createElement("div");
-  // Keep the probe in the viewport and above dialogs. Explicit pointer events
-  // override the body setting used while a Radix modal is open.
+  // Above dialogs; pointer-events:auto beats a Radix modal's body "none".
   probe.style.cssText =
     "position:fixed;top:0;left:0;width:60px;height:60px;margin:0;border:0;padding:0;opacity:0;overflow-y:scroll;pointer-events:auto;z-index:2147483647";
   const content = doc.createElement("div");
@@ -53,15 +51,14 @@ function measure(doc: Document): Measurement {
       }
       gutter = offset;
     }
-    // The sweep never reached the probe's own content, so hit testing is
-    // unusable here. A width is not distinguishable from no scrollbar.
+    // Hit testing unusable here: a width is indistinguishable from no scrollbar.
     return { gutter: 0, reliable: false };
   } finally {
     body.removeChild(probe);
   }
 }
 
-/** Measures the scrollbar's pointer-active width, or 0 when none is reliable. */
+/** Pointer-active scrollbar width, or 0 when nothing reliable was read. */
 export function measureOverlayScrollbarGutter(doc: Document): number {
   return measure(doc).gutter;
 }
@@ -71,8 +68,7 @@ export function applyOverlayScrollbarGutter(doc: Document): number {
   const { gutter, reliable } = measure(doc);
   const root = doc.documentElement;
   if (!reliable) {
-    // Keep the last good gutter: dropping it would shift every row that
-    // reserved it, on nothing more than one unreadable sweep.
+    // Keep the last good gutter: one unreadable sweep must not shift rows.
     return (
       Number.parseFloat(
         root.style.getPropertyValue(OVERLAY_SCROLLBAR_GUTTER_VAR),

--- a/studio/frontend/src/lib/overlay-scrollbar.ts
+++ b/studio/frontend/src/lib/overlay-scrollbar.ts
@@ -15,11 +15,13 @@ const MAX_GUTTER_PX = 48;
 /** Re-measuring is a forced layout, so resize bursts are coalesced. */
 const RESIZE_SETTLE_MS = 200;
 
-/** Measures the scrollbar's pointer-active width, or 0 when none is reliable. */
-export function measureOverlayScrollbarGutter(doc: Document): number {
+/** A measured width, plus whether the sweep could read the DOM at all. */
+type Measurement = { gutter: number; reliable: boolean };
+
+function measure(doc: Document): Measurement {
   const body = doc.body;
   if (!body) {
-    return 0;
+    return { gutter: 0, reliable: false };
   }
 
   const probe = doc.createElement("div");
@@ -34,7 +36,7 @@ export function measureOverlayScrollbarGutter(doc: Document): number {
 
   try {
     if (probe.offsetWidth - probe.clientWidth > 0) {
-      return 0;
+      return { gutter: 0, reliable: true };
     }
 
     // Reveal scrollbars configured to appear only while scrolling.
@@ -47,20 +49,36 @@ export function measureOverlayScrollbarGutter(doc: Document): number {
     let gutter = 0;
     for (let offset = 1; offset <= MAX_GUTTER_PX; offset++) {
       if (doc.elementFromPoint(right - offset, y) === content) {
-        return gutter;
+        return { gutter, reliable: true };
       }
       gutter = offset;
     }
-    return 0;
+    // The sweep never reached the probe's own content, so hit testing is
+    // unusable here. A width is not distinguishable from no scrollbar.
+    return { gutter: 0, reliable: false };
   } finally {
     body.removeChild(probe);
   }
 }
 
+/** Measures the scrollbar's pointer-active width, or 0 when none is reliable. */
+export function measureOverlayScrollbarGutter(doc: Document): number {
+  return measure(doc).gutter;
+}
+
 /** Publishes a positive gutter on the root element. */
 export function applyOverlayScrollbarGutter(doc: Document): number {
-  const gutter = measureOverlayScrollbarGutter(doc);
+  const { gutter, reliable } = measure(doc);
   const root = doc.documentElement;
+  if (!reliable) {
+    // Keep the last good gutter: dropping it would shift every row that
+    // reserved it, on nothing more than one unreadable sweep.
+    return (
+      Number.parseFloat(
+        root.style.getPropertyValue(OVERLAY_SCROLLBAR_GUTTER_VAR),
+      ) || 0
+    );
+  }
   if (gutter > 0) {
     root.style.setProperty(OVERLAY_SCROLLBAR_GUTTER_VAR, `${gutter}px`);
   } else {
@@ -74,7 +92,9 @@ export function watchOverlayScrollbarGutter(win: Window): () => void {
   const doc = win.document;
   let resizeTimer: ReturnType<typeof setTimeout> | undefined;
 
-  const remeasure = () => applyOverlayScrollbarGutter(doc);
+  // Hit testing a hidden page reads nothing, so skip the forced layout.
+  const remeasure = () =>
+    doc.visibilityState === "hidden" ? 0 : applyOverlayScrollbarGutter(doc);
   const onResize = () => {
     if (resizeTimer !== undefined) {
       clearTimeout(resizeTimer);

--- a/studio/frontend/src/main.tsx
+++ b/studio/frontend/src/main.tsx
@@ -9,6 +9,7 @@ import { App } from "./app/app";
 import { fetchDeviceType } from "./config/env";
 import { initializeLocale } from "./i18n";
 import { isTauri } from "./lib/api-base";
+import { watchOverlayScrollbarGutter } from "./lib/overlay-scrollbar";
 
 const globalCrypto = globalThis.crypto as Crypto | undefined;
 
@@ -47,6 +48,9 @@ const uaLower = navigator.userAgent.toLowerCase();
 if (uaLower.includes("linux") && !uaLower.includes("android")) {
   document.documentElement.classList.add("render-linux");
 }
+
+// Keep right-edge controls clear of overlay scrollbars.
+watchOverlayScrollbarGutter(window);
 
 createRoot(rootElement).render(
   <StrictMode>

--- a/studio/frontend/tests/overlay-scrollbar-gutter.test.ts
+++ b/studio/frontend/tests/overlay-scrollbar-gutter.test.ts
@@ -24,7 +24,6 @@ type Node = {
   getBoundingClientRect: () => { top: number; right: number; height: number };
 };
 
-/** Whether the probe overrides a non-interactive body. */
 function optsIntoHitTesting(node: Node): boolean {
   return /(^|;)\s*pointer-events\s*:\s*auto\s*(;|$)/.test(node.style.cssText);
 }
@@ -113,7 +112,6 @@ test("an overlay scrollbar's hit strip is measured, not assumed", () => {
   const { doc, bodyChildren } = fakeDocument({ railPx: 21, layoutPx: 0 });
 
   assert.equal(measureOverlayScrollbarGutter(doc), 21);
-  // The probe must always be removed.
   assert.deepEqual(bodyChildren, []);
 });
 
@@ -139,7 +137,6 @@ test("an unreadable sweep leaves the layout alone rather than guessing", () => {
 });
 
 test("an open modal's pointer-events:none does not erase the gutter", () => {
-  // Re-measurement can run while a modal disables body pointer events.
   const { doc, vars } = fakeDocument({
     railPx: 21,
     layoutPx: 0,
@@ -156,8 +153,7 @@ test("one unreadable sweep does not drop a gutter already in use", () => {
 
   assert.equal(applyOverlayScrollbarGutter(doc), 21);
 
-  // Same scrollbar, but this sweep read nothing. Re-measuring must not shift
-  // every row that already reserved the strip.
+  // Same scrollbar, unreadable sweep: rows that reserved the strip must hold.
   knobs.contentReachable = false;
   assert.equal(applyOverlayScrollbarGutter(doc), 21);
   assert.equal(vars.get(OVERLAY_SCROLLBAR_GUTTER_VAR), "21px");
@@ -243,7 +239,6 @@ test("regaining focus re-measures, so a changed scrollbar setting is picked up",
   handlers.get("focus")?.();
   assert.equal(vars.get(OVERLAY_SCROLLBAR_GUTTER_VAR), "15px");
 
-  // Turning overlay scrollbars off must remove the gutter again.
   railPx = 0;
   handlers.get("focus")?.();
   assert.equal(vars.has(OVERLAY_SCROLLBAR_GUTTER_VAR), false);

--- a/studio/frontend/tests/overlay-scrollbar-gutter.test.ts
+++ b/studio/frontend/tests/overlay-scrollbar-gutter.test.ts
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  OVERLAY_SCROLLBAR_GUTTER_VAR,
+  applyOverlayScrollbarGutter,
+  measureOverlayScrollbarGutter,
+  watchOverlayScrollbarGutter,
+} from "../src/lib/overlay-scrollbar.ts";
+
+const PROBE_WIDTH = 60;
+
+type Node = {
+  style: { cssText: string };
+  scrollTop: number;
+  children: Node[];
+  appendChild: (child: Node) => Node;
+  offsetWidth: number;
+  clientWidth: number;
+  getBoundingClientRect: () => { top: number; right: number; height: number };
+};
+
+/** Whether the probe overrides a non-interactive body. */
+function optsIntoHitTesting(node: Node): boolean {
+  return /(^|;)\s*pointer-events\s*:\s*auto\s*(;|$)/.test(node.style.cssText);
+}
+
+/** Simulates independent scrollbar hit-test and layout widths. */
+function fakeDocument({
+  railPx,
+  layoutPx,
+  contentReachable = true,
+  bodyPointerEventsNone = false,
+}: {
+  railPx: number;
+  layoutPx: number;
+  contentReachable?: boolean;
+  bodyPointerEventsNone?: boolean;
+}) {
+  const vars = new Map<string, string>();
+  const bodyChildren: Node[] = [];
+  const documentElement = {
+    style: {
+      setProperty: (name: string, value: string) => vars.set(name, value),
+      removeProperty: (name: string) => vars.delete(name),
+    },
+  };
+
+  function createElement(): Node {
+    const node: Node = {
+      style: { cssText: "" },
+      scrollTop: 0,
+      children: [],
+      appendChild: (child) => {
+        node.children.push(child);
+        return child;
+      },
+      offsetWidth: PROBE_WIDTH,
+      clientWidth: PROBE_WIDTH - layoutPx,
+      getBoundingClientRect: () => ({
+        top: 0,
+        right: PROBE_WIDTH,
+        height: PROBE_WIDTH,
+      }),
+    };
+    return node;
+  }
+
+  const doc = {
+    createElement,
+    documentElement,
+    body: {
+      appendChild: (child: Node) => {
+        bodyChildren.push(child);
+        return child;
+      },
+      removeChild: (child: Node) => {
+        bodyChildren.splice(bodyChildren.indexOf(child), 1);
+        return child;
+      },
+    },
+    elementFromPoint: (x: number) => {
+      const probe = bodyChildren[0];
+      if (!probe) {
+        return null;
+      }
+      // Radix disables pointer events on the body while a modal is open.
+      if (bodyPointerEventsNone && !optsIntoHitTesting(probe)) {
+        return documentElement;
+      }
+      // The rail occupies the trailing columns of the padding box.
+      if (x >= PROBE_WIDTH - railPx) {
+        return probe;
+      }
+      return contentReachable ? probe.children[0] : probe;
+    },
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  };
+
+  return { doc: doc as unknown as Document, vars, bodyChildren };
+}
+
+test("an overlay scrollbar's hit strip is measured, not assumed", () => {
+  // WebKitGTK 4.1 measured a 21px hit-test strip.
+  const { doc, bodyChildren } = fakeDocument({ railPx: 21, layoutPx: 0 });
+
+  assert.equal(measureOverlayScrollbarGutter(doc), 21);
+  // The probe must always be removed.
+  assert.deepEqual(bodyChildren, []);
+});
+
+test("a scrollbar that takes layout width reserves nothing", () => {
+  // Chromium and WebView2 already displace the content.
+  const { doc, vars } = fakeDocument({ railPx: 0, layoutPx: 10 });
+
+  assert.equal(measureOverlayScrollbarGutter(doc), 0);
+  applyOverlayScrollbarGutter(doc);
+  assert.equal(vars.has(OVERLAY_SCROLLBAR_GUTTER_VAR), false);
+});
+
+test("an unreadable sweep leaves the layout alone rather than guessing", () => {
+  const { doc, vars, bodyChildren } = fakeDocument({
+    railPx: 0,
+    layoutPx: 0,
+    contentReachable: false,
+  });
+
+  assert.equal(applyOverlayScrollbarGutter(doc), 0);
+  assert.equal(vars.has(OVERLAY_SCROLLBAR_GUTTER_VAR), false);
+  assert.deepEqual(bodyChildren, []);
+});
+
+test("an open modal's pointer-events:none does not erase the gutter", () => {
+  // Re-measurement can run while a modal disables body pointer events.
+  const { doc, vars } = fakeDocument({
+    railPx: 21,
+    layoutPx: 0,
+    bodyPointerEventsNone: true,
+  });
+
+  assert.equal(measureOverlayScrollbarGutter(doc), 21);
+  assert.equal(applyOverlayScrollbarGutter(doc), 21);
+  assert.equal(vars.get(OVERLAY_SCROLLBAR_GUTTER_VAR), "21px");
+});
+
+test("the measured width is published in px for the CSS utility", () => {
+  const { doc, vars } = fakeDocument({ railPx: 21, layoutPx: 0 });
+
+  assert.equal(applyOverlayScrollbarGutter(doc), 21);
+  assert.equal(vars.get(OVERLAY_SCROLLBAR_GUTTER_VAR), "21px");
+});
+
+test("regaining focus re-measures, so a changed scrollbar setting is picked up", () => {
+  // Changing the macOS scrollbar setting is followed by an app refocus.
+  let railPx = 0;
+  const { doc, vars } = fakeDocument({ railPx: 0, layoutPx: 0 });
+  const live = doc as unknown as {
+    elementFromPoint: (x: number) => unknown;
+    body: { appendChild: (c: unknown) => unknown };
+  };
+  const bodyProbes: { children: unknown[] }[] = [];
+  const appendChild = live.body.appendChild;
+  live.body.appendChild = (child: unknown) => {
+    bodyProbes.push(child as { children: unknown[] });
+    return appendChild(child);
+  };
+  live.elementFromPoint = (x: number) => {
+    const probe = bodyProbes[bodyProbes.length - 1];
+    if (x >= PROBE_WIDTH - railPx) {
+      return probe;
+    }
+    return probe.children[0];
+  };
+
+  const handlers = new Map<string, () => void>();
+  const win = {
+    document: doc,
+    addEventListener: (type: string, fn: () => void) => handlers.set(type, fn),
+    removeEventListener: (type: string) => handlers.delete(type),
+  } as unknown as Window;
+
+  const stop = watchOverlayScrollbarGutter(win);
+  assert.equal(vars.has(OVERLAY_SCROLLBAR_GUTTER_VAR), false);
+
+  railPx = 15;
+  handlers.get("focus")?.();
+  assert.equal(vars.get(OVERLAY_SCROLLBAR_GUTTER_VAR), "15px");
+
+  // Turning overlay scrollbars off must remove the gutter again.
+  railPx = 0;
+  handlers.get("focus")?.();
+  assert.equal(vars.has(OVERLAY_SCROLLBAR_GUTTER_VAR), false);
+
+  stop();
+  assert.equal(handlers.size, 0);
+});
+
+test("right-edge action lists reserve the gutter they publish", async () => {
+  const css = await readFile(
+    new URL("../src/index.css", import.meta.url),
+    "utf8",
+  );
+  // The utility must read the variable written by the probe.
+  assert.match(
+    css,
+    new RegExp(
+      `\\.overlay-scrollbar-gutter\\s*\\{[^}]*padding-right:\\s*var\\(${OVERLAY_SCROLLBAR_GUTTER_VAR},\\s*0px\\)`,
+    ),
+  );
+
+  const pickers = await readFile(
+    new URL(
+      "../src/features/model-picker/components/model-selector/pickers.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  // Every model row must sit inside the gutter wrapper.
+  assert.match(
+    pickers,
+    /"model-list-scroll[^"]*overflow-y-auto[^"]*"[\s\S]{0,800}"overlay-scrollbar-gutter",/,
+  );
+
+  const apiKeysTab = await readFile(
+    new URL(
+      "../src/features/settings/tabs/api-keys-tab.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  // Preserve classic padding and move every API-key row into the gutter.
+  assert.match(
+    apiKeysTab,
+    /"hover-scrollbar[^"]*overflow-y-auto[^"]*\bpr-1\b[^"]*"[\s\S]{0,200}<div className="overlay-scrollbar-gutter">[\s\S]{0,300}<ApiKeyRow/,
+  );
+
+  const projectSourceDropzone = await readFile(
+    new URL(
+      "../src/features/rag/components/project-source-dropzone.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  // Keep staged-source remove actions inside the gutter.
+  assert.match(
+    projectSourceDropzone,
+    /<ul className="[^"]*overlay-scrollbar-gutter[^"]*max-h-52[^"]*overflow-y-auto[^"]*">[\s\S]{0,1000}aria-label={`Remove \${entry\.file\.name}`}/,
+  );
+});

--- a/studio/frontend/tests/overlay-scrollbar-gutter.test.ts
+++ b/studio/frontend/tests/overlay-scrollbar-gutter.test.ts
@@ -43,10 +43,13 @@ function fakeDocument({
 }) {
   const vars = new Map<string, string>();
   const bodyChildren: Node[] = [];
+  // Mutable so a test can make a later sweep unreadable.
+  const knobs = { contentReachable };
   const documentElement = {
     style: {
       setProperty: (name: string, value: string) => vars.set(name, value),
       removeProperty: (name: string) => vars.delete(name),
+      getPropertyValue: (name: string) => vars.get(name) ?? "",
     },
   };
 
@@ -96,13 +99,13 @@ function fakeDocument({
       if (x >= PROBE_WIDTH - railPx) {
         return probe;
       }
-      return contentReachable ? probe.children[0] : probe;
+      return knobs.contentReachable ? probe.children[0] : probe;
     },
     addEventListener: () => undefined,
     removeEventListener: () => undefined,
   };
 
-  return { doc: doc as unknown as Document, vars, bodyChildren };
+  return { doc: doc as unknown as Document, vars, bodyChildren, knobs };
 }
 
 test("an overlay scrollbar's hit strip is measured, not assumed", () => {
@@ -146,6 +149,55 @@ test("an open modal's pointer-events:none does not erase the gutter", () => {
   assert.equal(measureOverlayScrollbarGutter(doc), 21);
   assert.equal(applyOverlayScrollbarGutter(doc), 21);
   assert.equal(vars.get(OVERLAY_SCROLLBAR_GUTTER_VAR), "21px");
+});
+
+test("one unreadable sweep does not drop a gutter already in use", () => {
+  const { doc, vars, knobs } = fakeDocument({ railPx: 21, layoutPx: 0 });
+
+  assert.equal(applyOverlayScrollbarGutter(doc), 21);
+
+  // Same scrollbar, but this sweep read nothing. Re-measuring must not shift
+  // every row that already reserved the strip.
+  knobs.contentReachable = false;
+  assert.equal(applyOverlayScrollbarGutter(doc), 21);
+  assert.equal(vars.get(OVERLAY_SCROLLBAR_GUTTER_VAR), "21px");
+
+  // A readable sweep still retires the gutter when the scrollbar really goes.
+  const { doc: gone, vars: goneVars } = fakeDocument({
+    railPx: 0,
+    layoutPx: 0,
+  });
+  goneVars.set(OVERLAY_SCROLLBAR_GUTTER_VAR, "21px");
+  assert.equal(applyOverlayScrollbarGutter(gone), 0);
+  assert.equal(goneVars.has(OVERLAY_SCROLLBAR_GUTTER_VAR), false);
+});
+
+test("a hidden page is not measured, since hit testing reads nothing", () => {
+  const { doc, vars } = fakeDocument({ railPx: 21, layoutPx: 0 });
+  const docHandlers = new Map<string, () => void>();
+  const live = doc as unknown as {
+    visibilityState: string;
+    addEventListener: (t: string, fn: () => void) => void;
+    removeEventListener: (t: string) => void;
+  };
+  live.visibilityState = "visible";
+  live.addEventListener = (t, fn) => docHandlers.set(t, fn);
+  live.removeEventListener = (t) => docHandlers.delete(t);
+
+  const win = {
+    document: doc,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  } as unknown as Window;
+
+  const stop = watchOverlayScrollbarGutter(win);
+  assert.equal(vars.get(OVERLAY_SCROLLBAR_GUTTER_VAR), "21px");
+
+  live.visibilityState = "hidden";
+  docHandlers.get("visibilitychange")?.();
+  assert.equal(vars.get(OVERLAY_SCROLLBAR_GUTTER_VAR), "21px");
+
+  stop();
 });
 
 test("the measured width is published in px for the CSS utility", () => {
@@ -227,10 +279,7 @@ test("right-edge action lists reserve the gutter they publish", async () => {
   );
 
   const apiKeysTab = await readFile(
-    new URL(
-      "../src/features/settings/tabs/api-keys-tab.tsx",
-      import.meta.url,
-    ),
+    new URL("../src/features/settings/tabs/api-keys-tab.tsx", import.meta.url),
     "utf8",
   );
   // Preserve classic padding and move every API-key row into the gutter.


### PR DESCRIPTION
## Summary

On WebKitGTK, overlay scrollbars take no layout width but still intercept pointer events along the right edge of a scroller. In the model picker, this left only 3 of the settings gear's 20 pixel columns clickable.

This PR measures that hit-test strip at runtime and reserves it for affected right-edge actions. It covers the model picker, API key actions, and staged project-source remove controls.

Reported in https://github.com/unsloth-test/unsloth-test/issues/2.

## What changed

- Add a short-lived scroll probe that measures the scrollbar's pointer-active width.
- Publish positive measurements as `--overlay-scrollbar-gutter` and expose a shared CSS utility.
- Apply the utility to model rows, API key rows, and staged project-source rows.
- Leave the variable unset for classic scrollbars or unreliable measurements, avoiding a second or guessed gutter.
- Re-measure after resize, focus, and visibility changes.
- Keep the probe measurable while a modal disables pointer events on the body.
- Add focused coverage for measurement, lifecycle updates, and all three consumers.

## Behavior boundaries

- Classic scrollbars retain their existing layout and padding.
- The model list reserves a stable gutter before it overflows, so rows do not shift as filtering changes the list height.
- Measurement failure leaves the current layout unchanged.
- The change is limited to overflowing lists with small actions at the right edge.
- macOS uses the same runtime measurement but was not directly exercised.

## Testing

- `node --experimental-strip-types --test tests/overlay-scrollbar-gutter.test.ts` (7 passed)
- Full frontend suite on the merged candidate (685 passed)
- Type checking and production builds
- Targeted lint and `git diff --check`

## Runtime validation

- WebKitGTK 2.52.3 measured a 21px overlay hit-test strip and restored the model settings action from 3/20 to 20/20 clickable columns.
- The staged-source remove action improved from 3/14 to 14/14 clickable columns.
- Headed Chrome measured a 10px layout scrollbar, left the overlay variable unset, and retained full clickability without extra padding.
