### PR TITLE
Stop two Studio contract tests reddening main on a rename and a 2px nudge

### DIFF
--- a/tests/python/test_studio_runtime_gate.py
+++ b/tests/python/test_studio_runtime_gate.py
@@ -71,7 +71,7 @@ def _slice_between(source, start, end):
     """
     for anchor in (start, end):
         assert anchor in source, f"anchor moved or was renamed: {anchor!r}"
-    return source[source.index(start):source.index(end)]
+    return source[source.index(start) : source.index(end)]
 
 
 def test_terminal_launch_boundaries_use_the_runtime_gate():

--- a/tests/python/test_studio_runtime_gate.py
+++ b/tests/python/test_studio_runtime_gate.py
@@ -61,6 +61,19 @@ def test_runtime_gate_handoff_is_one_shot(monkeypatch):
     assert gate.consume_runtime_gate_handoff() is False
 
 
+def _slice_between(source, start, end):
+    """The text from `start` up to `end`, or a failure that names what moved.
+
+    These are source-scraping contract tests, so a renamed anchor is a real
+    signal -- but `str.index` reports it as a bare `ValueError: substring not
+    found` with no clue which anchor went, which is how #8092's rename read as
+    an unexplained repo-wide red. Say which one.
+    """
+    for anchor in (start, end):
+        assert anchor in source, f"anchor moved or was renamed: {anchor!r}"
+    return source[source.index(start):source.index(end)]
+
+
 def test_terminal_launch_boundaries_use_the_runtime_gate():
     source = STUDIO_COMMAND.read_text(encoding = "utf-8")
     assert source.count("with _studio_runtime_launch_guard(") >= 4
@@ -70,19 +83,27 @@ def test_terminal_launch_boundaries_use_the_runtime_gate():
 
 def test_terminal_update_holds_the_gate_through_environment_mutation():
     source = STUDIO_COMMAND.read_text(encoding = "utf-8")
-    body = source[source.index("def update(") : source.index("def _release_self_exe_lock_windows")]
+    # Ended at the next definition rather than at a named helper inside the
+    # body: #8092 replaced `_release_self_exe_lock_windows` with the launcher
+    # transaction, and the old anchor took the whole slice down with it, which
+    # read as a repo-wide red rather than as the contract change it was.
+    body = _slice_between(source, "def update(", "class _WindowsLauncherUpdateTransaction")
     consume = body.index("_studio_runtime_gate.consume_runtime_gate_handoff()")
     guard = body.index("with _studio_runtime_launch_guard(", consume)
     idle_scan = body.index("_studio_runtime_gate.ensure_managed_environment_is_idle", guard)
-    release_self = body.index("_release_self_exe_lock_windows()", idle_scan)
-    setup = body.index("_run_setup_script(", release_self)
-    verify = body.index("_fail_if_install_damaged()", setup)
-    assert consume < guard < idle_scan < release_self < setup < verify
+    # The launcher transaction sits INSIDE the gate: it renames the running
+    # launcher aside, so a second Studio the gate never excluded would be
+    # mutating the same install underneath it.
+    launcher = body.index("with _WindowsLauncherUpdateTransaction(", idle_scan)
+    setup = body.index("_run_setup_script(", launcher)
+    validate = body.index("launcher_update.validate_launcher()", setup)
+    verify = body.index("_fail_if_install_damaged()", validate)
+    assert consume < guard < idle_scan < launcher < setup < validate < verify
 
 
 def test_terminal_setup_holds_the_gate_through_environment_mutation():
     source = STUDIO_COMMAND.read_text(encoding = "utf-8")
-    body = source[source.index("def setup(") : source.index("def _fail_if_install_damaged")]
+    body = _slice_between(source, "def setup(", "def _fail_if_install_damaged")
     consume = body.index("_studio_runtime_gate.consume_runtime_gate_handoff()")
     guard = body.index("with _studio_runtime_launch_guard(", consume)
     idle_scan = body.index("_studio_runtime_gate.ensure_managed_environment_is_idle", guard)

--- a/tests/python/test_studio_runtime_gate.py
+++ b/tests/python/test_studio_runtime_gate.py
@@ -62,12 +62,10 @@ def test_runtime_gate_handoff_is_one_shot(monkeypatch):
 
 
 def _slice_between(source, start, end):
-    """The text from `start` up to `end`, or a failure that names what moved.
+    """The text from `start` up to `end`, naming the anchor when one moved.
 
-    These are source-scraping contract tests, so a renamed anchor is a real
-    signal -- but `str.index` reports it as a bare `ValueError: substring not
-    found` with no clue which anchor went, which is how #8092's rename read as
-    an unexplained repo-wide red. Say which one.
+    `str.index` reports a rename as a bare `ValueError: substring not found`,
+    which is how #8092 read as an unexplained repo-wide red.
     """
     for anchor in (start, end):
         assert anchor in source, f"anchor moved or was renamed: {anchor!r}"
@@ -83,17 +81,14 @@ def test_terminal_launch_boundaries_use_the_runtime_gate():
 
 def test_terminal_update_holds_the_gate_through_environment_mutation():
     source = STUDIO_COMMAND.read_text(encoding = "utf-8")
