### PR TITLE
Studio: call XInitThreads so the Linux desktop app stops exiting on startup

### DIFF
--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -131,39 +131,35 @@ jobs:
           file "$BIN"
           du -h "$BIN"
 
-      # The bundle job in desktop-app-clean-machine-ci.yml launches a SHIPPED
-      # release, so it cannot see a source change. This does, and it is the only
-      # place a Linux startup regression can be caught before a release is cut.
+      # desktop-app-clean-machine-ci.yml launches a SHIPPED release, so this is
+      # the only job that catches a Linux startup regression from a source change
+      # before a release is cut.
       #
-      # Repeats deliberately. The X11 startup race behind #8062 killed the app on
-      # roughly a third of launches, so a single launch passes two times in three
-      # with the bug present. Ten independent launches miss it 1.7% of the time.
+      # Ten launches, not one: the #8062 X11 race killed roughly one launch in
+      # three, so a single launch passes two times in three with the bug present.
       #
-      # The backend is a stub: preflight only needs `-h` to exit 0 and
-      # `studio desktop-capabilities --json` to answer, and the crash happens
-      # milliseconds after the spawn, before a real backend has written anything.
-      # That buys the whole startup-to-app-shell transition without a Python
-      # install, so this stays a ~4 minute step.
+      # The backend is a stub -- preflight only needs `-h` to exit 0 and
+      # `studio desktop-capabilities --json` to answer, and the crash lands
+      # milliseconds after the spawn -- which covers the whole startup-to-app-shell
+      # transition without a Python install, in ~4 minutes.
       - name: Launch repeatedly under Xvfb
         run: |
           set -u
           BIN="$PWD/studio/src-tauri/target/debug/unsloth-studio"
           [ -x "$BIN" ] || { echo "::error::no debug binary at $BIN"; exit 1; }
 
-          # How sharp this job is depends on the runner's libX11. From 1.8
-          # (April 2022) libX11 calls XInitThreads() from its own constructor, so
-          # the #8062 race cannot happen there and these launches would pass with
-          # the fix reverted. ubuntu-22.04 ships 1.7.5, which does not.
+          # From libX11 1.8 the library calls XInitThreads() from its own
+          # constructor, so the #8062 race cannot happen and these launches would
+          # pass even with the fix reverted. ubuntu-22.04 ships 1.7.5, which does not.
           x11ver="$(dpkg-query -W -f='${Version}' libx11-6 2>/dev/null || true)"
           echo "libx11-6: ${x11ver:-not installed}"
           if [ -z "$x11ver" ] || dpkg --compare-versions "$x11ver" ge 2:1.8; then
             echo "::warning::libX11 ${x11ver:-unknown} initialises threading itself, so these launches no longer cover the #8062 race, only that the app starts. Keep this job on a runner with libX11 < 1.8 to keep that coverage."
           fi
 
