### PR TITLE
Studio: harden DSpark/MTP drafter detection and companion reclaim

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7245,6 +7245,10 @@ class LlamaCppBackend:
             return None
 
         target: Optional[str] = None
+        # Whether the question was actually answered. A listing that never
+        # completed (offline, transient Hub failure) leaves target None for a
+        # reason that says nothing about the repo's contents.
+        listing_answered = False
         from huggingface_hub import list_repo_files
 
         # Retry a transient listing blip; permanent repo/auth errors and offline
@@ -7254,6 +7258,7 @@ class LlamaCppBackend:
                 return None
             try:
                 target = pick(list_repo_files(hf_repo, token = hf_token))
+                listing_answered = True
                 break
             except Exception as e:
                 if type(e).__name__ in (
@@ -7284,9 +7289,15 @@ class LlamaCppBackend:
                 logger.debug(f"Offline cache lookup for {label} failed: {e}")
 
         # "The repo publishes none" and "the fetch failed" both return None, but
-        # only the second is worth retrying on the next Apply. Left unset on the
-        # early returns above, where the answer is genuinely unknown.
-        if outcome is not None and not cancel_event.is_set():
+        # only the second is worth retrying on the next Apply. Left unset unless
+        # the question was really answered -- by a listing that completed, or by
+        # a cache hit that produced a target regardless -- so an unreachable Hub
+        # is not recorded as a permanent absence.
+        if (
+            outcome is not None
+            and not cancel_event.is_set()
+            and (listing_answered or target is not None)
+        ):
             outcome["listed"] = target is not None
         if target is None or cancel_event.is_set():
             return None

--- a/studio/backend/hub/services/models/deletion.py
+++ b/studio/backend/hub/services/models/deletion.py
@@ -82,13 +82,28 @@ def _path_exists_or_symlink(path: Path) -> bool:
 
 
 def _repo_file_matches(target_repo, predicate) -> list[tuple[Path, Optional[Path], str]]:
+    """Files whose snapshot-relative path satisfies *predicate*.
+
+    Relative, not the bare ``file_name``: huggingface_hub sets that to
+    ``file_path.name`` (and our own recovery scan to ``entry.name``), so a
+    companion in ``dspark/`` or ``MTP/`` arrived here indistinguishable from a
+    root file. Every predicate below keys on the directory for at least one
+    supported layout, and the quant labels they extract are unchanged by the
+    prefix.
+    """
     matches: list[tuple[Path, Optional[Path], str]] = []
     for rev in getattr(target_repo, "revisions", ()):
+        snapshot = getattr(rev, "snapshot_path", None)
         for f in getattr(rev, "files", ()):
             name = str(getattr(f, "file_name", ""))
+            file_path = getattr(f, "file_path", None)
+            if snapshot and file_path:
+                try:
+                    name = Path(file_path).relative_to(Path(snapshot)).as_posix()
+                except ValueError:
+                    pass
             if not predicate(name):
                 continue
-            file_path = getattr(f, "file_path", None)
             if not file_path:
                 continue
             blob_path = getattr(f, "blob_path", None)

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -933,6 +933,62 @@ def test_download_dspark_still_reports_a_cached_sidecar_it_cannot_run(monkeypatc
     assert reached is False
 
 
+@pytest.mark.parametrize("shape", ["dangling", "directory"])
+def test_detect_dspark_file_skips_a_sidecar_it_cannot_open(tmp_path, shape):
+    """A dangling snapshot symlink or a directory named like a sidecar must read
+    as "no sidecar", not as a drafter: handing llama-server a --model-draft it
+    cannot open fails the whole load instead of falling back to no speculation.
+    detect_mtp_file has always guarded this."""
+    import os
+
+    weight = tmp_path / "model-Q4_K_M.gguf"
+    weight.write_bytes(b"target")
+    sidecar = tmp_path / "dspark-model-Q8_0.gguf"
+    if shape == "dangling":
+        os.symlink(tmp_path / "missing_blob", sidecar)
+    else:
+        sidecar.mkdir()
+
+    assert detect_dspark_file(str(weight)) is None
+    # Same shape, same answer for MTP: the two must not diverge.
+    mtp = tmp_path / "mtp-model.gguf"
+    if shape == "dangling":
+        os.symlink(tmp_path / "missing_blob", mtp)
+    else:
+        mtp.mkdir()
+    assert detect_mtp_file(str(weight)) is None
+
+
+@pytest.mark.parametrize("kind", ["dspark", "mtp"])
+def test_a_release_specific_sidecar_outranks_the_base_family(tmp_path, kind):
+    """Both prefix-match a 0731 weight, and only one is really its drafter. The
+    prefix rule cannot be tightened to equality -- mtp-gemma-4-12B-it.gguf really
+    does ship beside gemma-4-12B-it-qat-*.gguf -- so ranking settles it."""
+    weight = tmp_path / "DeepSeek-V4-Flash-0731-UD-Q4_K_XL.gguf"
+    weight.write_bytes(b"target")
+    base = tmp_path / f"{kind}-DeepSeek-V4-Flash-Q8_0.gguf"
+    exact = tmp_path / f"{kind}-DeepSeek-V4-Flash-0731-Q8_0.gguf"
+    base.write_bytes(b"x" * 10)
+    exact.write_bytes(b"x" * 4000)  # deliberately the larger, so size cannot decide
+
+    detect = detect_dspark_file if kind == "dspark" else detect_mtp_file
+    found = detect(str(weight))
+    assert found is not None and Path(found).name == exact.name
+
+
+def test_a_qat_weight_still_pairs_with_its_base_family_drafter(tmp_path):
+    """Negative control for the ranking above: unsloth/gemma-4-12B-it-qat-GGUF
+    ships mtp-gemma-4-12B-it.gguf, so the prefix rule has to keep working when no
+    more specific sidecar exists."""
+    weight = tmp_path / "gemma-4-12B-it-qat-UD-Q4_K_XL.gguf"
+    weight.write_bytes(b"target")
+    drafter = tmp_path / "mtp-gemma-4-12B-it.gguf"
+    drafter.write_bytes(b"draft")
+
+    found = detect_mtp_file(str(weight))
+    assert found is not None and Path(found).name == drafter.name
+
+
 def test_detect_mtp_file_returns_first_shard_of_split_subdir_drafter(tmp_path):
     """llama-server takes shard 1 as the model path, so a split MTP/ copy must
     not resolve to whichever shard happens to be smallest."""
@@ -1254,7 +1310,10 @@ def _cache_repo(tmp_path: Path, repo_id: str, names: list[str]):
         link.symlink_to(blob)
         files.append(
             SimpleNamespace(
-                file_name = name,
+                # Basename, like huggingface_hub (file_path.name) and our own
+                # recovery scan (entry.name); the directory only reaches the
+                # predicates via _repo_file_matches' snapshot-relative rebuild.
+                file_name = Path(name).name,
                 file_path = str(link),
                 blob_path = str(blob),
                 size_on_disk = 64,
@@ -1306,6 +1365,38 @@ def test_deleting_the_last_variant_reclaims_an_opt_in_dspark_drafter(tmp_path):
 
     assert not (snap / "model-Q4_K_M.gguf").is_symlink()
     assert not (snap / "dspark" / "dspark-DeepSeek-V4-Flash-0731-BF16.gguf").is_symlink()
+
+
+def test_a_suffix_scheme_sidecar_is_not_mistaken_for_a_quant(tmp_path):
+    """The second published naming scheme, <model>-dspark.gguf. Its basename
+    carries no drafter marker, only its dspark/ parent does, so a predicate fed
+    the bare file_name read it as a real Q8_0 variant: deleting the genuine Q8_0
+    would take the sidecar the Q4_K_M still needs, and no companion could ever be
+    reclaimed because a main GGUF always appeared to remain."""
+    from hub.services.models.deletion import _delete_gguf_variant_from_repos
+
+    repo, snap = _cache_repo(
+        tmp_path,
+        "unsloth/DeepSeek-V4-Flash-0731-GGUF",
+        [
+            "model-Q4_K_M.gguf",
+            "model-Q8_0.gguf",
+            "dspark/DeepSeek-V4-Flash-0731-Q8_0-dspark.gguf",
+        ],
+    )
+    _delete_gguf_variant_from_repos(
+        "unsloth/DeepSeek-V4-Flash-0731-GGUF", "Q8_0", [repo], None, root = tmp_path
+    )
+
+    assert not (snap / "model-Q8_0.gguf").is_symlink()
+    assert (snap / "model-Q4_K_M.gguf").is_symlink()
+    assert (snap / "dspark" / "DeepSeek-V4-Flash-0731-Q8_0-dspark.gguf").is_symlink()
+
+    # ...and it still goes with the last variant.
+    _delete_gguf_variant_from_repos(
+        "unsloth/DeepSeek-V4-Flash-0731-GGUF", "Q4_K_M", [repo], None, root = tmp_path
+    )
+    assert not (snap / "dspark" / "DeepSeek-V4-Flash-0731-Q8_0-dspark.gguf").is_symlink()
 
 
 def test_deleting_the_last_variant_keeps_a_dflash_weight(tmp_path):

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1045,6 +1045,35 @@ def test_root_mtp_ranking_spans_the_search_root(tmp_path):
     assert found is not None and Path(found).name == exact.name
 
 
+def test_a_more_specific_subdir_drafter_beats_a_base_family_root_one(tmp_path):
+    """Specificity has to be compared across layouts, not only within one: the
+    root file names a different family, so it is not this weight's drafter at all
+    and root preference must not save it."""
+    weight = tmp_path / "model_v2-Q4_K_M.gguf"
+    weight.write_bytes(b"target")
+    (tmp_path / "mtp-model.gguf").write_bytes(b"base")
+    (tmp_path / "MTP").mkdir()
+    exact = tmp_path / "MTP" / "mtp-model_v2-Q8_0.gguf"
+    exact.write_bytes(b"exact")
+
+    found = detect_mtp_file(str(weight))
+    assert found is not None and Path(found).name == exact.name
+
+
+def test_root_still_wins_when_both_layouts_name_the_same_family(tmp_path):
+    """Negative control: equal specificity is every published layout, and there
+    the root copy keeps its long-standing preference."""
+    weight = tmp_path / "model-Q4_K_M.gguf"
+    weight.write_bytes(b"target")
+    root = tmp_path / "mtp-model.gguf"
+    root.write_bytes(b"root")
+    (tmp_path / "MTP").mkdir()
+    (tmp_path / "MTP" / "model-Q8_0-MTP.gguf").write_bytes(b"sub")
+
+    found = detect_mtp_file(str(weight))
+    assert found is not None and Path(found).name == root.name
+
+
 def test_a_qat_weight_still_pairs_with_its_base_family_drafter(tmp_path):
     """Negative control for the ranking above: unsloth/gemma-4-12B-it-qat-GGUF
     ships mtp-gemma-4-12B-it.gguf, so the prefix rule has to keep working when no

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1093,6 +1093,24 @@ def test_an_unusable_candidate_does_not_win_the_tier_comparison(tmp_path):
     assert found is not None and Path(found).name == usable.name
 
 
+def test_a_rejected_candidate_does_not_win_the_tier_comparison(tmp_path):
+    """Same shape as the unusable case, via accept: a native grant can reject the
+    most specific root file, which is then skipped at emission. It must not have
+    spoken for its tier, or a base-family sibling goes out ahead of the more
+    specific accepted copy under MTP/."""
+    weight = tmp_path / "model_v2_release-Q4_K_M.gguf"
+    weight.write_bytes(b"target")
+    rejected = tmp_path / "mtp-model_v2_release.gguf"
+    rejected.write_bytes(b"out-of-grant")
+    (tmp_path / "mtp-model.gguf").write_bytes(b"base")
+    (tmp_path / "MTP").mkdir()
+    accepted = tmp_path / "MTP" / "mtp-model_v2-Q8_0.gguf"
+    accepted.write_bytes(b"mid")
+
+    found = detect_mtp_file(str(weight), accept = lambda candidate: rejected.name not in candidate)
+    assert found is not None and Path(found).name == accepted.name
+
+
 def test_a_qat_weight_still_pairs_with_its_base_family_drafter(tmp_path):
     """Negative control for the ranking above: unsloth/gemma-4-12B-it-qat-GGUF
     ships mtp-gemma-4-12B-it.gguf, so the prefix rule has to keep working when no

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1014,6 +1014,37 @@ def test_a_release_specific_sidecar_outranks_the_base_family(tmp_path, kind):
     assert found is not None and Path(found).name == exact.name
 
 
+def test_root_mtp_candidates_are_ranked_not_taken_in_directory_order(tmp_path):
+    """The root branch returns the first match it walks, so specificity has to be
+    applied before the walk: mtp-model.gguf sorts ahead of mtp-model_v2-Q8_0.gguf
+    yet only the second names this weight's family."""
+    weight = tmp_path / "model_v2-Q4_K_M.gguf"
+    weight.write_bytes(b"target")
+    (tmp_path / "mtp-model.gguf").write_bytes(b"base")
+    exact = tmp_path / "mtp-model_v2-Q8_0.gguf"
+    exact.write_bytes(b"exact")
+
+    found = detect_mtp_file(str(weight))
+    assert found is not None and Path(found).name == exact.name
+
+
+def test_root_mtp_ranking_spans_the_search_root(tmp_path):
+    """Same ordering hazard across the two scanned directories: the base sits in
+    the model's own folder and the exact match only in the search root."""
+    home = tmp_path / "home"
+    root = tmp_path / "root"
+    home.mkdir()
+    root.mkdir()
+    weight = home / "model_v2-Q4_K_M.gguf"
+    weight.write_bytes(b"target")
+    (home / "mtp-model.gguf").write_bytes(b"base")
+    exact = root / "mtp-model_v2-Q8_0.gguf"
+    exact.write_bytes(b"exact")
+
+    found = detect_mtp_file(str(weight), search_root = str(root))
+    assert found is not None and Path(found).name == exact.name
+
+
 def test_a_qat_weight_still_pairs_with_its_base_family_drafter(tmp_path):
     """Negative control for the ranking above: unsloth/gemma-4-12B-it-qat-GGUF
     ships mtp-gemma-4-12B-it.gguf, so the prefix rule has to keep working when no

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -922,6 +922,44 @@ def test_download_dspark_records_whether_the_repo_publishes_a_sidecar(monkeypatc
         assert b._dspark_sidecar_absent is expect_absent
 
 
+def test_an_unreachable_hub_is_not_recorded_as_a_missing_sidecar(monkeypatch, tmp_path):
+    """A listing that never completed says nothing about the repo. Recording it as
+    a definitive absence would suppress the reuse check's retry, so DSpark would
+    never be fetched once connectivity returned."""
+    import core.inference.llama_cpp as llama_cpp_module
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+    monkeypatch.setattr(
+        llama_cpp_module, "_companion_snapshot_sibling", lambda near_path, pick: None
+    )
+    monkeypatch.setattr(llama_cpp_module, "_hub_download_in_flight", lambda repo: False)
+    monkeypatch.setattr(
+        llama_cpp_module, "_hub_cache_dir_for_snapshot_path", lambda p: str(tmp_path)
+    )
+
+    def _explode(repo, token = None):
+        raise ConnectionError("hub unreachable")
+
+    monkeypatch.setattr("huggingface_hub.list_repo_files", _explode)
+    monkeypatch.setattr("utils.models.model_config._iter_hf_cache_snapshots", lambda *a, **k: [])
+
+    outcome: dict = {}
+    b = LlamaCppBackend()
+    b._cancel_event.clear()
+    assert (
+        b._download_companion_gguf(
+            hf_repo = "org/repo",
+            hf_token = None,
+            pick = lambda names: None,
+            label = "DSpark drafter",
+            outcome = outcome,
+        )
+        is None
+    )
+    assert "listed" not in outcome
+
+
 def test_download_dspark_still_reports_a_cached_sidecar_it_cannot_run(monkeypatch):
     """Skipping the fetch must not hide a sidecar already on disk: the route
     rediscovers it on every Apply, so answering None would leave the reuse check

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1074,6 +1074,25 @@ def test_root_still_wins_when_both_layouts_name_the_same_family(tmp_path):
     assert found is not None and Path(found).name == root.name
 
 
+def test_an_unusable_candidate_does_not_win_the_tier_comparison(tmp_path):
+    """Tier order is decided by specificity, so an unusable candidate that
+    outranks everything would put its tier first and then be skipped, handing
+    back a less specific sibling instead of the usable copy next door."""
+    import os
+
+    weight = tmp_path / "model_v2_release-Q4_K_M.gguf"
+    weight.write_bytes(b"target")
+    # Most specific, but a dangling link: it must not speak for the root tier.
+    os.symlink(tmp_path / "missing", tmp_path / "mtp-model_v2_release.gguf")
+    (tmp_path / "mtp-model.gguf").write_bytes(b"base")
+    (tmp_path / "MTP").mkdir()
+    usable = tmp_path / "MTP" / "mtp-model_v2-Q8_0.gguf"
+    usable.write_bytes(b"mid")
+
+    found = detect_mtp_file(str(weight))
+    assert found is not None and Path(found).name == usable.name
+
+
 def test_a_qat_weight_still_pairs_with_its_base_family_drafter(tmp_path):
     """Negative control for the ranking above: unsloth/gemma-4-12B-it-qat-GGUF
     ships mtp-gemma-4-12B-it.gguf, so the prefix rule has to keep working when no

--- a/studio/backend/tests/test_remote_access_settings.py
+++ b/studio/backend/tests/test_remote_access_settings.py
@@ -457,9 +457,7 @@ def test_stop_does_not_wait_forever_on_a_start_that_never_claims_ownership(monke
     monkeypatch.setattr(cloudflare_tunnel, "get_studio_tunnel_control_token", lambda: (1, 0))
     monkeypatch.setattr(cloudflare_tunnel, "capture_studio_tunnel_start_admission", lambda: (1, 0))
     stopped = threading.Event()
-    monkeypatch.setattr(
-        cloudflare_tunnel, "stop_studio_tunnel", lambda **_kw: stopped.set()
-    )
+    monkeypatch.setattr(cloudflare_tunnel, "stop_studio_tunnel", lambda **_kw: stopped.set())
     try:
         remote_access.stop_remote_access(_state())
         assert stopped.wait(5), "stop worker never reached stop_studio_tunnel"
@@ -492,7 +490,8 @@ def test_streaming_is_not_advertised_while_a_quick_tunnel_carries_the_traffic(mo
     assert remote_access.remote_access_status(_state())["streaming_supported"] is True
 
     monkeypatch.setattr(
-        cloudflare_tunnel, "get_studio_tunnel_status",
+        cloudflare_tunnel,
+        "get_studio_tunnel_status",
         lambda: _status("https://live.trycloudflare.com"),
     )
     assert remote_access.remote_access_status(_state())["streaming_supported"] is False

--- a/studio/backend/tests/test_secure_tunnel_gate.py
+++ b/studio/backend/tests/test_secure_tunnel_gate.py
@@ -326,11 +326,13 @@ def test_cors_preflight_cache_window_is_short():
         max_age = 60,
     )
     response = middleware.preflight_response(
-        Headers({
-            "origin": "https://browser-client.example",
-            "access-control-request-method": "POST",
-            "access-control-request-headers": "authorization",
-        })
+        Headers(
+            {
+                "origin": "https://browser-client.example",
+                "access-control-request-method": "POST",
+                "access-control-request-headers": "authorization",
+            }
+        )
     )
     assert response.status_code == 200
     assert int(response.headers["access-control-max-age"]) <= 60

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1893,47 +1893,39 @@ def detect_mtp_file(
                 except OSError:
                     continue
 
-    def _emit_root() -> Optional[str]:
-        # Ranking is stable, so files of equal specificity keep the scan order.
-        for f in sorted(root_candidates, key = lambda c: _drafter_stem_rank(c.name, kind = "mtp")):
+    def _first_pick(candidates: list[Path]) -> Optional[tuple[int, str]]:
+        """The candidate this tier would really launch, with its specificity.
+
+        Ranking the tier's best NAME would let a file that never launches speak
+        for it: rejected by ``accept`` (out of a native grant) or unresolvable,
+        it is skipped at emission and a less specific sibling goes out instead.
+        So each tier is represented by the first candidate that survives every
+        filter, which is the one actually on offer.
+        """
+        for c in candidates:
             try:
-                launch = _drafter_launch_path(f)
+                launch = _drafter_launch_path(c)
             except OSError:
                 continue
             if accept is not None and not accept(launch):
                 continue
-            return launch
+            return _drafter_stem_rank(c.name, kind = "mtp"), launch
         return None
 
-    def _emit_subdir() -> Optional[str]:
-        for candidate in sorted(dict.fromkeys(subdir_candidates), key = _smallest_first):
-            try:
-                resolved = _drafter_launch_path(candidate)
-            except OSError:
-                continue
-            if accept is not None and not accept(resolved):
-                continue
-            logger.info(f"Detected MTP subdirectory drafter: {resolved}")
-            return resolved
-        return None
-
-    def _best_rank(candidates: list[Path]) -> int:
-        # Ranks are negative stem lengths, so 0 is the worst an empty tier can
-        # score and the other side wins by default.
-        return min((_drafter_stem_rank(c.name, kind = "mtp") for c in candidates), default = 0)
+    # Ranking is stable, so files of equal specificity keep the scan order.
+    root_pick = _first_pick(
+        sorted(root_candidates, key = lambda c: _drafter_stem_rank(c.name, kind = "mtp"))
+    )
+    subdir_pick = _first_pick(sorted(dict.fromkeys(subdir_candidates), key = _smallest_first))
 
     # Root keeps its preference at equal specificity, which is every published
     # layout. It loses only to a strictly more specific companion copy, where
     # the root file names a different family and is not this weight's drafter.
-    order = (
-        (_emit_subdir, _emit_root)
-        if _best_rank(subdir_candidates) < _best_rank(root_candidates)
-        else (_emit_root, _emit_subdir)
-    )
-    for emit in order:
-        found = emit()
-        if found is not None:
-            return found
+    if subdir_pick is not None and (root_pick is None or subdir_pick[0] < root_pick[0]):
+        logger.info(f"Detected MTP subdirectory drafter: {subdir_pick[1]}")
+        return subdir_pick[1]
+    if root_pick is not None:
+        return root_pick[1]
     return None
 
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1840,6 +1840,16 @@ def detect_mtp_file(
                     continue
                 if not _matches_weight(f):
                     continue
+                # Launchability is settled here, not at emission: an unusable
+                # candidate that outranks everything (a dangling link, a partial
+                # split) would otherwise win the tier comparison below and then
+                # be skipped, handing back a less specific sibling. The subdir
+                # tier is filtered at collection for the same reason.
+                try:
+                    if not (f.is_file() and _launchable(f)):
+                        continue
+                except OSError:
+                    continue
                 root_candidates.append(f)
 
     subdir_candidates: list[Path] = []
@@ -1887,8 +1897,6 @@ def detect_mtp_file(
         # Ranking is stable, so files of equal specificity keep the scan order.
         for f in sorted(root_candidates, key = lambda c: _drafter_stem_rank(c.name, kind = "mtp")):
             try:
-                if not (f.is_file() and _launchable(f)):
-                    continue
                 launch = _drafter_launch_path(f)
             except OSError:
                 continue

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1824,6 +1824,12 @@ def detect_mtp_file(
     if search_root is not None:
         dirs.append(Path(search_root))
     if not skip_root:
+        # Collected before any is returned: two sidecars can both prefix-match
+        # (mtp-model.gguf and mtp-model_v2-Q8_0.gguf beside model_v2-*.gguf),
+        # and directory order would hand back whichever sorts first rather than
+        # the one that names this family. Ranking is stable, so files of equal
+        # specificity keep the scan order they had.
+        root_candidates: list[Path] = []
         for d in dirs:
             try:
                 entries = sorted(d.iterdir())
@@ -1835,15 +1841,17 @@ def detect_mtp_file(
                     continue
                 if not _matches_weight(f):
                     continue
-                try:
-                    if not (f.is_file() and _launchable(f)):
-                        continue
-                    launch = _drafter_launch_path(f)
-                except OSError:
+                root_candidates.append(f)
+        for f in sorted(root_candidates, key = lambda c: _drafter_stem_rank(c.name, kind = "mtp")):
+            try:
+                if not (f.is_file() and _launchable(f)):
                     continue
-                if accept is not None and not accept(launch):
-                    continue
-                return launch
+                launch = _drafter_launch_path(f)
+            except OSError:
+                continue
+            if accept is not None and not accept(launch):
+                continue
+            return launch
 
     subdir_candidates: list[Path] = []
     for d in dirs:

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1677,9 +1677,13 @@ def _drafter_matches_weight(candidate_name: str, weight_name: Optional[str], *, 
 
     A multi-model folder must not attach a foreign drafter, so the family the
     drafter names has to PREFIX the weight filename at a non-alphanumeric
-    boundary. Prefix alone is not enough: ``DeepSeek-V4-Flash-Lite`` and
-    ``DeepSeek-V4-Flash`` would otherwise pair in both directions and launch
-    the wrong sidecar as --model-draft.
+    boundary. That blocks one direction of a ``DeepSeek-V4-Flash-Lite`` /
+    ``DeepSeek-V4-Flash`` pair but not the other: the shorter family name is a
+    prefix of the longer weight, so a base-family sidecar still matches a
+    longer-named sibling's weights. Exact equality cannot replace the prefix
+    rule -- ``mtp-gemma-4-12B-it.gguf`` really does ship beside
+    ``gemma-4-12B-it-qat-*.gguf`` -- so the remaining direction is settled by
+    ranking: callers prefer the longest matching stem (see _drafter_stem_rank).
     """
     if weight_name is None:
         return True
@@ -1690,6 +1694,16 @@ def _drafter_matches_weight(candidate_name: str, weight_name: Optional[str], *, 
         and weight.startswith(stem)
         and (len(weight) == len(stem) or not weight[len(stem)].isalnum())
     )
+
+
+def _drafter_stem_rank(candidate_name: str, *, kind: str) -> int:
+    """Sort key placing the most specific family first (longest stem wins).
+
+    Both ``mtp-DeepSeek-V4-Flash-BF16.gguf`` and
+    ``mtp-DeepSeek-V4-Flash-0731-BF16.gguf`` prefix-match a 0731 weight, and
+    only the second is really its drafter.
+    """
+    return -len(_drafter_pairing_stem(candidate_name, kind = kind) or "")
 
 
 def _drafter_launch_path(candidate: Path) -> str:
@@ -1779,7 +1793,7 @@ def detect_mtp_file(
     def _launchable(candidate: Path) -> bool:
         return _drafter_split_is_complete(candidate)
 
-    def _smallest_first(candidate: Path) -> tuple[int, int, str]:
+    def _smallest_first(candidate: Path) -> tuple[int, int, int, str]:
         # Cheapest compatible copy wins. Size first: a fixed precision list ranked unknown quants
         # behind BF16, so a small K-quant lost to a far larger BF16. Precision breaks size ties,
         # name keeps it stable. Split copies collapse to shard 1, so sum across their shards.
@@ -1793,7 +1807,15 @@ def detect_mtp_file(
             precision = 2
         else:
             precision = 3
-        return _drafter_total_size(candidate), precision, name
+        # Family first, for the same reason as DSpark: both a base-family and a
+        # release-specific sidecar prefix-match, and only the longer one is
+        # really this weight's drafter.
+        return (
+            _drafter_stem_rank(candidate.name, kind = "mtp"),
+            _drafter_total_size(candidate),
+            precision,
+            name,
+        )
 
     p = Path(path)
     weight_name = p.name.lower() if p.suffix.lower() == ".gguf" else None
@@ -1900,11 +1922,13 @@ def detect_dspark_file(
     rejection as no sidecar at all.
     """
 
-    def _rank(candidate: Path) -> tuple[int, int, str]:
-        # Precision first (the model card's recommendation), then total size so
-        # a split copy cannot outrank a smaller single file, then name for a
-        # stable order.
+    def _rank(candidate: Path) -> tuple[int, int, int, str]:
+        # Most specific family first, so a base-family sidecar cannot win over
+        # the one that names this exact release. Then precision (the model
+        # card's recommendation), then total size so a split copy cannot
+        # outrank a smaller single file, then name for a stable order.
         return (
+            _drafter_stem_rank(candidate.name, kind = "dspark"),
             dspark_precision_rank(candidate.name),
             _drafter_total_size(candidate),
             candidate.name.lower(),
@@ -1953,7 +1977,12 @@ def detect_dspark_file(
                 try:
                     # Collapse a split copy to shard 1 before ranking.
                     launch = _local_gguf_load_path(candidate)
-                    if not _drafter_split_is_complete(launch):
+                    # is_file() follows the link, so this also drops a dangling
+                    # snapshot symlink and a directory named like a sidecar.
+                    # Without it --model-draft gets a path llama-server cannot
+                    # open, which fails the whole load rather than falling back
+                    # to no speculation (detect_mtp_file guards the same way).
+                    if not (launch.is_file() and _drafter_split_is_complete(launch)):
                         continue
                     resolved = launch.resolve()
                 except OSError:

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1823,13 +1823,12 @@ def detect_mtp_file(
     dirs = [start_dir]
     if search_root is not None:
         dirs.append(Path(search_root))
+    # Both tiers are collected before either is emitted: two sidecars can
+    # prefix-match the same weight (mtp-model.gguf and mtp-model_v2-Q8_0.gguf
+    # beside model_v2-*.gguf), across layouts as well as within one, and only the
+    # one naming this family is really its drafter.
+    root_candidates: list[Path] = []
     if not skip_root:
-        # Collected before any is returned: two sidecars can both prefix-match
-        # (mtp-model.gguf and mtp-model_v2-Q8_0.gguf beside model_v2-*.gguf),
-        # and directory order would hand back whichever sorts first rather than
-        # the one that names this family. Ranking is stable, so files of equal
-        # specificity keep the scan order they had.
-        root_candidates: list[Path] = []
         for d in dirs:
             try:
                 entries = sorted(d.iterdir())
@@ -1842,16 +1841,6 @@ def detect_mtp_file(
                 if not _matches_weight(f):
                     continue
                 root_candidates.append(f)
-        for f in sorted(root_candidates, key = lambda c: _drafter_stem_rank(c.name, kind = "mtp")):
-            try:
-                if not (f.is_file() and _launchable(f)):
-                    continue
-                launch = _drafter_launch_path(f)
-            except OSError:
-                continue
-            if accept is not None and not accept(launch):
-                continue
-            return launch
 
     subdir_candidates: list[Path] = []
     for d in dirs:
@@ -1894,15 +1883,49 @@ def detect_mtp_file(
                 except OSError:
                     continue
 
-    for candidate in sorted(dict.fromkeys(subdir_candidates), key = _smallest_first):
-        try:
-            resolved = _drafter_launch_path(candidate)
-        except OSError:
-            continue
-        if accept is not None and not accept(resolved):
-            continue
-        logger.info(f"Detected MTP subdirectory drafter: {resolved}")
-        return resolved
+    def _emit_root() -> Optional[str]:
+        # Ranking is stable, so files of equal specificity keep the scan order.
+        for f in sorted(root_candidates, key = lambda c: _drafter_stem_rank(c.name, kind = "mtp")):
+            try:
+                if not (f.is_file() and _launchable(f)):
+                    continue
+                launch = _drafter_launch_path(f)
+            except OSError:
+                continue
+            if accept is not None and not accept(launch):
+                continue
+            return launch
+        return None
+
+    def _emit_subdir() -> Optional[str]:
+        for candidate in sorted(dict.fromkeys(subdir_candidates), key = _smallest_first):
+            try:
+                resolved = _drafter_launch_path(candidate)
+            except OSError:
+                continue
+            if accept is not None and not accept(resolved):
+                continue
+            logger.info(f"Detected MTP subdirectory drafter: {resolved}")
+            return resolved
+        return None
+
+    def _best_rank(candidates: list[Path]) -> int:
+        # Ranks are negative stem lengths, so 0 is the worst an empty tier can
+        # score and the other side wins by default.
+        return min((_drafter_stem_rank(c.name, kind = "mtp") for c in candidates), default = 0)
+
+    # Root keeps its preference at equal specificity, which is every published
+    # layout. It loses only to a strictly more specific companion copy, where
+    # the root file names a different family and is not this weight's drafter.
+    order = (
+        (_emit_subdir, _emit_root)
+        if _best_rank(subdir_candidates) < _best_rank(root_candidates)
+        else (_emit_root, _emit_subdir)
+    )
+    for emit in order:
+        found = emit()
+        if found is not None:
+            return found
     return None
 
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1948,13 +1948,18 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
     gguf_variant?: string | null;
     // GGUF-only: scopes the training guard to the same placement policy /load
     // will use. Manual mode must match because it makes placement user-owned.
-    // The layer/MoE/split/KV/spec knobs are deliberately not sent: Auto mode's
-    // guard sizes conservatively, while Manual mode bypasses that estimate.
+    // The layer/MoE/split knobs are deliberately not sent: Auto mode's guard
+    // sizes conservatively, while Manual mode bypasses that estimate.
     // The safetensors fallback omits both fields and uses HF auto-placement.
     gpu_ids?: number[];
     gpu_memory_mode?: "auto" | "manual";
     cache_type_kv?: string | null;
     tensor_parallel?: boolean | null;
+    // The estimate charges a drafter whose size differs by mode (a DSpark
+    // sidecar is ~11 GB, and Auto reaches it), so this preflight has to be told
+    // what the load will send or it sizes a different model.
+    speculative_type?: string | null;
+    spec_draft_n_max?: number | null;
   }): Promise<boolean> {
     options?.abortSignal?.throwIfAborted();
     const validation = await validateModel({
@@ -2115,6 +2120,9 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
         gguf_variant: candidate.ggufVariant,
         cache_type_kv: config.kvCacheDtype,
         tensor_parallel: effectiveTensorParallel,
+        // The same values the load below sends.
+        speculative_type: effectiveSpeculativeType,
+        spec_draft_n_max: effectiveSpecDraftNMax,
         // The same remembered-derived GPU pick the load below sends.
         ...(candidate.kind === "gguf"
           ? {
@@ -2522,6 +2530,8 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
           // model has no remembered settings to prefer).
           gpu_ids: defaultGpuIds ?? undefined,
           gpu_memory_mode: rt.gpuMemoryMode,
+          speculative_type: specSettings.speculativeType,
+          spec_draft_n_max: specSettings.specDraftNMax,
         }))
       ) {
         toast.dismiss(toastId);


### PR DESCRIPTION
Follow-up to #7968. Three drafter-detection bugs found while reviewing that PR after it merged, each with a regression test that fails without its fix.

### `detect_dspark_file` accepted a sidecar it cannot open

It never checked that the candidate is a readable file, where `detect_mtp_file` always has. Two shapes reach it:

```
dangling snapshot symlink:   dspark -> .../missing_blob     mtp -> None
a DIRECTORY named like one:  dspark -> .../dspark-...gguf   mtp -> None
```

llama-server then gets a `--model-draft` it cannot open, which fails the whole load rather than falling back to no speculative decoding. Now guarded with `launch.is_file()`, which follows the link and so covers both.

### A base-family sidecar attached to a longer-named sibling's weights

`_drafter_matches_weight` requires the drafter's family to prefix the weight at a non-alphanumeric boundary. That blocks one direction of a `DeepSeek-V4-Flash` / `DeepSeek-V4-Flash-0731` pair but not the other:

```
mtp-DeepSeek-V4-Flash-BF16.gguf      -> DeepSeek-V4-Flash-0731-Q2_K-...gguf   True
mtp-DeepSeek-V4-Flash-0731-BF16.gguf -> DeepSeek-V4-Flash-Q2_K.gguf           False
```

Both are real Hub filenames, and `ggml-org/DeepSeek-V4-Flash-GGUF` and `ggml-org/DeepSeek-V4-Flash-0731-GGUF` are flat repos, so one scan folder for both hits it.

The prefix rule cannot be tightened to equality: `unsloth/gemma-4-12B-it-qat-GGUF` really does ship `mtp-gemma-4-12B-it.gguf` beside `gemma-4-12B-it-qat-*.gguf`. So the remaining direction is settled by ranking instead, with a new `_drafter_stem_rank` putting the longest matching family first in both detectors. The qat pairing has its own negative-control test.

### The deletion predicates never saw the directory

`_repo_file_matches` passed `file_name`, which huggingface_hub sets to `file_path.name` and our own recovery scan to `entry.name`. Both are basenames, so `dspark/` and `MTP/` were invisible to every predicate keyed on the parent directory.

Harmless for `dspark-<model>.gguf`, whose basename carries the marker. Not harmless for the other published scheme, `<model>-dspark.gguf`: its basename looks like an ordinary `Q8_0` quant, so deleting the genuine `Q8_0` variant also unlinked the sidecar the `Q4_K_M` still needed, and `_has_remaining_main_gguf` never went false, so no companion could ever be reclaimed.

`_repo_file_matches` now rebuilds the snapshot-relative path. Quant labels are unchanged by the prefix (`extract_quant_label` returns `UD-Q4_K_XL` either way), so only the directory-keyed answers move.

The test fixture was also passing relative paths as `file_name`, which is why this never showed up; it now mirrors production and the new test fails without the fix (`Deleted 2 file(s) ... variant Q8_0`).

### Testing

727 backend tests pass across the detection, deletion, picker, offline-cache and training-guard suites. Each fix was confirmed to fail its test when reverted.
