### PR TITLE
Repair seven tests left behind by their own subjects

### DIFF
--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -985,7 +985,7 @@ def test_admission_keepalives_do_not_spend_the_first_output_budget(monkeypatch):
     _install_fake_client(monkeypatch, [_QueuedThenServedStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    assert _run_stream(supervisor, timeout_seconds = 5.0) == ("report", "", "stop")
+    assert _run_stream(supervisor, timeout_seconds = 5.0) == ("report", "", "stop", None)
 
 
 def _comment_only_stream(comment: str):
@@ -1052,7 +1052,7 @@ def test_the_queue_wait_is_not_charged_to_the_model_budget(monkeypatch):
     _install_fake_client(monkeypatch, [_QueuedThenAdmitted()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    assert _run_stream(supervisor, timeout_seconds = 10.0) == ("report", "", "stop")
+    assert _run_stream(supervisor, timeout_seconds = 10.0) == ("report", "", "stop", None)
 
 
 def test_the_budget_starts_when_admission_ends(monkeypatch):
@@ -1528,7 +1528,7 @@ def test_first_output_deadline_disarms_once_output_starts(monkeypatch):
     _install_fake_client(monkeypatch, [_LongGenerationStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    report, _reasoning, finish_reason = _run_stream(supervisor, timeout_seconds = 30.0)
+    report, _reasoning, finish_reason, _usage = _run_stream(supervisor, timeout_seconds = 30.0)
     assert finish_reason == "stop"
     assert report.startswith("start w0 w1")
     assert report.endswith("w11")
@@ -1562,7 +1562,7 @@ def test_reasoning_only_prefix_disarms_the_first_output_deadline(monkeypatch):
     _install_fake_client(monkeypatch, [_LongThinkStream()])
     supervisor = _make_supervisor(_noop_check_active)
 
-    report, reasoning, _finish = _run_stream(supervisor, timeout_seconds = 30.0)
+    report, reasoning, _finish, _usage = _run_stream(supervisor, timeout_seconds = 30.0)
     assert report == "answer"
     assert reasoning.startswith("t0 ")
 

--- a/tests/python/test_studio_runtime_gate.py
+++ b/tests/python/test_studio_runtime_gate.py
@@ -70,14 +70,18 @@ def test_terminal_launch_boundaries_use_the_runtime_gate():
 
 def test_terminal_update_holds_the_gate_through_environment_mutation():
     source = STUDIO_COMMAND.read_text(encoding = "utf-8")
-    body = source[source.index("def update(") : source.index("def _release_self_exe_lock_windows")]
+    start = source.index("def update(")
+    # To the next top-level def, rather than naming the one that happens to follow today.
+    end = source.index("\ndef ", start + 1)
+    body = source[start:end]
     consume = body.index("_studio_runtime_gate.consume_runtime_gate_handoff()")
     guard = body.index("with _studio_runtime_launch_guard(", consume)
     idle_scan = body.index("_studio_runtime_gate.ensure_managed_environment_is_idle", guard)
-    release_self = body.index("_release_self_exe_lock_windows()", idle_scan)
-    setup = body.index("_run_setup_script(", release_self)
+    # The launcher transaction wraps the mutation; it replaced the self-exe lock release.
+    launcher = body.index("_WindowsLauncherUpdateTransaction()", idle_scan)
+    setup = body.index("_run_setup_script(", launcher)
     verify = body.index("_fail_if_install_damaged()", setup)
-    assert consume < guard < idle_scan < release_self < setup < verify
+    assert consume < guard < idle_scan < launcher < setup < verify
 
 
 def test_terminal_setup_holds_the_gate_through_environment_mutation():

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -56,6 +56,15 @@ IMAGE = FRONTEND / "components/assistant-ui/image.tsx"
 AUDIO_PLAYER = FRONTEND / "components/assistant-ui/audio-player.tsx"
 
 
+def _css_var_px(source: str, name: str) -> list[int]:
+    """Every pixel value assigned to CSS variable *name* in *source*.
+
+    Values, not a literal: these are visual nudges that get retuned, and pinning the
+    exact px only pins the day the test was written.
+    """
+    return [int(v) for v in re.findall(rf'"{re.escape(name)}":\s*"(\d+)px"', source)]
+
+
 def test_desktop_update_offer_remains_actionable_from_settings():
     provider = APP_PROVIDER.read_text(encoding = "utf-8")
     context = TAURI_UPDATE_CONTEXT.read_text(encoding = "utf-8")
@@ -496,9 +505,10 @@ def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
     assert "translate-y-[var(--studio-titlebar-navigation-offset-y,0px)]" in TITLEBAR.read_text(
         encoding = "utf-8"
     )
-    assert '"--studio-titlebar-navigation-offset-y": "2px"' in APP_PROVIDER.read_text(
-        encoding = "utf-8"
+    offsets = _css_var_px(
+        APP_PROVIDER.read_text(encoding = "utf-8"), "--studio-titlebar-navigation-offset-y"
     )
+    assert offsets and all(offset > 0 for offset in offsets), offsets
     assert "aria-hidden={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
     assert "inert={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
 
@@ -549,7 +559,8 @@ def test_mac_chat_header_controls_share_the_titlebar_row():
     assert "shouldUseNativeMacWindowTitlebar" not in source
     assert "[--studio-content-top-inset:var(--studio-mac-titlebar-height" not in source
     assert source.count("var(--studio-mac-traffic-light-inset") == 2
-    assert '"--studio-chat-header-padding-top": "7px"' in provider
+    paddings = _css_var_px(provider, "--studio-chat-header-padding-top")
+    assert paddings and all(padding > 0 for padding in paddings), paddings
     assert "pt-[var(--studio-content-top-inset,0px)] md:flex-row" in source
     assert "absolute top-[var(--studio-content-top-inset,0px)]" in source
 

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -69,6 +69,12 @@ def _chrome_style_blocks(source: str) -> dict[str, dict[str, str]]:
     }
 
 
+def _titlebar_nav_button_px(source: str) -> int | None:
+    """The navigation button's box, read off the class string that sizes it."""
+    match = re.search(r"const buttonClass =\s*\n?\s*\"[^\"]*?size-\[(\d+)px\]", source, re.S)
+    return int(match.group(1)) if match else None
+
+
 def _px(value: str | None) -> int | None:
     """*value* as whole pixels, or None if it is not a px literal (rem, calc, absent)."""
     match = re.fullmatch(r"(\d+)px", (value or "").strip())
@@ -515,7 +521,11 @@ def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
     assert "translate-y-[var(--studio-titlebar-navigation-offset-y,0px)]" in TITLEBAR.read_text(
         encoding = "utf-8"
     )
-    # The nudge has to move the navigation without pushing it out of the titlebar it sits in.
+    # The nudge has to move the navigation without pushing it out of the titlebar it sits
+    # in, so the button box travels with it. The container's mt-1 is deliberately not in
+    # the sum: translate-y is visual, and the margin already seats the box in the row.
+    button = _titlebar_nav_button_px(TITLEBAR.read_text(encoding = "utf-8"))
+    assert button is not None, "navigation button size no longer readable from buttonClass"
     blocks = _chrome_style_blocks(APP_PROVIDER.read_text(encoding = "utf-8"))
     nudged = {
         name: values
@@ -527,7 +537,8 @@ def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
         offset = _px(values["--studio-titlebar-navigation-offset-y"])
         titlebar = _px(values.get("--studio-desktop-titlebar-height"))
         assert offset is not None and offset > 0, (name, values)
-        assert titlebar is not None and offset < titlebar, (name, offset, titlebar)
+        assert titlebar is not None, (name, values)
+        assert offset + button <= titlebar, (name, offset, button, titlebar)
     assert "aria-hidden={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
     assert "inert={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
 

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -56,13 +56,23 @@ IMAGE = FRONTEND / "components/assistant-ui/image.tsx"
 AUDIO_PLAYER = FRONTEND / "components/assistant-ui/audio-player.tsx"
 
 
-def _css_var_px(source: str, name: str) -> list[int]:
-    """Every pixel value assigned to CSS variable *name* in *source*.
+def _chrome_style_blocks(source: str) -> dict[str, dict[str, str]]:
+    """Each ``const <NAME>_STYLE = { ... } as CSSProperties`` block as a var -> value map.
 
-    Values, not a literal: these are visual nudges that get retuned, and pinning the
-    exact px only pins the day the test was written.
+    Per block, so a value is only ever compared against the others that ship with it.
     """
-    return [int(v) for v in re.findall(rf'"{re.escape(name)}":\s*"(\d+)px"', source)]
+    return {
+        name: dict(re.findall(r'"(--[\w-]+)":\s*"([^"]+)"', body))
+        for name, body in re.findall(
+            r"const (\w+_STYLE) = \{(.*?)\} as CSSProperties;", source, re.S
+        )
+    }
+
+
+def _px(value: str | None) -> int | None:
+    """*value* as whole pixels, or None if it is not a px literal (rem, calc, absent)."""
+    match = re.fullmatch(r"(\d+)px", (value or "").strip())
+    return int(match.group(1)) if match else None
 
 
 def test_desktop_update_offer_remains_actionable_from_settings():
@@ -505,10 +515,19 @@ def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
     assert "translate-y-[var(--studio-titlebar-navigation-offset-y,0px)]" in TITLEBAR.read_text(
         encoding = "utf-8"
     )
-    offsets = _css_var_px(
-        APP_PROVIDER.read_text(encoding = "utf-8"), "--studio-titlebar-navigation-offset-y"
-    )
-    assert offsets and all(offset > 0 for offset in offsets), offsets
+    # The nudge has to move the navigation without pushing it out of the titlebar it sits in.
+    blocks = _chrome_style_blocks(APP_PROVIDER.read_text(encoding = "utf-8"))
+    nudged = {
+        name: values
+        for name, values in blocks.items()
+        if "--studio-titlebar-navigation-offset-y" in values
+    }
+    assert nudged, blocks.keys()
+    for name, values in nudged.items():
+        offset = _px(values["--studio-titlebar-navigation-offset-y"])
+        titlebar = _px(values.get("--studio-desktop-titlebar-height"))
+        assert offset is not None and offset > 0, (name, values)
+        assert titlebar is not None and offset < titlebar, (name, offset, titlebar)
     assert "aria-hidden={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
     assert "inert={(hasPinMode && !pinned && collapseToZero) || undefined}" in primitive
 
@@ -559,8 +578,22 @@ def test_mac_chat_header_controls_share_the_titlebar_row():
     assert "shouldUseNativeMacWindowTitlebar" not in source
     assert "[--studio-content-top-inset:var(--studio-mac-titlebar-height" not in source
     assert source.count("var(--studio-mac-traffic-light-inset") == 2
-    paddings = _css_var_px(provider, "--studio-chat-header-padding-top")
-    assert paddings and all(padding > 0 for padding in paddings), paddings
+    # Sharing the row is the contract: the padding must leave the control room inside the
+    # header, so a retune to a large value fails here rather than shipping a clipped row.
+    blocks = _chrome_style_blocks(provider)
+    padded = {
+        name: values
+        for name, values in blocks.items()
+        if "--studio-chat-header-padding-top" in values
+    }
+    assert padded, blocks.keys()
+    for name, values in padded.items():
+        padding = _px(values["--studio-chat-header-padding-top"])
+        header = _px(values.get("--studio-chat-header-height"))
+        control = _px(values.get("--studio-chat-control-height"))
+        assert padding is not None and padding > 0, (name, values)
+        assert header is not None and control is not None, (name, values)
+        assert padding + control <= header, (name, padding, control, header)
     assert "pt-[var(--studio-content-top-inset,0px)] md:flex-row" in source
     assert "absolute top-[var(--studio-content-top-inset,0px)]" in source
 


### PR DESCRIPTION
Seven tests are failing on `main` right now. All seven are cases where the code they cover moved on and the test did not, so they block `Repo tests (CPU)` and the Python matrix for every open PR without describing a real defect.

Reproduced on a clean `main` worktree before touching anything:

```
tests/test_research_runs_hardening.py  4 failed, 117 passed
tests/python/test_studio_runtime_gate.py + tests/studio/test_desktop_reliability_frontend_contract.py  3 failed, 32 passed, 11 skipped
```

## 1. `_stream_completion` arity (4 tests)

`_stream_completion` returns `(report, reasoning, finish_reason, usage)`. Every production caller unpacks four; six of the ten test call sites were updated and four were missed, so they still assert three:

```
AssertionError: assert ('report', '', 'stop', None) == ('report', '', 'stop')
ValueError: too many values to unpack (expected 3)
```

Finished the update in the style the already-updated sites use.

## 2. `test_terminal_update_holds_the_gate_through_environment_mutation`

The test slices `update()`'s body up to `def _release_self_exe_lock_windows`, and asserts that helper is called inside the guarded region. Both are gone: `_WindowsLauncherUpdateTransaction` replaced the self-exe lock release, and the source comment in `studio.py` says so.

The contract the test is named for still holds, so it now checks the same ordering against the current step, and bounds the slice at the next top-level `def` instead of naming whichever function happens to follow.

## 3. Two `test_desktop_reliability_frontend_contract` tests

These pin exact pixel values for two CSS custom properties:

```python
assert '"--studio-chat-header-padding-top": "7px"' in provider
assert '"--studio-titlebar-navigation-offset-y": "2px"' in ...
```

Both variables are still set; they are `9px` and `4px` now. These are visual nudges that get retuned, so a literal pins the day the test was written rather than the behaviour. They now assert every assigned value is a positive px, which keeps the intent (the control is nudged off the titlebar edge) and survives the next tweak.

## Verification

Each fix is mutation-checked, so none of them merely silences a test:

| Mutation | Result |
|---|---|
| drop `usage` from the `_stream_completion` return | 11 failed |
| reorder `update()` so setup precedes the idle scan | ordering test fails |
| set both CSS nudges to `0px` | both contract tests fail |

Suites after the change: `tests/python/` + the frontend contract file is 962 passed, and `test_research_runs_hardening.py` + `test_research_runs_storage.py` is 231 passed. Two failures remain in `tests/python/` (`test_e2e_no_torch_sandbox`, `test_tokenizers_and_torch_constraint`); both fail identically on unmodified `main` and are install/network sandbox tests, untouched here.

No production code is changed.