### PR TITLE
Fix Swagger UI and ReDoc being blanked by the studio CSP

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -802,8 +802,7 @@ def _build_csp(script_nonce: "str | None" = None, *, docs: bool = False) -> str:
     font_src = "font-src 'self' data:"
     if docs:
         script_src += f" 'unsafe-inline' {_DOCS_CDN}"
-        # ReDoc pulls a Google Fonts stylesheet, which 'unsafe-inline' does not
-        # cover, and that sheet then fetches the faces from gstatic.
+        # 'unsafe-inline' does not cover ReDoc's Google Fonts sheet, which pulls faces from gstatic.
         style_src += f" {_DOCS_CDN} {_DOCS_FONT_CSS}"
         font_src += f" {_DOCS_FONT_FILES}"
         worker_src += " blob:"

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -780,6 +780,8 @@ from starlette.datastructures import MutableHeaders  # noqa: E402
 _CSP_SCRIPT_NONCE_HEADER = "x-internal-script-nonce"
 _ARTIFACT_PREVIEW_FRAME_PATH = "/api/inference/artifact-preview-frame"
 _DOCS_CDN = "https://cdn.jsdelivr.net"
+_DOCS_FONT_CSS = "https://fonts.googleapis.com"
+_DOCS_FONT_FILES = "https://fonts.gstatic.com"
 _DOCS_PATHS = frozenset({"/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
@@ -797,9 +799,13 @@ def _build_csp(script_nonce: "str | None" = None, *, docs: bool = False) -> str:
     script_src = "script-src 'self'"
     style_src = "style-src 'self' 'unsafe-inline'"
     worker_src = "worker-src 'self'"
+    font_src = "font-src 'self' data:"
     if docs:
         script_src += f" 'unsafe-inline' {_DOCS_CDN}"
-        style_src += f" {_DOCS_CDN}"
+        # ReDoc pulls a Google Fonts stylesheet, which 'unsafe-inline' does not
+        # cover, and that sheet then fetches the faces from gstatic.
+        style_src += f" {_DOCS_CDN} {_DOCS_FONT_CSS}"
+        font_src += f" {_DOCS_FONT_FILES}"
         worker_src += " blob:"
     if script_nonce:
         script_src += f" 'nonce-{script_nonce}'"
@@ -828,7 +834,7 @@ def _build_csp(script_nonce: "str | None" = None, *, docs: bool = False) -> str:
         f"{style_src}; "
         f"{script_src}; "
         f"{worker_src}; "
-        "font-src 'self' data:; "
+        f"{font_src}; "
         "frame-src 'self'; "
         f"frame-ancestors {frame_ancestors}; "
         "form-action 'self'; "

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -779,6 +779,8 @@ from starlette.datastructures import MutableHeaders  # noqa: E402
 
 _CSP_SCRIPT_NONCE_HEADER = "x-internal-script-nonce"
 _ARTIFACT_PREVIEW_FRAME_PATH = "/api/inference/artifact-preview-frame"
+_DOCS_CDN = "https://cdn.jsdelivr.net"
+_DOCS_PATHS = frozenset({"/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
 # /content is Colab's working directory -- more reliable than env vars.
@@ -791,8 +793,14 @@ _IS_COLAB = os.path.isdir("/content") and (
 )
 
 
-def _build_csp(script_nonce: "str | None" = None) -> str:
+def _build_csp(script_nonce: "str | None" = None, *, docs: bool = False) -> str:
     script_src = "script-src 'self'"
+    style_src = "style-src 'self' 'unsafe-inline'"
+    worker_src = "worker-src 'self'"
+    if docs:
+        script_src += f" 'unsafe-inline' {_DOCS_CDN}"
+        style_src += f" {_DOCS_CDN}"
+        worker_src += " blob:"
     if script_nonce:
         script_src += f" 'nonce-{script_nonce}'"
     # Colab parent frames span multi-level *.prod.colab.dev subdomains (CSP wildcards match
@@ -817,8 +825,9 @@ def _build_csp(script_nonce: "str | None" = None) -> str:
         "img-src 'self' data: blob: https:; "
         "media-src 'self' data: blob: https:; "
         f"connect-src {connect_src}; "
-        "style-src 'self' 'unsafe-inline'; "
+        f"{style_src}; "
         f"{script_src}; "
+        f"{worker_src}; "
         "font-src 'self' data:; "
         "frame-src 'self'; "
         f"frame-ancestors {frame_ancestors}; "
@@ -856,7 +865,10 @@ class SecurityHeadersMiddleware:
                 nonce = headers.get(_CSP_SCRIPT_NONCE_HEADER)
                 if nonce is not None:
                     del headers[_CSP_SCRIPT_NONCE_HEADER]
-                headers.setdefault("Content-Security-Policy", _build_csp(nonce))
+                headers.setdefault(
+                    "Content-Security-Policy",
+                    _build_csp(nonce, docs = path in _DOCS_PATHS),
+                )
                 # Omit X-Frame-Options in Colab: DENY would block serve_kernel_port_as_iframe regardless of CSP.
                 if not _IS_COLAB and path != _ARTIFACT_PREVIEW_FRAME_PATH:
                     headers.setdefault("X-Frame-Options", "DENY")

--- a/studio/backend/tests/test_middleware.py
+++ b/studio/backend/tests/test_middleware.py
@@ -453,6 +453,27 @@ class TestSecurityHeadersMiddleware:
         nonced = main_module._build_csp("XYZ")
         assert "script-src 'self' 'nonce-XYZ';" in nonced
 
+    def test_docs_csp_allows_swagger_cdn_and_stays_scoped(self, main_module):
+        docs = main_module._build_csp(docs = True)
+        directives = {
+            chunk.strip().split(" ", 1)[0]: chunk.strip()
+            for chunk in docs.split(";")
+            if chunk.strip()
+        }
+        assert main_module._DOCS_CDN in directives["script-src"]
+        assert main_module._DOCS_CDN in directives["style-src"]
+        assert "'unsafe-inline'" in directives["script-src"]
+        assert "blob:" in directives["worker-src"]
+
+        plain = main_module._build_csp()
+        assert main_module._DOCS_CDN not in plain
+        assert "worker-src 'self';" in plain
+
+    def test_docs_paths_get_the_relaxed_csp(self, main_module):
+        assert "/docs" in main_module._DOCS_PATHS
+        assert "/redoc" in main_module._DOCS_PATHS
+        assert "/docs/oauth2-redirect" in main_module._DOCS_PATHS
+
     def test_img_and_media_allow_https_sources(self, main_module):
         # Model-card READMEs and citation favicons pull images/media from many
         # https origins (HF LFS/XET CDNs, shields/badge hosts, GitHub-hosted

--- a/studio/backend/tests/test_middleware.py
+++ b/studio/backend/tests/test_middleware.py
@@ -464,7 +464,6 @@ class TestSecurityHeadersMiddleware:
         assert main_module._DOCS_CDN in directives["style-src"]
         assert "'unsafe-inline'" in directives["script-src"]
         assert "blob:" in directives["worker-src"]
-        # ReDoc's font sheet and the faces it then pulls.
         assert main_module._DOCS_FONT_CSS in directives["style-src"]
         assert main_module._DOCS_FONT_FILES in directives["font-src"]
 
@@ -481,8 +480,7 @@ class TestSecurityHeadersMiddleware:
         assert "/docs/oauth2-redirect" in main_module._DOCS_PATHS
 
     def test_middleware_relaxes_only_the_docs_paths(self, main_module):
-        # The frozenset is an exact match on scope["path"], so pin the wiring:
-        # a docs path gets the CDN, its trailing-slash twin does not.
+        # _DOCS_PATHS matches scope["path"] exactly, so the trailing-slash twin stays strict.
         app = _make_csp_app(main_module)
 
         @app.get("/docs")

--- a/studio/backend/tests/test_middleware.py
+++ b/studio/backend/tests/test_middleware.py
@@ -464,15 +464,42 @@ class TestSecurityHeadersMiddleware:
         assert main_module._DOCS_CDN in directives["style-src"]
         assert "'unsafe-inline'" in directives["script-src"]
         assert "blob:" in directives["worker-src"]
+        # ReDoc's font sheet and the faces it then pulls.
+        assert main_module._DOCS_FONT_CSS in directives["style-src"]
+        assert main_module._DOCS_FONT_FILES in directives["font-src"]
 
         plain = main_module._build_csp()
         assert main_module._DOCS_CDN not in plain
+        assert main_module._DOCS_FONT_CSS not in plain
+        assert main_module._DOCS_FONT_FILES not in plain
         assert "worker-src 'self';" in plain
+        assert "font-src 'self' data:;" in plain
 
     def test_docs_paths_get_the_relaxed_csp(self, main_module):
         assert "/docs" in main_module._DOCS_PATHS
         assert "/redoc" in main_module._DOCS_PATHS
         assert "/docs/oauth2-redirect" in main_module._DOCS_PATHS
+
+    def test_middleware_relaxes_only_the_docs_paths(self, main_module):
+        # The frozenset is an exact match on scope["path"], so pin the wiring:
+        # a docs path gets the CDN, its trailing-slash twin does not.
+        app = _make_csp_app(main_module)
+
+        @app.get("/docs")
+        async def docs():
+            return {"ok": True}
+
+        @app.get("/docs/")
+        async def docs_slash():
+            return {"ok": True}
+
+        c = TestClient(app)
+        relaxed = c.get("/docs").headers["content-security-policy"]
+        assert main_module._DOCS_CDN in relaxed
+
+        for path in ("/docs/", "/plain"):
+            strict = c.get(path).headers["content-security-policy"]
+            assert main_module._DOCS_CDN not in strict, path
 
     def test_img_and_media_allow_https_sources(self, main_module):
         # Model-card READMEs and citation favicons pull images/media from many


### PR DESCRIPTION
/docs and /redoc return HTTP 200 with correct HTML but render as blank pages. The security hardening pass in #5375 applied script-src 'self' to every response via SecurityHeadersMiddleware, and FastAPI's built-in docs pages are hardcoded to load swagger-ui-bundle.js / redoc.standalone.js from cdn.jsdelivr.net and to bootstrap via an unnonced inline script. All of it gets blocked, so the page never initialises.

 _build_csp() now takes a docs flag, set only for /docs, /redoc, and /docs/oauth2-redirect. Those paths allow the jsDelivr origin in script-src/style-src, 'unsafe-inline' for the bootstrap script, and blob: in worker-src for ReDoc's search index. All other routes keep the strict policy unchanged.