### PR TITLE
Fix the status runtime-fields contract test left stale by #8074

### DIFF
--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -434,11 +434,24 @@ class TestRouteCompleteness:
             ), f"Non-GGUF LoadResponse should set context_length:\n{block[:200]}"
 
     def test_status_path(self):
-        """InferenceStatusResponse construction with llama_backend has the field."""
+        """InferenceStatusResponse construction with llama_backend has the field.
+
+        The route may splat the helper's result straight in, or bind it first
+        and adjust a field before passing it on. Both carry the runtime fields.
+        """
         blocks = self._find_construction_blocks("InferenceStatusResponse")
         found = False
         for block in blocks:
-            if "llama_backend" in block and "_llama_runtime_fields(llama_backend)" in block:
+            if "llama_backend" not in block:
+                continue
+            if "_llama_runtime_fields(llama_backend)" in block:
+                found = True
+                break
+            if "**_runtime_fields" in block:
+                # Only counts if that dict is the helper's, not any local name.
+                assert (
+                    "_runtime_fields = _llama_runtime_fields(llama_backend)" in self._source
+                ), "**_runtime_fields is not built from _llama_runtime_fields(llama_backend)"
                 found = True
                 break
         assert found, "No InferenceStatusResponse block with llama_backend has runtime fields"


### PR DESCRIPTION
`tests/test_native_context_length.py::TestRouteCompleteness::test_status_path` is red on main and on every PR branched from it. I hit it on two unrelated Studio PRs and traced it back here.

Bisected to #8074:

| commit | result |
| --- | --- |
| 2d231f88 (parent) | passes |
| e99651ba (#8074) | fails |

The test scans the `InferenceStatusResponse` construction block for a literal `_llama_runtime_fields(llama_backend)`. #8074 had to bind that call to `_runtime_fields` one line above the construction so it could overwrite `chat_template_override` before passing it on, since passing it twice is a `TypeError`. That moved the call outside the block the test reads.

Nothing is actually wrong with the route. The runtime fields are still applied, through `**_runtime_fields`. The test's pattern is just stale.

## Change

`test_status_path` accepts either shape now: the helper called inline, or its result splatted from a dict. The splat only counts when that dict is the helper's, so this does not degrade into a test that passes on anything.

## Testing

- `test_native_context_length.py` is 39 passing on this branch, 38 passing and 1 failing on main.
- Checked the test still catches what it is there for: deleting `**_runtime_fields` from the status route makes it fail again.
