### PR TITLE
Do not choose flex attention on a card that cannot run its kernel

### DIFF
--- a/tests/test_flex_attention_needs_ampere.py
+++ b/tests/test_flex_attention_needs_ampere.py
@@ -14,22 +14,18 @@
 
 """Flex attention must not be chosen on a card that cannot run its kernel.
 
-`Gemma3_(4B)-Vision-GRPO` passes on A100 and dies on both a Colab T4 and a
-Kaggle T4 with `RuntimeError: expected scalar type Half but found Float`, raised
-by torch's own eager fallback:
+`Gemma3_(4B)-Vision-GRPO` passes on A100 and dies on a Colab and a Kaggle T4 with
+`RuntimeError: expected scalar type Half but found Float`, from torch's own eager
+fallback in `sdpa_dense_backward`:
 
-    torch/_higher_order_ops/flex_attention.py, sdpa_dense_backward
     grad_value = softmax_scores.to(query.dtype).transpose(-2, -1) @ grad_out
 
-That line casts the scores to the query dtype and leaves `grad_out` alone. It is
-only reached when the HOP runs uncompiled, which is what happens on sm75, and a
-T4 also forces fp16, so query is Half against a Float grad.
+which casts the scores and not `grad_out`. Only reached when the HOP runs
+uncompiled, which is what sm75 gets, and such a card also forces fp16.
 
-`gemma3` is in `_FLEX_PREFERRED_MODELS` and its sdpa is disabled, so flex is
-exactly the path it took there, while the only availability question asked was
-`is_torch_flex_attn_available()` -- a torch-version check with nothing to say
-about the card. Verified by running the notebook on a Colab T4 with flex off:
-PASS in 1007s, against the failure at 1180s with it on.
+`gemma3` is in `_FLEX_PREFERRED_MODELS` with sdpa disabled, so flex is the path
+it took, while the only availability question asked was the torch-version one.
+Measured on a Colab T4: PASS in 1007s with flex off, failure at 1180s with it on.
 """
 
 import sys
@@ -70,24 +66,23 @@ def test_a_pre_ampere_card_does_not_get_flex(capability):
 
 @pytest.mark.parametrize("capability", [(8, 0), (8, 6), (8, 9), (9, 0), (10, 0), (12, 0)])
 def test_ampere_and_newer_are_untouched(capability):
-    """A100, A10, L4, H100, B200, RTX 50xx. The notebook passes on A100 with
-    flex on, so the fix must not take it away from them."""
+    """A100, A10, L4, H100, B200, RTX 50xx. The notebook passes on A100 with flex
+    on, so this must not take it away from them."""
     cuda, hip = _cuda([capability])
     with cuda, hip:
         assert U._flex_attention_gpu_is_supported() is True
 
 
 def test_a_mixed_box_follows_its_weakest_card():
-    """One process, one attn_implementation. A T4 beside an A100 still cannot
-    run the kernel, so the pair has to fall back together."""
+    """One process picks one attn_implementation, so the pair falls back together."""
     cuda, hip = _cuda([(8, 0), (7, 5)])
     with cuda, hip:
         assert U._flex_attention_gpu_is_supported() is False
 
 
 def test_rocm_is_not_judged_by_a_cuda_capability():
-    """`get_device_capability` answers on ROCm too, and its numbers are not
-    CUDA's. Reading them would disable flex on AMD cards for no reason."""
+    """`get_device_capability` answers on ROCm too, with numbers that are not
+    CUDA's, so reading them would disable flex on AMD for no reason."""
     cuda, hip = _cuda([(7, 5)], hip = "6.2.0")
     with cuda, hip:
         assert U._flex_attention_gpu_is_supported() is True
@@ -101,8 +96,7 @@ def test_no_cuda_device_is_left_alone():
 
 
 def test_an_unreadable_device_fails_open():
-    """A probe that raises must not silently switch every user's attention
-    backend. Same stance as the `is_torch_flex_attn_available` guard below it."""
+    """Same stance as the `is_torch_flex_attn_available` guard below it."""
 
     def _boom(index = 0):
         raise RuntimeError("no CUDA driver")
@@ -114,8 +108,8 @@ def test_an_unreadable_device_fails_open():
 
 
 def test_the_gate_runs_before_the_torch_version_check():
