### PR TITLE
Studio: keep the composer tool pills on one line

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -239,6 +239,7 @@ import {
   useState,
 } from "react";
 import { extractTaggedText, updateThreadMessage } from "@/features/chat/utils/update-thread-message";
+import { useComposerPillFit } from "@/hooks/use-composer-pill-fit";
 import { useIsMobile } from "@/hooks/use-mobile";
 
 // True while a file is dragged anywhere over the chat page, so the composer
@@ -2072,7 +2073,12 @@ const Composer: FC<{
     (artifactsEnabled ? 1 : 0) +
     (mcpEnabledForChat ? 1 : 0) +
     (effectiveDeepResearchEnabled ? 1 : 0);
-  const pillsCompact = isMobile || pillCount > 4;
+  // Under the count threshold the row still overflows on long labels ("Run
+  // automatically" next to "Deep research"), which dropped the dictate and
+  // send buttons onto a second line. Measuring collapses just enough.
+  const { pillRowRef, pillCompact } = useComposerPillFit(
+    isMobile || pillCount > 4,
+  );
   const setPendingImageEditReference = useChatRuntimeStore(
     (s) => s.setPendingImageEditReference,
   );
@@ -3057,8 +3063,9 @@ const Composer: FC<{
         data-dictating={isDictating ? "true" : undefined}
       >
         <div
+          ref={pillRowRef}
           className="unsloth-composer-left"
-          data-pill-compact={pillsCompact ? "true" : undefined}
+          data-pill-compact={pillCompact}
         >
           <ComposerToolsMenu
             side={effectiveMenuSide}

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -106,6 +106,7 @@ import {
   providerTypeSupportsVision,
 } from "./external-providers";
 import { useExternalProvidersStore } from "./stores/external-providers-store";
+import { useComposerPillFit } from "@/hooks/use-composer-pill-fit";
 import { useIsMobile } from "@/hooks/use-mobile";
 import {
   PLUS_MENU_ORDER,
@@ -793,7 +794,12 @@ export function SharedComposer({
     (showWebFetchPill ? 1 : 0) +
     (artifactsEnabled ? 1 : 0) +
     (mcpEnabledForChat ? 1 : 0);
-  const pillsCompact = isMobile || pillCount > 4;
+  // Under the count threshold the row still overflows on long labels, wrapping
+  // onto a second line inside the action bar. Measuring collapses just enough
+  // to keep it beside the dictate/send controls.
+  const { pillRowRef, pillCompact } = useComposerPillFit(
+    isMobile || pillCount > 4,
+  );
   // Backwards-compatible alias for call sites still referencing
   // `toolsDisabled` (rare; both pills used it before).
   const toolsDisabled = codeDisabled;
@@ -1977,8 +1983,9 @@ export function SharedComposer({
       />
       <div className="composer-action-wrapper">
         <div
+          ref={pillRowRef}
           className="flex min-w-0 flex-wrap items-center gap-0.5"
-          data-pill-compact={pillsCompact ? "true" : undefined}
+          data-pill-compact={pillCompact}
         >
           <input
             ref={fileInputRef}

--- a/studio/frontend/src/hooks/use-composer-pill-fit.ts
+++ b/studio/frontend/src/hooks/use-composer-pill-fit.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useCallback, useLayoutEffect, useState } from "react";
+
+/**
+ * Value for the pill row's `data-pill-compact` attribute.
+ * - `undefined`: every pill keeps its label.
+ * - `"first"`: only the leading permission pill drops to its icon.
+ * - `"true"`: every pill drops to its icon (the existing compact look).
+ */
+export type PillCompact = undefined | "first" | "true";
+
+/** Escalation order: give up the least label space that still fits. */
+const STAGES: PillCompact[] = [undefined, "first", "true"];
+
+function applyStage(row: HTMLElement, stage: PillCompact) {
+  if (stage === undefined) {
+    row.removeAttribute("data-pill-compact");
+  } else {
+    row.setAttribute("data-pill-compact", stage);
+  }
+}
+
+/**
+ * True while the row is one visual line: not wrapped inside itself, and nothing
+ * after it (the dictate/send cluster) pushed underneath it.
+ */
+function fitsOnOneLine(row: HTMLElement) {
+  const rect = row.getBoundingClientRect();
+  // Tallest child is one line; a wrapped row is about double. Measured, not a
+  // constant, so the UI font-scale setting cannot break the check.
+  let lineHeight = 0;
+  for (const child of Array.from(row.children)) {
+    lineHeight = Math.max(lineHeight, child.getBoundingClientRect().height);
+  }
+  if (lineHeight === 0) {
+    return true;
+  }
+  if (rect.height > lineHeight + 4) {
+    return false;
+  }
+  for (
+    let sibling = row.nextElementSibling;
+    sibling;
+    sibling = sibling.nextElementSibling
+  ) {
+    const siblingRect = sibling.getBoundingClientRect();
+    // Skips the hidden file inputs, and the textarea that flex `order` moves
+    // to the row above in single chat.
+    if (siblingRect.width === 0) {
+      continue;
+    }
+    if (siblingRect.top >= rect.bottom - 2) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Collapses `row` by the least amount that keeps it on one line, writes the
+ * winning `data-pill-compact` value to it, and returns that value.
+ * `forceCompact` skips measuring: nothing narrower is on offer.
+ *
+ * Exported for the unit test; components use the hook below.
+ */
+export function measurePillCompact(
+  row: HTMLElement,
+  forceCompact: boolean,
+): PillCompact {
+  if (forceCompact) {
+    applyStage(row, "true");
+    return "true";
+  }
+  // Falls through to the narrowest stage when even that overflows.
+  let fitted: PillCompact = "true";
+  for (const stage of STAGES) {
+    applyStage(row, stage);
+    // Reading geometry after the write forces the reflow this needs.
+    if (fitsOnOneLine(row)) {
+      fitted = stage;
+      break;
+    }
+  }
+  applyStage(row, fitted);
+  return fitted;
+}
+
+/**
+ * Keeps the composer's tool pills on one line with the dictate/send controls.
+ *
+ * The count rule (`forceCompact`) cannot see label widths, so four long labels
+ * ("Run automatically" next to "Deep research") still overflowed and dropped
+ * the mic and send button onto a second line. This measures the laid-out row
+ * and collapses only as far as it takes to fit.
+ *
+ * Returns a callback ref for the row and the `data-pill-compact` value to
+ * render on it, so React keeps the attribute the measurement settled on.
+ */
+export function useComposerPillFit(forceCompact: boolean) {
+  const [row, setRow] = useState<HTMLElement | null>(null);
+  const [compact, setCompact] = useState<PillCompact>(
+    forceCompact ? "true" : undefined,
+  );
+
+  const measure = useCallback(
+    (el: HTMLElement) => {
+      const next = measurePillCompact(el, forceCompact);
+      setCompact((prev) => (prev === next ? prev : next));
+    },
+    [forceCompact],
+  );
+
+  useLayoutEffect(() => {
+    if (!row) {
+      return;
+    }
+    // One measurement per frame: the observers also fire for the transient
+    // sizes the escalation loop itself produces.
+    let frame = 0;
+    const schedule = () => {
+      if (frame) {
+        return;
+      }
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        measure(row);
+      });
+    };
+    // First pass runs before paint, so the row never flashes wrapped.
+    measure(row);
+    const resize = new ResizeObserver(schedule);
+    resize.observe(row);
+    // The composer line owns the width the row has to fit into.
+    if (row.parentElement) {
+      resize.observe(row.parentElement);
+    }
+    // A model capability toggle adds or removes a pill without necessarily
+    // resizing what the observer above watches.
+    const mutations = new MutationObserver(schedule);
+    mutations.observe(row, { childList: true });
+    return () => {
+      if (frame) {
+        cancelAnimationFrame(frame);
+      }
+      resize.disconnect();
+      mutations.disconnect();
+    };
+  }, [row, measure]);
+
+  return { pillRowRef: setRow, pillCompact: compact };
+}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1663,11 +1663,53 @@ html[data-chat-font] .aui-root {
 		@apply pr-1.5;
 	}
 
-	/* Icon-only (compact) pills drop their label, so make the button a square
-	   and center the glyph; the rounded-full hover highlight then reads as a
-	   circle around the icon rather than a wide rounded rectangle. */
-	[data-pill-compact="true"] .composer-pill-btn:not([data-keep-label]) {
+	/* Collapsed (icon-only) pills. "true" collapses the whole row; "first"
+	   collapses only the leading permission pill, whose label is the widest and
+	   usually the only one that has to go for the row to share a line with the
+	   dictate/send controls. Compare keeps its label either way. */
+	[data-pill-compact="true"] .composer-pill-btn:not([data-keep-label]),
+	[data-pill-compact="first"]
+		.composer-pill-btn.composer-pill-permissions:not([data-keep-label]) {
+		/* Square button with a centered glyph, so the rounded-full hover
+		   highlight reads as a circle rather than a wide rectangle. */
 		@apply size-8 justify-center px-0;
+		/* Anchor for the tooltip standing in for the hidden label. */
+		position: relative;
+
+		& > span:not(.composer-pill-glyph) {
+			display: none;
+		}
+
+		/* Drop the dropdown caret so the icon is not squished. */
+		& .composer-pill-caret {
+			display: none;
+		}
+
+		/* Too small for the circle, so show a bare x. */
+		& .composer-pill-x {
+			@apply size-[min(calc(15px*var(--ui-font-scale,1)),calc(7.5px+7.5px*var(--ui-font-scale,1)))] bg-transparent p-0 dark:bg-transparent;
+		}
+
+		/* Hidden name comes back as a hover tooltip, like .tooltip-compact. */
+		&[data-pill-label]:hover::after {
+			content: attr(data-pill-label);
+			/* Always one nowrap line, so always a full pill. */
+			@apply pointer-events-none absolute bottom-[calc(100%+6px)] left-1/2 z-50 -translate-x-1/2 rounded-full bg-black px-2.5 py-1.5 text-ui-11 font-medium leading-snug whitespace-nowrap text-white shadow-md;
+		}
+
+		/* Caret pills (permissions, RAG, MCP) open a menu on click instead of
+		   toggling off, so keep the icon and skip the X swap. No data-active
+		   requirement: the off-switch glyph rules below hide the icon on hover
+		   even for inactive pills, leaving a blank slot when collapsed. */
+		&:has(.composer-pill-caret):hover
+			.composer-pill-glyph
+			> :not(.composer-pill-x) {
+			opacity: 1;
+		}
+
+		&:has(.composer-pill-caret) .composer-pill-x {
+			display: none;
+		}
 	}
 
 	.composer-pill-btn[data-active="true"] {
@@ -1696,23 +1738,6 @@ html[data-chat-font] .aui-root {
 		background-color: color-mix(in oklab, var(--bypass) 13%, transparent);
 	}
 
-	/* With more than 4 tools on, drop pill labels to icons only to cut clutter.
-	   Compare and the bypass-permissions pill keep their labels via
-	   data-keep-label; the permission pill sits before the collapsed icons, so
-	   they line up to its right. */
-	[data-pill-compact="true"]
-		.composer-pill-btn:not([data-keep-label])
-		> span:not(.composer-pill-glyph) {
-		display: none;
-	}
-
-	/* Drop the MCP dropdown caret when collapsed so the icon is not squished. */
-	[data-pill-compact="true"]
-		.composer-pill-btn:not([data-keep-label])
-		.composer-pill-caret {
-		display: none;
-	}
-
 	/* Fixed-width icon slot so every pill's icon occupies the same space and
 	   the labels line up on an even rhythm, regardless of icon size. */
 	.composer-pill-glyph {
@@ -1723,42 +1748,6 @@ html[data-chat-font] .aui-root {
 	   filling the icon slot so every pill's X is identical and centered. */
 	.composer-pill-x {
 		@apply pointer-events-none absolute inset-0 m-auto size-[var(--ui-icon-size)] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
-	}
-
-	/* Icon-only (compact) pills are too small for the circle, so show a bare x. */
-	[data-pill-compact="true"]
-		.composer-pill-btn:not([data-keep-label])
-		.composer-pill-x {
-		@apply size-[min(calc(15px*var(--ui-font-scale,1)),calc(7.5px+7.5px*var(--ui-font-scale,1)))] bg-transparent p-0 dark:bg-transparent;
-	}
-
-	/* Compact pills hide their labels, so surface the name as a hover
-	   tooltip styled like .tooltip-compact. */
-	[data-pill-compact="true"]
-		.composer-pill-btn:not([data-keep-label])[data-pill-label] {
-		position: relative;
-	}
-	[data-pill-compact="true"]
-		.composer-pill-btn:not([data-keep-label])[data-pill-label]:hover::after {
-		content: attr(data-pill-label);
-		/* Always one nowrap line, so always a full pill. */
-		@apply pointer-events-none absolute bottom-[calc(100%+6px)] left-1/2 z-50 -translate-x-1/2 rounded-full bg-black px-2.5 py-1.5 text-ui-11 font-medium leading-snug whitespace-nowrap text-white shadow-md;
-	}
-
-	/* Compact caret pills (RAG, MCP) open their menu on click instead of
-	   toggling off, so keep the icon and skip the X swap. No data-active
-	   requirement: the off-switch glyph rules below hide the icon on hover
-	   even for inactive pills, which left a blank slot in compact mode. */
-	[data-pill-compact="true"]
-		.composer-pill-btn:not([data-keep-label]):has(.composer-pill-caret):hover
-		.composer-pill-glyph
-		> :not(.composer-pill-x) {
-		opacity: 1;
-	}
-	[data-pill-compact="true"]
-		.composer-pill-btn:not([data-keep-label]):has(.composer-pill-caret)
-		.composer-pill-x {
-		display: none;
 	}
 
 	/* Hovering an active pill swaps the icon for an X (click to turn off). */

--- a/studio/frontend/tests/composer-pill-fit.test.ts
+++ b/studio/frontend/tests/composer-pill-fit.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type PillCompact,
+  measurePillCompact,
+} from "../src/hooks/use-composer-pill-fit.ts";
+
+const LINE_HEIGHT = 36;
+const CONTROLS_WIDTH = 84;
+
+/**
+ * Stands in for the laid-out pill row: a flex line that re-flows whenever
+ * `data-pill-compact` changes. `widths` is the row's natural width per stage,
+ * and anything over `available` wraps the way the browser would.
+ */
+function stubRow(widths: Record<string, number>, available: number) {
+  let attribute: string | null = null;
+  const width = () => widths[attribute ?? "none"];
+  // The row wraps first; short of that, the controls drop below it.
+  const rowWraps = () => width() > available;
+  const controlsWrap = () =>
+    !rowWraps() && width() + CONTROLS_WIDTH > available;
+  const controls = {
+    getBoundingClientRect: () => ({
+      width: CONTROLS_WIDTH,
+      top: controlsWrap() ? LINE_HEIGHT : 0,
+    }),
+    nextElementSibling: null,
+  };
+  return {
+    get attribute() {
+      return attribute;
+    },
+    setAttribute: (_name: string, value: string) => {
+      attribute = value;
+    },
+    removeAttribute: () => {
+      attribute = null;
+    },
+    children: [{ getBoundingClientRect: () => ({ height: LINE_HEIGHT }) }],
+    getBoundingClientRect: () => ({
+      height: rowWraps() ? LINE_HEIGHT * 2 : LINE_HEIGHT,
+      bottom: rowWraps() ? LINE_HEIGHT * 2 : LINE_HEIGHT,
+    }),
+    // A hidden input, so the check has to skip zero-width siblings to reach
+    // the controls behind it.
+    nextElementSibling: {
+      getBoundingClientRect: () => ({ width: 0, top: 0 }),
+      nextElementSibling: controls,
+    },
+  };
+}
+
+function measure(
+  widths: Record<string, number>,
+  available: number,
+  forceCompact = false,
+): { result: PillCompact; attribute: string | null } {
+  const row = stubRow(widths, available);
+  const result = measurePillCompact(
+    row as unknown as HTMLElement,
+    forceCompact,
+  );
+  return { result, attribute: row.attribute };
+}
+
+// "Run automatically" + "Deep research" + Search + Code, laid out three ways.
+const WIDTHS = { none: 470, first: 330, true: 190 };
+
+test("keeps every label when the row already fits", () => {
+  assert.equal(measure(WIDTHS, 640).result, undefined);
+});
+
+test("collapses the leading permission pill rather than wrap the controls", () => {
+  // 470 + 84 controls overflows 500; 330 + 84 does not.
+  assert.equal(measure(WIDTHS, 500).result, "first");
+});
+
+test("collapses the whole row when the first pill is not enough", () => {
+  assert.equal(measure(WIDTHS, 360).result, "true");
+});
+
+test("stays collapsed when even icons overflow", () => {
+  assert.equal(measure(WIDTHS, 120).result, "true");
+});
+
+test("skips measuring when the count or mobile rule already forces compact", () => {
+  assert.equal(measure(WIDTHS, 1200, true).result, "true");
+});
+
+test("leaves the row on the stage it returns, so the render agrees", () => {
+  // Measuring walks the wider stages first, so the last write has to be the
+  // winner and not whichever stage the loop tried last.
+  assert.equal(measure(WIDTHS, 500).attribute, "first");
+  assert.equal(measure(WIDTHS, 640).attribute, null);
+});


### PR DESCRIPTION
### Problem

The chat box fights for space. The composer only knows how to collapse tool pills to icons by *count* (more than 4 pills, or a mobile viewport). That rule cannot see how wide the labels actually are, so a row of only four pills with long labels ("Run automatically" next to "Deep research", plus Search and Code) overflows and drops the microphone and send button onto a second line.

### Fix

Measure the laid-out row and collapse the least that still fits, escalating only as far as needed:

1. every label shown
2. the first pill collapsed (the permission pill, whose label is the widest)
3. the whole row collapsed to icons (the existing compact look)

`studio/frontend/src/hooks/use-composer-pill-fit.ts` does the measuring. A `ResizeObserver` on the row and the composer line re-measures on width and UI font-scale changes, and a `MutationObserver` catches a pill being added or removed when a model capability toggles. It detects a real wrap two ways: the row growing past one line's height, and any following sibling (the dictate/send cluster) sitting below it. The first pass runs in a layout effect, so nothing flashes wrapped on mount.

`index.css` had the compact rules spread across six blocks, all keyed on `[data-pill-compact="true"]`. Those are consolidated into one nested block that also matches the new `"first"` value, scoped to the permission pill. A collapsed permission pill behaves exactly like the other collapsed pills already do: square icon button, hover tooltip carrying the hidden name, caret dropped, menu on click instead of the X swap.

Wired into both composers, since each wraps differently:

* `thread.tsx` (single chat): the composer line wraps, so the send cluster dropped below the pills.
* `shared-composer.tsx` (compare): the action bar does not wrap, so the pill row wrapped inside itself.

The count and mobile rule still short-circuits straight to full compact, so nothing changes for the cases it already handled.

### Tests

* 6 new cases in `studio/frontend/tests/composer-pill-fit.test.ts` covering each escalation step, the "even icons overflow" floor, the forced-compact short circuit, and the invariant that the attribute left on the row matches the value the hook returns.
* Full frontend suite: 836 passing.
* `test_deep_research_frontend_contract.py`, `test_chat_thinking_compact_layout.py`, `test_composer_rtl_bidi_attribute.py`, `test_ui_font_scale_contract.py`: 40 passing.
* `tsc -b`, the test tsconfig, biome, and `vite build` all clean.
