### PR TITLE
Stop the CUDA test spoofs reporting an exhausted card

### DIFF
--- a/tests/_zoo_aggressive_cuda_spoof.py
+++ b/tests/_zoo_aggressive_cuda_spoof.py
@@ -64,13 +64,9 @@ def apply() -> None:
     class _CudaRt:
         @staticmethod
         def cudaMemGetInfo(device: int = 0):
-            # FREE first, then total. Zero free is not a state any real idle GPU
-            # reports, and `torch.cuda.mem_get_info` delegates straight to here,
-            # so every consumer that sizes work against the free pool saw an
-            # exhausted card: unsloth_zoo's fused cross entropy divides by half
-            # of it and raises "No or negligible GPU memory available" rather
-            # than chunking, which failed `test_sft_trains_on_cpu` on a host
-            # with four idle GPUs.
+            # (free, total), and `torch.cuda.mem_get_info` delegates here. Zero
+            # free is an exhausted card: the fused loss takes half of it as its
+            # chunk target and raises instead of chunking.
             return (60 * 1024**3, 80 * 1024**3)
 
         @staticmethod

--- a/tests/_zoo_aggressive_cuda_spoof.py
+++ b/tests/_zoo_aggressive_cuda_spoof.py
@@ -64,7 +64,14 @@ def apply() -> None:
     class _CudaRt:
         @staticmethod
         def cudaMemGetInfo(device: int = 0):
-            return (0, 80 * 1024**3)
+            # FREE first, then total. Zero free is not a state any real idle GPU
+            # reports, and `torch.cuda.mem_get_info` delegates straight to here,
+            # so every consumer that sizes work against the free pool saw an
+            # exhausted card: unsloth_zoo's fused cross entropy divides by half
+            # of it and raises "No or negligible GPU memory available" rather
+            # than chunking, which failed `test_sft_trains_on_cpu` on a host
+            # with four idle GPUs.
+            return (60 * 1024**3, 80 * 1024**3)
 
         @staticmethod
         def cudaGetDeviceCount(*_a, **_k):
@@ -80,7 +87,7 @@ def apply() -> None:
     try:
         import torch.cuda.memory as _cuda_memory  # type: ignore
 
-        _cuda_memory.mem_get_info = lambda *a, **k: (0, 80 * 1024**3)
+        _cuda_memory.mem_get_info = lambda *a, **k: (60 * 1024**3, 80 * 1024**3)
         _cuda_memory.memory_stats = lambda *a, **k: {}
         _cuda_memory.memory_allocated = lambda *a, **k: 0
         _cuda_memory.max_memory_allocated = lambda *a, **k: 0

--- a/tests/_zoo_aggressive_cuda_spoof.py
+++ b/tests/_zoo_aggressive_cuda_spoof.py
@@ -64,9 +64,8 @@ def apply() -> None:
     class _CudaRt:
         @staticmethod
         def cudaMemGetInfo(device: int = 0):
-            # (free, total), and `torch.cuda.mem_get_info` delegates here. Zero
-            # free is an exhausted card: the fused loss takes half of it as its
-            # chunk target and raises instead of chunking.
+            # (free, total), where `torch.cuda.mem_get_info` delegates. Zero free
+            # is an exhausted card, and the fused loss raises instead of chunking.
             return (60 * 1024**3, 80 * 1024**3)
 
         @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,10 @@ def _patch_torch_cuda_for_import() -> None:
     (real-tensor tests still run on CPU)."""
     try:
         import torch.cuda.memory as _cuda_memory  # type: ignore
-        _cuda_memory.mem_get_info = lambda *a, **k: (0, 80 * 1024**3)
+        # Free first, then total. Zero free is not a plausible Ampere value: it
+        # is an exhausted card, and code that sizes work against the free pool
+        # treats it as fatal rather than importing.
+        _cuda_memory.mem_get_info = lambda *a, **k: (60 * 1024**3, 80 * 1024**3)
     except Exception:
         pass
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,7 @@ def _patch_torch_cuda_for_import() -> None:
     (real-tensor tests still run on CPU)."""
     try:
         import torch.cuda.memory as _cuda_memory  # type: ignore
