### PR TITLE
Fix training to honor locally selected model cache version

### DIFF
--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -851,9 +851,7 @@ class UnslothTrainer:
         self.trust_remote_code = trust_remote_code  # For AutoProcessor etc. used during training
         lookup_name = model_load_name or model_name
         exact_model_name = (
-            use_exact_model_name
-            if use_exact_model_name is not None
-            else model_revision is not None
+            use_exact_model_name if use_exact_model_name is not None else model_revision is not None
         )
         self.model_load_error = None
         try:

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -844,11 +844,17 @@ class UnslothTrainer:
         local_files_only: bool = False,
         actual_model_repo_id: Optional[str] = None,
         model_revision: Optional[str] = None,
+        use_exact_model_name: Optional[bool] = None,
     ) -> bool:
         """Load model for training (supports both text and vision models)"""
         self.load_in_4bit = load_in_4bit  # For training_meta.json
         self.trust_remote_code = trust_remote_code  # For AutoProcessor etc. used during training
         lookup_name = model_load_name or model_name
+        exact_model_name = (
+            use_exact_model_name
+            if use_exact_model_name is not None
+            else model_revision is not None
+        )
         self.model_load_error = None
         try:
             if self.model is not None:
@@ -1008,7 +1014,7 @@ class UnslothTrainer:
                     token = hf_token,
                     trust_remote_code = trust_remote_code,
                     revision = model_revision,
-                    use_exact_model_name = model_revision is not None,
+                    use_exact_model_name = exact_model_name,
                 )
                 logger.info("Loaded CSM audio model")
 
@@ -1029,7 +1035,7 @@ class UnslothTrainer:
                     token = hf_token,
                     trust_remote_code = trust_remote_code,
                     revision = model_revision,
-                    use_exact_model_name = model_revision is not None,
+                    use_exact_model_name = exact_model_name,
                 )
                 # Generation settings (notebook lines 100-105)
                 self.model.generation_config.language = "<|en|>"
@@ -1050,7 +1056,7 @@ class UnslothTrainer:
                     token = hf_token,
                     trust_remote_code = trust_remote_code,
                     revision = model_revision,
-                    use_exact_model_name = model_revision is not None,
+                    use_exact_model_name = exact_model_name,
                 )
                 logger.info(f"Loaded {self._audio_type} audio model (FastLanguageModel)")
 
@@ -1100,7 +1106,7 @@ class UnslothTrainer:
                     token = hf_token,
                     trust_remote_code = trust_remote_code,
                     revision = model_revision,
-                    use_exact_model_name = model_revision is not None,
+                    use_exact_model_name = exact_model_name,
                 )
                 logger.info("Loaded OuteTTS (dac) model (FastModel)")
 
@@ -1117,7 +1123,7 @@ class UnslothTrainer:
                     token = hf_token,
                     trust_remote_code = trust_remote_code,
                     revision = model_revision,
-                    use_exact_model_name = model_revision is not None,
+                    use_exact_model_name = exact_model_name,
                 )
                 logger.info("Loaded audio VLM model (FastModel)")
 
@@ -1132,7 +1138,7 @@ class UnslothTrainer:
                     token = hf_token,
                     trust_remote_code = trust_remote_code,
                     revision = model_revision,
-                    use_exact_model_name = model_revision is not None,
+                    use_exact_model_name = exact_model_name,
                 )
                 logger.info("Loaded vision model")
 
@@ -1160,7 +1166,7 @@ class UnslothTrainer:
                     token = hf_token,
                     trust_remote_code = trust_remote_code,
                     revision = model_revision,
-                    use_exact_model_name = model_revision is not None,
+                    use_exact_model_name = exact_model_name,
                 )
                 logger.info("Loaded text model")
 
@@ -1210,6 +1216,7 @@ class UnslothTrainer:
                     local_files_only = local_files_only,
                     actual_model_repo_id = actual_model_repo_id,
                     model_revision = model_revision,
+                    use_exact_model_name = use_exact_model_name,
                 )
             error_msg = str(e)
             error_lower = error_msg.lower()

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -322,6 +322,40 @@ _MODEL_SNAPSHOT_WEIGHTS = (
 )
 
 
