### PR TITLE
release-desktop: fail closed when trusted-signing-cli is missing or broken

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -752,10 +752,25 @@ jobs:
           }
           Write-Output "resolved: $($cli.Source)"
 
-          # Call through the resolved path and read $LASTEXITCODE explicitly:
-          # a native binary that exits non-zero does not raise, so
-          # $ErrorActionPreference alone would not catch it.
-          & $cli.Source --version
+          # Two different failure modes, and neither one covers the other:
+          #   * the binary cannot be started at all (a truncated cache entry
+          #     gives "Exec format error"). That raises a terminating error
+          #     under $ErrorActionPreference = "Stop", so it has to be caught
+          #     or the step dies here, before the recovery message below.
+          #   * the binary starts and exits non-zero. That does NOT raise, so
+          #     $LASTEXITCODE has to be read explicitly.
+          try {
+            & $cli.Source --version
+          }
+          catch {
+            # The PowerShell error spans several lines (message, offending line,
+            # caret). An annotation is truncated at the first newline, so flatten
+            # it, and put the recovery ahead of the detail so it survives even if
+            # the annotation is clipped for length.
+            $detail = ($_.Exception.Message -replace '\s+', ' ').Trim()
+            Write-Output "::error::trusted-signing-cli could not be started. If the cache restored a bad entry, bump the key in 'Restore trusted-signing-cli' to force a rebuild. Underlying error: $detail"
+            exit 1
+          }
           if ($LASTEXITCODE -ne 0) {
             Write-Output "::error::trusted-signing-cli is on PATH but exited $LASTEXITCODE. If the cache restored a bad entry, bump the key in 'Restore trusted-signing-cli' to force a rebuild."
             exit 1

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -733,12 +733,33 @@ jobs:
           echo "$env:USERPROFILE\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       # ── Windows: verify signing CLI is accessible ──
+      # Fails closed. This used to print a message and exit 0 on both branches,
+      # so a missing or broken binary reported success and the failure only
+      # surfaced later, inside the Tauri bundling step, as a signing error with
+      # no obvious cause. It matters more now that the binary comes from a
+      # cache: a truncated or corrupt cache entry restores, skips the install
+      # above, and would otherwise sail through this check.
       - name: Verify trusted-signing-cli
         if: matrix.platform == 'windows-latest'
         run: |
+          $ErrorActionPreference = "Stop"
           Write-Output "PATH: $env:PATH"
-          Get-Command trusted-signing-cli -ErrorAction SilentlyContinue || Write-Output "trusted-signing-cli NOT in PATH"
-          trusted-signing-cli --version || Write-Output "trusted-signing-cli failed to run"
+
+          $cli = Get-Command trusted-signing-cli -ErrorAction SilentlyContinue
+          if (-not $cli) {
+            Write-Output "::error::trusted-signing-cli is not on PATH. If the cache restored a bad entry, bump the key in 'Restore trusted-signing-cli' to force a rebuild."
+            exit 1
+          }
+          Write-Output "resolved: $($cli.Source)"
+
+          # Call through the resolved path and read $LASTEXITCODE explicitly:
+          # a native binary that exits non-zero does not raise, so
+          # $ErrorActionPreference alone would not catch it.
+          & $cli.Source --version
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "::error::trusted-signing-cli is on PATH but exited $LASTEXITCODE. If the cache restored a bad entry, bump the key in 'Restore trusted-signing-cli' to force a rebuild."
+            exit 1
+          }
 
       # ── Linux: pin AppImage packaging toolchain ──
       - name: Pin thin AppImage toolchain

