### PR TITLE
CI: share the Qwen3.5-2B tool-calling GGUF cache across Linux, macOS and Windows

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -332,7 +332,7 @@ jobs:
       # (Qwen3.5-2B at Q4_K_XL = ~1.28 GiB). Caching HF_HOME would
       # store xet chunks + blobs + snapshots = ~4 GiB compressed --
       # 4-5x file-size inflation, dominated by xet chunks. Use main's
-      # `--local-dir gguf-cache` pattern to cache the flat .gguf only.
+      # `--local-dir` pattern to cache the flat .gguf only.
       # Unsloth's /api/inference/load accepts either a HF repo (which
       # uses HF_HOME) or an absolute file path; passing the absolute
       # path keeps the test off HF_HOME entirely so the cache size
@@ -364,13 +364,21 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      # Cross-OS shared entry with the mac and Windows tool-calling phases:
+      # same repo, same file, same flat --local-dir payload, byte-identical on
+      # all three runners. The directory is renamed gguf-cache -> gguf-cache-tools
+      # to match them, and the key version is bumped in the SAME commit because
+      # actions/cache identifies an entry by key AND a hash of `path` -- moving
+      # the path without bumping the key gives a permanent restore miss plus a
+      # refused save ("Unable to reserve cache with key ...").
       - name: Restore GGUF model file
         id: cache-gguf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
-          path: gguf-cache
-          key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
+          path: gguf-cache-tools
+          key: gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v3
+          enableCrossOsArchive: true
 
       - name: Download GGUF if cache miss
         id: download-gguf
@@ -380,15 +388,16 @@ jobs:
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
-          mkdir -p gguf-cache
-          bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE" gguf-cache
+          mkdir -p gguf-cache-tools
+          bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE" gguf-cache-tools
 
       - name: Save GGUF model file
-        if: always() && github.ref == 'refs/heads/main' && steps.download-gguf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.download-gguf.outcome == 'success' && hashFiles('gguf-cache-tools/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: gguf-cache
-          key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
+          path: gguf-cache-tools
+          key: gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v3
+          enableCrossOsArchive: true
 
       - name: Install Unsloth (--local, --no-torch)
         uses: ./.github/actions/install-unsloth-local
@@ -432,7 +441,7 @@ jobs:
             -H 'content-type: application/json' \
             -d "{\"username\":\"unsloth\",\"password\":\"$NEW\"}" | jq -r .access_token)
           echo "API_KEY=$TOKEN" >> "$GITHUB_ENV"
-          GGUF_PATH="$GITHUB_WORKSPACE/gguf-cache/${GGUF_FILE}"
+          GGUF_PATH="$GITHUB_WORKSPACE/gguf-cache-tools/${GGUF_FILE}"
           ls -lh "$GGUF_PATH"
           curl -fs -X POST "http://127.0.0.1:${STUDIO_PORT}/api/inference/load" \
             -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' \

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -406,15 +406,21 @@ jobs:
           echo "GGUF_FILE=Qwen3.5-2B-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
           echo "STUDIO_PORT=18898" >> "$GITHUB_ENV"
 
-      # Key suffix bumped v1 -> v2 with the directory rename, and this is not
-      # cosmetic. actions/cache identifies an entry by key AND a version hash
-      # derived from the `path` input, but key uniqueness is global per ref. The
-      # old gguf-cache entry still holds the -v1 key, so a restore into
-      # gguf-cache-tools misses on version while the save is refused with
-      # "Unable to reserve cache with key ... another job may be creating this
-      # cache". Without the bump this phase re-downloads the model on every run,
-      # forever. Measured on staging before the bump: two consecutive runs both
-      # logged "Cache not found for input keys" and both failed to save.
+      # Cross-OS shared entry with the Linux tool-calling job in
+      # studio-inference-smoke.yml: same repo, same file, same flat
+      # --local-dir payload, byte-identical on all three runners. The key
+      # therefore carries no `runner.os`, and enableCrossOsArchive is what
+      # lets Windows -- which tars with --force-local -- join it.
+      #
+      # The suffix is bumped v2 -> v3 because the Linux side moves its
+      # directory to gguf-cache-tools in the same commit, and that is not
+      # cosmetic: actions/cache identifies an entry by key AND a version hash
+      # derived from the `path` input, while key uniqueness is global per ref.
+      # Move the path without bumping the key and the restore misses on
+      # version while the save is refused with "Unable to reserve cache with
+      # key ... another job may be creating this cache" -- measured on staging
+      # during the Mac consolidation: two consecutive runs both logged "Cache
+      # not found for input keys" and both failed to save.
       - name: Restore GGUF model file
         id: cache-gguf-tools
         if: ${{ !cancelled() && steps.assert-llama.outcome == 'success' }}
