### PR TITLE
fix(studio): reconcile per-model load settings after same-model reload

### DIFF
--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -34,6 +34,8 @@ import { resolveMlxKvBitsSeed } from "./resolve-mlx-kv-bits-seed";
 import { resolvePairedLoadParamSeed } from "./resolve-paired-load-param-seed";
 import type { PairedLoadParamSeed } from "./resolve-paired-load-param-seed";
 
+type LocalReasoningEffort = Extract<ReasoningEffort, "low" | "medium" | "high">;
+
 function pairedSeedPatch<T>(
   seed: PairedLoadParamSeed<T>,
   controlKey: string,

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -30,8 +30,21 @@ import type { ChatModelSummary } from "../types/runtime";
 import { sameGpuSelection } from "@/hooks/gpu-selection";
 import { resolveBatchSizeSeed } from "./resolve-batch-size-seed";
 import { resolveChatTemplateSeed } from "./resolve-chat-template-seed";
+import { resolveMlxKvBitsSeed } from "./resolve-mlx-kv-bits-seed";
+import { resolvePairedLoadParamSeed } from "./resolve-paired-load-param-seed";
+import type { PairedLoadParamSeed } from "./resolve-paired-load-param-seed";
 
-type LocalReasoningEffort = Extract<ReasoningEffort, "low" | "medium" | "high">;
+function pairedSeedPatch<T>(
+  seed: PairedLoadParamSeed<T>,
+  controlKey: string,
+  loadedKey: string,
+): Record<string, T | null> {
+  const patch: Record<string, T | null> = {};
+  if ("control" in seed) patch[controlKey] = seed.control ?? null;
+  if ("loaded" in seed) patch[loadedKey] = seed.loaded ?? null;
+  return patch;
+}
+
 
 function sameArray<T>(a: T[] | null, b: T[] | null): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
@@ -311,6 +324,64 @@ export function applyActiveModelStatusToStore(
   // A same-model reload from another client advances every loaded baseline.
   // Preserve each editable group only when this tab has an unapplied change.
   const preserveSameModelEdits = gpuStatusChanged && !hydratingExistingModel;
+  const speculativeSeed = resolvePairedLoadParamSeed({
+    incoming: currentSpecType,
+    previous: {
+      control: prevState.speculativeType,
+      loaded: prevState.loadedSpeculativeType,
+    },
+    hydratingExistingModel,
+    seedLoadParams,
+  });
+  const specDraftSeed = resolvePairedLoadParamSeed({
+    incoming:
+      status.spec_draft_n_max !== undefined
+        ? (status.spec_draft_n_max ?? null)
+        : undefined,
+    previous: {
+      control: prevState.specDraftNMax,
+      loaded: prevState.loadedSpecDraftNMax,
+    },
+    hydratingExistingModel,
+    seedLoadParams,
+  });
+  const kvCacheSeed = resolvePairedLoadParamSeed({
+    incoming:
+      status.cache_type_kv !== undefined ? status.cache_type_kv : undefined,
+    previous: {
+      control: prevState.kvCacheDtype,
+      loaded: prevState.loadedKvCacheDtype,
+    },
+    hydratingExistingModel,
+    seedLoadParams,
+  });
+  const tensorParallelSeed = resolvePairedLoadParamSeed({
+    incoming:
+      status.tensor_parallel !== undefined ? status.tensor_parallel : undefined,
+    previous: {
+      control: prevState.tensorParallel,
+      loaded: prevState.loadedTensorParallel,
+    },
+    hydratingExistingModel,
+    seedLoadParams,
+  });
+  const mlxKvBitsSeed = resolveMlxKvBitsSeed({
+    isMlx: status.is_mlx,
+    mlxKvBitsDefined: status.mlx_kv_bits !== undefined,
+    incomingRequested: status.mlx_kv_bits_requested ?? null,
+    incomingReason: status.mlx_kv_quant_reason ?? null,
+    incomingTemplateReason: status.chat_template_override_reason ?? null,
+    incomingNote: status.mlx_kv_quant_note ?? null,
+    previous: {
+      mlxKvBits: prevState.mlxKvBits,
+      loadedMlxKvBitsRequested: prevState.loadedMlxKvBitsRequested,
+      mlxKvQuantReason: prevState.mlxKvQuantReason,
+      chatTemplateOverrideReason: prevState.chatTemplateOverrideReason,
+      mlxKvQuantNote: prevState.mlxKvQuantNote,
+    },
+    hydratingExistingModel,
+    seedLoadParams,
+  });
   const gpuStatusFields = {
     ...incomingGpuFields,
     customContextLength: gpuPin,
@@ -358,75 +429,11 @@ export function applyActiveModelStatusToStore(
     activeModelIsLocal: status.is_local_model ?? false,
     specFallbackReason: status.spec_fallback_reason ?? null,
     specDrafterKind: status.spec_drafter_kind ?? null,
-    // The spec / KV seeds share the GPU-fields reseed mechanism below: a
-    // non-GGUF status leaves their loaded baselines null, so the "unseeded"
-    // guard re-fires every refresh -- hold them too while a staged pick's
-    // settings are being edited, or the refresh resets the staged edit.
-    // hydratingExistingModel reopens every load-param seed: when the active
-    // model changed underneath this tab (auto-switch, another client), the
-    // old model's baselines are stale and must adopt the new status.
-    ...(seedLoadParams &&
-      (prevState.loadedSpeculativeType === null || hydratingExistingModel) && {
-        speculativeType: currentSpecType,
-        loadedSpeculativeType: currentSpecType,
-      }),
-    ...(seedLoadParams &&
-      status.spec_draft_n_max !== undefined &&
-      (hydratingExistingModel ||
-        (prevState.loadedSpecDraftNMax === null &&
-          prevState.specDraftNMax === null)) && {
-        specDraftNMax: status.spec_draft_n_max ?? null,
-        loadedSpecDraftNMax: status.spec_draft_n_max ?? null,
-      }),
-    ...(seedLoadParams &&
-      status.cache_type_kv !== undefined &&
-      (prevState.loadedKvCacheDtype === null || hydratingExistingModel) && {
-        kvCacheDtype: status.cache_type_kv,
-        loadedKvCacheDtype: status.cache_type_kv,
-      }),
-    ...(seedLoadParams &&
-      status.tensor_parallel !== undefined &&
-      (prevState.loadedTensorParallel === null || hydratingExistingModel) && {
-        tensorParallel: status.tensor_parallel,
-        loadedTensorParallel: status.tensor_parallel,
-      }),
-    // Hydration only, so a steady poll never rewrites settings the store owns.
-    // Width, verdict and request move together; a late reply can overwrite a newer one.
-    ...(seedLoadParams &&
-      hydratingExistingModel &&
-      status.mlx_kv_bits !== undefined &&
-      (status.is_mlx === true
-        ? {
-            mlxKvBits: status.mlx_kv_bits_requested ?? null,
-            loadedMlxKvBitsRequested: status.mlx_kv_bits_requested ?? null,
-            mlxKvQuantReason: status.mlx_kv_quant_reason ?? null,
-            chatTemplateOverrideReason:
-              status.chat_template_override_reason ?? null,
-            mlxKvQuantNote: status.mlx_kv_quant_note ?? null,
-          }
-        : {
-            // The verdict retires; the editable width is dormant, not wrong.
-            loadedMlxKvBitsRequested: null,
-            mlxKvQuantReason: null,
-            chatTemplateOverrideReason: null,
-            mlxKvQuantNote: null,
-          })),
-    // Recovery for a hydration this tab never saw, and only when nothing is
-    // staged: re-seeding over an earlier edit would discard it.
-    ...(seedLoadParams &&
-      !hydratingExistingModel &&
-      status.is_mlx === true &&
-      status.mlx_kv_bits !== undefined &&
-      prevState.mlxKvBits === null &&
-      prevState.loadedMlxKvBitsRequested === null &&
-      prevState.mlxKvQuantReason === null &&
-      prevState.chatTemplateOverrideReason === null && {
-        mlxKvBits: status.mlx_kv_bits_requested ?? null,
-        loadedMlxKvBitsRequested: status.mlx_kv_bits_requested ?? null,
-        mlxKvQuantReason: status.mlx_kv_quant_reason ?? null,
-        chatTemplateOverrideReason: status.chat_template_override_reason ?? null,
-        mlxKvQuantNote: status.mlx_kv_quant_note ?? null,
-      }),
+    ...(seedLoadParams && pairedSeedPatch(speculativeSeed, "speculativeType", "loadedSpeculativeType")),
+    ...(seedLoadParams && pairedSeedPatch(specDraftSeed, "specDraftNMax", "loadedSpecDraftNMax")),
+    ...(seedLoadParams && pairedSeedPatch(kvCacheSeed, "kvCacheDtype", "loadedKvCacheDtype")),
+    ...(seedLoadParams && pairedSeedPatch(tensorParallelSeed, "tensorParallel", "loadedTensorParallel")),
+    ...(seedLoadParams && mlxKvBitsSeed),
     // Baseline only, never the control: the echo is the RESOLVED count and would
     // pin a blank "server default" control. The rollback re-sends the baseline,
     // so without this a rollback after a tab reload loses the override.

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -19,6 +19,7 @@ import {
   loadOptionalBool,
   loadedGpuMemoryFields,
   normalizeSpeculativeType,
+  readPersistedSpeculativeType,
   resolveToolsEnabledOnLoad,
   useChatRuntimeStore,
 } from "../stores/chat-runtime-store";
@@ -334,6 +335,7 @@ export function applyActiveModelStatusToStore(
     },
     hydratingExistingModel,
     seedLoadParams,
+    pristineControl: readPersistedSpeculativeType(),
   });
   const specDraftSeed = resolvePairedLoadParamSeed({
     incoming:
@@ -366,6 +368,7 @@ export function applyActiveModelStatusToStore(
     },
     hydratingExistingModel,
     seedLoadParams,
+    pristineControl: false,
   });
   const mlxKvBitsSeed = resolveMlxKvBitsSeed({
     isMlx: status.is_mlx,

--- a/studio/frontend/src/features/chat/lib/resolve-chat-template-seed.ts
+++ b/studio/frontend/src/features/chat/lib/resolve-chat-template-seed.ts
@@ -33,6 +33,12 @@ export function resolveChatTemplateSeed(options: {
   // While a load is in flight performLoad owns the load params, and an older backend
   // omitting the field says nothing about the template.
   if (incoming === undefined || !seedLoadParams) {
+    if (hydratingExistingModel && seedLoadParams) {
+      return {
+        chatTemplateOverride: null,
+        loadedChatTemplateOverride: null,
+      };
+    }
     return {};
   }
   const unseeded =

--- a/studio/frontend/src/features/chat/lib/resolve-mlx-kv-bits-seed.ts
+++ b/studio/frontend/src/features/chat/lib/resolve-mlx-kv-bits-seed.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// MLX KV width + verdict fields from /api/inference/status. The editable width is a
+// paired control/baseline like the other load params; the verdict strings are facts
+// about the running server and always follow the baseline.
+
+export interface MlxKvBitsSeedState {
+  mlxKvBits: number | null;
+  loadedMlxKvBitsRequested: number | null;
+  mlxKvQuantReason: string | null;
+  chatTemplateOverrideReason: string | null;
+  mlxKvQuantNote: string | null;
+}
+
+export type MlxKvBitsSeed = Partial<MlxKvBitsSeedState>;
+
+export function resolveMlxKvBitsSeed(options: {
+  isMlx: boolean | undefined;
+  mlxKvBitsDefined: boolean;
+  incomingRequested: number | null;
+  incomingReason: string | null;
+  incomingTemplateReason: string | null;
+  incomingNote: string | null;
+  previous: MlxKvBitsSeedState;
+  hydratingExistingModel: boolean;
+  seedLoadParams: boolean;
+}): MlxKvBitsSeed {
+  const {
+    isMlx,
+    mlxKvBitsDefined,
+    incomingRequested,
+    incomingReason,
+    incomingTemplateReason,
+    incomingNote,
+    previous,
+    hydratingExistingModel,
+    seedLoadParams,
+  } = options;
+  if (!seedLoadParams || !mlxKvBitsDefined) {
+    return {};
+  }
+  if (isMlx !== true) {
+    if (!hydratingExistingModel) {
+      return {};
+    }
+    return {
+      loadedMlxKvBitsRequested: null,
+      mlxKvQuantReason: null,
+      chatTemplateOverrideReason: null,
+      mlxKvQuantNote: null,
+    };
+  }
+  const verdict = {
+    mlxKvQuantReason: incomingReason,
+    chatTemplateOverrideReason: incomingTemplateReason,
+    mlxKvQuantNote: incomingNote,
+  };
+  const unseeded =
+    previous.loadedMlxKvBitsRequested === null &&
+    previous.mlxKvBits === null &&
+    previous.mlxKvQuantReason === null &&
+    previous.chatTemplateOverrideReason === null;
+  if (hydratingExistingModel || unseeded) {
+    return {
+      mlxKvBits: incomingRequested,
+      loadedMlxKvBitsRequested: incomingRequested,
+      ...verdict,
+    };
+  }
+  if (incomingRequested === previous.loadedMlxKvBitsRequested) {
+    return {};
+  }
+  const controlIsDirty =
+    previous.mlxKvBits !== previous.loadedMlxKvBitsRequested;
+  return {
+    loadedMlxKvBitsRequested: incomingRequested,
+    ...verdict,
+    ...(controlIsDirty ? {} : { mlxKvBits: incomingRequested }),
+  };
+}

--- a/studio/frontend/src/features/chat/lib/resolve-paired-load-param-seed.ts
+++ b/studio/frontend/src/features/chat/lib/resolve-paired-load-param-seed.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// What a fresh /api/inference/status does to one editable control / loaded-baseline pair.
+// Shared by the per-model load settings group (spec mode, KV dtype, tensor parallel, draft
+// count) so a same-checkpoint reload from another tab or API caller advances baselines
+// without clobbering a genuinely staged edit.
+
+export interface PairedLoadParamState<T> {
+  /** The editable control: what the next load or Apply would send. */
+  control: T | null;
+  /** What the resident server was launched with, as this tab last saw it. */
+  loaded: T | null;
+}
+
+/** The subset of the pair to write back; empty means leave the store alone. */
+export type PairedLoadParamSeed<T> = Partial<PairedLoadParamState<T>>;
+
+export function resolvePairedLoadParamSeed<T>(options: {
+  /** The status echo for this field; undefined on a backend that omits it. */
+  incoming: T | null | undefined;
+  previous: PairedLoadParamState<T>;
+  /** A different model or quant is being adopted, so both fields are stale. */
+  hydratingExistingModel: boolean;
+  /** No load of this tab's own is in flight (``!modelLoading``). */
+  seedLoadParams: boolean;
+  equals?: (a: T | null, b: T | null) => boolean;
+}): PairedLoadParamSeed<T> {
+  const {
+    incoming,
+    previous,
+    hydratingExistingModel,
+    seedLoadParams,
+    equals = (a, b) => a === b,
+  } = options;
+  if (incoming === undefined || !seedLoadParams) {
+    return {};
+  }
+  const unseeded = previous.loaded === null && previous.control === null;
+  if (hydratingExistingModel || unseeded) {
+    return { control: incoming, loaded: incoming };
+  }
+  if (equals(incoming, previous.loaded)) {
+    return {};
+  }
+  const controlIsDirty = !equals(previous.control, previous.loaded);
+  return {
+    loaded: incoming,
+    ...(controlIsDirty ? {} : { control: incoming }),
+  };
+}

--- a/studio/frontend/src/features/chat/lib/resolve-paired-load-param-seed.ts
+++ b/studio/frontend/src/features/chat/lib/resolve-paired-load-param-seed.ts
@@ -25,6 +25,8 @@ export function resolvePairedLoadParamSeed<T>(options: {
   /** No load of this tab's own is in flight (``!modelLoading``). */
   seedLoadParams: boolean;
   equals?: (a: T | null, b: T | null) => boolean;
+  /** Store default for the control while ``loaded`` is still null. */
+  pristineControl?: T | null;
 }): PairedLoadParamSeed<T> {
   const {
     incoming,
@@ -32,11 +34,26 @@ export function resolvePairedLoadParamSeed<T>(options: {
     hydratingExistingModel,
     seedLoadParams,
     equals = (a, b) => a === b,
+    pristineControl,
   } = options;
-  if (incoming === undefined || !seedLoadParams) {
+  if (!seedLoadParams) {
     return {};
   }
-  const unseeded = previous.loaded === null && previous.control === null;
+  if (incoming === undefined) {
+    if (hydratingExistingModel) {
+      return { control: null, loaded: null };
+    }
+    return {};
+  }
+  // A null loaded baseline means this tab has not hydrated the resident server yet.
+  // Non-null store defaults (tensorParallel=false, persisted speculativeType) are not
+  // user edits and must adopt the status echo together with the baseline. Nullable
+  // controls with a staged non-null value while loaded is null are real edits.
+  const unseeded =
+    previous.loaded === null &&
+    (previous.control === null ||
+      (pristineControl !== undefined &&
+        equals(previous.control, pristineControl)));
   if (hydratingExistingModel || unseeded) {
     return { control: incoming, loaded: incoming };
   }

--- a/studio/frontend/tests/load-param-status-seed.test.ts
+++ b/studio/frontend/tests/load-param-status-seed.test.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Same-checkpoint reload reconciliation for the per-model load settings group (#8039).
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import type {
+  PairedLoadParamSeed,
+  PairedLoadParamState,
+} from "../src/features/chat/lib/resolve-paired-load-param-seed.ts";
+import type {
+  MlxKvBitsSeed,
+  MlxKvBitsSeedState,
+} from "../src/features/chat/lib/resolve-mlx-kv-bits-seed.ts";
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { resolvePairedLoadParamSeed } = await import(
+  "../src/features/chat/lib/resolve-paired-load-param-seed.ts"
+);
+const { resolveMlxKvBitsSeed } = await import(
+  "../src/features/chat/lib/resolve-mlx-kv-bits-seed.ts"
+);
+
+const DELEGATES_TO_RESOLVERS =
+  /resolvePairedLoadParamSeed\(\{[\s\S]*resolveMlxKvBitsSeed\(\{/;
+
+function paired<T>(
+  control: T | null,
+  loaded: T | null,
+): PairedLoadParamState<T> {
+  return { control, loaded };
+}
+
+function seed<T>(
+  incoming: T | null | undefined,
+  previous: PairedLoadParamState<T>,
+  options: {
+    hydratingExistingModel?: boolean;
+    seedLoadParams?: boolean;
+  } = {},
+): PairedLoadParamSeed<T> {
+  return resolvePairedLoadParamSeed({
+    incoming,
+    previous,
+    hydratingExistingModel: options.hydratingExistingModel ?? false,
+    seedLoadParams: options.seedLoadParams ?? true,
+  });
+}
+
+function mlxSeed(
+  incomingRequested: number | null,
+  previous: MlxKvBitsSeedState,
+  options: {
+    hydratingExistingModel?: boolean;
+    seedLoadParams?: boolean;
+    isMlx?: boolean;
+  } = {},
+): MlxKvBitsSeed {
+  return resolveMlxKvBitsSeed({
+    isMlx: options.isMlx ?? true,
+    mlxKvBitsDefined: true,
+    incomingRequested,
+    incomingReason: "ok",
+    incomingTemplateReason: null,
+    incomingNote: null,
+    previous,
+    hydratingExistingModel: options.hydratingExistingModel ?? false,
+    seedLoadParams: options.seedLoadParams ?? true,
+  });
+}
+
+test("a same-model reload from another client advances an undirty speculative pair", () => {
+  assert.deepEqual(seed("mtp", paired("auto", "auto")), {
+    control: "mtp",
+    loaded: "mtp",
+  });
+});
+
+test("a dirty speculative control survives while its baseline advances", () => {
+  const result = seed("mtp", paired("ngram", "auto"));
+  assert.deepEqual(result, { loaded: "mtp" });
+});
+
+test("a steady speculative poll touches neither field", () => {
+  assert.deepEqual(seed("auto", paired("auto", "auto")), {});
+  assert.deepEqual(seed("auto", paired("ngram", "auto")), {});
+});
+
+test("tensor parallel and KV dtype follow the same dirty-control rule", () => {
+  assert.deepEqual(seed(true, paired(false, false)), {
+    control: true,
+    loaded: true,
+  });
+  assert.deepEqual(seed("q8_0", paired("q4_0", "q4_0")), {
+    control: "q8_0",
+    loaded: "q8_0",
+  });
+  assert.deepEqual(seed(4, paired(2, 2)), { control: 4, loaded: 4 });
+  assert.deepEqual(seed(4, paired(8, 2)), { loaded: 4 });
+});
+
+test("mlx kv width reconciles on a same-model reload", () => {
+  assert.deepEqual(
+    mlxSeed(8, {
+      mlxKvBits: 4,
+      loadedMlxKvBitsRequested: 4,
+      mlxKvQuantReason: "ok",
+      chatTemplateOverrideReason: null,
+      mlxKvQuantNote: null,
+    }),
+    {
+      mlxKvBits: 8,
+      loadedMlxKvBitsRequested: 8,
+      mlxKvQuantReason: "ok",
+      chatTemplateOverrideReason: null,
+      mlxKvQuantNote: null,
+    },
+  );
+  const dirty = mlxSeed(8, {
+    mlxKvBits: 6,
+    loadedMlxKvBitsRequested: 4,
+    mlxKvQuantReason: "old",
+    chatTemplateOverrideReason: null,
+    mlxKvQuantNote: null,
+  });
+  assert.equal(dirty.loadedMlxKvBitsRequested, 8);
+  assert.ok(!("mlxKvBits" in dirty));
+});
+
+test("the status applier delegates to the paired load-param resolvers", () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(
+    path.join(
+      here,
+      "../src/features/chat/lib/apply-inference-status-to-store.ts",
+    ),
+    "utf8",
+  );
+  assert.match(source, DELEGATES_TO_RESOLVERS);
+  assert.ok(
+    !source.includes("prevState.loadedSpeculativeType === null"),
+    "the inline speculative guard must not survive alongside the resolver",
+  );
+});

--- a/studio/frontend/tests/load-param-status-seed.test.ts
+++ b/studio/frontend/tests/load-param-status-seed.test.ts
@@ -44,6 +44,7 @@ function seed<T>(
   options: {
     hydratingExistingModel?: boolean;
     seedLoadParams?: boolean;
+    pristineControl?: T | null;
   } = {},
 ): PairedLoadParamSeed<T> {
   return resolvePairedLoadParamSeed({
@@ -51,6 +52,7 @@ function seed<T>(
     previous,
     hydratingExistingModel: options.hydratingExistingModel ?? false,
     seedLoadParams: options.seedLoadParams ?? true,
+    pristineControl: options.pristineControl,
   });
 }
 
@@ -91,6 +93,36 @@ test("a dirty speculative control survives while its baseline advances", () => {
 test("a steady speculative poll touches neither field", () => {
   assert.deepEqual(seed("auto", paired("auto", "auto")), {});
   assert.deepEqual(seed("auto", paired("ngram", "auto")), {});
+});
+
+test("an omitted speculative_type leaves the pair alone on older backends", () => {
+  assert.deepEqual(seed(undefined, paired("ngram", "auto")), {});
+});
+
+test("an omitted echo on model change clears a stale pair", () => {
+  assert.deepEqual(
+    seed(undefined, paired("mtp", "mtp"), { hydratingExistingModel: true }),
+    { control: null, loaded: null },
+  );
+});
+
+test("default controls hydrate with the resident server before a loaded baseline exists", () => {
+  assert.deepEqual(seed(true, paired(false, null), { pristineControl: false }), {
+    control: true,
+    loaded: true,
+  });
+  assert.deepEqual(
+    seed("mtp", paired("auto", null), { pristineControl: "auto" }),
+    {
+      control: "mtp",
+      loaded: "mtp",
+    },
+  );
+});
+
+test("a staged draft-token edit survives while loaded baseline is null", () => {
+  assert.deepEqual(seed(null, paired(8, null)), {});
+  assert.deepEqual(seed(4, paired(8, null)), { loaded: 4 });
 });
 
 test("tensor parallel and KV dtype follow the same dirty-control rule", () => {


### PR DESCRIPTION
## Summary

Fixes #8039 — when another tab or an OpenAI-API auto-switch reloads the **same** checkpoint with different load settings, this tab's store kept stale controls and baselines for the per-model load settings group.

## Root cause

`applyActiveModelStatusToStore` only reconciled same-checkpoint reloads for GPU placement (`gpuStatusChanged` + `preserveSameModelEdits`). The other load params only re-seeded on first hydration (`loaded* === null`) or model/variant change (`hydratingExistingModel`):

- `speculativeType` / `loadedSpeculativeType`
- `specDraftNMax` / `loadedSpecDraftNMax`
- `kvCacheDtype` / `loadedKvCacheDtype`
- `tensorParallel` / `loadedTensorParallel`
- MLX KV width + verdict fields

`chatTemplateOverride` already had the correct behavior via `resolveChatTemplateSeed`; this extends that pattern.

## Fix

- Add `resolvePairedLoadParamSeed` for generic control/baseline pairs
- Add `resolveMlxKvBitsSeed` for MLX width + verdict fields
- Route the load settings group through them in `applyActiveModelStatusToStore`

Behavior matches chat-template seeding:
1. **Steady poll** (incoming === loaded): no change
2. **Same-model reload** (incoming !== loaded): always advance `loaded*`; adopt control only if it still matches the old baseline
3. **Staged edit** (control !== loaded): preserve control, advance baseline

## Test plan

- [x] `studio/frontend/tests/load-param-status-seed.test.ts` — speculative, KV, tensor parallel, MLX, dirty-control cases
- [x] Full frontend test suite: 894 passed