### PR TITLE
Studio: cap llama.cpp source build parallelism by RAM

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -599,20 +599,18 @@ function Get-NvccMaxArch {
     return $null
 }
 
-# Reserved for the OS, and budgeted per compile job, both in MB. The budget is
-# set above the measured per-translation-unit peak rather than equal to it; see
-# the derivation on _LLAMA_BUILD_* in setup.sh, which these must match and which
-# the shell test pins. MSVC is the compiler here rather than gcc, and it is the
-# platform the freeze was reported on, so the headroom matters more, not less.
+# Reserved for the OS, and budgeted per compile job, both in MB. The budget sits
+# above the measured per-translation-unit peak on purpose; see the derivation on
+# _LLAMA_BUILD_* in setup.sh, which these must match and which the shell test
+# pins. MSVC and Windows, where the freeze was reported, need that headroom more.
 $LlamaBuildReserveMb = 2048
 $LlamaBuildMbPerJob = 2048
 
-# The cmake -j count. A negative $TotalMb means RAM was unreadable, which keeps
-# the old core-count behaviour. Zero is a reading, not a failure: a box with no
-# memory left is the last one that should be handed its full core count, so it
-# falls through and floors at 1, as _llama_jobs_for does for a numeric 0.
-# UNSLOTH_LLAMA_BUILD_JOBS wins. Pure so the tests can drive it without faking
-# hardware.
+# The cmake -j count. A negative $TotalMb means RAM was unreadable and keeps the
+# old core-count behaviour. Zero is a reading, not a failure: a box with no
+# memory left is the last one that should get its full core count, so it falls
+# through and floors at 1, as _llama_jobs_for does for a numeric 0.
+# UNSLOTH_LLAMA_BUILD_JOBS wins. Pure, so the tests can drive it.
 function Get-LlamaJobsFor {
     param([int]$Cores, [long]$TotalMb)
 
@@ -633,11 +631,9 @@ function Get-LlamaJobsFor {
 # a box with 8 GB already resident cannot host a 14 GB compile just because
 # 16 GB is fitted. AvailableMBytes counts the standby list, which the Free
 # counters do not, and the raw perf class is not localized the way Get-Counter
-# paths are. Installed RAM stays as the fallback, which is the pre-cap
-# behaviour. A reading of 0 is returned as 0 rather than treated as unreadable:
-# under real memory pressure Windows does report it, and falling back to
-# installed RAM there would hand the machine its full core count at the one
-# moment it can least afford it.
+# paths are; installed RAM stays the fallback. A reading of 0 is returned as 0
+# rather than treated as unreadable, since falling back to installed RAM under
+# real pressure would hand the machine its full core count at the worst moment.
 function Get-UsableMemoryMb {
     try {
         $avail = (Get-CimInstance Win32_PerfRawData_PerfOS_Memory -ErrorAction Stop).AvailableMBytes

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -599,6 +599,49 @@ function Get-NvccMaxArch {
     return $null
 }
 
+# Reserved for the OS, and budgeted per compile job, both in MB. An nvcc/hipcc
+# translation unit peaks near 2 GB, so core count alone oversubscribes RAM.
+# Keep in step with _LLAMA_BUILD_* in setup.sh.
+$LlamaBuildReserveMb = 2048
+$LlamaBuildMbPerJob = 2048
+
+# The cmake -j count. $TotalMb of 0 means RAM was unreadable, which keeps the
+# old core-count behaviour. UNSLOTH_LLAMA_BUILD_JOBS wins. Pure so the tests
+# can drive it without faking hardware.
+function Get-LlamaJobsFor {
+    param([int]$Cores, [long]$TotalMb)
+
+    $override = 0
+    if ($env:UNSLOTH_LLAMA_BUILD_JOBS -and
+        [int]::TryParse($env:UNSLOTH_LLAMA_BUILD_JOBS.Trim(), [ref]$override) -and $override -ge 1) {
+        return $override
+    }
+    if ($Cores -lt 1) { $Cores = 4 }
+    if ($TotalMb -le 0) { return $Cores }
+    $jobs = [int][Math]::Floor(($TotalMb - $LlamaBuildReserveMb) / $LlamaBuildMbPerJob)
+    if ($jobs -lt 1) { $jobs = 1 }
+    if ($jobs -gt $Cores) { $jobs = $Cores }
+    return $jobs
+}
+
+# Total physical RAM in MB; 0 when it cannot be read.
+function Get-TotalPhysicalMb {
+    try {
+        $bytes = (Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory
+        if ($bytes -gt 0) { return [long]($bytes / 1MB) }
+    } catch { }
+    try {
+        # TotalVisibleMemorySize is in KB and excludes hardware-reserved RAM.
+        $kb = (Get-CimInstance Win32_OperatingSystem -ErrorAction Stop).TotalVisibleMemorySize
+        if ($kb -gt 0) { return [long]($kb / 1KB) }
+    } catch { }
+    return 0
+}
+
+function Get-LlamaBuildJobs {
+    return (Get-LlamaJobsFor -Cores ([Environment]::ProcessorCount) -TotalMb (Get-TotalPhysicalMb))
+}
+
 # Classify the physical NVIDIA inventory for a cu126 fallback: "cu126" when it covers
 # every GPU, "uncovered" for an incompatible mix, empty when no fallback is needed or the
 # inventory is unreadable. CUDA_VISIBLE_DEVICES is ignored because the wheel must support
@@ -5863,13 +5906,12 @@ if ($LocalLlamaCppLinked) {
     }
 
     # -- Step C: Build llama-server --
-    $NumCpu = [Environment]::ProcessorCount
-    if ($NumCpu -lt 1) { $NumCpu = 4 }
+    $NumCpu = Get-LlamaBuildJobs
 
     if ($BuildOk) {
         Write-Host ""
         Write-Host "--- cmake build (llama-server) ---" -ForegroundColor Cyan
-        Write-Host "   Parallel jobs: $NumCpu" -ForegroundColor Gray
+        Write-Host "   Parallel jobs: $NumCpu of $([Environment]::ProcessorCount) cores (RAM-capped; UNSLOTH_LLAMA_BUILD_JOBS overrides)" -ForegroundColor Gray
         Write-Host ""
 
         $output = cmake --build $BuildDir --config Release --target llama-server -j $NumCpu 2>&1 | Out-String

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -605,9 +605,12 @@ function Get-NvccMaxArch {
 $LlamaBuildReserveMb = 2048
 $LlamaBuildMbPerJob = 2048
 
-# The cmake -j count. $TotalMb of 0 means RAM was unreadable, which keeps the
-# old core-count behaviour. UNSLOTH_LLAMA_BUILD_JOBS wins. Pure so the tests
-# can drive it without faking hardware.
+# The cmake -j count. A negative $TotalMb means RAM was unreadable, which keeps
+# the old core-count behaviour. Zero is a reading, not a failure: a box with no
+# memory left is the last one that should be handed its full core count, so it
+# falls through and floors at 1, as _llama_jobs_for does for a numeric 0.
+# UNSLOTH_LLAMA_BUILD_JOBS wins. Pure so the tests can drive it without faking
+# hardware.
 function Get-LlamaJobsFor {
     param([int]$Cores, [long]$TotalMb)
 
@@ -617,22 +620,26 @@ function Get-LlamaJobsFor {
         return $override
     }
     if ($Cores -lt 1) { $Cores = 4 }
-    if ($TotalMb -le 0) { return $Cores }
+    if ($TotalMb -lt 0) { return $Cores }
     $jobs = [int][Math]::Floor(($TotalMb - $LlamaBuildReserveMb) / $LlamaBuildMbPerJob)
     if ($jobs -lt 1) { $jobs = 1 }
     if ($jobs -gt $Cores) { $jobs = $Cores }
     return $jobs
 }
 
-# Usable RAM in MB; 0 when it cannot be read. Available, not installed: a box
-# with 8 GB already resident cannot host a 14 GB compile just because 16 GB is
-# fitted. AvailableMBytes counts the standby list, which the Free counters do
-# not, and the raw perf class is not localized the way Get-Counter paths are.
-# Installed RAM stays as the fallback, which is the pre-cap behaviour.
+# Usable RAM in MB; -1 when it cannot be read at all. Available, not installed:
+# a box with 8 GB already resident cannot host a 14 GB compile just because
+# 16 GB is fitted. AvailableMBytes counts the standby list, which the Free
+# counters do not, and the raw perf class is not localized the way Get-Counter
+# paths are. Installed RAM stays as the fallback, which is the pre-cap
+# behaviour. A reading of 0 is returned as 0 rather than treated as unreadable:
+# under real memory pressure Windows does report it, and falling back to
+# installed RAM there would hand the machine its full core count at the one
+# moment it can least afford it.
 function Get-UsableMemoryMb {
     try {
         $avail = (Get-CimInstance Win32_PerfRawData_PerfOS_Memory -ErrorAction Stop).AvailableMBytes
-        if ($avail -gt 0) { return [long]$avail }
+        if ($null -ne $avail) { return [long]$avail }
     } catch { }
     try {
         $bytes = (Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory
@@ -643,7 +650,7 @@ function Get-UsableMemoryMb {
         $kb = (Get-CimInstance Win32_OperatingSystem -ErrorAction Stop).TotalVisibleMemorySize
         if ($kb -gt 0) { return [long]($kb / 1KB) }
     } catch { }
-    return 0
+    return -1
 }
 
 function Get-LlamaBuildJobs {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -624,8 +624,16 @@ function Get-LlamaJobsFor {
     return $jobs
 }
 
-# Total physical RAM in MB; 0 when it cannot be read.
-function Get-TotalPhysicalMb {
+# Usable RAM in MB; 0 when it cannot be read. Available, not installed: a box
+# with 8 GB already resident cannot host a 14 GB compile just because 16 GB is
+# fitted. AvailableMBytes counts the standby list, which the Free counters do
+# not, and the raw perf class is not localized the way Get-Counter paths are.
+# Installed RAM stays as the fallback, which is the pre-cap behaviour.
+function Get-UsableMemoryMb {
+    try {
+        $avail = (Get-CimInstance Win32_PerfRawData_PerfOS_Memory -ErrorAction Stop).AvailableMBytes
+        if ($avail -gt 0) { return [long]$avail }
+    } catch { }
     try {
         $bytes = (Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory
         if ($bytes -gt 0) { return [long]($bytes / 1MB) }
@@ -639,7 +647,7 @@ function Get-TotalPhysicalMb {
 }
 
 function Get-LlamaBuildJobs {
-    return (Get-LlamaJobsFor -Cores ([Environment]::ProcessorCount) -TotalMb (Get-TotalPhysicalMb))
+    return (Get-LlamaJobsFor -Cores ([Environment]::ProcessorCount) -TotalMb (Get-UsableMemoryMb))
 }
 
 # Classify the physical NVIDIA inventory for a cu126 fallback: "cu126" when it covers

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -599,9 +599,11 @@ function Get-NvccMaxArch {
     return $null
 }
 
-# Reserved for the OS, and budgeted per compile job, both in MB. An nvcc/hipcc
-# translation unit peaks near 2 GB, so core count alone oversubscribes RAM.
-# Keep in step with _LLAMA_BUILD_* in setup.sh.
+# Reserved for the OS, and budgeted per compile job, both in MB. The budget is
+# set above the measured per-translation-unit peak rather than equal to it; see
+# the derivation on _LLAMA_BUILD_* in setup.sh, which these must match and which
+# the shell test pins. MSVC is the compiler here rather than gcc, and it is the
+# platform the freeze was reported on, so the headroom matters more, not less.
 $LlamaBuildReserveMb = 2048
 $LlamaBuildMbPerJob = 2048
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -329,16 +329,38 @@ _cg_dirs() {
     printf '%s\n' "$_root"
 }
 
+# Echo a cgroup hierarchy's mount point, or nothing. $1 = a mountinfo file,
+# $2 = "cgroup2" for the unified mount or a v1 controller name. mountinfo is
+# "... <mountpoint> <opts> [tags] - <fstype> <source> <superopts>", and a v1
+# hierarchy lists its controllers in the super options, so a co-mounted or
+# relocated one is found by name instead of assumed to sit at <root>/<name>.
+_cg_mount() {
+    [ -r "$1" ] || return 0
+    awk -v want="$2" '
+        {
+            for (i = 1; i <= NF; i++) if ($i == "-") break
+            if (i + 3 > NF) next
+            if (want == "cgroup2") {
+                if ($(i + 1) == "cgroup2") { print $5; exit }
+                next
+            }
+            if ($(i + 1) != "cgroup") next
+            n = split($(i + 3), opts, ",")
+            for (j = 1; j <= n; j++) if (opts[j] == want) { print $5; exit }
+        }' "$1" 2>/dev/null
+    return 0
+}
+
 # Echo the memory free under the binding cgroup limit in MiB, or nothing.
-# Args: cgroup root, /proc/self/cgroup path; both taken as arguments so the
-# tests can drive a real tree. Mirrors unsloth/dataset_num_proc.py: reading the
+# Args: fallback cgroup root, /proc/self/cgroup path, /proc/self/mountinfo
+# path; all taken as arguments so the tests can drive a real tree. Mirrors unsloth/dataset_num_proc.py: reading the
 # hierarchy root alone only works in a container with a private cgroup
 # namespace, and under Slurm, systemd or --cgroupns=host the binding limit is
 # the process's own path or an ancestor's. Each limit pairs with the usage of
 # the directory that set it, because an ancestor's usage counts siblings this
 # process cannot see. The smallest remaining allowance wins.
 _cgroup_free_mb() {
-    local _root=$1 _proc=$2 _rel _dir _used _limit _free _name _min=""
+    local _root=$1 _proc=$2 _mnt=${3:-} _rel _dir _used _limit _free _name _min="" _v2 _v1
     _consider() {
         [ -n "$1" ] || return 0
         if [[ "$2" =~ ^[0-9]+$ ]]; then _free=$(( $1 - $2 )); else _free=$1; fi
@@ -346,7 +368,10 @@ _cgroup_free_mb() {
         if [ -z "$_min" ] || [ "$_free" -lt "$_min" ]; then _min=$_free; fi
         return 0
     }
-    if [ -d "$_root" ]; then
+    # Prefer the real mount points; fall back to the conventional layout.
+    _v2=$(_cg_mount "$_mnt" cgroup2); [ -n "$_v2" ] || _v2=$_root
+    _v1=$(_cg_mount "$_mnt" memory);  [ -n "$_v1" ] || _v1="$_root/memory"
+    if [ -d "$_v2" ]; then
         # The v2 line is "0::<path>"; systemd hybrid mode adds v1 lines alongside.
         _rel=$(awk -F: '/^0::/ { print $3; exit }' "$_proc" 2>/dev/null || true)
         while IFS= read -r _dir; do
@@ -355,16 +380,16 @@ _cgroup_free_mb() {
                 _limit=$(_cg_limit "$(_cg_read "$_dir/$_name")")
                 _consider "$_limit" "$_used"
             done
-        done <<< "$(_cg_dirs "$_root" "$_rel")"
+        done <<< "$(_cg_dirs "$_v2" "$_rel")"
     fi
-    if [ -d "$_root/memory" ]; then
+    if [ -d "$_v1" ]; then
         # v1 is "<id>:<controllers>:<path>", and mounts are often combined.
         _rel=$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' "$_proc" 2>/dev/null || true)
         while IFS= read -r _dir; do
             _used=$(_cg_read "$_dir/memory.usage_in_bytes")
             _limit=$(_cg_limit "$(_cg_read "$_dir/memory.limit_in_bytes")")
             _consider "$_limit" "$_used"
-        done <<< "$(_cg_dirs "$_root/memory" "$_rel")"
+        done <<< "$(_cg_dirs "$_v1" "$_rel")"
     fi
     [ -n "$_min" ] && printf '%d' "$(( _min / 1048576 ))"
     return 0
@@ -385,7 +410,7 @@ _usable_ram_mb() {
     elif _bytes=$(sysctl -n hw.memsize 2>/dev/null); then
         [[ "$_bytes" =~ ^[0-9]+$ ]] && _mb=$(( _bytes / 1048576 ))
     fi
-    _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup)
+    _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup /proc/self/mountinfo)
     if [[ "$_free" =~ ^[0-9]+$ ]]; then
         if [ -z "$_mb" ] || [ "$_free" -lt "$_mb" ]; then _mb=$_free; fi
     fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -316,31 +316,32 @@ _cg_limit() {
     return 0
 }
 
-# Echo "$1/$2" and every ancestor up to $1, innermost first.
+# Echo "$1/$2" and every ancestor up to $1, innermost first, NUL-delimited. A
+# mount point is an arbitrary directory and may contain a newline, so a
+# line-delimited list would split one path into two and none of them would
+# exist. dirname is inlined for the same reason: $() eats a trailing newline.
 _cg_dirs() {
     local _root=$1 _cur
     if [ -n "${2:-}" ] && [ "$2" != "/" ]; then
         _cur="$_root/${2#/}"
-        while [ "$_cur" != "$_root" ] && [ "$_cur" != "/" ] && [ "$_cur" != "." ]; do
-            printf '%s\n' "$_cur"
-            _cur=$(dirname "$_cur")
+        while [ "$_cur" != "$_root" ] && [ "$_cur" != "/" ]; do
+            printf '%s\0' "$_cur"
+            case "$_cur" in
+                */*) _cur=${_cur%/*}; [ -n "$_cur" ] || _cur="/" ;;
+                *) break ;;
+            esac
         done
     fi
-    printf '%s\n' "$_root"
+    printf '%s\0' "$_root"
 }
 
-# Echo every matching cgroup hierarchy as "<mount root><tab><mount point>".
-# $1 = a mountinfo file, $2 = "cgroup2" for the unified mount or a v1 controller
-# name. mountinfo is "... <root> <mountpoint> <opts> [tags] - <fstype> <source>
-# <superopts>", and a v1 hierarchy lists its controllers in the super options,
-# so a co-mounted or relocated one is found by name instead of assumed to sit
-# at <root>/<name>.
-_cg_mounts() {
-    [ -r "$1" ] || return 0
-    # mountinfo escapes space, tab, newline and backslash in paths as \040 and
-    # friends, so both path fields are decoded before use. strtonum is a gawk
-    # extension; this arithmetic is POSIX and runs under mawk and BSD awk too.
-    awk -v want="$2" '
+# The mountinfo path decoder, as an awk function, in one place so its two
+# callers cannot drift. mountinfo escapes space, tab, newline and backslash in
+# paths as \040 and friends. strtonum is a gawk extension, so the octal
+# conversion is plain arithmetic that also runs under mawk and BSD awk, which
+# is what Debian and macOS give you.
+_cg_unesc_prog() {
+    cat <<'_CG_AWK_UNESC'
         function unesc(s,   out, i, c, o, v) {
             out = ""; i = 1
             while (i <= length(s)) {
@@ -353,16 +354,40 @@ _cg_mounts() {
             }
             return out
         }
+_CG_AWK_UNESC
+}
+
+# Echo $1 with its mountinfo escapes decoded. Decoding is deliberately not done
+# where the fields are read: \011 and \012 decode to the very tab and newline
+# that delimit the records below, so a mount point containing either would
+# split one record into two and the binding cgroup would never be inspected. An
+# escaped path holds neither, so it travels intact and is decoded here, once a
+# single path is in hand.
+_cg_unesc() {
+    [ -n "$1" ] || return 0
+    printf '%s\n' "$1" | awk "$(_cg_unesc_prog)"'{ printf "%s", unesc($0); exit }'
+    return 0
+}
+
+# Echo every matching cgroup hierarchy as "<mount root><tab><mount point>",
+# both still escaped. $1 = a mountinfo file, $2 = "cgroup2" for the unified
+# mount or a v1 controller name. mountinfo is "... <root> <mountpoint> <opts>
+# [tags] - <fstype> <source> <superopts>", and a v1 hierarchy lists its
+# controllers in the super options, so a co-mounted or relocated one is found
+# by name instead of assumed to sit at <root>/<name>.
+_cg_mounts() {
+    [ -r "$1" ] || return 0
+    awk -v want="$2" '
         {
             for (i = 1; i <= NF; i++) if ($i == "-") break
             if (i + 3 > NF) next
             if (want == "cgroup2") {
-                if ($(i + 1) == "cgroup2") print unesc($4) "\t" unesc($5)
+                if ($(i + 1) == "cgroup2") print $4 "\t" $5
                 next
             }
             if ($(i + 1) != "cgroup") next
             n = split($(i + 3), opts, ",")
-            for (j = 1; j <= n; j++) if (opts[j] == want) { print unesc($4) "\t" unesc($5); next }
+            for (j = 1; j <= n; j++) if (opts[j] == want) { print $4 "\t" $5; next }
         }' "$1" 2>/dev/null
     return 0
 }
@@ -386,19 +411,22 @@ _cg_rel() {
     return 0
 }
 
-# Pick one "<root><tab><point>" from the candidates on stdin. A hierarchy can be
-# mounted more than once, and taking the first would step past the binding mount
-# whenever an unrelated subtree is listed ahead of it. Prefer a mount whose root
-# contains the process path, most specific first; else keep the first seen.
-# Args: process cgroup path.
+# Pick one "<root><tab><point>" from the escaped candidates on stdin, and echo
+# it still escaped. A hierarchy can be mounted more than once, and taking the
+# first would step past the binding mount whenever an unrelated subtree is
+# listed ahead of it. Prefer a mount whose root contains the process path, most
+# specific first; else keep the first seen. Args: process cgroup path.
 _cg_pick_mount() {
-    local _rel=$1 _root _point _bestroot="" _bestpoint="" _firstroot="" _firstpoint=""
+    local _rel=$1 _root _point _droot _bestlen=0
+    local _bestroot="" _bestpoint="" _firstroot="" _firstpoint=""
     while IFS=$'\t' read -r _root _point; do
         [ -n "$_point" ] || continue
         if [ -z "$_firstpoint" ]; then _firstroot=$_root; _firstpoint=$_point; fi
-        [ -n "$(_cg_rel "$_root" "$_rel")" ] || continue
-        if [ -z "$_bestpoint" ] || [ "${#_root}" -gt "${#_bestroot}" ]; then
-            _bestroot=$_root; _bestpoint=$_point
+        # /proc/self/cgroup is not escaped, so the root is compared decoded.
+        _droot=$(_cg_unesc "$_root")
+        [ -n "$(_cg_rel "$_droot" "$_rel")" ] || continue
+        if [ -z "$_bestpoint" ] || [ "${#_droot}" -gt "$_bestlen" ]; then
+            _bestroot=$_root; _bestpoint=$_point; _bestlen=${#_droot}
         fi
     done
     if [ -n "$_bestpoint" ]; then
@@ -420,7 +448,7 @@ _cg_pick_mount() {
 _cgroup_free_mb() {
     local _root=$1 _proc=$2 _mnt=${3:-} _rel _dir _used _limit _free _name _min=""
     local _v2 _v1 _v2root _v1root _v2rel _v1rel
-    _consider() {
+    _cg_consider() {
         [ -n "$1" ] || return 0
         if [[ "$2" =~ ^[0-9]+$ ]]; then _free=$(( $1 - $2 )); else _free=$1; fi
         [ "$_free" -lt 0 ] && _free=0
@@ -441,27 +469,34 @@ _cgroup_free_mb() {
         }' "$_proc" 2>/dev/null || true)
     IFS=$'\t' read -r _v2root _v2 <<< "$(_cg_mounts "$_mnt" cgroup2 | _cg_pick_mount "$_v2rel")"
     IFS=$'\t' read -r _v1root _v1 <<< "$(_cg_mounts "$_mnt" memory | _cg_pick_mount "$_v1rel")"
+    # Escapes survive the tab- and newline-delimited transport above; a single
+    # path is in hand now, so decode it before touching the filesystem. The
+    # trailing sentinel keeps $() from eating a decoded trailing newline.
+    _v2root=$(_cg_unesc "$_v2root"; printf X); _v2root=${_v2root%X}
+    _v2=$(_cg_unesc "$_v2"; printf X); _v2=${_v2%X}
+    _v1root=$(_cg_unesc "$_v1root"; printf X); _v1root=${_v1root%X}
+    _v1=$(_cg_unesc "$_v1"; printf X); _v1=${_v1%X}
     [ -n "$_v2" ] || { _v2=$_root; _v2root="/"; }
     [ -n "$_v1" ] || { _v1="$_root/memory"; _v1root="/"; }
     if [ -d "$_v2" ]; then
         # The v2 line is "0::<path>"; systemd hybrid mode adds v1 lines alongside.
         _rel=$(_cg_rel "$_v2root" "$_v2rel")
-        while IFS= read -r _dir; do
+        while IFS= read -r -d '' _dir; do
             _used=$(_cg_read "$_dir/memory.current")
             for _name in memory.max memory.high; do
                 _limit=$(_cg_limit "$(_cg_read "$_dir/$_name")")
-                _consider "$_limit" "$_used"
+                _cg_consider "$_limit" "$_used"
             done
-        done <<< "$(_cg_dirs "$_v2" "$_rel")"
+        done < <(_cg_dirs "$_v2" "$_rel")
     fi
     if [ -d "$_v1" ]; then
         # v1 is "<id>:<controllers>:<path>", and mounts are often combined.
         _rel=$(_cg_rel "$_v1root" "$_v1rel")
-        while IFS= read -r _dir; do
+        while IFS= read -r -d '' _dir; do
             _used=$(_cg_read "$_dir/memory.usage_in_bytes")
             _limit=$(_cg_limit "$(_cg_read "$_dir/memory.limit_in_bytes")")
-            _consider "$_limit" "$_used"
-        done <<< "$(_cg_dirs "$_v1" "$_rel")"
+            _cg_consider "$_limit" "$_used"
+        done < <(_cg_dirs "$_v1" "$_rel")
     fi
     [ -n "$_min" ] && printf '%d' "$(( _min / 1048576 ))"
     return 0
@@ -471,14 +506,15 @@ _cgroup_free_mb() {
 # a workstation with 8 GiB already resident cannot host a 14 GiB compile just
 # because 16 GiB is fitted. /proc is not namespaced either, so a lower cgroup
 # allowance wins. macOS has no comparable reclaim-aware figure, so it keeps
-# installed RAM.
+# installed RAM. $1 is the meminfo file, an argument like every other reader's
+# path here so the tests can pin a number instead of racing the live one.
 _usable_ram_mb() {
-    local _bytes _mb="" _free
-    if [ -r /proc/meminfo ]; then
+    local _meminfo=${1:-/proc/meminfo} _bytes _mb="" _free
+    if [ -r "$_meminfo" ]; then
         # MemAvailable counts reclaimable page cache; MemFree does not. Absent
         # before Linux 3.14, where MemTotal is the only thing to go on.
-        _mb=$(awk '/^MemAvailable:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo)
-        [ -n "$_mb" ] || _mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo)
+        _mb=$(awk '/^MemAvailable:/ { printf "%d", $2 / 1024; exit }' "$_meminfo")
+        [ -n "$_mb" ] || _mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' "$_meminfo")
     elif _bytes=$(sysctl -n hw.memsize 2>/dev/null); then
         [[ "$_bytes" =~ ^[0-9]+$ ]] && _mb=$(( _bytes / 1048576 ))
     fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -537,8 +537,11 @@ _usable_ram_mb() {
     if [ -r "$_meminfo" ]; then
         # MemAvailable counts reclaimable page cache; MemFree does not. Absent
         # before Linux 3.14, where MemTotal is the only thing to go on.
-        _mb=$(awk '/^MemAvailable:/ { printf "%d", $2 / 1024; exit }' "$_meminfo")
-        [ -n "$_mb" ] || _mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' "$_meminfo")
+        # `|| true` because bash applies errexit to a failing assignment in
+        # POSIX mode (POSIXLY_CORRECT in the environment, or bash invoked as
+        # sh), and an unreadable meminfo must cost the cap, not the install.
+        _mb=$(awk '/^MemAvailable:/ { printf "%d", $2 / 1024; exit }' "$_meminfo") || true
+        [ -n "$_mb" ] || _mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' "$_meminfo") || true
     elif _bytes=$(sysctl -n hw.memsize 2>/dev/null); then
         [[ "$_bytes" =~ ^[0-9]+$ ]] && _mb=$(( _bytes / 1048576 ))
         # macOS has no MemAvailable, so hw.memsize is installed RAM and would
@@ -547,7 +550,7 @@ _usable_ram_mb() {
         _avail=$(vm_stat 2>/dev/null | _vm_stat_avail_mb || true)
         if [[ "$_avail" =~ ^[0-9]+$ ]] && [ "$_avail" -gt 0 ]; then _mb=$_avail; fi
     fi
-    _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup /proc/self/mountinfo)
+    _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup /proc/self/mountinfo) || true
     if [[ "$_free" =~ ^[0-9]+$ ]]; then
         if [ -z "$_mb" ] || [ "$_free" -lt "$_mb" ]; then _mb=$_free; fi
     fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -277,6 +277,48 @@ _resolve_cuda_archs() {
     printf '%s' "$_archs"
 }
 
+# Reserved for the OS, and budgeted per compile job, both in MiB. An nvcc/hipcc
+# translation unit peaks near 2 GiB, so core count alone oversubscribes RAM.
+_LLAMA_BUILD_RESERVE_MB=2048
+_LLAMA_BUILD_MB_PER_JOB=2048
+
+# Echo the cmake -j count. Args: core count, total RAM MiB ("" = unreadable,
+# which keeps the old core-count behaviour). UNSLOTH_LLAMA_BUILD_JOBS wins.
+# Pure so the tests can drive it without faking hardware.
+_llama_jobs_for() {
+    local _cores=$1 _mem_mb=$2 _jobs
+    if [[ "${UNSLOTH_LLAMA_BUILD_JOBS:-}" =~ ^[0-9]+$ ]] && [ "$UNSLOTH_LLAMA_BUILD_JOBS" -ge 1 ]; then
+        printf '%s' "$UNSLOTH_LLAMA_BUILD_JOBS"
+        return 0
+    fi
+    if ! [[ "$_cores" =~ ^[0-9]+$ ]] || [ "$_cores" -lt 1 ]; then _cores=4; fi
+    if ! [[ "$_mem_mb" =~ ^[0-9]+$ ]]; then
+        printf '%s' "$_cores"
+        return 0
+    fi
+    _jobs=$(( (_mem_mb - _LLAMA_BUILD_RESERVE_MB) / _LLAMA_BUILD_MB_PER_JOB ))
+    [ "$_jobs" -lt 1 ] && _jobs=1
+    [ "$_jobs" -gt "$_cores" ] && _jobs=$_cores
+    printf '%s' "$_jobs"
+}
+
+# Total physical RAM in MiB; empty when it cannot be read.
+_total_ram_mb() {
+    local _bytes
+    if [ -r /proc/meminfo ]; then
+        awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo
+    elif _bytes=$(sysctl -n hw.memsize 2>/dev/null); then
+        [[ "$_bytes" =~ ^[0-9]+$ ]] && printf '%d' "$(( _bytes / 1048576 ))"
+    fi
+    return 0
+}
+
+_llama_build_jobs() {
+    _llama_jobs_for \
+        "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)" \
+        "$(_total_ram_mb)"
+}
+
 # Opt-in staged GPU smoke test after a source build (#5854 gap 2). Default off:
 # llama-server's first GPU forward pass JIT-compiles CUDA kernels and stalls
 # installs for minutes on Blackwell. Same env as install_llama_prebuilt.py.
@@ -2217,7 +2259,8 @@ else
 
             substep "$_BUILD_DESC..."
 
-            NCPU=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+            NCPU=$(_llama_build_jobs)
+            verbose_substep "parallel jobs: $NCPU (RAM-capped; UNSLOTH_LLAMA_BUILD_JOBS overrides)"
             CMAKE_GENERATOR_ARGS=""
             if command -v ninja &>/dev/null; then
                 CMAKE_GENERATOR_ARGS="-G Ninja"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -535,7 +535,9 @@ _vm_stat_avail_mb() {
         /^Pages (free|inactive|speculative|purgeable)/ {
             gsub(/\./, "", $NF); pages += $NF
         }
-        END { if (ps > 0 && pages > 0) printf "%d", pages * ps / 1048576 }' || true
+        # A zero page count is a reading, not a parse failure; a missing page
+        # size is the only thing that means the output did not parse.
+        END { if (ps > 0) printf "%d", pages * ps / 1048576 }' || true
     return 0
 }
 
@@ -561,7 +563,9 @@ _usable_ram_mb() {
         # hand a busy Mac a budget it cannot honour. vm_stat is the equivalent;
         # installed RAM stays the fallback if the output does not parse.
         _avail=$(vm_stat 2>/dev/null | _vm_stat_avail_mb || true)
-        if [[ "$_avail" =~ ^[0-9]+$ ]] && [ "$_avail" -gt 0 ]; then _mb=$_avail; fi
+        # Zero included: a Mac with nothing reclaimable should build at 1 job,
+        # not fall back to installed RAM and take its full core count.
+        if [[ "$_avail" =~ ^[0-9]+$ ]]; then _mb=$_avail; fi
     fi
     _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup /proc/self/mountinfo)
     if [[ "$_free" =~ ^[0-9]+$ ]]; then

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -277,27 +277,19 @@ _resolve_cuda_archs() {
     printf '%s' "$_archs"
 }
 
-# Reserved for the OS, and budgeted per compile job, both in MiB.
-#
-# Measured on llama.cpp at ggml-org/llama.cpp master with CUDA 13.1: the
-# heaviest translation units are the flash-attention template instances, which
-# peak at ~400 MiB of RSS each, flat in the number of CUDA archs (nvcc compiles
-# archs one after another, so only wall time scales). A full CUDA build at -j20
-# peaked at 8.2 GiB in aggregate, and -j20 produced ~30 concurrent compiler
-# processes, because nvcc forks cicc and ptxas under itself.
-#
-# 2048 is deliberately above that measurement rather than equal to it. It has to
-# cover the ~1.5x process fan-out, MSVC on Windows and hipcc on ROCm which are
-# not measured here, older CUDA toolkits which were much heavier on the same
-# files (ggml-org/llama.cpp#17844 reports a build climbing past 16 GiB and
-# taking the machine with it), and the link step at the end. Erring high costs
-# build time on a small machine; erring low costs the machine.
+# Reserved for the OS, and budgeted per compile job, both in MiB. Measured on
+# llama.cpp with CUDA 13.1, the heaviest translation units (flash-attention
+# template instances) peak at ~400 MiB RSS each, and -j20 peaked at 8.2 GiB
+# across ~30 processes, since nvcc forks cicc and ptxas. 2048 is deliberately
+# above that: it must also cover MSVC and hipcc, older and far heavier CUDA
+# toolkits (ggml-org/llama.cpp#17844 climbs past 16 GiB), and the link step.
+# Erring high costs build time; erring low costs the machine.
 _LLAMA_BUILD_RESERVE_MB=2048
 _LLAMA_BUILD_MB_PER_JOB=2048
 
 # Echo the cmake -j count. Args: core count, total RAM MiB ("" = unreadable,
 # which keeps the old core-count behaviour). UNSLOTH_LLAMA_BUILD_JOBS wins.
-# Pure so the tests can drive it without faking hardware.
+# Pure, so the tests can drive it without faking hardware.
 _llama_jobs_for() {
     local _cores=$1 _mem_mb=$2 _jobs
     if [[ "${UNSLOTH_LLAMA_BUILD_JOBS:-}" =~ ^[0-9]+$ ]] && [ "$UNSLOTH_LLAMA_BUILD_JOBS" -ge 1 ]; then
@@ -315,13 +307,11 @@ _llama_jobs_for() {
     printf '%s' "$_jobs"
 }
 
-# Echo the first line of $1 with whitespace stripped, or nothing. setup.sh runs
-# under `set -euo pipefail`, and this is a best-effort read on the install's
-# critical path, so it must not fail: `head | tr` took the whole install down
-# whenever the pipeline returned non-zero, which -r alone does not rule out (a
-# directory passes it, and a cgroup can be torn down between the test and the
-# open). The read is a builtin and the strip is an expansion, so there is no
-# pipeline and no subprocess left to fail.
+# Echo the first line of $1 with whitespace stripped, or nothing. A builtin read
+# plus an expansion, not `head | tr`: this is best-effort on the install's
+# critical path under `set -euo pipefail`, and a failing pipeline took the whole
+# install down. -r alone does not rule that out (a directory passes it, and a
+# cgroup can be torn down between the test and the open); -f does.
 _cg_read() {
     local _v=""
     [ -f "$1" ] && [ -r "$1" ] || return 0
@@ -331,22 +321,19 @@ _cg_read() {
 }
 
 # Echo $1 when it is a real limit. v2 writes "max"; v1 a near-2^63 sentinel.
-# Zero is a limit, not the absence of one: memory.high throttles rather than
-# killing (cgroup-v2.rst, "Going over the high limit never invokes the OOM
-# killer"), so a process runs happily under MemoryHigh=0 and must not then be
-# handed its full core count. Rejecting zero here budgeted from host memory
-# instead, which is the oversubscription this cap exists to remove, and it is
-# the same reading the Windows and macOS sides already keep.
+# Zero is a limit, not the absence of one: memory.high throttles and never
+# invokes the OOM killer (cgroup-v2.rst), so a process runs happily under
+# MemoryHigh=0 and must not then be handed its full core count.
 _cg_limit() {
     [[ "$1" =~ ^[0-9]+$ ]] || return 0
     [ "$1" -lt 4611686018427387904 ] && printf '%s' "$1"
     return 0
 }
 
-# Echo "$1/$2" and every ancestor up to $1, innermost first, NUL-delimited. A
-# mount point is an arbitrary directory and may contain a newline, so a
-# line-delimited list would split one path into two and none of them would
-# exist. dirname is inlined for the same reason: $() eats a trailing newline.
+# Echo "$1/$2" and every ancestor up to $1, innermost first, NUL-delimited: a
+# mount point may contain a newline, so a line-delimited list would split one
+# path into two. dirname is inlined for the same reason ($() eats a trailing
+# newline).
 _cg_dirs() {
     local _root=$1 _cur
     if [ -n "${2:-}" ] && [ "$2" != "/" ]; then
@@ -362,11 +349,10 @@ _cg_dirs() {
     printf '%s\0' "$_root"
 }
 
-# The mountinfo path decoder, as an awk function, in one place so its two
-# callers cannot drift. mountinfo escapes space, tab, newline and backslash in
-# paths as \040 and friends. strtonum is a gawk extension, so the octal
-# conversion is plain arithmetic that also runs under mawk and BSD awk, which
-# is what Debian and macOS give you.
+# The mountinfo path decoder as an awk function, in one place so its two callers
+# cannot drift. mountinfo escapes space, tab, newline and backslash as \040 and
+# friends; strtonum is a gawk extension, so the octal maths is done by hand to
+# also run under the mawk and BSD awk that Debian and macOS ship.
 _cg_unesc_prog() {
     cat <<'_CG_AWK_UNESC'
         function unesc(s,   out, i, c, o, v) {
@@ -384,24 +370,22 @@ _cg_unesc_prog() {
 _CG_AWK_UNESC
 }
 
-# Echo $1 with its mountinfo escapes decoded. Decoding is deliberately not done
-# where the fields are read: \011 and \012 decode to the very tab and newline
-# that delimit the records below, so a mount point containing either would
-# split one record into two and the binding cgroup would never be inspected. An
-# escaped path holds neither, so it travels intact and is decoded here, once a
-# single path is in hand.
+# Echo $1 with its mountinfo escapes decoded. Decoding is deliberately late:
+# \011 and \012 decode to the very tab and newline that delimit the records
+# below, so decoding at the read would split one record into two. An escaped
+# path holds neither, so it travels intact and is decoded here.
 _cg_unesc() {
     [ -n "$1" ] || return 0
     printf '%s\n' "$1" | awk "$(_cg_unesc_prog)"'{ printf "%s", unesc($0); exit }' || true
     return 0
 }
 
-# Echo every matching cgroup hierarchy as "<mount root><tab><mount point>",
-# both still escaped. $1 = a mountinfo file, $2 = "cgroup2" for the unified
-# mount or a v1 controller name. mountinfo is "... <root> <mountpoint> <opts>
-# [tags] - <fstype> <source> <superopts>", and a v1 hierarchy lists its
-# controllers in the super options, so a co-mounted or relocated one is found
-# by name instead of assumed to sit at <root>/<name>.
+# Echo every matching cgroup hierarchy as "<mount root><tab><mount point>", both
+# still escaped. $1 = a mountinfo file, $2 = "cgroup2" or a v1 controller name.
+# mountinfo is "... <root> <mountpoint> <opts> [tags] - <fstype> <source>
+# <superopts>", and a v1 hierarchy lists its controllers in the super options,
+# so a co-mounted or relocated one is found by name rather than assumed to sit
+# at <root>/<name>.
 _cg_mounts() {
     [ -r "$1" ] || return 0
     awk -v want="$2" '
@@ -420,11 +404,10 @@ _cg_mounts() {
 }
 
 # Echo the process's path within a mount, or nothing when the mount does not
-# expose it. Args: mount root, process cgroup path. A bind-mounted subtree
-# (Docker without a cgroup namespace, a systemd slice) shows a mount root like
-# /slice while /proc/self/cgroup still reports the host-absolute /slice/job, and
-# the files are then at <mountpoint>/job. Joining the two unmapped walks a path
-# that does not exist and settles on an outer limit instead of the binding one.
+# expose it. Args: mount root, process cgroup path. A bind-mounted subtree shows
+# a mount root like /slice while /proc/self/cgroup reports /slice/job and the
+# files sit at <mountpoint>/job, so joining the two unmapped walks a path that
+# does not exist and settles on an outer limit instead of the binding one.
 _cg_rel() {
     local _root=$1 _rel=$2
     [ -n "$_rel" ] || return 0
@@ -438,19 +421,13 @@ _cg_rel() {
     return 0
 }
 
-# Echo EVERY "<root><tab><point>" on stdin whose root contains the process
-# path, still escaped, one per line; or the first seen when none does.
-#
-# A hierarchy can be mounted more than once, and the two mounts can expose
-# different subtree roots of the same superblock -- rootless podman inside
-# rootless podman is the documented case, where a host-derived bind mount sits
-# alongside a namespace-scoped one. Taking the first would step past the binding
-# mount, but so would taking only the most specific: a limit above the narrower
-# mount's root is invisible through it and visible through the broader one.
-# Every mount whose root contains the path genuinely constrains this process, so
-# all of them are inspected and the smallest allowance wins. Order does not
-# matter, because a minimum is order-independent.
-# Args: process cgroup path.
+# Echo EVERY "<root><tab><point>" on stdin whose root contains the process path
+# ($1), still escaped, one per line; or the first seen when none does. A
+# hierarchy can be mounted twice with different subtree roots (rootless podman
+# inside rootless podman): taking the first steps past the binding mount, and
+# taking only the most specific hides a limit above the narrower mount's root.
+# So every containing mount is inspected and the smallest allowance wins, which
+# makes the answer order-independent.
 _cg_pick_mounts() {
     local _rel=$1 _root _point _droot _any="" _firstroot="" _firstpoint=""
     while IFS=$'\t' read -r _root _point; do
@@ -466,14 +443,14 @@ _cg_pick_mounts() {
     return 0
 }
 
-# Echo the memory free under the binding cgroup limit in MiB, or nothing.
-# Args: fallback cgroup root, /proc/self/cgroup path, /proc/self/mountinfo
-# path; all taken as arguments so the tests can drive a real tree. Mirrors unsloth/dataset_num_proc.py: reading the
-# hierarchy root alone only works in a container with a private cgroup
-# namespace, and under Slurm, systemd or --cgroupns=host the binding limit is
-# the process's own path or an ancestor's. Each limit pairs with the usage of
-# the directory that set it, because an ancestor's usage counts siblings this
-# process cannot see. The smallest remaining allowance wins.
+# Echo the memory free under the binding cgroup limit in MiB, or nothing. Args:
+# fallback cgroup root, /proc/self/cgroup path, /proc/self/mountinfo path; all
+# arguments so the tests can drive a real tree. Mirrors dataset_num_proc.py:
+# reading the hierarchy root alone only works with a private cgroup namespace,
+# and under Slurm, systemd or --cgroupns=host the binding limit is the process's
+# own path or an ancestor's. Each limit pairs with the usage of the directory
+# that set it, since an ancestor's usage counts siblings this process cannot
+# see, and the smallest remaining allowance wins.
 _cgroup_free_mb() {
     local _root=$1 _proc=$2 _mnt=${3:-} _rel _dir _used _limit _free _name _min=""
     local _v2rel _v1rel _v2mnts _v1mnts _mroot _mpoint
@@ -484,10 +461,9 @@ _cgroup_free_mb() {
         if [ -z "$_min" ] || [ "$_free" -lt "$_min" ]; then _min=$_free; fi
         return 0
     }
-    # Prefer the real mounts; fall back to the conventional layout. The process
-    # path is read first so the right mount can be chosen among several.
-    # Only the first two colons are delimiters: a systemd unit name may contain
-    # one, and -F: with $3 would truncate the path there.
+    # The process path is read first so the right mount can be chosen among
+    # several. Only the first two colons are delimiters: a systemd unit name may
+    # contain one, and -F: with $3 would truncate the path there.
     _v2rel=$(awk '/^0::/ { print substr($0, 4); exit }' "$_proc" 2>/dev/null || true)
     _v1rel=$(awk '
         {
@@ -505,9 +481,9 @@ _cgroup_free_mb() {
     # The v2 line is "0::<path>"; systemd hybrid mode adds v1 lines alongside.
     while IFS=$'\t' read -r _mroot _mpoint; do
         [ -n "$_mpoint" ] || continue
-        # Escapes survive the tab- and newline-delimited transport above; a
-        # single path is in hand now, so decode it before touching the
-        # filesystem. The sentinel keeps $() from eating a trailing newline.
+        # Decode now that a single path is in hand, after it survived the tab-
+        # and newline-delimited transport. The sentinel keeps $() from eating a
+        # trailing newline.
         _mroot=$(_cg_unesc "$_mroot"; printf X); _mroot=${_mroot%X}
         _mpoint=$(_cg_unesc "$_mpoint"; printf X); _mpoint=${_mpoint%X}
         [ -d "$_mpoint" ] || continue
@@ -539,27 +515,15 @@ _cgroup_free_mb() {
     return 0
 }
 
-# macOS available memory in MiB, read from vm_stat on stdin. free + inactive is
-# the reclaim-aware equivalent of MemAvailable; the page size comes from the
-# header rather than being assumed 4096, which is wrong on Apple Silicon. Empty
-# when the output does not parse.
-#
-# Only those two, because the other candidates are not disjoint from them and
-# adding either overstates what can be reclaimed, which buys back exactly the
-# oversubscription this cap removes:
-#
-#   speculative -- xnu osfmk/mach/vm_statistics.h says so outright: "NB:
-#     speculative pages are already accounted for in free_count, so
-#     speculative_count is the number of free pages that are used to hold data
-#     that was read speculatively from disk".
-#   purgeable   -- an attribute of a page, not a queue it sits on. A volatile
-#     page is still on the active or inactive queue, so it is already counted
-#     there. The disjoint partition is free + active + inactive + wired +
-#     throttled + compressor.
-#
-# Dropping them under-counts by the purgeable pages sitting on the ACTIVE queue,
-# which are reclaimable but not in either term. That is the safe direction for a
-# cap: it costs build time on a busy Mac rather than the machine.
+# macOS available memory in MiB, read from vm_stat on stdin; empty when the
+# output does not parse. free + inactive is the reclaim-aware equivalent of
+# MemAvailable, and the page size is read from the header rather than assumed to
+# be 4096, which is wrong on Apple Silicon. Only those two: xnu's
+# osfmk/mach/vm_statistics.h says speculative pages "are already accounted for
+# in free_count", and purgeable is an attribute of a page rather than a queue,
+# so a volatile page is already counted on active or inactive. Adding either
+# double-counts. Under-counting is the safe direction for a cap: it costs build
+# time on a busy Mac rather than the machine.
 _vm_stat_avail_mb() {
     awk '
         /page size of/ {
@@ -568,36 +532,33 @@ _vm_stat_avail_mb() {
         /^Pages (free|inactive)/ {
             gsub(/\./, "", $NF); pages += $NF
         }
-        # A zero page count is a reading, not a parse failure; a missing page
-        # size is the only thing that means the output did not parse.
+        # A zero page count is a reading; only a missing page size is a failure.
         END { if (ps > 0) printf "%d", pages * ps / 1048576 }' || true
     return 0
 }
 
-# Usable RAM in MiB; empty when it cannot be read. MemAvailable, not MemTotal:
-# a workstation with 8 GiB already resident cannot host a 14 GiB compile just
+# Usable RAM in MiB; empty when it cannot be read. MemAvailable, not MemTotal: a
+# workstation with 8 GiB already resident cannot host a 14 GiB compile just
 # because 16 GiB is fitted. /proc is not namespaced either, so a lower cgroup
-# allowance wins. macOS has no comparable reclaim-aware figure, so it keeps
-# installed RAM. $1 is the meminfo file, an argument like every other reader's
+# allowance wins. $1 is the meminfo file, an argument like every other reader's
 # path here so the tests can pin a number instead of racing the live one.
 _usable_ram_mb() {
     local _meminfo=${1:-/proc/meminfo} _bytes _mb="" _free _avail
     if [ -r "$_meminfo" ]; then
         # MemAvailable counts reclaimable page cache; MemFree does not. Absent
-        # before Linux 3.14, where MemTotal is the only thing to go on.
-        # `|| true` because bash applies errexit to a failing assignment in
-        # POSIX mode (POSIXLY_CORRECT in the environment, or bash invoked as
-        # sh), and an unreadable meminfo must cost the cap, not the install.
+        # before Linux 3.14, where MemTotal is the only thing to go on. `|| true`
+        # because bash applies errexit to a failing assignment in POSIX mode, and
+        # an unreadable meminfo must cost the cap, not the install.
         _mb=$(awk '/^MemAvailable:/ { printf "%d", $2 / 1024; exit }' "$_meminfo") || true
         [ -n "$_mb" ] || _mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' "$_meminfo") || true
     elif _bytes=$(sysctl -n hw.memsize 2>/dev/null); then
         [[ "$_bytes" =~ ^[0-9]+$ ]] && _mb=$(( _bytes / 1048576 ))
         # macOS has no MemAvailable, so hw.memsize is installed RAM and would
-        # hand a busy Mac a budget it cannot honour. vm_stat is the equivalent;
-        # installed RAM stays the fallback if the output does not parse.
+        # hand a busy Mac a budget it cannot honour; vm_stat is the equivalent,
+        # with installed RAM as the fallback when it does not parse. Zero is
+        # kept: a Mac with nothing reclaimable should build at 1 job, not take
+        # its full core count.
         _avail=$(vm_stat 2>/dev/null | _vm_stat_avail_mb || true)
-        # Zero included: a Mac with nothing reclaimable should build at 1 job,
-        # not fall back to installed RAM and take its full core count.
         if [[ "$_avail" =~ ^[0-9]+$ ]]; then _mb=$_avail; fi
     fi
     _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup /proc/self/mountinfo)

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -302,10 +302,18 @@ _llama_jobs_for() {
     printf '%s' "$_jobs"
 }
 
-# Echo the first line of $1 with whitespace stripped, or nothing.
+# Echo the first line of $1 with whitespace stripped, or nothing. setup.sh runs
+# under `set -euo pipefail`, and this is a best-effort read on the install's
+# critical path, so it must not fail: `head | tr` took the whole install down
+# whenever the pipeline returned non-zero, which -r alone does not rule out (a
+# directory passes it, and a cgroup can be torn down between the test and the
+# open). The read is a builtin and the strip is an expansion, so there is no
+# pipeline and no subprocess left to fail.
 _cg_read() {
-    [ -r "$1" ] || return 0
-    head -n 1 "$1" 2>/dev/null | tr -d '[:space:]'
+    local _v=""
+    [ -f "$1" ] && [ -r "$1" ] || return 0
+    IFS= read -r _v < "$1" 2>/dev/null || true
+    printf '%s' "${_v//[[:space:]]/}"
     return 0
 }
 
@@ -365,7 +373,7 @@ _CG_AWK_UNESC
 # single path is in hand.
 _cg_unesc() {
     [ -n "$1" ] || return 0
-    printf '%s\n' "$1" | awk "$(_cg_unesc_prog)"'{ printf "%s", unesc($0); exit }'
+    printf '%s\n' "$1" | awk "$(_cg_unesc_prog)"'{ printf "%s", unesc($0); exit }' || true
     return 0
 }
 
@@ -388,7 +396,7 @@ _cg_mounts() {
             if ($(i + 1) != "cgroup") next
             n = split($(i + 3), opts, ",")
             for (j = 1; j <= n; j++) if (opts[j] == want) { print $4 "\t" $5; next }
-        }' "$1" 2>/dev/null
+        }' "$1" 2>/dev/null || true
     return 0
 }
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -331,9 +331,15 @@ _cg_read() {
 }
 
 # Echo $1 when it is a real limit. v2 writes "max"; v1 a near-2^63 sentinel.
+# Zero is a limit, not the absence of one: memory.high throttles rather than
+# killing (cgroup-v2.rst, "Going over the high limit never invokes the OOM
+# killer"), so a process runs happily under MemoryHigh=0 and must not then be
+# handed its full core count. Rejecting zero here budgeted from host memory
+# instead, which is the oversubscription this cap exists to remove, and it is
+# the same reading the Windows and macOS sides already keep.
 _cg_limit() {
     [[ "$1" =~ ^[0-9]+$ ]] || return 0
-    [ "$1" -gt 0 ] && [ "$1" -lt 4611686018427387904 ] && printf '%s' "$1"
+    [ "$1" -lt 4611686018427387904 ] && printf '%s' "$1"
     return 0
 }
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -302,14 +302,37 @@ _llama_jobs_for() {
     printf '%s' "$_jobs"
 }
 
-# Total physical RAM in MiB; empty when it cannot be read.
+# Echo the cgroup memory limit in MiB, or nothing. Args: the v2 then v1 limit
+# files, first readable numeric one wins. v2 writes "max" and v1 an enormous
+# sentinel when unlimited; neither parses as a limit worth applying.
+_cgroup_limit_mb() {
+    local _f _raw
+    for _f in "$@"; do
+        [ -r "$_f" ] || continue
+        _raw=$(cat "$_f" 2>/dev/null || true)
+        [[ "$_raw" =~ ^[0-9]+$ ]] || continue
+        printf '%d' "$(( _raw / 1048576 ))"
+        return 0
+    done
+    return 0
+}
+
+# Total RAM in MiB; empty when it cannot be read. /proc/meminfo is not namespaced,
+# so it reports the host inside a container and a memory-limited Docker or
+# Kubernetes build would budget from the host and get OOM-killed. A lower cgroup
+# limit wins; v1's unlimited sentinel never is one.
 _total_ram_mb() {
-    local _bytes
+    local _bytes _mb="" _limit
     if [ -r /proc/meminfo ]; then
-        awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo
+        _mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo)
     elif _bytes=$(sysctl -n hw.memsize 2>/dev/null); then
-        [[ "$_bytes" =~ ^[0-9]+$ ]] && printf '%d' "$(( _bytes / 1048576 ))"
+        [[ "$_bytes" =~ ^[0-9]+$ ]] && _mb=$(( _bytes / 1048576 ))
     fi
+    _limit=$(_cgroup_limit_mb /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes)
+    if [[ "$_limit" =~ ^[0-9]+$ ]] && [ "$_limit" -ge 1 ]; then
+        if [ -z "$_mb" ] || [ "$_limit" -lt "$_mb" ]; then _mb=$_limit; fi
+    fi
+    printf '%s' "$_mb"
     return 0
 }
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -329,11 +329,12 @@ _cg_dirs() {
     printf '%s\n' "$_root"
 }
 
-# Echo a cgroup hierarchy's mount point, or nothing. $1 = a mountinfo file,
-# $2 = "cgroup2" for the unified mount or a v1 controller name. mountinfo is
-# "... <mountpoint> <opts> [tags] - <fstype> <source> <superopts>", and a v1
-# hierarchy lists its controllers in the super options, so a co-mounted or
-# relocated one is found by name instead of assumed to sit at <root>/<name>.
+# Echo a cgroup hierarchy's "<mount root><tab><mount point>", or nothing.
+# $1 = a mountinfo file, $2 = "cgroup2" for the unified mount or a v1 controller
+# name. mountinfo is "... <root> <mountpoint> <opts> [tags] - <fstype> <source>
+# <superopts>", and a v1 hierarchy lists its controllers in the super options,
+# so a co-mounted or relocated one is found by name instead of assumed to sit
+# at <root>/<name>.
 _cg_mount() {
     [ -r "$1" ] || return 0
     awk -v want="$2" '
@@ -341,13 +342,32 @@ _cg_mount() {
             for (i = 1; i <= NF; i++) if ($i == "-") break
             if (i + 3 > NF) next
             if (want == "cgroup2") {
-                if ($(i + 1) == "cgroup2") { print $5; exit }
+                if ($(i + 1) == "cgroup2") { print $4 "\t" $5; exit }
                 next
             }
             if ($(i + 1) != "cgroup") next
             n = split($(i + 3), opts, ",")
-            for (j = 1; j <= n; j++) if (opts[j] == want) { print $5; exit }
+            for (j = 1; j <= n; j++) if (opts[j] == want) { print $4 "\t" $5; exit }
         }' "$1" 2>/dev/null
+    return 0
+}
+
+# Echo the process's path within a mount, or nothing when the mount does not
+# expose it. Args: mount root, process cgroup path. A bind-mounted subtree
+# (Docker without a cgroup namespace, a systemd slice) shows a mount root like
+# /slice while /proc/self/cgroup still reports the host-absolute /slice/job, and
+# the files are then at <mountpoint>/job. Joining the two unmapped walks a path
+# that does not exist and settles on an outer limit instead of the binding one.
+_cg_rel() {
+    local _root=$1 _rel=$2
+    [ -n "$_rel" ] || return 0
+    [ "$_root" = "/" ] && { printf '%s' "$_rel"; return 0; }
+    case "$_rel" in
+        "$_root") printf '%s' "/" ;;
+        "$_root"/*) printf '%s' "${_rel#"$_root"}" ;;
+        # Not under this mount's root: nothing here describes this process.
+        *) : ;;
+    esac
     return 0
 }
 
@@ -360,7 +380,8 @@ _cg_mount() {
 # the directory that set it, because an ancestor's usage counts siblings this
 # process cannot see. The smallest remaining allowance wins.
 _cgroup_free_mb() {
-    local _root=$1 _proc=$2 _mnt=${3:-} _rel _dir _used _limit _free _name _min="" _v2 _v1
+    local _root=$1 _proc=$2 _mnt=${3:-} _rel _dir _used _limit _free _name _min=""
+    local _v2 _v1 _v2root _v1root
     _consider() {
         [ -n "$1" ] || return 0
         if [[ "$2" =~ ^[0-9]+$ ]]; then _free=$(( $1 - $2 )); else _free=$1; fi
@@ -368,12 +389,15 @@ _cgroup_free_mb() {
         if [ -z "$_min" ] || [ "$_free" -lt "$_min" ]; then _min=$_free; fi
         return 0
     }
-    # Prefer the real mount points; fall back to the conventional layout.
-    _v2=$(_cg_mount "$_mnt" cgroup2); [ -n "$_v2" ] || _v2=$_root
-    _v1=$(_cg_mount "$_mnt" memory);  [ -n "$_v1" ] || _v1="$_root/memory"
+    # Prefer the real mounts; fall back to the conventional layout.
+    IFS=$'\t' read -r _v2root _v2 <<< "$(_cg_mount "$_mnt" cgroup2)"
+    IFS=$'\t' read -r _v1root _v1 <<< "$(_cg_mount "$_mnt" memory)"
+    [ -n "$_v2" ] || { _v2=$_root; _v2root="/"; }
+    [ -n "$_v1" ] || { _v1="$_root/memory"; _v1root="/"; }
     if [ -d "$_v2" ]; then
         # The v2 line is "0::<path>"; systemd hybrid mode adds v1 lines alongside.
         _rel=$(awk -F: '/^0::/ { print $3; exit }' "$_proc" 2>/dev/null || true)
+        _rel=$(_cg_rel "$_v2root" "$_rel")
         while IFS= read -r _dir; do
             _used=$(_cg_read "$_dir/memory.current")
             for _name in memory.max memory.high; do
@@ -385,6 +409,7 @@ _cgroup_free_mb() {
     if [ -d "$_v1" ]; then
         # v1 is "<id>:<controllers>:<path>", and mounts are often combined.
         _rel=$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' "$_proc" 2>/dev/null || true)
+        _rel=$(_cg_rel "$_v1root" "$_rel")
         while IFS= read -r _dir; do
             _used=$(_cg_read "$_dir/memory.usage_in_bytes")
             _limit=$(_cg_limit "$(_cg_read "$_dir/memory.limit_in_bytes")")

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -337,17 +337,32 @@ _cg_dirs() {
 # at <root>/<name>.
 _cg_mounts() {
     [ -r "$1" ] || return 0
+    # mountinfo escapes space, tab, newline and backslash in paths as \040 and
+    # friends, so both path fields are decoded before use. strtonum is a gawk
+    # extension; this arithmetic is POSIX and runs under mawk and BSD awk too.
     awk -v want="$2" '
+        function unesc(s,   out, i, c, o, v) {
+            out = ""; i = 1
+            while (i <= length(s)) {
+                c = substr(s, i, 1)
+                if (c == "\\" && substr(s, i + 1, 3) ~ /^[0-7][0-7][0-7]$/) {
+                    o = substr(s, i + 1, 3)
+                    v = (substr(o, 1, 1) + 0) * 64 + (substr(o, 2, 1) + 0) * 8 + (substr(o, 3, 1) + 0)
+                    out = out sprintf("%c", v); i += 4
+                } else { out = out c; i++ }
+            }
+            return out
+        }
         {
             for (i = 1; i <= NF; i++) if ($i == "-") break
             if (i + 3 > NF) next
             if (want == "cgroup2") {
-                if ($(i + 1) == "cgroup2") print $4 "\t" $5
+                if ($(i + 1) == "cgroup2") print unesc($4) "\t" unesc($5)
                 next
             }
             if ($(i + 1) != "cgroup") next
             n = split($(i + 3), opts, ",")
-            for (j = 1; j <= n; j++) if (opts[j] == want) { print $4 "\t" $5; next }
+            for (j = 1; j <= n; j++) if (opts[j] == want) { print unesc($4) "\t" unesc($5); next }
         }' "$1" 2>/dev/null
     return 0
 }
@@ -414,8 +429,16 @@ _cgroup_free_mb() {
     }
     # Prefer the real mounts; fall back to the conventional layout. The process
     # path is read first so the right mount can be chosen among several.
-    _v2rel=$(awk -F: '/^0::/ { print $3; exit }' "$_proc" 2>/dev/null || true)
-    _v1rel=$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' "$_proc" 2>/dev/null || true)
+    # Only the first two colons are delimiters: a systemd unit name may contain
+    # one, and -F: with $3 would truncate the path there.
+    _v2rel=$(awk '/^0::/ { print substr($0, 4); exit }' "$_proc" 2>/dev/null || true)
+    _v1rel=$(awk '
+        {
+            a = index($0, ":"); if (a == 0) next
+            rest = substr($0, a + 1)
+            b = index(rest, ":"); if (b == 0) next
+            if (substr(rest, 1, b - 1) ~ /(^|,)memory(,|$)/) { print substr(rest, b + 1); exit }
+        }' "$_proc" 2>/dev/null || true)
     IFS=$'\t' read -r _v2root _v2 <<< "$(_cg_mounts "$_mnt" cgroup2 | _cg_pick_mount "$_v2rel")"
     IFS=$'\t' read -r _v1root _v1 <<< "$(_cg_mounts "$_mnt" memory | _cg_pick_mount "$_v1rel")"
     [ -n "$_v2" ] || { _v2=$_root; _v2root="/"; }

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -277,8 +277,21 @@ _resolve_cuda_archs() {
     printf '%s' "$_archs"
 }
 
-# Reserved for the OS, and budgeted per compile job, both in MiB. An nvcc/hipcc
-# translation unit peaks near 2 GiB, so core count alone oversubscribes RAM.
+# Reserved for the OS, and budgeted per compile job, both in MiB.
+#
+# Measured on llama.cpp at ggml-org/llama.cpp master with CUDA 13.1: the
+# heaviest translation units are the flash-attention template instances, which
+# peak at ~400 MiB of RSS each, flat in the number of CUDA archs (nvcc compiles
+# archs one after another, so only wall time scales). A full CUDA build at -j20
+# peaked at 8.2 GiB in aggregate, and -j20 produced ~30 concurrent compiler
+# processes, because nvcc forks cicc and ptxas under itself.
+#
+# 2048 is deliberately above that measurement rather than equal to it. It has to
+# cover the ~1.5x process fan-out, MSVC on Windows and hipcc on ROCm which are
+# not measured here, older CUDA toolkits which were much heavier on the same
+# files (ggml-org/llama.cpp#17844 reports a build climbing past 16 GiB and
+# taking the machine with it), and the link step at the end. Erring high costs
+# build time on a small machine; erring low costs the machine.
 _LLAMA_BUILD_RESERVE_MB=2048
 _LLAMA_BUILD_MB_PER_JOB=2048
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -438,29 +438,31 @@ _cg_rel() {
     return 0
 }
 
-# Pick one "<root><tab><point>" from the escaped candidates on stdin, and echo
-# it still escaped. A hierarchy can be mounted more than once, and taking the
-# first would step past the binding mount whenever an unrelated subtree is
-# listed ahead of it. Prefer a mount whose root contains the process path, most
-# specific first; else keep the first seen. Args: process cgroup path.
-_cg_pick_mount() {
-    local _rel=$1 _root _point _droot _bestlen=0
-    local _bestroot="" _bestpoint="" _firstroot="" _firstpoint=""
+# Echo EVERY "<root><tab><point>" on stdin whose root contains the process
+# path, still escaped, one per line; or the first seen when none does.
+#
+# A hierarchy can be mounted more than once, and the two mounts can expose
+# different subtree roots of the same superblock -- rootless podman inside
+# rootless podman is the documented case, where a host-derived bind mount sits
+# alongside a namespace-scoped one. Taking the first would step past the binding
+# mount, but so would taking only the most specific: a limit above the narrower
+# mount's root is invisible through it and visible through the broader one.
+# Every mount whose root contains the path genuinely constrains this process, so
+# all of them are inspected and the smallest allowance wins. Order does not
+# matter, because a minimum is order-independent.
+# Args: process cgroup path.
+_cg_pick_mounts() {
+    local _rel=$1 _root _point _droot _any="" _firstroot="" _firstpoint=""
     while IFS=$'\t' read -r _root _point; do
         [ -n "$_point" ] || continue
         if [ -z "$_firstpoint" ]; then _firstroot=$_root; _firstpoint=$_point; fi
         # /proc/self/cgroup is not escaped, so the root is compared decoded.
         _droot=$(_cg_unesc "$_root")
         [ -n "$(_cg_rel "$_droot" "$_rel")" ] || continue
-        if [ -z "$_bestpoint" ] || [ "${#_droot}" -gt "$_bestlen" ]; then
-            _bestroot=$_root; _bestpoint=$_point; _bestlen=${#_droot}
-        fi
+        printf '%s\t%s\n' "$_root" "$_point"
+        _any=1
     done
-    if [ -n "$_bestpoint" ]; then
-        printf '%s\t%s' "$_bestroot" "$_bestpoint"
-    elif [ -n "$_firstpoint" ]; then
-        printf '%s\t%s' "$_firstroot" "$_firstpoint"
-    fi
+    [ -n "$_any" ] || [ -z "$_firstpoint" ] || printf '%s\t%s\n' "$_firstroot" "$_firstpoint"
     return 0
 }
 
@@ -474,7 +476,7 @@ _cg_pick_mount() {
 # process cannot see. The smallest remaining allowance wins.
 _cgroup_free_mb() {
     local _root=$1 _proc=$2 _mnt=${3:-} _rel _dir _used _limit _free _name _min=""
-    local _v2 _v1 _v2root _v1root _v2rel _v1rel
+    local _v2rel _v1rel _v2mnts _v1mnts _mroot _mpoint
     _cg_consider() {
         [ -n "$1" ] || return 0
         if [[ "$2" =~ ^[0-9]+$ ]]; then _free=$(( $1 - $2 )); else _free=$1; fi
@@ -494,37 +496,45 @@ _cgroup_free_mb() {
             b = index(rest, ":"); if (b == 0) next
             if (substr(rest, 1, b - 1) ~ /(^|,)memory(,|$)/) { print substr(rest, b + 1); exit }
         }' "$_proc" 2>/dev/null || true)
-    IFS=$'\t' read -r _v2root _v2 <<< "$(_cg_mounts "$_mnt" cgroup2 | _cg_pick_mount "$_v2rel")"
-    IFS=$'\t' read -r _v1root _v1 <<< "$(_cg_mounts "$_mnt" memory | _cg_pick_mount "$_v1rel")"
-    # Escapes survive the tab- and newline-delimited transport above; a single
-    # path is in hand now, so decode it before touching the filesystem. The
-    # trailing sentinel keeps $() from eating a decoded trailing newline.
-    _v2root=$(_cg_unesc "$_v2root"; printf X); _v2root=${_v2root%X}
-    _v2=$(_cg_unesc "$_v2"; printf X); _v2=${_v2%X}
-    _v1root=$(_cg_unesc "$_v1root"; printf X); _v1root=${_v1root%X}
-    _v1=$(_cg_unesc "$_v1"; printf X); _v1=${_v1%X}
-    [ -n "$_v2" ] || { _v2=$_root; _v2root="/"; }
-    [ -n "$_v1" ] || { _v1="$_root/memory"; _v1root="/"; }
-    if [ -d "$_v2" ]; then
-        # The v2 line is "0::<path>"; systemd hybrid mode adds v1 lines alongside.
-        _rel=$(_cg_rel "$_v2root" "$_v2rel")
+    _v2mnts=$(_cg_mounts "$_mnt" cgroup2 | _cg_pick_mounts "$_v2rel")
+    _v1mnts=$(_cg_mounts "$_mnt" memory | _cg_pick_mounts "$_v1rel")
+    # Fall back to the conventional layout when mountinfo is unreadable.
+    [ -n "$_v2mnts" ] || _v2mnts=$(printf '/\t%s' "$_root")
+    [ -n "$_v1mnts" ] || _v1mnts=$(printf '/\t%s' "$_root/memory")
+
+    # The v2 line is "0::<path>"; systemd hybrid mode adds v1 lines alongside.
+    while IFS=$'\t' read -r _mroot _mpoint; do
+        [ -n "$_mpoint" ] || continue
+        # Escapes survive the tab- and newline-delimited transport above; a
+        # single path is in hand now, so decode it before touching the
+        # filesystem. The sentinel keeps $() from eating a trailing newline.
+        _mroot=$(_cg_unesc "$_mroot"; printf X); _mroot=${_mroot%X}
+        _mpoint=$(_cg_unesc "$_mpoint"; printf X); _mpoint=${_mpoint%X}
+        [ -d "$_mpoint" ] || continue
+        _rel=$(_cg_rel "$_mroot" "$_v2rel")
         while IFS= read -r -d '' _dir; do
             _used=$(_cg_read "$_dir/memory.current")
             for _name in memory.max memory.high; do
                 _limit=$(_cg_limit "$(_cg_read "$_dir/$_name")")
                 _cg_consider "$_limit" "$_used"
             done
-        done < <(_cg_dirs "$_v2" "$_rel")
-    fi
-    if [ -d "$_v1" ]; then
-        # v1 is "<id>:<controllers>:<path>", and mounts are often combined.
-        _rel=$(_cg_rel "$_v1root" "$_v1rel")
+        done < <(_cg_dirs "$_mpoint" "$_rel")
+    done <<< "$_v2mnts"
+
+    # v1 is "<id>:<controllers>:<path>", and mounts are often combined.
+    while IFS=$'\t' read -r _mroot _mpoint; do
+        [ -n "$_mpoint" ] || continue
+        _mroot=$(_cg_unesc "$_mroot"; printf X); _mroot=${_mroot%X}
+        _mpoint=$(_cg_unesc "$_mpoint"; printf X); _mpoint=${_mpoint%X}
+        [ -d "$_mpoint" ] || continue
+        _rel=$(_cg_rel "$_mroot" "$_v1rel")
         while IFS= read -r -d '' _dir; do
             _used=$(_cg_read "$_dir/memory.usage_in_bytes")
             _limit=$(_cg_limit "$(_cg_read "$_dir/memory.limit_in_bytes")")
             _cg_consider "$_limit" "$_used"
-        done < <(_cg_dirs "$_v1" "$_rel")
-    fi
+        done < <(_cg_dirs "$_mpoint" "$_rel")
+    done <<< "$_v1mnts"
+
     [ -n "$_min" ] && printf '%d' "$(( _min / 1048576 ))"
     return 0
 }

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -550,7 +550,7 @@ _usable_ram_mb() {
         _avail=$(vm_stat 2>/dev/null | _vm_stat_avail_mb || true)
         if [[ "$_avail" =~ ^[0-9]+$ ]] && [ "$_avail" -gt 0 ]; then _mb=$_avail; fi
     fi
-    _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup /proc/self/mountinfo) || true
+    _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup /proc/self/mountinfo)
     if [[ "$_free" =~ ^[0-9]+$ ]]; then
         if [ -z "$_mb" ] || [ "$_free" -lt "$_mb" ]; then _mb=$_free; fi
     fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -302,35 +302,92 @@ _llama_jobs_for() {
     printf '%s' "$_jobs"
 }
 
-# Echo the cgroup memory limit in MiB, or nothing. Args: the v2 then v1 limit
-# files, first readable numeric one wins. v2 writes "max" and v1 an enormous
-# sentinel when unlimited; neither parses as a limit worth applying.
-_cgroup_limit_mb() {
-    local _f _raw
-    for _f in "$@"; do
-        [ -r "$_f" ] || continue
-        _raw=$(cat "$_f" 2>/dev/null || true)
-        [[ "$_raw" =~ ^[0-9]+$ ]] || continue
-        printf '%d' "$(( _raw / 1048576 ))"
-        return 0
-    done
+# Echo the first line of $1 with whitespace stripped, or nothing.
+_cg_read() {
+    [ -r "$1" ] || return 0
+    head -n 1 "$1" 2>/dev/null | tr -d '[:space:]'
     return 0
 }
 
-# Total RAM in MiB; empty when it cannot be read. /proc/meminfo is not namespaced,
-# so it reports the host inside a container and a memory-limited Docker or
-# Kubernetes build would budget from the host and get OOM-killed. A lower cgroup
-# limit wins; v1's unlimited sentinel never is one.
-_total_ram_mb() {
-    local _bytes _mb="" _limit
+# Echo $1 when it is a real limit. v2 writes "max"; v1 a near-2^63 sentinel.
+_cg_limit() {
+    [[ "$1" =~ ^[0-9]+$ ]] || return 0
+    [ "$1" -gt 0 ] && [ "$1" -lt 4611686018427387904 ] && printf '%s' "$1"
+    return 0
+}
+
+# Echo "$1/$2" and every ancestor up to $1, innermost first.
+_cg_dirs() {
+    local _root=$1 _cur
+    if [ -n "${2:-}" ] && [ "$2" != "/" ]; then
+        _cur="$_root/${2#/}"
+        while [ "$_cur" != "$_root" ] && [ "$_cur" != "/" ] && [ "$_cur" != "." ]; do
+            printf '%s\n' "$_cur"
+            _cur=$(dirname "$_cur")
+        done
+    fi
+    printf '%s\n' "$_root"
+}
+
+# Echo the memory free under the binding cgroup limit in MiB, or nothing.
+# Args: cgroup root, /proc/self/cgroup path; both taken as arguments so the
+# tests can drive a real tree. Mirrors unsloth/dataset_num_proc.py: reading the
+# hierarchy root alone only works in a container with a private cgroup
+# namespace, and under Slurm, systemd or --cgroupns=host the binding limit is
+# the process's own path or an ancestor's. Each limit pairs with the usage of
+# the directory that set it, because an ancestor's usage counts siblings this
+# process cannot see. The smallest remaining allowance wins.
+_cgroup_free_mb() {
+    local _root=$1 _proc=$2 _rel _dir _used _limit _free _name _min=""
+    _consider() {
+        [ -n "$1" ] || return 0
+        if [[ "$2" =~ ^[0-9]+$ ]]; then _free=$(( $1 - $2 )); else _free=$1; fi
+        [ "$_free" -lt 0 ] && _free=0
+        if [ -z "$_min" ] || [ "$_free" -lt "$_min" ]; then _min=$_free; fi
+        return 0
+    }
+    if [ -d "$_root" ]; then
+        # The v2 line is "0::<path>"; systemd hybrid mode adds v1 lines alongside.
+        _rel=$(awk -F: '/^0::/ { print $3; exit }' "$_proc" 2>/dev/null || true)
+        while IFS= read -r _dir; do
+            _used=$(_cg_read "$_dir/memory.current")
+            for _name in memory.max memory.high; do
+                _limit=$(_cg_limit "$(_cg_read "$_dir/$_name")")
+                _consider "$_limit" "$_used"
+            done
+        done <<< "$(_cg_dirs "$_root" "$_rel")"
+    fi
+    if [ -d "$_root/memory" ]; then
+        # v1 is "<id>:<controllers>:<path>", and mounts are often combined.
+        _rel=$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' "$_proc" 2>/dev/null || true)
+        while IFS= read -r _dir; do
+            _used=$(_cg_read "$_dir/memory.usage_in_bytes")
+            _limit=$(_cg_limit "$(_cg_read "$_dir/memory.limit_in_bytes")")
+            _consider "$_limit" "$_used"
+        done <<< "$(_cg_dirs "$_root/memory" "$_rel")"
+    fi
+    [ -n "$_min" ] && printf '%d' "$(( _min / 1048576 ))"
+    return 0
+}
+
+# Usable RAM in MiB; empty when it cannot be read. MemAvailable, not MemTotal:
+# a workstation with 8 GiB already resident cannot host a 14 GiB compile just
+# because 16 GiB is fitted. /proc is not namespaced either, so a lower cgroup
+# allowance wins. macOS has no comparable reclaim-aware figure, so it keeps
+# installed RAM.
+_usable_ram_mb() {
+    local _bytes _mb="" _free
     if [ -r /proc/meminfo ]; then
-        _mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo)
+        # MemAvailable counts reclaimable page cache; MemFree does not. Absent
+        # before Linux 3.14, where MemTotal is the only thing to go on.
+        _mb=$(awk '/^MemAvailable:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo)
+        [ -n "$_mb" ] || _mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo)
     elif _bytes=$(sysctl -n hw.memsize 2>/dev/null); then
         [[ "$_bytes" =~ ^[0-9]+$ ]] && _mb=$(( _bytes / 1048576 ))
     fi
-    _limit=$(_cgroup_limit_mb /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes)
-    if [[ "$_limit" =~ ^[0-9]+$ ]] && [ "$_limit" -ge 1 ]; then
-        if [ -z "$_mb" ] || [ "$_limit" -lt "$_mb" ]; then _mb=$_limit; fi
+    _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup)
+    if [[ "$_free" =~ ^[0-9]+$ ]]; then
+        if [ -z "$_mb" ] || [ "$_free" -lt "$_mb" ]; then _mb=$_free; fi
     fi
     printf '%s' "$_mb"
     return 0
@@ -339,7 +396,7 @@ _total_ram_mb() {
 _llama_build_jobs() {
     _llama_jobs_for \
         "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)" \
-        "$(_total_ram_mb)"
+        "$(_usable_ram_mb)"
 }
 
 # Opt-in staged GPU smoke test after a source build (#5854 gap 2). Default off:

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -539,16 +539,33 @@ _cgroup_free_mb() {
     return 0
 }
 
-# macOS available memory in MiB, read from vm_stat on stdin. free + inactive +
-# speculative + purgeable is the reclaim-aware equivalent of MemAvailable; the
-# page size comes from the header rather than being assumed 4096, which is wrong
-# on Apple Silicon. Empty when the output does not parse.
+# macOS available memory in MiB, read from vm_stat on stdin. free + inactive is
+# the reclaim-aware equivalent of MemAvailable; the page size comes from the
+# header rather than being assumed 4096, which is wrong on Apple Silicon. Empty
+# when the output does not parse.
+#
+# Only those two, because the other candidates are not disjoint from them and
+# adding either overstates what can be reclaimed, which buys back exactly the
+# oversubscription this cap removes:
+#
+#   speculative -- xnu osfmk/mach/vm_statistics.h says so outright: "NB:
+#     speculative pages are already accounted for in free_count, so
+#     speculative_count is the number of free pages that are used to hold data
+#     that was read speculatively from disk".
+#   purgeable   -- an attribute of a page, not a queue it sits on. A volatile
+#     page is still on the active or inactive queue, so it is already counted
+#     there. The disjoint partition is free + active + inactive + wired +
+#     throttled + compressor.
+#
+# Dropping them under-counts by the purgeable pages sitting on the ACTIVE queue,
+# which are reclaimable but not in either term. That is the safe direction for a
+# cap: it costs build time on a busy Mac rather than the machine.
 _vm_stat_avail_mb() {
     awk '
         /page size of/ {
             for (i = 1; i < NF; i++) if ($i == "of") { ps = $(i + 1) + 0; break }
         }
-        /^Pages (free|inactive|speculative|purgeable)/ {
+        /^Pages (free|inactive)/ {
             gsub(/\./, "", $NF); pages += $NF
         }
         # A zero page count is a reading, not a parse failure; a missing page

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -329,25 +329,25 @@ _cg_dirs() {
     printf '%s\n' "$_root"
 }
 
-# Echo a cgroup hierarchy's "<mount root><tab><mount point>", or nothing.
+# Echo every matching cgroup hierarchy as "<mount root><tab><mount point>".
 # $1 = a mountinfo file, $2 = "cgroup2" for the unified mount or a v1 controller
 # name. mountinfo is "... <root> <mountpoint> <opts> [tags] - <fstype> <source>
 # <superopts>", and a v1 hierarchy lists its controllers in the super options,
 # so a co-mounted or relocated one is found by name instead of assumed to sit
 # at <root>/<name>.
-_cg_mount() {
+_cg_mounts() {
     [ -r "$1" ] || return 0
     awk -v want="$2" '
         {
             for (i = 1; i <= NF; i++) if ($i == "-") break
             if (i + 3 > NF) next
             if (want == "cgroup2") {
-                if ($(i + 1) == "cgroup2") { print $4 "\t" $5; exit }
+                if ($(i + 1) == "cgroup2") print $4 "\t" $5
                 next
             }
             if ($(i + 1) != "cgroup") next
             n = split($(i + 3), opts, ",")
-            for (j = 1; j <= n; j++) if (opts[j] == want) { print $4 "\t" $5; exit }
+            for (j = 1; j <= n; j++) if (opts[j] == want) { print $4 "\t" $5; next }
         }' "$1" 2>/dev/null
     return 0
 }
@@ -371,6 +371,29 @@ _cg_rel() {
     return 0
 }
 
+# Pick one "<root><tab><point>" from the candidates on stdin. A hierarchy can be
+# mounted more than once, and taking the first would step past the binding mount
+# whenever an unrelated subtree is listed ahead of it. Prefer a mount whose root
+# contains the process path, most specific first; else keep the first seen.
+# Args: process cgroup path.
+_cg_pick_mount() {
+    local _rel=$1 _root _point _bestroot="" _bestpoint="" _firstroot="" _firstpoint=""
+    while IFS=$'\t' read -r _root _point; do
+        [ -n "$_point" ] || continue
+        if [ -z "$_firstpoint" ]; then _firstroot=$_root; _firstpoint=$_point; fi
+        [ -n "$(_cg_rel "$_root" "$_rel")" ] || continue
+        if [ -z "$_bestpoint" ] || [ "${#_root}" -gt "${#_bestroot}" ]; then
+            _bestroot=$_root; _bestpoint=$_point
+        fi
+    done
+    if [ -n "$_bestpoint" ]; then
+        printf '%s\t%s' "$_bestroot" "$_bestpoint"
+    elif [ -n "$_firstpoint" ]; then
+        printf '%s\t%s' "$_firstroot" "$_firstpoint"
+    fi
+    return 0
+}
+
 # Echo the memory free under the binding cgroup limit in MiB, or nothing.
 # Args: fallback cgroup root, /proc/self/cgroup path, /proc/self/mountinfo
 # path; all taken as arguments so the tests can drive a real tree. Mirrors unsloth/dataset_num_proc.py: reading the
@@ -381,7 +404,7 @@ _cg_rel() {
 # process cannot see. The smallest remaining allowance wins.
 _cgroup_free_mb() {
     local _root=$1 _proc=$2 _mnt=${3:-} _rel _dir _used _limit _free _name _min=""
-    local _v2 _v1 _v2root _v1root
+    local _v2 _v1 _v2root _v1root _v2rel _v1rel
     _consider() {
         [ -n "$1" ] || return 0
         if [[ "$2" =~ ^[0-9]+$ ]]; then _free=$(( $1 - $2 )); else _free=$1; fi
@@ -389,15 +412,17 @@ _cgroup_free_mb() {
         if [ -z "$_min" ] || [ "$_free" -lt "$_min" ]; then _min=$_free; fi
         return 0
     }
-    # Prefer the real mounts; fall back to the conventional layout.
-    IFS=$'\t' read -r _v2root _v2 <<< "$(_cg_mount "$_mnt" cgroup2)"
-    IFS=$'\t' read -r _v1root _v1 <<< "$(_cg_mount "$_mnt" memory)"
+    # Prefer the real mounts; fall back to the conventional layout. The process
+    # path is read first so the right mount can be chosen among several.
+    _v2rel=$(awk -F: '/^0::/ { print $3; exit }' "$_proc" 2>/dev/null || true)
+    _v1rel=$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' "$_proc" 2>/dev/null || true)
+    IFS=$'\t' read -r _v2root _v2 <<< "$(_cg_mounts "$_mnt" cgroup2 | _cg_pick_mount "$_v2rel")"
+    IFS=$'\t' read -r _v1root _v1 <<< "$(_cg_mounts "$_mnt" memory | _cg_pick_mount "$_v1rel")"
     [ -n "$_v2" ] || { _v2=$_root; _v2root="/"; }
     [ -n "$_v1" ] || { _v1="$_root/memory"; _v1root="/"; }
     if [ -d "$_v2" ]; then
         # The v2 line is "0::<path>"; systemd hybrid mode adds v1 lines alongside.
-        _rel=$(awk -F: '/^0::/ { print $3; exit }' "$_proc" 2>/dev/null || true)
-        _rel=$(_cg_rel "$_v2root" "$_rel")
+        _rel=$(_cg_rel "$_v2root" "$_v2rel")
         while IFS= read -r _dir; do
             _used=$(_cg_read "$_dir/memory.current")
             for _name in memory.max memory.high; do
@@ -408,8 +433,7 @@ _cgroup_free_mb() {
     fi
     if [ -d "$_v1" ]; then
         # v1 is "<id>:<controllers>:<path>", and mounts are often combined.
-        _rel=$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' "$_proc" 2>/dev/null || true)
-        _rel=$(_cg_rel "$_v1root" "$_rel")
+        _rel=$(_cg_rel "$_v1root" "$_v1rel")
         while IFS= read -r _dir; do
             _used=$(_cg_read "$_dir/memory.usage_in_bytes")
             _limit=$(_cg_limit "$(_cg_read "$_dir/memory.limit_in_bytes")")

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -535,7 +535,7 @@ _vm_stat_avail_mb() {
         /^Pages (free|inactive|speculative|purgeable)/ {
             gsub(/\./, "", $NF); pages += $NF
         }
-        END { if (ps > 0 && pages > 0) printf "%d", pages * ps / 1048576 }'
+        END { if (ps > 0 && pages > 0) printf "%d", pages * ps / 1048576 }' || true
     return 0
 }
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -502,6 +502,22 @@ _cgroup_free_mb() {
     return 0
 }
 
+# macOS available memory in MiB, read from vm_stat on stdin. free + inactive +
+# speculative + purgeable is the reclaim-aware equivalent of MemAvailable; the
+# page size comes from the header rather than being assumed 4096, which is wrong
+# on Apple Silicon. Empty when the output does not parse.
+_vm_stat_avail_mb() {
+    awk '
+        /page size of/ {
+            for (i = 1; i < NF; i++) if ($i == "of") { ps = $(i + 1) + 0; break }
+        }
+        /^Pages (free|inactive|speculative|purgeable)/ {
+            gsub(/\./, "", $NF); pages += $NF
+        }
+        END { if (ps > 0 && pages > 0) printf "%d", pages * ps / 1048576 }'
+    return 0
+}
+
 # Usable RAM in MiB; empty when it cannot be read. MemAvailable, not MemTotal:
 # a workstation with 8 GiB already resident cannot host a 14 GiB compile just
 # because 16 GiB is fitted. /proc is not namespaced either, so a lower cgroup
@@ -509,7 +525,7 @@ _cgroup_free_mb() {
 # installed RAM. $1 is the meminfo file, an argument like every other reader's
 # path here so the tests can pin a number instead of racing the live one.
 _usable_ram_mb() {
-    local _meminfo=${1:-/proc/meminfo} _bytes _mb="" _free
+    local _meminfo=${1:-/proc/meminfo} _bytes _mb="" _free _avail
     if [ -r "$_meminfo" ]; then
         # MemAvailable counts reclaimable page cache; MemFree does not. Absent
         # before Linux 3.14, where MemTotal is the only thing to go on.
@@ -517,6 +533,11 @@ _usable_ram_mb() {
         [ -n "$_mb" ] || _mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' "$_meminfo")
     elif _bytes=$(sysctl -n hw.memsize 2>/dev/null); then
         [[ "$_bytes" =~ ^[0-9]+$ ]] && _mb=$(( _bytes / 1048576 ))
+        # macOS has no MemAvailable, so hw.memsize is installed RAM and would
+        # hand a busy Mac a budget it cannot honour. vm_stat is the equivalent;
+        # installed RAM stays the fallback if the output does not parse.
+        _avail=$(vm_stat 2>/dev/null | _vm_stat_avail_mb || true)
+        if [[ "$_avail" =~ ^[0-9]+$ ]] && [ "$_avail" -gt 0 ]; then _mb=$_avail; fi
     fi
     _free=$(_cgroup_free_mb /sys/fs/cgroup /proc/self/cgroup /proc/self/mountinfo)
     if [[ "$_free" =~ ^[0-9]+$ ]]; then

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -73,7 +73,8 @@ assert_eq "junk override ignored" "7" "$(run_jobs 20 16384 "lots")"
 # namespace, but under Slurm, systemd or --cgroupns=host the binding limit is
 # the process's own path or an ancestor's, and a root-only read sees "max".
 _CG_FILE=$(mktemp)
-for _fn in _cg_read _cg_limit _cg_dirs _cg_mounts _cg_rel _cg_pick_mount _cgroup_free_mb; do
+for _fn in _cg_read _cg_limit _cg_dirs _cg_unesc_prog _cg_unesc _cg_mounts _cg_rel \
+           _cg_pick_mount _cgroup_free_mb; do
     sed -n "/^${_fn}()/,/^}/p" "$SETUP_SH" >> "$_CG_FILE"
 done
 if [ ! -s "$_CG_FILE" ]; then
@@ -284,19 +285,52 @@ printf '4:cpu,memoryfoo:/slice:tenant/task\n' > "$_TMPD/colonv1.bad"
 assert_eq "a lookalike controller is not matched" "" \
     "$(run_cgroup "$_TMPD/colon/v1" "$_TMPD/colonv1.bad")"
 
-# The min() that ties it together. _usable_ram_mb hardcodes the real paths, so
-# stub the reader to prove the wiring rather than just the parts.
+# 27) \012 is a legal escape, and decoding it where the fields are read put a
+#     newline into the reader's own line-oriented output, splitting one mount
+#     record into two. The record has to travel escaped and be decoded once.
+_NL=$'\n'
+mkdir -p "$_TMPD/esc/two${_NL}lines/job"
+printf '8589934592\n' > "$_TMPD/esc/two${_NL}lines/memory.max"
+printf '3221225472\n' > "$_TMPD/esc/two${_NL}lines/job/memory.max"
+printf '0::/slice/job\n' > "$_TMPD/escnl.proc"
+printf '%s\n' "72 30 0:62 /slice $_TMPD/esc/two\\012lines rw - cgroup2 cgroup2 rw" \
+    > "$_TMPD/escnl.mnt"
+assert_eq "a newline in the mount point survives" "3072" \
+    "$(run_cgroup "$_TMPD/esc" "$_TMPD/escnl.proc" "$_TMPD/escnl.mnt")"
+
+# 28) And the same mount point one level down, so the ancestor walk has to
+#     carry the newline too rather than only the leaf lookup.
+mkdir -p "$_TMPD/esc/two${_NL}lines/outer/inner"
+printf '2147483648\n' > "$_TMPD/esc/two${_NL}lines/outer/memory.max"
+printf 'max\n'        > "$_TMPD/esc/two${_NL}lines/outer/inner/memory.max"
+printf '0::/slice/outer/inner\n' > "$_TMPD/escnl2.proc"
+assert_eq "a newline survives the ancestor walk" "2048" \
+    "$(run_cgroup "$_TMPD/esc" "$_TMPD/escnl2.proc" "$_TMPD/escnl.mnt")"
+
+# The min() that ties it together. Drive _usable_ram_mb from a pinned meminfo
+# rather than the live one: MemAvailable moves between two reads, so comparing
+# a cached host figure against a second read is a race on any Linux runner.
 _RAM_FILE=$(mktemp)
 sed -n '/^_usable_ram_mb()/,/^}/p' "$SETUP_SH" > "$_RAM_FILE"
+printf 'MemTotal:       16777216 kB\nMemAvailable:   12582912 kB\n' > "$_TMPD/meminfo"
+# $1 = the cgroup allowance the stubbed reader returns.
 run_usable_ram() {
     FAKE_FREE="$1" bash -c \
-        '. "$1"; _cgroup_free_mb() { printf "%s" "$FAKE_FREE"; }; _usable_ram_mb' _ "$_RAM_FILE"
+        '. "$1"; _cgroup_free_mb() { printf "%s" "$FAKE_FREE"; }; _usable_ram_mb "$2"' \
+        _ "$_RAM_FILE" "$_TMPD/meminfo"
 }
-_HOST_MB=$(run_usable_ram "")
 
 assert_eq "a lower cgroup allowance wins" "512" "$(run_usable_ram 512)"
-assert_eq "a higher allowance is ignored" "$_HOST_MB" "$(run_usable_ram 8796093022207)"
-assert_eq "no cgroup leaves host memory" "$_HOST_MB" "$(run_usable_ram "")"
+assert_eq "a higher allowance is ignored" "12288" "$(run_usable_ram 8796093022207)"
+# Host memory is what is available, not what is fitted: 16 GiB with 12 GiB free
+# budgets from 12.
+assert_eq "no cgroup leaves host memory" "12288" "$(run_usable_ram "")"
+
+# MemTotal is still the pre-3.14 fallback when MemAvailable is absent.
+printf 'MemTotal:       16777216 kB\n' > "$_TMPD/meminfo-old"
+assert_eq "pre-3.14 kernels fall back to MemTotal" "16384" \
+    "$(bash -c '. "$1"; _cgroup_free_mb() { :; }; _usable_ram_mb "$2"' \
+        _ "$_RAM_FILE" "$_TMPD/meminfo-old")"
 
 # End to end: a 4 GB allowance builds at -j1, not -j(cores).
 assert_eq "4 GB allowance floors at 1 job" "1" "$(run_jobs 20 "$(run_usable_ram 4096)" "")"
@@ -343,6 +377,17 @@ _check_ps1 "setup.ps1 per-job budget matches setup.sh" '^\$LlamaBuildMbPerJob = 
 _check_ps1 "setup.ps1 budgets from available memory" 'AvailableMBytes'
 _check_ps1 "setup.ps1 feeds it to the job count" 'Get-LlamaJobsFor .*-TotalMb \(Get-UsableMemoryMb\)'
 _check_ps1 "setup.ps1 keeps installed RAM as the fallback" 'TotalPhysicalMemory'
+# Zero available memory is a reading, not a failure. Treating it as unreadable
+# fell back to installed RAM and handed a machine with nothing left its full
+# core count, so only a negative value now means "could not read".
+_check_ps1 "setup.ps1 keeps a zero reading" '^[[:space:]]*if \(\$null -ne \$avail\) \{ return \[long\]\$avail \}$'
+_check_ps1 "setup.ps1 signals unreadable memory as -1" '^[[:space:]]*return -1$'
+_check_ps1 "setup.ps1 treats only a negative as unreadable" '^[[:space:]]*if \(\$TotalMb -lt 0\) \{ return \$Cores \}$'
+if grep -qE '^\s*if \(\$TotalMb -le 0\) \{ return \$Cores \}' "$SETUP_PS1"; then
+    echo "  FAIL: setup.ps1 still treats zero available memory as unreadable"; FAIL=$((FAIL + 1))
+else
+    echo "  PASS: setup.ps1 no longer treats zero as unreadable"; PASS=$((PASS + 1))
+fi
 
 # The bare ProcessorCount is what caused the hang; it must not come back.
 if grep -qE '^\s*\$NumCpu = \[Environment\]::ProcessorCount' "$SETUP_PS1"; then

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -550,8 +550,10 @@ assert_eq "pre-3.14 kernels fall back to MemTotal" "16384" \
         _ "$_RAM_FILE" "$_TMPD/meminfo-old")"
 
 # macOS has no MemAvailable, so the reclaim-aware figure comes from vm_stat.
-# Fed synthetically: 1024 + 1024 + 512 + 512 pages at the 16 KiB Apple Silicon
-# page size is 48 MiB, and the page size is read rather than assumed to be 4096.
+# Fed synthetically: free 1024 + inactive 1024 at the 16 KiB Apple Silicon page
+# size is 32 MiB, and the page size is read rather than assumed to be 4096.
+# speculative and purgeable are deliberately NOT in the sum; the fixture carries
+# both so that adding either back is visible as a wrong number.
 _VM_SAMPLE=$(printf '%s\n' \
     "Mach Virtual Memory Statistics: (page size of 16384 bytes)" \
     "Pages free:                                    1024." \
@@ -561,10 +563,26 @@ _VM_SAMPLE=$(printf '%s\n' \
     "Pages wired down:                            999999." \
     "Pages purgeable:                                512.")
 run_vm_stat() { bash -c ". '$_RAM_FILE'; _vm_stat_avail_mb" _; }
-assert_eq "vm_stat sums the reclaimable classes" "48" "$(printf '%s\n' "$_VM_SAMPLE" | run_vm_stat)"
+assert_eq "vm_stat sums the disjoint reclaimable queues" "32" "$(printf '%s\n' "$_VM_SAMPLE" | run_vm_stat)"
 # active and wired are resident, not reclaimable, and must not be counted.
-assert_eq "vm_stat ignores active and wired" "48" \
+assert_eq "vm_stat ignores active and wired" "32" \
     "$(printf '%s\n' "$_VM_SAMPLE" | sed 's/999999/1/' | run_vm_stat)"
+# speculative is a SUBSET of free, not a sibling of it: xnu's
+# osfmk/mach/vm_statistics.h states "speculative pages are already accounted for
+# in free_count". Adding it counts those pages twice and overstates what can be
+# reclaimed, which is the direction that hands the machine more jobs than it can
+# hold. Raising it alone must not move the answer.
+assert_eq "a larger speculative count does not change the answer" "32" \
+    "$(printf '%s\n' "$_VM_SAMPLE" | sed 's/^Pages speculative:.*/Pages speculative:  99999./' | run_vm_stat)"
+# purgeable is an attribute of a page, not a queue: a volatile page still sits on
+# the active or inactive queue and is already counted there.
+assert_eq "a larger purgeable count does not change the answer" "32" \
+    "$(printf '%s\n' "$_VM_SAMPLE" | sed 's/^Pages purgeable:.*/Pages purgeable:  99999./' | run_vm_stat)"
+# And the two terms that ARE counted must each move it.
+assert_eq "free moves the answer" "48" \
+    "$(printf '%s\n' "$_VM_SAMPLE" | sed 's/^Pages free:.*/Pages free:  2048./' | run_vm_stat)"
+assert_eq "inactive moves the answer" "48" \
+    "$(printf '%s\n' "$_VM_SAMPLE" | sed 's/^Pages inactive:.*/Pages inactive:  2048./' | run_vm_stat)"
 assert_eq "vm_stat gibberish yields nothing" "" "$(printf 'no stats here\n' | run_vm_stat)"
 # A header with no reclaimable pages is a zero reading, not a parse failure.
 assert_eq "vm_stat reports a genuine zero" "0" \

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -329,7 +329,7 @@ assert_eq "a trailing newline is not eaten" "1024" \
 # test and the open. These drive the helpers with the real options on.
 _STRICT_FILE=$(mktemp)
 for _fn in _cg_read _cg_limit _cg_dirs _cg_unesc_prog _cg_unesc _cg_mounts \
-           _cg_rel _cg_pick_mount _cgroup_free_mb _usable_ram_mb; do
+           _cg_rel _cg_pick_mount _cgroup_free_mb _vm_stat_avail_mb _usable_ram_mb; do
     sed -n "/^${_fn}()/,/^}/p" "$SETUP_SH" >> "$_STRICT_FILE"
 done
 sed -n '/^_LLAMA_BUILD_RESERVE_MB=/,/^_LLAMA_BUILD_MB_PER_JOB=/p' "$SETUP_SH" >> "$_STRICT_FILE"
@@ -430,6 +430,21 @@ assert_eq "POSIX mode: a failing awk does not abort _cg_unesc" "SURVIVED[]" \
     "$(run_posix_assign "$_TMPD/noawk" '_cg_unesc /a/b')"
 assert_eq "POSIX mode: a failing awk does not abort _cg_mounts" "SURVIVED[]" \
     "$(run_posix_assign "$_TMPD/noawk" '_cg_mounts '"$_TMPD"'/strict.mnt cgroup2')"
+
+# The macOS branch: vm_stat does not exist on Linux, and _vm_stat_avail_mb is a
+# pipeline, so it has to survive both a missing binary and a failing awk.
+assert_eq "POSIX mode: a missing vm_stat does not abort _vm_stat_avail_mb" "SURVIVED[]" \
+    "$(run_posix_assign "$_TMPD/noawk" '_vm_stat_avail_mb </dev/null')"
+assert_eq "POSIX mode: a failing awk does not abort _vm_stat_avail_mb" "SURVIVED[]" \
+    "$(run_posix_assign "$_TMPD/noawk" 'printf "" | _vm_stat_avail_mb')"
+# The macOS path of _usable_ram_mb, reached by making the meminfo unreadable and
+# stubbing sysctl, must also survive a vm_stat that is absent or unparseable.
+assert_eq "POSIX mode: the macOS branch survives an unparseable vm_stat" "SURVIVED[16384]" \
+    "$(PATH="$_TMPD/noawk:$PATH" bash --posix -c \
+        'set -euo pipefail; . "$1"
+         sysctl() { printf "17179869184"; }
+         v=$(_usable_ram_mb "$2"); printf "SURVIVED[%s]" "$v"' \
+        _ "$_STRICT_FILE" "$_TMPD/nope" 2>/dev/null)"
 # And with a working awk the numbers are still right under POSIX rules.
 # 12288 MiB available -> (12288 - 2048) / 2048 = 5.
 assert_eq "POSIX mode: the normal path still produces the capped count" "5" \
@@ -485,9 +500,24 @@ assert_eq "vm_stat ignores active and wired" "48" \
 assert_eq "vm_stat gibberish yields nothing" "" "$(printf 'no stats here\n' | run_vm_stat)"
 
 # And _usable_ram_mb must consult it. An unreadable meminfo path forces the
-# branch that reads hw.memsize, so this runs on Linux runners too.
+# branch that reads hw.memsize -- but that branch is an `elif` on sysctl
+# succeeding, and sysctl has no hw.memsize on Linux, so the branch was never
+# entered and this asserted nothing off a Mac. Stubbing sysctl is what makes it
+# run on a Linux runner, which is where CI actually is.
 assert_eq "_usable_ram_mb prefers vm_stat over hw.memsize" "777" \
-    "$(bash -c '. "$1"; _cgroup_free_mb() { :; }; _vm_stat_avail_mb() { printf "777"; }; _usable_ram_mb "$2"' \
+    "$(bash -c '. "$1"
+                sysctl() { printf "17179869184"; }
+                _cgroup_free_mb() { :; }
+                _vm_stat_avail_mb() { printf "777"; }
+                _usable_ram_mb "$2"' \
+        _ "$_RAM_FILE" "$_TMPD/no-meminfo")"
+# And falls back to installed RAM when vm_stat gives nothing.
+assert_eq "_usable_ram_mb falls back to hw.memsize" "16384" \
+    "$(bash -c '. "$1"
+                sysctl() { printf "17179869184"; }
+                _cgroup_free_mb() { :; }
+                _vm_stat_avail_mb() { :; }
+                _usable_ram_mb "$2"' \
         _ "$_RAM_FILE" "$_TMPD/no-meminfo")"
 
 # End to end: a 4 GB allowance builds at -j1, not -j(cores).

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -73,7 +73,7 @@ assert_eq "junk override ignored" "7" "$(run_jobs 20 16384 "lots")"
 # namespace, but under Slurm, systemd or --cgroupns=host the binding limit is
 # the process's own path or an ancestor's, and a root-only read sees "max".
 _CG_FILE=$(mktemp)
-for _fn in _cg_read _cg_limit _cg_dirs _cg_mount _cgroup_free_mb; do
+for _fn in _cg_read _cg_limit _cg_dirs _cg_mount _cg_rel _cgroup_free_mb; do
     sed -n "/^${_fn}()/,/^}/p" "$SETUP_SH" >> "$_CG_FILE"
 done
 if [ ! -s "$_CG_FILE" ]; then
@@ -171,6 +171,40 @@ printf '0::/a\n'      > "$_TMPD/hyb.proc"
 printf '%s\n' "43 30 0:38 / $_TMPD/hyb/unified rw - cgroup2 cgroup2 rw" > "$_TMPD/hyb.mnt"
 assert_eq "v2 found at a relocated unified mount" "1024" \
     "$(run_cgroup "$_TMPD/hyb" "$_TMPD/hyb.proc" "$_TMPD/hyb.mnt")"
+
+# 14) A bind-mounted subtree: mount root /slice at the mount point, while
+#     /proc/self/cgroup still reports the host-absolute /slice/job. The files
+#     are at <mountpoint>/job, so joining the two unmapped walks a path that
+#     does not exist and settles on the outer slice limit instead of the job's.
+mkdir -p "$_TMPD/bind/cg/job"
+printf '8589934592\n' > "$_TMPD/bind/cg/memory.max"
+printf '1073741824\n' > "$_TMPD/bind/cg/job/memory.max"
+printf '0::/slice/job\n' > "$_TMPD/bind.proc"
+printf '%s\n' "50 30 0:40 /slice $_TMPD/bind/cg rw - cgroup2 cgroup2 rw" > "$_TMPD/bind.mnt"
+assert_eq "bind mount finds the innermost limit" "1024" \
+    "$(run_cgroup "$_TMPD/bind" "$_TMPD/bind.proc" "$_TMPD/bind.mnt")"
+
+# 15) The same fixture with the mount root claimed as "/" picks the outer limit,
+#     which is what the unmapped join used to do.
+printf '%s\n' "50 30 0:40 / $_TMPD/bind/cg rw - cgroup2 cgroup2 rw" > "$_TMPD/bind.slash"
+assert_eq "an unmapped join settles for the outer limit" "8192" \
+    "$(run_cgroup "$_TMPD/bind" "$_TMPD/bind.proc" "$_TMPD/bind.slash")"
+
+# 16) A process outside the mount's root gets nothing from it rather than a
+#     limit belonging to some other part of the tree.
+printf '0::/elsewhere/job\n' > "$_TMPD/bind.out"
+assert_eq "a path outside the mount root yields the mount's own limit" "8192" \
+    "$(run_cgroup "$_TMPD/bind" "$_TMPD/bind.out" "$_TMPD/bind.mnt")"
+
+# 17) v1 bind mounts map the same way, via the controller's own path column.
+mkdir -p "$_TMPD/bind/v1/task"
+printf '4294967296\n' > "$_TMPD/bind/v1/memory.limit_in_bytes"
+printf '2147483648\n' > "$_TMPD/bind/v1/task/memory.limit_in_bytes"
+printf '3:memory:/docker/abc/task\n' > "$_TMPD/bindv1.proc"
+printf '%s\n' "51 30 0:41 /docker/abc $_TMPD/bind/v1 rw - cgroup cgroup rw,memory" \
+    > "$_TMPD/bindv1.mnt"
+assert_eq "v1 bind mount finds the innermost limit" "2048" \
+    "$(run_cgroup "$_TMPD/bind" "$_TMPD/bindv1.proc" "$_TMPD/bindv1.mnt")"
 
 # The min() that ties it together. _usable_ram_mb hardcodes the real paths, so
 # stub the reader to prove the wiring rather than just the parts.

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -354,6 +354,41 @@ assert_eq "strict: _cg_mounts on an unreadable file does not abort" "0" \
     "$(run_strict_rc '_cg_mounts "'"$_TMPD"'/strict" cgroup2')"
 assert_eq "strict: _cg_unesc does not abort" "0" \
     "$(run_strict_rc '_cg_unesc /a/b')"
+
+# The -f guard is not only about failing: reading a FIFO blocks forever, and an
+# install that hangs is worse than one that stops. Nothing in cgroupfs is a
+# FIFO, but the guard is what makes that true of any path handed to the reader.
+if mkfifo "$_TMPD/fifo" 2>/dev/null; then
+    _fifo_rc=$(timeout 5 bash -c 'set -euo pipefail; . "$1"; _cg_read "$2" >/dev/null' \
+                   _ "$_STRICT_FILE" "$_TMPD/fifo" >/dev/null 2>&1; printf '%s' "$?")
+    assert_eq "strict: _cg_read on a FIFO returns instead of blocking" "0" "$_fifo_rc"
+else
+    echo "  SKIP: mkfifo unavailable"
+fi
+
+# Whitespace really is stripped, rather than the trailing newline happening to
+# be eaten by read. A value with padding must still compare as a number.
+mkdir -p "$_TMPD/strict/pad"
+printf '  4294967296  \n' > "$_TMPD/strict/pad/memory.max"
+printf '0::/pad\n' > "$_TMPD/strictpad.proc"
+assert_eq "a padded limit value is still parsed" "4096" \
+    "$(run_cgroup "$_TMPD/strict" "$_TMPD/strictpad.proc" "$_TMPD/strict.mnt")"
+
+# If awk itself fails -- missing, or a busybox build without the applet -- the
+# reader must give up on the cgroup allowance, not take the install with it.
+mkdir -p "$_TMPD/noawk"
+printf '#!/bin/sh\nexit 1\n' > "$_TMPD/noawk/awk"
+chmod +x "$_TMPD/noawk/awk"
+_noawk_rc=$(PATH="$_TMPD/noawk:$PATH" bash -c \
+    'set -euo pipefail; . "$1"; _cgroup_free_mb "$2" "$3" "$4" >/dev/null' \
+    _ "$_STRICT_FILE" "$_TMPD/strict" "$_TMPD/strict.proc" "$_TMPD/strict.mnt" >/dev/null 2>&1
+    printf '%s' "$?")
+assert_eq "strict: a failing awk does not abort the install" "0" "$_noawk_rc"
+printf 'MemTotal:       16777216 kB\nMemAvailable:   12582912 kB\n' > "$_TMPD/meminfo-strict"
+_noawk_jobs=$(PATH="$_TMPD/noawk:$PATH" bash -c \
+    'set -euo pipefail; . "$1"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
+    _ "$_STRICT_FILE" "$_TMPD/meminfo-strict" 2>/dev/null)
+assert_eq "a failing awk falls back to the core count" "20" "$_noawk_jobs"
 assert_eq "strict: _cgroup_free_mb on a real tree does not abort" "0" \
     "$(run_strict_rc '_cgroup_free_mb "'"$_TMPD"'/strict" "'"$_TMPD"'/strict.proc" "'"$_TMPD"'/strict.mnt"')"
 assert_eq "strict: _cgroup_free_mb on nothing does not abort" "0" \
@@ -371,6 +406,29 @@ assert_eq "strict: _llama_jobs_for with the floor binding does not abort" "0" \
 # And the value still arrives, rather than the function exiting early with none.
 assert_eq "strict: the job count still comes out" "7" \
     "$(bash -c 'set -euo pipefail; . "$1"; _llama_jobs_for 20 16384' _ "$_STRICT_FILE")"
+
+# POSIX mode is the strict end of the range: bash applies errexit to a failing
+# assignment there, which it does not do by default. A user with POSIXLY_CORRECT
+# exported, or bash invoked as sh, gets those semantics, and an unreadable file
+# must cost the cap rather than the install. This is what pins the `|| true` on
+# each read; without them the shell exits before the job count is ever printed.
+run_posix() {
+    PATH="$1:$PATH" bash --posix -c \
+        'set -euo pipefail; . "$1"; shift; eval "$@"' _ "$_STRICT_FILE" "$2" 2>/dev/null
+}
+assert_eq "POSIX mode: an unreadable meminfo still yields the core count" "20" \
+    "$(run_posix "$_TMPD/noawk" '_llama_jobs_for 20 "$(_usable_ram_mb '"$_TMPD"'/nope)"')"
+assert_eq "POSIX mode: a failing awk still yields the core count" "20" \
+    "$(run_posix "$_TMPD/noawk" '_llama_jobs_for 20 "$(_usable_ram_mb '"$_TMPD"'/meminfo-strict)"')"
+assert_eq "POSIX mode: a failing awk does not abort _cgroup_free_mb" "0" \
+    "$(PATH="$_TMPD/noawk:$PATH" bash --posix -c \
+        'set -euo pipefail; . "$1"; _cgroup_free_mb "$2" "$3" "$4" >/dev/null' \
+        _ "$_STRICT_FILE" "$_TMPD/strict" "$_TMPD/strict.proc" "$_TMPD/strict.mnt" \
+        >/dev/null 2>&1; printf '%s' "$?")"
+# 12288 MiB available -> (12288 - 2048) / 2048 = 5.
+assert_eq "POSIX mode: the normal path still produces the capped count" "5" \
+    "$(bash --posix -c 'set -euo pipefail; . "$1"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
+        _ "$_STRICT_FILE" "$_TMPD/meminfo-strict" 2>/dev/null)"
 
 rm -f "$_STRICT_FILE"
 

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -412,23 +412,30 @@ assert_eq "strict: the job count still comes out" "7" \
 # exported, or bash invoked as sh, gets those semantics, and an unreadable file
 # must cost the cap rather than the install. This is what pins the `|| true` on
 # each read; without them the shell exits before the job count is ever printed.
-run_posix() {
+# The distinguishing form is the assignment: `v=$(reader)` propagates the
+# reader's failure, while passing it as an argument discards the status. The
+# real call site is NCPU=$(_llama_build_jobs), so pin the assignment form.
+run_posix_assign() {  # $1 = a PATH prefix, $2 = the expression to assign from
     PATH="$1:$PATH" bash --posix -c \
-        'set -euo pipefail; . "$1"; shift; eval "$@"' _ "$_STRICT_FILE" "$2" 2>/dev/null
+        'set -euo pipefail; . "$1"; shift; v=$(eval "$@"); printf "SURVIVED[%s]" "$v"' \
+        _ "$_STRICT_FILE" "$2" 2>/dev/null
 }
-assert_eq "POSIX mode: an unreadable meminfo still yields the core count" "20" \
-    "$(run_posix "$_TMPD/noawk" '_llama_jobs_for 20 "$(_usable_ram_mb '"$_TMPD"'/nope)"')"
-assert_eq "POSIX mode: a failing awk still yields the core count" "20" \
-    "$(run_posix "$_TMPD/noawk" '_llama_jobs_for 20 "$(_usable_ram_mb '"$_TMPD"'/meminfo-strict)"')"
-assert_eq "POSIX mode: a failing awk does not abort _cgroup_free_mb" "0" \
-    "$(PATH="$_TMPD/noawk:$PATH" bash --posix -c \
-        'set -euo pipefail; . "$1"; _cgroup_free_mb "$2" "$3" "$4" >/dev/null' \
-        _ "$_STRICT_FILE" "$_TMPD/strict" "$_TMPD/strict.proc" "$_TMPD/strict.mnt" \
-        >/dev/null 2>&1; printf '%s' "$?")"
+assert_eq "POSIX mode: a failing awk does not abort _usable_ram_mb" "SURVIVED[]" \
+    "$(run_posix_assign "$_TMPD/noawk" '_usable_ram_mb '"$_TMPD"'/meminfo-strict')"
+assert_eq "POSIX mode: a failing awk does not abort _cgroup_free_mb" "SURVIVED[]" \
+    "$(run_posix_assign "$_TMPD/noawk" '_cgroup_free_mb '"$_TMPD"'/strict '"$_TMPD"'/strict.proc '"$_TMPD"'/strict.mnt')"
+assert_eq "POSIX mode: a failing awk does not abort _cg_unesc" "SURVIVED[]" \
+    "$(run_posix_assign "$_TMPD/noawk" '_cg_unesc /a/b')"
+assert_eq "POSIX mode: a failing awk does not abort _cg_mounts" "SURVIVED[]" \
+    "$(run_posix_assign "$_TMPD/noawk" '_cg_mounts '"$_TMPD"'/strict.mnt cgroup2')"
+# And with a working awk the numbers are still right under POSIX rules.
 # 12288 MiB available -> (12288 - 2048) / 2048 = 5.
 assert_eq "POSIX mode: the normal path still produces the capped count" "5" \
     "$(bash --posix -c 'set -euo pipefail; . "$1"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
         _ "$_STRICT_FILE" "$_TMPD/meminfo-strict" 2>/dev/null)"
+assert_eq "POSIX mode: an unreadable meminfo keeps the core count" "20" \
+    "$(bash --posix -c 'set -euo pipefail; . "$1"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
+        _ "$_STRICT_FILE" "$_TMPD/nope" 2>/dev/null)"
 
 rm -f "$_STRICT_FILE"
 

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# _llama_jobs_for() from studio/setup.sh: the cmake -j count.
+#
+# A 20-thread 16 GB box used to build llama.cpp at -j20. Each nvcc job peaks near
+# 2 GB, so that oversubscribed RAM until the machine stopped responding. The job
+# count is now the smaller of the core count and what RAM can hold.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
+SETUP_PS1="$SCRIPT_DIR/../../studio/setup.ps1"
+PASS=0
+FAIL=0
+
+# Extract the constants and the helper (same sed range as the other function tests).
+_FUNC_FILE=$(mktemp)
+sed -n '/^_LLAMA_BUILD_RESERVE_MB=/,/^_LLAMA_BUILD_MB_PER_JOB=/p' "$SETUP_SH" > "$_FUNC_FILE"
+sed -n '/^_llama_jobs_for()/,/^}/p' "$SETUP_SH" >> "$_FUNC_FILE"
+if [ ! -s "$_FUNC_FILE" ]; then
+    echo "FAIL: could not extract _llama_jobs_for from setup.sh"
+    exit 1
+fi
+
+assert_eq() {
+    _label="$1"; _expected="$2"; _actual="$3"
+    if [ "$_actual" = "$_expected" ]; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected '$_expected', got '$_actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# $1 = cores, $2 = total RAM MiB, $3 = UNSLOTH_LLAMA_BUILD_JOBS
+run_jobs() {
+    UNSLOTH_LLAMA_BUILD_JOBS="${3:-}" \
+        bash -c ". '$_FUNC_FILE'; _llama_jobs_for \"\$1\" \"\$2\"" _ "$1" "$2"
+}
+
+echo "=== test_llama_build_jobs ==="
+
+# 1) The reported case: 20 threads, 16 GB. (16384 - 2048) / 2048 = 7.
+assert_eq "20 cores / 16 GB caps at 7" "7" "$(run_jobs 20 16384 "")"
+
+# 2) RAM is only a ceiling, never a floor: a 4-core 64 GB box still gets 4.
+assert_eq "cores win when RAM is ample" "4" "$(run_jobs 4 65536 "")"
+
+# 3) Small-RAM machines still make progress rather than dividing to zero.
+assert_eq "4 GB floors at 1" "1" "$(run_jobs 8 4096 "")"
+assert_eq "2 GB floors at 1" "1" "$(run_jobs 8 2048 "")"
+
+# 4) Unreadable RAM keeps the previous behaviour instead of guessing low.
+assert_eq "empty RAM keeps cores" "20" "$(run_jobs 20 "" "")"
+assert_eq "garbage RAM keeps cores" "20" "$(run_jobs 20 "unknown" "")"
+
+# 5) Unreadable core count falls back to 4, as the old nproc chain did.
+assert_eq "garbage cores default to 4" "4" "$(run_jobs "" 65536 "")"
+
+# 6) The override wins over both, so a large-RAM builder can opt out.
+assert_eq "override wins over cap" "32" "$(run_jobs 20 16384 32)"
+assert_eq "override wins over cores" "64" "$(run_jobs 4 4096 64)"
+
+# 7) A junk or zero override is ignored rather than producing -j0.
+assert_eq "zero override ignored" "7" "$(run_jobs 20 16384 0)"
+assert_eq "junk override ignored" "7" "$(run_jobs 20 16384 "lots")"
+
+# ── Windows parity (static check) ──
+# setup.ps1 carries its own copy because it cannot source setup.sh. The user who
+# reported this was on Windows, so a cap that only lands on Unix fixes nothing.
+_check_ps1() {
+    _label="$1"; _pattern="$2"
+    if grep -qE "$_pattern" "$SETUP_PS1"; then
+        echo "  PASS: $_label"; PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (no match for '$_pattern' in setup.ps1)"; FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== setup.ps1 parity ==="
+_check_ps1 "setup.ps1 caps the job count" '^[[:space:]]*\$NumCpu = Get-LlamaBuildJobs$'
+_check_ps1 "setup.ps1 honours the override" 'UNSLOTH_LLAMA_BUILD_JOBS'
+_check_ps1 "setup.ps1 reserve matches setup.sh" '^\$LlamaBuildReserveMb = 2048$'
+_check_ps1 "setup.ps1 per-job budget matches setup.sh" '^\$LlamaBuildMbPerJob = 2048$'
+
+# The bare ProcessorCount is what caused the hang; it must not come back.
+if grep -qE '^\s*\$NumCpu = \[Environment\]::ProcessorCount' "$SETUP_PS1"; then
+    echo "  FAIL: setup.ps1 still sets -j from the raw core count"; FAIL=$((FAIL + 1))
+else
+    echo "  PASS: setup.ps1 no longer sets -j from the raw core count"; PASS=$((PASS + 1))
+fi
+
+rm -f "$_FUNC_FILE"
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -498,6 +498,10 @@ assert_eq "vm_stat sums the reclaimable classes" "48" "$(printf '%s\n' "$_VM_SAM
 assert_eq "vm_stat ignores active and wired" "48" \
     "$(printf '%s\n' "$_VM_SAMPLE" | sed 's/999999/1/' | run_vm_stat)"
 assert_eq "vm_stat gibberish yields nothing" "" "$(printf 'no stats here\n' | run_vm_stat)"
+# A header with no reclaimable pages is a zero reading, not a parse failure.
+assert_eq "vm_stat reports a genuine zero" "0" \
+    "$(printf '%s\n' "Mach Virtual Memory Statistics: (page size of 16384 bytes)" \
+        "Pages active: 999999." | run_vm_stat)"
 
 # And _usable_ram_mb must consult it. An unreadable meminfo path forces the
 # branch that reads hw.memsize -- but that branch is an `elif` on sysctl
@@ -511,7 +515,18 @@ assert_eq "_usable_ram_mb prefers vm_stat over hw.memsize" "777" \
                 _vm_stat_avail_mb() { printf "777"; }
                 _usable_ram_mb "$2"' \
         _ "$_RAM_FILE" "$_TMPD/no-meminfo")"
-# And falls back to installed RAM when vm_stat gives nothing.
+# Zero is a reading and is kept. Falling back to 16 GiB of installed RAM on a
+# Mac with nothing reclaimable is exactly the oversubscription this PR removes.
+assert_eq "_usable_ram_mb keeps a zero reading" "0" \
+    "$(bash -c '. "$1"
+                sysctl() { printf "17179869184"; }
+                _cgroup_free_mb() { :; }
+                _vm_stat_avail_mb() { printf "0"; }
+                _usable_ram_mb "$2"' \
+        _ "$_RAM_FILE" "$_TMPD/no-meminfo")"
+# And zero usable still builds, at one job.
+assert_eq "zero usable RAM still builds at 1 job" "1" "$(run_jobs 20 0 "")"
+# Only unparseable output falls back to installed RAM.
 assert_eq "_usable_ram_mb falls back to hw.memsize" "16384" \
     "$(bash -c '. "$1"
                 sysctl() { printf "17179869184"; }

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -73,7 +73,7 @@ assert_eq "junk override ignored" "7" "$(run_jobs 20 16384 "lots")"
 # namespace, but under Slurm, systemd or --cgroupns=host the binding limit is
 # the process's own path or an ancestor's, and a root-only read sees "max".
 _CG_FILE=$(mktemp)
-for _fn in _cg_read _cg_limit _cg_dirs _cg_mount _cg_rel _cgroup_free_mb; do
+for _fn in _cg_read _cg_limit _cg_dirs _cg_mounts _cg_rel _cg_pick_mount _cgroup_free_mb; do
     sed -n "/^${_fn}()/,/^}/p" "$SETUP_SH" >> "$_CG_FILE"
 done
 if [ ! -s "$_CG_FILE" ]; then
@@ -205,6 +205,47 @@ printf '%s\n' "51 30 0:41 /docker/abc $_TMPD/bind/v1 rw - cgroup cgroup rw,memor
     > "$_TMPD/bindv1.mnt"
 assert_eq "v1 bind mount finds the innermost limit" "2048" \
     "$(run_cgroup "$_TMPD/bind" "$_TMPD/bindv1.proc" "$_TMPD/bindv1.mnt")"
+
+# 18) A hierarchy mounted more than once: an unrelated subtree listed first
+#     must not shadow the mount that actually contains the process.
+mkdir -p "$_TMPD/multi/unrelated" "$_TMPD/multi/real/job"
+printf '8589934592\n' > "$_TMPD/multi/unrelated/memory.max"
+printf '8589934592\n' > "$_TMPD/multi/real/memory.max"
+printf '1073741824\n' > "$_TMPD/multi/real/job/memory.max"
+printf '0::/slice/job\n' > "$_TMPD/multi.proc"
+{
+    printf '%s\n' "60 30 0:50 /unrelated $_TMPD/multi/unrelated rw - cgroup2 cgroup2 rw"
+    printf '%s\n' "61 30 0:51 /slice $_TMPD/multi/real rw - cgroup2 cgroup2 rw"
+} > "$_TMPD/multi.mnt"
+assert_eq "the containing mount wins over an earlier one" "1024" \
+    "$(run_cgroup "$_TMPD/multi" "$_TMPD/multi.proc" "$_TMPD/multi.mnt")"
+
+# 19) Most specific wins when several roots contain the path.
+{
+    printf '%s\n' "62 30 0:52 / $_TMPD/multi/unrelated rw - cgroup2 cgroup2 rw"
+    printf '%s\n' "63 30 0:53 /slice $_TMPD/multi/real rw - cgroup2 cgroup2 rw"
+} > "$_TMPD/multi.spec"
+assert_eq "the most specific containing root wins" "1024" \
+    "$(run_cgroup "$_TMPD/multi" "$_TMPD/multi.proc" "$_TMPD/multi.spec")"
+
+# 20) When no mount contains the path, the first is still used rather than
+#     dropping the hierarchy entirely.
+printf '0::/nowhere\n' > "$_TMPD/multi.none"
+assert_eq "no containing mount falls back to the first" "8192" \
+    "$(run_cgroup "$_TMPD/multi" "$_TMPD/multi.none" "$_TMPD/multi.mnt")"
+
+# 21) The same, for a v1 controller listed twice.
+mkdir -p "$_TMPD/multi/v1a" "$_TMPD/multi/v1b/task"
+printf '8589934592\n' > "$_TMPD/multi/v1a/memory.limit_in_bytes"
+printf '4294967296\n' > "$_TMPD/multi/v1b/memory.limit_in_bytes"
+printf '2147483648\n' > "$_TMPD/multi/v1b/task/memory.limit_in_bytes"
+printf '3:memory:/docker/abc/task\n' > "$_TMPD/multiv1.proc"
+{
+    printf '%s\n' "64 30 0:54 /other $_TMPD/multi/v1a rw - cgroup cgroup rw,memory"
+    printf '%s\n' "65 30 0:55 /docker/abc $_TMPD/multi/v1b rw - cgroup cgroup rw,memory"
+} > "$_TMPD/multiv1.mnt"
+assert_eq "v1 picks the containing mount too" "2048" \
+    "$(run_cgroup "$_TMPD/multi" "$_TMPD/multiv1.proc" "$_TMPD/multiv1.mnt")"
 
 # The min() that ties it together. _usable_ram_mb hardcodes the real paths, so
 # stub the reader to prove the wiring rather than just the parts.

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -73,7 +73,7 @@ assert_eq "junk override ignored" "7" "$(run_jobs 20 16384 "lots")"
 # namespace, but under Slurm, systemd or --cgroupns=host the binding limit is
 # the process's own path or an ancestor's, and a root-only read sees "max".
 _CG_FILE=$(mktemp)
-for _fn in _cg_read _cg_limit _cg_dirs _cgroup_free_mb; do
+for _fn in _cg_read _cg_limit _cg_dirs _cg_mount _cgroup_free_mb; do
     sed -n "/^${_fn}()/,/^}/p" "$SETUP_SH" >> "$_CG_FILE"
 done
 if [ ! -s "$_CG_FILE" ]; then
@@ -82,9 +82,12 @@ if [ ! -s "$_CG_FILE" ]; then
 fi
 
 _TMPD=$(mktemp -d)
-# $1 = cgroup root, $2 = the /proc/self/cgroup stand-in
+# $1 = fallback root, $2 = /proc/self/cgroup stand-in, $3 = mountinfo stand-in.
+# The mountinfo argument is always passed, and defaults to a path that does not
+# exist, so a Linux runner's real mounts cannot leak into these fixtures.
 run_cgroup() {
-    bash -c ". '$_CG_FILE'; _cgroup_free_mb \"\$1\" \"\$2\"" _ "$1" "$2"
+    bash -c ". '$_CG_FILE'; _cgroup_free_mb \"\$1\" \"\$2\" \"\$3\"" \
+        _ "$1" "$2" "${3:-$_TMPD/no-mountinfo}"
 }
 
 echo "=== cgroup limits ==="
@@ -137,6 +140,37 @@ assert_eq "v1 sentinel is not a limit" "" "$(run_cgroup "$_TMPD/v1" "$_TMPD/v1.p
 
 # 9) No cgroupfs at all: nothing to report, and no error.
 assert_eq "absent hierarchy reports nothing" "" "$(run_cgroup "$_TMPD/missing" "$_TMPD/missing.proc")"
+
+# 10) v1 mounted somewhere other than <root>/memory. Without reading mountinfo
+#     this branch was skipped and the budget silently fell back to host memory.
+mkdir -p "$_TMPD/odd/mem-controller/slice"
+printf '2147483648\n' > "$_TMPD/odd/mem-controller/slice/memory.limit_in_bytes"
+printf '2:memory:/slice\n' > "$_TMPD/odd.proc"
+printf '%s\n' "40 30 0:35 / $_TMPD/odd/mem-controller rw - cgroup cgroup rw,memory" > "$_TMPD/odd.mnt"
+assert_eq "v1 found at a relocated mount" "2048" \
+    "$(run_cgroup "$_TMPD/odd" "$_TMPD/odd.proc" "$_TMPD/odd.mnt")"
+assert_eq "and missed without mountinfo" "" "$(run_cgroup "$_TMPD/odd" "$_TMPD/odd.proc")"
+
+# 11) v1 co-mounted with other controllers: matched by super option, not name.
+printf '%s\n' "41 30 0:36 / $_TMPD/odd/mem-controller rw - cgroup cgroup rw,cpu,memory,cpuacct" \
+    > "$_TMPD/odd.co"
+assert_eq "v1 found on a co-mounted hierarchy" "2048" \
+    "$(run_cgroup "$_TMPD/odd" "$_TMPD/odd.proc" "$_TMPD/odd.co")"
+
+# 12) A controller that is not memory must not be mistaken for it.
+printf '%s\n' "42 30 0:37 / $_TMPD/odd/mem-controller rw - cgroup cgroup rw,cpu,cpuacct" \
+    > "$_TMPD/odd.other"
+assert_eq "a non-memory hierarchy is not used" "" \
+    "$(run_cgroup "$_TMPD/odd" "$_TMPD/odd.proc" "$_TMPD/odd.other")"
+
+# 13) v2 unified mounted away from the root, as under systemd hybrid mode.
+mkdir -p "$_TMPD/hyb/unified/a"
+printf 'max\n'        > "$_TMPD/hyb/unified/memory.max"
+printf '1073741824\n' > "$_TMPD/hyb/unified/a/memory.max"
+printf '0::/a\n'      > "$_TMPD/hyb.proc"
+printf '%s\n' "43 30 0:38 / $_TMPD/hyb/unified rw - cgroup2 cgroup2 rw" > "$_TMPD/hyb.mnt"
+assert_eq "v2 found at a relocated unified mount" "1024" \
+    "$(run_cgroup "$_TMPD/hyb" "$_TMPD/hyb.proc" "$_TMPD/hyb.mnt")"
 
 # The min() that ties it together. _usable_ram_mb hardcodes the real paths, so
 # stub the reader to prove the wiring rather than just the parts.

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -317,6 +317,63 @@ printf '%s\n' "74 30 0:64 /slice $_TMPD/esc/trail\\012 rw - cgroup2 cgroup2 rw" 
 assert_eq "a trailing newline is not eaten" "1024" \
     "$(run_cgroup "$_TMPD/esc" "$_TMPD/esctrail.proc" "$_TMPD/esctrail.mnt")"
 
+# ── The shell options the real script runs under ──
+# Everything above sources into a plain `bash -c`, but studio/setup.sh:5 is
+# `set -euo pipefail`, and NCPU=$(_llama_build_jobs) sits on the install's
+# critical path. A helper returning non-zero there does not degrade the job
+# count, it aborts the install at the build step. `head | tr` inside _cg_read
+# did exactly that for any input where the pipeline failed, which -r alone does
+# not rule out: a directory passes it, and a cgroup can be torn down between the
+# test and the open. These drive the helpers with the real options on.
+_STRICT_FILE=$(mktemp)
+for _fn in _cg_read _cg_limit _cg_dirs _cg_unesc_prog _cg_unesc _cg_mounts \
+           _cg_rel _cg_pick_mount _cgroup_free_mb _usable_ram_mb; do
+    sed -n "/^${_fn}()/,/^}/p" "$SETUP_SH" >> "$_STRICT_FILE"
+done
+sed -n '/^_LLAMA_BUILD_RESERVE_MB=/,/^_LLAMA_BUILD_MB_PER_JOB=/p' "$SETUP_SH" >> "$_STRICT_FILE"
+sed -n '/^_llama_jobs_for()/,/^}/p' "$SETUP_SH" >> "$_STRICT_FILE"
+
+# Echoes the exit status of running $1 under the real options.
+run_strict_rc() {
+    bash -c 'set -euo pipefail; . "$1"; shift; eval "$@" >/dev/null 2>&1' \
+        _ "$_STRICT_FILE" "$1" >/dev/null 2>&1
+    printf '%s' "$?"
+}
+
+mkdir -p "$_TMPD/strict/leaf"
+printf '4294967296\n' > "$_TMPD/strict/leaf/memory.max"
+printf '0::/leaf\n'   > "$_TMPD/strict.proc"
+printf '%s\n' "1 2 0:1 / $_TMPD/strict rw - cgroup2 cgroup2 rw" > "$_TMPD/strict.mnt"
+
+# A directory passes `[ -r ]`, so this is the shape that took the install down.
+assert_eq "strict: _cg_read on a directory does not abort" "0" \
+    "$(run_strict_rc '_cg_read "'"$_TMPD"'/strict"')"
+assert_eq "strict: _cg_read on a missing file does not abort" "0" \
+    "$(run_strict_rc '_cg_read "'"$_TMPD"'/strict/nope"')"
+assert_eq "strict: _cg_mounts on an unreadable file does not abort" "0" \
+    "$(run_strict_rc '_cg_mounts "'"$_TMPD"'/strict" cgroup2')"
+assert_eq "strict: _cg_unesc does not abort" "0" \
+    "$(run_strict_rc '_cg_unesc /a/b')"
+assert_eq "strict: _cgroup_free_mb on a real tree does not abort" "0" \
+    "$(run_strict_rc '_cgroup_free_mb "'"$_TMPD"'/strict" "'"$_TMPD"'/strict.proc" "'"$_TMPD"'/strict.mnt"')"
+assert_eq "strict: _cgroup_free_mb on nothing does not abort" "0" \
+    "$(run_strict_rc '_cgroup_free_mb /nx /nx /nx')"
+assert_eq "strict: _usable_ram_mb does not abort" "0" \
+    "$(run_strict_rc '_usable_ram_mb')"
+# The two AND-lists in _llama_jobs_for are the classic `set -e` footgun; cover
+# the branch where each of them is false.
+assert_eq "strict: _llama_jobs_for with the cap binding does not abort" "0" \
+    "$(run_strict_rc '_llama_jobs_for 20 16384')"
+assert_eq "strict: _llama_jobs_for with cores binding does not abort" "0" \
+    "$(run_strict_rc '_llama_jobs_for 4 65536')"
+assert_eq "strict: _llama_jobs_for with the floor binding does not abort" "0" \
+    "$(run_strict_rc '_llama_jobs_for 8 0')"
+# And the value still arrives, rather than the function exiting early with none.
+assert_eq "strict: the job count still comes out" "7" \
+    "$(bash -c 'set -euo pipefail; . "$1"; _llama_jobs_for 20 16384' _ "$_STRICT_FILE")"
+
+rm -f "$_STRICT_FILE"
+
 # The min() that ties it together. Drive _usable_ram_mb from a pinned meminfo
 # rather than the live one: MemAvailable moves between two reads, so comparing
 # a cached host figure against a second read is a race on any Linux runner.

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -10,6 +10,11 @@
 # _LLAMA_BUILD_* in setup.sh for where the per-job budget comes from.
 set -e
 
+# The override is a supported env var, so a developer or CI shell may export it.
+# Every assertion below that is not about the override must not see it;
+# run_jobs sets it explicitly per call, but the direct invocations do not.
+unset UNSLOTH_LLAMA_BUILD_JOBS
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
 SETUP_PS1="$SCRIPT_DIR/../../studio/setup.ps1"
@@ -76,7 +81,7 @@ assert_eq "junk override ignored" "7" "$(run_jobs 20 16384 "lots")"
 # the process's own path or an ancestor's, and a root-only read sees "max".
 _CG_FILE=$(mktemp)
 for _fn in _cg_read _cg_limit _cg_dirs _cg_unesc_prog _cg_unesc _cg_mounts _cg_rel \
-           _cg_pick_mount _cgroup_free_mb; do
+           _cg_pick_mounts _cgroup_free_mb; do
     sed -n "/^${_fn}()/,/^}/p" "$SETUP_SH" >> "$_CG_FILE"
 done
 if [ ! -s "$_CG_FILE" ]; then
@@ -130,12 +135,18 @@ rm -f "$_TMPD/anc/a/memory.high"
 #     "no limit" budgeted from host memory and took the full core count. Only
 #     memory.high is exercised: memory.max of 0 OOM-kills, so nothing is left
 #     running to read it.
-printf '0\n' > "$_TMPD/anc/a/memory.high"
+#     The fixture carries no other limit, so dropping the zero does not fall
+#     back to an ancestor's number, it falls back to host memory and the full
+#     core count -- which is the behaviour being pinned.
+mkdir -p "$_TMPD/zh/leaf"
+printf 'max\n' > "$_TMPD/zh/memory.max"
+printf 'max\n' > "$_TMPD/zh/leaf/memory.max"
+printf '0\n'   > "$_TMPD/zh/leaf/memory.high"
+printf '0::/leaf\n' > "$_TMPD/zh.proc"
 assert_eq "a zero memory.high is a limit, not the absence of one" "0" \
-    "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")"
+    "$(run_cgroup "$_TMPD/zh" "$_TMPD/zh.proc")"
 assert_eq "and a zero allowance builds at 1 job, not \$(nproc)" "1" \
-    "$(run_jobs 20 "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")" "")"
-rm -f "$_TMPD/anc/a/memory.high"
+    "$(run_jobs 20 "$(run_cgroup "$_TMPD/zh" "$_TMPD/zh.proc")" "")"
 
 # 6) v2 "max" everywhere is not a limit.
 mkdir -p "$_TMPD/unl"
@@ -262,6 +273,39 @@ printf '3:memory:/docker/abc/task\n' > "$_TMPD/multiv1.proc"
 assert_eq "v1 picks the containing mount too" "2048" \
     "$(run_cgroup "$_TMPD/multi" "$_TMPD/multiv1.proc" "$_TMPD/multiv1.mnt")"
 
+# 21b) A limit ABOVE the narrower mount's root is invisible through that mount
+#      and visible through the broader one, so taking only the most specific
+#      hides it. The same hierarchy really is mounted twice with different
+#      subtree roots: rootless podman inside rootless podman leaves a
+#      host-derived bind mount beside a namespace-scoped one. Every containing
+#      mount is inspected and the smallest allowance wins.
+mkdir -p "$_TMPD/anc2/broad/slice/job/task" "$_TMPD/anc2/narrow/task"
+printf 'max\n'        > "$_TMPD/anc2/broad/memory.max"
+printf '1073741824\n' > "$_TMPD/anc2/broad/slice/memory.max"
+printf 'max\n'        > "$_TMPD/anc2/broad/slice/job/memory.max"
+printf 'max\n'        > "$_TMPD/anc2/broad/slice/job/task/memory.max"
+printf '8589934592\n' > "$_TMPD/anc2/narrow/memory.max"
+printf 'max\n'        > "$_TMPD/anc2/narrow/task/memory.max"
+printf '0::/slice/job/task\n' > "$_TMPD/anc2.proc"
+{
+    printf '%s\n' "80 30 0:70 / $_TMPD/anc2/broad rw - cgroup2 cgroup2 rw"
+    printf '%s\n' "81 30 0:70 /slice/job $_TMPD/anc2/narrow rw - cgroup2 cgroup2 rw"
+} > "$_TMPD/anc2.mnt"
+assert_eq "an ancestor limit above the narrower mount is still seen" "1024" \
+    "$(run_cgroup "$_TMPD/anc2" "$_TMPD/anc2.proc" "$_TMPD/anc2.mnt")"
+# Order must not matter, since the answer is a minimum over all of them.
+{
+    printf '%s\n' "81 30 0:70 /slice/job $_TMPD/anc2/narrow rw - cgroup2 cgroup2 rw"
+    printf '%s\n' "80 30 0:70 / $_TMPD/anc2/broad rw - cgroup2 cgroup2 rw"
+} > "$_TMPD/anc2rev.mnt"
+assert_eq "and the mount order does not change the answer" "1024" \
+    "$(run_cgroup "$_TMPD/anc2" "$_TMPD/anc2.proc" "$_TMPD/anc2rev.mnt")"
+# The narrower mount still contributes: make its own limit the binding one.
+printf '536870912\n' > "$_TMPD/anc2/narrow/task/memory.max"
+assert_eq "the narrower mount still contributes its own limit" "512" \
+    "$(run_cgroup "$_TMPD/anc2" "$_TMPD/anc2.proc" "$_TMPD/anc2.mnt")"
+printf 'max\n' > "$_TMPD/anc2/narrow/task/memory.max"
+
 # 22) mountinfo escapes space, tab, newline and backslash as octal. Returning
 #     the fields verbatim gave a path that does not exist.
 mkdir -p "$_TMPD/esc/a b/job"
@@ -341,11 +385,18 @@ assert_eq "a trailing newline is not eaten" "1024" \
 # test and the open. These drive the helpers with the real options on.
 _STRICT_FILE=$(mktemp)
 for _fn in _cg_read _cg_limit _cg_dirs _cg_unesc_prog _cg_unesc _cg_mounts \
-           _cg_rel _cg_pick_mount _cgroup_free_mb _vm_stat_avail_mb _usable_ram_mb; do
+           _cg_rel _cg_pick_mounts _cgroup_free_mb _vm_stat_avail_mb _usable_ram_mb; do
     sed -n "/^${_fn}()/,/^}/p" "$SETUP_SH" >> "$_STRICT_FILE"
 done
 sed -n '/^_LLAMA_BUILD_RESERVE_MB=/,/^_LLAMA_BUILD_MB_PER_JOB=/p' "$SETUP_SH" >> "$_STRICT_FILE"
 sed -n '/^_llama_jobs_for()/,/^}/p' "$SETUP_SH" >> "$_STRICT_FILE"
+
+# _usable_ram_mb hardcodes /sys/fs/cgroup, so inside a memory-limited container
+# the assertions about HOST memory would receive the container's allowance
+# instead of the fixture. Anything below that is not testing the cgroup reader
+# itself stubs it out; the reader has its own assertions above, which pass it
+# real fixture trees.
+_NO_CGROUP='_cgroup_free_mb() { :; }; '
 
 # Echoes the exit status of running $1 under the real options.
 run_strict_rc() {
@@ -372,12 +423,15 @@ assert_eq "strict: _cg_unesc does not abort" "0" \
 # The -f guard is not only about failing: reading a FIFO blocks forever, and an
 # install that hangs is worse than one that stops. Nothing in cgroupfs is a
 # FIFO, but the guard is what makes that true of any path handed to the reader.
-if mkfifo "$_TMPD/fifo" 2>/dev/null; then
+if mkfifo "$_TMPD/fifo" 2>/dev/null && command -v timeout >/dev/null 2>&1; then
     _fifo_rc=$(timeout 5 bash -c 'set -euo pipefail; . "$1"; _cg_read "$2" >/dev/null' \
                    _ "$_STRICT_FILE" "$_TMPD/fifo" >/dev/null 2>&1; printf '%s' "$?")
     assert_eq "strict: _cg_read on a FIFO returns instead of blocking" "0" "$_fifo_rc"
 else
-    echo "  SKIP: mkfifo unavailable"
+    # Stock macOS has mkfifo but ships no GNU timeout (it is gtimeout, from
+    # coreutils), and an unbounded read here would hang the suite rather than
+    # fail it.
+    echo "  SKIP: mkfifo or timeout unavailable"
 fi
 
 # Whitespace really is stripped, rather than the trailing newline happening to
@@ -400,8 +454,8 @@ _noawk_rc=$(PATH="$_TMPD/noawk:$PATH" bash -c \
 assert_eq "strict: a failing awk does not abort the install" "0" "$_noawk_rc"
 printf 'MemTotal:       16777216 kB\nMemAvailable:   12582912 kB\n' > "$_TMPD/meminfo-strict"
 _noawk_jobs=$(PATH="$_TMPD/noawk:$PATH" bash -c \
-    'set -euo pipefail; . "$1"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
-    _ "$_STRICT_FILE" "$_TMPD/meminfo-strict" 2>/dev/null)
+    'set -euo pipefail; . "$1"; eval "$3"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
+    _ "$_STRICT_FILE" "$_TMPD/meminfo-strict" "$_NO_CGROUP" 2>/dev/null)
 assert_eq "a failing awk falls back to the core count" "20" "$_noawk_jobs"
 assert_eq "strict: _cgroup_free_mb on a real tree does not abort" "0" \
     "$(run_strict_rc '_cgroup_free_mb "'"$_TMPD"'/strict" "'"$_TMPD"'/strict.proc" "'"$_TMPD"'/strict.mnt"')"
@@ -429,10 +483,12 @@ assert_eq "strict: the job count still comes out" "7" \
 # The distinguishing form is the assignment: `v=$(reader)` propagates the
 # reader's failure, while passing it as an argument discards the status. The
 # real call site is NCPU=$(_llama_build_jobs), so pin the assignment form.
-run_posix_assign() {  # $1 = a PATH prefix, $2 = the expression to assign from
+# $1 = a PATH prefix, $2 = the expression to assign from, $3 = a prelude (used
+# to stub the cgroup reader out of the host-memory cases).
+run_posix_assign() {
     PATH="$1:$PATH" bash --posix -c \
-        'set -euo pipefail; . "$1"; shift; v=$(eval "$@"); printf "SURVIVED[%s]" "$v"' \
-        _ "$_STRICT_FILE" "$2" 2>/dev/null
+        'set -euo pipefail; . "$1"; eval "${3:-}"; v=$(eval "$2"); printf "SURVIVED[%s]" "$v"' \
+        _ "$_STRICT_FILE" "$2" "${3:-}" 2>/dev/null
 }
 assert_eq "POSIX mode: a failing awk does not abort _usable_ram_mb" "SURVIVED[]" \
     "$(run_posix_assign "$_TMPD/noawk" '_usable_ram_mb '"$_TMPD"'/meminfo-strict')"
@@ -460,11 +516,11 @@ assert_eq "POSIX mode: the macOS branch survives an unparseable vm_stat" "SURVIV
 # And with a working awk the numbers are still right under POSIX rules.
 # 12288 MiB available -> (12288 - 2048) / 2048 = 5.
 assert_eq "POSIX mode: the normal path still produces the capped count" "5" \
-    "$(bash --posix -c 'set -euo pipefail; . "$1"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
-        _ "$_STRICT_FILE" "$_TMPD/meminfo-strict" 2>/dev/null)"
+    "$(bash --posix -c 'set -euo pipefail; . "$1"; eval "$3"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
+        _ "$_STRICT_FILE" "$_TMPD/meminfo-strict" "$_NO_CGROUP" 2>/dev/null)"
 assert_eq "POSIX mode: an unreadable meminfo keeps the core count" "20" \
-    "$(bash --posix -c 'set -euo pipefail; . "$1"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
-        _ "$_STRICT_FILE" "$_TMPD/nope" 2>/dev/null)"
+    "$(bash --posix -c 'set -euo pipefail; . "$1"; eval "$3"; _llama_jobs_for 20 "$(_usable_ram_mb "$2")"' \
+        _ "$_STRICT_FILE" "$_TMPD/nope" "$_NO_CGROUP" 2>/dev/null)"
 
 rm -f "$_STRICT_FILE"
 

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -67,65 +67,111 @@ assert_eq "override wins over cores" "64" "$(run_jobs 4 4096 64)"
 assert_eq "zero override ignored" "7" "$(run_jobs 20 16384 0)"
 assert_eq "junk override ignored" "7" "$(run_jobs 20 16384 "lots")"
 
-# ── Container limits ──
-# /proc/meminfo is not namespaced, so it reports the host's RAM inside a
-# container. Without this a 4 GB container on a big host budgets from the host
-# and the build gets OOM-killed.
+# ── Container and slice limits ──
+# /proc/meminfo is not namespaced, so it reports the host inside a container.
+# Reading only the hierarchy root works in a container with a private cgroup
+# namespace, but under Slurm, systemd or --cgroupns=host the binding limit is
+# the process's own path or an ancestor's, and a root-only read sees "max".
 _CG_FILE=$(mktemp)
-sed -n '/^_cgroup_limit_mb()/,/^}/p' "$SETUP_SH" > "$_CG_FILE"
+for _fn in _cg_read _cg_limit _cg_dirs _cgroup_free_mb; do
+    sed -n "/^${_fn}()/,/^}/p" "$SETUP_SH" >> "$_CG_FILE"
+done
 if [ ! -s "$_CG_FILE" ]; then
-    echo "FAIL: could not extract _cgroup_limit_mb from setup.sh"
+    echo "FAIL: could not extract the cgroup readers from setup.sh"
     exit 1
 fi
 
 _TMPD=$(mktemp -d)
+# $1 = cgroup root, $2 = the /proc/self/cgroup stand-in
 run_cgroup() {
-    bash -c ". '$_CG_FILE'; _cgroup_limit_mb \"\$@\"" _ "$@"
+    bash -c ". '$_CG_FILE'; _cgroup_free_mb \"\$1\" \"\$2\"" _ "$1" "$2"
 }
 
-echo "=== cgroup limit ==="
+echo "=== cgroup limits ==="
 
-# 1) cgroup v2 in a 4 GB container.
-printf '4294967296' > "$_TMPD/v2"
-assert_eq "v2 limit read as MiB" "4096" "$(run_cgroup "$_TMPD/v2")"
+# 1) v2, limit on the process's own leaf: the container-with-cgroupns shape.
+mkdir -p "$_TMPD/leaf/a"
+printf 'max\n'        > "$_TMPD/leaf/memory.max"
+printf '4294967296\n' > "$_TMPD/leaf/a/memory.max"
+printf '0::/a\n'      > "$_TMPD/leaf.proc"
+assert_eq "v2 leaf limit" "4096" "$(run_cgroup "$_TMPD/leaf" "$_TMPD/leaf.proc")"
 
-# 2) v2 on an unconstrained host writes the literal "max".
-printf 'max' > "$_TMPD/v2max"
-assert_eq "v2 'max' is not a limit" "" "$(run_cgroup "$_TMPD/v2max")"
+# 2) v2, limit on an ancestor: the systemd slice and Slurm job-step shape. A
+#    root-only reader saw "max" here and budgeted from the host.
+mkdir -p "$_TMPD/anc/a/b"
+printf 'max\n'        > "$_TMPD/anc/memory.max"
+printf '4294967296\n' > "$_TMPD/anc/a/memory.max"
+printf 'max\n'        > "$_TMPD/anc/a/b/memory.max"
+printf '0::/a/b\n'    > "$_TMPD/anc.proc"
+assert_eq "v2 ancestor limit" "4096" "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")"
 
-# 3) v1 in a 2 GB container, reached only when v2 is absent.
-printf '2147483648' > "$_TMPD/v1"
-assert_eq "v1 limit read as MiB" "2048" "$(run_cgroup "$_TMPD/missing" "$_TMPD/v1")"
+# 3) Usage is subtracted, paired with the directory that set the limit.
+printf '1073741824\n' > "$_TMPD/anc/a/memory.current"
+assert_eq "usage subtracted from its own limit" "3072" "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")"
 
-# 4) v1's unlimited sentinel is enormous, so it loses the min() below.
-printf '9223372036854771712' > "$_TMPD/v1max"
-assert_eq "v1 sentinel is astronomically large" "8796093022207" "$(run_cgroup "$_TMPD/v1max")"
+# 4) Over-usage floors at zero rather than going negative.
+printf '8589934592\n' > "$_TMPD/anc/a/memory.current"
+assert_eq "over-usage floors at 0" "0" "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")"
+rm -f "$_TMPD/anc/a/memory.current"
 
-# 5) No cgroup files at all: nothing to report.
-assert_eq "absent files report nothing" "" "$(run_cgroup "$_TMPD/missing" "$_TMPD/also-missing")"
+# 5) memory.high binds as much as memory.max, and the smaller wins.
+printf '2147483648\n' > "$_TMPD/anc/a/memory.high"
+assert_eq "memory.high counts, smallest wins" "2048" "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")"
+rm -f "$_TMPD/anc/a/memory.high"
 
-# 6) v2 wins when both exist, since it is passed first.
-assert_eq "v2 wins over v1" "4096" "$(run_cgroup "$_TMPD/v2" "$_TMPD/v1")"
+# 6) v2 "max" everywhere is not a limit.
+mkdir -p "$_TMPD/unl"
+printf 'max\n'   > "$_TMPD/unl/memory.max"
+printf '0::/\n'  > "$_TMPD/unl.proc"
+assert_eq "v2 'max' is not a limit" "" "$(run_cgroup "$_TMPD/unl" "$_TMPD/unl.proc")"
 
-# The min() that ties it together. _total_ram_mb hardcodes the real cgroup paths,
-# so stub the reader to prove the wiring rather than just the parts.
+# 7) v1 under <root>/memory, with its own controller column.
+mkdir -p "$_TMPD/v1/memory/slice"
+printf '2147483648\n' > "$_TMPD/v1/memory/slice/memory.limit_in_bytes"
+printf '2:cpu,memory:/slice\n' > "$_TMPD/v1.proc"
+assert_eq "v1 limit via its controller column" "2048" "$(run_cgroup "$_TMPD/v1" "$_TMPD/v1.proc")"
+
+# 8) v1's unlimited sentinel is not a limit.
+printf '9223372036854771712\n' > "$_TMPD/v1/memory/slice/memory.limit_in_bytes"
+assert_eq "v1 sentinel is not a limit" "" "$(run_cgroup "$_TMPD/v1" "$_TMPD/v1.proc")"
+
+# 9) No cgroupfs at all: nothing to report, and no error.
+assert_eq "absent hierarchy reports nothing" "" "$(run_cgroup "$_TMPD/missing" "$_TMPD/missing.proc")"
+
+# The min() that ties it together. _usable_ram_mb hardcodes the real paths, so
+# stub the reader to prove the wiring rather than just the parts.
 _RAM_FILE=$(mktemp)
-sed -n '/^_total_ram_mb()/,/^}/p' "$SETUP_SH" > "$_RAM_FILE"
-# The stub ignores the real paths _total_ram_mb passes it and echoes $FAKE_LIMIT.
-run_total_ram() {
-    FAKE_LIMIT="$1" bash -c \
-        '. "$1"; _cgroup_limit_mb() { printf "%s" "$FAKE_LIMIT"; }; _total_ram_mb' _ "$_RAM_FILE"
+sed -n '/^_usable_ram_mb()/,/^}/p' "$SETUP_SH" > "$_RAM_FILE"
+run_usable_ram() {
+    FAKE_FREE="$1" bash -c \
+        '. "$1"; _cgroup_free_mb() { printf "%s" "$FAKE_FREE"; }; _usable_ram_mb' _ "$_RAM_FILE"
 }
-_HOST_MB=$(run_total_ram "")
+_HOST_MB=$(run_usable_ram "")
 
-# A limit below host RAM wins; one above it, including v1's sentinel, does not.
-assert_eq "a lower cgroup limit wins" "512" "$(run_total_ram 512)"
-assert_eq "a higher limit is ignored" "$_HOST_MB" "$(run_total_ram 8796093022207)"
-assert_eq "no limit leaves host RAM" "$_HOST_MB" "$(run_total_ram "")"
-assert_eq "a zero limit is ignored" "$_HOST_MB" "$(run_total_ram 0)"
+assert_eq "a lower cgroup allowance wins" "512" "$(run_usable_ram 512)"
+assert_eq "a higher allowance is ignored" "$_HOST_MB" "$(run_usable_ram 8796093022207)"
+assert_eq "no cgroup leaves host memory" "$_HOST_MB" "$(run_usable_ram "")"
 
-# End to end: a 4 GB container on this host builds at -j1, not -j(cores).
-assert_eq "4 GB container floors at 1 job" "1" "$(run_jobs 20 "$(run_total_ram 4096)" "")"
+# End to end: a 4 GB allowance builds at -j1, not -j(cores).
+assert_eq "4 GB allowance floors at 1 job" "1" "$(run_jobs 20 "$(run_usable_ram 4096)" "")"
+
+# Host memory comes from what is actually available, not what is installed: a
+# 16 GiB box with 8 GiB resident must not be handed a 14 GiB compile budget.
+# Match the awk field pattern, not the bare word, so prose about MemAvailable
+# cannot satisfy this on its own.
+if grep -q '/\^MemAvailable:/' "$SETUP_SH"; then
+    echo "  PASS: host memory reads MemAvailable"; PASS=$((PASS + 1))
+else
+    echo "  FAIL: host memory still reads MemTotal only"; FAIL=$((FAIL + 1))
+fi
+# MemTotal stays as the pre-3.14 fallback, and must come after MemAvailable.
+_AVAIL_LINE=$(grep -n '/\^MemAvailable:/' "$SETUP_SH" | head -1 | cut -d: -f1)
+_TOTAL_LINE=$(grep -n '/\^MemTotal:/' "$SETUP_SH" | head -1 | cut -d: -f1)
+if [ -n "$_AVAIL_LINE" ] && [ -n "$_TOTAL_LINE" ] && [ "$_AVAIL_LINE" -lt "$_TOTAL_LINE" ]; then
+    echo "  PASS: MemTotal kept as the fallback, after MemAvailable"; PASS=$((PASS + 1))
+else
+    echo "  FAIL: MemTotal must remain, and only as the fallback"; FAIL=$((FAIL + 1))
+fi
 
 rm -rf "$_TMPD" "$_CG_FILE" "$_RAM_FILE"
 
@@ -146,6 +192,11 @@ _check_ps1 "setup.ps1 caps the job count" '^[[:space:]]*\$NumCpu = Get-LlamaBuil
 _check_ps1 "setup.ps1 honours the override" 'UNSLOTH_LLAMA_BUILD_JOBS'
 _check_ps1 "setup.ps1 reserve matches setup.sh" '^\$LlamaBuildReserveMb = 2048$'
 _check_ps1 "setup.ps1 per-job budget matches setup.sh" '^\$LlamaBuildMbPerJob = 2048$'
+# Windows has no cgroups, but it has the same installed-versus-available gap.
+# AvailableMBytes counts the standby list; the Free counters do not.
+_check_ps1 "setup.ps1 budgets from available memory" 'AvailableMBytes'
+_check_ps1 "setup.ps1 feeds it to the job count" 'Get-LlamaJobsFor .*-TotalMb \(Get-UsableMemoryMb\)'
+_check_ps1 "setup.ps1 keeps installed RAM as the fallback" 'TotalPhysicalMemory'
 
 # The bare ProcessorCount is what caused the hang; it must not come back.
 if grep -qE '^\s*\$NumCpu = \[Environment\]::ProcessorCount' "$SETUP_PS1"; then

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -3,9 +3,11 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 # _llama_jobs_for() from studio/setup.sh: the cmake -j count.
 #
-# A 20-thread 16 GB box used to build llama.cpp at -j20. Each nvcc job peaks near
-# 2 GB, so that oversubscribed RAM until the machine stopped responding. The job
-# count is now the smaller of the core count and what RAM can hold.
+# A 20-thread 16 GB box used to build llama.cpp at -j20 and stopped responding.
+# A full CUDA build at -j20 measures ~8.2 GiB in aggregate, from ~30 concurrent
+# compiler processes, which a 16 GB machine with a desktop on it does not have.
+# The job count is now the smaller of the core count and what RAM can hold; see
+# _LLAMA_BUILD_* in setup.sh for where the per-job budget comes from.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -321,7 +321,7 @@ assert_eq "a trailing newline is not eaten" "1024" \
 # rather than the live one: MemAvailable moves between two reads, so comparing
 # a cached host figure against a second read is a race on any Linux runner.
 _RAM_FILE=$(mktemp)
-sed -n '/^_usable_ram_mb()/,/^}/p' "$SETUP_SH" > "$_RAM_FILE"
+sed -n '/^_vm_stat_avail_mb()/,/^}/p;/^_usable_ram_mb()/,/^}/p' "$SETUP_SH" > "$_RAM_FILE"
 printf 'MemTotal:       16777216 kB\nMemAvailable:   12582912 kB\n' > "$_TMPD/meminfo"
 # $1 = the cgroup allowance the stubbed reader returns.
 run_usable_ram() {
@@ -341,6 +341,30 @@ printf 'MemTotal:       16777216 kB\n' > "$_TMPD/meminfo-old"
 assert_eq "pre-3.14 kernels fall back to MemTotal" "16384" \
     "$(bash -c '. "$1"; _cgroup_free_mb() { :; }; _usable_ram_mb "$2"' \
         _ "$_RAM_FILE" "$_TMPD/meminfo-old")"
+
+# macOS has no MemAvailable, so the reclaim-aware figure comes from vm_stat.
+# Fed synthetically: 1024 + 1024 + 512 + 512 pages at the 16 KiB Apple Silicon
+# page size is 48 MiB, and the page size is read rather than assumed to be 4096.
+_VM_SAMPLE=$(printf '%s\n' \
+    "Mach Virtual Memory Statistics: (page size of 16384 bytes)" \
+    "Pages free:                                    1024." \
+    "Pages active:                                999999." \
+    "Pages inactive:                                1024." \
+    "Pages speculative:                              512." \
+    "Pages wired down:                            999999." \
+    "Pages purgeable:                                512.")
+run_vm_stat() { bash -c ". '$_RAM_FILE'; _vm_stat_avail_mb" _; }
+assert_eq "vm_stat sums the reclaimable classes" "48" "$(printf '%s\n' "$_VM_SAMPLE" | run_vm_stat)"
+# active and wired are resident, not reclaimable, and must not be counted.
+assert_eq "vm_stat ignores active and wired" "48" \
+    "$(printf '%s\n' "$_VM_SAMPLE" | sed 's/999999/1/' | run_vm_stat)"
+assert_eq "vm_stat gibberish yields nothing" "" "$(printf 'no stats here\n' | run_vm_stat)"
+
+# And _usable_ram_mb must consult it. An unreadable meminfo path forces the
+# branch that reads hw.memsize, so this runs on Linux runners too.
+assert_eq "_usable_ram_mb prefers vm_stat over hw.memsize" "777" \
+    "$(bash -c '. "$1"; _cgroup_free_mb() { :; }; _vm_stat_avail_mb() { printf "777"; }; _usable_ram_mb "$2"' \
+        _ "$_RAM_FILE" "$_TMPD/no-meminfo")"
 
 # End to end: a 4 GB allowance builds at -j1, not -j(cores).
 assert_eq "4 GB allowance floors at 1 job" "1" "$(run_jobs 20 "$(run_usable_ram 4096)" "")"

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -307,6 +307,16 @@ printf '0::/slice/outer/inner\n' > "$_TMPD/escnl2.proc"
 assert_eq "a newline survives the ancestor walk" "2048" \
     "$(run_cgroup "$_TMPD/esc" "$_TMPD/escnl2.proc" "$_TMPD/escnl.mnt")"
 
+# 29) A trailing newline is the one $() silently eats, so the decode carries a
+#     sentinel. Without it the path loses its last character and does not exist.
+mkdir -p "$_TMPD/esc/trail${_NL}/job"
+printf '1073741824\n' > "$_TMPD/esc/trail${_NL}/job/memory.max"
+printf '0::/slice/job\n' > "$_TMPD/esctrail.proc"
+printf '%s\n' "74 30 0:64 /slice $_TMPD/esc/trail\\012 rw - cgroup2 cgroup2 rw" \
+    > "$_TMPD/esctrail.mnt"
+assert_eq "a trailing newline is not eaten" "1024" \
+    "$(run_cgroup "$_TMPD/esc" "$_TMPD/esctrail.proc" "$_TMPD/esctrail.mnt")"
+
 # The min() that ties it together. Drive _usable_ram_mb from a pinned meminfo
 # rather than the live one: MemAvailable moves between two reads, so comparing
 # a cached host figure against a second read is a race on any Linux runner.

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -125,6 +125,18 @@ printf '2147483648\n' > "$_TMPD/anc/a/memory.high"
 assert_eq "memory.high counts, smallest wins" "2048" "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")"
 rm -f "$_TMPD/anc/a/memory.high"
 
+# 5b) A zero limit is a limit. memory.high throttles rather than killing, so a
+#     process really does run under systemd's MemoryHigh=0, and treating that as
+#     "no limit" budgeted from host memory and took the full core count. Only
+#     memory.high is exercised: memory.max of 0 OOM-kills, so nothing is left
+#     running to read it.
+printf '0\n' > "$_TMPD/anc/a/memory.high"
+assert_eq "a zero memory.high is a limit, not the absence of one" "0" \
+    "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")"
+assert_eq "and a zero allowance builds at 1 job, not \$(nproc)" "1" \
+    "$(run_jobs 20 "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")" "")"
+rm -f "$_TMPD/anc/a/memory.high"
+
 # 6) v2 "max" everywhere is not a limit.
 mkdir -p "$_TMPD/unl"
 printf 'max\n'   > "$_TMPD/unl/memory.max"

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
-# _llama_jobs_for() from studio/setup.sh: the cmake -j count.
-#
-# A 20-thread 16 GB box used to build llama.cpp at -j20 and stopped responding.
-# A full CUDA build at -j20 measures ~8.2 GiB in aggregate, from ~30 concurrent
-# compiler processes, which a 16 GB machine with a desktop on it does not have.
-# The job count is now the smaller of the core count and what RAM can hold; see
-# _LLAMA_BUILD_* in setup.sh for where the per-job budget comes from.
+# _llama_jobs_for() from studio/setup.sh: the cmake -j count. A 20-thread 16 GB
+# box built llama.cpp at -j20 and stopped responding; that build measures
+# ~8.2 GiB across ~30 concurrent compiler processes, which such a machine does
+# not have. The count is now the smaller of the core count and what RAM can
+# hold; see _LLAMA_BUILD_* in setup.sh for the per-job budget.
 set -e
 
-# The override is a supported env var, so a developer or CI shell may export it.
-# Every assertion below that is not about the override must not see it;
-# run_jobs sets it explicitly per call, but the direct invocations do not.
+# The override is a supported env var, so a developer or CI shell may export it,
+# and nothing below but the override assertions may see it.
 unset UNSLOTH_LLAMA_BUILD_JOBS
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -76,9 +73,9 @@ assert_eq "junk override ignored" "7" "$(run_jobs 20 16384 "lots")"
 
 # ── Container and slice limits ──
 # /proc/meminfo is not namespaced, so it reports the host inside a container.
-# Reading only the hierarchy root works in a container with a private cgroup
-# namespace, but under Slurm, systemd or --cgroupns=host the binding limit is
-# the process's own path or an ancestor's, and a root-only read sees "max".
+# Reading only the hierarchy root works with a private cgroup namespace, but
+# under Slurm, systemd or --cgroupns=host the binding limit is the process's own
+# path or an ancestor's, and a root-only read sees "max".
 _CG_FILE=$(mktemp)
 for _fn in _cg_read _cg_limit _cg_dirs _cg_unesc_prog _cg_unesc _cg_mounts _cg_rel \
            _cg_pick_mounts _cgroup_free_mb; do
@@ -90,9 +87,9 @@ if [ ! -s "$_CG_FILE" ]; then
 fi
 
 _TMPD=$(mktemp -d)
-# $1 = fallback root, $2 = /proc/self/cgroup stand-in, $3 = mountinfo stand-in.
-# The mountinfo argument is always passed, and defaults to a path that does not
-# exist, so a Linux runner's real mounts cannot leak into these fixtures.
+# $1 = fallback root, $2 = /proc/self/cgroup stand-in, $3 = mountinfo stand-in,
+# always passed and defaulting to a path that does not exist, so a runner's real
+# mounts cannot leak into these fixtures.
 run_cgroup() {
     bash -c ". '$_CG_FILE'; _cgroup_free_mb \"\$1\" \"\$2\" \"\$3\"" \
         _ "$1" "$2" "${3:-$_TMPD/no-mountinfo}"
@@ -130,14 +127,12 @@ printf '2147483648\n' > "$_TMPD/anc/a/memory.high"
 assert_eq "memory.high counts, smallest wins" "2048" "$(run_cgroup "$_TMPD/anc" "$_TMPD/anc.proc")"
 rm -f "$_TMPD/anc/a/memory.high"
 
-# 5b) A zero limit is a limit. memory.high throttles rather than killing, so a
-#     process really does run under systemd's MemoryHigh=0, and treating that as
-#     "no limit" budgeted from host memory and took the full core count. Only
-#     memory.high is exercised: memory.max of 0 OOM-kills, so nothing is left
-#     running to read it.
-#     The fixture carries no other limit, so dropping the zero does not fall
-#     back to an ancestor's number, it falls back to host memory and the full
-#     core count -- which is the behaviour being pinned.
+# 5b) A zero limit is a limit: memory.high throttles rather than killing, so a
+#     process really does run under systemd's MemoryHigh=0, and calling that "no
+#     limit" budgeted from host memory and took the full core count. Only
+#     memory.high is exercised, since memory.max of 0 OOM-kills. The fixture
+#     carries no other limit, so dropping the zero falls back to host memory
+#     rather than to an ancestor's number.
 mkdir -p "$_TMPD/zh/leaf"
 printf 'max\n' > "$_TMPD/zh/memory.max"
 printf 'max\n' > "$_TMPD/zh/leaf/memory.max"
@@ -198,10 +193,10 @@ printf '%s\n' "43 30 0:38 / $_TMPD/hyb/unified rw - cgroup2 cgroup2 rw" > "$_TMP
 assert_eq "v2 found at a relocated unified mount" "1024" \
     "$(run_cgroup "$_TMPD/hyb" "$_TMPD/hyb.proc" "$_TMPD/hyb.mnt")"
 
-# 14) A bind-mounted subtree: mount root /slice at the mount point, while
-#     /proc/self/cgroup still reports the host-absolute /slice/job. The files
-#     are at <mountpoint>/job, so joining the two unmapped walks a path that
-#     does not exist and settles on the outer slice limit instead of the job's.
+# 14) A bind-mounted subtree: mount root /slice, while /proc/self/cgroup reports
+#     the host-absolute /slice/job and the files sit at <mountpoint>/job. Joining
+#     the two unmapped walks a path that does not exist and settles on the outer
+#     slice limit instead of the job's.
 mkdir -p "$_TMPD/bind/cg/job"
 printf '8589934592\n' > "$_TMPD/bind/cg/memory.max"
 printf '1073741824\n' > "$_TMPD/bind/cg/job/memory.max"
@@ -275,10 +270,9 @@ assert_eq "v1 picks the containing mount too" "2048" \
 
 # 21b) A limit ABOVE the narrower mount's root is invisible through that mount
 #      and visible through the broader one, so taking only the most specific
-#      hides it. The same hierarchy really is mounted twice with different
-#      subtree roots: rootless podman inside rootless podman leaves a
-#      host-derived bind mount beside a namespace-scoped one. Every containing
-#      mount is inspected and the smallest allowance wins.
+#      hides it. A hierarchy really is mounted twice with different subtree
+#      roots (rootless podman inside rootless podman), so every containing mount
+#      is inspected and the smallest allowance wins.
 mkdir -p "$_TMPD/anc2/broad/slice/job/task" "$_TMPD/anc2/narrow/task"
 printf 'max\n'        > "$_TMPD/anc2/broad/memory.max"
 printf '1073741824\n' > "$_TMPD/anc2/broad/slice/memory.max"
@@ -344,8 +338,8 @@ assert_eq "a lookalike controller is not matched" "" \
     "$(run_cgroup "$_TMPD/colon/v1" "$_TMPD/colonv1.bad")"
 
 # 27) \012 is a legal escape, and decoding it where the fields are read put a
-#     newline into the reader's own line-oriented output, splitting one mount
-#     record into two. The record has to travel escaped and be decoded once.
+#     newline into the reader's own line-oriented output, splitting one record
+#     into two. The record has to travel escaped and be decoded once.
 _NL=$'\n'
 mkdir -p "$_TMPD/esc/two${_NL}lines/job"
 printf '8589934592\n' > "$_TMPD/esc/two${_NL}lines/memory.max"
@@ -377,12 +371,12 @@ assert_eq "a trailing newline is not eaten" "1024" \
 
 # ── The shell options the real script runs under ──
 # Everything above sources into a plain `bash -c`, but studio/setup.sh:5 is
-# `set -euo pipefail`, and NCPU=$(_llama_build_jobs) sits on the install's
-# critical path. A helper returning non-zero there does not degrade the job
-# count, it aborts the install at the build step. `head | tr` inside _cg_read
-# did exactly that for any input where the pipeline failed, which -r alone does
-# not rule out: a directory passes it, and a cgroup can be torn down between the
-# test and the open. These drive the helpers with the real options on.
+# `set -euo pipefail` and NCPU=$(_llama_build_jobs) sits on the install's
+# critical path, so a helper returning non-zero aborts the install at the build
+# step rather than degrading the job count. `head | tr` inside _cg_read did
+# exactly that, which -r alone does not rule out: a directory passes it, and a
+# cgroup can be torn down between the test and the open. These use the real
+# options.
 _STRICT_FILE=$(mktemp)
 for _fn in _cg_read _cg_limit _cg_dirs _cg_unesc_prog _cg_unesc _cg_mounts \
            _cg_rel _cg_pick_mounts _cgroup_free_mb _vm_stat_avail_mb _usable_ram_mb; do
@@ -392,10 +386,9 @@ sed -n '/^_LLAMA_BUILD_RESERVE_MB=/,/^_LLAMA_BUILD_MB_PER_JOB=/p' "$SETUP_SH" >>
 sed -n '/^_llama_jobs_for()/,/^}/p' "$SETUP_SH" >> "$_STRICT_FILE"
 
 # _usable_ram_mb hardcodes /sys/fs/cgroup, so inside a memory-limited container
-# the assertions about HOST memory would receive the container's allowance
-# instead of the fixture. Anything below that is not testing the cgroup reader
-# itself stubs it out; the reader has its own assertions above, which pass it
-# real fixture trees.
+# the HOST-memory assertions would receive the container's allowance instead of
+# the fixture. Anything below not testing the cgroup reader itself stubs it out;
+# the reader has its own assertions above, against real fixture trees.
 _NO_CGROUP='_cgroup_free_mb() { :; }; '
 
 # Echoes the exit status of running $1 under the real options.
@@ -422,20 +415,19 @@ assert_eq "strict: _cg_unesc does not abort" "0" \
 
 # The -f guard is not only about failing: reading a FIFO blocks forever, and an
 # install that hangs is worse than one that stops. Nothing in cgroupfs is a
-# FIFO, but the guard is what makes that true of any path handed to the reader.
+# FIFO; the guard makes that true of any path handed to the reader.
 if mkfifo "$_TMPD/fifo" 2>/dev/null && command -v timeout >/dev/null 2>&1; then
     _fifo_rc=$(timeout 5 bash -c 'set -euo pipefail; . "$1"; _cg_read "$2" >/dev/null' \
                    _ "$_STRICT_FILE" "$_TMPD/fifo" >/dev/null 2>&1; printf '%s' "$?")
     assert_eq "strict: _cg_read on a FIFO returns instead of blocking" "0" "$_fifo_rc"
 else
-    # Stock macOS has mkfifo but ships no GNU timeout (it is gtimeout, from
-    # coreutils), and an unbounded read here would hang the suite rather than
-    # fail it.
+    # Stock macOS ships mkfifo but no GNU timeout (it is gtimeout, from
+    # coreutils), and an unbounded read would hang the suite rather than fail it.
     echo "  SKIP: mkfifo or timeout unavailable"
 fi
 
-# Whitespace really is stripped, rather than the trailing newline happening to
-# be eaten by read. A value with padding must still compare as a number.
+# Whitespace really is stripped, rather than the trailing newline happening to be
+# eaten by read: a padded value must still compare as a number.
 mkdir -p "$_TMPD/strict/pad"
 printf '  4294967296  \n' > "$_TMPD/strict/pad/memory.max"
 printf '0::/pad\n' > "$_TMPD/strictpad.proc"
@@ -476,13 +468,11 @@ assert_eq "strict: the job count still comes out" "7" \
     "$(bash -c 'set -euo pipefail; . "$1"; _llama_jobs_for 20 16384' _ "$_STRICT_FILE")"
 
 # POSIX mode is the strict end of the range: bash applies errexit to a failing
-# assignment there, which it does not do by default. A user with POSIXLY_CORRECT
-# exported, or bash invoked as sh, gets those semantics, and an unreadable file
-# must cost the cap rather than the install. This is what pins the `|| true` on
-# each read; without them the shell exits before the job count is ever printed.
-# The distinguishing form is the assignment: `v=$(reader)` propagates the
-# reader's failure, while passing it as an argument discards the status. The
-# real call site is NCPU=$(_llama_build_jobs), so pin the assignment form.
+# assignment there, which it does not do by default, and POSIXLY_CORRECT or bash
+# invoked as sh gets those semantics. This is what pins the `|| true` on each
+# read; without them the shell exits before the job count is ever printed. The
+# assignment is the distinguishing form -- `v=$(reader)` propagates the failure,
+# an argument discards it -- and the real call site is NCPU=$(_llama_build_jobs).
 # $1 = a PATH prefix, $2 = the expression to assign from, $3 = a prelude (used
 # to stub the cgroup reader out of the host-memory cases).
 run_posix_assign() {
@@ -524,9 +514,9 @@ assert_eq "POSIX mode: an unreadable meminfo keeps the core count" "20" \
 
 rm -f "$_STRICT_FILE"
 
-# The min() that ties it together. Drive _usable_ram_mb from a pinned meminfo
-# rather than the live one: MemAvailable moves between two reads, so comparing
-# a cached host figure against a second read is a race on any Linux runner.
+# The min() that ties it together. Drive _usable_ram_mb from a pinned meminfo:
+# MemAvailable moves between two reads, so comparing a cached host figure
+# against a second read of the live one races on any Linux runner.
 _RAM_FILE=$(mktemp)
 sed -n '/^_vm_stat_avail_mb()/,/^}/p;/^_usable_ram_mb()/,/^}/p' "$SETUP_SH" > "$_RAM_FILE"
 printf 'MemTotal:       16777216 kB\nMemAvailable:   12582912 kB\n' > "$_TMPD/meminfo"
@@ -549,11 +539,11 @@ assert_eq "pre-3.14 kernels fall back to MemTotal" "16384" \
     "$(bash -c '. "$1"; _cgroup_free_mb() { :; }; _usable_ram_mb "$2"' \
         _ "$_RAM_FILE" "$_TMPD/meminfo-old")"
 
-# macOS has no MemAvailable, so the reclaim-aware figure comes from vm_stat.
-# Fed synthetically: free 1024 + inactive 1024 at the 16 KiB Apple Silicon page
-# size is 32 MiB, and the page size is read rather than assumed to be 4096.
-# speculative and purgeable are deliberately NOT in the sum; the fixture carries
-# both so that adding either back is visible as a wrong number.
+# macOS has no MemAvailable, so the reclaim-aware figure comes from vm_stat. Fed
+# synthetically: free 1024 + inactive 1024 at the 16 KiB Apple Silicon page size
+# is 32 MiB, and the page size is read rather than assumed to be 4096. The
+# fixture carries speculative and purgeable, which are deliberately NOT in the
+# sum, so that adding either back is visible as a wrong number.
 _VM_SAMPLE=$(printf '%s\n' \
     "Mach Virtual Memory Statistics: (page size of 16384 bytes)" \
     "Pages free:                                    1024." \
@@ -569,9 +559,8 @@ assert_eq "vm_stat ignores active and wired" "32" \
     "$(printf '%s\n' "$_VM_SAMPLE" | sed 's/999999/1/' | run_vm_stat)"
 # speculative is a SUBSET of free, not a sibling of it: xnu's
 # osfmk/mach/vm_statistics.h states "speculative pages are already accounted for
-# in free_count". Adding it counts those pages twice and overstates what can be
-# reclaimed, which is the direction that hands the machine more jobs than it can
-# hold. Raising it alone must not move the answer.
+# in free_count", so adding it double-counts and hands the machine more jobs
+# than it can hold. Raising it alone must not move the answer.
 assert_eq "a larger speculative count does not change the answer" "32" \
     "$(printf '%s\n' "$_VM_SAMPLE" | sed 's/^Pages speculative:.*/Pages speculative:  99999./' | run_vm_stat)"
 # purgeable is an attribute of a page, not a queue: a volatile page still sits on
@@ -589,11 +578,9 @@ assert_eq "vm_stat reports a genuine zero" "0" \
     "$(printf '%s\n' "Mach Virtual Memory Statistics: (page size of 16384 bytes)" \
         "Pages active: 999999." | run_vm_stat)"
 
-# And _usable_ram_mb must consult it. An unreadable meminfo path forces the
-# branch that reads hw.memsize -- but that branch is an `elif` on sysctl
-# succeeding, and sysctl has no hw.memsize on Linux, so the branch was never
-# entered and this asserted nothing off a Mac. Stubbing sysctl is what makes it
-# run on a Linux runner, which is where CI actually is.
+# And _usable_ram_mb must consult it. An unreadable meminfo forces the hw.memsize
+# branch, but that is an `elif` on sysctl succeeding and Linux sysctl has no
+# hw.memsize, so stubbing sysctl is what makes this run on a Linux CI runner.
 assert_eq "_usable_ram_mb prefers vm_stat over hw.memsize" "777" \
     "$(bash -c '. "$1"
                 sysctl() { printf "17179869184"; }
@@ -601,8 +588,8 @@ assert_eq "_usable_ram_mb prefers vm_stat over hw.memsize" "777" \
                 _vm_stat_avail_mb() { printf "777"; }
                 _usable_ram_mb "$2"' \
         _ "$_RAM_FILE" "$_TMPD/no-meminfo")"
-# Zero is a reading and is kept. Falling back to 16 GiB of installed RAM on a
-# Mac with nothing reclaimable is exactly the oversubscription this PR removes.
+# Zero is a reading and is kept: falling back to 16 GiB of installed RAM on a
+# Mac with nothing reclaimable is the oversubscription this PR removes.
 assert_eq "_usable_ram_mb keeps a zero reading" "0" \
     "$(bash -c '. "$1"
                 sysctl() { printf "17179869184"; }
@@ -626,8 +613,7 @@ assert_eq "4 GB allowance floors at 1 job" "1" "$(run_jobs 20 "$(run_usable_ram 
 
 # Host memory comes from what is actually available, not what is installed: a
 # 16 GiB box with 8 GiB resident must not be handed a 14 GiB compile budget.
-# Match the awk field pattern, not the bare word, so prose about MemAvailable
-# cannot satisfy this on its own.
+# Match the awk field pattern, not the bare word, so prose cannot satisfy this.
 if grep -q '/\^MemAvailable:/' "$SETUP_SH"; then
     echo "  PASS: host memory reads MemAvailable"; PASS=$((PASS + 1))
 else
@@ -645,8 +631,8 @@ fi
 rm -rf "$_TMPD" "$_CG_FILE" "$_RAM_FILE"
 
 # ── Windows parity (static check) ──
-# setup.ps1 carries its own copy because it cannot source setup.sh. The user who
-# reported this was on Windows, so a cap that only lands on Unix fixes nothing.
+# setup.ps1 carries its own copy because it cannot source setup.sh, and the user
+# who reported this was on Windows, so a Unix-only cap fixes nothing.
 _check_ps1() {
     _label="$1"; _pattern="$2"
     if grep -qE "$_pattern" "$SETUP_PS1"; then
@@ -666,9 +652,9 @@ _check_ps1 "setup.ps1 per-job budget matches setup.sh" '^\$LlamaBuildMbPerJob = 
 _check_ps1 "setup.ps1 budgets from available memory" 'AvailableMBytes'
 _check_ps1 "setup.ps1 feeds it to the job count" 'Get-LlamaJobsFor .*-TotalMb \(Get-UsableMemoryMb\)'
 _check_ps1 "setup.ps1 keeps installed RAM as the fallback" 'TotalPhysicalMemory'
-# Zero available memory is a reading, not a failure. Treating it as unreadable
-# fell back to installed RAM and handed a machine with nothing left its full
-# core count, so only a negative value now means "could not read".
+# Zero available memory is a reading, not a failure: treating it as unreadable
+# fell back to installed RAM and handed an exhausted machine its full core
+# count, so only a negative value now means "could not read".
 _check_ps1 "setup.ps1 keeps a zero reading" '^[[:space:]]*if \(\$null -ne \$avail\) \{ return \[long\]\$avail \}$'
 _check_ps1 "setup.ps1 signals unreadable memory as -1" '^[[:space:]]*return -1$'
 _check_ps1 "setup.ps1 treats only a negative as unreadable" '^[[:space:]]*if \(\$TotalMb -lt 0\) \{ return \$Cores \}$'

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -67,6 +67,68 @@ assert_eq "override wins over cores" "64" "$(run_jobs 4 4096 64)"
 assert_eq "zero override ignored" "7" "$(run_jobs 20 16384 0)"
 assert_eq "junk override ignored" "7" "$(run_jobs 20 16384 "lots")"
 
+# ── Container limits ──
+# /proc/meminfo is not namespaced, so it reports the host's RAM inside a
+# container. Without this a 4 GB container on a big host budgets from the host
+# and the build gets OOM-killed.
+_CG_FILE=$(mktemp)
+sed -n '/^_cgroup_limit_mb()/,/^}/p' "$SETUP_SH" > "$_CG_FILE"
+if [ ! -s "$_CG_FILE" ]; then
+    echo "FAIL: could not extract _cgroup_limit_mb from setup.sh"
+    exit 1
+fi
+
+_TMPD=$(mktemp -d)
+run_cgroup() {
+    bash -c ". '$_CG_FILE'; _cgroup_limit_mb \"\$@\"" _ "$@"
+}
+
+echo "=== cgroup limit ==="
+
+# 1) cgroup v2 in a 4 GB container.
+printf '4294967296' > "$_TMPD/v2"
+assert_eq "v2 limit read as MiB" "4096" "$(run_cgroup "$_TMPD/v2")"
+
+# 2) v2 on an unconstrained host writes the literal "max".
+printf 'max' > "$_TMPD/v2max"
+assert_eq "v2 'max' is not a limit" "" "$(run_cgroup "$_TMPD/v2max")"
+
+# 3) v1 in a 2 GB container, reached only when v2 is absent.
+printf '2147483648' > "$_TMPD/v1"
+assert_eq "v1 limit read as MiB" "2048" "$(run_cgroup "$_TMPD/missing" "$_TMPD/v1")"
+
+# 4) v1's unlimited sentinel is enormous, so it loses the min() below.
+printf '9223372036854771712' > "$_TMPD/v1max"
+assert_eq "v1 sentinel is astronomically large" "8796093022207" "$(run_cgroup "$_TMPD/v1max")"
+
+# 5) No cgroup files at all: nothing to report.
+assert_eq "absent files report nothing" "" "$(run_cgroup "$_TMPD/missing" "$_TMPD/also-missing")"
+
+# 6) v2 wins when both exist, since it is passed first.
+assert_eq "v2 wins over v1" "4096" "$(run_cgroup "$_TMPD/v2" "$_TMPD/v1")"
+
+# The min() that ties it together. _total_ram_mb hardcodes the real cgroup paths,
+# so stub the reader to prove the wiring rather than just the parts.
+_RAM_FILE=$(mktemp)
+sed -n '/^_total_ram_mb()/,/^}/p' "$SETUP_SH" > "$_RAM_FILE"
+# The stub ignores the real paths _total_ram_mb passes it and echoes $FAKE_LIMIT.
+run_total_ram() {
+    FAKE_LIMIT="$1" bash -c \
+        '. "$1"; _cgroup_limit_mb() { printf "%s" "$FAKE_LIMIT"; }; _total_ram_mb' _ "$_RAM_FILE"
+}
+_HOST_MB=$(run_total_ram "")
+
+# A limit below host RAM wins; one above it, including v1's sentinel, does not.
+assert_eq "a lower cgroup limit wins" "512" "$(run_total_ram 512)"
+assert_eq "a higher limit is ignored" "$_HOST_MB" "$(run_total_ram 8796093022207)"
+assert_eq "no limit leaves host RAM" "$_HOST_MB" "$(run_total_ram "")"
+assert_eq "a zero limit is ignored" "$_HOST_MB" "$(run_total_ram 0)"
+
+# End to end: a 4 GB container on this host builds at -j1, not -j(cores).
+assert_eq "4 GB container floors at 1 job" "1" "$(run_jobs 20 "$(run_total_ram 4096)" "")"
+
+rm -rf "$_TMPD" "$_CG_FILE" "$_RAM_FILE"
+
 # ── Windows parity (static check) ──
 # setup.ps1 carries its own copy because it cannot source setup.sh. The user who
 # reported this was on Windows, so a cap that only lands on Unix fixes nothing.

--- a/tests/sh/test_llama_build_jobs.sh
+++ b/tests/sh/test_llama_build_jobs.sh
@@ -247,6 +247,43 @@ printf '3:memory:/docker/abc/task\n' > "$_TMPD/multiv1.proc"
 assert_eq "v1 picks the containing mount too" "2048" \
     "$(run_cgroup "$_TMPD/multi" "$_TMPD/multiv1.proc" "$_TMPD/multiv1.mnt")"
 
+# 22) mountinfo escapes space, tab, newline and backslash as octal. Returning
+#     the fields verbatim gave a path that does not exist.
+mkdir -p "$_TMPD/esc/a b/job"
+printf '8589934592\n' > "$_TMPD/esc/a b/memory.max"
+printf '1073741824\n' > "$_TMPD/esc/a b/job/memory.max"
+printf '0::/slice/job\n' > "$_TMPD/esc.proc"
+printf '%s\n' "70 30 0:60 /slice $_TMPD/esc/a\\040b rw - cgroup2 cgroup2 rw" > "$_TMPD/esc.mnt"
+assert_eq "an escaped mount point is decoded" "1024" \
+    "$(run_cgroup "$_TMPD/esc" "$_TMPD/esc.proc" "$_TMPD/esc.mnt")"
+
+# 23) The mount root is escaped the same way, and has to match the process path.
+mkdir -p "$_TMPD/esc/plain/job"
+printf '2147483648\n' > "$_TMPD/esc/plain/job/memory.max"
+printf '0::/a b/job\n' > "$_TMPD/escroot.proc"
+printf '%s\n' "71 30 0:61 /a\\040b $_TMPD/esc/plain rw - cgroup2 cgroup2 rw" > "$_TMPD/escroot.mnt"
+assert_eq "an escaped mount root is decoded" "2048" \
+    "$(run_cgroup "$_TMPD/esc" "$_TMPD/escroot.proc" "$_TMPD/escroot.mnt")"
+
+# 24) A colon is legal in a systemd unit name, and -F: with $3 truncated there.
+mkdir -p "$_TMPD/colon/cg/slice:tenant/job"
+printf '8589934592\n' > "$_TMPD/colon/cg/slice:tenant/memory.max"
+printf '1073741824\n' > "$_TMPD/colon/cg/slice:tenant/job/memory.max"
+printf '0::/slice:tenant/job\n' > "$_TMPD/colon.proc"
+assert_eq "v2 keeps a colon in the path" "1024" "$(run_cgroup "$_TMPD/colon/cg" "$_TMPD/colon.proc")"
+
+# 25) Same for v1, where the path is the third field rather than the remainder.
+mkdir -p "$_TMPD/colon/v1/memory/slice:tenant/task"
+printf '8589934592\n' > "$_TMPD/colon/v1/memory/slice:tenant/memory.limit_in_bytes"
+printf '2147483648\n' > "$_TMPD/colon/v1/memory/slice:tenant/task/memory.limit_in_bytes"
+printf '4:memory:/slice:tenant/task\n' > "$_TMPD/colonv1.proc"
+assert_eq "v1 keeps a colon in the path" "2048" "$(run_cgroup "$_TMPD/colon/v1" "$_TMPD/colonv1.proc")"
+
+# 26) The controller column is still matched exactly, not by substring.
+printf '4:cpu,memoryfoo:/slice:tenant/task\n' > "$_TMPD/colonv1.bad"
+assert_eq "a lookalike controller is not matched" "" \
+    "$(run_cgroup "$_TMPD/colon/v1" "$_TMPD/colonv1.bad")"
+
 # The min() that ties it together. _usable_ram_mb hardcodes the real paths, so
 # stub the reader to prove the wiring rather than just the parts.
 _RAM_FILE=$(mktemp)


### PR DESCRIPTION
## Summary

The llama.cpp source build passed the logical core count straight to `cmake -j`. On a 20-thread 16 GB machine that is `-j20`, and an nvcc translation unit peaks near 2 GB, so the build oversubscribed memory until the machine stopped responding. The reporter could not open PowerShell to stop it and had to kill it from Task Manager and uninstall.

This budgets the job count from RAM instead of core count.

## What changed

`studio/setup.sh` and `studio/setup.ps1` now derive `-j` from total physical RAM: reserve 2 GB for the OS, allow 2 GB per compile job, and clamp the result to the core count.

- RAM is only ever a ceiling. A 4-core 64 GB box still builds at `-j4`, so machines with headroom are unaffected.
- A 20-core 16 GB box now builds at `-j7` instead of `-j20`.
- Small-RAM machines floor at `-j1` rather than dividing to zero.
- When RAM cannot be read the job count falls back to the old core count, so an unreadable host is never slowed down by a guess.
- Inside a memory-limited container the cgroup limit wins over `MemTotal`, which is not namespaced and reports the host. v2 `memory.max` is read first, then v1 `memory.limit_in_bytes`; v2's `max` does not parse and v1's unlimited sentinel loses the comparison, so neither needs a special case. Windows has no cgroups, so `setup.ps1` is unchanged here.
- `UNSLOTH_LLAMA_BUILD_JOBS` overrides both, for anyone who wants their cores back. A zero or non-numeric value is ignored rather than producing `-j0`.

Windows prints `Parallel jobs: 7 of 20 cores (RAM-capped; UNSLOTH_LLAMA_BUILD_JOBS overrides)` so the number is no longer unexplained. Linux and macOS log the same line under `--verbose`.

`setup.ps1` carries its own copy of the helper because it cannot source `setup.sh`. The reserve and per-job constants are pinned to matching values by the test below, so the two cannot drift.

## Behavior boundaries

- Only the source build path changes. Prebuilt installs do not compile and are untouched.
- The CPU fallback rebuilds and the optional `llama-quantize` and diffusion visual server targets reuse the same job count, as before.
- No change to which backend is built, to cmake arguments, or to build success or failure handling.

## Testing

`tests/sh/test_llama_build_jobs.sh` (27 assertions) drives the helpers directly, so no hardware is faked:

- the reported 20-core 16 GB case caps at 7
- cores still win when RAM is ample
- 4 GB and 2 GB floor at 1
- empty and non-numeric RAM keep the core count
- a non-numeric core count falls back to 4
- the override wins over both the cap and the core count
- zero and non-numeric overrides are ignored
- cgroup v2, v2 `max`, v1, v1's unlimited sentinel, absent files, and v2 winning over v1, all against real temp files
- the `min()` inside `_total_ram_mb`, stubbing the reader since that function hardcodes the real `/sys` paths

It also statically checks `setup.ps1` for parity: that it calls the helper, honours the override, uses the same two constants, and that the bare `[Environment]::ProcessorCount` assignment that caused the hang has not come back.

Also run:

- `bash tests/sh/test_llama_build_jobs.sh` (27 passed)
- every other `tests/sh/*.sh` suite (4 pre-existing macOS-host failures, identical on `main`)
- `python -m pytest tests/studio/install tests/python/test_cross_platform_parity.py tests/studio/test_ci_shell_suite_coverage.py -q` (1697 passed; the 41 failures are `TestSetupPs1*` cases needing a working local pwsh and are identical on `main`)
- `bash -n studio/setup.sh`
- the helper exercised end to end under `set -euo pipefail`, including the `NCPU=$(...)` assignment form

The new suite is picked up automatically by Backend CI and `tests/run_all.sh`, both of which discover `tests/sh/*.sh`; `test_ci_shell_suite_coverage.py` passes with it in place.
