### PR TITLE
Allowlist the huggingface-hub backoff loop that reddened every PR

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -211,6 +211,14 @@
       "evidence_hash": "c066cc27bce31ee7b6ce07411ee7a7d9ecfbf3aafc8848f6641fabfe522a7703"
     },
     {
+      "package": "huggingface-hub",
+      "file": "huggingface_hub/utils/_http.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L461:     while True: sha256:0c9641548adea74be4a8b0e86e8b75cc937a2b0f833b57dfa3d30d3e24d2537a",
+      "evidence_hash": "70d25136ca2a91d192bd816706db7113a2ad0f96bc1b2381d0d4747a5ff1925d"
+    },
+    {
       "package": "ipython",
       "file": "IPython/core/interactiveshell.py",
       "check": "Enumerates filesystem AND makes network calls",


### PR DESCRIPTION
`pip scan-packages` is failing on every open pull request, on the `hf-stack`, `studio` and `extras` legs:

```
[1] CRITICAL  C2 polling/beaconing loop detected
    Package:  huggingface-hub
    File:     huggingface_hub/utils/_http.py
    Evidence: L461:     while True: sha256:0c9641548adea74be4a8b0e86e8b75cc937a2b0f833b57dfa3d30d3e24d2537a
Summary: 1 CRITICAL, 295 MEDIUM
```

huggingface-hub 1.27 refactored `http_backoff` and `http_stream_backoff` onto a shared `_http_backoff` generator. That moved the retry loop and changed the code inside it, and since the baseline hashes the matched code rather than its line number, a changed body correctly reopens the finding instead of staying silently suppressed. The two `_http.py` entries already in the baseline cover the same construct at its earlier locations.

Reviewed against the 1.27.0 sdist. The loop is bounded, not a beacon:

```python
while True:
    nb_tries += 1
    ...
    if nb_tries > max_retries:
        hf_raise_for_status(response)   # raises
        return False                    # or returns, ending the loop
```

The entry was generated with `scan_packages.py`'s own evidence hash and inserted beside its siblings, so the diff is eight added lines and no reordering of the other 222 entries.

This does not fix the three `Repo tests (CPU)` failures currently on main; #8115 covers those.