@@ -423,7 +429,8 @@ jobs:
         timeout-minutes: 15
         with:
           path: gguf-cache-tools
-          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v2
+          key: gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v3
+          enableCrossOsArchive: true
 
       - name: Download GGUF if cache miss
         id: download-gguf-tools
@@ -445,7 +452,8 @@ jobs:
         timeout-minutes: 15
         with:
           path: gguf-cache-tools
-          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v2
+          key: gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v3
+          enableCrossOsArchive: true
 
       - name: Reset auth + boot Unsloth (API-only, default tool policy)
         id: boot-tools

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -578,14 +578,21 @@ jobs:
           echo "STUDIO_PORT=18898" >> "$GITHUB_ENV"
           echo "HF_HOME=${{ github.workspace }}/hf-cache-tools" >> "$GITHUB_ENV"
 
-      # Key suffix bumped v1 -> v2 with the directory rename, and this is not
-      # cosmetic. actions/cache identifies an entry by key AND a version hash
-      # derived from the `path` input, but key uniqueness is global per ref. The
-      # old gguf-cache entry still holds the -v1 key, so a restore into
-      # gguf-cache-tools misses on version while the save is refused with
-      # "Unable to reserve cache with key ... another job may be creating this
-      # cache". Measured on staging during the Mac consolidation: two consecutive
-      # runs both logged "Cache not found for input keys" and both failed to save.
+      # Cross-OS shared entry with the Linux tool-calling job in
+      # studio-inference-smoke.yml: same repo, same file, same flat
+      # --local-dir payload, byte-identical on all three runners. The key
+      # therefore carries no `runner.os`, and enableCrossOsArchive is what
+      # lets Windows -- which tars with --force-local -- join it.
+      #
+      # The suffix is bumped v2 -> v3 because the Linux side moves its
+      # directory to gguf-cache-tools in the same commit, and that is not
+      # cosmetic: actions/cache identifies an entry by key AND a version hash
+      # derived from the `path` input, while key uniqueness is global per ref.
+      # Move the path without bumping the key and the restore misses on
+      # version while the save is refused with "Unable to reserve cache with
+      # key ... another job may be creating this cache" -- measured on staging
+      # during the Mac consolidation: two consecutive runs both logged "Cache
+      # not found for input keys" and both failed to save.
       - name: Restore GGUF model cache
         if: ${{ !cancelled() && steps.shim.outcome == 'success' }}
         id: cache-gguf-tools
@@ -594,7 +601,8 @@ jobs:
         continue-on-error: true
         with:
           path: gguf-cache-tools
-          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v2
+          key: gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v3
+          enableCrossOsArchive: true
 
       - name: Download GGUF if cache miss
         id: download-gguf-tools
@@ -609,12 +617,13 @@ jobs:
           bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE" gguf-cache-tools
 
       - name: Save GGUF model cache
-        if: always() && github.ref == 'refs/heads/main' && steps.download-gguf-tools.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.download-gguf-tools.outcome == 'success' && hashFiles('gguf-cache-tools/**/*.gguf') != ''
         timeout-minutes: 15
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: gguf-cache-tools
-          key: ${{ runner.os }}-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v2
+          key: gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v3
+          enableCrossOsArchive: true
 
       - name: Reset auth + boot Unsloth (API-only, default tool policy)
         id: boot-tools


### PR DESCRIPTION
## What

The same consolidation as #8068, applied to the second cache family that is genuinely
duplicated across OSes: the `Qwen3.5-2B-UD-Q4_K_XL.gguf` tool-calling model.

Three jobs download the same file from the same repo into the same flat `--local-dir` layout:

