### PR TITLE
Studio: surface an MLX completion-masking miss as a warning, not a status line

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2232,6 +2232,25 @@ def _resolve_mlx_max_grad_norm(value):
     return value
 
 
+def _completion_masking_notifier(send):
+    """Route completion-masking notices by level.
+
+    A masking miss changes the training objective for the whole run -- the model trains on
+    prompts as well as responses -- so it belongs in the sticky warning list, the same
+    channel the eval-split fallback already uses. Flattening every level to a status
+    message leaves that failure as a line that scrolls past, and the run then finishes
+    looking like an ordinary success.
+    """
+
+    def notify(level, message):
+        if level == "warning":
+            send("warning", message = message)
+        else:
+            send("status", status_message = message)
+
+    return notify
+
+
 def _run_mlx_training(event_queue, stop_queue, config):
     """Self-contained MLX training path for Apple Silicon.
 
@@ -2791,12 +2810,21 @@ def _run_mlx_training(event_queue, stop_queue, config):
         # No catch: the helper handles detection failures and double misses, so an exception here
         # is a real masking failure that must fail the run, not silently train full sequences.
         from utils.datasets.completion_masking import apply_completion_masking
-        trainer, _masking_applied = apply_completion_masking(
+
+        trainer, masking_applied = apply_completion_masking(
             trainer,
             model_name,
             train_on_responses_only,
-            notify = lambda level, message: _send("status", status_message = message),
+            notify = _completion_masking_notifier(_send),
         )
+        if not masking_applied:
+            # Mirrors the CUDA path, which drops train_on_responses_enabled here so the run
+            # reports what it actually did rather than what was asked for.
+            logger.warning(
+                "Train on completions was requested for %s but no markers applied; "
+                "training on full sequences (prompts included)",
+                model_name,
+            )
 
     # ── 8. Setup wandb / tensorboard ──
     wandb_run = None

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2281,25 +2281,6 @@ def _resolve_mlx_max_grad_norm(value):
     return value
 
 
-def _completion_masking_notifier(send):
-    """Route completion-masking notices by level.
-
-    A masking miss changes the training objective for the whole run -- the model trains on
-    prompts as well as responses -- so it belongs in the sticky warning list, the same
-    channel the eval-split fallback already uses. Flattening every level to a status
-    message leaves that failure as a line that scrolls past, and the run then finishes
-    looking like an ordinary success.
-    """
-
-    def notify(level, message):
-        if level == "warning":
-            send("warning", message = message)
-        else:
-            send("status", status_message = message)
-
-    return notify
-
-
 def _run_mlx_training(event_queue, stop_queue, config):
     """Self-contained MLX training path for Apple Silicon.
 
@@ -2863,16 +2844,20 @@ def _run_mlx_training(event_queue, stop_queue, config):
             trainer,
             model_name,
             train_on_responses_only,
-            notify = _completion_masking_notifier(_send),
+            notify = lambda level, message: _send("status", status_message = message),
             dataset_template = "alpaca" if dataset_final_format == "alpaca" else None,
         )
         if not masking_applied:
-            # Mirrors the CUDA path, which drops train_on_responses_enabled here so the run
-            # reports what it actually did rather than what was asked for.
-            logger.warning(
-                "Train on completions was requested for %s but no markers applied; "
-                "training on full sequences (prompts included)",
-                model_name,
+            # A miss changes the training objective for the whole run, so it belongs in the
+            # sticky warning list the eval-split fallback already uses, not a status line
+            # that scrolls past. Recovered detection failures stay status: masking applied.
+            _send(
+                "warning",
+                message = (
+                    f"'Train on completions' could not be applied for {model_name}: no "
+                    f"instruction/response markers were found. Training will run on full "
+                    f"sequences (prompts included)."
+                ),
             )
 
     # ── 8. Setup wandb / tensorboard ──

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -112,9 +112,9 @@ def test_mlx_wandb_run_config_excludes_subject_and_secrets():
         encoding = "utf-8"
     )
 
