### PR TITLE
Match the LM Studio GGUF suffix case insensitively

### DIFF
--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -369,7 +369,7 @@ def _scan_lmstudio_dir(lm_dir: Path, *, entry_limit: int | None = None) -> List[
             break
         try:
             if not child.is_dir():
-                if child.suffix == ".gguf" and child.is_file():
+                if child.suffix.lower() == ".gguf" and child.is_file():
                     try:
                         updated_at = child.stat().st_mtime
                     except OSError:
@@ -422,7 +422,7 @@ def _scan_lmstudio_dir(lm_dir: Path, *, entry_limit: int | None = None) -> List[
                                 updated_at = updated_at,
                             )
                         )
-                    elif model_dir.suffix == ".gguf" and model_dir.is_file():
+                    elif model_dir.suffix.lower() == ".gguf" and model_dir.is_file():
                         try:
                             updated_at = model_dir.stat().st_mtime
                         except OSError:

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -4469,10 +4469,9 @@ def test_dataset_status_includes_generation(monkeypatch):
 
 @pytest.mark.parametrize("layout", ["flat", "publisher_child"])
 def test_lmstudio_scan_matches_gguf_suffix_case_insensitively(tmp_path, layout):
-    """The custom and models-dir scans lower() the suffix; these two branches did
-    not, so an LM Studio file named .GGUF was invisible only here. Windows and
-    macOS treat the two spellings as one name, so the file is reachable but
-    unlisted."""
+    """The custom and models-dir scans lower() the suffix; these two did not, so a
+    .GGUF was invisible only here. Windows and macOS treat the two spellings as one
+    name, so the file is reachable but unlisted."""
     lm_dir = tmp_path / "models"
     holder = lm_dir if layout == "flat" else lm_dir / "publisher"
     holder.mkdir(parents = True)

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -4465,3 +4465,20 @@ def test_dataset_status_includes_generation(monkeypatch):
 
     assert result.state == "running"
     assert result.generation == 4
+
+
+@pytest.mark.parametrize("layout", ["flat", "publisher_child"])
+def test_lmstudio_scan_matches_gguf_suffix_case_insensitively(tmp_path, layout):
+    """The custom and models-dir scans lower() the suffix; these two branches did
+    not, so an LM Studio file named .GGUF was invisible only here. Windows and
+    macOS treat the two spellings as one name, so the file is reachable but
+    unlisted."""
+    lm_dir = tmp_path / "models"
+    holder = lm_dir if layout == "flat" else lm_dir / "publisher"
+    holder.mkdir(parents = True)
+    for name in ("lower.gguf", "UPPER.GGUF", "Mixed.GguF"):
+        (holder / name).write_bytes(b"x")
+
+    found = {Path(row.path).name for row in local_inventory._scan_lmstudio_dir(lm_dir)}
+
+    assert found == {"lower.gguf", "UPPER.GGUF", "Mixed.GguF"}


### PR DESCRIPTION
`_scan_lmstudio_dir` compares the file suffix exactly, so a GGUF named `Model.GGUF` is skipped in the LM Studio scan. The other two scans in the same file already lower it (`local_inventory.py:152` and `:603`), and the custom-folder tests have used an uppercase `Qwen3.6-27B-MTP-Q8_0.GGUF` fixture for a while, so this is the LM Studio branch being out of step rather than a new rule.

It matters most on Windows and macOS, where the filesystem is case insensitive: the file is perfectly reachable and the user can open it in LM Studio, but Studio does not list it. On a case sensitive filesystem it is the same miss for anyone whose quantizer wrote an uppercase extension.

Both affected branches are in `_scan_lmstudio_dir`, one for the flat layout and one for a file sitting directly under a publisher directory.

Before, with `lower.gguf`, `UPPER.GGUF` and `Mixed.GguF` in the scan directory:

```
flat layout             -> ['lower.gguf']
publisher child layout  -> ['lower.gguf']
```

After:

```
flat layout             -> ['lower.gguf', 'UPPER.GGUF', 'Mixed.GguF']
publisher child layout  -> ['lower.gguf', 'UPPER.GGUF', 'Mixed.GguF']
```

Added `test_lmstudio_scan_matches_gguf_suffix_case_insensitively`, parametrized over the two layouts. It fails 2/2 without the change and passes with it. `studio/backend/hub/tests/test_model_services.py` is 146 passed.

Found while going over #7379, which makes the on-device inventory decide whether anything gets downloaded. It does not touch this file, so this is separate.
