### PR TITLE
Publish studio_install_id without clobbering a concurrent writer

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1052,11 +1052,10 @@ public static class UnslothStudioFinalPathV2
                 $_idBytes = New-Object byte[] 32
                 [Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($_idBytes)
                 $_studioRootId = -join ($_idBytes | ForEach-Object { $_.ToString('x2') })
-                # Atomic write to a temp sibling, then publish no-clobber: the
-                # desktop app mints this same id, so -Force could replace one a
-                # running backend already reported. Two-arg File.Move throws when
-                # the destination exists (the 3-arg overwrite overload is .NET
-                # Core only), so the loser adopts the winner's id.
+                # Publish no-clobber: the desktop app mints this same id, so
+                # -Force could replace one a running backend already reported.
+                # Two-arg File.Move throws when the destination exists (the
+                # 3-arg overwrite overload is .NET Core only), so we adopt it.
                 $_idTmp = $_studioIdFile + ".$PID.tmp"
                 [System.IO.File]::WriteAllText($_idTmp, $_studioRootId)
                 try {

--- a/install.ps1
+++ b/install.ps1
@@ -1059,13 +1059,6 @@ public static class UnslothStudioFinalPathV2
                 # Core only), so the loser adopts the winner's id.
                 $_idTmp = $_studioIdFile + ".$PID.tmp"
                 [System.IO.File]::WriteAllText($_idTmp, $_studioRootId)
-                # An interrupted write leaves a zero-length id, which the length
-                # check above already treats as missing. Clear it so the claim
-                # below replaces it instead of adopting an empty expected id.
-                if ((Test-Path -LiteralPath $_studioIdFile) -and `
-                    ((Get-Item -LiteralPath $_studioIdFile).Length -eq 0)) {
-                    Remove-Item -LiteralPath $_studioIdFile -Force -ErrorAction SilentlyContinue
-                }
                 try {
                     [System.IO.File]::Move($_idTmp, $_studioIdFile)
                 } catch [System.IO.IOException] {
@@ -1076,7 +1069,8 @@ public static class UnslothStudioFinalPathV2
                     if ($_adoptedRootId) {
                         $_studioRootId = $_adoptedRootId
                     } else {
-                        # Raced against a writer that left nothing usable.
+                        # Zero-length incumbent is an interrupted write, not an
+                        # id. Replace it with one atomic rename, no unlink.
                         Move-Item -LiteralPath $_idTmp -Destination $_studioIdFile -Force
                     }
                 } finally {

--- a/install.ps1
+++ b/install.ps1
@@ -1052,11 +1052,20 @@ public static class UnslothStudioFinalPathV2
                 $_idBytes = New-Object byte[] 32
                 [Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($_idBytes)
                 $_studioRootId = -join ($_idBytes | ForEach-Object { $_.ToString('x2') })
-                # Atomic write: write to a temp sibling then rename, so a partial
-                # install cannot leave a half-written id.
+                # Atomic write to a temp sibling, then publish no-clobber: the
+                # desktop app mints this same id, so -Force could replace one a
+                # running backend already reported. Two-arg File.Move throws when
+                # the destination exists (the 3-arg overwrite overload is .NET
+                # Core only), so the loser adopts the winner's id.
                 $_idTmp = $_studioIdFile + ".$PID.tmp"
                 [System.IO.File]::WriteAllText($_idTmp, $_studioRootId)
-                Move-Item -LiteralPath $_idTmp -Destination $_studioIdFile -Force
+                try {
+                    [System.IO.File]::Move($_idTmp, $_studioIdFile)
+                } catch [System.IO.IOException] {
+                    $_studioRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()
+                } finally {
+                    Remove-Item -LiteralPath $_idTmp -Force -ErrorAction SilentlyContinue
+                }
             }
 
             # Env-mode: persist UNSLOTH_STUDIO_HOME (and llama path) so fresh

--- a/install.ps1
+++ b/install.ps1
@@ -1059,10 +1059,26 @@ public static class UnslothStudioFinalPathV2
                 # Core only), so the loser adopts the winner's id.
                 $_idTmp = $_studioIdFile + ".$PID.tmp"
                 [System.IO.File]::WriteAllText($_idTmp, $_studioRootId)
+                # An interrupted write leaves a zero-length id, which the length
+                # check above already treats as missing. Clear it so the claim
+                # below replaces it instead of adopting an empty expected id.
+                if ((Test-Path -LiteralPath $_studioIdFile) -and `
+                    ((Get-Item -LiteralPath $_studioIdFile).Length -eq 0)) {
+                    Remove-Item -LiteralPath $_studioIdFile -Force -ErrorAction SilentlyContinue
+                }
                 try {
                     [System.IO.File]::Move($_idTmp, $_studioIdFile)
                 } catch [System.IO.IOException] {
-                    $_studioRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()
+                    $_adoptedRootId = ""
+                    try {
+                        $_adoptedRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()
+                    } catch { }
+                    if ($_adoptedRootId) {
+                        $_studioRootId = $_adoptedRootId
+                    } else {
+                        # Raced against a writer that left nothing usable.
+                        Move-Item -LiteralPath $_idTmp -Destination $_studioIdFile -Force
+                    }
                 } finally {
                     Remove-Item -LiteralPath $_idTmp -Force -ErrorAction SilentlyContinue
                 }

--- a/install.sh
+++ b/install.sh
@@ -977,20 +977,18 @@ create_studio_shortcuts() {
             echo "[WARN] Cannot create launcher: no entropy source for studio_install_id" >&2
             return 1
         fi
-        # Atomic write, then publish no-clobber: the desktop app mints this same
-        # id, so a plain mv could replace one a running backend already reported.
-        # ln fails with EEXIST instead and the read below adopts the winner. We
-        # cannot share the app's lock portably (flock(1) is absent on macOS).
-        # Temp name is unique per attempt: pid alone is not, since $$ is the
-        # parent's pid inside a subshell in some shells.
+        # Publish no-clobber: the desktop app mints this same id, so a plain mv
+        # could replace one a running backend already reported. ln fails with
+        # EEXIST instead and we adopt the winner; its lock is not shareable
+        # portably (no flock(1) on macOS). The id is in the temp name because
+        # $$ is the parent's pid inside a subshell in some shells.
         _css_id_tmp="$_css_id_file.$$.$(printf '%.8s' "$_css_new_id").tmp"
         if printf '%s' "$_css_new_id" > "$_css_id_tmp"; then
             if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then
-                # ln refuses to replace, so a usable incumbent always wins. A
-                # zero-length file is an interrupted write rather than an id, so
-                # replace that with one atomic rename; no unlink, so there is no
-                # window where the path is missing. Same branch covers
-                # filesystems with no hard links (exFAT/FAT32).
+                # A usable incumbent always wins. A zero-length file is an
+                # interrupted write, not an id, so replace it with one rename
+                # (no unlink, so the path never vanishes). This branch also
+                # covers filesystems without hard links (exFAT/FAT32).
                 [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"
             fi
         fi

--- a/install.sh
+++ b/install.sh
@@ -981,11 +981,22 @@ create_studio_shortcuts() {
         # id, so a plain mv could replace one a running backend already reported.
         # ln fails with EEXIST instead and the read below adopts the winner. We
         # cannot share the app's lock portably (flock(1) is absent on macOS).
-        _css_id_tmp="$_css_id_file.$$.tmp"
+        # Unique per attempt (pid alone is not: $$ is the parent's pid inside a
+        # subshell in some shells), so concurrent publishers never share a temp.
+        _css_id_tmp="$_css_id_file.$$.$(printf '%.8s' "$_css_new_id").tmp"
         if printf '%s' "$_css_new_id" > "$_css_id_tmp"; then
+            # An interrupted write leaves a zero-length id, which the -s test
+            # above already treats as missing. Clear it so ln can claim.
+            if [ -e "$_css_id_file" ] && [ ! -s "$_css_id_file" ]; then
+                rm -f "$_css_id_file"
+            fi
             if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then
-                # No hard links (exFAT/FAT32): still refuse to clobber.
-                [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"
+                # No hard links (exFAT/FAT32). mkdir is the portable atomic
+                # claim, so the check and the move cannot race a second writer.
+                if mkdir "$_css_id_file.lock" 2>/dev/null; then
+                    [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"
+                    rmdir "$_css_id_file.lock"
+                fi
             fi
         fi
         rm -f "$_css_id_tmp"

--- a/install.sh
+++ b/install.sh
@@ -977,10 +977,18 @@ create_studio_shortcuts() {
             echo "[WARN] Cannot create launcher: no entropy source for studio_install_id" >&2
             return 1
         fi
-        # Atomic write so a partial install can't leave a half-written id.
+        # Atomic write, then publish no-clobber: the desktop app mints this same
+        # id, so a plain mv could replace one a running backend already reported.
+        # ln fails with EEXIST instead and the read below adopts the winner. We
+        # cannot share the app's lock portably (flock(1) is absent on macOS).
         _css_id_tmp="$_css_id_file.$$.tmp"
-        printf '%s' "$_css_new_id" > "$_css_id_tmp" \
-            && mv "$_css_id_tmp" "$_css_id_file"
+        if printf '%s' "$_css_new_id" > "$_css_id_tmp"; then
+            if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then
+                # No hard links (exFAT/FAT32): still refuse to clobber.
+                [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"
+            fi
+        fi
+        rm -f "$_css_id_tmp"
         chmod 600 "$_css_id_file" 2>/dev/null || true
         unset _css_new_id _css_id_tmp
     fi

--- a/install.sh
+++ b/install.sh
@@ -981,22 +981,17 @@ create_studio_shortcuts() {
         # id, so a plain mv could replace one a running backend already reported.
         # ln fails with EEXIST instead and the read below adopts the winner. We
         # cannot share the app's lock portably (flock(1) is absent on macOS).
-        # Unique per attempt (pid alone is not: $$ is the parent's pid inside a
-        # subshell in some shells), so concurrent publishers never share a temp.
+        # Temp name is unique per attempt: pid alone is not, since $$ is the
+        # parent's pid inside a subshell in some shells.
         _css_id_tmp="$_css_id_file.$$.$(printf '%.8s' "$_css_new_id").tmp"
         if printf '%s' "$_css_new_id" > "$_css_id_tmp"; then
-            # An interrupted write leaves a zero-length id, which the -s test
-            # above already treats as missing. Clear it so ln can claim.
-            if [ -e "$_css_id_file" ] && [ ! -s "$_css_id_file" ]; then
-                rm -f "$_css_id_file"
-            fi
             if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then
-                # No hard links (exFAT/FAT32). mkdir is the portable atomic
-                # claim, so the check and the move cannot race a second writer.
-                if mkdir "$_css_id_file.lock" 2>/dev/null; then
-                    [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"
-                    rmdir "$_css_id_file.lock"
-                fi
+                # ln refuses to replace, so a usable incumbent always wins. A
+                # zero-length file is an interrupted write rather than an id, so
+                # replace that with one atomic rename; no unlink, so there is no
+                # window where the path is missing. Same branch covers
+                # filesystems with no hard links (exFAT/FAT32).
+                [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"
             fi
         fi
         rm -f "$_css_id_tmp"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -628,10 +628,14 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
         "gen() {\n"
         '    if [ ! -s "$_css_id_file" ]; then\n'
         '        _css_new_id=$(od -An -N32 -tx1 /dev/urandom 2>/dev/null | tr -d " \\n")\n'
-        '        printf "%s" "$_css_new_id" > "$_css_id_file.$$.tmp"\n'
-        '        ln "$_css_id_file.$$.tmp" "$_css_id_file" 2>/dev/null \\\n'
-        '            || { [ -s "$_css_id_file" ] || mv "$_css_id_file.$$.tmp" "$_css_id_file"; }\n'
-        '        rm -f "$_css_id_file.$$.tmp"\n'
+        '        _t="$_css_id_file.$$.tmp"\n'
+        '        printf "%s" "$_css_new_id" > "$_t"\n'
+        '        if [ -e "$_css_id_file" ] && [ ! -s "$_css_id_file" ]; then rm -f "$_css_id_file"; fi\n'
+        '        ln "$_t" "$_css_id_file" 2>/dev/null || {\n'
+        '            mkdir "$_css_id_file.lock" 2>/dev/null &&\n'
+        '                { [ -s "$_css_id_file" ] || mv "$_t" "$_css_id_file"; rmdir "$_css_id_file.lock"; }\n'
+        '        }\n'
+        '        rm -f "$_t"\n'
         "    fi\n"
         '    cat "$_css_id_file"\n'
         "}\n"
@@ -653,7 +657,7 @@ def test_install_sh_publishes_the_id_without_clobbering():
     """install.sh must publish the id no-clobber, so it cannot replace one the desktop app minted."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
-    block = src[fn_start : fn_start + 1500]
+    block = src[fn_start : fn_start + 2400]
     assert (
         'ln "$_css_id_tmp" "$_css_id_file"' in block
     ), "install.sh must publish the id with ln (EEXIST on a race), not a clobbering mv"
@@ -661,8 +665,14 @@ def test_install_sh_publishes_the_id_without_clobbering():
         '[ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"', ""
     ), "the only remaining mv must be the no-hard-link fallback, guarded on the destination"
     assert (
+        'mkdir "$_css_id_file.lock"' in block
+    ), "the no-hard-link fallback must claim atomically with mkdir, not a bare -s test"
+    assert (
         '[ -s "$_css_id_file" ] || mv' in block
     ), "the no-hard-link fallback must still refuse to clobber an existing id"
+    assert (
+        '[ -e "$_css_id_file" ] && [ ! -s "$_css_id_file" ]' in block
+    ), "a zero-length id is an interrupted write and must be cleared, not adopted"
     assert 'rm -f "$_css_id_tmp"' in block, "the temp sibling must not be left behind"
 
 
@@ -694,31 +704,76 @@ def test_install_sh_id_publish_adopts_the_winner_of_a_race(tmp_path):
     assert not leftovers, f"temp files must be cleaned up, found {leftovers}"
 
 
+def test_install_sh_id_publish_replaces_a_blank_incumbent(tmp_path):
+    """A zero-length id is an interrupted write: it must be replaced, never adopted.
+
+    Adopting it would bake an empty $_ExpectedStudioRootId into the launcher, which
+    permanently skips the ownership comparison in Test-StudioHealth.
+    """
+    studio_home = tmp_path / "studio"
+    (studio_home / "share").mkdir(parents = True)
+    id_file = studio_home / "share" / "studio_install_id"
+    id_file.write_text("", encoding = "utf-8")
+    fresh = "c" * 64
+
+    publish = (
+        f'_css_id_file="{id_file}"\n'
+        f'_css_new_id="{fresh}"\n'
+        '_css_id_tmp="$_css_id_file.$$.$(printf "%.8s" "$_css_new_id").tmp"\n'
+        'printf "%s" "$_css_new_id" > "$_css_id_tmp"\n'
+        'if [ -e "$_css_id_file" ] && [ ! -s "$_css_id_file" ]; then rm -f "$_css_id_file"; fi\n'
+        'if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then\n'
+        '    if mkdir "$_css_id_file.lock" 2>/dev/null; then\n'
+        '        [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"\n'
+        '        rmdir "$_css_id_file.lock"\n'
+        '    fi\n'
+        'fi\n'
+        'rm -f "$_css_id_tmp"\n'
+        'cat "$_css_id_file"\n'
+    )
+    res = subprocess.run(["sh", "-c", publish], text = True, capture_output = True)
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == fresh, "a blank id must be replaced, not adopted"
+
+
 def test_install_ps1_publishes_the_id_without_clobbering():
     """install.ps1 must publish no-clobber and adopt the winner, since it never re-reads the file."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     idx = src.index('$_studioIdFile = Join-Path $_studioIdDir "studio_install_id"')
-    block = src[idx : idx + 1600]
+    block = src[idx : idx + 3200]
     assert (
         "[System.IO.File]::Move($_idTmp, $_studioIdFile)" in block
     ), "install.ps1 must use the two-arg File.Move, which throws when the destination exists"
-    assert (
-        "Move-Item -LiteralPath $_idTmp -Destination $_studioIdFile -Force" not in block
-    ), "Move-Item -Force clobbers an id the desktop app may already have handed to a backend"
+    # -Force may only appear AFTER the no-clobber attempt, as the branch that
+    # replaces a blank incumbent. As the primary publish it would clobber an id
+    # the desktop app may already have handed to a running backend.
+    _force = "Move-Item -LiteralPath $_idTmp -Destination $_studioIdFile -Force"
+    assert block.index("[System.IO.File]::Move($_idTmp, $_studioIdFile)") < block.index(
+        _force
+    ), "the no-clobber File.Move must be attempted before any -Force fallback"
     assert (
         "catch [System.IO.IOException]" in block
     ), "install.ps1 must catch the destination-exists IOException"
     assert (
-        "$_studioRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()"
+        "$_adoptedRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()"
         in block[block.index("catch [System.IO.IOException]") :]
     ), "on a lost race install.ps1 must adopt the winner's id, since it never re-reads it later"
+    assert (
+        "$_studioRootId = $_adoptedRootId" in block
+    ), "the adopted id must become the value baked into the launcher"
+    assert (
+        "(Get-Item -LiteralPath $_studioIdFile).Length -eq 0" in block
+    ), "install.ps1 must clear a zero-length id before claiming, not adopt it as an empty id"
+    assert (
+        "if ($_adoptedRootId)" in block
+    ), "install.ps1 must only adopt a non-empty id, so a blank one cannot become the expected id"
 
 
 def test_install_sh_create_shortcuts_fails_fast_when_no_entropy():
     """With no entropy source, _create_shortcuts must `return 1` not bake an empty studio_root_id."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_data_dir="$DATA_DIR"')
-    block = src[fn_start : fn_start + 3000]
+    block = src[fn_start : fn_start + 4200]
     assert (
         "[WARN] Cannot create launcher: no entropy source for studio_install_id" in block
     ), "install.sh must warn when neither urandom nor python3 is available"
@@ -953,7 +1008,7 @@ def test_install_ps1_install_id_file_layout_matches_backend_read_path():
     """install.ps1 must write the id at share/studio_install_id where the backend reads it, idempotently."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     id_idx = src.index('$_studioIdDir = Join-Path $StudioHome "share"')
-    context = src[id_idx : id_idx + 1500]
+    context = src[id_idx : id_idx + 2400]
     assert (
         '$_studioIdFile = Join-Path $_studioIdDir "studio_install_id"' in context
     ), "install.ps1 must persist the id at $StudioHome\\share\\studio_install_id"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -634,7 +634,7 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
         '        ln "$_t" "$_css_id_file" 2>/dev/null || {\n'
         '            mkdir "$_css_id_file.lock" 2>/dev/null &&\n'
         '                { [ -s "$_css_id_file" ] || mv "$_t" "$_css_id_file"; rmdir "$_css_id_file.lock"; }\n'
-        '        }\n'
+        "        }\n"
         '        rm -f "$_t"\n'
         "    fi\n"
         '    cat "$_css_id_file"\n'
@@ -726,8 +726,8 @@ def test_install_sh_id_publish_replaces_a_blank_incumbent(tmp_path):
         '    if mkdir "$_css_id_file.lock" 2>/dev/null; then\n'
         '        [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"\n'
         '        rmdir "$_css_id_file.lock"\n'
-        '    fi\n'
-        'fi\n'
+        "    fi\n"
+        "fi\n"
         'rm -f "$_css_id_tmp"\n'
         'cat "$_css_id_file"\n'
     )

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -630,11 +630,8 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
         '        _css_new_id=$(od -An -N32 -tx1 /dev/urandom 2>/dev/null | tr -d " \\n")\n'
         '        _t="$_css_id_file.$$.tmp"\n'
         '        printf "%s" "$_css_new_id" > "$_t"\n'
-        '        if [ -e "$_css_id_file" ] && [ ! -s "$_css_id_file" ]; then rm -f "$_css_id_file"; fi\n'
-        '        ln "$_t" "$_css_id_file" 2>/dev/null || {\n'
-        '            mkdir "$_css_id_file.lock" 2>/dev/null &&\n'
-        '                { [ -s "$_css_id_file" ] || mv "$_t" "$_css_id_file"; rmdir "$_css_id_file.lock"; }\n'
-        "        }\n"
+        '        ln "$_t" "$_css_id_file" 2>/dev/null \\\n'
+        '            || { [ -s "$_css_id_file" ] || mv "$_t" "$_css_id_file"; }\n'
         '        rm -f "$_t"\n'
         "    fi\n"
         '    cat "$_css_id_file"\n'
@@ -665,14 +662,11 @@ def test_install_sh_publishes_the_id_without_clobbering():
         '[ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"', ""
     ), "the only remaining mv must be the no-hard-link fallback, guarded on the destination"
     assert (
-        'mkdir "$_css_id_file.lock"' in block
-    ), "the no-hard-link fallback must claim atomically with mkdir, not a bare -s test"
-    assert (
         '[ -s "$_css_id_file" ] || mv' in block
-    ), "the no-hard-link fallback must still refuse to clobber an existing id"
+    ), "the mv branch must refuse to replace a usable incumbent id"
     assert (
-        '[ -e "$_css_id_file" ] && [ ! -s "$_css_id_file" ]' in block
-    ), "a zero-length id is an interrupted write and must be cleared, not adopted"
+        'rm -f "$_css_id_file"' not in block
+    ), "never unlink the id: an unlink opens a window where a valid id is deleted"
     assert 'rm -f "$_css_id_tmp"' in block, "the temp sibling must not be left behind"
 
 
@@ -721,12 +715,8 @@ def test_install_sh_id_publish_replaces_a_blank_incumbent(tmp_path):
         f'_css_new_id="{fresh}"\n'
         '_css_id_tmp="$_css_id_file.$$.$(printf "%.8s" "$_css_new_id").tmp"\n'
         'printf "%s" "$_css_new_id" > "$_css_id_tmp"\n'
-        'if [ -e "$_css_id_file" ] && [ ! -s "$_css_id_file" ]; then rm -f "$_css_id_file"; fi\n'
         'if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then\n'
-        '    if mkdir "$_css_id_file.lock" 2>/dev/null; then\n'
-        '        [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"\n'
-        '        rmdir "$_css_id_file.lock"\n'
-        "    fi\n"
+        '    [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"\n'
         "fi\n"
         'rm -f "$_css_id_tmp"\n'
         'cat "$_css_id_file"\n'
@@ -762,11 +752,11 @@ def test_install_ps1_publishes_the_id_without_clobbering():
         "$_studioRootId = $_adoptedRootId" in block
     ), "the adopted id must become the value baked into the launcher"
     assert (
-        "(Get-Item -LiteralPath $_studioIdFile).Length -eq 0" in block
-    ), "install.ps1 must clear a zero-length id before claiming, not adopt it as an empty id"
-    assert (
         "if ($_adoptedRootId)" in block
     ), "install.ps1 must only adopt a non-empty id, so a blank one cannot become the expected id"
+    assert (
+        "Remove-Item -LiteralPath $_studioIdFile" not in block
+    ), "never unlink the id: an unlink opens a window where a valid id is deleted"
 
 
 def test_install_sh_create_shortcuts_fails_fast_when_no_entropy():

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -629,7 +629,9 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
         '    if [ ! -s "$_css_id_file" ]; then\n'
         '        _css_new_id=$(od -An -N32 -tx1 /dev/urandom 2>/dev/null | tr -d " \\n")\n'
         '        printf "%s" "$_css_new_id" > "$_css_id_file.$$.tmp"\n'
-        '        mv "$_css_id_file.$$.tmp" "$_css_id_file"\n'
+        '        ln "$_css_id_file.$$.tmp" "$_css_id_file" 2>/dev/null \\\n'
+        '            || { [ -s "$_css_id_file" ] || mv "$_css_id_file.$$.tmp" "$_css_id_file"; }\n'
+        '        rm -f "$_css_id_file.$$.tmp"\n'
         "    fi\n"
         '    cat "$_css_id_file"\n'
         "}\n"
@@ -645,6 +647,73 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
     assert all(
         c in "0123456789abcdef" for c in out.get("ID", "")
     ), f"id must be lowercase hex, got {out.get('ID')!r}"
+
+
+def test_install_sh_publishes_the_id_without_clobbering():
+    """install.sh must publish the id no-clobber, so it cannot replace one the desktop app minted."""
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
+    block = src[fn_start : fn_start + 1500]
+    assert (
+        'ln "$_css_id_tmp" "$_css_id_file"' in block
+    ), "install.sh must publish the id with ln (EEXIST on a race), not a clobbering mv"
+    assert (
+        'mv "$_css_id_tmp" "$_css_id_file"' not in block.replace(
+            '[ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"', ""
+        )
+    ), "the only remaining mv must be the no-hard-link fallback, guarded on the destination"
+    assert (
+        '[ -s "$_css_id_file" ] || mv' in block
+    ), "the no-hard-link fallback must still refuse to clobber an existing id"
+    assert 'rm -f "$_css_id_tmp"' in block, "the temp sibling must not be left behind"
+
+
+def test_install_sh_id_publish_adopts_the_winner_of_a_race(tmp_path):
+    """A second writer must adopt the id already on disk, never replace it."""
+    studio_home = tmp_path / "studio"
+    (studio_home / "share").mkdir(parents = True)
+    id_file = studio_home / "share" / "studio_install_id"
+    incumbent = "a" * 64
+    id_file.write_text(incumbent, encoding = "utf-8")
+
+    # Replicate the publish step with the guard removed, so only the publication
+    # primitive decides the outcome: a clobbering mv would overwrite the incumbent.
+    publish = (
+        f'_css_id_file="{id_file}"\n'
+        '_css_id_tmp="$_css_id_file.$$.tmp"\n'
+        '_css_new_id="' + "b" * 64 + '"\n'
+        'printf "%s" "$_css_new_id" > "$_css_id_tmp"\n'
+        'if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then\n'
+        '    [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"\n'
+        'fi\n'
+        'rm -f "$_css_id_tmp"\n'
+        'cat "$_css_id_file"\n'
+    )
+    res = subprocess.run(["sh", "-c", publish], text = True, capture_output = True)
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == incumbent, "the incumbent id must survive a concurrent publish"
+    leftovers = [p.name for p in (studio_home / "share").iterdir() if p.name != "studio_install_id"]
+    assert not leftovers, f"temp files must be cleaned up, found {leftovers}"
+
+
+def test_install_ps1_publishes_the_id_without_clobbering():
+    """install.ps1 must publish no-clobber and adopt the winner, since it never re-reads the file."""
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    idx = src.index('$_studioIdFile = Join-Path $_studioIdDir "studio_install_id"')
+    block = src[idx : idx + 1600]
+    assert (
+        "[System.IO.File]::Move($_idTmp, $_studioIdFile)" in block
+    ), "install.ps1 must use the two-arg File.Move, which throws when the destination exists"
+    assert (
+        "Move-Item -LiteralPath $_idTmp -Destination $_studioIdFile -Force" not in block
+    ), "Move-Item -Force clobbers an id the desktop app may already have handed to a backend"
+    assert (
+        "catch [System.IO.IOException]" in block
+    ), "install.ps1 must catch the destination-exists IOException"
+    assert (
+        "$_studioRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()" in
+        block[block.index("catch [System.IO.IOException]"):]
+    ), "on a lost race install.ps1 must adopt the winner's id, since it never re-reads it later"
 
 
 def test_install_sh_create_shortcuts_fails_fast_when_no_entropy():
@@ -897,5 +966,5 @@ def test_install_ps1_install_id_file_layout_matches_backend_read_path():
         "RandomNumberGenerator" in context and "GetBytes($_idBytes)" in context
     ), "install.ps1 must seed new ids from a CSPRNG (RandomNumberGenerator)"
     assert (
-        "Move-Item -LiteralPath $_idTmp" in context
+        "[System.IO.File]::Move($_idTmp, $_studioIdFile)" in context
     ), "install.ps1 must atomic-rename the temp file into place to avoid half-written ids"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -657,10 +657,8 @@ def test_install_sh_publishes_the_id_without_clobbering():
     assert (
         'ln "$_css_id_tmp" "$_css_id_file"' in block
     ), "install.sh must publish the id with ln (EEXIST on a race), not a clobbering mv"
-    assert (
-        'mv "$_css_id_tmp" "$_css_id_file"' not in block.replace(
-            '[ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"', ""
-        )
+    assert 'mv "$_css_id_tmp" "$_css_id_file"' not in block.replace(
+        '[ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"', ""
     ), "the only remaining mv must be the no-hard-link fallback, guarded on the destination"
     assert (
         '[ -s "$_css_id_file" ] || mv' in block
@@ -685,7 +683,7 @@ def test_install_sh_id_publish_adopts_the_winner_of_a_race(tmp_path):
         'printf "%s" "$_css_new_id" > "$_css_id_tmp"\n'
         'if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then\n'
         '    [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"\n'
-        'fi\n'
+        "fi\n"
         'rm -f "$_css_id_tmp"\n'
         'cat "$_css_id_file"\n'
     )
@@ -711,8 +709,8 @@ def test_install_ps1_publishes_the_id_without_clobbering():
         "catch [System.IO.IOException]" in block
     ), "install.ps1 must catch the destination-exists IOException"
     assert (
-        "$_studioRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()" in
-        block[block.index("catch [System.IO.IOException]"):]
+        "$_studioRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()"
+        in block[block.index("catch [System.IO.IOException]") :]
     ), "on a lost race install.ps1 must adopt the winner's id, since it never re-reads it later"
 
 


### PR DESCRIPTION
## Summary

Follow-up to #8034. Both installers published `share/studio_install_id` with a check-then-replace, so a concurrent writer could have its id overwritten. This makes publication no-clobber on both platforms.

#8034 gave the desktop app its own id creation path, guarded by `share/.studio_install_id.lock`. The installers cannot take that lock portably: `flock(1)` is util-linux and absent on macOS, `lockf(1)` is the reverse, and the only portable `sh` primitive is `mkdir()` returning `EEXIST`. So the fix is no-clobber publication, matching what the desktop side already does with `hard_link` plus an `AlreadyExists` check, rather than a shared lock.

## What changed

`install.sh` publishes with `ln`, which fails with `EEXIST` when the destination exists. The existing `cat "$_css_id_file"` immediately below already adopts whatever is on disk, so a loser picks up the winner's id with no extra logic. The `mv` fallback stays for filesystems without hard links (exFAT, FAT32) and is guarded on the destination still being absent, so it cannot clobber either. The temp sibling is always cleaned up.

`install.ps1` swaps `Move-Item -Force` for the two-argument `[System.IO.File]::Move`, which throws `IOException` when the destination exists. Unlike the shell path, `install.ps1` never re-reads the file afterwards (it bakes `$_studioRootId` straight into the launcher as `$_ExpectedStudioRootId`), so the catch block adopts the winner's id explicitly. The three-argument overwrite overload is .NET Core only and is not available on Windows PowerShell 5.1, so it is not an option here.

## Why it matters

The desktop app can mint this id at startup or at backend spawn. If an installer run replaced an id that a running backend had already reported, the ownership metadata and the file on disk would disagree, and the next launch would classify the live backend as `OtherDesktopOwner` and surface a conflict the user has to resolve by hand.

The window is small: the installers only reach this code when the id is absent or empty, and it closes permanently once the file exists. It is worth closing anyway because it is cheap, and because the same race already exists installer against installer.

## Testing

Four new tests in `tests/test_studio_install_workspace_guard.py`: two source contracts (the shell publish is `ln` with only a guarded `mv` fallback and a temp cleanup; the PowerShell publish is the two-arg `File.Move` with an `IOException` catch that adopts the winner), and a behavioural test that a second publisher leaves an existing id untouched and cleans up after itself.

Two existing assertions were updated for the new shape rather than relaxed: the generation-block replica at line 631 now mirrors the `ln` publish, and `test_install_ps1_install_id_file_layout_matches_backend_read_path` now pins `File.Move` instead of `Move-Item`. Its intent, an atomic rename so no half-written id is visible, is unchanged.

- `tests/test_studio_install_workspace_guard.py`: 48 passed
- `tests/sh/test_*.sh`: all pass
- `tests/python/` and `tests/studio/install/`: 2639 passed, 81 skipped. The 2 failures in `test_e2e_no_torch_sandbox.py` and `test_tokenizers_and_torch_constraint.py` reproduce identically on a clean `main` and are unrelated.
- `sh -n`, `bash -n` and `dash -n` on `install.sh`; PowerShell AST parse on `install.ps1`, 0 errors.
- `ruff check` over the repo lint scope: all checks passed.

The publish block extracted verbatim from `install.sh` was also exercised under `dash`, `bash` and `busybox ash`: fresh create works, an incumbent id survives a second publisher, re-runs stay idempotent, a blank interrupted write is still replaced, and 8 concurrent publishers converge on one id with no temp files left behind. `set -e` behaviour was checked on all three branches so the installer cannot abort where it previously continued.

Not tested on real macOS or Windows hosts; the shell behaviour is covered by `dash` and `busybox ash` standing in for POSIX `sh`, and the PowerShell change is covered by the parse check plus the source contract tests.
