### PR TITLE
fix(tokenizer): enable add_bos_token for Gemma 4 base models

### DIFF
--- a/tests/python/test_gemma4_base_bos_token.py
+++ b/tests/python/test_gemma4_base_bos_token.py
@@ -28,7 +28,11 @@ import unsloth.tokenizer_utils as tu
 
 
 class _Tok:
-    def __init__(self, add_bos_token = False, bos_token_id = 2):
+    def __init__(
+        self,
+        add_bos_token = False,
+        bos_token_id = 2,
+    ):
         self.add_bos_token = add_bos_token
         self.bos_token_id = bos_token_id
 

--- a/tests/python/test_gemma4_base_bos_token.py
+++ b/tests/python/test_gemma4_base_bos_token.py
@@ -1,0 +1,92 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gemma 4 base tokenizers must prepend <bos> at load time.
+
+unsloth/gemma-4-* base mirrors ship without add_bos_token: true while
+google/gemma-4-* includes it. Without the runtime fix, generation repeats
+degenerate text. See unslothai/unsloth#7903.
+"""
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+import unsloth.tokenizer_utils as tu
+
+
+class _Tok:
+    def __init__(self, add_bos_token = False, bos_token_id = 2):
+        self.add_bos_token = add_bos_token
+        self.bos_token_id = bos_token_id
+
+
+@pytest.mark.parametrize(
+    "model_name,expected",
+    [
+        ("unsloth/gemma-4-E2B", True),
+        ("unsloth/gemma-4-E4B", True),
+        ("unsloth/gemma-4-31B", True),
+        ("unsloth/gemma-4-26B-A4B", True),
+        ("unsloth/gemma-4-E2B-unsloth-bnb-4bit", True),
+        ("unsloth/gemma-4-E2B-it", False),
+        ("unsloth/gemma-4-E2B-it-unsloth-bnb-4bit", False),
+        ("google/gemma-4-E2B-it", False),
+        ("unsloth/gemma-3-4b", False),
+        ("unsloth/Qwen2.5-7B-Instruct", False),
+    ],
+)
+def test_is_gemma4_base_model_name(model_name, expected):
+    assert tu._is_gemma4_base_model_name(model_name) is expected
+
+
+def test_fix_gemma4_base_bos_token_sets_flag():
+    tok = _Tok(add_bos_token = False)
+    fixed = tu._fix_gemma4_base_bos_token(tok, "unsloth/gemma-4-E2B")
+    assert fixed.add_bos_token is True
+
+
+def test_fix_gemma4_base_bos_token_skips_it_variants():
+    tok = _Tok(add_bos_token = False)
+    fixed = tu._fix_gemma4_base_bos_token(tok, "unsloth/gemma-4-E2B-it")
+    assert fixed.add_bos_token is False
+
+
+def test_load_correct_tokenizer_enables_bos_for_gemma4_base():
+    name = "unsloth/gemma-4-E2B"
+
+    def from_pretrained(model_name, **kwargs):
+        return _Tok(add_bos_token = False)
+
+    with patch.object(tu, "AutoTokenizer", types.SimpleNamespace(from_pretrained = from_pretrained)):
+        result = tu._load_correct_tokenizer(name, fix_tokenizer = True)
+
+    assert result.add_bos_token is True
+
+
+@pytest.mark.e2e
+def test_gemma4_e2b_hub_tokenizer_prepends_bos():
+    pytest.importorskip("transformers")
+    from transformers import AutoTokenizer
+
+    tok = tu.load_correct_tokenizer("unsloth/gemma-4-E2B", fix_tokenizer = True)
+    assert tok.add_bos_token is True
+    ids = tok("This book is largely concerned with Hobbits,")["input_ids"]
+    assert ids[0] == tok.bos_token_id
+
+    # Control: raw Hub tokenizer still omits BOS without the fix.
+    raw = AutoTokenizer.from_pretrained("unsloth/gemma-4-E2B", trust_remote_code = True)
+    raw_ids = raw("This book is largely concerned with Hobbits,")["input_ids"]
+    assert raw_ids[0] != raw.bos_token_id

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -101,6 +101,7 @@ def _apply_post_load_tokenizer_fixes(tokenizer, model_name, fix_tokenizer):
         return tokenizer
     return _fix_gemma4_base_bos_token(tokenizer, model_name)
 
+
 # Check environments
 # A KAGGLE_* variable is not a Kaggle kernel - the Kaggle CLI reads
 # KAGGLE_USERNAME / KAGGLE_KEY from the environment on ordinary machines, and

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -68,6 +68,39 @@ IGNORED_TOKENIZER_NAMES = frozenset(
 )
 os.environ["UNSLOTH_IGNORED_TOKENIZER_NAMES"] = "\n".join(IGNORED_TOKENIZER_NAMES)
 
+# Gemma 4 base (non-it) mirrors on the Hub ship without add_bos_token: true even
+# though google/gemma-4-* does. -it variants are fine: chat_template.jinja emits
+# {{- bos_token -}}. See unslothai/unsloth#7903.
+_GEMMA4_BASE_MODEL_RE = re.compile(
+    r"^gemma-4-(?:e2b|e4b|31b|26b-a4b)(?:-unsloth-bnb-4bit)?$",
+    flags = re.IGNORECASE,
+)
+
+
+def _model_basename(model_name):
+    return model_name.rstrip("/\\").replace("\\", "/").split("/")[-1]
+
+
+def _is_gemma4_base_model_name(model_name):
+    base = _model_basename(model_name).lower()
+    if "-it" in base:
+        return False
+    return _GEMMA4_BASE_MODEL_RE.match(base) is not None
+
+
+def _fix_gemma4_base_bos_token(tokenizer, model_name):
+    if tokenizer is None or not _is_gemma4_base_model_name(model_name):
+        return tokenizer
+    if hasattr(tokenizer, "add_bos_token") and not tokenizer.add_bos_token:
+        tokenizer.add_bos_token = True
+    return tokenizer
+
+
+def _apply_post_load_tokenizer_fixes(tokenizer, model_name, fix_tokenizer):
+    if not fix_tokenizer:
+        return tokenizer
+    return _fix_gemma4_base_bos_token(tokenizer, model_name)
+
 # Check environments
 # A KAGGLE_* variable is not a Kaggle kernel - the Kaggle CLI reads
 # KAGGLE_USERNAME / KAGGLE_KEY from the environment on ordinary machines, and
@@ -626,13 +659,13 @@ def _load_correct_tokenizer(
     )
 
     if not fix_tokenizer or tokenizer_name.lower() in IGNORED_TOKENIZER_NAMES:
-        return fast_tokenizer
+        return _apply_post_load_tokenizer_fixes(fast_tokenizer, tokenizer_name, fix_tokenizer)
     # Ignore Mistral ones - they're a bit weird to handle!
     elif "mistral" in tokenizer_name.lower():
-        return fast_tokenizer
+        return _apply_post_load_tokenizer_fixes(fast_tokenizer, tokenizer_name, fix_tokenizer)
     # Ignore Phi-4 ones as well
     elif "phi-4" in tokenizer_name.lower():
-        return fast_tokenizer
+        return _apply_post_load_tokenizer_fixes(fast_tokenizer, tokenizer_name, fix_tokenizer)
     elif slow_tokenizer is not None:
         if hasattr(fast_tokenizer, "add_bos_token") and hasattr(slow_tokenizer, "add_bos_token"):
             fast_tokenizer.add_bos_token = slow_tokenizer.add_bos_token
@@ -641,13 +674,17 @@ def _load_correct_tokenizer(
 
         # Confirm if slow and fast are equivalent!
         if assert_same_tokenization(slow_tokenizer, fast_tokenizer):
-            return fast_tokenizer
+            return _apply_post_load_tokenizer_fixes(fast_tokenizer, tokenizer_name, fix_tokenizer)
         else:
             logger.warning(f"Unsloth: Will load {tokenizer_name} as a legacy tokenizer.")
-            return convert_to_fast_tokenizer(slow_tokenizer)
+            return _apply_post_load_tokenizer_fixes(
+                convert_to_fast_tokenizer(slow_tokenizer),
+                tokenizer_name,
+                fix_tokenizer,
+            )
         pass
     else:
-        return fast_tokenizer
+        return _apply_post_load_tokenizer_fixes(fast_tokenizer, tokenizer_name, fix_tokenizer)
 
 
 def _fix_pad_token(tokenizer):


### PR DESCRIPTION
Gemma 4 base (non-it) unsloth Hub mirrors ship without add_bos_token: true even though google/gemma-4-* includes it. Without BOS, base-model inference degenerates into repeated text.

Set add_bos_token at load time for the four base families (E2B, E4B, 31B, 26B-A4B) and their -unsloth-bnb-4bit variants. -it models are untouched because their chat templates already emit bos_token.

Fixes #7903.