### PR TITLE
Studio: label the chat model bar by repo, not the HF cache path

### DIFF
--- a/studio/backend/core/inference/model_ids.py
+++ b/studio/backend/core/inference/model_ids.py
@@ -84,7 +84,11 @@ def _is_hub_repo_id(identifier: str) -> bool:
     carries a repo id plus a filename, so two or more slashes."""
     if identifier.count("/") != 1:
         return False
-    stem = identifier[: -len(_GGUF_SUFFIX)] if identifier.lower().endswith(_GGUF_SUFFIX) else identifier
+    stem = (
+        identifier[: -len(_GGUF_SUFFIX)]
+        if identifier.lower().endswith(_GGUF_SUFFIX)
+        else identifier
+    )
     return not _looks_like_path(stem)
 
 

--- a/studio/backend/core/inference/model_ids.py
+++ b/studio/backend/core/inference/model_ids.py
@@ -79,6 +79,16 @@ def public_model_id(identifier: Optional[str]) -> Optional[str]:
     return name or identifier
 
 
+def _is_hub_repo_id(identifier: str) -> bool:
+    """``org/name``, including the ``org/name.gguf`` repos that exist on the Hub (e.g.
+    lex-au/Orpheus-3b-FT-Q8_0.gguf). Same rule as ``_is_direct_gguf_file_ref``: a file
+    reference carries a repo id plus a filename, so two or more slashes."""
+    if identifier.count("/") != 1:
+        return False
+    stem = identifier[: -len(_GGUF_SUFFIX)] if identifier.lower().endswith(_GGUF_SUFFIX) else identifier
+    return not _looks_like_path(stem)
+
+
 def display_model_name(identifier: Optional[str]) -> Optional[str]:
     """The short label a UI should show for *identifier*.
 
@@ -87,9 +97,11 @@ def display_model_name(identifier: Optional[str]) -> Optional[str]:
     identifier instead leaks the host layout on Windows, where ``C:\\Users\\...`` has
     no ``/`` to split on and the whole path becomes the label.
     """
+    if not identifier:
+        return identifier
+    if _is_hub_repo_id(identifier):
+        return identifier.split("/")[1]
     clean = public_model_id(identifier)
-    if not clean:
-        return clean
     return clean.rsplit("/", 1)[-1] or clean
 
 

--- a/studio/backend/core/inference/model_ids.py
+++ b/studio/backend/core/inference/model_ids.py
@@ -79,6 +79,20 @@ def public_model_id(identifier: Optional[str]) -> Optional[str]:
     return name or identifier
 
 
+def display_model_name(identifier: Optional[str]) -> Optional[str]:
+    """The short label a UI should show for *identifier*.
+
+    ``public_model_id`` then its trailing segment, so a HF cache snapshot reads as
+    ``X-GGUF`` and not the commit sha its directory is named after. Splitting the raw
+    identifier instead leaks the host layout on Windows, where ``C:\\Users\\...`` has
+    no ``/`` to split on and the whole path becomes the label.
+    """
+    clean = public_model_id(identifier)
+    if not clean:
+        return clean
+    return clean.rsplit("/", 1)[-1] or clean
+
+
 def model_id_matches(requested: Optional[str], internal: Optional[str]) -> bool:
     """Whether a client-supplied *requested* id refers to *internal*.
 

--- a/studio/backend/core/inference/model_ids.py
+++ b/studio/backend/core/inference/model_ids.py
@@ -80,9 +80,8 @@ def public_model_id(identifier: Optional[str]) -> Optional[str]:
 
 
 def _is_hub_repo_id(identifier: str) -> bool:
-    """``org/name``, including the ``org/name.gguf`` repos that exist on the Hub (e.g.
-    lex-au/Orpheus-3b-FT-Q8_0.gguf). Same rule as ``_is_direct_gguf_file_ref``: a file
-    reference carries a repo id plus a filename, so two or more slashes."""
+    """``org/name``, including Hub repos named ``org/name.gguf``. A file reference
+    carries a repo id plus a filename, so two or more slashes."""
     if identifier.count("/") != 1:
         return False
     stem = identifier[: -len(_GGUF_SUFFIX)] if identifier.lower().endswith(_GGUF_SUFFIX) else identifier