| runner | workflow / job | path before | key before |
|---|---|---|---|
| ubuntu-latest | `studio-inference-smoke` / tool-calling | `gguf-cache` | `Linux-gguf-...-v1` |
| macos-15 | `studio-mac-inference-smoke` / phase 2 | `gguf-cache-tools` | `macOS-gguf-...-v2` |
| windows-latest | `studio-windows-inference-smoke` / phase 2 | `gguf-cache-tools` | `Windows-gguf-...-v2` |

Two things had to change together: the Linux job moves to `gguf-cache-tools`, and all three
converge on one key with no `runner.os`, `gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v3`,
plus `enableCrossOsArchive: true`.

## The path and the key must move in the same commit

`actions/cache` identifies an entry by the key **and** by a version hash derived from the
`path` input, while key uniqueness is global per ref. Change `path` while leaving the key and
you get a permanent restore miss (version mismatch) plus a refused save
("Unable to reserve cache with key ... another job may be creating this cache") - the model
then re-downloads on every run, forever. This was measured on staging during the Mac phase
consolidation: two consecutive runs both logged "Cache not found for input keys" and both
failed to save. That is why the suffix goes to `v3` here.

The stale comments in the mac and Windows workflows that described the old `v1 -> v2` bump are
rewritten to describe the current state.

## Evidence

The flat `--local-dir` payload is byte-identical on all three runners. Probe inventory of
`hf download unsloth/gemma-3-270m-it-GGUF <file> --local-dir` on `ubuntu-latest`, `macos-15`
and `windows-latest` (the mechanism is per-directory, not per-model):

```
FILE  253934624  <model>.gguf                                      sha256=e5420636...  (all 3 OSes)
FILE          1  .cache/huggingface/.gitignore                     sha256=684888c0...  (all 3 OSes)
FILE        191  .cache/huggingface/CACHEDIR.TAG                   Linux/macOS
FILE        195  .cache/huggingface/CACHEDIR.TAG                   Windows (CRLF)
FILE          0  .cache/huggingface/download/<model>.gguf.lock     Linux/macOS only
FILE    124-128  .cache/huggingface/download/<model>.gguf.metadata (per-download timestamp)
```

`WIN_NAME_PROBLEMS=0`, `CASE_COLLISIONS=0`, `SYMLINKS=0` on all three: nothing in this layout
is OS-specific in a way that matters. Only the model file is read back.

Cross-OS restore proven end to end on
https://github.com/danielhanchen/unsloth-staging-2/actions/runs/31141007275, including this
exact flat layout:

- ubuntu-latest save -> macos-15 restore, no flag: `Cache restored from key: xosprobe-g1-flat`
- ubuntu-latest save -> windows-latest restore, no flag: `Cache not found for input keys`
- ubuntu-latest save -> windows-latest restore, `enableCrossOsArchive: true`: `Cache restored from key: xosprobe-g1-flatx`
- windows-latest save -> ubuntu-latest restore, `enableCrossOsArchive: true`: `Cache restored from key: xosprobe-g1-winsave`

In every hit the restored `.gguf` had the same sha256 as the one the saving OS wrote.

## Cost

This is the expensive one and it should be merged with eyes open. The path move makes the new
key genuinely cold on every OS, so the first `main` run after merge re-downloads **1.22 GiB
per runner, three times total**, before any of them can save. On the runners I measured that is
roughly 15-25 s of download plus one save; the Linux job in `studio-inference-smoke` will
normally win the race and seed the entry for the other two.

Steady state after that: one 1.22 GiB entry instead of three, and the macOS and Windows phases
restore from whatever Linux seeded rather than each maintaining their own copy. macOS is the
slowest at cache I/O of the three (46-63 MB/s restore versus 89 on Windows and 127 on Linux in
the probe), so moving it from "maintains its own entry" to "consumes Linux's" is a small win
for it too.

If the one-time 3.66 GiB of downloads is unwelcome right now, this PR can wait; #8068 is the
cheap half of the same idea (no path change, 254 MiB per OS) and stands alone.

## Also in this change

The Linux and Windows saves gain `hashFiles('gguf-cache-tools/**/*.gguf') != ''`, matching the
guard the mac workflow already had. A shared key means one bad save would poison three OSes.
