### PR TITLE
Let the /status runtime-fields contract accept a hoisted splat

### DIFF
--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -400,24 +400,81 @@ class TestRouteCompleteness:
             idx = end
         return blocks
 
+    _NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+
     @staticmethod
     def _is_runtime_fields_call(node) -> bool:
+        """``_llama_runtime_fields(llama_backend)``, argument included.
+
+        The argument is half the contract: a same-named helper called on something else does not
+        prove the GGUF ``/status`` response is fed from the llama backend.
+        """
         return (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
             and node.func.id == "_llama_runtime_fields"
+            and len(node.args) == 1
+            and not node.keywords
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "llama_backend"
         )
+
+    def _bindings_in_own_scope(self, scope, name: str) -> list:
+        """Every rebinding of ``name`` in ``scope``'s OWN body, as (node, value) pairs.
+
+        Nested functions, lambdas and classes are separate scopes, so a binding inside one says
+        nothing about the outer name and is skipped. A binding form this does not model (a for
+        target, a ``with ... as``) yields a None value, which the caller reads as "not the helper"
+        so an unrecognised rebind fails closed rather than passing silently.
+        """
+        found: list = []
+        handled: set = set()
+
+        def walk(node) -> None:
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, self._NESTED_SCOPES):
+                    continue
+                if isinstance(child, ast.Assign):
+                    for target in child.targets:
+                        if isinstance(target, ast.Name) and target.id == name:
+                            found.append((child, child.value))
+                            handled.add(id(target))
+                elif isinstance(child, (ast.AnnAssign, ast.AugAssign, ast.NamedExpr)):
+                    target = child.target
+                    if isinstance(target, ast.Name) and target.id == name:
+                        # AnnAssign may be a bare declaration with no value; AugAssign rebinds to
+                        # something derived, never the helper call itself.
+                        value = child.value if isinstance(child, (ast.AnnAssign, ast.NamedExpr)) else None
+                        found.append((child, value))
+                        handled.add(id(target))
+                elif (
+                    isinstance(child, ast.Name)
+                    and child.id == name
+                    and isinstance(child.ctx, ast.Store)
+                    and id(child) not in handled
+                ):
+                    found.append((child, None))
+                walk(child)
+
+        walk(scope)
+        return found
 
     def _status_calls_getting_runtime_fields(self) -> list:
         """``InferenceStatusResponse(...)`` calls that actually receive the llama runtime fields.
 
         A call site may hoist the helper call to overwrite one entry before splatting, since
         passing an overriding keyword alongside ``**fields`` is a TypeError. That is a valid way
-        to receive the fields, so accept it, but only when the assignment that REACHES the call
-        supplies them: a later ``name = {}`` in the same function rebinds the name and the
-        response gets nothing, and a same-named assignment in some other function is irrelevant.
-        Subscript writes such as ``fields["x"] = y`` mutate rather than rebind, so they do not
-        count as a reassignment.
+        to receive the fields, so accept it.
+
+        Accepting a hoist means deciding which assignment reaches the call, and "the last one by
+        line number" is not that: a conditional rebind, an annotated rebind, or a binding inside a
+        nested function all defeat it. Rather than model control flow, require that EVERY binding
+        of the splatted name in the function's own scope is the helper call. That is stricter than
+        a reaching-definition check and needs no flow analysis: one hoisted assignment passes, and
+        any rebind to anything else fails, whether conditional or not.
+
+        Subscript writes such as ``fields["x"] = y`` mutate rather than rebind, so they are not
+        bindings and correctly do not count.
         """
         tree = ast.parse(self._source)
         funcs = [
@@ -446,14 +503,10 @@ class TestRouteCompleteness:
                 if not enclosing:
                     continue
                 scope = max(enclosing, key = lambda f: f.lineno)
-                reaching = None
-                for node in ast.walk(scope):
-                    if not isinstance(node, ast.Assign) or node.lineno >= call.lineno:
-                        continue
-                    if any(isinstance(t, ast.Name) and t.id == kw.value.id for t in node.targets):
-                        if reaching is None or node.lineno > reaching.lineno:
-                            reaching = node
-                if reaching is not None and self._is_runtime_fields_call(reaching.value):
+                bindings = self._bindings_in_own_scope(scope, kw.value.id)
+                if bindings and all(
+                    self._is_runtime_fields_call(value) for _node, value in bindings
+                ):
                     found.append(call)
                     break
         return found

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -463,22 +463,153 @@ class TestRouteCompleteness:
         walk(scope)
         return found
 
+    @staticmethod
+    def _parameter_names(scope) -> set:
+        """Every name ``scope`` binds through its signature.
+
+        A parameter is a binding that no assignment statement records, so without this a function
+        taking ``fields`` and reassigning it to the helper AFTER the constructor would look like a
+        single clean hoist while the call actually splatted the incoming argument.
+        """
+        args = getattr(scope, "args", None)
+        if args is None:
+            return set()
+        names = {
+            a.arg
+            for a in (
+                list(getattr(args, "posonlyargs", []) or [])
+                + list(args.args or [])
+                + list(args.kwonlyargs or [])
+            )
+        }
+        for extra in (args.vararg, args.kwarg):
+            if extra is not None:
+                names.add(extra.arg)
+        return names
+
+    @staticmethod
+    def _statement_chain(scope, call) -> list:
+        """``[(block, index), ...]`` from ``scope``'s body down to the statement holding ``call``.
+
+        Each entry is a statement list and the position within it of the statement containing the
+        call, which is what lets the caller ask "did a binding run before this" without a real
+        control-flow graph: an earlier sibling in a shared block always executes first.
+        """
+        chain: list = []
+
+        def contains(node) -> bool:
+            return any(n is call for n in ast.walk(node))
+
+        def descend(block) -> None:
+            for i, stmt in enumerate(block):
+                if not contains(stmt):
+                    continue
+                chain.append((block, i))
+                for _field, value in ast.iter_fields(stmt):
+                    if (
+                        isinstance(value, list)
+                        and value
+                        and isinstance(value[0], ast.stmt)
+                        and any(contains(s) for s in value)
+                    ):
+                        descend(value)
+                        break
+                return
+
+        descend(scope.body)
+        return chain
+
+    def _binding_dominates(self, scope, name: str, call) -> bool:
+        """True when a helper binding of ``name`` provably runs before ``call``.
+
+        Sibling order in one statement list is the only ordering Python guarantees without
+        modelling control flow, so that is all this claims: the binding has to be an earlier
+        statement in a block that also (transitively) contains the call. A binding tucked inside an
+        earlier ``if`` is not a sibling and does not count, which is the point -- a conditional
+        hoist can be skipped, leaving the constructor to splat a stale or unbound name.
+        """
+        for block, index in self._statement_chain(scope, call):
+            for stmt in block[:index]:
+                if isinstance(stmt, ast.Assign):
+                    targets = stmt.targets
+                elif isinstance(stmt, ast.AnnAssign):
+                    targets = [stmt.target]
+                else:
+                    continue
+                if not any(isinstance(t, ast.Name) and t.id == name for t in targets):
+                    continue
+                if self._is_runtime_fields_call(stmt.value):
+                    return True
+        return False
+
+    # The fields this contract asserts reach the response. Overwriting one is as fatal as deleting
+    # it: the route answers, so nothing raises, and /status quietly reports a value the backend
+    # never produced.
+    _PROTECTED_RUNTIME_KEYS = frozenset({"native_context_length"})
+
+    def _mutations_are_safe(self, scope, name: str) -> bool:
+        """True when nothing in ``scope`` can remove a protected key from ``name``.
+
+        The real call site edits one entry of the hoisted dict before splatting it, so mutation has
+        to be allowed -- but only the additive kind. A subscript write to an unprotected key adds or
+        replaces something this contract makes no claim about. Anything else fails closed: ``del``,
+        a computed subscript key we cannot read, and every method call, because ``pop``, ``clear``
+        and ``popitem`` all drop keys and ``update`` can overwrite them. A legitimate new pattern
+        will trip this and get a human to re-read the contract, which is the cheaper mistake.
+        """
+        ok = True
+
+        def walk(node) -> None:
+            nonlocal ok
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, self._NESTED_SCOPES):
+                    continue
+                if isinstance(child, ast.Delete):
+                    for target in child.targets:
+                        value = getattr(target, "value", None)
+                        if isinstance(value, ast.Name) and value.id == name:
+                            ok = False
+                elif isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute):
+                    obj = child.func.value
+                    if isinstance(obj, ast.Name) and obj.id == name:
+                        ok = False
+                elif isinstance(child, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+                    targets = child.targets if isinstance(child, ast.Assign) else [child.target]
+                    for target in targets:
+                        if not isinstance(target, ast.Subscript):
+                            continue
+                        obj = target.value
+                        if not (isinstance(obj, ast.Name) and obj.id == name):
+                            continue
+                        key = target.slice
+                        if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
+                            ok = False  # a computed key could be any of the protected ones
+                        elif key.value in self._PROTECTED_RUNTIME_KEYS:
+                            ok = False
+                walk(child)
+
+        walk(scope)
+        return ok
+
     def _status_calls_getting_runtime_fields(self) -> list:
         """``InferenceStatusResponse(...)`` calls that actually receive the llama runtime fields.
 
         A call site may hoist the helper call to overwrite one entry before splatting, since
         passing an overriding keyword alongside ``**fields`` is a TypeError. That is a valid way
-        to receive the fields, so accept it.
+        to receive the fields, so accept it -- under three conditions, because a hoist turns one
+        expression into a name whose value depends on everything the function does to it:
 
-        Accepting a hoist means deciding which assignment reaches the call, and "the last one by
-        line number" is not that: a conditional rebind, an annotated rebind, or a binding inside a
-        nested function all defeat it. Rather than model control flow, require that EVERY binding
-        of the splatted name in the function's own scope is the helper call. That is stricter than
-        a reaching-definition check and needs no flow analysis: one hoisted assignment passes, and
-        any rebind to anything else fails, whether conditional or not.
-
-        Subscript writes such as ``fields["x"] = y`` mutate rather than rebind, so they are not
-        bindings and correctly do not count.
+        1. EVERY binding of the name in the function's own scope is the helper call. Stricter than
+           reaching definitions and needs no flow analysis: one hoist passes, any rebind to
+           anything else fails, conditional or not. Parameters count as bindings, so a name that
+           arrives as an argument and is reassigned later cannot pass on the later assignment.
+        2. One of those bindings DOMINATES the call, as an earlier sibling statement. Condition 1
+           alone accepts a binding that is conditional or sits after the constructor, where some
+           executions reach the splat with a different dict or an unbound name.
+        3. No mutation between them can remove a protected key. The splatted dict is deliberately
+           edited at the real call site, and a future ``pop`` or ``del`` of
+           ``native_context_length`` would leave this contract green while /status stopped
+           reporting the field.
         """
         tree = ast.parse(self._source)
         funcs = [
@@ -507,12 +638,20 @@ class TestRouteCompleteness:
                 if not enclosing:
                     continue
                 scope = max(enclosing, key = lambda f: f.lineno)
-                bindings = self._bindings_in_own_scope(scope, kw.value.id)
-                if bindings and all(
+                name = kw.value.id
+                if name in self._parameter_names(scope):
+                    continue
+                bindings = self._bindings_in_own_scope(scope, name)
+                if not bindings or not all(
                     self._is_runtime_fields_call(value) for _node, value in bindings
                 ):
-                    found.append(call)
-                    break
+                    continue
+                if not self._binding_dominates(scope, name, call):
+                    continue
+                if not self._mutations_are_safe(scope, name):
+                    continue
+                found.append(call)
+                break
         return found
 
     def test_gguf_load_responses_have_field(self):
@@ -554,6 +693,78 @@ class TestRouteCompleteness:
         calls = self._status_calls_getting_runtime_fields()
         assert calls, "No InferenceStatusResponse block with llama_backend has runtime fields"
         assert "for name in _InferenceRuntimeFields.model_fields" in self._source
+
+    # ── the hoist analysis itself, on synthetic sources ──────────────────────
+    def _accepts(self, body: str) -> bool:
+        """Run the analyser over a synthetic route function instead of the real file."""
+        import textwrap
+
+        self._source = "async def status(llama_backend):\n" + textwrap.indent(
+            textwrap.dedent(body).strip("\n"), "    "
+        )
+        return bool(self._status_calls_getting_runtime_fields())
+
+    def test_the_hoist_analysis_accepts_the_shape_the_route_actually_uses(self):
+        # Sibling hoist, then one edit to a field this contract makes no claim about. The three
+        # rejection tests below are only meaningful if this stays accepted.
+        assert self._accepts(
+            """
+            if llama_backend is not None:
+                fields = _llama_runtime_fields(llama_backend)
+                fields["chat_template_override"] = None
+                return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+        # The unhoisted form needs no analysis at all.
+        assert self._accepts(
+            "return InferenceStatusResponse(**_llama_runtime_fields(llama_backend))"
+        )
+
+    def test_the_hoist_analysis_rejects_a_binding_that_can_be_skipped(self):
+        """A conditional hoist is not a hoist: the constructor can run without it.
+
+        Every binding is the helper call, so a bindings-only check passes this, and the route
+        raises UnboundLocalError on the branch that skipped the assignment. Requiring the binding
+        to be an earlier sibling of the call rejects it.
+        """
+        assert not self._accepts(
+            """
+            if llama_backend.is_gguf:
+                fields = _llama_runtime_fields(llama_backend)
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+
+    def test_the_hoist_analysis_rejects_a_binding_that_lands_after_the_call(self):
+        """A name that arrives as an argument and is rebound later never reaches the splat."""
+        import textwrap
+
+        self._source = textwrap.dedent(
+            """
+            async def status(llama_backend, fields):
+                response = InferenceStatusResponse(is_gguf = True, **fields)
+                fields = _llama_runtime_fields(llama_backend)
+                return response
+            """
+        )
+        assert not self._status_calls_getting_runtime_fields()
+
+    def test_the_hoist_analysis_rejects_dropping_a_protected_field(self):
+        """The dict is edited before the splat, so removal has to be checked, not just binding."""
+        for destructive in (
+            'del fields["native_context_length"]',
+            'fields.pop("native_context_length", None)',
+            "fields.clear()",
+            'fields[_key] = None',  # a computed key could be the protected one
+            'fields["native_context_length"] = None',
+        ):
+            assert not self._accepts(
+                f"""
+                fields = _llama_runtime_fields(llama_backend)
+                {destructive}
+                return InferenceStatusResponse(is_gguf = True, **fields)
+                """
+            ), f"{destructive} left the /status contract green"
 
     def test_non_gguf_status_path_reports_runtime_context_length(self):
         """Non-GGUF InferenceStatusResponse reports context_length from model_info."""

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -368,6 +368,15 @@ class TestPydanticModels:
 # =====================================================================
 
 
+# `match` capture nodes, which bind a name without an ast.Name store. Looked up rather than named
+# directly so this file still parses on a Python without them.
+_MATCH_CAPTURES = tuple(
+    node
+    for node in (getattr(ast, attr, None) for attr in ("MatchAs", "MatchStar", "MatchMapping"))
+    if node is not None
+) or (type(None),)
+
+
 class TestRouteCompleteness:
     """All response construction sites in routes/inference.py include native_context_length."""
 
@@ -426,6 +435,13 @@ class TestRouteCompleteness:
         nothing about the outer name and is skipped. A binding form this does not model (a for
         target, a ``with ... as``) yields a None value, which the caller reads as "not the helper"
         so an unrecognised rebind fails closed rather than passing silently.
+
+        Not every binding is an ``ast.Name`` store, though, and the ones that are not would slip
+        past a Name-only walk entirely rather than fail closed. ``except E as fields`` is the sharp
+        one: Python DELETES the target when the handler ends, so a handled-exception path can reach
+        the constructor with the name unbound. ``import x as fields`` and the capture patterns of a
+        ``match`` statement bind through their own node types too. All are recorded with a None
+        value.
         """
         found: list = []
         handled: set = set()
@@ -456,6 +472,17 @@ class TestRouteCompleteness:
                     and child.id == name
                     and isinstance(child.ctx, ast.Store)
                     and id(child) not in handled
+                ):
+                    found.append((child, None))
+                elif isinstance(child, ast.ExceptHandler) and child.name == name:
+                    found.append((child, None))
+                elif isinstance(child, ast.alias) and (child.asname or child.name) == name:
+                    found.append((child, None))
+                elif isinstance(child, (ast.Global, ast.Nonlocal)) and name in child.names:
+                    found.append((child, None))
+                elif isinstance(child, _MATCH_CAPTURES) and name in (
+                    getattr(child, "name", None),
+                    getattr(child, "rest", None),  # MatchMapping spells its capture `rest`
                 ):
                     found.append((child, None))
                 walk(child)
@@ -547,16 +574,23 @@ class TestRouteCompleteness:
     # never produced.
     _PROTECTED_RUNTIME_KEYS = frozenset({"native_context_length"})
 
-    def _mutations_are_safe(self, scope, name: str) -> bool:
+    def _mutations_are_safe(self, scope, name: str, call) -> bool:
         """True when nothing in ``scope`` can remove a protected key from ``name``.
 
         The real call site edits one entry of the hoisted dict before splatting it, so mutation has
         to be allowed -- but only the additive kind. A subscript write to an unprotected key adds or
-        replaces something this contract makes no claim about. Anything else fails closed: ``del``,
-        a computed subscript key we cannot read, and every method call, because ``pop``, ``clear``
-        and ``popitem`` all drop keys and ``update`` can overwrite them. A legitimate new pattern
-        will trip this and get a human to re-read the contract, which is the cheaper mistake.
+        replaces something this contract makes no claim about.
+
+        Everything else about the name fails closed, and the rule is stated positively for that
+        reason: the ONLY reads of the name allowed anywhere in the scope are the splat itself and
+        the object of an allowed subscript write. Enumerating forbidden mutations instead
+        (``del``, ``pop``, ``clear``) misses the one that reaches them all -- ``alias = fields``,
+        after which every check aimed at ``fields`` looks at the wrong name while the same dict
+        loses keys through ``alias``. Passing the dict to a function is the same hole with the
+        mutation offsite. A legitimate new pattern will trip this and get a human to re-read the
+        contract, which is the cheaper mistake.
         """
+        allowed_reads: set = {id(call_kw.value) for call_kw in call.keywords if call_kw.arg is None}
         ok = True
 
         def walk(node) -> None:
@@ -564,16 +598,7 @@ class TestRouteCompleteness:
             for child in ast.iter_child_nodes(node):
                 if isinstance(child, self._NESTED_SCOPES):
                     continue
-                if isinstance(child, ast.Delete):
-                    for target in child.targets:
-                        value = getattr(target, "value", None)
-                        if isinstance(value, ast.Name) and value.id == name:
-                            ok = False
-                elif isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute):
-                    obj = child.func.value
-                    if isinstance(obj, ast.Name) and obj.id == name:
-                        ok = False
-                elif isinstance(child, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+                if isinstance(child, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
                     targets = child.targets if isinstance(child, ast.Assign) else [child.target]
                     for target in targets:
                         if not isinstance(target, ast.Subscript):
@@ -586,9 +611,29 @@ class TestRouteCompleteness:
                             ok = False  # a computed key could be any of the protected ones
                         elif key.value in self._PROTECTED_RUNTIME_KEYS:
                             ok = False
+                        else:
+                            allowed_reads.add(id(obj))
                 walk(child)
 
         walk(scope)
+        if not ok:
+            return False
+
+        def check_reads(node) -> None:
+            nonlocal ok
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, self._NESTED_SCOPES):
+                    continue
+                if (
+                    isinstance(child, ast.Name)
+                    and child.id == name
+                    and not isinstance(child.ctx, ast.Store)
+                    and id(child) not in allowed_reads
+                ):
+                    ok = False
+                check_reads(child)
+
+        check_reads(scope)
         return ok
 
     def _status_calls_getting_runtime_fields(self) -> list:
@@ -648,7 +693,7 @@ class TestRouteCompleteness:
                     continue
                 if not self._binding_dominates(scope, name, call):
                     continue
-                if not self._mutations_are_safe(scope, name):
+                if not self._mutations_are_safe(scope, name, call):
                     continue
                 found.append(call)
                 break
@@ -765,6 +810,51 @@ class TestRouteCompleteness:
                 return InferenceStatusResponse(is_gguf = True, **fields)
                 """
             ), f"{destructive} left the /status contract green"
+
+    def test_the_hoist_analysis_rejects_reaching_the_dict_by_another_name(self):
+        """Naming the dict twice routes every mutation past a check aimed at the first name.
+
+        `alias = fields` then `alias.pop(...)` drops a protected key while nothing touches
+        `fields`, and handing the dict to a function moves the same mutation offsite. So the rule
+        is positive: the only reads of the splatted name are the splat and the object of an
+        allowed subscript write.
+        """
+        for leak in ("alias = fields\n                alias.pop('native_context_length')",
+                     "_scrub(fields)",
+                     "return InferenceStatusResponse(is_gguf = True, **fields, extra = fields)"):
+            assert not self._accepts(
+                f"""
+                fields = _llama_runtime_fields(llama_backend)
+                {leak}
+                return InferenceStatusResponse(is_gguf = True, **fields)
+                """
+            ), f"{leak!r} left the /status contract green"
+
+    def test_the_hoist_analysis_rejects_a_binding_form_with_no_name_node(self):
+        """`except E as fields` deletes the name when the handler ends.
+
+        The exception target is not an `ast.Name` store, so a Name-only walk misses the rebind
+        entirely rather than failing closed on it, and a handled-exception path then reaches the
+        constructor with `fields` unbound.
+        """
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            try:
+                _probe()
+            except Exception as fields:
+                pass
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+        # Same for the other name-binding forms that carry no Name node.
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            import json as fields
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
 
     def test_non_gguf_status_path_reports_runtime_context_length(self):
         """Non-GGUF InferenceStatusResponse reports context_length from model_info."""

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -10,9 +10,9 @@ overwritten by VRAM-capping logic.
 Needs no GPU, network, or libraries beyond pytest and pydantic.
 """
 
+import ast
 import io
 import json
-import re
 import struct
 import sys
 import types as _types
@@ -400,23 +400,63 @@ class TestRouteCompleteness:
             idx = end
         return blocks
 
-    def _gets_llama_runtime_fields(self, block: str) -> bool:
-        """True if ``block`` receives the llama runtime fields, inline or via a hoisted dict.
+    @staticmethod
+    def _is_runtime_fields_call(node) -> bool:
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_llama_runtime_fields"
+        )
 
-        A call site may have to hoist the call to overwrite one entry before splatting, since
+    def _status_calls_getting_runtime_fields(self) -> list:
+        """``InferenceStatusResponse(...)`` calls that actually receive the llama runtime fields.
+
+        A call site may hoist the helper call to overwrite one entry before splatting, since
         passing an overriding keyword alongside ``**fields`` is a TypeError. That is a valid way
-        to receive the fields, so accept it rather than demanding the call be inline.
+        to receive the fields, so accept it, but only when the assignment that REACHES the call
+        supplies them: a later ``name = {}`` in the same function rebinds the name and the
+        response gets nothing, and a same-named assignment in some other function is irrelevant.
+        Subscript writes such as ``fields["x"] = y`` mutate rather than rebind, so they do not
+        count as a reassignment.
         """
-        if "_llama_runtime_fields(llama_backend)" in block:
-            return True
-        for name in re.findall(r"\*\*(\w+)", block):
-            if re.search(
-                rf"^\s*{re.escape(name)}\s*=\s*_llama_runtime_fields\(llama_backend\)",
-                self._source,
-                re.M,
+        tree = ast.parse(self._source)
+        funcs = [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+        found = []
+        for call in ast.walk(tree):
+            if not (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "InferenceStatusResponse"
             ):
-                return True
-        return False
+                continue
+            for kw in call.keywords:
+                if kw.arg is not None:
+                    continue
+                if self._is_runtime_fields_call(kw.value):
+                    found.append(call)
+                    break
+                if not isinstance(kw.value, ast.Name):
+                    continue
+                # Innermost function containing this call.
+                enclosing = [
+                    f for f in funcs if f.lineno <= call.lineno <= (f.end_lineno or call.lineno)
+                ]
+                if not enclosing:
+                    continue
+                scope = max(enclosing, key = lambda f: f.lineno)
+                reaching = None
+                for node in ast.walk(scope):
+                    if not isinstance(node, ast.Assign) or node.lineno >= call.lineno:
+                        continue
+                    if any(
+                        isinstance(t, ast.Name) and t.id == kw.value.id for t in node.targets
+                    ):
+                        if reaching is None or node.lineno > reaching.lineno:
+                            reaching = node
+                if reaching is not None and self._is_runtime_fields_call(reaching.value):
+                    found.append(call)
+                    break
+        return found
 
     def test_gguf_load_responses_have_field(self):
         """Every GGUF LoadResponse (is_gguf = True) includes native_context_length."""
@@ -454,13 +494,8 @@ class TestRouteCompleteness:
 
     def test_status_path(self):
         """InferenceStatusResponse construction with llama_backend has the field."""
-        blocks = self._find_construction_blocks("InferenceStatusResponse")
-        found = False
-        for block in blocks:
-            if "llama_backend" in block and self._gets_llama_runtime_fields(block):
-                found = True
-                break
-        assert found, "No InferenceStatusResponse block with llama_backend has runtime fields"
+        calls = self._status_calls_getting_runtime_fields()
+        assert calls, "No InferenceStatusResponse block with llama_backend has runtime fields"
         assert "for name in _InferenceRuntimeFields.model_fields" in self._source
 
     def test_non_gguf_status_path_reports_runtime_context_length(self):

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -755,7 +755,7 @@ class TestRouteCompleteness:
             'del fields["native_context_length"]',
             'fields.pop("native_context_length", None)',
             "fields.clear()",
-            'fields[_key] = None',  # a computed key could be the protected one
+            "fields[_key] = None",  # a computed key could be the protected one
             'fields["native_context_length"] = None',
         ):
             assert not self._accepts(

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -368,6 +368,8 @@ class TestPydanticModels:
 # =====================================================================
 
 
+_HTTP_METHODS = frozenset({"get", "post", "put", "patch", "delete", "head", "options"})
+
 # `match` capture nodes, which bind a name without an ast.Name store. Looked up rather than named
 # directly so this file still parses on a Python without them.
 _MATCH_CAPTURES = tuple(
@@ -600,6 +602,13 @@ class TestRouteCompleteness:
                     continue
                 if isinstance(child, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
                     targets = child.targets if isinstance(child, ast.Assign) else [child.target]
+                    if len(targets) > 1 and any(
+                        isinstance(t, ast.Name) and t.id == name for t in targets
+                    ):
+                        # `fields = alias = helper(...)` binds the same dict twice. The binding
+                        # check sees one clean helper assignment and every other check is aimed at
+                        # `fields`, so `alias.pop(...)` would pass unseen.
+                        ok = False
                     for target in targets:
                         if not isinstance(target, ast.Subscript):
                             continue
@@ -636,6 +645,27 @@ class TestRouteCompleteness:
         check_reads(scope)
         return ok
 
+    @staticmethod
+    def _route_handler(tree, path: str):
+        """The function registered at ``path``, found through its router decorator.
+
+        The decorator is the definition of the endpoint, so matching on it rather than on the
+        function's name keeps this pointed at whatever serves ``/status`` after a rename.
+        """
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                if not (isinstance(decorator, ast.Call) and decorator.args):
+                    continue
+                func = decorator.func
+                if not (isinstance(func, ast.Attribute) and func.attr in _HTTP_METHODS):
+                    continue
+                first = decorator.args[0]
+                if isinstance(first, ast.Constant) and first.value == path:
+                    return node
+        return None
+
     def _status_calls_getting_runtime_fields(self) -> list:
         """``InferenceStatusResponse(...)`` calls that actually receive the llama runtime fields.
 
@@ -655,13 +685,20 @@ class TestRouteCompleteness:
            edited at the real call site, and a future ``pop`` or ``del`` of
            ``native_context_length`` would leave this contract green while /status stopped
            reporting the field.
+
+        Only the ``/status`` handler is searched. The caller asserts that SOME call qualifies, so
+        over the whole module any unrelated route or helper that happens to hoist the same helper
+        would satisfy it while the GGUF branch of ``get_status`` quietly dropped the fields.
         """
         tree = ast.parse(self._source)
         funcs = [
             n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
         ]
+        handler = self._route_handler(tree, "/status")
+        if handler is None:
+            return []  # no handler to check is not a passing contract
         found = []
-        for call in ast.walk(tree):
+        for call in ast.walk(handler):
             if not (
                 isinstance(call, ast.Call)
                 and isinstance(call.func, ast.Name)
@@ -744,9 +781,10 @@ class TestRouteCompleteness:
         """Run the analyser over a synthetic route function instead of the real file."""
         import textwrap
 
-        self._source = "async def status(llama_backend):\n" + textwrap.indent(
-            textwrap.dedent(body).strip("\n"), "    "
-        )
+        self._source = (
+            '@router.get("/status", response_model = InferenceStatusResponse)\n'
+            "async def get_status(llama_backend):\n"
+        ) + textwrap.indent(textwrap.dedent(body).strip("\n"), "    ")
         return bool(self._status_calls_getting_runtime_fields())
 
     def test_the_hoist_analysis_accepts_the_shape_the_route_actually_uses(self):
@@ -786,7 +824,8 @@ class TestRouteCompleteness:
 
         self._source = textwrap.dedent(
             """
-            async def status(llama_backend, fields):
+            @router.get("/status")
+            async def get_status(llama_backend, fields):
                 response = InferenceStatusResponse(is_gguf = True, **fields)
                 fields = _llama_runtime_fields(llama_backend)
                 return response
@@ -857,6 +896,52 @@ class TestRouteCompleteness:
             return InferenceStatusResponse(is_gguf = True, **fields)
             """
         )
+
+    def test_the_hoist_analysis_rejects_a_chained_assignment(self):
+        """`fields = alias = helper(...)` binds the same dict under two names at once.
+
+        The binding check sees one clean helper assignment, and every other check is aimed at
+        `fields`, so the protected key can leave through `alias` unobserved.
+        """
+        assert not self._accepts(
+            """
+            fields = alias = _llama_runtime_fields(llama_backend)
+            alias.pop("native_context_length")
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+
+    def test_the_contract_is_tied_to_the_status_route(self):
+        """`test_status_path` asserts only that SOME call qualifies.
+
+        Searched over the whole module, an unrelated route or helper that hoists the same dict
+        would satisfy it while the GGUF branch of the real handler dropped the fields. The handler
+        is found through its router decorator, so a rename of the function still matches.
+        """
+        import textwrap
+
+        self._source = textwrap.dedent(
+            """
+            def _some_helper(llama_backend):
+                fields = _llama_runtime_fields(llama_backend)
+                return InferenceStatusResponse(is_gguf = True, **fields)
+
+            @router.get("/status", response_model = InferenceStatusResponse)
+            async def get_status(llama_backend):
+                return InferenceStatusResponse(is_gguf = True)
+            """
+        )
+        assert not self._status_calls_getting_runtime_fields()
+
+        # And with no /status handler at all there is nothing to certify.
+        self._source = textwrap.dedent(
+            """
+            def _some_helper(llama_backend):
+                fields = _llama_runtime_fields(llama_backend)
+                return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+        assert not self._status_calls_getting_runtime_fields()
 
     def test_non_gguf_status_path_reports_runtime_context_length(self):
         """Non-GGUF InferenceStatusResponse reports context_length from model_info."""

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -12,6 +12,7 @@ Needs no GPU, network, or libraries beyond pytest and pydantic.
 
 import io
 import json
+import re
 import struct
 import sys
 import types as _types
@@ -399,6 +400,24 @@ class TestRouteCompleteness:
             idx = end
         return blocks
 
+    def _gets_llama_runtime_fields(self, block: str) -> bool:
+        """True if ``block`` receives the llama runtime fields, inline or via a hoisted dict.
+
+        A call site may have to hoist the call to overwrite one entry before splatting, since
+        passing an overriding keyword alongside ``**fields`` is a TypeError. That is a valid way
+        to receive the fields, so accept it rather than demanding the call be inline.
+        """
+        if "_llama_runtime_fields(llama_backend)" in block:
+            return True
+        for name in re.findall(r"\*\*(\w+)", block):
+            if re.search(
+                rf"^\s*{re.escape(name)}\s*=\s*_llama_runtime_fields\(llama_backend\)",
+                self._source,
+                re.M,
+            ):
+                return True
+        return False
+
     def test_gguf_load_responses_have_field(self):
         """Every GGUF LoadResponse (is_gguf = True) includes native_context_length."""
         blocks = self._find_construction_blocks("LoadResponse")
@@ -438,7 +457,7 @@ class TestRouteCompleteness:
         blocks = self._find_construction_blocks("InferenceStatusResponse")
         found = False
         for block in blocks:
-            if "llama_backend" in block and "_llama_runtime_fields(llama_backend)" in block:
+            if "llama_backend" in block and self._gets_llama_runtime_fields(block):
                 found = True
                 break
         assert found, "No InferenceStatusResponse block with llama_backend has runtime fields"

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -411,7 +411,16 @@ class TestRouteCompleteness:
             idx = end
         return blocks
 
-    _NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+    # Comprehensions included: in Python 3 their targets live in their own scope, so
+    # `[None for fields in values]` does NOT rebind the hoisted dict, and recording it as a
+    # rebind failed the contract on code that is perfectly fine.
+    _CALLABLE_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+    _NESTED_SCOPES = _CALLABLE_SCOPES + (
+        ast.ListComp,
+        ast.SetComp,
+        ast.DictComp,
+        ast.GeneratorExp,
+    )
 
     @staticmethod
     def _is_runtime_fields_call(node) -> bool:
@@ -477,7 +486,10 @@ class TestRouteCompleteness:
                 elif (
                     isinstance(child, ast.Name)
                     and child.id == name
-                    and isinstance(child.ctx, ast.Store)
+                    # Del as well as Store: `del llama_backend` after the allowed
+                    # initialisation leaves the name unbound at the helper call, which is an
+                    # UnboundLocalError rather than a response.
+                    and isinstance(child.ctx, (ast.Store, ast.Del))
                     and id(child) not in handled
                 ):
                     found.append((child, None))
@@ -658,7 +670,10 @@ class TestRouteCompleteness:
                         ok = False
                 elif isinstance(child, (ast.Global, ast.Nonlocal)) and name in child.names:
                     ok = False
-                check_reads(child, nested or isinstance(child, self._NESTED_SCOPES))
+                # Only callable scopes set `nested`. A comprehension target is local and
+                # harmless, but a comprehension READING the dict is a real use of it, and the
+                # `not store` arm already catches that.
+                check_reads(child, nested or isinstance(child, self._CALLABLE_SCOPES))
 
         check_reads(scope)
         return ok
@@ -694,8 +709,7 @@ class TestRouteCompleteness:
                     return node
         return None
 
-    @staticmethod
-    def _returned_calls(scope, class_name: str) -> list:
+    def _returned_calls(self, scope, class_name: str) -> list:
         """``return ClassName(...)`` in ``scope``'s OWN body, nested scopes excluded.
 
         Two narrowings, both because the caller only asks whether SOME call qualifies. A nested
@@ -704,18 +718,43 @@ class TestRouteCompleteness:
         sees, so it cannot stand in for the response that goes out.
         """
         calls: list = []
+        # `response = ClassName(...)` then `return response` is a behaviour-preserving
+        # refactor, so the construction is traced through a single local rather than read as
+        # discarded. Only when that name is bound exactly once, to the construction: any
+        # other binding of it and we no longer know what the return carries.
+        built: dict = {}
+        rebound: set = set()
+        returned: set = set()
 
         def walk(node) -> None:
             for child in ast.iter_child_nodes(node):
-                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+                if isinstance(child, self._CALLABLE_SCOPES):
                     continue
                 if isinstance(child, ast.Return) and isinstance(child.value, ast.Call):
                     call = child.value
                     if isinstance(call.func, ast.Name) and call.func.id == class_name:
                         calls.append(call)
+                elif isinstance(child, ast.Return) and isinstance(child.value, ast.Name):
+                    returned.add(child.value.id)
+                elif isinstance(child, ast.Assign) and len(child.targets) == 1:
+                    target = child.targets[0]
+                    if isinstance(target, ast.Name):
+                        value = child.value
+                        if (
+                            isinstance(value, ast.Call)
+                            and isinstance(value.func, ast.Name)
+                            and value.func.id == class_name
+                            and target.id not in built
+                        ):
+                            built[target.id] = value
+                        else:
+                            rebound.add(target.id)
                 walk(child)
 
         walk(scope)
+        for local, call in built.items():
+            if local in returned and local not in rebound:
+                calls.append(call)
         return calls
 
     # How the handler is allowed to obtain each name the helper call is spelled with. The
@@ -766,6 +805,10 @@ class TestRouteCompleteness:
                     and not value.keywords
                 )
 
+            if dependency in self._parameter_names(scope):
+                # A parameter is a binding with no source to check, and a plain FastAPI
+                # parameter would not carry the backend singleton anyway.
+                return False
             bindings = self._bindings_in_own_scope(scope, dependency)
             if not bindings:
                 continue  # never rebound here: it is the module-level name
@@ -937,9 +980,12 @@ class TestRouteCompleteness:
         """Run the analyser over a synthetic route function instead of the real file."""
         import textwrap
 
+        # No `llama_backend` parameter: the real handler takes `current_subject` and gets the
+        # backend from `get_llama_cpp_backend()`. A dependency arriving as a parameter has no
+        # source to verify, which the analyser now rejects, so the fixture must not fake one.
         self._source = (
             '@router.get("/status", response_model = InferenceStatusResponse)\n'
-            "async def get_status(llama_backend):\n"
+            "async def get_status(current_subject = None):\n"
         ) + textwrap.indent(textwrap.dedent(body).strip("\n"), "    ")
         return bool(self._status_calls_getting_runtime_fields())
 
@@ -1332,6 +1378,86 @@ class TestRouteCompleteness:
             """
         )
         assert not self._status_calls_getting_runtime_fields()
+
+    def test_the_hoist_analysis_rejects_a_deleted_dependency(self):
+        """`del llama_backend` after the allowed init leaves the name unbound at the call.
+
+        The Name node has Del context, not Store, so the bindings walk skipped it and the
+        dependency check saw only the clean initialisation.
+        """
+        assert not self._accepts(
+            """
+            llama_backend = get_llama_cpp_backend()
+            del llama_backend
+            fields = _llama_runtime_fields(llama_backend)
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+
+    def test_the_hoist_analysis_rejects_a_dependency_that_arrives_as_a_parameter(self):
+        """A parameter is a binding with no source to verify.
+
+        With no local initialisation the dependency check read the name as module level and
+        accepted it, but a plain FastAPI parameter does not carry the backend singleton.
+        """
+        import textwrap
+
+        self._source = textwrap.dedent(
+            """
+            @router.get("/status")
+            async def get_status(llama_backend):
+                fields = _llama_runtime_fields(llama_backend)
+                return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+        assert not self._status_calls_getting_runtime_fields()
+
+    def test_the_hoist_analysis_follows_a_response_bound_to_a_local(self):
+        """`response = InferenceStatusResponse(...)` then `return response` is a refactor.
+
+        Reading only inline returns treated it as discarded, so the contract failed on code
+        that still sends the fields. It is traced through a single local bound exactly once
+        to the construction; any other binding of that name and we no longer know what the
+        return carries.
+        """
+        assert self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            response = InferenceStatusResponse(is_gguf = True, **fields)
+            return response
+            """
+        )
+        # Rebound in between: what comes back is no longer that construction.
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            response = InferenceStatusResponse(is_gguf = True, **fields)
+            response = InferenceStatusResponse(is_gguf = True)
+            return response
+            """
+        )
+
+    def test_an_unrelated_comprehension_does_not_break_the_contract(self):
+        """A comprehension target is scoped to the comprehension in Python 3.
+
+        `[None for fields in values]` does not touch the hoisted dict, so recording it as a
+        rebind failed the contract on code that is fine. A comprehension that READS the dict
+        is a different matter and still disqualifies.
+        """
+        assert self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            _unused = [None for fields in _values]
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            _leaked = [v for v in fields]
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
 
     def test_non_gguf_status_path_reports_runtime_context_length(self):
         """Non-GGUF InferenceStatusResponse reports context_length from model_info."""

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -451,6 +451,11 @@ class TestRouteCompleteness:
         def walk(node) -> None:
             for child in ast.iter_child_nodes(node):
                 if isinstance(child, self._NESTED_SCOPES):
+                    # The BODY is a separate scope, but a `def`/`class` also binds its own
+                    # name out here, so `def fields(): ...` after the hoist leaves the splat
+                    # receiving a function. Record the declaration, skip the body.
+                    if getattr(child, "name", None) == name:
+                        found.append((child, None))
                     continue
                 if isinstance(child, ast.Assign):
                     for target in child.targets:
@@ -478,7 +483,12 @@ class TestRouteCompleteness:
                     found.append((child, None))
                 elif isinstance(child, ast.ExceptHandler) and child.name == name:
                     found.append((child, None))
-                elif isinstance(child, ast.alias) and (child.asname or child.name) == name:
+                elif isinstance(child, ast.alias) and name in (
+                    child.asname,
+                    # `import a.b` with no asname binds only the TOP package, and the alias
+                    # node spells the whole dotted path, so comparing the raw name misses it.
+                    None if child.asname else child.name.split(".")[0],
+                ):
                     found.append((child, None))
                 elif isinstance(child, (ast.Global, ast.Nonlocal)) and name in child.names:
                     found.append((child, None))
@@ -628,11 +638,14 @@ class TestRouteCompleteness:
         if not ok:
             return False
 
+        # Nested scopes ARE walked here, unlike the allow-scan above. A closure that
+        # names the dict can do anything to it, and its call site reads nothing
+        # syntactically: `def scrub(): fields.pop("native_context_length")` followed by
+        # `scrub()` is invisible to both a mutation list and a call-site check. Reading
+        # the name inside a closure is therefore itself the disqualifier.
         def check_reads(node) -> None:
             nonlocal ok
             for child in ast.iter_child_nodes(node):
-                if isinstance(child, self._NESTED_SCOPES):
-                    continue
                 if (
                     isinstance(child, ast.Name)
                     and child.id == name
@@ -666,6 +679,30 @@ class TestRouteCompleteness:
                     return node
         return None
 
+    @staticmethod
+    def _returned_calls(scope, class_name: str) -> list:
+        """``return ClassName(...)`` in ``scope``'s OWN body, nested scopes excluded.
+
+        Two narrowings, both because the caller only asks whether SOME call qualifies. A nested
+        helper is a separate scope the handler may never call, so a hoist left behind in one
+        certifies nothing; and a construction that is not returned is a value the caller never
+        sees, so it cannot stand in for the response that goes out.
+        """
+        calls: list = []
+
+        def walk(node) -> None:
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+                    continue
+                if isinstance(child, ast.Return) and isinstance(child.value, ast.Call):
+                    call = child.value
+                    if isinstance(call.func, ast.Name) and call.func.id == class_name:
+                        calls.append(call)
+                walk(child)
+
+        walk(scope)
+        return calls
+
     def _status_calls_getting_runtime_fields(self) -> list:
         """``InferenceStatusResponse(...)`` calls that actually receive the llama runtime fields.
 
@@ -686,9 +723,11 @@ class TestRouteCompleteness:
            ``native_context_length`` would leave this contract green while /status stopped
            reporting the field.
 
-        Only the ``/status`` handler is searched. The caller asserts that SOME call qualifies, so
-        over the whole module any unrelated route or helper that happens to hoist the same helper
-        would satisfy it while the GGUF branch of ``get_status`` quietly dropped the fields.
+        Only the ``/status`` handler is searched, and only what it RETURNS. The caller asserts
+        that SOME call qualifies, so anything looser certifies the wrong code: over the whole
+        module, an unrelated route hoisting the same helper; inside the handler but in a nested
+        helper, one the handler may never call; anywhere but a return, a constructed response that
+        is discarded while the real answer goes out without the fields.
         """
         tree = ast.parse(self._source)
         funcs = [
@@ -698,13 +737,7 @@ class TestRouteCompleteness:
         if handler is None:
             return []  # no handler to check is not a passing contract
         found = []
-        for call in ast.walk(handler):
-            if not (
-                isinstance(call, ast.Call)
-                and isinstance(call.func, ast.Name)
-                and call.func.id == "InferenceStatusResponse"
-            ):
-                continue
+        for call in self._returned_calls(handler, "InferenceStatusResponse"):
             for kw in call.keywords:
                 if kw.arg is not None:
                     continue
@@ -942,6 +975,73 @@ class TestRouteCompleteness:
             """
         )
         assert not self._status_calls_getting_runtime_fields()
+
+    def test_the_hoist_analysis_rejects_a_qualifying_call_the_route_never_returns(self):
+        """A nested helper is a scope the handler may never call, and a discarded construction
+        is a value the caller never sees. Either one standing in for the response means the
+        real `/status` answer can lose the fields with this contract still green."""
+        import textwrap
+
+        # A qualifying hoist inside a nested helper, and a bare response returned.
+        self._source = textwrap.dedent(
+            """
+            @router.get("/status")
+            async def get_status(llama_backend):
+                def _unused():
+                    fields = _llama_runtime_fields(llama_backend)
+                    return InferenceStatusResponse(is_gguf = True, **fields)
+                return InferenceStatusResponse(is_gguf = True)
+            """
+        )
+        assert not self._status_calls_getting_runtime_fields()
+
+        # A qualifying construction that is built and thrown away.
+        self._source = textwrap.dedent(
+            """
+            @router.get("/status")
+            async def get_status(llama_backend):
+                fields = _llama_runtime_fields(llama_backend)
+                InferenceStatusResponse(is_gguf = True, **fields)
+                return InferenceStatusResponse(is_gguf = True)
+            """
+        )
+        assert not self._status_calls_getting_runtime_fields()
+
+    def test_the_hoist_analysis_rejects_a_closure_that_touches_the_dict(self):
+        """A closure's call site reads nothing syntactically.
+
+        `def scrub(): fields.pop("native_context_length")` then `scrub()` removes the field
+        while no statement in the handler names `fields` at all, so naming it inside a nested
+        scope has to be the disqualifier.
+        """
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            def _scrub():
+                fields.pop("native_context_length")
+            _scrub()
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+
+    def test_the_hoist_analysis_rejects_a_declaration_that_shadows_the_dict(self):
+        """`def`/`class` bind their own name in the enclosing scope, and `import a.b` binds `a`.
+
+        The body of a `def` is a separate scope, but the name it creates is not, so skipping
+        the whole node let a later declaration shadow the hoisted dict unnoticed.
+        """
+        for shadow in (
+            "def fields():\n                    pass",
+            "class fields:\n                    pass",
+            "import fields.submodule",
+        ):
+            assert not self._accepts(
+                f"""
+                fields = _llama_runtime_fields(llama_backend)
+                {shadow}
+                return InferenceStatusResponse(is_gguf = True, **fields)
+                """
+            ), f"{shadow!r} left the /status contract green"
 
     def test_non_gguf_status_path_reports_runtime_context_length(self):
         """Non-GGUF InferenceStatusResponse reports context_length from model_info."""

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -641,19 +641,20 @@ class TestRouteCompleteness:
         # Nested scopes ARE walked here, unlike the allow-scan above. A closure that
         # names the dict can do anything to it, and its call site reads nothing
         # syntactically: `def scrub(): fields.pop("native_context_length")` followed by
-        # `scrub()` is invisible to both a mutation list and a call-site check. Reading
-        # the name inside a closure is therefore itself the disqualifier.
-        def check_reads(node) -> None:
+        # `scrub()` is invisible to both a mutation list and a call-site check. Naming it
+        # inside a closure is therefore itself the disqualifier -- including a STORE, since
+        # `nonlocal fields` then `fields = {}` replaces the dict outright while the
+        # bindings walk, which stops at the scope boundary, never sees it.
+        def check_reads(node, nested: bool = False) -> None:
             nonlocal ok
             for child in ast.iter_child_nodes(node):
-                if (
-                    isinstance(child, ast.Name)
-                    and child.id == name
-                    and not isinstance(child.ctx, ast.Store)
-                    and id(child) not in allowed_reads
-                ):
+                if isinstance(child, ast.Name) and child.id == name:
+                    store = isinstance(child.ctx, ast.Store)
+                    if (nested or not store) and id(child) not in allowed_reads:
+                        ok = False
+                elif isinstance(child, (ast.Global, ast.Nonlocal)) and name in child.names:
                     ok = False
-                check_reads(child)
+                check_reads(child, nested or isinstance(child, self._NESTED_SCOPES))
 
         check_reads(scope)
         return ok
@@ -672,7 +673,15 @@ class TestRouteCompleteness:
                 if not (isinstance(decorator, ast.Call) and decorator.args):
                     continue
                 func = decorator.func
-                if not (isinstance(func, ast.Attribute) and func.attr in _HTTP_METHODS):
+                # GET on `router`, not any verb on any object. A `@router.post("/status")`
+                # or a handler on some other router is a different endpoint, and accepting
+                # it would certify the wrong one.
+                if not (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "get"
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "router"
+                ):
                     continue
                 first = decorator.args[0]
                 if isinstance(first, ast.Constant) and first.value == path:
@@ -702,6 +711,29 @@ class TestRouteCompleteness:
 
         walk(scope)
         return calls
+
+    # How the handler is allowed to obtain each name the helper call is spelled with. The
+    # helper itself is module level, so any local binding of it is a substitution.
+    _DEPENDENCY_SOURCES = {"_llama_runtime_fields": (), "llama_backend": ("get_llama_cpp_backend",)}
+
+    def _dependencies_are_intact(self, scope) -> bool:
+        """True when nothing in ``scope`` replaces the helper or the backend it is called on.
+
+        ``_is_runtime_fields_call`` only checks spelling, so without this
+        ``_llama_runtime_fields = lambda _: {}`` above the hoist passes while the real helper
+        is never called, and the response defaults every runtime field to None.
+        """
+        for dependency, allowed in self._DEPENDENCY_SOURCES.items():
+            for _node, value in self._bindings_in_own_scope(scope, dependency):
+                if not (
+                    isinstance(value, ast.Call)
+                    and isinstance(value.func, ast.Name)
+                    and value.func.id in allowed
+                    and not value.args
+                    and not value.keywords
+                ):
+                    return False
+        return True
 
     def _status_calls_getting_runtime_fields(self) -> list:
         """``InferenceStatusResponse(...)`` calls that actually receive the llama runtime fields.
@@ -742,6 +774,12 @@ class TestRouteCompleteness:
                 if kw.arg is not None:
                     continue
                 if self._is_runtime_fields_call(kw.value):
+                    if any(
+                        other is not kw
+                        and (other.arg in self._PROTECTED_RUNTIME_KEYS or other.arg is None)
+                        for other in call.keywords
+                    ):
+                        continue
                     found.append(call)
                     break
                 if not isinstance(kw.value, ast.Name):
@@ -754,6 +792,22 @@ class TestRouteCompleteness:
                     continue
                 scope = max(enclosing, key = lambda f: f.lineno)
                 name = kw.value.id
+                # `f(**fields, native_context_length = None)` is a duplicate keyword, so the
+                # route raises the moment it runs, and a second `**` can overwrite the field
+                # with anything. Either way the response this certifies is not the one that
+                # goes out.
+                if any(
+                    other is not kw
+                    and (other.arg in self._PROTECTED_RUNTIME_KEYS or other.arg is None)
+                    for other in call.keywords
+                ):
+                    continue
+                # The helper and the backend are read by NAME, so a local rebinding of
+                # either -- `_llama_runtime_fields = lambda _: {}` -- satisfies the spelling
+                # check while calling something else entirely. The helper is module level and
+                # must not be bound here at all; the backend is obtained exactly one way.
+                if not self._dependencies_are_intact(scope):
+                    continue
                 if name in self._parameter_names(scope):
                     continue
                 bindings = self._bindings_in_own_scope(scope, name)
@@ -1042,6 +1096,90 @@ class TestRouteCompleteness:
                 return InferenceStatusResponse(is_gguf = True, **fields)
                 """
             ), f"{shadow!r} left the /status contract green"
+
+    def test_the_hoist_analysis_rejects_a_nonlocal_rebinding(self):
+        """`nonlocal fields` then `fields = {}` replaces the dict from inside a closure.
+
+        The bindings walk stops at the scope boundary and a Store is not a read, so the
+        rebind was invisible to every check while the response lost the fields entirely.
+        """
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            def _replace():
+                nonlocal fields
+                fields = {}
+            _replace()
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+
+    def test_the_hoist_analysis_rejects_a_keyword_colliding_with_the_splat(self):
+        """A duplicate keyword is a TypeError, and a second splat can overwrite the field.
+
+        Either way the response this would certify is not the one the route produces, and
+        in the duplicate-keyword case the route does not produce one at all.
+        """
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            return InferenceStatusResponse(**fields, native_context_length = None)
+            """
+        )
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            return InferenceStatusResponse(**fields, **_overrides)
+            """
+        )
+        # The unhoisted form is held to the same rule.
+        assert not self._accepts(
+            "return InferenceStatusResponse("
+            "**_llama_runtime_fields(llama_backend), native_context_length = None)"
+        )
+
+    def test_the_hoist_analysis_rejects_a_substituted_helper_or_backend(self):
+        """The call is matched by spelling, so the names it is spelled with matter.
+
+        `_llama_runtime_fields = lambda _: {}` above the hoist passes every structural check
+        while the real helper is never called. The backend has exactly one legitimate source
+        in the handler, and that one still passes.
+        """
+        for substitution in (
+            "_llama_runtime_fields = lambda _: {}",
+            "llama_backend = _some_other_backend()",
+        ):
+            assert not self._accepts(
+                f"""
+                {substitution}
+                fields = _llama_runtime_fields(llama_backend)
+                return InferenceStatusResponse(is_gguf = True, **fields)
+                """
+            ), f"{substitution!r} left the /status contract green"
+
+        # The way the real handler gets it.
+        assert self._accepts(
+            """
+            llama_backend = get_llama_cpp_backend()
+            fields = _llama_runtime_fields(llama_backend)
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+
+    def test_the_status_handler_is_the_get_route_on_the_module_router(self):
+        """A `post("/status")` or a handler on some other router is a different endpoint."""
+        import textwrap
+
+        for decorator in ('@router.post("/status")', '@other_router.get("/status")'):
+            self._source = textwrap.dedent(
+                f"""
+                {decorator}
+                async def not_the_status_route(llama_backend):
+                    fields = _llama_runtime_fields(llama_backend)
+                    return InferenceStatusResponse(is_gguf = True, **fields)
+                """
+            )
+            assert not self._status_calls_getting_runtime_fields(), decorator
 
     def test_non_gguf_status_path_reports_runtime_context_length(self):
         """Non-GGUF InferenceStatusResponse reports context_length from model_info."""

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -444,7 +444,11 @@ class TestRouteCompleteness:
                     if isinstance(target, ast.Name) and target.id == name:
                         # AnnAssign may be a bare declaration with no value; AugAssign rebinds to
                         # something derived, never the helper call itself.
-                        value = child.value if isinstance(child, (ast.AnnAssign, ast.NamedExpr)) else None
+                        value = (
+                            child.value
+                            if isinstance(child, (ast.AnnAssign, ast.NamedExpr))
+                            else None
+                        )
                         found.append((child, value))
                         handled.add(id(target))
                 elif (

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -819,9 +819,11 @@ class TestRouteCompleteness:
         is positive: the only reads of the splatted name are the splat and the object of an
         allowed subscript write.
         """
-        for leak in ("alias = fields\n                alias.pop('native_context_length')",
-                     "_scrub(fields)",
-                     "return InferenceStatusResponse(is_gguf = True, **fields, extra = fields)"):
+        for leak in (
+            "alias = fields\n                alias.pop('native_context_length')",
+            "_scrub(fields)",
+            "return InferenceStatusResponse(is_gguf = True, **fields, extra = fields)",
+        ):
             assert not self._accepts(
                 f"""
                 fields = _llama_runtime_fields(llama_backend)

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -558,8 +558,8 @@ class TestRouteCompleteness:
         descend(scope.body)
         return chain
 
-    def _binding_dominates(self, scope, name: str, call) -> bool:
-        """True when a helper binding of ``name`` provably runs before ``call``.
+    def _binding_dominates(self, scope, name: str, call, predicate = None) -> bool:
+        """True when a binding of ``name`` matching ``predicate`` provably runs before ``call``.
 
         Sibling order in one statement list is the only ordering Python guarantees without
         modelling control flow, so that is all this claims: the binding has to be an earlier
@@ -577,7 +577,7 @@ class TestRouteCompleteness:
                     continue
                 if not any(isinstance(t, ast.Name) and t.id == name for t in targets):
                     continue
-                if self._is_runtime_fields_call(stmt.value):
+                if (predicate or self._is_runtime_fields_call)(stmt.value):
                     return True
         return False
 
@@ -586,7 +586,7 @@ class TestRouteCompleteness:
     # never produced.
     _PROTECTED_RUNTIME_KEYS = frozenset({"native_context_length"})
 
-    def _mutations_are_safe(self, scope, name: str, call) -> bool:
+    def _mutations_are_safe(self, scope, name: str, calls) -> bool:
         """True when nothing in ``scope`` can remove a protected key from ``name``.
 
         The real call site edits one entry of the hoisted dict before splatting it, so mutation has
@@ -602,7 +602,11 @@ class TestRouteCompleteness:
         mutation offsite. A legitimate new pattern will trip this and get a human to re-read the
         contract, which is the cheaper mistake.
         """
-        allowed_reads: set = {id(call_kw.value) for call_kw in call.keywords if call_kw.arg is None}
+        # Every response branch that splats the dict, not just the one being checked: with
+        # two GGUF returns each would otherwise read the other's splat as an illegal use.
+        allowed_reads: set = {
+            id(kw.value) for one in calls for kw in one.keywords if kw.arg is None
+        }
         ok = True
 
         def walk(node) -> None:
@@ -666,7 +670,9 @@ class TestRouteCompleteness:
         The decorator is the definition of the endpoint, so matching on it rather than on the
         function's name keeps this pointed at whatever serves ``/status`` after a rename.
         """
-        for node in ast.walk(tree):
+        # Module level only. A nested `@router.get("/status")` inside a factory is not the
+        # endpoint this module registers, and may never be registered at all.
+        for node in tree.body:
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             for decorator in node.decorator_list:
@@ -716,23 +722,57 @@ class TestRouteCompleteness:
     # helper itself is module level, so any local binding of it is a substitution.
     _DEPENDENCY_SOURCES = {"_llama_runtime_fields": (), "llama_backend": ("get_llama_cpp_backend",)}
 
-    def _dependencies_are_intact(self, scope) -> bool:
+    @staticmethod
+    def _rebound_in_a_nested_scope(scope, names) -> bool:
+        """A closure declaring one of ``names`` ``global`` or ``nonlocal`` can replace it.
+
+        ``_bindings_in_own_scope`` stops at the scope boundary by design, so a nested
+        ``global _llama_runtime_fields`` followed by an assignment is invisible to it.
+        """
+        for node in ast.walk(scope):
+            if node is scope or not isinstance(
+                node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+            ):
+                continue
+            for inner in ast.walk(node):
+                if isinstance(inner, (ast.Global, ast.Nonlocal)) and any(
+                    n in names for n in inner.names
+                ):
+                    return True
+        return False
+
+    def _dependencies_are_intact(self, scope, helper_call) -> bool:
         """True when nothing in ``scope`` replaces the helper or the backend it is called on.
 
         ``_is_runtime_fields_call`` only checks spelling, so without this
         ``_llama_runtime_fields = lambda _: {}`` above the hoist passes while the real helper
         is never called, and the response defaults every runtime field to None.
+
+        A binding of the right SHAPE is not enough for the backend either. Placing
+        ``llama_backend = get_llama_cpp_backend()`` after the helper call leaves it an
+        uninitialised local at the call, which is an UnboundLocalError, so the accepted
+        binding also has to dominate.
         """
+        if self._rebound_in_a_nested_scope(scope, set(self._DEPENDENCY_SOURCES)):
+            return False
         for dependency, allowed in self._DEPENDENCY_SOURCES.items():
-            for _node, value in self._bindings_in_own_scope(scope, dependency):
-                if not (
+
+            def _from_allowed(value, allowed = allowed) -> bool:
+                return (
                     isinstance(value, ast.Call)
                     and isinstance(value.func, ast.Name)
                     and value.func.id in allowed
                     and not value.args
                     and not value.keywords
-                ):
-                    return False
+                )
+
+            bindings = self._bindings_in_own_scope(scope, dependency)
+            if not bindings:
+                continue  # never rebound here: it is the module-level name
+            if not all(_from_allowed(value) for _node, value in bindings):
+                return False
+            if not self._binding_dominates(scope, dependency, helper_call, _from_allowed):
+                return False
         return True
 
     def _status_calls_getting_runtime_fields(self) -> list:
@@ -768,8 +808,30 @@ class TestRouteCompleteness:
         handler = self._route_handler(tree, "/status")
         if handler is None:
             return []  # no handler to check is not a passing contract
+        # EVERY GGUF branch, not any one of them. The caller asserts only that the list is
+        # non-empty, so with two GGUF returns a special-cased branch carrying the hoist
+        # certified the ordinary branch that returns without the fields.
+        gguf_calls = [
+            call
+            for call in self._returned_calls(handler, "InferenceStatusResponse")
+            if any(
+                kw.arg == "is_gguf"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+                for kw in call.keywords
+            )
+        ]
+        if not gguf_calls:
+            return []  # no GGUF response to certify
+        def scope_of(node):
+            """Innermost function containing ``node``."""
+            enclosing = [
+                f for f in funcs if f.lineno <= node.lineno <= (f.end_lineno or node.lineno)
+            ]
+            return max(enclosing, key = lambda f: f.lineno) if enclosing else handler
+
         found = []
-        for call in self._returned_calls(handler, "InferenceStatusResponse"):
+        for call in gguf_calls:
             for kw in call.keywords:
                 if kw.arg is not None:
                     continue
@@ -779,6 +841,8 @@ class TestRouteCompleteness:
                         and (other.arg in self._PROTECTED_RUNTIME_KEYS or other.arg is None)
                         for other in call.keywords
                     ):
+                        continue
+                    if not self._dependencies_are_intact(scope_of(call), kw.value):
                         continue
                     found.append(call)
                     break
@@ -802,12 +866,6 @@ class TestRouteCompleteness:
                     for other in call.keywords
                 ):
                     continue
-                # The helper and the backend are read by NAME, so a local rebinding of
-                # either -- `_llama_runtime_fields = lambda _: {}` -- satisfies the spelling
-                # check while calling something else entirely. The helper is module level and
-                # must not be bound here at all; the backend is obtained exactly one way.
-                if not self._dependencies_are_intact(scope):
-                    continue
                 if name in self._parameter_names(scope):
                     continue
                 bindings = self._bindings_in_own_scope(scope, name)
@@ -815,13 +873,24 @@ class TestRouteCompleteness:
                     self._is_runtime_fields_call(value) for _node, value in bindings
                 ):
                     continue
+                # The helper and the backend are read by NAME, so a local rebinding of
+                # either -- `_llama_runtime_fields = lambda _: {}` -- satisfies the spelling
+                # check while calling something else entirely. The helper is module level and
+                # must not be bound here at all; the backend is obtained exactly one way, and
+                # that binding has to run BEFORE the helper call, not merely before the
+                # response, or the name is an uninitialised local at the call.
+                if not all(
+                    self._dependencies_are_intact(scope, value) for _node, value in bindings
+                ):
+                    continue
                 if not self._binding_dominates(scope, name, call):
                     continue
-                if not self._mutations_are_safe(scope, name, call):
+                if not self._mutations_are_safe(scope, name, gguf_calls):
                     continue
                 found.append(call)
                 break
-        return found
+        # One unqualified GGUF branch invalidates the lot: users on it get None.
+        return found if len(found) == len(gguf_calls) else []
 
     def test_gguf_load_responses_have_field(self):
         """Every GGUF LoadResponse (is_gguf = True) includes native_context_length."""
@@ -887,7 +956,8 @@ class TestRouteCompleteness:
         )
         # The unhoisted form needs no analysis at all.
         assert self._accepts(
-            "return InferenceStatusResponse(**_llama_runtime_fields(llama_backend))"
+            "return InferenceStatusResponse(is_gguf = True, "
+            "**_llama_runtime_fields(llama_backend))"
         )
 
     def test_the_hoist_analysis_rejects_a_binding_that_can_be_skipped(self):
@@ -1134,7 +1204,7 @@ class TestRouteCompleteness:
         )
         # The unhoisted form is held to the same rule.
         assert not self._accepts(
-            "return InferenceStatusResponse("
+            "return InferenceStatusResponse(is_gguf = True, "
             "**_llama_runtime_fields(llama_backend), native_context_length = None)"
         )
 
@@ -1180,6 +1250,88 @@ class TestRouteCompleteness:
                 """
             )
             assert not self._status_calls_getting_runtime_fields(), decorator
+
+    def test_every_gguf_return_branch_has_to_qualify(self):
+        """`test_status_path` only asks that the list be non-empty.
+
+        With two GGUF returns, a special-cased branch carrying the hoist certified the
+        ordinary branch that answers without the fields, and users on that branch get
+        native_context_length = None.
+        """
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            if _special:
+                return InferenceStatusResponse(is_gguf = True, **fields)
+            return InferenceStatusResponse(is_gguf = True)
+            """
+        )
+        # Both branches carrying it is the shape that should pass.
+        assert self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            if _special:
+                return InferenceStatusResponse(is_gguf = True, **fields)
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+        # A non-GGUF return alongside is not this contract's business.
+        assert self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            if not _is_gguf:
+                return InferenceStatusResponse(is_gguf = False)
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+
+    def test_the_hoist_analysis_rejects_a_dependency_replaced_from_a_closure(self):
+        """`global _llama_runtime_fields` inside a nested function replaces the module name.
+
+        The bindings walk stops at the scope boundary, so the substitution was invisible
+        while the response came from the replacement.
+        """
+        assert not self._accepts(
+            """
+            def _swap():
+                global _llama_runtime_fields
+                _llama_runtime_fields = lambda _: {}
+            _swap()
+            fields = _llama_runtime_fields(llama_backend)
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+
+    def test_the_hoist_analysis_rejects_a_backend_bound_after_it_is_used(self):
+        """Binding shape is not enough: it has to run first.
+
+        `fields = _llama_runtime_fields(llama_backend)` above
+        `llama_backend = get_llama_cpp_backend()` makes the name an uninitialised local at
+        the call, which is an UnboundLocalError, not a response.
+        """
+        assert not self._accepts(
+            """
+            fields = _llama_runtime_fields(llama_backend)
+            llama_backend = get_llama_cpp_backend()
+            return InferenceStatusResponse(is_gguf = True, **fields)
+            """
+        )
+
+    def test_the_status_handler_has_to_be_module_level(self):
+        """A nested `@router.get("/status")` inside a factory is not this module's endpoint."""
+        import textwrap
+
+        self._source = textwrap.dedent(
+            """
+            def make_routes():
+                @router.get("/status")
+                async def get_status(llama_backend):
+                    fields = _llama_runtime_fields(llama_backend)
+                    return InferenceStatusResponse(is_gguf = True, **fields)
+                return get_status
+            """
+        )
+        assert not self._status_calls_getting_runtime_fields()
 
     def test_non_gguf_status_path_reports_runtime_context_length(self):
         """Non-GGUF InferenceStatusResponse reports context_length from model_info."""

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -420,7 +420,9 @@ class TestRouteCompleteness:
         count as a reassignment.
         """
         tree = ast.parse(self._source)
-        funcs = [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+        funcs = [
+            n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
         found = []
         for call in ast.walk(tree):
             if not (
@@ -448,9 +450,7 @@ class TestRouteCompleteness:
                 for node in ast.walk(scope):
                     if not isinstance(node, ast.Assign) or node.lineno >= call.lineno:
                         continue
-                    if any(
-                        isinstance(t, ast.Name) and t.id == kw.value.id for t in node.targets
-                    ):
+                    if any(isinstance(t, ast.Name) and t.id == kw.value.id for t in node.targets):
                         if reaching is None or node.lineno > reaching.lineno:
                             reaching = node
                 if reaching is not None and self._is_runtime_fields_call(reaching.value):

--- a/studio/backend/tests/test_openai_auto_download.py
+++ b/studio/backend/tests/test_openai_auto_download.py
@@ -1589,6 +1589,12 @@ def test_a_quant_request_is_not_satisfied_by_transformers_weights(monkeypatch):
         "get_inference_backend",
         lambda: type("B", (), {"active_model_name": "/srv/models/tuned"})(),
     )
+    # Pin it: unpatched this reads the machine's SAVED setting, so the 404 below turns into the
+    # 503 switch-failed branch for anyone who has ever enabled auto-switch in Studio. The default
+    # is False, which is why CI never saw it.
+    monkeypatch.setattr(
+        "utils.openai_auto_switch_settings.get_openai_auto_switch_enabled", lambda: False
+    )
     monkeypatch.setattr(inference_route, "_unavailable_model_message", _fake_unavailable_message)
     with pytest.raises(HTTPException) as excinfo:
         asyncio.run(inference_route._reject_unservable_model("alias:Q4_K_M", _Req()))


### PR DESCRIPTION
`TestRouteCompleteness::test_status_path` fails on main. It asserts the literal string

```
_llama_runtime_fields(llama_backend)
```

appears inside the `InferenceStatusResponse(...)` construction block.

#8074 hoisted that call one line above the constructor so `chat_template_override` could be overwritten before splatting, which the code comments there explain: passing an overriding keyword alongside `**fields` is a `TypeError` whatever the values are.

```python
_runtime_fields = _llama_runtime_fields(llama_backend)
_runtime_fields["chat_template_override"] = _reported_chat_template_override
return InferenceStatusResponse(
    ...
    **_runtime_fields,
```

The call site is right; the test's assumption that the call is inline is not. This accepts either form: the call inline, or a name splatted into the constructor that the module assigns from `_llama_runtime_fields(llama_backend)`.

### Verification

- Reproduced on a clean `origin/main` checkout at `0ebc912c7`.
- `studio/backend/tests/test_native_context_length.py`: 39 passed (was 38 passed, 1 failed).
- The contract still bites: replacing the assignment with `_runtime_fields = {}` fails the test again. A relaxed assertion that can no longer fail would be worse than the brittle one.

This is the fourth stale static contract on main in a day, after the three #8072 fixed. They share a shape: asserting an exact source string that a legitimate refactor then moves.