### PR TITLE
Fix the four Studio reds on main

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -583,7 +583,7 @@ function MlxAdvancedSettings({
         </Select>
       </div>
       {outcome ? (
-        <p className="text-[11px] leading-snug text-muted-foreground">
+        <p className="text-ui-11 leading-snug text-muted-foreground">
           {outcome}
         </p>
       ) : null}
@@ -595,7 +595,7 @@ function MlxAdvancedSettings({
         readOnly={!servedByMlx}
       />
       {templateOutcome ? (
-        <p className="text-[11px] leading-snug text-muted-foreground">
+        <p className="text-ui-11 leading-snug text-muted-foreground">
           {templateOutcome}
         </p>
       ) : null}

--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -111,6 +111,27 @@ let STORE: any = makeStore();
 // but they are the same landmine as syncModelCapabilities was, waiting for the
 // first scenario that turns a GPU option on. Stubbed so the harness is complete
 // rather than complete-by-luck.
+// Imported by chat-adapter.ts from ../lib/mlx-runtime-state. Mirrors the real
+// one rather than returning {}: a non-MLX response retires the verdict but
+// leaves mlxKvBits absent, and a scenario that saw an empty object would keep
+// a stale width alive and pass for the wrong reason.
+function mlxRuntimeStateFrom(resp: any) {
+  if (resp?.is_mlx !== true) {
+    return {
+      loadedMlxKvBitsRequested: null,
+      mlxKvQuantReason: null,
+      chatTemplateOverrideReason: null,
+      mlxKvQuantNote: null,
+    };
+  }
+  return {
+    mlxKvBits: resp.mlx_kv_bits_requested ?? null,
+    loadedMlxKvBitsRequested: resp.mlx_kv_bits_requested ?? null,
+    mlxKvQuantReason: resp.mlx_kv_quant_reason ?? null,
+    chatTemplateOverrideReason: resp.chat_template_override_reason ?? null,
+    mlxKvQuantNote: resp.mlx_kv_quant_note ?? null,
+  };
+}
 async function prepareHfTokenForUse(token: any) {
   return { proceed: true, token };
 }

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -3,6 +3,7 @@
 
 """Static contracts for focused packaged-desktop reliability behavior."""
 
+import re
 from pathlib import Path
 
 
@@ -413,7 +414,12 @@ def test_desktop_titlebar_separates_navigation_from_sidebar_brand():
     sidebar = APP_SIDEBAR.read_text(encoding = "utf-8")
     header = sidebar.split("<SidebarHeader", 1)[1].split("</SidebarHeader>", 1)[0]
 
-    assert 'import { ArrowLeft, ArrowRight } from "lucide-react";' in titlebar
+    # The names, not the whole import list: #8025 added Minus/Square/X to the
+    # same line for the window controls and this went red on every open PR.
+    lucide = re.search(r"import \{([^}]*)\} from \"lucide-react\";", titlebar)
+    assert lucide is not None, "titlebar no longer imports from lucide-react"
+    icons = {name.strip() for name in lucide.group(1).split(",")}
+    assert {"ArrowLeft", "ArrowRight"} <= icons, icons
     assert "<ArrowLeft" in titlebar
     assert "<ArrowRight" in titlebar
     assert "window.history.back()" in titlebar


### PR DESCRIPTION
`Repo tests (CPU)` is currently red on every open PR, and none of it comes from those PRs. Three contracts on main are failing:

| test | count |
| --- | ---: |
| `test_desktop_reliability_frontend_contract.py::test_desktop_titlebar_separates_navigation_from_sidebar_brand` | 1 |
| `test_chat_autoload_failure_gate.py` | 16 |
| `test_ui_font_scale_contract.py::test_no_raw_pixel_text_utilities` | 1 |

## Titlebar import

#8025 added the window controls and widened the import to

```tsx
import { ArrowLeft, ArrowRight, Minus, Square, X } from "lucide-react";
```

The contract pinned the whole line as a literal, so it went red on a change that did exactly what it should. It now parses the import and asserts the two icon names it actually cares about are in it, so adding a sixth icon does not break it again.

## Autoload harness

#8007 added `mlxRuntimeStateFrom` to `chat-adapter.ts`. The autoload harness slices that region and supplies its imports itself, so every one of its 16 scenarios died on a bare `ReferenceError`, which the retry loop scores as a failed load. The test already names the missing symbol rather than reporting a wrong-model assertion, which is how this was quick to place.

The stub mirrors `mlx-runtime-state.ts` rather than returning `{}`. A non-MLX response retires the verdict but leaves `mlxKvBits` absent, because the width is dormant there rather than wrong, and a preset carrying it has to survive the round trip. An empty object would keep a stale width alive and let a scenario pass for the wrong reason.

## Raw pixel text

`model-config-page.tsx` grew two `text-[11px]` utilities. Those ignore the UI font size preference, which is the whole point of the `text-ui-*` tokens in `index.css`. Swapped for `text-ui-11`, which is the same 11px at scale 1.

## Checks

- `tests/studio`: 2668 passed, 3 skipped. Was 18 failed before.
- Searched the tree for the same shapes: no `text-[Npx]` utilities remain anywhere under `studio/frontend/src`, and no other harness that slices `chat-adapter.ts` reaches `mlxRuntimeStateFrom`.
- Three other exact-import assertions exist (`test_compact_dropdown_submenus.py`, `test_usage_examples_agent_detection_contract.py`, `test_model_picker_contracts.py`). They pass today and are single-symbol module imports, so they are much less likely to gain siblings the way the lucide icon set did. Left alone to keep this diff to the reds.
- No runtime behaviour changes: one className string, one test-harness stub, one assertion loosened to its intent.