### PR TITLE
CI: share the gemma-3-270m-it model cache across Linux, macOS and Windows

### DIFF
--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -718,13 +718,17 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -738,11 +742,12 @@ jobs:
           bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE"
 
       - name: Save HF_HOME for ${{ env.GGUF_REPO }}
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Install Unsloth (--local, --no-torch)
         uses: ./.github/actions/install-unsloth-local

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -75,15 +75,19 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
           path: hf-cache
-          # Same key as studio-ui-smoke.yml so the two jobs share a
-          # single GGUF download across CI.
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          # Shared by every gemma-3-270m-it job in CI (Linux, macOS and
+          # Windows alike) so the model is downloaded once, not once per OS.
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -108,11 +112,12 @@ jobs:
         # same 4.6GB model held four times on four different PR refs and no copy
         # on main at all. That is the thrash loop: PR misses -> downloads ->
         # saves its own copy -> evicts main's -> next PR misses.
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Install Unsloth (--local, --no-torch)
         uses: ./.github/actions/install-unsloth-local

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -91,13 +91,17 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -122,11 +126,12 @@ jobs:
         # same 4.6GB model held four times on four different PR refs and no copy
         # on main at all. That is the thrash loop: PR misses -> downloads ->
         # saves its own copy -> evicts main's -> next PR misses.
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Install Unsloth (--local, --no-torch)
         uses: ./.github/actions/install-unsloth-local

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -155,6 +155,9 @@ jobs:
           echo "GGUF_FILE=gemma-3-270m-it-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
           echo "STUDIO_PORT=18888" >> "$GITHUB_ENV"
 
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME for unsloth/gemma-3-270m-it-GGUF
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -162,7 +165,8 @@ jobs:
         timeout-minutes: 15
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
+          key: hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -195,7 +199,8 @@ jobs:
         timeout-minutes: 15
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
+          key: hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v3
+          enableCrossOsArchive: true
       - name: Install OpenAI + Anthropic Python SDKs
         timeout-minutes: 5
         run: pip install 'openai>=1.50' 'anthropic>=0.40'

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -88,13 +88,17 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -127,11 +131,12 @@ jobs:
         # same 4.6GB model held four times on four different PR refs and no copy
         # on main at all. That is the thrash loop: PR misses -> downloads ->
         # saves its own copy -> evicts main's -> next PR misses.
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Install Unsloth (--local, --no-torch)
         id: install_unsloth

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -87,13 +87,17 @@ jobs:
           python -m pip install --quiet 'pytest>=8'
           python -m pytest tests/studio/test_stt_model_search_locator_contract.py -q
 
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -118,11 +122,12 @@ jobs:
         # same 4.6GB model held four times on four different PR refs and no copy
         # on main at all. That is the thrash loop: PR misses -> downloads ->
         # saves its own copy -> evicts main's -> next PR misses.
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Install Unsloth (--local, --no-torch)
         uses: ./.github/actions/install-unsloth-local

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -67,13 +67,17 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -98,11 +102,12 @@ jobs:
         # same 4.6GB model held four times on four different PR refs and no copy
         # on main at all. That is the thrash loop: PR misses -> downloads ->
         # saves its own copy -> evicts main's -> next PR misses.
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
         shell: pwsh

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -277,6 +277,9 @@ jobs:
       # populates the cache key on a real miss only; cache keys are
       # immutable, so a corrupted cached entry persists until the -v1
       # suffix below is bumped.
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME cache for unsloth/gemma-3-270m-it-GGUF
         id: cache-hf
         timeout-minutes: 15
@@ -284,7 +287,8 @@ jobs:
         continue-on-error: true
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
+          key: hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -316,11 +320,12 @@ jobs:
         # same 4.6GB model held four times on four different PR refs and no copy
         # on main at all. That is the thrash loop: PR misses -> downloads ->
         # saves its own copy -> evicts main's -> next PR misses.
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2
+          key: hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v3
+          enableCrossOsArchive: true
 
       - name: Reset auth + boot Unsloth (API-only)
         timeout-minutes: 2
