### PR TITLE
Render a static prefix when default_system_message is None

### DIFF
--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -331,3 +331,22 @@ def test_bos_token_with_quote_or_backslash_is_not_emitted_twice():
     ):
         rendered = _render(jinja_template, messages, bos_token = bos)
         assert rendered.count(bos) == 1, rendered
+
+
+def test_bos_only_prefix_still_rejects_system_message():
+    bos = _BosFakeTokenizer.bos_token
+    _, jinja_template, _, _ = construct_chat_template(
+        tokenizer = _BosFakeTokenizer(),
+        chat_template = bos + _NO_SYSTEM_CHAT_TEMPLATE.removeprefix("PREAMBLE\n"),
+        default_system_message = None,
+        extra_eos_tokens = ["</s>"],
+    )
+    with pytest.raises(RuntimeError, match = "Only user and assistant roles are supported!"):
+        _render(
+            jinja_template,
+            [
+                {"role": "system", "content": "Be terse."},
+                {"role": "user", "content": "Hi"},
+            ],
+            bos_token = bos,
+        )

--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -203,16 +203,7 @@ def test_static_prefix_without_system_still_rejects_system_message():
 
 @pytest.mark.parametrize("default_system_message", [None, "You are helpful."])
 def test_static_prefix_without_system_renders_in_every_conversation(default_system_message):
-    """A prefix with no {SYSTEM} placeholder is static, so it belongs in every
-    rendered conversation and must match the Ollama modelfile from the same call.
-
-    With `default_system_message = None` the prefix used to be emitted only from
-    the `{% if messages[0]['role'] == 'system' %}` arm, and that arm cannot be
-    reached: a system message hits the loop's `raise_exception` (asserted just
-    above). So a plain user/assistant conversation dropped the prefix entirely
-    while `create_ollama_modelfile` still served it, and the model was finetuned
-    without the text it was later prompted with.
-    """
+    """A static prefix must render regardless of the default system message."""
     modelfile, jinja_template, _, _ = construct_chat_template(
         tokenizer = _SuccessFakeTokenizer(),
         chat_template = _NO_SYSTEM_CHAT_TEMPLATE,
@@ -221,7 +212,6 @@ def test_static_prefix_without_system_renders_in_every_conversation(default_syst
     )
     rendered = _render(jinja_template, [{"role": "user", "content": "Hi"}])
     assert rendered.startswith("PREAMBLE\n"), rendered
-    # The served template carries the same prefix, so training must too.
     assert "PREAMBLE\n" in modelfile.split("TEMPLATE ")[1]
 
 

--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -201,6 +201,30 @@ def test_static_prefix_without_system_still_rejects_system_message():
         )
 
 
