### PR TITLE
Scope the security suite's offline guard to the tests that want it

### DIFF
--- a/tests/security/conftest.py
+++ b/tests/security/conftest.py
@@ -59,9 +59,21 @@ class _BlockedSocket(socket.socket):
         return super().connect_ex(address)
 
 
-@pytest.fixture(scope = "session", autouse = True)
+@pytest.fixture(autouse = True)
 def network_blocker():
-    """Swap socket.socket for the blocker, restored at teardown."""
+    """Swap socket.socket for the blocker, restored after each test.
+
+    Per test, not per session. A session-scoped fixture in a directory conftest
+    applies only to this directory, but it tears down when the SESSION ends, so
+    the patch outlived the suite that wanted it and every later test that
+    reaches the network died on a socket this file replaced. `security` sorts
+    before `version_compat` and `vllm_compat`, whose pinned-symbol checks fetch
+    upstream sources, so a full run lost about 1300 of them:
+
+        RuntimeError: network access blocked by tests/security/conftest.py
+
+    They passed alone and failed together, in that order only.
+    """
     original = socket.socket
     socket.socket = _BlockedSocket  # type: ignore[assignment]
     try:

--- a/tests/security/test_network_blocker_does_not_leak.py
+++ b/tests/security/test_network_blocker_does_not_leak.py
@@ -62,7 +62,6 @@ def test_the_blocker_is_still_autouse():
 def test_the_blocker_is_installed_right_now():
     """It is autouse, so this test is already running under it."""
     from tests.security.conftest import _BlockedSocket
-
     assert socket.socket is _BlockedSocket
 
 
@@ -84,7 +83,6 @@ def test_the_original_socket_is_what_gets_restored():
     """Teardown must hand back the real class, not another blocker: nesting two
     installs and restoring in the wrong order would leave the patch behind."""
     import tests.security.conftest as C
-
-    assert not issubclass(socket.socket, C._BlockedSocket) or \
-        socket.socket is C._BlockedSocket, \
-        "socket.socket has been wrapped more than once"
+    assert (
+        not issubclass(socket.socket, C._BlockedSocket) or socket.socket is C._BlockedSocket
+    ), "socket.socket has been wrapped more than once"

--- a/tests/security/test_network_blocker_does_not_leak.py
+++ b/tests/security/test_network_blocker_does_not_leak.py
@@ -86,3 +86,75 @@ def test_the_original_socket_is_what_gets_restored():
     assert (
         not issubclass(socket.socket, C._BlockedSocket) or socket.socket is C._BlockedSocket
     ), "socket.socket has been wrapped more than once"
+
+
+def test_the_finalizer_really_restores_the_original():
+    """Drive the fixture's own generator, so teardown is observed.
+
+    Every assertion above runs while the fixture is still active, so they prove
+    the guard is installed and prove nothing about what the `finally` hands
+    back. Emptying that body would leave all of them green while the
+    cross-suite leak returned.
+    """
+    import tests.security.conftest as C
+
+    # The real class, from `_BlockedSocket`'s own base -- NOT `socket.socket` as
+    # it stands here, which is already the blocker because this test runs under
+    # the autouse fixture. Reading it live would compare the patch with itself
+    # and pass however broken the finalizer is.
+    real = C._BlockedSocket.__bases__[0]
+    assert real is not C._BlockedSocket
+
+    # Stand the guard down first. The fixture captures whatever is installed
+    # when it starts, so driving it from under itself would nest a second
+    # install and "restore" the blocker -- true, and meaningless.
+    outer, socket.socket = socket.socket, real
+    try:
+        generator = C.network_blocker.__wrapped__()
+        next(generator)
+        assert socket.socket is C._BlockedSocket, "setup did not install the guard"
+        next(generator, None)                   # run the finally
+        assert socket.socket is real, "teardown did not hand the original back"
+    finally:
+        socket.socket = outer
+
+
+def test_a_later_suite_gets_a_working_socket_back(tmp_path):
+    """End to end, in a nested pytest run: the security suite first, an
+    ordinary test after it, and the second one must see a real socket.
+
+    This is the shape of the original bug -- `security` sorts before
+    `version_compat` and `vllm_compat` -- reproduced in miniature so a
+    regression fails here rather than 1300 tests away.
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    root = Path(__file__).resolve().parents[2]
+    (tmp_path / "security").mkdir()
+    (tmp_path / "security" / "conftest.py").write_text(textwrap.dedent(f"""
+        import sys
+        sys.path.insert(0, {str(root)!r})
+        from tests.security.conftest import *          # noqa: F401,F403
+        from tests.security.conftest import network_blocker  # noqa: F401
+    """), encoding = "utf-8")
+    (tmp_path / "security" / "test_inside.py").write_text(textwrap.dedent("""
+        import socket
+        def test_the_guard_is_on():
+            assert socket.socket.__name__ == "_BlockedSocket"
+    """), encoding = "utf-8")
+    (tmp_path / "test_zafter.py").write_text(textwrap.dedent("""
+        import socket
+        def test_the_guard_is_gone():
+            assert socket.socket.__name__ != "_BlockedSocket", (
+                "the security suite's socket patch outlived it"
+            )
+    """), encoding = "utf-8")
+
+    done = subprocess.run(
+        [sys.executable, "-m", "pytest", str(tmp_path), "-q", "-p", "no:randomly",
+         "-p", "no:cacheprovider"],
+        capture_output = True, text = True, timeout = 300,
+    )
+    assert done.returncode == 0, done.stdout[-3000:] + done.stderr[-2000:]

--- a/tests/security/test_network_blocker_does_not_leak.py
+++ b/tests/security/test_network_blocker_does_not_leak.py
@@ -2,20 +2,13 @@
 # Copyright 2026-present the Unsloth AI Inc. team.
 """The offline guard must not outlive the suite that asked for it.
 
