### PR TITLE
Deduplicate the scan-packages baseline, and gate it with tests

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1587,46 +1587,6 @@
       "evidence_hash": "d416b79dd17b24214f3f7653ac01354507d7bf0fc464dee30a4a4b8998f063ba"
     },
     {
-      "package": "openai",
-      "file": "openai/_base_client.py",
-      "check": "C2 polling/beaconing loop detected",
-      "severity": "CRITICAL",
-      "evidence": "L274:         while True: sha256:90a38e5c1e26893c7c273354143612640e9a9c0f079d3e2b60612d79f24e80a6",
-      "evidence_hash": "1022e8e8649436ec64a98a9d9141d085452c49549fd2157b0278fc369a83ac66"
-    },
-    {
-      "package": "openai",
-      "file": "openai/auth/_workload.py",
-      "check": "Accesses cloud metadata/IMDS AND makes network calls",
-      "severity": "CRITICAL",
-      "evidence": "IMDS: L97:             url = \"http://169.254.169.254/metadata/identity/oauth2/token\" | L150:             url = \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity\"\nNetwork: L78:     http_client: httpx.Client | None = None, | L109:                 with httpx.Client() as client: | L134:     http_client: httpx.Client | None = None, | L156:                 with httpx.Client() as client: | L251:         exchange_client = DefaultHttpx2Client(follow_redirects=False) if self._use_httpx2 else httpx.Client()",
-      "evidence_hash": "9717e51cb961dc14c458955d91a1e48e3753997346ecea0106bded3a8d64bfe0"
-    },
-    {
-      "package": "openai",
-      "file": "openai/resources/beta/responses/responses.py",
-      "check": "C2 polling/beaconing loop detected",
-      "severity": "CRITICAL",
-      "evidence": "L4000:         while True: sha256:f8ab538118daba9ec06e27399dbdc90a4521c3390e6a47a6348a1f180a83effd",
-      "evidence_hash": "31481ea83c687acc27144d72d3832d4fb98dd1c79fb5e0ddd85080de95997b9f"
-    },
-    {
-      "package": "openai",
-      "file": "openai/resources/realtime/realtime.py",
-      "check": "C2 polling/beaconing loop detected",
-      "severity": "CRITICAL",
-      "evidence": "L311:         while True: sha256:5b63313072aae9ca28677e03426513ccf12221e4f4e0ea6c31efbe09790633b5",
-      "evidence_hash": "05e1af469d651b51673763a7c4cdf759af9472fb627b7b470adc28cc237bd650"
-    },
-    {
-      "package": "openai",
-      "file": "openai/resources/responses/responses.py",
-      "check": "C2 polling/beaconing loop detected",
-      "severity": "CRITICAL",
-      "evidence": "L3951:         while True: sha256:d68ef896bf0743ca430cfacb9a3353da1f3b9c51c3a21b6450a07a32b55aa2ac",
-      "evidence_hash": "160eecdd79b521bffbe8476f782b69a0724c35d1b19376a7600807165fd54f9f"
-    },
-    {
       "package": "unsloth-zoo",
       "file": "tests/test_gemma4_forced_float32_ple_dtype.py",
       "check": "Advanced obfuscation (marshal/compile/zlib) + exec/eval",

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -1667,3 +1667,137 @@ def test_check_py_file_stamps_the_file_digest():
     assert findings, "expected at least one finding"
     expected = hashlib.sha256(src.encode("utf-8", "replace")).hexdigest()
     assert all(f.file_sha256 == expected for f in findings)
+
+
+def test_the_shipped_baseline_hashes_match_their_evidence():
+    """A hand-added entry with a stale `evidence_hash` suppresses nothing: the key
+    is the hash, not the evidence text beside it, so the finding stays red and the
+    entry reads as a review that happened. Recompute every one of them."""
+    import json
+    import pathlib
+
+    path = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "scan_packages_baseline.json"
+    entries = json.loads(path.read_text(encoding = "utf-8"))["entries"]
+    assert entries, "the shipped baseline is empty"
+    wrong = [
+        (e.get("package"), e.get("file"), e.get("check"))
+        for e in entries
+        if e.get("evidence_hash") != sp._evidence_hash(e.get("evidence") or "")
+    ]
+    assert not wrong, f"evidence_hash does not match evidence: {wrong}"
+
+
+def _baseline_key(entry):
+    """The scanner's OWN key, not the raw fields: `_load_baseline` normalizes the
+    package name and strips an sdist's version-carrying archive root, so
+    `huggingface_hub` and `huggingface-hub`, or `foo-1.0/foo/a.py` and `foo/a.py`,
+    collapse to one runtime entry while a raw comparison sees two and reports
+    nothing."""
+    return (
+        sp._norm_pkg(entry.get("package") or ""),
+        sp._relpath_in_package(entry.get("file") or ""),
+        entry.get("check"),
+        entry.get("evidence_hash"),
+    )
+
+
+def _baseline_duplicates(entries):
+    """Keys whose entries say the same thing twice, or contradict each other.
+
+    Sharing a key is not itself an error: `_load_baseline` unions the pins under
+    one key into a set, so two reviewed versions with identical evidence but
+    different surrounding bytes are the supported way to approve both exact files.
+    What has no reading is a pin repeated verbatim, or an unpinned entry sitting
+    beside a pinned one -- unpinned wins there, so every pin next to it is inert
+    and reads as a narrower approval than the baseline actually grants.
+    """
+    groups = {}
+    for entry in entries:
+        groups.setdefault(_baseline_key(entry), []).append(entry.get("file_sha256") or None)
+    dupes = set()
+    for key, pins in groups.items():
+        if len(pins) != len(set(pins)) or (None in pins and len(pins) > 1):
+            dupes.add(key)
+    return dupes
+
+
+def test_the_shipped_baseline_has_no_duplicate_keys():
+    """Two entries saying the same thing means one of them was reviewed against
+    code that is no longer there, and nothing says which."""
+    import json
+    import pathlib
+
+    path = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "scan_packages_baseline.json"
+    entries = json.loads(path.read_text(encoding = "utf-8"))["entries"]
+    dupes = _baseline_duplicates(entries)
+    assert not dupes, f"duplicate baseline keys: {sorted(dupes)}"
+
+
+def test_two_reviewed_versions_may_share_a_key_with_distinct_pins(tmp_path):
+    """The representation `_load_baseline` exists to support: one evidence string
+    approved for exactly two file contents. Rejecting it would force the entry to
+    be widened to an unpinned suppression, which approves strictly more."""
+    import json
+
+    same = dict(
+        package = "requests",
+        file = "requests/api.py",
+        check = "C2 polling/beaconing loop detected",
+        severity = "CRITICAL",
+        evidence = "L1:     while True:",
+        evidence_hash = sp._evidence_hash("L1:     while True:"),
+    )
+    entries = [dict(file_sha256 = "a" * 64, **same), dict(file_sha256 = "b" * 64, **same)]
+    assert not _baseline_duplicates(entries)
+
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps({"version": 1, "entries": entries}))
+    loaded = sp._load_baseline(str(path))
+    assert list(loaded.values()) == [{"a" * 64, "b" * 64}], "the loader unions the pins"
+
+
+@pytest.mark.parametrize(
+    "pins",
+    [
+        (None, None),  # the same unpinned approval, written twice
+        ("c" * 64, "c" * 64),  # the same pin, written twice
+        (None, "c" * 64),  # unpinned wins, so the pinned entry is inert
+        ("c" * 64, None),  # and in either order
+    ],
+)
+def test_a_key_that_says_the_same_thing_twice_is_still_a_duplicate(pins):
+    same = dict(
+        package = "requests",
+        file = "requests/api.py",
+        check = "C2 polling/beaconing loop detected",
+        evidence_hash = sp._evidence_hash("L1:     while True:"),
+    )
+    entries = [dict(same, **({"file_sha256": p} if p else {})) for p in pins]
+    assert _baseline_duplicates(entries) == {_baseline_key(entries[0])}
+
+
+def test_the_duplicate_check_sees_through_normalization(tmp_path):
+    """Two entries that differ only in the ways `_load_baseline` normalizes away
+    are one runtime key, so a raw field comparison reports nothing and leaves
+    exactly the review ambiguity the check exists to catch."""
+    import json
+
+    same = dict(
+        check = "C2 polling/beaconing loop detected",
+        severity = "CRITICAL",
+        evidence = "L1:     while True:",
+        evidence_hash = sp._evidence_hash("L1:     while True:"),
+    )
+    entries = [
+        dict(package = "huggingface_hub", file = "foo-1.0/huggingface_hub/a.py", **same),
+        dict(package = "huggingface-hub", file = "huggingface_hub/a.py", **same),
+    ]
+    assert _baseline_duplicates(entries) == {_baseline_key(entries[0])}
+
+    raw = [(e["package"], e["file"], e["check"], e["evidence_hash"]) for e in entries]
+    assert raw[0] != raw[1], "a raw comparison would have called these distinct"
+
+    # And the loader agrees: two entries in, one key out.
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps({"version": 1, "entries": entries}))
+    assert len(sp._load_baseline(str(path))) == 1