@@ -1428,13 +1433,17 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -1449,11 +1458,12 @@ jobs:
           bash .github/scripts/hf-download-with-retry.sh ggml-org/models tinyllamas/stories260K.gguf
 
       - name: Save HF_HOME for ${{ env.GGUF_REPO }}
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
         shell: pwsh

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -83,13 +83,17 @@ jobs:
           # then fatal-errors with "Cache folder path is retrieved
           # for pip but doesn't exist on disk".
 
+      # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
+      # Linux, macOS and Windows, so the key carries no `runner.os`, and
+      # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
@@ -114,11 +118,12 @@ jobs:
         # same 4.6GB model held four times on four different PR refs and no copy
         # on main at all. That is the thrash loop: PR misses -> downloads ->
         # saves its own copy -> evicts main's -> next PR misses.
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v2
+          key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
+          enableCrossOsArchive: true
 
       - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
         shell: pwsh


### PR DESCRIPTION
## What

One `actions/cache` entry for the gemma-3-270m-it model instead of three.

Every job that primes `HF_HOME` with `unsloth/gemma-3-270m-it-GGUF` / `UD-Q4_K_XL` already
used the identical `path: hf-cache`. The only thing splitting them into three separate cache
entries was `${{ runner.os }}` at the front of the key. This drops it, bumps `v2` -> `v3`, and
sets `enableCrossOsArchive: true` so Windows can join the same entry.

Ten cache steps across nine jobs now resolve to one key,
`hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v3`:

| runner | workflow / job |
|---|---|
| ubuntu-latest | `studio-api-smoke` / api-smoke |
| ubuntu-latest | `studio-ui-smoke` / ui-smoke |
| ubuntu-latest | `studio-inference-smoke` / openai-anthropic |
| ubuntu-latest | `local-agent-guides-ci` / prompt-cache |
| macos-15 | `studio-mac-ui-smoke` / ui-smoke |
| macos-15 | `studio-mac-inference-smoke` / inference-smoke (phase 1) |
| windows-latest | `studio-windows-api-smoke` / api-smoke |
| windows-latest | `studio-windows-ui-smoke` / ui-smoke |
| windows-latest | `studio-windows-inference-smoke` / inference-smoke (phase 1) |
| windows-latest | `studio-windows-inference-smoke` / no-vs-cpu |

Live caches on `main` today hold `Linux-hf-...`, `macOS-hf-...` and `Windows-hf-...` for this
model, 0.22 GiB each, byte-identical.

## Why this is safe: the payload really is identical

I did not infer this from the toolkit source. I ran a probe on a staging repo that downloads
this exact model on `ubuntu-latest`, `macos-15` and `windows-latest` and dumps a sorted
inventory of everything under `hf-cache` with per-file sha256, symlink targets, and a check
for Windows-illegal characters.

All three OSes produce the same tree:

```
hub/models--unsloth--gemma-3-270m-it-GGUF/blobs/e5420636...   253934624   sha256=e5420636...
hub/models--unsloth--gemma-3-270m-it-GGUF/refs/main                   40   sha256=a21cf7fe...
hub/models--unsloth--gemma-3-270m-it-GGUF/snapshots/c90975db.../gemma-3-270m-it-UD-Q4_K_XL.gguf
    -> ../../blobs/e5420636...   (symlink, not dangling)
```

- The blob filename is the file's own sha256, the snapshot directory is the repo commit sha.
  Both are content-derived, so both are OS-independent.
- `WIN_NAME_PROBLEMS=0` and `CASE_COLLISIONS=0` on all three: no `: ? * < > | "`, no trailing
  dot or space, no reserved device name, no case-only collisions. The GGUF and hub filenames
  are already cross-OS safe as they stand.
- Windows-hosted runners **do** create the snapshot symlink, so the hub layout is reproduced
  there identically rather than degraded to a copy.