-    """`is_torch_flex_attn_available` is a torch-version answer and says yes on
-    a T4. If it were consulted first the card check could never refuse."""
+    """It answers yes on a T4, so consulting it first would mean the card check
+    could never refuse."""
     stub = types.ModuleType("transformers.utils.import_utils")
     stub.is_torch_flex_attn_available = lambda: True
     cuda, hip = _cuda([(7, 5)])

--- a/tests/test_flex_attention_needs_ampere.py
+++ b/tests/test_flex_attention_needs_ampere.py
@@ -1,0 +1,123 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flex attention must not be chosen on a card that cannot run its kernel.
+
+`Gemma3_(4B)-Vision-GRPO` passes on A100 and dies on both a Colab T4 and a
+Kaggle T4 with `RuntimeError: expected scalar type Half but found Float`, raised
+by torch's own eager fallback:
+
+    torch/_higher_order_ops/flex_attention.py, sdpa_dense_backward
+    grad_value = softmax_scores.to(query.dtype).transpose(-2, -1) @ grad_out
+
+That line casts the scores to the query dtype and leaves `grad_out` alone. It is
+only reached when the HOP runs uncompiled, which is what happens on sm75, and a
+T4 also forces fp16, so query is Half against a Float grad.
+
+`gemma3` is in `_FLEX_PREFERRED_MODELS` and its sdpa is disabled, so flex is
+exactly the path it took there, while the only availability question asked was
+`is_torch_flex_attn_available()` -- a torch-version check with nothing to say
+about the card. Verified by running the notebook on a Colab T4 with flex off:
+PASS in 1007s, against the failure at 1180s with it on.
+"""
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+import unsloth.models._utils as U
+
+
+class _Model:
+    _supports_flex_attn = True
+
+
+def _supports(model_type = "gemma3"):
+    return U._supports_flex_attention(_Model, {}, model_type)
+
+
+def _cuda(capabilities, hip = None):
+    """Patch just enough of torch for the vendor/capability probe."""
+    return mock.patch.multiple(
+        U.torch.cuda,
+        is_available = lambda: bool(capabilities),
+        device_count = lambda: len(capabilities),
+        get_device_capability = lambda index = 0: capabilities[index],
+    ), mock.patch.object(U.torch.version, "hip", hip, create = True)
+
+
+@pytest.mark.parametrize("capability", [(7, 0), (7, 5)])
+def test_a_pre_ampere_card_does_not_get_flex(capability):
+    """(7, 5) is the T4 this was measured on; (7, 0) is V100, same fallback."""
+    cuda, hip = _cuda([capability])
+    with cuda, hip:
+        assert U._flex_attention_gpu_is_supported() is False
+        assert _supports() is False
+
+
+@pytest.mark.parametrize("capability", [(8, 0), (8, 6), (8, 9), (9, 0), (10, 0), (12, 0)])
+def test_ampere_and_newer_are_untouched(capability):
+    """A100, A10, L4, H100, B200, RTX 50xx. The notebook passes on A100 with
+    flex on, so the fix must not take it away from them."""
+    cuda, hip = _cuda([capability])
+    with cuda, hip:
+        assert U._flex_attention_gpu_is_supported() is True
+
+
+def test_a_mixed_box_follows_its_weakest_card():
+    """One process, one attn_implementation. A T4 beside an A100 still cannot
+    run the kernel, so the pair has to fall back together."""
+    cuda, hip = _cuda([(8, 0), (7, 5)])
+    with cuda, hip:
+        assert U._flex_attention_gpu_is_supported() is False
+
+
+def test_rocm_is_not_judged_by_a_cuda_capability():
+    """`get_device_capability` answers on ROCm too, and its numbers are not
+    CUDA's. Reading them would disable flex on AMD cards for no reason."""
+    cuda, hip = _cuda([(7, 5)], hip = "6.2.0")
+    with cuda, hip:
+        assert U._flex_attention_gpu_is_supported() is True
+
+
+def test_no_cuda_device_is_left_alone():
+    """CPU, MPS and XPU boxes keep whatever they had."""
+    cuda, hip = _cuda([])
+    with cuda, hip:
+        assert U._flex_attention_gpu_is_supported() is True
+
+
+def test_an_unreadable_device_fails_open():
+    """A probe that raises must not silently switch every user's attention
+    backend. Same stance as the `is_torch_flex_attn_available` guard below it."""
+    def _boom(index = 0):
+        raise RuntimeError("no CUDA driver")
+    with mock.patch.multiple(U.torch.cuda,
+                             is_available = lambda: True,
+                             device_count = lambda: 1,
+                             get_device_capability = _boom):
+        assert U._flex_attention_gpu_is_supported() is True
+
+
+def test_the_gate_runs_before_the_torch_version_check():
+    """`is_torch_flex_attn_available` is a torch-version answer and says yes on
+    a T4. If it were consulted first the card check could never refuse."""
+    stub = types.ModuleType("transformers.utils.import_utils")
+    stub.is_torch_flex_attn_available = lambda: True
+    cuda, hip = _cuda([(7, 5)])
+    with cuda, hip, mock.patch.dict(sys.modules,
+                                    {"transformers.utils.import_utils": stub}):
+        assert _supports() is False