-    # Ended at the next definition rather than at a named helper inside the
-    # body: #8092 replaced `_release_self_exe_lock_windows` with the launcher
-    # transaction, and the old anchor took the whole slice down with it, which
-    # read as a repo-wide red rather than as the contract change it was.
+    # Ended at the next definition, not a helper inside the body: #8092 removed
+    # `_release_self_exe_lock_windows` and the old anchor took the slice with it.
     body = _slice_between(source, "def update(", "class _WindowsLauncherUpdateTransaction")
     consume = body.index("_studio_runtime_gate.consume_runtime_gate_handoff()")
     guard = body.index("with _studio_runtime_launch_guard(", consume)
     idle_scan = body.index("_studio_runtime_gate.ensure_managed_environment_is_idle", guard)
-    # The launcher transaction sits INSIDE the gate: it renames the running
-    # launcher aside, so a second Studio the gate never excluded would be
-    # mutating the same install underneath it.
+    # Inside the gate: it renames the running launcher aside, so an unexcluded
+    # second Studio would be mutating the same install underneath it.
     launcher = body.index("with _WindowsLauncherUpdateTransaction(", idle_scan)
     setup = body.index("_run_setup_script(", launcher)
     validate = body.index("launcher_update.validate_launcher()", setup)

--- a/tests/python/test_studio_runtime_gate.py
+++ b/tests/python/test_studio_runtime_gate.py
@@ -64,8 +64,8 @@ def test_runtime_gate_handoff_is_one_shot(monkeypatch):
 def _slice_between(source, start, end):
     """The text from `start` up to `end`, naming the anchor when one moved.
 
-    `str.index` reports a rename as a bare `ValueError: substring not found`,
-    which is how #8092 read as an unexplained repo-wide red.
+    Bare `str.index` reports a rename as `ValueError: substring not found`, which
+    is how #8092 read as an unexplained repo-wide red.
     """
     for anchor in (start, end):
         assert anchor in source, f"anchor moved or was renamed: {anchor!r}"

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -496,8 +496,7 @@ def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
     assert "translate-y-[var(--studio-titlebar-navigation-offset-y,0px)]" in TITLEBAR.read_text(
         encoding = "utf-8"
     )
-    # A small positive nudge: zero puts the row on the traffic lights, and a
-    # large one drops it out of the 48px titlebar.
+    # Zero puts the row on the traffic lights; large drops it out of the 48px bar.
     assert 0 < _provider_css_px("--studio-titlebar-navigation-offset-y") <= 8
     assert "aria-hidden={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
     assert "inert={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
@@ -545,10 +544,9 @@ def test_visible_mac_sidebar_header_is_a_drag_region():
 def _provider_css_px(name):
     """The px value the provider sets for a CSS custom property.
 
-    Read rather than pinned as a literal: #8102 nudged the mac titlebar by 2px
-    and reddened the whole repo, because these assertions spelled out the
-    number. What the layout actually depends on is that the row keeps its
-    shape, so that is what is asserted below.
+    Read rather than pinned: #8102 nudged the mac titlebar 2px and reddened the
+    repo because these assertions spelled the number out. The layout depends on
+    the row keeping its shape, so that is what is asserted below.
     """
     import re
 
@@ -565,8 +563,8 @@ def test_mac_chat_header_controls_share_the_titlebar_row():
     assert "shouldUseNativeMacWindowTitlebar" not in source
     assert "[--studio-content-top-inset:var(--studio-mac-titlebar-height" not in source
     assert source.count("var(--studio-mac-traffic-light-inset") == 2
