### PR TITLE
Make a fatal X11 error visible in the Linux desktop legs

### DIFF
--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -424,6 +424,16 @@ jobs:
           "$PY" -c "import torch; print('torch', torch.__version__)"
 
       - name: Launch under Xvfb and prove it stays up
+        env:
+          # Without this a fatal X11 error is completely invisible. GTK3 registers
+          # gdk_x_io_error() as its XSetIOErrorHandler, and that handler reports with
+          # g_debug() and then calls _exit(1) (gtk-3-24 gdk/x11/gdkmain-x11.c; the comment
+          # there says g_warning() was avoided because it could be redirected). g_debug()
+          # output is dropped unless G_MESSAGES_DEBUG names the domain, so the app exits 1
+          # having printed nothing at all and the step reports a bare rc=1 with no cause.
+          # That is exactly what #8062 looked like until this variable was set, at which
+          # point the next line read "Fatal IO error 11 ... on X server".
+          G_MESSAGES_DEBUG: all
         run: |
           set -a; [ -f ./clean-machine.env ] && . ./clean-machine.env; set +a
           # The one platform where a hosted runner can give the app a real display, so this


### PR DESCRIPTION
One environment variable on the Linux launch step, and it is the difference between an unexplained exit code and a diagnosis.

## The problem

When the packaged desktop app hits a fatal X11 I/O error, the job reports this and nothing else:

```
##[error]desktop app exited early with rc=1
```

No app output, no cause, no annotation pointing anywhere. The app itself printed nothing, because GTK swallows the message.

`gdk_x_io_error()` is registered as the `XSetIOErrorHandler` in `_gdk_x11_windowing_init()`. It reports the error with `g_debug()` and then calls `_exit(1)`:

```c
/* ... We g_debug() instead of g_warning(), because g_warning()
 * could possibly be redirected to the log */
g_debug ("%s: Fatal IO error %d (%s) on X server %s.\n", ...);
_exit (1);
```

(`gtk-3-24`, `gdk/x11/gdkmain-x11.c`.) `g_debug()` output is dropped unless `G_MESSAGES_DEBUG` names the domain, so by default the process exits 1 in silence.

## What it buys

This is exactly what #8062 looked like before the variable was set. With it, the line immediately after the backend spawn reads:

```
(unsloth-studio:4313): Gdk-DEBUG: unsloth-studio: Fatal IO error 11 (Resource temporarily unavailable) on X server :77.
```

That single line is what turned that investigation from "the app exits for no visible reason" into a named failure mode with a known handler and a known exit path.

## Cost

None on a passing run. `G_MESSAGES_DEBUG` only produces output on the debug path, and the app writes to `logs/app-stdout.log`, which is already uploaded as an artifact and already tailed by the failure branch of the launch step.

Scoped to the launch step rather than the job, so it cannot add noise to the installer or preflight steps.

`actionlint` reports no new findings against `origin/main` for this file.

## Related

- #8062 is the underlying Linux defect, which this does not attempt to fix.
- The launch step only prints its diagnostic at all because of the `wait` fix in #8026; before that, `bash -e` aborted the step on the `wait` line and neither the annotation nor the app output ever appeared.