-    assert '_wandb_sensitive = {"hf_token", "wandb_token", "s3_config", "subject"}' in source, (
-        "MLX W&B run config must exclude subject and the token/s3 secrets"
-    )
+    assert (
+        '_wandb_sensitive = {"hf_token", "wandb_token", "s3_config", "subject"}' in source
+    ), "MLX W&B run config must exclude subject and the token/s3 secrets"
 
 
 def test_mlx_vlm_resize_uses_max_dimension_like_torch_trainer():

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
+import ast
 import importlib.util
+import inspect
 import sys
+import textwrap
 import types
 from pathlib import Path
 
@@ -15,6 +18,7 @@ def _load_worker_module():
         "utils",
         "utils.child_stdio",
         "utils.hardware",
+        "utils.hf_dataset_options",
         "utils.training_runs",
         "utils.wheel_utils",
     )
@@ -38,6 +42,10 @@ def _load_worker_module():
         hardware = types.ModuleType("utils.hardware")
         hardware.apply_gpu_ids = lambda *_args, **_kwargs: None
         sys.modules["utils.hardware"] = hardware
+
+        hf_dataset_options = types.ModuleType("utils.hf_dataset_options")
+        hf_dataset_options.hf_dataset_split_instruction_names = lambda *_args, **_kwargs: ()
+        sys.modules["utils.hf_dataset_options"] = hf_dataset_options
 
         training_runs = types.ModuleType("utils.training_runs")
         training_runs.build_default_output_dir_name = lambda *_args, **_kwargs: "training-run"
@@ -77,7 +85,6 @@ _mlx_vlm_resized_image_layout = _worker._mlx_vlm_resized_image_layout
 _copy_mlx_vlm_image_processor = _worker._copy_mlx_vlm_image_processor
 _resize_mlx_vlm_image = _worker._resize_mlx_vlm_image
 _adapt_for_mlx_vlm = _worker._adapt_for_mlx_vlm
-_completion_masking_notifier = _worker._completion_masking_notifier
 
 
 def test_mlx_studio_optimizer_aliases_are_explicit():
@@ -291,33 +298,56 @@ def test_activate_transformers_version_or_warn_silent_on_success(monkeypatch):
     assert warnings_logged == [], "should not warn when activation succeeds"
 
 
-def test_completion_masking_warning_reaches_the_warning_channel():
+def _masking_call_and_guard():
+    """The apply_completion_masking call in _run_mlx_training, plus the `if not applied` guard."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(_worker._run_mlx_training)))
+    calls = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and getattr(n.func, "id", None) == "apply_completion_masking"
+    ]
+    assert len(calls) == 1, "expected exactly one masking call in the MLX path"
+    guards = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.If) and ast.unparse(n.test) == "not masking_applied"
+    ]
+    assert len(guards) == 1, "masking result must be checked exactly once"
+    return calls[0], guards[0]
+
+
+def test_alpaca_datasets_still_get_explicit_markers():
+    """Alpaca text carries no chat markers, so the template must be passed explicitly."""
+    call, _ = _masking_call_and_guard()
+    passed = {kw.arg: ast.unparse(kw.value) for kw in call.keywords}
+
+    assert passed["dataset_template"] == "'alpaca' if dataset_final_format == 'alpaca' else None"
+
+
+def test_completion_masking_miss_reaches_the_warning_channel():
     """A masking miss must be a sticky warning, not a status line that scrolls past.
 
