### PR TITLE
CI: always run Studio export/load-orchestrator and the security audit

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -49,32 +49,8 @@ name: Security audit
 
 on:
   pull_request:
-    paths:
-      - 'studio/backend/requirements/**'
-      - 'studio/frontend/package.json'
-      - 'studio/frontend/package-lock.json'
-      - 'studio/src-tauri/Cargo.toml'
-      - 'studio/src-tauri/Cargo.lock'
-      - 'pyproject.toml'
-      - 'scripts/scan_packages.py'
-      - 'scripts/scan_packages_baseline.json'
-      - 'scripts/scan_npm_packages.py'
-      - 'scripts/scan_npm_packages_baseline.json'
-      - '.github/workflows/security-audit.yml'
   push:
     branches: [main]
-    paths:
-      - 'studio/backend/requirements/**'
-      - 'studio/frontend/package.json'
-      - 'studio/frontend/package-lock.json'
-      - 'studio/src-tauri/Cargo.toml'
-      - 'studio/src-tauri/Cargo.lock'
-      - 'pyproject.toml'
-      - 'scripts/scan_packages.py'
-      - 'scripts/scan_packages_baseline.json'
-      - 'scripts/scan_npm_packages.py'
-      - 'scripts/scan_npm_packages_baseline.json'
-      - '.github/workflows/security-audit.yml'
   schedule:
     - cron: '13 4 * * *'   # 04:13 UTC daily, off the cron rush
   workflow_dispatch:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -2,14 +2,15 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
 # Multi-language supply-chain audit. Triggers:
-#   - PRs touching any dependency manifest (Python / npm / Cargo), a
-#     scanner or its allowlist baseline, or this workflow file,
-#   - push to main / pip,
+#   - every pull request, deliberately not path-filtered, so nothing
+#     slips past the audit by touching only files outside the
+#     dependency manifests,
+#   - push to main,
 #   - nightly @ 04:13 UTC so newly-published advisories surface even
 #     when no PR opens,
 #   - workflow_dispatch for ad-hoc invocations.
 #
-# Two jobs:
+# Six jobs:
 #   - advisory-audit:    one runner that runs pip-audit + npm audit +
 #                        cargo audit back-to-back. All three are
 #                        advisory-DB lookups -- fast, lockfile-driven,
@@ -24,6 +25,12 @@
 #                        independent so a CVE-DB hit in advisory-audit
 #                        does not block the supply-chain pattern scan
 #                        (or vice versa).
+#   - npm-scan-packages: npm tarball content scan, no npm install.
+#   - workflow-trigger-lint:
+#                        bans pull_request_target + shared cache keys.
+#   - tests-security:    pytest tests/security regression suite.
+#   - npm-provenance-and-install-scripts:
+#                        npm audit signatures + new-postinstall gate.
 #
 # All steps are non-blocking initially. The default branch already
 # carries a known-vuln backlog (the dependabot banner shows 17 today,

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -540,7 +540,7 @@ jobs:
       # / tokens / cred files committed accidentally. --only-verified
       # filters out probabilistic findings, so we only flag tokens
       # that the source provider confirmed are live. On push to main
-      # / pip we scan the full repo; on PR we scan base..head.
+      # we scan the full repo; on PR we scan base..head.
       # SHA-pinned for the same reason as harden-runner above.
       # v3.95.2 commit:
       # ─────────────────────────────────────────────────────────────

--- a/.github/workflows/studio-export-capability-ci.yml
+++ b/.github/workflows/studio-export-capability-ci.yml
@@ -22,13 +22,6 @@ on:
       - '.github/workflows/studio-export-capability-ci.yml'
   push:
     branches: [main]
-    paths:
-      - 'studio/backend/utils/hardware/hardware.py'
-      - 'studio/backend/core/export/export.py'
-      - 'studio/backend/routes/export.py'
-      - 'studio/backend/main.py'
-      - 'studio/backend/tests/test_export_capability.py'
-      - '.github/workflows/studio-export-capability-ci.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/studio-load-orchestrator-ci.yml
+++ b/.github/workflows/studio-load-orchestrator-ci.yml
@@ -25,11 +25,6 @@ on:
       - '.github/workflows/studio-load-orchestrator-ci.yml'
   push:
     branches: [main]
-    paths:
-      - 'studio/backend/routes/inference.py'
-      - 'studio/backend/core/inference/llama_cpp.py'
-      - 'tests/studio/load_freeze/**'
-      - '.github/workflows/studio-load-orchestrator-ci.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Makes three CI workflows always run instead of being path-filtered.

## Studio: export capability and load orchestrator

All Unsloth Studio CI should always run on push to main. After #8085, 14 of the 16 `studio-*` workflows are unfiltered on push, but these two were still path-filtered there (pre-existing: they were part of the group that already mirrored their PR filters onto push). This drops `push.paths` from:

- `.github/workflows/studio-export-capability-ci.yml`
- `.github/workflows/studio-load-orchestrator-ci.yml`

`push.branches: [main]` stays, and the `pull_request.paths` filters on both files are untouched. All 16 studio workflows are now consistent on push: 0 still carry `push.paths`.

## security-audit.yml

`security-audit.yml` is the supply-chain gate. It runs advisory-audit, pip-scan-packages, npm-scan-packages, workflow-trigger-lint, tests-security and npm-provenance-and-install-scripts. It was filtered to 11 dependency-manifest paths, so a PR touching anything outside those paths skipped the audit entirely. That is the wrong default for a security gate: it should run on every PR so a bad change is caught wherever it lands.

This removes `paths:` from both the `push` and the `pull_request` triggers. To be clear about provenance: the `push.paths` block was added by #8085 and this reverts that specific part of it, while also removing the older `pull_request` filter that predates it. `schedule` (nightly 04:13 UTC) and `workflow_dispatch` are unchanged, as is `push.branches: [main]`.

## Scope

`lint-ci.yml` is already unfiltered on both triggers and is not touched. No other workflow is touched.

The diff is 36 deleted lines and 0 added lines: 4 `paths:` keys and their 32 list entries. No reformatting and no whitespace changes, so the comment blocks in these files are preserved verbatim.

## Verification

Parsed each file with PyYAML and compared against the base revision:

- `studio-export-capability-ci.yml`: `push.paths` absent, `push.branches == ['main']`, `pull_request.paths` identical to base, everything else structurally identical.
- `studio-load-orchestrator-ci.yml`: same four checks pass.
- `security-audit.yml`: `push.paths` absent, `pull_request.paths` absent, `push.branches == ['main']`, `schedule` and `workflow_dispatch` present and identical to base, everything else structurally identical.
- All 35 workflow files still parse as valid YAML.
- `python3 scripts/lint_workflow_triggers.py` passes: no `pull_request_target`, no unjustified `workflow_run`, no PR/publish cache-key collision.
- Repo-wide: `studio-*` workflows with `push.paths` remaining = 0 (of 16).