-          # Read the minimum the app enforces rather than restating it: a bump to
-          # MIN_DESKTOP_BACKEND_VERSION would otherwise leave the stub Stale,
-          # park the app on the repair screen and quietly stop testing the
-          # startup transition this job exists to test.
+          # Derived, not hardcoded: a bump to MIN_DESKTOP_BACKEND_VERSION would
+          # leave the stub Stale, park the app on the repair screen and quietly
+          # stop testing the startup transition this job exists to test.
           STUB_VERSION="$(sed -n 's/.*MIN_DESKTOP_BACKEND_VERSION: &str = "\([^"]*\)".*/\1/p' \
             studio/src-tauri/src/preflight/version.rs)"
           [ -n "$STUB_VERSION" ] || {
@@ -200,7 +196,7 @@ jobs:
             (
               export DISPLAY=":$D" HOME="$H" XDG_RUNTIME_DIR="$H/xdg" XDG_CONFIG_HOME="$H/.config"
               # Without this GTK drops its fatal-X-error report and the app exits
-              # 1 with no output whatsoever, which is what made #8062 so opaque.
+              # 1 with no output at all, which is what made #8062 so opaque.
               export G_MESSAGES_DEBUG=all RUST_BACKTRACE=full
               unset UNSLOTH_STUDIO_HOME STUDIO_HOME
               exec "$BIN"
@@ -209,9 +205,9 @@ jobs:
             for _ in $(seq 1 20); do kill -0 "$APP" 2>/dev/null || break; sleep 1; done
             if kill -0 "$APP" 2>/dev/null; then
               kill -TERM "$APP" 2>/dev/null || true
-              # Surviving only counts if the launch got as far as the transition
-              # that used to kill it. An app parked on the install or repair
-              # screen also survives 20s while testing none of this.
+              # Surviving only counts if the launch reached the transition that
+              # used to kill it: an app parked on the install or repair screen
+              # also survives 20s while testing none of this.
               if grep -q "start_managed_server spawned" "launch-logs/app-$i.log"; then
                 echo "launch $i: reached the backend spawn and stayed up"
               else
@@ -229,8 +225,7 @@ jobs:
             wait "$XV" 2>/dev/null || true
           done
 
-          # Every launch must reach the app shell and stay there. Anything else is
-          # a user watching the window vanish on startup.
+          # Anything less is a user watching the window vanish on startup.
           if [ "$fails" -ne 0 ]; then
             echo "::error::$fails of 10 launches did not reach the app shell and stay there"
             exit 1

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libappindicator3-dev \
-            librsvg2-dev libxdo-dev libssl-dev patchelf
+            librsvg2-dev libxdo-dev libssl-dev patchelf xvfb
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
@@ -130,6 +130,88 @@ jobs:
           fi
           file "$BIN"
           du -h "$BIN"
+
+      # The bundle job in desktop-app-clean-machine-ci.yml launches a SHIPPED
+      # release, so it cannot see a source change. This does, and it is the only
+      # place a Linux startup regression can be caught before a release is cut.
+      #
+      # Repeats deliberately. The X11 startup race behind #8062 killed the app on
+      # roughly a third of launches, so a single launch passes two times in three
+      # with the bug present. Ten independent launches miss it 1.7% of the time.
+      #
+      # The backend is a stub: preflight only needs `-h` to exit 0 and
+      # `studio desktop-capabilities --json` to answer, and the crash happens
+      # milliseconds after the spawn, before a real backend has written anything.
+      # That buys the whole startup-to-app-shell transition without a Python
+      # install, so this stays a ~4 minute step.
+      - name: Launch repeatedly under Xvfb
+        run: |
+          set -u
+          BIN="$PWD/studio/src-tauri/target/debug/unsloth-studio"
+          [ -x "$BIN" ] || { echo "::error::no debug binary at $BIN"; exit 1; }
+          mkdir -p "$RUNNER_TEMP/stub" launch-logs
+          cat > "$RUNNER_TEMP/stub/unsloth" <<'STUB'
+          #!/bin/sh
+          case "$*" in
+            "-h") exit 0 ;;
+            *desktop-capabilities*)
+              printf '%s\n' '{"desktop_protocol_version":1,"desktop_manageability_version":2,"supports_api_only":true,"supports_provision_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_install_ok":true,"version":"2026.8.4"}'
+              exit 0 ;;
+            *studio*--api-only*) exec sleep 60 ;;
+          esac
+          exit 1
+          STUB
+          chmod +x "$RUNNER_TEMP/stub/unsloth"
+
+          fails=0
+          for i in $(seq 1 10); do
+            H="$RUNNER_TEMP/launch-$i"
+            rm -rf "$H"
+            mkdir -p "$H/.unsloth/studio/unsloth_studio/bin" "$H/.config" "$H/xdg"
+            cp "$RUNNER_TEMP/stub/unsloth" "$H/.unsloth/studio/unsloth_studio/bin/unsloth"
+            D=$((70 + i))
+            Xvfb ":$D" -screen 0 1440x900x24 -nolisten tcp > "launch-logs/xvfb-$i.log" 2>&1 &
+            XV=$!
+            for _ in $(seq 1 40); do [ -e "/tmp/.X11-unix/X$D" ] && break; sleep 0.25; done
+            (
+              export DISPLAY=":$D" HOME="$H" XDG_RUNTIME_DIR="$H/xdg" XDG_CONFIG_HOME="$H/.config"
+              # Without this GTK drops its fatal-X-error report and the app exits
+              # 1 with no output whatsoever, which is what made #8062 so opaque.
+              export G_MESSAGES_DEBUG=all RUST_BACKTRACE=full
+              unset UNSLOTH_STUDIO_HOME STUDIO_HOME
+              exec "$BIN"
+            ) > "launch-logs/app-$i.log" 2>&1 &
+            APP=$!
+            for _ in $(seq 1 20); do kill -0 "$APP" 2>/dev/null || break; sleep 1; done
+            if kill -0 "$APP" 2>/dev/null; then
+              echo "launch $i: still up"
+              kill -TERM "$APP" 2>/dev/null || true
+            else
+              rc=0; wait "$APP" 2>/dev/null || rc=$?
+              fails=$((fails + 1))
+              echo "::error::launch $i exited early with rc=$rc"
+              tail -25 "launch-logs/app-$i.log" || true
+            fi
+            kill "$XV" 2>/dev/null || true
+            wait "$XV" 2>/dev/null || true
+          done
+
+          # Every launch must reach the app shell and stay there. Anything else is
+          # a user watching the window vanish on startup.
+          if [ "$fails" -ne 0 ]; then
+            echo "::error::$fails of 10 launches died early"
+            exit 1
+          fi
+          echo "10 of 10 launches stayed up"
+
+      - name: Upload launch logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: tauri-launch-logs
+          path: launch-logs
+          if-no-files-found: warn
+          retention-days: 1
 
       - name: Upload Tauri debug build
         # Failures only, and only the binary -- never the whole target/debug

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -149,18 +149,42 @@ jobs:
           set -u
           BIN="$PWD/studio/src-tauri/target/debug/unsloth-studio"
           [ -x "$BIN" ] || { echo "::error::no debug binary at $BIN"; exit 1; }
+
+          # How sharp this job is depends on the runner's libX11. From 1.8
+          # (April 2022) libX11 calls XInitThreads() from its own constructor, so
+          # the #8062 race cannot happen there and these launches would pass with
+          # the fix reverted. ubuntu-22.04 ships 1.7.5, which does not.
+          x11ver="$(dpkg-query -W -f='${Version}' libx11-6 2>/dev/null || true)"
+          echo "libx11-6: ${x11ver:-not installed}"
+          if [ -z "$x11ver" ] || dpkg --compare-versions "$x11ver" ge 2:1.8; then
+            echo "::warning::libX11 ${x11ver:-unknown} initialises threading itself, so these launches no longer cover the #8062 race, only that the app starts. Keep this job on a runner with libX11 < 1.8 to keep that coverage."
+          fi
+
+          # Read the minimum the app enforces rather than restating it: a bump to
+          # MIN_DESKTOP_BACKEND_VERSION would otherwise leave the stub Stale,
+          # park the app on the repair screen and quietly stop testing the
+          # startup transition this job exists to test.
+          STUB_VERSION="$(sed -n 's/.*MIN_DESKTOP_BACKEND_VERSION: &str = "\([^"]*\)".*/\1/p' \
+            studio/src-tauri/src/preflight/version.rs)"
+          [ -n "$STUB_VERSION" ] || {
+            echo "::error::could not read MIN_DESKTOP_BACKEND_VERSION from preflight/version.rs"
+            exit 1
+          }
+          echo "stub backend version: $STUB_VERSION"
+
           mkdir -p "$RUNNER_TEMP/stub" launch-logs
           cat > "$RUNNER_TEMP/stub/unsloth" <<'STUB'
           #!/bin/sh
           case "$*" in
             "-h") exit 0 ;;
             *desktop-capabilities*)
-              printf '%s\n' '{"desktop_protocol_version":1,"desktop_manageability_version":2,"supports_api_only":true,"supports_provision_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_install_ok":true,"version":"2026.8.4"}'
+              printf '%s\n' '{"desktop_protocol_version":1,"desktop_manageability_version":2,"supports_api_only":true,"supports_provision_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_install_ok":true,"version":"__STUB_VERSION__"}'
               exit 0 ;;
             *studio*--api-only*) exec sleep 60 ;;
           esac
           exit 1
           STUB
