### PR TITLE
Studio: keep chat titles whole so a wider sidebar shows more of them

### DIFF
--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -17,6 +17,7 @@ from utils.utils import safe_curated_detail, log_and_http_error
 from storage.studio_db import (
     ChatMessageConflictError,
     ChatMessageProtectedError,
+    ChatThreadTitleMismatch,
     CorruptSettingsError,
     clear_chat_history,
     count_chat_threads,
@@ -70,6 +71,9 @@ class ChatThread(BaseModel):
 
 class ChatThreadPatch(BaseModel):
     title: Optional[str] = None
+    # Set to apply the patch only while the row still holds this title, so a
+    # rename racing a background rewrite wins.
+    expectedTitle: Optional[str] = None
     modelType: Optional[Literal["base", "lora", "model1", "model2"]] = None
     modelId: Optional[str] = None
     pairId: Optional[str] = None
@@ -276,6 +280,7 @@ async def patch_thread(
     current_subject: str = Depends(get_current_subject),
 ):
     patch = payload.model_dump(exclude_unset = True)
+    expected_title = patch.pop("expectedTitle", None)
     for field in ("title", "modelType", "modelId", "archived", "createdAt", "updatedAt"):
         if field in patch and patch[field] is None:
             raise HTTPException(status_code = 400, detail = f"{field} cannot be null")
@@ -284,10 +289,17 @@ async def patch_thread(
             status_code = 404,
             detail = f"Project {patch['projectId']} not found",
         )
-    thread = update_chat_thread(
-        thread_id,
-        patch,
-    )
+    try:
+        thread = update_chat_thread(
+            thread_id,
+            patch,
+            expected_title = expected_title,
+        )
+    except ChatThreadTitleMismatch:
+        raise HTTPException(
+            status_code = 409,
+            detail = f"Thread {thread_id} was renamed since it was read",
+        )
     if thread is None:
         raise HTTPException(status_code = 404, detail = f"Thread {thread_id} not found")
     return ChatThread(**thread)

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -17,7 +17,7 @@ from utils.utils import safe_curated_detail, log_and_http_error
 from storage.studio_db import (
     ChatMessageConflictError,
     ChatMessageProtectedError,
-    ChatThreadTitleMismatch,
+    ChatThreadPreconditionFailed,
     CorruptSettingsError,
     clear_chat_history,
     count_chat_threads,
@@ -74,6 +74,9 @@ class ChatThreadPatch(BaseModel):
     # Set to apply the patch only while the row still holds this title, so a
     # rename racing a background rewrite wins.
     expectedTitle: Optional[str] = None
+    # Set to apply it only while this is still the thread's opening user
+    # message, so a title derived from one that was deleted is rejected.
+    expectedOpeningMessageId: Optional[str] = None
     modelType: Optional[Literal["base", "lora", "model1", "model2"]] = None
     modelId: Optional[str] = None
     pairId: Optional[str] = None
@@ -281,6 +284,7 @@ async def patch_thread(
 ):
     patch = payload.model_dump(exclude_unset = True)
     expected_title = patch.pop("expectedTitle", None)
+    expected_opening_message_id = patch.pop("expectedOpeningMessageId", None)
     for field in ("title", "modelType", "modelId", "archived", "createdAt", "updatedAt"):
         if field in patch and patch[field] is None:
             raise HTTPException(status_code = 400, detail = f"{field} cannot be null")
@@ -294,11 +298,12 @@ async def patch_thread(
             thread_id,
             patch,
             expected_title = expected_title,
+            expected_opening_message_id = expected_opening_message_id,
         )
-    except ChatThreadTitleMismatch:
+    except ChatThreadPreconditionFailed:
         raise HTTPException(
             status_code = 409,
-            detail = f"Thread {thread_id} was renamed since it was read",
+            detail = f"Thread {thread_id} changed since it was read",
         )
     if thread is None:
         raise HTTPException(status_code = 404, detail = f"Thread {thread_id} not found")

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -71,11 +71,9 @@ class ChatThread(BaseModel):
 
 class ChatThreadPatch(BaseModel):
     title: Optional[str] = None
-    # Set to apply the patch only while the row still holds this title, so a
-    # rename racing a background rewrite wins.
+    # Apply only while the row still holds this title, so a rename beats a background rewrite.
     expectedTitle: Optional[str] = None
-    # Set to apply it only while this is still the thread's opening user
-    # message, so a title derived from one that was deleted is rejected.
+    # Apply only while this is still the opening user message, so a title from a deleted one is rejected.
     expectedOpeningMessageId: Optional[str] = None
     modelType: Optional[Literal["base", "lora", "model1", "model2"]] = None
     modelId: Optional[str] = None

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -1642,8 +1642,7 @@ def update_chat_thread(
 
     conn = get_connection()
     try:
-        # The guards ride in the WHERE clause so the checks and the write are
-        # one statement.
+        # Guards ride in the WHERE clause, so check and write are one statement.
         where = ["id = ?"]
         guard: list = [id]
         if expected_title is not None:

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -1583,7 +1583,17 @@ def upsert_chat_thread(thread: dict) -> dict:
         conn.close()
 
 
-def update_chat_thread(id: str, patch: dict) -> Optional[dict]:
+class ChatThreadTitleMismatch(Exception):
+    """The thread's title changed between the caller reading it and writing it."""
+
+
+def update_chat_thread(
+    id: str,
+    patch: dict,
+    expected_title: Optional[str] = None,
+) -> Optional[dict]:
+    """Patch a thread. With expected_title, the write only lands while the row
+    still holds that title, so a concurrent rename wins instead of being lost."""
     allowed = {
         "title": ("title", patch.get("title")),
         "modelType": ("model_type", patch.get("modelType")),
@@ -1621,13 +1631,22 @@ def update_chat_thread(id: str, patch: dict) -> Optional[dict]:
 
     conn = get_connection()
     try:
-        conn.execute(
-            f"UPDATE chat_threads SET {', '.join(assignments)} WHERE id = ?",
-            (*values, id),
+        # The title guard rides in the WHERE clause so the check and the write
+        # are one statement.
+        where = "WHERE id = ?" if expected_title is None else "WHERE id = ? AND title = ?"
+        guard = () if expected_title is None else (expected_title,)
+        cursor = conn.execute(
+            f"UPDATE chat_threads SET {', '.join(assignments)} {where}",
+            (*values, id, *guard),
         )
+        applied = cursor.rowcount
         conn.commit()
         row = conn.execute("SELECT * FROM chat_threads WHERE id = ?", (id,)).fetchone()
-        return _chat_thread_from_row(row) if row is not None else None
+        if row is None:
+            return None
+        if expected_title is not None and applied == 0:
+            raise ChatThreadTitleMismatch(id)
+        return _chat_thread_from_row(row)
     finally:
         conn.close()
 

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -1583,17 +1583,28 @@ def upsert_chat_thread(thread: dict) -> dict:
         conn.close()
 
 
-class ChatThreadTitleMismatch(Exception):
-    """The thread's title changed between the caller reading it and writing it."""
+class ChatThreadPreconditionFailed(Exception):
+    """The thread changed between the caller reading it and writing it."""
+
+
+# Same order the title migration picks its opening message in.
+_OPENING_USER_MESSAGE = """(
+    SELECT id FROM chat_messages
+    WHERE thread_id = ? AND role = 'user'
+    ORDER BY created_at ASC, id ASC LIMIT 1
+) IS ?"""
 
 
 def update_chat_thread(
     id: str,
     patch: dict,
     expected_title: Optional[str] = None,
+    expected_opening_message_id: Optional[str] = None,
 ) -> Optional[dict]:
     """Patch a thread. With expected_title, the write only lands while the row
-    still holds that title, so a concurrent rename wins instead of being lost."""
+    still holds that title, so a concurrent rename wins instead of being lost.
+    expected_opening_message_id guards a title derived from that message: if it
+    is gone, the write is rejected rather than expanding deleted text."""
     allowed = {
         "title": ("title", patch.get("title")),
         "modelType": ("model_type", patch.get("modelType")),
@@ -1631,21 +1642,28 @@ def update_chat_thread(
 
     conn = get_connection()
     try:
-        # The title guard rides in the WHERE clause so the check and the write
-        # are one statement.
-        where = "WHERE id = ?" if expected_title is None else "WHERE id = ? AND title = ?"
-        guard = () if expected_title is None else (expected_title,)
+        # The guards ride in the WHERE clause so the checks and the write are
+        # one statement.
+        where = ["id = ?"]
+        guard: list = [id]
+        if expected_title is not None:
+            where.append("title = ?")
+            guard.append(expected_title)
+        if expected_opening_message_id is not None:
+            where.append(_OPENING_USER_MESSAGE)
+            guard += [id, expected_opening_message_id]
+        guarded = expected_title is not None or expected_opening_message_id is not None
         cursor = conn.execute(
-            f"UPDATE chat_threads SET {', '.join(assignments)} {where}",
-            (*values, id, *guard),
+            f"UPDATE chat_threads SET {', '.join(assignments)} WHERE {' AND '.join(where)}",
+            (*values, *guard),
         )
         applied = cursor.rowcount
         conn.commit()
         row = conn.execute("SELECT * FROM chat_threads WHERE id = ?", (id,)).fetchone()
         if row is None:
             return None
-        if expected_title is not None and applied == 0:
-            raise ChatThreadTitleMismatch(id)
+        if guarded and applied == 0:
+            raise ChatThreadPreconditionFailed(id)
         return _chat_thread_from_row(row)
     finally:
         conn.close()

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -725,16 +725,27 @@ export async function saveChatThread(
   return savedThread;
 }
 
+export interface UpdateChatThreadOptions {
+  /** Apply the patch only while the row still holds this title. The server
+   *  answers 409 otherwise, so a rename beats a background rewrite. */
+  expectedTitle?: string;
+}
+
 export async function updateChatThread(
   threadId: string,
   patch: Partial<ThreadRecord>,
+  options: UpdateChatThreadOptions = {},
 ): Promise<ThreadRecord> {
+  const body =
+    options.expectedTitle === undefined
+      ? patch
+      : { ...patch, expectedTitle: options.expectedTitle };
   const response = await authFetch(
     `/api/chat/threads/${encodeURIComponent(threadId)}`,
     {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(patch),
+      body: JSON.stringify(body),
     },
   );
   const thread = await parseJsonOrThrow<ThreadRecord>(response);

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -726,11 +726,9 @@ export async function saveChatThread(
 }
 
 export interface UpdateChatThreadOptions {
-  /** Apply the patch only while the row still holds this title. The server
-   *  answers 409 otherwise, so a rename beats a background rewrite. */
+  /** Apply only while the row still holds this title, else 409. */
   expectedTitle?: string;
-  /** And only while this is still the thread's opening user message, so a
-   *  title taken from a prompt that was just deleted is rejected. */
+  /** And only while this is still the thread's opening user message. */
   expectedOpeningMessageId?: string;
 }
 

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -729,6 +729,9 @@ export interface UpdateChatThreadOptions {
   /** Apply the patch only while the row still holds this title. The server
    *  answers 409 otherwise, so a rename beats a background rewrite. */
   expectedTitle?: string;
+  /** And only while this is still the thread's opening user message, so a
+   *  title taken from a prompt that was just deleted is rejected. */
+  expectedOpeningMessageId?: string;
 }
 
 export async function updateChatThread(
@@ -736,10 +739,13 @@ export async function updateChatThread(
   patch: Partial<ThreadRecord>,
   options: UpdateChatThreadOptions = {},
 ): Promise<ThreadRecord> {
-  const body =
-    options.expectedTitle === undefined
-      ? patch
-      : { ...patch, expectedTitle: options.expectedTitle };
+  const body: Record<string, unknown> = { ...patch };
+  if (options.expectedTitle !== undefined) {
+    body.expectedTitle = options.expectedTitle;
+  }
+  if (options.expectedOpeningMessageId !== undefined) {
+    body.expectedOpeningMessageId = options.expectedOpeningMessageId;
+  }
   const response = await authFetch(
     `/api/chat/threads/${encodeURIComponent(threadId)}`,
     {

--- a/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
@@ -23,6 +23,7 @@ import {
   removeChatThreadTombstones,
 } from "../utils/chat-thread-tombstones";
 import { requestPromptQueueStop } from "../utils/prompt-queue-boundary";
+import { repairLegacyChatTitles } from "../utils/repair-legacy-chat-titles";
 
 export interface SidebarItem {
   type: "single" | "compare";
@@ -131,6 +132,9 @@ export function useChatSidebarItems(options?: {
         if (cancelled || seq !== requestSeq) return;
         setAllThreads(threads);
         setLoaded(true);
+        // Older pre-cut titles cannot grow with the sidebar. Each patch fires
+        // a history update, which reloads the list.
+        void repairLegacyChatTitles(threads).catch(() => undefined);
       } catch (error) {
         if (isExpectedBackgroundChatStorageError(error)) {
           return;

--- a/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
@@ -118,29 +118,23 @@ export function useChatSidebarItems(options?: {
 
     async function doLoad(seq: number) {
       try {
+        const listThreads = requireMessages
+          ? listStoredChatThreadsWithMessages
+          : listStoredChatThreads;
         // includeArchived: archived threads are filtered out of Recents by
         // groupThreads, but the hook still needs them for archivedItems.
-        const args = {
+        const threads = await listThreads({
           includeArchived: true,
           projectId: options?.projectId,
-        };
-        const loaded = requireMessages
-          ? await listStoredChatThreadsWithMessages(args)
-          : {
-              threads: await listStoredChatThreads(args),
-              messagesByThreadId: undefined,
-            };
+        });
         // Discard the response if a newer request was scheduled while we
         // were in flight, or if the effect was torn down.
         if (cancelled || seq !== requestSeq) return;
-        setAllThreads(loaded.threads);
+        setAllThreads(threads);
         setLoaded(true);
-        // Older pre-cut titles cannot grow with the sidebar. Pass the messages
-        // this load already fetched so the repair does not refetch them.
-        void repairLegacyChatTitles(
-          loaded.threads,
-          loaded.messagesByThreadId,
-        ).catch(() => undefined);
+        // Older pre-cut titles cannot grow with the sidebar. The repair reads
+        // its own messages, as late as it can, rather than taking this list's.
+        void repairLegacyChatTitles(threads).catch(() => undefined);
       } catch (error) {
         if (isExpectedBackgroundChatStorageError(error)) {
           return;

--- a/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
@@ -132,8 +132,8 @@ export function useChatSidebarItems(options?: {
         if (cancelled || seq !== requestSeq) return;
         setAllThreads(threads);
         setLoaded(true);
-        // Older pre-cut titles cannot grow with the sidebar. The repair reads
-        // its own messages, as late as it can, rather than taking this list's.
+        // Pre-cut legacy titles cannot grow with the sidebar. The repair reads
+        // its own messages, as late as it can, not this list's.
         void repairLegacyChatTitles(threads).catch(() => undefined);
       } catch (error) {
         if (isExpectedBackgroundChatStorageError(error)) {

--- a/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
@@ -118,23 +118,29 @@ export function useChatSidebarItems(options?: {
 
     async function doLoad(seq: number) {
       try {
-        const listThreads = requireMessages
-          ? listStoredChatThreadsWithMessages
-          : listStoredChatThreads;
         // includeArchived: archived threads are filtered out of Recents by
         // groupThreads, but the hook still needs them for archivedItems.
-        const threads = await listThreads({
+        const args = {
           includeArchived: true,
           projectId: options?.projectId,
-        });
+        };
+        const loaded = requireMessages
+          ? await listStoredChatThreadsWithMessages(args)
+          : {
+              threads: await listStoredChatThreads(args),
+              messagesByThreadId: undefined,
+            };
         // Discard the response if a newer request was scheduled while we
         // were in flight, or if the effect was torn down.
         if (cancelled || seq !== requestSeq) return;
-        setAllThreads(threads);
+        setAllThreads(loaded.threads);
         setLoaded(true);
-        // Older pre-cut titles cannot grow with the sidebar. Each patch fires
-        // a history update, which reloads the list.
-        void repairLegacyChatTitles(threads).catch(() => undefined);
+        // Older pre-cut titles cannot grow with the sidebar. Pass the messages
+        // this load already fetched so the repair does not refetch them.
+        void repairLegacyChatTitles(
+          loaded.threads,
+          loaded.messagesByThreadId,
+        ).catch(() => undefined);
       } catch (error) {
         if (isExpectedBackgroundChatStorageError(error)) {
           return;

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -101,6 +101,7 @@ import {
   markChatThreadDeleted,
 } from "./utils/chat-thread-tombstones";
 import { chatHistoryClearBoundary } from "./utils/chat-history-clear-boundary";
+import { fallbackTitleFromUserText } from "./utils/chat-title";
 import { syncExportedRepositoryToBackend } from "./utils/delete-thread-message";
 import { getImageInputUnavailableReason } from "./utils/image-input-support";
 import { isAssistantLocalThreadId } from "./utils/thread-ids";
@@ -579,14 +580,6 @@ async function generateTitleWithModel(payload: {
 }
 
 const inflightTitleByKey = new Set<string>();
-
-function fallbackTitleFromUserText(userText: string): string {
-  const firstLine = (userText || "").split(/\r?\n/, 1)[0] ?? "";
-  const cleaned = firstLine.replace(/\s+/g, " ").trim();
-  const max = 48;
-  if (!cleaned) return "New Chat";
-  return cleaned.slice(0, max) + (cleaned.length > max ? "..." : "");
-}
 
 function cloneContent(
   content: ThreadMessage["content"],

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -22,6 +22,7 @@ import {
   syncChatMessages,
   updateChatProject,
   updateChatThread,
+  type UpdateChatThreadOptions,
 } from "../api/chat-api";
 import { db, DEXIE_DB_NAME } from "../db";
 import type {
@@ -724,11 +725,12 @@ export async function saveStoredChatThread(
 export async function updateStoredChatThread(
   threadId: string,
   patch: Partial<ThreadRecord>,
+  options: UpdateChatThreadOptions = {},
 ): Promise<ThreadRecord | undefined> {
   if (isThreadIncognito(threadId)) return undefined;
   const thread = await ensureStoredChatThread(threadId);
   if (!thread) return undefined;
-  return updateChatThread(threadId, patch);
+  return updateChatThread(threadId, patch, options);
 }
 
 export async function deleteStoredChatThreads(

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -534,6 +534,15 @@ export async function listStoredChatMessages(
   );
 }
 
+/** Dexie-only read, for callers that already know the backend has nothing. */
+export async function listLegacyChatMessages(
+  threadId: string,
+): Promise<MessageRecord[]> {
+  if (isThreadIncognito(threadId)) return [];
+  if (isChatThreadDeleted(threadId)) return [];
+  return db.messages.where("threadId").equals(threadId).toArray();
+}
+
 export async function getStoredChatMessage(
   threadId: string,
   messageId: string,
@@ -597,11 +606,19 @@ export async function listStoredChatThreads(
     );
 }
 
+export interface ChatThreadsWithMessages {
+  threads: ThreadRecord[];
+  /** Every listed thread's messages, so callers need not fetch them again. */
+  messagesByThreadId: Map<string, MessageRecord[]>;
+}
+
 export async function listStoredChatThreadsWithMessages(
   args: ThreadListArgs = {},
-): Promise<ThreadRecord[]> {
+): Promise<ChatThreadsWithMessages> {
   const threads = await listStoredChatThreads(args);
-  if (threads.length === 0) return [];
+  if (threads.length === 0) {
+    return { threads: [], messagesByThreadId: new Map() };
+  }
   // One batched HTTP call instead of N. Per-thread legacy Dexie fallback
   // only fires when the batch result is empty.
   const threadIds = threads.map((t) => t.id);
@@ -615,13 +632,20 @@ export async function listStoredChatThreadsWithMessages(
     threads.map(async (thread) => {
       const backendMessages = backendByThread.get(thread.id) ?? [];
       if (backendMessages.length > 0) {
-        return { thread, hasContent: true };
+        return { thread, messages: backendMessages, hasContent: true };
       }
       const legacy = await listStoredChatMessages(thread.id).catch(() => null);
-      return { thread, hasContent: legacy === null || legacy.length > 0 };
+      return {
+        thread,
+        messages: legacy ?? [],
+        hasContent: legacy === null || legacy.length > 0,
+      };
     }),
   );
-  return entries.filter((e) => e.hasContent).map((e) => e.thread);
+  return {
+    threads: entries.filter((e) => e.hasContent).map((e) => e.thread),
+    messagesByThreadId: new Map(entries.map((e) => [e.thread.id, e.messages])),
+  };
 }
 
 export async function listStoredChatProjects(

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -540,7 +540,14 @@ export async function listLegacyChatMessages(
 ): Promise<MessageRecord[]> {
   if (isThreadIncognito(threadId)) return [];
   if (isChatThreadDeleted(threadId)) return [];
-  return db.messages.where("threadId").equals(threadId).toArray();
+  const messages = await db.messages
+    .where("threadId")
+    .equals(threadId)
+    .toArray();
+  // Index order, so sort it the way the backend lists messages.
+  return messages.sort(
+    (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
+  );
 }
 
 export async function getStoredChatMessage(
@@ -637,14 +644,21 @@ export async function listStoredChatThreadsWithMessages(
       const legacy = await listStoredChatMessages(thread.id).catch(() => null);
       return {
         thread,
-        messages: legacy ?? [],
+        // null is "the read failed", which the map must not report as empty.
+        messages: legacy,
         hasContent: legacy === null || legacy.length > 0,
       };
     }),
   );
   return {
     threads: entries.filter((e) => e.hasContent).map((e) => e.thread),
-    messagesByThreadId: new Map(entries.map((e) => [e.thread.id, e.messages])),
+    messagesByThreadId: new Map(
+      entries
+        .filter((e): e is typeof e & { messages: MessageRecord[] } =>
+          e.messages !== null,
+        )
+        .map((e) => [e.thread.id, e.messages]),
+    ),
   };
 }
 

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -25,6 +25,7 @@ import {
   type UpdateChatThreadOptions,
 } from "../api/chat-api";
 import { db, DEXIE_DB_NAME } from "../db";
+import { trustsLocalOnlyMessages } from "./chat-title";
 import type {
   MessageRecord,
   ModelType,
@@ -534,12 +535,21 @@ export async function listStoredChatMessages(
   );
 }
 
-/** Dexie-only read, for callers that already know the backend has nothing. */
-export async function listLegacyChatMessages(
+/** Dexie rows for a thread the backend could not account for.
+ *
+ *  Local-only messages are trusted on the same terms as `listStoredChatMessages`
+ *  merges them: while the import is unfinished, or when the backend holds
+ *  nothing. Past that, a Dexie row the backend does not have is a leftover, not
+ *  news, since deleting a message prunes the backend and leaves Dexie alone. */
+export async function listUnimportedChatMessages(
   threadId: string,
+  backendCount: number,
 ): Promise<MessageRecord[]> {
   if (isThreadIncognito(threadId)) return [];
   if (isChatThreadDeleted(threadId)) return [];
+  if (!trustsLocalOnlyMessages(isLegacyChatImportDone(), backendCount)) {
+    return [];
+  }
   const messages = await db.messages
     .where("threadId")
     .equals(threadId)

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -597,19 +597,11 @@ export async function listStoredChatThreads(
     );
 }
 
-export interface ChatThreadsWithMessages {
-  threads: ThreadRecord[];
-  /** Every listed thread's messages, so callers need not fetch them again. */
-  messagesByThreadId: Map<string, MessageRecord[]>;
-}
-
 export async function listStoredChatThreadsWithMessages(
   args: ThreadListArgs = {},
-): Promise<ChatThreadsWithMessages> {
+): Promise<ThreadRecord[]> {
   const threads = await listStoredChatThreads(args);
-  if (threads.length === 0) {
-    return { threads: [], messagesByThreadId: new Map() };
-  }
+  if (threads.length === 0) return [];
   // One batched HTTP call instead of N. Per-thread legacy Dexie fallback
   // only fires when the batch result is empty.
   const threadIds = threads.map((t) => t.id);
@@ -623,27 +615,13 @@ export async function listStoredChatThreadsWithMessages(
     threads.map(async (thread) => {
       const backendMessages = backendByThread.get(thread.id) ?? [];
       if (backendMessages.length > 0) {
-        return { thread, messages: backendMessages, hasContent: true };
+        return { thread, hasContent: true };
       }
       const legacy = await listStoredChatMessages(thread.id).catch(() => null);
-      return {
-        thread,
-        // null is "the read failed", which the map must not report as empty.
-        messages: legacy,
-        hasContent: legacy === null || legacy.length > 0,
-      };
+      return { thread, hasContent: legacy === null || legacy.length > 0 };
     }),
   );
-  return {
-    threads: entries.filter((e) => e.hasContent).map((e) => e.thread),
-    messagesByThreadId: new Map(
-      entries
-        .filter((e): e is typeof e & { messages: MessageRecord[] } =>
-          e.messages !== null,
-        )
-        .map((e) => [e.thread.id, e.messages]),
-    ),
-  };
+  return entries.filter((e) => e.hasContent).map((e) => e.thread);
 }
 
 export async function listStoredChatProjects(

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -22,7 +22,6 @@ import {
   syncChatMessages,
   updateChatProject,
   updateChatThread,
-  type UpdateChatThreadOptions,
 } from "../api/chat-api";
 import { db, DEXIE_DB_NAME } from "../db";
 import type {
@@ -725,12 +724,11 @@ export async function saveStoredChatThread(
 export async function updateStoredChatThread(
   threadId: string,
   patch: Partial<ThreadRecord>,
-  options: UpdateChatThreadOptions = {},
 ): Promise<ThreadRecord | undefined> {
   if (isThreadIncognito(threadId)) return undefined;
   const thread = await ensureStoredChatThread(threadId);
   if (!thread) return undefined;
-  return updateChatThread(threadId, patch, options);
+  return updateChatThread(threadId, patch);
 }
 
 export async function deleteStoredChatThreads(

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -25,7 +25,6 @@ import {
   type UpdateChatThreadOptions,
 } from "../api/chat-api";
 import { db, DEXIE_DB_NAME } from "../db";
-import { trustsLocalOnlyMessages } from "./chat-title";
 import type {
   MessageRecord,
   ModelType,
@@ -532,31 +531,6 @@ export async function listStoredChatMessages(
   }
   return legacyMessages.filter(
     (message) => !isChatThreadDeleted(message.threadId),
-  );
-}
-
-/** Dexie rows for a thread the backend could not account for.
- *
- *  Local-only messages are trusted on the same terms as `listStoredChatMessages`
- *  merges them: while the import is unfinished, or when the backend holds
- *  nothing. Past that, a Dexie row the backend does not have is a leftover, not
- *  news, since deleting a message prunes the backend and leaves Dexie alone. */
-export async function listUnimportedChatMessages(
-  threadId: string,
-  backendCount: number,
-): Promise<MessageRecord[]> {
-  if (isThreadIncognito(threadId)) return [];
-  if (isChatThreadDeleted(threadId)) return [];
-  if (!trustsLocalOnlyMessages(isLegacyChatImportDone(), backendCount)) {
-    return [];
-  }
-  const messages = await db.messages
-    .where("threadId")
-    .equals(threadId)
-    .toArray();
-  // Index order, so sort it the way the backend lists messages.
-  return messages.sort(
-    (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
   );
 }
 

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -21,8 +21,11 @@ function firstLineOf(text: string): string {
 export function fallbackTitleFromUserText(userText: string): string {
   const cleaned = firstLineOf(userText);
   if (!cleaned) return "New Chat";
-  if (cleaned.length <= FALLBACK_TITLE_MAX) return cleaned;
-  return cleaned.slice(0, FALLBACK_TITLE_MAX).trimEnd() + "…";
+  // Cut on code points: a UTF-16 cut can halve an emoji, and the lone
+  // surrogate that leaves fails the backend's SQLite bind.
+  const points = Array.from(cleaned);
+  if (points.length <= FALLBACK_TITLE_MAX) return cleaned;
+  return points.slice(0, FALLBACK_TITLE_MAX).join("").trimEnd() + "…";
 }
 
 /** Pre-filter on the title alone: only these are worth fetching messages for. */

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -82,6 +82,9 @@ export interface LegacyTitleRepair {
   threadId: string;
   /** The clipped title the rewrite is based on, guarding the write. */
   previousTitle: string;
+  /** The message the new title came from, guarding it too: deleting it must
+   *  not leave its text expanded into the title. */
+  openingMessageId: string;
   title: string;
 }
 
@@ -142,22 +145,25 @@ export function planLegacyTitleRepairs(
   for (const thread of threads) {
     const messages = messagesByThreadId.get(thread.id) ?? [];
     // Earliest, not first in the array: a local read is in index order.
+    // Ties break on id, the order the backend reads it in.
     const opening = messages
       .filter((m) => m.role === "user")
-      .reduce<MessageRecord | undefined>(
-        (earliest, m) =>
-          earliest === undefined || m.createdAt < earliest.createdAt
-            ? m
-            : earliest,
-        undefined,
-      );
+      .reduce<MessageRecord | undefined>((earliest, m) => {
+        if (earliest === undefined) return m;
+        if (m.createdAt !== earliest.createdAt) {
+          return m.createdAt < earliest.createdAt ? m : earliest;
+        }
+        return m.id < earliest.id ? m : earliest;
+      }, undefined);
     const userText = textOf(opening);
+    if (opening === undefined) continue;
     if (!isLegacyClippedTitle(thread.title, userText)) continue;
     const title = fallbackTitleFromUserText(userText);
     if (title === thread.title) continue;
     repairs.push({
       threadId: thread.id,
       previousTitle: thread.title,
+      openingMessageId: opening.id,
       title,
     });
   }

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -100,42 +100,6 @@ export function selectLegacyRepairPage(
   };
 }
 
-/** Whether a Dexie row the backend does not have still counts as real. Once the
- *  import is done and the backend has the thread, it is a leftover: a deletion
- *  prunes the backend without clearing Dexie. */
-export function trustsLocalOnlyMessages(
-  importDone: boolean,
-  backendCount: number,
-): boolean {
-  return !importDone || backendCount === 0;
-}
-
-/** Candidates no rewrite could be made of. Their opening message may just be
- *  missing from what was read, so they are worth a local look before being
- *  written off. */
-export function threadsWithoutRepairs(
-  candidates: ThreadRecord[],
-  repairs: LegacyTitleRepair[],
-): string[] {
-  const planned = new Set(repairs.map((repair) => repair.threadId));
-  return candidates
-    .map((thread) => thread.id)
-    .filter((id) => !planned.has(id));
-}
-
-/** Both sources for one thread, newest duplicate dropped by id. A part-imported
- *  chat can hold its opening message locally and its later turns remotely. */
-export function mergeMessagesById(
-  first: readonly MessageRecord[],
-  second: readonly MessageRecord[],
-): MessageRecord[] {
-  const byId = new Map(first.map((message) => [message.id, message]));
-  for (const message of second) {
-    if (!byId.has(message.id)) byId.set(message.id, message);
-  }
-  return [...byId.values()];
-}
-
 /** Threads nothing is known about at all, so nothing can be concluded. */
 export function threadsMissingMessages(
   ids: readonly string[],

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -3,20 +3,19 @@
 
 import type { MessageRecord, ThreadRecord } from "../types";
 
-/** The sidebar clips the title with CSS, so store the whole first line and a
- *  wider sidebar shows more of it. Caps a pasted wall of text, and matches the
- *  rename input's maxLength, which counts UTF-16 units and includes any
- *  ellipsis this adds. */
+/** Store the whole first line and let the sidebar clip it with CSS, so a wider
+ *  one shows more. Matches the rename input's maxLength: UTF-16 units, ellipsis
+ *  included. */
 export const FALLBACK_TITLE_MAX = 120;
 
-/** Older titles were stored pre-cut at 48 chars with a literal "...", so no
- *  width could reveal more. Kept to find and rewrite those rows. */
+/** Older titles were stored pre-cut at 48 chars with a literal "...". Kept to
+ *  find and rewrite those rows. */
 export const LEGACY_FALLBACK_TITLE_MAX = 48;
 const LEGACY_FALLBACK_SUFFIX = "...";
 
-/** Drop unpaired surrogates. They render as nothing, and one reaching the
- *  backend fails its SQLite bind, so the title write 500s. Iteration yields a
- *  valid pair whole, leaving a lone surrogate as a single unit in the range. */
+/** Drop unpaired surrogates: they render as nothing, and one reaching the
+ *  backend fails its SQLite bind and 500s the title write. Iteration yields a
+ *  valid pair whole, so a length-1 unit in the range is a lone surrogate. */
 function dropLoneSurrogates(text: string): string {
   let out = "";
   for (const character of text) {
@@ -29,14 +28,12 @@ function dropLoneSurrogates(text: string): string {
 
 function firstLineOf(text: string): string {
   const firstLine = (text || "").split(/\r?\n/, 1)[0] ?? "";
-  // Drop first: a surrogate removed from between two spaces would otherwise
-  // leave the pair behind, and one at the end would leave a trailing space.
+  // Drop surrogates first, or removing one can leave a double or trailing space.
   return dropLoneSurrogates(firstLine).replace(/\s+/g, " ").trim();
 }
 
-/** Cut to at most `maxUnits` UTF-16 units, the unit maxLength counts, without
- *  splitting an astral character in half. A lone surrogate parses fine and then
- *  fails the backend's SQLite bind. */
+/** Cut to at most `maxUnits` UTF-16 units without splitting an astral character:
+ *  a lone surrogate parses fine and then fails the backend's SQLite bind. */
 function cutToUnits(text: string, maxUnits: number): string {
   let out = "";
   for (const character of text) {
@@ -50,8 +47,7 @@ export function fallbackTitleFromUserText(userText: string): string {
   const cleaned = firstLineOf(userText);
   if (!cleaned) return "New Chat";
   if (cleaned.length <= FALLBACK_TITLE_MAX) return cleaned;
-  // The ellipsis takes one of the budget, so the whole title still fits what
-  // the rename input accepts.
+  // The ellipsis takes one of the budget, so the title still fits the input.
   return cutToUnits(cleaned, FALLBACK_TITLE_MAX - 1).trimEnd() + "…";
 }
 
@@ -97,16 +93,16 @@ export interface LegacyTitleRepair {
   threadId: string;
   /** The clipped title the rewrite is based on, guarding the write. */
   previousTitle: string;
-  /** The message the new title came from, guarding it too: deleting it must
-   *  not leave its text expanded into the title. */
+  /** The message the title came from, guarded too: deleting it must not leave
+   *  its text expanded into the title. */
   openingMessageId: string;
   title: string;
 }
 
 export interface LegacyRepairPage {
   candidates: ThreadRecord[];
-  /** Everything this page did not take. The next page reads from here, so a
-   *  row this page failed on cannot be picked up again by the same drain. */
+  /** What this page skipped. The next page reads it, so a row this page failed
+   *  on is not redrawn by the same drain. */
   rest: ThreadRecord[];
   hasMore: boolean;
 }
@@ -140,9 +136,8 @@ export function threadsMissingMessages(
 
 /** Of those, the ones still worth retrying: no record of their import
  *  finishing, so their messages may yet land. One the ledger knows is simply
- *  empty, every message deleted, which no later pass can change. Retrying
- *  those would re-read them on every refresh for the session, since the title
- *  stays clipped and keeps matching the pre-filter. */
+ *  empty, and retrying it would re-read it on every refresh for the session,
+ *  since its title stays clipped and keeps matching the pre-filter. */
 export function threadsAwaitingImport(
   ids: readonly string[],
   messagesByThreadId: ReadonlyMap<string, MessageRecord[]>,
@@ -162,8 +157,7 @@ export function planLegacyTitleRepairs(
   const repairs: LegacyTitleRepair[] = [];
   for (const thread of threads) {
     const messages = messagesByThreadId.get(thread.id) ?? [];
-    // Earliest, not first in the array: a local read is in index order.
-    // Ties break on id, the order the backend reads it in.
+    // Earliest, not first in the array; ties break on id, as the backend does.
     const opening = messages
       .filter((m) => m.role === "user")
       .reduce<MessageRecord | undefined>((earliest, m) => {

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -100,6 +100,18 @@ export function selectLegacyRepairPage(
   };
 }
 
+/** Repairs whose row still holds the title they were planned from. The write
+ *  carries that title as a guard, but only a backend that knows the field
+ *  enforces it, so an older one needs this check to respect a rename. */
+export function repairsStillValid(
+  repairs: LegacyTitleRepair[],
+  currentTitleById: ReadonlyMap<string, string>,
+): LegacyTitleRepair[] {
+  return repairs.filter(
+    (repair) => currentTitleById.get(repair.threadId) === repair.previousTitle,
+  );
+}
+
 /** Threads nothing is known about at all, so nothing can be concluded. */
 export function threadsMissingMessages(
   ids: readonly string[],

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -100,8 +100,33 @@ export function selectLegacyRepairPage(
   };
 }
 
-/** Threads the backend has nothing for. A chat still only in Dexie reads empty
- *  there, so it needs a local read before it can be written off. */
+/** Candidates no rewrite could be made of. Their opening message may just be
+ *  missing from what was read, so they are worth a local look before being
+ *  written off. */
+export function threadsWithoutRepairs(
+  candidates: ThreadRecord[],
+  repairs: LegacyTitleRepair[],
+): string[] {
+  const planned = new Set(repairs.map((repair) => repair.threadId));
+  return candidates
+    .map((thread) => thread.id)
+    .filter((id) => !planned.has(id));
+}
+
+/** Both sources for one thread, newest duplicate dropped by id. A part-imported
+ *  chat can hold its opening message locally and its later turns remotely. */
+export function mergeMessagesById(
+  first: readonly MessageRecord[],
+  second: readonly MessageRecord[],
+): MessageRecord[] {
+  const byId = new Map(first.map((message) => [message.id, message]));
+  for (const message of second) {
+    if (!byId.has(message.id)) byId.set(message.id, message);
+  }
+  return [...byId.values()];
+}
+
+/** Threads nothing is known about at all, so nothing can be concluded. */
 export function threadsMissingMessages(
   ids: readonly string[],
   messagesByThreadId: ReadonlyMap<string, MessageRecord[]>,

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -14,9 +14,24 @@ export const FALLBACK_TITLE_MAX = 120;
 export const LEGACY_FALLBACK_TITLE_MAX = 48;
 const LEGACY_FALLBACK_SUFFIX = "...";
 
+/** Drop unpaired surrogates. They render as nothing, and one reaching the
+ *  backend fails its SQLite bind, so the title write 500s. Iteration yields a
+ *  valid pair whole, leaving a lone surrogate as a single unit in the range. */
+function dropLoneSurrogates(text: string): string {
+  let out = "";
+  for (const character of text) {
+    const code = character.codePointAt(0) ?? 0;
+    if (character.length === 1 && code >= 0xd800 && code <= 0xdfff) continue;
+    out += character;
+  }
+  return out;
+}
+
 function firstLineOf(text: string): string {
   const firstLine = (text || "").split(/\r?\n/, 1)[0] ?? "";
-  return firstLine.replace(/\s+/g, " ").trim();
+  // Drop first: a surrogate removed from between two spaces would otherwise
+  // leave the pair behind, and one at the end would leave a trailing space.
+  return dropLoneSurrogates(firstLine).replace(/\s+/g, " ").trim();
 }
 
 /** Cut to at most `maxUnits` UTF-16 units, the unit maxLength counts, without

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -75,7 +75,9 @@ export interface LegacyTitleRepair {
 
 export interface LegacyRepairPage {
   candidates: ThreadRecord[];
-  /** Rows left for the next page, which the caller has to schedule itself. */
+  /** Everything this page did not take. The next page reads from here, so a
+   *  row this page failed on cannot be picked up again by the same drain. */
+  rest: ThreadRecord[];
   hasMore: boolean;
 }
 
@@ -89,8 +91,11 @@ export function selectLegacyRepairPage(
     (thread) =>
       couldBeLegacyClippedTitle(thread.title) && !attempted.has(thread.id),
   );
+  const candidates = pending.slice(0, limit);
+  const taken = new Set(candidates.map((thread) => thread.id));
   return {
-    candidates: pending.slice(0, limit),
+    candidates,
+    rest: threads.filter((thread) => !taken.has(thread.id)),
     hasMore: pending.length > limit,
   };
 }
@@ -113,7 +118,17 @@ export function planLegacyTitleRepairs(
   const repairs: LegacyTitleRepair[] = [];
   for (const thread of threads) {
     const messages = messagesByThreadId.get(thread.id) ?? [];
-    const userText = textOf(messages.find((m) => m.role === "user"));
+    // Earliest, not first in the array: a local read is in index order.
+    const opening = messages
+      .filter((m) => m.role === "user")
+      .reduce<MessageRecord | undefined>(
+        (earliest, m) =>
+          earliest === undefined || m.createdAt < earliest.createdAt
+            ? m
+            : earliest,
+        undefined,
+      );
+    const userText = textOf(opening);
     if (!isLegacyClippedTitle(thread.title, userText)) continue;
     const title = fallbackTitleFromUserText(userText);
     if (title === thread.title) continue;

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import type { MessageRecord, ThreadRecord } from "../types";
+
+/** The sidebar clips the title with CSS, so store the whole first line and a
+ *  wider sidebar shows more of it. Caps a pasted wall of text, at the rename
+ *  input's maxLength. */
+export const FALLBACK_TITLE_MAX = 120;
+
+/** Older titles were stored pre-cut at 48 chars with a literal "...", so no
+ *  width could reveal more. Kept to find and rewrite those rows. */
+export const LEGACY_FALLBACK_TITLE_MAX = 48;
+const LEGACY_FALLBACK_SUFFIX = "...";
+
+function firstLineOf(text: string): string {
+  const firstLine = (text || "").split(/\r?\n/, 1)[0] ?? "";
+  return firstLine.replace(/\s+/g, " ").trim();
+}
+
+export function fallbackTitleFromUserText(userText: string): string {
+  const cleaned = firstLineOf(userText);
+  if (!cleaned) return "New Chat";
+  if (cleaned.length <= FALLBACK_TITLE_MAX) return cleaned;
+  return cleaned.slice(0, FALLBACK_TITLE_MAX).trimEnd() + "…";
+}
+
+/** Pre-filter on the title alone: only these are worth fetching messages for. */
+export function couldBeLegacyClippedTitle(title: string | undefined): boolean {
+  return (
+    typeof title === "string" &&
+    title.endsWith(LEGACY_FALLBACK_SUFFIX) &&
+    title.length === LEGACY_FALLBACK_TITLE_MAX + LEGACY_FALLBACK_SUFFIX.length
+  );
+}
+
+/** True when `title` is exactly the old 48-character cut of `userText`. */
+export function isLegacyClippedTitle(
+  title: string | undefined,
+  userText: string,
+): boolean {
+  if (!couldBeLegacyClippedTitle(title)) return false;
+  const kept = (title as string).slice(0, LEGACY_FALLBACK_TITLE_MAX);
+  const cleaned = firstLineOf(userText);
+  return (
+    cleaned.length > LEGACY_FALLBACK_TITLE_MAX &&
+    cleaned.slice(0, LEGACY_FALLBACK_TITLE_MAX) === kept
+  );
+}
+
+function textOf(message: MessageRecord | undefined): string {
+  if (!message) return "";
+  const content = message.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(
+      (part): part is Extract<typeof part, { type: "text" }> =>
+        part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("")
+    .trim();
+}
+
+export interface LegacyTitleRepair {
+  threadId: string;
+  title: string;
+}
+
+/** Rows to rewrite. A title must be the exact old cut of its own first
+ *  message, so a rename ending in "..." is left alone. */
+export function planLegacyTitleRepairs(
+  threads: ThreadRecord[],
+  messagesByThreadId: Map<string, MessageRecord[]>,
+): LegacyTitleRepair[] {
+  const repairs: LegacyTitleRepair[] = [];
+  for (const thread of threads) {
+    const messages = messagesByThreadId.get(thread.id) ?? [];
+    const userText = textOf(messages.find((m) => m.role === "user"));
+    if (!isLegacyClippedTitle(thread.title, userText)) continue;
+    const title = fallbackTitleFromUserText(userText);
+    if (title !== thread.title) repairs.push({ threadId: thread.id, title });
+  }
+  return repairs;
+}

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -68,6 +68,8 @@ function textOf(message: MessageRecord | undefined): string {
 
 export interface LegacyTitleRepair {
   threadId: string;
+  /** The clipped title the rewrite is based on, guarding the write. */
+  previousTitle: string;
   title: string;
 }
 
@@ -83,7 +85,12 @@ export function planLegacyTitleRepairs(
     const userText = textOf(messages.find((m) => m.role === "user"));
     if (!isLegacyClippedTitle(thread.title, userText)) continue;
     const title = fallbackTitleFromUserText(userText);
-    if (title !== thread.title) repairs.push({ threadId: thread.id, title });
+    if (title === thread.title) continue;
+    repairs.push({
+      threadId: thread.id,
+      previousTitle: thread.title,
+      title,
+    });
   }
   return repairs;
 }

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -4,8 +4,9 @@
 import type { MessageRecord, ThreadRecord } from "../types";
 
 /** The sidebar clips the title with CSS, so store the whole first line and a
- *  wider sidebar shows more of it. Caps a pasted wall of text, at the rename
- *  input's maxLength. */
+ *  wider sidebar shows more of it. Caps a pasted wall of text, and matches the
+ *  rename input's maxLength, which counts UTF-16 units and includes any
+ *  ellipsis this adds. */
 export const FALLBACK_TITLE_MAX = 120;
 
 /** Older titles were stored pre-cut at 48 chars with a literal "...", so no
@@ -18,14 +19,25 @@ function firstLineOf(text: string): string {
   return firstLine.replace(/\s+/g, " ").trim();
 }
 
+/** Cut to at most `maxUnits` UTF-16 units, the unit maxLength counts, without
+ *  splitting an astral character in half. A lone surrogate parses fine and then
+ *  fails the backend's SQLite bind. */
+function cutToUnits(text: string, maxUnits: number): string {
+  let out = "";
+  for (const character of text) {
+    if (out.length + character.length > maxUnits) break;
+    out += character;
+  }
+  return out;
+}
+
 export function fallbackTitleFromUserText(userText: string): string {
   const cleaned = firstLineOf(userText);
   if (!cleaned) return "New Chat";
-  // Cut on code points: a UTF-16 cut can halve an emoji, and the lone
-  // surrogate that leaves fails the backend's SQLite bind.
-  const points = Array.from(cleaned);
-  if (points.length <= FALLBACK_TITLE_MAX) return cleaned;
-  return points.slice(0, FALLBACK_TITLE_MAX).join("").trimEnd() + "…";
+  if (cleaned.length <= FALLBACK_TITLE_MAX) return cleaned;
+  // The ellipsis takes one of the budget, so the whole title still fits what
+  // the rename input accepts.
+  return cutToUnits(cleaned, FALLBACK_TITLE_MAX - 1).trimEnd() + "…";
 }
 
 /** Pre-filter on the title alone: only these are worth fetching messages for. */

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -73,6 +73,37 @@ export interface LegacyTitleRepair {
   title: string;
 }
 
+export interface LegacyRepairPage {
+  candidates: ThreadRecord[];
+  /** Rows left for the next page, which the caller has to schedule itself. */
+  hasMore: boolean;
+}
+
+/** One page of rows to look at, skipping the ones already tried. */
+export function selectLegacyRepairPage(
+  threads: ThreadRecord[],
+  attempted: ReadonlySet<string>,
+  limit: number,
+): LegacyRepairPage {
+  const pending = threads.filter(
+    (thread) =>
+      couldBeLegacyClippedTitle(thread.title) && !attempted.has(thread.id),
+  );
+  return {
+    candidates: pending.slice(0, limit),
+    hasMore: pending.length > limit,
+  };
+}
+
+/** Threads the backend has nothing for. A chat still only in Dexie reads empty
+ *  there, so it needs a local read before it can be written off. */
+export function threadsMissingMessages(
+  ids: readonly string[],
+  messagesByThreadId: ReadonlyMap<string, MessageRecord[]>,
+): string[] {
+  return ids.filter((id) => (messagesByThreadId.get(id) ?? []).length === 0);
+}
+
 /** Rows to rewrite. A title must be the exact old cut of its own first
  *  message, so a rename ending in "..." is left alone. */
 export function planLegacyTitleRepairs(

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -115,24 +115,27 @@ export function selectLegacyRepairPage(
   };
 }
 
-/** Repairs whose row still holds the title they were planned from. The write
- *  carries that title as a guard, but only a backend that knows the field
- *  enforces it, so an older one needs this check to respect a rename. */
-export function repairsStillValid(
-  repairs: LegacyTitleRepair[],
-  currentTitleById: ReadonlyMap<string, string>,
-): LegacyTitleRepair[] {
-  return repairs.filter(
-    (repair) => currentTitleById.get(repair.threadId) === repair.previousTitle,
-  );
-}
-
-/** Threads nothing is known about at all, so nothing can be concluded. */
+/** Threads the backend holds no messages for. */
 export function threadsMissingMessages(
   ids: readonly string[],
   messagesByThreadId: ReadonlyMap<string, MessageRecord[]>,
 ): string[] {
   return ids.filter((id) => (messagesByThreadId.get(id) ?? []).length === 0);
+}
+
+/** Of those, the ones still worth retrying: no record of their import
+ *  finishing, so their messages may yet land. One the ledger knows is simply
+ *  empty, every message deleted, which no later pass can change. Retrying
+ *  those would re-read them on every refresh for the session, since the title
+ *  stays clipped and keeps matching the pre-filter. */
+export function threadsAwaitingImport(
+  ids: readonly string[],
+  messagesByThreadId: ReadonlyMap<string, MessageRecord[]>,
+  importedThreadIds: ReadonlySet<string>,
+): string[] {
+  return threadsMissingMessages(ids, messagesByThreadId).filter(
+    (id) => !importedThreadIds.has(id),
+  );
 }
 
 /** Rows to rewrite. A title must be the exact old cut of its own first

--- a/studio/frontend/src/features/chat/utils/chat-title.ts
+++ b/studio/frontend/src/features/chat/utils/chat-title.ts
@@ -100,6 +100,16 @@ export function selectLegacyRepairPage(
   };
 }
 
+/** Whether a Dexie row the backend does not have still counts as real. Once the
+ *  import is done and the backend has the thread, it is a leftover: a deletion
+ *  prunes the backend without clearing Dexie. */
+export function trustsLocalOnlyMessages(
+  importDone: boolean,
+  backendCount: number,
+): boolean {
+  return !importDone || backendCount === 0;
+}
+
 /** Candidates no rewrite could be made of. Their opening message may just be
  *  missing from what was read, so they are worth a local look before being
  *  written off. */

--- a/studio/frontend/src/features/chat/utils/openapi-support.ts
+++ b/studio/frontend/src/features/chat/utils/openapi-support.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** Whether the served schema declares the conditional title patch.
+ *
+ *  The desktop app ships its own frontend against a separately installed
+ *  backend, and an older one drops `expectedTitle` and applies the write
+ *  unguarded. Anything unrecognised reads as unsupported. */
+export function schemaDeclaresExpectedTitle(document: unknown): boolean {
+  if (typeof document !== "object" || document === null) return false;
+  const components = (document as { components?: unknown }).components;
+  if (typeof components !== "object" || components === null) return false;
+  const schemas = (components as { schemas?: unknown }).schemas;
+  if (typeof schemas !== "object" || schemas === null) return false;
+  const patch = (schemas as Record<string, unknown>).ChatThreadPatch;
+  if (typeof patch !== "object" || patch === null) return false;
+  const properties = (patch as { properties?: unknown }).properties;
+  if (typeof properties !== "object" || properties === null) return false;
+  return "expectedTitle" in (properties as Record<string, unknown>);
+}

--- a/studio/frontend/src/features/chat/utils/openapi-support.ts
+++ b/studio/frontend/src/features/chat/utils/openapi-support.ts
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-/** Both fields the conditional title patch rides on. */
 const GUARD_FIELDS = ["expectedTitle", "expectedOpeningMessageId"] as const;
 
-/** Whether the served schema declares the conditional title patch.
- *
- *  The desktop app ships its own frontend against a separately installed
- *  backend, and an older one drops these fields and applies the write
- *  unguarded. Anything unrecognised reads as unsupported. */
+/** Whether the served schema declares the guard fields. The desktop app ships
+ *  its own frontend against a separately installed backend, and an older one
+ *  drops these and writes unguarded. Anything unrecognised is unsupported. */
 export function schemaDeclaresRepairGuards(document: unknown): boolean {
   if (typeof document !== "object" || document === null) return false;
   const components = (document as { components?: unknown }).components;
@@ -25,9 +22,9 @@ export function schemaDeclaresRepairGuards(document: unknown): boolean {
 
 export interface GuardProbe {
   supported: boolean;
-  /** Only a schema that arrived and parsed settles the question. Anything else
-   *  is a moment in time: a 401 while the token warms up, a 503 during startup.
-   *  Remembering those would park the migration for the whole session. */
+  /** Only a schema that arrived and parsed settles it. A 401 while the token
+   *  warms up or a 503 at startup is a moment, not an answer, and caching one
+   *  would park the migration for the session. */
   settled: boolean;
 }
 

--- a/studio/frontend/src/features/chat/utils/openapi-support.ts
+++ b/studio/frontend/src/features/chat/utils/openapi-support.ts
@@ -18,3 +18,16 @@ export function schemaDeclaresExpectedTitle(document: unknown): boolean {
   if (typeof properties !== "object" || properties === null) return false;
   return "expectedTitle" in (properties as Record<string, unknown>);
 }
+
+export interface GuardProbe {
+  supported: boolean;
+  /** Only a schema that arrived and parsed settles the question. Anything else
+   *  is a moment in time: a 401 while the token warms up, a 503 during startup.
+   *  Remembering those would park the migration for the whole session. */
+  settled: boolean;
+}
+
+export function readGuardProbe(ok: boolean, document: unknown): GuardProbe {
+  if (!ok) return { supported: false, settled: false };
+  return { supported: schemaDeclaresExpectedTitle(document), settled: true };
+}

--- a/studio/frontend/src/features/chat/utils/openapi-support.ts
+++ b/studio/frontend/src/features/chat/utils/openapi-support.ts
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+/** Both fields the conditional title patch rides on. */
+const GUARD_FIELDS = ["expectedTitle", "expectedOpeningMessageId"] as const;
+
 /** Whether the served schema declares the conditional title patch.
  *
  *  The desktop app ships its own frontend against a separately installed
- *  backend, and an older one drops `expectedTitle` and applies the write
+ *  backend, and an older one drops these fields and applies the write
  *  unguarded. Anything unrecognised reads as unsupported. */
-export function schemaDeclaresExpectedTitle(document: unknown): boolean {
+export function schemaDeclaresRepairGuards(document: unknown): boolean {
   if (typeof document !== "object" || document === null) return false;
   const components = (document as { components?: unknown }).components;
   if (typeof components !== "object" || components === null) return false;
@@ -16,7 +19,8 @@ export function schemaDeclaresExpectedTitle(document: unknown): boolean {
   if (typeof patch !== "object" || patch === null) return false;
   const properties = (patch as { properties?: unknown }).properties;
   if (typeof properties !== "object" || properties === null) return false;
-  return "expectedTitle" in (properties as Record<string, unknown>);
+  const declared = properties as Record<string, unknown>;
+  return GUARD_FIELDS.every((field) => field in declared);
 }
 
 export interface GuardProbe {
@@ -29,5 +33,5 @@ export interface GuardProbe {
 
 export function readGuardProbe(ok: boolean, document: unknown): GuardProbe {
   if (!ok) return { supported: false, settled: false };
-  return { supported: schemaDeclaresExpectedTitle(document), settled: true };
+  return { supported: schemaDeclaresRepairGuards(document), settled: true };
 }

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -2,11 +2,15 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { batchListChatMessages } from "../api/chat-api";
-import type { ThreadRecord } from "../types";
-import { updateStoredChatThread } from "./chat-history-storage";
+import type { MessageRecord, ThreadRecord } from "../types";
 import {
-  couldBeLegacyClippedTitle,
+  listLegacyChatMessages,
+  updateStoredChatThread,
+} from "./chat-history-storage";
+import {
   planLegacyTitleRepairs,
+  selectLegacyRepairPage,
+  threadsMissingMessages,
 } from "./chat-title";
 import { runWithConcurrency } from "./run-with-concurrency";
 
@@ -14,39 +18,53 @@ import { runWithConcurrency } from "./run-with-concurrency";
  *  the ones that could not be rewritten off every later refresh. */
 const attempted = new Set<string>();
 
-/** Rows per pass, so a long history drains over a few refreshes instead of
- *  putting its whole backlog on the backend at once. */
+/** Rows per pass, so a long history drains in pages instead of putting its
+ *  whole backlog on the backend at once. */
 const REPAIR_PER_PASS = 100;
 
 /** Writes in flight. Each PATCH is a synchronous SQLite call server side. */
 const REPAIR_CONCURRENCY = 4;
 
+/** Breather between pages. */
+const REPAIR_PAGE_PAUSE_MS = 500;
+
 /** Rewrite titles stored pre-cut at 48 chars so they grow with the sidebar
- *  again. Takes whichever threads the caller just loaded. */
+ *  again. `known` is the caller's own message map, when it already has one. */
 export async function repairLegacyChatTitles(
   threads: ThreadRecord[],
+  known?: Map<string, MessageRecord[]>,
 ): Promise<number> {
-  const candidates = threads
-    .filter(
-      (thread) =>
-        couldBeLegacyClippedTitle(thread.title) && !attempted.has(thread.id),
-    )
-    .slice(0, REPAIR_PER_PASS);
+  const { candidates, hasMore } = selectLegacyRepairPage(
+    threads,
+    attempted,
+    REPAIR_PER_PASS,
+  );
   if (candidates.length === 0) return 0;
   const ids = candidates.map((thread) => thread.id);
   for (const id of ids) attempted.add(id);
 
-  let repairs: ReturnType<typeof planLegacyTitleRepairs>;
+  let messages: Map<string, MessageRecord[]>;
   try {
-    // One batched call, not one per row.
-    const messagesByThreadId = await batchListChatMessages(ids);
-    repairs = planLegacyTitleRepairs(candidates, messagesByThreadId);
+    // One batched call, and none at all when the caller already fetched them.
+    messages = known
+      ? new Map(known)
+      : await batchListChatMessages(ids);
+    // A chat still only in Dexie (legacy import pending or failed) reads empty
+    // from the backend, so look locally before writing it off.
+    await runWithConcurrency(
+      threadsMissingMessages(ids, messages),
+      REPAIR_CONCURRENCY,
+      async (id) => {
+        messages.set(id, await listLegacyChatMessages(id));
+      },
+    );
   } catch {
     // Nothing was decided, so let a later refresh try these again.
     for (const id of ids) attempted.delete(id);
     return 0;
   }
 
+  const repairs = planLegacyTitleRepairs(candidates, messages);
   let repaired = 0;
   await runWithConcurrency(repairs, REPAIR_CONCURRENCY, async (repair) => {
     try {
@@ -63,5 +81,13 @@ export async function repairLegacyChatTitles(
       attempted.delete(repair.threadId);
     }
   });
+
+  // A page that wrote nothing fires no history update, so the next page has to
+  // be scheduled here rather than left waiting on an unrelated refresh.
+  if (hasMore) {
+    setTimeout(() => {
+      void repairLegacyChatTitles(threads, known).catch(() => undefined);
+    }, REPAIR_PAGE_PAUSE_MS);
+  }
   return repaired;
 }

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -11,7 +11,7 @@ import {
   selectLegacyRepairPage,
   threadsMissingMessages,
 } from "./chat-title";
-import { schemaDeclaresExpectedTitle } from "./openapi-support";
+import { type GuardProbe, readGuardProbe } from "./openapi-support";
 import { runWithConcurrency } from "./run-with-concurrency";
 import { createSerialQueue } from "./serial-queue";
 
@@ -44,14 +44,19 @@ let guardSupport: Promise<boolean> | null = null;
  *  without touching anything. Anything unreadable reads as unsupported. */
 function backendEnforcesTitleGuard(): Promise<boolean> {
   guardSupport ??= (async () => {
+    let probe: GuardProbe = { supported: false, settled: false };
     try {
       const response = await authFetch("/openapi.json");
-      if (!response.ok) return false;
-      return schemaDeclaresExpectedTitle(await response.json());
+      probe = readGuardProbe(
+        response.ok,
+        response.ok ? await response.json() : null,
+      );
     } catch {
-      guardSupport = null;
-      return false;
+      probe = { supported: false, settled: false };
     }
+    // Only a settled answer is worth remembering.
+    if (!probe.settled) guardSupport = null;
+    return probe.supported;
   })();
   return guardSupport;
 }

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -2,13 +2,16 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
-import { batchListChatMessages, listChatThreads } from "../api/chat-api";
+import {
+  batchListChatMessages,
+  listChatImportLedger,
+  updateChatThread,
+} from "../api/chat-api";
 import type { MessageRecord, ThreadRecord } from "../types";
-import { updateStoredChatThread } from "./chat-history-storage";
 import {
   planLegacyTitleRepairs,
-  repairsStillValid,
   selectLegacyRepairPage,
+  threadsAwaitingImport,
   threadsMissingMessages,
 } from "./chat-title";
 import { type GuardProbe, readGuardProbe } from "./openapi-support";
@@ -101,35 +104,35 @@ async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
   // imported yet reads as unknown below and is retried once they land.
   const repairs = planLegacyTitleRepairs(candidates, messages);
 
-  // Nothing known at all reads as an incomplete answer, not an empty chat: a
-  // clipped title means there was an opening message once. Leave those rows for
-  // a later refresh rather than writing them off for the session.
-  for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);
-
-  // expectedTitle is only enforced by a backend that knows the field. The
-  // desktop app ships its own frontend and can meet an older one, which would
-  // apply the write regardless, so confirm the titles here too. One call for
-  // the page, taken last, so a rename is respected either way.
-  let live: ReturnType<typeof repairsStillValid>;
-  try {
-    const current = await listChatThreads({ includeArchived: true });
-    live = repairsStillValid(
-      repairs,
-      new Map(current.map((thread) => [thread.id, thread.title])),
-    );
-  } catch {
-    for (const id of ids) attempted.delete(id);
-    return 0;
+  // A chat with nothing stored is either mid-import, so worth another pass, or
+  // one the user emptied, which no pass can change. The ledger tells them
+  // apart, and is only worth fetching when there is something to decide.
+  const withoutMessages = threadsMissingMessages(ids, messages);
+  if (withoutMessages.length > 0) {
+    let imported = new Set<string>();
+    try {
+      imported = await listChatImportLedger();
+    } catch {
+      // Undecided, so keep every one of them retryable.
+    }
+    for (const id of threadsAwaitingImport(ids, messages, imported)) {
+      attempted.delete(id);
+    }
   }
 
   let repaired = 0;
-  await runWithConcurrency(live, REPAIR_CONCURRENCY, async (repair) => {
+  await runWithConcurrency(repairs, REPAIR_CONCURRENCY, async (repair) => {
     try {
-      // Both guards make this atomic where the backend enforces them: a
-      // rename or a deleted opening prompt landing now answers 409, so the
-      // user's title stays and no deleted text is expanded into one. A title
-      // patch leaves updatedAt alone, so Recents keeps its order.
-      await updateStoredChatThread(
+      // The backend PATCH directly, not updateStoredChatThread: that ensures
+      // the thread first, which re-imports one deleted on another client from
+      // the Dexie rows still sitting here. A migration must never create
+      // anything, so a missing thread has to stay missing and 404.
+      //
+      // Both guards make this atomic: a rename or a deleted opening prompt
+      // landing now answers 409, so the user's title stays and no deleted text
+      // is expanded into one. A title patch leaves updatedAt alone, so Recents
+      // keeps its order.
+      await updateChatThread(
         repair.threadId,
         { title: repair.title },
         {

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { authFetch } from "@/features/auth";
 import { batchListChatMessages, listChatThreads } from "../api/chat-api";
 import type { MessageRecord, ThreadRecord } from "../types";
 import { updateStoredChatThread } from "./chat-history-storage";
@@ -10,6 +11,7 @@ import {
   selectLegacyRepairPage,
   threadsMissingMessages,
 } from "./chat-title";
+import { schemaDeclaresExpectedTitle } from "./openapi-support";
 import { runWithConcurrency } from "./run-with-concurrency";
 import { createSerialQueue } from "./serial-queue";
 
@@ -31,6 +33,29 @@ const REPAIR_PAGE_PAUSE_MS = 500;
  *  if their passes queue rather than run alongside each other. */
 const serial = createSerialQueue();
 
+/** Cached once the served schema answers. A failed probe is not cached, so a
+ *  hiccup at startup does not park the migration for the session. */
+let guardSupport: Promise<boolean> | null = null;
+
+/** Whether this backend enforces the conditional title patch.
+ *
+ *  Probing by sending one is not an option: an older backend would apply the
+ *  write, which is the harm being checked for. The served schema says so
+ *  without touching anything. Anything unreadable reads as unsupported. */
+function backendEnforcesTitleGuard(): Promise<boolean> {
+  guardSupport ??= (async () => {
+    try {
+      const response = await authFetch("/openapi.json");
+      if (!response.ok) return false;
+      return schemaDeclaresExpectedTitle(await response.json());
+    } catch {
+      guardSupport = null;
+      return false;
+    }
+  })();
+  return guardSupport;
+}
+
 /** Rewrite titles stored pre-cut at 48 chars so they grow with the sidebar
  *  again. */
 export function repairLegacyChatTitles(
@@ -40,6 +65,10 @@ export function repairLegacyChatTitles(
 }
 
 async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
+  // Nothing is claimed or marked until the guard is known to be enforced: a
+  // rewrite that can silently beat a rename is not worth a tidier title.
+  if (!(await backendEnforcesTitleGuard())) return 0;
+
   const { candidates, rest, hasMore } = selectLegacyRepairPage(
     threads,
     attempted,

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -3,42 +3,71 @@
 
 import { batchListChatMessages } from "../api/chat-api";
 import type { ThreadRecord } from "../types";
-import { updateStoredChatThread } from "./chat-history-storage";
+import {
+  listStoredChatThreads,
+  updateStoredChatThread,
+} from "./chat-history-storage";
 import {
   couldBeLegacyClippedTitle,
   planLegacyTitleRepairs,
 } from "./chat-title";
+import { runWithConcurrency } from "./run-with-concurrency";
 
 /** Threads already tried. A repaired title stops matching anyway; this keeps
  *  the ones that could not be rewritten off every later refresh. */
 const attempted = new Set<string>();
+
+/** Rows per pass, so a long history drains over a few refreshes instead of
+ *  putting its whole backlog on the backend at once. */
+const REPAIR_PER_PASS = 100;
+
+/** Writes in flight. Each PATCH is a synchronous SQLite call server side. */
+const REPAIR_CONCURRENCY = 4;
 
 /** Rewrite titles stored pre-cut at 48 chars so they grow with the sidebar
  *  again. Takes whichever threads the caller just loaded. */
 export async function repairLegacyChatTitles(
   threads: ThreadRecord[],
 ): Promise<number> {
-  const candidates = threads.filter(
-    (thread) =>
-      couldBeLegacyClippedTitle(thread.title) && !attempted.has(thread.id),
-  );
-  if (candidates.length === 0) return 0;
-  for (const thread of candidates) attempted.add(thread.id);
+  const ids = threads
+    .filter(
+      (thread) =>
+        couldBeLegacyClippedTitle(thread.title) && !attempted.has(thread.id),
+    )
+    .map((thread) => thread.id)
+    .slice(0, REPAIR_PER_PASS);
+  if (ids.length === 0) return 0;
+  for (const id of ids) attempted.add(id);
 
-  // One batched call, not one per row.
-  const messagesByThreadId = await batchListChatMessages(
-    candidates.map((thread) => thread.id),
-  ).catch(() => null);
-  if (!messagesByThreadId) return 0;
+  let repairs: ReturnType<typeof planLegacyTitleRepairs>;
+  try {
+    // One batched call, not one per row.
+    const messagesByThreadId = await batchListChatMessages(ids);
+    // Read the titles last. The caller's list is a snapshot by now, and a
+    // rename that landed since has to win over the rewrite.
+    const current = await listStoredChatThreads({ includeArchived: true });
+    const byId = new Map(current.map((thread) => [thread.id, thread]));
+    repairs = planLegacyTitleRepairs(
+      ids
+        .map((id) => byId.get(id))
+        .filter((thread): thread is ThreadRecord => thread !== undefined),
+      messagesByThreadId,
+    );
+  } catch {
+    // Nothing was decided, so let a later refresh try these again.
+    for (const id of ids) attempted.delete(id);
+    return 0;
+  }
 
-  const repairs = planLegacyTitleRepairs(candidates, messagesByThreadId);
+  let repaired = 0;
   // A title patch leaves updatedAt alone, so Recents keeps its order.
-  const results = await Promise.all(
-    repairs.map((repair) =>
-      updateStoredChatThread(repair.threadId, { title: repair.title })
-        .then(() => true)
-        .catch(() => false),
-    ),
-  );
-  return results.filter(Boolean).length;
+  await runWithConcurrency(repairs, REPAIR_CONCURRENCY, async (repair) => {
+    try {
+      await updateStoredChatThread(repair.threadId, { title: repair.title });
+      repaired += 1;
+    } catch {
+      attempted.delete(repair.threadId);
+    }
+  });
+  return repaired;
 }

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -34,7 +34,7 @@ export async function repairLegacyChatTitles(
   threads: ThreadRecord[],
   known?: Map<string, MessageRecord[]>,
 ): Promise<number> {
-  const { candidates, hasMore } = selectLegacyRepairPage(
+  const { candidates, rest, hasMore } = selectLegacyRepairPage(
     threads,
     attempted,
     REPAIR_PER_PASS,
@@ -64,6 +64,11 @@ export async function repairLegacyChatTitles(
     return 0;
   }
 
+  // Nothing found anywhere reads as an incomplete answer, not an empty chat:
+  // a clipped title means there was an opening message once. Leave those rows
+  // for a later refresh rather than writing them off for the session.
+  for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);
+
   const repairs = planLegacyTitleRepairs(candidates, messages);
   let repaired = 0;
   await runWithConcurrency(repairs, REPAIR_CONCURRENCY, async (repair) => {
@@ -83,10 +88,11 @@ export async function repairLegacyChatTitles(
   });
 
   // A page that wrote nothing fires no history update, so the next page has to
-  // be scheduled here rather than left waiting on an unrelated refresh.
+  // be scheduled here rather than left waiting on an unrelated refresh. It runs
+  // on `rest`, so rows this page unmarked cannot be drawn again by this drain.
   if (hasMore) {
     setTimeout(() => {
-      void repairLegacyChatTitles(threads, known).catch(() => undefined);
+      void repairLegacyChatTitles(rest, known).catch(() => undefined);
     }, REPAIR_PAGE_PAUSE_MS);
   }
   return repaired;

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -31,18 +31,14 @@ const REPAIR_PAGE_PAUSE_MS = 500;
 const serial = createSerialQueue();
 
 /** Rewrite titles stored pre-cut at 48 chars so they grow with the sidebar
- *  again. `known` is the caller's own message map, when it already has one. */
+ *  again. */
 export function repairLegacyChatTitles(
   threads: ThreadRecord[],
-  known?: Map<string, MessageRecord[]>,
 ): Promise<number> {
-  return serial(() => runRepairPass(threads, known));
+  return serial(() => runRepairPass(threads));
 }
 
-async function runRepairPass(
-  threads: ThreadRecord[],
-  known?: Map<string, MessageRecord[]>,
-): Promise<number> {
+async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
   const { candidates, rest, hasMore } = selectLegacyRepairPage(
     threads,
     attempted,
@@ -54,17 +50,19 @@ async function runRepairPass(
 
   let messages: Map<string, MessageRecord[]>;
   try {
-    // One batched call, and none at all when the caller already fetched them.
-    messages = known ? known : await batchListChatMessages(ids);
+    // Read here, not from a map the caller fetched earlier: the backend's own
+    // view, taken as late as possible, is what the rewrite has to be based on.
+    // One batched call for the page.
+    messages = await batchListChatMessages(ids);
   } catch {
     // Nothing was decided, so let a later refresh try these again.
     for (const id of ids) attempted.delete(id);
     return 0;
   }
 
-  // Stored messages are the only source here. Dexie holds rows the backend has
-  // pruned, since deleting a message never clears them, so reading it could put
-  // a deleted prompt back into a title. A chat whose messages have not been
+  // Backend messages only. Dexie keeps rows the backend has pruned, since
+  // deleting a message never clears them, so anything that merges the two could
+  // put a deleted prompt back into a title. A chat whose messages have not been
   // imported yet reads as unknown below and is retried once they land.
   const repairs = planLegacyTitleRepairs(candidates, messages);
 
@@ -95,7 +93,7 @@ async function runRepairPass(
   // on `rest`, so rows this page unmarked cannot be drawn again by this drain.
   if (hasMore) {
     setTimeout(() => {
-      void repairLegacyChatTitles(rest, known).catch(() => undefined);
+      void repairLegacyChatTitles(rest).catch(() => undefined);
     }, REPAIR_PAGE_PAUSE_MS);
   }
   return repaired;

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { batchListChatMessages } from "../api/chat-api";
+import type { ThreadRecord } from "../types";
+import { updateStoredChatThread } from "./chat-history-storage";
+import {
+  couldBeLegacyClippedTitle,
+  planLegacyTitleRepairs,
+} from "./chat-title";
+
+/** Threads already tried. A repaired title stops matching anyway; this keeps
+ *  the ones that could not be rewritten off every later refresh. */
+const attempted = new Set<string>();
+
+/** Rewrite titles stored pre-cut at 48 chars so they grow with the sidebar
+ *  again. Takes whichever threads the caller just loaded. */
+export async function repairLegacyChatTitles(
+  threads: ThreadRecord[],
+): Promise<number> {
+  const candidates = threads.filter(
+    (thread) =>
+      couldBeLegacyClippedTitle(thread.title) && !attempted.has(thread.id),
+  );
+  if (candidates.length === 0) return 0;
+  for (const thread of candidates) attempted.add(thread.id);
+
+  // One batched call, not one per row.
+  const messagesByThreadId = await batchListChatMessages(
+    candidates.map((thread) => thread.id),
+  ).catch(() => null);
+  if (!messagesByThreadId) return 0;
+
+  const repairs = planLegacyTitleRepairs(candidates, messagesByThreadId);
+  // A title patch leaves updatedAt alone, so Recents keeps its order.
+  const results = await Promise.all(
+    repairs.map((repair) =>
+      updateStoredChatThread(repair.threadId, { title: repair.title })
+        .then(() => true)
+        .catch(() => false),
+    ),
+  );
+  return results.filter(Boolean).length;
+}

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -125,13 +125,17 @@ async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
   let repaired = 0;
   await runWithConcurrency(live, REPAIR_CONCURRENCY, async (repair) => {
     try {
-      // expectedTitle makes this atomic where the backend enforces it: a
-      // rename landing now answers 409 and keeps the user's title. A title
+      // Both guards make this atomic where the backend enforces them: a
+      // rename or a deleted opening prompt landing now answers 409, so the
+      // user's title stays and no deleted text is expanded into one. A title
       // patch leaves updatedAt alone, so Recents keeps its order.
       await updateStoredChatThread(
         repair.threadId,
         { title: repair.title },
-        { expectedTitle: repair.previousTitle },
+        {
+          expectedTitle: repair.previousTitle,
+          expectedOpeningMessageId: repair.openingMessageId,
+        },
       );
       repaired += 1;
     } catch {

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -4,7 +4,7 @@
 import { batchListChatMessages } from "../api/chat-api";
 import type { MessageRecord, ThreadRecord } from "../types";
 import {
-  listLegacyChatMessages,
+  listUnimportedChatMessages,
   updateStoredChatThread,
 } from "./chat-history-storage";
 import {
@@ -15,6 +15,7 @@ import {
   threadsWithoutRepairs,
 } from "./chat-title";
 import { runWithConcurrency } from "./run-with-concurrency";
+import { createSerialQueue } from "./serial-queue";
 
 /** Threads already tried. A repaired title stops matching anyway; this keeps
  *  the ones that could not be rewritten off every later refresh. */
@@ -30,9 +31,20 @@ const REPAIR_CONCURRENCY = 4;
 /** Breather between pages. */
 const REPAIR_PAGE_PAUSE_MS = 500;
 
+/** Several sidebars can be mounted at once, so REPAIR_CONCURRENCY only holds
+ *  if their passes queue rather than run alongside each other. */
+const serial = createSerialQueue();
+
 /** Rewrite titles stored pre-cut at 48 chars so they grow with the sidebar
  *  again. `known` is the caller's own message map, when it already has one. */
-export async function repairLegacyChatTitles(
+export function repairLegacyChatTitles(
+  threads: ThreadRecord[],
+  known?: Map<string, MessageRecord[]>,
+): Promise<number> {
+  return serial(() => runRepairPass(threads, known));
+}
+
+async function runRepairPass(
   threads: ThreadRecord[],
   known?: Map<string, MessageRecord[]>,
 ): Promise<number> {
@@ -61,9 +73,14 @@ export async function repairLegacyChatTitles(
     const unexplained = threadsWithoutRepairs(candidates, repairs);
     if (unexplained.length > 0) {
       await runWithConcurrency(unexplained, REPAIR_CONCURRENCY, async (id) => {
-        const local = await listLegacyChatMessages(id);
+        const backend = messages.get(id) ?? [];
+        // A read that fails leaves this row unexplained. The page still writes
+        // what it planned and still moves on to the rest.
+        const local = await listUnimportedChatMessages(id, backend.length).catch(
+          () => [],
+        );
         if (local.length === 0) return;
-        messages.set(id, mergeMessagesById(messages.get(id) ?? [], local));
+        messages.set(id, mergeMessagesById(backend, local));
       });
       repairs = planLegacyTitleRepairs(candidates, messages);
     }

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -18,12 +18,11 @@ import { type GuardProbe, readGuardProbe } from "./openapi-support";
 import { runWithConcurrency } from "./run-with-concurrency";
 import { createSerialQueue } from "./serial-queue";
 
-/** Threads already tried. A repaired title stops matching anyway; this keeps
- *  the ones that could not be rewritten off every later refresh. */
+/** Threads already tried, so ones that could not be rewritten stay off every
+ *  later refresh. */
 const attempted = new Set<string>();
 
-/** Rows per pass, so a long history drains in pages instead of putting its
- *  whole backlog on the backend at once. */
+/** Rows per pass, so a long history drains in pages. */
 const REPAIR_PER_PASS = 100;
 
 /** Writes in flight. Each PATCH is a synchronous SQLite call server side. */
@@ -32,19 +31,17 @@ const REPAIR_CONCURRENCY = 4;
 /** Breather between pages. */
 const REPAIR_PAGE_PAUSE_MS = 500;
 
-/** Several sidebars can be mounted at once, so REPAIR_CONCURRENCY only holds
- *  if their passes queue rather than run alongside each other. */
+/** Several sidebars can be mounted at once, so REPAIR_CONCURRENCY only holds if
+ *  their passes queue rather than overlap. */
 const serial = createSerialQueue();
 
 /** Cached once the served schema answers. A failed probe is not cached, so a
- *  hiccup at startup does not park the migration for the session. */
+ *  startup hiccup does not park the migration for the session. */
 let guardSupport: Promise<boolean> | null = null;
 
-/** Whether this backend enforces the conditional title patch.
- *
- *  Probing by sending one is not an option: an older backend would apply the
- *  write, which is the harm being checked for. The served schema says so
- *  without touching anything. Anything unreadable reads as unsupported. */
+/** Whether this backend enforces the conditional title patch. Probing by
+ *  sending one would let an older backend apply the write, the very harm being
+ *  checked for, so the served schema answers; anything unreadable is a no. */
 function backendEnforcesTitleGuard(): Promise<boolean> {
   guardSupport ??= (async () => {
     let probe: GuardProbe = { supported: false, settled: false };
@@ -64,8 +61,7 @@ function backendEnforcesTitleGuard(): Promise<boolean> {
   return guardSupport;
 }
 
-/** Rewrite titles stored pre-cut at 48 chars so they grow with the sidebar
- *  again. */
+/** Rewrite titles stored pre-cut at 48 chars so they grow with the sidebar. */
 export function repairLegacyChatTitles(
   threads: ThreadRecord[],
 ): Promise<number> {
@@ -73,8 +69,8 @@ export function repairLegacyChatTitles(
 }
 
 async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
-  // Nothing is claimed or marked until the guard is known to be enforced: a
-  // rewrite that can silently beat a rename is not worth a tidier title.
+  // Claim nothing until the guard is known: a rewrite that can silently beat a
+  // rename is not worth a tidier title.
   if (!(await backendEnforcesTitleGuard())) return 0;
 
   const { candidates, rest, hasMore } = selectLegacyRepairPage(
@@ -88,9 +84,8 @@ async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
 
   let messages: Map<string, MessageRecord[]>;
   try {
-    // Read here, not from a map the caller fetched earlier: the backend's own
-    // view, taken as late as possible, is what the rewrite has to be based on.
-    // One batched call for the page.
+    // Not the caller's earlier map: the backend's own view, taken as late as
+    // possible, is what the rewrite has to be based on. One batched call.
     messages = await batchListChatMessages(ids);
   } catch {
     // Nothing was decided, so let a later refresh try these again.
@@ -98,15 +93,13 @@ async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
     return 0;
   }
 
-  // Backend messages only. Dexie keeps rows the backend has pruned, since
-  // deleting a message never clears them, so anything that merges the two could
-  // put a deleted prompt back into a title. A chat whose messages have not been
-  // imported yet reads as unknown below and is retried once they land.
+  // Backend messages only: Dexie keeps rows the backend has pruned, so merging
+  // the two could put a deleted prompt back into a title. A chat not imported
+  // yet reads as unknown below and is retried once its messages land.
   const repairs = planLegacyTitleRepairs(candidates, messages);
 
-  // A chat with nothing stored is either mid-import, so worth another pass, or
-  // one the user emptied, which no pass can change. The ledger tells them
-  // apart, and is only worth fetching when there is something to decide.
+  // Nothing stored means either mid-import or emptied by the user; the ledger
+  // tells them apart, and is only fetched when there is something to decide.
   const withoutMessages = threadsMissingMessages(ids, messages);
   if (withoutMessages.length > 0) {
     let imported = new Set<string>();
@@ -124,14 +117,11 @@ async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
   await runWithConcurrency(repairs, REPAIR_CONCURRENCY, async (repair) => {
     try {
       // The backend PATCH directly, not updateStoredChatThread: that ensures
-      // the thread first, which re-imports one deleted on another client from
-      // the Dexie rows still sitting here. A migration must never create
-      // anything, so a missing thread has to stay missing and 404.
-      //
-      // Both guards make this atomic: a rename or a deleted opening prompt
-      // landing now answers 409, so the user's title stays and no deleted text
-      // is expanded into one. A title patch leaves updatedAt alone, so Recents
-      // keeps its order.
+      // the thread first, re-importing one deleted on another client from the
+      // Dexie rows still here, and a migration must never create anything.
+      // Both guards answer 409 if a rename or a delete of the opening prompt
+      // lands first, and a title patch leaves updatedAt alone, so Recents keeps
+      // its order.
       await updateChatThread(
         repair.threadId,
         { title: repair.title },
@@ -146,9 +136,8 @@ async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
     }
   });
 
-  // A page that wrote nothing fires no history update, so the next page has to
-  // be scheduled here rather than left waiting on an unrelated refresh. It runs
-  // on `rest`, so rows this page unmarked cannot be drawn again by this drain.
+  // A page that wrote nothing fires no history update, so schedule the next one
+  // here. It runs on `rest`, so rows this page unmarked are not drawn again.
   if (hasMore) {
     setTimeout(() => {
       void repairLegacyChatTitles(rest).catch(() => undefined);

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -8,9 +8,11 @@ import {
   updateStoredChatThread,
 } from "./chat-history-storage";
 import {
+  mergeMessagesById,
   planLegacyTitleRepairs,
   selectLegacyRepairPage,
   threadsMissingMessages,
+  threadsWithoutRepairs,
 } from "./chat-title";
 import { runWithConcurrency } from "./run-with-concurrency";
 
@@ -44,32 +46,37 @@ export async function repairLegacyChatTitles(
   for (const id of ids) attempted.add(id);
 
   let messages: Map<string, MessageRecord[]>;
+  let repairs: ReturnType<typeof planLegacyTitleRepairs>;
   try {
     // One batched call, and none at all when the caller already fetched them.
     messages = known
       ? new Map(known)
       : await batchListChatMessages(ids);
-    // A chat still only in Dexie (legacy import pending or failed) reads empty
-    // from the backend, so look locally before writing it off.
-    await runWithConcurrency(
-      threadsMissingMessages(ids, messages),
-      REPAIR_CONCURRENCY,
-      async (id) => {
-        messages.set(id, await listLegacyChatMessages(id));
-      },
-    );
+    repairs = planLegacyTitleRepairs(candidates, messages);
+
+    // A row nothing could be made of may just be missing its opening message
+    // here: a legacy chat can sit in Dexie entirely, or hold its first turn
+    // there while later ones have already been imported. Look locally before
+    // writing any of them off.
+    const unexplained = threadsWithoutRepairs(candidates, repairs);
+    if (unexplained.length > 0) {
+      await runWithConcurrency(unexplained, REPAIR_CONCURRENCY, async (id) => {
+        const local = await listLegacyChatMessages(id);
+        if (local.length === 0) return;
+        messages.set(id, mergeMessagesById(messages.get(id) ?? [], local));
+      });
+      repairs = planLegacyTitleRepairs(candidates, messages);
+    }
   } catch {
     // Nothing was decided, so let a later refresh try these again.
     for (const id of ids) attempted.delete(id);
     return 0;
   }
 
-  // Nothing found anywhere reads as an incomplete answer, not an empty chat:
-  // a clipped title means there was an opening message once. Leave those rows
-  // for a later refresh rather than writing them off for the session.
+  // Nothing known at all reads as an incomplete answer, not an empty chat: a
+  // clipped title means there was an opening message once. Leave those rows for
+  // a later refresh rather than writing them off for the session.
   for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);
-
-  const repairs = planLegacyTitleRepairs(candidates, messages);
   let repaired = 0;
   await runWithConcurrency(repairs, REPAIR_CONCURRENCY, async (repair) => {
     try {

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { batchListChatMessages } from "../api/chat-api";
+import { batchListChatMessages, listChatThreads } from "../api/chat-api";
 import type { MessageRecord, ThreadRecord } from "../types";
 import { updateStoredChatThread } from "./chat-history-storage";
 import {
   planLegacyTitleRepairs,
+  repairsStillValid,
   selectLegacyRepairPage,
   threadsMissingMessages,
 } from "./chat-title";
@@ -71,12 +72,28 @@ async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
   // a later refresh rather than writing them off for the session.
   for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);
 
+  // expectedTitle is only enforced by a backend that knows the field. The
+  // desktop app ships its own frontend and can meet an older one, which would
+  // apply the write regardless, so confirm the titles here too. One call for
+  // the page, taken last, so a rename is respected either way.
+  let live: ReturnType<typeof repairsStillValid>;
+  try {
+    const current = await listChatThreads({ includeArchived: true });
+    live = repairsStillValid(
+      repairs,
+      new Map(current.map((thread) => [thread.id, thread.title])),
+    );
+  } catch {
+    for (const id of ids) attempted.delete(id);
+    return 0;
+  }
+
   let repaired = 0;
-  await runWithConcurrency(repairs, REPAIR_CONCURRENCY, async (repair) => {
+  await runWithConcurrency(live, REPAIR_CONCURRENCY, async (repair) => {
     try {
-      // expectedTitle guards the write: a rename that landed since this list
-      // was read answers 409 and keeps the user's title. A title patch leaves
-      // updatedAt alone, so Recents keeps its order.
+      // expectedTitle makes this atomic where the backend enforces it: a
+      // rename landing now answers 409 and keeps the user's title. A title
+      // patch leaves updatedAt alone, so Recents keeps its order.
       await updateStoredChatThread(
         repair.threadId,
         { title: repair.title },

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -3,10 +3,7 @@
 
 import { batchListChatMessages } from "../api/chat-api";
 import type { ThreadRecord } from "../types";
-import {
-  listStoredChatThreads,
-  updateStoredChatThread,
-} from "./chat-history-storage";
+import { updateStoredChatThread } from "./chat-history-storage";
 import {
   couldBeLegacyClippedTitle,
   planLegacyTitleRepairs,
@@ -29,30 +26,21 @@ const REPAIR_CONCURRENCY = 4;
 export async function repairLegacyChatTitles(
   threads: ThreadRecord[],
 ): Promise<number> {
-  const ids = threads
+  const candidates = threads
     .filter(
       (thread) =>
         couldBeLegacyClippedTitle(thread.title) && !attempted.has(thread.id),
     )
-    .map((thread) => thread.id)
     .slice(0, REPAIR_PER_PASS);
-  if (ids.length === 0) return 0;
+  if (candidates.length === 0) return 0;
+  const ids = candidates.map((thread) => thread.id);
   for (const id of ids) attempted.add(id);
 
   let repairs: ReturnType<typeof planLegacyTitleRepairs>;
   try {
     // One batched call, not one per row.
     const messagesByThreadId = await batchListChatMessages(ids);
-    // Read the titles last. The caller's list is a snapshot by now, and a
-    // rename that landed since has to win over the rewrite.
-    const current = await listStoredChatThreads({ includeArchived: true });
-    const byId = new Map(current.map((thread) => [thread.id, thread]));
-    repairs = planLegacyTitleRepairs(
-      ids
-        .map((id) => byId.get(id))
-        .filter((thread): thread is ThreadRecord => thread !== undefined),
-      messagesByThreadId,
-    );
+    repairs = planLegacyTitleRepairs(candidates, messagesByThreadId);
   } catch {
     // Nothing was decided, so let a later refresh try these again.
     for (const id of ids) attempted.delete(id);
@@ -60,10 +48,16 @@ export async function repairLegacyChatTitles(
   }
 
   let repaired = 0;
-  // A title patch leaves updatedAt alone, so Recents keeps its order.
   await runWithConcurrency(repairs, REPAIR_CONCURRENCY, async (repair) => {
     try {
-      await updateStoredChatThread(repair.threadId, { title: repair.title });
+      // expectedTitle guards the write: a rename that landed since this list
+      // was read answers 409 and keeps the user's title. A title patch leaves
+      // updatedAt alone, so Recents keeps its order.
+      await updateStoredChatThread(
+        repair.threadId,
+        { title: repair.title },
+        { expectedTitle: repair.previousTitle },
+      );
       repaired += 1;
     } catch {
       attempted.delete(repair.threadId);

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -3,16 +3,11 @@
 
 import { batchListChatMessages } from "../api/chat-api";
 import type { MessageRecord, ThreadRecord } from "../types";
+import { updateStoredChatThread } from "./chat-history-storage";
 import {
-  listUnimportedChatMessages,
-  updateStoredChatThread,
-} from "./chat-history-storage";
-import {
-  mergeMessagesById,
   planLegacyTitleRepairs,
   selectLegacyRepairPage,
   threadsMissingMessages,
-  threadsWithoutRepairs,
 } from "./chat-title";
 import { runWithConcurrency } from "./run-with-concurrency";
 import { createSerialQueue } from "./serial-queue";
@@ -58,42 +53,26 @@ async function runRepairPass(
   for (const id of ids) attempted.add(id);
 
   let messages: Map<string, MessageRecord[]>;
-  let repairs: ReturnType<typeof planLegacyTitleRepairs>;
   try {
     // One batched call, and none at all when the caller already fetched them.
-    messages = known
-      ? new Map(known)
-      : await batchListChatMessages(ids);
-    repairs = planLegacyTitleRepairs(candidates, messages);
-
-    // A row nothing could be made of may just be missing its opening message
-    // here: a legacy chat can sit in Dexie entirely, or hold its first turn
-    // there while later ones have already been imported. Look locally before
-    // writing any of them off.
-    const unexplained = threadsWithoutRepairs(candidates, repairs);
-    if (unexplained.length > 0) {
-      await runWithConcurrency(unexplained, REPAIR_CONCURRENCY, async (id) => {
-        const backend = messages.get(id) ?? [];
-        // A read that fails leaves this row unexplained. The page still writes
-        // what it planned and still moves on to the rest.
-        const local = await listUnimportedChatMessages(id, backend.length).catch(
-          () => [],
-        );
-        if (local.length === 0) return;
-        messages.set(id, mergeMessagesById(backend, local));
-      });
-      repairs = planLegacyTitleRepairs(candidates, messages);
-    }
+    messages = known ? known : await batchListChatMessages(ids);
   } catch {
     // Nothing was decided, so let a later refresh try these again.
     for (const id of ids) attempted.delete(id);
     return 0;
   }
 
+  // Stored messages are the only source here. Dexie holds rows the backend has
+  // pruned, since deleting a message never clears them, so reading it could put
+  // a deleted prompt back into a title. A chat whose messages have not been
+  // imported yet reads as unknown below and is retried once they land.
+  const repairs = planLegacyTitleRepairs(candidates, messages);
+
   // Nothing known at all reads as an incomplete answer, not an empty chat: a
   // clipped title means there was an opening message once. Leave those rows for
   // a later refresh rather than writing them off for the session.
   for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);
+
   let repaired = 0;
   await runWithConcurrency(repairs, REPAIR_CONCURRENCY, async (repair) => {
     try {

--- a/studio/frontend/src/features/chat/utils/run-with-concurrency.ts
+++ b/studio/frontend/src/features/chat/utils/run-with-concurrency.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** Run `task` over `items`, at most `limit` at a time, in order. */
+export async function runWithConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T) => Promise<void>,
+): Promise<void> {
+  const lanes = Math.max(1, Math.min(limit, items.length));
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: lanes }, async () => {
+      while (next < items.length) {
+        const item = items[next];
+        next += 1;
+        await task(item as T);
+      }
+    }),
+  );
+}

--- a/studio/frontend/src/features/chat/utils/serial-queue.ts
+++ b/studio/frontend/src/features/chat/utils/serial-queue.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** One task at a time, in call order. A rejected task does not block the next. */
+export function createSerialQueue() {
+  let tail: Promise<unknown> = Promise.resolve();
+  return function run<T>(task: () => Promise<T>): Promise<T> {
+    const next = tail.then(task, task);
+    tail = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  };
+}

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -8,9 +8,11 @@ import type {
 import {
   fallbackTitleFromUserText,
   isLegacyClippedTitle,
+  mergeMessagesById,
   planLegacyTitleRepairs,
   selectLegacyRepairPage,
   threadsMissingMessages,
+  threadsWithoutRepairs,
 } from "../src/features/chat/utils/chat-title.ts";
 
 const LONG =
@@ -176,4 +178,47 @@ test("a thread the backend has nothing for still gets a local read", () => {
     "b",
     "c",
   ]);
+});
+
+test("a part-imported chat is spotted and planned from both sources", () => {
+  // The backend holds a later turn, so the row does not read as empty and the
+  // clipped title cannot be explained from it alone.
+  const legacy = LONG.slice(0, 48) + "...";
+  const candidates = [thread("a", legacy)];
+  const remote: MessageRecord = {
+    ...userMessage("a", "a later question entirely"),
+    id: "a-m9",
+    createdAt: 99,
+  };
+  const local: MessageRecord = {
+    ...userMessage("a", LONG),
+    id: "a-m1",
+    createdAt: 1,
+  };
+
+  const messages = new Map<string, MessageRecord[]>([["a", [remote]]]);
+  const first = planLegacyTitleRepairs(candidates, messages);
+  assert.deepEqual(first, []);
+  // Not empty, so the old empty-only check would never have looked locally.
+  assert.deepEqual(threadsMissingMessages(["a"], messages), []);
+  assert.deepEqual(threadsWithoutRepairs(candidates, first), ["a"]);
+
+  messages.set("a", mergeMessagesById(messages.get("a") ?? [], [local]));
+  assert.deepEqual(planLegacyTitleRepairs(candidates, messages), [
+    { threadId: "a", previousTitle: legacy, title: LONG },
+  ]);
+});
+
+test("merging keeps one copy of a message both sources hold", () => {
+  const shared = userMessage("a", LONG);
+  const other: MessageRecord = {
+    ...userMessage("a", "next"),
+    id: "a-m2",
+    createdAt: 2,
+  };
+  const merged = mergeMessagesById([shared], [shared, other]);
+  assert.deepEqual(
+    merged.map((m) => m.id),
+    ["a-m1", "a-m2"],
+  );
 });

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -9,6 +9,7 @@ import {
   fallbackTitleFromUserText,
   isLegacyClippedTitle,
   planLegacyTitleRepairs,
+  repairsStillValid,
   selectLegacyRepairPage,
   threadsMissingMessages,
 } from "../src/features/chat/utils/chat-title.ts";
@@ -195,4 +196,26 @@ test("a chat with nothing stored is left for a later refresh", () => {
   assert.deepEqual(planLegacyTitleRepairs(candidates, messages), [
     { threadId: "a", previousTitle: legacy, title: LONG },
   ]);
+});
+
+test("a rename drops the rewrite even where the guard is not enforced", () => {
+  // The desktop app can meet an older backend, which ignores expectedTitle and
+  // would apply the write. This check is what stops it there.
+  const legacy = LONG.slice(0, 48) + "...";
+  const repairs = [
+    { threadId: "a", previousTitle: legacy, title: LONG },
+    { threadId: "b", previousTitle: legacy, title: LONG },
+    { threadId: "c", previousTitle: legacy, title: LONG },
+  ];
+  const current = new Map([
+    ["a", legacy],
+    // Renamed since the page was planned.
+    ["b", "what the user typed"],
+    // "c" is missing: the thread is gone.
+  ]);
+
+  assert.deepEqual(
+    repairsStillValid(repairs, current).map((r) => r.threadId),
+    ["a"],
+  );
 });

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  MessageRecord,
+  ThreadRecord,
+} from "../src/features/chat/types.ts";
+import {
+  fallbackTitleFromUserText,
+  isLegacyClippedTitle,
+  planLegacyTitleRepairs,
+} from "../src/features/chat/utils/chat-title.ts";
+
+const LONG =
+  "Can you plot a Mandelbrot set and explain how the escape time algorithm works";
+
+function thread(id: string, title: string): ThreadRecord {
+  return { id, title, createdAt: 1, updatedAt: 1 } as ThreadRecord;
+}
+
+function userMessage(threadId: string, text: string): MessageRecord {
+  return {
+    id: `${threadId}-m1`,
+    threadId,
+    role: "user",
+    content: [{ type: "text", text }],
+    createdAt: 1,
+  } as MessageRecord;
+}
+
+test("a title the sidebar can clip keeps the whole first line", () => {
+  assert.equal(fallbackTitleFromUserText(LONG), LONG);
+  assert.equal(fallbackTitleFromUserText("  spaced   out  "), "spaced out");
+  assert.equal(fallbackTitleFromUserText("first\nsecond"), "first");
+  assert.equal(fallbackTitleFromUserText("   "), "New Chat");
+});
+
+test("only a pasted wall of text is cut, and with a real ellipsis", () => {
+  const wall = "x".repeat(200);
+  const title = fallbackTitleFromUserText(wall);
+  assert.equal(title.length, 121);
+  assert.ok(title.endsWith("…"));
+  assert.ok(!title.includes("..."));
+});
+
+test("a legacy title is recognised only against the text it was cut from", () => {
+  const legacy = LONG.slice(0, 48) + "...";
+  assert.equal(isLegacyClippedTitle(legacy, LONG), true);
+  assert.equal(
+    isLegacyClippedTitle(legacy, "a different first message"),
+    false,
+  );
+  // A rename that merely ends in "..." is left alone.
+  assert.equal(isLegacyClippedTitle("Wait for it...", LONG), false);
+  assert.equal(isLegacyClippedTitle(LONG, LONG), false);
+});
+
+test("repair rewrites legacy rows and leaves every other row untouched", () => {
+  const legacy = LONG.slice(0, 48) + "...";
+  const threads = [
+    thread("a", legacy),
+    thread("b", "Mandelbrot escape time"),
+    thread("c", legacy),
+  ];
+  const messages = new Map<string, MessageRecord[]>([
+    ["a", [userMessage("a", LONG)]],
+    ["b", [userMessage("b", LONG)]],
+    // No stored messages: nothing to rewrite the title from.
+    ["c", []],
+  ]);
+
+  assert.deepEqual(planLegacyTitleRepairs(threads, messages), [
+    { threadId: "a", title: LONG },
+  ]);
+});

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -31,6 +31,10 @@ function userMessage(threadId: string, text: string): MessageRecord {
   } as MessageRecord;
 }
 
+/** A high surrogate with no low after it, or a low with no high before it. */
+const UNPAIRED_SURROGATE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
 test("a title the sidebar can clip keeps the whole first line", () => {
   assert.equal(fallbackTitleFromUserText(LONG), LONG);
   assert.equal(fallbackTitleFromUserText("  spaced   out  "), "spaced out");
@@ -41,23 +45,37 @@ test("a title the sidebar can clip keeps the whole first line", () => {
 test("only a pasted wall of text is cut, and with a real ellipsis", () => {
   const wall = "x".repeat(200);
   const title = fallbackTitleFromUserText(wall);
-  assert.equal(title.length, 121);
+  // 120 UTF-16 units all in, the ellipsis included, which is what the rename
+  // input accepts. A longer one cannot be edited until a character is deleted.
+  assert.equal(title.length, 120);
   assert.ok(title.endsWith("…"));
   assert.ok(!title.includes("..."));
 });
 
-/** A high surrogate with no low after it, or a low with no high before it. */
-const UNPAIRED_SURROGATE =
-  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+test("an emoji wall is capped by the same budget the input counts", () => {
+  // maxLength counts UTF-16 units, so 120 astral code points would be 240.
+  const title = fallbackTitleFromUserText("\u{1F600}".repeat(200));
+  assert.ok(title.length <= 120);
+  assert.equal(UNPAIRED_SURROGATE.test(title), false);
+  assert.ok(title.endsWith("…"));
+});
+
+test("a line already inside the budget is stored whole", () => {
+  const exact = "y".repeat(120);
+  assert.equal(fallbackTitleFromUserText(exact), exact);
+});
 
 test("the cap never splits an emoji into a lone surrogate", () => {
   // A lone surrogate survives JSON.stringify but fails the backend's SQLite
   // bind, so the title write would 500.
   const line = "x".repeat(119) + "\u{1F600} tail";
+  // A raw cut at the budget lands mid-pair.
   assert.equal(UNPAIRED_SURROGATE.test(line.slice(0, 120)), true);
   const title = fallbackTitleFromUserText(line);
   assert.equal(UNPAIRED_SURROGATE.test(title), false);
-  assert.equal(title, "x".repeat(119) + "\u{1F600}" + "…");
+  // The emoji needs two units and only one is left, so it is left out whole.
+  assert.equal(title, "x".repeat(119) + "…");
+  assert.equal(title.length, 120);
 });
 
 test("a legacy title is recognised only against the text it was cut from", () => {

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -78,6 +78,22 @@ test("the cap never splits an emoji into a lone surrogate", () => {
   assert.equal(title.length, 120);
 });
 
+test("a lone surrogate is dropped even when the line is under the cap", () => {
+  // The cut sanitises what it walks, so only over-cap input used to be safe.
+  // Under the cap the line was stored as it came, and one unpaired surrogate
+  // reaching the backend fails its SQLite bind and 500s the title write.
+  const line = "x".repeat(60) + "\uD83D";
+  assert.ok(line.length <= 120);
+  assert.equal(UNPAIRED_SURROGATE.test(line), true);
+  const title = fallbackTitleFromUserText(line);
+  assert.equal(UNPAIRED_SURROGATE.test(title), false);
+  assert.equal(title, "x".repeat(60));
+  // A trailing low surrogate with no high before it goes the same way.
+  assert.equal(fallbackTitleFromUserText("hi \uDE00"), "hi");
+  // A valid pair under the cap is untouched.
+  assert.equal(fallbackTitleFromUserText("hi \u{1F600}"), "hi \u{1F600}");
+});
+
 test("a legacy title is recognised only against the text it was cut from", () => {
   const legacy = LONG.slice(0, 48) + "...";
   assert.equal(isLegacyClippedTitle(legacy, LONG), true);

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -245,6 +245,27 @@ test("a chat with nothing stored is left for a later refresh", () => {
   ]);
 });
 
+test("a chat whose opening prompt is gone is decided, not retried forever", () => {
+  // Nothing stored means the import may still land, so those rows are unmarked
+  // and tried again. A chat that does have messages is a complete answer: the
+  // opening prompt was deleted or edited, so no later pass can prove the title.
+  // Unmarking it too would re-select it on every refresh for the session, since
+  // its title stays clipped and keeps matching the pre-filter.
+  const legacy = LONG.slice(0, 48) + "...";
+  const candidates = [thread("a", legacy)];
+  const messages = new Map<string, MessageRecord[]>([
+    ["a", [{ ...userMessage("a", "a different question entirely"), id: "a-m9" }]],
+  ]);
+
+  assert.deepEqual(planLegacyTitleRepairs(candidates, messages), []);
+  assert.deepEqual(threadsMissingMessages(["a"], messages), []);
+  // So it stays marked, and the next page passes over it.
+  assert.deepEqual(
+    selectLegacyRepairPage(candidates, new Set(["a"]), 100).candidates,
+    [],
+  );
+});
+
 test("a rename drops the rewrite even where the guard is not enforced", () => {
   // The desktop app can meet an older backend, which ignores expectedTitle and
   // would apply the write. This check is what stops it there.

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -84,6 +84,6 @@ test("repair rewrites legacy rows and leaves every other row untouched", () => {
   ]);
 
   assert.deepEqual(planLegacyTitleRepairs(threads, messages), [
-    { threadId: "a", title: LONG },
+    { threadId: "a", previousTitle: legacy, title: LONG },
   ]);
 });

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -9,8 +9,8 @@ import {
   fallbackTitleFromUserText,
   isLegacyClippedTitle,
   planLegacyTitleRepairs,
-  repairsStillValid,
   selectLegacyRepairPage,
+  threadsAwaitingImport,
   threadsMissingMessages,
 } from "../src/features/chat/utils/chat-title.ts";
 
@@ -266,24 +266,28 @@ test("a chat whose opening prompt is gone is decided, not retried forever", () =
   );
 });
 
-test("a rename drops the rewrite even where the guard is not enforced", () => {
-  // The desktop app can meet an older backend, which ignores expectedTitle and
-  // would apply the write. This check is what stops it there.
-  const legacy = LONG.slice(0, 48) + "...";
-  const repairs = [
-    { threadId: "a", previousTitle: legacy, openingMessageId: "a-m1", title: LONG },
-    { threadId: "b", previousTitle: legacy, openingMessageId: "b-m1", title: LONG },
-    { threadId: "c", previousTitle: legacy, openingMessageId: "c-m1", title: LONG },
-  ];
-  const current = new Map([
-    ["a", legacy],
-    // Renamed since the page was planned.
-    ["b", "what the user typed"],
-    // "c" is missing: the thread is gone.
+test("an emptied chat is decided, one still importing is not", () => {
+  // Both read back as zero messages. The ledger is what tells them apart: a
+  // thread it knows was imported, so empty is the whole answer, while one it
+  // has never seen may still be on its way.
+  const ids = ["emptied", "importing", "fine"];
+  const messages = new Map<string, MessageRecord[]>([
+    ["emptied", []],
+    ["importing", []],
+    ["fine", [userMessage("fine", LONG)]],
   ]);
 
+  assert.deepEqual(threadsMissingMessages(ids, messages), [
+    "emptied",
+    "importing",
+  ]);
   assert.deepEqual(
-    repairsStillValid(repairs, current).map((r) => r.threadId),
-    ["a"],
+    threadsAwaitingImport(ids, messages, new Set(["emptied"])),
+    ["importing"],
   );
+  // An unreadable ledger decides nothing, so both stay retryable.
+  assert.deepEqual(threadsAwaitingImport(ids, messages, new Set()), [
+    "emptied",
+    "importing",
+  ]);
 });

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -8,12 +8,9 @@ import type {
 import {
   fallbackTitleFromUserText,
   isLegacyClippedTitle,
-  mergeMessagesById,
   planLegacyTitleRepairs,
   selectLegacyRepairPage,
   threadsMissingMessages,
-  threadsWithoutRepairs,
-  trustsLocalOnlyMessages,
 } from "../src/features/chat/utils/chat-title.ts";
 
 const LONG =
@@ -181,56 +178,21 @@ test("a thread the backend has nothing for still gets a local read", () => {
   ]);
 });
 
-test("a part-imported chat is spotted and planned from both sources", () => {
-  // The backend holds a later turn, so the row does not read as empty and the
-  // clipped title cannot be explained from it alone.
+
+
+test("a chat with nothing stored is left for a later refresh", () => {
+  // Its messages may simply not be imported yet. The row is not written off,
+  // and once they land a later pass rewrites the title from them.
   const legacy = LONG.slice(0, 48) + "...";
   const candidates = [thread("a", legacy)];
-  const remote: MessageRecord = {
-    ...userMessage("a", "a later question entirely"),
-    id: "a-m9",
-    createdAt: 99,
-  };
-  const local: MessageRecord = {
-    ...userMessage("a", LONG),
-    id: "a-m1",
-    createdAt: 1,
-  };
+  const messages = new Map<string, MessageRecord[]>();
 
-  const messages = new Map<string, MessageRecord[]>([["a", [remote]]]);
-  const first = planLegacyTitleRepairs(candidates, messages);
-  assert.deepEqual(first, []);
-  // Not empty, so the old empty-only check would never have looked locally.
+  assert.deepEqual(planLegacyTitleRepairs(candidates, messages), []);
+  assert.deepEqual(threadsMissingMessages(["a"], messages), ["a"]);
+
+  messages.set("a", [userMessage("a", LONG)]);
   assert.deepEqual(threadsMissingMessages(["a"], messages), []);
-  assert.deepEqual(threadsWithoutRepairs(candidates, first), ["a"]);
-
-  messages.set("a", mergeMessagesById(messages.get("a") ?? [], [local]));
   assert.deepEqual(planLegacyTitleRepairs(candidates, messages), [
     { threadId: "a", previousTitle: legacy, title: LONG },
   ]);
-});
-
-test("merging keeps one copy of a message both sources hold", () => {
-  const shared = userMessage("a", LONG);
-  const other: MessageRecord = {
-    ...userMessage("a", "next"),
-    id: "a-m2",
-    createdAt: 2,
-  };
-  const merged = mergeMessagesById([shared], [shared, other]);
-  assert.deepEqual(
-    merged.map((m) => m.id),
-    ["a-m1", "a-m2"],
-  );
-});
-
-test("a local-only message is a leftover once the import is done", () => {
-  // Deleting a message prunes the backend and leaves the Dexie copy, so past
-  // the import a local-only row must not be read back as the opening prompt.
-  assert.equal(trustsLocalOnlyMessages(true, 3), false);
-  // Nothing on the backend: nothing has been pruned, so Dexie is all there is.
-  assert.equal(trustsLocalOnlyMessages(true, 0), true);
-  // Import unfinished: the backend's view is not authoritative yet.
-  assert.equal(trustsLocalOnlyMessages(false, 3), true);
-  assert.equal(trustsLocalOnlyMessages(false, 0), true);
 });

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -43,6 +43,20 @@ test("only a pasted wall of text is cut, and with a real ellipsis", () => {
   assert.ok(!title.includes("..."));
 });
 
+/** A high surrogate with no low after it, or a low with no high before it. */
+const UNPAIRED_SURROGATE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+test("the cap never splits an emoji into a lone surrogate", () => {
+  // A lone surrogate survives JSON.stringify but fails the backend's SQLite
+  // bind, so the title write would 500.
+  const line = "x".repeat(119) + "\u{1F600} tail";
+  assert.equal(UNPAIRED_SURROGATE.test(line.slice(0, 120)), true);
+  const title = fallbackTitleFromUserText(line);
+  assert.equal(UNPAIRED_SURROGATE.test(title), false);
+  assert.equal(title, "x".repeat(119) + "\u{1F600}" + "…");
+});
+
 test("a legacy title is recognised only against the text it was cut from", () => {
   const legacy = LONG.slice(0, 48) + "...";
   assert.equal(isLegacyClippedTitle(legacy, LONG), true);

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -105,7 +105,7 @@ test("repair rewrites legacy rows and leaves every other row untouched", () => {
   ]);
 
   assert.deepEqual(planLegacyTitleRepairs(threads, messages), [
-    { threadId: "a", previousTitle: legacy, title: LONG },
+    { threadId: "a", previousTitle: legacy, openingMessageId: "a-m1", title: LONG },
   ]);
 });
 
@@ -151,8 +151,37 @@ test("the opening message is the earliest one, not the first row returned", () =
       [thread("a", legacy)],
       new Map([["a", [later, opening]]]),
     ),
-    [{ threadId: "a", previousTitle: legacy, title: LONG }],
+    // Guarded on the opening message, not the row the array happens to start on.
+    [{ threadId: "a", previousTitle: legacy, openingMessageId: "a-m1", title: LONG }],
   );
+});
+
+test("two prompts sharing a timestamp break on id, as the backend does", () => {
+  // The write is guarded on this id, so the two have to agree on which message
+  // is the opening one or every such repair would be rejected.
+  const legacy = LONG.slice(0, 48) + "...";
+  const first: MessageRecord = { ...userMessage("a", LONG), id: "a-m1" };
+  const second: MessageRecord = {
+    ...userMessage("a", "a different question"),
+    id: "a-m2",
+  };
+
+  for (const order of [
+    [first, second],
+    [second, first],
+  ]) {
+    assert.deepEqual(
+      planLegacyTitleRepairs([thread("a", legacy)], new Map([["a", order]])),
+      [
+        {
+          threadId: "a",
+          previousTitle: legacy,
+          openingMessageId: "a-m1",
+          title: LONG,
+        },
+      ],
+    );
+  }
 });
 
 test("a page skips rows already tried and reports the leftovers", () => {
@@ -212,7 +241,7 @@ test("a chat with nothing stored is left for a later refresh", () => {
   messages.set("a", [userMessage("a", LONG)]);
   assert.deepEqual(threadsMissingMessages(["a"], messages), []);
   assert.deepEqual(planLegacyTitleRepairs(candidates, messages), [
-    { threadId: "a", previousTitle: legacy, title: LONG },
+    { threadId: "a", previousTitle: legacy, openingMessageId: "a-m1", title: LONG },
   ]);
 });
 
@@ -221,9 +250,9 @@ test("a rename drops the rewrite even where the guard is not enforced", () => {
   // would apply the write. This check is what stops it there.
   const legacy = LONG.slice(0, 48) + "...";
   const repairs = [
-    { threadId: "a", previousTitle: legacy, title: LONG },
-    { threadId: "b", previousTitle: legacy, title: LONG },
-    { threadId: "c", previousTitle: legacy, title: LONG },
+    { threadId: "a", previousTitle: legacy, openingMessageId: "a-m1", title: LONG },
+    { threadId: "b", previousTitle: legacy, openingMessageId: "b-m1", title: LONG },
+    { threadId: "c", previousTitle: legacy, openingMessageId: "c-m1", title: LONG },
   ];
   const current = new Map([
     ["a", legacy],

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -13,6 +13,7 @@ import {
   selectLegacyRepairPage,
   threadsMissingMessages,
   threadsWithoutRepairs,
+  trustsLocalOnlyMessages,
 } from "../src/features/chat/utils/chat-title.ts";
 
 const LONG =
@@ -221,4 +222,15 @@ test("merging keeps one copy of a message both sources hold", () => {
     merged.map((m) => m.id),
     ["a-m1", "a-m2"],
   );
+});
+
+test("a local-only message is a leftover once the import is done", () => {
+  // Deleting a message prunes the backend and leaves the Dexie copy, so past
+  // the import a local-only row must not be read back as the opening prompt.
+  assert.equal(trustsLocalOnlyMessages(true, 3), false);
+  // Nothing on the backend: nothing has been pruned, so Dexie is all there is.
+  assert.equal(trustsLocalOnlyMessages(true, 0), true);
+  // Import unfinished: the backend's view is not authoritative yet.
+  assert.equal(trustsLocalOnlyMessages(false, 3), true);
+  assert.equal(trustsLocalOnlyMessages(false, 0), true);
 });

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -45,8 +45,7 @@ test("a title the sidebar can clip keeps the whole first line", () => {
 test("only a pasted wall of text is cut, and with a real ellipsis", () => {
   const wall = "x".repeat(200);
   const title = fallbackTitleFromUserText(wall);
-  // 120 UTF-16 units all in, the ellipsis included, which is what the rename
-  // input accepts. A longer one cannot be edited until a character is deleted.
+  // 120 UTF-16 units including the ellipsis, which is what the input accepts.
   assert.equal(title.length, 120);
   assert.ok(title.endsWith("…"));
   assert.ok(!title.includes("..."));
@@ -66,8 +65,7 @@ test("a line already inside the budget is stored whole", () => {
 });
 
 test("the cap never splits an emoji into a lone surrogate", () => {
-  // A lone surrogate survives JSON.stringify but fails the backend's SQLite
-  // bind, so the title write would 500.
+  // A lone surrogate survives JSON.stringify but 500s the backend's SQLite bind.
   const line = "x".repeat(119) + "\u{1F600} tail";
   // A raw cut at the budget lands mid-pair.
   assert.equal(UNPAIRED_SURROGATE.test(line.slice(0, 120)), true);
@@ -79,9 +77,8 @@ test("the cap never splits an emoji into a lone surrogate", () => {
 });
 
 test("a lone surrogate is dropped even when the line is under the cap", () => {
-  // The cut sanitises what it walks, so only over-cap input used to be safe.
-  // Under the cap the line was stored as it came, and one unpaired surrogate
-  // reaching the backend fails its SQLite bind and 500s the title write.
+  // The cut sanitises what it walks, so under-cap lines used to be stored as
+  // they came, and one unpaired surrogate 500s the backend's title write.
   const line = "x".repeat(60) + "\uD83D";
   assert.ok(line.length <= 120);
   assert.equal(UNPAIRED_SURROGATE.test(line), true);
@@ -126,9 +123,8 @@ test("repair rewrites legacy rows and leaves every other row untouched", () => {
 });
 
 test("a drain advances even when a whole page failed and was unmarked", () => {
-  // Failures get unmarked so a later refresh can retry them. If the next page
-  // were selected off the same list it would draw them straight back in and
-  // spin on the failing rows, never reaching the rest.
+  // Failures get unmarked for a later refresh. Selecting the next page off the
+  // same list would draw them straight back in and never reach the rest.
   const legacy = LONG.slice(0, 48) + "...";
   const threads = ["a", "b", "c", "d"].map((id) => thread(id, legacy));
 
@@ -148,8 +144,7 @@ test("a drain advances even when a whole page failed and was unmarked", () => {
 });
 
 test("the opening message is the earliest one, not the first row returned", () => {
-  // A local Dexie read comes back in index order, so the array can start on a
-  // later turn.
+  // A local read comes back in index order, so it can start on a later turn.
   const later: MessageRecord = {
     ...userMessage("a", "a later question entirely"),
     id: "a-m9",
@@ -173,8 +168,7 @@ test("the opening message is the earliest one, not the first row returned", () =
 });
 
 test("two prompts sharing a timestamp break on id, as the backend does", () => {
-  // The write is guarded on this id, so the two have to agree on which message
-  // is the opening one or every such repair would be rejected.
+  // The write is guarded on this id, so both orders must pick the same message.
   const legacy = LONG.slice(0, 48) + "...";
   const first: MessageRecord = { ...userMessage("a", LONG), id: "a-m1" };
   const second: MessageRecord = {
@@ -230,8 +224,7 @@ test("a page skips rows already tried and reports the leftovers", () => {
 });
 
 test("a thread the backend has nothing for still gets a local read", () => {
-  // A legacy chat not yet imported reads empty from the backend, and an id it
-  // has never heard of is missing from the map entirely.
+  // A not-yet-imported chat reads empty; an unknown id is missing from the map.
   const messages = new Map<string, MessageRecord[]>([
     ["a", [userMessage("a", LONG)]],
     ["b", []],
@@ -245,8 +238,7 @@ test("a thread the backend has nothing for still gets a local read", () => {
 
 
 test("a chat with nothing stored is left for a later refresh", () => {
-  // Its messages may simply not be imported yet. The row is not written off,
-  // and once they land a later pass rewrites the title from them.
+  // Its messages may not be imported yet, so a later pass rewrites the title.
   const legacy = LONG.slice(0, 48) + "...";
   const candidates = [thread("a", legacy)];
   const messages = new Map<string, MessageRecord[]>();
@@ -262,11 +254,9 @@ test("a chat with nothing stored is left for a later refresh", () => {
 });
 
 test("a chat whose opening prompt is gone is decided, not retried forever", () => {
-  // Nothing stored means the import may still land, so those rows are unmarked
-  // and tried again. A chat that does have messages is a complete answer: the
-  // opening prompt was deleted or edited, so no later pass can prove the title.
-  // Unmarking it too would re-select it on every refresh for the session, since
-  // its title stays clipped and keeps matching the pre-filter.
+  // A chat that does have messages is a complete answer: the opening prompt was
+  // deleted or edited, so no later pass can prove the title. Unmarking it would
+  // re-select it on every refresh, since its title stays clipped.
   const legacy = LONG.slice(0, 48) + "...";
   const candidates = [thread("a", legacy)];
   const messages = new Map<string, MessageRecord[]>([
@@ -283,9 +273,8 @@ test("a chat whose opening prompt is gone is decided, not retried forever", () =
 });
 
 test("an emptied chat is decided, one still importing is not", () => {
-  // Both read back as zero messages. The ledger is what tells them apart: a
-  // thread it knows was imported, so empty is the whole answer, while one it
-  // has never seen may still be on its way.
+  // Both read back as zero messages. The ledger tells them apart: one it knows
+  // was imported is simply empty, one it has never seen may still be on its way.
   const ids = ["emptied", "importing", "fine"];
   const messages = new Map<string, MessageRecord[]>([
     ["emptied", []],

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -9,6 +9,8 @@ import {
   fallbackTitleFromUserText,
   isLegacyClippedTitle,
   planLegacyTitleRepairs,
+  selectLegacyRepairPage,
+  threadsMissingMessages,
 } from "../src/features/chat/utils/chat-title.ts";
 
 const LONG =
@@ -85,5 +87,47 @@ test("repair rewrites legacy rows and leaves every other row untouched", () => {
 
   assert.deepEqual(planLegacyTitleRepairs(threads, messages), [
     { threadId: "a", previousTitle: legacy, title: LONG },
+  ]);
+});
+
+test("a page skips rows already tried and reports the leftovers", () => {
+  const legacy = LONG.slice(0, 48) + "...";
+  const threads = [
+    thread("a", legacy),
+    thread("b", "a plain title"),
+    thread("c", legacy),
+    thread("d", legacy),
+  ];
+
+  const first = selectLegacyRepairPage(threads, new Set(), 2);
+  assert.deepEqual(
+    first.candidates.map((t) => t.id),
+    ["a", "c"],
+  );
+  // Without this the rest of a long history waits on an unrelated refresh.
+  assert.equal(first.hasMore, true);
+
+  const second = selectLegacyRepairPage(threads, new Set(["a", "c"]), 2);
+  assert.deepEqual(
+    second.candidates.map((t) => t.id),
+    ["d"],
+  );
+  assert.equal(second.hasMore, false);
+
+  const done = selectLegacyRepairPage(threads, new Set(["a", "c", "d"]), 2);
+  assert.deepEqual(done.candidates, []);
+  assert.equal(done.hasMore, false);
+});
+
+test("a thread the backend has nothing for still gets a local read", () => {
+  // A legacy chat not yet imported reads empty from the backend, and an id it
+  // has never heard of is missing from the map entirely.
+  const messages = new Map<string, MessageRecord[]>([
+    ["a", [userMessage("a", LONG)]],
+    ["b", []],
+  ]);
+  assert.deepEqual(threadsMissingMessages(["a", "b", "c"], messages), [
+    "b",
+    "c",
   ]);
 });

--- a/studio/frontend/tests/chat-title-clip.test.ts
+++ b/studio/frontend/tests/chat-title-clip.test.ts
@@ -90,6 +90,52 @@ test("repair rewrites legacy rows and leaves every other row untouched", () => {
   ]);
 });
 
+test("a drain advances even when a whole page failed and was unmarked", () => {
+  // Failures get unmarked so a later refresh can retry them. If the next page
+  // were selected off the same list it would draw them straight back in and
+  // spin on the failing rows, never reaching the rest.
+  const legacy = LONG.slice(0, 48) + "...";
+  const threads = ["a", "b", "c", "d"].map((id) => thread(id, legacy));
+
+  const first = selectLegacyRepairPage(threads, new Set(), 2);
+  assert.deepEqual(
+    first.candidates.map((t) => t.id),
+    ["a", "b"],
+  );
+  // Every write failed, so nothing stayed marked.
+  const second = selectLegacyRepairPage(first.rest, new Set(), 2);
+  assert.deepEqual(
+    second.candidates.map((t) => t.id),
+    ["c", "d"],
+  );
+  assert.equal(second.hasMore, false);
+  assert.deepEqual(second.rest, []);
+});
+
+test("the opening message is the earliest one, not the first row returned", () => {
+  // A local Dexie read comes back in index order, so the array can start on a
+  // later turn.
+  const later: MessageRecord = {
+    ...userMessage("a", "a later question entirely"),
+    id: "a-m9",
+    createdAt: 99,
+  };
+  const opening: MessageRecord = {
+    ...userMessage("a", LONG),
+    id: "a-m1",
+    createdAt: 1,
+  };
+  const legacy = LONG.slice(0, 48) + "...";
+
+  assert.deepEqual(
+    planLegacyTitleRepairs(
+      [thread("a", legacy)],
+      new Map([["a", [later, opening]]]),
+    ),
+    [{ threadId: "a", previousTitle: legacy, title: LONG }],
+  );
+});
+
 test("a page skips rows already tried and reports the leftovers", () => {
   const legacy = LONG.slice(0, 48) + "...";
   const threads = [

--- a/studio/frontend/tests/openapi-support.test.ts
+++ b/studio/frontend/tests/openapi-support.test.ts
@@ -34,8 +34,7 @@ test("a backend that declares the fields enforces the guards", () => {
 });
 
 test("a backend from before the fields does not", () => {
-  // It drops the unknown fields and applies the write, so the migration has to
-  // stay off there.
+  // It drops the unknown fields and writes anyway, so the migration stays off.
   assert.equal(schemaDeclaresRepairGuards(documentWith(OLD_PROPERTIES)), false);
 });
 
@@ -78,8 +77,8 @@ test("a schema that arrived settles the question either way", () => {
 });
 
 test("an HTTP failure is a moment, not an answer", () => {
-  // 401 while the token warms up, 503 during startup. Remembering these would
-  // park the migration for the rest of the session.
+  // 401 while the token warms up, 503 at startup. Caching one would park the
+  // migration for the session.
   assert.deepEqual(readGuardProbe(false, null), {
     supported: false,
     settled: false,

--- a/studio/frontend/tests/openapi-support.test.ts
+++ b/studio/frontend/tests/openapi-support.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { schemaDeclaresExpectedTitle } from "../src/features/chat/utils/openapi-support.ts";
+
+/** The shape FastAPI serves for the patch model. */
+function documentWith(properties: Record<string, unknown>) {
+  return {
+    components: {
+      schemas: {
+        ChatThreadPatch: { title: "ChatThreadPatch", type: "object", properties },
+      },
+    },
+  };
+}
+
+const OLD_PROPERTIES = {
+  title: { type: "string" },
+  modelType: { type: "string" },
+  archived: { type: "boolean" },
+};
+
+test("a backend that declares the field enforces the guard", () => {
+  assert.equal(
+    schemaDeclaresExpectedTitle(
+      documentWith({ ...OLD_PROPERTIES, expectedTitle: { type: "string" } }),
+    ),
+    true,
+  );
+});
+
+test("a backend from before the field does not", () => {
+  // It drops the unknown field and applies the write, so the migration has to
+  // stay off there.
+  assert.equal(schemaDeclaresExpectedTitle(documentWith(OLD_PROPERTIES)), false);
+});
+
+test("anything unreadable reads as unsupported", () => {
+  for (const document of [
+    null,
+    undefined,
+    "",
+    42,
+    {},
+    { components: null },
+    { components: {} },
+    { components: { schemas: {} } },
+    { components: { schemas: { ChatThreadPatch: {} } } },
+    { components: { schemas: { ChatThreadPatch: { properties: null } } } },
+  ]) {
+    assert.equal(schemaDeclaresExpectedTitle(document), false);
+  }
+});

--- a/studio/frontend/tests/openapi-support.test.ts
+++ b/studio/frontend/tests/openapi-support.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import {
   readGuardProbe,
-  schemaDeclaresExpectedTitle,
+  schemaDeclaresRepairGuards,
 } from "../src/features/chat/utils/openapi-support.ts";
 
 /** The shape FastAPI serves for the patch model. */
@@ -23,19 +23,30 @@ const OLD_PROPERTIES = {
   archived: { type: "boolean" },
 };
 
-test("a backend that declares the field enforces the guard", () => {
-  assert.equal(
-    schemaDeclaresExpectedTitle(
-      documentWith({ ...OLD_PROPERTIES, expectedTitle: { type: "string" } }),
-    ),
-    true,
-  );
+const GUARDED = {
+  ...OLD_PROPERTIES,
+  expectedTitle: { type: "string" },
+  expectedOpeningMessageId: { type: "string" },
+};
+
+test("a backend that declares the fields enforces the guards", () => {
+  assert.equal(schemaDeclaresRepairGuards(documentWith(GUARDED)), true);
 });
 
-test("a backend from before the field does not", () => {
-  // It drops the unknown field and applies the write, so the migration has to
+test("a backend from before the fields does not", () => {
+  // It drops the unknown fields and applies the write, so the migration has to
   // stay off there.
-  assert.equal(schemaDeclaresExpectedTitle(documentWith(OLD_PROPERTIES)), false);
+  assert.equal(schemaDeclaresRepairGuards(documentWith(OLD_PROPERTIES)), false);
+});
+
+test("half the guards is not enough", () => {
+  // Only the pair rejects a repair based on a deleted prompt.
+  assert.equal(
+    schemaDeclaresRepairGuards(
+      documentWith({ ...OLD_PROPERTIES, expectedTitle: { type: "string" } }),
+    ),
+    false,
+  );
 });
 
 test("anything unreadable reads as unsupported", () => {
@@ -51,15 +62,12 @@ test("anything unreadable reads as unsupported", () => {
     { components: { schemas: { ChatThreadPatch: {} } } },
     { components: { schemas: { ChatThreadPatch: { properties: null } } } },
   ]) {
-    assert.equal(schemaDeclaresExpectedTitle(document), false);
+    assert.equal(schemaDeclaresRepairGuards(document), false);
   }
 });
 
 test("a schema that arrived settles the question either way", () => {
-  const supported = readGuardProbe(
-    true,
-    documentWith({ ...OLD_PROPERTIES, expectedTitle: { type: "string" } }),
-  );
+  const supported = readGuardProbe(true, documentWith(GUARDED));
   assert.deepEqual(supported, { supported: true, settled: true });
 
   // An old backend is a real answer, so it is worth remembering.

--- a/studio/frontend/tests/openapi-support.test.ts
+++ b/studio/frontend/tests/openapi-support.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { schemaDeclaresExpectedTitle } from "../src/features/chat/utils/openapi-support.ts";
+import {
+  readGuardProbe,
+  schemaDeclaresExpectedTitle,
+} from "../src/features/chat/utils/openapi-support.ts";
 
 /** The shape FastAPI serves for the patch model. */
 function documentWith(properties: Record<string, unknown>) {
@@ -50,4 +53,27 @@ test("anything unreadable reads as unsupported", () => {
   ]) {
     assert.equal(schemaDeclaresExpectedTitle(document), false);
   }
+});
+
+test("a schema that arrived settles the question either way", () => {
+  const supported = readGuardProbe(
+    true,
+    documentWith({ ...OLD_PROPERTIES, expectedTitle: { type: "string" } }),
+  );
+  assert.deepEqual(supported, { supported: true, settled: true });
+
+  // An old backend is a real answer, so it is worth remembering.
+  assert.deepEqual(readGuardProbe(true, documentWith(OLD_PROPERTIES)), {
+    supported: false,
+    settled: true,
+  });
+});
+
+test("an HTTP failure is a moment, not an answer", () => {
+  // 401 while the token warms up, 503 during startup. Remembering these would
+  // park the migration for the rest of the session.
+  assert.deepEqual(readGuardProbe(false, null), {
+    supported: false,
+    settled: false,
+  });
 });

--- a/studio/frontend/tests/run-with-concurrency.test.ts
+++ b/studio/frontend/tests/run-with-concurrency.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runWithConcurrency } from "../src/features/chat/utils/run-with-concurrency.ts";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+test("never runs more than the limit at once", async () => {
+  const gates = Array.from({ length: 10 }, deferred);
+  let active = 0;
+  let peak = 0;
+  const started: number[] = [];
+
+  const all = runWithConcurrency([...gates.keys()], 3, async (index) => {
+    started.push(index);
+    active += 1;
+    peak = Math.max(peak, active);
+    await gates[index].promise;
+    active -= 1;
+  });
+
+  await Promise.resolve();
+  assert.deepEqual(started, [0, 1, 2]);
+  for (const gate of gates) gate.resolve();
+  await all;
+  assert.equal(peak, 3);
+  assert.equal(started.length, 10);
+});
+
+test("a limit above the item count still runs every item once", async () => {
+  const seen: number[] = [];
+  await runWithConcurrency([1, 2, 3], 99, async (n) => {
+    seen.push(n);
+  });
+  assert.deepEqual(seen.sort(), [1, 2, 3]);
+});
+
+test("an empty list resolves without running anything", async () => {
+  let ran = false;
+  await runWithConcurrency([], 4, async () => {
+    ran = true;
+  });
+  assert.equal(ran, false);
+});

--- a/studio/frontend/tests/serial-queue.test.ts
+++ b/studio/frontend/tests/serial-queue.test.ts
@@ -14,8 +14,8 @@ function deferred() {
 }
 
 test("a second caller waits rather than running alongside the first", async () => {
-  // Two sidebars can be mounted at once. Without this their passes overlap and
-  // the write concurrency cap is only per pass.
+  // Two sidebars can be mounted at once; overlapping passes would make the
+  // write concurrency cap per pass only.
   const run = createSerialQueue();
   const first = deferred();
   let active = 0;

--- a/studio/frontend/tests/serial-queue.test.ts
+++ b/studio/frontend/tests/serial-queue.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createSerialQueue } from "../src/features/chat/utils/serial-queue.ts";
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+test("a second caller waits rather than running alongside the first", async () => {
+  // Two sidebars can be mounted at once. Without this their passes overlap and
+  // the write concurrency cap is only per pass.
+  const run = createSerialQueue();
+  const first = deferred();
+  let active = 0;
+  let peak = 0;
+
+  const a = run(async () => {
+    active += 1;
+    peak = Math.max(peak, active);
+    await first.promise;
+    active -= 1;
+  });
+  const b = run(async () => {
+    active += 1;
+    peak = Math.max(peak, active);
+    active -= 1;
+  });
+
+  await Promise.resolve();
+  assert.equal(active, 1);
+  first.resolve();
+  await Promise.all([a, b]);
+  assert.equal(peak, 1);
+});
+
+test("a rejected task does not block the next one", async () => {
+  const run = createSerialQueue();
+  let ran = false;
+  const failed = run(async () => {
+    throw new Error("read failed");
+  });
+  const after = run(async () => {
+    ran = true;
+    return 7;
+  });
+  await assert.rejects(failed, /read failed/);
+  assert.equal(await after, 7);
+  assert.equal(ran, true);
+});
+
+test("tasks run in the order they were queued", async () => {
+  const run = createSerialQueue();
+  const order: number[] = [];
+  await Promise.all(
+    [1, 2, 3].map((n) =>
+      run(async () => {
+        order.push(n);
+      }),
+    ),
+  );
+  assert.deepEqual(order, [1, 2, 3]);
+});

--- a/tests/studio/test_chat_thread_title_cas.py
+++ b/tests/studio/test_chat_thread_title_cas.py
@@ -180,9 +180,6 @@ def test_a_thread_with_no_messages_left_reads_as_a_mismatch(probe):
 def test_the_route_turns_a_failed_precondition_into_409():
     source = ROUTE.read_text(encoding = "utf-8")
     assert 'expected_title = patch.pop("expectedTitle", None)' in source
-    assert (
-        'expected_opening_message_id = patch.pop("expectedOpeningMessageId", None)'
-        in source
-    )
+    assert 'expected_opening_message_id = patch.pop("expectedOpeningMessageId", None)' in source
     assert "except ChatThreadPreconditionFailed:" in source
     assert "status_code = 409," in source

--- a/tests/studio/test_chat_thread_title_cas.py
+++ b/tests/studio/test_chat_thread_title_cas.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""A title patch can carry a guard, so a rename beats a background rewrite.
+
+studio_db imports its siblings by bare name (utils.paths), so the functional
+checks run in a subprocess with studio/backend on PYTHONPATH rather than
+putting those names on this session's sys.path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+BACKEND = REPO / "studio" / "backend"
+ROUTE = BACKEND / "routes" / "chat_history.py"
+
+PROBE = r"""
+import json, sys
+from storage import studio_db as db
+
+def thread(thread_id, title):
+    db.upsert_chat_thread({
+        "id": thread_id,
+        "title": title,
+        "modelType": "base",
+        "createdAt": 1,
+        "updatedAt": 1,
+    })
+
+out = {}
+
+# No guard: the write lands, as every other caller expects.
+thread("t1", "old")
+out["unguarded"] = db.update_chat_thread("t1", {"title": "new"})["title"]
+
+# Guard matches: the rewrite lands.
+thread("t2", "legacy title...")
+out["guard_match"] = db.update_chat_thread(
+    "t2", {"title": "whole first line"}, expected_title = "legacy title..."
+)["title"]
+
+# A rename landed after the rewrite read the row: the rename has to win.
+thread("t3", "legacy title...")
+db.update_chat_thread("t3", {"title": "what the user typed"})
+try:
+    db.update_chat_thread(
+        "t3", {"title": "whole first line"}, expected_title = "legacy title..."
+    )
+    out["guard_stale"] = "no error"
+except db.ChatThreadTitleMismatch:
+    out["guard_stale"] = "mismatch"
+out["after_stale"] = db.get_chat_thread("t3")["title"]
+
+# A thread that is gone reads as missing, not as a mismatch.
+out["missing"] = db.update_chat_thread(
+    "gone", {"title": "anything"}, expected_title = "legacy title..."
+)
+
+# updatedAt is untouched by a title patch, so Recents keeps its order.
+out["updated_at"] = db.get_chat_thread("t2")["updatedAt"]
+
+print(json.dumps(out))
+"""
+
+
+@pytest.fixture(scope = "module")
+def probe(tmp_path_factory) -> dict:
+    env = dict(os.environ)
+    env["UNSLOTH_STUDIO_HOME"] = str(tmp_path_factory.mktemp("studio_home"))
+    env["PYTHONPATH"] = str(BACKEND)
+    result = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output = True,
+        text = True,
+        env = env,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_a_patch_without_a_guard_still_applies(probe):
+    assert probe["unguarded"] == "new"
+
+
+def test_the_guard_lets_the_write_through_while_the_title_is_unchanged(probe):
+    assert probe["guard_match"] == "whole first line"
+
+
+def test_a_rename_between_the_read_and_the_write_wins(probe):
+    assert probe["guard_stale"] == "mismatch"
+    assert probe["after_stale"] == "what the user typed"
+
+
+def test_a_missing_thread_reads_as_missing_not_as_a_mismatch(probe):
+    assert probe["missing"] is None
+
+
+def test_a_title_patch_leaves_updated_at_alone(probe):
+    assert probe["updated_at"] == 1
+
+
+def test_the_route_turns_a_mismatch_into_409():
+    source = ROUTE.read_text(encoding = "utf-8")
+    assert 'expected_title = patch.pop("expectedTitle", None)' in source
+    assert "except ChatThreadTitleMismatch:" in source
+    assert "status_code = 409," in source

--- a/tests/studio/test_chat_thread_title_cas.py
+++ b/tests/studio/test_chat_thread_title_cas.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-"""A title patch can carry a guard, so a rename beats a background rewrite.
+"""A title patch can carry guards, so a rename or a deleted opening message
+beats a background rewrite.
 
 studio_db imports its siblings by bare name (utils.paths), so the functional
 checks run in a subprocess with studio/backend on PYTHONPATH rather than
@@ -26,6 +27,15 @@ ROUTE = BACKEND / "routes" / "chat_history.py"
 PROBE = r"""
 import json, sys
 from storage import studio_db as db
+
+def message(thread_id, message_id, role, text, created_at):
+    db.upsert_chat_message({
+        "id": message_id,
+        "threadId": thread_id,
+        "role": role,
+        "content": [{"type": "text", "text": text}],
+        "createdAt": created_at,
+    })
 
 def thread(thread_id, title):
     db.upsert_chat_thread({
@@ -56,9 +66,54 @@ try:
         "t3", {"title": "whole first line"}, expected_title = "legacy title..."
     )
     out["guard_stale"] = "no error"
-except db.ChatThreadTitleMismatch:
+except db.ChatThreadPreconditionFailed:
     out["guard_stale"] = "mismatch"
 out["after_stale"] = db.get_chat_thread("t3")["title"]
+
+# The opening message guard, while that message is still the opening one.
+thread("t4", "legacy title...")
+message("t4", "m2", "user", "second", 20)
+message("t4", "m1", "user", "first", 10)
+message("t4", "a1", "assistant", "reply", 15)
+out["opening_match"] = db.update_chat_thread(
+    "t4",
+    {"title": "whole first line"},
+    expected_title = "legacy title...",
+    expected_opening_message_id = "m1",
+)["title"]
+
+# The opening message was deleted after the rewrite read it. Its text must not
+# be expanded into the title.
+thread("t5", "legacy title...")
+message("t5", "t5m1", "user", "first", 10)
+message("t5", "t5m2", "user", "second", 20)
+db.sync_chat_messages("t5", [
+    {"id": "t5m2", "threadId": "t5", "role": "user",
+     "content": [{"type": "text", "text": "second"}], "createdAt": 20},
+], prune_missing = True)
+try:
+    db.update_chat_thread(
+        "t5",
+        {"title": "whole first line"},
+        expected_title = "legacy title...",
+        expected_opening_message_id = "t5m1",
+    )
+    out["opening_deleted"] = "no error"
+except db.ChatThreadPreconditionFailed:
+    out["opening_deleted"] = "mismatch"
+out["after_opening_deleted"] = db.get_chat_thread("t5")["title"]
+
+# A thread whose messages are all gone: the subquery is NULL, still no match.
+thread("t6", "legacy title...")
+try:
+    db.update_chat_thread(
+        "t6",
+        {"title": "whole first line"},
+        expected_opening_message_id = "t6m1",
+    )
+    out["opening_empty"] = "no error"
+except db.ChatThreadPreconditionFailed:
+    out["opening_empty"] = "mismatch"
 
 # A thread that is gone reads as missing, not as a mismatch.
 out["missing"] = db.update_chat_thread(
@@ -108,8 +163,26 @@ def test_a_title_patch_leaves_updated_at_alone(probe):
     assert probe["updated_at"] == 1
 
 
-def test_the_route_turns_a_mismatch_into_409():
+def test_the_opening_guard_matches_the_earliest_user_message(probe):
+    """Earliest by createdAt, not by insertion order, and not the assistant's."""
+    assert probe["opening_match"] == "whole first line"
+
+
+def test_a_prompt_deleted_between_the_read_and_the_write_wins(probe):
+    assert probe["opening_deleted"] == "mismatch"
+    assert probe["after_opening_deleted"] == "legacy title..."
+
+
+def test_a_thread_with_no_messages_left_reads_as_a_mismatch(probe):
+    assert probe["opening_empty"] == "mismatch"
+
+
+def test_the_route_turns_a_failed_precondition_into_409():
     source = ROUTE.read_text(encoding = "utf-8")
     assert 'expected_title = patch.pop("expectedTitle", None)' in source
-    assert "except ChatThreadTitleMismatch:" in source
+    assert (
+        'expected_opening_message_id = patch.pop("expectedOpeningMessageId", None)'
+        in source
+    )
+    assert "except ChatThreadPreconditionFailed:" in source
     assert "status_code = 409," in source

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -23,25 +23,21 @@ def _read(path: Path) -> str:
     return " ".join(path.read_text(encoding = "utf-8").split())
 
 
-def test_the_sidebar_hands_its_messages_to_the_repair():
-    """The with-messages load already fetched every thread's messages, so the
-    repair must not go and fetch the same rows a second time."""
-    storage = _read(STORAGE)
-    assert "export interface ChatThreadsWithMessages" in storage
-    assert (
-        "messagesByThreadId: new Map( entries .filter((e): e is typeof e & { messages: MessageRecord[] } => e.messages !== null, )"
-        in storage
-    )
-    # A read that failed is unknown. Reporting it as an empty chat would let the
-    # repair write the row off for the session.
-    assert "messages: legacy," in storage
-
+def test_the_repair_reads_its_own_messages_as_late_as_it_can():
+    """Not the sidebar's map. That map takes its empty-backend entries from
+    listStoredChatMessages, which merges Dexie rows the backend has pruned, and
+    it is fetched at load time rather than at write time."""
     hook = _read(HOOK)
-    assert "? await listStoredChatThreadsWithMessages(args)" in hook
-    assert "void repairLegacyChatTitles( loaded.threads, loaded.messagesByThreadId, )" in hook
+    assert "void repairLegacyChatTitles(threads).catch(() => undefined);" in hook
 
     repair = _read(REPAIR)
-    assert "messages = known ? known : await batchListChatMessages(ids);" in repair
+    assert "messages = await batchListChatMessages(ids);" in repair
+    assert "export function repairLegacyChatTitles( threads: ThreadRecord[], ): Promise<number> {" in repair
+
+    storage = _read(STORAGE)
+    # The shared list function keeps its original shape: nothing hands a
+    # message map out of it.
+    assert "messagesByThreadId" not in storage
 
 
 def test_the_repair_reads_only_stored_messages():
@@ -63,7 +59,7 @@ def test_the_next_page_is_scheduled_rather_than_waited_for():
     assert "if (hasMore) { setTimeout(" in repair
     # On `rest`: a row this page unmarked must not be drawn again by the same
     # drain, or a failing PATCH starves every row behind it.
-    assert "void repairLegacyChatTitles(rest, known)" in repair
+    assert "void repairLegacyChatTitles(rest)" in repair
     assert "REPAIR_PAGE_PAUSE_MS" in repair
 
 
@@ -72,7 +68,7 @@ def test_only_one_repair_pass_runs_at_a_time():
     only holds if their passes queue."""
     repair = _read(REPAIR)
     assert "const serial = createSerialQueue();" in repair
-    assert "return serial(() => runRepairPass(threads, known));" in repair
+    assert "return serial(() => runRepairPass(threads));" in repair
 
 
 def test_a_failed_read_leaves_the_rows_retryable():

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -61,4 +61,7 @@ def test_the_next_page_is_scheduled_rather_than_waited_for():
 
 def test_a_failed_read_leaves_the_rows_retryable():
     repair = _read(REPAIR)
-    assert "} catch { // Nothing was decided, so let a later refresh try these again. for (const id of ids) attempted.delete(id); return 0; }" in repair
+    assert (
+        "} catch { // Nothing was decided, so let a later refresh try these again. for (const id of ids) attempted.delete(id); return 0; }"
+        in repair
+    )

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -39,8 +39,7 @@ def test_the_repair_reads_its_own_messages_as_late_as_it_can():
     )
 
     storage = _read(STORAGE)
-    # The shared list function keeps its original shape: nothing hands a
-    # message map out of it.
+    # Nothing hands a message map out of the shared list function.
     assert "messagesByThreadId" not in storage
 
 
@@ -61,8 +60,7 @@ def test_an_emptied_chat_is_not_retried_for_the_session():
     title stays clipped and keeps matching the pre-filter."""
     repair = _read(REPAIR)
     assert "const withoutMessages = threadsMissingMessages(ids, messages);" in repair
-    # Only fetched when there is something to decide, so a page of ordinary
-    # rows does not pay for it.
+    # Only fetched when there is something to decide.
     assert "if (withoutMessages.length > 0) {" in repair
     assert "imported = await listChatImportLedger();" in repair
     assert (
@@ -86,8 +84,7 @@ def test_the_next_page_is_scheduled_rather_than_waited_for():
     would come back for the rest of the backlog."""
     repair = _read(REPAIR)
     assert "if (hasMore) { setTimeout(" in repair
-    # On `rest`: a row this page unmarked must not be drawn again by the same
-    # drain, or a failing PATCH starves every row behind it.
+    # On `rest`: a row this page unmarked must not starve the rows behind it.
     assert "void repairLegacyChatTitles(rest)" in repair
     assert "REPAIR_PAGE_PAUSE_MS" in repair
 
@@ -132,13 +129,11 @@ def test_the_migration_stays_off_where_the_guard_is_not_enforced():
         "probe = readGuardProbe( response.ok, response.ok ? await response.json() : null, );"
         in repair
     )
-    # Only a settled answer is cached. A 401 while the token warms up, or a 503
-    # during startup, would otherwise park the migration for the session.
+    # Only a settled answer is cached, or a 401 at startup parks the migration.
     assert "if (!probe.settled) guardSupport = null;" in repair
 
     backend = (BACKEND / "routes/chat_history.py").read_text(encoding = "utf-8")
-    # The probe reads the schema, so the fields have to be declared on the
-    # model. It looks for both, and both are what make the write safe.
+    # The probe reads the schema, so the fields have to be declared on the model.
     assert "expectedTitle: Optional[str] = None" in backend
 
 

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -51,11 +51,13 @@ def test_a_legacy_only_chat_falls_back_to_a_local_read():
     # Any row no rewrite could be made of, not just an empty one: a chat can be
     # part imported, holding its opening turn locally and later ones remotely.
     assert "const unexplained = threadsWithoutRepairs(candidates, repairs);" in repair
-    assert "const local = await listLegacyChatMessages(id);" in repair
-    assert "messages.set(id, mergeMessagesById(messages.get(id) ?? [], local));" in repair
+    # Per row: one failing local read must not throw away the page's other
+    # repairs or stop it advancing to the rows behind it.
+    assert "await listUnimportedChatMessages(id, backend.length).catch( () => [], )" in repair
+    assert "messages.set(id, mergeMessagesById(backend, local));" in repair
 
     storage = _read(STORAGE)
-    assert "export async function listLegacyChatMessages(" in storage
+    assert "export async function listUnimportedChatMessages(" in storage
     assert 'db.messages .where("threadId") .equals(threadId) .toArray()' in storage
 
 
@@ -73,6 +75,21 @@ def test_the_next_page_is_scheduled_rather_than_waited_for():
 def test_rows_with_nothing_found_stay_retryable():
     repair = _read(REPAIR)
     assert "for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);" in repair
+
+
+def test_only_one_repair_pass_runs_at_a_time():
+    """Several sidebars can be mounted at once, so the write concurrency cap
+    only holds if their passes queue."""
+    repair = _read(REPAIR)
+    assert "const serial = createSerialQueue();" in repair
+    assert "return serial(() => runRepairPass(threads, known));" in repair
+
+
+def test_a_leftover_dexie_row_is_not_read_back_as_the_opening_prompt():
+    """Deleting a message prunes the backend and leaves the Dexie copy, so the
+    repair must not resurrect it into the title."""
+    storage = _read(STORAGE)
+    assert "if (!trustsLocalOnlyMessages(isLegacyChatImportDone(), backendCount)) { return []; }" in storage
 
 
 def test_a_local_read_is_sorted_like_the_backend_lists_messages():

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -28,7 +28,10 @@ def test_the_sidebar_hands_its_messages_to_the_repair():
     repair must not go and fetch the same rows a second time."""
     storage = _read(STORAGE)
     assert "export interface ChatThreadsWithMessages" in storage
-    assert "messagesByThreadId: new Map( entries .filter((e): e is typeof e & { messages: MessageRecord[] } => e.messages !== null, )" in storage
+    assert (
+        "messagesByThreadId: new Map( entries .filter((e): e is typeof e & { messages: MessageRecord[] } => e.messages !== null, )"
+        in storage
+    )
     # A read that failed is unknown. Reporting it as an empty chat would let the
     # repair write the row off for the session.
     assert "messages: legacy," in storage
@@ -66,17 +69,17 @@ def test_the_next_page_is_scheduled_rather_than_waited_for():
 
 def test_rows_with_nothing_found_stay_retryable():
     repair = _read(REPAIR)
-    assert (
-        "for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);"
-        in repair
-    )
+    assert "for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);" in repair
 
 
 def test_a_local_read_is_sorted_like_the_backend_lists_messages():
     """planLegacyTitleRepairs wants the opening message, and a Dexie read
     arrives in index order."""
     storage = _read(STORAGE)
-    assert "messages.sort( (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id), )" in storage
+    assert (
+        "messages.sort( (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id), )"
+        in storage
+    )
 
 
 def test_a_failed_read_leaves_the_rows_retryable():

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -79,7 +79,10 @@ def test_a_rename_wins_even_where_the_guard_is_not_enforced():
     desktop app ships its own frontend, so it can meet one that does not."""
     repair = _read(REPAIR)
     assert "const current = await listChatThreads({ includeArchived: true });" in repair
-    assert "live = repairsStillValid( repairs, new Map(current.map((thread) => [thread.id, thread.title])), );" in repair
+    assert (
+        "live = repairsStillValid( repairs, new Map(current.map((thread) => [thread.id, thread.title])), );"
+        in repair
+    )
     # The write runs over the confirmed set, not the planned one.
     assert "await runWithConcurrency(live, REPAIR_CONCURRENCY," in repair
     assert "{ expectedTitle: repair.previousTitle }," in repair

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -74,6 +74,17 @@ def test_only_one_repair_pass_runs_at_a_time():
     assert "return serial(() => runRepairPass(threads));" in repair
 
 
+def test_a_rename_wins_even_where_the_guard_is_not_enforced():
+    """expectedTitle is only enforced by a backend that knows the field, and the
+    desktop app ships its own frontend, so it can meet one that does not."""
+    repair = _read(REPAIR)
+    assert "const current = await listChatThreads({ includeArchived: true });" in repair
+    assert "live = repairsStillValid( repairs, new Map(current.map((thread) => [thread.id, thread.title])), );" in repair
+    # The write runs over the confirmed set, not the planned one.
+    assert "await runWithConcurrency(live, REPAIR_CONCURRENCY," in repair
+    assert "{ expectedTitle: repair.previousTitle }," in repair
+
+
 def test_a_failed_read_leaves_the_rows_retryable():
     repair = _read(REPAIR)
     assert (

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -89,7 +89,10 @@ def test_a_leftover_dexie_row_is_not_read_back_as_the_opening_prompt():
     """Deleting a message prunes the backend and leaves the Dexie copy, so the
     repair must not resurrect it into the title."""
     storage = _read(STORAGE)
-    assert "if (!trustsLocalOnlyMessages(isLegacyChatImportDone(), backendCount)) { return []; }" in storage
+    assert (
+        "if (!trustsLocalOnlyMessages(isLegacyChatImportDone(), backendCount)) { return []; }"
+        in storage
+    )
 
 
 def test_a_local_read_is_sorted_like_the_backend_lists_messages():

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -32,7 +32,10 @@ def test_the_repair_reads_its_own_messages_as_late_as_it_can():
 
     repair = _read(REPAIR)
     assert "messages = await batchListChatMessages(ids);" in repair
-    assert "export function repairLegacyChatTitles( threads: ThreadRecord[], ): Promise<number> {" in repair
+    assert (
+        "export function repairLegacyChatTitles( threads: ThreadRecord[], ): Promise<number> {"
+        in repair
+    )
 
     storage = _read(STORAGE)
     # The shared list function keeps its original shape: nothing hands a

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -28,7 +28,10 @@ def test_the_sidebar_hands_its_messages_to_the_repair():
     repair must not go and fetch the same rows a second time."""
     storage = _read(STORAGE)
     assert "export interface ChatThreadsWithMessages" in storage
-    assert "messagesByThreadId: new Map(entries.map((e) => [e.thread.id, e.messages]))" in storage
+    assert "messagesByThreadId: new Map( entries .filter((e): e is typeof e & { messages: MessageRecord[] } => e.messages !== null, )" in storage
+    # A read that failed is unknown. Reporting it as an empty chat would let the
+    # repair write the row off for the session.
+    assert "messages: legacy," in storage
 
     hook = _read(HOOK)
     assert "? await listStoredChatThreadsWithMessages(args)" in hook
@@ -55,8 +58,25 @@ def test_the_next_page_is_scheduled_rather_than_waited_for():
     would come back for the rest of the backlog."""
     repair = _read(REPAIR)
     assert "if (hasMore) { setTimeout(" in repair
-    assert "void repairLegacyChatTitles(threads, known)" in repair
+    # On `rest`: a row this page unmarked must not be drawn again by the same
+    # drain, or a failing PATCH starves every row behind it.
+    assert "void repairLegacyChatTitles(rest, known)" in repair
     assert "REPAIR_PAGE_PAUSE_MS" in repair
+
+
+def test_rows_with_nothing_found_stay_retryable():
+    repair = _read(REPAIR)
+    assert (
+        "for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);"
+        in repair
+    )
+
+
+def test_a_local_read_is_sorted_like_the_backend_lists_messages():
+    """planLegacyTitleRepairs wants the opening message, and a Dexie read
+    arrives in index order."""
+    storage = _read(STORAGE)
+    assert "messages.sort( (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id), )" in storage
 
 
 def test_a_failed_read_leaves_the_rows_retryable():

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -96,7 +96,10 @@ def test_the_migration_stays_off_where_the_guard_is_not_enforced():
     repair = _read(REPAIR)
     assert "if (!(await backendEnforcesTitleGuard())) return 0;" in repair
     assert 'const response = await authFetch("/openapi.json");' in repair
-    assert "probe = readGuardProbe( response.ok, response.ok ? await response.json() : null, );" in repair
+    assert (
+        "probe = readGuardProbe( response.ok, response.ok ? await response.json() : null, );"
+        in repair
+    )
     # Only a settled answer is cached. A 401 while the token warms up, or a 503
     # during startup, would otherwise park the migration for the session.
     assert "if (!probe.settled) guardSupport = null;" in repair

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -53,7 +53,32 @@ def test_the_repair_reads_only_stored_messages():
     assert "listUnimportedChatMessages" not in repair
     assert "mergeMessagesById" not in repair
     assert "db.messages" not in repair
-    assert "for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);" in repair
+
+
+def test_an_emptied_chat_is_not_retried_for_the_session():
+    """A chat the user deleted every message from reads back the same as one
+    still importing. Retrying it would re-read it on every refresh, since its
+    title stays clipped and keeps matching the pre-filter."""
+    repair = _read(REPAIR)
+    assert "const withoutMessages = threadsMissingMessages(ids, messages);" in repair
+    # Only fetched when there is something to decide, so a page of ordinary
+    # rows does not pay for it.
+    assert "if (withoutMessages.length > 0) {" in repair
+    assert "imported = await listChatImportLedger();" in repair
+    assert (
+        "for (const id of threadsAwaitingImport(ids, messages, imported)) { attempted.delete(id); }"
+        in repair
+    )
+
+
+def test_the_repair_never_creates_anything():
+    """updateStoredChatThread ensures the thread first, which re-imports one
+    deleted on another client from the Dexie rows still sitting here. A
+    migration patching a row that is gone has to 404, not resurrect it."""
+    repair = _read(REPAIR)
+    # The storage layer is out of the picture entirely, not just at this call.
+    assert 'from "./chat-history-storage"' not in repair
+    assert "await updateChatThread( repair.threadId, { title: repair.title }," in repair
 
 
 def test_the_next_page_is_scheduled_rather_than_waited_for():
@@ -75,17 +100,14 @@ def test_only_one_repair_pass_runs_at_a_time():
     assert "return serial(() => runRepairPass(threads));" in repair
 
 
-def test_a_rename_wins_even_where_the_guard_is_not_enforced():
-    """expectedTitle is only enforced by a backend that knows the field, and the
-    desktop app ships its own frontend, so it can meet one that does not."""
+def test_a_rename_is_left_to_the_backend_guard():
+    """The pass only runs where the guard is enforced, so re-listing the whole
+    history per page to check titles client side was both redundant and
+    quadratic: every page of 100 pulled every thread the account has."""
     repair = _read(REPAIR)
-    assert "const current = await listChatThreads({ includeArchived: true });" in repair
-    assert (
-        "live = repairsStillValid( repairs, new Map(current.map((thread) => [thread.id, thread.title])), );"
-        in repair
-    )
-    # The write runs over the confirmed set, not the planned one.
-    assert "await runWithConcurrency(live, REPAIR_CONCURRENCY," in repair
+    assert "listChatThreads" not in repair
+    assert "repairsStillValid" not in repair
+    assert "await runWithConcurrency(repairs, REPAIR_CONCURRENCY," in repair
     assert "expectedTitle: repair.previousTitle," in repair
 
 

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 FRONTEND = REPO / "studio/frontend/src/features/chat"
+BACKEND = REPO / "studio/backend"
 REPAIR = FRONTEND / "utils/repair-legacy-chat-titles.ts"
 HOOK = FRONTEND / "hooks/use-chat-sidebar-items.ts"
 STORAGE = FRONTEND / "utils/chat-history-storage.ts"
@@ -86,6 +87,22 @@ def test_a_rename_wins_even_where_the_guard_is_not_enforced():
     # The write runs over the confirmed set, not the planned one.
     assert "await runWithConcurrency(live, REPAIR_CONCURRENCY," in repair
     assert "{ expectedTitle: repair.previousTitle }," in repair
+
+
+def test_the_migration_stays_off_where_the_guard_is_not_enforced():
+    """A backend from before expectedTitle drops it and writes anyway. Sending
+    one to find out is the destructive act itself, so the served schema is what
+    answers, and anything unreadable counts as unsupported."""
+    repair = _read(REPAIR)
+    assert "if (!(await backendEnforcesTitleGuard())) return 0;" in repair
+    assert 'const response = await authFetch("/openapi.json");' in repair
+    assert "return schemaDeclaresExpectedTitle(await response.json());" in repair
+    # A failed probe is not cached, or one hiccup parks the migration all session.
+    assert "guardSupport = null;" in repair
+
+    backend = (BACKEND / "routes/chat_history.py").read_text(encoding = "utf-8")
+    # The probe reads the schema, so the field has to be declared on the model.
+    assert "expectedTitle: Optional[str] = None" in backend
 
 
 def test_a_failed_read_leaves_the_rows_retryable():

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -41,24 +41,22 @@ def test_the_sidebar_hands_its_messages_to_the_repair():
     assert "void repairLegacyChatTitles( loaded.threads, loaded.messagesByThreadId, )" in hook
 
     repair = _read(REPAIR)
-    assert "messages = known ? new Map(known) : await batchListChatMessages(ids);" in repair
+    assert "messages = known ? known : await batchListChatMessages(ids);" in repair
 
 
-def test_a_legacy_only_chat_falls_back_to_a_local_read():
-    """A chat still only in Dexie reads empty from the backend. Without the
-    local read it would sit in `attempted` with its title still clipped."""
+def test_the_repair_reads_only_stored_messages():
+    """Dexie keeps rows the backend has pruned, because deleting a message never
+    clears them. Reading it here could put a deleted prompt back into a title,
+    so a chat whose messages are not stored yet is left for a later refresh
+    instead."""
     repair = _read(REPAIR)
-    # Any row no rewrite could be made of, not just an empty one: a chat can be
-    # part imported, holding its opening turn locally and later ones remotely.
-    assert "const unexplained = threadsWithoutRepairs(candidates, repairs);" in repair
-    # Per row: one failing local read must not throw away the page's other
-    # repairs or stop it advancing to the rows behind it.
-    assert "await listUnimportedChatMessages(id, backend.length).catch( () => [], )" in repair
-    assert "messages.set(id, mergeMessagesById(backend, local));" in repair
-
-    storage = _read(STORAGE)
-    assert "export async function listUnimportedChatMessages(" in storage
-    assert 'db.messages .where("threadId") .equals(threadId) .toArray()' in storage
+    assert "listUnimportedChatMessages" not in repair
+    assert "mergeMessagesById" not in repair
+    assert "db.messages" not in repair
+    assert (
+        "for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);"
+        in repair
+    )
 
 
 def test_the_next_page_is_scheduled_rather_than_waited_for():
@@ -72,37 +70,12 @@ def test_the_next_page_is_scheduled_rather_than_waited_for():
     assert "REPAIR_PAGE_PAUSE_MS" in repair
 
 
-def test_rows_with_nothing_found_stay_retryable():
-    repair = _read(REPAIR)
-    assert "for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);" in repair
-
-
 def test_only_one_repair_pass_runs_at_a_time():
     """Several sidebars can be mounted at once, so the write concurrency cap
     only holds if their passes queue."""
     repair = _read(REPAIR)
     assert "const serial = createSerialQueue();" in repair
     assert "return serial(() => runRepairPass(threads, known));" in repair
-
-
-def test_a_leftover_dexie_row_is_not_read_back_as_the_opening_prompt():
-    """Deleting a message prunes the backend and leaves the Dexie copy, so the
-    repair must not resurrect it into the title."""
-    storage = _read(STORAGE)
-    assert (
-        "if (!trustsLocalOnlyMessages(isLegacyChatImportDone(), backendCount)) { return []; }"
-        in storage
-    )
-
-
-def test_a_local_read_is_sorted_like_the_backend_lists_messages():
-    """planLegacyTitleRepairs wants the opening message, and a Dexie read
-    arrives in index order."""
-    storage = _read(STORAGE)
-    assert (
-        "messages.sort( (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id), )"
-        in storage
-    )
 
 
 def test_a_failed_read_leaves_the_rows_retryable():

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -53,10 +53,7 @@ def test_the_repair_reads_only_stored_messages():
     assert "listUnimportedChatMessages" not in repair
     assert "mergeMessagesById" not in repair
     assert "db.messages" not in repair
-    assert (
-        "for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);"
-        in repair
-    )
+    assert "for (const id of threadsMissingMessages(ids, messages)) attempted.delete(id);" in repair
 
 
 def test_the_next_page_is_scheduled_rather_than_waited_for():

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -96,9 +96,10 @@ def test_the_migration_stays_off_where_the_guard_is_not_enforced():
     repair = _read(REPAIR)
     assert "if (!(await backendEnforcesTitleGuard())) return 0;" in repair
     assert 'const response = await authFetch("/openapi.json");' in repair
-    assert "return schemaDeclaresExpectedTitle(await response.json());" in repair
-    # A failed probe is not cached, or one hiccup parks the migration all session.
-    assert "guardSupport = null;" in repair
+    assert "probe = readGuardProbe( response.ok, response.ok ? await response.json() : null, );" in repair
+    # Only a settled answer is cached. A 401 while the token warms up, or a 503
+    # during startup, would otherwise park the migration for the session.
+    assert "if (!probe.settled) guardSupport = null;" in repair
 
     backend = (BACKEND / "routes/chat_history.py").read_text(encoding = "utf-8")
     # The probe reads the schema, so the field has to be declared on the model.

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -86,7 +86,17 @@ def test_a_rename_wins_even_where_the_guard_is_not_enforced():
     )
     # The write runs over the confirmed set, not the planned one.
     assert "await runWithConcurrency(live, REPAIR_CONCURRENCY," in repair
-    assert "{ expectedTitle: repair.previousTitle }," in repair
+    assert "expectedTitle: repair.previousTitle," in repair
+
+
+def test_the_write_is_guarded_on_the_message_it_took_the_title_from():
+    """Deleting the opening prompt does not change the title, so expectedTitle
+    alone still matches and would expand the deleted text."""
+    repair = _read(REPAIR)
+    assert "expectedOpeningMessageId: repair.openingMessageId," in repair
+
+    backend = (BACKEND / "routes/chat_history.py").read_text(encoding = "utf-8")
+    assert "expectedOpeningMessageId: Optional[str] = None" in backend
 
 
 def test_the_migration_stays_off_where_the_guard_is_not_enforced():
@@ -105,7 +115,8 @@ def test_the_migration_stays_off_where_the_guard_is_not_enforced():
     assert "if (!probe.settled) guardSupport = null;" in repair
 
     backend = (BACKEND / "routes/chat_history.py").read_text(encoding = "utf-8")
-    # The probe reads the schema, so the field has to be declared on the model.
+    # The probe reads the schema, so the fields have to be declared on the
+    # model. It looks for both, and both are what make the write safe.
     assert "expectedTitle: Optional[str] = None" in backend
 
 

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -48,8 +48,11 @@ def test_a_legacy_only_chat_falls_back_to_a_local_read():
     """A chat still only in Dexie reads empty from the backend. Without the
     local read it would sit in `attempted` with its title still clipped."""
     repair = _read(REPAIR)
-    assert "threadsMissingMessages(ids, messages)" in repair
-    assert "messages.set(id, await listLegacyChatMessages(id))" in repair
+    # Any row no rewrite could be made of, not just an empty one: a chat can be
+    # part imported, holding its opening turn locally and later ones remotely.
+    assert "const unexplained = threadsWithoutRepairs(candidates, repairs);" in repair
+    assert "const local = await listLegacyChatMessages(id);" in repair
+    assert "messages.set(id, mergeMessagesById(messages.get(id) ?? [], local));" in repair
 
     storage = _read(STORAGE)
     assert "export async function listLegacyChatMessages(" in storage

--- a/tests/studio/test_legacy_chat_title_repair.py
+++ b/tests/studio/test_legacy_chat_title_repair.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Wiring for the legacy chat title repair, where a unit test cannot reach.
+
+The repair module pulls in the chat API, so these are source checks on the
+seams: which map it reads from, and what keeps it going page to page.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+FRONTEND = REPO / "studio/frontend/src/features/chat"
+REPAIR = FRONTEND / "utils/repair-legacy-chat-titles.ts"
+HOOK = FRONTEND / "hooks/use-chat-sidebar-items.ts"
+STORAGE = FRONTEND / "utils/chat-history-storage.ts"
+
+
+def _read(path: Path) -> str:
+    return " ".join(path.read_text(encoding = "utf-8").split())
+
+
+def test_the_sidebar_hands_its_messages_to_the_repair():
+    """The with-messages load already fetched every thread's messages, so the
+    repair must not go and fetch the same rows a second time."""
+    storage = _read(STORAGE)
+    assert "export interface ChatThreadsWithMessages" in storage
+    assert "messagesByThreadId: new Map(entries.map((e) => [e.thread.id, e.messages]))" in storage
+
+    hook = _read(HOOK)
+    assert "? await listStoredChatThreadsWithMessages(args)" in hook
+    assert "void repairLegacyChatTitles( loaded.threads, loaded.messagesByThreadId, )" in hook
+
+    repair = _read(REPAIR)
+    assert "messages = known ? new Map(known) : await batchListChatMessages(ids);" in repair
+
+
+def test_a_legacy_only_chat_falls_back_to_a_local_read():
+    """A chat still only in Dexie reads empty from the backend. Without the
+    local read it would sit in `attempted` with its title still clipped."""
+    repair = _read(REPAIR)
+    assert "threadsMissingMessages(ids, messages)" in repair
+    assert "messages.set(id, await listLegacyChatMessages(id))" in repair
+
+    storage = _read(STORAGE)
+    assert "export async function listLegacyChatMessages(" in storage
+    assert 'db.messages .where("threadId") .equals(threadId) .toArray()' in storage
+
+
+def test_the_next_page_is_scheduled_rather_than_waited_for():
+    """A page that writes nothing fires no history update, so nothing else
+    would come back for the rest of the backlog."""
+    repair = _read(REPAIR)
+    assert "if (hasMore) { setTimeout(" in repair
+    assert "void repairLegacyChatTitles(threads, known)" in repair
+    assert "REPAIR_PAGE_PAUSE_MS" in repair
+
+
+def test_a_failed_read_leaves_the_rows_retryable():
+    repair = _read(REPAIR)
+    assert "} catch { // Nothing was decided, so let a later refresh try these again. for (const id of ids) attempted.delete(id); return 0; }" in repair


### PR DESCRIPTION
Widening the chat sidebar never revealed any more of a chat title. The rows kept their `...` no matter how much room they had.

The clip was not in the layout, it was baked into the stored title. When a chat had no model written title we fell back to the first user message cut at 48 characters with a literal `...` appended, and that string is what went into the database. No width could bring back characters that were never stored.

The giveaway is that the `...` lands at a different x on each row. A CSS clip ends every row at the same pixel, a character count ends them wherever the glyphs happen to fall.

## Changes

- `chat-title.ts` (new): the fallback title now keeps the whole first line and lets the sidebar row clip it with CSS, so the text grows with the sidebar. The 120 character cap only keeps a pasted wall of text out of the store and matches the rename input's `maxLength`.
- `repair-legacy-chat-titles.ts` (new): titles already stored pre-cut are rewritten from their own first message when the sidebar loads, otherwise existing chats would keep the old clip forever. One batched `messages:batch` call covers every candidate rather than one request per row.
- `use-chat-sidebar-items.ts`: runs the repair after each load and skips threads it already tried.

## Notes on the repair

- A title only qualifies if it is exactly the old 48 character cut of its own first user message, so a chat someone renamed to something ending in `...` is left alone.
- A title patch does not touch `updatedAt`, so Recents keeps its order while rows are rewritten.
- It takes whichever threads the caller just loaded, so a project scoped sidebar repairs its own rows instead of waiting for a full listing.

## Testing

- New `tests/chat-title-clip.test.ts` covers the title itself and the repair plan, including the rename that must not be touched.
- Full suite 734 passing, typecheck and eslint clean, production build clean.
