### PR TITLE
CI: move the capacity sweeper off the retiring ubuntu-22.04 image

### DIFF
--- a/.github/workflows/ci-capacity.yml
+++ b/.github/workflows/ci-capacity.yml
@@ -144,7 +144,7 @@ jobs:
   # Three limits on that floor. All are real, none is fixable here, and they
   # are the reason `pause` is not the default.
   #
-  # It needs a runner. This job asks for an ubuntu-22.04 hosted runner out of
+  # It needs a runner. This job asks for an ubuntu-24.04 hosted runner out of
   # the same account-wide pool the sweeper exists to relieve, so under the
   # saturation this file is written for, the guard queues with everything else.
   # The true bound is MAX_DISABLED_MINUTES plus that wait, and on the numbers in
@@ -178,13 +178,13 @@ jobs:
     name: Re-enable anything left disabled
     # The complement of the condition on `sweep` below, so each trigger starts
     # only the job it asked for. Without it every ci-pause dispatch also took a
-    # second ubuntu-22.04 runner out of the pool the sweep in the same run is
+    # second ubuntu-24.04 runner out of the pool the sweep in the same run is
     # trying to free, and ran an enable loop on the one event that is asking for
     # the opposite. The floor under a pause is the cron, not this job appearing
     # on unrelated triggers; a manual restore is `mode=resume`, which enables the
     # whole allowlist rather than only what is past the cutoff.
     if: ${{ github.event_name == 'schedule' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -290,7 +290,7 @@ jobs:
   sweep:
     name: Free capacity
     if: ${{ github.event_name != 'schedule' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:


### PR DESCRIPTION
`ubuntu-22.04` deprecates from **2026-09-17** and retires **2027-04-17**, with brownout windows in between ([actions/runner-images#14254](https://github.com/actions/runner-images/issues/14254)). The ARM variant is covered by the same notice.

Both jobs in `ci-capacity.yml` run `git`, `gh` and `jq` and produce no artifact, so the runner label carries no compatibility contract here. Plain label swap, plus the two comments that name the label so they do not go stale against it.

The `guard` job runs on a `7,37 * * * *` cron, 48 times a day, which makes it both the most frequent consumer of this label in the repo and the one most likely to meet a brownout.

## Everything else on 22.04 stays, deliberately

| workflow | why it stays |
| --- | --- |
| `release-desktop.yml` | builds shipped bundles; the runner sets the glibc floor for users |
| `desktop-app-clean-machine-ci.yml` | tests those bundles on the floor they target |
| `studio-tauri-smoke.yml` | needs libX11 < 1.8 |

The last one is the interesting case. From libX11 1.8 the library calls `XInitThreads()` from its own constructor, so the #8062 race cannot occur and that job's launch loop would pass **with the fix reverted**. `ubuntu-22.04` ships 1.7.5. The job already prints the runner's libX11 version and warns when it finds 1.8 or newer, so it will say so itself if anyone moves it.

## Not in scope

The llama.cpp prebuilt legs are a separate problem and are untouched. Their Linux build jobs pin `ubuntu-22.04` to hold a glibc 2.35 / GLIBCXX <= 3.4.30 floor so bundles load on Ubuntu 22.04 and Debian 12, and a 24.04 build needs `GLIBC_2.38`. Moving those needs a container to pin the userspace independently of the runner, which upstream `ggml-org/llama.cpp` does not currently do either (their containers are for toolchain provisioning, and their ROCm jobs still pin `ubuntu-22.04`). Retirement is April 2027, so there is time to prototype that properly.