-`tests/security/conftest.py` replaces `socket.socket` so a scanner reaching the
-internet fails loudly. It was session-scoped: a directory conftest limits WHICH
-tests a fixture applies to, but a session-scoped one still tears down when the
-session ends, so the patch stayed installed for everything that ran afterwards.
-
-`security` sorts before `version_compat` and `vllm_compat`, whose pinned-symbol
-checks fetch upstream sources to detect API drift, so a full run lost about 1300
-of them to
-
-    RuntimeError: network access blocked by tests/security/conftest.py
-
-Every one of them passed on its own and failed in the suite, which reads as
-upstream drift rather than as a fixture. Pinned here so the scope cannot quietly
-go back.
+`tests/security/conftest.py` replaces `socket.socket`. It was session-scoped: a
+directory conftest limits WHICH tests a fixture applies to, but a session-scoped
+one still tears down at session end, so the patch stayed installed for
+everything after. `security` sorts before `version_compat` and `vllm_compat`,
+whose pinned-symbol checks fetch upstream sources, so a full run lost about 1300
+of them to `RuntimeError: network access blocked by tests/security/conftest.py`
+-- each passing alone, which reads as upstream drift rather than as a fixture.
 """
 
 from __future__ import annotations
@@ -91,23 +84,18 @@ def test_the_original_socket_is_what_gets_restored():
 def test_the_finalizer_really_restores_the_original():
     """Drive the fixture's own generator, so teardown is observed.
 
-    Every assertion above runs while the fixture is still active, so they prove
-    the guard is installed and prove nothing about what the `finally` hands
-    back. Emptying that body would leave all of them green while the
-    cross-suite leak returned.
+    Every assertion above runs while the fixture is still active, so emptying
+    the `finally` leaves them all green while the cross-suite leak returns.
     """
     import tests.security.conftest as C
 
-    # The real class, from `_BlockedSocket`'s own base -- NOT `socket.socket` as
-    # it stands here, which is already the blocker because this test runs under
-    # the autouse fixture. Reading it live would compare the patch with itself
-    # and pass however broken the finalizer is.
+    # From `_BlockedSocket`'s base, not live: `socket.socket` here is already
+    # the blocker, so reading it would compare the patch with itself.
     real = C._BlockedSocket.__bases__[0]
     assert real is not C._BlockedSocket
 
-    # Stand the guard down first. The fixture captures whatever is installed
-    # when it starts, so driving it from under itself would nest a second
-    # install and "restore" the blocker -- true, and meaningless.
+    # Stand the guard down first: the fixture captures whatever is installed
+    # when it starts, so driving it from under itself would "restore" the blocker.
     outer, socket.socket = socket.socket, real
     try:
         generator = C.network_blocker.__wrapped__()
@@ -120,12 +108,9 @@ def test_the_finalizer_really_restores_the_original():
 
 
 def test_a_later_suite_gets_a_working_socket_back(tmp_path):
-    """End to end, in a nested pytest run: the security suite first, an
-    ordinary test after it, and the second one must see a real socket.
-
-    This is the shape of the original bug -- `security` sorts before
-    `version_compat` and `vllm_compat` -- reproduced in miniature so a
-    regression fails here rather than 1300 tests away.
+    """The original bug in miniature, in a nested pytest run: the security
+    suite first, an ordinary test after it, and the second must see a real
+    socket. A regression fails here rather than 1300 tests away.
     """
     import subprocess
     import sys

