### PR TITLE
Report a denied UNSLOTH_LOCAL_LLAMA_CPP_DIR instead of aborting on errexit

### DIFF
--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1951,7 +1951,11 @@ if [ -n "${UNSLOTH_LOCAL_LLAMA_CPP_DIR:-}" ]; then
         step "llama.cpp" "UNSLOTH_LOCAL_LLAMA_CPP_DIR does not exist: $UNSLOTH_LOCAL_LLAMA_CPP_DIR" "$C_ERR"
         setup_fail 1 "UNSLOTH_LOCAL_LLAMA_CPP_DIR does not exist: $UNSLOTH_LOCAL_LLAMA_CPP_DIR"
     fi
-    _RESOLVED_LOCAL="$(CDPATH= cd -P -- "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" && pwd -P)"
+    # In an if condition, so a denied dir reports instead of tripping errexit here.
+    if ! _RESOLVED_LOCAL="$(CDPATH= cd -P -- "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" 2>/dev/null && pwd -P)"; then
+        # owner-unverified: this is the user's own tree, never advise deleting it.
+        _path_access_denied "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" "UNSLOTH_LOCAL_LLAMA_CPP_DIR" owner-unverified
+    fi
     # Canonicalize the install path the same way before comparing: _RESOLVED_LOCAL
     # is fully resolved, but LLAMA_CPP_DIR is textual ($UNSLOTH_HOME/llama.cpp). If
     # $HOME (or UNSLOTH_HOME) contains a symlink, the two never match even when the
@@ -1960,8 +1964,11 @@ if [ -n "${UNSLOTH_LOCAL_LLAMA_CPP_DIR:-}" ]; then
     # this works whether or not the leaf currently exists.
     _CANON_LLAMA_CPP_DIR="$LLAMA_CPP_DIR"
     _LLAMA_CPP_PARENT="$(dirname "$LLAMA_CPP_DIR")"
-    if [ -d "$_LLAMA_CPP_PARENT" ]; then
-        _CANON_LLAMA_CPP_DIR="$(CDPATH= cd -P -- "$_LLAMA_CPP_PARENT" && pwd -P)/$(basename "$LLAMA_CPP_DIR")"
+    # Also an if condition: an unsearchable parent keeps the textual path rather
+    # than aborting, which is what an absent parent already does.
+    if [ -d "$_LLAMA_CPP_PARENT" ] &&
+       _canon_parent="$(CDPATH= cd -P -- "$_LLAMA_CPP_PARENT" 2>/dev/null && pwd -P)"; then
+        _CANON_LLAMA_CPP_DIR="$_canon_parent/$(basename "$LLAMA_CPP_DIR")"
     fi
     if [ "$_RESOLVED_LOCAL" = "$_CANON_LLAMA_CPP_DIR" ]; then
         # Points at the canonical install location itself: never delete-then-link

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1018,11 +1018,21 @@ _path_access_denied() {
     setup_fail 1 "Permission denied reading the existing $_pad_label at $_pad_dir. Delete or rename that folder (Unsloth reinstalls it) or restore access, then re-run setup. Reinstalling the app does not reset it."
 }
 
