### PR TITLE
release-desktop: skip the Defender scan when Defender is unavailable

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -982,8 +982,32 @@ jobs:
           Update-MpSignature -UpdateSource MicrosoftUpdateServer -ErrorAction Continue
           & $mp -SignatureUpdate 2>&1 | Write-Host
 
-          $status = Get-MpComputerStatus
-          $pref = Get-MpPreference
+          # Read these defensively. A runner can come up with the Defender WMI
+          # provider dead ("Provider load failure") and the service RPC endpoint
+          # down (0x800106ba), which is how the platform incident on 2026-08-06
+          # presented: the cmdlets throw, $status/$pref land null, and every check
+          # below then reads as a misconfiguration it is not.
+          $status = $null
+          $pref = $null
+          $unavailable = @()
+          try { $status = Get-MpComputerStatus -ErrorAction Stop }
+          catch { $unavailable += "Get-MpComputerStatus: $($_.Exception.Message)" }
+          try { $pref = Get-MpPreference -ErrorAction Stop }
+          catch { $unavailable += "Get-MpPreference: $($_.Exception.Message)" }
+          if (-not $unavailable -and -not $status) { $unavailable += 'Get-MpComputerStatus returned nothing' }
+          if (-not $unavailable -and -not $pref)   { $unavailable += 'Get-MpPreference returned nothing' }
+
+          # Absent scanner vs. bad verdict. Everything below this point assumes a
+          # Defender that answers; when it does not answer at all there is no scan
+          # to interpret, so skip instead of failing closed. This is deliberately
+          # narrow: it triggers only when the cmdlets themselves fail, which is an
+          # unavailable engine. A Defender that IS present but misconfigured still
+          # fails below, and an actual detection still fails the job.
+          if ($unavailable) {
+            Write-Host "::warning::Defender is unavailable on this runner ($($unavailable -join '; ')); skipping the bundle scan. This is a missing scanner, not a clean verdict - these bundles were not scanned."
+            exit 0
+          }
+
           Write-Host "engine $($status.AMEngineVersion), signatures $($status.AntivirusSignatureVersion) ($($status.AntivirusSignatureLastUpdated))"
 
           # Set-MpPreference can return cleanly and still be ignored, so verify.


### PR DESCRIPTION
## Summary

Treat an *unavailable* Defender as "no scan happened" and skip, instead of failing the release. A Defender that is present but misconfigured still fails closed, and an actual detection still fails the job. Nothing about the detection path changes.

## Why

Two consecutive `Build Windows (x64)` attempts on run [31117717223](https://github.com/unslothai/unsloth/actions/runs/31117717223) failed at `Scan Windows bundles with Defender` during the 2026-08-06 Actions incident. Neither failure was a detection. The runners came up with the Defender WMI provider dead and the service RPC endpoint down:

```
Update-MpSignature: The remote procedure call failed.
Get-MpComputerStatus: Provider load failure
Get-MpPreference:    Provider load failure
ERROR: ValidateMapsConnection failed (0x800106ba)
[Failed][0x800106ba] The RPC server is unavailable.
##[error]Defender cannot give an authoritative verdict here
  (RealTimeProtectionEnabled=false (AMRunningMode=); MAPSReporting=, expected 2 (Advanced))
```

`Get-MpComputerStatus` and `Get-MpPreference` threw, so `$status` and `$pref` were null. Every downstream check then read a null as a *misconfiguration* (`RealTimeProtectionEnabled=false`, `MAPSReporting=<empty>`) and the gate failed closed. The Windows app itself built and signed successfully both times.

The gate was doing the right thing with the information it had, but it could not tell "Defender says this is bad" from "there is no Defender here". Those deserve different outcomes.

## What changed

`Get-MpComputerStatus` / `Get-MpPreference` are now read through `try`/`catch` with `-ErrorAction Stop`. If either throws or yields nothing, the step emits a warning naming the failure and exits 0 without scanning.

The trigger is deliberately narrow: only the cmdlets themselves failing, which means the engine is not answering at all. Anything that can still produce a verdict keeps the old behaviour.

The warning states plainly that the bundles were **not** scanned, so a skip is never mistaken for a clean result in the log.

## Behaviour matrix

| Defender state | Before | After |
| --- | --- | --- |
| Cmdlets throw / return nothing (engine unavailable) | fail | **skip with warning** |
| Present but misconfigured (RTP off, MAPS not Advanced, ...) | fail | fail (unchanged) |
| Present, configured, bundle flagged | fail | fail (unchanged) |
| Present, configured, bundle clean | scan and pass | scan and pass (unchanged) |

## Checks

- `release-desktop.yml` parses as YAML.
- The step's `run:` script parses with 0 errors via `[System.Management.Automation.Language.Parser]`.
- The branch logic was exercised against stubbed cmdlets for all four rows above and produced skip / fail / fail / proceed respectively.

## Tradeoff

This accepts an unscanned Windows bundle when the runner's scanner is broken, rather than blocking the release. That is a deliberate loosening of a supply-chain gate. The alternative, waiting for a healthy runner, is unbounded when the degradation is fleet-wide, as it was here. The signing path is untouched, so bundles remain signed and `Verify every executable in the Windows bundles is signed` still runs.