+          sed -i "s/__STUB_VERSION__/$STUB_VERSION/" "$RUNNER_TEMP/stub/unsloth"
           chmod +x "$RUNNER_TEMP/stub/unsloth"
 
           fails=0
@@ -184,8 +208,17 @@ jobs:
             APP=$!
             for _ in $(seq 1 20); do kill -0 "$APP" 2>/dev/null || break; sleep 1; done
             if kill -0 "$APP" 2>/dev/null; then
-              echo "launch $i: still up"
               kill -TERM "$APP" 2>/dev/null || true
+              # Surviving only counts if the launch got as far as the transition
+              # that used to kill it. An app parked on the install or repair
+              # screen also survives 20s while testing none of this.
+              if grep -q "start_managed_server spawned" "launch-logs/app-$i.log"; then
+                echo "launch $i: reached the backend spawn and stayed up"
+              else
+                fails=$((fails + 1))
+                echo "::error::launch $i never reached the backend spawn, so it never exercised the startup transition"
+                tail -25 "launch-logs/app-$i.log" || true
+              fi
             else
               rc=0; wait "$APP" 2>/dev/null || rc=$?
               fails=$((fails + 1))
@@ -199,10 +232,10 @@ jobs:
           # Every launch must reach the app shell and stay there. Anything else is
           # a user watching the window vanish on startup.
           if [ "$fails" -ne 0 ]; then
