### PR TITLE
fix(security): re-baseline the huggingface-hub HTTP backoff loop for 1.x

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -211,6 +211,14 @@
       "evidence_hash": "c066cc27bce31ee7b6ce07411ee7a7d9ecfbf3aafc8848f6641fabfe522a7703"
     },
     {
+      "package": "huggingface-hub",
+      "file": "huggingface_hub/utils/_http.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L461:     while True: sha256:0c9641548adea74be4a8b0e86e8b75cc937a2b0f833b57dfa3d30d3e24d2537a",
+      "evidence_hash": "70d25136ca2a91d192bd816706db7113a2ad0f96bc1b2381d0d4747a5ff1925d"
+    },
+    {
       "package": "ipython",
       "file": "IPython/core/interactiveshell.py",
       "check": "Enumerates filesystem AND makes network calls",


### PR DESCRIPTION
All three `pip scan-packages` shards are red on `main`, and all three fail on the same single unsuppressed CRITICAL:

```
[1] CRITICAL  C2 polling/beaconing loop detected
    Package:  huggingface-hub
    File:     huggingface_hub/utils/_http.py
    Evidence: L461:     while True: sha256:0c9641548adea74be4a8b0e86e8b75cc937a2b0f833b57dfa3d30d3e24d2537a
```

Each shard reports 1 CRITICAL and 0 HIGH, so this one finding is the whole reason `SCAN_ENFORCE=1` exits 1 on `studio`, `hf-stack` and `extras` alike.

## Why it reopened

`RE_C2_POLLING` looks for a `while True` loop containing a sleep and an HTTP call. That is the right shape for malware beaconing and also the exact shape of any retry-with-backoff helper, so `huggingface_hub/utils/_http.py` has been reviewed and baselined before, twice, at L462 and L298 against huggingface-hub 0.x.

huggingface-hub has since released 1.x, which moves from `requests` to `httpx` and refactors `http_backoff` into a shared `_http_backoff_impl`. The check uses a greedy `DOTALL` span, so its recorded evidence digest covers a large region of the file; that region is now different code and the digest changed. The baseline did exactly what it is documented to do and reopened the finding for review instead of suppressing changed code under a coarse key. This is dependency drift, not a regression in this repo.

## Review of the new code

`huggingface_hub/utils/_http.py:461` in 1.27.0 is `_http_backoff_impl`, described upstream as "Internal implementation of HTTP backoff logic shared between `http_backoff` and `http_stream_backoff`". It retries an `httpx` request on caller-configured exception types and status codes, sleeps with exponential backoff bounded by `max_wait_time`, and honours a 429 rate-limit reset. There is no beaconing, no remote-controlled interval, and no payload execution. Benign, the same judgement as the two entries it succeeds.

## The change

One entry added. I added the 1.x entry rather than replacing the 0.x ones, matching how this file already carries several entries per file across versions (`hf_api.py` has three), so a pinned older huggingface-hub stays covered.

## Verification

Locally, `python scripts/scan_packages.py huggingface-hub` goes from `Summary: 1 CRITICAL, 6 MEDIUM` (3 suppressed) to `Summary: 6 MEDIUM` (4 suppressed), exit 0.

I also ran the real `Security audit` workflow on a staging replica of this branch rather than queueing it here. All three shards pass, each with exactly one more finding suppressed and the CRITICAL gone:

| Shard | Before | After | Suppressed |
|---|---|---|---|
| studio | `1 CRITICAL, 295 MEDIUM` | `295 MEDIUM` | 152 to 153 |
| hf-stack | `1 CRITICAL, 190 MEDIUM` | `190 MEDIUM` | 126 to 127 |
| extras | `1 CRITICAL, 182 MEDIUM` | `182 MEDIUM` | 98 to 99 |

## Worth considering separately

This will recur. The baseline pins a digest over a greedy `DOTALL` span of a third-party file, so any upstream release that edits anywhere in that span reopens the entry and turns the security gate red with no change on our side. That is a deliberate and defensible trade, precision over stability, but it does mean routine dependency bumps can block CI. Narrowing the recorded span for this check, or pinning `huggingface-hub`, would both reduce the churn. Out of scope here.