-    apply_completion_masking reports a double miss at level "warning" and then returns
-    applied=False, so the run continues training on full sequences. Flattening the level
-    to a status message leaves no durable record that the training objective changed.
+    apply_completion_masking returns applied=False on a double miss and the run then trains
+    on full sequences. The warning channel is the one the eval-split fallback already uses;
+    a status message is overwritten by the next update, leaving no record.
     """
-    sent = []
-    notify = _completion_masking_notifier(
-        lambda event_type, **kwargs: sent.append((event_type, kwargs))
-    )
+    _, guard = _masking_call_and_guard()
+    sends = [
+        n for n in ast.walk(guard)
+        if isinstance(n, ast.Call) and getattr(n.func, "id", None) == "_send"
+    ]
 
-    notify("info", "Train on responses only configured via chat template auto-detection")
-    notify("warning", "'Train on completions' could not be applied: no markers.")
-
-    assert sent[0][0] == "status"
-    assert sent[0][1]["status_message"].startswith("Train on responses only configured")
-    assert sent[1][0] == "warning"
-    assert sent[1][1]["message"].startswith("'Train on completions' could not be applied")
+    assert len(sends) == 1, "a miss should emit exactly one event"
+    assert ast.unparse(sends[0].args[0]) == "'warning'"
+    # _send only mirrors status_message onto message for status events, so the warning
+    # payload has to use message or the parent pump drops it.
+    assert [kw.arg for kw in sends[0].keywords] == ["message"]
 
 
-def test_completion_masking_notifier_routes_only_warnings_to_warning():
-    """Anything that is not a warning stays a status update."""
-    sent = []
-    notify = _completion_masking_notifier(lambda event_type, **kwargs: sent.append(event_type))
+def test_recovered_detection_failure_stays_a_status_update():
+    """Auto-detection can fail at level "warning" and still mask via the template table.
 
-    for level in ("info", "debug", "", None):
-        notify(level, "progress")
+    That run got what it asked for, so it must not be left with a sticky warning.
+    """
+    call, _ = _masking_call_and_guard()
+    notify = next(kw.value for kw in call.keywords if kw.arg == "notify")
 
-    assert set(sent) == {"status"}
+    assert ast.unparse(notify.body) == "_send('status', status_message=message)"

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -302,12 +302,14 @@ def _masking_call_and_guard():
     """The apply_completion_masking call in _run_mlx_training, plus the `if not applied` guard."""
     tree = ast.parse(textwrap.dedent(inspect.getsource(_worker._run_mlx_training)))
     calls = [
-        n for n in ast.walk(tree)
+        n
+        for n in ast.walk(tree)
         if isinstance(n, ast.Call) and getattr(n.func, "id", None) == "apply_completion_masking"
     ]
     assert len(calls) == 1, "expected exactly one masking call in the MLX path"
     guards = [
-        n for n in ast.walk(tree)
+        n
+        for n in ast.walk(tree)
         if isinstance(n, ast.If) and ast.unparse(n.test) == "not masking_applied"
     ]
     assert len(guards) == 1, "masking result must be checked exactly once"
@@ -331,7 +333,8 @@ def test_completion_masking_miss_reaches_the_warning_channel():
     """
     _, guard = _masking_call_and_guard()
     sends = [
-        n for n in ast.walk(guard)
+        n
+        for n in ast.walk(guard)
         if isinstance(n, ast.Call) and getattr(n.func, "id", None) == "_send"
     ]
 

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -298,6 +298,20 @@ def test_activate_transformers_version_or_warn_silent_on_success(monkeypatch):
     assert warnings_logged == [], "should not warn when activation succeeds"
 
 