### PR DESCRIPTION
`pip scan-packages :: hf-stack` and `:: extras` are failing on every open PR, on one CRITICAL:

```
[1] CRITICAL  C2 polling/beaconing loop detected
    Package:  huggingface-hub
    File:     huggingface_hub/utils/_http.py
    Evidence: L461:     while True: sha256:0c9641548adea74be4a8b0e86e8b75cc937a2b0f833b57dfa3d30d3e24d2537a
```

That is `http_backoff`'s retry loop, and the same loop is already in the baseline twice for the same file (L462 and L298). huggingface_hub 1.27.0 was published at 12:48 today, shifting the loop by one line and adding a comment inside it:

```python
    while True:
        nb_tries += 1
        ratelimit_reset = None
        # Fetched on each attempt: a previous attempt may have closed the shared client (see `close_session` below),
        # and closed `httpx.Client` objects cannot be reused.
        client = get_session()
```

The baseline key is a hash over the matched code, deliberately, so that changed code reopens a reviewed finding. It did its job; the code is benign and the entry is added.

The timing pins it to the release rather than to any PR: #7866 passed both legs at 11:58 and 12:10, #7867 failed them at 12:51 and 12:57, and nothing else changed in between.

## Also in here

Five `openai` entries appear twice, byte for byte, from two `--write-baseline` runs. Dropped, and two tests added so neither problem is silent again:

- every shipped entry's `evidence_hash` must recompute from its own `evidence`. A hand-added entry with a stale hash suppresses nothing, because the key *is* the hash, so the finding stays red while the entry reads as a review that happened.
- no key may appear twice, since that means one of the two was reviewed against code that is no longer there and nothing says which.

`tests/security/test_scan_packages.py`: 105 passed.
