### PR TITLE
Studio: do not fail a cached dataset load on a bookkeeping write

### DIFF
--- a/studio/backend/hub/utils/dataset_cache.py
+++ b/studio/backend/hub/utils/dataset_cache.py
@@ -11,6 +11,8 @@ import tempfile
 from pathlib import Path, PurePosixPath
 from typing import Any, Optional
 
+from loggers import get_logger
+
 from hub.utils.dataset_processed_cache import (
     mark_app_processed_dataset_cache_complete,
     normalized_commit_hash,
@@ -23,6 +25,7 @@ from hub.utils.hf_cache_state import (
     validated_repo_cache_path,
 )
 
+logger = get_logger(__name__)
 
 TRAINING_DATA_EXTS = (".parquet", ".json", ".jsonl", ".csv")
 
@@ -556,7 +559,19 @@ def load_cached_hf_dataset(
         )
     dataset = load_dataset(**kwargs)
     if app_cache is not None:
-        mark_app_processed_dataset_cache_complete(app_cache)
+        # Best effort on purpose. The completion flag is advisory -- nothing reads it
+        # back to gate a load -- so a cache purge racing this load, a read-only studio
+        # home, or a full disk must not discard a dataset that already loaded. Letting
+        # it propagate costs a full Hub re-download of a perfectly good cached dataset,
+        # and fails the run outright when offline or resuming with exact resources.
+        try:
+            mark_app_processed_dataset_cache_complete(app_cache)
+        except (OSError, RuntimeError, ValueError):
+            logger.warning(
+                "Could not record processed dataset cache completion for %s",
+                repo_id,
+                exc_info = True,
+            )
     return dataset
 
 

--- a/studio/backend/hub/utils/dataset_cache.py
+++ b/studio/backend/hub/utils/dataset_cache.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 from loggers import get_logger
 
 from hub.utils.dataset_processed_cache import (
+    UnsafeDatasetCachePathError,
     mark_app_processed_dataset_cache_complete,
     normalized_commit_hash,
     prepare_app_processed_dataset_cache,
@@ -564,8 +565,15 @@ def load_cached_hf_dataset(
         # home, or a full disk must not discard a dataset that already loaded. Letting
         # it propagate costs a full Hub re-download of a perfectly good cached dataset,
         # and fails the run outright when offline or resuming with exact resources.
+        #
+        # UnsafeDatasetCachePathError is deliberately not best effort. Marking is the
+        # only check that runs after the load, so it is what catches the entry being
+        # swapped for a symlink or an escape between prepare and here. Swallowing that
+        # would hand back a dataset read from outside the trusted cache root.
         try:
             mark_app_processed_dataset_cache_complete(app_cache)
+        except UnsafeDatasetCachePathError:
+            raise
         except (OSError, RuntimeError, ValueError):
             logger.warning(
                 "Could not record processed dataset cache completion for %s",

--- a/studio/backend/hub/utils/dataset_processed_cache.py
+++ b/studio/backend/hub/utils/dataset_processed_cache.py
@@ -155,6 +155,16 @@ def _cache_root_is_present() -> bool:
         root_path = app_processed_dataset_cache_root().expanduser()
     except (OSError, RuntimeError, TypeError, ValueError):
         return False
+    # The configured root is the trust anchor, so classify it too -- the walk below only
+    # covers its descendants. Anything ABOVE it is the user's own filesystem layout and
+    # deliberately out of scope. This only runs once resolution has already failed, so a
+    # live symlink pointing the cache at another volume -- a legitimate setup -- resolves
+    # normally and never reaches here.
+    try:
+        if configured_root.is_symlink():
+            return True
+    except OSError:
+        return True
     if _symlinked_component(root_path, configured_root) is not None:
         return True
     try:

--- a/studio/backend/hub/utils/dataset_processed_cache.py
+++ b/studio/backend/hub/utils/dataset_processed_cache.py
@@ -116,6 +116,29 @@ def _resolved_app_processed_dataset_cache_root(*, create: bool) -> Optional[Path
         return None
 
 
+def _symlinked_component(path: Path, root: Path) -> Optional[Path]:
+    """First symlinked component on the way from ``root`` down to ``path``, if any.
+
+    Walks the components rather than testing only the leaf, because a swapped hashed
+    parent redirects the entry just as effectively as a swapped leaf, and ``is_symlink()``
+    on the leaf reports False in that case. Returns None when ``path`` is not lexically
+    under ``root``; the caller's escape check covers that.
+    """
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return None
+    current = root
+    for part in relative.parts:
+        current = current / part
+        try:
+            if current.is_symlink():
+                return current
+        except OSError:
+            return current
+    return None
+
+
 def _cache_root_is_present() -> bool:
     try:
         root_path = app_processed_dataset_cache_root().expanduser()
@@ -206,12 +229,15 @@ def mark_app_processed_dataset_cache_complete(entry: AppProcessedDatasetCache) -
         if _cache_root_is_present():
             raise UnsafeDatasetCachePathError("Dataset cache root is not inside the trusted root")
         raise FileNotFoundError("Dataset cache root is unavailable")
-    # Classify a symlinked entry BEFORE resolving it. A symlink whose target is removed
+    # Classify symlinked components BEFORE resolving. A symlink whose target is removed
     # between the load and here makes strict resolution raise FileNotFoundError, which a
     # best-effort caller reads as "the entry was purged" -- hiding the very swap this
-    # check exists to catch.
-    if entry.path.is_symlink() or entry.cache_dir.is_symlink():
-        raise UnsafeDatasetCachePathError(f"Dataset cache path is a symlink: {entry.path}")
+    # check exists to catch. Every component under the root has to be checked, not just
+    # the leaf: swapping a hashed parent redirects the entry just as effectively.
+    for candidate in (entry.path, entry.cache_dir):
+        linked = _symlinked_component(candidate, root)
+        if linked is not None:
+            raise UnsafeDatasetCachePathError(f"Dataset cache path is a symlink: {linked}")
     entry_path = entry.path.resolve(strict = True)
     try:
         entry_path.relative_to(root)

--- a/studio/backend/hub/utils/dataset_processed_cache.py
+++ b/studio/backend/hub/utils/dataset_processed_cache.py
@@ -140,8 +140,24 @@ def _symlinked_component(path: Path, root: Path) -> Optional[Path]:
 
 
 def _cache_root_is_present() -> bool:
+    """Whether the root is present-but-unresolvable rather than simply gone.
+
+    A dangling symlink anywhere between ``cache_root()`` and ``snapshot-loads`` leaves
+    ``exists()`` False on the leaf -- it follows the broken parent -- while the tree has
+    in fact been redirected. Testing only the leaf therefore reports a redirected root as
+    a plain missing directory, which the caller treats as a benign purge. Walk the
+    components so any link in the chain counts as present.
+    """
+    from utils.paths.storage_roots import cache_root
+
     try:
+        configured_root = Path(cache_root()).expanduser()
         root_path = app_processed_dataset_cache_root().expanduser()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+    if _symlinked_component(root_path, configured_root) is not None:
+        return True
+    try:
         return root_path.is_symlink() or root_path.exists()
     except (OSError, RuntimeError, TypeError, ValueError):
         return False

--- a/studio/backend/hub/utils/dataset_processed_cache.py
+++ b/studio/backend/hub/utils/dataset_processed_cache.py
@@ -206,6 +206,12 @@ def mark_app_processed_dataset_cache_complete(entry: AppProcessedDatasetCache) -
         if _cache_root_is_present():
             raise UnsafeDatasetCachePathError("Dataset cache root is not inside the trusted root")
         raise FileNotFoundError("Dataset cache root is unavailable")
+    # Classify a symlinked entry BEFORE resolving it. A symlink whose target is removed
+    # between the load and here makes strict resolution raise FileNotFoundError, which a
+    # best-effort caller reads as "the entry was purged" -- hiding the very swap this
+    # check exists to catch.
+    if entry.path.is_symlink() or entry.cache_dir.is_symlink():
+        raise UnsafeDatasetCachePathError(f"Dataset cache path is a symlink: {entry.path}")
     entry_path = entry.path.resolve(strict = True)
     try:
         entry_path.relative_to(root)
@@ -213,8 +219,6 @@ def mark_app_processed_dataset_cache_complete(entry: AppProcessedDatasetCache) -
         raise UnsafeDatasetCachePathError(
             f"Dataset cache entry escapes the cache root: {entry.path}"
         ) from error
-    if entry.path.is_symlink() or entry.cache_dir.is_symlink():
-        raise UnsafeDatasetCachePathError(f"Dataset cache path is a symlink: {entry.path}")
     _atomic_write_metadata(
         entry_path / _METADATA_FILENAME,
         _metadata_payload(

--- a/studio/backend/hub/utils/dataset_processed_cache.py
+++ b/studio/backend/hub/utils/dataset_processed_cache.py
@@ -20,6 +20,16 @@ _CACHE_DIRNAME = "snapshot-loads"
 _METADATA_FILENAME = "metadata.json"
 
 
+class UnsafeDatasetCachePathError(OSError):
+    """A processed cache entry is not provably inside the trusted cache root.
+
+    Kept distinct from a plain ``OSError`` so a caller doing best-effort bookkeeping can
+    swallow "the write did not land" (purged entry, read-only home, full disk) without
+    also swallowing "this path is no longer trusted". Subclasses ``OSError`` so existing
+    ``except OSError`` callers keep catching it.
+    """
+
+
 @dataclass(frozen = True)
 class AppProcessedDatasetCache:
     repo_id: str
@@ -106,6 +116,14 @@ def _resolved_app_processed_dataset_cache_root(*, create: bool) -> Optional[Path
         return None
 
 
+def _cache_root_is_present() -> bool:
+    try:
+        root_path = app_processed_dataset_cache_root().expanduser()
+        return root_path.is_symlink() or root_path.exists()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+
+
 def _atomic_write_metadata(path: Path, payload: dict[str, Any]) -> None:
     temporary = path.with_name(f".{path.name}.tmp-{uuid.uuid4().hex[:8]}")
     try:
@@ -182,11 +200,21 @@ def prepare_app_processed_dataset_cache(repo_id: str, snapshot: Path) -> AppProc
 def mark_app_processed_dataset_cache_complete(entry: AppProcessedDatasetCache) -> None:
     root = _resolved_app_processed_dataset_cache_root(create = False)
     if root is None:
-        raise OSError("Dataset cache root is unavailable")
+        # A root that is simply gone was purged out from under us -- benign. A root that
+        # is still there but would not resolve inside the trusted root is a symlink or an
+        # escape, so it must not be reported as a mere missing directory.
+        if _cache_root_is_present():
+            raise UnsafeDatasetCachePathError("Dataset cache root is not inside the trusted root")
+        raise FileNotFoundError("Dataset cache root is unavailable")
     entry_path = entry.path.resolve(strict = True)
-    entry_path.relative_to(root)
+    try:
+        entry_path.relative_to(root)
+    except ValueError as error:
+        raise UnsafeDatasetCachePathError(
+            f"Dataset cache entry escapes the cache root: {entry.path}"
+        ) from error
     if entry.path.is_symlink() or entry.cache_dir.is_symlink():
-        raise OSError(f"Dataset cache path is a symlink: {entry.path}")
+        raise UnsafeDatasetCachePathError(f"Dataset cache path is a symlink: {entry.path}")
     _atomic_write_metadata(
         entry_path / _METADATA_FILENAME,
         _metadata_payload(

--- a/studio/backend/tests/test_dataset_cache_paths.py
+++ b/studio/backend/tests/test_dataset_cache_paths.py
@@ -4,6 +4,7 @@
 import errno
 import json
 import os
+import shutil
 import sys
 import time
 import types
@@ -915,6 +916,28 @@ def test_completion_marking_reports_a_swapped_in_symlink_as_unsafe(tmp_path):
     entry.cache_dir.rmdir()
     entry.cache_dir.symlink_to(external, target_is_directory = True)
 
+    with pytest.raises(dataset_processed_cache.UnsafeDatasetCachePathError):
+        dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
+
+
+def test_completion_marking_reports_a_dangling_symlink_as_unsafe(tmp_path):
+    """A symlinked entry whose target disappears is still a swap, not a purge.
+
+    Strict resolution raises ``FileNotFoundError`` for a dangling link, which a
+    best-effort caller reads as "the entry was purged" -- so the symlink has to be
+    classified before the entry is resolved, or the swap is silently tolerated.
+    """
+    repo_id = "Org/Data"
+    _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")
+    (snapshot / "train.parquet").write_bytes(b"rows")
+    entry = dataset_processed_cache.prepare_app_processed_dataset_cache(repo_id, snapshot)
+    external = tmp_path / "external"
+    external.mkdir()
+    shutil.rmtree(entry.path)
+    entry.path.symlink_to(external, target_is_directory = True)
+    external.rmdir()
+
+    assert entry.path.is_symlink() and not entry.path.exists()
     with pytest.raises(dataset_processed_cache.UnsafeDatasetCachePathError):
         dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
 

--- a/studio/backend/tests/test_dataset_cache_paths.py
+++ b/studio/backend/tests/test_dataset_cache_paths.py
@@ -942,6 +942,33 @@ def test_completion_marking_reports_a_dangling_symlink_as_unsafe(tmp_path):
         dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
 
 
+@pytest.mark.parametrize("swap", ["leaf", "parent", "grandparent"])
+def test_completion_marking_reports_a_symlinked_ancestor_as_unsafe(tmp_path, swap):
+    """A swapped hashed parent redirects the entry just as well as a swapped leaf.
+
+    ``is_symlink()`` on the leaf reports False when an ancestor is the link, so checking
+    only the leaf leaves the dangling-ancestor case to strict resolution, which raises
+    ``FileNotFoundError`` and reads as a benign purge.
+    """
+    repo_id = "Org/Data"
+    _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")
+    (snapshot / "train.parquet").write_bytes(b"rows")
+    entry = dataset_processed_cache.prepare_app_processed_dataset_cache(repo_id, snapshot)
+    external = tmp_path / "external"
+    external.mkdir()
+    target = {
+        "leaf": entry.path,
+        "parent": entry.path.parent,
+        "grandparent": entry.path.parent.parent,
+    }[swap]
+    shutil.rmtree(target)
+    target.symlink_to(external, target_is_directory = True)
+    external.rmdir()
+
+    with pytest.raises(dataset_processed_cache.UnsafeDatasetCachePathError):
+        dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
+
+
 def test_cached_load_still_fails_on_an_unsafe_cache_path(monkeypatch, tmp_path):
     """Best effort covers a failed write, never a path that left the trusted cache root."""
     repo_id = "Org/Data"

--- a/studio/backend/tests/test_dataset_cache_paths.py
+++ b/studio/backend/tests/test_dataset_cache_paths.py
@@ -969,6 +969,47 @@ def test_completion_marking_reports_a_symlinked_ancestor_as_unsafe(tmp_path, swa
         dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
 
 
+@pytest.mark.parametrize("swap", ["snapshot_loads", "hf_datasets"])
+def test_completion_marking_reports_a_symlinked_root_ancestor_as_unsafe(tmp_path, swap):
+    """A redirected root is not a missing root.
+
+    ``exists()`` on the leaf follows a dangling parent and reports False, so testing only
+    the leaf makes a redirected cache root look like a plain purge -- which the caller
+    swallows.
+    """
+    repo_id = "Org/Data"
+    _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")
+    (snapshot / "train.parquet").write_bytes(b"rows")
+    entry = dataset_processed_cache.prepare_app_processed_dataset_cache(repo_id, snapshot)
+    root = dataset_processed_cache.app_processed_dataset_cache_root()
+    target = root if swap == "snapshot_loads" else root.parent
+    external = tmp_path / "external"
+    external.mkdir()
+    shutil.rmtree(target)
+    target.symlink_to(external, target_is_directory = True)
+    external.rmdir()
+
+    with pytest.raises(dataset_processed_cache.UnsafeDatasetCachePathError):
+        dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
+
+
+def test_completion_marking_treats_a_real_purge_as_benign(tmp_path):
+    """The counterpart: a root that is genuinely gone must stay a benign failure.
+
+    Tightening the symlink classification must not turn an ordinary cache purge into a
+    hard failure, which would defeat the point of the best-effort handler.
+    """
+    repo_id = "Org/Data"
+    _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")
+    (snapshot / "train.parquet").write_bytes(b"rows")
+    entry = dataset_processed_cache.prepare_app_processed_dataset_cache(repo_id, snapshot)
+    shutil.rmtree(dataset_processed_cache.app_processed_dataset_cache_root().parent)
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
+    assert not isinstance(excinfo.value, dataset_processed_cache.UnsafeDatasetCachePathError)
+
+
 def test_cached_load_still_fails_on_an_unsafe_cache_path(monkeypatch, tmp_path):
     """Best effort covers a failed write, never a path that left the trusted cache root."""
     repo_id = "Org/Data"

--- a/studio/backend/tests/test_dataset_cache_paths.py
+++ b/studio/backend/tests/test_dataset_cache_paths.py
@@ -871,6 +871,35 @@ def test_app_processed_cache_is_deterministic_and_discoverable(monkeypatch, tmp_
     assert list(dataset_processed_cache.iter_app_processed_dataset_caches()) == [second]
 
 
+def test_cached_load_survives_a_failed_completion_write(monkeypatch, tmp_path):
+    """A dataset that loaded must not be discarded because bookkeeping failed.
+
+    ``complete`` is advisory -- nothing reads it back to gate a load -- so a cache purge
+    racing the load, a read-only studio home or a full disk must not turn a successful
+    cached load into an exception. Propagating it costs a full Hub re-download of a good
+    cached dataset, and fails the run outright offline or on an exact-resource resume.
+    """
+    repo_id = "Org/Data"
+    _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")
+    (snapshot / "train.parquet").write_bytes(b"rows")
+    calls = _fake_datasets(monkeypatch)
+
+    def _explode(entry):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(dataset_cache, "mark_app_processed_dataset_cache_complete", _explode)
+
+    result = dataset_cache.load_cached_hf_dataset(
+        repo_id,
+        str(snapshot),
+        subset = None,
+        split = "train",
+    )
+
+    assert result == {"loaded": True}
+    assert len(calls) == 1
+
+
 def test_app_processed_cache_rejects_symlinked_parent(monkeypatch, tmp_path):
     repo_id = "Org/Data"
     _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")

--- a/studio/backend/tests/test_dataset_cache_paths.py
+++ b/studio/backend/tests/test_dataset_cache_paths.py
@@ -993,6 +993,50 @@ def test_completion_marking_reports_a_symlinked_root_ancestor_as_unsafe(tmp_path
         dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
 
 
+def test_completion_marking_reports_a_symlinked_cache_root_as_unsafe(tmp_path):
+    """The configured root is the trust anchor, so it is classified too.
+
+    The descendant walk starts below it, so a swap of the configured directory itself
+    would otherwise leave every walked child reporting False.
+    """
+    repo_id = "Org/Data"
+    _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")
+    (snapshot / "train.parquet").write_bytes(b"rows")
+    entry = dataset_processed_cache.prepare_app_processed_dataset_cache(repo_id, snapshot)
+    configured = tmp_path / "app-cache"
+    external = tmp_path / "external"
+    external.mkdir()
+    shutil.rmtree(configured)
+    configured.symlink_to(external, target_is_directory = True)
+    external.rmdir()
+
+    with pytest.raises(dataset_processed_cache.UnsafeDatasetCachePathError):
+        dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
+
+
+def test_completion_marking_allows_a_live_symlinked_cache_root(tmp_path):
+    """Pointing the cache at another volume is a legitimate setup, not an attack.
+
+    Only a root that fails to resolve is suspicious. A live symlink resolves normally and
+    must keep working, or this hardening breaks anyone who moved their cache off the
+    system disk.
+    """
+    repo_id = "Org/Data"
+    _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")
+    (snapshot / "train.parquet").write_bytes(b"rows")
+    real_cache = tmp_path / "real-cache"
+    real_cache.mkdir()
+    (tmp_path / "app-cache").symlink_to(real_cache, target_is_directory = True)
+
+    entry = dataset_processed_cache.prepare_app_processed_dataset_cache(repo_id, snapshot)
+    dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
+
+    assert (
+        dataset_processed_cache.prepare_app_processed_dataset_cache(repo_id, snapshot).complete
+        is True
+    )
+
+
 def test_completion_marking_treats_a_real_purge_as_benign(tmp_path):
     """The counterpart: a root that is genuinely gone must stay a benign failure.
 

--- a/studio/backend/tests/test_dataset_cache_paths.py
+++ b/studio/backend/tests/test_dataset_cache_paths.py
@@ -900,6 +900,46 @@ def test_cached_load_survives_a_failed_completion_write(monkeypatch, tmp_path):
     assert len(calls) == 1
 
 
+def test_completion_marking_reports_a_swapped_in_symlink_as_unsafe(tmp_path):
+    """Marking is the only check that runs after the load, so it must still fail loudly.
+
+    ``prepare`` validates the entry, then the load runs; an entry swapped for a symlink in
+    that window is caught here or nowhere.
+    """
+    repo_id = "Org/Data"
+    _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")
+    (snapshot / "train.parquet").write_bytes(b"rows")
+    entry = dataset_processed_cache.prepare_app_processed_dataset_cache(repo_id, snapshot)
+    external = tmp_path / "external"
+    external.mkdir()
+    entry.cache_dir.rmdir()
+    entry.cache_dir.symlink_to(external, target_is_directory = True)
+
+    with pytest.raises(dataset_processed_cache.UnsafeDatasetCachePathError):
+        dataset_processed_cache.mark_app_processed_dataset_cache_complete(entry)
+
+
+def test_cached_load_still_fails_on_an_unsafe_cache_path(monkeypatch, tmp_path):
+    """Best effort covers a failed write, never a path that left the trusted cache root."""
+    repo_id = "Org/Data"
+    _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")
+    (snapshot / "train.parquet").write_bytes(b"rows")
+    _fake_datasets(monkeypatch)
+
+    def _unsafe(entry):
+        raise dataset_processed_cache.UnsafeDatasetCachePathError("cache path is a symlink")
+
+    monkeypatch.setattr(dataset_cache, "mark_app_processed_dataset_cache_complete", _unsafe)
+
+    with pytest.raises(dataset_processed_cache.UnsafeDatasetCachePathError):
+        dataset_cache.load_cached_hf_dataset(
+            repo_id,
+            str(snapshot),
+            subset = None,
+            split = "train",
+        )
+
+
 def test_app_processed_cache_rejects_symlinked_parent(monkeypatch, tmp_path):
     repo_id = "Org/Data"
     _, snapshot = _dataset_repo(tmp_path, repo_id, "commit-a")


### PR DESCRIPTION
Follow-up to my testing on #7633, against the merged result on main. One commit, two files.

`load_cached_hf_dataset` calls `mark_app_processed_dataset_cache_complete` immediately after the dataset has already loaded, uncaught:

```python
dataset = load_dataset(**kwargs)
if app_cache is not None:
    mark_app_processed_dataset_cache_complete(app_cache)
return dataset
```

That call raises in ordinary situations. Probed against a real cached snapshot in an isolated `UNSLOTH_STUDIO_HOME`:

| scenario | exception |
|---|---|
| cache purged mid-load (user deletes the dataset cache) | `FileNotFoundError` |
| studio cache root gone | `OSError` |
| read-only volume or full disk | `PermissionError` |

End-to-end through the real loader, with the entry directory read-only:

```
call 2, entry dir read-only:
  RAISED PermissionError: [Errno 13] Permission denied: .../.metadata.json.tmp-3d8f59fa
  ...the identical load with the dir writable returns 51760 rows
```

The dataset loaded fine. Only the metadata write failed, and it takes the load down with it.

## Why the consequence is out of proportion

The flag being recorded is advisory. Nothing outside `dataset_processed_cache.py` reads `complete` back — no load, inventory or deletion path gates on it — so failing to write it costs nothing on its own.

The fallout is not advisory though. `FileNotFoundError` and `PermissionError` both classify as cache-artifact errors, so:

- a normal cached start discards a perfectly good cached dataset and **re-downloads the whole thing from the Hub**
- an offline start, or a resume that requires exact resources, has no fallback and **fails the run**

## The change

Make it best effort and log. This matches how the rest of the module already treats this cache — `_read_cache_entry`, `iter_app_processed_dataset_caches` and `delete_app_processed_dataset_caches` all swallow `(OSError, RuntimeError, ValueError)`.

## Verification

The new test fails with `PermissionError` without the change and passes with it. On this branch:

```
tests/test_dataset_cache_paths.py          87 passed
tests/test_training_cached_start.py       162 passed
tests/test_gguf_load_cache_reuse.py        40 passed
hub/tests/test_dataset_services.py         31 passed
```

Tested on an M2 MacBook Air (16GB); the probing is filesystem-level so it is not Apple-Silicon specific.

## Unrelated, but worth recording

While tracing this I checked the disk-duplication issue I raised on #7633 (the Studio-private Arrow copy per snapshot revision). **It is properly addressed now.** The inventory surfaces it — it correctly reported a real 40.4 MB entry attributed to `yahma/alpaca-cleaned` — and `delete_app_processed_dataset_caches` reclaims it, including when the repo id is passed with different casing. The `row_limit` streaming path also skips creating it entirely for sliced runs: about 15 training runs against a cached dataset wrote nothing new to `~/.unsloth/studio/cache/hf-datasets`.