-            echo "::error::$fails of 10 launches died early"
+            echo "::error::$fails of 10 launches did not reach the app shell and stay there"
             exit 1
           fi
-          echo "10 of 10 launches stayed up"
+          echo "10 of 10 launches reached the backend spawn and stayed up"
 
       - name: Upload launch logs
         if: failure()

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -464,9 +464,8 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn main() {
-    // Before anything can open an X display: GTK3 does not call XInitThreads
-    // itself, and this process has more than one thread on X. See x11_threads
-    // for the crash that leaves behind.
+    // Must precede any Xlib call: GTK3 never calls XInitThreads and this
+    // process drives X from several threads. See x11_threads for the crash.
     x11_threads::init_x11_threads();
 
     // Fix PATH for GUI apps (macOS .app bundles, Linux AppImage, Windows)

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -18,6 +18,7 @@ mod preflight;
 mod process;
 mod update;
 mod windows_job;
+mod x11_threads;
 
 use log::{info, warn};
 use process::new_backend_state;
@@ -463,6 +464,11 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn main() {
+    // Before anything can open an X display: GTK3 does not call XInitThreads
+    // itself, and this process has more than one thread on X. See x11_threads
+    // for the crash that leaves behind.
+    x11_threads::init_x11_threads();
+
     // Fix PATH for GUI apps (macOS .app bundles, Linux AppImage, Windows)
     // GUI apps don't inherit shell dotfile PATH — this spawns the user's
     // login shell to source .zshrc/.bashrc/.profile and sets PATH properly.

--- a/studio/src-tauri/src/x11_threads.rs
+++ b/studio/src-tauri/src/x11_threads.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+//! Turn on Xlib's internal locking before anything opens an X display.
+//!
+//! GTK3 never calls `XInitThreads()`: `libgdk-3.so` does not so much as
+//! reference the symbol. Without it every Xlib lock is a no-op, so the request
+//! sequence numbers Xlib keeps for its XCB transport are maintained with no
+//! mutual exclusion at all. This process is unavoidably multi-threaded around
+//! the X connection -- WebKitGTK's UI-process compositor and GLib worker
+//! threads, tao's event loop and the clipboard all live here -- so the
+//! sequence counter can be advanced by one thread between another thread
+//! writing its request and recording it.
+//!
+//! When that happens libX11 either aborts on its own assertion:
+//!
+//! ```text
+//! [xcb] Unknown request in queue while dequeuing
+//! [xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
+//! [xcb] Aborting, sorry about that.
+//! unsloth-studio: ../../src/xcb_io.c:175: dequeue_pending_request:
+//!     Assertion `!xcb_xlib_unknown_req_in_deq' failed.
+//! ```
+//!
+//! or, more often, `_XReply` cannot match a reply to its request and calls
+//! `_XIOError` even though `xcb_connection_has_error()` is 0. GDK installs
+//! `gdk_x_io_error()` as the Xlib IO error handler, and that reports through
+//! `g_debug()` -- dropped unless `G_MESSAGES_DEBUG` names the domain -- and
+//! then calls `_exit(1)`. The result is the app vanishing with a bare rc=1 and
+//! no output at all, which is issue #8062.
+//!
+//! `XInitThreads()` has to run before any other Xlib call, so this is the
+//! first thing `main` does, ahead of the GTK initialisation Tauri performs
+//! while it builds the app.
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::os::raw::{c_char, c_int, c_void};
+
+    extern "C" {
+        fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    }
+
+    const RTLD_DEFAULT: *mut c_void = std::ptr::null_mut();
+
+    /// Resolved at run time rather than linked: the crate does not otherwise
+    /// link libX11, and on a Wayland-only or headless system the symbol may
+    /// legitimately be absent, where there is no X connection to protect.
+    pub fn init() -> bool {
+        let symbol = unsafe { dlsym(RTLD_DEFAULT, c"XInitThreads".as_ptr()) };
+        if symbol.is_null() {
+            return false;
+        }
+        let init_threads: extern "C" fn() -> c_int = unsafe { std::mem::transmute(symbol) };
+        init_threads() != 0
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    /// Only Xlib needs this. Windows and macOS marshal their UI calls through
+    /// their own main-thread requirements instead.
+    pub fn init() -> bool {
+        false
+    }
+}
+
+/// Returns whether Xlib locking is now on. False on non-Linux, and on Linux
+/// when libX11 is not loaded at all.
+pub fn init_x11_threads() -> bool {
+    imp::init()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_is_safe_to_call_and_idempotent() {
+        // Never panics, whatever the platform, and repeat calls are harmless:
+        // XInitThreads is documented as safe to call more than once.
+        let first = init_x11_threads();
+        assert_eq!(first, init_x11_threads());
+    }
+}

--- a/studio/src-tauri/src/x11_threads.rs
+++ b/studio/src-tauri/src/x11_threads.rs
@@ -3,35 +3,28 @@
 
 //! Turn on Xlib's internal locking before anything opens an X display.
 //!
-//! GTK3 never calls `XInitThreads()`: `libgdk-3.so` does not so much as
-//! reference the symbol. Without it every Xlib lock is a no-op, so the request
-//! sequence numbers Xlib keeps for its XCB transport are maintained with no
-//! mutual exclusion at all. This process is unavoidably multi-threaded around
-//! the X connection -- WebKitGTK's UI-process compositor and GLib worker
-//! threads, tao's event loop and the clipboard all live here -- so the
-//! sequence counter can be advanced by one thread between another thread
-//! writing its request and recording it.
+//! GTK3 never calls `XInitThreads()` (`libgdk-3.so` does not even reference the
+//! symbol), so every Xlib lock is a no-op. This process drives X from several
+//! threads regardless -- WebKitGTK's compositor, GLib workers, tao's event loop,
+//! the clipboard -- so the request/reply sequence Xlib keeps for its XCB
+//! transport gets corrupted.
 //!
-//! When that happens libX11 either aborts on its own assertion:
+//! That surfaces either as libX11 aborting on its own assertion:
 //!
 //! ```text
-//! [xcb] Unknown request in queue while dequeuing
 //! [xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
-//! [xcb] Aborting, sorry about that.
 //! unsloth-studio: ../../src/xcb_io.c:175: dequeue_pending_request:
 //!     Assertion `!xcb_xlib_unknown_req_in_deq' failed.
 //! ```
 //!
-//! or, more often, `_XReply` cannot match a reply to its request and calls
-//! `_XIOError` even though `xcb_connection_has_error()` is 0. GDK installs
-//! `gdk_x_io_error()` as the Xlib IO error handler, and that reports through
-//! `g_debug()` -- dropped unless `G_MESSAGES_DEBUG` names the domain -- and
-//! then calls `_exit(1)`. The result is the app vanishing with a bare rc=1 and
-//! no output at all, which is issue #8062.
+//! or, more often, `_XReply` failing to match a reply and calling `_XIOError`
+//! while `xcb_connection_has_error()` is 0. GDK's IO error handler reports that
+//! through `g_debug()` (dropped unless `G_MESSAGES_DEBUG` names the domain) and
+//! then `_exit(1)`s, so the app vanishes with a bare rc=1 and no output at all:
+//! issue #8062.
 //!
-//! `XInitThreads()` has to run before any other Xlib call, so this is the
-//! first thing `main` does, ahead of the GTK initialisation Tauri performs
-//! while it builds the app.
+//! `XInitThreads()` must precede every other Xlib call, hence `main`'s first
+//! statement, ahead of the GTK init Tauri performs while building the app.
 
 #[cfg(target_os = "linux")]
 mod imp {
@@ -44,8 +37,8 @@ mod imp {
     const RTLD_DEFAULT: *mut c_void = std::ptr::null_mut();
 
     /// Resolved at run time rather than linked: the crate does not otherwise
-    /// link libX11, and on a Wayland-only or headless system the symbol may
-    /// legitimately be absent, where there is no X connection to protect.
+    /// link libX11, and on Wayland-only or headless systems the symbol is
+    /// legitimately absent -- there is no X connection to protect.
     pub fn init() -> bool {
         let symbol = unsafe { dlsym(RTLD_DEFAULT, c"XInitThreads".as_ptr()) };
         if symbol.is_null() {
@@ -58,15 +51,14 @@ mod imp {
 
 #[cfg(not(target_os = "linux"))]
 mod imp {
-    /// Only Xlib needs this. Windows and macOS marshal their UI calls through
-    /// their own main-thread requirements instead.
+    /// Only Xlib needs this; Windows and macOS have their own main-thread rules.
     pub fn init() -> bool {
         false
     }
 }
 
-/// Returns whether Xlib locking is now on. False on non-Linux, and on Linux
-/// when libX11 is not loaded at all.
+/// Returns whether Xlib locking is now on: false on non-Linux, and on Linux
+/// when libX11 is not loaded.
 pub fn init_x11_threads() -> bool {
     imp::init()
 }
@@ -77,8 +69,7 @@ mod tests {
 
     #[test]
     fn init_is_safe_to_call_and_idempotent() {
-        // Never panics, whatever the platform, and repeat calls are harmless:
-        // XInitThreads is documented as safe to call more than once.
+        // Never panics on any platform; XInitThreads is safe to call repeatedly.
         let first = init_x11_threads();
         assert_eq!(first, init_x11_threads());
     }


### PR DESCRIPTION
Fixes #8062.

## The bug

On Linux the desktop app exits with status 1 a few milliseconds after it spawns
the managed backend, printing nothing at all. It reproduces on about a third of
launches. macOS and Windows are unaffected.

## Root cause

libX11 names it itself. Launching the app repeatedly under Xvfb, one launch in
roughly thirty dies like this instead of silently:

```
[xcb] Unknown request in queue while dequeuing
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
unsloth-studio: ../../src/xcb_io.c:175: dequeue_pending_request:
    Assertion `!xcb_xlib_unknown_req_in_deq' failed.
```

and another variant trips `!xcb_xlib_threads_sequence_lost` in the same file.
Both fire on the main thread, inside `XPending` called from GDK's GLib event
source.

Nothing in the process ever calls `XInitThreads()`:

- `libgdk-3.so` does not so much as reference the symbol, so GTK3 never enables
  Xlib locking.
- tao has one `XInitThreads()` call, in `platform_impl/linux/x11/xdisplay.rs`,
  which the GTK backend we build never reaches. wry, tauri-runtime-wry and
  tauri have none.

Meanwhile the process definitely does drive Xlib from more than one thread.
`tao::platform_impl::platform::device::spawn` (`linux/device.rs`) starts a
thread that opens a display and sits in `XNextEvent` forever, to deliver raw
key `DeviceEvent`s. Under gdb that thread is visible in exactly this state at
the moment the app dies:

```
Thread 4 "unsloth-studio":
  __poll -> xcb_wait_for_event -> _XReadEvents -> XNextEvent
  -> tao::platform_impl::platform::device::spawn::{closure#0} at linux/device.rs:32
```

With Xlib's locking disabled every lock is a no-op, so the request/reply
bookkeeping libX11 keeps for its XCB transport is maintained with no mutual
exclusion. When it desynchronises, libX11 either aborts on one of the
assertions above or, far more often, cannot match a reply to its request in
`_XReply` and calls `_XIOError` even though `xcb_connection_has_error()` is 0.
That second path is the silent one: GDK installs `gdk_x_io_error()` as the Xlib
IO error handler, and it reports through `g_debug()` (dropped unless
`G_MESSAGES_DEBUG` names the domain) before calling `_exit(1)`.

An instrumented build that replaces GDK's handler prints the whole picture on
a failing launch:

```
fatal IO error on display fd=5 xcb_error=Some(0) errno=EAGAIN thread=main on_main_thread=true
  _XIOError <- _XReply <- XInternAtom <- gdk_x11_atom_to_xatom_for_display
  <- gtk_widget_realize <- gtk_widget_show <- show_all
  <- tao WindowRequest handler <- g_main_context_dispatch
```

`xcb_error=0` is the tell: the XCB connection is perfectly healthy, so the
"Fatal IO error 11 (Resource temporarily unavailable)" wording is a stale errno
and not a socket problem.

It surfaces where it does because that is when the first window is realised.
The startup-screen to app-shell transition calls `setResizable`, `setSize`,
`center` and `show`, and `show` is the first thing that makes the main thread
issue a burst of round-trip X requests while the device thread is also on Xlib.
The missing `[backend]` log lines and the orphaned backend's SIGPIPE are
downstream of the app dying, not separate faults.

## Who this affects, and why you may not be able to reproduce it

libX11 1.8 (April 2022) added `--enable-thread-safety-constructor`, on by
default, which calls `XInitThreads()` from the library's own constructor. On
any distro with libX11 >= 1.8 the race therefore cannot happen and this patch
is a no-op.

It is still live on everything older, which is a large share of the installed
base for a `.deb` and an `.AppImage`: Ubuntu 22.04 LTS ships `2:1.7.5`
(supported into 2027, ESM beyond), as do Debian 11 and the RHEL 8/9 family.
Ubuntu 24.04 ships `2:1.8.7`.

That is also why the CI evidence below is on `ubuntu-22.04` and why a dev box on
24.04 will sit there launching the unpatched build all day without seeing it.

## The fix

`XInitThreads()`, as the first thing `main` does, before anything can open an X
display. That is the documented remedy and the one libX11's own message asks
for: it turns the no-op locks into real ones so concurrent Xlib use of the
connection is safe.

It is resolved with `dlsym` rather than linked. The crate does not otherwise
link libX11 (it arrives transitively through `libgdk-3`), and on a Wayland-only
or headless system the symbol may legitimately be absent, where there is no X
connection to protect.

This addresses the cause rather than the symptom: the crash is Xlib request
bookkeeping corrupted by unlocked concurrent access, and this is what makes
that access locked. It is not a timing tweak and it does not merely widen the
window. It does not make GDK or GTK thread-safe, and nothing here licenses
calling GTK off the main thread; it makes the Xlib layer behave as every
multi-threaded X client is required to configure it.

## Validation

The existing `desktop-app-clean-machine-ci.yml` Linux job launches a shipped
release bundle, so it cannot test a source change at all. I built the Tauri app
from source on `ubuntu-22.04` and launched it repeatedly under Xvfb, with a
stub backend so preflight reaches `ManagedReady` and the app performs the same
window transition without a 15 minute Python install.

Same runner image, same harness, same trial count, only the patch differs:

| build | early exits |
|---|---|
| `main` | 9 / 30 |
| `main` + this patch | 0 / 30 |

Earlier 12-trial runs on unmodified `main` gave 4/12 and 4/12, so 17 of 54
launches of the unpatched build died. At that rate, thirty clean launches
happen by chance with probability 0.7^30, about 2e-5.

## Regression guard

`studio-tauri-smoke.yml` already built the Linux debug binary and then threw it
away. It now launches it ten times under Xvfb and fails if any launch exits
early. Ten independent launches would have missed this bug 1.7% of the time,
against 67% for a single launch. The stub backend keeps the step at about four
minutes.

Three things keep the guard from going quietly blind:

- Surviving 20s is not enough on its own. An app parked on the install or
  repair screen also survives while exercising none of this, so each launch must
  also show `start_managed_server spawned` in its log. Verified by pinning the
  stub to a stale version: the app reports `ManagedStale`, stays up for the full
  window, and the step now fails instead of passing.
- The stub's reported version is read out of `MIN_DESKTOP_BACKEND_VERSION`
  rather than restated, so bumping that constant cannot silently strand the stub
  on the repair screen.
- The step prints the runner's libX11 version and warns when it is >= 1.8,
  where the constructor makes these launches cover only that the app starts.
  Moving this job to a newer runner label is otherwise an invisible way to lose
  the coverage.

The step also exports `G_MESSAGES_DEBUG=all`, without which a fatal X error
leaves nothing but a bare rc=1. #8063 does the same for the bundle job's launch
step; different file, no overlap.
