### PR TITLE
CI: stop running workflows on the pip branch, and mirror push path filters for the non-Studio workflows

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -42,7 +42,7 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/consolidated-tests-ci.yml'
   push:
-    branches: [main, pip]
+    branches: [main]
     paths:
       - 'unsloth/**'
       - 'unsloth_cli/**'

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -43,6 +43,13 @@ on:
       - '.github/workflows/consolidated-tests-ci.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'studio/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - '.github/workflows/consolidated-tests-ci.yml'
   workflow_dispatch:
     inputs:
       unsloth_zoo_ref:

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -28,7 +28,7 @@ name: Lint CI
 on:
   pull_request:
   push:
-    branches: [main, pip]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -79,7 +79,7 @@ on:
       - 'tests/conftest.py'
       - '.github/workflows/mlx-ci.yml'
   push:
-    branches: [main, pip]
+    branches: [main]
     paths:
       - 'unsloth/__init__.py'
       - 'unsloth/_gpu_init.py'

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -80,6 +80,16 @@ on:
       - '.github/workflows/mlx-ci.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'unsloth/__init__.py'
+      - 'unsloth/_gpu_init.py'
+      - 'studio/backend/utils/hardware/**'
+      - 'studio/backend/core/training/worker.py'
+      - 'studio/backend/core/inference/mlx_inference.py'
+      - 'tests/studio/test_mlx_training_worker_behaviors.py'
+      - 'tests/studio/run_real_mlx_smoke.py'
+      - 'tests/conftest.py'
+      - '.github/workflows/mlx-ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -63,6 +63,18 @@ on:
       - '.github/workflows/security-audit.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/backend/requirements/**'
+      - 'studio/frontend/package.json'
+      - 'studio/frontend/package-lock.json'
+      - 'studio/src-tauri/Cargo.toml'
+      - 'studio/src-tauri/Cargo.lock'
+      - 'pyproject.toml'
+      - 'scripts/scan_packages.py'
+      - 'scripts/scan_packages_baseline.json'
+      - 'scripts/scan_npm_packages.py'
+      - 'scripts/scan_npm_packages_baseline.json'
+      - '.github/workflows/security-audit.yml'
   schedule:
     - cron: '13 4 * * *'   # 04:13 UTC daily, off the cron rush
   workflow_dispatch:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -62,7 +62,7 @@ on:
       - 'scripts/scan_npm_packages_baseline.json'
       - '.github/workflows/security-audit.yml'
   push:
-    branches: [main, pip]
+    branches: [main]
     paths:
       - 'studio/backend/requirements/**'
       - 'studio/frontend/package.json'

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -37,6 +37,17 @@ on:
       - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'install.sh'