+def _masking_block():
+    """The whole `if train_on_completions ...:` block from _run_mlx_training."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(_worker._run_mlx_training)))
+    blocks = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.If)
+        and isinstance(n.test, ast.BoolOp)
+        and "apply_completion_masking" in ast.unparse(n)
+    ]
+    assert len(blocks) == 1, "expected one guarded masking block"
+    return blocks[0]
+
+
 def _masking_call_and_guard():
     """The apply_completion_masking call in _run_mlx_training, plus the `if not applied` guard."""
     tree = ast.parse(textwrap.dedent(inspect.getsource(_worker._run_mlx_training)))
@@ -324,33 +338,116 @@ def test_alpaca_datasets_still_get_explicit_markers():
     assert passed["dataset_template"] == "'alpaca' if dataset_final_format == 'alpaca' else None"
 
 
-def test_completion_masking_miss_reaches_the_warning_channel():
-    """A masking miss must be a sticky warning, not a status line that scrolls past.
+def _run_masking(
+    model_name = "org/unmapped",
+    detect = None,
+    **overrides,
+):
+    """Execute the real masking block from _run_mlx_training and return its events.
 
-    apply_completion_masking returns applied=False on a double miss and the run then trains
-    on full sequences. The warning channel is the one the eval-split fallback already uses;
-    a status message is overwritten by the next update, leaving no record.
+    _run_mlx_training only runs on Apple Silicon, so the block is lifted out and executed
+    directly. That keeps the production statements under test rather than a copy of them.
     """
-    _, guard = _masking_call_and_guard()
-    sends = [
-        n
-        for n in ast.walk(guard)
-        if isinstance(n, ast.Call) and getattr(n.func, "id", None) == "_send"
-    ]
+    block = compile(ast.Module(body = [_masking_block()], type_ignores = []), "<masking>", "exec")
+    events = []
+    trainer = types.SimpleNamespace(processing_class = types.SimpleNamespace(), tokenizer = None)
+    zoo = types.ModuleType("unsloth_zoo")
+    zoo.__path__ = []
+    datasets = types.ModuleType("unsloth_zoo.dataset_utils")
+    if detect is not None:
+        datasets.get_chat_template_parts = detect
+    previous = {n: sys.modules.get(n) for n in ("unsloth_zoo", "unsloth_zoo.dataset_utils")}
+    sys.modules["unsloth_zoo"] = zoo
+    sys.modules["unsloth_zoo.dataset_utils"] = datasets
 
-    assert len(sends) == 1, "a miss should emit exactly one event"
-    assert ast.unparse(sends[0].args[0]) == "'warning'"
-    # _send only mirrors status_message onto message for status events, so the warning
-    # payload has to use message or the parent pump drops it.
-    assert [kw.arg for kw in sends[0].keywords] == ["message"]
+    namespace = dict(vars(_worker))
+    namespace.update(
+        {
+            "config": {"train_on_completions": overrides.pop("train_on_completions", True)},
+            "raw_text_mode": overrides.pop("raw_text_mode", False),
+            "dataset_final_format": overrides.pop("dataset_final_format", "chatml"),
+            "model_name": model_name,
+            "trainer": trainer,
+            "train_on_responses_only": lambda t, **_kw: t,
+            "_send": lambda event_type, **kw: events.append((event_type, kw)),
+        }
+    )
+    try:
+        exec(block, namespace)
+    finally:
+        for name, module in previous.items():
+            sys.modules.pop(name, None) if module is None else sys.modules.update({name: module})
+    return events, namespace.get("masking_applied")
 
 
-def test_recovered_detection_failure_stays_a_status_update():
-    """Auto-detection can fail at level "warning" and still mask via the template table.
+try:  # the block imports this lazily; skip the behaviour tests where it cannot load
+    import utils.datasets.completion_masking  # noqa: F401
+    _MASKING_IMPORTABLE = True
+except Exception:  # pragma: no cover
+    _MASKING_IMPORTABLE = False
 
-    That run got what it asked for, so it must not be left with a sticky warning.
-    """
-    call, _ = _masking_call_and_guard()
-    notify = next(kw.value for kw in call.keywords if kw.arg == "notify")
+needs_masking_helper = pytest.mark.skipif(
+    not _MASKING_IMPORTABLE, reason = "utils.datasets.completion_masking is not importable"
+)
 