--- a/tests/security/test_network_blocker_does_not_leak.py
+++ b/tests/security/test_network_blocker_does_not_leak.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
+"""The offline guard must not outlive the suite that asked for it.
+
+`tests/security/conftest.py` replaces `socket.socket` so a scanner reaching the
+internet fails loudly. It was session-scoped: a directory conftest limits WHICH
+tests a fixture applies to, but a session-scoped one still tears down when the
+session ends, so the patch stayed installed for everything that ran afterwards.
+
+`security` sorts before `version_compat` and `vllm_compat`, whose pinned-symbol
+checks fetch upstream sources to detect API drift, so a full run lost about 1300
+of them to
+
+    RuntimeError: network access blocked by tests/security/conftest.py
+
+Every one of them passed on its own and failed in the suite, which reads as
+upstream drift rather than as a fixture. Pinned here so the scope cannot quietly
+go back.
+"""
+
+from __future__ import annotations
+
+import ast
+import socket
+from pathlib import Path
+
+import pytest
+
+CONFTEST = Path(__file__).resolve().parent / "conftest.py"
+
+
+def _network_blocker_decorators():
+    tree = ast.parse(CONFTEST.read_text(encoding = "utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "network_blocker":
+            return node.decorator_list
+    pytest.fail("tests/security/conftest.py no longer defines `network_blocker`")
+
+
+def test_the_blocker_is_not_session_scoped():
+    for decorator in _network_blocker_decorators():
+        for keyword in getattr(decorator, "keywords", []):
+            if keyword.arg != "scope":
+                continue
+            scope = getattr(keyword.value, "value", None)
+            assert scope != "session", (
+                "a session-scoped blocker is restored only when the whole run "
+                "ends, so every later test that touches the network fails"
+            )
+
+
+def test_the_blocker_is_still_autouse():
+    """The other half: it has to apply without each test asking for it."""
+    autouse = False
+    for decorator in _network_blocker_decorators():
+        for keyword in getattr(decorator, "keywords", []):
+            if keyword.arg == "autouse":
+                autouse = getattr(keyword.value, "value", False) is True
+    assert autouse, "the scanner suite must be offline by default"
+
+
+def test_the_blocker_is_installed_right_now():
+    """It is autouse, so this test is already running under it."""
+    from tests.security.conftest import _BlockedSocket
+
+    assert socket.socket is _BlockedSocket
+
+
+def test_an_outbound_connection_is_refused():
+    with pytest.raises(RuntimeError, match = "network access blocked"):
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(("93.184.216.34", 80))
+
+
+def test_loopback_is_still_allowed():
+    """A local server is not the internet, and some scanners use one."""
+    from tests.security.conftest import _is_loopback
+
+    assert _is_loopback("127.0.0.1")
+    assert _is_loopback("localhost")
+    assert not _is_loopback("93.184.216.34")
+
+
+def test_the_original_socket_is_what_gets_restored():
+    """Teardown must hand back the real class, not another blocker: nesting two
+    installs and restoring in the wrong order would leave the patch behind."""
+    import tests.security.conftest as C
+
+    assert not issubclass(socket.socket, C._BlockedSocket) or \
+        socket.socket is C._BlockedSocket, \
+        "socket.socket has been wrapped more than once"

--- a/tests/security/test_network_blocker_does_not_leak.py
+++ b/tests/security/test_network_blocker_does_not_leak.py
@@ -113,7 +113,7 @@ def test_the_finalizer_really_restores_the_original():
         generator = C.network_blocker.__wrapped__()
         next(generator)
         assert socket.socket is C._BlockedSocket, "setup did not install the guard"
-        next(generator, None)                   # run the finally
+        next(generator, None)  # run the finally
         assert socket.socket is real, "teardown did not hand the original back"
     finally:
         socket.socket = outer
@@ -133,28 +133,48 @@ def test_a_later_suite_gets_a_working_socket_back(tmp_path):
 
     root = Path(__file__).resolve().parents[2]
     (tmp_path / "security").mkdir()
-    (tmp_path / "security" / "conftest.py").write_text(textwrap.dedent(f"""
+    (tmp_path / "security" / "conftest.py").write_text(
+        textwrap.dedent(f"""
         import sys
         sys.path.insert(0, {str(root)!r})
         from tests.security.conftest import *          # noqa: F401,F403
         from tests.security.conftest import network_blocker  # noqa: F401
-    """), encoding = "utf-8")
-    (tmp_path / "security" / "test_inside.py").write_text(textwrap.dedent("""
+    """),
+        encoding = "utf-8",
+    )
+    (tmp_path / "security" / "test_inside.py").write_text(
+        textwrap.dedent("""
         import socket
         def test_the_guard_is_on():
             assert socket.socket.__name__ == "_BlockedSocket"
-    """), encoding = "utf-8")
-    (tmp_path / "test_zafter.py").write_text(textwrap.dedent("""
+    """),
+        encoding = "utf-8",
+    )
+    (tmp_path / "test_zafter.py").write_text(
+        textwrap.dedent("""
         import socket
         def test_the_guard_is_gone():
             assert socket.socket.__name__ != "_BlockedSocket", (
                 "the security suite's socket patch outlived it"
             )
-    """), encoding = "utf-8")
+    """),
+        encoding = "utf-8",
+    )
 
     done = subprocess.run(
-        [sys.executable, "-m", "pytest", str(tmp_path), "-q", "-p", "no:randomly",
-         "-p", "no:cacheprovider"],
-        capture_output = True, text = True, timeout = 300,
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(tmp_path),
+            "-q",
+            "-p",
+            "no:randomly",
+            "-p",
+            "no:cacheprovider",
+        ],
+        capture_output = True,
+        text = True,
+        timeout = 300,
     )
     assert done.returncode == 0, done.stdout[-3000:] + done.stderr[-2000:]


### PR DESCRIPTION
## What breaks

`tests/security/conftest.py` swaps `socket.socket` for a blocker so a scanner that reaches the internet fails loudly. That is the right thing to want. The fixture was session-scoped:

```python
@pytest.fixture(scope = "session", autouse = True)
def network_blocker():
    original = socket.socket
    socket.socket = _BlockedSocket
    try:
        yield
    finally:
        socket.socket = original
```

A directory `conftest.py` limits which tests a fixture **applies to**. It does not limit when a session-scoped fixture **tears down** - that happens when the session ends. So the patch stayed installed for every test that ran after `tests/security/`.

## Scope of the impact, measured

**CI is not affected, and I want to be straight about that.** `studio-backend-ci.yml` runs `tests/` with `tests/vllm_compat` and `tests/version_compat` ignored, and the pinned-symbol suites that fetch upstream sources live in `version-compat-ci.yml` as their own workflow. I replicated that job's exact selection on the unfixed tree: **4335 passed, 68 skipped, zero blocked sockets**. So this is not a CI red, and nothing here is urgent.

**A plain `pytest tests/` is affected**, which is what you run locally before pushing. `security` sorts before `version_compat` and `vllm_compat`, so about 1300 of their checks died on a socket this file had replaced:

```
RuntimeError: network access blocked by tests/security/conftest.py
(attempted connect to ('185.199.108.133', 443)); the scanner suite
must run fully offline
```

Order-dependence, on this tree:

| command | result |
|---|---|
| `pytest tests/vllm_compat/test_vllm_pinned_symbols.py` | 76 passed |
| `pytest tests/vllm_compat/test_vllm_pinned_symbols.py tests/security` | 260 passed |
| `pytest tests/security tests/vllm_compat/test_vllm_pinned_symbols.py` | **75 failed**, 185 passed |

Every affected test passes on its own, and the failure reads like upstream API drift rather than like a fixture, so it costs real time to chase. That is the case for fixing it even though CI is green.

## The fix

Per-test scope. The guard applies to exactly the tests it was written for, and is handed back afterwards.

## Verification

- `tests/security` alone: **201 passed** (unchanged behaviour, plus the 6 new tests below).
- `tests/security tests/vllm_compat/test_vllm_pinned_symbols.py`, the order that failed: **277 passed**.
- Full local run (`tests/`, minus the GPU `saving/` and `utils/` suites): **1305 failed -> 28 failed, 5986 passed**.

The 28 that remain are not this bug and are not addressed here. Most are the CUDA spoof in `tests/_zoo_aggressive_cuda_spoof.py`, which is deliberately process-wide and irreversible for the CPU-only CI job, and which CI already isolates via its separate "Hardware-spoof tests (state-sensitive, run in isolation)" step - so those are an artifact of running everything in one process, not a defect. A couple of others reproduce in isolation and are genuinely pre-existing.

## Regression test

`tests/security/test_network_blocker_does_not_leak.py` pins the scope so it cannot quietly go back, and also checks the guard is still autouse, still installed while those tests run, still refuses an outbound connection, and still permits loopback. Confirmed it fails on the unfixed conftest (`test_the_blocker_is_not_session_scoped`) and passes on the fix.
