### PR TITLE
CI: stop main and nightly runs cancelling each other

### DIFF
--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -100,7 +100,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -52,7 +52,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -60,7 +60,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -51,7 +51,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   # Drafts are listed only to a token with push access, and every desktop-v* release here

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -32,7 +32,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -84,7 +84,11 @@ on:
       - '.github/scripts/ci-min-system-prompt.txt'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The event is part of the group so a scheduled run and a push to main cannot
+  # coalesce. Both resolve to refs/heads/main, and the default queue: single keeps
+  # only one pending run, so without this a merge burst silently drops the nightly:
+  # cancel-in-progress protects the running run, never the pending one.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # Latest-only on branches, never on main. Pushes to main land in bursts, so
   # cancelling superseded runs there throws away the run that would have
   # reported a regression, and the run that writes the shared caches. Same

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -85,7 +85,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lockfile-audit.yml
+++ b/.github/workflows/lockfile-audit.yml
@@ -49,7 +49,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lockfile-audit.yml
+++ b/.github/workflows/lockfile-audit.yml
@@ -48,7 +48,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The event is part of the group so a scheduled run and a push to main cannot
+  # coalesce. Both resolve to refs/heads/main, and the default queue: single keeps
+  # only one pending run, so without this a merge burst silently drops the nightly:
+  # cancel-in-progress protects the running run, never the pending one.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # Latest-only on branches, never on main. Pushes to main land in bursts, so
   # cancelling superseded runs there throws away the run that would have
   # reported a regression, and the run that writes the shared caches. Same

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -83,7 +83,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -50,7 +50,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ossf.yml
+++ b/.github/workflows/ossf.yml
@@ -19,7 +19,11 @@ on:
 # run is still a data point worth keeping. Grouping only coalesces the burst of
 # main pushes down to one in-flight run plus one pending.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The event is part of the group so a scheduled run and a push to main cannot
+  # coalesce. Both resolve to refs/heads/main, and the default queue: single keeps
+  # only one pending run, so without this a merge burst silently drops the nightly:
+  # cancel-in-progress protects the running run, never the pending one.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: false
 
 # Declare default permissions as read only.

--- a/.github/workflows/ossf.yml
+++ b/.github/workflows/ossf.yml
@@ -14,6 +14,14 @@ on:
   push:
     branches: [ "main" ]
 
+# Serialize, never cancel. The value of this workflow is the SARIF history in
+# the code scanning dashboard and the published OpenSSF result, so a superseded
+# run is still a data point worth keeping. Grouping only coalesces the burst of
+# main pushes down to one in-flight run plus one pending.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 # Declare default permissions as read only.
 permissions: read-all
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -50,6 +50,12 @@ env:
 concurrency:
   group: release-desktop-${{ github.repository }}
   cancel-in-progress: false
+  # publish-desktop-updater.yml shares this group and already sets queue: max.
+  # Without it here, the default queue: single silently cancels a *pending*
+  # release the moment a second one is dispatched or a publish lands, which
+  # looks identical to a release that was never dispatched. A queued release
+  # holds no runner, so waiting is free.
+  queue: max
 
 jobs:
   prepare-version:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -69,7 +69,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -68,7 +68,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The event is part of the group so a scheduled run and a push to main cannot
+  # coalesce. Both resolve to refs/heads/main, and the default queue: single keeps
+  # only one pending run, so without this a merge burst silently drops the nightly:
+  # cancel-in-progress protects the running run, never the pending one.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # Latest-only on branches, never on main. Pushes to main land in bursts, so
   # cancelling superseded runs there throws away the run that would have
   # reported a regression, and the run that writes the shared caches. Same

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     - cron: '30 5 * * *' # Runs at 5:30 UTC every day
 
+# Serialize, never cancel. This job comments on up to 500 issues per run, so a
+# cancelled run leaves a half-pinged backlog and no record of where it stopped.
+# Two runs overlapping would double-ping the same issues.
+concurrency:
+  group: stale-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -39,7 +39,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -44,7 +44,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-export-capability-ci.yml
+++ b/.github/workflows/studio-export-capability-ci.yml
@@ -33,7 +33,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -25,7 +25,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -52,7 +52,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-load-orchestrator-ci.yml
+++ b/.github/workflows/studio-load-orchestrator-ci.yml
@@ -34,7 +34,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -54,7 +54,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -25,7 +25,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -53,7 +53,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -28,7 +28,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -32,7 +32,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -31,7 +31,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -45,7 +45,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -30,7 +30,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -40,7 +40,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -46,7 +46,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -30,7 +30,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches. Same
+  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
`studio-ui-smoke.yml` already carries this fix and the incident that produced it:

> Never on main: pushes land in bursts, so cancelling superseded runs there means a deterministic failure can go unreported for as long as the bursts continue. The collapsed-row break below sat on main for 14 hours behind four cancelled runs.

Nothing about that reasoning is specific to that workflow. `group: ${{ github.workflow }}-${{ github.ref }}` resolves to one group for every push to `main`, so a burst of merges cancels its own predecessors. The same expression also puts **scheduled** runs on `refs/heads/main`, so a push to main cancels the nightly too. That second effect is the one nobody has been looking at: `lockfile-audit`, `security-audit` and `local-agent-guides-ci` have been losing crons to merges.

### What changes

