### PR TITLE
Studio: pin the /status chat template echo behaviour

### DIFF
--- a/studio/backend/tests/test_inference_status_loaded_gguf.py
+++ b/studio/backend/tests/test_inference_status_loaded_gguf.py
@@ -127,9 +127,7 @@ def test_the_users_chat_template_override_wins_over_the_runtime_projection(statu
     assert status.chat_template_override == "user-template"
 
 
-def test_an_auto_applied_chat_template_is_not_reported_as_the_users(
-    status_route, monkeypatch
-):
+def test_an_auto_applied_chat_template_is_not_reported_as_the_users(status_route, monkeypatch):
     # A bundled family template is not a user override; re-sending it would pin
     # it onto the next, unrelated model.
     monkeypatch.setattr(

--- a/studio/backend/tests/test_inference_status_loaded_gguf.py
+++ b/studio/backend/tests/test_inference_status_loaded_gguf.py
@@ -116,3 +116,27 @@ def test_a_local_path_load_without_a_lease_is_still_local(status_route):
     status = status_route(_StatusBackend(local, native_grant_backed = False))
     assert status.is_gguf is True
     assert status.is_local_model is True
+
+
+def test_the_users_chat_template_override_wins_over_the_runtime_projection(status_route):
+    # The field is on the shared runtime fields, so the projection carries it too.
+    # It must be overridden, not passed alongside, or the call is a TypeError.
+    backend = _StatusBackend("org/A-GGUF")
+    backend.chat_template_override = "user-template"
+    status = status_route(backend)
+    assert status.chat_template_override == "user-template"
+
+
+def test_an_auto_applied_chat_template_is_not_reported_as_the_users(
+    status_route, monkeypatch
+):
+    # A bundled family template is not a user override; re-sending it would pin
+    # it onto the next, unrelated model.
+    monkeypatch.setattr(
+        inference_route,
+        "resolve_effective_chat_template_override",
+        lambda **k: "bundled-template",
+    )
+    backend = _StatusBackend("org/A-GGUF")
+    backend.chat_template_override = "bundled-template"
+    assert status_route(backend).chat_template_override is None


### PR DESCRIPTION
## Context

This started as a fix for the `/api/inference/status` 500, but #8074 landed that first. Rebased onto it, so the source fix is gone and only the missing test coverage is left.

## What is still missing

#8074 added a source-level contract: no runtime field is also passed as an explicit keyword at a `**_llama_runtime_fields(...)` splat site. That is the right guard for the collision that caused the 500, but it reads source text, not values, so it cannot see whether the assignment it relies on is still there.

Delete the line #8074 added:

```python
_runtime_fields["chat_template_override"] = _reported_chat_template_override
```

and the contract stays green, because there is no explicit keyword to collide with. `/status` quietly starts reporting `llama_backend.chat_template_override` raw. The auto-applied bundled family template that `get_status` deliberately reports as `None` now reads as a user override, the frontend adopts it as editable state, and re-sends it as an explicit override for the next, unrelated model. That is the exact behaviour the surrounding comment says must not happen.

Verified on this branch with that one line removed:

```
tests/studio/test_inference_status_runtime_fields_contract.py   2 passed
tests/test_inference_status_loaded_gguf.py                      1 failed, 5 passed
```

The failure is `test_an_auto_applied_chat_template_is_not_reported_as_the_users`.

## Change

Two cases added to `tests/test_inference_status_loaded_gguf.py`, which already drives the real `get_status` handler against the real response model:

- a user override is echoed back
- an auto-applied bundled template still reports `None`

No source changes. The first case is the weaker of the two on its own, since the projected value and the expected value coincide there, but it documents the intended contract next to the one that catches the regression.

```
tests/test_inference_status_loaded_gguf.py                      6 passed
tests/studio/test_inference_status_runtime_fields_contract.py   2 passed
```

## Note

The original diff here duplicated #8074 (same approach, assign into the dict before splatting). Reduced rather than closed, since the behavioural gap above is real and unclaimed. Happy to close instead if you would rather fold these into the contract file.