--- a/tests/test_flex_attention_needs_ampere.py
+++ b/tests/test_flex_attention_needs_ampere.py
@@ -103,12 +103,13 @@ def test_no_cuda_device_is_left_alone():
 def test_an_unreadable_device_fails_open():
     """A probe that raises must not silently switch every user's attention
     backend. Same stance as the `is_torch_flex_attn_available` guard below it."""
+
     def _boom(index = 0):
         raise RuntimeError("no CUDA driver")
-    with mock.patch.multiple(U.torch.cuda,
-                             is_available = lambda: True,
-                             device_count = lambda: 1,
-                             get_device_capability = _boom):
+
+    with mock.patch.multiple(
+        U.torch.cuda, is_available = lambda: True, device_count = lambda: 1, get_device_capability = _boom
+    ):
         assert U._flex_attention_gpu_is_supported() is True
 
 
@@ -118,6 +119,5 @@ def test_the_gate_runs_before_the_torch_version_check():
     stub = types.ModuleType("transformers.utils.import_utils")
     stub.is_torch_flex_attn_available = lambda: True
     cuda, hip = _cuda([(7, 5)])
-    with cuda, hip, mock.patch.dict(sys.modules,
-                                    {"transformers.utils.import_utils": stub}):
+    with cuda, hip, mock.patch.dict(sys.modules, {"transformers.utils.import_utils": stub}):
         assert _supports() is False

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -451,12 +451,42 @@ def _is_eager_only(model_type):
     return any(model_type.startswith(p) for p in _EAGER_ONLY_PREFIXES)
 
 
+# Ampere. Below it, torch's flex attention has no Triton kernel to lower to and
+# the HOP runs its eager `sdpa_dense` fallback instead, whose backward does
+#     grad_value = softmax_scores.to(query.dtype).transpose(-2, -1) @ grad_out
+# casting the scores but not `grad_out`. On a pre-Ampere card Unsloth also forces
+# fp16, so query is Half against a Float grad and CUDA refuses the matmul.
+_FLEX_ATTENTION_MIN_CAPABILITY = (8, 0)
+
+
+def _flex_attention_gpu_is_supported():
+    """False only for NVIDIA cards below Ampere.
+
+    ROCm, XPU, MPS and CPU are left alone: a card whose vendor is not judged
+    here keeps exactly the behaviour it had. Any failure to read the device
+    also leaves it alone, so this can only ever remove a broken path.
+    """
+    try:
+        if getattr(torch.version, "hip", None):
+            return True
+        if not torch.cuda.is_available():
+            return True
+        return all(
+            torch.cuda.get_device_capability(index) >= _FLEX_ATTENTION_MIN_CAPABILITY
+            for index in range(torch.cuda.device_count())
+        )
+    except Exception:
+        return True
+
+
 def _supports_flex_attention(model_class, config, model_type):
     if os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0":
         return False
     if not getattr(model_class, "_supports_flex_attn", False):
         return False
     if _is_flex_excluded(model_type):
+        return False
+    if not _flex_attention_gpu_is_supported():
         return False
     for attention_config in _iter_attention_configs(config):
         attention_dropout = _config_get(attention_config, "attention_dropout", 0) or 0

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -451,20 +451,18 @@ def _is_eager_only(model_type):
     return any(model_type.startswith(p) for p in _EAGER_ONLY_PREFIXES)
 
 
