### PR TITLE
release-desktop: cache trusted-signing-cli and add job timeouts

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -55,6 +55,8 @@ jobs:
   prepare-version:
     name: Prepare release versions
     runs-on: ubuntu-latest
+    # Version resolution only; observed 8-16s.
+    timeout-minutes: 15
     outputs:
       studio_version: ${{ steps.prepare.outputs.studio_version }}
       app_version: ${{ steps.prepare.outputs.app_version }}
@@ -363,6 +365,8 @@ jobs:
     name: Build ${{ matrix.label }}
     needs: prepare-version
     runs-on: ${{ matrix.platform }}
+    # 6.9-20.9 min observed across platforms and cache states.
+    timeout-minutes: 60
 
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -663,10 +667,32 @@ jobs:
           rm -f certificate.p12
 
       # ── Windows: install Azure Trusted Signing CLI ──
-      - name: Install trusted-signing-cli
+      # `cargo install` builds this from source: 241s and 248s on the last two
+      # cache-miss runs. It was only ever fast when the ~550 MB rust-cache
+      # happened to restore `~/.cargo/bin` too, and that entry is the first
+      # thing evicted under repo cache pressure, which is why Windows swung
+      # between 8.8 min and 20.9 min. A dedicated single-binary cache keeps the
+      # compile off the critical path independently of the big Rust cache.
+      - name: Restore trusted-signing-cli
+        id: cache_trusted_signing_cli
         if: matrix.platform == 'windows-latest'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: ~/.cargo/bin/trusted-signing-cli.exe
+          # The version is in the key, so a bump invalidates the cache instead
+          # of silently reusing the old binary.
+          key: trusted-signing-cli-0.10.0-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install trusted-signing-cli
+        if: matrix.platform == 'windows-latest' && steps.cache_trusted_signing_cli.outputs.cache-hit != 'true'
         run: |
           cargo install trusted-signing-cli --version 0.10.0 --locked
+
+      # Unconditional: on a cache hit the install step above is skipped, and the
+      # cargo bin dir still has to reach PATH or signing fails.
+      - name: Add cargo bin to PATH
+        if: matrix.platform == 'windows-latest'
+        run: |
           echo "$env:USERPROFILE\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       # ── Windows: verify signing CLI is accessible ──
@@ -798,9 +824,9 @@ jobs:
         if: matrix.platform == 'macos-latest'
         shell: bash
         # `--timeout` below caps the polling, but not the upload that precedes
-        # it. This job sets no timeout of its own, so without a backstop a stuck
-        # Notary service would hold `max-parallel: 1` for GitHub's 6h default
-        # and discard the Linux and Windows builds with it.
+        # it. Without a step-level backstop a stuck Notary service would hold
+        # `max-parallel: 1` for the whole job budget and discard the Linux and
+        # Windows builds with it, so cap it tighter than the job here.
         timeout-minutes: 45
         env:
           ARTIFACT_PATHS: ${{ steps.build_macos.outputs.artifactPaths }}
@@ -1302,6 +1328,8 @@ jobs:
     name: Publish desktop release
     needs: [prepare-version, build]
     runs-on: ubuntu-latest
+    # Artifact download plus release upload; observed 17-40s.
+    timeout-minutes: 20
     permissions:
       contents: write  # create the versioned Release and replace updater-channel metadata
     env:


### PR DESCRIPTION
Two independent, low-risk hardening changes to `.github/workflows/release-desktop.yml`.

## 1. Dedicated cache for `trusted-signing-cli`

`cargo install trusted-signing-cli --version 0.10.0 --locked` compiles the binary from source. On the last two cache-miss runs that step took **241s** and **248s** (runs 31062471161 and 30998969937).

It is only fast when `swatinem/rust-cache` happens to restore `~/.cargo/bin` as part of its ~550 MB cache entry, which is the first thing evicted under repo cache pressure. That coupling is why the Windows build swings between **8.8 min and 20.9 min** for no change in the build itself.

This adds a small dedicated `actions/cache` entry for just the one binary, so it survives independently of the big Rust cache, and skips the compile on a hit.

- `actions/cache` is SHA-pinned (`0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0`) to match the convention used by every other action in this repo.
- The cache key includes the version string, `runner.os` and `runner.arch`, so a future version bump invalidates the entry automatically rather than silently reusing a stale binary.
- The `GITHUB_PATH` append is split into its own step that runs on both hit and miss. It previously lived inside the install step; leaving it there while making the install conditional would drop `~/.cargo/bin` from PATH on a cache hit and break signing.
- `--version 0.10.0 --locked` is unchanged. 0.10.0 has no prebuilt release, and 0.11.0 renames the binary to `artifact-signing-cli`, so a bump is a separate breaking change and out of scope here.
- The existing `Verify trusted-signing-cli` step is untouched and still runs after, so a bad cache restore fails the job before any signing is attempted.

## 2. Job-level `timeout-minutes`

All three jobs inherited GitHub's 6-hour default, so a hung step could hold the runner (and, with `max-parallel: 1`, the whole release) for hours. Observed durations, with headroom:

| Job | Observed | Timeout |
| --- | --- | --- |
| `prepare-version` | 8-16s | 15 |
| `build` | 6.9-20.9 min | 60 |
| `publish-release` | 17-40s | 20 |

The step-level `timeout-minutes: 20` on `Scan Windows bundles with Defender` and `timeout-minutes: 45` on the macOS notarization step are deliberately tighter than the job budget and are left as-is. The stale comment on the notarization step (which said the job set no timeout of its own) is updated to match.

Verified the file still parses as valid YAML and that, apart from the additions above, the parsed job and step structure is byte-identical to `main`.