--- a/tests/security/test_release_desktop_signing.py
+++ b/tests/security/test_release_desktop_signing.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The Windows signing toolchain check has to fail closed.
+
+An unsigned or half-signed installer is the failure this workflow exists to
+prevent, so the step that proves `trusted-signing-cli` works must not be able to
+report success when it does not. The check previously ended both of its branches
+in `|| Write-Output "..."`, which exits 0, so a missing or broken binary passed
+and only surfaced later inside the Tauri bundling step.
+"""
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-desktop.yml"
+
+
+def _verify_step():
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
+    return next(
+        step
+        for step in workflow["jobs"]["build"]["steps"]
+        if step.get("name") == "Verify trusted-signing-cli"
+    )
+
+
+def test_the_check_exits_non_zero_on_both_failure_paths():
+    run = _verify_step()["run"]
+    # One for "not on PATH", one for "on PATH but exited non-zero".
+    assert run.count("exit 1") == 2
+
+
+def test_failures_are_not_swallowed_by_a_fallback_message():
+    run = _verify_step()["run"]
+    assert "|| Write-Output" not in run
+
+
+def test_the_native_exit_code_is_inspected():
+    # $ErrorActionPreference does not trap a native binary exiting non-zero,
+    # so $LASTEXITCODE has to be read explicitly for the check to mean anything.
+    run = _verify_step()["run"]
+    assert "$LASTEXITCODE" in run
+
+
+def test_the_operator_is_told_how_to_recover_from_a_bad_cache():
+    # The binary is restored from a cache keyed on its version, so a corrupt
+    # entry survives until the key changes. Failing closed without saying that
+    # would turn a rare cache fault into an unexplained release outage.
+    run = _verify_step()["run"]
+    assert run.count("bump the key") == 2
+
+
+def test_the_check_still_only_runs_on_windows():
+    assert _verify_step()["if"] == "matrix.platform == 'windows-latest'"

--- a/tests/security/test_release_desktop_signing.py
+++ b/tests/security/test_release_desktop_signing.py
@@ -28,10 +28,27 @@ def _verify_step():
     )
 
 
-def test_the_check_exits_non_zero_on_both_failure_paths():
+def test_the_check_exits_non_zero_on_every_failure_path():
     run = _verify_step()["run"]
-    # One for "not on PATH", one for "on PATH but exited non-zero".
-    assert run.count("exit 1") == 2
+    # Not on PATH, cannot be started, and started but exited non-zero.
+    assert run.count("exit 1") == 3
+
+
+def test_a_binary_that_cannot_start_is_caught():
+    # A truncated cache entry gives "Exec format error", which is a terminating
+    # PowerShell error, not a native exit code. Without the catch the step dies
+    # on that line and never prints the cache-bump recovery.
+    run = _verify_step()["run"]
+    assert "try {" in run
+    assert "catch {" in run
+
+
+def test_the_launch_error_is_flattened_to_one_line():
+    # A PowerShell error spans message, offending line and caret. An annotation
+    # is truncated at the first newline, so an unflattened message would drop
+    # the recovery guidance that follows it.
+    run = _verify_step()["run"]
+    assert "-replace '\\s+', ' '" in run
 
 
 def test_failures_are_not_swallowed_by_a_fallback_message():
@@ -51,7 +68,7 @@ def test_the_operator_is_told_how_to_recover_from_a_bad_cache():
     # entry survives until the key changes. Failing closed without saying that
     # would turn a rare cache fault into an unexplained release outage.
     run = _verify_step()["run"]
-    assert run.count("bump the key") == 2
+    assert run.count("bump the key") == 3
 
 
 def test_the_check_still_only_runs_on_windows():


### PR DESCRIPTION
The Windows signing toolchain check could report success when the toolchain did not work.

Both branches ended in `|| Write-Output "..."`, which exits 0:

```powershell
Get-Command trusted-signing-cli -ErrorAction SilentlyContinue || Write-Output "trusted-signing-cli NOT in PATH"
trusted-signing-cli --version || Write-Output "trusted-signing-cli failed to run"
```

So a missing or non-functional binary printed a message and the step passed. The failure only surfaced further down, inside the Tauri bundling step, as a signing error with no obvious cause.

This became more likely with the dedicated cache added in #8087. On a cache hit the install step is skipped, so a truncated or corrupt cache entry restores and goes straight into signing. This check was the only thing positioned to catch that, and it could not.

## Changes

- Exit 1 when the binary is not on PATH.
- Exit 1 when it is on PATH but exits non-zero. `$LASTEXITCODE` is read explicitly, because `$ErrorActionPreference` does not trap a native binary exiting non-zero, which is what made the original second branch meaningless even without the `||`.
- Log the resolved path, and invoke through it rather than re-resolving.
- Both error messages name the recovery: bump the key in `Restore trusted-signing-cli`. A bad cache entry survives until the version key changes, and failing closed without saying so would turn a rare cache fault into an unexplained release outage.

## Verification

`pwsh` is available locally, so the step body was extracted from the YAML and executed against all three cases rather than only reviewed:

| Case | Result |
| --- | --- |
| binary absent | exit 1, `::error::... not on PATH` |
| present, exits 3 | exit 1, `::error::... exited 3` |
| healthy | exit 0, prints resolved path and version |

`tests/security/test_release_desktop_signing.py` pins that both failure paths exit non-zero, that `|| Write-Output` does not come back, and that `$LASTEXITCODE` is still inspected. Full `tests/security` suite: 212 passed.

Behaviour on a healthy runner is unchanged; this only converts a silent pass into a loud failure.