### PR TITLE
Attach save_lora without a vLLM engine

### DIFF
--- a/tests/test_save_lora_without_vllm.py
+++ b/tests/test_save_lora_without_vllm.py
@@ -36,8 +36,7 @@ import pathlib
 
 import pytest
 
-_UTILS = (pathlib.Path(__file__).resolve().parents[1]
-          / "unsloth" / "models" / "_utils.py")
+_UTILS = pathlib.Path(__file__).resolve().parents[1] / "unsloth" / "models" / "_utils.py"
 
 
 def _patch_function():

--- a/tests/test_save_lora_without_vllm.py
+++ b/tests/test_save_lora_without_vllm.py
@@ -14,19 +14,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """`save_lora` must be attached with or without a vLLM engine.
 
-`patch_peft_fast_inference` set `save_lora` only inside `if vllm_engine is not
-None`, but unsloth_zoo's `save_lora` is `save_pretrained` over the lora_A/lora_B
-keys of the state dict and never touches the engine. So a GRPO run with
-`fast_inference = False` reached the notebook's `model.save_lora(...)` and got
-
-    AttributeError: 'Lfm2ForCausalLM' object has no attribute 'save_lora'
-
-which names neither vLLM nor the flag that caused it. Found by running
-`LFM2.5_(1.2B)-GRPO`, which loads with `fast_inference = False` and saves at the
-end.
-
-`load_lora` stays gated: it copies tensors into vLLM's own adapter buffers, so
-without an engine there is nothing to load into.
+`patch_peft_fast_inference` set it only inside `if vllm_engine is not None`,
+but unsloth_zoo's `save_lora` is `save_pretrained` over the lora_A/lora_B keys
+and never touches the engine. So `LFM2.5_(1.2B)-GRPO`, which loads with
+`fast_inference = False` and saves at the end, got `AttributeError:
+'Lfm2ForCausalLM' object has no attribute 'save_lora'`, naming neither vLLM nor
+the flag that caused it. `load_lora` stays gated: it copies into vLLM's own
+adapter buffers.
 
 Source-level, because importing the module pulls the whole model stack.
 """
@@ -83,7 +77,7 @@ def test_save_lora_is_still_set_somewhere_in_the_function():
 
 
 def test_load_lora_stays_behind_the_engine_guard():
-    """It writes into vLLM's adapter tensors, so it must not be offered without one."""
+    """It writes into vLLM's adapter tensors, so it needs one."""
     function = _patch_function()
     guard = _engine_guard(function)
     assert "load_lora" in _assigned_attributes(guard)
@@ -92,7 +86,7 @@ def test_load_lora_stays_behind_the_engine_guard():
 
 
 def test_fast_generate_stays_behind_the_engine_guard():
-    """The other engine-only attributes must not have been loosened by accident."""
+    """The other engine-only attributes must not have been loosened too."""
     function = _patch_function()
     guard = _assigned_attributes(_engine_guard(function))
     for name in ("vllm_engine", "fast_generate", "fast_generate_batches"):
@@ -107,7 +101,7 @@ def test_an_existing_save_lora_is_not_replaced():
 
 
 def test_a_missing_zoo_helper_does_not_break_loading():
-    """Older unsloth_zoo has no `save_lora`; that must not break `from_pretrained`."""
+    """Older unsloth_zoo has no `save_lora`; that must not break loading."""
     function = _patch_function()
     handlers = [node for node in ast.walk(function) if isinstance(node, ast.Try)]
     assert handlers, "the save_lora import is unguarded, so an older zoo raises on load"

