### PR TITLE
Studio: stop /api/inference/status raising on every loaded GGUF

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8029,6 +8029,12 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
                 and _reported_chat_template_override == _auto_chat_template_override
             ):
                 _reported_chat_template_override = None
+            # chat_template_override is one of the runtime fields, so it arrives in the
+            # dict below as the raw backend value. Overwrite it rather than passing it
+            # as a second keyword: two values for one keyword is a TypeError, whatever
+            # the values are.
+            _runtime_fields = _llama_runtime_fields(llama_backend)
+            _runtime_fields["chat_template_override"] = _reported_chat_template_override
             return InferenceStatusResponse(
                 active_model = _display_model_id,
                 model_identifier = _reported_model_identifier,
@@ -8040,8 +8046,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
                 loading = [],
                 loaded = [_display_model_id] if _display_model_id else [],
                 inference = _inference_cfg,
-                **_llama_runtime_fields(llama_backend),
-                chat_template_override = _reported_chat_template_override,
+                **_runtime_fields,
                 requested_context_length = llama_backend.requested_n_ctx,
                 llama_cpp_supports_mtp = _supports_mtp,
                 spec_fallback_reason = llama_backend.spec_fallback_reason,

--- a/tests/studio/test_inference_status_runtime_fields_contract.py
+++ b/tests/studio/test_inference_status_runtime_fields_contract.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""A runtime field must not be passed twice into an inference response (#8007).
+
+`_llama_runtime_fields()` returns one entry per field on `_InferenceRuntimeFields`, and
+callers splat it. Passing any of those same names as an explicit keyword in the same call
+is `TypeError: got multiple values for keyword argument`, whatever the two values are, so
+pinning the duplicate to None does not help -- the key has to be absent from the dict.
+
+#8007 added `chat_template_override` to `_InferenceRuntimeFields` while `get_status` was
+already passing it explicitly. Every `/api/inference/status` poll with a GGUF loaded then
+raised, the chat UI showed "Failed to get status", and the model picker rendered empty.
+
+Checked at source level: importing the routes module pulls in the whole studio stack, and
+this is a call-shape property that AST can see directly.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODELS_PATH = REPO_ROOT / "studio" / "backend" / "models" / "inference.py"
+ROUTE_PATH = REPO_ROOT / "studio" / "backend" / "routes" / "inference.py"
+
+SPLAT_HELPER = "_llama_runtime_fields"
+RUNTIME_MODEL = "_InferenceRuntimeFields"
+
+
+def _runtime_field_names() -> set[str]:
+    """Field names declared on `_InferenceRuntimeFields`, read without importing it."""
+    tree = ast.parse(MODELS_PATH.read_text(encoding = "utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == RUNTIME_MODEL:
+            # Direct BaseModel subclass, so its own AnnAssign nodes are the whole field set.
+            bases = {ast.unparse(b) for b in node.bases}
+            assert bases == {"BaseModel"}, (
+                f"{RUNTIME_MODEL} now inherits from {sorted(bases)}; this test reads only its "
+                "own annotated fields and would miss inherited ones"
+            )
+            return {
+                stmt.target.id
+                for stmt in node.body
+                if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+            }
+    raise AssertionError(f"{RUNTIME_MODEL} not found in {MODELS_PATH}")
+
+
+def _splat_call_sites() -> list[tuple[int, set[str]]]:
+    """(line, explicit keyword names) for every call that splats the runtime-fields helper."""
+    tree = ast.parse(ROUTE_PATH.read_text(encoding = "utf-8"))
+    sites = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        splats = any(
+            kw.arg is None
+            and isinstance(kw.value, ast.Call)
+            and isinstance(kw.value.func, ast.Name)
+            and kw.value.func.id == SPLAT_HELPER
+            for kw in node.keywords
+        )
+        if splats:
+            sites.append((node.lineno, {kw.arg for kw in node.keywords if kw.arg is not None}))
+    return sites
+
+
+def test_runtime_fields_are_not_also_passed_explicitly():
+    """No call may splat the runtime fields and name one of them as a keyword too."""
+    runtime_fields = _runtime_field_names()
+    sites = _splat_call_sites()
+    assert sites, f"no `**{SPLAT_HELPER}(...)` call sites found; did the helper get renamed?"
+
+    collisions = {
+        line: sorted(explicit & runtime_fields)
+        for line, explicit in sites
+        if explicit & runtime_fields
+    }
+    assert not collisions, (
+        f"{ROUTE_PATH.name} splats **{SPLAT_HELPER}(...) and passes the same field(s) "
+        f"explicitly, which raises TypeError at call time: "
+        + "; ".join(f"line {line}: {names}" for line, names in sorted(collisions.items()))
+        + f". Assign into the dict before splatting instead of adding a second keyword."
+    )
+
+
+def test_chat_template_override_is_a_runtime_field():
+    """Guards the premise: if this moves off the model, the regression above changes shape."""
+    assert "chat_template_override" in _runtime_field_names()


### PR DESCRIPTION
`/api/inference/status` has returned 500 for every loaded GGUF since #8007 landed on main.

```
TypeError: models.inference.InferenceStatusResponse() got multiple values
           for keyword argument 'chat_template_override'
  studio/backend/routes/inference.py:8032, in get_status
```

## What happens

`_llama_runtime_fields()` builds its dict by comprehension over `_InferenceRuntimeFields.model_fields`, so it returns one entry per field on that model. `get_status` splats that dict and passes the same keyword explicitly:

```python
**_llama_runtime_fields(llama_backend),
chat_template_override = _reported_chat_template_override,
```

#8007 added `chat_template_override` to `_InferenceRuntimeFields`. From that commit on, the key is in the dict and in the argument list, and Python raises before the response is constructed.

The sibling field was handled correctly: `chat_template_override_reason` is pinned to `None` inside `fields.update(...)`. That pattern does not work here, because the collision does not depend on the values. The key has to be absent from the dict, not `None`.

The other splat site (line 3706) does not name any runtime field explicitly, so it was never affected.

## User-visible effect

The chat UI polls status from first paint. With status failing it shows `Failed to get status` and two `Failed to refresh models` toasts, and the model picker renders with no models in it.

That is also what took `studio-windows-ui-smoke` red on main. The assertion that fired reads

```
model picker text was identical for qwen + llama queries -- typeahead may not be filtering
```

which is a downstream symptom: with an empty picker, both queries produce the same text. Typeahead filtering is fine. The screenshots in that run's artifacts show the empty picker with both error toasts.

## The fix

Assign into the dict, then splat once, so the reported-override logic above still wins:

```python
_runtime_fields = _llama_runtime_fields(llama_backend)
_runtime_fields["chat_template_override"] = _reported_chat_template_override
```

## Test

`tests/studio/test_inference_status_runtime_fields_contract.py` parses both modules and asserts that no call splatting `**_llama_runtime_fields(...)` also names one of `_InferenceRuntimeFields`'s fields as an explicit keyword. It is source level because importing the routes module pulls in the whole studio stack, and this is a call-shape property AST can see directly.

Verified in both directions: it fails on the parent commit, reporting `line 8032: ['chat_template_override']`, and passes with the fix.

It guards the general case rather than this one field, so the next field added to `_InferenceRuntimeFields` cannot reintroduce the same collision at either splat site.
