### PR TITLE
Normalize the /api/health wait and extract it into one script

### DIFF
--- a/.github/scripts/wait-for-health.sh
+++ b/.github/scripts/wait-for-health.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+#
+# Poll a booted Studio's /api/health until it reports healthy, and on timeout
+# print the tail of that server's log before failing.
+#
+# Usage:
+#   wait-for-health.sh --port 18888 [--log logs/studio.log] [--tmp /tmp/health.json]
+#
+# Fourteen steps across eight workflows ran this same poll, in two dialects that
+# disagreed about what a failure looks like. This is the union of the two, taking
+# the better half of each:
+#
+#  * Retry on ANY not-yet-healthy answer, not just on a refused connection. The
+#    "exit-0" dialect ran `jq -e` as a bare command under `bash -e`, so a server
+#    that answered the very first poll with `status != "healthy"` failed the step
+#    on the spot instead of giving the model loader the remaining seconds. The
+#    other eleven copies already retried; now all fourteen do.
+#  * Tail the log when the deadline passes. Eleven copies ended on a bare
+#    `jq -e '.status == "healthy"'`, whose entire output on failure is a non-zero
+#    exit code -- no message, and nothing about why the server never came up. The
+#    log tail is the only place that says.
+#
+# Parameters, and why each one is a parameter:
+#
+#  * --port  differs per call site; several workflows run two or three servers in
+#            one job on different ports.
+#  * --log   is whichever log the matching boot-studio-api-only.sh call was told
+#            to write. Five distinct names are in use, and tailing the wrong one
+#            on failure is worse than tailing none.
+#  * --tmp   is where the last poll's response body is left for later steps and
+#            for a human reading the runner. Five distinct names are in use so
+#            that a later phase in the same job does not overwrite the evidence
+#            an earlier phase left behind.
+#
+# The deadline is fixed at 180s because all fourteen converted call sites used
+# 180. The three "boot briefly to confirm the install is still usable" steps poll
+# for 60s, but they also boot and kill the server in the same shell and keep the
+# pid in a local variable, so they are not call sites for this and no --timeout
+# flag exists yet to serve them.
+
+set -uo pipefail
+
+# Every converted call site polled for 180s, and studio-ui-smoke.yml carried the
+# reason: a cold runner with venv warm-up plus lazy imports has been seen to
+# exceed 60s, and failing the wait costs more than waiting two more minutes.
+TIMEOUT_SECONDS=180
+
+PORT=""
+LOG="logs/studio.log"
+TMP="/tmp/health.json"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --port) PORT="$2"; shift 2 ;;
+    --log)  LOG="$2";  shift 2 ;;
+    --tmp)  TMP="$2";  shift 2 ;;
+    *) echo "wait-for-health.sh: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$PORT" ] || { echo "wait-for-health.sh: --port is required" >&2; exit 2; }
+
+for _ in $(seq 1 "$TIMEOUT_SECONDS"); do
+  if curl -fs "http://127.0.0.1:${PORT}/api/health" > "$TMP" \
+     && jq -e '.status == "healthy"' "$TMP" > /dev/null; then
+    echo "[health] 127.0.0.1:${PORT} reported healthy"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Unsloth did not become healthy in ${TIMEOUT_SECONDS}s"
+if [ -f "$LOG" ]; then
+  tail -200 "$LOG"
+else
+  echo "wait-for-health.sh: no log at '$LOG' to tail" >&2
+fi
+exit 1

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -30,6 +30,8 @@ on:
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
+      # Same for the /api/health wait that runs after a boot.
+      - '.github/scripts/wait-for-health.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -131,13 +133,7 @@ jobs:
 
       - name: Wait for /api/health
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
-              jq -e '.status == "healthy"' /tmp/health.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health.json
+          bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Pass bootstrap password + rotated targets to the test
         # The test does its own bootstrap-login + rotation to exercise

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -41,6 +41,8 @@ on:
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
+      # Same for the /api/health wait that runs after a boot.
+      - '.github/scripts/wait-for-health.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -145,16 +147,7 @@ jobs:
 
       - name: Wait for /api/health
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
-              jq -e '.status == "healthy"' /tmp/health.json
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "Unsloth did not become healthy in 180s"
-          tail -200 logs/studio.log
-          exit 1
+          bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Password rotation (old must fail, new must work)
         run: |

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -43,6 +43,8 @@ on:
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
+      # Same for the /api/health wait that runs after a boot.
+      - '.github/scripts/wait-for-health.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -209,16 +211,7 @@ jobs:
       - name: Wait for /api/health
         timeout-minutes: 5
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
-              jq -e '.status == "healthy"' /tmp/health.json
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "Unsloth did not become healthy in 180s"
-          tail -200 logs/studio.log
-          exit 1
+          bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Password rotation (old must fail, new must work)
         timeout-minutes: 3

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -38,6 +38,8 @@ on:
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
+      # Same for the /api/health wait that runs after a boot.
+      - '.github/scripts/wait-for-health.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -203,13 +205,7 @@ jobs:
 
       - name: Wait for /api/health
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
-              jq -e '.status == "healthy"' /tmp/health.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health.json
+          bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Pass bootstrap password to the Playwright step
         run: |