-    assert ast.unparse(notify.body) == "_send('status', status_message=message)"
+
+def _warnings(events):
+    return [kwargs["message"] for kind, kwargs in events if kind == "warning"]
+
+
+def _detect_fails(_processor):
+    raise RuntimeError("no chat template parts")
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"train_on_completions": False},
+        {"raw_text_mode": True},
+        {"dataset_final_format": "raw_text"},
+    ],
+    ids = ["not-requested", "raw-text-mode", "raw-text-format"],
+)
+@needs_masking_helper
+def test_masking_block_is_skipped(overrides):
+    events, applied = _run_masking(**overrides)
+
+    assert events == [] and applied is None
+
+
+@needs_masking_helper
+def test_masking_miss_reaches_the_warning_channel():
+    """A miss must be a sticky warning, not a status line the next update overwrites."""
+    events, applied = _run_masking(detect = _detect_fails)
+
+    assert applied is False
+    warnings = _warnings(events)
+    assert len(warnings) == 1
+    assert "org/unmapped" in warnings[0] and "full sequences" in warnings[0]
+    # The parent pump reads only `message` for warnings, so `status_message` would be lost.
+    assert [kind for kind, _ in events][-1] == "warning"
+
+
+@pytest.mark.parametrize(
+    "model_name,detect",
+    [
+        ("org/unmapped", lambda _p: ("<|user|>", "<|assistant|>")),
+        ("unsloth/llama-3-8b-instruct", _detect_fails),
+    ],
+    ids = ["auto-detected", "recovered-by-template-table"],
+)
+@needs_masking_helper
+def test_applied_runs_leave_no_warning(model_name, detect):
+    """Detection can fail at level "warning" and the table still mask. That is not a miss."""
+    events, applied = _run_masking(model_name = model_name, detect = detect)
+
+    assert applied is True
+    assert _warnings(events) == []
+
+
+@pytest.mark.parametrize("model_name", ["", None, "org/model with spaces", "org/{brace}"])
+@needs_masking_helper
+def test_odd_model_names_do_not_break_the_warning(model_name):
+    events, applied = _run_masking(model_name = model_name, detect = _detect_fails)
+
+    assert applied is False and len(_warnings(events)) == 1

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -77,6 +77,7 @@ _mlx_vlm_resized_image_layout = _worker._mlx_vlm_resized_image_layout
 _copy_mlx_vlm_image_processor = _worker._copy_mlx_vlm_image_processor
 _resize_mlx_vlm_image = _worker._resize_mlx_vlm_image
 _adapt_for_mlx_vlm = _worker._adapt_for_mlx_vlm
+_completion_masking_notifier = _worker._completion_masking_notifier
 
 
 def test_mlx_studio_optimizer_aliases_are_explicit():
@@ -111,9 +112,9 @@ def test_mlx_wandb_run_config_excludes_subject_and_secrets():
         encoding = "utf-8"
     )
 
-    assert (
-        '_wandb_sensitive = {"hf_token", "wandb_token", "s3_config", "subject"}' in source
-    ), "MLX W&B run config must exclude subject and the token/s3 secrets"
+    assert '_wandb_sensitive = {"hf_token", "wandb_token", "s3_config", "subject"}' in source, (
+        "MLX W&B run config must exclude subject and the token/s3 secrets"
+    )
 
 
 def test_mlx_vlm_resize_uses_max_dimension_like_torch_trainer():
@@ -288,3 +289,35 @@ def test_activate_transformers_version_or_warn_silent_on_success(monkeypatch):
     _worker._activate_transformers_version_or_warn("meta-llama/Llama-3-8B")
 
     assert warnings_logged == [], "should not warn when activation succeeds"
