### PR TITLE
Unbreak Repo tests (CPU) on main: two stale frontend-contract harnesses

### DIFF
--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -82,6 +82,25 @@ function resolveInferenceCheckpointId(status: any) {
 function snapshotQueuedChatRunSettings(state: any) {
   return { ...state, params: { ...state.params } };
 }
+// Mirrors ../lib/mlx-runtime-state. No scenario here loads an MLX model, so the
+// non-MLX branch is the only one reached, but the symbol has to exist.
+function mlxRuntimeStateFrom(resp: any) {
+  if (resp?.is_mlx !== true) {
+    return {
+      loadedMlxKvBitsRequested: null,
+      mlxKvQuantReason: null,
+      chatTemplateOverrideReason: null,
+      mlxKvQuantNote: null,
+    };
+  }
+  return {
+    mlxKvBits: resp.mlx_kv_bits_requested ?? null,
+    loadedMlxKvBitsRequested: resp.mlx_kv_bits_requested ?? null,
+    mlxKvQuantReason: resp.mlx_kv_quant_reason ?? null,
+    chatTemplateOverrideReason: resp.chat_template_override_reason ?? null,
+    mlxKvQuantNote: resp.mlx_kv_quant_note ?? null,
+  };
+}
 
 function makeStore(): any {
   const state: any = {

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -3,6 +3,7 @@
 
 """Static contracts for focused packaged-desktop reliability behavior."""
 
+import re
 from pathlib import Path
 
 
@@ -49,6 +50,16 @@ TRAINING_CONFIG_ACTIONS = FRONTEND / "features/studio/wizard/config-actions.tsx"
 MARKDOWN_TEXT = FRONTEND / "components/assistant-ui/markdown-text.tsx"
 IMAGE = FRONTEND / "components/assistant-ui/image.tsx"
 AUDIO_PLAYER = FRONTEND / "components/assistant-ui/audio-player.tsx"
+
+
+def _named_imports(source, module):
+    """Named specifiers imported from ``module``, so adding one does not break a contract."""
+    match = re.search(
+        r"import\s*\{([^}]*)\}\s*from\s*[\"']" + re.escape(module) + r"[\"']", source
+    )
+    if match is None:
+        return set()
+    return {part.strip() for part in match.group(1).split(",") if part.strip()}
 
 
 def test_desktop_update_offer_remains_actionable_from_settings():
@@ -413,7 +424,9 @@ def test_desktop_titlebar_separates_navigation_from_sidebar_brand():
     sidebar = APP_SIDEBAR.read_text(encoding = "utf-8")
     header = sidebar.split("<SidebarHeader", 1)[1].split("</SidebarHeader>", 1)[0]
 
-    assert 'import { ArrowLeft, ArrowRight } from "lucide-react";' in titlebar
+    imported = _named_imports(titlebar, "lucide-react")
+    assert "ArrowLeft" in imported
+    assert "ArrowRight" in imported
     assert "<ArrowLeft" in titlebar
     assert "<ArrowRight" in titlebar
     assert "window.history.back()" in titlebar

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -54,9 +54,7 @@ AUDIO_PLAYER = FRONTEND / "components/assistant-ui/audio-player.tsx"
 
 def _named_imports(source, module):
     """Named specifiers imported from ``module``, so adding one does not break a contract."""
-    match = re.search(
-        r"import\s*\{([^}]*)\}\s*from\s*[\"']" + re.escape(module) + r"[\"']", source
-    )
+    match = re.search(r"import\s*\{([^}]*)\}\s*from\s*[\"']" + re.escape(module) + r"[\"']", source)
     if match is None:
         return set()
     return {part.strip() for part in match.group(1).split(",") if part.strip()}


### PR DESCRIPTION
`Repo tests (CPU)` is red on main for two independent reasons, both of them test harnesses that went stale when frontend code moved under them. Neither is a product bug, and both fail every open PR that merges main.

### 1. Titlebar contract asserts an exact import line

```python
assert 'import { ArrowLeft, ArrowRight } from "lucide-react";' in titlebar
```

#8016 added `Minus`, `Square` and `X` to that import for the window chrome:

```tsx
import { ArrowLeft, ArrowRight, Minus, Square, X } from "lucide-react";
```

so the literal string no longer appears. The test cares that the two history arrows are imported and rendered, not about who else shares the import, so it now matches the named specifiers via a small `_named_imports` helper.

### 2. Chat autoload harness is missing an `mlxRuntimeStateFrom` stub

#8007 added `mlxRuntimeStateFrom` to `chat-adapter.ts`. The sliced region the harness compiles imports it, so all 16 scenarios in `test_chat_autoload_failure_gate.py` fail with the harness's own assertion:

> the sliced region uses ['mlxRuntimeStateFrom'], imported by chat-adapter.ts but absent from this harness. Add a stub to PREAMBLE

Added a stub mirroring `../lib/mlx-runtime-state`. No scenario here loads an MLX model, so only the non-MLX branch is reached, but the symbol has to exist.

### Verification

On a clean `origin/main` checkout both reproduce: 1 failure in `test_desktop_reliability_frontend_contract.py` and 16 in `test_chat_autoload_failure_gate.py`. With this change the two files are 42 passed.

The relaxed titlebar assertion still bites: removing `ArrowLeft, ArrowRight` from the import fails the test again. A contract that can no longer fail would be worse than a brittle one.