-    # The chat header sits one row below the titlebar navigation, and the two
-    # move together: this gap is what keeps them on the same visual line.
+    # The header and the titlebar navigation move together; this gap is what
+    # keeps them on the same visual line.
     assert (
         _provider_css_px("--studio-chat-header-padding-top")
         - _provider_css_px("--studio-titlebar-navigation-offset-y")

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -545,8 +545,8 @@ def _provider_css_px(name):
     """The px value the provider sets for a CSS custom property.
 
     Read rather than pinned: #8102 nudged the mac titlebar 2px and reddened the
-    repo because these assertions spelled the number out. The layout depends on
-    the row keeping its shape, so that is what is asserted below.
+    repo because these assertions spelled the number out. What matters is the
+    row keeping its shape, so that is what the callers assert.
     """
     import re
 
@@ -563,8 +563,7 @@ def test_mac_chat_header_controls_share_the_titlebar_row():
     assert "shouldUseNativeMacWindowTitlebar" not in source
     assert "[--studio-content-top-inset:var(--studio-mac-titlebar-height" not in source
     assert source.count("var(--studio-mac-traffic-light-inset") == 2
-    # The header and the titlebar navigation move together; this gap is what
-    # keeps them on the same visual line.
+    # This gap is what keeps the header and the titlebar navigation on one line.
     assert (
         _provider_css_px("--studio-chat-header-padding-top")
         - _provider_css_px("--studio-titlebar-navigation-offset-y")

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -496,9 +496,9 @@ def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
     assert "translate-y-[var(--studio-titlebar-navigation-offset-y,0px)]" in TITLEBAR.read_text(
         encoding = "utf-8"
     )
-    assert '"--studio-titlebar-navigation-offset-y": "2px"' in APP_PROVIDER.read_text(
-        encoding = "utf-8"
-    )
+    # A small positive nudge: zero puts the row on the traffic lights, and a
+    # large one drops it out of the 48px titlebar.
+    assert 0 < _provider_css_px("--studio-titlebar-navigation-offset-y") <= 8
     assert "aria-hidden={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
     assert "inert={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
 
@@ -542,14 +542,33 @@ def test_visible_mac_sidebar_header_is_a_drag_region():
     assert header.index(drag_region) < header.index('"relative z-10 flex items-center')
 
 
+def _provider_css_px(name):
+    """The px value the provider sets for a CSS custom property.
+
+    Read rather than pinned as a literal: #8102 nudged the mac titlebar by 2px
+    and reddened the whole repo, because these assertions spelled out the
+    number. What the layout actually depends on is that the row keeps its
+    shape, so that is what is asserted below.
+    """
+    import re
+
+    provider = APP_PROVIDER.read_text(encoding = "utf-8")
+    found = re.findall(rf'"{re.escape(name)}":\s*"(-?\d+)px"', provider)
+    assert found, f"the provider no longer sets {name}"
+    assert len(set(found)) == 1, f"{name} is set to more than one value: {sorted(set(found))}"
+    return int(found[0])
+
+
 def test_mac_chat_header_controls_share_the_titlebar_row():
     source = CHAT_PAGE.read_text(encoding = "utf-8")
-    provider = APP_PROVIDER.read_text(encoding = "utf-8")
 
     assert "shouldUseNativeMacWindowTitlebar" not in source
     assert "[--studio-content-top-inset:var(--studio-mac-titlebar-height" not in source
     assert source.count("var(--studio-mac-traffic-light-inset") == 2
-    assert '"--studio-chat-header-padding-top": "7px"' in provider
+    # The chat header sits one row below the titlebar navigation, and the two
+    # move together: this gap is what keeps them on the same visual line.
+    assert (_provider_css_px("--studio-chat-header-padding-top")
+            - _provider_css_px("--studio-titlebar-navigation-offset-y")) == 5
     assert "pt-[var(--studio-content-top-inset,0px)] md:flex-row" in source
     assert "absolute top-[var(--studio-content-top-inset,0px)]" in source
 

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -567,8 +567,10 @@ def test_mac_chat_header_controls_share_the_titlebar_row():
     assert source.count("var(--studio-mac-traffic-light-inset") == 2
     # The chat header sits one row below the titlebar navigation, and the two
     # move together: this gap is what keeps them on the same visual line.
-    assert (_provider_css_px("--studio-chat-header-padding-top")
-            - _provider_css_px("--studio-titlebar-navigation-offset-y")) == 5
+    assert (
+        _provider_css_px("--studio-chat-header-padding-top")
+        - _provider_css_px("--studio-titlebar-navigation-offset-y")
+    ) == 5
     assert "pt-[var(--studio-content-top-inset,0px)] md:flex-row" in source
     assert "absolute top-[var(--studio-content-top-inset,0px)]" in source
 


### PR DESCRIPTION
Two source-scraping contract tests are failing on `main` right now, and both fail for the same reason: they pin a spelling rather than the behaviour, so an ordinary change to the code under test reads as a repo-wide red.

`tests/python/test_studio_runtime_gate.py::test_terminal_update_holds_the_gate_through_environment_mutation`

#8092 replaced `_release_self_exe_lock_windows` with `_WindowsLauncherUpdateTransaction`. The test sliced `studio.py` from `def update(` up to that helper name, so the rename took the whole slice down with it:

```
body = source[source.index("def update(") : source.index("def _release_self_exe_lock_windows")]
E   ValueError: substring not found
```

It now ends at the next definition rather than at a name inside the body, and asserts the ordering that actually matters, including that the launcher transaction sits INSIDE the gate: the transaction renames the running launcher aside, so a second Studio the gate never excluded would be mutating the same install underneath it.

`tests/studio/test_desktop_reliability_frontend_contract.py`

#8102 nudged the mac titlebar by 2px (`--studio-titlebar-navigation-offset-y` 2px to 4px, `--studio-chat-header-padding-top` 7px to 9px) and reddened two tests, because they spelled the numbers out as literals. What the layout depends on is the row keeping its shape, so the offset is now bounded (positive, and inside the 48px titlebar) and the chat header is asserted to stay 5px below it.

Still catches a real break: moving the padding to 12px reproduces the failure.

Both slices also go through a helper that reports a moved anchor by name, so the next rename says which one went instead of raising a bare index error.

Verified with `pytest tests/python tests/studio`: 3721 passed, the two failures gone. The two remaining local failures (`test_e2e_no_torch_sandbox`, `test_tokenizers_and_torch_constraint`) build a no-torch venv and fail in my sandbox on `main` too; CI reports neither.