### PR TITLE
Studio: line up every sidebar row pill with New Chat

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -901,6 +901,12 @@ export function AppSidebar() {
   const chatDisabled = trainingInProgress;
   const usesDesktopTitlebar = usesCustomTitlebar || usesNativeMacTitlebar;
 
+  // One box for every row pill, so a hover pill has the same edges wherever it
+  // lands. The list scroller hides its rail (index.css) instead of eating width.
+  const rowPadding = usesDesktopTitlebar
+    ? "pl-[5px] pr-2"
+    : "pl-1.5 pr-1.75";
+
 
   // One definition per row, so pinned rows and the flyout can't drift apart.
   const navRows: Record<SidebarNavItemId, NavRowDef> = {
@@ -1829,11 +1835,10 @@ export function AppSidebar() {
         )}
       </SidebarHeader>
 
-      {/* Paired padding shifts Tauri's primary pills left without changing width. */}
       <SidebarGroup
         className={cn(
           "group-data-[collapsible=icon]:px-0 shrink-0 transition-[padding]",
-          usesDesktopTitlebar ? "pl-[5px] pr-2" : "pl-1.5 pr-1.75",
+          rowPadding,
           usesDesktopTitlebar ? "pt-[11px]" : "pt-[9px]",
           // Scrolled: New Chat is pinned, give a little gap below it.
           scrolled ? "pb-[5px]" : "pb-px",
@@ -1920,7 +1925,7 @@ export function AppSidebar() {
           data-tour="navbar"
           className={cn(
             "group-data-[collapsible=icon]:px-0 py-0 shrink-0",
-            usesDesktopTitlebar ? "pl-[5px] pr-2" : "pl-1.5 pr-1.75",
+            rowPadding,
           )}
         >
 
@@ -2086,7 +2091,7 @@ export function AppSidebar() {
                   </CollapsibleTrigger>
                 </SidebarGroupLabel>
                 <CollapsibleContent>
-                  <SidebarGroupContent className="pl-1.5 pr-1.75">
+                  <SidebarGroupContent className={rowPadding}>
                     <SidebarMenu>
                       {pinnedProjectRecords.map((project) => {
                         const projectChats =
@@ -2236,13 +2241,7 @@ export function AppSidebar() {
                 </CollapsibleTrigger>
               </SidebarGroupLabel>
               <CollapsibleContent>
-                <SidebarGroupContent
-                  className={
-                    usesDesktopTitlebar
-                      ? "pl-2 pr-[5px]"
-                      : "pl-1.5 pr-1.75"
-                  }
-                >
+                <SidebarGroupContent className={rowPadding}>
                   <SidebarMenu>
                     {recentChatItems.map((item) =>
                       renderChatSidebarItem(item, "recent"),
@@ -2274,7 +2273,7 @@ export function AppSidebar() {
               </CollapsibleTrigger>
             </SidebarGroupLabel>
             <CollapsibleContent>
-              <SidebarGroupContent className="pl-1.5 pr-1.75">
+              <SidebarGroupContent className={rowPadding}>
                 <SidebarMenu>
                   {runItems.map((run) => {
                     // Explicit selection wins. Otherwise highlight the active job only while the "Current Run"
@@ -2366,6 +2365,8 @@ export function AppSidebar() {
       <SidebarFooter
         className={cn(
           "relative pb-[11px] group-data-[collapsible=icon]:px-0",
+          // Same box as the rows above.
+          rowPadding,
           // pt-[3px] cancels the profile button's -3px margin, so the 8px
           // above it is whatever sits over the footer edge (the fade plateau,
           // or the list's pb-2 once the fade is hidden) and 8px sits below.
@@ -2374,7 +2375,7 @@ export function AppSidebar() {
       >
         {/* Fade above the profile box, shown only when there's more list below
             the fold; at the bottom (or short lists) it fades so the last row
-            shows fully (Gemini-style). right-2 keeps it clear of the 8px scrollbar gutter. */}
+            shows fully (Gemini-style). No scroll rail to clear, so full width. */}
         <div
           aria-hidden="true"
           className={cn(
@@ -2382,7 +2383,7 @@ export function AppSidebar() {
             // ramp is still part-transparent there and slices the last row
             // mid-glyph. from-[8px] holds it opaque just across the clip, and
             // matches the list's pb-2 so the gap is the same once it hides.
-            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[8px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
+            "pointer-events-none absolute inset-x-0 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[8px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
             // Shorter fade with the update card so the list reads closer to
             // it, but still tall enough to clear a row.
             showUpdateCard ? "h-7" : "h-10",

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2676,42 +2676,49 @@ html[data-chat-font] .aui-root {
 	background: oklch(0.72 0 0 / 0.5);
 }
 
-/* Sidebars, settings and search: hide the scroll thumb at rest and reveal it
-   only while the area is hovered, so the rail never sits visible over content. */
-.sidebar-scroll-fade,
+/* Settings and search: hide the scroll thumb at rest and reveal it only while
+   the area is hovered, so the rail never sits visible over content. */
 .run-settings-scroll,
 .hover-scrollbar {
 	scrollbar-color: transparent transparent;
 }
 
-.sidebar-scroll-fade::-webkit-scrollbar-thumb,
 .run-settings-scroll::-webkit-scrollbar-thumb,
 .hover-scrollbar::-webkit-scrollbar-thumb {
 	background: transparent;
 }
 
-.sidebar-scroll-fade:hover,
 .run-settings-scroll:hover,
 .hover-scrollbar:hover {
 	scrollbar-color: oklch(0.5 0 0 / 0.4) transparent;
 }
 
-.sidebar-scroll-fade:hover::-webkit-scrollbar-thumb,
 .run-settings-scroll:hover::-webkit-scrollbar-thumb,
 .hover-scrollbar:hover::-webkit-scrollbar-thumb {
 	background: oklch(0.5 0 0 / 0.4);
 }
 
-.dark .sidebar-scroll-fade:hover,
 .dark .run-settings-scroll:hover,
 .dark .hover-scrollbar:hover {
 	scrollbar-color: oklch(0.72 0 0 / 0.4) transparent;
 }
 
-.dark .sidebar-scroll-fade:hover::-webkit-scrollbar-thumb,
 .dark .run-settings-scroll:hover::-webkit-scrollbar-thumb,
 .dark .hover-scrollbar:hover::-webkit-scrollbar-thumb {
 	background: oklch(0.72 0 0 / 0.4);
+}
+
+/* Sidebar list: no scroll rail. A rail narrows the rows inside the scroller,
+   so their pills came out short of New Chat above it, by 8px on WebKit, a thin
+   rail on Chromium, nothing under macOS overlay scrollbars. The thumb was
+   already transparent at rest, and the fades still show there is more list. */
+.sidebar-scroll-fade {
+	scrollbar-width: none;
+}
+
+.sidebar-scroll-fade::-webkit-scrollbar {
+	width: 0;
+	height: 0;
 }
 
 /* Run settings: always reserve the scrollbar gutter so the header close

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -73,22 +73,36 @@ test("footer profile sits 11px above the sidebar edge", async () => {
   );
 });
 
-test("Tauri primary navigation sits 1px left", async () => {
+test("every sidebar row pill sits in one shared box", async () => {
+  // A recent chat's pill has to match New Chat's, so the padding is defined
+  // once and every group takes it.
   const source = await sidebarSource();
-  const shiftedInsets = source.match(
-    /usesDesktopTitlebar \? "pl-\[5px\] pr-2" : "pl-1\.5 pr-1\.75"/g,
+  assert.match(
+    source,
+    /const rowPadding = usesDesktopTitlebar\s*\?\s*"pl-\[5px\] pr-2"\s*:\s*"pl-1\.5 pr-1\.75"/,
   );
-  assert.equal(shiftedInsets?.length, 2);
+  // New Chat, the nav rows, pinned projects, Recents, training runs, footer.
+  assert.equal(source.match(/(?<!const )rowPadding[,}]/g)?.length, 6);
+  assert.equal(source.match(/"pl-2 pr-\[5px\]"/g), null);
 });
 
-test("Tauri chat Recents sits 2px right", async () => {
+test("the sidebar list keeps no scroll rail to steal row width", async () => {
+  // A rail narrows every row under New Chat, which sits above the scroller.
+  const css = await readFile(
+    new URL("../src/index.css", import.meta.url),
+    "utf8",
+  );
+  assert.match(css, /\.sidebar-scroll-fade \{\s*scrollbar-width: none;\s*\}/);
+  assert.match(
+    css,
+    /\.sidebar-scroll-fade::-webkit-scrollbar \{\s*width: 0;\s*height: 0;\s*\}/,
+  );
+});
+
+test("Tauri chat Recents label keeps its 2px shift", async () => {
   const source = await sidebarSource();
   assert.match(
     source,
     /scrolled && "is-scrolled",\s*usesDesktopTitlebar && "translate-x-\[2px\]"/,
-  );
-  assert.match(
-    source,
-    /usesDesktopTitlebar\s*\?\s*"pl-2 pr-\[5px\]"\s*:\s*"pl-1\.5 pr-1\.75"/,
   );
 });


### PR DESCRIPTION
The hover pill on the nav rows and on recent chats is not the same width as the one on New Chat, so the sidebar reads as slightly ragged down its right edge.

Two separate offsets, neither of them in the pill styling.

**The scroll rail.** New Chat sits above the scrolling list and gets the sidebar's full width. Everything below it (Model hub, Projects, Images, Train, More and all of Recents) lives inside the scroller, and the global `::-webkit-scrollbar { width: 8px }` gives that scroller a rail which takes 8px off every row inside it. We already knew about that lane, the footer fade has a comment about keeping clear of it, we just never compensated the rows.

**A 3px shift on Recents.** The nav groups used `pl-[5px] pr-2` while Recents used the mirrored `pl-2 pr-[5px]`. Same total width, but every recent chat pill sat 3px right of the nav pills, so fixing the width alone would still have left the right edges off.

## Changes

- `index.css`: the sidebar list no longer draws a scroll rail. I went with this over padding compensation because the width a rail takes is not a constant: 8px on WebKit (the desktop app), a thin rail on Chromium, nothing under macOS overlay scrollbars. Hardcoding 8px would make the rows too wide in the browser build. The thumb was already fully transparent until hover, and the top and bottom fades still signal more list.
- `app-sidebar.tsx`: one `rowPadding` definition now feeds all six groups (New Chat, nav rows, pinned projects, Recents, training runs, footer card). The mirrored Recents inset is gone, and the footer fade spans the full width now that there is no lane to clear.

Geometry for sidebar width `W` on the desktop app:

| row | before | after |
| --- | --- | --- |
| New Chat | `[5, W-8]` | `[5, W-8]` |
| nav rows | `[5, W-16]` | `[5, W-8]` |
| recent chats | `[8, W-13]` | `[5, W-8]` |

## Testing

Two tests pinned the old offsets by name, `Tauri primary navigation sits 1px left` and `Tauri chat Recents sits 2px right`. Since the shift is the bug, I rewrote them to assert the new rule rather than dropping them: one shared padding box across all six groups, and no rail in the list. The Recents label's own 2px shift is untouched and still covered.

Full suite 734 passing, typecheck clean, eslint unchanged from baseline on the touched file.
