### PR TITLE
fix(studio): find MTP/DSpark sidecars in custom folders with nested quants

### DIFF
--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1321,7 +1321,13 @@ def test_companion_search_root_keeps_non_quant_directories(tmp_path):
 
 
 def test_custom_scan_folder_variant_finds_nested_mtp_drafter(tmp_path):
-    """Custom-folder scan roots are passed with a nested gguf_variant (#8077).
+    """Custom-folder scan roots are passed with a nested gguf_variant.
+
+    Layout reproduced for this PR (LM Studio nested-quant, not the flat tree
+    described in #8077):
+
+        <scan_root>/unsloth/gemma-4-31b-it/Q4_K_M/gemma-4-31B-it-Q4_K_M.gguf
+        <scan_root>/unsloth/gemma-4-31b-it/mtp-gemma-4-31B-it.gguf
 
     Companions sit beside the model directory, not at the scan root. Using the
     selected scan folder as the companion search root would miss them.
@@ -1373,6 +1379,35 @@ def test_companion_search_root_falls_back_when_weight_outside_selection(tmp_path
     assert _local_gguf_companion_search_root(
         str(scan_root), str(model_dir / "model-Q4_K_M.gguf")
     ) == str(scan_root)
+
+
+def test_custom_scan_folder_flat_layout_finds_mtp_beside_gguf(tmp_path):
+    """#8077 as written: sidecar beside the GGUF, or in MTP/ next to it.
+
+    detect_mtp_file already scans the weight directory, so a custom-folder
+    load of this tree should succeed even when the companion search root is
+    still the scan folder. This PR is not what makes this layout work.
+    """
+    scan_root = tmp_path / "oobabooga" / "models"
+    model_dir = scan_root / "lmstudio-community" / "gemma-4-31b-it-GGUF"
+    model_dir.mkdir(parents = True)
+    weight = model_dir / "gemma-4-31B-it-Q4_K_M.gguf"
+    weight.write_bytes(b"x")
+    beside = model_dir / "mtp-gemma-4-31B-it.gguf"
+    beside.write_bytes(b"x")
+
+    config = ModelConfig.from_identifier(str(scan_root), gguf_variant = "Q4_K_M")
+    assert config and config.is_gguf
+    assert config.gguf_file == str(weight.resolve())
+    assert config.gguf_mtp_file == str(beside.resolve())
+
+    mtp_dir = model_dir / "MTP"
+    mtp_dir.mkdir()
+    subdir = mtp_dir / "mtp-gemma-4-31B-it-Q8_0.gguf"
+    subdir.write_bytes(b"x")
+    beside.unlink()
+    config = ModelConfig.from_identifier(str(scan_root), gguf_variant = "Q4_K_M")
+    assert config and config.gguf_mtp_file == str(subdir.resolve())
 
 
 def test_custom_scan_folder_variant_finds_nested_mmproj(tmp_path):

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1370,7 +1370,9 @@ def test_companion_search_root_falls_back_when_weight_outside_selection(tmp_path
     weight.write_bytes(b"x")
     model_dir.joinpath("model-Q4_K_M.gguf").symlink_to(weight)
 
-    assert _local_gguf_companion_search_root(str(scan_root), str(model_dir / "model-Q4_K_M.gguf")) == str(scan_root)
+    assert _local_gguf_companion_search_root(
+        str(scan_root), str(model_dir / "model-Q4_K_M.gguf")
+    ) == str(scan_root)
 
 
 def test_custom_scan_folder_variant_finds_nested_mmproj(tmp_path):

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1320,6 +1320,76 @@ def test_companion_search_root_keeps_non_quant_directories(tmp_path):
         assert _local_gguf_companion_search_root(str(directory), str(weight)) == str(directory)
 
 
+def test_custom_scan_folder_variant_finds_nested_mtp_drafter(tmp_path):
+    """Custom-folder scan roots are passed with a nested gguf_variant (#8077).
+
+    Companions sit beside the model directory, not at the scan root. Using the
+    selected scan folder as the companion search root would miss them.
+    """
+    scan_root = tmp_path / "custom"
+    model_dir = scan_root / "unsloth" / "gemma-4-31b-it"
+    quant_dir = model_dir / "Q4_K_M"
+    quant_dir.mkdir(parents = True)
+    weight = quant_dir / "gemma-4-31B-it-Q4_K_M.gguf"
+    weight.write_bytes(b"x")
+    drafter = model_dir / "mtp-gemma-4-31B-it.gguf"
+    drafter.write_bytes(b"x")
+
+    assert _local_gguf_companion_search_root(str(scan_root), str(weight)) == str(model_dir)
+    config = ModelConfig.from_identifier(str(scan_root), gguf_variant = "Q4_K_M")
+    assert config and config.is_gguf
+    assert config.gguf_file == str(weight.resolve())
+    assert config.gguf_mtp_file == str(drafter.resolve())
+
+
+def test_custom_scan_folder_variant_finds_nested_dspark_sidecar(tmp_path):
+    scan_root = tmp_path / "custom"
+    model_dir = scan_root / "deepseek"
+    quant_dir = model_dir / "UD-Q4_K_M"
+    quant_dir.mkdir(parents = True)
+    weight = quant_dir / "DeepSeek-V4-Flash-0731-UD-Q4_K_M.gguf"
+    weight.write_bytes(b"x")
+    dspark_dir = model_dir / "dspark"
+    dspark_dir.mkdir()
+    sidecar = dspark_dir / "dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf"
+    sidecar.write_bytes(b"x")
+
+    config = ModelConfig.from_identifier(str(scan_root), gguf_variant = "UD-Q4_K_M")
+    assert config and config.is_gguf
+    assert config.gguf_dspark_file == str(sidecar.resolve())
+
+
+def test_companion_search_root_falls_back_when_weight_outside_selection(tmp_path):
+    """A symlinked weight outside the selected tree keeps the selected scan root."""
+    scan_root = tmp_path / "custom"
+    model_dir = scan_root / "publisher" / "model"
+    model_dir.mkdir(parents = True)
+    external = tmp_path / "external"
+    external.mkdir()
+    weight = external / "model-Q4_K_M.gguf"
+    weight.write_bytes(b"x")
+    model_dir.joinpath("model-Q4_K_M.gguf").symlink_to(weight)
+
+    assert _local_gguf_companion_search_root(str(scan_root), str(model_dir / "model-Q4_K_M.gguf")) == str(scan_root)
+
+
+def test_custom_scan_folder_variant_finds_nested_mmproj(tmp_path):
+    """mmproj shares the companion search root with MTP/DSpark sidecars."""
+    scan_root = tmp_path / "custom"
+    model_dir = scan_root / "unsloth" / "gemma-4-31b-it"
+    quant_dir = model_dir / "Q4_K_M"
+    quant_dir.mkdir(parents = True)
+    weight = quant_dir / "gemma-4-31B-it-Q4_K_M.gguf"
+    weight.write_bytes(b"x")
+    mmproj = model_dir / "mmproj-gemma-4-31B-it-F16.gguf"
+    mmproj.write_bytes(b"x")
+
+    assert _local_gguf_companion_search_root(str(scan_root), str(weight)) == str(model_dir)
+    config = ModelConfig.from_identifier(str(scan_root), gguf_variant = "Q4_K_M")
+    assert config and config.is_gguf
+    assert config.gguf_mmproj_file == str(mmproj.resolve())
+
+
 # ── DSpark drafters (DeepSeek V4 Flash) ──────────────────────────────
 
 DEEPSEEK_SIBLINGS = [

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -2555,12 +2555,31 @@ def _local_gguf_companion_search_root(selected_path: str, gguf_file: str) -> str
     gguf_path = Path(gguf_file)
     # One shared quant vocabulary: a local copy fell behind on bpw, hiding IQ4_XS-3.53bpw dirs.
     quant_dir_re = rf"{_GGUF_KNOWN_QUANT_RE.pattern}(-[0-9]+(?:\.[0-9]+)?bpw)?"
-    search_dir = gguf_path.parent if selected.suffix.lower() == ".gguf" else selected
-    if not search_dir.name:
-        return str(search_dir)
-    if re.fullmatch(quant_dir_re, search_dir.name, re.IGNORECASE):
-        return str(search_dir.parent)
-    return str(search_dir)
+
+    def _promote_quant_dir(directory: Path) -> Path:
+        if directory.name and re.fullmatch(quant_dir_re, directory.name, re.IGNORECASE):
+            return directory.parent
+        return directory
+
+    if selected.suffix.lower() == ".gguf":
+        return str(_promote_quant_dir(gguf_path.parent))
+
+    # Directory selection: a registered custom scan folder or a publisher directory
+    # is often passed here together with a nested ``gguf_variant``. Companions
+    # (mmproj, MTP, DSpark) live beside the model folder, not at the scan root.
+    # Both paths are resolved before relative_to; if the weight is a symlink that
+    # resolves outside the selected tree, relative_to fails and we keep the
+    # selected directory as the scan root. That is the conservative answer for HF
+    # cache blob layouts, but symlinks into a custom folder do not get this fix.
+    try:
+        gguf_path.resolve().relative_to(selected.resolve())
+        search_dir = gguf_path.parent
+    except (OSError, RuntimeError, ValueError):
+        search_dir = selected
+        if not search_dir.name:
+            return str(search_dir)
+
+    return str(_promote_quant_dir(search_dir))
 
 
 def _snapshot_selection_key(snapshot: Path) -> tuple[float, str]:


### PR DESCRIPTION
## Summary

Helps #8077 — speculative decoding sidecars (`mtp-*.gguf`, `dspark/`) were not detected for models in registered custom scan folders when the weight lives in a nested quant subdirectory.

## Root cause

`_local_gguf_companion_search_root()` used the **selected directory** (often the custom scan-folder root) as the companion search root whenever the load request was not a direct `.gguf` path. Custom-folder loads pass the scan root plus a `gguf_variant`, so companions beside the actual model directory were never scanned.

HF-cache downloads worked because they load by repo id and fetch companions through the hub path, not this local resolver.

## Fix

When the resolved weight file lives under the selected directory, derive the companion search root from the weight path (with existing quant-directory promotion) instead of the scan root.

## Test plan

- [x] `test_custom_scan_folder_variant_finds_nested_mtp_drafter` — LM Studio layout, Gemma 31B, `Q4_K_M/` quant subdir
- [x] `test_custom_scan_folder_variant_finds_nested_dspark_sidecar` — DeepSeek V4 Flash `dspark/` subdir
- [x] Existing companion-search-root regression tests still pass