### PR TITLE
Studio: bring back the sidebar scrollbar without losing row width

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -164,6 +164,7 @@ import {
   Fragment,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -701,18 +702,23 @@ export function AppSidebar() {
   const [scrolled, setScrolled] = useState(false);
   // Bottom fade hides at the very bottom / for short lists so the last row isn't washed out.
   const [canScrollDown, setCanScrollDown] = useState(false);
-  // Driven only from onScroll + a content-change effect below. No
-  // ResizeObserver: its callback-driven setState caused a render loop (React
-  // #185). Both setters bail out when unchanged, so neither path can loop.
-  const syncScrollState = useCallback((el: HTMLDivElement) => {
-    // Rail width: 0 where scrollbars overlay (macOS default), 8px where they
-    // are classic (Show scroll bars: Always, Windows, Linux). Only rows inside
-    // the scroller lose it, so the rows outside pad by it to keep one edge.
-    // Written straight to the DOM: state here would loop (React #185).
+  // Rail width: 0 where scrollbars overlay (macOS default) or the list does not
+  // overflow, 8px where they are classic (Show scroll bars: Always, Windows,
+  // Linux). Only rows inside the scroller lose it, so the rows outside pad by it
+  // to keep one edge. Written straight to the DOM: state here would loop
+  // (React #185).
+  const measureScrollRail = useCallback((el: HTMLDivElement) => {
     el.parentElement?.style.setProperty(
       "--sidebar-rail",
       `${el.offsetWidth - el.clientWidth}px`,
     );
+  }, []);
+
+  // Driven only from onScroll + a content-change effect below. No
+  // ResizeObserver: its callback-driven setState caused a render loop (React
+  // #185). Both setters bail out when unchanged, so neither path can loop.
+  const syncScrollState = useCallback((el: HTMLDivElement) => {
+    measureScrollRail(el);
     const nextScrolled = el.scrollTop > 0;
     setScrolled((prev) => (prev === nextScrolled ? prev : nextScrolled));
     const nextCanScrollDown =
@@ -720,7 +726,7 @@ export function AppSidebar() {
     setCanScrollDown((prev) =>
       prev === nextCanScrollDown ? prev : nextCanScrollDown,
     );
-  }, []);
+  }, [measureScrollRail]);
 
   const isRecipesRoute = pathname.startsWith("/data-recipes");
   const isExportRoute = pathname === "/export" || pathname.startsWith("/export/");
@@ -937,12 +943,18 @@ export function AppSidebar() {
 
   // Recompute bottom-fade on mount and whenever list height can change: onScroll never fires
   // for short, non-scrolling lists. Guarded setState below can't loop.
-  useEffect(() => {
+  // Measures the rail on the same beat: a classic scrollbar only takes width
+  // once the list overflows, so mount and every one of these is when that can
+  // change. Runs before paint, since a frame on the 0px fallback is a frame of
+  // the misalignment the rail width exists to cancel.
+  useLayoutEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
+    measureScrollRail(el);
     const next = el.scrollHeight - el.scrollTop - el.clientHeight > 1;
     setCanScrollDown((prev) => (prev === next ? prev : next));
   }, [
+    measureScrollRail,
     recentChatItems.length,
     runItems.length,
     projects.length,

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1004,15 +1004,15 @@ export function AppSidebar() {
   // One box for every row pill, so a hover pill has the same edges wherever it
   // lands. Rows outside the list scroller add the rail width it does not lose,
   // so both end on the same edge whether or not the scrollbar takes space.
+  // Logical sides: the rail sits on the inline end, which is the left under
+  // dir=rtl, and a physical pr- would then pad away from it.
   const rowPadding = usesDesktopTitlebar
-    ? "pl-[5px] pr-[calc(var(--sidebar-rail,0px)+5px)]"
-    : "pl-1.5 pr-[calc(var(--sidebar-rail,0px)+6px)]";
+    ? "ps-[5px] pe-[calc(var(--sidebar-rail,0px)+5px)]"
+    : "ps-1.5 pe-[calc(var(--sidebar-rail,0px)+6px)]";
 
   // Inside it the rail already sits in that space, so this is just the gap
-  // between a pill and the scrollbar, matched to the gap on the left.
-  const scrollRowPadding = usesDesktopTitlebar
-    ? "pl-[5px] pr-[5px]"
-    : "pl-1.5 pr-1.5";
+  // between a pill and the scrollbar, matched to the gap on the other side.
+  const scrollRowPadding = usesDesktopTitlebar ? "px-[5px]" : "px-1.5";
 
 
   // One definition per row, so pinned rows and the flyout can't drift apart.
@@ -2496,7 +2496,7 @@ export function AppSidebar() {
             // ramp is still part-transparent there and slices the last row
             // mid-glyph. from-[8px] holds it opaque just across the clip, and
             // matches the list's pb-2 so the gap is the same once it hides.
-            "pointer-events-none absolute left-0 right-[var(--sidebar-rail,0px)] bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[8px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
+            "pointer-events-none absolute start-0 end-[var(--sidebar-rail,0px)] bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[8px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
             // Shorter fade with the update card so the list reads closer to
             // it, but still tall enough to clear a row.
             showUpdateCard ? "h-7" : "h-10",

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -164,7 +164,6 @@ import {
   Fragment,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -703,10 +702,10 @@ export function AppSidebar() {
   // Bottom fade hides at the very bottom / for short lists so the last row isn't washed out.
   const [canScrollDown, setCanScrollDown] = useState(false);
   // Rail width: 0 where scrollbars overlay (macOS default) or the list does not
-  // overflow, 8px where they are classic (Show scroll bars: Always, Windows,
-  // Linux). Only rows inside the scroller lose it, so the rows outside pad by it
-  // to keep one edge. Written straight to the DOM, and only on a change: state
-  // here would loop (React #185).
+  // overflow, the platform's thin rail where they are classic (Show scroll bars:
+  // Always, Windows, Linux). Only rows inside the scroller lose it, so the rows
+  // outside pad by it to keep one edge. Written straight to the DOM, and only on
+  // a change: state here would loop (React #185).
   const railWidthRef = useRef<number | null>(null);
   const measureScrollRail = useCallback((el: HTMLDivElement) => {
     const rail = el.offsetWidth - el.clientWidth;
@@ -714,6 +713,33 @@ export function AppSidebar() {
     railWidthRef.current = rail;
     el.parentElement?.style.setProperty("--sidebar-rail", `${rail}px`);
   }, []);
+
+  // A callback ref, not an effect: the mobile Sheet unmounts its subtree on
+  // close and the 768px breakpoint swaps it for the desktop one, so the
+  // scroller is a new node each time while an effect keyed on a stable callback
+  // never re-runs. Runs before paint, as the effect did.
+  const railObserverRef = useRef<ResizeObserver | null>(null);
+  const attachScroller = useCallback(
+    (el: HTMLDivElement | null) => {
+      railObserverRef.current?.disconnect();
+      railObserverRef.current = null;
+      scrollRef.current = el;
+      // Per node: a new parent has no variable yet even when it measures the
+      // same rail, and the cache would otherwise skip the write.
+      railWidthRef.current = null;
+      if (!el) return;
+      measureScrollRail(el);
+      // Watch the box, not renders: the Images disclosure and the project
+      // toggles change the row count without rendering this component, and a
+      // scrollbar appearing shrinks the content box by its own width. Safe
+      // where the earlier observer was not: it writes a CSS variable, never
+      // state, so there is no render to feed back (React #185).
+      const observer = new ResizeObserver(() => measureScrollRail(el));
+      observer.observe(el);
+      railObserverRef.current = observer;
+    },
+    [measureScrollRail],
+  );
 
   // Driven only from onScroll + a content-change effect below. No
   // ResizeObserver: its callback-driven setState caused a render loop (React
@@ -940,27 +966,6 @@ export function AppSidebar() {
     (trainingInProgress || exportInProgress || anyChatRunning || storeThreadId != null);
   // The Train-page status poll doesn't run off-route; keep state fresh so the spinner clears.
   useTrainingCompletionWatch();
-
-  // The rail comes and goes as the list crosses the overflow threshold, and
-  // plenty of controls move it without rendering this component at all: the
-  // Images disclosure reads its own store, the project toggles rebuild rows
-  // below. Listing those is how this was wrong twice, so watch the box instead.
-  // A scrollbar appearing shrinks the scroller's content box by its own width,
-  // which is exactly what this reports.
-  //
-  // Safe where the earlier observer was not: it writes a CSS variable, never
-  // state, so there is no render to feed back (React #185). That variable only
-  // pads rows outside the scroller, and the write is guarded, so it cannot
-  // re-trigger this. Measured once first, before paint, since a frame on the
-  // 0px fallback is a frame of the misalignment the width exists to cancel.
-  useLayoutEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    measureScrollRail(el);
-    const observer = new ResizeObserver(() => measureScrollRail(el));
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [measureScrollRail]);
 
   // Recompute bottom-fade on mount and whenever list height can change: onScroll never fires
   // for short, non-scrolling lists. Guarded setState below can't loop.
@@ -2006,7 +2011,7 @@ export function AppSidebar() {
       </SidebarGroup>
 
       <SidebarContent
-        ref={scrollRef}
+        ref={attachScroller}
         onScroll={(e) => syncScrollState(e.currentTarget)}
         // Collapsible groups animate their height; re-measure the fade once the animation settles.
         onAnimationEnd={(e) => {
@@ -2482,7 +2487,8 @@ export function AppSidebar() {
       >
         {/* Fade above the profile box, shown only when there's more list below
             the fold; at the bottom (or short lists) it fades so the last row
-            shows fully (Gemini-style). No scroll rail to clear, so full width. */}
+            shows fully (Gemini-style). It stops at the rail: the thumb ends its
+            travel in this band, and a full-width gradient washed it out. */}
         <div
           aria-hidden="true"
           className={cn(
@@ -2490,7 +2496,7 @@ export function AppSidebar() {
             // ramp is still part-transparent there and slices the last row
             // mid-glyph. from-[8px] holds it opaque just across the clip, and
             // matches the list's pb-2 so the gap is the same once it hides.
-            "pointer-events-none absolute inset-x-0 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[8px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
+            "pointer-events-none absolute left-0 right-[var(--sidebar-rail,0px)] bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] from-[8px] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
             // Shorter fade with the update card so the list reads closer to
             // it, but still tall enough to clear a row.
             showUpdateCard ? "h-7" : "h-10",

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -701,11 +701,10 @@ export function AppSidebar() {
   const [scrolled, setScrolled] = useState(false);
   // Bottom fade hides at the very bottom / for short lists so the last row isn't washed out.
   const [canScrollDown, setCanScrollDown] = useState(false);
-  // Rail width: 0 where scrollbars overlay (macOS default) or the list does not
-  // overflow, the platform's thin rail where they are classic (Show scroll bars:
-  // Always, Windows, Linux). Only rows inside the scroller lose it, so the rows
-  // outside pad by it to keep one edge. Written straight to the DOM, and only on
-  // a change: state here would loop (React #185).
+  // Rail width: 0 where scrollbars overlay (macOS default) or the list fits,
+  // the platform's thin rail where they are classic. Only rows inside the
+  // scroller lose it, so the rows outside pad by it to keep one edge. Written
+  // to the DOM, and only on a change: state here would loop (React #185).
   const railWidthRef = useRef<number | null>(null);
   const measureScrollRail = useCallback((el: HTMLDivElement) => {
     const rail = el.offsetWidth - el.clientWidth;
@@ -715,25 +714,25 @@ export function AppSidebar() {
   }, []);
 
   // A callback ref, not an effect: the mobile Sheet unmounts its subtree on
-  // close and the 768px breakpoint swaps it for the desktop one, so the
-  // scroller is a new node each time while an effect keyed on a stable callback
-  // never re-runs. Runs before paint, as the effect did.
+  // close and the breakpoint swaps it for the desktop one, so the scroller is a
+  // new node each time and an effect keyed on a stable callback never re-runs.
+  // Still runs before paint.
   const railObserverRef = useRef<ResizeObserver | null>(null);
   const attachScroller = useCallback(
     (el: HTMLDivElement | null) => {
       railObserverRef.current?.disconnect();
       railObserverRef.current = null;
       scrollRef.current = el;
-      // Per node: a new parent has no variable yet even when it measures the
-      // same rail, and the cache would otherwise skip the write.
+      // Per node: a new parent has no variable yet even at the same rail, and
+      // the cache would otherwise skip the write.
       railWidthRef.current = null;
       if (!el) return;
       measureScrollRail(el);
       // Watch the box, not renders: the Images disclosure and the project
       // toggles change the row count without rendering this component, and a
       // scrollbar appearing shrinks the content box by its own width. Safe
-      // where the earlier observer was not: it writes a CSS variable, never
-      // state, so there is no render to feed back (React #185).
+      // where the earlier observer was not: it writes a variable, never state,
+      // so there is no render to feed back (React #185).
       const observer = new ResizeObserver(() => measureScrollRail(el));
       observer.observe(el);
       railObserverRef.current = observer;
@@ -1004,8 +1003,7 @@ export function AppSidebar() {
   // One box for every row pill, so a hover pill has the same edges wherever it
   // lands. Rows outside the list scroller add the rail width it does not lose,
   // so both end on the same edge whether or not the scrollbar takes space.
-  // Logical sides: the rail sits on the inline end, which is the left under
-  // dir=rtl, and a physical pr- would then pad away from it.
+  // Logical sides, since the rail is on the inline end and moves under rtl.
   const rowPadding = usesDesktopTitlebar
     ? "ps-[5px] pe-[calc(var(--sidebar-rail,0px)+5px)]"
     : "ps-1.5 pe-[calc(var(--sidebar-rail,0px)+6px)]";
@@ -2487,8 +2485,8 @@ export function AppSidebar() {
       >
         {/* Fade above the profile box, shown only when there's more list below
             the fold; at the bottom (or short lists) it fades so the last row
-            shows fully (Gemini-style). It stops at the rail: the thumb ends its
-            travel in this band, and a full-width gradient washed it out. */}
+            shows fully (Gemini-style). Stops at the rail: the thumb ends its
+            travel in this band and a full-width gradient washed it out. */}
         <div
           aria-hidden="true"
           className={cn(

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -705,20 +705,20 @@ export function AppSidebar() {
   // Rail width: 0 where scrollbars overlay (macOS default) or the list does not
   // overflow, 8px where they are classic (Show scroll bars: Always, Windows,
   // Linux). Only rows inside the scroller lose it, so the rows outside pad by it
-  // to keep one edge. Written straight to the DOM: state here would loop
-  // (React #185).
+  // to keep one edge. Written straight to the DOM, and only on a change: state
+  // here would loop (React #185).
+  const railWidthRef = useRef<number | null>(null);
   const measureScrollRail = useCallback((el: HTMLDivElement) => {
-    el.parentElement?.style.setProperty(
-      "--sidebar-rail",
-      `${el.offsetWidth - el.clientWidth}px`,
-    );
+    const rail = el.offsetWidth - el.clientWidth;
+    if (rail === railWidthRef.current) return;
+    railWidthRef.current = rail;
+    el.parentElement?.style.setProperty("--sidebar-rail", `${rail}px`);
   }, []);
 
   // Driven only from onScroll + a content-change effect below. No
   // ResizeObserver: its callback-driven setState caused a render loop (React
   // #185). Both setters bail out when unchanged, so neither path can loop.
   const syncScrollState = useCallback((el: HTMLDivElement) => {
-    measureScrollRail(el);
     const nextScrolled = el.scrollTop > 0;
     setScrolled((prev) => (prev === nextScrolled ? prev : nextScrolled));
     const nextCanScrollDown =
@@ -726,7 +726,7 @@ export function AppSidebar() {
     setCanScrollDown((prev) =>
       prev === nextCanScrollDown ? prev : nextCanScrollDown,
     );
-  }, [measureScrollRail]);
+  }, []);
 
   const isRecipesRoute = pathname.startsWith("/data-recipes");
   const isExportRoute = pathname === "/export" || pathname.startsWith("/export/");
@@ -941,20 +941,35 @@ export function AppSidebar() {
   // The Train-page status poll doesn't run off-route; keep state fresh so the spinner clears.
   useTrainingCompletionWatch();
 
-  // Recompute bottom-fade on mount and whenever list height can change: onScroll never fires
-  // for short, non-scrolling lists. Guarded setState below can't loop.
-  // Measures the rail on the same beat: a classic scrollbar only takes width
-  // once the list overflows, so mount and every one of these is when that can
-  // change. Runs before paint, since a frame on the 0px fallback is a frame of
-  // the misalignment the rail width exists to cancel.
+  // The rail comes and goes as the list crosses the overflow threshold, and
+  // plenty of controls move it without rendering this component at all: the
+  // Images disclosure reads its own store, the project toggles rebuild rows
+  // below. Listing those is how this was wrong twice, so watch the box instead.
+  // A scrollbar appearing shrinks the scroller's content box by its own width,
+  // which is exactly what this reports.
+  //
+  // Safe where the earlier observer was not: it writes a CSS variable, never
+  // state, so there is no render to feed back (React #185). That variable only
+  // pads rows outside the scroller, and the write is guarded, so it cannot
+  // re-trigger this. Measured once first, before paint, since a frame on the
+  // 0px fallback is a frame of the misalignment the width exists to cancel.
   useLayoutEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     measureScrollRail(el);
+    const observer = new ResizeObserver(() => measureScrollRail(el));
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [measureScrollRail]);
+
+  // Recompute bottom-fade on mount and whenever list height can change: onScroll never fires
+  // for short, non-scrolling lists. Guarded setState below can't loop.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
     const next = el.scrollHeight - el.scrollTop - el.clientHeight > 1;
     setCanScrollDown((prev) => (prev === next ? prev : next));
   }, [
-    measureScrollRail,
     recentChatItems.length,
     runItems.length,
     projects.length,

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -705,6 +705,14 @@ export function AppSidebar() {
   // ResizeObserver: its callback-driven setState caused a render loop (React
   // #185). Both setters bail out when unchanged, so neither path can loop.
   const syncScrollState = useCallback((el: HTMLDivElement) => {
+    // Rail width: 0 where scrollbars overlay (macOS default), 8px where they
+    // are classic (Show scroll bars: Always, Windows, Linux). Only rows inside
+    // the scroller lose it, so the rows outside pad by it to keep one edge.
+    // Written straight to the DOM: state here would loop (React #185).
+    el.parentElement?.style.setProperty(
+      "--sidebar-rail",
+      `${el.offsetWidth - el.clientWidth}px`,
+    );
     const nextScrolled = el.scrollTop > 0;
     setScrolled((prev) => (prev === nextScrolled ? prev : nextScrolled));
     const nextCanScrollDown =
@@ -962,10 +970,17 @@ export function AppSidebar() {
   const usesDesktopTitlebar = usesCustomTitlebar || usesNativeMacTitlebar;
 
   // One box for every row pill, so a hover pill has the same edges wherever it
-  // lands. The list scroller hides its rail (index.css) instead of eating width.
+  // lands. Rows outside the list scroller add the rail width it does not lose,
+  // so both end on the same edge whether or not the scrollbar takes space.
   const rowPadding = usesDesktopTitlebar
-    ? "pl-[5px] pr-2"
-    : "pl-1.5 pr-1.75";
+    ? "pl-[5px] pr-[calc(var(--sidebar-rail,0px)+5px)]"
+    : "pl-1.5 pr-[calc(var(--sidebar-rail,0px)+6px)]";
+
+  // Inside it the rail already sits in that space, so this is just the gap
+  // between a pill and the scrollbar, matched to the gap on the left.
+  const scrollRowPadding = usesDesktopTitlebar
+    ? "pl-[5px] pr-[5px]"
+    : "pl-1.5 pr-1.5";
 
 
   // One definition per row, so pinned rows and the flyout can't drift apart.
@@ -1985,7 +2000,7 @@ export function AppSidebar() {
           data-tour="navbar"
           className={cn(
             "group-data-[collapsible=icon]:px-0 py-0 shrink-0",
-            rowPadding,
+            scrollRowPadding,
           )}
         >
 
@@ -2156,7 +2171,7 @@ export function AppSidebar() {
                   </CollapsibleTrigger>
                 </SidebarGroupLabel>
                 <CollapsibleContent>
-                  <SidebarGroupContent className={rowPadding}>
+                  <SidebarGroupContent className={scrollRowPadding}>
                     <SidebarMenu>
                       {pinnedProjectRecords.map((project) => {
                         const projectChats =
@@ -2306,7 +2321,7 @@ export function AppSidebar() {
                 </CollapsibleTrigger>
               </SidebarGroupLabel>
               <CollapsibleContent>
-                <SidebarGroupContent className={rowPadding}>
+                <SidebarGroupContent className={scrollRowPadding}>
                   <SidebarMenu>
                     {recentChatItems.map((item) =>
                       renderChatSidebarItem(item, "recent"),
@@ -2338,7 +2353,7 @@ export function AppSidebar() {
               </CollapsibleTrigger>
             </SidebarGroupLabel>
             <CollapsibleContent>
-              <SidebarGroupContent className={rowPadding}>
+              <SidebarGroupContent className={scrollRowPadding}>
                 <SidebarMenu>
                   {runItems.map((run) => {
                     // Explicit selection wins. Otherwise highlight the active job only while the "Current Run"

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2667,47 +2667,40 @@ html[data-chat-font] .aui-root {
 
 /* Settings and search: hide the scroll thumb at rest and reveal it only while
    the area is hovered, so the rail never sits visible over content. */
+.sidebar-scroll-fade,
 .run-settings-scroll,
 .hover-scrollbar {
 	scrollbar-color: transparent transparent;
 }
 
+.sidebar-scroll-fade::-webkit-scrollbar-thumb,
 .run-settings-scroll::-webkit-scrollbar-thumb,
 .hover-scrollbar::-webkit-scrollbar-thumb {
 	background: transparent;
 }
 
+.sidebar-scroll-fade:hover,
 .run-settings-scroll:hover,
 .hover-scrollbar:hover {
 	scrollbar-color: oklch(0.5 0 0 / 0.4) transparent;
 }
 
+.sidebar-scroll-fade:hover::-webkit-scrollbar-thumb,
 .run-settings-scroll:hover::-webkit-scrollbar-thumb,
 .hover-scrollbar:hover::-webkit-scrollbar-thumb {
 	background: oklch(0.5 0 0 / 0.4);
 }
 
+.dark .sidebar-scroll-fade:hover,
 .dark .run-settings-scroll:hover,
 .dark .hover-scrollbar:hover {
 	scrollbar-color: oklch(0.72 0 0 / 0.4) transparent;
 }
 
+.dark .sidebar-scroll-fade:hover::-webkit-scrollbar-thumb,
 .dark .run-settings-scroll:hover::-webkit-scrollbar-thumb,
 .dark .hover-scrollbar:hover::-webkit-scrollbar-thumb {
 	background: oklch(0.72 0 0 / 0.4);
-}
-
-/* Sidebar list: no scroll rail. A rail narrows the rows inside the scroller,
-   so their pills came out short of New Chat above it, by 8px on WebKit, a thin
-   rail on Chromium, nothing under macOS overlay scrollbars. The thumb was
-   already transparent at rest, and the fades still show there is more list. */
-.sidebar-scroll-fade {
-	scrollbar-width: none;
-}
-
-.sidebar-scroll-fade::-webkit-scrollbar {
-	width: 0;
-	height: 0;
 }
 
 /* Run settings: always reserve the scrollbar gutter so the header close

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -34,19 +34,18 @@
 	   pinned New Chat / Search header. */
 	/* Top edge: when scrolled, rows dissolve as they pass under the pinned
 	   New Chat / Search header (mask — fades content to transparent).
-	   A mask covers the border box, and the scrollbar sits inside it, so the
-	   ramp dissolved the top of the thumb along with the rows. The second
-	   layer holds the rail's own column opaque; layers union by default
-	   (mask-composite: add). Nothing but the scrollbar is in that column, so it
-	   costs the fade nothing, and at rail 0 the layer is empty. */
+	   A mask covers the border box, scrollbar included, so the ramp dissolved
+	   the thumb's top too. Second layer holds the rail column opaque (layers
+	   union by default); nothing else is in that column, and at rail 0 it is
+	   empty. */
 	.sidebar-scroll-fade.is-scrolled {
 		-webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 14px),
 			linear-gradient(to left, #000 var(--sidebar-rail, 0px), transparent 0);
 		mask-image: linear-gradient(to bottom, transparent 0, #000 14px),
 			linear-gradient(to left, #000 var(--sidebar-rail, 0px), transparent 0);
 	}
-	/* The rail sits on the inline end, the left under rtl, and a gradient
-	   cannot say that. */
+	/* The rail is on the inline end, the left under rtl; a gradient cannot say
+	   that. */
 	[dir="rtl"] .sidebar-scroll-fade.is-scrolled {
 		-webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 14px),
 			linear-gradient(to right, #000 var(--sidebar-rail, 0px), transparent 0);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -33,10 +33,25 @@
 	   scrolled, the TOP edge also fades so rows dissolve as they pass under the
 	   pinned New Chat / Search header. */
 	/* Top edge: when scrolled, rows dissolve as they pass under the pinned
-	   New Chat / Search header (mask — fades content to transparent). */
+	   New Chat / Search header (mask — fades content to transparent).
+	   A mask covers the border box, and the scrollbar sits inside it, so the
+	   ramp dissolved the top of the thumb along with the rows. The second
+	   layer holds the rail's own column opaque; layers union by default
+	   (mask-composite: add). Nothing but the scrollbar is in that column, so it
+	   costs the fade nothing, and at rail 0 the layer is empty. */
 	.sidebar-scroll-fade.is-scrolled {
-		-webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 14px);
-		mask-image: linear-gradient(to bottom, transparent 0, #000 14px);
+		-webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 14px),
+			linear-gradient(to left, #000 var(--sidebar-rail, 0px), transparent 0);
+		mask-image: linear-gradient(to bottom, transparent 0, #000 14px),
+			linear-gradient(to left, #000 var(--sidebar-rail, 0px), transparent 0);
+	}
+	/* The rail sits on the inline end, the left under rtl, and a gradient
+	   cannot say that. */
+	[dir="rtl"] .sidebar-scroll-fade.is-scrolled {
+		-webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 14px),
+			linear-gradient(to right, #000 var(--sidebar-rail, 0px), transparent 0);
+		mask-image: linear-gradient(to bottom, transparent 0, #000 14px),
+			linear-gradient(to right, #000 var(--sidebar-rail, 0px), transparent 0);
 	}
 	/* Bottom edge: Gemini-style sticky gradient OVERLAY painted in the sidebar
 	   background colour, so the last rows wash into the profile footer. Uses a

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -76,16 +76,17 @@ test("footer profile sits 11px above the sidebar edge", async () => {
 test("every sidebar row pill sits in one shared box", async () => {
   // A recent chat's pill has to match New Chat's. The rows inside the list
   // scroller lose the scrollbar rail's width, so the rows outside it add that
-  // same width back and both end on one edge. Right pad matches left, so a
-  // pill sits the same distance from the scrollbar as from the near edge.
+  // same width back and both end on one edge. Both pads match, so a pill sits
+  // the same distance from the scrollbar as from the near edge. Logical sides:
+  // the rail moves to the left under dir=rtl.
   const source = await sidebarSource();
   assert.match(
     source,
-    /const rowPadding = usesDesktopTitlebar\s*\?\s*"pl-\[5px\] pr-\[calc\(var\(--sidebar-rail,0px\)\+5px\)\]"\s*:\s*"pl-1\.5 pr-\[calc\(var\(--sidebar-rail,0px\)\+6px\)\]"/,
+    /const rowPadding = usesDesktopTitlebar\s*\?\s*"ps-\[5px\] pe-\[calc\(var\(--sidebar-rail,0px\)\+5px\)\]"\s*:\s*"ps-1\.5 pe-\[calc\(var\(--sidebar-rail,0px\)\+6px\)\]"/,
   );
   assert.match(
     source,
-    /const scrollRowPadding = usesDesktopTitlebar\s*\?\s*"pl-\[5px\] pr-\[5px\]"\s*:\s*"pl-1\.5 pr-1\.5"/,
+    /const scrollRowPadding = usesDesktopTitlebar \? "px-\[5px\]" : "px-1\.5"/,
   );
   // New Chat and the footer sit outside the scroller.
   assert.equal(source.match(/(?<!const )rowPadding[,}]/g)?.length, 2);
@@ -135,10 +136,10 @@ test("the sidebar list measures its scroll rail", async () => {
     source,
     /if \(rail === railWidthRef\.current\) return;/,
   );
-  // The footer fade stops at the rail: the thumb ends its travel in that band.
+  // The fade stops at the rail too: the thumb ends its travel in that band.
   assert.match(
     source,
-    /absolute left-0 right-\[var\(--sidebar-rail,0px\)\] bottom-full/,
+    /absolute start-0 end-\[var\(--sidebar-rail,0px\)\] bottom-full/,
   );
   const css = await readFile(
     new URL("../src/index.css", import.meta.url),

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -154,6 +154,15 @@ test("the sidebar list measures its scroll rail", async () => {
   );
   // Thumb stays hidden until the list is hovered, as the other lists do.
   assert.match(css, /\.sidebar-scroll-fade:hover::-webkit-scrollbar-thumb,/);
+  // A mask covers the scrollbar, so the top fade keeps the rail column opaque.
+  assert.match(
+    css,
+    /mask-image: linear-gradient\(to bottom, transparent 0, #000 14px\),\s*linear-gradient\(to left, #000 var\(--sidebar-rail, 0px\), transparent 0\);/,
+  );
+  assert.match(
+    css,
+    /\[dir="rtl"\] \.sidebar-scroll-fade\.is-scrolled \{[\s\S]*linear-gradient\(to right, #000 var\(--sidebar-rail, 0px\), transparent 0\);/,
+  );
 });
 
 test("Tauri chat Recents label keeps its 2px shift", async () => {

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -102,6 +102,14 @@ test("the sidebar list measures its scroll rail", async () => {
     source,
     /el\.parentElement\?\.style\.setProperty\(\s*"--sidebar-rail",\s*`\$\{el\.offsetWidth - el\.clientWidth\}px`,\s*\)/,
   );
+  // Scroll events alone would leave the first paint on the 0px fallback, so a
+  // list that overflows on arrival stays misaligned until the user scrolls it.
+  // Measured on mount and on every content change too, before paint.
+  assert.match(
+    source,
+    /useLayoutEffect\(\(\) => \{\s*const el = scrollRef\.current;\s*if \(!el\) return;\s*measureScrollRail\(el\);/,
+  );
+  assert.match(source, /const syncScrollState = useCallback\(\(el: HTMLDivElement\) => \{\s*measureScrollRail\(el\);/);
   const css = await readFile(
     new URL("../src/index.css", import.meta.url),
     "utf8",

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -100,16 +100,31 @@ test("the sidebar list measures its scroll rail", async () => {
   const source = await sidebarSource();
   assert.match(
     source,
-    /el\.parentElement\?\.style\.setProperty\(\s*"--sidebar-rail",\s*`\$\{el\.offsetWidth - el\.clientWidth\}px`,\s*\)/,
+    /const rail = el\.offsetWidth - el\.clientWidth;[\s\S]*el\.parentElement\?\.style\.setProperty\(\s*"--sidebar-rail",\s*`\$\{rail\}px`,?\s*\)/,
   );
-  // Scroll events alone would leave the first paint on the 0px fallback, so a
-  // list that overflows on arrival stays misaligned until the user scrolls it.
-  // Measured on mount and on every content change too, before paint.
+  // Measured before paint, or a list that overflows on arrival stays
+  // misaligned until something happens to fire a scroll.
   assert.match(
     source,
     /useLayoutEffect\(\(\) => \{\s*const el = scrollRef\.current;\s*if \(!el\) return;\s*measureScrollRail\(el\);/,
   );
-  assert.match(source, /const syncScrollState = useCallback\(\(el: HTMLDivElement\) => \{\s*measureScrollRail\(el\);/);
+  // Then off the box, not off renders: the Images disclosure and the project
+  // toggles change the row count without rendering AppSidebar or firing a
+  // collapsible animation, and a scrollbar appearing shrinks the content box.
+  assert.match(
+    source,
+    /const observer = new ResizeObserver\(\(\) => measureScrollRail\(el\)\);\s*observer\.observe\(el\);\s*return \(\) => observer\.disconnect\(\);/,
+  );
+  // Writes a variable, never state: that pairing is what looped.
+  assert.equal(
+    /new ResizeObserver\([^)]*set[A-Z]/.test(source),
+    false,
+  );
+  // And only on a change, so it cannot re-trigger itself.
+  assert.match(
+    source,
+    /if \(rail === railWidthRef\.current\) return;/,
+  );
   const css = await readFile(
     new URL("../src/index.css", import.meta.url),
     "utf8",

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -74,29 +74,47 @@ test("footer profile sits 11px above the sidebar edge", async () => {
 });
 
 test("every sidebar row pill sits in one shared box", async () => {
-  // A recent chat's pill has to match New Chat's, so the padding is defined
-  // once and every group takes it.
+  // A recent chat's pill has to match New Chat's. The rows inside the list
+  // scroller lose the scrollbar rail's width, so the rows outside it add that
+  // same width back and both end on one edge. Right pad matches left, so a
+  // pill sits the same distance from the scrollbar as from the near edge.
   const source = await sidebarSource();
   assert.match(
     source,
-    /const rowPadding = usesDesktopTitlebar\s*\?\s*"pl-\[5px\] pr-2"\s*:\s*"pl-1\.5 pr-1\.75"/,
+    /const rowPadding = usesDesktopTitlebar\s*\?\s*"pl-\[5px\] pr-\[calc\(var\(--sidebar-rail,0px\)\+5px\)\]"\s*:\s*"pl-1\.5 pr-\[calc\(var\(--sidebar-rail,0px\)\+6px\)\]"/,
   );
-  // New Chat, the nav rows, pinned projects, Recents, training runs, footer.
-  assert.equal(source.match(/(?<!const )rowPadding[,}]/g)?.length, 6);
+  assert.match(
+    source,
+    /const scrollRowPadding = usesDesktopTitlebar\s*\?\s*"pl-\[5px\] pr-\[5px\]"\s*:\s*"pl-1\.5 pr-1\.5"/,
+  );
+  // New Chat and the footer sit outside the scroller.
+  assert.equal(source.match(/(?<!const )rowPadding[,}]/g)?.length, 2);
+  // Nav rows, pinned projects, Recents, training runs sit inside it.
+  assert.equal(source.match(/scrollRowPadding[,}]/g)?.length, 4);
   assert.equal(source.match(/"pl-2 pr-\[5px\]"/g), null);
 });
 
-test("the sidebar list keeps no scroll rail to steal row width", async () => {
-  // A rail narrows every row under New Chat, which sits above the scroller.
+test("the sidebar list measures its scroll rail", async () => {
+  // 0 where scrollbars overlay, 8px where they are classic. Read off the
+  // scroller and written to the DOM: state here loops (React #185).
+  const source = await sidebarSource();
+  assert.match(
+    source,
+    /el\.parentElement\?\.style\.setProperty\(\s*"--sidebar-rail",\s*`\$\{el\.offsetWidth - el\.clientWidth\}px`,\s*\)/,
+  );
   const css = await readFile(
     new URL("../src/index.css", import.meta.url),
     "utf8",
   );
-  assert.match(css, /\.sidebar-scroll-fade \{\s*scrollbar-width: none;\s*\}/);
-  assert.match(
-    css,
-    /\.sidebar-scroll-fade::-webkit-scrollbar \{\s*width: 0;\s*height: 0;\s*\}/,
+  // No width override: the rail keeps the 8px the rest of the app uses, and
+  // hiding it outright is what took the scrollbar away.
+  assert.equal(/\.sidebar-scroll-fade[^{]*\{[^}]*scrollbar-width/.test(css), false);
+  assert.equal(
+    /\.sidebar-scroll-fade::-webkit-scrollbar \{/.test(css),
+    false,
   );
+  // Thumb stays hidden until the list is hovered, as the other lists do.
+  assert.match(css, /\.sidebar-scroll-fade:hover::-webkit-scrollbar-thumb,/);
 });
 
 test("Tauri chat Recents label keeps its 2px shift", async () => {

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -95,25 +95,35 @@ test("every sidebar row pill sits in one shared box", async () => {
 });
 
 test("the sidebar list measures its scroll rail", async () => {
-  // 0 where scrollbars overlay, 8px where they are classic. Read off the
-  // scroller and written to the DOM: state here loops (React #185).
+  // 0 where scrollbars overlay, the platform's thin rail where they are
+  // classic. Read off the scroller and written to the DOM: state loops (#185).
   const source = await sidebarSource();
   assert.match(
     source,
     /const rail = el\.offsetWidth - el\.clientWidth;[\s\S]*el\.parentElement\?\.style\.setProperty\(\s*"--sidebar-rail",\s*`\$\{rail\}px`,?\s*\)/,
   );
-  // Measured before paint, or a list that overflows on arrival stays
-  // misaligned until something happens to fire a scroll.
+  // Attached by a callback ref, not an effect. The mobile Sheet unmounts its
+  // subtree on close and the breakpoint swaps it for the desktop one, so the
+  // scroller is a new node that an effect keyed on a stable callback misses.
+  assert.match(source, /ref=\{attachScroller\}/);
   assert.match(
     source,
-    /useLayoutEffect\(\(\) => \{\s*const el = scrollRef\.current;\s*if \(!el\) return;\s*measureScrollRail\(el\);/,
+    /const attachScroller = useCallback\(\s*\(el: HTMLDivElement \| null\) => \{/,
   );
+  assert.equal(/useLayoutEffect/.test(source), false);
+  // Old observer goes first, or a detached node keeps one.
+  assert.match(source, /railObserverRef\.current\?\.disconnect\(\);/);
+  // Cache is per node: a new parent has no variable even at the same width.
+  assert.match(source, /railWidthRef\.current = null;/);
+  // Measured on attach, or a list that overflows on arrival stays misaligned
+  // until something happens to fire a scroll.
+  assert.match(source, /if \(!el\) return;\s*measureScrollRail\(el\);/);
   // Then off the box, not off renders: the Images disclosure and the project
   // toggles change the row count without rendering AppSidebar or firing a
   // collapsible animation, and a scrollbar appearing shrinks the content box.
   assert.match(
     source,
-    /const observer = new ResizeObserver\(\(\) => measureScrollRail\(el\)\);\s*observer\.observe\(el\);\s*return \(\) => observer\.disconnect\(\);/,
+    /const observer = new ResizeObserver\(\(\) => measureScrollRail\(el\)\);\s*observer\.observe\(el\);\s*railObserverRef\.current = observer;/,
   );
   // Writes a variable, never state: that pairing is what looped.
   assert.equal(
@@ -125,11 +135,16 @@ test("the sidebar list measures its scroll rail", async () => {
     source,
     /if \(rail === railWidthRef\.current\) return;/,
   );
+  // The footer fade stops at the rail: the thumb ends its travel in that band.
+  assert.match(
+    source,
+    /absolute left-0 right-\[var\(--sidebar-rail,0px\)\] bottom-full/,
+  );
   const css = await readFile(
     new URL("../src/index.css", import.meta.url),
     "utf8",
   );
-  // No width override: the rail keeps the 8px the rest of the app uses, and
+  // No width override: the rail keeps the width the rest of the app uses, and
   // hiding it outright is what took the scrollbar away.
   assert.equal(/\.sidebar-scroll-fade[^{]*\{[^}]*scrollbar-width/.test(css), false);
   assert.equal(

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -74,11 +74,10 @@ test("footer profile sits 11px above the sidebar edge", async () => {
 });
 
 test("every sidebar row pill sits in one shared box", async () => {
-  // A recent chat's pill has to match New Chat's. The rows inside the list
-  // scroller lose the scrollbar rail's width, so the rows outside it add that
-  // same width back and both end on one edge. Both pads match, so a pill sits
-  // the same distance from the scrollbar as from the near edge. Logical sides:
-  // the rail moves to the left under dir=rtl.
+  // A recent chat's pill has to match New Chat's. The rows inside the scroller
+  // lose the rail's width, so the rows outside add it back and both end on one
+  // edge; both pads match, so a pill sits the same distance from the scrollbar
+  // as from the near edge. Logical sides, since the rail moves under rtl.
   const source = await sidebarSource();
   assert.match(
     source,
@@ -103,9 +102,8 @@ test("the sidebar list measures its scroll rail", async () => {
     source,
     /const rail = el\.offsetWidth - el\.clientWidth;[\s\S]*el\.parentElement\?\.style\.setProperty\(\s*"--sidebar-rail",\s*`\$\{rail\}px`,?\s*\)/,
   );
-  // Attached by a callback ref, not an effect. The mobile Sheet unmounts its
-  // subtree on close and the breakpoint swaps it for the desktop one, so the
-  // scroller is a new node that an effect keyed on a stable callback misses.
+  // A callback ref, not an effect: the Sheet unmounts on close and the
+  // breakpoint swaps subtrees, so the scroller is a new node each time.
   assert.match(source, /ref=\{attachScroller\}/);
   assert.match(
     source,
@@ -116,12 +114,12 @@ test("the sidebar list measures its scroll rail", async () => {
   assert.match(source, /railObserverRef\.current\?\.disconnect\(\);/);
   // Cache is per node: a new parent has no variable even at the same width.
   assert.match(source, /railWidthRef\.current = null;/);
-  // Measured on attach, or a list that overflows on arrival stays misaligned
-  // until something happens to fire a scroll.
+  // Measured on attach, or a list overflowing on arrival stays misaligned
+  // until something fires a scroll.
   assert.match(source, /if \(!el\) return;\s*measureScrollRail\(el\);/);
   // Then off the box, not off renders: the Images disclosure and the project
-  // toggles change the row count without rendering AppSidebar or firing a
-  // collapsible animation, and a scrollbar appearing shrinks the content box.
+  // toggles change the row count without rendering AppSidebar, and a scrollbar
+  // appearing shrinks the content box.
   assert.match(
     source,
     /const observer = new ResizeObserver\(\(\) => measureScrollRail\(el\)\);\s*observer\.observe\(el\);\s*railObserverRef\.current = observer;/,


### PR DESCRIPTION
### The problem

#8079 lined up the sidebar row pills by removing the list scroller's rail:

```css
.sidebar-scroll-fade { scrollbar-width: none; }
.sidebar-scroll-fade::-webkit-scrollbar { width: 0; height: 0; }
```

That fixed the alignment, but it also took away the scrollbar entirely, so there is no longer anything showing that the list continues below the fold. The rail should be visible. It just must not come out of the row width.

### Why the rows drifted apart

New Chat and the footer profile sit outside the scroller. Everything else, the nav rows, pinned projects, Recents and training runs, sits inside it. A scrollbar rail is taken off the inside rows only, so the two groups ended up on different right edges whenever the rail took space.

Which it does not always do. Under macOS overlay scrollbars the rail is 0px wide and nothing drifts, which is why this only showed up for some people. With Show scroll bars set to Always, or on Windows and Linux, it is a classic rail and the inside rows come up short.

### The fix

Measure the rail off the scroller and give it back to the rows that never lost it:

```ts
el.parentElement?.style.setProperty(
  "--sidebar-rail",
  `${el.offsetWidth - el.clientWidth}px`,
);
```

Rows outside the scroller pad by `calc(var(--sidebar-rail,0px) + 6px)`, rows inside it pad by `6px`. Both land on the same edge for any rail width, including 0. It is written straight to the DOM rather than held in state, since a state write here is what caused the React #185 loop noted in that file.

The right pad matches the left, so a pill now sits the same distance from the scrollbar as from the near edge. It was 6px against 7px before.

The rail keeps the 8px the rest of the app uses, and the thumb goes back to being hidden until the list is hovered, matching Run settings and the other lists. That part was removed alongside the width in #8079.

### Checks

Measured in Chromium against the built stylesheet, with the same box structure as the component.

Right edges of New Chat, a row inside the scroller, and the footer:

| rail | overflowing | New Chat | inside | footer |
| --- | --- | --- | --- | --- |
| 0px | yes | 250 | 250 | 250 |
| 0px | no | 250 | 250 | 250 |
| 11px | yes | 239 | 239 | 239 |
| 11px | no | 239 | 239 | 239 |

Gaps either side of a pill, where the right gap is measured to the scrollbar:

| rail | left | right |
| --- | --- | --- |
| 0px | 6px | 6px |
| 11px | 6px | 6px |

Frontend suite 900/900. The two tests #8079 added for the old behaviour now pin this one instead: the padding pair, the four groups inside the scroller against the two outside, and the measurement itself.