+def _repo_id_from_cache_local_path(local_path: str) -> Optional[str]:
+    """Recover the Hugging Face repo id encoded in a cache directory or snapshot path."""
+    from core.inference.model_ids import hf_cache_repo_id
+
+    repo_id = hf_cache_repo_id(local_path)
+    if repo_id:
+        return repo_id
+    try:
+        resolved = Path(local_path).expanduser().resolve(strict = True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    for candidate in (resolved, *resolved.parents):
+        name = candidate.name
+        if name.startswith("models--") and name.count("--") >= 2:
+            return name.removeprefix("models--").replace("--", "/")
+    return None
+
+
+def _model_snapshot_repo_candidates(model_name: str, local_path: Optional[str]) -> tuple[str, ...]:
+    """Repo ids to try when resolving a user-selected cache path for training."""
+    from utils.paths.path_utils import resolve_cached_repo_id_case
+
+    candidates: list[str] = []
+    if not is_local_path(model_name):
+        resolved_name = resolve_cached_repo_id_case(canonical_model_repo_id(model_name))
+        if resolved_name:
+            candidates.append(resolved_name)
+    if local_path:
+        path_repo_id = _repo_id_from_cache_local_path(local_path)
+        if path_repo_id and path_repo_id not in candidates:
+            candidates.append(path_repo_id)
+    return tuple(candidates)
+
+
 def _with_load_subdirs(model_name: str, names: tuple[str, ...]) -> tuple[str, ...]:
     """Extend snapshot filenames with the subdirectories a load actually reads.
 
@@ -341,7 +375,9 @@ def _resolve_model_snapshot(model_name: str, local_path: Optional[str]) -> Optio
         latest_snapshot_from_cache_path,
     )
 
-    repo_id = canonical_model_repo_id(model_name)
+    repo_ids = _model_snapshot_repo_candidates(model_name, local_path)
+    if not repo_ids and not is_local_path(model_name):
+        repo_ids = (canonical_model_repo_id(model_name),)
     metadata_names = _with_load_subdirs(model_name, _MODEL_SNAPSHOT_METADATA)
     weight_names = _with_load_subdirs(model_name, _MODEL_SNAPSHOT_WEIGHTS)
     # Pass 1 demands metadata AND weights, so neither a metadata-only refs/main nor a
@@ -351,21 +387,28 @@ def _resolve_model_snapshot(model_name: str, local_path: Optional[str]) -> Optio
         {"metadata_filenames": metadata_names},
     )
     if local_path:
-        for kwargs in passes:
-            snapshot = latest_snapshot_from_cache_path(local_path, "model", repo_id, **kwargs)
-            if snapshot:
-                return snapshot
+        for repo_id in repo_ids:
+            for kwargs in passes:
+                snapshot = latest_snapshot_from_cache_path(
+                    local_path,
+                    "model",
+                    repo_id,
+                    **kwargs,
+                )
+                if snapshot:
+                    return snapshot
         return None
-    for kwargs in passes:
-        for repo_dir in iter_repo_cache_dirs("model", repo_id):
-            snapshot = latest_snapshot_from_cache_path(
-                str(repo_dir),
-                "model",
-                repo_id,
-                **kwargs,
-            )
-            if snapshot:
-                return snapshot
+    for repo_id in repo_ids:
+        for kwargs in passes:
+            for repo_dir in iter_repo_cache_dirs("model", repo_id):
+                snapshot = latest_snapshot_from_cache_path(
+                    str(repo_dir),
+                    "model",
+                    repo_id,
+                    **kwargs,
+                )
+                if snapshot:
+                    return snapshot
     return None
 
 
@@ -437,8 +480,13 @@ def _apply_model_cache_pin(config: dict[str, Any], warnings: list[str]) -> None:
         else:
             config["model_revision"] = Path(pin).name
     elif model_claimed:
+        local_path = config.get("model_local_path")
         pinned_repo_id = canonical_model_repo_id(model_name)
-        pin = _resolve_model_snapshot(model_name, config.get("model_local_path"))
+        if local_path:
+            path_repo_id = _repo_id_from_cache_local_path(str(local_path))
+            if path_repo_id:
+                pinned_repo_id = path_repo_id
+        pin = _resolve_model_snapshot(model_name, local_path)
         if pin is None:
             warnings.append(
                 f"Cached copy of {model_name} not found on disk; downloading from Hugging Face."

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -92,6 +92,23 @@ def _resolve_cached_model_load_name(config: dict) -> str:
     return config.get("model_snapshot_path") or config["model_name"]
 
 
+def _training_use_exact_model_name(config: dict) -> bool:
+    """Keep Studio's selected model version when loading from cache or after a pin.
+
+    Without this, Unsloth's mapper can rewrite a user-selected base repo (e.g.
+    ``unsloth/Qwen3-4B-Instruct-2507``) to its ``-unsloth-bnb-4bit`` sibling when
+    ``load_in_4bit`` is enabled, even though the user explicitly picked the local
+    cache for the base repo.
+    """
+    if config.get("model_revision"):
+        return True
+    if config.get("model_snapshot_path"):
+        return True
+    if config.get("model_known_cached") or config.get("model_local_path"):
+        return True
+    return False
+
+
 def _effective_training_load_in_4bit(
     config: dict, model_load_target: str, hf_token: str | None
 ) -> bool:
@@ -2600,6 +2617,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
     model_load_name = _resolve_cached_model_load_name(config)
     model_local_only = _model_local_files_only(config)
     model_revision = None if model_local_only else config.get("model_revision")
+    use_exact_model_name = _training_use_exact_model_name(config)
 
     if config.get("use_loftq"):
         message = "LoftQ is not supported for MLX training yet."
@@ -4077,6 +4095,7 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
         model_load_name = _resolve_cached_model_load_name(config)
         model_local_only = _model_local_files_only(config)
         model_revision = None if model_local_only else config.get("model_revision")
+        use_exact_model_name = _training_use_exact_model_name(config)
         dataset_local_only = _dataset_local_files_only(config)
         eval_steps = config.get("eval_steps", 0.00)
 
@@ -4250,6 +4269,7 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                 local_files_only = model_local_only,
                 actual_model_repo_id = config.get("actual_model_repo_id"),
                 model_revision = model_revision,
+                use_exact_model_name = use_exact_model_name,
             )
             fallback_error = (
                 _model_cache_fallback_error(config, trainer.model_load_error)
@@ -4314,6 +4334,7 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                         local_files_only = model_local_only,
                         actual_model_repo_id = config.get("actual_model_repo_id"),
                         model_revision = model_revision,
+                        use_exact_model_name = use_exact_model_name,
                     )
         finally:
             _load_watchdog_stop.set()
@@ -4842,6 +4863,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
     model_load_name = _resolve_cached_model_load_name(config)
     model_local_only = _model_local_files_only(config)
     model_revision = None if model_local_only else config.get("model_revision")
+    use_exact_model_name = _training_use_exact_model_name(config)
     training_start_time = time.time()
 
     # ── 1. Import embedding-specific libraries ──
@@ -4919,7 +4941,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
                 full_finetuning = not use_lora,
                 token = hf_token,
                 revision = model_revision,
-                use_exact_model_name = model_revision is not None,
+                use_exact_model_name = use_exact_model_name,
             )
         except Exception as error:
             if not model_local_only:
@@ -4947,7 +4969,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
                 full_finetuning = not use_lora,
                 token = hf_token,
                 revision = model_revision,
-                use_exact_model_name = model_revision is not None,
+                use_exact_model_name = use_exact_model_name,
             )
     except Exception as e:
         event_queue.put(

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -2013,6 +2013,69 @@ def test_resolve_model_snapshot_keeps_selected_cache_path_strict(monkeypatch):
     assert set(resolved_paths) == {str(fallback_path)}
 
 
+def test_resolve_model_snapshot_uses_cache_path_repo_id(tmp_path):
+    from core.training.training import _resolve_model_snapshot
+
+    repo_root = tmp_path / "models--Qwen--Qwen3-4B-Instruct-2507"
+    snap = repo_root / "snapshots" / "rev"
+    snap.mkdir(parents = True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors").write_bytes(b"x")
+    (repo_root / "refs").mkdir()
+    (repo_root / "refs" / "main").write_text("rev")
+
+    resolved = _resolve_model_snapshot(
+        "unsloth/Qwen3-4B-Instruct-2507",
+        str(repo_root),
+    )
+
+    assert resolved == str(snap.resolve())
+
+
+def test_apply_cache_pins_records_path_repo_id(tmp_path):
+    from core.training.training import _apply_cache_pins
+
+    repo_root = tmp_path / "models--Qwen--Qwen3-4B-Instruct-2507"
+    snap = repo_root / "snapshots" / "rev"
+    snap.mkdir(parents = True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors").write_bytes(b"x")
+    (repo_root / "refs").mkdir()
+    (repo_root / "refs" / "main").write_text("rev")
+
+    config = {
+        "model_name": "unsloth/Qwen3-4B-Instruct-2507",
+        "model_known_cached": True,
+        "model_local_path": str(repo_root),
+        "hf_dataset": "",
+    }
+    _apply_cache_pins(config)
+
+    assert config["model_snapshot_path"] == str(snap.resolve())
+    assert config["actual_model_repo_id"] == "Qwen/Qwen3-4B-Instruct-2507"
+
+
+def test_training_use_exact_model_name_for_cached_selection():
+    from core.training import worker
+
+    assert worker._training_use_exact_model_name(
+        {
+            "model_name": "unsloth/Qwen3-4B-Instruct-2507",
+            "model_known_cached": True,
+            "model_local_path": "/cache/models--unsloth--Qwen3-4B-Instruct-2507",
+        }
+    )
+    assert worker._training_use_exact_model_name(
+        {
+            "model_name": "unsloth/Qwen3-4B-Instruct-2507",
+            "model_snapshot_path": "/cache/models--unsloth--Qwen3-4B-Instruct-2507/snapshots/rev",
+        }
+    )
+    assert not worker._training_use_exact_model_name(
+        {"model_name": "unsloth/Qwen3-4B-Instruct-2507"}
+    )
+
+
 @pytest.mark.parametrize(
     "resume_from_checkpoint",
     [None, "/outputs/run/checkpoint-5"],

--- a/studio/frontend/src/features/training/api/mappers.ts
+++ b/studio/frontend/src/features/training/api/mappers.ts
@@ -89,13 +89,16 @@ export function buildTrainingStartPayload(
     }
   }
 
+  const preferLocalModelCache =
+    config.modelKnownCached || Boolean(config.modelLocalPath?.trim());
+
   return {
     model_name: config.selectedModel ?? "",
     project_name: (config.projectName || "").trim() || null,
     training_type: toBackendTrainingType(config.trainingMethod),
     hf_token: hfToken,
-    model_known_cached: config.modelKnownCached,
-    model_local_path: config.modelKnownCached ? config.modelLocalPath : null,
+    model_known_cached: preferLocalModelCache,
+    model_local_path: preferLocalModelCache ? config.modelLocalPath : null,
     model_format: config.modelFormat,
     load_in_4bit: trainingLoadsIn4Bit(config),
     max_seq_length: config.contextLength,


### PR DESCRIPTION
## Summary

Fixes #8113

When a user selects a locally cached model for fine-tuning (e.g. `unsloth/Qwen3-4B-Instruct-2507`), training could ignore that selection and download the mapped `-unsloth-bnb-4bit` variant from Hugging Face instead.

This PR:

- Resolves cached model snapshots using the repo id encoded in the selected cache path, not only the UI model name (handles cases where the cached copy is under a different org/repo spelling).
- Passes `use_exact_model_name` during training loads whenever the user selected a cached model or a snapshot pin is active, preventing Unsloth's mapper from rewriting the repo id to a different variant.
- Forwards `model_local_path` in the training start payload whenever a cache path is present in the UI state (not only when `modelKnownCached` is true).

## Test plan

- [x] `test_resolve_model_snapshot_uses_cache_path_repo_id`
- [x] `test_apply_cache_pins_records_path_repo_id`
- [x] `test_training_use_exact_model_name_for_cached_selection`
- [x] Frontend test suite (`npm test`) passes