### PR TITLE
Compare the drafter path with forward slashes on Windows too

### DIFF
--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1233,9 +1233,11 @@ def test_cached_dspark_lookup_prefers_q8_and_excludes_dflash(tmp_path, monkeypat
     # `as_posix()`, because the lookup returns an OS-native path: on Windows it
     # comes back with backslashes and the literal below never matched, so this
     # was the one red in an otherwise green cross-platform run.
-    assert Path(
-        backend._cached_repo_dspark_drafter("some/repo")
-    ).as_posix().endswith("dspark/dspark-model-Q8_0.gguf")
+    assert (
+        Path(backend._cached_repo_dspark_drafter("some/repo"))
+        .as_posix()
+        .endswith("dspark/dspark-model-Q8_0.gguf")
+    )
 
 
 # ── Deletion: only auto-fetched companions are reclaimed ─────────────

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1230,9 +1230,12 @@ def test_cached_dspark_lookup_prefers_q8_and_excludes_dflash(tmp_path, monkeypat
     )
     backend = llama_cpp_module.LlamaCppBackend.__new__(llama_cpp_module.LlamaCppBackend)
 
-    assert backend._cached_repo_dspark_drafter("some/repo").endswith(
-        "dspark/dspark-model-Q8_0.gguf"
-    )
+    # `as_posix()`, because the lookup returns an OS-native path: on Windows it
+    # comes back with backslashes and the literal below never matched, so this
+    # was the one red in an otherwise green cross-platform run.
+    assert Path(
+        backend._cached_repo_dspark_drafter("some/repo")
+    ).as_posix().endswith("dspark/dspark-model-Q8_0.gguf")
 
 
 # ── Deletion: only auto-fetched companions are reclaimed ─────────────


### PR DESCRIPTION
## What breaks

`_cached_repo_dspark_drafter` returns an OS-native path. On Windows that is

```
C:\Users\runneradmin\...\snapshot\dspark\dspark-model-Q8_0.gguf
```

and the test asserts

```python
assert backend._cached_repo_dspark_drafter("some/repo").endswith(
    "dspark/dspark-model-Q8_0.gguf"
)
```

Forward slashes against backslashes, so it can only fail there. Green on Linux and macOS, red on Windows:

```
AssertionError: assert False
 +  where False = 'C:\\...\\snapshot\\dspark\\dspark-model-Q8_0.gguf'.endswith('dspark/dspark-model-Q8_0.gguf')
```

## How it surfaced

Running the Studio drafter work across the OS triple on a staging fork. Everything else came back green - `macos-14`, `ubuntu-latest`, the Playwright job, and the native `Mac Studio UI + API + Update`, `Mac Studio GGUF`, `Windows Unsloth API` and `Windows Unsloth UI` workflows. This assertion was the only red in the set, and it is the test rather than the code: returning a native path is correct.

## The fix

Compare through `Path(...).as_posix()`.

```python
>>> win = r"C:\Users\runneradmin\...\snapshot\dspark\dspark-model-Q8_0.gguf"
>>> win.endswith("dspark/dspark-model-Q8_0.gguf")
False
>>> PureWindowsPath(win).as_posix().endswith("dspark/dspark-model-Q8_0.gguf")
True
```

## Scope

An AST scan over the whole `studio/` tree for the same shape - a filesystem-path literal containing a separator, compared with `startswith`/`endswith` - finds no other instance. The other `endswith` hits in these tests are URLs, which are `/` on every platform. So this is the only one, and the change is a single assertion.

Locally: the three files the Windows job runs are `162 passed`.