+@pytest.mark.parametrize("default_system_message", [None, "You are helpful."])
+def test_static_prefix_without_system_renders_in_every_conversation(default_system_message):
+    """A prefix with no {SYSTEM} placeholder is static, so it belongs in every
+    rendered conversation and must match the Ollama modelfile from the same call.
+
+    With `default_system_message = None` the prefix used to be emitted only from
+    the `{% if messages[0]['role'] == 'system' %}` arm, and that arm cannot be
+    reached: a system message hits the loop's `raise_exception` (asserted just
+    above). So a plain user/assistant conversation dropped the prefix entirely
+    while `create_ollama_modelfile` still served it, and the model was finetuned
+    without the text it was later prompted with.
+    """
+    modelfile, jinja_template, _, _ = construct_chat_template(
+        tokenizer = _SuccessFakeTokenizer(),
+        chat_template = _NO_SYSTEM_CHAT_TEMPLATE,
+        default_system_message = default_system_message,
+        extra_eos_tokens = ["</s>"],
+    )
+    rendered = _render(jinja_template, [{"role": "user", "content": "Hi"}])
+    assert rendered.startswith("PREAMBLE\n"), rendered
+    # The served template carries the same prefix, so training must too.
+    assert "PREAMBLE\n" in modelfile.split("TEMPLATE ")[1]
+
+
 def test_auto_appended_eos_prefers_the_tokenizer_eos_deterministically():
     """When the template has no EOS after {OUTPUT}, construct_chat_template appends one
     itself and picks `extra_eos_tokens[0]`. `extra_eos_tokens.insert(0, tokenizer.eos_token)`

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2702,6 +2702,7 @@ extra_eos_tokens = None,
             system_part = system_part.replace(tokenizer.bos_token, "", 1)
         partial_system = process(system_part, "{SYSTEM}", "messages[0]['content']")
         partial_system = partial_system.replace("{SYSTEM}", "")
+        system_expr = partial_system
 
         if "{SYSTEM}" in partial_system:
             if default_system_message is None:
@@ -2726,7 +2727,18 @@ extra_eos_tokens = None,
                 "{% set loop_messages = messages %}"\
             "{% endif %}"
         else:
-            partial_system += "{% endif %}"
+            # A prefix with no {SYSTEM} is static, so it belongs in every
+            # conversation, which is what the Ollama modelfile below already
+            # emits. Without this arm it only rendered when messages[0] was a
+            # system message, and that case raises anyway, so it never rendered
+            # at all. The two arms are identical literals here, so the "system
+            # part is the same" regex further down folds them into one
+            # unconditional emit and a caller-supplied system message still
+            # reaches the loop's raise_exception.
+            partial_system += "{% else %}"\
+                "{{ " + system_expr + " }}"\
+                "{% set loop_messages = messages %}"\
+            "{% endif %}"
 
         jinja_template = partial_system + jinja_template
 

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2749,7 +2749,7 @@ extra_eos_tokens = None,
 
     # Check if system part is the same!
     jinja_template = re.sub(
-        r"\{\% if messages\[0\]\['role'\] \=\= 'system' \%\}\{\{ '(.+?)' \}\}"\
+        r"\{\% if messages\[0\]\['role'\] \=\= 'system' \%\}\{\{ '(.*?)' \}\}"\
         r"\{\% set loop\_messages \= messages\[1\:\] \%\}"\
         r"\{\% else \%\}\{\{ '\1' \}\}\{\% set loop\_messages \= messages \%\}\{\% endif \%\}"\
         r"\{\% for message in loop\_messages \%\}",

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2727,14 +2727,8 @@ extra_eos_tokens = None,
                 "{% set loop_messages = messages %}"\
             "{% endif %}"
         else:
-            # A prefix with no {SYSTEM} is static, so it belongs in every
-            # conversation, which is what the Ollama modelfile below already
-            # emits. Without this arm it only rendered when messages[0] was a
-            # system message, and that case raises anyway, so it never rendered
-            # at all. The two arms are identical literals here, so the "system
-            # part is the same" regex further down folds them into one
-            # unconditional emit and a caller-supplied system message still
-            # reaches the loop's raise_exception.
+            # Emit a static prefix on both branches so the collapse below
+            # makes it unconditional.
             partial_system += "{% else %}"\
                 "{{ " + system_expr + " }}"\
                 "{% set loop_messages = messages %}"\


### PR DESCRIPTION
### Summary

A chat template can begin with a static preamble that has no `{SYSTEM}` placeholder, for example Unsloth's own Alpaca-style header. When `default_system_message` is `None`, that preamble never appears in any rendered conversation, while the Ollama modelfile returned by the same call still contains it.

### Repro

```python
T = ("Below are some instructions that describe some tasks.\n\n"
     "### User: {INPUT}\n### Assistant: {OUTPUT}</s>"
     "### User: {INPUT}\n### Assistant: {OUTPUT}</s>")

modelfile, jinja, _, _ = construct_chat_template(
    tokenizer=tok, chat_template=T, default_system_message=None,
    extra_eos_tokens=["</s>"])
```

```
default_system_message=None
   trained on (HF jinja) : '### User: Hi\n### Assistant: Yo</s>'
   served    (modelfile) : 'Below are some instructions that describe some tasks.\n\n{{ if .Prompt }}### User: '

default_system_message='Be helpful.'
   trained on (HF jinja) : 'Below are some instructions that describe some tasks.\n\n### User: Hi\n### Assistant: Yo</s>'
   served    (modelfile) : 'Below are some instructions that describe some tasks.\n\n{{ if .Prompt }}### User: '
```

The preamble has no `{SYSTEM}` slot, so whether the caller passed a default system message should not decide whether it is part of the prompt. Today it does.

### Cause

The generated template puts the prefix inside the system arm only:

```
{% if messages[0]['role'] == 'system' %}{{ 'PREAMBLE\n\n' }}{% set loop_messages = messages[1:] %}{% endif %}
{% for message in messages %}...
```

With no `{SYSTEM}` slot that arm cannot be reached. A caller-supplied system message is not consumed by the system part, so it reaches the loop and hits `raise_exception('Only user and assistant roles are supported!')`, which `test_static_prefix_without_system_still_rejects_system_message` already pins. So the only conversations that render successfully are the ones that take the `{% endif %}` path, and those drop the prefix.

The effect is train/serve skew rather than an error: `apply_chat_template` builds training text from the Jinja template through `dataset.map`, while `save.py:create_ollama_modelfile` serves the modelfile, so the model is finetuned without the text it is later prompted with. Nothing warns.

### Fix

Give that branch the same `{% else %}` arm the `default_system_message is not None` path already gets. With no `{SYSTEM}` in the system part the two arms are identical literals, so the existing "Check if system part is the same!" regex a few lines down folds them into a single unconditional emit:

```
{{ 'PREAMBLE\n\n' }}{% for message in messages %}...
```

This deliberately keeps #7199's behaviour: a caller-supplied system message still reaches `raise_exception`, because the collapsed template loops over `messages` and the template genuinely cannot render one. The change is only about what a plain user/assistant conversation renders.

### Blast radius

Generated `jinja_template` and `modelfile` compared before and after across 21 combinations (7 system-part shapes, including none, `{SYSTEM}`-bearing, apostrophe-bearing and BOS-prefixed, times 3 `default_system_message` values):

- 18 byte-identical
- 3 changed, all of them a static prefix with `default_system_message=None`, which is the bug
- every modelfile unchanged

### Test

`test_static_prefix_without_system_renders_in_every_conversation` in `tests/python/test_construct_chat_template_validation.py`, parametrized over `default_system_message`, asserting the prefix is in the rendered conversation and in the modelfile from the same call. It uses the file's existing `_NO_SYSTEM_CHAT_TEMPLATE` and CPU-only `_SuccessFakeTokenizer`, so it needs no GPU or download.

Fails before on the `None` case, passes after. The whole file goes 20 passed / 1 failed to 21 passed, and `tests/python/test_get_chat_template_escaping.py` alongside it stays green (193 passed together). `ruff check` clean on both changed files.