@@ -305,13 +301,8 @@ jobs:
 
       - name: Wait for /api/health on 18897
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:18897/api/health" > /tmp/health2.json; then
-              jq -e '.status == "healthy"' /tmp/health2.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health2.json
+          bash .github/scripts/wait-for-health.sh \
+            --port 18897 --log logs/studio_extra.log --tmp /tmp/health2.json
 
       - name: Pass bootstrap pw for extra UI test
         run: |
@@ -401,13 +392,8 @@ jobs:
 
       - name: Wait for /api/health on 18894
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:18894/api/health" > /tmp/health_api.json; then
-              jq -e '.status == "healthy"' /tmp/health_api.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health_api.json
+          bash .github/scripts/wait-for-health.sh \
+            --port 18894 --log logs/studio_api.log --tmp /tmp/health_api.json
 
       - name: Pass bootstrap password + rotated targets to the API test
         run: |

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -32,6 +32,8 @@ on:
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
+      # Same for the /api/health wait that runs after a boot.
+      - '.github/scripts/wait-for-health.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -142,17 +144,11 @@ jobs:
           bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
-        # 180 s -- a cold runner with venv warm-up + lazy imports has
-        # been seen to exceed 60 s. Failing the wait is more expensive
-        # than waiting an extra two minutes.
+        # The 180 s deadline lives in wait-for-health.sh, along with the
+        # reason for it: a cold runner with venv warm-up + lazy imports
+        # has been seen to exceed 60 s.
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
-              jq -e '.status == "healthy"' /tmp/health.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health.json
+          bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Pass bootstrap password to the Playwright step
         # The Playwright test does its OWN /change-password through the
@@ -218,13 +214,8 @@ jobs:
 
       - name: Wait for /api/health on 18894
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:18894/api/health" > /tmp/health2.json; then
-              jq -e '.status == "healthy"' /tmp/health2.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health2.json
+          bash .github/scripts/wait-for-health.sh \
+            --port 18894 --log logs/studio_extra.log --tmp /tmp/health2.json
 
       - name: Pass bootstrap pw for extra UI test
         run: |
@@ -275,13 +266,8 @@ jobs:
 
       - name: Wait for /api/health on 18898
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:18898/api/health" > /tmp/health4.json; then
-              jq -e '.status == "healthy"' /tmp/health4.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health4.json
+          bash .github/scripts/wait-for-health.sh \
+            --port 18898 --log logs/studio_modelcfg.log --tmp /tmp/health4.json
 
       - name: Pass bootstrap pw for model-config test
         run: |
@@ -318,13 +304,8 @@ jobs:
 
       - name: Wait for /api/health on 18896
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:18896/api/health" > /tmp/health3.json; then
-              jq -e '.status == "healthy"' /tmp/health3.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health3.json
+          bash .github/scripts/wait-for-health.sh \
+            --port 18896 --log logs/studio_ime.log --tmp /tmp/health3.json
 
       - name: Pass bootstrap pw for IME / i18n test
         # IME smoke does the change-password against the bootstrap that

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -25,6 +25,8 @@ on:
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
+      # Same for the /api/health wait that runs after a boot.
+      - '.github/scripts/wait-for-health.sh'
   push:
     branches: [main, pip]
   workflow_dispatch:
@@ -198,13 +200,7 @@ jobs:
 
       - name: Wait for /api/health
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
-              jq -e '.status == "healthy"' /tmp/health.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health.json
+          bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Pass bootstrap password + rotated targets to the test
         run: |

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -39,6 +39,8 @@ on:
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
+      # Same for the /api/health wait that runs after a boot.
+      - '.github/scripts/wait-for-health.sh'
   push:
     branches: [main, pip]
   workflow_dispatch:
@@ -331,16 +333,7 @@ jobs:
       - name: Wait for /api/health
         timeout-minutes: 10
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
-              jq -e '.status == "healthy"' /tmp/health.json
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "Unsloth did not become healthy in 180s"
-          tail -200 logs/studio.log
-          exit 1
+          bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Password rotation (old must fail, new must work)
         timeout-minutes: 3

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -24,6 +24,8 @@ on:
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
+      # Same for the /api/health wait that runs after a boot.
+      - '.github/scripts/wait-for-health.sh'
   push:
     branches: [main, pip]
   workflow_dispatch:
@@ -315,13 +317,7 @@ jobs:
 
       - name: Wait for /api/health
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
-              jq -e '.status == "healthy"' /tmp/health.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health.json
+          bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Pass bootstrap password to the Playwright step
         run: |
@@ -367,13 +363,8 @@ jobs:
 
       - name: Wait for /api/health on 18897
         run: |
-          for i in $(seq 1 180); do
-            if curl -fs "http://127.0.0.1:18897/api/health" > /tmp/health2.json; then
-              jq -e '.status == "healthy"' /tmp/health2.json && break
-            fi
-            sleep 1
-          done
-          jq -e '.status == "healthy"' /tmp/health2.json
+          bash .github/scripts/wait-for-health.sh \
+            --port 18897 --log logs/studio_extra.log --tmp /tmp/health2.json
 
       - name: Pass bootstrap pw for extra UI test
         run: |


### PR DESCRIPTION
Fourteen steps across eight workflows ran the same `/api/health` poll, in two dialects that disagreed about what a failure looks like. `.github/scripts/wait-for-health.sh` takes the three things that actually differ: `--port`, `--log`, `--tmp`.

```yaml
- name: Wait for /api/health on 18898
  run: |
    for i in $(seq 1 180); do
      if curl -fs "http://127.0.0.1:18898/api/health" > /tmp/health4.json; then
        jq -e '.status == "healthy"' /tmp/health4.json && break
      fi
      sleep 1
    done
    jq -e '.status == "healthy"' /tmp/health4.json
```

becomes

```yaml
- name: Wait for /api/health on 18898
  run: |
    bash .github/scripts/wait-for-health.sh \
      --port 18898 --log logs/studio_modelcfg.log --tmp /tmp/health4.json
```

110 lines of duplicated YAML down to 20.

## The survey

27 steps in the repo poll `/api/health`. 14 are a plain wait and are converted here. The other 13 are not, and each has a reason:

| Left inline | Count | Why |
|---|---|---|
| Wait + log in + rotate password + load a model, all one step | 7 | The poll is the first paragraph of a step that then does auth rotation and a model load. Splitting those is a separate change with its own risk. |
| Boot briefly to confirm the install is still usable | 3 | Boot, wait and kill in one step, pid in a local shell variable, 60 s deadline rather than 180. Same reason #8029 left them alone. |
| Poll inside a Playwright retry loop | 2 | Re-boots mid-loop and reassigns the pid in the running shell. |
| Shortcut-launch probe on Windows | 1 | PowerShell, and it scans a port *range* to discover which port the shortcut chose. Not the same operation. |

## The normalisation

The 14 came in two dialects, and neither was a superset of the other. The new script is the union, taking the better half of each.