+
         # Free first, then total. Zero free is not a plausible Ampere value: it
         # is an exhausted card, and code that sizes work against the free pool
         # treats it as fatal rather than importing.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,9 +98,8 @@ def _patch_torch_cuda_for_import() -> None:
     try:
         import torch.cuda.memory as _cuda_memory  # type: ignore
 
-        # Free first, then total. Zero free is not a plausible Ampere value: it
-        # is an exhausted card, and code that sizes work against the free pool
-        # treats it as fatal rather than importing.
+        # (free, total). Zero free is an exhausted card, not a plausible
+        # Ampere value, and callers that size against it treat it as fatal.
         _cuda_memory.mem_get_info = lambda *a, **k: (60 * 1024**3, 80 * 1024**3)
     except Exception:
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,8 +98,8 @@ def _patch_torch_cuda_for_import() -> None:
     try:
         import torch.cuda.memory as _cuda_memory  # type: ignore
 
-        # (free, total). Zero free is an exhausted card, not a plausible
-        # Ampere value, and callers that size against it treat it as fatal.
+        # (free, total). Zero free is an exhausted card, which callers that size
+        # against it treat as fatal.
         _cuda_memory.mem_get_info = lambda *a, **k: (60 * 1024**3, 80 * 1024**3)
     except Exception:
         pass