27 workflows that can produce a run on `refs/heads/main` (push to main, a cron, or `repository_dispatch`) move from `cancel-in-progress: true` to `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`. PR branches keep cancelling, which is what you want there.

Left alone: `interrupted-install-ci`, `pester-guard-ci` and `startup-profile-ci`, which only ever run from a PR or a hand dispatch.

### This is happening right now, and it is the concurrency group doing it

`studio-mac-inference-smoke.yml` on `main`, last 78 completed runs, 2026-08-05T15:26Z to 2026-08-07T01:59Z: **74 cancelled, 4 successful.** The current cancelled streak is 68.

I checked whether that was really `cancel-in-progress` rather than hand-cancelling or the [Aug 6 Actions incident](https://github.com/orgs/community/discussions/204152), because both are plausible and neither would be worth changing a workflow over. It is neither:

- **Each cancelled run ends a median of 2 seconds after the next main run is created.** 74 out of 74. A person cancelling runs to free capacity does not hit a 2-second window 74 times in a row; a platform outage does not either. That timing is `cancel-in-progress` firing when the successor claims the group.
- **All 4 survivors are the runs where the next push happened to be far away**: the following run appeared 250s, 546s, 1,819s and 17,750s after they finished. Nothing about the code decided those outcomes, only merge spacing did.
- **Excluding the outage window entirely (08-06 15:22Z to 23:00Z) leaves 74 runs, 70 cancelled, 4 successful.** The incident is not the explanation.

The mechanism is just arithmetic. Median spacing between main runs over that window is **6.9 minutes**, and this workflow needs 20 to 60 minutes. It cannot finish, so it essentially never does.

### The cache consequence is measurable

`studio-mac-inference-smoke.yml` saves its caches under `if: always() && github.ref == 'refs/heads/main'`. When the main run never survives, the save never runs. The repo's cache list is the evidence:

| cache | Linux | Windows | macOS |
|---|---|---|---|
| `gguf-unsloth/Qwen3.5-2B-GGUF-...UD-Q4_K_XL` | 1,257.95 MiB | 1,257.95 MiB | **absent** |
| `hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v2` | 228.15 MiB | 228.16 MiB | 228.16 MiB |

The one macOS entry that exists is the small model shared with `studio-mac-ui-smoke.yml`. Every macOS run is re-downloading the 1.2 GiB tool-calling GGUF from Hugging Face because no main run has ever lived long enough to save it.

This is also why this PR matters to #8068 and #8069. Those make the model caches shared across Linux, macOS and Windows, but the save is still gated on main, so a shared cache that main never writes is still a cache that does not exist. I verified this branch merges cleanly with #8068, #8069 and #8060.

### Cost, honestly

Peak concurrency does not change. The group still admits one running run at a time, so main never holds more than one run per workflow either way. What changes is that the run **finishes** instead of being killed two minutes in, so main costs more job-minutes than it did. The default `queue: single` bounds the rest: a burst of four merges leaves one running plus one pending and quietly drops the two in the middle, rather than queueing all four.

That cost buys back two things. A regression on main gets reported by the run that found it. And eight of these workflows call `actions/cache/save` **only** on main, so today a cancelled main run is a shared cache that never gets written, which every later PR then pays for:

`local-agent-guides-ci` (4 saves), `studio-inference-smoke` (3), `studio-mac-inference-smoke` (3), `studio-windows-inference-smoke` (4), `studio-api-smoke`, `studio-mac-ui-smoke`, `studio-windows-api-smoke`, `studio-windows-ui-smoke` (1 each).

### Three separate cases in the same diff

**`release-desktop.yml` gains `queue: max`.** It shares the group `release-desktop-${{ github.repository }}` with `publish-desktop-updater.yml`, which already sets it. Under the default `queue: single` a *pending* release is cancelled the moment a second one is dispatched or a publish lands, and that happens regardless of `cancel-in-progress: false`, which only governs the running run. A silently dropped release looks exactly like one that was never dispatched. A pending run holds no runner, so queueing costs nothing.

**`stale.yml` gains a non-cancelling group.** It comments on up to 500 issues per run, so a cancelled run leaves a half-pinged backlog with no record of where it stopped, and two overlapping runs double-ping the same issues.

**`ossf.yml` gains a non-cancelling group.** Its value is the SARIF history and the published OpenSSF result, so a superseded run is still a data point worth keeping. Grouping only coalesces a burst of main pushes down to one running plus one pending.

### Note on the macOS pool

I flagged this as a risk and then measured it, and the risk is not there. Five of these are macOS workflows and the org has 5 concurrent macOS slots across every repo, but macOS is **not** what the release pipelines queue behind. Across every clean attempt-1 release run, macOS was the fastest class to get a runner: llama.cpp's two macOS jobs waited 6 seconds on 08-03 while its Linux and Windows jobs each accumulated ~5h48m of queue, and `release-desktop`'s macOS leg waited 1m54s against 2h54m for Windows. The numbers and their provenance are in #8071.

So letting macOS main runs finish costs macOS job-minutes that nothing is currently waiting on. The remaining honest cost of this PR is Linux and Windows job-minutes on main, which is the contended class. That is bounded by the group admitting one running run at a time, and by main pushes being a small share of the ~1,000 runs this repo creates per 75 minutes at peak, but I have not measured the main-vs-PR split and will not claim a number for it.