+      - 'pyproject.toml'
+      - 'tests/studio/**'
+      - '.github/workflows/studio-api-smoke.yml'
+      - '.github/scripts/boot-studio-api-only.sh'
+      - '.github/scripts/wait-for-health.sh'
+      - '.github/actions/install-unsloth-local/action.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -36,18 +36,7 @@ on:
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/**'
-      - 'unsloth/**'
-      - 'unsloth_cli/**'
-      - 'install.sh'
-      - 'pyproject.toml'
-      - 'tests/studio/**'
-      - '.github/workflows/studio-api-smoke.yml'
-      - '.github/scripts/boot-studio-api-only.sh'
-      - '.github/scripts/wait-for-health.sh'
-      - '.github/actions/install-unsloth-local/action.yml'
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -40,17 +40,7 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/studio-backend-ci.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/**'
-      - 'unsloth/**'
-      - 'unsloth_cli/**'
-      - 'tests/**'
-      - 'install.sh'
-      - 'install.ps1'
-      - 'scripts/**'
-      - 'pyproject.toml'
-      - '.github/workflows/studio-backend-ci.yml'
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -41,6 +41,16 @@ on:
       - '.github/workflows/studio-backend-ci.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'tests/**'
+      - 'install.sh'
+      - 'install.ps1'
+      - 'scripts/**'
+      - 'pyproject.toml'
+      - '.github/workflows/studio-backend-ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -22,6 +22,13 @@ on:
       - '.github/workflows/studio-frontend-ci.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/frontend/**'
+      - 'scripts/check_frontend_dep_removal.py'
+      - 'tests/studio/test_frontend_dep_removal.py'
+      - 'scripts/sync_allow_scripts_pins.py'
+      - 'tests/studio/test_sync_allow_scripts_pins.py'
+      - '.github/workflows/studio-frontend-ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -21,14 +21,7 @@ on:
       - 'tests/studio/test_sync_allow_scripts_pins.py'
       - '.github/workflows/studio-frontend-ci.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/frontend/**'
-      - 'scripts/check_frontend_dep_removal.py'
-      - 'tests/studio/test_frontend_dep_removal.py'
-      - 'scripts/sync_allow_scripts_pins.py'
-      - 'tests/studio/test_sync_allow_scripts_pins.py'
-      - '.github/workflows/studio-frontend-ci.yml'
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -47,17 +47,7 @@ on:
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/**'
-      - 'unsloth/**'
-      - 'unsloth_cli/**'
-      - 'install.sh'
-      - 'pyproject.toml'
-      - '.github/workflows/studio-inference-smoke.yml'
-      - '.github/scripts/boot-studio-api-only.sh'
-      - '.github/scripts/wait-for-health.sh'
-      - '.github/actions/install-unsloth-local/action.yml'
+    branches: [main]
   # Manual trigger for pre-warming HF_HOME caches on main, or re-running
   # against an arbitrary branch without pushing a no-op commit.
   workflow_dispatch:

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -48,6 +48,16 @@ on:
       - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'install.sh'
+      - 'pyproject.toml'
+      - '.github/workflows/studio-inference-smoke.yml'
+      - '.github/scripts/boot-studio-api-only.sh'
+      - '.github/scripts/wait-for-health.sh'
+      - '.github/actions/install-unsloth-local/action.yml'
   # Manual trigger for pre-warming HF_HOME caches on main, or re-running
   # against an arbitrary branch without pushing a no-op commit.
   workflow_dispatch:

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -49,17 +49,7 @@ on:
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/**'
-      - 'unsloth/**'
-      - 'unsloth_cli/**'
-      - 'install.sh'
-      - 'pyproject.toml'
-      - '.github/workflows/studio-mac-inference-smoke.yml'
-      - '.github/scripts/boot-studio-api-only.sh'
-      - '.github/scripts/wait-for-health.sh'
-      - '.github/actions/install-unsloth-local/action.yml'
+    branches: [main]
   # Manual trigger for pre-warming model caches on main, or re-running
   # against an arbitrary branch without pushing a no-op commit.
   workflow_dispatch:

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -50,6 +50,16 @@ on:
       - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'install.sh'
+      - 'pyproject.toml'
+      - '.github/workflows/studio-mac-inference-smoke.yml'
+      - '.github/scripts/boot-studio-api-only.sh'
+      - '.github/scripts/wait-for-health.sh'
+      - '.github/actions/install-unsloth-local/action.yml'
   # Manual trigger for pre-warming model caches on main, or re-running
   # against an arbitrary branch without pushing a no-op commit.
   workflow_dispatch:

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -20,14 +20,7 @@ on:
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/install_llama_prebuilt.py'
-      - 'studio/setup.sh'
-      - 'install.sh'
-      - '.github/scripts/assert-llama-loads.sh'
-      - '.github/workflows/studio-mac-install-matrix.yml'
-      - '.github/actions/install-unsloth-local/action.yml'
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -21,6 +21,13 @@ on:
       - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/install_llama_prebuilt.py'
+      - 'studio/setup.sh'
+      - 'install.sh'
+      - '.github/scripts/assert-llama-loads.sh'
+      - '.github/workflows/studio-mac-install-matrix.yml'
+      - '.github/actions/install-unsloth-local/action.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -50,20 +50,7 @@ on:
       # studio-mac-api-smoke.yml watched is already covered above, and
       # tests/studio/** covers studio_api_smoke.py itself.
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/**'
-      - 'unsloth/**'
-      - 'unsloth_cli/**'
-      - 'install.sh'
-      - 'pyproject.toml'
-      - 'tests/studio/**'
-      - '.github/scripts/run-studio-permission-browser.sh'
-      - '.github/workflows/studio-mac-ui-smoke.yml'
-      - '.github/scripts/boot-studio-api-only.sh'
-      - '.github/scripts/wait-for-health.sh'
-      - '.github/actions/install-unsloth-local/action.yml'
-      - 'scripts/uninstall.sh'
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -51,6 +51,19 @@ on:
       # tests/studio/** covers studio_api_smoke.py itself.
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'install.sh'
+      - 'pyproject.toml'
+      - 'tests/studio/**'
+      - '.github/scripts/run-studio-permission-browser.sh'
+      - '.github/workflows/studio-mac-ui-smoke.yml'
+      - '.github/scripts/boot-studio-api-only.sh'
+      - '.github/scripts/wait-for-health.sh'
+      - '.github/actions/install-unsloth-local/action.yml'
+      - 'scripts/uninstall.sh'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -24,12 +24,7 @@ on:
       - 'unsloth_cli/**'
       - '.github/workflows/studio-tauri-smoke.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/frontend/**'
-      - 'studio/src-tauri/**'
-      - 'unsloth_cli/**'
-      - '.github/workflows/studio-tauri-smoke.yml'
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -25,6 +25,11 @@ on:
       - '.github/workflows/studio-tauri-smoke.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/frontend/**'
+      - 'studio/src-tauri/**'
+      - 'unsloth_cli/**'
+      - '.github/workflows/studio-tauri-smoke.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -38,19 +38,7 @@ on:
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/**'
-      - 'unsloth/**'
-      - 'unsloth_cli/**'
-      - 'install.sh'
-      - 'pyproject.toml'
-      - 'tests/studio/**'
-      - '.github/scripts/run-studio-permission-browser.sh'
-      - '.github/workflows/studio-ui-smoke.yml'
-      - '.github/scripts/boot-studio-api-only.sh'
-      - '.github/scripts/wait-for-health.sh'
-      - '.github/actions/install-unsloth-local/action.yml'
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -39,6 +39,18 @@ on:
       - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'install.sh'
+      - 'pyproject.toml'
+      - 'tests/studio/**'
+      - '.github/scripts/run-studio-permission-browser.sh'
+      - '.github/workflows/studio-ui-smoke.yml'
+      - '.github/scripts/boot-studio-api-only.sh'
+      - '.github/scripts/wait-for-health.sh'
+      - '.github/actions/install-unsloth-local/action.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -27,18 +27,7 @@ on:
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'install.sh'
-      - 'scripts/uninstall.sh'
-      - 'studio/setup.sh'
-      - 'studio/install_python_stack.py'
-      - 'studio/install_llama_prebuilt.py'
-      - 'studio/backend/requirements/**'
-      - 'unsloth_cli/commands/studio.py'
-      - 'pyproject.toml'
-      - '.github/workflows/studio-update-smoke.yml'
-      - '.github/actions/install-unsloth-local/action.yml'
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -28,6 +28,17 @@ on:
       - '.github/actions/install-unsloth-local/action.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'install.sh'
+      - 'scripts/uninstall.sh'
+      - 'studio/setup.sh'
+      - 'studio/install_python_stack.py'
+      - 'studio/install_llama_prebuilt.py'
+      - 'studio/backend/requirements/**'
+      - 'unsloth_cli/commands/studio.py'
+      - 'pyproject.toml'
+      - '.github/workflows/studio-update-smoke.yml'
+      - '.github/actions/install-unsloth-local/action.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -28,17 +28,7 @@ on:
       # Same for the /api/health wait that runs after a boot.
       - '.github/scripts/wait-for-health.sh'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/**'
-      - 'unsloth/**'
-      - 'unsloth_cli/**'
-      - 'install.ps1'
-      - 'pyproject.toml'
-      - 'tests/studio/**'
-      - '.github/workflows/studio-windows-api-smoke.yml'
-      - '.github/scripts/boot-studio-api-only.sh'
-      - '.github/scripts/wait-for-health.sh'
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -29,6 +29,16 @@ on:
       - '.github/scripts/wait-for-health.sh'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'install.ps1'
+      - 'pyproject.toml'
+      - 'tests/studio/**'
+      - '.github/workflows/studio-windows-api-smoke.yml'
+      - '.github/scripts/boot-studio-api-only.sh'
+      - '.github/scripts/wait-for-health.sh'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -42,18 +42,7 @@ on:
       # Same for the /api/health wait that runs after a boot.
       - '.github/scripts/wait-for-health.sh'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/**'
-      - 'unsloth/**'
-      - 'unsloth_cli/**'
-      - 'install.ps1'
-      - 'pyproject.toml'
-      - 'tests/studio_setup_ps1/**'
-      - 'tests/studio/*.ps1'
-      - '.github/workflows/studio-windows-inference-smoke.yml'
-      - '.github/scripts/boot-studio-api-only.sh'
-      - '.github/scripts/wait-for-health.sh'
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -43,6 +43,17 @@ on:
       - '.github/scripts/wait-for-health.sh'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'install.ps1'
+      - 'pyproject.toml'
+      - 'tests/studio_setup_ps1/**'
+      - 'tests/studio/*.ps1'
+      - '.github/workflows/studio-windows-inference-smoke.yml'
+      - '.github/scripts/boot-studio-api-only.sh'
+      - '.github/scripts/wait-for-health.sh'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -28,6 +28,17 @@ on:
       - '.github/scripts/wait-for-health.sh'
   push:
     branches: [main, pip]
+    paths:
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - 'install.ps1'
+      - 'pyproject.toml'
+      - 'tests/studio/**'
+      - '.github/scripts/run-studio-permission-browser.sh'
+      - '.github/workflows/studio-windows-ui-smoke.yml'
+      - '.github/scripts/boot-studio-api-only.sh'
+      - '.github/scripts/wait-for-health.sh'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -27,18 +27,7 @@ on:
       # Same for the /api/health wait that runs after a boot.
       - '.github/scripts/wait-for-health.sh'
   push:
-    branches: [main, pip]
-    paths:
-      - 'studio/**'
-      - 'unsloth/**'
-      - 'unsloth_cli/**'
-      - 'install.ps1'
-      - 'pyproject.toml'
-      - 'tests/studio/**'
-      - '.github/scripts/run-studio-permission-browser.sh'
-      - '.github/workflows/studio-windows-ui-smoke.yml'
-      - '.github/scripts/boot-studio-api-only.sh'
-      - '.github/scripts/wait-for-health.sh'
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -35,20 +35,7 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/studio-windows-update-smoke.yml'
   push:
-    branches: [main, pip]
-    paths:
-      - 'install.ps1'
-      - 'scripts/uninstall.ps1'
-      - 'tests/studio/test_uninstall_*.ps1'
-      - 'tests/studio/test_psmodulepath_normalization.ps1'
-      - 'studio/setup.ps1'
-      - 'studio/setup.bat'
-      - 'studio/install_python_stack.py'
-      - 'studio/install_llama_prebuilt.py'
-      - 'studio/backend/requirements/**'
-      - 'unsloth_cli/commands/studio.py'
-      - 'pyproject.toml'
-      - '.github/workflows/studio-windows-update-smoke.yml'
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -36,6 +36,19 @@ on:
       - '.github/workflows/studio-windows-update-smoke.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'install.ps1'
+      - 'scripts/uninstall.ps1'
+      - 'tests/studio/test_uninstall_*.ps1'
+      - 'tests/studio/test_psmodulepath_normalization.ps1'
+      - 'studio/setup.ps1'
+      - 'studio/setup.bat'
+      - 'studio/install_python_stack.py'
+      - 'studio/install_llama_prebuilt.py'
+      - 'studio/backend/requirements/**'
+      - 'unsloth_cli/commands/studio.py'
+      - 'pyproject.toml'
+      - '.github/workflows/studio-windows-update-smoke.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -26,7 +26,7 @@ on:
       - 'unsloth_cli/**'
       - '.github/workflows/wheel-smoke.yml'
   push:
-    branches: [main, pip]
+    branches: [main]
     paths:
       - 'pyproject.toml'
       - 'studio/**'

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -27,6 +27,12 @@ on:
       - '.github/workflows/wheel-smoke.yml'
   push:
     branches: [main, pip]
+    paths:
+      - 'pyproject.toml'
+      - 'studio/**'
+      - 'unsloth/**'
+      - 'unsloth_cli/**'
+      - '.github/workflows/wheel-smoke.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Two trigger-level CI changes. No job logic, no step changes.

## 1. Stop running CI on the `pip` branch (19 workflows)

`pip` is the release branch. It is merged from a `main` that has already had
the full matrix run against it, so every release re-ran a matrix that had just
passed on the identical tree. This was the single largest source of duplicate
CI on release days.

Every `push` trigger that listed `pip` now lists only `main`:

```diff
   push:
-    branches: [main, pip]
+    branches: [main]
```

Applied to: consolidated-tests-ci, lint-ci, mlx-ci, security-audit,
studio-api-smoke, studio-backend-ci, studio-frontend-ci, studio-inference-smoke,
studio-mac-inference-smoke, studio-mac-install-matrix, studio-mac-ui-smoke,
studio-tauri-smoke, studio-ui-smoke, studio-update-smoke,
studio-windows-api-smoke, studio-windows-inference-smoke,
studio-windows-ui-smoke, studio-windows-update-smoke, wheel-smoke.

`pull_request` triggers are untouched, so nothing changes for PR gating. A
release can still be validated on demand via `workflow_dispatch` where the
workflow defines one.

## 2. Mirror `pull_request.paths` onto `push.paths` for the non-Studio workflows

Four workflows had a `paths` filter on `pull_request` but none on `push`, so a
merge to `main` re-ran them in full even when nothing in their trigger set had
changed. Each now carries the same `paths` list on both triggers:

- `consolidated-tests-ci.yml`
- `mlx-ci.yml`
- `security-audit.yml`
- `wheel-smoke.yml`

This follows the six workflows in the repo that already mirror their PR path
filters onto push, so the convention is now consistent for the non-Studio set.

## Studio workflows are deliberately left unfiltered on push

An earlier revision of this branch also added `push.paths` to the 14
`studio-*` workflows. That has been reverted. Unsloth Studio CI should always
run post-merge regardless of which paths a merge touched, so the `studio-*`
push triggers stay unfiltered. Their `pull_request.paths` filters are
unchanged, so Studio PR gating behaves exactly as it does today.

## Verification

Checked programmatically against the merge base:

- The 14 `studio-*` files are byte-identical to their pre-branch state apart
  from the `pip` removal.
- For all four non-Studio workflows, `push.paths == pull_request.paths` after
  a YAML parse.
- No `push` trigger anywhere in `.github/workflows/` still references `pip`,
  and no other trigger's `branches` / `branches-ignore` list ever did. The
  remaining `pip` matches in the tree are all `cache: 'pip'` on
  `actions/setup-python`, which are unrelated.
- All 35 workflow files still parse as valid YAML, and each changed file is
  structurally identical to its merge-base version once the two intended keys
  (`push.branches`, `push.paths`) are normalised away.
- Every line in the diff is either one of the 19 `branches` replacements or an
  added `paths` entry in one of the four non-Studio files. Files were edited as
  text, so comments and formatting are preserved with no reformatting churn.

Diff against the merge base: 19 files changed, 54 insertions, 19 deletions.