-# Ampere. Below it, torch's flex attention has no Triton kernel to lower to and
-# the HOP runs its eager `sdpa_dense` fallback instead, whose backward does
-#     grad_value = softmax_scores.to(query.dtype).transpose(-2, -1) @ grad_out
-# casting the scores but not `grad_out`. On a pre-Ampere card Unsloth also forces
-# fp16, so query is Half against a Float grad and CUDA refuses the matmul.
+# Ampere. Below it the flex HOP runs its eager `sdpa_dense` fallback, whose
+# backward does `softmax_scores.to(query.dtype) @ grad_out` -- casting the scores
+# but not `grad_out`. Such a card also forces fp16 here, so query is Half against
+# a Float grad and the matmul is refused.
 _FLEX_ATTENTION_MIN_CAPABILITY = (8, 0)
 
 
 def _flex_attention_gpu_is_supported():
     """False only for NVIDIA cards below Ampere.
 
-    ROCm, XPU, MPS and CPU are left alone: a card whose vendor is not judged
-    here keeps exactly the behaviour it had. Any failure to read the device
-    also leaves it alone, so this can only ever remove a broken path.
+    ROCm, XPU, MPS, CPU and an unreadable device are left alone, so this can
+    only ever remove a path that was already broken.
     """
     try:
         if getattr(torch.version, "hip", None):


### PR DESCRIPTION
`Gemma3_(4B)-Vision-GRPO` passes on an A100 and dies on both a Colab T4 and a Kaggle T4:

```
RuntimeError: expected scalar type Half but found Float
```

The frame is torch's own eager fallback, not ours:

```
torch/_higher_order_ops/flex_attention.py, sdpa_dense_backward
    grad_value = softmax_scores.to(query.dtype).transpose(-2, -1) @ grad_out
```

It casts the scores to the query dtype and leaves `grad_out` alone. That line is only reached when the flex-attention HOP runs uncompiled, which is what a pre-Ampere card gets, and such a card also forces fp16 here, so `query` is Half against a Float grad and CUDA refuses the matmul. CPU would promote; CUDA does not.

`gemma3` is in `_FLEX_PREFERRED_MODELS` and its sdpa is disabled by `DISABLE_SDPA_MODEL_NAMES`, so flex is exactly the path it takes there. The only availability question `_supports_flex_attention` asked was `is_torch_flex_attn_available()` -- a torch-version check with nothing to say about the card, and it answers yes on a T4. This adds the device question, ahead of that one for the same reason.

### Measurements

| GPU | outcome |
| --- | --- |
| A100 | PASS, 3 separate runs |
| Colab T4 | `Half but found Float` at 1180s |
| Kaggle T4 | same fingerprint |
| Colab T4, flex off | **PASS**, 1007s, terminal sentinel, no error output |

torch 2.7.0+cu126, transformers 4.56.2, trl 0.22.2, unsloth 2026.8.8, unsloth_zoo 2026.8.5.

The last row is what this PR makes the default for those cards: I reproduced the proposed gate with `UNSLOTH_ENABLE_FLEX_ATTENTION=0` rather than assert the fix would work.

### Scope

Deliberately narrow, so a fix for one vendor cannot regress another:

- ROCm short-circuits on `torch.version.hip`. `get_device_capability` answers there too, with numbers that are not CUDA's, so reading them would disable flex on AMD cards for no reason.
- CPU, MPS and XPU are untouched.
- A probe that raises fails open, matching the stance of the `is_torch_flex_attn_available` guard below it. This can only ever remove a path that was already broken.
- A mixed box follows its weakest card, since one process picks one `attn_implementation`.

Direct evidence is sm75 (T4). The threshold is drawn at the Ampere line because that is where the Triton lowering exists and where bf16 becomes available; sm70 (V100) is covered by the same reasoning but I have not run it.

13 tests, including that the card check runs before the version check, that Ampere through Blackwell are untouched, and that ROCm is not judged by a CUDA capability. `tests/test_attention_implementation.py` and `tests/test_attn_impl_honor_explicit.py` still pass.