+# POSIX makes a trailing slash follow a final symlink, so "link/" is never -L.
+# Strip it, but never past the root.
+_studio_rstrip_slash() {
+    _srs_path="$1"
+    while [ "$_srs_path" != "/" ] && [ "${_srs_path%/}" != "$_srs_path" ]; do
+        _srs_path="${_srs_path%/}"
+    done
+    printf '%s' "$_srs_path"
+}
+
 # An unsearchable ancestor makes everything under it unstattable, so a real path
 # reads as missing. Walk up to the deepest ancestor we can stat and report if it
 # is the blocker. Returns without reporting when the path is simply absent.
 _report_denied_ancestor() {
-    _rda_probe="$1"
+    _rda_probe="$(_studio_rstrip_slash "$1")"
     _rda_hops=0
     while [ ! -e "$_rda_probe" ] && [ "$_rda_probe" != "/" ] && [ "$_rda_probe" != "." ]; do
         # A symlink we cannot follow is the deepest component we can name, so keep
@@ -1035,6 +1045,7 @@ _report_denied_ancestor() {
                 /*) _rda_probe="$_rda_target" ;;
                 *) _rda_probe="$(dirname -- "$_rda_probe")/$_rda_target" ;;
             esac
+            _rda_probe="$(_studio_rstrip_slash "$_rda_probe")"
             continue
         fi
         # -- so a path starting with "-" is an operand, not a dirname option.

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -978,16 +978,14 @@ _studio_owned_adoptable() {
     [ -f "$1/UNSLOTH_WHISPER_PREBUILT_INFO.json" ] && return 0
     return 1
 }
-# Search (+x), not read (+r), is what the marker probes need: inside a directory
-# we cannot search every probe reports absent, so our own install reads as someone else's.
+# Marker probes need search (+x), not read (+r): in an unsearchable dir every probe reports absent, so our install looks foreign.
 _studio_dir_unsearchable() {
     [ -d "$1" ] || return 1
     ( cd -- "$1" ) 2>/dev/null && return 1
     return 0
 }
 
-# Also needs +r, for callers that list or replace the tree: mode 111 is searchable
-# but still fails install_llama_prebuilt.py.
+# Also needs +r for callers that list or replace the tree: mode 111 is searchable but still fails install_llama_prebuilt.py.
 _studio_dir_unreadable() {
     [ -d "$1" ] || return 1
     _studio_dir_unsearchable "$1" && return 0
@@ -1018,8 +1016,7 @@ _path_access_denied() {
     setup_fail 1 "Permission denied reading the existing $_pad_label at $_pad_dir. Delete or rename that folder (Unsloth reinstalls it) or restore access, then re-run setup. Reinstalling the app does not reset it."
 }
 
-# POSIX makes a trailing slash follow a final symlink, so "link/" is never -L.
-# Strip it, but never past the root.
+# POSIX follows a final symlink when the path ends in /, so "link/" is never -L. Strip it, but never past the root.
 _studio_rstrip_slash() {
     _srs_path="$1"
     while [ "$_srs_path" != "/" ] && [ "${_srs_path%/}" != "$_srs_path" ]; do
@@ -1028,16 +1025,14 @@ _studio_rstrip_slash() {
     printf '%s' "$_srs_path"
 }
 
-# An unsearchable ancestor makes everything under it unstattable, so a real path
-# reads as missing. Walk up to the deepest ancestor we can stat and report if it
-# is the blocker. Returns without reporting when the path is simply absent.
+# An unsearchable ancestor makes a real path read as missing. Walk up to the deepest
+# ancestor we can stat and report it as the blocker; stay quiet if the path is just absent.
 _report_denied_ancestor() {
     _rda_probe="$(_studio_rstrip_slash "$1")"
     _rda_hops=0
     while [ ! -e "$_rda_probe" ] && [ "$_rda_probe" != "/" ] && [ "$_rda_probe" != "." ]; do
-        # A symlink we cannot follow is the deepest component we can name, so keep
-        # walking through its target: that is where the denied ancestor lives.
-        # The hop cap keeps a symlink cycle from looping forever.
+        # An unfollowable symlink is the deepest name we have, so walk its target:
+        # the denied ancestor lives there. The hop cap breaks symlink cycles.
         if [ -L "$_rda_probe" ] && [ "$_rda_hops" -lt 40 ]; then
             _rda_hops=$((_rda_hops + 1))
             _rda_target="$(readlink -- "$_rda_probe")" || break
@@ -1048,7 +1043,7 @@ _report_denied_ancestor() {
             _rda_probe="$(_studio_rstrip_slash "$_rda_probe")"
             continue
         fi
-        # -- so a path starting with "-" is an operand, not a dirname option.
+        # -- keeps a leading-dash path an operand, not a dirname option.
         _rda_probe="$(dirname -- "$_rda_probe")"
     done
     if _studio_dir_unsearchable "$_rda_probe"; then
@@ -1986,13 +1981,13 @@ _has_local_llama_server() {
 _LOCAL_LLAMA_CPP_LINKED=false
 if [ -n "${UNSLOTH_LOCAL_LLAMA_CPP_DIR:-}" ]; then
     if [ ! -d "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" ]; then
-        # A build under an unsearchable ancestor cannot be stat'd either, so report
-        # permissions first rather than sending the user to fix a correct path.
+        # A build under an unsearchable ancestor cannot be stat'd, so report permissions
+        # rather than sending the user to fix a path that is already correct.
         _report_denied_ancestor "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" "UNSLOTH_LOCAL_LLAMA_CPP_DIR"
         step "llama.cpp" "UNSLOTH_LOCAL_LLAMA_CPP_DIR does not exist: $UNSLOTH_LOCAL_LLAMA_CPP_DIR" "$C_ERR"
         setup_fail 1 "UNSLOTH_LOCAL_LLAMA_CPP_DIR does not exist: $UNSLOTH_LOCAL_LLAMA_CPP_DIR"
     fi
-    # In an if condition, so a denied dir reports instead of tripping errexit here.
+    # In an if condition so a denied dir reports instead of tripping errexit.
     if ! _RESOLVED_LOCAL="$(CDPATH= cd -P -- "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" 2>/dev/null && pwd -P)"; then
         # owner-unverified: this is the user's own tree, never advise deleting it.
         _path_access_denied "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" "UNSLOTH_LOCAL_LLAMA_CPP_DIR" owner-unverified
@@ -2006,8 +2001,8 @@ if [ -n "${UNSLOTH_LOCAL_LLAMA_CPP_DIR:-}" ]; then
     _CANON_LLAMA_CPP_DIR="$LLAMA_CPP_DIR"
     _LLAMA_CPP_PARENT="$(dirname "$LLAMA_CPP_DIR")"
     if [ -d "$_LLAMA_CPP_PARENT" ]; then
-        # Report rather than carry on: nothing can be written under a parent we
-        # cannot search, so the link below would abort raw a few lines later.
+        # Nothing can be written under a parent we cannot search, so report here
+        # rather than let the link below abort raw a few lines later.
         if _canon_parent="$(CDPATH= cd -P -- "$_LLAMA_CPP_PARENT" 2>/dev/null && pwd -P)"; then
             _CANON_LLAMA_CPP_DIR="$_canon_parent/$(basename "$LLAMA_CPP_DIR")"
         else

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -982,7 +982,7 @@ _studio_owned_adoptable() {
 # we cannot search every probe reports absent, so our own install reads as someone else's.
 _studio_dir_unsearchable() {
     [ -d "$1" ] || return 1
-    ( cd "$1" ) 2>/dev/null && return 1
+    ( cd -- "$1" ) 2>/dev/null && return 1
     return 0
 }
 
@@ -991,7 +991,7 @@ _studio_dir_unsearchable() {
 _studio_dir_unreadable() {
     [ -d "$1" ] || return 1
     _studio_dir_unsearchable "$1" && return 0
-    ls -A "$1" >/dev/null 2>&1 && return 1
+    ls -A -- "$1" >/dev/null 2>&1 && return 1
     return 0
 }
 
@@ -1023,8 +1023,22 @@ _path_access_denied() {
 # is the blocker. Returns without reporting when the path is simply absent.
 _report_denied_ancestor() {
     _rda_probe="$1"
+    _rda_hops=0
     while [ ! -e "$_rda_probe" ] && [ "$_rda_probe" != "/" ] && [ "$_rda_probe" != "." ]; do
-        _rda_probe="$(dirname "$_rda_probe")"
+        # A symlink we cannot follow is the deepest component we can name, so keep
+        # walking through its target: that is where the denied ancestor lives.
+        # The hop cap keeps a symlink cycle from looping forever.
+        if [ -L "$_rda_probe" ] && [ "$_rda_hops" -lt 40 ]; then
+            _rda_hops=$((_rda_hops + 1))
+            _rda_target="$(readlink -- "$_rda_probe")" || break
+            case "$_rda_target" in
+                /*) _rda_probe="$_rda_target" ;;
+                *) _rda_probe="$(dirname -- "$_rda_probe")/$_rda_target" ;;
+            esac
+            continue
+        fi
+        # -- so a path starting with "-" is an operand, not a dirname option.
+        _rda_probe="$(dirname -- "$_rda_probe")"
     done
     if _studio_dir_unsearchable "$_rda_probe"; then
         _path_access_denied "$_rda_probe" "$2" owner-unverified

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1018,6 +1018,19 @@ _path_access_denied() {
     setup_fail 1 "Permission denied reading the existing $_pad_label at $_pad_dir. Delete or rename that folder (Unsloth reinstalls it) or restore access, then re-run setup. Reinstalling the app does not reset it."
 }
 
+# An unsearchable ancestor makes everything under it unstattable, so a real path
+# reads as missing. Walk up to the deepest ancestor we can stat and report if it
+# is the blocker. Returns without reporting when the path is simply absent.
+_report_denied_ancestor() {
+    _rda_probe="$1"
+    while [ ! -e "$_rda_probe" ] && [ "$_rda_probe" != "/" ] && [ "$_rda_probe" != "." ]; do
+        _rda_probe="$(dirname "$_rda_probe")"
+    done
+    if _studio_dir_unsearchable "$_rda_probe"; then
+        _path_access_denied "$_rda_probe" "$2" owner-unverified
+    fi
+}
+
 _assert_studio_owned_or_absent() {
     _aso_dir="$1"
     _aso_label="$2"
@@ -1948,6 +1961,9 @@ _has_local_llama_server() {
 _LOCAL_LLAMA_CPP_LINKED=false
 if [ -n "${UNSLOTH_LOCAL_LLAMA_CPP_DIR:-}" ]; then
     if [ ! -d "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" ]; then
+        # A build under an unsearchable ancestor cannot be stat'd either, so report
+        # permissions first rather than sending the user to fix a correct path.
+        _report_denied_ancestor "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" "UNSLOTH_LOCAL_LLAMA_CPP_DIR"
         step "llama.cpp" "UNSLOTH_LOCAL_LLAMA_CPP_DIR does not exist: $UNSLOTH_LOCAL_LLAMA_CPP_DIR" "$C_ERR"
         setup_fail 1 "UNSLOTH_LOCAL_LLAMA_CPP_DIR does not exist: $UNSLOTH_LOCAL_LLAMA_CPP_DIR"
     fi
@@ -1964,11 +1980,14 @@ if [ -n "${UNSLOTH_LOCAL_LLAMA_CPP_DIR:-}" ]; then
     # this works whether or not the leaf currently exists.
     _CANON_LLAMA_CPP_DIR="$LLAMA_CPP_DIR"
     _LLAMA_CPP_PARENT="$(dirname "$LLAMA_CPP_DIR")"
-    # Also an if condition: an unsearchable parent keeps the textual path rather
-    # than aborting, which is what an absent parent already does.
-    if [ -d "$_LLAMA_CPP_PARENT" ] &&
-       _canon_parent="$(CDPATH= cd -P -- "$_LLAMA_CPP_PARENT" 2>/dev/null && pwd -P)"; then
-        _CANON_LLAMA_CPP_DIR="$_canon_parent/$(basename "$LLAMA_CPP_DIR")"
+    if [ -d "$_LLAMA_CPP_PARENT" ]; then
+        # Report rather than carry on: nothing can be written under a parent we
+        # cannot search, so the link below would abort raw a few lines later.
+        if _canon_parent="$(CDPATH= cd -P -- "$_LLAMA_CPP_PARENT" 2>/dev/null && pwd -P)"; then
+            _CANON_LLAMA_CPP_DIR="$_canon_parent/$(basename "$LLAMA_CPP_DIR")"
+        else
+            _path_access_denied "$_LLAMA_CPP_PARENT" "Unsloth install directory" owner-unverified
+        fi
     fi
     if [ "$_RESOLVED_LOCAL" = "$_CANON_LLAMA_CPP_DIR" ]; then
         # Points at the canonical install location itself: never delete-then-link

--- a/tests/sh/test_setup_sh_denied_install_tree.sh
+++ b/tests/sh/test_setup_sh_denied_install_tree.sh
@@ -111,6 +111,20 @@ else
     ok "no unguarded rm -rf of the install dir remains"
 fi
 
+# A bare $(cd ...) assignment aborts under errexit before setup_fail can report,
+# so the desktop app gets an exit code with no [TAURI:ERROR]. Both must sit in an
+# if condition, which errexit exempts.
+if grep -qE '^\s*_RESOLVED_LOCAL="\$\(CDPATH= cd' "$SETUP_SH"; then
+    bad "a denied UNSLOTH_LOCAL_LLAMA_CPP_DIR reports instead of tripping errexit"
+else
+    ok "a denied UNSLOTH_LOCAL_LLAMA_CPP_DIR reports instead of tripping errexit"
+fi
+if grep -qE '^\s*_CANON_LLAMA_CPP_DIR="\$\(CDPATH= cd' "$SETUP_SH"; then
+    bad "an unsearchable install parent keeps the textual path instead of aborting"
+else
+    ok "an unsearchable install parent keeps the textual path instead of aborting"
+fi
+
 echo ""
 echo "=== behaviour against a genuinely unsearchable tree ==="
 

--- a/tests/sh/test_setup_sh_denied_install_tree.sh
+++ b/tests/sh/test_setup_sh_denied_install_tree.sh
@@ -144,7 +144,8 @@ import sys, pathlib
 src = pathlib.Path(sys.argv[1]).read_text()
 out = []
 for name in ("_studio_owned_adoptable", "_studio_dir_unsearchable",
-             "_studio_dir_unreadable", "_report_denied_ancestor",
+             "_studio_dir_unreadable", "_studio_rstrip_slash",
+             "_report_denied_ancestor",
              "_path_access_denied", "_assert_studio_owned_or_absent"):
     i = src.index(name + "() {")
     out.append(src[i:src.index("\n}\n", i) + 3])
@@ -308,6 +309,24 @@ else
     esac
 fi
 chmod 755 "$SYM/shared/denied"
+
+# A trailing slash follows the link, so "link/" is not -L: it must still report.
+chmod 000 "$SYM/shared/denied"
+if [ -d "$SYM/tmp/local/llama.cpp" ]; then
+    echo "  SKIP: this host cannot make an ancestor unsearchable (running as root?)"
+else
+    case "$(rda "$WORK" "$SYM/tmp/local/")" in
+        *"$SYM/shared/denied"*) ok "a trailing slash still finds the denied target" ;;
+        *) bad "a trailing slash still finds the denied target" ;;
+    esac
+fi
+chmod 755 "$SYM/shared/denied"
+
+# Stripping must stop at the root instead of emptying the path.
+case "$(bash -c '. "$1"; _studio_rstrip_slash "/"; printf "|"; _studio_rstrip_slash "//"' _ "$WORK/helpers.sh")" in
+    "/|/") ok "stripping trailing slashes never consumes the root" ;;
+    *) bad "stripping trailing slashes never consumes the root" ;;
+esac
 
 # A dangling symlink is genuinely missing, so it must not be reported as denied.
 ln -s "$SYM/gone" "$SYM/tmp/dangle"

--- a/tests/sh/test_setup_sh_denied_install_tree.sh
+++ b/tests/sh/test_setup_sh_denied_install_tree.sh
@@ -29,7 +29,7 @@ assert_contains "defines the unsearchable-directory probe" \
 # cd needs +x, exactly what the marker probes need; ls needs +r, which is neither
 # sufficient nor necessary. Pin the cd form.
 assert_contains "the probe tests search (cd), not read (ls)" \
-    "$SETUP_SH" '( cd "$1" ) 2>/dev/null && return 1'
+    "$SETUP_SH" '( cd -- "$1" ) 2>/dev/null && return 1'
 assert_contains "defines the denial reporter" \
     "$SETUP_SH" "_path_access_denied() {"
 assert_contains "the ownership guard checks readability before blaming ownership" \
@@ -280,6 +280,62 @@ case "$out" in
     *NOT_REPORTED*) ok "a genuinely missing path is not reported as denied" ;;
     *) bad "a genuinely missing path is not reported as denied (got: $out)" ;;
 esac
+
+# Run the reporter over $2 from directory $1, with errexit on like the real script.
+rda() {
+    ( cd "$1" && bash -c 'set -e
+        . "$1"
+        C_ERR= C_WARN= C_DIM= C_OK= C_RST=
+        step() { printf "STEP|%s|%s\n" "$1" "$2"; }; substep() { :; }
+        setup_fail() { printf "FAIL|%s\n" "$2"; exit "$1"; }
+        _report_denied_ancestor "$2" "UNSLOTH_LOCAL_LLAMA_CPP_DIR"
+        echo "NOT_REPORTED"' _ "$WORK/helpers.sh" "$2" 2>&1 )
+}
+
+# A symlink pointing under a denied ancestor is unstattable the whole way down,
+# so a lexical walk alone would call the real build missing.
+SYM="$WORK/sym"; mkdir -p "$SYM/shared/denied/build/llama.cpp" "$SYM/tmp"
+ln -s "$SYM/shared/denied/build" "$SYM/tmp/local"
+chmod 000 "$SYM/shared/denied"
+if [ -d "$SYM/tmp/local/llama.cpp" ]; then
+    echo "  SKIP: this host cannot make an ancestor unsearchable (running as root?)"
+else
+    ok "the symlink target is really unreachable (negative control)"
+    out=$(rda "$WORK" "$SYM/tmp/local/llama.cpp")
+    case "$out" in
+        *"$SYM/shared/denied"*) ok "a symlinked build names the denied target ancestor" ;;
+        *) bad "a symlinked build names the denied target ancestor (got: $out)" ;;
+    esac
+fi
+chmod 755 "$SYM/shared/denied"
+
+# A dangling symlink is genuinely missing, so it must not be reported as denied.
+ln -s "$SYM/gone" "$SYM/tmp/dangle"
+case "$(rda "$WORK" "$SYM/tmp/dangle/llama.cpp")" in
+    *NOT_REPORTED*) ok "a dangling symlink is not reported as denied" ;;
+    *) bad "a dangling symlink is not reported as denied" ;;
+esac
+
+# A symlink cycle must terminate on the hop cap instead of looping forever.
+ln -s "$SYM/tmp/a" "$SYM/tmp/b"; ln -s "$SYM/tmp/b" "$SYM/tmp/a"
+case "$(rda "$WORK" "$SYM/tmp/a/llama.cpp")" in
+    *NOT_REPORTED*) ok "a symlink cycle terminates without reporting" ;;
+    *) bad "a symlink cycle terminates without reporting" ;;
+esac
+
+# A relative path starting with "-" must reach the reporter, not be eaten by
+# dirname as an option and abort the whole run on errexit.
+DASH="$WORK/dash"; mkdir -p "$DASH"
+( cd "$DASH" && mkdir -p -- "-denied/llama.cpp" && chmod 000 -- "-denied" )
+if [ -d "$DASH/-denied/llama.cpp" ]; then
+    echo "  SKIP: this host cannot make an ancestor unsearchable (running as root?)"
+else
+    case "$(rda "$DASH" "-denied/llama.cpp")" in
+        *"cannot be read: permission denied"*) ok "a leading-dash path reports instead of aborting" ;;
+        *) bad "a leading-dash path reports instead of aborting" ;;
+    esac
+fi
+chmod 755 -- "$DASH/-denied"
 
 echo ""
 echo "=== Results ==="

--- a/tests/sh/test_setup_sh_denied_install_tree.sh
+++ b/tests/sh/test_setup_sh_denied_install_tree.sh
@@ -26,8 +26,7 @@ echo "=== setup.sh: the guards exist and probe the right permission ==="
 
 assert_contains "defines the unsearchable-directory probe" \
     "$SETUP_SH" "_studio_dir_unsearchable() {"
-# cd needs +x, exactly what the marker probes need; ls needs +r, which is neither
-# sufficient nor necessary. Pin the cd form.
+# cd needs +x, what the marker probes need; ls needs +r, neither sufficient nor necessary. Pin the cd form.
 assert_contains "the probe tests search (cd), not read (ls)" \
     "$SETUP_SH" '( cd -- "$1" ) 2>/dev/null && return 1'
 assert_contains "defines the denial reporter" \
@@ -111,9 +110,8 @@ else
     ok "no unguarded rm -rf of the install dir remains"
 fi
 
-# A bare $(cd ...) assignment aborts under errexit before setup_fail can report,
-# so the desktop app gets an exit code with no [TAURI:ERROR]. Both must sit in an
-# if condition, which errexit exempts.
+# A bare $(cd ...) assignment aborts under errexit before setup_fail can report, leaving
+# an exit code with no [TAURI:ERROR]. Both must sit in an if condition, which errexit exempts.
 if grep -qE '^\s*_RESOLVED_LOCAL="\$\(CDPATH= cd' "$SETUP_SH"; then
     bad "a denied UNSLOTH_LOCAL_LLAMA_CPP_DIR reports instead of tripping errexit"
 else
@@ -127,8 +125,7 @@ fi
 # Carrying on past a denied parent only moves the abort to the ln a few lines down.
 assert_contains "a denied install parent stops rather than continuing" \
     "$SETUP_SH" '_path_access_denied "$_LLAMA_CPP_PARENT" "Unsloth install directory" owner-unverified'
-# An unsearchable ancestor makes a real path unstattable, so [ ! -d ] reads it as
-# missing and would send the user to fix a path that is already correct.
+# An unsearchable ancestor makes a real path unstattable, so [ ! -d ] would call it missing.
 assert_contains "a denied ancestor is reported before the missing-path guard" \
     "$SETUP_SH" '_report_denied_ancestor "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" "UNSLOTH_LOCAL_LLAMA_CPP_DIR"'
 
@@ -293,8 +290,7 @@ rda() {
         echo "NOT_REPORTED"' _ "$WORK/helpers.sh" "$2" 2>&1 )
 }
 
-# A symlink pointing under a denied ancestor is unstattable the whole way down,
-# so a lexical walk alone would call the real build missing.
+# A symlink under a denied ancestor is unstattable all the way down, so a lexical walk alone would call the build missing.
 SYM="$WORK/sym"; mkdir -p "$SYM/shared/denied/build/llama.cpp" "$SYM/tmp"
 ln -s "$SYM/shared/denied/build" "$SYM/tmp/local"
 chmod 000 "$SYM/shared/denied"
@@ -342,8 +338,7 @@ case "$(rda "$WORK" "$SYM/tmp/a/llama.cpp")" in
     *) bad "a symlink cycle terminates without reporting" ;;
 esac
 
-# A relative path starting with "-" must reach the reporter, not be eaten by
-# dirname as an option and abort the whole run on errexit.
+# A leading-dash path must reach the reporter, not be eaten as a dirname option and abort on errexit.
 DASH="$WORK/dash"; mkdir -p "$DASH"
 ( cd "$DASH" && mkdir -p -- "-denied/llama.cpp" && chmod 000 -- "-denied" )
 if [ -d "$DASH/-denied/llama.cpp" ]; then

--- a/tests/sh/test_setup_sh_denied_install_tree.sh
+++ b/tests/sh/test_setup_sh_denied_install_tree.sh
@@ -120,10 +120,17 @@ else
     ok "a denied UNSLOTH_LOCAL_LLAMA_CPP_DIR reports instead of tripping errexit"
 fi
 if grep -qE '^\s*_CANON_LLAMA_CPP_DIR="\$\(CDPATH= cd' "$SETUP_SH"; then
-    bad "an unsearchable install parent keeps the textual path instead of aborting"
+    bad "an unsearchable install parent is reported instead of aborting"
 else
-    ok "an unsearchable install parent keeps the textual path instead of aborting"
+    ok "an unsearchable install parent is reported instead of aborting"
 fi
+# Carrying on past a denied parent only moves the abort to the ln a few lines down.
+assert_contains "a denied install parent stops rather than continuing" \
+    "$SETUP_SH" '_path_access_denied "$_LLAMA_CPP_PARENT" "Unsloth install directory" owner-unverified'
+# An unsearchable ancestor makes a real path unstattable, so [ ! -d ] reads it as
+# missing and would send the user to fix a path that is already correct.
+assert_contains "a denied ancestor is reported before the missing-path guard" \
+    "$SETUP_SH" '_report_denied_ancestor "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" "UNSLOTH_LOCAL_LLAMA_CPP_DIR"'
 
 echo ""
 echo "=== behaviour against a genuinely unsearchable tree ==="
@@ -137,7 +144,7 @@ import sys, pathlib
 src = pathlib.Path(sys.argv[1]).read_text()
 out = []
 for name in ("_studio_owned_adoptable", "_studio_dir_unsearchable",
-             "_studio_dir_unreadable",
+             "_studio_dir_unreadable", "_report_denied_ancestor",
              "_path_access_denied", "_assert_studio_owned_or_absent"):
     i = src.index(name + "() {")
     out.append(src[i:src.index("\n}\n", i) + 3])
@@ -238,6 +245,41 @@ else
     esac
 fi
 chmod 755 "$NOLIST"
+
+# A real build under an unsearchable ancestor must report permissions, not "missing".
+ANC="$WORK/anc"; mkdir -p "$ANC/denied/llama.cpp"
+chmod 000 "$ANC/denied"
+if [ -d "$ANC/denied/llama.cpp" ]; then
+    echo "  SKIP: this host cannot make an ancestor unsearchable (running as root?)"
+else
+    ok "the ancestor is really unsearchable (negative control)"
+    out=$(bash -c '. "$1"
+        C_ERR= C_WARN= C_DIM= C_OK= C_RST=
+        step() { printf "STEP|%s|%s\n" "$1" "$2"; }; substep() { :; }
+        setup_fail() { printf "FAIL|%s\n" "$2"; exit "$1"; }
+        _report_denied_ancestor "$2" "UNSLOTH_LOCAL_LLAMA_CPP_DIR"
+        echo "NOT_REPORTED"' _ "$WORK/helpers.sh" "$ANC/denied/llama.cpp" 2>&1)
+    case "$out" in
+        *"cannot be read: permission denied"*) ok "a build under a denied ancestor reports permissions" ;;
+        *) bad "a build under a denied ancestor reports permissions (got: $out)" ;;
+    esac
+    case "$out" in
+        *"$ANC/denied"*) ok "the message names the denied ancestor, not the leaf" ;;
+        *) bad "the message names the denied ancestor, not the leaf (got: $out)" ;;
+    esac
+fi
+chmod 755 "$ANC/denied"
+# A genuinely missing path must still be reported as missing, not as denied.
+out=$(bash -c '. "$1"
+    C_ERR= C_WARN= C_DIM= C_OK= C_RST=
+    step() { :; }; substep() { :; }
+    setup_fail() { printf "FAIL|%s\n" "$2"; exit "$1"; }
+    _report_denied_ancestor "$2" "UNSLOTH_LOCAL_LLAMA_CPP_DIR"
+    echo "NOT_REPORTED"' _ "$WORK/helpers.sh" "$WORK/definitely-absent" 2>&1)
+case "$out" in
+    *NOT_REPORTED*) ok "a genuinely missing path is not reported as denied" ;;
+    *) bad "a genuinely missing path is not reported as denied (got: $out)" ;;
+esac
 
 echo ""
 echo "=== Results ==="


### PR DESCRIPTION
## Problem

`studio/setup.sh` runs under `set -euo pipefail`. Two path resolutions assign straight from a command substitution:

```sh
_RESOLVED_LOCAL="$(CDPATH= cd -P -- "$UNSLOTH_LOCAL_LLAMA_CPP_DIR" && pwd -P)"
_CANON_LLAMA_CPP_DIR="$(CDPATH= cd -P -- "$_LLAMA_CPP_PARENT" && pwd -P)/$(basename "$LLAMA_CPP_DIR")"
```

If the `cd` fails, errexit kills the script on that line, before `setup_fail` can run. So pointing `--with-llama-cpp-dir` (or `UNSLOTH_LOCAL_LLAMA_CPP_DIR`) at a directory the current user cannot traverse exits 1 with no `[TAURI:ERROR]` line, and the desktop app shows a bare exit code instead of the reason. Reproduced against a mode-000 directory:

```
cd: /path/to/denied: Permission denied
exited with 1 and no setup_fail ran
```

The second site has the same exposure when the install parent, normally `~/.unsloth`, exists but is unsearchable.

`setup.ps1` already reports this case, so this is the POSIX side of it. Three sibling call sites in this same file (lines 936, 959, 963) already guard the pattern; these two were the stragglers.

## Fix

Move both into an `if` condition, which errexit exempts.

- A denied `UNSLOTH_LOCAL_LLAMA_CPP_DIR` now goes through `_path_access_denied` in `owner-unverified` mode, so the message never tells the user to delete a tree Unsloth does not own, and `setup_fail` emits the structured `[TAURI:ERROR]` the desktop app reads.
- An unsearchable install parent keeps the textual path instead of aborting, which is exactly what an absent parent already does.

## Behaviour

| case | before | after |
|---|---|---|
| `--with-llama-cpp-dir` at a denied directory | exit 1, no `[TAURI:ERROR]` | permissions block with recovery steps, plus the marker |
| readable directory | unchanged | unchanged |
| unsearchable install parent | errexit abort | textual path kept, setup continues |

Scope is deliberately small: no behaviour changes on any readable path, and no new strings, since it reuses the existing `_path_access_denied` wording.

## Testing

- `bash tests/sh/test_setup_sh_denied_install_tree.sh` (32 checks, 2 new). Both new checks fail when either bare assignment is restored.
- All 42 files under `tests/sh` pass.
- `python -m pytest tests/studio/install/test_denied_llama_cpp_preflight.py tests/studio/install/test_setup_denied_install_tree.py` (49 passed), and `tests/studio/install` is 1702 passed. The 3 failures in `test_managed_node_runtime.py` reproduce identically on current main.
- `bash -n` and `bash --posix -n` clean; shellcheck reports the same 37 findings as main, none in the changed lines.