**Retry on any not-yet-healthy answer, not just on a refused connection.** Three copies ran

```bash
if curl -fs ".../api/health" > /tmp/health.json; then
  jq -e '.status == "healthy"' /tmp/health.json
  exit 0
fi
```

Under `bash -e` that bare `jq -e` is a hard failure, so a server that answered the *very first* poll with `status != "healthy"` failed the step on the spot instead of getting the remaining 179 seconds. The other eleven copies already retried, because `jq ... && break` is an AND-list and `set -e` does not fire on it. Now all fourteen retry. Demonstrated below against a stub that reports `starting` for three seconds.

**Tail the log when the deadline passes.** Eleven copies ended on a bare `jq -e '.status == "healthy"'`, whose entire output on failure is a non-zero exit status: no message, and nothing about why the server never came up. The three that tailed the log were right, and that is the dialect the plan picked.

So each dialect gains what the other had. Nothing is weakened: the eleven keep their retry behaviour and gain diagnostics, the three keep their diagnostics and gain the retry the majority already had.

## The interface

`--port` differs per call site (several workflows run two or three servers in one job on different ports). `--log` is whichever log the matching `boot-studio-api-only.sh` call was told to write; five distinct names are in use and tailing the wrong one on failure is worse than tailing none. `--tmp` is where the last poll's response body is left for later steps and for a human reading the runner; five distinct names are in use so a later phase in the same job does not overwrite the evidence an earlier phase left. `--log` and `--tmp` default to the majority values, so eight of the fourteen call sites are a single line.

The 180 s deadline is fixed in the script rather than a flag: every converted call site used 180, and the only 60 s pollers are the boot-briefly steps, which are not call sites. `studio-ui-smoke.yml` carried the only comment explaining *why* 180; that reasoning moved into the script header rather than being deleted.

## Verification

**No coverage moved.** `scripts/workflow_coverage_diff.py` against `origin/main` across all eight files: 14 LOST / 14 ADDED, one pair per converted step, and the step count per job is unchanged in every file. No unexplained loss.

**Every call site asks for exactly what its old inline body did.** A checker reconstructs `(port, log, tmp)` from each pre-change body at `origin/main` and compares it to the arguments now passed: **14 call sites checked, 0 mismatches, 13 polls left inline by design.** For the eleven break-then-assert copies the old body never named a log, so the expected `--log` is taken from the nearest preceding `boot-studio-api-only.sh` call in the same job, which is the log that server is actually writing.

That check walks steps positionally. Keying on `(job, step name)` looks right and is not: the consolidated workflows have two steps with the *same* name in the *same* job (phase 1 and phase 3), so a dict keeps only the last one and silently compares the wrong pair.

**Behaviour tested against a stub server**, with `HOME` pointed at a scratch directory:

```
1. healthy immediately          -> [health] 127.0.0.1:19801 reported healthy, exit 0, 0.01 s
                                   /tmp/health.json holds the response body
2. unhealthy 3 s, then healthy  -> exit 0 after 3.0 s
2b. same server, OLD exit-0 dialect
                                -> false / exit 1   <- the bug the normalisation fixes
3. never healthy                -> "Unsloth did not become healthy in ...s"
                                   + the 200-line log tail, exit 1
4. nothing listening, log absent-> deadline message + "no log at '...' to tail", exit 1
5. --port omitted / unknown flag-> exit 2
```

**`shellcheck` clean** on the new script.

**`actionlint` introduces nothing.** Compared against the same eight files at `origin/main` rather than by absolute count: base 39 findings, head 25. The 14 that disappeared are all `SC2034: i appears unused` from the fourteen `for i in $(seq 1 180)` loops that no longer exist. Zero added, and the message set is otherwise identical.

**Each caller's `paths:` filter gains the script**, so an edit to it re-runs the workflows that call it. That is the trap #8015 hit and #8029 fixed: centralising a body moves it out from under filters that only name the workflow file. None of these eight has a `paths:` filter on its `push:` trigger, so there is nothing to add there.

Sibling of #8029, which extracted the boot these waits follow.
