### PR TITLE
Stop referencing a TAURI signing password secret that does not exist

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -754,7 +754,14 @@ jobs:
         env:
           ARTIFACT_PATHS: ${{ steps.build_linux.outputs.artifactPaths }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # The signing key is not password protected, and no secret of this name
+          # exists, so this expression has always resolved to the empty string.
+          # Stated literally rather than left pointing at a secret that is not
+          # there: the value is unchanged, but it no longer reads as configuration
+          # someone forgot to set. Empty is not the same as unset here -- tauri
+          # prompts for a password when the variable is absent, which would hang
+          # the job, so the line stays.
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ''
         run: |
           set -euo pipefail
           deb_path="$(
@@ -803,7 +810,14 @@ jobs:
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5  # v0.6.2
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # The signing key is not password protected, and no secret of this name
+          # exists, so this expression has always resolved to the empty string.
+          # Stated literally rather than left pointing at a secret that is not
+          # there: the value is unchanged, but it no longer reads as configuration
+          # someone forgot to set. Empty is not the same as unset here -- tauri
+          # prompts for a password when the variable is absent, which would hang
+          # the job, so the line stays.
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ''
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
@@ -961,7 +975,14 @@ jobs:
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5  # v0.6.2
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # The signing key is not password protected, and no secret of this name
+          # exists, so this expression has always resolved to the empty string.
+          # Stated literally rather than left pointing at a secret that is not
+          # there: the value is unchanged, but it no longer reads as configuration
+          # someone forgot to set. Empty is not the same as unset here -- tauri
+          # prompts for a password when the variable is absent, which would hang
+          # the job, so the line stays.
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ''
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
`release-desktop.yml` reads `secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD` in three places. **That secret is not configured on this repository.** The secret list holds `TAURI_SIGNING_PRIVATE_KEY` but no `PASSWORD` counterpart.

An unset secret in an expression resolves to the empty string, so this has always passed an empty password, and releases have been signing correctly on that basis. The signing key is not password protected.

## Nothing about the behaviour changes

The value is the empty string before and after. What changes is that the workflow no longer reads as though a secret is missing, which is exactly how it looked during a secret audit and cost real time to run down.

## Why the lines are not simply deleted

Empty and unset are not equivalent here. `tauri-cli` prompts for a password when the variable is absent, and an interactive prompt in CI hangs the job until it times out. Deleting the lines would be a behaviour change with a bad failure mode on a signed release.

`studio-tauri-smoke.yml` already sets this literally to `''` for the same reason, so this matches an existing convention in the repo rather than inventing one.