### PR TITLE
Fix on-device GGUF image/video picks asking for a quantization

### DIFF
--- a/studio/frontend/src/app/routes/images.tsx
+++ b/studio/frontend/src/app/routes/images.tsx
@@ -10,8 +10,8 @@ export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/images",
   staticData: { title: "Images" },
-  // A diffusion pick from the chat picker arrives as ?model= (+ ?quant= for an exact filename, ?ggufQuant= for a label the
-  // page resolves), which the page loads and then clears.
+  // A chat-picker pick arrives as ?model= (+ ?quant= for an exact filename, ?ggufQuant= for a label the page resolves),
+  // which the page loads and then clears.
   validateSearch: (
     search: Record<string, unknown>,
   ): { model?: string; quant?: string; ggufQuant?: string } => ({

--- a/studio/frontend/src/app/routes/images.tsx
+++ b/studio/frontend/src/app/routes/images.tsx
@@ -10,12 +10,16 @@ export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/images",
   staticData: { title: "Images" },
-  // A diffusion pick made from the chat picker arrives here as ?model= (+ ?quant=), which the page loads and then clears.
+  // A diffusion pick made from the chat picker arrives here as ?model= (+ ?quant= for an exact filename, or ?ggufQuant= for a
+  // label the page still has to resolve), which the page loads and then clears.
   validateSearch: (
     search: Record<string, unknown>,
-  ): { model?: string; quant?: string } => ({
+  ): { model?: string; quant?: string; ggufQuant?: string } => ({
     ...(typeof search.model === "string" ? { model: search.model } : {}),
     ...(typeof search.quant === "string" ? { quant: search.quant } : {}),
+    ...(typeof search.ggufQuant === "string"
+      ? { ggufQuant: search.ggufQuant }
+      : {}),
   }),
   beforeLoad: () => requireAuth(),
   component: () => null,

--- a/studio/frontend/src/app/routes/images.tsx
+++ b/studio/frontend/src/app/routes/images.tsx
@@ -10,8 +10,8 @@ export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/images",
   staticData: { title: "Images" },
-  // A diffusion pick made from the chat picker arrives here as ?model= (+ ?quant= for an exact filename, or ?ggufQuant= for a
-  // label the page still has to resolve), which the page loads and then clears.
+  // A diffusion pick from the chat picker arrives as ?model= (+ ?quant= for an exact filename, ?ggufQuant= for a label the
+  // page resolves), which the page loads and then clears.
   validateSearch: (
     search: Record<string, unknown>,
   ): { model?: string; quant?: string; ggufQuant?: string } => ({

--- a/studio/frontend/src/app/routes/video.tsx
+++ b/studio/frontend/src/app/routes/video.tsx
@@ -10,8 +10,8 @@ export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/video",
   staticData: { title: "Video" },
-  // A diffusion pick from the chat picker arrives as ?model= (+ ?quant= for an exact filename, ?ggufQuant= for a label the
-  // page resolves), which the page loads and then clears.
+  // A chat-picker pick arrives as ?model= (+ ?quant= for an exact filename, ?ggufQuant= for a label the page resolves),
+  // which the page loads and then clears.
   validateSearch: (
     search: Record<string, unknown>,
   ): { model?: string; quant?: string; ggufQuant?: string } => ({

--- a/studio/frontend/src/app/routes/video.tsx
+++ b/studio/frontend/src/app/routes/video.tsx
@@ -10,8 +10,8 @@ export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/video",
   staticData: { title: "Video" },
-  // A diffusion pick made from the chat picker arrives here as ?model= (+ ?quant= for an exact filename, or ?ggufQuant= for a
-  // label the page still has to resolve), which the page loads and then clears.
+  // A diffusion pick from the chat picker arrives as ?model= (+ ?quant= for an exact filename, ?ggufQuant= for a label the
+  // page resolves), which the page loads and then clears.
   validateSearch: (
     search: Record<string, unknown>,
   ): { model?: string; quant?: string; ggufQuant?: string } => ({

--- a/studio/frontend/src/app/routes/video.tsx
+++ b/studio/frontend/src/app/routes/video.tsx
@@ -10,12 +10,16 @@ export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/video",
   staticData: { title: "Video" },
-  // A diffusion pick made from the chat picker arrives here as ?model= (+ ?quant=), which the page loads and then clears.
+  // A diffusion pick made from the chat picker arrives here as ?model= (+ ?quant= for an exact filename, or ?ggufQuant= for a
+  // label the page still has to resolve), which the page loads and then clears.
   validateSearch: (
     search: Record<string, unknown>,
-  ): { model?: string; quant?: string } => ({
+  ): { model?: string; quant?: string; ggufQuant?: string } => ({
     ...(typeof search.model === "string" ? { model: search.model } : {}),
     ...(typeof search.quant === "string" ? { quant: search.quant } : {}),
+    ...(typeof search.ggufQuant === "string"
+      ? { ggufQuant: search.ggufQuant }
+      : {}),
   }),
   beforeLoad: () => requireAuth(),
   component: () => null,

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2006,6 +2006,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     const key = `${wanted}|${routeSearch.quant ?? ""}|${routeSearch.ggufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
+    // This arrival owns the page like a direct pick does, so a download staged by an earlier one cannot land on top.
+    const token = pickGuard.claim();
     void navigateSelf({ to: "/images", search: {}, replace: true });
     // A label means a GGUF repo whatever the catalog says, and a label is not loadable, so resolve it rather than routing it
     // through the classifier's filename slot.
@@ -2027,7 +2029,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       void Promise.resolve().then(() => loadGgufRepoPick(pick.repoId, null, false));
       return;
     }
-    void loadOrStage(pick.repoId, pick.opts, false);
+    void loadOrStage(pick.repoId, pick.opts, false, token);
   }, [
     active,
     routeSearch.model,
@@ -2036,6 +2038,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     loadOrStage,
     loadGgufRepoPick,
     navigateSelf,
+    pickGuard,
   ]);
 
   // Reload the current model with the current advanced options.
@@ -2194,8 +2197,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         toast.error("Could not resolve the trained adapter's name.");
         return;
       }
-      // The deploy owns the page now: a resolving pick would load over the base about to load.
-      pickGuard.release();
+      // The deploy owns the page now: a resolving pick, or a staged download, would load over the base it is about to.
+      pickGuard.cancel();
       pendingDeploy.current = { loraId: stem, family: args.family };
       if (args.trigger.trim()) setPrompt(args.trigger.trim());
       setPageMode("create");
@@ -2212,8 +2215,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
 
   const handleUnload = useCallback(async () => {
     // Ejecting cancels any in-flight replacement load, so tear down its client-side tracking too, or the toast leaks forever.
-    // A pick still resolving its filename counts: it would load the model just ejected.
-    pickGuard.release();
+    // Cancel, not release: a pick still resolving, and a download already staged, would both load back what was just ejected.
+    pickGuard.cancel();
     if (pollTimer.current) clearTimeout(pollTimer.current);
     pollTimer.current = null;
     dismissLoadToast();

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -73,6 +73,7 @@ import { ChevronDown } from "lucide-react";
 import { NegativePromptField } from "@/components/negative-prompt-field";
 import { cn } from "@/lib/utils";
 import { BlobUrlCache } from "@/lib/blob-url-cache";
+import { resolveDiffusionGgufFilename } from "@/lib/diffusion-gguf-filename";
 import { diffusionRoutePick } from "@/lib/diffusion-route-pick";
 import { toast } from "@/lib/toast";
 
@@ -1909,6 +1910,45 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     [stage, currentLoadAdvanced],
   );
 
+  // A GGUF pick can arrive with only a repo id: a pinned row sends its quant label, a curated artifact sends neither, and a
+  // local GGUF directory is a repo too. The backend rejects a gguf load with no filename, and a pipeline load of a GGUF repo,
+  // so both dead-ended. The repo's listing names the file, so resolve it before giving up.
+  const loadGgufRepoPick = useCallback(
+    async (
+      repoId: string,
+      quantHint: string | null,
+      isDownloaded?: boolean,
+    ): Promise<boolean> => {
+      const filename = await resolveDiffusionGgufFilename(repoId, {
+        quant: quantHint,
+        hfToken: hfApiToken(getHfToken()),
+      });
+      // Still ambiguous (several quants on disk, or the listing failed): only the expander can say which.
+      if (!filename) {
+        toast.error("Pick a quantization for this model to load it");
+        return false;
+      }
+      // Optimistic label, reverted if the load never starts, like the curated GGUF branch below.
+      const prevQuant = quant;
+      quantRevert.current = { prev: prevQuant };
+      setQuant(quantHint ?? filename);
+      const d = defaultsFor(repoId);
+      setSteps(d.steps);
+      setGuidance(d.guidance);
+      const started = await loadOrStage(
+        repoId,
+        { kind: "gguf", filename },
+        isDownloaded,
+      );
+      if (!started) {
+        setQuant(prevQuant);
+        quantRevert.current = null;
+      }
+      return started;
+    },
+    [loadOrStage, quant],
+  );
+
   // A diffusion model picked from the chat picker arrives as ?model= on this route. Load it once, then clear the params.
   const routeSearch = useSearch({ strict: false }) as {
     model?: string;
@@ -1937,8 +1977,23 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       routeSearch.quant,
       loadSpecFor(wanted, IMAGE_CATALOG),
     );
+    // A curated GGUF artifact resolves to kind "gguf" with no filename: the catalog lists the repo, not its files.
+    if (pick.opts.kind === "gguf" && !pick.opts.filename) {
+      // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
+      void Promise.resolve().then(() =>
+        loadGgufRepoPick(pick.repoId, routeSearch.quant ?? null, false),
+      );
+      return;
+    }
     void loadOrStage(pick.repoId, pick.opts, false);
-  }, [active, routeSearch.model, routeSearch.quant, loadOrStage, navigateSelf]);
+  }, [
+    active,
+    routeSearch.model,
+    routeSearch.quant,
+    loadOrStage,
+    loadGgufRepoPick,
+    navigateSelf,
+  ]);
 
   // Reload the current model with the current advanced options.
   const handleReapply = useCallback(() => {
@@ -1989,8 +2044,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         const filename = slash >= 0 ? norm.slice(slash + 1) : norm;
         const dir = slash >= 0 ? norm.slice(0, slash) : ".";
         if (!filename.toLowerCase().endsWith(".gguf")) {
-          // A repo pick that reached here has no filename to load, and a quant label cannot be mapped back to one.
-          toast.error("Pick a quantization for this model to load it");
+          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings.
+          void loadGgufRepoPick(id, meta.ggufVariant ?? null, meta.isDownloaded);
           return;
         }
         // A direct pick carries no curated variant label; surface the filename so the selector stops advertising the old quant.
@@ -2030,6 +2085,17 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         });
         return;
       }
+      // A GGUF repo with no filename: a pinned row sends its label alone, a curated artifact sends neither. Both used to
+      // fall through to the pipeline branch below, which the backend rejects for a single-file GGUF repo.
+      if (spec?.kind === "gguf" || meta.ggufVariant) {
+        // An artifact that names its file short-circuits the listing; otherwise the label is the hint.
+        void loadGgufRepoPick(
+          id,
+          spec?.filename ?? meta.ggufVariant ?? null,
+          meta.isDownloaded,
+        );
+        return;
+      }
       // Otherwise treat it as a full diffusers repo. The backend gates loads to unsloth/* repos or on-device paths.
       if (meta.source !== "local" && !id.toLowerCase().startsWith("unsloth/")) {
         toast.error("Only unsloth or on-device image models can be loaded here");
@@ -2049,7 +2115,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         }
       });
     },
-    [busy, handleLoad, loadOrStage, quant],
+    [busy, handleLoad, loadGgufRepoPick, loadOrStage, quant],
   );
 
   // Deploy a freshly-trained adapter from the Train tab: switch to Create, load the base, and queue the adapter for the LoRA discovery effect.

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -1841,12 +1841,22 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     // The Advanced values the plan was built from. Staging does not set `busy`, so the user can change precision or LoRAs while
     // the download runs; without this the completed load would use the new values against the old file set.
     advanced: LoadAdvanced;
+    // The pick that staged it. A download outlives its pick, so a newer one must not be evicted when this lands.
+    token: number;
   } | null>(null);
   const handleLoadRef = useRef(handleLoad);
   handleLoadRef.current = handleLoad;
   // Set when a staged download finished while this page was hidden: both diffusion pages stay mounted and a load evicts
   // whatever holds the GPU. The pick is not dropped; it fires when this page comes back.
   const stagedLoadDeferred = useRef(false);
+  // Staging does not set `busy`, so a pick made while the download ran already owns the page; only the newest one may load.
+  // `isLatest`, not `holds`: leaving the page is not a new pick, and the deferred load below is exactly that case.
+  const runStagedLoad = useCallback(() => {
+    const pending = pendingStagedLoad.current;
+    pendingStagedLoad.current = null;
+    if (!pending || !pickGuard.isLatest(pending.token)) return;
+    void handleLoadRef.current(pending.repoId, pending.opts, pending.advanced);
+  }, [pickGuard]);
   const { stage } = useStagedDownload({
     scopeId: "diffusion",
     onReady: () => {
@@ -1854,29 +1864,26 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         stagedLoadDeferred.current = true;
         return;
       }
-      const pending = pendingStagedLoad.current;
-      pendingStagedLoad.current = null;
-      if (pending) void handleLoadRef.current(pending.repoId, pending.opts, pending.advanced);
+      runStagedLoad();
     },
   });
 
   useEffect(() => {
     if (!active || !stagedLoadDeferred.current) return;
     stagedLoadDeferred.current = false;
-    const pending = pendingStagedLoad.current;
-    pendingStagedLoad.current = null;
-    if (pending) void handleLoadRef.current(pending.repoId, pending.opts, pending.advanced);
-  }, [active]);
+    runStagedLoad();
+  }, [active, runStagedLoad]);
 
   // Stage a not-yet-downloaded hub pick, else load it directly. Returns true when the pick was accepted either way.
-  // `isCurrent` lets an awaiting caller drop out here too: the plan below is a second window for a newer pick to take the page.
+  // `token` lets an awaiting caller drop out here too: the plan below is a second window for a newer pick to take the page.
   const loadOrStage = useCallback(
     async (
       repoId: string,
       opts: { kind: "gguf" | "single_file" | "pipeline"; filename?: string },
       isDownloaded?: boolean,
-      isCurrent?: () => boolean,
+      token?: number,
     ): Promise<boolean> => {
+      const owns = () => token === undefined || pickGuard.holds(token);
       if (isDownloaded !== false) return handleLoadRef.current(repoId, opts);
       // ONE snapshot for the plan and the load it fires: the download runs for minutes without setting `busy`.
       const advanced = currentLoadAdvanced(repoId);
@@ -1897,9 +1904,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           loras: advanced.loras,
         });
         // Superseded mid-plan: neither stage nor load, and leave `pendingStagedLoad` to its new owner.
-        if (isCurrent && !isCurrent()) return false;
+        if (!owns()) return false;
         if (plan.entries.length > 0) {
-          pendingStagedLoad.current = { repoId, opts, advanced };
+          pendingStagedLoad.current = { repoId, opts, advanced, token: token ?? pickGuard.claim() };
           stage(
             plan.entries.map((e) => ({
               repoId: e.repo_id,
@@ -1913,10 +1920,10 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       } catch {
         // No plan (older backend, metadata hiccup): fall back to the load's own download.
       }
-      if (isCurrent && !isCurrent()) return false;
+      if (!owns()) return false;
       return handleLoadRef.current(repoId, opts);
     },
-    [stage, currentLoadAdvanced],
+    [stage, currentLoadAdvanced, pickGuard],
   );
 
   // A GGUF pick can arrive with only a repo id: a pinned row sends its quant label, a curated artifact sends neither, and a
@@ -1957,7 +1964,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           quantRevert.current = null;
         },
         load: (filename) =>
-          loadOrStage(repoId, { kind: "gguf", filename }, isDownloaded, isCurrent),
+          loadOrStage(repoId, { kind: "gguf", filename }, isDownloaded, token),
       });
     },
     [loadOrStage, pickGuard, quant],
@@ -2037,7 +2044,6 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       // This pick owns the page now, so one still awaiting a listing or a plan drops out. Before any branch: staging does not
       // set `busy`, so any pick can land on top of an awaiting one.
       const token = pickGuard.claim();
-      const isCurrent = () => isMounted.current && pickGuard.holds(token);
       // Curated non-GGUF model: load as a full pipeline or single-file safetensors.
       const spec = loadSpecFor(id, IMAGE_CATALOG);
       if (spec && spec.kind !== "gguf") {
@@ -2049,7 +2055,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           id,
           { kind: spec.kind, filename: spec.filename },
           meta.isDownloaded,
-          isCurrent,
+          token,
         );
         return;
       }
@@ -2066,10 +2072,10 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           id,
           { kind: "gguf", filename: meta.ggufFilename },
           meta.isDownloaded,
-          isCurrent,
+          token,
         ).then((started) => {
           // `quantRevert` is one slot, so only the pick that set the label may take it back.
-          if (!started && isCurrent()) {
+          if (!started && pickGuard.holds(token)) {
             setQuant(prevQuant);
             quantRevert.current = null;
           }
@@ -2154,9 +2160,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       const d = defaultsFor(id);
       setSteps(d.steps);
       setGuidance(d.guidance);
-      void loadOrStage(id, { kind: "pipeline" }, meta.isDownloaded, isCurrent).then(
+      void loadOrStage(id, { kind: "pipeline" }, meta.isDownloaded, token).then(
         (started) => {
-          if (!started && isCurrent()) {
+          if (!started && pickGuard.holds(token)) {
             setQuant(prevQuant);
             quantRevert.current = null;
           }

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -74,6 +74,7 @@ import { NegativePromptField } from "@/components/negative-prompt-field";
 import { cn } from "@/lib/utils";
 import { BlobUrlCache } from "@/lib/blob-url-cache";
 import { resolveDiffusionGgufFilename } from "@/lib/diffusion-gguf-filename";
+import { createPickGuard, runGgufRepoPick } from "@/lib/diffusion-gguf-pick";
 import { diffusionRoutePick } from "@/lib/diffusion-route-pick";
 import { toast } from "@/lib/toast";
 
@@ -1191,6 +1192,10 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   const lastLoadRevert = useRef<{ prev: typeof lastLoad.current } | null>(null);
   // A trained adapter awaiting deployment: applied once the base is loaded and LoRA-capable for its family.
   const pendingDeploy = useRef<{ loraId: string; family: string } | null>(null);
+  // Which pick owns the page. Resolving a repo-level GGUF pick is a listing request and staging is a plan request, neither of
+  // which sets `busy`, so the user can pick again or switch pages mid-flight; the superseded pick must then do nothing.
+  // Lazy state, not a ref: the guard is created once per page and read from handlers, and a ref cannot be written during render.
+  const [pickGuard] = useState(createPickGuard);
 
   const dismissLoadToast = useCallback(() => {
     if (loadToastId.current != null) toast.dismiss(loadToastId.current);
@@ -1865,11 +1870,14 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   }, [active]);
 
   // Stage a not-yet-downloaded hub pick, else load it directly. Returns true when the pick was accepted either way.
+  // `isCurrent` lets an awaiting caller drop out here too: the plan request below is a second window in which a newer pick can
+  // take the page, and loading anyway would evict the model that pick just asked for.
   const loadOrStage = useCallback(
     async (
       repoId: string,
       opts: { kind: "gguf" | "single_file" | "pipeline"; filename?: string },
       isDownloaded?: boolean,
+      isCurrent?: () => boolean,
     ): Promise<boolean> => {
       if (isDownloaded !== false) return handleLoadRef.current(repoId, opts);
       // ONE snapshot for the plan and the load it fires: the download runs for minutes without setting `busy`.
@@ -1890,6 +1898,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           // planned a quantized file set and staged too little. Same list handleLoad bakes.
           loras: advanced.loras,
         });
+        // Superseded while the plan was in flight: neither stage nor load, and leave `pendingStagedLoad` to its new owner.
+        if (isCurrent && !isCurrent()) return false;
         if (plan.entries.length > 0) {
           pendingStagedLoad.current = { repoId, opts, advanced };
           stage(
@@ -1905,6 +1915,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       } catch {
         // No plan (older backend, metadata hiccup): fall back to the load's own download.
       }
+      if (isCurrent && !isCurrent()) return false;
       return handleLoadRef.current(repoId, opts);
     },
     [stage, currentLoadAdvanced],
@@ -1918,41 +1929,53 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       repoId: string,
       quantHint: string | null,
       isDownloaded?: boolean,
+      localPath?: string | null,
     ): Promise<boolean> => {
-      const filename = await resolveDiffusionGgufFilename(repoId, {
-        quant: quantHint,
-        hfToken: hfApiToken(getHfToken()),
-      });
-      // Still ambiguous (several quants on disk, or the listing failed): only the expander can say which.
-      if (!filename) {
-        toast.error("Pick a quantization for this model to load it");
-        return false;
-      }
-      // Optimistic label, reverted if the load never starts, like the curated GGUF branch below.
+      // Claimed here, not by the caller, so every entry point is covered; the next pick's claim makes this one inert.
+      const token = pickGuard.claim();
+      const isCurrent = () => isMounted.current && pickGuard.holds(token);
       const prevQuant = quant;
-      quantRevert.current = { prev: prevQuant };
-      setQuant(quantHint ?? filename);
-      const d = defaultsFor(repoId);
-      setSteps(d.steps);
-      setGuidance(d.guidance);
-      const started = await loadOrStage(
-        repoId,
-        { kind: "gguf", filename },
-        isDownloaded,
-      );
-      if (!started) {
-        setQuant(prevQuant);
-        quantRevert.current = null;
-      }
-      return started;
+      return runGgufRepoPick({
+        isCurrent,
+        resolve: () =>
+          resolveDiffusionGgufFilename(repoId, {
+            quant: quantHint,
+            localPath,
+            hfToken: hfApiToken(getHfToken()),
+          }),
+        // Still ambiguous (several quants on disk, or the listing failed): only the expander can say which.
+        onAmbiguous: () =>
+          toast.error("Pick a quantization for this model to load it"),
+        // Optimistic label, reverted if the load never starts, like the curated GGUF branch below.
+        onResolved: (filename) => {
+          quantRevert.current = { prev: prevQuant };
+          setQuant(quantHint ?? filename);
+          const d = defaultsFor(repoId);
+          setSteps(d.steps);
+          setGuidance(d.guidance);
+        },
+        onNotStarted: () => {
+          setQuant(prevQuant);
+          quantRevert.current = null;
+        },
+        load: (filename) =>
+          loadOrStage(repoId, { kind: "gguf", filename }, isDownloaded, isCurrent),
+      });
     },
-    [loadOrStage, quant],
+    [loadOrStage, pickGuard, quant],
   );
+
+  // A hidden page owns nothing: both diffusion pages stay mounted, so a resolution started here must not fire a load after the
+  // user moved to the other one.
+  useEffect(() => {
+    if (!active) pickGuard.release();
+  }, [active, pickGuard]);
 
   // A diffusion model picked from the chat picker arrives as ?model= on this route. Load it once, then clear the params.
   const routeSearch = useSearch({ strict: false }) as {
     model?: string;
     quant?: string;
+    ggufQuant?: string;
   };
   const navigateSelf = useNavigate();
   const handledRouteModel = useRef<string | null>(null);
@@ -1967,10 +1990,20 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       handledRouteModel.current = null;
       return;
     }
-    const key = `${wanted}|${routeSearch.quant ?? ""}`;
+    const routedGgufQuant = routeSearch.ggufQuant?.trim() || null;
+    const key = `${wanted}|${routeSearch.quant ?? ""}|${routedGgufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
     void navigateSelf({ to: "/images", search: {}, replace: true });
+    // A label, so a GGUF repo whatever the catalog says: the picker only sends one for a pick it knows holds quants, and a
+    // label is not loadable, so it goes to the resolver rather than through the route classifier's filename slot.
+    if (routedGgufQuant) {
+      // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
+      void Promise.resolve().then(() =>
+        loadGgufRepoPick(wanted, routedGgufQuant, false),
+      );
+      return;
+    }
     // Same catalog lookup a direct pick makes: the chat picker can only forward a GGUF filename.
     const pick = diffusionRoutePick(
       wanted,
@@ -1979,10 +2012,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     );
     // A curated GGUF artifact resolves to kind "gguf" with no filename: the catalog lists the repo, not its files.
     if (pick.opts.kind === "gguf" && !pick.opts.filename) {
-      // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
-      void Promise.resolve().then(() =>
-        loadGgufRepoPick(pick.repoId, routeSearch.quant ?? null, false),
-      );
+      void Promise.resolve().then(() => loadGgufRepoPick(pick.repoId, null, false));
       return;
     }
     void loadOrStage(pick.repoId, pick.opts, false);
@@ -1990,6 +2020,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     active,
     routeSearch.model,
     routeSearch.quant,
+    routeSearch.ggufQuant,
     loadOrStage,
     loadGgufRepoPick,
     navigateSelf,
@@ -2006,6 +2037,10 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     (id: string, meta: ModelSelectorChangeMeta) => {
       // Ignore picks while a load/generation/unload is in flight: the backend rejects a second load with a 409.
       if (busy !== null) return;
+      // This pick now owns the page, so an earlier one still waiting on a listing or a download plan drops out. Claimed before
+      // any branch, because staging does not set `busy` and any pick can therefore land on top of an awaiting one.
+      const token = pickGuard.claim();
+      const isCurrent = () => isMounted.current && pickGuard.holds(token);
       // Curated non-GGUF model: load as a full pipeline or single-file safetensors.
       const spec = loadSpecFor(id, IMAGE_CATALOG);
       if (spec && spec.kind !== "gguf") {
@@ -2013,7 +2048,12 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         const d = defaultsFor(id);
         setSteps(d.steps);
         setGuidance(d.guidance);
-        void loadOrStage(id, { kind: spec.kind, filename: spec.filename }, meta.isDownloaded);
+        void loadOrStage(
+          id,
+          { kind: spec.kind, filename: spec.filename },
+          meta.isDownloaded,
+          isCurrent,
+        );
         return;
       }
       // GGUF quant pick from the variant expander. Optimistic for instant picker feedback, but revert if the load fails to START
@@ -2029,8 +2069,11 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           id,
           { kind: "gguf", filename: meta.ggufFilename },
           meta.isDownloaded,
+          isCurrent,
         ).then((started) => {
-          if (!started) {
+          // Only the pick that set the label may take it back: `quantRevert` is one slot, so a stale revert would restore this
+          // pick's old label over the newer one.
+          if (!started && isCurrent()) {
             setQuant(prevQuant);
             quantRevert.current = null;
           }
@@ -2044,8 +2087,14 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         const filename = slash >= 0 ? norm.slice(slash + 1) : norm;
         const dir = slash >= 0 ? norm.slice(0, slash) : ".";
         if (!filename.toLowerCase().endsWith(".gguf")) {
-          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings.
-          void loadGgufRepoPick(id, meta.ggufVariant ?? null, meta.isDownloaded);
+          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings. A local
+          // pick passes its directory too: the listing enumerates that path instead of resolving the id as a hub repo.
+          void loadGgufRepoPick(
+            id,
+            meta.ggufVariant ?? null,
+            meta.isDownloaded,
+            meta.source === "local" ? id : null,
+          );
           return;
         }
         // A direct pick carries no curated variant label; surface the filename so the selector stops advertising the old quant.
@@ -2093,6 +2142,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           id,
           spec?.filename ?? meta.ggufVariant ?? null,
           meta.isDownloaded,
+          meta.source === "local" ? id : null,
         );
         return;
       }
@@ -2108,14 +2158,16 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       const d = defaultsFor(id);
       setSteps(d.steps);
       setGuidance(d.guidance);
-      void loadOrStage(id, { kind: "pipeline" }, meta.isDownloaded).then((started) => {
-        if (!started) {
-          setQuant(prevQuant);
-          quantRevert.current = null;
-        }
-      });
+      void loadOrStage(id, { kind: "pipeline" }, meta.isDownloaded, isCurrent).then(
+        (started) => {
+          if (!started && isCurrent()) {
+            setQuant(prevQuant);
+            quantRevert.current = null;
+          }
+        },
+      );
     },
-    [busy, handleLoad, loadGgufRepoPick, loadOrStage, quant],
+    [busy, handleLoad, loadGgufRepoPick, loadOrStage, pickGuard, quant],
   );
 
   // Deploy a freshly-trained adapter from the Train tab: switch to Create, load the base, and queue the adapter for the LoRA discovery effect.
@@ -2132,6 +2184,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         toast.error("Could not resolve the trained adapter's name.");
         return;
       }
+      // The deploy owns the page now: a pick still resolving its filename would load over the base this is about to load.
+      pickGuard.release();
       pendingDeploy.current = { loraId: stem, family: args.family };
       if (args.trigger.trim()) setPrompt(args.trigger.trim());
       setPageMode("create");
@@ -2143,11 +2197,13 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         if (!started) pendingDeploy.current = null;
       });
     },
-    [busy, handleLoad, setPageMode],
+    [busy, handleLoad, pickGuard, setPageMode],
   );
 
   const handleUnload = useCallback(async () => {
     // Ejecting cancels any in-flight replacement load, so tear down its client-side tracking too, or the toast leaks forever.
+    // A pick still resolving its filename counts: it would load the model the user just ejected.
+    pickGuard.release();
     if (pollTimer.current) clearTimeout(pollTimer.current);
     pollTimer.current = null;
     dismissLoadToast();
@@ -2165,7 +2221,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     } finally {
       setBusy(null);
     }
-  }, [refreshStatus, dismissLoadToast]);
+  }, [refreshStatus, dismissLoadToast, pickGuard]);
 
   const handleGenerate = useCallback(async () => {
     if (!prompt.trim()) {

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -1196,8 +1196,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   const lastLoadRevert = useRef<{ prev: typeof lastLoad.current } | null>(null);
   // A trained adapter awaiting deployment: applied once the base is loaded and LoRA-capable for its family.
   const pendingDeploy = useRef<{ loraId: string; family: string } | null>(null);
-  // Which pick owns the page: resolving one is a listing request and staging is a plan request, and neither sets `busy`, so a
-  // pick can land on top of an awaiting one. Lazy state rather than a ref, which cannot be written during render.
+  // Which pick owns the page: resolving and staging are requests that do not set `busy`, so a pick can land on an awaiting
+  // one. Lazy state, not a ref: a ref cannot be written during render.
   const [pickGuard] = useState(createPickGuard);
 
   const dismissLoadToast = useCallback(() => {
@@ -1845,7 +1845,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     // The Advanced values the plan was built from. Staging does not set `busy`, so the user can change precision or LoRAs while
     // the download runs; without this the completed load would use the new values against the old file set.
     advanced: LoadAdvanced;
-    // The pick that staged it. A download outlives its pick, so a newer one must not be evicted when this lands.
+    // The pick that staged it: a download outlives its pick, so it must not evict a newer one when it lands.
     token: number;
   } | null>(null);
   const handleLoadRef = useRef(handleLoad);
@@ -1853,8 +1853,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   // Set when a staged download finished while this page was hidden: both diffusion pages stay mounted and a load evicts
   // whatever holds the GPU. The pick is not dropped; it fires when this page comes back.
   const stagedLoadDeferred = useRef(false);
-  // Staging does not set `busy`, so a pick made while the download ran already owns the page; only the newest one may load.
-  // `isLatest`, not `holds`: leaving the page is not a new pick, and the deferred load below is exactly that case.
+  // A pick made while the download ran already owns the page; only the newest may load. `isLatest`, not `holds`: leaving the
+  // page is not a new pick, and the deferred load below is exactly that case.
   const runStagedLoad = useCallback(() => {
     const pending = pendingStagedLoad.current;
     pendingStagedLoad.current = null;
@@ -1879,7 +1879,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   }, [active, runStagedLoad]);
 
   // Stage a not-yet-downloaded hub pick, else load it directly. Returns true when the pick was accepted either way.
-  // `token` lets an awaiting caller drop out here too: the plan below is a second window for a newer pick to take the page.
+  // `token` lets an awaiting caller drop out: the plan below is a second window for a newer pick to take the page.
   const loadOrStage = useCallback(
     async (
       repoId: string,
@@ -1930,9 +1930,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     [stage, currentLoadAdvanced, pickGuard],
   );
 
-  // A GGUF pick can arrive with only a repo id: a pinned row sends its quant label, a curated artifact sends neither, and a
-  // local GGUF directory is a repo too. The backend rejects a gguf load with no filename, and a pipeline load of a GGUF repo,
-  // so both dead-ended. The repo's listing names the file, so resolve it before giving up.
+  // A GGUF pick can arrive with only a repo id (a pinned row, a curated artifact, a local GGUF directory). The backend
+  // rejects a gguf load with no filename and a pipeline load of a GGUF repo, so name the file from the listing first.
   const loadGgufRepoPick = useCallback(
     async (
       repoId: string,
@@ -1952,7 +1951,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             localPath,
             hfToken: hfApiToken(getHfToken()),
           }),
-        // Still ambiguous (several quants on disk, or the listing failed): only the expander can say which.
+        // Still ambiguous (several quants, or the listing failed): only the expander can say which.
         onAmbiguous: () =>
           toast.error("Pick a quantization for this model to load it"),
         // Optimistic label, reverted if the load never starts, like the curated GGUF branch below.
@@ -1998,19 +1997,19 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       handledRouteModel.current = null;
       return;
     }
-    // `quant` is a filename, used verbatim; a label there (a hand-built link, an older producer) is resolved instead.
-    // The two fields, not the object: `routeSearch` is rebuilt every render, and naming it here would put it in the deps.
+    // `quant` is used verbatim as a filename; a label there (a hand-built link, an older producer) is resolved instead.
+    // The two fields, not the object: `routeSearch` is rebuilt every render, so it would churn the deps.
     const routed = { quant: routeSearch.quant, ggufQuant: routeSearch.ggufQuant };
     const routedFilename = routedGgufFilename(routed);
     const routedLabel = routedGgufLabel(routed);
     const key = `${wanted}|${routeSearch.quant ?? ""}|${routeSearch.ggufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
-    // This arrival owns the page like a direct pick does, so a download staged by an earlier one cannot land on top.
+    // This arrival owns the page like a direct pick, so a download staged by an earlier one cannot land on top.
     const token = pickGuard.claim();
     void navigateSelf({ to: "/images", search: {}, replace: true });
-    // A label means a GGUF repo whatever the catalog says, and a label is not loadable, so resolve it rather than routing it
-    // through the classifier's filename slot.
+    // A label means a GGUF repo whatever the catalog says, and is not loadable, so resolve it instead of routing it as a
+    // filename.
     if (routedLabel) {
       // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
       void Promise.resolve().then(() =>
@@ -2052,8 +2051,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     (id: string, meta: ModelSelectorChangeMeta) => {
       // Ignore picks while a load/generation/unload is in flight: the backend rejects a second load with a 409.
       if (busy !== null) return;
-      // This pick owns the page now, so one still awaiting a listing or a plan drops out. Before any branch: staging does not
-      // set `busy`, so any pick can land on top of an awaiting one.
+      // This pick owns the page now, so one still awaiting a listing or a plan drops out. Before any branch: staging never
+      // sets `busy`, so any pick can land on an awaiting one.
       const token = pickGuard.claim();
       // Curated non-GGUF model: load as a full pipeline or single-file safetensors.
       const spec = loadSpecFor(id, IMAGE_CATALOG);
@@ -2100,8 +2099,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         const filename = slash >= 0 ? norm.slice(slash + 1) : norm;
         const dir = slash >= 0 ? norm.slice(0, slash) : ".";
         if (!filename.toLowerCase().endsWith(".gguf")) {
-          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings, and a
-          // local pick passes its directory so the listing enumerates that path instead of a hub repo.
+          // A repo id or local directory, not a file. The listing names its .gguf and the label picks between siblings; a
+          // local pick passes its directory so the listing reads that path, not a hub repo.
           void loadGgufRepoPick(
             id,
             meta.ggufVariant ?? null,
@@ -2147,8 +2146,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         });
         return;
       }
-      // A GGUF repo with no filename: a pinned row sends its label alone, a curated artifact sends neither. Both used to
-      // fall through to the pipeline branch below, which the backend rejects for a single-file GGUF repo.
+      // A GGUF repo with no filename: these used to fall through to the pipeline branch below, which the backend rejects
+      // for a single-file GGUF repo.
       if (spec?.kind === "gguf" || meta.ggufVariant) {
         // An artifact that names its file short-circuits the listing; otherwise the label is the hint.
         void loadGgufRepoPick(
@@ -2197,7 +2196,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         toast.error("Could not resolve the trained adapter's name.");
         return;
       }
-      // The deploy owns the page now: a resolving pick, or a staged download, would load over the base it is about to.
+      // The deploy owns the page now: a resolving pick or a staged download would load over the base it is about to.
       pickGuard.cancel();
       pendingDeploy.current = { loraId: stem, family: args.family };
       if (args.trigger.trim()) setPrompt(args.trigger.trim());
@@ -2215,7 +2214,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
 
   const handleUnload = useCallback(async () => {
     // Ejecting cancels any in-flight replacement load, so tear down its client-side tracking too, or the toast leaks forever.
-    // Cancel, not release: a pick still resolving, and a download already staged, would both load back what was just ejected.
+    // Cancel, not release: a resolving pick or a staged download would load back what was just ejected.
     pickGuard.cancel();
     if (pollTimer.current) clearTimeout(pollTimer.current);
     pollTimer.current = null;

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -76,6 +76,10 @@ import { BlobUrlCache } from "@/lib/blob-url-cache";
 import { resolveDiffusionGgufFilename } from "@/lib/diffusion-gguf-filename";
 import { createPickGuard, runGgufRepoPick } from "@/lib/diffusion-gguf-pick";
 import { diffusionRoutePick } from "@/lib/diffusion-route-pick";
+import {
+  routedGgufFilename,
+  routedGgufLabel,
+} from "@/lib/diffusion-route-search";
 import { toast } from "@/lib/toast";
 
 import {
@@ -1994,24 +1998,28 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       handledRouteModel.current = null;
       return;
     }
-    const routedGgufQuant = routeSearch.ggufQuant?.trim() || null;
-    const key = `${wanted}|${routeSearch.quant ?? ""}|${routedGgufQuant ?? ""}`;
+    // `quant` is a filename, used verbatim; a label there (a hand-built link, an older producer) is resolved instead.
+    // The two fields, not the object: `routeSearch` is rebuilt every render, and naming it here would put it in the deps.
+    const routed = { quant: routeSearch.quant, ggufQuant: routeSearch.ggufQuant };
+    const routedFilename = routedGgufFilename(routed);
+    const routedLabel = routedGgufLabel(routed);
+    const key = `${wanted}|${routeSearch.quant ?? ""}|${routeSearch.ggufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
     void navigateSelf({ to: "/images", search: {}, replace: true });
     // A label means a GGUF repo whatever the catalog says, and a label is not loadable, so resolve it rather than routing it
     // through the classifier's filename slot.
-    if (routedGgufQuant) {
+    if (routedLabel) {
       // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
       void Promise.resolve().then(() =>
-        loadGgufRepoPick(wanted, routedGgufQuant, false),
+        loadGgufRepoPick(wanted, routedLabel, false),
       );
       return;
     }
     // Same catalog lookup a direct pick makes: the chat picker can only forward a GGUF filename.
     const pick = diffusionRoutePick(
       wanted,
-      routeSearch.quant,
+      routedFilename ?? undefined,
       loadSpecFor(wanted, IMAGE_CATALOG),
     );
     // A curated GGUF artifact resolves to kind "gguf" with no filename: the catalog lists the repo, not its files.

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -1192,9 +1192,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   const lastLoadRevert = useRef<{ prev: typeof lastLoad.current } | null>(null);
   // A trained adapter awaiting deployment: applied once the base is loaded and LoRA-capable for its family.
   const pendingDeploy = useRef<{ loraId: string; family: string } | null>(null);
-  // Which pick owns the page. Resolving a repo-level GGUF pick is a listing request and staging is a plan request, neither of
-  // which sets `busy`, so the user can pick again or switch pages mid-flight; the superseded pick must then do nothing.
-  // Lazy state, not a ref: the guard is created once per page and read from handlers, and a ref cannot be written during render.
+  // Which pick owns the page: resolving one is a listing request and staging is a plan request, and neither sets `busy`, so a
+  // pick can land on top of an awaiting one. Lazy state rather than a ref, which cannot be written during render.
   const [pickGuard] = useState(createPickGuard);
 
   const dismissLoadToast = useCallback(() => {
@@ -1870,8 +1869,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   }, [active]);
 
   // Stage a not-yet-downloaded hub pick, else load it directly. Returns true when the pick was accepted either way.
-  // `isCurrent` lets an awaiting caller drop out here too: the plan request below is a second window in which a newer pick can
-  // take the page, and loading anyway would evict the model that pick just asked for.
+  // `isCurrent` lets an awaiting caller drop out here too: the plan below is a second window for a newer pick to take the page.
   const loadOrStage = useCallback(
     async (
       repoId: string,
@@ -1898,7 +1896,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           // planned a quantized file set and staged too little. Same list handleLoad bakes.
           loras: advanced.loras,
         });
-        // Superseded while the plan was in flight: neither stage nor load, and leave `pendingStagedLoad` to its new owner.
+        // Superseded mid-plan: neither stage nor load, and leave `pendingStagedLoad` to its new owner.
         if (isCurrent && !isCurrent()) return false;
         if (plan.entries.length > 0) {
           pendingStagedLoad.current = { repoId, opts, advanced };
@@ -1931,7 +1929,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       isDownloaded?: boolean,
       localPath?: string | null,
     ): Promise<boolean> => {
-      // Claimed here, not by the caller, so every entry point is covered; the next pick's claim makes this one inert.
+      // Claimed here so every entry point is covered; the next pick's claim makes this one inert.
       const token = pickGuard.claim();
       const isCurrent = () => isMounted.current && pickGuard.holds(token);
       const prevQuant = quant;
@@ -1965,8 +1963,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     [loadOrStage, pickGuard, quant],
   );
 
-  // A hidden page owns nothing: both diffusion pages stay mounted, so a resolution started here must not fire a load after the
-  // user moved to the other one.
+  // A hidden page owns nothing: both stay mounted, so a resolution started here must not load after the user switched.
   useEffect(() => {
     if (!active) pickGuard.release();
   }, [active, pickGuard]);
@@ -1995,8 +1992,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
     void navigateSelf({ to: "/images", search: {}, replace: true });
-    // A label, so a GGUF repo whatever the catalog says: the picker only sends one for a pick it knows holds quants, and a
-    // label is not loadable, so it goes to the resolver rather than through the route classifier's filename slot.
+    // A label means a GGUF repo whatever the catalog says, and a label is not loadable, so resolve it rather than routing it
+    // through the classifier's filename slot.
     if (routedGgufQuant) {
       // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
       void Promise.resolve().then(() =>
@@ -2037,8 +2034,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     (id: string, meta: ModelSelectorChangeMeta) => {
       // Ignore picks while a load/generation/unload is in flight: the backend rejects a second load with a 409.
       if (busy !== null) return;
-      // This pick now owns the page, so an earlier one still waiting on a listing or a download plan drops out. Claimed before
-      // any branch, because staging does not set `busy` and any pick can therefore land on top of an awaiting one.
+      // This pick owns the page now, so one still awaiting a listing or a plan drops out. Before any branch: staging does not
+      // set `busy`, so any pick can land on top of an awaiting one.
       const token = pickGuard.claim();
       const isCurrent = () => isMounted.current && pickGuard.holds(token);
       // Curated non-GGUF model: load as a full pipeline or single-file safetensors.
@@ -2071,8 +2068,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           meta.isDownloaded,
           isCurrent,
         ).then((started) => {
-          // Only the pick that set the label may take it back: `quantRevert` is one slot, so a stale revert would restore this
-          // pick's old label over the newer one.
+          // `quantRevert` is one slot, so only the pick that set the label may take it back.
           if (!started && isCurrent()) {
             setQuant(prevQuant);
             quantRevert.current = null;
@@ -2087,8 +2083,8 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         const filename = slash >= 0 ? norm.slice(slash + 1) : norm;
         const dir = slash >= 0 ? norm.slice(0, slash) : ".";
         if (!filename.toLowerCase().endsWith(".gguf")) {
-          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings. A local
-          // pick passes its directory too: the listing enumerates that path instead of resolving the id as a hub repo.
+          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings, and a
+          // local pick passes its directory so the listing enumerates that path instead of a hub repo.
           void loadGgufRepoPick(
             id,
             meta.ggufVariant ?? null,
@@ -2184,7 +2180,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         toast.error("Could not resolve the trained adapter's name.");
         return;
       }
-      // The deploy owns the page now: a pick still resolving its filename would load over the base this is about to load.
+      // The deploy owns the page now: a resolving pick would load over the base about to load.
       pickGuard.release();
       pendingDeploy.current = { loraId: stem, family: args.family };
       if (args.trigger.trim()) setPrompt(args.trigger.trim());
@@ -2202,7 +2198,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
 
   const handleUnload = useCallback(async () => {
     // Ejecting cancels any in-flight replacement load, so tear down its client-side tracking too, or the toast leaks forever.
-    // A pick still resolving its filename counts: it would load the model the user just ejected.
+    // A pick still resolving its filename counts: it would load the model just ejected.
     pickGuard.release();
     if (pollTimer.current) clearTimeout(pollTimer.current);
     pollTimer.current = null;

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -58,6 +58,7 @@ import {
   useOnlineStatus,
 } from "@/features/hub";
 import { useDebouncedValue, useGpuInfo, useInferenceGpuInfo } from "@/hooks";
+import { diffusionRouteSearch } from "@/lib/diffusion-route-search";
 import { extractParamLabel } from "@/lib/model-size";
 import { toast } from "@/lib/toast";
 import { cn, formatCompact } from "@/lib/utils";
@@ -2651,8 +2652,11 @@ export function HubModelPicker({
         if (page) {
           void navigateToPage({
             to: `/${page}`,
-            // The target page uses this verbatim as the gguf filename, so it must be ggufFilename (an exact repo filename), never ggufVariant (a label like "Q4_K_M", which routed a file that does not exist). No filename means a curated non-GGUF pick.
-            search: { model: id, quant: meta.ggufFilename ?? undefined },
+            // `quant` is used verbatim as the gguf filename, so only ggufFilename (an exact repo filename) may go there, never
+            // ggufVariant (a label like "Q4_K_M", which routed a file that does not exist). A pinned row has only the label, so
+            // it rides ggufQuant and the page resolves it against the listing; without that it arrived as a bare repo id and
+            // every non-curated GGUF repo read as a pipeline.
+            search: diffusionRouteSearch(id, meta),
           });
           return;
         }

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -2652,10 +2652,8 @@ export function HubModelPicker({
         if (page) {
           void navigateToPage({
             to: `/${page}`,
-            // `quant` is used verbatim as the gguf filename, so only ggufFilename (an exact repo filename) may go there, never
-            // ggufVariant (a label like "Q4_K_M", which routed a file that does not exist). A pinned row has only the label, so
-            // it rides ggufQuant and the page resolves it against the listing; without that it arrived as a bare repo id and
-            // every non-curated GGUF repo read as a pipeline.
+            // `quant` is used verbatim as the gguf filename, so a label like "Q4_K_M" cannot go there. A pinned row has only
+            // the label, so it rides ggufQuant; dropping it made every non-curated GGUF repo arrive as a bare repo id.
             search: diffusionRouteSearch(id, meta),
           });
           return;

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -2652,8 +2652,8 @@ export function HubModelPicker({
         if (page) {
           void navigateToPage({
             to: `/${page}`,
-            // `quant` is used verbatim as the gguf filename, so a label like "Q4_K_M" cannot go there. A pinned row has only
-            // the label, so it rides ggufQuant; dropping it made every non-curated GGUF repo arrive as a bare repo id.
+            // `quant` is used verbatim as the gguf filename, so a label like "Q4_K_M" rides ggufQuant instead; dropping it
+            // made every non-curated GGUF repo arrive as a bare repo id.
             search: diffusionRouteSearch(id, meta),
           });
           return;
@@ -3464,9 +3464,8 @@ export function HubModelPicker({
                 isLora: false,
                 ggufVariant: entry.quant,
                 isDownloaded: true,
-                // The row loads one quant, so it is a GGUF pick like the expander's. Without this the diffusion pages read
-                // the label-only meta as a curated repo and asked for a pipeline, which a GGUF repo rejects. No filename:
-                // the pin stores a label, and the pages resolve it against the listing.
+                // The row loads one quant, so it is a GGUF pick like the expander's; without this the pages asked for a
+                // pipeline, which a GGUF repo rejects. No filename: the pin stores a label, resolved against the listing.
                 isGguf: true,
               })
             }

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3462,6 +3462,10 @@ export function HubModelPicker({
                 isLora: false,
                 ggufVariant: entry.quant,
                 isDownloaded: true,
+                // The row loads one quant, so it is a GGUF pick like the expander's. Without this the diffusion pages read
+                // the label-only meta as a curated repo and asked for a pipeline, which a GGUF repo rejects. No filename:
+                // the pin stores a label, and the pages resolve it against the listing.
+                isGguf: true,
               })
             }
             vramStatus={null}

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -65,6 +65,7 @@ import { formatBytes, formatEta } from "@/features/hub/lib/format";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useStagedDownload } from "@/features/hub/download-manager";
 import { cn } from "@/lib/utils";
+import { resolveDiffusionGgufFilename } from "@/lib/diffusion-gguf-filename";
 import { diffusionRoutePick } from "@/lib/diffusion-route-pick";
 import { toast } from "@/lib/toast";
 
@@ -1240,6 +1241,46 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     [stage],
   );
 
+  // A GGUF pick can arrive with only a repo id: a pinned row sends its quant label, a curated artifact sends neither, and a
+  // local GGUF directory is a repo too. The backend rejects a gguf load with no filename, and a pipeline load of a GGUF repo,
+  // so both dead-ended. The repo's listing names the file, so resolve it before giving up.
+  const loadGgufRepoPick = useCallback(
+    async (
+      repoId: string,
+      quantHint: string | null,
+      isDownloaded?: boolean,
+    ): Promise<boolean> => {
+      const filename = await resolveDiffusionGgufFilename(repoId, {
+        quant: quantHint,
+        hfToken: hfApiToken(getHfToken()),
+      });
+      // Still ambiguous (several quants on disk, or the listing failed): only the expander can say which.
+      if (!filename) {
+        toast.error("Pick a quantization for this model to load it");
+        return false;
+      }
+      // Optimistic label, reverted if the load never starts, like the curated GGUF branch below.
+      const prevQuant = quant;
+      quantRevert.current = { prev: prevQuant };
+      setQuant(quantHint ?? filename);
+      // Filename-qualified like the expander branch: the LTX variant lives in the checkpoint name, not the repo id.
+      const d = defaultsFor(`${repoId}/${filename}`);
+      setSteps(d.steps);
+      setGuidance(d.guidance);
+      const started = await loadOrStage(
+        repoId,
+        { kind: "gguf", filename },
+        isDownloaded,
+      );
+      if (!started) {
+        setQuant(prevQuant);
+        quantRevert.current = null;
+      }
+      return started;
+    },
+    [loadOrStage, quant],
+  );
+
   // A diffusion model picked from the chat picker arrives as ?model= on this route. Load it once, then clear the params.
   const routeSearch = useSearch({ strict: false }) as {
     model?: string;
@@ -1267,8 +1308,23 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       routeSearch.quant,
       loadSpecFor(wanted, VIDEO_CATALOG),
     );
+    // A curated GGUF artifact resolves to kind "gguf" with no filename: the catalog lists the repo, not its files.
+    if (pick.opts.kind === "gguf" && !pick.opts.filename) {
+      // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
+      void Promise.resolve().then(() =>
+        loadGgufRepoPick(pick.repoId, routeSearch.quant ?? null, false),
+      );
+      return;
+    }
     void loadOrStage(pick.repoId, pick.opts, false);
-  }, [active, routeSearch.model, routeSearch.quant, loadOrStage, navigateSelf]);
+  }, [
+    active,
+    routeSearch.model,
+    routeSearch.quant,
+    loadOrStage,
+    loadGgufRepoPick,
+    navigateSelf,
+  ]);
 
   // Reload the current model with the current advanced options.
   const handleReapply = useCallback(() => {
@@ -1321,8 +1377,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
         const filename = slash >= 0 ? norm.slice(slash + 1) : norm;
         const dir = slash >= 0 ? norm.slice(0, slash) : ".";
         if (!filename.toLowerCase().endsWith(".gguf")) {
-          // No filename to load, and a quant label can't be mapped back to one.
-          toast.error("Pick a quantization for this model to load it");
+          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings.
+          void loadGgufRepoPick(id, meta.ggufVariant ?? null, meta.isDownloaded);
           return;
         }
         const prevQuant = quant;
@@ -1359,6 +1415,17 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
         });
         return;
       }
+      // A GGUF repo with no filename: a pinned row sends its label alone, a curated artifact sends neither. Both used to
+      // fall through to the pipeline branch below, which the backend rejects for a single-file GGUF repo.
+      if (spec?.kind === "gguf" || meta.ggufVariant) {
+        // An artifact that names its file short-circuits the listing; otherwise the label is the hint.
+        void loadGgufRepoPick(
+          id,
+          spec?.filename ?? meta.ggufVariant ?? null,
+          meta.isDownloaded,
+        );
+        return;
+      }
       // Otherwise treat it as a full diffusers repo. The backend gates loads to unsloth/* repos, the family bases, or on-device paths.
       if (meta.source !== "local" && !id.toLowerCase().startsWith("unsloth/")) {
         toast.error("Only unsloth or on-device video models can be loaded here");
@@ -1370,7 +1437,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       setGuidance(d.guidance);
       void loadOrStage(id, { kind: "pipeline" }, meta.isDownloaded);
     },
-    [busy, handleLoad, loadOrStage, quant],
+    [busy, handleLoad, loadGgufRepoPick, loadOrStage, quant],
   );
 
   const handleUnload = useCallback(async () => {

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -633,9 +633,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   // The Reapply target (and its canReapply flag) to restore if the optimistic swap fails: handleLoad overwrites lastLoad at
   // load start, and a load failing AFTER that leaves the previous model resident, so the poll rolls it back.
   const lastLoadRevert = useRef<{ prev: typeof lastLoad.current; canReapply: boolean } | null>(null);
-  // Which pick owns the page. Resolving a repo-level GGUF pick is a listing request and staging is a plan request, neither of
-  // which sets `busy`, so the user can pick again or switch pages mid-flight; the superseded pick must then do nothing.
-  // Lazy state, not a ref: the guard is created once per page and read from handlers, and a ref cannot be written during render.
+  // Which pick owns the page: resolving one is a listing request and staging is a plan request, and neither sets `busy`, so a
+  // pick can land on top of an awaiting one. Lazy state rather than a ref, which cannot be written during render.
   const [pickGuard] = useState(createPickGuard);
 
   const dismissLoadToast = useCallback(() => {
@@ -1211,8 +1210,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   }, [active]);
 
   // Stage a not-yet-downloaded hub pick, else load it directly.
-  // `isCurrent` lets an awaiting caller drop out here too: the plan request below is a second window in which a newer pick can
-  // take the page, and loading anyway would evict the model that pick just asked for.
+  // `isCurrent` lets an awaiting caller drop out here too: the plan below is a second window for a newer pick to take the page.
   const loadOrStage = useCallback(
     async (
       repoId: string,
@@ -1229,7 +1227,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           // Same token handleLoad sends: without it the metadata lookup fails on a gated base and the plan drops the companion entry, so the load pulls those files inline.
           hf_token: hfApiToken(getHfToken()),
         });
-        // Superseded while the plan was in flight: neither stage nor load, and leave `pendingStagedLoad` to its new owner.
+        // Superseded mid-plan: neither stage nor load, and leave `pendingStagedLoad` to its new owner.
         if (isCurrent && !isCurrent()) return false;
         if (plan.entries.length > 0) {
           pendingStagedLoad.current = { repoId, opts };
@@ -1262,7 +1260,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       isDownloaded?: boolean,
       localPath?: string | null,
     ): Promise<boolean> => {
-      // Claimed here, not by the caller, so every entry point is covered; the next pick's claim makes this one inert.
+      // Claimed here so every entry point is covered; the next pick's claim makes this one inert.
       const token = pickGuard.claim();
       const isCurrent = () => isMounted.current && pickGuard.holds(token);
       const prevQuant = quant;
@@ -1297,8 +1295,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     [loadOrStage, pickGuard, quant],
   );
 
-  // A hidden page owns nothing: both diffusion pages stay mounted, so a resolution started here must not fire a load after the
-  // user moved to the other one.
+  // A hidden page owns nothing: both stay mounted, so a resolution started here must not load after the user switched.
   useEffect(() => {
     if (!active) pickGuard.release();
   }, [active, pickGuard]);
@@ -1326,8 +1323,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
     void navigateSelf({ to: "/video", search: {}, replace: true });
-    // A label, so a GGUF repo whatever the catalog says: the picker only sends one for a pick it knows holds quants, and a
-    // label is not loadable, so it goes to the resolver rather than through the route classifier's filename slot.
+    // A label means a GGUF repo whatever the catalog says, and a label is not loadable, so resolve it rather than routing it
+    // through the classifier's filename slot.
     if (routedGgufQuant) {
       // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
       void Promise.resolve().then(() =>
@@ -1368,8 +1365,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     (id: string, meta: ModelSelectorChangeMeta) => {
       // Ignore picks while a load/generation/unload is in flight.
       if (busy !== null) return;
-      // This pick now owns the page, so an earlier one still waiting on a listing or a download plan drops out. Claimed before
-      // any branch, because staging does not set `busy` and any pick can therefore land on top of an awaiting one.
+      // This pick owns the page now, so one still awaiting a listing or a plan drops out. Before any branch: staging does not
+      // set `busy`, so any pick can land on top of an awaiting one.
       const token = pickGuard.claim();
       const isCurrent = () => isMounted.current && pickGuard.holds(token);
       // Curated non-GGUF model: load as a full pipeline.
@@ -1404,8 +1401,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           meta.isDownloaded,
           isCurrent,
         ).then((started) => {
-          // Only the pick that set the label may take it back: `quantRevert` is one slot, so a stale revert would restore this
-          // pick's old label over the newer one.
+          // `quantRevert` is one slot, so only the pick that set the label may take it back.
           if (!started && isCurrent()) {
             setQuant(prevQuant);
             quantRevert.current = null;
@@ -1420,8 +1416,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
         const filename = slash >= 0 ? norm.slice(slash + 1) : norm;
         const dir = slash >= 0 ? norm.slice(0, slash) : ".";
         if (!filename.toLowerCase().endsWith(".gguf")) {
-          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings. A local
-          // pick passes its directory too: the listing enumerates that path instead of resolving the id as a hub repo.
+          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings, and a
+          // local pick passes its directory so the listing enumerates that path instead of a hub repo.
           void loadGgufRepoPick(
             id,
             meta.ggufVariant ?? null,
@@ -1491,7 +1487,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   );
 
   const handleUnload = useCallback(async () => {
-    // A pick still resolving its filename would load the model the user just ejected.
+    // A pick still resolving its filename would load the model just ejected.
     pickGuard.release();
     if (pollTimer.current) clearTimeout(pollTimer.current);
     pollTimer.current = null;

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1337,6 +1337,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     const key = `${wanted}|${routeSearch.quant ?? ""}|${routeSearch.ggufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
+    // This arrival owns the page like a direct pick does, so a download staged by an earlier one cannot land on top.
+    const token = pickGuard.claim();
     void navigateSelf({ to: "/video", search: {}, replace: true });
     // A label means a GGUF repo whatever the catalog says, and a label is not loadable, so resolve it rather than routing it
     // through the classifier's filename slot.
@@ -1358,7 +1360,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       void Promise.resolve().then(() => loadGgufRepoPick(pick.repoId, null, false));
       return;
     }
-    void loadOrStage(pick.repoId, pick.opts, false);
+    void loadOrStage(pick.repoId, pick.opts, false, token);
   }, [
     active,
     routeSearch.model,
@@ -1367,6 +1369,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     loadOrStage,
     loadGgufRepoPick,
     navigateSelf,
+    pickGuard,
   ]);
 
   // Reload the current model with the current advanced options.
@@ -1501,8 +1504,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   );
 
   const handleUnload = useCallback(async () => {
-    // A pick still resolving its filename would load the model just ejected.
-    pickGuard.release();
+    // Cancel, not release: a pick still resolving, and a download already staged, would load back what was just ejected.
+    pickGuard.cancel();
     if (pollTimer.current) clearTimeout(pollTimer.current);
     pollTimer.current = null;
     dismissLoadToast();

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1183,11 +1183,21 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   const pendingStagedLoad = useRef<{
     repoId: string;
     opts: { kind: "gguf" | "single_file" | "pipeline"; filename?: string };
+    // The pick that staged it. A download outlives its pick, so a newer one must not be evicted when this lands.
+    token: number;
   } | null>(null);
   const handleLoadRef = useRef(handleLoad);
   handleLoadRef.current = handleLoad;
   // A download finishing while this page is hidden must not evict the model the visible page loaded. The pick is held, not dropped.
   const stagedLoadDeferred = useRef(false);
+  // Staging does not set `busy`, so a pick made while the download ran already owns the page; only the newest one may load.
+  // `isLatest`, not `holds`: leaving the page is not a new pick, and the deferred load below is exactly that case.
+  const runStagedLoad = useCallback(() => {
+    const pending = pendingStagedLoad.current;
+    pendingStagedLoad.current = null;
+    if (!pending || !pickGuard.isLatest(pending.token)) return;
+    void handleLoadRef.current(pending.repoId, pending.opts);
+  }, [pickGuard]);
   const { stage } = useStagedDownload({
     scopeId: "diffusion",
     onReady: () => {
@@ -1195,29 +1205,26 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
         stagedLoadDeferred.current = true;
         return;
       }
-      const pending = pendingStagedLoad.current;
-      pendingStagedLoad.current = null;
-      if (pending) void handleLoadRef.current(pending.repoId, pending.opts);
+      runStagedLoad();
     },
   });
 
   useEffect(() => {
     if (!active || !stagedLoadDeferred.current) return;
     stagedLoadDeferred.current = false;
-    const pending = pendingStagedLoad.current;
-    pendingStagedLoad.current = null;
-    if (pending) void handleLoadRef.current(pending.repoId, pending.opts);
-  }, [active]);
+    runStagedLoad();
+  }, [active, runStagedLoad]);
 
   // Stage a not-yet-downloaded hub pick, else load it directly.
-  // `isCurrent` lets an awaiting caller drop out here too: the plan below is a second window for a newer pick to take the page.
+  // `token` lets an awaiting caller drop out here too: the plan below is a second window for a newer pick to take the page.
   const loadOrStage = useCallback(
     async (
       repoId: string,
       opts: { kind: "gguf" | "single_file" | "pipeline"; filename?: string },
       isDownloaded?: boolean,
-      isCurrent?: () => boolean,
+      token?: number,
     ): Promise<boolean> => {
+      const owns = () => token === undefined || pickGuard.holds(token);
       if (isDownloaded !== false) return handleLoadRef.current(repoId, opts);
       try {
         const plan = await getVideoDownloadPlan({
@@ -1228,9 +1235,9 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           hf_token: hfApiToken(getHfToken()),
         });
         // Superseded mid-plan: neither stage nor load, and leave `pendingStagedLoad` to its new owner.
-        if (isCurrent && !isCurrent()) return false;
+        if (!owns()) return false;
         if (plan.entries.length > 0) {
-          pendingStagedLoad.current = { repoId, opts };
+          pendingStagedLoad.current = { repoId, opts, token: token ?? pickGuard.claim() };
           stage(
             plan.entries.map((e) => ({
               repoId: e.repo_id,
@@ -1244,10 +1251,10 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       } catch {
         // No plan (older backend, metadata hiccup): fall back to the load's own download.
       }
-      if (isCurrent && !isCurrent()) return false;
+      if (!owns()) return false;
       return handleLoadRef.current(repoId, opts);
     },
-    [stage],
+    [stage, pickGuard],
   );
 
   // A GGUF pick can arrive with only a repo id: a pinned row sends its quant label, a curated artifact sends neither, and a
@@ -1289,7 +1296,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           quantRevert.current = null;
         },
         load: (filename) =>
-          loadOrStage(repoId, { kind: "gguf", filename }, isDownloaded, isCurrent),
+          loadOrStage(repoId, { kind: "gguf", filename }, isDownloaded, token),
       });
     },
     [loadOrStage, pickGuard, quant],
@@ -1368,7 +1375,6 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       // This pick owns the page now, so one still awaiting a listing or a plan drops out. Before any branch: staging does not
       // set `busy`, so any pick can land on top of an awaiting one.
       const token = pickGuard.claim();
-      const isCurrent = () => isMounted.current && pickGuard.holds(token);
       // Curated non-GGUF model: load as a full pipeline.
       const spec = loadSpecFor(id, VIDEO_CATALOG);
       if (spec && spec.kind !== "gguf") {
@@ -1382,7 +1388,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           id,
           { kind: spec.kind, filename: spec.filename },
           meta.isDownloaded,
-          isCurrent,
+          token,
         );
         return;
       }
@@ -1399,10 +1405,10 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           id,
           { kind: "gguf", filename: meta.ggufFilename },
           meta.isDownloaded,
-          isCurrent,
+          token,
         ).then((started) => {
           // `quantRevert` is one slot, so only the pick that set the label may take it back.
-          if (!started && isCurrent()) {
+          if (!started && pickGuard.holds(token)) {
             setQuant(prevQuant);
             quantRevert.current = null;
           }
@@ -1481,7 +1487,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       const d = defaultsFor(id);
       setSteps(d.steps);
       setGuidance(d.guidance);
-      void loadOrStage(id, { kind: "pipeline" }, meta.isDownloaded, isCurrent);
+      void loadOrStage(id, { kind: "pipeline" }, meta.isDownloaded, token);
     },
     [busy, handleLoad, loadGgufRepoPick, loadOrStage, pickGuard, quant],
   );

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -68,6 +68,10 @@ import { cn } from "@/lib/utils";
 import { resolveDiffusionGgufFilename } from "@/lib/diffusion-gguf-filename";
 import { createPickGuard, runGgufRepoPick } from "@/lib/diffusion-gguf-pick";
 import { diffusionRoutePick } from "@/lib/diffusion-route-pick";
+import {
+  routedGgufFilename,
+  routedGgufLabel,
+} from "@/lib/diffusion-route-search";
 import { toast } from "@/lib/toast";
 
 import {
@@ -1325,24 +1329,28 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       handledRouteModel.current = null;
       return;
     }
-    const routedGgufQuant = routeSearch.ggufQuant?.trim() || null;
-    const key = `${wanted}|${routeSearch.quant ?? ""}|${routedGgufQuant ?? ""}`;
+    // `quant` is a filename, used verbatim; a label there (a hand-built link, an older producer) is resolved instead.
+    // The two fields, not the object: `routeSearch` is rebuilt every render, and naming it here would put it in the deps.
+    const routed = { quant: routeSearch.quant, ggufQuant: routeSearch.ggufQuant };
+    const routedFilename = routedGgufFilename(routed);
+    const routedLabel = routedGgufLabel(routed);
+    const key = `${wanted}|${routeSearch.quant ?? ""}|${routeSearch.ggufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
     void navigateSelf({ to: "/video", search: {}, replace: true });
     // A label means a GGUF repo whatever the catalog says, and a label is not loadable, so resolve it rather than routing it
     // through the classifier's filename slot.
-    if (routedGgufQuant) {
+    if (routedLabel) {
       // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
       void Promise.resolve().then(() =>
-        loadGgufRepoPick(wanted, routedGgufQuant, false),
+        loadGgufRepoPick(wanted, routedLabel, false),
       );
       return;
     }
     // Same catalog lookup a direct pick makes: the chat picker can only forward a GGUF filename, so a curated single-file artifact would load as a pipeline and fail.
     const pick = diffusionRoutePick(
       wanted,
-      routeSearch.quant,
+      routedFilename ?? undefined,
       loadSpecFor(wanted, VIDEO_CATALOG),
     );
     // A curated GGUF artifact resolves to kind "gguf" with no filename: the catalog lists the repo, not its files.

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -66,6 +66,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useStagedDownload } from "@/features/hub/download-manager";
 import { cn } from "@/lib/utils";
 import { resolveDiffusionGgufFilename } from "@/lib/diffusion-gguf-filename";
+import { createPickGuard, runGgufRepoPick } from "@/lib/diffusion-gguf-pick";
 import { diffusionRoutePick } from "@/lib/diffusion-route-pick";
 import { toast } from "@/lib/toast";
 
@@ -632,6 +633,10 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   // The Reapply target (and its canReapply flag) to restore if the optimistic swap fails: handleLoad overwrites lastLoad at
   // load start, and a load failing AFTER that leaves the previous model resident, so the poll rolls it back.
   const lastLoadRevert = useRef<{ prev: typeof lastLoad.current; canReapply: boolean } | null>(null);
+  // Which pick owns the page. Resolving a repo-level GGUF pick is a listing request and staging is a plan request, neither of
+  // which sets `busy`, so the user can pick again or switch pages mid-flight; the superseded pick must then do nothing.
+  // Lazy state, not a ref: the guard is created once per page and read from handlers, and a ref cannot be written during render.
+  const [pickGuard] = useState(createPickGuard);
 
   const dismissLoadToast = useCallback(() => {
     if (loadToastId.current != null) toast.dismiss(loadToastId.current);
@@ -1206,11 +1211,14 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   }, [active]);
 
   // Stage a not-yet-downloaded hub pick, else load it directly.
+  // `isCurrent` lets an awaiting caller drop out here too: the plan request below is a second window in which a newer pick can
+  // take the page, and loading anyway would evict the model that pick just asked for.
   const loadOrStage = useCallback(
     async (
       repoId: string,
       opts: { kind: "gguf" | "single_file" | "pipeline"; filename?: string },
       isDownloaded?: boolean,
+      isCurrent?: () => boolean,
     ): Promise<boolean> => {
       if (isDownloaded !== false) return handleLoadRef.current(repoId, opts);
       try {
@@ -1221,6 +1229,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           // Same token handleLoad sends: without it the metadata lookup fails on a gated base and the plan drops the companion entry, so the load pulls those files inline.
           hf_token: hfApiToken(getHfToken()),
         });
+        // Superseded while the plan was in flight: neither stage nor load, and leave `pendingStagedLoad` to its new owner.
+        if (isCurrent && !isCurrent()) return false;
         if (plan.entries.length > 0) {
           pendingStagedLoad.current = { repoId, opts };
           stage(
@@ -1236,6 +1246,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       } catch {
         // No plan (older backend, metadata hiccup): fall back to the load's own download.
       }
+      if (isCurrent && !isCurrent()) return false;
       return handleLoadRef.current(repoId, opts);
     },
     [stage],
@@ -1249,42 +1260,54 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       repoId: string,
       quantHint: string | null,
       isDownloaded?: boolean,
+      localPath?: string | null,
     ): Promise<boolean> => {
-      const filename = await resolveDiffusionGgufFilename(repoId, {
-        quant: quantHint,
-        hfToken: hfApiToken(getHfToken()),
-      });
-      // Still ambiguous (several quants on disk, or the listing failed): only the expander can say which.
-      if (!filename) {
-        toast.error("Pick a quantization for this model to load it");
-        return false;
-      }
-      // Optimistic label, reverted if the load never starts, like the curated GGUF branch below.
+      // Claimed here, not by the caller, so every entry point is covered; the next pick's claim makes this one inert.
+      const token = pickGuard.claim();
+      const isCurrent = () => isMounted.current && pickGuard.holds(token);
       const prevQuant = quant;
-      quantRevert.current = { prev: prevQuant };
-      setQuant(quantHint ?? filename);
-      // Filename-qualified like the expander branch: the LTX variant lives in the checkpoint name, not the repo id.
-      const d = defaultsFor(`${repoId}/${filename}`);
-      setSteps(d.steps);
-      setGuidance(d.guidance);
-      const started = await loadOrStage(
-        repoId,
-        { kind: "gguf", filename },
-        isDownloaded,
-      );
-      if (!started) {
-        setQuant(prevQuant);
-        quantRevert.current = null;
-      }
-      return started;
+      return runGgufRepoPick({
+        isCurrent,
+        resolve: () =>
+          resolveDiffusionGgufFilename(repoId, {
+            quant: quantHint,
+            localPath,
+            hfToken: hfApiToken(getHfToken()),
+          }),
+        // Still ambiguous (several quants on disk, or the listing failed): only the expander can say which.
+        onAmbiguous: () =>
+          toast.error("Pick a quantization for this model to load it"),
+        // Optimistic label, reverted if the load never starts, like the curated GGUF branch below.
+        onResolved: (filename) => {
+          quantRevert.current = { prev: prevQuant };
+          setQuant(quantHint ?? filename);
+          // Filename-qualified like the expander branch: the LTX variant lives in the checkpoint name, not the repo id.
+          const d = defaultsFor(`${repoId}/${filename}`);
+          setSteps(d.steps);
+          setGuidance(d.guidance);
+        },
+        onNotStarted: () => {
+          setQuant(prevQuant);
+          quantRevert.current = null;
+        },
+        load: (filename) =>
+          loadOrStage(repoId, { kind: "gguf", filename }, isDownloaded, isCurrent),
+      });
     },
-    [loadOrStage, quant],
+    [loadOrStage, pickGuard, quant],
   );
+
+  // A hidden page owns nothing: both diffusion pages stay mounted, so a resolution started here must not fire a load after the
+  // user moved to the other one.
+  useEffect(() => {
+    if (!active) pickGuard.release();
+  }, [active, pickGuard]);
 
   // A diffusion model picked from the chat picker arrives as ?model= on this route. Load it once, then clear the params.
   const routeSearch = useSearch({ strict: false }) as {
     model?: string;
     quant?: string;
+    ggufQuant?: string;
   };
   const navigateSelf = useNavigate();
   const handledRouteModel = useRef<string | null>(null);
@@ -1298,10 +1321,20 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       handledRouteModel.current = null;
       return;
     }
-    const key = `${wanted}|${routeSearch.quant ?? ""}`;
+    const routedGgufQuant = routeSearch.ggufQuant?.trim() || null;
+    const key = `${wanted}|${routeSearch.quant ?? ""}|${routedGgufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
     void navigateSelf({ to: "/video", search: {}, replace: true });
+    // A label, so a GGUF repo whatever the catalog says: the picker only sends one for a pick it knows holds quants, and a
+    // label is not loadable, so it goes to the resolver rather than through the route classifier's filename slot.
+    if (routedGgufQuant) {
+      // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
+      void Promise.resolve().then(() =>
+        loadGgufRepoPick(wanted, routedGgufQuant, false),
+      );
+      return;
+    }
     // Same catalog lookup a direct pick makes: the chat picker can only forward a GGUF filename, so a curated single-file artifact would load as a pipeline and fail.
     const pick = diffusionRoutePick(
       wanted,
@@ -1310,10 +1343,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     );
     // A curated GGUF artifact resolves to kind "gguf" with no filename: the catalog lists the repo, not its files.
     if (pick.opts.kind === "gguf" && !pick.opts.filename) {
-      // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
-      void Promise.resolve().then(() =>
-        loadGgufRepoPick(pick.repoId, routeSearch.quant ?? null, false),
-      );
+      void Promise.resolve().then(() => loadGgufRepoPick(pick.repoId, null, false));
       return;
     }
     void loadOrStage(pick.repoId, pick.opts, false);
@@ -1321,6 +1351,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     active,
     routeSearch.model,
     routeSearch.quant,
+    routeSearch.ggufQuant,
     loadOrStage,
     loadGgufRepoPick,
     navigateSelf,
@@ -1337,6 +1368,10 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     (id: string, meta: ModelSelectorChangeMeta) => {
       // Ignore picks while a load/generation/unload is in flight.
       if (busy !== null) return;
+      // This pick now owns the page, so an earlier one still waiting on a listing or a download plan drops out. Claimed before
+      // any branch, because staging does not set `busy` and any pick can therefore land on top of an awaiting one.
+      const token = pickGuard.claim();
+      const isCurrent = () => isMounted.current && pickGuard.holds(token);
       // Curated non-GGUF model: load as a full pipeline.
       const spec = loadSpecFor(id, VIDEO_CATALOG);
       if (spec && spec.kind !== "gguf") {
@@ -1346,7 +1381,12 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
         const d = defaultsFor(spec.filename ? `${id}/${spec.filename}` : id);
         setSteps(d.steps);
         setGuidance(d.guidance);
-        void loadOrStage(id, { kind: spec.kind, filename: spec.filename }, meta.isDownloaded);
+        void loadOrStage(
+          id,
+          { kind: spec.kind, filename: spec.filename },
+          meta.isDownloaded,
+          isCurrent,
+        );
         return;
       }
       // GGUF quant pick from the variant expander. Optimistic for picker feedback, reverted if the load fails to START; the poll owns the after-start revert.
@@ -1362,8 +1402,11 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           id,
           { kind: "gguf", filename: meta.ggufFilename },
           meta.isDownloaded,
+          isCurrent,
         ).then((started) => {
-          if (!started) {
+          // Only the pick that set the label may take it back: `quantRevert` is one slot, so a stale revert would restore this
+          // pick's old label over the newer one.
+          if (!started && isCurrent()) {
             setQuant(prevQuant);
             quantRevert.current = null;
           }
@@ -1377,8 +1420,14 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
         const filename = slash >= 0 ? norm.slice(slash + 1) : norm;
         const dir = slash >= 0 ? norm.slice(0, slash) : ".";
         if (!filename.toLowerCase().endsWith(".gguf")) {
-          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings.
-          void loadGgufRepoPick(id, meta.ggufVariant ?? null, meta.isDownloaded);
+          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings. A local
+          // pick passes its directory too: the listing enumerates that path instead of resolving the id as a hub repo.
+          void loadGgufRepoPick(
+            id,
+            meta.ggufVariant ?? null,
+            meta.isDownloaded,
+            meta.source === "local" ? id : null,
+          );
           return;
         }
         const prevQuant = quant;
@@ -1423,6 +1472,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           id,
           spec?.filename ?? meta.ggufVariant ?? null,
           meta.isDownloaded,
+          meta.source === "local" ? id : null,
         );
         return;
       }
@@ -1435,12 +1485,14 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       const d = defaultsFor(id);
       setSteps(d.steps);
       setGuidance(d.guidance);
-      void loadOrStage(id, { kind: "pipeline" }, meta.isDownloaded);
+      void loadOrStage(id, { kind: "pipeline" }, meta.isDownloaded, isCurrent);
     },
-    [busy, handleLoad, loadGgufRepoPick, loadOrStage, quant],
+    [busy, handleLoad, loadGgufRepoPick, loadOrStage, pickGuard, quant],
   );
 
   const handleUnload = useCallback(async () => {
+    // A pick still resolving its filename would load the model the user just ejected.
+    pickGuard.release();
     if (pollTimer.current) clearTimeout(pollTimer.current);
     pollTimer.current = null;
     dismissLoadToast();
@@ -1457,7 +1509,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     } finally {
       setBusy(null);
     }
-  }, [refreshStatus, dismissLoadToast]);
+  }, [refreshStatus, dismissLoadToast, pickGuard]);
 
   const handleCancelGenerate = useCallback(async () => {
     try {

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -637,8 +637,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   // The Reapply target (and its canReapply flag) to restore if the optimistic swap fails: handleLoad overwrites lastLoad at
   // load start, and a load failing AFTER that leaves the previous model resident, so the poll rolls it back.
   const lastLoadRevert = useRef<{ prev: typeof lastLoad.current; canReapply: boolean } | null>(null);
-  // Which pick owns the page: resolving one is a listing request and staging is a plan request, and neither sets `busy`, so a
-  // pick can land on top of an awaiting one. Lazy state rather than a ref, which cannot be written during render.
+  // Which pick owns the page: resolving and staging are requests that do not set `busy`, so a pick can land on an awaiting
+  // one. Lazy state, not a ref: a ref cannot be written during render.
   const [pickGuard] = useState(createPickGuard);
 
   const dismissLoadToast = useCallback(() => {
@@ -1187,15 +1187,15 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   const pendingStagedLoad = useRef<{
     repoId: string;
     opts: { kind: "gguf" | "single_file" | "pipeline"; filename?: string };
-    // The pick that staged it. A download outlives its pick, so a newer one must not be evicted when this lands.
+    // The pick that staged it: a download outlives its pick, so it must not evict a newer one when it lands.
     token: number;
   } | null>(null);
   const handleLoadRef = useRef(handleLoad);
   handleLoadRef.current = handleLoad;
   // A download finishing while this page is hidden must not evict the model the visible page loaded. The pick is held, not dropped.
   const stagedLoadDeferred = useRef(false);
-  // Staging does not set `busy`, so a pick made while the download ran already owns the page; only the newest one may load.
-  // `isLatest`, not `holds`: leaving the page is not a new pick, and the deferred load below is exactly that case.
+  // A pick made while the download ran already owns the page; only the newest may load. `isLatest`, not `holds`: leaving the
+  // page is not a new pick, and the deferred load below is exactly that case.
   const runStagedLoad = useCallback(() => {
     const pending = pendingStagedLoad.current;
     pendingStagedLoad.current = null;
@@ -1220,7 +1220,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   }, [active, runStagedLoad]);
 
   // Stage a not-yet-downloaded hub pick, else load it directly.
-  // `token` lets an awaiting caller drop out here too: the plan below is a second window for a newer pick to take the page.
+  // `token` lets an awaiting caller drop out: the plan below is a second window for a newer pick to take the page.
   const loadOrStage = useCallback(
     async (
       repoId: string,
@@ -1261,9 +1261,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     [stage, pickGuard],
   );
 
-  // A GGUF pick can arrive with only a repo id: a pinned row sends its quant label, a curated artifact sends neither, and a
-  // local GGUF directory is a repo too. The backend rejects a gguf load with no filename, and a pipeline load of a GGUF repo,
-  // so both dead-ended. The repo's listing names the file, so resolve it before giving up.
+  // A GGUF pick can arrive with only a repo id (a pinned row, a curated artifact, a local GGUF directory). The backend
+  // rejects a gguf load with no filename and a pipeline load of a GGUF repo, so name the file from the listing first.
   const loadGgufRepoPick = useCallback(
     async (
       repoId: string,
@@ -1283,7 +1282,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
             localPath,
             hfToken: hfApiToken(getHfToken()),
           }),
-        // Still ambiguous (several quants on disk, or the listing failed): only the expander can say which.
+        // Still ambiguous (several quants, or the listing failed): only the expander can say which.
         onAmbiguous: () =>
           toast.error("Pick a quantization for this model to load it"),
         // Optimistic label, reverted if the load never starts, like the curated GGUF branch below.
@@ -1329,19 +1328,19 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
       handledRouteModel.current = null;
       return;
     }
-    // `quant` is a filename, used verbatim; a label there (a hand-built link, an older producer) is resolved instead.
-    // The two fields, not the object: `routeSearch` is rebuilt every render, and naming it here would put it in the deps.
+    // `quant` is used verbatim as a filename; a label there (a hand-built link, an older producer) is resolved instead.
+    // The two fields, not the object: `routeSearch` is rebuilt every render, so it would churn the deps.
     const routed = { quant: routeSearch.quant, ggufQuant: routeSearch.ggufQuant };
     const routedFilename = routedGgufFilename(routed);
     const routedLabel = routedGgufLabel(routed);
     const key = `${wanted}|${routeSearch.quant ?? ""}|${routeSearch.ggufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
-    // This arrival owns the page like a direct pick does, so a download staged by an earlier one cannot land on top.
+    // This arrival owns the page like a direct pick, so a download staged by an earlier one cannot land on top.
     const token = pickGuard.claim();
     void navigateSelf({ to: "/video", search: {}, replace: true });
-    // A label means a GGUF repo whatever the catalog says, and a label is not loadable, so resolve it rather than routing it
-    // through the classifier's filename slot.
+    // A label means a GGUF repo whatever the catalog says, and is not loadable, so resolve it instead of routing it as a
+    // filename.
     if (routedLabel) {
       // Deferred, not inline: resolution is a request, and the load it fires owns the state a direct pick sets.
       void Promise.resolve().then(() =>
@@ -1383,8 +1382,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     (id: string, meta: ModelSelectorChangeMeta) => {
       // Ignore picks while a load/generation/unload is in flight.
       if (busy !== null) return;
-      // This pick owns the page now, so one still awaiting a listing or a plan drops out. Before any branch: staging does not
-      // set `busy`, so any pick can land on top of an awaiting one.
+      // This pick owns the page now, so one still awaiting a listing or a plan drops out. Before any branch: staging never
+      // sets `busy`, so any pick can land on an awaiting one.
       const token = pickGuard.claim();
       // Curated non-GGUF model: load as a full pipeline.
       const spec = loadSpecFor(id, VIDEO_CATALOG);
@@ -1433,8 +1432,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
         const filename = slash >= 0 ? norm.slice(slash + 1) : norm;
         const dir = slash >= 0 ? norm.slice(0, slash) : ".";
         if (!filename.toLowerCase().endsWith(".gguf")) {
-          // A repo id or local directory, not a file. The listing names its .gguf; the label picks between siblings, and a
-          // local pick passes its directory so the listing enumerates that path instead of a hub repo.
+          // A repo id or local directory, not a file. The listing names its .gguf and the label picks between siblings; a
+          // local pick passes its directory so the listing reads that path, not a hub repo.
           void loadGgufRepoPick(
             id,
             meta.ggufVariant ?? null,
@@ -1477,8 +1476,8 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
         });
         return;
       }
-      // A GGUF repo with no filename: a pinned row sends its label alone, a curated artifact sends neither. Both used to
-      // fall through to the pipeline branch below, which the backend rejects for a single-file GGUF repo.
+      // A GGUF repo with no filename: these used to fall through to the pipeline branch below, which the backend rejects
+      // for a single-file GGUF repo.
       if (spec?.kind === "gguf" || meta.ggufVariant) {
         // An artifact that names its file short-circuits the listing; otherwise the label is the hint.
         void loadGgufRepoPick(
@@ -1504,7 +1503,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   );
 
   const handleUnload = useCallback(async () => {
-    // Cancel, not release: a pick still resolving, and a download already staged, would load back what was just ejected.
+    // Cancel, not release: a resolving pick or a staged download would load back what was just ejected.
     pickGuard.cancel();
     if (pollTimer.current) clearTimeout(pollTimer.current);
     pollTimer.current = null;

--- a/studio/frontend/src/lib/diffusion-gguf-filename.ts
+++ b/studio/frontend/src/lib/diffusion-gguf-filename.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { listGgufVariants } from "@/features/hub";
+import { isGgufName, pickGgufFilename } from "./gguf-filename-pick";
+
+/** The .gguf for a pick that arrived with only a repo id (and maybe a quant
+ *  label). Reads the listing the picker rows already read, through the same
+ *  cache, so the row just clicked usually costs no request. Null when the repo
+ *  is ambiguous or unreadable. */
+export async function resolveDiffusionGgufFilename(
+  repoId: string,
+  options?: {
+    quant?: string | null;
+    localPath?: string | null;
+    hfToken?: string;
+  },
+): Promise<string | null> {
+  const quant = options?.quant?.trim() || null;
+  // Already a filename, so no listing is needed.
+  if (quant && isGgufName(quant)) return quant;
+  try {
+    const res = await listGgufVariants(repoId, options?.hfToken, {
+      preferLocalCache: true,
+      localPath: options?.localPath ?? null,
+    });
+    return pickGgufFilename(
+      Array.isArray(res?.variants) ? res.variants : [],
+      quant,
+    );
+  } catch {
+    // Unreachable Hub or unreadable directory: the caller prompts instead.
+    return null;
+  }
+}

--- a/studio/frontend/src/lib/diffusion-gguf-filename.ts
+++ b/studio/frontend/src/lib/diffusion-gguf-filename.ts
@@ -4,10 +4,8 @@
 import { listGgufVariants } from "@/features/hub";
 import { isGgufName, pickGgufFilename } from "./gguf-filename-pick";
 
-/** The .gguf for a pick that arrived with only a repo id (and maybe a quant
- *  label). Reads the listing the picker rows already read, through the same
- *  cache, so the row just clicked usually costs no request. Null when the repo
- *  is ambiguous or unreadable. */
+/** The .gguf for a pick that arrived with only a repo id (and maybe a quant label). Shares the picker rows' cached listing,
+ *  so the row just clicked usually costs no request. Null when the repo is ambiguous or unreadable. */
 export async function resolveDiffusionGgufFilename(
   repoId: string,
   options?: {
@@ -17,7 +15,7 @@ export async function resolveDiffusionGgufFilename(
   },
 ): Promise<string | null> {
   const quant = options?.quant?.trim() || null;
-  // Already a filename, so no listing is needed.
+  // Already a filename: no listing needed.
   if (quant && isGgufName(quant)) return quant;
   try {
     const res = await listGgufVariants(repoId, options?.hfToken, {

--- a/studio/frontend/src/lib/diffusion-gguf-pick.ts
+++ b/studio/frontend/src/lib/diffusion-gguf-pick.ts
@@ -9,20 +9,26 @@ export interface PickGuard {
   claim(): number;
   /** Leave the page unowned: a page switch, an unload, an unmount. */
   release(): void;
+  /** Is this token still the owner? False after a release, so nothing lands on a page nobody is picking for. */
   holds(token: number): boolean;
+  /** Has nothing been picked since this token? Survives a release, so a staged download still loads on the way back. */
+  isLatest(token: number): boolean;
 }
 
 export function createPickGuard(): PickGuard {
-  let current = 0;
+  let latest = 0;
+  let owner = 0;
   return {
     claim: () => {
-      current += 1;
-      return current;
+      latest += 1;
+      owner = latest;
+      return latest;
     },
     release: () => {
-      current += 1;
+      owner = 0;
     },
-    holds: (token) => token === current,
+    holds: (token) => token !== 0 && token === owner,
+    isLatest: (token) => token !== 0 && token === latest,
   };
 }
 

--- a/studio/frontend/src/lib/diffusion-gguf-pick.ts
+++ b/studio/frontend/src/lib/diffusion-gguf-pick.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Ownership of a diffusion page's model pick across an await. Resolving a repo-level GGUF pick is a listing request that can
+// take seconds, and neither page sets `busy` for it, so the user can pick again or switch pages meanwhile. No app deps, so
+// both pages share one copy and the ordering is testable without a React harness.
+
+/** Which pick owns the page. A claim invalidates every token handed out before it, so the newest pick always wins. */
+export interface PickGuard {
+  /** Take the page for a new pick. */
+  claim(): number;
+  /** Give the page up, so no outstanding token owns it: a page switch, an unload, an unmount. */
+  release(): void;
+  /** Does this token still own the page? */
+  holds(token: number): boolean;
+}
+
+export function createPickGuard(): PickGuard {
+  // Starts at 1 so 0 is never a live token; release() lands on a value nobody was handed.
+  let current = 0;
+  return {
+    claim: () => {
+      current += 1;
+      return current;
+    },
+    release: () => {
+      current += 1;
+    },
+    holds: (token) => token === current,
+  };
+}
+
+/** The page-specific halves of a repo-level GGUF pick. Only `isCurrent` is about staleness; the rest is the page's own state. */
+export interface GgufRepoPickHandlers {
+  /** The repo's listing, resolved to the one .gguf this pick means, or null when the repo cannot name it. */
+  resolve(): Promise<string | null>;
+  /** False once a newer pick, a page switch or an unmount has taken the page. */
+  isCurrent(): boolean;
+  /** Nothing to load: several quants on disk, a stale label, or an unreadable listing. */
+  onAmbiguous(): void;
+  /** Optimistic quant label plus per-model defaults, applied before the load starts. */
+  onResolved(filename: string): void;
+  /** Undo `onResolved`: the load never started. */
+  onNotStarted(): void;
+  /** Start (or stage) the load. True when the pick was accepted. */
+  load(filename: string): Promise<boolean>;
+}
+
+/** Resolve a repo-level GGUF pick to a filename and load it, doing nothing at all once the pick no longer owns the page. */
+export async function runGgufRepoPick(
+  handlers: GgufRepoPickHandlers,
+): Promise<boolean> {
+  const filename = await handlers.resolve();
+  // Silent, not just load-free: a toast here would blame a model the user has already moved on from, and touching the quant
+  // label or the defaults would overwrite the pick that replaced this one.
+  if (!handlers.isCurrent()) return false;
+  if (!filename) {
+    handlers.onAmbiguous();
+    return false;
+  }
+  handlers.onResolved(filename);
+  const started = await handlers.load(filename);
+  // Only the pick that applied the optimistic label may take it back: `quantRevert` is one slot, so a stale revert would
+  // restore this pick's old label over the newer one.
+  if (!started && handlers.isCurrent()) handlers.onNotStarted();
+  return started;
+}

--- a/studio/frontend/src/lib/diffusion-gguf-pick.ts
+++ b/studio/frontend/src/lib/diffusion-gguf-pick.ts
@@ -1,22 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Ownership of a diffusion page's model pick across an await. Resolving a repo-level GGUF pick is a listing request that can
-// take seconds, and neither page sets `busy` for it, so the user can pick again or switch pages meanwhile. No app deps, so
-// both pages share one copy and the ordering is testable without a React harness.
+// Ownership of a diffusion page's model pick across an await: resolving one is a listing request that can take seconds, and
+// neither page sets `busy` for it. No app deps, so both pages share a copy and the ordering is testable.
 
-/** Which pick owns the page. A claim invalidates every token handed out before it, so the newest pick always wins. */
+/** Which pick owns the page. A claim invalidates every token handed out before it, so the newest pick wins. */
 export interface PickGuard {
-  /** Take the page for a new pick. */
   claim(): number;
-  /** Give the page up, so no outstanding token owns it: a page switch, an unload, an unmount. */
+  /** Leave the page unowned: a page switch, an unload, an unmount. */
   release(): void;
-  /** Does this token still own the page? */
   holds(token: number): boolean;
 }
 
 export function createPickGuard(): PickGuard {
-  // Starts at 1 so 0 is never a live token; release() lands on a value nobody was handed.
   let current = 0;
   return {
     claim: () => {
@@ -30,11 +26,10 @@ export function createPickGuard(): PickGuard {
   };
 }
 
-/** The page-specific halves of a repo-level GGUF pick. Only `isCurrent` is about staleness; the rest is the page's own state. */
+/** The page's own halves of a repo-level GGUF pick. Only `isCurrent` is about staleness. */
 export interface GgufRepoPickHandlers {
-  /** The repo's listing, resolved to the one .gguf this pick means, or null when the repo cannot name it. */
+  /** The listing, resolved to the one .gguf this pick means, or null when the repo cannot name it. */
   resolve(): Promise<string | null>;
-  /** False once a newer pick, a page switch or an unmount has taken the page. */
   isCurrent(): boolean;
   /** Nothing to load: several quants on disk, a stale label, or an unreadable listing. */
   onAmbiguous(): void;
@@ -42,17 +37,16 @@ export interface GgufRepoPickHandlers {
   onResolved(filename: string): void;
   /** Undo `onResolved`: the load never started. */
   onNotStarted(): void;
-  /** Start (or stage) the load. True when the pick was accepted. */
   load(filename: string): Promise<boolean>;
 }
 
-/** Resolve a repo-level GGUF pick to a filename and load it, doing nothing at all once the pick no longer owns the page. */
+/** Resolve a repo-level GGUF pick and load it, doing nothing at all once the pick no longer owns the page. */
 export async function runGgufRepoPick(
   handlers: GgufRepoPickHandlers,
 ): Promise<boolean> {
   const filename = await handlers.resolve();
-  // Silent, not just load-free: a toast here would blame a model the user has already moved on from, and touching the quant
-  // label or the defaults would overwrite the pick that replaced this one.
+  // Silent, not just load-free: a toast would blame a model the user has moved on from, and the label and defaults now
+  // belong to the pick that replaced this one.
   if (!handlers.isCurrent()) return false;
   if (!filename) {
     handlers.onAmbiguous();
@@ -60,8 +54,7 @@ export async function runGgufRepoPick(
   }
   handlers.onResolved(filename);
   const started = await handlers.load(filename);
-  // Only the pick that applied the optimistic label may take it back: `quantRevert` is one slot, so a stale revert would
-  // restore this pick's old label over the newer one.
+  // `quantRevert` is one slot, so only the pick that set the label may take it back.
   if (!started && handlers.isCurrent()) handlers.onNotStarted();
   return started;
 }

--- a/studio/frontend/src/lib/diffusion-gguf-pick.ts
+++ b/studio/frontend/src/lib/diffusion-gguf-pick.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Ownership of a diffusion page's model pick across an await: resolving one is a listing request that can take seconds, and
-// neither page sets `busy` for it. No app deps, so both pages share a copy and the ordering is testable.
+// Ownership of a diffusion page's model pick across an await: resolving is a slow listing request and neither page sets
+// `busy` for it. No app deps, so both pages share this and the ordering is testable.
 
 /** Which pick owns the page. A claim invalidates every token handed out before it, so the newest pick wins. */
 export interface PickGuard {
   claim(): number;
-  /** Leave the page unowned, without ending the pick: a page switch, an unmount. */
+  /** Leave the page unowned without ending the pick: a page switch, an unmount. */
   release(): void;
   /** End the pick outright: an eject or a deploy, which the staged download must not undo. */
   cancel(): void;
@@ -41,7 +41,7 @@ export function createPickGuard(): PickGuard {
 
 /** The page's own halves of a repo-level GGUF pick. Only `isCurrent` is about staleness. */
 export interface GgufRepoPickHandlers {
-  /** The listing, resolved to the one .gguf this pick means, or null when the repo cannot name it. */
+  /** The one .gguf this pick means, or null when the repo cannot name it. */
   resolve(): Promise<string | null>;
   isCurrent(): boolean;
   /** Nothing to load: several quants on disk, a stale label, or an unreadable listing. */
@@ -53,13 +53,12 @@ export interface GgufRepoPickHandlers {
   load(filename: string): Promise<boolean>;
 }
 
-/** Resolve a repo-level GGUF pick and load it, doing nothing at all once the pick no longer owns the page. */
+/** Resolve a repo-level GGUF pick and load it; does nothing once the pick no longer owns the page. */
 export async function runGgufRepoPick(
   handlers: GgufRepoPickHandlers,
 ): Promise<boolean> {
   const filename = await handlers.resolve();
-  // Silent, not just load-free: a toast would blame a model the user has moved on from, and the label and defaults now
-  // belong to the pick that replaced this one.
+  // Silent, not just load-free: a toast would blame a model the user has moved on from.
   if (!handlers.isCurrent()) return false;
   if (!filename) {
     handlers.onAmbiguous();

--- a/studio/frontend/src/lib/diffusion-gguf-pick.ts
+++ b/studio/frontend/src/lib/diffusion-gguf-pick.ts
@@ -7,11 +7,13 @@
 /** Which pick owns the page. A claim invalidates every token handed out before it, so the newest pick wins. */
 export interface PickGuard {
   claim(): number;
-  /** Leave the page unowned: a page switch, an unload, an unmount. */
+  /** Leave the page unowned, without ending the pick: a page switch, an unmount. */
   release(): void;
-  /** Is this token still the owner? False after a release, so nothing lands on a page nobody is picking for. */
+  /** End the pick outright: an eject or a deploy, which the staged download must not undo. */
+  cancel(): void;
+  /** Is this token still the owner? False after a release, so nothing lands on a page nobody is looking at. */
   holds(token: number): boolean;
-  /** Has nothing been picked since this token? Survives a release, so a staged download still loads on the way back. */
+  /** Is this still the last pick made? Survives a release, so a staged download resumes on the way back. */
   isLatest(token: number): boolean;
 }
 
@@ -25,6 +27,11 @@ export function createPickGuard(): PickGuard {
       return latest;
     },
     release: () => {
+      owner = 0;
+    },
+    cancel: () => {
+      // Past every token handed out, so nothing outstanding is the latest pick either.
+      latest += 1;
       owner = 0;
     },
     holds: (token) => token !== 0 && token === owner,

--- a/studio/frontend/src/lib/diffusion-route-search.ts
+++ b/studio/frontend/src/lib/diffusion-route-search.ts
@@ -15,9 +15,8 @@ export interface DiffusionRouteSearch {
 const trimmed = (value: string | null | undefined): string | null =>
   typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 
-/** The search params for a diffusion pick routed out of the chat picker. A pinned row carries only a label, so forwarding the
- *  filename alone left the page a bare repo id: curated repos still resolved through the catalog, every other on-device GGUF
- *  repo read as a pipeline. The label rides its own param because `quant` is consumed as a filename. */
+/** Search params for a diffusion pick routed out of the chat picker. The label rides its own param because `quant` is
+ *  consumed as a filename; forwarding the filename alone left a pinned row as a bare repo id that read as a pipeline. */
 export function diffusionRouteSearch(
   model: string,
   meta: { ggufFilename?: string | null; ggufVariant?: string | null },
@@ -36,8 +35,8 @@ export function routedGgufFilename(
   return quant && isGgufName(quant) ? quant : null;
 }
 
-/** The quant label a routed pick carries. `quant` is used verbatim as a filename, so a value there that is not one is a
- *  label (a hand-built link, or a producer that predates the split) and joins ggufQuant to be resolved rather than posted. */
+/** The quant label a routed pick carries. A non-filename in `quant` (hand-built link, older producer) is a label too, so it
+ *  joins ggufQuant to be resolved rather than posted verbatim. */
 export function routedGgufLabel(
   search: Pick<DiffusionRouteSearch, "quant" | "ggufQuant">,
 ): string | null {

--- a/studio/frontend/src/lib/diffusion-route-search.ts
+++ b/studio/frontend/src/lib/diffusion-route-search.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { isGgufName } from "./gguf-filename-pick.ts";
+
 /** What the chat picker puts in the URL when a diffusion pick routes to /images or /video. */
 export interface DiffusionRouteSearch {
   model: string;
@@ -24,4 +26,22 @@ export function diffusionRouteSearch(
   if (filename) return { model, quant: filename };
   const label = trimmed(meta.ggufVariant);
   return label ? { model, ggufQuant: label } : { model };
+}
+
+/** The exact .gguf a routed pick names, if it names one. */
+export function routedGgufFilename(
+  search: Pick<DiffusionRouteSearch, "quant">,
+): string | null {
+  const quant = trimmed(search.quant);
+  return quant && isGgufName(quant) ? quant : null;
+}
+
+/** The quant label a routed pick carries. `quant` is used verbatim as a filename, so a value there that is not one is a
+ *  label (a hand-built link, or a producer that predates the split) and joins ggufQuant to be resolved rather than posted. */
+export function routedGgufLabel(
+  search: Pick<DiffusionRouteSearch, "quant" | "ggufQuant">,
+): string | null {
+  const quant = trimmed(search.quant);
+  if (quant && isGgufName(quant)) return null;
+  return trimmed(search.ggufQuant) ?? quant;
 }

--- a/studio/frontend/src/lib/diffusion-route-search.ts
+++ b/studio/frontend/src/lib/diffusion-route-search.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** What the chat picker puts in the URL when a diffusion pick routes to /images or /video. */
+export interface DiffusionRouteSearch {
+  model: string;
+  /** An exact repo filename, never a label: the target page uses it verbatim as the gguf filename. */
+  quant?: string;
+  /** A quant label (`Q4_K_S`) for a pick that has no filename, e.g. a pinned row. The page resolves it against the listing. */
+  ggufQuant?: string;
+}
+
+const trimmed = (value: string | null | undefined): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+
+/** The search params for a diffusion pick routed out of the chat picker. A pinned row carries only a label, so forwarding the
+ *  filename alone dropped it at the URL boundary and the page saw a bare repo id: curated ones still resolved through the
+ *  catalog, every other on-device GGUF repo read as a pipeline, which the backend rejects. The label rides its own param
+ *  because `quant` is consumed as a filename. */
+export function diffusionRouteSearch(
+  model: string,
+  meta: { ggufFilename?: string | null; ggufVariant?: string | null },
+): DiffusionRouteSearch {
+  const filename = trimmed(meta.ggufFilename);
+  if (filename) return { model, quant: filename };
+  const label = trimmed(meta.ggufVariant);
+  return label ? { model, ggufQuant: label } : { model };
+}

--- a/studio/frontend/src/lib/diffusion-route-search.ts
+++ b/studio/frontend/src/lib/diffusion-route-search.ts
@@ -14,9 +14,8 @@ const trimmed = (value: string | null | undefined): string | null =>
   typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 
 /** The search params for a diffusion pick routed out of the chat picker. A pinned row carries only a label, so forwarding the
- *  filename alone dropped it at the URL boundary and the page saw a bare repo id: curated ones still resolved through the
- *  catalog, every other on-device GGUF repo read as a pipeline, which the backend rejects. The label rides its own param
- *  because `quant` is consumed as a filename. */
+ *  filename alone left the page a bare repo id: curated repos still resolved through the catalog, every other on-device GGUF
+ *  repo read as a pipeline. The label rides its own param because `quant` is consumed as a filename. */
 export function diffusionRouteSearch(
   model: string,
   meta: { ggufFilename?: string | null; ggufVariant?: string | null },

--- a/studio/frontend/src/lib/gguf-filename-pick.ts
+++ b/studio/frontend/src/lib/gguf-filename-pick.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Picking the .gguf a repo-level pick means. No app deps so it stays testable;
+// the request that feeds it lives in diffusion-gguf-filename.ts.
+
+/** A row of the repo's GGUF listing. Loose so an older response still resolves. */
+export interface GgufFilenameCandidate {
+  filename?: unknown;
+  quant?: unknown;
+  downloaded?: unknown;
+}
+
+function asName(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export const isGgufName = (value: string): boolean =>
+  value.toLowerCase().endsWith(".gguf");
+
+/** The .gguf to load, given the listing and what the pick carried: a filename, a
+ *  quant label, or nothing. Diffusion loads need a real filename and a label is
+ *  not one. Null when the repo is ambiguous, so the caller keeps its prompt. */
+export function pickGgufFilename(
+  variants: readonly GgufFilenameCandidate[],
+  quant?: string | null,
+): string | null {
+  const listed = variants.flatMap((v) => {
+    const filename = asName(v.filename);
+    return filename && isGgufName(filename)
+      ? [
+          {
+            filename,
+            quant: asName(v.quant),
+            downloaded: v.downloaded === true,
+          },
+        ]
+      : [];
+  });
+  const wanted = quant?.trim() || null;
+
+  // Already a filename. Prefer the listing's spelling, but honour an unlisted
+  // one: a failed listing must not invalidate a name the caller had.
+  if (wanted && isGgufName(wanted)) {
+    const match = listed.find(
+      (v) => v.filename.toLowerCase() === wanted.toLowerCase(),
+    );
+    return match?.filename ?? wanted;
+  }
+  // A label. Downloaded first: a remote sibling can share it. Matched before the
+  // fallbacks below so a stale label prompts instead of loading another quant.
+  if (wanted) {
+    const byLabel = listed.filter(
+      (v) => v.quant?.toLowerCase() === wanted.toLowerCase(),
+    );
+    return (byLabel.find((v) => v.downloaded) ?? byLabel[0])?.filename ?? null;
+  }
+  // No label: the repo names itself only if it holds one file. Downloaded first,
+  // so a fully listed remote repo still resolves to the quant on disk.
+  const downloaded = listed.filter((v) => v.downloaded);
+  if (downloaded.length === 1) return downloaded[0].filename;
+  if (listed.length === 1) return listed[0].filename;
+  return null;
+}

--- a/studio/frontend/src/lib/gguf-filename-pick.ts
+++ b/studio/frontend/src/lib/gguf-filename-pick.ts
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Picking the .gguf a repo-level pick means. No app deps so it stays testable;
-// the request that feeds it lives in diffusion-gguf-filename.ts.
+// Picking the .gguf a repo-level pick means. No app deps so it stays testable; the request lives in diffusion-gguf-filename.ts.
 
 /** A row of the repo's GGUF listing. Loose so an older response still resolves. */
 export interface GgufFilenameCandidate {
@@ -18,9 +17,8 @@ function asName(value: unknown): string | null {
 export const isGgufName = (value: string): boolean =>
   value.toLowerCase().endsWith(".gguf");
 
-/** The .gguf to load, given the listing and what the pick carried: a filename, a
- *  quant label, or nothing. Diffusion loads need a real filename and a label is
- *  not one. Null when the repo is ambiguous, so the caller keeps its prompt. */
+/** The .gguf to load, given the listing and what the pick carried: a filename, a quant label, or nothing. A load needs a real
+ *  filename and a label is not one. Null when the repo is ambiguous, so the caller keeps its prompt. */
 export function pickGgufFilename(
   variants: readonly GgufFilenameCandidate[],
   quant?: string | null,
@@ -39,24 +37,21 @@ export function pickGgufFilename(
   });
   const wanted = quant?.trim() || null;
 
-  // Already a filename. Prefer the listing's spelling, but honour an unlisted
-  // one: a failed listing must not invalidate a name the caller had.
+  // Already a filename. Prefer the listing's spelling, but honour an unlisted one: a failed listing must not lose the caller's.
   if (wanted && isGgufName(wanted)) {
     const match = listed.find(
       (v) => v.filename.toLowerCase() === wanted.toLowerCase(),
     );
     return match?.filename ?? wanted;
   }
-  // A label. Downloaded first: a remote sibling can share it. Matched before the
-  // fallbacks below so a stale label prompts instead of loading another quant.
+  // A label. Downloaded first (a remote sibling can share it), and before the fallbacks so a stale label prompts.
   if (wanted) {
     const byLabel = listed.filter(
       (v) => v.quant?.toLowerCase() === wanted.toLowerCase(),
     );
     return (byLabel.find((v) => v.downloaded) ?? byLabel[0])?.filename ?? null;
   }
-  // No label: the repo names itself only if it holds one file. Downloaded first,
-  // so a fully listed remote repo still resolves to the quant on disk.
+  // No label: only a lone file names itself. Downloaded first, so a fully listed remote repo resolves to the quant on disk.
   const downloaded = listed.filter((v) => v.downloaded);
   if (downloaded.length === 1) return downloaded[0].filename;
   if (listed.length === 1) return listed[0].filename;

--- a/studio/frontend/tests/diffusion-gguf-pick.test.ts
+++ b/studio/frontend/tests/diffusion-gguf-pick.test.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type GgufRepoPickHandlers,
+  createPickGuard,
+  runGgufRepoPick,
+} from "../src/lib/diffusion-gguf-pick.ts";
+
+/** A listing whose completion the test controls. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+/** Records every side effect a pick is allowed to have, so a stale one can be asserted to have had none. */
+function recorder(
+  overrides: Partial<Omit<GgufRepoPickHandlers, "load">> & {
+    /** What `load` reports back: false is "the load never started". */
+    starts?: boolean | (() => boolean);
+  } = {},
+): { handlers: GgufRepoPickHandlers; log: string[] } {
+  const { starts = true, ...rest } = overrides;
+  const log: string[] = [];
+  const handlers: GgufRepoPickHandlers = {
+    resolve: () => Promise.resolve("model-Q4_K_S.gguf"),
+    isCurrent: () => true,
+    onAmbiguous: () => log.push("ambiguous"),
+    onResolved: (filename) => log.push(`resolved:${filename}`),
+    onNotStarted: () => log.push("reverted"),
+    load: (filename) => {
+      log.push(`load:${filename}`);
+      return Promise.resolve(typeof starts === "function" ? starts() : starts);
+    },
+    ...rest,
+  };
+  return { handlers, log };
+}
+
+test("a resolved pick applies its label and loads", async () => {
+  const { handlers, log } = recorder();
+  assert.equal(await runGgufRepoPick(handlers), true);
+  assert.deepEqual(log, [
+    "resolved:model-Q4_K_S.gguf",
+    "load:model-Q4_K_S.gguf",
+  ]);
+});
+
+test("an unresolvable pick prompts and loads nothing", async () => {
+  const { handlers, log } = recorder({ resolve: () => Promise.resolve(null) });
+  assert.equal(await runGgufRepoPick(handlers), false);
+  assert.deepEqual(log, ["ambiguous"]);
+});
+
+test("a load that never starts takes its own label back", async () => {
+  const { handlers, log } = recorder({ starts: false });
+  assert.equal(await runGgufRepoPick(handlers), false);
+  assert.deepEqual(log, [
+    "resolved:model-Q4_K_S.gguf",
+    "load:model-Q4_K_S.gguf",
+    "reverted",
+  ]);
+});
+
+test("a superseded pick does nothing at all when its listing lands", async () => {
+  // Not even the prompt: it would blame a model the user has already moved on from.
+  const listing = deferred<string | null>();
+  const { handlers, log } = recorder({
+    resolve: () => listing.promise,
+    isCurrent: () => false,
+  });
+  const done = runGgufRepoPick(handlers);
+  listing.resolve("model-Q4_K_S.gguf");
+  assert.equal(await done, false);
+  assert.deepEqual(log, []);
+});
+
+test("a superseded pick does not prompt either", async () => {
+  const { handlers, log } = recorder({
+    resolve: () => Promise.resolve(null),
+    isCurrent: () => false,
+  });
+  assert.equal(await runGgufRepoPick(handlers), false);
+  assert.deepEqual(log, []);
+});
+
+test("a stale failure does not revert the newer selection's label", async () => {
+  // quantRevert is a single slot, so a late rollback would restore this pick's old label over the one that replaced it.
+  let current = true;
+  const { handlers, log } = recorder({
+    isCurrent: () => current,
+    // The next pick takes the page while this one's load is in flight, and this load then reports it never started.
+    starts: () => {
+      current = false;
+      return false;
+    },
+  });
+  assert.equal(await runGgufRepoPick(handlers), false);
+  assert.deepEqual(log, [
+    "resolved:model-Q4_K_S.gguf",
+    "load:model-Q4_K_S.gguf",
+  ]);
+});
+
+test("the newest pick owns the page, whatever order the listings land in", async () => {
+  const guard = createPickGuard();
+  const listings = [deferred<string | null>(), deferred<string | null>()];
+  const log: string[] = [];
+  const run = (index: number) => {
+    const token = guard.claim();
+    return runGgufRepoPick({
+      resolve: () => listings[index].promise,
+      isCurrent: () => guard.holds(token),
+      onAmbiguous: () => log.push(`ambiguous:${index}`),
+      onResolved: () => {},
+      onNotStarted: () => {},
+      load: (filename) => {
+        log.push(`load:${index}:${filename}`);
+        return Promise.resolve(true);
+      },
+    });
+  };
+
+  const first = run(0);
+  await flush();
+  const second = run(1);
+  await flush();
+  // The newer listing lands first, then the stale one.
+  listings[1].resolve("b.gguf");
+  await flush();
+  listings[0].resolve("a.gguf");
+
+  assert.deepEqual(await Promise.all([first, second]), [false, true]);
+  assert.deepEqual(log, ["load:1:b.gguf"]);
+});
+
+test("releasing the page invalidates the pick holding it", () => {
+  // A page switch, an unload or an unmount: nobody owns the page afterwards.
+  const guard = createPickGuard();
+  const token = guard.claim();
+  assert.equal(guard.holds(token), true);
+  guard.release();
+  assert.equal(guard.holds(token), false);
+  // And the token a release lands on is not claimable by an outstanding holder.
+  assert.notEqual(guard.claim(), token);
+});

--- a/studio/frontend/tests/diffusion-gguf-pick.test.ts
+++ b/studio/frontend/tests/diffusion-gguf-pick.test.ts
@@ -21,7 +21,7 @@ function deferred<T>() {
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
-/** Records every side effect a pick is allowed to have, so a stale one can be asserted to have had none. */
+/** Every side effect a pick may have, so a stale one can be asserted to have had none. */
 function recorder(
   overrides: Partial<Omit<GgufRepoPickHandlers, "load">> & {
     /** What `load` reports back: false is "the load never started". */
@@ -93,11 +93,11 @@ test("a superseded pick does not prompt either", async () => {
 });
 
 test("a stale failure does not revert the newer selection's label", async () => {
-  // quantRevert is a single slot, so a late rollback would restore this pick's old label over the one that replaced it.
+  // quantRevert is one slot, so a late rollback would restore this pick's old label over the one that replaced it.
   let current = true;
   const { handlers, log } = recorder({
     isCurrent: () => current,
-    // The next pick takes the page while this one's load is in flight, and this load then reports it never started.
+    // The next pick takes the page while this load is in flight, and the load then reports it never started.
     starts: () => {
       current = false;
       return false;

--- a/studio/frontend/tests/diffusion-gguf-pick.test.ts
+++ b/studio/frontend/tests/diffusion-gguf-pick.test.ts
@@ -152,3 +152,13 @@ test("releasing the page invalidates the pick holding it", () => {
   // And the token a release lands on is not claimable by an outstanding holder.
   assert.notEqual(guard.claim(), token);
 });
+
+test("a release is not a new pick, so a staged download still lands", () => {
+  // Leaving the page defers the staged load rather than dropping it; only another pick may take it.
+  const guard = createPickGuard();
+  const staged = guard.claim();
+  guard.release();
+  assert.equal(guard.isLatest(staged), true);
+  guard.claim();
+  assert.equal(guard.isLatest(staged), false);
+});

--- a/studio/frontend/tests/diffusion-gguf-pick.test.ts
+++ b/studio/frontend/tests/diffusion-gguf-pick.test.ts
@@ -153,6 +153,19 @@ test("releasing the page invalidates the pick holding it", () => {
   assert.notEqual(guard.claim(), token);
 });
 
+test("an eject ends the pick, so a staged download does not come back", () => {
+  // Release and cancel differ exactly here: leaving the page defers the staged load, ejecting drops it.
+  const guard = createPickGuard();
+  const staged = guard.claim();
+  guard.cancel();
+  assert.equal(guard.holds(staged), false);
+  assert.equal(guard.isLatest(staged), false);
+  // And the page is claimable again afterwards, with a token of its own.
+  const next = guard.claim();
+  assert.notEqual(next, staged);
+  assert.equal(guard.holds(next), true);
+});
+
 test("a release is not a new pick, so a staged download still lands", () => {
   // Leaving the page defers the staged load rather than dropping it; only another pick may take it.
   const guard = createPickGuard();

--- a/studio/frontend/tests/diffusion-route-search.test.ts
+++ b/studio/frontend/tests/diffusion-route-search.test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type DiffusionRouteSearch,
+  diffusionRouteSearch,
+} from "../src/lib/diffusion-route-search.ts";
+
+const REPO = "unsloth/Z-Image-Turbo-GGUF";
+
+test("an expander pick routes its exact filename as the quant", () => {
+  assert.deepEqual(
+    diffusionRouteSearch(REPO, {
+      ggufFilename: "z-image-turbo-Q4_K_S.gguf",
+      ggufVariant: "Q4_K_S",
+    }),
+    { model: REPO, quant: "z-image-turbo-Q4_K_S.gguf" },
+  );
+});
+
+test("a pinned pick routes its label, and never as the quant", () => {
+  // The target reads `quant` verbatim as a filename, so a label there routes a file that does not exist.
+  const search: DiffusionRouteSearch = diffusionRouteSearch(REPO, {
+    ggufVariant: "Q4_K_S",
+  });
+  // Asserted before the shape below: deepEqual narrows `search` to the literal it matched.
+  assert.equal(search.quant, undefined);
+  assert.deepEqual(search, { model: REPO, ggufQuant: "Q4_K_S" });
+});
+
+test("a non-catalog repo keeps its label too", () => {
+  // The gap this closes: the page cannot recognise a GGUF repo it has no catalog entry for, so the label is the only evidence.
+  assert.deepEqual(
+    diffusionRouteSearch("QuantStack/SomeDiffusion-GGUF", {
+      ggufVariant: "Q6_K",
+    }),
+    { model: "QuantStack/SomeDiffusion-GGUF", ggufQuant: "Q6_K" },
+  );
+});
+
+test("a curated non-GGUF pick routes the model alone", () => {
+  assert.deepEqual(diffusionRouteSearch("unsloth/FLUX.1-schnell", {}), {
+    model: "unsloth/FLUX.1-schnell",
+  });
+});
+
+test("blank metadata is dropped rather than routed", () => {
+  assert.deepEqual(
+    diffusionRouteSearch(REPO, { ggufFilename: "  ", ggufVariant: "" }),
+    { model: REPO },
+  );
+  // A filename wins over a label, and both are trimmed.
+  assert.deepEqual(
+    diffusionRouteSearch(REPO, {
+      ggufFilename: " a-Q8_0.gguf ",
+      ggufVariant: " Q8_0 ",
+    }),
+    { model: REPO, quant: "a-Q8_0.gguf" },
+  );
+  assert.deepEqual(
+    diffusionRouteSearch(REPO, { ggufFilename: null, ggufVariant: " Q8_0 " }),
+    { model: REPO, ggufQuant: "Q8_0" },
+  );
+});

--- a/studio/frontend/tests/diffusion-route-search.test.ts
+++ b/studio/frontend/tests/diffusion-route-search.test.ts
@@ -34,7 +34,7 @@ test("a pinned pick routes its label, and never as the quant", () => {
 });
 
 test("a non-catalog repo keeps its label too", () => {
-  // The gap this closes: the page cannot recognise a GGUF repo it has no catalog entry for, so the label is the only evidence.
+  // The gap this closes: with no catalog entry for the repo, the label is the page's only evidence that it is GGUF.
   assert.deepEqual(
     diffusionRouteSearch("QuantStack/SomeDiffusion-GGUF", {
       ggufVariant: "Q6_K",
@@ -79,7 +79,7 @@ test("an arrival naming a real file loads it, label or no label", () => {
 });
 
 test("a label left in the filename slot is resolved, not posted", () => {
-  // A hand-built link, or a producer that predates the split: posting "Q4_K_S" as a filename is a certain error.
+  // A hand-built link, or a producer predating the split: posting "Q4_K_S" as a filename is a certain error.
   assert.equal(routedGgufLabel({ quant: "Q4_K_S" }), "Q4_K_S");
   assert.equal(routedGgufFilename({ quant: "Q4_K_S" }), null);
 });

--- a/studio/frontend/tests/diffusion-route-search.test.ts
+++ b/studio/frontend/tests/diffusion-route-search.test.ts
@@ -7,6 +7,8 @@ import test from "node:test";
 import {
   type DiffusionRouteSearch,
   diffusionRouteSearch,
+  routedGgufFilename,
+  routedGgufLabel,
 } from "../src/lib/diffusion-route-search.ts";
 
 const REPO = "unsloth/Z-Image-Turbo-GGUF";
@@ -64,4 +66,40 @@ test("blank metadata is dropped rather than routed", () => {
     diffusionRouteSearch(REPO, { ggufFilename: null, ggufVariant: " Q8_0 " }),
     { model: REPO, ggufQuant: "Q8_0" },
   );
+});
+
+test("an arrival naming a real file loads it, label or no label", () => {
+  const search = { model: "m", quant: "a-Q8_0.gguf", ggufQuant: "Q4_K_S" };
+  assert.equal(routedGgufFilename(search), "a-Q8_0.gguf");
+  assert.equal(
+    routedGgufLabel(search),
+    null,
+    "the exact filename wins and needs no listing",
+  );
+});
+
+test("a label left in the filename slot is resolved, not posted", () => {
+  // A hand-built link, or a producer that predates the split: posting "Q4_K_S" as a filename is a certain error.
+  assert.equal(routedGgufLabel({ quant: "Q4_K_S" }), "Q4_K_S");
+  assert.equal(routedGgufFilename({ quant: "Q4_K_S" }), null);
+});
+
+test("an arrival with only the label slot resolves it", () => {
+  assert.equal(routedGgufLabel({ ggufQuant: "Q6_K" }), "Q6_K");
+  assert.equal(
+    routedGgufFilename({}),
+    null,
+    "and nothing lands in the filename slot",
+  );
+});
+
+test("an arrival with neither leaves the old path alone", () => {
+  assert.equal(routedGgufLabel({}), null);
+  assert.equal(routedGgufFilename({}), null);
+  assert.equal(routedGgufLabel({ quant: "  ", ggufQuant: "" }), null);
+});
+
+test("case and whitespace do not change which slot a value belongs to", () => {
+  assert.equal(routedGgufFilename({ quant: " A-Q8_0.GGUF " }), "A-Q8_0.GGUF");
+  assert.equal(routedGgufLabel({ ggufQuant: " Q4_K_S " }), "Q4_K_S");
 });

--- a/studio/frontend/tests/gguf-filename-pick.test.ts
+++ b/studio/frontend/tests/gguf-filename-pick.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { pickGgufFilename } from "../src/lib/gguf-filename-pick.ts";
+
+const Q4 = {
+  filename: "z-image-turbo-Q4_K_S.gguf",
+  quant: "Q4_K_S",
+  downloaded: true,
+};
+const Q8 = {
+  filename: "z-image-turbo-Q8_0.gguf",
+  quant: "Q8_0",
+  downloaded: false,
+};
+
+test("a repo holding one quant names it without a label", () => {
+  // The On Device row with a lone quant chip: the click carries only the repo.
+  assert.equal(pickGgufFilename([Q4]), Q4.filename);
+});
+
+test("one downloaded quant wins over undownloaded siblings", () => {
+  assert.equal(pickGgufFilename([Q4, Q8]), Q4.filename);
+});
+
+test("a quant label resolves to that quant's real filename", () => {
+  // Filenames do not follow the repo name, so a label is never a filename.
+  assert.equal(pickGgufFilename([Q4, Q8], "Q8_0"), Q8.filename);
+  assert.equal(pickGgufFilename([Q4, Q8], "q8_0"), Q8.filename);
+});
+
+test("a label prefers the copy on disk when both are listed", () => {
+  const remoteDup = {
+    ...Q4,
+    filename: "mirror/z-image.gguf",
+    downloaded: false,
+  };
+  assert.equal(pickGgufFilename([remoteDup, Q4], "Q4_K_S"), Q4.filename);
+});
+
+test("a label that matches nothing does not fall back to the sole file", () => {
+  // A pin left from a deleted quant must prompt, not load another quant.
+  assert.equal(pickGgufFilename([Q4], "Q2_K"), null);
+});
+
+test("an exact filename passes through, normalised to the listing", () => {
+  assert.equal(pickGgufFilename([Q4], Q4.filename), Q4.filename);
+  assert.equal(
+    pickGgufFilename([Q4], "Z-IMAGE-TURBO-Q4_K_S.GGUF"),
+    Q4.filename,
+  );
+  // Unlisted (offline or failed listing): the caller's own name still routes.
+  assert.equal(
+    pickGgufFilename([], "some-model-Q6_K.gguf"),
+    "some-model-Q6_K.gguf",
+  );
+});
+
+test("several downloaded quants stay ambiguous", () => {
+  const both = [Q4, { ...Q8, downloaded: true }];
+  assert.equal(pickGgufFilename(both), null);
+});
+
+test("an empty or malformed listing resolves to nothing", () => {
+  assert.equal(pickGgufFilename([]), null);
+  assert.equal(pickGgufFilename([{ filename: 42, quant: null }]), null);
+  // A companion .safetensors row is not a GGUF checkpoint.
+  assert.equal(
+    pickGgufFilename([{ filename: "model.safetensors", quant: "BF16" }]),
+    null,
+  );
+});


### PR DESCRIPTION
A GGUF pick can still reach the diffusion load carrying only a repo id and never a concrete `.gguf` filename. The backend requires one, so the pick dead-ends on a model the picker just advertised as one click loadable.

## Scope

This is a follow up to #8053, which fixed the collapsed On Device row by making it forward `ggufFilename`. Two sibling paths still send a repo id with no filename, and one of them produces the same error message that #8053 removed.

## What is still broken on main

**1. A pinned diffusion quant, clicked in the Images or Video picker.** `renderPinnedQuantRow` sends `ggufVariant` (a label like `Q4_K_S`) with no `ggufFilename` and no `isGguf`. The pages read the label only meta as a curated repo and ask for a pipeline load:

```
{"detail":"'unsloth/Z-Image-Turbo-GGUF' is a single-file GGUF repo; load it with model_kind 'gguf' and a .gguf filename, not as a full pipeline."}
```

Reachable from a normal flow: the collapsed On Device row has a pin control, so pinning a diffusion quant and then clicking it is enough.

**2. The same pinned quant, clicked in the chat picker.** The diffusion routing forwards `quant: meta.ggufFilename ?? undefined`, which is undefined here, so the Images page falls to the catalog spec. `loadSpecFor()` returns `{kind: "gguf"}` with no filename, because the catalog lists repos and not their files:

```
$ node --experimental-strip-types verify.ts
catalog spec for unsloth/Z-Image-Turbo-GGUF = {"kind":"gguf"}
route load posts: {"kind":"gguf"}
  -> backend needs a filename for kind 'gguf': MISSING = hard error
```

```
{"detail":"a single-file checkpoint name is required for a 'gguf' load."}
```

## Fix

A resolver that turns a repo level pick into a real filename using the repo's own listing, read through the cache the picker rows already use, so the row just clicked usually costs no extra request.

Resolution order: exact filename, then quant label (favouring the copy on disk), then a sole downloaded file, then a sole file.

Two deliberate non-behaviours:

- A genuinely ambiguous repo (several quants on disk) returns null and keeps the existing prompt, since only the expander can say which.
- A stale label that matches nothing does **not** fall back to the sole file, so a pin left from a deleted quant prompts rather than quietly loading a different quant.

Wired into `handleModelSelect` and the route arrival effect on both `images-page.tsx` and `video-page.tsx`, plus `isGguf: true` on the pinned row.

The existing `meta.isGguf` branch now resolves instead of showing the toast. That branch is not reachable from a local GGUF directory today (those expand rather than select), so this part is defensive: it is the exact shape that regressed before #8053, and it now resolves rather than dead ends.

Split into two modules so the selection logic is testable on its own: `gguf-filename-pick.ts` is the pure pick with no app deps, `diffusion-gguf-filename.ts` is the request.

## Compatibility

Frontend TypeScript only. No backend, Python, kernel or hardware paths touched, and no API or payload shape changed.

The `isGguf: true` added to the pinned row is a no op for chat, which already derived the same value:

```ts
const isGguf = explicitIsGguf ?? (ggufVariant != null || nativePathToken != null || model?.isGguf === true);
```

The pinned row always sets `ggufVariant`, so that expression was already true. Passing it explicitly produces the identical result.

The new branch in `handleModelSelect` sits after the existing curated, expander, direct `.gguf` and `.safetensors` branches, so every pick that worked before still takes its original branch. It only catches picks that previously fell through to the pipeline load, which the backend rejected.

## Testing

Verified against a live Studio on macOS/MPS using `unsloth/Z-Image-Turbo-GGUF`, a repo holding one quant (`z-image-turbo-Q4_K_S.gguf`).

- Both failures above reproduce against the running server before the change.
- The resolver picks `z-image-turbo-Q4_K_S.gguf`, and the load the fixed code posts is accepted and the model actually loads: `loaded: true, model_kind: gguf, family: z-image`. Unloaded afterwards.
- 8 new unit tests: sole quant, label to filename, downloaded preference, stale label, filename passthrough and case normalisation, ambiguous repos, malformed listings.
- Full suite passes (946 tests), `tsc -b` and the test project both clean, `catalog:check` passes, `vite build` succeeds.
- ESLint on the touched files stays at the 49 pre-existing problems, none added.

Verified through the API and unit tests rather than a browser click through, so a manual pass on the pinned row in the Images picker is worth doing before merge.
