### PR TITLE
Let the titlebar import contract tolerate extra lucide-react icons

### DIFF
--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -413,7 +413,7 @@ def test_desktop_titlebar_separates_navigation_from_sidebar_brand():
     sidebar = APP_SIDEBAR.read_text(encoding = "utf-8")
     header = sidebar.split("<SidebarHeader", 1)[1].split("</SidebarHeader>", 1)[0]
 
-    assert 'import { ArrowLeft, ArrowRight } from "lucide-react";' in titlebar
+    assert "import { ArrowLeft, ArrowRight" in titlebar
     assert "<ArrowLeft" in titlebar
     assert "<ArrowRight" in titlebar
     assert "window.history.back()" in titlebar


### PR DESCRIPTION
`test_desktop_titlebar_separates_navigation_from_sidebar_brand` asserts the import line verbatim:

```python
assert 'import { ArrowLeft, ArrowRight } from "lucide-react";' in titlebar
```

`studio/frontend/src/components/tauri/window-titlebar.tsx:12` has been

```ts
import { ArrowLeft, ArrowRight, Minus, Square, X } from "lucide-react";
```

since #8025 added the window control icons, so the substring no longer matches and the test fails. It is red on `main` on its own, not only in PRs:

```
$ git checkout 34a709295 && python3 -m pytest tests/studio/test_desktop_reliability_frontend_contract.py -q
1 failed, 25 passed
E   assert 'import { ArrowLeft, ArrowRight } from "lucide-react";' in '...'
```

That puts `Repo tests (CPU)` red on every open PR regardless of what the PR changes.

The contract this test is about is that the titlebar owns the history arrows, which the next two asserts already cover with `<ArrowLeft` and `<ArrowRight`. Pinning the rest of the import list adds nothing and breaks whenever an unrelated icon is added, so this drops the tail of the literal.

The assertion is still load-bearing. Both mutations go red:

| mutation to `window-titlebar.tsx:12` | result |
| --- | --- |
| baseline | 26 passed |
| `import { Minus, Square, X } from "lucide-react";` (arrows dropped) | 1 failed, 25 passed |
| `import { ArrowRight, ArrowLeft, Minus, Square, X } ...` (reordered) | 1 failed, 25 passed |

Checked: `ruff check` clean, `scripts/run_ruff_format.py` leaves it alone, `python -m compileall` OK, and the 38 studio titlebar and frontend-contract tests pass.
