### PR TITLE
Studio: say what a failed launcher move-aside costs

### DIFF
--- a/tests/python/test_windows_studio_update_launcher.py
+++ b/tests/python/test_windows_studio_update_launcher.py
@@ -534,3 +534,26 @@ def test_the_update_lock_lives_outside_the_replaceable_venv(monkeypatch, studio,
 
     assert seen["venv_locks"] == []
     assert len(seen["home_locks"]) == 1
+
+
+def test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade(monkeypatch, studio, tmp_path, capsys):
+    # Aborting here would make an antivirus hold enough to render the
+    # environment unupdatable, which main did not do either. But the cost has to
+    # be visible: uv cannot replace a launcher it could not move, and the pip
+    # fallback drops --upgrade-package, so unsloth stays at its old version.
+    scripts, launcher = _configure_windows(monkeypatch, studio, tmp_path)
+    ran = []
+
+    def refuse_move(source, destination):
+        raise OSError("access is denied")
+
+    monkeypatch.setattr(studio.os, "replace", refuse_move)
+    monkeypatch.setattr(studio, "_run_setup_script", lambda **_kwargs: ran.append(True))
+    monkeypatch.setattr(studio.subprocess, "run", _successful_version_run())
+
+    _update(studio)
+
+    assert ran == [True]
+    err = capsys.readouterr().err
+    assert "could not move the Unsloth launcher aside" in err
+    assert "may not be upgraded" in err

--- a/tests/python/test_windows_studio_update_launcher.py
+++ b/tests/python/test_windows_studio_update_launcher.py
@@ -546,8 +546,15 @@ def test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade(
     scripts, launcher = _configure_windows(monkeypatch, studio, tmp_path)
     ran = []
 
+    real_replace = studio.os.replace
+
     def refuse_move(source, destination):
-        raise OSError("access is denied")
+        # Only the move aside: patching os.replace wholesale would also break
+        # _atomic_copy's backup, and the test would then be passing on a
+        # compound failure rather than the one it names.
+        if str(destination).endswith(".update-stale"):
+            raise OSError("access is denied")
+        return real_replace(source, destination)
 
     monkeypatch.setattr(studio.os, "replace", refuse_move)
     monkeypatch.setattr(studio, "_run_setup_script", lambda **_kwargs: ran.append(True))
@@ -559,3 +566,5 @@ def test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade(
     err = capsys.readouterr().err
     assert "could not move the Unsloth launcher aside" in err
     assert "may not be upgraded" in err
+    # The backup still succeeded, so this is the move-aside failure alone.
+    assert "could not back up" not in err

--- a/tests/python/test_windows_studio_update_launcher.py
+++ b/tests/python/test_windows_studio_update_launcher.py
@@ -545,6 +545,7 @@ def test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade(
     # fallback drops --upgrade-package, so unsloth stays at its old version.
     scripts, launcher = _configure_windows(monkeypatch, studio, tmp_path)
     ran = []
+    seen = {}
 
     real_replace = studio.os.replace
 
@@ -557,7 +558,12 @@ def test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade(
         return real_replace(source, destination)
 
     monkeypatch.setattr(studio.os, "replace", refuse_move)
-    monkeypatch.setattr(studio, "_run_setup_script", lambda **_kwargs: ran.append(True))
+    def setup(**_kwargs):
+        ran.append(True)
+        # Sampled here: a successful update unlinks the backup on the way out.
+        seen["backup"] = (scripts / "unsloth.exe.update-backup").read_bytes()
+
+    monkeypatch.setattr(studio, "_run_setup_script", setup)
     monkeypatch.setattr(studio.subprocess, "run", _successful_version_run())
 
     _update(studio)
@@ -568,3 +574,4 @@ def test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade(
     assert "may not be upgraded" in err
     # The backup still succeeded, so this is the move-aside failure alone.
     assert "could not back up" not in err
+    assert seen["backup"] == ORIGINAL_LAUNCHER

--- a/tests/python/test_windows_studio_update_launcher.py
+++ b/tests/python/test_windows_studio_update_launcher.py
@@ -536,7 +536,9 @@ def test_the_update_lock_lives_outside_the_replaceable_venv(monkeypatch, studio,
     assert len(seen["home_locks"]) == 1
 
 
-def test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade(monkeypatch, studio, tmp_path, capsys):
+def test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade(
+    monkeypatch, studio, tmp_path, capsys
+):
     # Aborting here would make an antivirus hold enough to render the
     # environment unupdatable, which main did not do either. But the cost has to
     # be visible: uv cannot replace a launcher it could not move, and the pip

--- a/tests/python/test_windows_studio_update_launcher.py
+++ b/tests/python/test_windows_studio_update_launcher.py
@@ -558,6 +558,7 @@ def test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade(
         return real_replace(source, destination)
 
     monkeypatch.setattr(studio.os, "replace", refuse_move)
+
     def setup(**_kwargs):
         ran.append(True)
         # Sampled here: a successful update unlinks the backup on the way out.

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3376,7 +3376,16 @@ class _WindowsLauncherUpdateTransaction:
         try:
             os.replace(self.launcher, self.stale)
         except OSError as exc:
+            # Not fatal: an antivirus hold must not make the environment
+            # unupdatable. But say what it costs, because uv cannot then replace
+            # the launcher and the pip fallback drops --upgrade-package, so
+            # unsloth is left at its old version while everything else updates.
             typer.echo(f"Warning: could not move the Unsloth launcher aside: {exc}", err = True)
+            typer.echo(
+                "  unsloth itself may not be upgraded. Close anything holding "
+                f"{self.launcher} and re-run the update.",
+                err = True,
+            )
 
     def _retained_backup(self) -> Optional[Path]:
         """The backup, when it exists and is usable. Nothing to point users at otherwise."""


### PR DESCRIPTION
## Summary

Follow-up to #8092. When the Windows update transaction cannot free `Scripts\unsloth.exe`, the update continues with a warning that does not say what continuing costs.

## Why

The transaction moves the launcher aside before setup so the installer can publish a replacement. If `os.replace` fails, because antivirus or an ACL is holding the file, `_move_launcher_aside` warns and carries on.

Carrying on is the right call. An antivirus hold must not make the environment unupdatable, and failing here would turn a partial update into a hard block on every update.

The problem is that the consequence was invisible:

- uv only self-replaces its own executable, so it cannot replace a launcher it could not move.
- The pip fallback strips `--upgrade-package` and finds the bare `unsloth` requirement already satisfied.
- Setup exits 0 with `unsloth` still at its old version.

The update then reports success while `unsloth` did not move, and the desktop keeps finding the backend stale and retrying the repair. That loop is visible in the support diagnostics that motivated #8092:

```
15:10:00 [WARN] Managed repair update finished, but preflight is still not ready; falling back to installer
```

## Change

Name the cost and the remedy, so a partial update is not mistaken for a complete one:

```
Warning: could not move the Unsloth launcher aside: <error>
  unsloth itself may not be upgraded. Close anything holding
  C:\Users\...\Scripts\unsloth.exe and re-run the update.
```

No behaviour change beyond the message. AST check confirms no definitions added or removed.

## Testing

```
python -m pytest -q tests/python/test_windows_studio_update_launcher.py unsloth_cli/tests
876 passed, 4 skipped
```

`test_a_failed_move_aside_warns_that_unsloth_may_not_upgrade` covers it, and fails without the change.