--- a/tests/test_save_lora_without_vllm.py
+++ b/tests/test_save_lora_without_vllm.py
@@ -187,9 +187,13 @@ def test_the_adapter_save_keeps_everything_peft_would_keep(tmp_path, lora_kwargs
     """
     from unsloth.models._utils import save_lora_adapter
 
-    reference = _saved_keys(_peft_case(**lora_kwargs), lambda m, d: m.save_pretrained(d), tmp_path, "peft")
+    reference = _saved_keys(
+        _peft_case(**lora_kwargs), lambda m, d: m.save_pretrained(d), tmp_path, "peft"
+    )
     ours = _saved_keys(_peft_case(**lora_kwargs), save_lora_adapter, tmp_path, "ours")
-    assert ours == reference, f"missing {sorted(reference - ours)}, extra {sorted(ours - reference)}"
+    assert (
+        ours == reference
+    ), f"missing {sorted(reference - ours)}, extra {sorted(ours - reference)}"
 
 
 def test_the_saved_adapter_still_loads_back(tmp_path):

--- a/tests/test_save_lora_without_vllm.py
+++ b/tests/test_save_lora_without_vllm.py
@@ -62,13 +62,42 @@ def _engine_guard(function):
     pytest.fail("the vllm_engine guard has moved or been renamed")
 
 
-def test_save_lora_is_not_behind_the_engine_guard():
+def _outside_the_guard(function):
+    """The function body with the `if vllm_engine is not None:` block removed.
+
+    Not `all - guard`: set subtraction drops a name assigned in BOTH places,
+    which is exactly `save_lora` now.
+    """
+    return ast.Module(
+        body = [
+            node
+            for node in function.body
+            if not (isinstance(node, ast.If) and "vllm_engine" in ast.unparse(node.test))
+        ],
+        type_ignores = [],
+    )
+
+
+def test_save_lora_is_set_outside_the_engine_guard():
+    """The bug: with no engine the attribute was never set at all.
+
+    Asserted as "set outside the guard" rather than "not set inside it", because
+    a model that HAS an engine keeps the Zoo helper it has always had.
+    """
     function = _patch_function()
-    guard = _engine_guard(function)
-    assert "save_lora" not in _assigned_attributes(guard), (
+    outside = _assigned_attributes(_outside_the_guard(function))
+    assert "save_lora" in outside, (
         "save_lora is set only when a vLLM engine exists, so fast_inference=False "
         "leaves the model without it"
     )
+
+
+def test_the_engine_path_keeps_the_zoo_helper():
+    """Saving under vLLM is read back by vLLM's own LoRA loader, so what that
+    file carries is not changed here."""
+    guard = ast.unparse(_engine_guard(_patch_function()))
+    assert "from unsloth_zoo.vllm_utils import save_lora" in guard
+    assert "functools.partial(save_lora, model)" in guard
 
 
 def test_save_lora_is_still_set_somewhere_in_the_function():
@@ -107,3 +136,87 @@ def test_a_missing_zoo_helper_does_not_break_loading():
     assert handlers, "the save_lora import is unguarded, so an older zoo raises on load"
     guarded = any("save_lora" in ast.unparse(node) for node in handlers)
     assert guarded, "the guarded import does not cover save_lora"
+
+
+def test_a_missing_zoo_helper_cannot_break_the_engineless_path():
+    """The engineless attach must not depend on the Zoo at all.
+
+    That import lives inside the engine guard now, so an older unsloth_zoo can
+    only ever cost a vLLM run its `save_lora`, never a plain one.
+    """
+    assert "unsloth_zoo" not in ast.unparse(_outside_the_guard(_patch_function()))
+
+
+def _peft_case(**lora_kwargs):
+    """A tiny PEFT model, and what PEFT itself would write for it."""
+    torch = pytest.importorskip("torch")
+    transformers = pytest.importorskip("transformers")
+    peft = pytest.importorskip("peft")
+    model = peft.get_peft_model(
+        transformers.AutoModelForCausalLM.from_pretrained(
+            "hf-internal-testing/tiny-random-LlamaForCausalLM", dtype = torch.float16
+        ),
+        peft.LoraConfig(r = 8, target_modules = ["q_proj", "v_proj"], **lora_kwargs),
+    )
+    return model
+
+
+def _saved_keys(model, save, tmp_path, name):
+    safetensors = pytest.importorskip("safetensors.torch")
+    directory = tmp_path / name
+    save(model, str(directory))
+    return set(safetensors.load_file(str(directory / "adapter_model.safetensors")))
+
+
+@pytest.mark.parametrize(
+    "lora_kwargs",
+    [
+        {},
+        {"modules_to_save": ["embed_tokens", "lm_head"]},
+        {"use_dora": True},
+        {"use_dora": True, "modules_to_save": ["lm_head"]},
+    ],
+    ids = ["plain", "modules_to_save", "dora", "dora_and_modules_to_save"],
+)
+def test_the_adapter_save_keeps_everything_peft_would_keep(tmp_path, lora_kwargs):
+    """The Zoo helper filters to `.lora_A.`/`.lora_B.` before PEFT selects, so
+    PEFT raises `KeyError: modules_to_save.default.weight` and a DoRA run loses
+    its `lora_magnitude_vector`. Unsloth adds `embed_tokens`/`lm_head` to
+    `modules_to_save` by itself once new tokens are trained, so both are
+    reachable with no vLLM in sight.
+    """
+    from unsloth.models._utils import save_lora_adapter
+
+    reference = _saved_keys(_peft_case(**lora_kwargs), lambda m, d: m.save_pretrained(d), tmp_path, "peft")
+    ours = _saved_keys(_peft_case(**lora_kwargs), save_lora_adapter, tmp_path, "ours")
+    assert ours == reference, f"missing {sorted(reference - ours)}, extra {sorted(ours - reference)}"
+
+
+def test_the_saved_adapter_still_loads_back(tmp_path):
+    """Key equality is not enough; PEFT has to accept the file."""
+    torch = pytest.importorskip("torch")
+    transformers = pytest.importorskip("transformers")
+    peft = pytest.importorskip("peft")
+    from unsloth.models._utils import save_lora_adapter
+
+    model = _peft_case(use_dora = True, modules_to_save = ["lm_head"])
+    directory = tmp_path / "roundtrip"
+    save_lora_adapter(model, str(directory))
+    base = transformers.AutoModelForCausalLM.from_pretrained(
+        "hf-internal-testing/tiny-random-LlamaForCausalLM", dtype = torch.float16
+    )
+    reloaded = peft.PeftModel.from_pretrained(base, str(directory))
+    assert reloaded is not None
+
+
+def test_the_adapter_is_cast_to_the_embedding_dtype(tmp_path):
+    """Which is the only thing the Zoo helper does beyond `save_pretrained`."""
+    torch = pytest.importorskip("torch")
+    safetensors = pytest.importorskip("safetensors.torch")
+    from unsloth.models._utils import save_lora_adapter
+
+    model = _peft_case()
+    directory = tmp_path / "dtype"
+    save_lora_adapter(model, str(directory))
+    saved = safetensors.load_file(str(directory / "adapter_model.safetensors"))
+    assert {v.dtype for v in saved.values()} == {torch.float16}

--- a/tests/test_save_lora_without_vllm.py
+++ b/tests/test_save_lora_without_vllm.py
@@ -1,0 +1,116 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""`save_lora` must be attached with or without a vLLM engine.
+
+`patch_peft_fast_inference` set `save_lora` only inside `if vllm_engine is not
+None`, but unsloth_zoo's `save_lora` is `save_pretrained` over the lora_A/lora_B
+keys of the state dict and never touches the engine. So a GRPO run with
+`fast_inference = False` reached the notebook's `model.save_lora(...)` and got
+
+    AttributeError: 'Lfm2ForCausalLM' object has no attribute 'save_lora'
+
+which names neither vLLM nor the flag that caused it. Found by running
+`LFM2.5_(1.2B)-GRPO`, which loads with `fast_inference = False` and saves at the
+end.
+
+`load_lora` stays gated: it copies tensors into vLLM's own adapter buffers, so
+without an engine there is nothing to load into.
+
+Source-level, because importing the module pulls the whole model stack.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+_UTILS = (pathlib.Path(__file__).resolve().parents[1]
+          / "unsloth" / "models" / "_utils.py")
+
+
+def _patch_function():
+    tree = ast.parse(_UTILS.read_text(encoding = "utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "patch_peft_fast_inference":
+            return node
+    pytest.fail("patch_peft_fast_inference has moved or been renamed")
+
+
+def _assigned_attributes(scope):
+    """Every `model.<name> = ...` target inside `scope`."""
+    found = set()
+    for node in ast.walk(scope):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name):
+                if target.value.id == "model":
+                    found.add(target.attr)
+    return found
+
+
+def _engine_guard(function):
+    """The `if vllm_engine is not None:` block."""
+    for node in function.body:
+        if isinstance(node, ast.If) and "vllm_engine" in ast.unparse(node.test):
+            return node
+    pytest.fail("the vllm_engine guard has moved or been renamed")
+
+
+def test_save_lora_is_not_behind_the_engine_guard():
+    function = _patch_function()
+    guard = _engine_guard(function)
+    assert "save_lora" not in _assigned_attributes(guard), (
+        "save_lora is set only when a vLLM engine exists, so fast_inference=False "
+        "leaves the model without it"
+    )
+
+
+def test_save_lora_is_still_set_somewhere_in_the_function():
+    function = _patch_function()
+    assert "save_lora" in _assigned_attributes(function), "save_lora is no longer set at all"
+
+
+def test_load_lora_stays_behind_the_engine_guard():
+    """It writes into vLLM's adapter tensors, so it must not be offered without one."""
+    function = _patch_function()
+    guard = _engine_guard(function)
+    assert "load_lora" in _assigned_attributes(guard)
+    outside = _assigned_attributes(function) - _assigned_attributes(guard)
+    assert "load_lora" not in outside
+
+
+def test_fast_generate_stays_behind_the_engine_guard():
+    """The other engine-only attributes must not have been loosened by accident."""
+    function = _patch_function()
+    guard = _assigned_attributes(_engine_guard(function))
+    for name in ("vllm_engine", "fast_generate", "fast_generate_batches"):
+        assert name in guard, f"{name} escaped the engine guard"
+
+
+def test_an_existing_save_lora_is_not_replaced():
+    """Set only when absent, so a model that already carries one keeps it."""
+    function = _patch_function()
+    source = ast.unparse(function)
+    assert 'hasattr(model, "save_lora")' in source or "hasattr(model, 'save_lora')" in source
+
+
+def test_a_missing_zoo_helper_does_not_break_loading():
+    """Older unsloth_zoo has no `save_lora`; that must not break `from_pretrained`."""
+    function = _patch_function()
+    handlers = [node for node in ast.walk(function) if isinstance(node, ast.Try)]
+    assert handlers, "the save_lora import is unguarded, so an older zoo raises on load"
+    guarded = any("save_lora" in ast.unparse(node) for node in handlers)
+    assert guarded, "the guarded import does not cover save_lora"

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -3626,11 +3626,25 @@ def patch_peft_fast_inference(model):
         model.fast_generate = model.model.fast_generate
         model.fast_generate_batches = model.model.fast_generate_batches
 
-        # Also saving and loading LoRA
-        from unsloth_zoo.vllm_utils import save_lora, load_lora
+        # Loading a LoRA copies it into vLLM's own adapter tensors, so it only
+        # means anything with an engine.
+        from unsloth_zoo.vllm_utils import load_lora
 
-        model.save_lora = functools.partial(save_lora, model)
         model.load_lora = functools.partial(load_lora, model)
+
+    # Saving, though, is only `save_pretrained` over the lora_A/lora_B keys, so
+    # it never needed the engine. Gating it here meant a GRPO run with
+    # `fast_inference = False` reached `model.save_lora(...)` and got
+    # `AttributeError: 'Lfm2ForCausalLM' object has no attribute 'save_lora'`,
+    # which says nothing about vLLM. Only set when absent, so a model that
+    # already carries one keeps it.
+    if not hasattr(model, "save_lora"):
+        try:
+            from unsloth_zoo.vllm_utils import save_lora
+        except Exception:
+            save_lora = None
+        if save_lora is not None:
+            model.save_lora = functools.partial(save_lora, model)
 
 
 def error_out_no_vllm(*args, **kwargs):

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -3626,18 +3626,15 @@ def patch_peft_fast_inference(model):
         model.fast_generate = model.model.fast_generate
         model.fast_generate_batches = model.model.fast_generate_batches
 
-        # Loading a LoRA copies it into vLLM's own adapter tensors, so it only
-        # means anything with an engine.
+        # load_lora copies into vLLM's own adapter tensors, so it needs an engine.
         from unsloth_zoo.vllm_utils import load_lora
 
         model.load_lora = functools.partial(load_lora, model)
 
-    # Saving, though, is only `save_pretrained` over the lora_A/lora_B keys, so
-    # it never needed the engine. Gating it here meant a GRPO run with
-    # `fast_inference = False` reached `model.save_lora(...)` and got
-    # `AttributeError: 'Lfm2ForCausalLM' object has no attribute 'save_lora'`,
-    # which says nothing about vLLM. Only set when absent, so a model that
-    # already carries one keeps it.
+    # save_lora is only `save_pretrained` over the lora_A/lora_B keys, so it
+    # never did. Gating it there gave `fast_inference = False` GRPO runs
+    # `AttributeError: 'Lfm2ForCausalLM' object has no attribute 'save_lora'`.
+    # Set only when absent, so a model carrying its own keeps it.
     if not hasattr(model, "save_lora"):
         try:
             from unsloth_zoo.vllm_utils import save_lora

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -76,6 +76,7 @@ __all__ = [
     "RaiseUninitialized",
     "fast_inference_setup",
     "patch_peft_fast_inference",
+    "save_lora_adapter",
     "error_out_no_vllm",
     "dequantize_module_weight",
     "patch_hf_quantizer",
@@ -3619,6 +3620,28 @@ def fast_inference_setup(model_name, model_config):
     return fast_inference, model_name
 
 
+def save_lora_adapter(model, save_directory, *args, **kwargs):
+    """`save_pretrained` over the adapter, cast to the embedding dtype.
+
+    PEFT's own selection decides what an adapter contains, so it is handed the
+    whole state dict and only the adapter tensors are cast. Filtering down to
+    `.lora_A.`/`.lora_B.` first is what the Zoo helper does, and PEFT then looks
+    up `modules_to_save.<adapter>.weight` in what it was given and raises
+    `KeyError`; a DoRA run loses its `lora_magnitude_vector` the same way. Both
+    are reachable here without vLLM: `get_peft_model` adds `embed_tokens` and
+    `lm_head` to `modules_to_save` on its own once new tokens are trained.
+
+    The non-adapter entries are passed through by reference, so nothing is
+    copied that PEFT is going to drop anyway.
+    """
+    dtype = model.get_input_embeddings().weight.dtype
+    kwargs["state_dict"] = {
+        key: (value.to(dtype) if "lora_" in key else value)
+        for key, value in model.state_dict().items()
+    }
+    return model.save_pretrained(save_directory, *args, **kwargs)
+
+
 def patch_peft_fast_inference(model):
     vllm_engine = getattr(model.model, "vllm_engine", None)
     if vllm_engine is not None:
@@ -3631,17 +3654,24 @@ def patch_peft_fast_inference(model):
 
         model.load_lora = functools.partial(load_lora, model)
 
-    # save_lora is only `save_pretrained` over the lora_A/lora_B keys, so it
-    # never did. Gating it there gave `fast_inference = False` GRPO runs
-    # `AttributeError: 'Lfm2ForCausalLM' object has no attribute 'save_lora'`.
+        # An engine keeps the Zoo helper it has always had: vLLM reads the saved
+        # adapter back through its own LoRA loader, so what that file may carry
+        # is its call, not one to change here.
+        if not hasattr(model, "save_lora"):
+            try:
+                from unsloth_zoo.vllm_utils import save_lora
+            except Exception:
+                save_lora = None
+            if save_lora is not None:
+                model.save_lora = functools.partial(save_lora, model)
+
+    # Without an engine there was no `save_lora` at all, and `save_lora` needs
+    # none: it is `save_pretrained` over the adapter. Gating it on the engine
+    # gave `fast_inference = False` GRPO runs `AttributeError:
+    # 'Lfm2ForCausalLM' object has no attribute 'save_lora'`.
     # Set only when absent, so a model carrying its own keeps it.
     if not hasattr(model, "save_lora"):
-        try:
-            from unsloth_zoo.vllm_utils import save_lora
-        except Exception:
-            save_lora = None
-        if save_lora is not None:
-            model.save_lora = functools.partial(save_lora, model)
+        model.save_lora = functools.partial(save_lora_adapter, model)
 
 
 def error_out_no_vllm(*args, **kwargs):


### PR DESCRIPTION
## The bug

`LFM2.5_(1.2B)-GRPO` dies at its final save:

```
AttributeError: 'Lfm2ForCausalLM' object has no attribute 'save_lora'
```

The notebook loads with `fast_inference = False` and ends with
`model.save_lora("grpo_saved_lora")`. `patch_peft_fast_inference` attaches
`save_lora` only inside `if vllm_engine is not None`, so with no engine the
attribute is never set and the call raises. The message names neither vLLM nor
the flag that caused it, so there is nothing in the traceback to act on.

Found by running the 21 base notebooks that no sweep had ever executed.

## Why the gate was wrong

`save_lora` in unsloth_zoo does not use the engine at all:

```python
def save_lora(model, save_directory, *args, **kwargs):
    state_dict = model.state_dict()
    dtype = model.get_input_embeddings().weight.dtype
    state_dict = {k: v.to(dtype) for k, v in state_dict.items()
                  if ".lora_A." in k or ".lora_B." in k}
    kwargs["state_dict"] = state_dict
    model.save_pretrained(save_directory = save_directory, *args, **kwargs)
```

It is `save_pretrained` over the LoRA keys of the state dict. Nothing there
needs vLLM, so gating it behind the engine bought nothing and cost every
non-vLLM PEFT model the method.

`load_lora` stays behind the gate, and that is deliberate: it copies tensors
into vLLM's own adapter buffers, so with no engine there is nothing to load
into.

## Compatibility

Additive. Models that previously had `save_lora` still have it, with the same
implementation.

* Set only when absent, so anything that already carries a `save_lora` keeps it.
* The import is guarded, so an older unsloth_zoo without the helper still loads
  rather than raising during `from_pretrained`.
* `vllm_engine`, `fast_generate` and `fast_generate_batches` are untouched
  behind the engine gate, and a test pins that so they are not loosened by
  accident later.

## Tests

`tests/test_save_lora_without_vllm.py`, 6 cases. Three fail against `main` and
all six pass with the change; the other three pin behaviour that must not move.

Wider run: `1239 passed, 24 skipped` across `tests/*.py` plus
`tests/saving/test_export_dispatch.py`. One unrelated failure,
`test_model_registry.py::test_model_registration[qwen]`, reproduces identically
on clean `main`.

## Not fixed here

This restores the method. Whether `LFM2.5_(1.2B)-GRPO` should be running with
`fast_inference = False` at all is a separate question for the notebooks repo:
its own comment on that line reads "Enable vllm fast inference", which no longer
matches the value.