### PR TITLE
Desktop: Fix unresponsive model selector on Images/Video pages on macOS

### DIFF
--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2458,8 +2458,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     // titlebar here (34px on win/linux, 0 under macOS's native one) as chat does.
     <div className="diffusion-surface flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-[var(--studio-content-top-inset,0px)]">
       {/* Top: the model selector, sitting clear of the sidebar and level with the settings column below. Load progress shows in a toast. */}
-      <div className="relative flex h-[48px] shrink-0 items-start justify-between pl-[var(--studio-media-header-left-inset,1.5rem)] pr-2 pt-[var(--studio-chat-header-padding-top,11px)]">
-        <div className="flex items-center gap-2">
+      <div className="pointer-events-none relative z-40 flex h-[48px] shrink-0 items-start justify-between pl-[var(--studio-media-header-left-inset,1.5rem)] pr-2 pt-[var(--studio-chat-header-padding-top,11px)]">
+        <div className="pointer-events-auto flex items-center gap-2">
           {pageMode === "train" ? (
             <TrainBaseSelector
               families={trainFamilies}
@@ -2517,7 +2517,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             ]}
           />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="pointer-events-auto flex items-center gap-2">
           {/* Video is a separate page, so it sits out here rather than in the mode strip. */}
           <MediaPageLink to="/video" label="Video" icon={FlimSlateIcon} />
         </div>

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1508,8 +1508,8 @@ export function VideoPage({ active = true }: { active?: boolean }) {
     // titlebar here (34px on win/linux, 0 under macOS's native one) as chat does.
     <div className="diffusion-surface flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-[var(--studio-content-top-inset,0px)]">
       {/* Top: the model selector, sitting clear of the sidebar and level with the controls column below. Load progress shows in a toast. */}
-      <div className="flex h-[48px] shrink-0 items-start justify-between pl-[var(--studio-media-header-left-inset,1.5rem)] pr-2 pt-[var(--studio-chat-header-padding-top,11px)]">
-        <div className="flex items-center gap-3">
+      <div className="pointer-events-none relative z-40 flex h-[48px] shrink-0 items-start justify-between pl-[var(--studio-media-header-left-inset,1.5rem)] pr-2 pt-[var(--studio-chat-header-padding-top,11px)]">
+        <div className="pointer-events-auto flex items-center gap-3">
           <ModelSelector
             models={VIDEO_MODELS}
             value={status?.loaded ? status.repo_id ?? undefined : undefined}
@@ -1536,7 +1536,7 @@ export function VideoPage({ active = true }: { active?: boolean }) {
             </div>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="pointer-events-auto flex items-center gap-2">
           {/* Images is a separate page, so it sits out here, not in this page's controls. */}
           <MediaPageLink to="/images" label="Images" icon={Image03Icon} />
         </div>

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -3,6 +3,7 @@
 
 """Static contracts for focused packaged-desktop reliability behavior."""
 
+import re
 from pathlib import Path
 
 
@@ -556,6 +557,31 @@ def test_media_pages_clear_the_custom_titlebar():
     for page in (IMAGES_PAGE, VIDEO_PAGE):
         shell = page.read_text(encoding = "utf-8").split('"diffusion-surface', 1)[1].split(">", 1)[0]
         assert "pt-[var(--studio-content-top-inset,0px)]" in shell, page.name
+
+
+def test_media_page_headers_out_stack_the_mac_drag_region():
+    """macOS gives the media pages a 0px inset, so their 48px header lands on top of the
+    navbar's 34px drag strip. The band has to out-stack that strip yet stay click-through,
+    so its controls take clicks and its empty space still drags the window."""
+    navbar = NAVBAR.read_text(encoding = "utf-8")
+
+    # The strip the band has to beat: same z-40, but earlier in DOM order.
+    assert "pointer-events-none absolute inset-x-0 top-0 z-40 h-[48px]" in navbar
+    assert "data-tauri-drag-region" in navbar
+
+    for page in (IMAGES_PAGE, VIDEO_PAGE):
+        source = page.read_text(encoding = "utf-8")
+        before, marker, band = source.partition("h-[48px] shrink-0 items-start justify-between")
+        assert marker, page.name
+        opening = before.rsplit('<div className="', 1)[1]
+        for token in ("pointer-events-none", "relative", "z-40"):
+            assert token in opening, (page.name, token)
+
+        band = band.split("MediaPageLink", 1)[0]
+        groups = re.findall(r'<div className="([^"]*flex items-center gap-[^"]*)"', band)
+        assert len(groups) >= 2, (page.name, groups)
+        for group in groups:
+            assert "pointer-events-auto" in group, (page.name, group)
 
 
 def test_a_stopped_repair_update_is_recorded_as_canceled_not_failed():

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -560,12 +560,11 @@ def test_media_pages_clear_the_custom_titlebar():
 
 
 def test_media_page_headers_out_stack_the_mac_drag_region():
-    """macOS gives the media pages a 0px inset, so their 48px header lands on top of the
-    navbar's 34px drag strip. The band has to out-stack that strip yet stay click-through,
-    so its controls take clicks and its empty space still drags the window."""
+    """macOS insets the media pages 0px, so their 48px header overlaps the navbar's 34px drag
+    strip: the band must out-stack it yet stay click-through (controls click, gaps drag)."""
     navbar = NAVBAR.read_text(encoding = "utf-8")
 
-    # The strip the band has to beat: same z-40, but earlier in DOM order.
+    # The strip to beat: same z-40, but earlier in DOM order.
     assert "pointer-events-none absolute inset-x-0 top-0 z-40 h-[48px]" in navbar
     assert "data-tauri-drag-region" in navbar
 


### PR DESCRIPTION
On macOS, the Navbar renders an invisible titlebar drag strip across the top 34px of the window at z-40. The Images and Video page headers sat underneath it, so hovering or clicking "Select image model" / "Select video model" (and the Create/Train switch on Images) hit the drag strip instead of the controls the selector appeared completely unresponsive and clicks dragged the window.

Fix mirrors the chat header: the media page header bands are now relative z-40 pointer-events-none with pointer-events-auto on the control groups, so the controls sit above the drag strip while the empty header area still drags the window. Windows/Linux are unaffected (content there is already inset below the custom titlebar).