--- a/tests/test_cuda_spoof_reports_free_memory.py
+++ b/tests/test_cuda_spoof_reports_free_memory.py
@@ -1,0 +1,79 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Every CUDA spoof in the suite must report a plausible amount of FREE memory.
+
+`torch.cuda.mem_get_info` returns `(free, total)` and delegates to
+`cudart().cudaMemGetInfo`, so a spoof answering zero free describes an exhausted
+card. Code that sizes work against the free pool then refuses to run at all:
+unsloth_zoo's fused cross entropy takes half of it as its chunk target and
+raises "No or negligible GPU memory available for fused cross entropy" instead
+of chunking. That failed `test_sft_trains_on_cpu` on a host with four idle GPUs,
+and read as a product bug for as long as nobody looked at the fixture.
+
+Source-level, because importing either spoof mutates the interpreter's torch.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parent
+_SPOOFS = ("conftest.py", "_zoo_aggressive_cuda_spoof.py")
+
+
+def _memory_tuples(path):
+    """Every `(free, total)` literal a memory probe in `path` hands back."""
+    found = []
+    tree = ast.parse(path.read_text(encoding = "utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and node.targets:
+            name = getattr(node.targets[0], "attr", "") or ""
+            values = [node.value]
+        elif isinstance(node, ast.FunctionDef):
+            name = node.name
+            values = [n.value for n in ast.walk(node)
+                      if isinstance(n, ast.Return) and n.value]
+        else:
+            continue
+        if "memgetinfo" not in name.lower().replace("_", ""):
+            continue
+        for value in values:
+            if isinstance(value, ast.Lambda):
+                value = value.body
+            if not (isinstance(value, ast.Tuple) and len(value.elts) == 2):
+                continue
+            try:
+                # `ast.literal_eval` cannot fold `60 * 1024**3`, which is how
+                # every one of these is written. Evaluate the arithmetic with
+                # nothing in scope instead.
+                found.append(tuple(
+                    eval(ast.unparse(e), {"__builtins__": {}}, {}) for e in value.elts
+                ))
+            except Exception:
+                pass
+    return found
+
+
+@pytest.mark.parametrize("filename", _SPOOFS)
+def test_a_spoofed_card_is_not_reported_as_full(filename):
+    tuples = _memory_tuples(_ROOT / filename)
+    assert tuples, f"no mem_get_info tuple found in {filename}; did it move?"
+    for free, total in tuples:
+        assert free > 0, f"{filename} reports {free} bytes free, i.e. an exhausted card"
+        assert free <= total, f"{filename} reports more free ({free}) than total ({total})"
+        # Half the free pool is the fused loss's chunk target, capped at 4GB.
+        # Under 8GB free changes the sizing the rest of the suite assumes.
+        assert free >= 8 * 1024 ** 3, f"{filename} reports only {free} bytes free"

--- a/tests/test_cuda_spoof_reports_free_memory.py
+++ b/tests/test_cuda_spoof_reports_free_memory.py
@@ -12,15 +12,13 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""Every CUDA spoof in the suite must report a plausible amount of FREE memory.
+"""Every CUDA spoof must report a plausible amount of FREE memory.
 
 `torch.cuda.mem_get_info` returns `(free, total)` and delegates to
 `cudart().cudaMemGetInfo`, so a spoof answering zero free describes an exhausted
-card. Code that sizes work against the free pool then refuses to run at all:
-unsloth_zoo's fused cross entropy takes half of it as its chunk target and
-raises "No or negligible GPU memory available for fused cross entropy" instead
-of chunking. That failed `test_sft_trains_on_cpu` on a host with four idle GPUs,
-and read as a product bug for as long as nobody looked at the fixture.
+card. unsloth_zoo's fused cross entropy takes half of it as its chunk target and
+raises rather than chunking, which failed `test_sft_trains_on_cpu` on a host with
+four idle GPUs and read as a product bug until someone read the fixture.
 
 Source-level, because importing either spoof mutates the interpreter's torch.
 """
@@ -55,9 +53,8 @@ def _memory_tuples(path):
             if not (isinstance(value, ast.Tuple) and len(value.elts) == 2):
                 continue
             try:
-                # `ast.literal_eval` cannot fold `60 * 1024**3`, which is how
-                # every one of these is written. Evaluate the arithmetic with
-                # nothing in scope instead.
+                # `literal_eval` cannot fold `60 * 1024**3`, which is how these
+                # are written. Evaluate with nothing in scope instead.
                 found.append(
                     tuple(eval(ast.unparse(e), {"__builtins__": {}}, {}) for e in value.elts)
                 )
@@ -74,5 +71,4 @@ def test_a_spoofed_card_is_not_reported_as_full(filename):
         assert free > 0, f"{filename} reports {free} bytes free, i.e. an exhausted card"
         assert free <= total, f"{filename} reports more free ({free}) than total ({total})"
         # Half the free pool is the fused loss's chunk target, capped at 4GB.
-        # Under 8GB free changes the sizing the rest of the suite assumes.
         assert free >= 8 * 1024**3, f"{filename} reports only {free} bytes free"

--- a/tests/test_cuda_spoof_reports_free_memory.py
+++ b/tests/test_cuda_spoof_reports_free_memory.py
@@ -16,9 +16,8 @@
 
 `torch.cuda.mem_get_info` returns `(free, total)` and delegates to
 `cudart().cudaMemGetInfo`, so a spoof answering zero free describes an exhausted
-card. unsloth_zoo's fused cross entropy takes half of it as its chunk target and
-raises rather than chunking, which failed `test_sft_trains_on_cpu` on a host with
-four idle GPUs and read as a product bug until someone read the fixture.
+card. The fused cross entropy then raises rather than chunking, which failed
+`test_sft_trains_on_cpu` on a host with four idle GPUs and read as a product bug.
 
 Source-level, because importing either spoof mutates the interpreter's torch.
 """
@@ -53,8 +52,8 @@ def _memory_tuples(path):
             if not (isinstance(value, ast.Tuple) and len(value.elts) == 2):
                 continue
             try:
-                # `literal_eval` cannot fold `60 * 1024**3`, which is how these
-                # are written. Evaluate with nothing in scope instead.
+                # `literal_eval` cannot fold `60 * 1024**3`, so evaluate with
+                # nothing in scope instead.
                 found.append(
                     tuple(eval(ast.unparse(e), {"__builtins__": {}}, {}) for e in value.elts)
                 )

--- a/tests/test_cuda_spoof_reports_free_memory.py
+++ b/tests/test_cuda_spoof_reports_free_memory.py
@@ -44,8 +44,7 @@ def _memory_tuples(path):
             values = [node.value]
         elif isinstance(node, ast.FunctionDef):
             name = node.name
-            values = [n.value for n in ast.walk(node)
-                      if isinstance(n, ast.Return) and n.value]
+            values = [n.value for n in ast.walk(node) if isinstance(n, ast.Return) and n.value]
         else:
             continue
         if "memgetinfo" not in name.lower().replace("_", ""):
@@ -59,9 +58,9 @@ def _memory_tuples(path):
                 # `ast.literal_eval` cannot fold `60 * 1024**3`, which is how
                 # every one of these is written. Evaluate the arithmetic with
                 # nothing in scope instead.
-                found.append(tuple(
-                    eval(ast.unparse(e), {"__builtins__": {}}, {}) for e in value.elts
-                ))
+                found.append(
+                    tuple(eval(ast.unparse(e), {"__builtins__": {}}, {}) for e in value.elts)
+                )
             except Exception:
                 pass
     return found
@@ -76,4 +75,4 @@ def test_a_spoofed_card_is_not_reported_as_full(filename):
         assert free <= total, f"{filename} reports more free ({free}) than total ({total})"
         # Half the free pool is the fused loss's chunk target, capped at 4GB.
         # Under 8GB free changes the sizing the rest of the suite assumes.
-        assert free >= 8 * 1024 ** 3, f"{filename} reports only {free} bytes free"
+        assert free >= 8 * 1024**3, f"{filename} reports only {free} bytes free"


### PR DESCRIPTION
## The bug

Both CUDA spoofs answer `mem_get_info` as `(0, 80 * 1024**3)`:

- `tests/conftest.py:100`, whose docstring says it returns "plausible Ampere values"
- `tests/_zoo_aggressive_cuda_spoof.py`, in `_CudaRt.cudaMemGetInfo`

That tuple is `(free, total)`, so what it actually describes is a card with nothing left. And `torch.cuda.mem_get_info` delegates to `cudart().cudaMemGetInfo`, so patching only the `torch.cuda.memory` binding does not help: the aggressive spoof's zero is what every caller sees.

Anything that sizes work against the free pool then refuses to run. `unsloth_zoo`'s fused cross entropy takes half of it as its chunk target:

```python
free, total = torch.cuda.mem_get_info(0)
target_gb = min(free / 1024**3 * 0.5, 4.0)
if target_gb <= 1e-9:
    raise RuntimeError("Unsloth: No or negligible GPU memory available for fused cross entropy.")
```

so it raises rather than chunking, and `tests/version_compat/test_trl_fake_train_cpu.py::test_sft_trains_on_cpu` fails on a host with four completely idle GPUs. The error names GPU memory, so it reads as a product bug until you look at the fixture.

CI does not run that file (`studio-backend-ci.yml` passes `--ignore=tests/version_compat`, and `version-compat-ci.yml` runs only the pinned-symbol files), which is why this has been red only locally.

## The change

Both spoofs report 60GB free of 80GB. Nothing else about them moves.

`tests/test_cuda_spoof_reports_free_memory.py` holds every `mem_get_info` spoof in the suite to a positive free figure that does not exceed the total, and to at least 8GB, since half the free pool is the fused loss's chunk target and it caps that at 4GB. It reads the sources with `ast` rather than importing them, because importing either spoof mutates the interpreter's `torch` for whatever runs next. It fails on `main` for both files.

## Tests

`tests/version_compat/` goes from `1 failed, 1580 passed` to `1620 passed, 191 skipped` together with the rest of the spoof consumers (`tests/studio/test_xpu_spoof_pipeline.py`, `tests/test_gguf_basename_platform_matrix.py`, `tests/vllm_compat/`).

Two failures in `tests/vllm_compat/test_unsloth_zoo_imports.py` are unrelated and reproduce identically on a clean `main` checkout.