### PR TITLE
Match the widened _stream_completion return in four stale assertions

### DIFF
--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -985,7 +985,7 @@ def test_admission_keepalives_do_not_spend_the_first_output_budget(monkeypatch):
     _install_fake_client(monkeypatch, [_QueuedThenServedStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    assert _run_stream(supervisor, timeout_seconds = 5.0) == ("report", "", "stop")
+    assert _run_stream(supervisor, timeout_seconds = 5.0) == ("report", "", "stop", None)
 
 
 def _comment_only_stream(comment: str):
@@ -1052,7 +1052,7 @@ def test_the_queue_wait_is_not_charged_to_the_model_budget(monkeypatch):
     _install_fake_client(monkeypatch, [_QueuedThenAdmitted()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    assert _run_stream(supervisor, timeout_seconds = 10.0) == ("report", "", "stop")
+    assert _run_stream(supervisor, timeout_seconds = 10.0) == ("report", "", "stop", None)
 
 
 def test_the_budget_starts_when_admission_ends(monkeypatch):
@@ -1528,7 +1528,7 @@ def test_first_output_deadline_disarms_once_output_starts(monkeypatch):
     _install_fake_client(monkeypatch, [_LongGenerationStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    report, _reasoning, finish_reason = _run_stream(supervisor, timeout_seconds = 30.0)
+    report, _reasoning, finish_reason, _usage = _run_stream(supervisor, timeout_seconds = 30.0)
     assert finish_reason == "stop"
     assert report.startswith("start w0 w1")
     assert report.endswith("w11")
@@ -1562,7 +1562,7 @@ def test_reasoning_only_prefix_disarms_the_first_output_deadline(monkeypatch):
     _install_fake_client(monkeypatch, [_LongThinkStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    report, reasoning, _finish = _run_stream(supervisor, timeout_seconds = 30.0)
+    report, reasoning, _finish, _usage = _run_stream(supervisor, timeout_seconds = 30.0)
     assert report == "answer"
     assert reasoning.startswith("t0 ")
 
@@ -1728,3 +1728,60 @@ def test_stream_completion_rechecks_the_lease_between_transport_retries(monkeypa
         _run_stream(supervisor)
     assert len(sent) == 1
     assert checks == ["run-1"]
+
+
+def test_every_stream_assertion_matches_the_return_arity():
+    """`_stream_completion`'s tuple width, read from its annotation, must match
+    every comparison and unpack in this file.
+
+    #7985 widened the return to carry `usage` and updated most call sites but
+    not four of them, which reddened the whole repo on every open PR: two
+    compared against a 3-tuple and two unpacked into three names. Nothing here
+    tied the two together, so the drift was invisible until CI ran.
+    """
+    import ast
+    import inspect as _inspect
+    import re
+
+    from core import research_runs as _rr
+
+    annotation = str(_inspect.signature(
+        _rr.ResearchSupervisor._stream_completion).return_annotation)
+    # `tuple[a, b, c, d]` -> 4, counting only top-level commas so that a nested
+    # `dict[str, int]` does not read as two extra members.
+    inner = annotation[annotation.index("[") + 1 : annotation.rindex("]")]
+    depth, width = 0, 1
+    for ch in inner:
+        if ch in "[(": depth += 1
+        elif ch in "])": depth -= 1
+        elif ch == "," and depth == 0: width += 1
+
+    source = Path(__file__).read_text(encoding = "utf-8")
+    tree = ast.parse(source)
+
+    def _calls_run_stream(node):
+        return (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                and node.func.id == "_run_stream")
+
+    compared, unpacked = 0, 0
+    for node in ast.walk(tree):
+        # `_run_stream(...) == (a, b, c, d)`
+        if isinstance(node, ast.Compare) and _calls_run_stream(node.left):
+            for other in node.comparators:
+                if isinstance(other, ast.Tuple):
+                    assert len(other.elts) == width, (
+                        f"line {node.lineno}: compares against a "
+                        f"{len(other.elts)}-tuple, but _stream_completion "
+                        f"returns {width} values")
+                    compared += 1
+        # `a, b, c, d = _run_stream(...)`
+        if isinstance(node, ast.Assign) and _calls_run_stream(node.value):
+            for target in node.targets:
+                if isinstance(target, ast.Tuple):
+                    assert len(target.elts) == width, (
+                        f"line {node.lineno}: unpacks {len(target.elts)} names "
+                        f"from a {width}-value return")
+                    unpacked += 1
+
+    # Not a vacuous pass: both shapes are present in this file today.
+    assert compared >= 5 and unpacked >= 2, (compared, unpacked)

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1745,23 +1745,30 @@ def test_every_stream_assertion_matches_the_return_arity():
 
     from core import research_runs as _rr
 
-    annotation = str(_inspect.signature(
-        _rr.ResearchSupervisor._stream_completion).return_annotation)
+    annotation = str(
+        _inspect.signature(_rr.ResearchSupervisor._stream_completion).return_annotation
+    )
     # `tuple[a, b, c, d]` -> 4, counting only top-level commas so that a nested
     # `dict[str, int]` does not read as two extra members.
     inner = annotation[annotation.index("[") + 1 : annotation.rindex("]")]
     depth, width = 0, 1
     for ch in inner:
-        if ch in "[(": depth += 1
-        elif ch in "])": depth -= 1
-        elif ch == "," and depth == 0: width += 1
+        if ch in "[(":
+            depth += 1
+        elif ch in "])":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            width += 1
 
     source = Path(__file__).read_text(encoding = "utf-8")
     tree = ast.parse(source)
 
     def _calls_run_stream(node):
-        return (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-                and node.func.id == "_run_stream")
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_run_stream"
+        )
 
     compared, unpacked = 0, 0
     for node in ast.walk(tree):
@@ -1772,7 +1779,8 @@ def test_every_stream_assertion_matches_the_return_arity():
                     assert len(other.elts) == width, (
                         f"line {node.lineno}: compares against a "
                         f"{len(other.elts)}-tuple, but _stream_completion "
-                        f"returns {width} values")
+                        f"returns {width} values"
+                    )
                     compared += 1
         # `a, b, c, d = _run_stream(...)`
         if isinstance(node, ast.Assign) and _calls_run_stream(node.value):
@@ -1780,7 +1788,8 @@ def test_every_stream_assertion_matches_the_return_arity():
                 if isinstance(target, ast.Tuple):
                     assert len(target.elts) == width, (
                         f"line {node.lineno}: unpacks {len(target.elts)} names "
-                        f"from a {width}-value return")
+                        f"from a {width}-value return"
+                    )
                     unpacked += 1
 
     # Not a vacuous pass: both shapes are present in this file today.

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1731,8 +1731,7 @@ def test_stream_completion_rechecks_the_lease_between_transport_retries(monkeypa
 
 
 def test_every_stream_assertion_matches_the_return_arity():
-    """Every `_run_stream` comparison and unpack must match the tuple width
-    `_stream_completion` declares.
+    """Every `_run_stream` compare and unpack must match `_stream_completion`'s arity.
 
     #7985 widened the return to carry `usage` and missed four call sites here,
     reddening every open PR. Nothing tied the two together, so it took CI.

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1731,25 +1731,21 @@ def test_stream_completion_rechecks_the_lease_between_transport_retries(monkeypa
 
 
 def test_every_stream_assertion_matches_the_return_arity():
-    """`_stream_completion`'s tuple width, read from its annotation, must match
-    every comparison and unpack in this file.
+    """Every `_run_stream` comparison and unpack must match the tuple width
+    `_stream_completion` declares.
 
-    #7985 widened the return to carry `usage` and updated most call sites but
-    not four of them, which reddened the whole repo on every open PR: two
-    compared against a 3-tuple and two unpacked into three names. Nothing here
-    tied the two together, so the drift was invisible until CI ran.
+    #7985 widened the return to carry `usage` and missed four call sites here,
+    reddening every open PR. Nothing tied the two together, so it took CI.
     """
     import ast
     import inspect as _inspect
-    import re
 
     from core import research_runs as _rr
 
     annotation = str(
         _inspect.signature(_rr.ResearchSupervisor._stream_completion).return_annotation
     )
-    # `tuple[a, b, c, d]` -> 4, counting only top-level commas so that a nested
-    # `dict[str, int]` does not read as two extra members.
+    # Top-level commas only, so a nested `dict[str, int]` is one member.
     inner = annotation[annotation.index("[") + 1 : annotation.rindex("]")]
     depth, width = 0, 1
     for ch in inner:


### PR DESCRIPTION
Four assertions in `test_research_runs_hardening.py` still expect the 3-tuple `_stream_completion` returned before #7985 widened it to carry `usage`:

```
E   AssertionError: assert ('report', '', 'stop', None) == ('report', '', 'stop')
E   ValueError: too many values to unpack (expected 3)
```

Two compare against a 3-tuple, two unpack into three names. Most call sites in the file were updated with that change; these were missed.

Why it matters beyond this file

`Backend tests` runs on every Python in the matrix, so this is red on 3.10, 3.11, 3.12 and 3.13 for every open PR regardless of what that PR touches. Confirmed on two branches that share no files with this one and no files with each other: #8110 (`tests/security/`) and #8115 (`tests/python/`, `tests/studio/`) fail identically.

The change

The four sites, updated to the current arity. `usage` is `None` in these fixtures, so the added element is `None` in the comparisons and `_usage` in the unpacks.

Plus a guard, because nothing tied the two together and that is why the drift was invisible until CI ran. `test_every_stream_assertion_matches_the_return_arity` reads the tuple width from `_stream_completion`'s own return annotation and checks every `_run_stream` comparison and unpack in the file against it. It counts only top-level commas, so the nested `dict[str, int]` does not read as two extra members, and it asserts that both shapes are actually present so it cannot pass vacuously.

Verification

- `tests/test_research_runs_hardening.py`: 122 passed.
- The guard fails on the pre-fix file: restoring one stale assertion turns it red, so it catches exactly the drift it is for.
