### PR TITLE
Studio: send the GGUF filename when a collapsed On Device row is picked

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3542,6 +3542,7 @@ export function HubModelPicker({
       isLora: false,
       loadId: c.load_id,
       ggufVariant: variant.quant,
+      ggufFilename: variant.filename,
       isDownloaded: true,
       expectedBytes,
       isGguf: true,


### PR DESCRIPTION
## Problem

An image or video GGUF model already on disk cannot be loaded from the On Device list. Clicking it shows "Pick a quantization for this model to load it", on a row that already names its quantization. Reported on Discord against FLUX.2-klein.

## Root cause

#7736 collapses a repo holding a single quant into one row carrying that quant as a chip, and defaults "Show all quantizations" to off, so that row is what most people see. Its pick sends `ggufVariant` but not `ggufFilename`. Images and Video gate their GGUF load branch on both fields, so the pick falls through to the direct-file branch, which rejects the repo id for not ending in `.gguf`. The diffusion pages landed after that row, in #6763, so this path has never loaded.

The quant label cannot stand in for the filename: GGUF filenames do not follow the repo name (`FLUX.1-schnell` publishes `flux1-schnell-*.gguf`). The row already holds the exact name in `sole.variant.filename`.

## Fix

Send `ggufFilename` with the pick. This also fixes picking one of these models from the chat picker, which forwards that field as `?quant=` when routing to Images or Video and was forwarding nothing.

## Testing

- `node --experimental-strip-types --test "tests/**/*.test.ts"` (724 passed)
- `git diff --check`
