### PR TITLE
Desktop: fit windows within the monitor work area

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -525,6 +525,8 @@ function TauriWrapper({ children }: { children: ReactNode }) {
   const [desktopAuthReady, setDesktopAuthReady] = useState(!isTauri);
   const [desktopAuthRetry, setDesktopAuthRetry] = useState(0);
   const [nativeMacControlsHidden, setNativeMacControlsHidden] = useState(false);
+
+  const [windowRevealRevision, setWindowRevealRevision] = useState(0);
   const usesCustomTitlebar = shouldUseCustomWindowTitlebar();
   const usesNativeMacTitlebar = shouldUseNativeMacWindowTitlebar();
   const hidesTitlebarSidebar = HIDDEN_TITLEBAR_SIDEBAR_ROUTES.has(pathname);
@@ -534,6 +536,35 @@ function TauriWrapper({ children }: { children: ReactNode }) {
     return () => {
       windowLayoutGenerationRef.current += 1;
       appliedWindowModeRef.current = null;
+    };
+  }, []);
+
+
+  useEffect(() => {
+    if (!isTauri) return;
+    let disposed = false;
+    let stopListening: (() => void) | undefined;
+
+    void wasLaunchedHidden().then(async (hiddenAtLaunch) => {
+      if (!hiddenAtLaunch || disposed) return;
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      const unlisten = await getCurrentWindow().onFocusChanged(({ payload }) => {
+        if (!payload || disposed) return;
+        stopListening?.();
+        stopListening = undefined;
+        // Native tray reveal focuses the window. Re-run the deferred layout now
+        // that currentMonitor() can resolve the restored display.
+        launchedHidden = Promise.resolve(false);
+        appliedWindowModeRef.current = null;
+        setWindowRevealRevision((revision) => revision + 1);
+      });
+      if (disposed) unlisten();
+      else stopListening = unlisten;
+    });
+
+    return () => {
+      disposed = true;
+      stopListening?.();
     };
   }, []);
 
@@ -567,7 +598,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         /* swallow; window may still be functional */
       }
     });
