### PR TITLE
Studio: keep the upgrade intent when the pip fallback runs

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3508,18 +3508,34 @@ def _translate_pip_args_for_uv(args: tuple[str, ...]) -> list[str]:
 def _build_pip_cmd(args: tuple[str, ...]) -> list[str]:
     """Build a standard pip install command.
 
-    Strips uv-only flags like --upgrade-package that pip doesn't understand.
+    pip has no --upgrade-package, so uv's flag is translated rather than
+    dropped. Dropping it made this fallback a no-op on the update path:
+    `studio update` passes --upgrade-package unsloth with a base.txt that lists
+    a bare unsloth, so pip found the requirement already satisfied, installed
+    nothing, and the update still reported success. Any uv failure reached that,
+    not just the Windows in-use launcher.
+
+    --upgrade-strategy is pinned to only-if-needed rather than left to pip's
+    default, because that default is the load-bearing part: it upgrades the
+    named packages without dragging the existing torch build along.
     """
     cmd = [sys.executable, "-m", "pip", "install"]
+    upgrade: list[str] = []
     skip_next = False
     for arg in args:
         if skip_next:
             skip_next = False
+            upgrade.append(arg)
             continue
         if arg == "--upgrade-package":
-            skip_next = True  # skip the flag and its value
+            skip_next = True  # the flag; its value is the package to upgrade
             continue
         cmd.append(arg)
+    if upgrade:
+        cmd += ["--upgrade", "--upgrade-strategy", "only-if-needed"]
+        # Every current caller also names these as positionals or via -r, but a
+        # future one might not, and pip would then upgrade nothing.
+        cmd += [name for name in upgrade if name not in cmd]
     return cmd
 
 

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -511,3 +511,36 @@ class TestProgressLineNotes:
             and any(isinstance(t, ast.Name) and t.id == "_PROGRESS_LINE_ACTIVE" for t in n.targets)
             for n in ast.walk(fn)
         ), "install_python_stack() must reset _PROGRESS_LINE_ACTIVE"
+
+
+class TestBuildPipCmdUpgradeIntent:
+    """pip has no --upgrade-package, so uv's flag must be translated, not dropped.
+
+    Dropping it made the fallback a no-op on the update path: `studio update`
+    passes --upgrade-package unsloth with a base.txt listing a bare unsloth, so
+    pip found it satisfied, installed nothing, and the update reported success.
+    """
+
+    def test_update_path_keeps_the_upgrade_intent(self):
+        cmd = ips._build_pip_cmd(
+            ("--no-cache-dir", "--upgrade-package", "unsloth", "--upgrade-package", "unsloth-zoo")
+        )
+        assert "--upgrade" in cmd
+        assert "unsloth" in cmd and "unsloth-zoo" in cmd
+        assert "--upgrade-package" not in cmd, "pip does not understand the uv flag"
+
+    def test_torch_is_not_dragged_along(self):
+        # only-if-needed is pip's current default, but it is the load-bearing
+        # part: eager would re-resolve the existing torch build.
+        cmd = ips._build_pip_cmd(("--upgrade-package", "unsloth"))
+        assert cmd[cmd.index("--upgrade-strategy") + 1] == "only-if-needed"
+
+    def test_names_already_present_are_not_duplicated(self):
+        cmd = ips._build_pip_cmd(
+            ("--no-deps", "--upgrade-package", "unsloth", "unsloth")
+        )
+        assert cmd.count("unsloth") == 1
+
+    def test_commands_without_the_flag_are_untouched(self):
+        cmd = ips._build_pip_cmd(("--no-cache-dir", "somepackage"))
+        assert cmd == [sys.executable, "-m", "pip", "install", "--no-cache-dir", "somepackage"]

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -536,9 +536,7 @@ class TestBuildPipCmdUpgradeIntent:
         assert cmd[cmd.index("--upgrade-strategy") + 1] == "only-if-needed"
 
     def test_names_already_present_are_not_duplicated(self):
-        cmd = ips._build_pip_cmd(
-            ("--no-deps", "--upgrade-package", "unsloth", "unsloth")
-        )
+        cmd = ips._build_pip_cmd(("--no-deps", "--upgrade-package", "unsloth", "unsloth"))
         assert cmd.count("unsloth") == 1
 
     def test_commands_without_the_flag_are_untouched(self):


### PR DESCRIPTION
## Summary

`unsloth studio update` could report success having upgraded nothing. Follow-up to #8092 and #8109, but not Windows-specific.

## The bug

`pip_install` runs uv and falls back to pip on any nonzero exit (`install_python_stack.py:3664-3691`). The fallback builds its command with `_build_pip_cmd`, which dropped `--upgrade-package` and its value, because pip has no such flag:

```python
if arg == "--upgrade-package":
    skip_next = True  # skip the flag and its value
    continue
```

On the update path that made the fallback a no-op:

```python
pip_install(
    "Updating base packages",
    "--no-cache-dir",
    "--upgrade-package", "unsloth",
    "--upgrade-package", "unsloth-zoo",
    req = REQ_ROOT / "base.txt",
)
```

`base.txt` lists a bare `unsloth-zoo` and `unsloth`, so the fallback became `pip install --no-cache-dir -r base.txt`. Per pip's docs, "pip install prefers to leave the installed version as-is unless `--upgrade` is specified", so both requirements were already satisfied, pip installed nothing, and exited 0.

Nothing downstream catches it. `_fail_if_install_damaged` checks file integrity, not versions, and the launcher `--version` probe passes against the old launcher. The update reports success.

## Why this is broader than #8109

#8109 warns about one trigger: a failed launcher move-aside on Windows, after which uv cannot replace the in-use `unsloth.exe`. But **any** uv failure reaches this fallback, so the same silent no-op was possible on Linux and macOS from a network failure, an index outage, a resolver error, or a corrupt cache.

An update that reports success while changing nothing is also what leaves the desktop looping on `Managed repair update finished, but preflight is still not ready`.

## Change

Translate the flag rather than dropping it:

```
pip install --no-cache-dir --upgrade --upgrade-strategy only-if-needed unsloth unsloth-zoo -r base.txt
```

`--upgrade-strategy only-if-needed` is pip's current default, but it is pinned explicitly because it is the load-bearing part: it upgrades the named packages without re-resolving the existing torch build, which is the property the comment at `install_python_stack.py:3950-3952` depends on.

All three `--upgrade-package` call sites already name the packages as positionals or via `base.txt`, so the translation covers the same set. Names are appended only when not already present, so nothing is duplicated and a future caller that names a package not otherwise in the install set still gets it upgraded. Commands without the flag are byte-for-byte unchanged.

## Testing

```
python -m pytest -q tests/python/test_install_python_stack.py \
  tests/python/test_flash_attn_install_python_stack.py unsloth_cli/tests
915 passed, 4 skipped
```

Four cases added in `TestBuildPipCmdUpgradeIntent`. The two substantive ones fail against `main`; the other two are guards that the translation does not duplicate names or alter commands lacking the flag.