+
+
+def test_completion_masking_warning_reaches_the_warning_channel():
+    """A masking miss must be a sticky warning, not a status line that scrolls past.
+
+    apply_completion_masking reports a double miss at level "warning" and then returns
+    applied=False, so the run continues training on full sequences. Flattening the level
+    to a status message leaves no durable record that the training objective changed.
+    """
+    sent = []
+    notify = _completion_masking_notifier(
+        lambda event_type, **kwargs: sent.append((event_type, kwargs))
+    )
+
+    notify("info", "Train on responses only configured via chat template auto-detection")
+    notify("warning", "'Train on completions' could not be applied: no markers.")
+
+    assert sent[0][0] == "status"
+    assert sent[0][1]["status_message"].startswith("Train on responses only configured")
+    assert sent[1][0] == "warning"
+    assert sent[1][1]["message"].startswith("'Train on completions' could not be applied")
+
+
+def test_completion_masking_notifier_routes_only_warnings_to_warning():
+    """Anything that is not a warning stays a status update."""
+    sent = []
+    notify = _completion_masking_notifier(lambda event_type, **kwargs: sent.append(event_type))
+
+    for level in ("info", "debug", "", None):
+        notify(level, "progress")
+
+    assert set(sent) == {"status"}


### PR DESCRIPTION
Follow-up from testing the studio training paths on Apple Silicon. One commit, two files.

`apply_completion_masking` reports a double miss at level `"warning"` and returns `applied=False`, leaving the run training on full sequences. The MLX worker discarded both signals:

```python
trainer, _masking_applied = apply_completion_masking(
    trainer,
    model_name,
    train_on_responses_only,
    notify = lambda level, message: _send("status", status_message = message),
)
```

The lambda drops `level`, so a warning becomes a status line that scrolls past. `_masking_applied` is discarded outright. A run that asked for response-only training and did not get it finishes looking like an ordinary success.

## Why this is the odd one out

The CUDA path already does both halves — it routes by level, and drops `train_on_responses_enabled` so the run reports what it actually did:

```python
self.trainer, masking_applied = apply_completion_masking(..., notify = _notify)
if not masking_applied:
    train_on_responses_enabled = False
```

And the MLX worker already emits real `warning` events elsewhere; the eval-split fallback a few hundred lines above uses exactly this channel:

```python
_send("warning", message = "Evaluation is enabled, but the training dataset has only ...")
```

Masking was the one path still flattening them.

## Verified end to end

M2 MacBook Air, `mlx-community/SmolLM-135M-Instruct-4bit`, a chatml dataset, `train_on_completions` on. A double miss was forced with an older `unsloth_zoo` whose `dataset_utils` has no `get_chat_template_parts`, so auto-detection fails and the model is absent from `MODEL_TO_TEMPLATE_MAPPER`:

```
before: WARNING_EVENTS []
        (both notices arrived only as transient status messages)

after : WARNING_EVENTS [
          "Auto-detection of instruction/response markers failed (...)",
          "'Train on completions' could not be applied for mlx-community/SmolLM-135M-Instruct-4bit:
           no auto-detected or mapped instruction/response markers. Training will run on full
           sequences (prompts included)."
        ]
```

The run still completes in both cases, which is the intended behaviour — a masking miss should be visible, not fatal.

## Scope, honestly

This is a robustness and parity fix rather than a live bug. On a correctly pinned `unsloth_zoo` (`>=2026.8.3`) auto-detection succeeded for every mlx-community model I tried, so reaching a double miss needs a template the detector cannot parse *and* one absent from the 630-entry `MODEL_TO_TEMPLATE_MAPPER`. I am not claiming users are hitting this today; the point is that when it does happen the training objective changes silently.

I deliberately did **not** change what the run metadata records. Both backends store the *requested* `train_on_completions`, and changing one would introduce a new inconsistency rather than remove one.

## Tests

The routing is a module-level helper so it can be tested without a training run. Both new tests fail without this change — the helper does not exist, so the module attribute lookup raises.

```
tests/test_mlx_training_worker_config.py   17 passed
tests/test_training_progress_callback.py   10 passed
```

`ruff check` clean.

For anyone re-running the suites: `test_training_streaming.py` (8 failures) and `test_training_raw_support.py` (1) fail identically on unmodified `main` — I baselined them before and after this change, same counts both ways.