-  }, [status]);
+  }, [status, windowRevealRevision]);
 
   useEffect(() => {
     if (!isTauri) {

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -75,11 +75,93 @@ function logicalPerCssPx(monitorScale: number): number {
   return Number.isFinite(ratio) && ratio > 1 ? ratio : 1;
 }
 
+type WindowLayoutObserver = {
+  waitForSettled: () => Promise<void>;
+  dispose: () => void;
+};
+
+const WINDOW_LAYOUT_POLL_MS = 50;
+const WINDOW_LAYOUT_FALLBACK_MS = 300;
+const WINDOW_LAYOUT_TIMEOUT_MS = 1000;
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+}
+
+/** Watches native geometry changes that may arrive after a restore call resolves. */
+async function observeWindowLayout(
+  win: TauriWindow,
+  isCurrent: WindowLayoutGuard,
+): Promise<WindowLayoutObserver | null> {
+  let revision = 0;
+  const noteChange = () => {
+    revision += 1;
+  };
+  const unlistenResized = await win.onResized(noteChange);
+  let unlistenMoved: (() => void) | undefined;
+  try {
+    unlistenMoved = await win.onMoved(noteChange);
+  } catch (error) {
+    unlistenResized();
+    throw error;
+  }
+  if (!isCurrent()) {
+    unlistenResized();
+    unlistenMoved();
+    return null;
+  }
+
+  return {
+    waitForSettled: async () => {
+      let observedRevision = revision;
+      let sawPostShowChange = false;
+      for (
+        let elapsed = 0;
+        elapsed < WINDOW_LAYOUT_TIMEOUT_MS && isCurrent();
+        elapsed += WINDOW_LAYOUT_POLL_MS
+      ) {
+        await delay(WINDOW_LAYOUT_POLL_MS);
+        if (revision !== observedRevision) {
+          observedRevision = revision;
+          sawPostShowChange = true;
+          continue;
+        }
+        if (
+          sawPostShowChange ||
+          elapsed + WINDOW_LAYOUT_POLL_MS >= WINDOW_LAYOUT_FALLBACK_MS
+        ) {
+          return;
+        }
+      }
+    },
+    dispose: () => {
+      unlistenResized();
+      unlistenMoved();
+    },
+  };
+}
+
+function measureTauriWindowLayout(
+  windowModule: WindowModule,
+  win: TauriWindow,
+  isCurrent: WindowLayoutGuard,
+): Promise<MeasuredWindowLayout<TauriMonitor> | null> {
+  return measureWindowLayout(
+    {
+      currentMonitor: () => windowModule.currentMonitor(),
+      primaryMonitor: () => windowModule.primaryMonitor(),
+      innerSize: () => win.innerSize(),
+      outerSize: () => win.outerSize(),
+    },
+    isCurrent,
+  );
+}
+
 /** Sizes the window and centers it inside the work area. */
 async function placeWindow(
   win: TauriWindow,
   { LogicalSize, PhysicalPosition }: WindowModule,
-  { monitor }: MeasuredWindowLayout<TauriMonitor>,
+  { monitor, frameSize }: MeasuredWindowLayout<TauriMonitor>,
   size: LogicalWindowSize,
   isCurrent: WindowLayoutGuard,
 ): Promise<void> {
@@ -93,8 +175,8 @@ async function placeWindow(
   const scaleFactor = await win.scaleFactor();
   if (!isCurrent()) return;
   const position = calculateCenteredPosition(monitor.workArea, {
-    width: Math.round(size.width * scaleFactor),
-    height: Math.round(size.height * scaleFactor),
+    width: Math.round(size.width * scaleFactor) + frameSize.width,
+    height: Math.round(size.height * scaleFactor) + frameSize.height,
   });
   await win.setPosition(new PhysicalPosition(position.x, position.y));
 }
@@ -112,7 +194,7 @@ async function showSetupWindow(isCurrent: WindowLayoutGuard): Promise<void> {
   if (!isCurrent()) return;
   await win.setResizable(false);
   if (!isCurrent()) return;
-  const measured = await measureWindowLayout(windowModule, isCurrent);
+  const measured = await measureTauriWindowLayout(windowModule, win, isCurrent);
   if (!measured) return;
   // Keep the non-resizable setup window fully visible.
   const setupSize = fitWindowSize(
@@ -157,9 +239,8 @@ async function applyAppWindowLayout(
 ): Promise<void> {
   const windowModule = await import("@tauri-apps/api/window");
   const { invoke } = await import("@tauri-apps/api/core");
-  const { restoreStateCurrent, StateFlags } = await import(
-    "@tauri-apps/plugin-window-state"
-  );
+  const { restoreStateCurrent, StateFlags } =
+    await import("@tauri-apps/plugin-window-state");
   if (!isCurrent()) return;
 
   const win = windowModule.getCurrentWindow();
@@ -175,59 +256,66 @@ async function applyAppWindowLayout(
 
   await win.setResizable(true);
   if (!isCurrent()) return;
-  let measured = await measureWindowLayout(windowModule, isCurrent);
+  const measured = await measureTauriWindowLayout(windowModule, win, isCurrent);
   if (!measured) return;
 
   let requestedSize: LogicalWindowSize | undefined;
   let restored = false;
-  if (hasInitializedAppLayout && hasSavedState) {
-    restored = true;
-    // Subsequent launch: plugin restores size/position/maximized, with built-in
-    // off-screen protection for positions saved on a now-disconnected display.
-    await restoreStateCurrent(
-      StateFlags.SIZE | StateFlags.POSITION | StateFlags.MAXIMIZED,
-    );
-    if (!isCurrent()) return;
-    // Remeasure after restore in case the window moved to another monitor.
-    measured = (await measureWindowLayout(windowModule, isCurrent)) ?? measured;
-  } else {
-    // First launch: fit to the current work area and center.
-    const cssSafeLogicalWidth = measured.monitor
-      ? Math.round(
-          MIN_DESKTOP_LAYOUT_WIDTH *
-            logicalPerCssPx(measured.monitor.scaleFactor),
-        )
-      : undefined;
-    requestedSize = calculateFirstAppWindowSize(
-      measured.bounds,
-      cssSafeLogicalWidth,
-    );
-    await placeWindow(win, windowModule, measured, requestedSize, isCurrent);
-  }
-  // Apply work-area constraints after restore to preserve the saved size.
-  await finalizeAppWindowLayout({
-    restored,
-    measured,
-    show: () => win.show(),
-    measure: () => measureWindowLayout(windowModule, isCurrent),
-    setMinimumConstraints: (minimum) =>
-      win.setSizeConstraints({
-        minWidth: minimum.width,
-        minHeight: minimum.height,
-      }),
-    enforceBounds: (bounds) =>
-      enforceWindowSizeBounds(
-        win,
-        windowModule.LogicalSize,
-        isCurrent,
-        bounds,
-        requestedSize,
-      ),
-    isCurrent,
-  });
+  let layoutObserver: WindowLayoutObserver | null = null;
+  try {
+    if (hasInitializedAppLayout && hasSavedState) {
+      restored = true;
+      // Subscribe before restoring so native events cannot race listener setup.
+      layoutObserver = await observeWindowLayout(win, isCurrent);
+      if (!layoutObserver) return;
+      // Subsequent launch: plugin restores size/position/maximized, with built-in
+      // off-screen protection for positions saved on a now-disconnected display.
+      await restoreStateCurrent(
+        StateFlags.SIZE | StateFlags.POSITION | StateFlags.MAXIMIZED,
+      );
+      if (!isCurrent()) return;
+    } else {
+      // First launch: fit to the current work area and center.
+      const cssSafeLogicalWidth = measured.monitor
+        ? Math.round(
+            MIN_DESKTOP_LAYOUT_WIDTH *
+              logicalPerCssPx(measured.monitor.scaleFactor),
+          )
+        : undefined;
+      requestedSize = calculateFirstAppWindowSize(
+        measured.bounds,
+        cssSafeLogicalWidth,
+      );
+      await placeWindow(win, windowModule, measured, requestedSize, isCurrent);
+    }
+    // Apply work-area constraints after restore to preserve the saved size.
+    await finalizeAppWindowLayout({
+      restored,
+      measured,
+      show: () => win.show(),
+      waitForSettled: layoutObserver?.waitForSettled,
+      measure: () => measureTauriWindowLayout(windowModule, win, isCurrent),
+      setMinimumConstraints: (minimum) =>
+        win.setSizeConstraints({
+          minWidth: minimum.width,
+          minHeight: minimum.height,
+        }),
+      enforceBounds: (bounds) =>
+        enforceWindowSizeBounds(
+          win,
+          windowModule.LogicalSize,
+          isCurrent,
+          bounds,
+          requestedSize,
+        ),
+      isCurrent,
+    });
 
-  if (!isCurrent()) return;
-  await invoke("mark_app_window_layout_initialized");
+    if (!isCurrent()) return;
+    await invoke("mark_app_window_layout_initialized");
+  } finally {
+    layoutObserver?.dispose();
+  }
 }
 
 async function showWindowFallback(): Promise<void> {
@@ -563,10 +651,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         </>
       }
     >
-      <LlamaUpdateBanner
-        positioned={false}
-        enabled={!hidesTitlebarSidebar}
-      />
+      <LlamaUpdateBanner positioned={false} enabled={!hidesTitlebarSidebar} />
       <DownloadManagerPanel positioned={false} />
     </TauriUpdateLayer>
   ) : (
@@ -607,10 +692,10 @@ function TauriWrapper({ children }: { children: ReactNode }) {
           }
           style={
             nativeMacControlsHidden
-              ? {
+              ? ({
                   ...MAC_NATIVE_CHROME_STYLE,
                   "--studio-mac-traffic-light-inset": "6px",
-                } as CSSProperties
+                } as CSSProperties)
               : MAC_NATIVE_CHROME_STYLE
           }
         >

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -37,26 +37,33 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  type LogicalWindowSize,
+  PREFERRED_SETUP_WINDOW_SIZE,
+  type WindowSizeBounds,
+  calculateCenteredPosition,
+  calculateFirstAppWindowSize,
+  constrainWindowSize,
+  fitWindowSize,
+} from "./window-layout";
+import {
+  type MeasuredWindowLayout,
+  type WindowLayoutGuard,
+  finalizeAppWindowLayout,
+  measureWindowLayout,
+} from "./window-layout-lifecycle";
 
 interface AppProviderProps {
   children: ReactNode;
 }
 
 type TauriWindowMode = "setup" | "app";
-type WindowLayoutGuard = () => boolean;
-type LogicalWindowSize = {
-  width: number;
-  height: number;
-};
+type WindowModule = typeof import("@tauri-apps/api/window");
+type TauriWindow = Awaited<ReturnType<WindowModule["getCurrentWindow"]>>;
+type TauriMonitor = NonNullable<
+  Awaited<ReturnType<WindowModule["currentMonitor"]>>
+>;
 
-const MIN_WINDOW_WIDTH = 900;
-const MIN_WINDOW_HEIGHT = 600;
-const SETUP_WINDOW_WIDTH = 760;
-const SETUP_WINDOW_HEIGHT = 560;
-const MINIMUM_APP_WINDOW_SIZE: LogicalWindowSize = {
-  width: MIN_WINDOW_WIDTH,
-  height: MIN_WINDOW_HEIGHT,
-};
 // Keep in step with MOBILE_BREAKPOINT in hooks/use-mobile.ts.
 const MIN_DESKTOP_LAYOUT_WIDTH = 768;
 
@@ -68,72 +75,94 @@ function logicalPerCssPx(monitorScale: number): number {
   return Number.isFinite(ratio) && ratio > 1 ? ratio : 1;
 }
 
+/** Sizes the window and centers it inside the work area. */
+async function placeWindow(
+  win: TauriWindow,
+  { LogicalSize, PhysicalPosition }: WindowModule,
+  { monitor }: MeasuredWindowLayout<TauriMonitor>,
+  size: LogicalWindowSize,
+  isCurrent: WindowLayoutGuard,
+): Promise<void> {
+  await win.setSize(new LogicalSize(size.width, size.height));
+  if (!isCurrent()) return;
+  if (!monitor) {
+    await win.center();
+    return;
+  }
+  // Center from the requested size because GTK may still report stale geometry.
+  const scaleFactor = await win.scaleFactor();
+  if (!isCurrent()) return;
+  const position = calculateCenteredPosition(monitor.workArea, {
+    width: Math.round(size.width * scaleFactor),
+    height: Math.round(size.height * scaleFactor),
+  });
+  await win.setPosition(new PhysicalPosition(position.x, position.y));
+}
+
 async function showSetupWindow(isCurrent: WindowLayoutGuard): Promise<void> {
-  const { getCurrentWindow, LogicalSize } = await import(
-    "@tauri-apps/api/window"
-  );
+  const windowModule = await import("@tauri-apps/api/window");
   const { invoke } = await import("@tauri-apps/api/core");
   if (!isCurrent()) return;
 
-  const win = getCurrentWindow();
+  const win = windowModule.getCurrentWindow();
   await invoke("reset_app_window_layout_initialized");
+  if (!isCurrent()) return;
+  // Clear app-mode constraints before showing the smaller setup window.
+  await win.setSizeConstraints(null);
   if (!isCurrent()) return;
   await win.setResizable(false);
   if (!isCurrent()) return;
-  await win.setSize(new LogicalSize(SETUP_WINDOW_WIDTH, SETUP_WINDOW_HEIGHT));
-  if (!isCurrent()) return;
-  await win.center();
+  const measured = await measureWindowLayout(windowModule, isCurrent);
+  if (!measured) return;
+  // Keep the non-resizable setup window fully visible.
+  const setupSize = fitWindowSize(
+    PREFERRED_SETUP_WINDOW_SIZE,
+    measured.bounds.maximum,
+  );
+  await placeWindow(win, windowModule, measured, setupSize, isCurrent);
   if (!isCurrent()) return;
   await win.show();
 }
 
-async function enforceMinimumWindowSize(
-  win: Awaited<
-    ReturnType<typeof import("@tauri-apps/api/window")["getCurrentWindow"]>
-  >,
-  LogicalSize: typeof import("@tauri-apps/api/window")["LogicalSize"],
+async function enforceWindowSizeBounds(
+  win: TauriWindow,
+  LogicalSize: WindowModule["LogicalSize"],
   isCurrent: WindowLayoutGuard,
-  requestedSize: LogicalWindowSize = MINIMUM_APP_WINDOW_SIZE,
+  bounds: WindowSizeBounds,
+  requestedSize: LogicalWindowSize = bounds.minimum,
 ): Promise<void> {
-  const [innerSize, scaleFactor] = await Promise.all([
-    win.innerSize(),
-    win.scaleFactor(),
-  ]);
+  const [innerSize, scaleFactor, isMaximized, isFullscreen] = await Promise.all(
+    [win.innerSize(), win.scaleFactor(), win.isMaximized(), win.isFullscreen()],
+  );
   if (!isCurrent()) return;
+  // Let the window manager size maximized and fullscreen windows.
+  if (isMaximized || isFullscreen) return;
 
-  const logicalWidth = Math.round(innerSize.width / scaleFactor);
-  const logicalHeight = Math.round(innerSize.height / scaleFactor);
-  // Linux reports innerSize from a cache updated by WebKitGTK configure events.
-  // That event can arrive after this check, leaving the old setup size in the
-  // cache even though the first app resize has completed.
-  const nextWidth = Math.max(
-    logicalWidth,
-    MIN_WINDOW_WIDTH,
-    requestedSize.width,
-  );
-  const nextHeight = Math.max(
-    logicalHeight,
-    MIN_WINDOW_HEIGHT,
-    requestedSize.height,
-  );
-  if (nextWidth !== logicalWidth || nextHeight !== logicalHeight) {
-    await win.setSize(new LogicalSize(nextWidth, nextHeight));
+  const currentSize = {
+    width: Math.round(innerSize.width / scaleFactor),
+    height: Math.round(innerSize.height / scaleFactor),
+  };
+  // Linux can briefly report the pre-resize size from its GTK cache.
+  const nextSize = constrainWindowSize(currentSize, requestedSize, bounds);
+  if (
+    nextSize.width !== currentSize.width ||
+    nextSize.height !== currentSize.height
+  ) {
+    await win.setSize(new LogicalSize(nextSize.width, nextSize.height));
   }
 }
 
 async function applyAppWindowLayout(
   isCurrent: WindowLayoutGuard,
 ): Promise<void> {
-  const { getCurrentWindow, currentMonitor, LogicalSize } = await import(
-    "@tauri-apps/api/window"
-  );
+  const windowModule = await import("@tauri-apps/api/window");
   const { invoke } = await import("@tauri-apps/api/core");
   const { restoreStateCurrent, StateFlags } = await import(
     "@tauri-apps/plugin-window-state"
   );
   if (!isCurrent()) return;
 
-  const win = getCurrentWindow();
+  const win = windowModule.getCurrentWindow();
   // Setup-window activity may create plugin state before the full app is ever
   // shown, so use a dedicated full-app marker to decide whether restoration is
   // appropriate. Keep checking plugin state so a missing/corrupt state file
@@ -146,54 +175,56 @@ async function applyAppWindowLayout(
 
   await win.setResizable(true);
   if (!isCurrent()) return;
+  let measured = await measureWindowLayout(windowModule, isCurrent);
+  if (!measured) return;
 
   let requestedSize: LogicalWindowSize | undefined;
+  let restored = false;
   if (hasInitializedAppLayout && hasSavedState) {
+    restored = true;
     // Subsequent launch: plugin restores size/position/maximized, with built-in
     // off-screen protection for positions saved on a now-disconnected display.
     await restoreStateCurrent(
       StateFlags.SIZE | StateFlags.POSITION | StateFlags.MAXIMIZED,
     );
+    if (!isCurrent()) return;
+    // Remeasure after restore in case the window moved to another monitor.
+    measured = (await measureWindowLayout(windowModule, isCurrent)) ?? measured;
   } else {
-    // First launch: fit to the current monitor and center.
-    const monitor = await currentMonitor();
-    if (!isCurrent()) return;
-    let finalW = MIN_WINDOW_WIDTH;
-    let finalH = MIN_WINDOW_HEIGHT;
-    if (monitor) {
-      const scale = monitor.scaleFactor;
-      const screenW = monitor.size.width / scale;
-      const screenH = monitor.size.height / scale;
-      finalW = Math.max(
-        MIN_WINDOW_WIDTH,
-        Math.round(screenW * 0.75),
-        // Windows text scaling shrinks CSS px, so the window would open under
-        // the sidebar's mobile breakpoint. No-op elsewhere; never exceed the
-        // screen.
-        Math.min(
-          Math.round(MIN_DESKTOP_LAYOUT_WIDTH * logicalPerCssPx(scale)),
-          Math.round(screenW),
-        ),
-      );
-      const targetH = Math.max(MIN_WINDOW_HEIGHT, Math.round(finalW / 1.618));
-      finalH = Math.min(targetH, Math.round(screenH * 0.85));
-    }
-    requestedSize = { width: finalW, height: finalH };
-    await win.setSize(new LogicalSize(finalW, finalH));
-    if (!isCurrent()) return;
-    await win.center();
+    // First launch: fit to the current work area and center.
+    const cssSafeLogicalWidth = measured.monitor
+      ? Math.round(
+          MIN_DESKTOP_LAYOUT_WIDTH *
+            logicalPerCssPx(measured.monitor.scaleFactor),
+        )
+      : undefined;
+    requestedSize = calculateFirstAppWindowSize(
+      measured.bounds,
+      cssSafeLogicalWidth,
+    );
+    await placeWindow(win, windowModule, measured, requestedSize, isCurrent);
   }
-  if (!isCurrent()) return;
-  await win.show();
-  if (!isCurrent()) return;
-  // Apply constraints after restore/show: doing so before plugin restore can emit
-  // a Resized event and overwrite the plugin's cached saved size.
-  await win.setSizeConstraints({
-    minWidth: MIN_WINDOW_WIDTH,
-    minHeight: MIN_WINDOW_HEIGHT,
+  // Apply work-area constraints after restore to preserve the saved size.
+  await finalizeAppWindowLayout({
+    restored,
+    measured,
+    show: () => win.show(),
+    measure: () => measureWindowLayout(windowModule, isCurrent),
+    setMinimumConstraints: (minimum) =>
+      win.setSizeConstraints({
+        minWidth: minimum.width,
+        minHeight: minimum.height,
+      }),
+    enforceBounds: (bounds) =>
+      enforceWindowSizeBounds(
+        win,
+        windowModule.LogicalSize,
+        isCurrent,
+        bounds,
+        requestedSize,
+      ),
+    isCurrent,
   });
-  if (!isCurrent()) return;
-  await enforceMinimumWindowSize(win, LogicalSize, isCurrent, requestedSize);
 
   if (!isCurrent()) return;
   await invoke("mark_app_window_layout_initialized");

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -50,6 +50,7 @@ import {
   type MeasuredWindowLayout,
   type WindowLayoutGuard,
   finalizeAppWindowLayout,
+  shouldFinishWindowLayoutWait,
   measureWindowLayout,
 } from "./window-layout-lifecycle";
 
@@ -90,7 +91,6 @@ type WindowLayoutObserver = {
 };
 
 const WINDOW_LAYOUT_POLL_MS = 50;
-const WINDOW_LAYOUT_FALLBACK_MS = 300;
 const WINDOW_LAYOUT_TIMEOUT_MS = 1000;
 
 function delay(milliseconds: number): Promise<void> {
@@ -135,10 +135,7 @@ async function observeWindowLayout(
           sawPostShowChange = true;
           continue;
         }
-        if (
-          sawPostShowChange ||
-          elapsed + WINDOW_LAYOUT_POLL_MS >= WINDOW_LAYOUT_FALLBACK_MS
-        ) {
+        if (shouldFinishWindowLayoutWait(sawPostShowChange)) {
           return;
         }
       }

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -304,9 +304,10 @@ async function applyAppWindowLayout(
       restored,
       measured,
       show: async () => {
-        if (await wasLaunchedHidden()) return;
-        if (!isCurrent()) return;
+        if (await wasLaunchedHidden()) return false;
+        if (!isCurrent()) return false;
         await win.show();
+        return true;
       },
       waitForSettled: layoutObserver?.waitForSettled,
       measure: () => measureTauriWindowLayout(windowModule, win, isCurrent),

--- a/studio/frontend/src/app/window-layout-lifecycle.ts
+++ b/studio/frontend/src/app/window-layout-lifecycle.ts
@@ -66,6 +66,7 @@ export async function finalizeAppWindowLayout<Monitor extends WorkAreaMonitor>({
   enforceBounds,
   isCurrent,
 }: FinalizeAppWindowLayoutOptions<Monitor>): Promise<void> {
+  if (!isCurrent()) return;
   await show();
   if (!isCurrent()) return;
 

--- a/studio/frontend/src/app/window-layout-lifecycle.ts
+++ b/studio/frontend/src/app/window-layout-lifecycle.ts
@@ -80,6 +80,11 @@ export async function measureWindowLayout<Monitor extends WorkAreaMonitor>(
   return { bounds, monitor, frameSize };
 }
 
+export function shouldFinishWindowLayoutWait(
+  sawPostShowChange: boolean,
+): boolean {
+  return sawPostShowChange;
+}
 type FinalizeAppWindowLayoutOptions<Monitor extends WorkAreaMonitor> = {
   restored: boolean;
   measured: MeasuredWindowLayout<Monitor>;

--- a/studio/frontend/src/app/window-layout-lifecycle.ts
+++ b/studio/frontend/src/app/window-layout-lifecycle.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  DEFAULT_APP_WINDOW_SIZE_BOUNDS,
+  type LogicalWindowSize,
+  type WindowSizeBounds,
+  calculateWindowSizeBounds,
+} from "./window-layout.ts";
+
+export type WindowLayoutGuard = () => boolean;
+
+type WorkAreaMonitor = {
+  scaleFactor: number;
+  workArea: {
+    size: {
+      toLogical: (scaleFactor: number) => LogicalWindowSize;
+    };
+  };
+};
+
+export type MeasuredWindowLayout<Monitor extends WorkAreaMonitor> = {
+  bounds: WindowSizeBounds;
+  monitor: Monitor | null;
+};
+
+type WindowMonitorReader<Monitor extends WorkAreaMonitor> = {
+  currentMonitor: () => Promise<Monitor | null>;
+  primaryMonitor: () => Promise<Monitor | null>;
+};
+
+/** Size bounds the window has to stay within on its current monitor. */
+export async function measureWindowLayout<Monitor extends WorkAreaMonitor>(
+  { currentMonitor, primaryMonitor }: WindowMonitorReader<Monitor>,
+  isCurrent: WindowLayoutGuard,
+): Promise<MeasuredWindowLayout<Monitor> | null> {
+  // Some platforms cannot resolve the monitor for a hidden window.
+  const monitor = (await currentMonitor()) ?? (await primaryMonitor());
+  if (!isCurrent()) return null;
+
+  const bounds = monitor
+    ? calculateWindowSizeBounds(
+        monitor.workArea.size.toLogical(monitor.scaleFactor),
+      )
+    : DEFAULT_APP_WINDOW_SIZE_BOUNDS;
+  return { bounds, monitor };
+}
+
+type FinalizeAppWindowLayoutOptions<Monitor extends WorkAreaMonitor> = {
+  restored: boolean;
+  measured: MeasuredWindowLayout<Monitor>;
+  show: () => Promise<void>;
+  measure: () => Promise<MeasuredWindowLayout<Monitor> | null>;
+  setMinimumConstraints: (minimum: LogicalWindowSize) => Promise<void>;
+  enforceBounds: (bounds: WindowSizeBounds) => Promise<void>;
+  isCurrent: WindowLayoutGuard;
+};
+
+/** Shows the app window, then applies bounds from the visible monitor. */
+export async function finalizeAppWindowLayout<Monitor extends WorkAreaMonitor>({
+  restored,
+  measured,
+  show,
+  measure,
+  setMinimumConstraints,
+  enforceBounds,
+  isCurrent,
+}: FinalizeAppWindowLayoutOptions<Monitor>): Promise<void> {
+  await show();
+  if (!isCurrent()) return;
+
+  // Once visible, a restored window can resolve its saved secondary monitor.
+  if (restored) {
+    measured = (await measure()) ?? measured;
+    if (!isCurrent()) return;
+  }
+
+  await setMinimumConstraints(measured.bounds.minimum);
+  if (!isCurrent()) return;
+  // Do not cap restored sizes against a temporary monitor fallback.
+  await enforceBounds(
+    restored ? { minimum: measured.bounds.minimum } : measured.bounds,
+  );
+}

--- a/studio/frontend/src/app/window-layout-lifecycle.ts
+++ b/studio/frontend/src/app/window-layout-lifecycle.ts
@@ -83,7 +83,7 @@ export async function measureWindowLayout<Monitor extends WorkAreaMonitor>(
 type FinalizeAppWindowLayoutOptions<Monitor extends WorkAreaMonitor> = {
   restored: boolean;
   measured: MeasuredWindowLayout<Monitor>;
-  show: () => Promise<void>;
+  show: () => Promise<boolean>;
   waitForSettled?: () => Promise<void>;
   measure: () => Promise<MeasuredWindowLayout<Monitor> | null>;
   setMinimumConstraints: (minimum: LogicalWindowSize) => Promise<void>;
@@ -103,8 +103,11 @@ export async function finalizeAppWindowLayout<Monitor extends WorkAreaMonitor>({
   isCurrent,
 }: FinalizeAppWindowLayoutOptions<Monitor>): Promise<void> {
   if (!isCurrent()) return;
-  await show();
+  const shown = await show();
   if (!isCurrent()) return;
+  // A restored hidden autostart cannot reliably resolve its saved monitor yet.
+  // Keep the plugin-restored geometry untouched until native tray reveal.
+  if (restored && !shown) return;
 
   // Native restore calls complete before GTK/Cocoa move and resize events have
   // necessarily updated Tauri's cached geometry.

--- a/studio/frontend/src/app/window-layout-lifecycle.ts
+++ b/studio/frontend/src/app/window-layout-lifecycle.ts
@@ -19,37 +19,72 @@ type WorkAreaMonitor = {
   };
 };
 
+type PhysicalWindowSize = {
+  width: number;
+  height: number;
+};
+
 export type MeasuredWindowLayout<Monitor extends WorkAreaMonitor> = {
   bounds: WindowSizeBounds;
   monitor: Monitor | null;
+  /** Physical pixels outside the webview's inner rectangle. */
+  frameSize: PhysicalWindowSize;
 };
 
 type WindowMonitorReader<Monitor extends WorkAreaMonitor> = {
   currentMonitor: () => Promise<Monitor | null>;
   primaryMonitor: () => Promise<Monitor | null>;
+  innerSize?: () => Promise<PhysicalWindowSize>;
+  outerSize?: () => Promise<PhysicalWindowSize>;
 };
 
 /** Size bounds the window has to stay within on its current monitor. */
 export async function measureWindowLayout<Monitor extends WorkAreaMonitor>(
-  { currentMonitor, primaryMonitor }: WindowMonitorReader<Monitor>,
+  reader: WindowMonitorReader<Monitor>,
   isCurrent: WindowLayoutGuard,
 ): Promise<MeasuredWindowLayout<Monitor> | null> {
   // Some platforms cannot resolve the monitor for a hidden window.
-  const monitor = (await currentMonitor()) ?? (await primaryMonitor());
+  const monitor =
+    (await reader.currentMonitor()) ?? (await reader.primaryMonitor());
   if (!isCurrent()) return null;
 
-  const bounds = monitor
-    ? calculateWindowSizeBounds(
-        monitor.workArea.size.toLogical(monitor.scaleFactor),
-      )
+  const frameSize = { width: 0, height: 0 };
+  let availableInnerSize: LogicalWindowSize | undefined;
+  if (monitor) {
+    availableInnerSize = monitor.workArea.size.toLogical(monitor.scaleFactor);
+    if (reader.innerSize && reader.outerSize) {
+      const [innerSize, outerSize] = await Promise.all([
+        reader.innerSize(),
+        reader.outerSize(),
+      ]);
+      if (!isCurrent()) return null;
+      frameSize.width = Math.max(0, outerSize.width - innerSize.width);
+      frameSize.height = Math.max(0, outerSize.height - innerSize.height);
+      // Tauri sizes the inner rectangle but positions the outer rectangle.
+      availableInnerSize = {
+        width: Math.max(
+          1,
+          availableInnerSize.width - frameSize.width / monitor.scaleFactor,
+        ),
+        height: Math.max(
+          1,
+          availableInnerSize.height - frameSize.height / monitor.scaleFactor,
+        ),
+      };
+    }
+  }
+
+  const bounds = availableInnerSize
+    ? calculateWindowSizeBounds(availableInnerSize)
     : DEFAULT_APP_WINDOW_SIZE_BOUNDS;
-  return { bounds, monitor };
+  return { bounds, monitor, frameSize };
 }
 
 type FinalizeAppWindowLayoutOptions<Monitor extends WorkAreaMonitor> = {
   restored: boolean;
   measured: MeasuredWindowLayout<Monitor>;
   show: () => Promise<void>;
+  waitForSettled?: () => Promise<void>;
   measure: () => Promise<MeasuredWindowLayout<Monitor> | null>;
   setMinimumConstraints: (minimum: LogicalWindowSize) => Promise<void>;
   enforceBounds: (bounds: WindowSizeBounds) => Promise<void>;
@@ -61,6 +96,7 @@ export async function finalizeAppWindowLayout<Monitor extends WorkAreaMonitor>({
   restored,
   measured,
   show,
+  waitForSettled,
   measure,
   setMinimumConstraints,
   enforceBounds,
@@ -70,8 +106,11 @@ export async function finalizeAppWindowLayout<Monitor extends WorkAreaMonitor>({
   await show();
   if (!isCurrent()) return;
 
-  // Once visible, a restored window can resolve its saved secondary monitor.
+  // Native restore calls complete before GTK/Cocoa move and resize events have
+  // necessarily updated Tauri's cached geometry.
   if (restored) {
+    await waitForSettled?.();
+    if (!isCurrent()) return;
     measured = (await measure()) ?? measured;
     if (!isCurrent()) return;
   }

--- a/studio/frontend/src/app/window-layout.ts
+++ b/studio/frontend/src/app/window-layout.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export type LogicalWindowSize = {
+  width: number;
+  height: number;
+};
+
+export type PhysicalWindowRect = {
+  position: { x: number; y: number };
+  size: { width: number; height: number };
+};
+
+export type WindowSizeBounds = {
+  minimum: LogicalWindowSize;
+  maximum?: LogicalWindowSize;
+};
+
+export const MINIMUM_APP_WINDOW_SIZE: LogicalWindowSize = {
+  width: 900,
+  height: 600,
+};
+
+export const PREFERRED_SETUP_WINDOW_SIZE: LogicalWindowSize = {
+  width: 760,
+  height: 560,
+};
+
+// Preserve the nominal fallback when no monitor can be read.
+export const DEFAULT_APP_WINDOW_SIZE_BOUNDS: WindowSizeBounds = {
+  minimum: MINIMUM_APP_WINDOW_SIZE,
+};
+
+// Leave resize room when the nominal minimum does not fit.
+const RELAXED_MINIMUM_RATIO = 0.85;
+const FIRST_WINDOW_WIDTH_RATIO = 0.75;
+const FIRST_WINDOW_HEIGHT_RATIO = 0.85;
+const FIRST_WINDOW_ASPECT_RATIO = 1.618;
+
+function relaxMinimum(preferred: number, maximum: number): number {
+  if (preferred <= maximum) return preferred;
+  return Math.max(1, Math.floor(maximum * RELAXED_MINIMUM_RATIO));
+}
+
+/** Bounds a frameless window to the monitor work area. */
+export function calculateWindowSizeBounds(
+  workAreaSize: LogicalWindowSize,
+): WindowSizeBounds {
+  const maximum = {
+    width: Math.max(1, Math.floor(workAreaSize.width)),
+    height: Math.max(1, Math.floor(workAreaSize.height)),
+  };
+  return {
+    minimum: {
+      width: relaxMinimum(MINIMUM_APP_WINDOW_SIZE.width, maximum.width),
+      height: relaxMinimum(MINIMUM_APP_WINDOW_SIZE.height, maximum.height),
+    },
+    maximum,
+  };
+}
+
+export function fitWindowSize(
+  size: LogicalWindowSize,
+  maximum?: LogicalWindowSize,
+): LogicalWindowSize {
+  if (!maximum) return size;
+  return {
+    width: Math.min(size.width, maximum.width),
+    height: Math.min(size.height, maximum.height),
+  };
+}
+
+export function calculateFirstAppWindowSize(
+  { minimum, maximum }: WindowSizeBounds,
+  cssSafeLogicalWidth?: number,
+): LogicalWindowSize {
+  if (!maximum) return minimum;
+
+  const width = Math.max(
+    minimum.width,
+    Math.round(maximum.width * FIRST_WINDOW_WIDTH_RATIO),
+    Math.min(cssSafeLogicalWidth ?? 0, maximum.width),
+  );
+  // Preserve requested height when the work area is short.
+  const heightCap = Math.max(
+    MINIMUM_APP_WINDOW_SIZE.height,
+    Math.round(maximum.height * FIRST_WINDOW_HEIGHT_RATIO),
+  );
+  const height = Math.max(
+    minimum.height,
+    Math.min(Math.round(width / FIRST_WINDOW_ASPECT_RATIO), heightCap),
+  );
+  return fitWindowSize({ width, height }, maximum);
+}
+
+export function constrainWindowSize(
+  currentSize: LogicalWindowSize,
+  requestedSize: LogicalWindowSize,
+  { minimum, maximum }: WindowSizeBounds,
+): LogicalWindowSize {
+  return fitWindowSize(
+    {
+      width: Math.max(currentSize.width, minimum.width, requestedSize.width),
+      height: Math.max(
+        currentSize.height,
+        minimum.height,
+        requestedSize.height,
+      ),
+    },
+    maximum,
+  );
+}
+
+/** Centers a physical window size inside the work area. */
+export function calculateCenteredPosition(
+  workArea: PhysicalWindowRect,
+  windowSize: { width: number; height: number },
+): { x: number; y: number } {
+  return {
+    x:
+      workArea.position.x +
+      Math.max(0, Math.floor((workArea.size.width - windowSize.width) / 2)),
+    y:
+      workArea.position.y +
+      Math.max(0, Math.floor((workArea.size.height - windowSize.height) / 2)),
+  };
+}

--- a/studio/frontend/tests/window-layout.test.ts
+++ b/studio/frontend/tests/window-layout.test.ts
@@ -251,3 +251,32 @@ test("remeasures a restored window after show on its compact secondary", async (
   });
   assert.deepEqual(savedSize, { width: 900, height: 556 });
 });
+
+test("stale layouts do not show the window", async () => {
+  let shown = false;
+
+  await finalizeAppWindowLayout({
+    restored: false,
+    measured: {
+      bounds: {
+        minimum: { width: 900, height: 600 },
+      },
+      monitor: null,
+    },
+    show: async () => {
+      shown = true;
+    },
+    measure: async () => {
+      throw new Error("stale layouts must not remeasure");
+    },
+    setMinimumConstraints: async () => {
+      throw new Error("stale layouts must not set constraints");
+    },
+    enforceBounds: async () => {
+      throw new Error("stale layouts must not enforce bounds");
+    },
+    isCurrent: () => false,
+  });
+
+  assert.equal(shown, false);
+});

--- a/studio/frontend/tests/window-layout.test.ts
+++ b/studio/frontend/tests/window-layout.test.ts
@@ -126,6 +126,45 @@ test("fits the non-resizable setup window to the available area", () => {
   );
 });
 
+test("reserves the outer window frame inside the work area", async () => {
+  const monitor = {
+    scaleFactor: 1,
+    workArea: {
+      position: { x: 0, y: 0 },
+      size: {
+        width: 700,
+        height: 500,
+        toLogical: () => ({ width: 700, height: 500 }),
+      },
+    },
+  };
+  const measured = await measureWindowLayout(
+    {
+      currentMonitor: async () => monitor,
+      primaryMonitor: async () => monitor,
+      innerSize: async () => ({ width: 760, height: 560 }),
+      outerSize: async () => ({ width: 776, height: 577 }),
+    },
+    () => true,
+  );
+
+  assert.ok(measured);
+  assert.deepEqual(measured.frameSize, { width: 16, height: 17 });
+  assert.deepEqual(measured.bounds.maximum, { width: 684, height: 483 });
+  const setupSize = fitWindowSize(
+    PREFERRED_SETUP_WINDOW_SIZE,
+    measured.bounds.maximum,
+  );
+  assert.deepEqual(setupSize, { width: 684, height: 483 });
+  assert.deepEqual(
+    calculateCenteredPosition(monitor.workArea, {
+      width: setupSize.width + measured.frameSize.width,
+      height: setupSize.height + measured.frameSize.height,
+    }),
+    { x: 0, y: 0 },
+  );
+});
+
 test("caps an oversized window to a compact work area", () => {
   const bounds = calculateWindowSizeBounds({ width: 1080, height: 550 });
 
@@ -252,6 +291,52 @@ test("remeasures a restored window after show on its compact secondary", async (
   assert.deepEqual(savedSize, { width: 900, height: 556 });
 });
 
+test("waits for restored geometry before enforcing its minimum", async () => {
+  const events: string[] = [];
+  let currentSize = { width: 760, height: 560 };
+  const measured = {
+    bounds: {
+      minimum: { width: 900, height: 600 },
+      maximum: { width: 1920, height: 1040 },
+    },
+    monitor: null,
+    frameSize: { width: 0, height: 0 },
+  };
+
+  await finalizeAppWindowLayout({
+    restored: true,
+    measured,
+    show: async () => {
+      events.push("show");
+    },
+    waitForSettled: async () => {
+      events.push("settled");
+      currentSize = { width: 1200, height: 800 };
+    },
+    measure: async () => {
+      events.push("measure");
+      return measured;
+    },
+    setMinimumConstraints: async () => {
+      events.push("constraints");
+    },
+    enforceBounds: async (bounds) => {
+      events.push("enforce");
+      currentSize = constrainWindowSize(currentSize, bounds.minimum, bounds);
+    },
+    isCurrent: () => true,
+  });
+
+  assert.deepEqual(events, [
+    "show",
+    "settled",
+    "measure",
+    "constraints",
+    "enforce",
+  ]);
+  assert.deepEqual(currentSize, { width: 1200, height: 800 });
+});
+
 test("stale layouts do not show the window", async () => {
   let shown = false;
 
@@ -262,6 +347,7 @@ test("stale layouts do not show the window", async () => {
         minimum: { width: 900, height: 600 },
       },
       monitor: null,
+      frameSize: { width: 0, height: 0 },
     },
     show: async () => {
       shown = true;

--- a/studio/frontend/tests/window-layout.test.ts
+++ b/studio/frontend/tests/window-layout.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/app/window-layout.ts";
 import {
   finalizeAppWindowLayout,
+  shouldFinishWindowLayoutWait,
   measureWindowLayout,
 } from "../src/app/window-layout-lifecycle.ts";
 
@@ -31,6 +32,10 @@ function workArea(
   };
 }
 
+test("waits for the first native restore event before settling", () => {
+  assert.equal(shouldFinishWindowLayoutWait(false), false);
+  assert.equal(shouldFinishWindowLayoutWait(true), true);
+});
 test("keeps the nominal minimum and preferred size on a roomy work area", () => {
   const bounds = calculateWindowSizeBounds({ width: 1920, height: 1040 });
 

--- a/studio/frontend/tests/window-layout.test.ts
+++ b/studio/frontend/tests/window-layout.test.ts
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_APP_WINDOW_SIZE_BOUNDS,
+  PREFERRED_SETUP_WINDOW_SIZE,
+  calculateCenteredPosition,
+  calculateFirstAppWindowSize,
+  calculateWindowSizeBounds,
+  constrainWindowSize,
+  fitWindowSize,
+} from "../src/app/window-layout.ts";
+import {
+  finalizeAppWindowLayout,
+  measureWindowLayout,
+} from "../src/app/window-layout-lifecycle.ts";
+
+// A work area is the panel minus the taskbar, in logical pixels.
+function workArea(
+  width: number,
+  height: number,
+  taskbar: number,
+  scaleFactor: number,
+) {
+  return {
+    width: width / scaleFactor,
+    height: (height - taskbar) / scaleFactor,
+  };
+}
+
+test("keeps the nominal minimum and preferred size on a roomy work area", () => {
+  const bounds = calculateWindowSizeBounds({ width: 1920, height: 1040 });
+
+  assert.deepEqual(bounds.minimum, { width: 900, height: 600 });
+  assert.deepEqual(calculateFirstAppWindowSize(bounds), {
+    width: 1440,
+    height: 884,
+  });
+});
+
+test("fits a 1366x768 panel at 125% scaling above the taskbar", () => {
+  const bounds = calculateWindowSizeBounds(workArea(1366, 768, 40, 1.25));
+
+  assert.deepEqual(bounds.maximum, { width: 1092, height: 582 });
+  const size = calculateFirstAppWindowSize(bounds);
+  assert.deepEqual(size, { width: 900, height: 556 });
+  // The window clears the taskbar.
+  assert.ok(size.height <= (768 - 40) / 1.25);
+});
+
+test("fits a 1080p panel at 175% scaling above the taskbar", () => {
+  const bounds = calculateWindowSizeBounds(workArea(1920, 1080, 48, 1.75));
+
+  assert.deepEqual(bounds.maximum, { width: 1097, height: 589 });
+  const size = calculateFirstAppWindowSize(bounds);
+  assert.deepEqual(size, { width: 900, height: 556 });
+  assert.ok(size.height <= (1080 - 48) / 1.75);
+});
+
+test("fits a 1600x900 panel at 150% scaling above the taskbar", () => {
+  const bounds = calculateWindowSizeBounds(workArea(1600, 900, 40, 1.5));
+
+  assert.deepEqual(bounds.maximum, { width: 1066, height: 573 });
+  const size = calculateFirstAppWindowSize(bounds);
+  assert.deepEqual(size, { width: 900, height: 556 });
+  assert.ok(size.height <= (900 - 40) / 1.5);
+});
+
+test("preserves the desktop CSS width floor under Windows text scaling", () => {
+  const bounds = calculateWindowSizeBounds(workArea(2880, 1800, 0, 2.5));
+  const cssSafeLogicalWidth = 768 * 1.25;
+
+  assert.deepEqual(calculateFirstAppWindowSize(bounds, cssSafeLogicalWidth), {
+    width: 960,
+    height: 600,
+  });
+  assert.equal(960 / 1.25, 768);
+
+  const compactBounds = calculateWindowSizeBounds({ width: 920, height: 550 });
+  assert.deepEqual(
+    calculateFirstAppWindowSize(compactBounds, cssSafeLogicalWidth),
+    { width: 920, height: 550 },
+  );
+});
+
+test("relaxes a minimum that does not fit, keeping room to resize", () => {
+  for (const [panel, scaleFactor] of [
+    [768, 1.25],
+    [768, 1.5],
+    [1080, 1.75],
+    [900, 1.5],
+  ] as const) {
+    const { minimum, maximum } = calculateWindowSizeBounds(
+      workArea(1366, panel, 40, scaleFactor),
+    );
+    assert.ok(maximum);
+    assert.ok(
+      minimum.height <= maximum.height,
+      `minimum ${minimum.height} exceeds work area ${maximum.height}`,
+    );
+    // Keep a vertical resize range.
+    assert.ok(
+      minimum.height < maximum.height,
+      `minimum ${minimum.height} leaves no vertical resize range`,
+    );
+  }
+});
+
+test("fits the non-resizable setup window to the available area", () => {
+  const bounds = calculateWindowSizeBounds(workArea(1366, 768, 40, 1.5));
+
+  assert.deepEqual(fitWindowSize(PREFERRED_SETUP_WINDOW_SIZE, bounds.maximum), {
+    width: 760,
+    height: 485,
+  });
+  // Roomy panels retain the preferred size.
+  assert.deepEqual(
+    fitWindowSize(
+      PREFERRED_SETUP_WINDOW_SIZE,
+      calculateWindowSizeBounds({ width: 1920, height: 1040 }).maximum,
+    ),
+    PREFERRED_SETUP_WINDOW_SIZE,
+  );
+});
+
+test("caps an oversized window to a compact work area", () => {
+  const bounds = calculateWindowSizeBounds({ width: 1080, height: 550 });
+
+  assert.deepEqual(
+    constrainWindowSize({ width: 1400, height: 900 }, bounds.minimum, bounds),
+    { width: 1080, height: 550 },
+  );
+});
+
+test("grows past a stale setup size without exceeding the work area", () => {
+  const bounds = calculateWindowSizeBounds(workArea(1366, 768, 40, 1.25));
+  const requested = calculateFirstAppWindowSize(bounds);
+
+  assert.deepEqual(
+    constrainWindowSize({ width: 760, height: 560 }, requested, bounds),
+    { width: 900, height: 560 },
+  );
+});
+
+test("centers against the work area of the monitor it is on", () => {
+  const secondary = {
+    position: { x: 1920, y: 40 },
+    size: { width: 1366, height: 728 },
+  };
+
+  assert.deepEqual(
+    calculateCenteredPosition(secondary, { width: 1125, height: 728 }),
+    { x: 2040, y: 40 },
+  );
+  // Oversized windows pin to the work-area origin.
+  assert.deepEqual(
+    calculateCenteredPosition(secondary, { width: 1500, height: 800 }),
+    { x: 1920, y: 40 },
+  );
+});
+
+test("falls back to the nominal size when no monitor can be read", () => {
+  assert.deepEqual(
+    calculateFirstAppWindowSize(DEFAULT_APP_WINDOW_SIZE_BOUNDS),
+    {
+      width: 900,
+      height: 600,
+    },
+  );
+  assert.deepEqual(
+    fitWindowSize(PREFERRED_SETUP_WINDOW_SIZE, undefined),
+    PREFERRED_SETUP_WINDOW_SIZE,
+  );
+});
+
+test("remeasures a restored window after show on its compact secondary", async () => {
+  const events: string[] = [];
+  let visible = false;
+  let savedSize = { width: 900, height: 556 };
+  const monitor = (
+    name: string,
+    width: number,
+    height: number,
+    scale: number,
+  ) => ({
+    name,
+    scaleFactor: scale,
+    workArea: {
+      size: {
+        toLogical: () => ({ width: width / scale, height: height / scale }),
+      },
+    },
+  });
+  const primary = monitor("roomy primary", 1920, 1040, 1);
+  const secondary = monitor("compact secondary", 1366, 728, 1.25);
+  const currentMonitor = async () => {
+    events.push(`current:${visible ? "visible" : "hidden"}`);
+    return visible ? secondary : null;
+  };
+  const primaryMonitor = async () => {
+    events.push("primary");
+    return primary;
+  };
+  const measure = () =>
+    measureWindowLayout({ currentMonitor, primaryMonitor }, () => true);
+
+  let measured = await measure();
+  assert.ok(measured);
+  events.push("restore");
+  measured = (await measure()) ?? measured;
+
+  let constrainedMinimum: { width: number; height: number } | undefined;
+  let enforcementBounds: Parameters<typeof constrainWindowSize>[2] | undefined;
+  await finalizeAppWindowLayout({
+    restored: true,
+    measured,
+    show: async () => {
+      events.push("show");
+      visible = true;
+    },
+    measure,
+    setMinimumConstraints: async (minimum) => {
+      events.push("constraints");
+      constrainedMinimum = minimum;
+    },
+    enforceBounds: async (bounds) => {
+      events.push("enforce");
+      enforcementBounds = bounds;
+      savedSize = constrainWindowSize(savedSize, bounds.minimum, bounds);
+    },
+    isCurrent: () => true,
+  });
+
+  assert.deepEqual(events, [
+    "current:hidden",
+    "primary",
+    "restore",
+    "current:hidden",
+    "primary",
+    "show",
+    "current:visible",
+    "constraints",
+    "enforce",
+  ]);
+  assert.deepEqual(constrainedMinimum, { width: 900, height: 494 });
+  assert.deepEqual(enforcementBounds, {
+    minimum: { width: 900, height: 494 },
+  });
+  assert.deepEqual(savedSize, { width: 900, height: 556 });
+});

--- a/studio/frontend/tests/window-layout.test.ts
+++ b/studio/frontend/tests/window-layout.test.ts
@@ -259,6 +259,7 @@ test("remeasures a restored window after show on its compact secondary", async (
     show: async () => {
       events.push("show");
       visible = true;
+      return true;
     },
     measure,
     setMinimumConstraints: async (minimum) => {
@@ -308,6 +309,7 @@ test("waits for restored geometry before enforcing its minimum", async () => {
     measured,
     show: async () => {
       events.push("show");
+      return true;
     },
     waitForSettled: async () => {
       events.push("settled");
@@ -337,6 +339,42 @@ test("waits for restored geometry before enforcing its minimum", async () => {
   assert.deepEqual(currentSize, { width: 1200, height: 800 });
 });
 
+test("preserves restored geometry while an autostart window stays hidden", async () => {
+  const events: string[] = [];
+  const measured = {
+    bounds: {
+      minimum: { width: 900, height: 600 },
+      maximum: { width: 1920, height: 1040 },
+    },
+    monitor: null,
+    frameSize: { width: 0, height: 0 },
+  };
+
+  await finalizeAppWindowLayout({
+    restored: true,
+    measured,
+    show: async () => {
+      events.push("show");
+      return false;
+    },
+    waitForSettled: async () => {
+      events.push("settled");
+    },
+    measure: async () => {
+      events.push("measure");
+      return measured;
+    },
+    setMinimumConstraints: async () => {
+      events.push("constraints");
+    },
+    enforceBounds: async () => {
+      events.push("enforce");
+    },
+    isCurrent: () => true,
+  });
+
+  assert.deepEqual(events, ["show"]);
+});
 test("stale layouts do not show the window", async () => {
   let shown = false;
 
@@ -351,6 +389,7 @@ test("stale layouts do not show the window", async () => {
     },
     show: async () => {
       shown = true;
+      return true;
     },
     measure: async () => {
       throw new Error("stale layouts must not remeasure");

--- a/studio/src-tauri/capabilities/default.json
+++ b/studio/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "core:window:allow-show",
     "core:window:allow-hide",
     "core:window:allow-set-focus",
+    "core:window:allow-set-position",
     "core:window:allow-set-size",
     "core:window:allow-set-resizable",
     "core:window:allow-set-size-constraints",

--- a/studio/src-tauri/capabilities/default.json
+++ b/studio/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "core:window:allow-set-size-constraints",
     "core:window:allow-center",
     "core:window:allow-current-monitor",
+    "core:window:allow-primary-monitor",
     "core:window:allow-start-dragging",
     "core:window:allow-start-resize-dragging",
     "core:window:allow-minimize",

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -363,28 +363,40 @@ def test_full_app_layout_uses_its_own_initialized_marker():
 
     assert 'invoke<boolean>("has_initialized_app_window_layout")' in source
     setup_layout = source.split("async function showSetupWindow", 1)[1].split(
-        "async function enforceMinimumWindowSize", 1
+        "async function enforceWindowSizeBounds", 1
     )[0]
     reset_call = 'invoke("reset_app_window_layout_initialized")'
     assert reset_call in setup_layout
-    assert setup_layout.index(reset_call) < setup_layout.index("win.setSize")
+    assert setup_layout.index(reset_call) < setup_layout.index("placeWindow(")
     assert 'invoke("mark_app_window_layout_initialized")' in source
     assert "hasInitializedAppLayout && hasSavedState" in source
 
 
 def test_first_app_layout_survives_a_stale_setup_window_size():
     source = APP_PROVIDER.read_text(encoding = "utf-8")
-    minimum_helper = source.split("async function enforceMinimumWindowSize", 1)[1].split(
+    bounds_helper = source.split("async function enforceWindowSizeBounds", 1)[1].split(
         "async function applyAppWindowLayout", 1
     )[0]
     app_layout = source.split("async function applyAppWindowLayout", 1)[1].split(
         "async function showWindowFallback", 1
     )[0]
 
-    assert "requestedSize.width" in minimum_helper
-    assert "requestedSize.height" in minimum_helper
-    assert "requestedSize = { width: finalW, height: finalH };" in app_layout
-    assert "enforceMinimumWindowSize(win, LogicalSize, isCurrent, requestedSize)" in app_layout
+    assert "requestedSize: LogicalWindowSize = bounds.minimum" in bounds_helper
+    assert "constrainWindowSize(currentSize, requestedSize, bounds)" in bounds_helper
+    assert "const cssSafeLogicalWidth = measured.monitor" in app_layout
+    first_size_call = app_layout.split(
+        "requestedSize = calculateFirstAppWindowSize(", 1
+    )[1].split(");", 1)[0]
+    assert "measured.bounds," in first_size_call
+    assert "cssSafeLogicalWidth," in first_size_call
+    assert "finalizeAppWindowLayout({" in app_layout
+    assert "enforceWindowSizeBounds(" in app_layout
+    finalize_call = app_layout.split("finalizeAppWindowLayout({", 1)[1].split("});", 1)[0]
+    assert "measured," in finalize_call
+    # Limit the check to this call's arguments.
+    bounds_call = app_layout.split("enforceWindowSizeBounds(", 1)[1].split(");", 1)[0]
+    assert "bounds," in bounds_call
+    assert "requestedSize," in bounds_call
 
 
 def test_expanded_titlebar_button_and_corner_match_sidebar_edge():

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -384,9 +384,9 @@ def test_first_app_layout_survives_a_stale_setup_window_size():
     assert "requestedSize: LogicalWindowSize = bounds.minimum" in bounds_helper
     assert "constrainWindowSize(currentSize, requestedSize, bounds)" in bounds_helper
     assert "const cssSafeLogicalWidth = measured.monitor" in app_layout
-    first_size_call = app_layout.split(
-        "requestedSize = calculateFirstAppWindowSize(", 1
-    )[1].split(");", 1)[0]
+    first_size_call = app_layout.split("requestedSize = calculateFirstAppWindowSize(", 1)[1].split(
+        ");", 1
+    )[0]
     assert "measured.bounds," in first_size_call
     assert "cssSafeLogicalWidth," in first_size_call
     assert "finalizeAppWindowLayout({" in app_layout


### PR DESCRIPTION
## Summary

Studio sizes its desktop window from the monitor's full resolution, then enforces a 900x600 minimum. On displays whose usable area is shorter than 600 logical pixels, the window extends behind the taskbar or dock and cannot be resized to fit.

This PR sizes and positions desktop windows against `monitor.workArea`. It keeps the first app window and the non-resizable setup window inside the usable area while preserving the Windows text-scaling width floor.

## What changed

- Fit first-launch and setup window sizes to the monitor work area.
- Keep the 900x600 minimum when it fits. If it does not, relax the oversized dimension to 85 percent of the available space so the window remains resizable.
- Clear app-mode constraints before returning to the smaller setup window.
- Center using the requested physical size instead of stale GTK geometry immediately after a resize.
- Restore saved geometry before applying constraints, then remeasure once the window is visible so saved secondary-monitor placement uses the correct work area.
- Preserve restored window sizes unless they fall below the visible monitor's minimum.
- Leave maximized and fullscreen sizing to the window manager.
- Add the Tauri permission required for explicit window positioning.

## Behavior boundaries

- First launch retains the existing width ratio, aspect ratio, height cap, and Windows desktop CSS breakpoint floor.
- Setup and repair windows remain centered and non-resizable.
- Saved oversized windows are not capped against a temporary monitor fallback.
- Browser mode is unchanged.
- Existing windows are not continuously resized when moved between monitors.
- The nominal 900x600 fallback remains when no monitor can be resolved.

## Testing

- `npm test` (475 passed)
- Layout tests (12 passed)
- Desktop reliability frontend contract tests (25 passed)
- Rust app-layout tests (5 passed)
- `npm run typecheck`
- `npm run build`
- Focused ESLint and Prettier checks
- `git diff --check`

## Runtime validation

Ran the Linux Tauri app under Xvfb with Muffin on a 1000x500 display and a 40-pixel bottom dock. Muffin reported a 1000x460 work area. Studio opened at 900x460 at x=50, y=0 with a 900x391 minimum, fitting the usable area and retaining vertical resize room.

Windows, macOS, and real fractional-DPI multi-monitor hardware were not available. Their shared sizing and lifecycle paths are covered by deterministic tests.
