### PR TITLE
Studio: fix the stale status-path guard failing Backend CI on every PR

### DIFF
--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -434,12 +434,36 @@ class TestRouteCompleteness:
             ), f"Non-GGUF LoadResponse should set context_length:\n{block[:200]}"
 
     def test_status_path(self):
-        """InferenceStatusResponse construction with llama_backend has the field."""
+        """InferenceStatusResponse construction with llama_backend has the field.
+
+        Matched on the spread rather than on the _llama_runtime_fields(...) call appearing
+        literally inside the constructor. #8074 hoisted that call into a local so it could
+        add chat_template_override before spreading, which left the fields reaching the
+        response exactly as before while this assertion, which only ever searched the text
+        between InferenceStatusResponse( and its closing paren, could no longer see it.
+        """
+        import re
+
         blocks = self._find_construction_blocks("InferenceStatusResponse")
         found = False
         for block in blocks:
-            if "llama_backend" in block and "_llama_runtime_fields(llama_backend)" in block:
-                found = True
+            if "llama_backend" not in block:
+                continue
+            if "_llama_runtime_fields(llama_backend)" in block:
+                found = True  # called inline
+                break
+            # Spread from a prepared local: tie that exact name back to its assignment,
+            # so a local built from anything else (or from {}) is not mistaken for this.
+            # A bare source-wide search is not enough -- there is another call site, and
+            # it would vouch for a spread that never touched llama_backend.
+            for name in re.findall(r"\*\*(\w+)", block):
+                if re.search(
+                    rf"{re.escape(name)}\s*=\s*_llama_runtime_fields\(llama_backend\)",
+                    self._source,
+                ):
+                    found = True
+                    break
+            if found:
                 break
         assert found, "No InferenceStatusResponse block with llama_backend has runtime fields"
         assert "for name in _InferenceRuntimeFields.model_fields" in self._source


### PR DESCRIPTION
`test_status_path` searches the text between `InferenceStatusResponse(` and its closing paren for a literal `_llama_runtime_fields(llama_backend)` call.

#8074 hoisted that call into a local so it could add `chat_template_override` before spreading it:

```python
_runtime_fields = _llama_runtime_fields(llama_backend)
_runtime_fields["chat_template_override"] = _reported_chat_template_override
return InferenceStatusResponse(
    ...
    **_runtime_fields,
```

The runtime fields still reach the response exactly as before, but the call now sits one line above the window the test inspects. The guard has failed on main ever since, so every PR opened since then shows a red Backend CI across Python 3.10, 3.11, 3.12 and 3.13 for a defect that does not exist. Current main is `1 failed, 17758 passed`.

## Change

Accept the spread as well as the inline call, and tie the spread name back to its own assignment. A file-wide search for the call would have been simpler but is wrong: there is a second `_llama_runtime_fields` call site, and it would happily vouch for a spread that never touched `llama_backend`.

## Verification

Mutation tested, since the point of this guard is to fail when the fields stop reaching the response:

| mutation | result |
|---|---|
| drop `**_runtime_fields` from the constructor | fails |
| build the local as `{}` | fails |
| call `_llama_runtime_fields(None)` | fails |
| unmutated | 39 passed |

No production code is touched.