The three entries that do vary are not content: `hub/CACHEDIR.TAG` is 191 bytes on
Linux/macOS and 195 on Windows (CRLF), the `hub/.locks/*.lock` placeholder is absent on
Windows, and `xet/logs/xet_<timestamp>_<pid>.log` is per-run noise. None of them is read back
by `huggingface_hub`, and a single shared entry means only one of the three variants is ever
stored anyway.

## Empirical proof of the cross-OS restore

The same probe saves on one OS and restores on another. Run:
https://github.com/danielhanchen/unsloth-staging-2/actions/runs/31141007275

| saved on | restored on | `enableCrossOsArchive` | result |
|---|---|---|---|
| ubuntu-latest | macos-15 | not set | `Cache restored from key: xosprobe-g1-flat` |
| ubuntu-latest | windows-latest | not set | `Cache not found for input keys: xosprobe-g1-flat` |
| ubuntu-latest | macos-15 | `true` | `Cache restored from key: xosprobe-g1-flatx` |
| ubuntu-latest | windows-latest | `true` | `Cache restored from key: xosprobe-g1-flatx` |
| ubuntu-latest (HF_HOME tree) | macos-15 | `true` | `Cache restored from key: xosprobe-g1-hf` |
| ubuntu-latest (HF_HOME tree) | windows-latest | `true` | `Cache restored from key: xosprobe-g1-hf` |
| windows-latest | ubuntu-latest | `true` | `Cache restored from key: xosprobe-g1-winsave` |

Linux and macOS share with no flag at all (both runners have zstd 1.5.7 on `PATH`, so both
compute the same compression component of the cache version hash). Windows needs
`enableCrossOsArchive: true` and then works in both directions; it extracts with
`"C:\Program Files\Git\usr\bin\tar.exe" ... --force-local --use-compress-program "zstd -d"`.

After the cross-OS restore on Windows, the relative snapshot symlink is intact and
`huggingface_hub` resolves the model offline from the Linux-written tree:

```
OFFLINE_RESOLVE ok D:\a\...\hf-cache\hub\models--unsloth--gemma-3-270m-it-GGUF\snapshots\c90975db...\gemma-3-270m-it-UD-Q4_K_XL.gguf 253934624
```

Same on macOS. The restored inventories on macOS and Windows are 21-for-21 identical to the
Linux one that produced them, including every sha256.

## Cost

`path` is unchanged, so this is a pure key rename. The new key is cold, and prefix
`restore-keys` cannot rescue it (the old keys have the OS as a *prefix*, so nothing matches).
The first `main` run after merge therefore re-downloads 254 MiB once per OS, about 10 s each
on the runners I measured, then one of them saves and the other two log the benign
"Unable to reserve cache with key ... another job may be creating this cache" they already log
today when two Linux workflows race for the same key.

Steady state: one 0.22 GiB entry instead of three, and macOS/Windows jobs now restore from
whatever the far more frequent Linux workflows seeded, which is the real win here.

## Also in this change

The save gates gain `hashFiles('hf-cache/**/*.gguf') != ''`. With a per-OS key a bad save only
hurt that OS; with a shared key it would poison all three, so the saves now require an actual
`.gguf` to be present. `studio-mac-inference-smoke` already had this guard and keeps its
`!= 'skipped'` semantics so a partial, resumable download still gets stored.

## Deliberately not changed

The other five cache families are single-OS and have nothing to share with:
`gemma-4-E4B-it` (Linux only, 4.6 GiB), `gemma-4-E2B-it` + mmproj (macOS only, 3.26 GiB),
`Qwen3-VL-2B-Instruct` UD-Q4_K_XL + mmproj (Linux only, 1.62 GiB) and
`Qwen3-VL-2B-Instruct` UD-IQ2_XXS + mmproj (Windows only, 1.14 GiB). Renaming their keys would
buy a cold re-download and no sharing. The two Qwen3-VL entries are the same repo at different
quants, so they are not interchangeable either.