@@ -92,10 +91,9 @@ def _is_hub_repo_id(identifier: str) -> bool:
 def display_model_name(identifier: Optional[str]) -> Optional[str]:
     """The short label a UI should show for *identifier*.
 
-    ``public_model_id`` then its trailing segment, so a HF cache snapshot reads as
-    ``X-GGUF`` and not the commit sha its directory is named after. Splitting the raw
-    identifier instead leaks the host layout on Windows, where ``C:\\Users\\...`` has
-    no ``/`` to split on and the whole path becomes the label.
+    Trailing segment of the public id, so a HF cache snapshot reads as ``X-GGUF`` and
+    not its commit sha. Splitting the raw identifier instead leaks the host layout on
+    Windows, where ``C:\\Users\\...`` has no ``/`` to split on.
     """
     if not identifier:
         return identifier

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3705,7 +3705,7 @@ def _gguf_load_response(
         status = status,
         model = model,
         # Not the bare identifier: the already-resident path leaves display_name unset,
-        # and a cached repo loads from its snapshot dir, so clients labelled it by path.
+        # and a cached repo loads from its snapshot dir, so clients label it by path.
         display_name = display_name or display_model_name(model) or model,
         is_lora = False,
         is_gguf = True,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2015,7 +2015,7 @@ def _request_used_api_key(request: Any) -> bool:
 from state.tool_approvals import resolve_tool_decision
 
 from core.inference.key_exchange import decrypt_api_key
-from core.inference.model_ids import model_id_matches, public_model_id
+from core.inference.model_ids import display_model_name, model_id_matches, public_model_id
 from core.inference.api_monitor import api_monitor
 from core.inference.llama_http import nonstreaming_client
 from core.inference.tool_call_parser import (
@@ -3704,7 +3704,9 @@ def _gguf_load_response(
     return LoadResponse(
         status = status,
         model = model,
-        display_name = display_name or model,
+        # Not the bare identifier: the already-resident path leaves display_name unset,
+        # and a cached repo loads from its snapshot dir, so clients labelled it by path.
+        display_name = display_name or display_model_name(model) or model,
         is_lora = False,
         is_gguf = True,
         is_local_model = is_local_model,

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1819,10 +1819,9 @@ async def list_models(current_subject: str = Depends(get_current_subject)):
             )
             loaded_models.append(model_info)
 
-        # Include active GGUF model (loaded via llama-server). The id stays the raw
-        # identifier: agents-tab's discoverGgufModels drops path-shaped ids to keep a
-        # native lease's unloadable label out of the copied --model command. Only the
-        # label is cleaned, from the display id /api/inference/status publishes.
+        # Include active GGUF model (loaded via llama-server). Only the label is cleaned,
+        # from the display id /api/inference/status publishes; the id stays the raw
+        # identifier that agents-tab's discoverGgufModels filters path-shaped ids on.
         from routes.inference import _llama_status_model_ids, get_llama_cpp_backend
 
         llama_backend = get_llama_cpp_backend()

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -20,6 +20,8 @@ from pydantic import BaseModel
 from typing import List, Optional
 import structlog
 from loggers import get_logger
+# Dependency-light leaf (PEP 562 package init): no llama.cpp / torch import chain.
+from core.inference.model_ids import display_model_name
 from utils.utils import canonical_model_repo_id, log_and_http_error
 
 import re as _re
@@ -1806,7 +1808,7 @@ async def list_models(current_subject: str = Depends(get_current_subject)):
             _audio_type = model_data.get("audio_type")
             model_info = ModelDetails(
                 id = model_name,
-                name = model_name.split("/")[-1] if "/" in model_name else model_name,
+                name = display_model_name(model_name),
                 is_vision = _is_vision,
                 is_lora = model_data.get("is_lora", False),
                 is_mlx = model_data.get("is_mlx", False),
@@ -1817,21 +1819,27 @@ async def list_models(current_subject: str = Depends(get_current_subject)):
             )
             loaded_models.append(model_info)
 
-        # Include active GGUF model (loaded via llama-server).
-        from routes.inference import get_llama_cpp_backend
+        # Include active GGUF model (loaded via llama-server). Both fields come from the
+        # pair /api/inference/status publishes, so the two endpoints cannot drift: the id
+        # is what a client holds as params.checkpoint (a native-lease load never exposes
+        # its leased path), and the name is the display id, never the raw identifier.
+        from routes.inference import _llama_status_model_ids, get_llama_cpp_backend
 
         llama_backend = get_llama_cpp_backend()
         if llama_backend.is_loaded and llama_backend.model_identifier:
-            loaded_models.append(
-                ModelDetails(
-                    id = llama_backend.model_identifier,
-                    name = llama_backend.model_identifier.split("/")[-1],
-                    is_gguf = True,
-                    is_vision = llama_backend.is_vision,
-                    is_audio = getattr(llama_backend, "_is_audio", False),
-                    audio_type = getattr(llama_backend, "_audio_type", None),
+            display_id, reported_identifier = _llama_status_model_ids(llama_backend)
+            checkpoint_id = reported_identifier or display_id
+            if checkpoint_id:
+                loaded_models.append(
+                    ModelDetails(
+                        id = checkpoint_id,
+                        name = display_model_name(display_id or checkpoint_id),
+                        is_gguf = True,
+                        is_vision = llama_backend.is_vision,
+                        is_audio = getattr(llama_backend, "_is_audio", False),
+                        audio_type = getattr(llama_backend, "_audio_type", None),
+                    )
                 )
-            )
 
         # Combine default and loaded; prefer loaded entries for duplicate ids so runtime flags survive.
         all_models = []
@@ -1842,7 +1850,7 @@ async def list_models(current_subject: str = Depends(get_current_subject)):
             if model_id not in seen_ids:
                 model_info = loaded_by_id.get(model_id) or ModelDetails(
                     id = model_id,
-                    name = model_id.split("/")[-1] if "/" in model_id else model_id,
+                    name = display_model_name(model_id),
                     is_gguf = model_id.upper().endswith("-GGUF"),
                     is_mlx = _looks_like_mlx_repo(model_id),
                 )

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1820,9 +1820,8 @@ async def list_models(current_subject: str = Depends(get_current_subject)):
             )
             loaded_models.append(model_info)
 
-        # Include active GGUF model (loaded via llama-server). Only the label is cleaned,
-        # from the display id /api/inference/status publishes; the id stays the raw
-        # identifier that agents-tab's discoverGgufModels filters path-shaped ids on.
+        # Active GGUF model (llama-server), labelled from the display id
+        # /api/inference/status publishes; the id stays raw for agents-tab's path filter.
         from routes.inference import _llama_status_model_ids, get_llama_cpp_backend
 
         llama_backend = get_llama_cpp_backend()

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from typing import List, Optional
 import structlog
 from loggers import get_logger
+
 # Dependency-light leaf (PEP 562 package init): no llama.cpp / torch import chain.
 from core.inference.model_ids import display_model_name
 from utils.utils import canonical_model_repo_id, log_and_http_error

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1819,27 +1819,25 @@ async def list_models(current_subject: str = Depends(get_current_subject)):
             )
             loaded_models.append(model_info)
 
-        # Include active GGUF model (loaded via llama-server). Both fields come from the
-        # pair /api/inference/status publishes, so the two endpoints cannot drift: the id
-        # is what a client holds as params.checkpoint (a native-lease load never exposes
-        # its leased path), and the name is the display id, never the raw identifier.
+        # Include active GGUF model (loaded via llama-server). The id stays the raw
+        # identifier: agents-tab's discoverGgufModels drops path-shaped ids to keep a
+        # native lease's unloadable label out of the copied --model command. Only the
+        # label is cleaned, from the display id /api/inference/status publishes.
         from routes.inference import _llama_status_model_ids, get_llama_cpp_backend
 
         llama_backend = get_llama_cpp_backend()
         if llama_backend.is_loaded and llama_backend.model_identifier:
-            display_id, reported_identifier = _llama_status_model_ids(llama_backend)
-            checkpoint_id = reported_identifier or display_id
-            if checkpoint_id:
-                loaded_models.append(
-                    ModelDetails(
-                        id = checkpoint_id,
-                        name = display_model_name(display_id or checkpoint_id),
-                        is_gguf = True,
-                        is_vision = llama_backend.is_vision,
-                        is_audio = getattr(llama_backend, "_is_audio", False),
-                        audio_type = getattr(llama_backend, "_audio_type", None),
-                    )
+            display_id, _reported_identifier = _llama_status_model_ids(llama_backend)
+            loaded_models.append(
+                ModelDetails(
+                    id = llama_backend.model_identifier,
+                    name = display_model_name(display_id or llama_backend.model_identifier),
+                    is_gguf = True,
+                    is_vision = llama_backend.is_vision,
+                    is_audio = getattr(llama_backend, "_is_audio", False),
+                    audio_type = getattr(llama_backend, "_audio_type", None),
                 )
+            )
 
         # Combine default and loaded; prefer loaded entries for duplicate ids so runtime flags survive.
         all_models = []

--- a/studio/backend/tests/test_model_ids.py
+++ b/studio/backend/tests/test_model_ids.py
@@ -87,8 +87,8 @@ def test_display_model_name_uses_the_repo_leaf_not_the_snapshot_sha():
         "/snapshots/57326b941c4603e24d1a5e71c22520c66e086eb8"
     )
     assert display_model_name(posix) == "DeepSeek-V4-Flash-0731-GGUF"
-    # The reported case: a Windows cache path has no "/" to split on, so a raw
-    # rsplit would label the model with the whole home directory.
+    # Reported case: a Windows cache path has no "/", so a raw rsplit labels the
+    # model with the whole home directory.
     windows = (
         "C:\\Users\\An\\.cache\\huggingface\\hub"
         "\\models--unsloth--DeepSeek-V4-Flash-0731-GGUF"
@@ -112,11 +112,10 @@ def test_display_model_name_leaves_ordinary_ids_alone():
 def test_display_model_name_keeps_gguf_on_hub_repo_ids():
     from core.inference.model_ids import display_model_name
 
-    # Real Hub repos are named this way (lex-au/Orpheus-3b-FT-Q8_0.gguf); the suffix is
-    # part of the repo leaf, not a file extension to strip.
+    # A real Hub repo: the suffix is part of the leaf, not an extension to strip.
     assert display_model_name("lex-au/Orpheus-3b-FT-Q8_0.gguf") == "Orpheus-3b-FT-Q8_0.gguf"
     # A file inside a repo (>= 2 slashes) is still a file reference.
     assert display_model_name("lex-au/Orpheus-3b-FT/Q8_0.gguf") == "Q8_0"
-    # And an anchored one-slash path is a path, not a repo id.
+    # An anchored one-slash id is a path, not a repo id.
     assert display_model_name("/srv/Qwen3-Q4.gguf") == "Qwen3-Q4"
     assert display_model_name("C:\\models\\Qwen3-Q4.gguf") == "Qwen3-Q4"

--- a/studio/backend/tests/test_model_ids.py
+++ b/studio/backend/tests/test_model_ids.py
@@ -107,3 +107,16 @@ def test_display_model_name_leaves_ordinary_ids_alone():
     )
     assert display_model_name(None) is None
     assert display_model_name("") == ""
+
+
+def test_display_model_name_keeps_gguf_on_hub_repo_ids():
+    from core.inference.model_ids import display_model_name
+
+    # Real Hub repos are named this way (lex-au/Orpheus-3b-FT-Q8_0.gguf); the suffix is
+    # part of the repo leaf, not a file extension to strip.
+    assert display_model_name("lex-au/Orpheus-3b-FT-Q8_0.gguf") == "Orpheus-3b-FT-Q8_0.gguf"
+    # A file inside a repo (>= 2 slashes) is still a file reference.
+    assert display_model_name("lex-au/Orpheus-3b-FT/Q8_0.gguf") == "Q8_0"
+    # And an anchored one-slash path is a path, not a repo id.
+    assert display_model_name("/srv/Qwen3-Q4.gguf") == "Qwen3-Q4"
+    assert display_model_name("C:\\models\\Qwen3-Q4.gguf") == "Qwen3-Q4"

--- a/studio/backend/tests/test_model_ids.py
+++ b/studio/backend/tests/test_model_ids.py
@@ -102,9 +102,7 @@ def test_display_model_name_leaves_ordinary_ids_alone():
 
     assert display_model_name("unsloth/Qwen3-30B-A3B-GGUF") == "Qwen3-30B-A3B-GGUF"
     assert display_model_name("Qwen3-30B-A3B") == "Qwen3-30B-A3B"
-    assert display_model_name("/srv/models/Qwen3-30B-A3B-Q4_K_M.gguf") == (
-        "Qwen3-30B-A3B-Q4_K_M"
-    )
+    assert display_model_name("/srv/models/Qwen3-30B-A3B-Q4_K_M.gguf") == ("Qwen3-30B-A3B-Q4_K_M")
     assert display_model_name(None) is None
     assert display_model_name("") == ""
 

--- a/studio/backend/tests/test_model_ids.py
+++ b/studio/backend/tests/test_model_ids.py
@@ -77,3 +77,33 @@ def test_matches_clean_and_legacy():
     assert not model_id_matches("other", path)
     assert not model_id_matches(None, path)
     assert not model_id_matches("x", None)
+
+
+def test_display_model_name_uses_the_repo_leaf_not_the_snapshot_sha():
+    from core.inference.model_ids import display_model_name
+
+    posix = (
+        "/home/u/.cache/huggingface/hub/models--unsloth--DeepSeek-V4-Flash-0731-GGUF"
+        "/snapshots/57326b941c4603e24d1a5e71c22520c66e086eb8"
+    )
+    assert display_model_name(posix) == "DeepSeek-V4-Flash-0731-GGUF"
+    # The reported case: a Windows cache path has no "/" to split on, so a raw
+    # rsplit would label the model with the whole home directory.
+    windows = (
+        "C:\\Users\\An\\.cache\\huggingface\\hub"
+        "\\models--unsloth--DeepSeek-V4-Flash-0731-GGUF"
+        "\\snapshots\\57326b941c4603e24d1a5e71c22520c66e086eb8"
+    )
+    assert display_model_name(windows) == "DeepSeek-V4-Flash-0731-GGUF"
+
+
+def test_display_model_name_leaves_ordinary_ids_alone():
+    from core.inference.model_ids import display_model_name
+
+    assert display_model_name("unsloth/Qwen3-30B-A3B-GGUF") == "Qwen3-30B-A3B-GGUF"
+    assert display_model_name("Qwen3-30B-A3B") == "Qwen3-30B-A3B"
+    assert display_model_name("/srv/models/Qwen3-30B-A3B-Q4_K_M.gguf") == (
+        "Qwen3-30B-A3B-Q4_K_M"
+    )
+    assert display_model_name(None) is None
+    assert display_model_name("") == ""

--- a/studio/backend/tests/test_models_list_resident_gguf_label.py
+++ b/studio/backend/tests/test_models_list_resident_gguf_label.py
@@ -3,10 +3,9 @@
 
 """GET /api/models/list must label the resident GGUF the way the chat model bar reads it.
 
-The bar renders the ``name`` of the models[] entry whose ``id`` equals the client's
-``params.checkpoint``, which for a GGUF out of the HF cache is the snapshot directory.
-Naming that entry by splitting the raw identifier on "/" showed the commit sha on POSIX
-and, on Windows (backslashes, nothing to split on), the entire home directory.
+The bar renders the ``name`` of the models[] entry whose ``id`` is the client's
+``params.checkpoint``, which for a cached GGUF is the snapshot directory. Splitting that
+raw identifier on "/" showed the commit sha on POSIX and the whole home dir on Windows.
 """
 
 import asyncio
@@ -58,8 +57,8 @@ def test_hf_cache_snapshot_is_labelled_by_its_repo_leaf(monkeypatch):
 
         assert len(entries) == 1
         entry = entries[0]
-        # The id stays the loadable identifier the client holds as its checkpoint, so the
-        # picker still finds this entry; only the label is cleaned up.
+        # The id stays the checkpoint the client holds, so the picker still finds
+        # this entry; only the label is cleaned up.
         assert entry.id == snapshot
         assert entry.name == "DeepSeek-V4-Flash-0731-GGUF"
         assert entry.is_gguf is True
@@ -75,8 +74,8 @@ def test_standalone_gguf_is_labelled_by_its_file_stem(monkeypatch):
 
 def test_native_lease_keeps_the_path_shaped_id_agents_tab_filters_on(monkeypatch):
     # agents-tab's discoverGgufModels drops path-shaped ids so a native lease's label,
-    # which cannot reload the file, never becomes a named model in a --model command.
-    # Only the label is cleaned here.
+    # which cannot reload the file, never lands in a --model command. Only the label
+    # is cleaned here.
     entries = _list_models(
         monkeypatch,
         _FakeLlama(
@@ -107,7 +106,7 @@ def test_plain_repo_ids_are_unchanged(monkeypatch):
 
 def test_already_resident_load_response_never_echoes_the_snapshot_path(monkeypatch):
     # The already-loaded fast path leaves display_name unset, so the response fell back
-    # to the identifier the GGUF loaded from -- the client then labels the model with it.
+    # to the identifier the GGUF loaded from, and the client labelled the model with it.
     import routes.inference as inf_route
 
     monkeypatch.setattr(
@@ -123,7 +122,7 @@ def test_already_resident_load_response_never_echoes_the_snapshot_path(monkeypat
     )
 
     assert resp.display_name == "DeepSeek-V4-Flash-0731-GGUF"
-    # The loadable identifier itself is unchanged; only the label is cleaned up.
+    # The loadable identifier itself is unchanged.
     assert resp.model == _POSIX_SNAPSHOT
 
 
@@ -145,8 +144,8 @@ def test_an_explicit_display_name_still_wins(monkeypatch):
 
 
 def test_a_hub_repo_id_ending_in_gguf_keeps_its_suffix(monkeypatch):
-    # lex-au/Orpheus-3b-FT-Q8_0.gguf and friends are real repo ids, not file paths, so
-    # the label is the repo leaf whole; only a >= 2-slash id names a file inside a repo.
+    # These are real repo ids, not file paths, so the label is the whole repo leaf;
+    # only a >= 2-slash id names a file inside a repo.
     class _Backend(_FakeUnsloth):
         default_models = ["lex-au/Orpheus-3b-FT-Q8_0.gguf"]
 

--- a/studio/backend/tests/test_models_list_resident_gguf_label.py
+++ b/studio/backend/tests/test_models_list_resident_gguf_label.py
@@ -73,9 +73,10 @@ def test_standalone_gguf_is_labelled_by_its_file_stem(monkeypatch):
     assert entries[0].name == "Qwen3-30B-A3B-Q4_K_M"
 
 
-def test_native_lease_load_reports_its_label_and_never_the_leased_path(monkeypatch):
-    # A native-lease load withholds the host path from /api/inference/status, so the
-    # client's checkpoint is the display label; /list has to agree or the picker misses.
+def test_native_lease_keeps_the_path_shaped_id_agents_tab_filters_on(monkeypatch):
+    # agents-tab's discoverGgufModels drops path-shaped ids so a native lease's label,
+    # which cannot reload the file, never becomes a named model in a --model command.
+    # Only the label is cleaned here.
     entries = _list_models(
         monkeypatch,
         _FakeLlama(
@@ -85,9 +86,8 @@ def test_native_lease_load_reports_its_label_and_never_the_leased_path(monkeypat
         ),
     )
 
-    assert entries[0].id == "Qwen3-4B-Q4_K_M.gguf"
+    assert entries[0].id == "/private/var/leases/xyz/Qwen3-4B-Q4_K_M.gguf"
     assert entries[0].name == "Qwen3-4B-Q4_K_M"
-    assert "/private/var/leases" not in entries[0].id
 
 
 def test_plain_repo_ids_are_unchanged(monkeypatch):
@@ -142,3 +142,17 @@ def test_an_explicit_display_name_still_wins(monkeypatch):
     )
 
     assert resp.display_name == "DeepSeek-V4-Flash-0731 (UD-IQ2_M)"
+
+
+def test_a_hub_repo_id_ending_in_gguf_keeps_its_suffix(monkeypatch):
+    # lex-au/Orpheus-3b-FT-Q8_0.gguf and friends are real repo ids, not file paths, so
+    # the label is the repo leaf whole; only a >= 2-slash id names a file inside a repo.
+    class _Backend(_FakeUnsloth):
+        default_models = ["lex-au/Orpheus-3b-FT-Q8_0.gguf"]
+
+    monkeypatch.setattr(models_route, "get_inference_backend", lambda: _Backend())
+    monkeypatch.setattr(inf, "get_llama_cpp_backend", lambda: _FakeLlama(None))
+
+    entries = asyncio.run(models_route.list_models(current_subject = "unsloth")).models
+
+    assert entries[0].name == "Orpheus-3b-FT-Q8_0.gguf"

--- a/studio/backend/tests/test_models_list_resident_gguf_label.py
+++ b/studio/backend/tests/test_models_list_resident_gguf_label.py
@@ -33,7 +33,13 @@ _WINDOWS_SNAPSHOT = (
 class _FakeLlama:
     is_vision = False
 
-    def __init__(self, identifier, *, native_grant_backed = False, display_label = None):
+    def __init__(
+        self,
+        identifier,
+        *,
+        native_grant_backed = False,
+        display_label = None,
+    ):
         self.is_loaded = True
         self.model_identifier = identifier
         self._native_grant_backed = native_grant_backed
@@ -65,9 +71,7 @@ def test_hf_cache_snapshot_is_labelled_by_its_repo_leaf(monkeypatch):
 
 
 def test_standalone_gguf_is_labelled_by_its_file_stem(monkeypatch):
-    entries = _list_models(
-        monkeypatch, _FakeLlama("/srv/models/Qwen3-30B-A3B-Q4_K_M.gguf")
-    )
+    entries = _list_models(monkeypatch, _FakeLlama("/srv/models/Qwen3-30B-A3B-Q4_K_M.gguf"))
 
     assert entries[0].name == "Qwen3-30B-A3B-Q4_K_M"
 
@@ -109,9 +113,7 @@ def test_already_resident_load_response_never_echoes_the_snapshot_path(monkeypat
     # to the identifier the GGUF loaded from, and the client labelled the model with it.
     import routes.inference as inf_route
 
-    monkeypatch.setattr(
-        inf_route, "_llama_runtime_fields", lambda backend: {}
-    )
+    monkeypatch.setattr(inf_route, "_llama_runtime_fields", lambda backend: {})
     monkeypatch.setattr(inf_route, "load_inference_config", lambda identifier: {})
 
     resp = inf_route._gguf_load_response(

--- a/studio/backend/tests/test_models_list_resident_gguf_label.py
+++ b/studio/backend/tests/test_models_list_resident_gguf_label.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""GET /api/models/list must label the resident GGUF the way the chat model bar reads it.
+
+The bar renders the ``name`` of the models[] entry whose ``id`` equals the client's
+``params.checkpoint``, which for a GGUF out of the HF cache is the snapshot directory.
+Naming that entry by splitting the raw identifier on "/" showed the commit sha on POSIX
+and, on Windows (backslashes, nothing to split on), the entire home directory.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parents[1]
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import routes.inference as inf  # noqa: E402
+import routes.models as models_route  # noqa: E402
+
+_POSIX_SNAPSHOT = (
+    "/home/u/.cache/huggingface/hub/models--unsloth--DeepSeek-V4-Flash-0731-GGUF"
+    "/snapshots/57326b941c4603e24d1a5e71c22520c66e086eb8"
+)
+_WINDOWS_SNAPSHOT = (
+    "C:\\Users\\An\\.cache\\huggingface\\hub"
+    "\\models--unsloth--DeepSeek-V4-Flash-0731-GGUF"
+    "\\snapshots\\57326b941c4603e24d1a5e71c22520c66e086eb8"
+)
+
+
+class _FakeLlama:
+    is_vision = False
+
+    def __init__(self, identifier, *, native_grant_backed = False, display_label = None):
+        self.is_loaded = True
+        self.model_identifier = identifier
+        self._native_grant_backed = native_grant_backed
+        self._native_display_label = display_label
+
+
+class _FakeUnsloth:
+    default_models: list = []
+    models: dict = {}
+
+
+def _list_models(monkeypatch, llama):
+    monkeypatch.setattr(models_route, "get_inference_backend", lambda: _FakeUnsloth())
+    monkeypatch.setattr(inf, "get_llama_cpp_backend", lambda: llama)
+    return asyncio.run(models_route.list_models(current_subject = "unsloth")).models
+
+
+def test_hf_cache_snapshot_is_labelled_by_its_repo_leaf(monkeypatch):
+    for snapshot in (_POSIX_SNAPSHOT, _WINDOWS_SNAPSHOT):
+        entries = _list_models(monkeypatch, _FakeLlama(snapshot))
+
+        assert len(entries) == 1
+        entry = entries[0]
+        # The id stays the loadable identifier the client holds as its checkpoint, so the
+        # picker still finds this entry; only the label is cleaned up.
+        assert entry.id == snapshot
+        assert entry.name == "DeepSeek-V4-Flash-0731-GGUF"
+        assert entry.is_gguf is True
+
+
+def test_standalone_gguf_is_labelled_by_its_file_stem(monkeypatch):
+    entries = _list_models(
+        monkeypatch, _FakeLlama("/srv/models/Qwen3-30B-A3B-Q4_K_M.gguf")
+    )
+
+    assert entries[0].name == "Qwen3-30B-A3B-Q4_K_M"
+
+
+def test_native_lease_load_reports_its_label_and_never_the_leased_path(monkeypatch):
+    # A native-lease load withholds the host path from /api/inference/status, so the
+    # client's checkpoint is the display label; /list has to agree or the picker misses.
+    entries = _list_models(
+        monkeypatch,
+        _FakeLlama(
+            "/private/var/leases/xyz/Qwen3-4B-Q4_K_M.gguf",
+            native_grant_backed = True,
+            display_label = "Qwen3-4B-Q4_K_M.gguf",
+        ),
+    )
+
+    assert entries[0].id == "Qwen3-4B-Q4_K_M.gguf"
+    assert entries[0].name == "Qwen3-4B-Q4_K_M"
+    assert "/private/var/leases" not in entries[0].id
+
+
+def test_plain_repo_ids_are_unchanged(monkeypatch):
+    class _Backend(_FakeUnsloth):
+        default_models = ["unsloth/Qwen3-4B-Instruct-2507", "Qwen3-4B"]
+
+    monkeypatch.setattr(models_route, "get_inference_backend", lambda: _Backend())
+    monkeypatch.setattr(inf, "get_llama_cpp_backend", lambda: _FakeLlama(None))
+
+    entries = asyncio.run(models_route.list_models(current_subject = "unsloth")).models
+
+    assert [(e.id, e.name) for e in entries] == [
+        ("unsloth/Qwen3-4B-Instruct-2507", "Qwen3-4B-Instruct-2507"),
+        ("Qwen3-4B", "Qwen3-4B"),
+    ]
+
+
+def test_already_resident_load_response_never_echoes_the_snapshot_path(monkeypatch):
+    # The already-loaded fast path leaves display_name unset, so the response fell back
+    # to the identifier the GGUF loaded from -- the client then labels the model with it.
+    import routes.inference as inf_route
+
+    monkeypatch.setattr(
+        inf_route, "_llama_runtime_fields", lambda backend: {}
+    )
+    monkeypatch.setattr(inf_route, "load_inference_config", lambda identifier: {})
+
+    resp = inf_route._gguf_load_response(
+        _FakeLlama(_POSIX_SNAPSHOT),
+        "already_loaded",
+        _POSIX_SNAPSHOT,
+        is_local_model = True,
+    )
+
+    assert resp.display_name == "DeepSeek-V4-Flash-0731-GGUF"
+    # The loadable identifier itself is unchanged; only the label is cleaned up.
+    assert resp.model == _POSIX_SNAPSHOT
+
+
+def test_an_explicit_display_name_still_wins(monkeypatch):
+    import routes.inference as inf_route
+
+    monkeypatch.setattr(inf_route, "_llama_runtime_fields", lambda backend: {})
+    monkeypatch.setattr(inf_route, "load_inference_config", lambda identifier: {})
+
+    resp = inf_route._gguf_load_response(
+        _FakeLlama(_POSIX_SNAPSHOT),
+        "loaded",
+        _POSIX_SNAPSHOT,
+        display_name = "DeepSeek-V4-Flash-0731 (UD-IQ2_M)",
+        is_local_model = True,
+    )
+
+    assert resp.display_name == "DeepSeek-V4-Flash-0731 (UD-IQ2_M)"

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -10,6 +10,8 @@ import {
   useTransformersUpgradeDialogStore,
 } from "@/features/transformers-upgrade";
 import { consumeNativePathToken } from "@/features/native-intents/api";
+// eslint-disable-next-line no-restricted-imports -- Avoid the hub barrel's React and download-manager exports.
+import { modelDisplayName } from "@/features/hub/lib/model-identity";
 import { prepareHfTokenForUse } from "@/features/hf-auth";
 import {
   notifyNative,
@@ -234,7 +236,10 @@ export function syncModelCapabilities(
       ...models,
       {
         id: modelId,
-        name: resp.display_name || modelId,
+        // Labelled like the catalog entry that replaces this one on the next
+        // /api/models/list. /status has no display_name, and an older backend echoed
+        // the identifier it loaded from: for a cached GGUF, a host path in the bar.
+        name: modelDisplayName(resp.display_name || modelId),
         isLora: Boolean(resp.is_lora),
         ...synced,
       },

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -236,9 +236,8 @@ export function syncModelCapabilities(
       ...models,
       {
         id: modelId,
-        // Labelled like the catalog entry that replaces this one on the next
-        // /api/models/list. /status has no display_name, and an older backend echoed
-        // the load identifier: for a cached GGUF, a host path in the bar.
+        // Label like the catalog entry that replaces this on the next /api/models/list;
+        // the fallback keeps a cached GGUF's snapshot path out of the bar.
         name: modelDisplayName(resp.display_name || modelId),
         isLora: Boolean(resp.is_lora),
         ...synced,

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -238,7 +238,7 @@ export function syncModelCapabilities(
         id: modelId,
         // Labelled like the catalog entry that replaces this one on the next
         // /api/models/list. /status has no display_name, and an older backend echoed
-        // the identifier it loaded from: for a cached GGUF, a host path in the bar.
+        // the load identifier: for a cached GGUF, a host path in the bar.
         name: modelDisplayName(resp.display_name || modelId),
         isLora: Boolean(resp.is_lora),
         ...synced,

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -112,7 +112,7 @@ function ensureActiveModelInStoreList(
   }
   const summary: ChatModelSummary = {
     id: checkpointId,
-    // active_model is already the clean public id; the leaf matches the catalog rows,
+    // active_model is already the clean public id; its leaf matches the catalog rows,
     // and the fallback keeps a snapshot path out of the trigger.
     name: modelDisplayName(status.active_model ?? checkpointId),
     isVision: status.is_vision ?? false,

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -4,6 +4,8 @@
 // Barrel import (lint rule); the model-picker cycle is fine because the call
 // happens at runtime, not module eval.
 import { resolveResidentInitialConfig } from "@/features/model-picker";
+// eslint-disable-next-line no-restricted-imports -- Avoid the hub barrel's React and download-manager exports.
+import { modelDisplayName } from "@/features/hub/lib/model-identity";
 import { getInferenceStatus } from "../api/chat-api";
 import {
   mergeBackendRecommendedInference,
@@ -110,7 +112,9 @@ function ensureActiveModelInStoreList(
   }
   const summary: ChatModelSummary = {
     id: checkpointId,
-    name: status.active_model ?? checkpointId,
+    // active_model is already the clean public id; the leaf matches the catalog rows,
+    // and the fallback keeps a snapshot path out of the trigger.
+    name: modelDisplayName(status.active_model ?? checkpointId),
     isVision: status.is_vision ?? false,
     isLora: false,
     isGguf: status.is_gguf ?? false,

--- a/studio/frontend/src/features/hub/lib/model-identity.ts
+++ b/studio/frontend/src/features/hub/lib/model-identity.ts
@@ -128,8 +128,8 @@ export function publicModelId(identifier: string): string {
   return name.replace(GGUF_SUFFIX_RE, "") || trimmed;
 }
 
-/** `org/name`, including the `org/name.gguf` repos that exist on the Hub. A file
-* reference carries a repo id plus a filename, so two or more slashes. */
+/** `org/name`, including Hub repos named `org/name.gguf`. A file reference carries a
+* repo id plus a filename, so two or more slashes. */
 function isHubRepoId(identifier: string): boolean {
   if (identifier.split("/").length - 1 !== 1) {
     return false;
@@ -138,11 +138,10 @@ function isHubRepoId(identifier: string): boolean {
 }
 
 /**
-* The short label to show for a model id, for ids with no catalog entry to take a name
-* from. Mirrors ``display_model_name`` in core/inference/model_ids.py: the public id's
-* trailing segment, so a repo id and the HF cache snapshot it loads from both read as
-* ``DeepSeek-V4-Flash-0731-GGUF``. Splitting the raw id leaks the host layout on Windows,
-* where ``C:\\Users\\...`` holds no ``/`` to split on.
+* The short label for a model id with no catalog entry to take a name from. Mirrors
+* ``display_model_name`` in core/inference/model_ids.py: the public id's trailing
+* segment, so a repo id and the HF cache snapshot it loads from read alike. Splitting
+* the raw id leaks the host layout on Windows, where ``C:\\Users\\...`` holds no ``/``.
 */
 export function modelDisplayName(identifier: string): string {
   const trimmed = identifier.trim();

--- a/studio/frontend/src/features/hub/lib/model-identity.ts
+++ b/studio/frontend/src/features/hub/lib/model-identity.ts
@@ -129,6 +129,18 @@ export function publicModelId(identifier: string): string {
 }
 
 /**
+* The short label to show for a model id, for ids with no catalog entry to take a name
+* from. Mirrors ``display_model_name`` in core/inference/model_ids.py: the public id's
+* trailing segment, so a repo id and the HF cache snapshot it loads from both read as
+* ``DeepSeek-V4-Flash-0731-GGUF``. Splitting the raw id leaks the host layout on Windows,
+* where ``C:\\Users\\...`` holds no ``/`` to split on.
+*/
+export function modelDisplayName(identifier: string): string {
+  const clean = publicModelId(identifier);
+  return clean.slice(clean.lastIndexOf("/") + 1) || clean;
+}
+
+/**
 * Whether the model the backend reports as loaded is one of *candidates*.
 *
 * A GGUF from an inactive HF cache loads by path, so a caller holding only the public id would

--- a/studio/frontend/src/features/hub/lib/model-identity.ts
+++ b/studio/frontend/src/features/hub/lib/model-identity.ts
@@ -128,6 +128,15 @@ export function publicModelId(identifier: string): string {
   return name.replace(GGUF_SUFFIX_RE, "") || trimmed;
 }
 
+/** `org/name`, including the `org/name.gguf` repos that exist on the Hub. A file
+* reference carries a repo id plus a filename, so two or more slashes. */
+function isHubRepoId(identifier: string): boolean {
+  if (identifier.split("/").length - 1 !== 1) {
+    return false;
+  }
+  return !looksLikeModelPath(identifier.replace(GGUF_SUFFIX_RE, ""));
+}
+
 /**
 * The short label to show for a model id, for ids with no catalog entry to take a name
 * from. Mirrors ``display_model_name`` in core/inference/model_ids.py: the public id's
@@ -136,7 +145,11 @@ export function publicModelId(identifier: string): string {
 * where ``C:\\Users\\...`` holds no ``/`` to split on.
 */
 export function modelDisplayName(identifier: string): string {
-  const clean = publicModelId(identifier);
+  const trimmed = identifier.trim();
+  if (isHubRepoId(trimmed)) {
+    return trimmed.slice(trimmed.indexOf("/") + 1);
+  }
+  const clean = publicModelId(trimmed);
   return clean.slice(clean.lastIndexOf("/") + 1) || clean;
 }
 

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -757,10 +757,9 @@ export function ModelSelector({
   const currentModel = useMemo(() => {
     if (!selected) return undefined;
     const found = optionById.get(selected);
-    // No catalog entry yet (just after a refresh) or never listed. A cached GGUF's
-    // checkpoint is its snapshot path, so shown raw it reads as a home dir. The leaf,
-    // not the namespaced public id (#7966), so the label does not change once the
-    // catalog arrives and names the same model by its leaf.
+    // No catalog entry (yet, or ever); a cached GGUF's checkpoint is a snapshot path.
+    // The leaf, not the namespaced public id (#7966), matches the catalog row that
+    // later replaces this one.
     const fallbackName = modelDisplayName(selected);
     if (activeGgufVariant) {
       const desc = `GGUF · ${activeGgufVariant}`;

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -36,7 +36,10 @@ import {
   useState,
 } from "react";
 import type { HfTaskFilter } from "@/features/hub/hooks/use-hub-model-search";
-import { isOllamaLinkPath } from "../model-config/model-identity";
+import {
+  isOllamaLinkPath,
+  modelDisplayName,
+} from "../model-config/model-identity";
 import {
   type PerModelConfig,
   resolveInitialConfig,
@@ -754,13 +757,16 @@ export function ModelSelector({
   const currentModel = useMemo(() => {
     if (!selected) return undefined;
     const found = optionById.get(selected);
+    // No catalog entry yet (the window right after a refresh), or never listed. The
+    // checkpoint for a cached GGUF is its snapshot path, so raw it shows a home dir.
+    const fallbackName = modelDisplayName(selected);
     if (activeGgufVariant) {
       const desc = `GGUF · ${activeGgufVariant}`;
       return found
         ? { ...found, description: desc }
-        : { id: selected, name: selected, description: desc };
+        : { id: selected, name: fallbackName, description: desc };
     }
-    return found ?? { id: selected, name: selected };
+    return found ?? { id: selected, name: fallbackName };
   }, [selected, optionById, activeGgufVariant]);
 
   function handleSelect(id: string, meta: ModelSelectorChangeMeta) {

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -757,8 +757,8 @@ export function ModelSelector({
   const currentModel = useMemo(() => {
     if (!selected) return undefined;
     const found = optionById.get(selected);
-    // No catalog entry yet (the window right after a refresh), or never listed. The
-    // checkpoint for a cached GGUF is its snapshot path, so raw it shows a home dir.
+    // No catalog entry yet (just after a refresh) or never listed. A cached GGUF's
+    // checkpoint is its snapshot path, so shown raw it reads as a home dir.
     const fallbackName = modelDisplayName(selected);
     if (activeGgufVariant) {
       const desc = `GGUF · ${activeGgufVariant}`;

--- a/studio/frontend/src/features/model-picker/model-config/model-identity.ts
+++ b/studio/frontend/src/features/model-picker/model-config/model-identity.ts
@@ -12,6 +12,7 @@ export {
   isNativeFileLabel,
   isOllamaLinkPath,
   isStandaloneGgufPath,
+  modelDisplayName,
   normalizeGgufVariantIdentity,
   normalizeModelIdentity,
   publicModelId,

--- a/studio/frontend/tests/model-identity.test.ts
+++ b/studio/frontend/tests/model-identity.test.ts
@@ -446,3 +446,15 @@ test("labels a model id with the repo leaf, never the raw path", () => {
   assert.equal(modelDisplayName("Qwen3-30B-A3B"), "Qwen3-30B-A3B");
   assert.equal(modelDisplayName(""), "");
 });
+
+test("keeps .gguf on Hub repo ids, which are not file paths", () => {
+  // lex-au/Orpheus-3b-FT-Q8_0.gguf and friends are real repos; the suffix is part of
+  // the leaf. Only a >= 2-slash id names a file inside a repo.
+  assert.equal(
+    modelDisplayName("lex-au/Orpheus-3b-FT-Q8_0.gguf"),
+    "Orpheus-3b-FT-Q8_0.gguf",
+  );
+  assert.equal(modelDisplayName("lex-au/Orpheus-3b-FT/Q8_0.gguf"), "Q8_0");
+  assert.equal(modelDisplayName("/srv/Qwen3-Q4.gguf"), "Qwen3-Q4");
+  assert.equal(modelDisplayName(String.raw`C:\models\Qwen3-Q4.gguf`), "Qwen3-Q4");
+});

--- a/studio/frontend/tests/model-identity.test.ts
+++ b/studio/frontend/tests/model-identity.test.ts
@@ -424,8 +424,8 @@ test("preserves existing platform and Hub identity rules", () => {
 
 
 test("labels a model id with the repo leaf, never the raw path", () => {
-  // The reported case: a Windows HF cache path holds no "/", so splitting the raw id
-  // would put the whole home directory in the chat model bar.
+  // Reported case: a Windows HF cache path holds no "/", so splitting the raw id
+  // puts the whole home directory in the chat model bar.
   assert.equal(
     modelDisplayName(
       String.raw`C:\Users\An\.cache\huggingface\hub\models--unsloth--DeepSeek-V4-Flash-0731-GGUF\snapshots\57326b941c4603e24d1a5e71c22520c66e086eb8`,
@@ -448,8 +448,8 @@ test("labels a model id with the repo leaf, never the raw path", () => {
 });
 
 test("keeps .gguf on Hub repo ids, which are not file paths", () => {
-  // lex-au/Orpheus-3b-FT-Q8_0.gguf and friends are real repos; the suffix is part of
-  // the leaf. Only a >= 2-slash id names a file inside a repo.
+  // These are real repos; the suffix is part of the leaf. Only a >= 2-slash id
+  // names a file inside a repo.
   assert.equal(
     modelDisplayName("lex-au/Orpheus-3b-FT-Q8_0.gguf"),
     "Orpheus-3b-FT-Q8_0.gguf",

--- a/studio/frontend/tests/model-identity.test.ts
+++ b/studio/frontend/tests/model-identity.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   isOllamaLinkPath,
   isStandaloneGgufPath,
+  modelDisplayName,
   modelIdsMatch,
   normalizeModelIdentity,
   publicModelId,
@@ -419,4 +420,29 @@ test("preserves existing platform and Hub identity rules", () => {
     "//server/share/models/demo",
   );
   assert.equal(normalizeModelIdentity("Org/Model"), "org/model");
+});
+
+
+test("labels a model id with the repo leaf, never the raw path", () => {
+  // The reported case: a Windows HF cache path holds no "/", so splitting the raw id
+  // would put the whole home directory in the chat model bar.
+  assert.equal(
+    modelDisplayName(
+      String.raw`C:\Users\An\.cache\huggingface\hub\models--unsloth--DeepSeek-V4-Flash-0731-GGUF\snapshots\57326b941c4603e24d1a5e71c22520c66e086eb8`,
+    ),
+    "DeepSeek-V4-Flash-0731-GGUF",
+  );
+  assert.equal(
+    modelDisplayName(
+      "/home/u/.cache/huggingface/hub/models--unsloth--DeepSeek-V4-Flash-0731-GGUF/snapshots/57326b941c4603e24d1a5e71c22520c66e086eb8",
+    ),
+    "DeepSeek-V4-Flash-0731-GGUF",
+  );
+  assert.equal(
+    modelDisplayName("/srv/models/Qwen3-30B-A3B-Q4_K_M.gguf"),
+    "Qwen3-30B-A3B-Q4_K_M",
+  );
+  assert.equal(modelDisplayName("unsloth/Qwen3-30B-A3B-GGUF"), "Qwen3-30B-A3B-GGUF");
+  assert.equal(modelDisplayName("Qwen3-30B-A3B"), "Qwen3-30B-A3B");
+  assert.equal(modelDisplayName(""), "");
 });


### PR DESCRIPTION
### Problem

A user reported that the chat model bar shows this instead of the model name:

```
C:\Users\An\.cache\huggingface\hub\models--unsloth--DeepSeek-V4-Flash-0731-GGUF\snapshots\57326b941c4603e24d1a5e71c22520c66e086eb8   GGUF · UD-IQ2_M
```

It should read `DeepSeek-V4-Flash-0731-GGUF  GGUF · UD-IQ2_M`.

### Cause

A GGUF loaded out of the HF cache is identified by its snapshot directory, and that is what the client keeps as `params.checkpoint` (it is the loadable id; `/api/inference/status` publishes it as `model_identifier` alongside the clean `active_model`). The model bar renders the `name` of the `models[]` entry whose id matches that checkpoint, and `/api/models/list` built that name by splitting the raw identifier on `/`:

```python
id   = llama_backend.model_identifier,
name = llama_backend.model_identifier.split("/")[-1],
```

On Windows the path is backslash separated, so there is nothing to split on and the whole string becomes the label. On Linux and macOS the same line returns the commit sha the snapshot directory is named after, which is the form I reproduced locally.

The "sometimes after a refresh" half is the same value arriving from a second source: the already resident load path leaves `display_name` unset, and `_gguf_load_response` fell back to `display_name = model`, so the client seeded its `models[]` entry from the raw path again.

### Fix

Backend:

- `core/inference/model_ids.py`: new `display_model_name()`, which is `public_model_id()` then the trailing segment, so a cache snapshot resolves through its `models--org--name` segment. Path aware, so a Windows path works.
- `routes/models.py`: every `name =` in `list_models` uses it. The resident GGUF entry now takes its `(display, identifier)` pair from `_llama_status_model_ids`, the same helper `/api/inference/status` uses, so the two endpoints cannot drift. That also stops a native lease load listing its leased path as the entry id, which never matched the client's checkpoint.
- `routes/inference.py`: `_gguf_load_response` no longer falls back to the bare identifier for `display_name`.

Frontend, for the window before `/api/models/list` answers and for older backends:

- `modelDisplayName()` in `hub/lib/model-identity.ts`, mirroring the Python helper.
- Used in the `ModelSelector` trigger fallback and in the two store inserts (`ensureActiveModelInStoreList`, `syncModelCapabilities`).

Ids are untouched anywhere; only labels change.

### Verification

Reproduced on an isolated Studio (`UNSLOTH_STUDIO_HOME`, port 8901) with `unsloth/Qwen3-0.6B-GGUF` UD-IQ2_M loaded from a cache snapshot, driven with Playwright.

| | model bar |
|---|---|
| before | `50968a4468ef4233ed78cd7c3de230dd1d61a56b  GGUF · UD-IQ2_M` |
| after | `Qwen3-0.6B-GGUF  GGUF · UD-IQ2_M` |

Checked on first paint, after a reload, and with `/api/models/list` stubbed empty so the label comes only from `/api/inference/status`. All three read `Qwen3-0.6B-GGUF`.

Tests: 6 new in `tests/test_models_list_resident_gguf_label.py` (including the literal `C:\Users\An\...` path from the report, plus the native lease case), 2 added to `test_model_ids.py`, 1 to the frontend `model-identity.test.ts`. The route tests fail on the current code and pass with the change. 405 backend tests across the related suites pass, 731/731 frontend, typecheck and build clean.


### Relation to #7966

#7966 landed on main while this was open and fixes the same symptom from the other end: the `ModelSelector` fallback for a model that is absent from the option list. Merged main in and kept this branch's version of that hunk, with one difference. #7966 labels the fallback `publicModelId(selected)`, which keeps the owner (`unsloth/DeepSeek-V4-Flash-0731-GGUF`); this uses the leaf, matching every catalog row and the `/api/models/list` names below, so the label does not change once the catalog arrives and names the same model by its leaf. #7966's own test asserts `publicModelId` directly and is untouched.

The rest of this PR is the other half of the same bug and is not covered by #7966: the fallback only runs when the model is missing from `models[]`, and the reported case is a model that IS listed, whose `name` the backend built by splitting the raw identifier on `/`.
