### PR TITLE
Do not stage diffusion files that are already in the cache

### DIFF
--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -1698,18 +1698,24 @@ class DiffusionBackend:
             straight from cache instead of staging a download that fetches nothing.
             Entries are what the Downloads panel lists, so a cached repo listed here
             reads as a re-download of a model the user already has. No revision drops nothing,
-            so an unpinnable repo stages in full as it always did."""
+            so an unpinnable repo stages in full as it always did.
+
+            All or nothing per repo, never a subset. Every diffusion entry for a repo rides the
+            one "@diffusion" scope slot, and download_registry refuses a claim whose scoped_files
+            differ from the live job's: a shrinking list would 409 a second pick sharing this base
+            where it used to adopt the running job. Staging a cached file costs nothing anyway,
+            since hf_hub_download returns the pointer without a transfer."""
             cached = self._files_already_cached(repo, files, revision)
-            missing = [name for name in files if name not in cached]
-            if missing:
-                entries.append(
-                    {
-                        "repo_id": repo,
-                        "files": missing,
-                        "bytes": int(sum(sized.get(name, 0) for name in missing)),
-                        "gguf_filename": gguf,
-                    }
-                )
+            if files and cached.issuperset(files):
+                return
+            entries.append(
+                {
+                    "repo_id": repo,
+                    "files": files,
+                    "bytes": int(sum(sized.get(name, 0) for name in files)),
+                    "gguf_filename": gguf,
+                }
+            )
 
         for repo, files in te_files.values():
             # No revision: te_prequant_hub_files reports names and sizes only, so a pre-cast

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -1461,6 +1461,7 @@ class DiffusionBackend:
         single_file_is_pipeline: bool = False,
         include_transformer: bool = False,
         sizes_out: Optional[dict[str, int]] = None,
+        file_sizes_out: Optional[dict[tuple[str, str], int]] = None,
         skip_te_components: tuple[str, ...] = (),
     ) -> tuple[int, list[str]]:
         """Total download size for the progress bar, plus the base-repo files to
@@ -1468,6 +1469,8 @@ class DiffusionBackend:
 
         ``sizes_out``, when given, is filled with per-repo byte totals so the download
         plan can size one job per repo off this same single pair of Hub lookups.
+        ``file_sizes_out`` is the per (repo, filename) breakdown, so the plan can drop
+        files already cached and still size what is left.
 
         For a ``pipeline`` load the whole repo IS the pipeline (``base_repo`` is the
         repo itself), so the transformer/ subfolder is INCLUDED -- unlike the GGUF /
@@ -1516,6 +1519,8 @@ class DiffusionBackend:
                         continue
                     base_files.append(s.rfilename)
                     total += s.size or 0
+                    if file_sizes_out is not None:
+                        file_sizes_out[(repo_id, s.rfilename)] = s.size or 0
                 if sizes_out is not None:
                     sizes_out[repo_id] = total
                 return total, base_files
@@ -1526,6 +1531,8 @@ class DiffusionBackend:
                 total += gguf_bytes
                 if sizes_out is not None:
                     sizes_out[repo_id] = gguf_bytes
+                if file_sizes_out is not None:
+                    file_sizes_out[(repo_id, gguf_filename)] = gguf_bytes
             # A whole-pipeline single file (SDXL) needs only the base's config/tokenizer, not its weights.
             if kind == "single_file" and single_file_is_pipeline:
                 base_filter = _base_config_file_downloaded
@@ -1540,12 +1547,38 @@ class DiffusionBackend:
                 if base_filter(s.rfilename) and not _dense_te_shard(s.rfilename):
                     base_files.append(s.rfilename)
                     base_bytes += s.size or 0
+                    if file_sizes_out is not None:
+                        file_sizes_out[(base_repo, s.rfilename)] = s.size or 0
             total += base_bytes
             if sizes_out is not None:
                 sizes_out[base_repo] = base_bytes
         except Exception as exc:  # noqa: BLE001 — estimate is best-effort
             logger.warning("diffusion.size_estimate_failed: %s", exc)
         return total, base_files
+
+    @staticmethod
+    def _files_already_cached(repo_id: str, files: list[str]) -> set[str]:
+        """Of ``files``, the names already on disk under either root a load resolves
+        through: Studio pins its live setting, the prefetch writes under
+        huggingface_hub's import-time constant. Only a str is a cached path; a miss is
+        None and a known-absent file is a sentinel. Never raises: an unreadable cache
+        means "stage it", which is the old behaviour."""
+        try:
+            from huggingface_hub import try_to_load_from_cache
+        except Exception:  # noqa: BLE001 — no hub package: stage everything
+            return set()
+        cached: set[str] = set()
+        for name in files:
+            for root in (hub_cache_dir(), None):
+                try:
+                    hit = try_to_load_from_cache(repo_id, name, cache_dir = root)
+                except Exception:  # noqa: BLE001 — a cache we cannot read is not a verdict
+                    continue
+                # is_file() too: a dangling symlink is a path but not usable bytes.
+                if isinstance(hit, str) and Path(hit).is_file():
+                    cached.add(name)
+                    break
+        return cached
 
     def download_plan(
         self,
@@ -1581,6 +1614,7 @@ class DiffusionBackend:
         # Only a checkpoint that really resolves on the Hub earns the right to drop dense shards.
         te_files = self._te_prequant_plan_files(fam, text_encoder_quant, hf_token)
         sizes: dict[str, int] = {}
+        file_sizes: dict[tuple[str, str], int] = {}
         total, base_files = self._estimate_download_bytes(
             repo_id,
             gguf_filename,
@@ -1592,6 +1626,7 @@ class DiffusionBackend:
             include_transformer = kind == "gguf"
             and self._dense_quant_prefetch_needed(fam, {**load_kwargs, "base_repo": base}),
             sizes_out = sizes,
+            file_sizes_out = file_sizes,
             skip_te_components = tuple(te_files),
         )
         # Decided once, from the staged file list, and both probed and reported: a gated base
@@ -1601,37 +1636,50 @@ class DiffusionBackend:
         fetch_base = prefer_ungated_mirror(base, hf_token, files = base_files)
         _assert_base_repo_accessible(fetch_base, hf_token)
         entries: list[dict[str, Any]] = []
+
+        def _stage(repo: str, files: list[str], sized: dict[str, int], gguf: Optional[str]) -> int:
+            """Queue what is missing and return the bytes dropped as already cached.
+
+            A pick whose files are all on disk yields no entry, so the caller loads
+            straight from cache instead of staging a download that fetches nothing.
+            Entries are what the Downloads panel lists, so a cached repo listed here
+            reads as a re-download of a model the user already has."""
+            cached = self._files_already_cached(repo, files)
+            missing = [name for name in files if name not in cached]
+            dropped = sum(sized.get(name, 0) for name in cached)
+            if missing:
+                entries.append(
+                    {
+                        "repo_id": repo,
+                        "files": missing,
+                        "bytes": int(sum(sized.get(name, 0) for name in missing)),
+                        "gguf_filename": gguf,
+                    }
+                )
+            return int(dropped)
+
+        skipped = 0
         for repo, files in te_files.values():
-            entries.append(
-                {
-                    "repo_id": repo,
-                    "files": [name for name, _size in files],
-                    "bytes": int(sum(size for _name, size in files)),
-                    "gguf_filename": None,
-                }
-            )
             total += int(sum(size for _name, size in files))
+            skipped += _stage(repo, [n for n, _s in files], dict(files), None)
         if gguf_filename and not Path(repo_id).expanduser().exists():
-            entries.append(
-                {
-                    "repo_id": repo_id,
-                    "files": [gguf_filename],
-                    "bytes": int(sizes.get(repo_id, 0)),
-                    "gguf_filename": gguf_filename,
-                }
+            skipped += _stage(
+                repo_id,
+                [gguf_filename],
+                {gguf_filename: int(sizes.get(repo_id, 0))},
+                gguf_filename,
             )
         if base_files and not Path(base).expanduser().exists():
             # STAGED before the loader runs, so it must name the MIRROR: a gated upstream here 401s
             # an anonymous user at staging and the swap downstream is never reached. status(), the
             # API base repo, saved configs and LoRA tags keep the vendor id; sizes key on it too.
-            entries.append(
-                {
-                    "repo_id": fetch_base,
-                    "files": base_files,
-                    "bytes": int(sizes.get(base, 0)),
-                    "gguf_filename": None,
-                }
+            skipped += _stage(
+                fetch_base,
+                base_files,
+                {name: file_sizes.get((base, name), 0) for name in base_files},
+                None,
             )
+        total = max(0, total - skipped)
         return {"entries": entries, "total_bytes": int(total)}
 
     @staticmethod

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -146,6 +146,17 @@ install_torchao_windows_rocm_stub()
 _MODEL_KINDS = frozenset({"gguf", "single_file", "pipeline"})
 
 
+def _record_sha(shas_out: Optional[dict[str, str]], repo_id: str, info: Any) -> None:
+    """Note the commit ``info`` describes, so a cache probe can be pinned to it.
+
+    Best-effort: a listing with no ``sha`` just means the plan cannot pin, and stages as before."""
+    if shas_out is None:
+        return
+    sha = getattr(info, "sha", None)
+    if isinstance(sha, str) and sha:
+        shas_out[repo_id] = sha
+
+
 def hub_cache_dir() -> str:
     """The cache root every loader call must be pinned to.
 
@@ -1462,6 +1473,7 @@ class DiffusionBackend:
         include_transformer: bool = False,
         sizes_out: Optional[dict[str, int]] = None,
         file_sizes_out: Optional[dict[tuple[str, str], int]] = None,
+        shas_out: Optional[dict[str, str]] = None,
         skip_te_components: tuple[str, ...] = (),
     ) -> tuple[int, list[str]]:
         """Total download size for the progress bar, plus the base-repo files to
@@ -1470,7 +1482,8 @@ class DiffusionBackend:
         ``sizes_out``, when given, is filled with per-repo byte totals so the download
         plan can size one job per repo off this same single pair of Hub lookups.
         ``file_sizes_out`` is the per (repo, filename) breakdown, so the plan can drop
-        files already cached and still size what is left.
+        files already cached and still size what is left. ``shas_out`` is each repo's CURRENT
+        commit, so a cache hit only excuses a file sitting in the revision this lookup described.
 
         For a ``pipeline`` load the whole repo IS the pipeline (``base_repo`` is the
         repo itself), so the transformer/ subfolder is INCLUDED -- unlike the GGUF /
@@ -1503,6 +1516,7 @@ class DiffusionBackend:
         try:
             if kind == "pipeline":
                 info = api.model_info(repo_id, files_metadata = True, token = hf_token)
+                _record_sha(shas_out, repo_id, info)
                 picked = [
                     s
                     for s in info.siblings
@@ -1527,6 +1541,7 @@ class DiffusionBackend:
             # Skip the Hub size lookup for a LOCAL gguf path: model_info raises on a filesystem path.
             if gguf_filename and not Path(repo_id).expanduser().exists():
                 info = api.model_info(repo_id, files_metadata = True, token = hf_token)
+                _record_sha(shas_out, repo_id, info)
                 gguf_bytes = sum(s.size or 0 for s in info.siblings if s.rfilename == gguf_filename)
                 total += gguf_bytes
                 if sizes_out is not None:
@@ -1542,6 +1557,7 @@ class DiffusionBackend:
                     return _base_file_downloaded(rfilename, include_transformer = include_transformer)
 
             base_info = api.model_info(base_repo, files_metadata = True, token = hf_token)
+            _record_sha(shas_out, base_repo, base_info)
             base_bytes = 0
             for s in base_info.siblings:
                 if base_filter(s.rfilename) and not _dense_te_shard(s.rfilename):
@@ -1557,28 +1573,56 @@ class DiffusionBackend:
         return total, base_files
 
     @staticmethod
-    def _files_already_cached(repo_id: str, files: list[str]) -> set[str]:
-        """Of ``files``, the names already on disk under either root a load resolves
-        through: Studio pins its live setting, the prefetch writes under
-        huggingface_hub's import-time constant. Only a str is a cached path; a miss is
-        None and a known-absent file is a sentinel. Never raises: an unreadable cache
-        means "stage it", which is the old behaviour."""
+    def _files_already_cached(
+        repo_id: str,
+        files: list[str],
+        revision: Optional[str] = None,
+    ) -> set[str]:
+        """Of ``files``, the names on disk AT ``revision`` under either root a load resolves
+        through: Studio pins its live setting, ``cache_dir = None`` falls back to
+        huggingface_hub's constant, and both prefetch fetches pass ``reuse_other_cache_root``.
+
+        ``revision`` is REQUIRED to drop anything. Defaulted, ``try_to_load_from_cache`` reads the
+        cache's OWN ``refs/main``, which a republished repo leaves on the superseded commit: the
+        stale blob would leave the plan and the loader would pull the new one inline, outside the
+        panel's progress and disk preflight. No commit is no verdict, so nothing is skipped.
+
+        Only a str is a cached path; a miss is None and a known-absent file is a sentinel. Never
+        raises: an unreadable cache means "stage it"."""
+        if not revision:
+            return set()
         try:
             from huggingface_hub import try_to_load_from_cache
-        except Exception:  # noqa: BLE001 — no hub package: stage everything
+
+            # Once, and inside the try: hub_cache_dir is a SQLite read plus Path.home(), which
+            # raises with no home. Per file and outside, it was the one way this could 500.
+            roots = (hub_cache_dir(), None)
+        except Exception:  # noqa: BLE001 — no hub package / unreadable settings: stage everything
             return set()
         cached: set[str] = set()
         for name in files:
-            for root in (hub_cache_dir(), None):
+            for root in roots:
                 try:
-                    hit = try_to_load_from_cache(repo_id, name, cache_dir = root)
+                    hit = try_to_load_from_cache(repo_id, name, cache_dir = root, revision = revision)
                 except Exception:  # noqa: BLE001 — a cache we cannot read is not a verdict
                     continue
-                # is_file() too: a dangling symlink is a path but not usable bytes.
+                # is_file() is belt and braces: hub already ends on os.path.isfile today.
                 if isinstance(hit, str) and Path(hit).is_file():
                     cached.add(name)
                     break
         return cached
+
+    @staticmethod
+    def _current_sha(repo_id: str, hf_token: Optional[str]) -> Optional[str]:
+        """``repo_id``'s current commit, or None when the Hub does not say.
+
+        Only for the MIRROR: a mirror is a separate repo with its own history, so the vendor sha
+        ``_estimate_download_bytes`` recorded would never hit. One call, only when a swap fired."""
+        try:
+            from huggingface_hub import HfApi
+            return getattr(HfApi().model_info(repo_id, token = hf_token), "sha", None) or None
+        except Exception:  # noqa: BLE001 — no sha means no skip, never a failed plan
+            return None
 
     def download_plan(
         self,
@@ -1615,7 +1659,10 @@ class DiffusionBackend:
         te_files = self._te_prequant_plan_files(fam, text_encoder_quant, hf_token)
         sizes: dict[str, int] = {}
         file_sizes: dict[tuple[str, str], int] = {}
-        total, base_files = self._estimate_download_bytes(
+        shas: dict[str, str] = {}
+        # The estimate's total is discarded (it counts every file the pick needs, not what is
+        # left to fetch); base_files and the out-params are what this call is for.
+        _estimate_total, base_files = self._estimate_download_bytes(
             repo_id,
             gguf_filename,
             base,
@@ -1627,6 +1674,7 @@ class DiffusionBackend:
             and self._dense_quant_prefetch_needed(fam, {**load_kwargs, "base_repo": base}),
             sizes_out = sizes,
             file_sizes_out = file_sizes,
+            shas_out = shas,
             skip_te_components = tuple(te_files),
         )
         # Decided once, from the staged file list, and both probed and reported: a gated base
@@ -1637,16 +1685,22 @@ class DiffusionBackend:
         _assert_base_repo_accessible(fetch_base, hf_token)
         entries: list[dict[str, Any]] = []
 
-        def _stage(repo: str, files: list[str], sized: dict[str, int], gguf: Optional[str]) -> int:
-            """Queue what is missing and return the bytes dropped as already cached.
+        def _stage(
+            repo: str,
+            files: list[str],
+            sized: dict[str, int],
+            gguf: Optional[str],
+            revision: Optional[str] = None,
+        ) -> None:
+            """Queue the files the cache is missing at ``revision``.
 
             A pick whose files are all on disk yields no entry, so the caller loads
             straight from cache instead of staging a download that fetches nothing.
             Entries are what the Downloads panel lists, so a cached repo listed here
-            reads as a re-download of a model the user already has."""
-            cached = self._files_already_cached(repo, files)
+            reads as a re-download of a model the user already has. No revision drops nothing,
+            so an unpinnable repo stages in full as it always did."""
+            cached = self._files_already_cached(repo, files, revision)
             missing = [name for name in files if name not in cached]
-            dropped = sum(sized.get(name, 0) for name in cached)
             if missing:
                 entries.append(
                     {
@@ -1656,31 +1710,43 @@ class DiffusionBackend:
                         "gguf_filename": gguf,
                     }
                 )
-            return int(dropped)
 
-        skipped = 0
         for repo, files in te_files.values():
-            total += int(sum(size for _name, size in files))
-            skipped += _stage(repo, [n for n, _s in files], dict(files), None)
+            # No revision: te_prequant_hub_files reports names and sizes only, so a pre-cast
+            # checkpoint stages whole rather than drop off a stale refs/main. Surfacing its
+            # info.sha would close this, and is worth doing: these replace tens of GB.
+            _stage(repo, [n for n, _s in files], dict(files), None)
         if gguf_filename and not Path(repo_id).expanduser().exists():
-            skipped += _stage(
+            _stage(
                 repo_id,
                 [gguf_filename],
-                {gguf_filename: int(sizes.get(repo_id, 0))},
+                # file_sizes, not sizes: a base repo equal to the checkpoint repo overwrites
+                # sizes[repo_id] with the base total, mis-sizing this row.
+                {gguf_filename: int(file_sizes.get((repo_id, gguf_filename), 0))},
                 gguf_filename,
+                shas.get(repo_id),
             )
         if base_files and not Path(base).expanduser().exists():
             # STAGED before the loader runs, so it must name the MIRROR: a gated upstream here 401s
             # an anonymous user at staging and the swap downstream is never reached. status(), the
             # API base repo, saved configs and LoRA tags keep the vendor id; sizes key on it too.
-            skipped += _stage(
+            # The commit follows the id: the sizes came from the vendor, the probe must not.
+            base_rev = (
+                shas.get(base) if fetch_base == base else self._current_sha(fetch_base, hf_token)
+            )
+            _stage(
                 fetch_base,
                 base_files,
                 {name: file_sizes.get((base, name), 0) for name in base_files},
                 None,
+                base_rev,
             )
-        total = max(0, total - skipped)
-        return {"entries": entries, "total_bytes": int(total)}
+        # Derived, never decremented: a separately carried total can only drift from the rows
+        # the panel shows. Empty entries therefore mean exactly zero.
+        return {
+            "entries": entries,
+            "total_bytes": int(sum(e["bytes"] for e in entries)),
+        }
 
     @staticmethod
     def _hub_cache_repo_dir(repo_id: str) -> Path:

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -147,9 +147,9 @@ _MODEL_KINDS = frozenset({"gguf", "single_file", "pipeline"})
 
 
 def _record_sha(shas_out: Optional[dict[str, str]], repo_id: str, info: Any) -> None:
-    """Note the commit ``info`` describes, so a cache probe can be pinned to it.
+    """Note the commit ``info`` describes so a cache probe can pin to it.
 
-    Best-effort: a listing with no ``sha`` just means the plan cannot pin, and stages as before."""
+    No ``sha`` just means the plan cannot pin, and stages as before."""
     if shas_out is None:
         return
     sha = getattr(info, "sha", None)
@@ -1481,9 +1481,9 @@ class DiffusionBackend:
 
         ``sizes_out``, when given, is filled with per-repo byte totals so the download
         plan can size one job per repo off this same single pair of Hub lookups.
-        ``file_sizes_out`` is the per (repo, filename) breakdown, so the plan can drop
-        files already cached and still size what is left. ``shas_out`` is each repo's CURRENT
-        commit, so a cache hit only excuses a file sitting in the revision this lookup described.
+        ``file_sizes_out`` is the per (repo, filename) breakdown, so the plan can drop cached
+        files and size the rest. ``shas_out`` is each repo's CURRENT commit, so a cache hit
+        counts only in that revision.
 
         For a ``pipeline`` load the whole repo IS the pipeline (``base_repo`` is the
         repo itself), so the transformer/ subfolder is INCLUDED -- unlike the GGUF /
@@ -1580,29 +1580,25 @@ class DiffusionBackend:
     ) -> set[str]:
         """Of ``files``, the names ONE root serves whole at ``revision``: all of them, or none.
 
-        Both roots are searched -- Studio pins its live setting, ``cache_dir = None`` falls back
-        to huggingface_hub's constant -- but hits are never UNIONED across them. A set split
-        between the roots is complete in neither: ``_prefetch_files`` hands back a snapshot only
-        when every file came from the SAME root, else None, and ``from_pretrained`` is then pinned
-        to ``hub_cache_dir()`` (the ``cache_dir`` in every ``pipe_kwargs`` below) and cannot see
-        the other root. Dropping such a repo moves its refetch inline, outside the panel's
-        progress and disk preflight. Fallback-holds-all still drops: the prefetch returns that
-        snapshot and the load reads it off disk, and a lone GGUF resolves through the same reuse.
+        Both roots are searched -- Studio's live setting, and ``cache_dir = None`` for
+        huggingface_hub's constant -- but hits are never UNIONED. A set split between the roots is
+        complete in neither: ``_prefetch_files`` hands back a snapshot only when every file came
+        from the SAME root, else None, and ``from_pretrained`` is then pinned to ``hub_cache_dir()``
+        and cannot see the other root, so dropping the repo moves its refetch inline, outside the
+        panel's progress and disk preflight. One root holding all of it still drops.
 
-        ``revision`` is REQUIRED to drop anything. Defaulted, ``try_to_load_from_cache`` reads the
-        cache's OWN ``refs/main``, which a republished repo leaves on the superseded commit: the
-        stale blob would leave the plan and the loader would pull the new one inline, outside the
-        panel's progress and disk preflight. No commit is no verdict, so nothing is skipped.
+        ``revision`` is REQUIRED to drop anything: defaulted, ``try_to_load_from_cache`` reads the
+        cache's OWN ``refs/main``, which a republished repo leaves on the superseded commit, so the
+        stale blob would leave the plan and the loader would pull the new one inline.
 
-        Only a str is a cached path; a miss is None and a known-absent file is a sentinel. Never
-        raises: an unreadable cache means "stage it"."""
+        Only a str is a cached path. Never raises: an unreadable cache means "stage it"."""
         if not revision or not files:
             return set()
         try:
             from huggingface_hub import try_to_load_from_cache
 
-            # Once, and inside the try: hub_cache_dir is a SQLite read plus Path.home(), which
-            # raises with no home. Per file and outside, it was the one way this could 500.
+            # Once, inside the try: hub_cache_dir is a SQLite read plus Path.home(), which raises
+            # with no home -- per file and outside, it was the one way this could 500.
             roots = (hub_cache_dir(), None)
         except Exception:  # noqa: BLE001 — no hub package / unreadable settings: stage everything
             return set()
@@ -1624,8 +1620,8 @@ class DiffusionBackend:
         live = _hits(live_root)
         if live == wanted:
             return wanted
-        # A partial live hit IS the split: the prefetch takes those here and the rest from the
-        # fallback, so it returns no snapshot and the pinned load refetches the fallback's share.
+        # A partial live hit IS the split: no single-root snapshot, so the pinned load refetches
+        # the fallback's share.
         if live:
             return set()
         return wanted if _hits(fallback_root) == wanted else set()
@@ -1634,8 +1630,8 @@ class DiffusionBackend:
     def _current_sha(repo_id: str, hf_token: Optional[str]) -> Optional[str]:
         """``repo_id``'s current commit, or None when the Hub does not say.
 
-        Only for the MIRROR: a mirror is a separate repo with its own history, so the vendor sha
-        ``_estimate_download_bytes`` recorded would never hit. One call, only when a swap fired."""
+        Only for the MIRROR: it is a separate repo with its own history, so the vendor sha
+        ``_estimate_download_bytes`` recorded would never hit."""
         try:
             from huggingface_hub import HfApi
             return getattr(HfApi().model_info(repo_id, token = hf_token), "sha", None) or None
@@ -1678,8 +1674,7 @@ class DiffusionBackend:
         sizes: dict[str, int] = {}
         file_sizes: dict[tuple[str, str], int] = {}
         shas: dict[str, str] = {}
-        # The estimate's total is discarded (it counts every file the pick needs, not what is
-        # left to fetch); base_files and the out-params are what this call is for.
+        # Total discarded: it counts every file the pick needs, not what is left to fetch.
         _estimate_total, base_files = self._estimate_download_bytes(
             repo_id,
             gguf_filename,
@@ -1712,21 +1707,17 @@ class DiffusionBackend:
         ) -> None:
             """Queue the files the cache is missing at ``revision``.
 
-            A pick whose files are all on disk yields no entry, so the caller loads
-            straight from cache instead of staging a download that fetches nothing.
-            Entries are what the Downloads panel lists, so a cached repo listed here
-            reads as a re-download of a model the user already has. No revision drops nothing,
-            so an unpinnable repo stages in full as it always did.
+            Entries are what the Downloads panel lists, so an all-cached pick yields none rather
+            than reading as a re-download of a model the user already has. No revision drops
+            nothing, so an unpinnable repo stages in full as it always did.
 
-            All or nothing per repo, never a subset. Every diffusion entry for a repo rides the
-            one "@diffusion" scope slot, and download_registry refuses a claim whose scoped_files
-            differ from the live job's: a shrinking list would 409 a second pick sharing this base
-            where it used to adopt the running job. Staging a cached file costs nothing anyway,
-            since hf_hub_download returns the pointer without a transfer.
+            All or nothing per repo, never a subset: every diffusion entry for a repo rides the one
+            "@diffusion" scope slot, and download_registry refuses a claim whose scoped_files differ
+            from the live job's, so a shrinking list would 409 a second pick sharing this base where
+            it used to adopt the running job. Staging a cached file costs nothing anyway, since
+            hf_hub_download returns the pointer without a transfer.
 
-            "Cached" is per ROOT, never a union across the two: a set split between the live and
-            fallback roots is complete in neither, so dropping it would move the refetch inline.
-            See ``_files_already_cached``."""
+            "Cached" is per ROOT, never a union across the two; see ``_files_already_cached``."""
             cached = self._files_already_cached(repo, files, revision)
             if files and cached.issuperset(files):
                 return
@@ -1741,15 +1732,15 @@ class DiffusionBackend:
 
         for repo, files in te_files.values():
             # No revision: te_prequant_hub_files reports names and sizes only, so a pre-cast
-            # checkpoint stages whole rather than drop off a stale refs/main. Surfacing its
-            # info.sha would close this, and is worth doing: these replace tens of GB.
+            # checkpoint stages whole, not off a stale refs/main. Worth surfacing its info.sha:
+            # these replace tens of GB.
             _stage(repo, [n for n, _s in files], dict(files), None)
         if gguf_filename and not Path(repo_id).expanduser().exists():
             _stage(
                 repo_id,
                 [gguf_filename],
-                # file_sizes, not sizes: a base repo equal to the checkpoint repo overwrites
-                # sizes[repo_id] with the base total, mis-sizing this row.
+                # file_sizes, not sizes: a base repo equal to this one overwrote sizes[repo_id]
+                # with the base total, mis-sizing this row.
                 {gguf_filename: int(file_sizes.get((repo_id, gguf_filename), 0))},
                 gguf_filename,
                 shas.get(repo_id),
@@ -1769,8 +1760,7 @@ class DiffusionBackend:
                 None,
                 base_rev,
             )
-        # Derived, never decremented: a separately carried total can only drift from the rows
-        # the panel shows. Empty entries therefore mean exactly zero.
+        # Derived, never decremented: a carried total can only drift from the rows the panel shows.
         return {
             "entries": entries,
             "total_bytes": int(sum(e["bytes"] for e in entries)),

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -1578,9 +1578,16 @@ class DiffusionBackend:
         files: list[str],
         revision: Optional[str] = None,
     ) -> set[str]:
-        """Of ``files``, the names on disk AT ``revision`` under either root a load resolves
-        through: Studio pins its live setting, ``cache_dir = None`` falls back to
-        huggingface_hub's constant, and both prefetch fetches pass ``reuse_other_cache_root``.
+        """Of ``files``, the names ONE root serves whole at ``revision``: all of them, or none.
+
+        Both roots are searched -- Studio pins its live setting, ``cache_dir = None`` falls back
+        to huggingface_hub's constant -- but hits are never UNIONED across them. A set split
+        between the roots is complete in neither: ``_prefetch_files`` hands back a snapshot only
+        when every file came from the SAME root, else None, and ``from_pretrained`` is then pinned
+        to ``hub_cache_dir()`` (the ``cache_dir`` in every ``pipe_kwargs`` below) and cannot see
+        the other root. Dropping such a repo moves its refetch inline, outside the panel's
+        progress and disk preflight. Fallback-holds-all still drops: the prefetch returns that
+        snapshot and the load reads it off disk, and a lone GGUF resolves through the same reuse.
 
         ``revision`` is REQUIRED to drop anything. Defaulted, ``try_to_load_from_cache`` reads the
         cache's OWN ``refs/main``, which a republished repo leaves on the superseded commit: the
@@ -1589,7 +1596,7 @@ class DiffusionBackend:
 
         Only a str is a cached path; a miss is None and a known-absent file is a sentinel. Never
         raises: an unreadable cache means "stage it"."""
-        if not revision:
+        if not revision or not files:
             return set()
         try:
             from huggingface_hub import try_to_load_from_cache
@@ -1599,18 +1606,29 @@ class DiffusionBackend:
             roots = (hub_cache_dir(), None)
         except Exception:  # noqa: BLE001 — no hub package / unreadable settings: stage everything
             return set()
-        cached: set[str] = set()
-        for name in files:
-            for root in roots:
+        wanted = set(files)
+        live_root, fallback_root = roots
+
+        def _hits(root: Optional[str]) -> set[str]:
+            found: set[str] = set()
+            for name in wanted:
                 try:
                     hit = try_to_load_from_cache(repo_id, name, cache_dir = root, revision = revision)
                 except Exception:  # noqa: BLE001 — a cache we cannot read is not a verdict
                     continue
                 # is_file() is belt and braces: hub already ends on os.path.isfile today.
                 if isinstance(hit, str) and Path(hit).is_file():
-                    cached.add(name)
-                    break
-        return cached
+                    found.add(name)
+            return found
+
+        live = _hits(live_root)
+        if live == wanted:
+            return wanted
+        # A partial live hit IS the split: the prefetch takes those here and the rest from the
+        # fallback, so it returns no snapshot and the pinned load refetches the fallback's share.
+        if live:
+            return set()
+        return wanted if _hits(fallback_root) == wanted else set()
 
     @staticmethod
     def _current_sha(repo_id: str, hf_token: Optional[str]) -> Optional[str]:
@@ -1704,7 +1722,11 @@ class DiffusionBackend:
             one "@diffusion" scope slot, and download_registry refuses a claim whose scoped_files
             differ from the live job's: a shrinking list would 409 a second pick sharing this base
             where it used to adopt the running job. Staging a cached file costs nothing anyway,
-            since hf_hub_download returns the pointer without a transfer."""
+            since hf_hub_download returns the pointer without a transfer.
+
+            "Cached" is per ROOT, never a union across the two: a set split between the live and
+            fallback roots is complete in neither, so dropping it would move the refetch inline.
+            See ``_files_already_cached``."""
             cached = self._files_already_cached(repo, files, revision)
             if files and cached.issuperset(files):
                 return

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -161,6 +161,33 @@ def _no_background_model_scan(monkeypatch):
     monkeypatch.setattr(local_model_resolver, "_scan", (time.monotonic(), {}))
 
 
+@pytest.fixture(scope = "session")
+def _empty_hf_hub_cache(tmp_path_factory):
+    """One empty hub-cache root for the whole session; per-test mktemp is quadratic."""
+    return str(tmp_path_factory.mktemp("hf_hub_cache_empty"))
+
+
+@pytest.fixture(autouse = True)
+def _hf_cache_is_empty(_empty_hf_hub_cache, monkeypatch):
+    """Point BOTH hub-cache roots at an empty dir, so the suite is host independent.
+
+    Studio pins its live setting out of this env snapshot; huggingface_hub falls back to
+    ``constants.HF_HUB_CACHE``. A dev holding FLUX.1-dev otherwise watches its files leave a
+    download plan AND the mirror swap decline. Pinned at the ROOT, not by stubbing a probe: that
+    reaches only one of the four cache reads, and ``_upstream_is_cached`` walks the tree itself.
+    Tests that own the cache setting replace the whole dict, so they still win.
+    """
+    from utils import hf_cache_settings
+
+    monkeypatch.setitem(hf_cache_settings._EXPLICIT_CACHE_ENV, "HF_HUB_CACHE", _empty_hf_hub_cache)
+    monkeypatch.setenv("HF_HUB_CACHE", _empty_hf_hub_cache)
+    try:
+        from huggingface_hub import constants
+    except Exception:  # optional deps absent on some CI legs
+        return
+    monkeypatch.setattr(constants, "HF_HUB_CACHE", _empty_hf_hub_cache)
+
+
 @pytest.fixture(autouse = True)
 def _assume_bare_metal(monkeypatch):
     """Pin the virtualised-Metal detector off so the suite is host independent.

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -175,8 +175,7 @@ def _hf_cache_is_empty(_empty_hf_hub_cache, monkeypatch):
     ``constants.HF_HUB_CACHE``. A dev holding FLUX.1-dev otherwise watches its files leave a
     download plan AND the mirror swap decline. Pinned at the ROOT, not by stubbing a probe: that
     reaches only one of the four cache reads, and ``_upstream_is_cached`` walks the tree itself.
-    Tests that own the cache setting replace the whole dict, so they still win.
-    """
+    Tests that own the cache setting replace the whole dict, so they still win."""
     from utils import hf_cache_settings
 
     monkeypatch.setitem(hf_cache_settings._EXPLICIT_CACHE_ENV, "HF_HUB_CACHE", _empty_hf_hub_cache)

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -5425,8 +5425,7 @@ def test_a_superseding_load_fences_queued_generations_too(fake_runtime, tmp_path
 
 
 def test_download_plan_skips_files_already_in_the_cache(monkeypatch):
-    # A model fully on disk must plan nothing: entries are what the Downloads panel lists, so
-    # staging a cached repo reads as re-downloading a model the user already has.
+    # Entries are what the Downloads panel lists, so a model fully on disk must plan nothing.
     _fake_hf_api(
         monkeypatch,
         {
@@ -5512,7 +5511,6 @@ def _seed_cache_file(
     target.parent.mkdir(parents = True, exist_ok = True)
     if dangling:
         # A snapshot entry is a symlink into blobs/; a pruned blob leaves the link but no bytes.
-        # Windows without developer mode cannot make one, and hub writes plain files there too.
         try:
             _os.symlink(repo / "blobs" / "gone", target)
         except (OSError, NotImplementedError):
@@ -5536,9 +5534,9 @@ def _two_cache_roots(monkeypatch, tmp_path):
 
 
 def test_files_already_cached_needs_a_revision_to_drop_anything(monkeypatch, tmp_path):
-    """No commit, no verdict. try_to_load_from_cache would otherwise resolve the cache's OWN
-    refs/main, which a republished repo leaves on the superseded commit: the stale blob reads as
-    cached, the file leaves the plan, and the loader pulls the new one outside the panel."""
+    """No commit, no verdict: try_to_load_from_cache would otherwise resolve the cache's OWN
+    refs/main, stale on a republished repo, and the loader would pull the new blob outside the
+    panel."""
     live, _other = _two_cache_roots(monkeypatch, tmp_path)
     sha = "a" * 40
     _seed_cache_file(live, "unsloth/FLUX.1-dev-GGUF", "flux1-dev-Q4_K_M.gguf", sha)
@@ -5583,9 +5581,8 @@ def test_files_already_cached_skips_unusable_hits(monkeypatch, tmp_path):
 
 
 def test_files_already_cached_takes_the_whole_set_from_the_fallback_root(monkeypatch, tmp_path):
-    """The other root still counts, as a WHOLE: every diffusion fetch passes
-    reuse_other_cache_root, so a repo left behind by a cache-folder change really does satisfy the
-    load -- _prefetch_files resolves every file there and hands from_pretrained that snapshot."""
+    """The other root still counts, as a WHOLE: every diffusion fetch passes reuse_other_cache_root,
+    so _prefetch_files resolves every file there and hands from_pretrained that snapshot."""
     _live, other = _two_cache_roots(monkeypatch, tmp_path)
     sha = "c" * 40
     repo = "black-forest-labs/FLUX.1-dev"
@@ -5597,11 +5594,10 @@ def test_files_already_cached_takes_the_whole_set_from_the_fallback_root(monkeyp
 
 
 def test_files_already_cached_refuses_a_set_split_over_two_roots(monkeypatch, tmp_path):
-    """Never a per-file union. Neither root holds a complete snapshot, so _prefetch_files finds
-    the files under two roots, returns None instead of a snapshot dir, and from_pretrained falls
-    back to the hub id pinned to hub_cache_dir() -- which cannot see the fallback root. Calling
-    this repo cached drops it from the plan and the loader then refetches the other root's share
-    inline, outside the Downloads panel's progress and its disk preflight."""
+    """Never a per-file union. Neither root holds a complete snapshot, so _prefetch_files returns
+    None instead of a snapshot dir and from_pretrained falls back to the hub id pinned to
+    hub_cache_dir(), which cannot see the fallback root: calling this repo cached would refetch
+    that root's share inline, outside the Downloads panel's progress and its disk preflight."""
     live, other = _two_cache_roots(monkeypatch, tmp_path)
     sha = "c" * 40
     repo = "black-forest-labs/FLUX.1-dev"
@@ -5617,9 +5613,8 @@ def test_files_already_cached_refuses_a_set_split_over_two_roots(monkeypatch, tm
 
 
 def test_download_plan_stages_a_repo_split_across_two_cache_roots(monkeypatch, tmp_path):
-    """End to end: a base repo whose files sit half in the live root and half in the import-time
-    one must keep its row. Dropping it tells the panel there is nothing to fetch and the load then
-    pulls the fallback root's files itself."""
+    """End to end: a base repo half in the live root and half in the import-time one keeps its row.
+    Dropping it tells the panel there is nothing to fetch and the load pulls the rest itself."""
     live, other = _two_cache_roots(monkeypatch, tmp_path)
     base_sha = "9" * 40
     base = "black-forest-labs/FLUX.1-dev"
@@ -5715,8 +5710,8 @@ def test_files_already_cached_survives_an_unreadable_root(monkeypatch, tmp_path)
 
 
 def test_download_plan_stages_a_half_cached_repo_whole(monkeypatch):
-    """A repo is dropped only when ALL of it is cached. A shrinking file list would 409 a second
-    pick sharing this base, since every diffusion entry rides the one "@diffusion" scope slot and
+    """Dropped only when ALL of it is cached: a shrinking file list would 409 a second pick sharing
+    this base, since every diffusion entry rides the one "@diffusion" scope slot and
     download_registry refuses a claim whose scoped_files differ from the live job's."""
     _fake_hf_api(
         monkeypatch,
@@ -5751,8 +5746,7 @@ def test_download_plan_stages_a_half_cached_repo_whole(monkeypatch):
     )
 
     by_repo = {e["repo_id"]: e for e in plan["entries"]}
-    # Staged from the ungated mirror, as every other plan test here: nothing is cached, so
-    # prefer_ungated_mirror swaps the gated vendor id for the one the fetch will really name.
+    # Nothing is cached, so prefer_ungated_mirror swaps the gated vendor id for the mirror.
     assert set(by_repo) == {"unsloth/FLUX.1-dev-GGUF", "unsloth/FLUX.1-dev"}
     base = by_repo["unsloth/FLUX.1-dev"]
     # The whole scoped list, not just the missing VAE: the cached file is still staged.
@@ -5841,9 +5835,9 @@ def _fake_hf_api_with_shas(monkeypatch, repos):
 
 
 def test_download_plan_pins_each_probe_to_the_commit_it_just_read(monkeypatch):
-    """The sha every model_info reported must reach that repo's own probe, and the MIRROR must be
-    probed at ITS commit: a mirror is a separate repo with its own history, so the vendor's sha
-    would never hit and a cached mirror would re-stage in full."""
+    """Each probe gets the sha its own model_info reported, the MIRROR at ITS commit: a mirror is a
+    separate repo with its own history, so the vendor's sha would never hit and a cached mirror
+    would re-stage in full."""
     gguf_sha, vendor_sha, mirror_sha = "f" * 40, "d" * 40, "e" * 40
     _fake_hf_api_with_shas(
         monkeypatch,

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -5483,9 +5483,7 @@ def test_download_plan_stages_only_what_the_cache_is_missing(monkeypatch):
     monkeypatch.setattr(
         DiffusionBackend,
         "_files_already_cached",
-        staticmethod(
-            lambda repo_id, files: set() if repo_id.endswith("-GGUF") else set(files)
-        ),
+        staticmethod(lambda repo_id, files: set() if repo_id.endswith("-GGUF") else set(files)),
     )
 
     plan = DiffusionBackend().download_plan(

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -5564,27 +5564,127 @@ def test_files_already_cached_ignores_a_superseded_revision(monkeypatch, tmp_pat
     )
 
 
-def test_files_already_cached_reads_both_roots_and_skips_unusable_hits(monkeypatch, tmp_path):
-    """Both roots count: every diffusion fetch passes reuse_other_cache_root, so bytes left in the
-    pre-change root really do satisfy the load. A dangling symlink is a path but not usable bytes,
-    and an absent file is simply missing."""
+def test_files_already_cached_skips_unusable_hits(monkeypatch, tmp_path):
+    """A dangling symlink is a path but not usable bytes, and an absent file is simply missing, so
+    neither can complete the live root's set."""
+    live, _other = _two_cache_roots(monkeypatch, tmp_path)
+    sha = "c" * 40
+    repo = "black-forest-labs/FLUX.1-dev"
+    _seed_cache_file(live, repo, "model_index.json", sha)
+    _seed_cache_file(live, repo, "vae/diffusion_pytorch_model.safetensors", sha)
+    _seed_cache_file(live, repo, "text_encoder/model.safetensors", sha, dangling = True)
+
+    probe = DiffusionBackend._files_already_cached
+    files = ["model_index.json", "vae/diffusion_pytorch_model.safetensors"]
+    assert probe(repo, files, sha) == set(files)
+    # The dangling link and the file that was never fetched both leave the set incomplete.
+    assert probe(repo, [*files, "text_encoder/model.safetensors"], sha) == set()
+    assert probe(repo, [*files, "scheduler/scheduler_config.json"], sha) == set()
+
+
+def test_files_already_cached_takes_the_whole_set_from_the_fallback_root(monkeypatch, tmp_path):
+    """The other root still counts, as a WHOLE: every diffusion fetch passes
+    reuse_other_cache_root, so a repo left behind by a cache-folder change really does satisfy the
+    load -- _prefetch_files resolves every file there and hands from_pretrained that snapshot."""
+    _live, other = _two_cache_roots(monkeypatch, tmp_path)
+    sha = "c" * 40
+    repo = "black-forest-labs/FLUX.1-dev"
+    files = ["model_index.json", "vae/diffusion_pytorch_model.safetensors"]
+    for name in files:
+        _seed_cache_file(other, repo, name, sha)
+
+    assert DiffusionBackend._files_already_cached(repo, files, sha) == set(files)
+
+
+def test_files_already_cached_refuses_a_set_split_over_two_roots(monkeypatch, tmp_path):
+    """Never a per-file union. Neither root holds a complete snapshot, so _prefetch_files finds
+    the files under two roots, returns None instead of a snapshot dir, and from_pretrained falls
+    back to the hub id pinned to hub_cache_dir() -- which cannot see the fallback root. Calling
+    this repo cached drops it from the plan and the loader then refetches the other root's share
+    inline, outside the Downloads panel's progress and its disk preflight."""
     live, other = _two_cache_roots(monkeypatch, tmp_path)
     sha = "c" * 40
     repo = "black-forest-labs/FLUX.1-dev"
     _seed_cache_file(live, repo, "model_index.json", sha)
     _seed_cache_file(other, repo, "vae/diffusion_pytorch_model.safetensors", sha)
-    _seed_cache_file(live, repo, "text_encoder/model.safetensors", sha, dangling = True)
+    files = ["model_index.json", "vae/diffusion_pytorch_model.safetensors"]
 
-    assert DiffusionBackend._files_already_cached(
-        repo,
-        [
-            "model_index.json",
-            "vae/diffusion_pytorch_model.safetensors",
-            "text_encoder/model.safetensors",
-            "scheduler/scheduler_config.json",
-        ],
-        sha,
-    ) == {"model_index.json", "vae/diffusion_pytorch_model.safetensors"}
+    # Every file is on disk somewhere, at the right commit, and nothing is missing.
+    assert DiffusionBackend._files_already_cached(repo, files, sha) == set()
+    # One root holding the whole set is the only thing that changes the verdict.
+    _seed_cache_file(live, repo, "vae/diffusion_pytorch_model.safetensors", sha)
+    assert DiffusionBackend._files_already_cached(repo, files, sha) == set(files)
+
+
+def test_download_plan_stages_a_repo_split_across_two_cache_roots(monkeypatch, tmp_path):
+    """End to end: a base repo whose files sit half in the live root and half in the import-time
+    one must keep its row. Dropping it tells the panel there is nothing to fetch and the load then
+    pulls the fallback root's files itself."""
+    live, other = _two_cache_roots(monkeypatch, tmp_path)
+    base_sha = "9" * 40
+    base = "black-forest-labs/FLUX.1-dev"
+    _fake_hf_api_with_shas(
+        monkeypatch,
+        {
+            "unsloth/FLUX.1-dev-GGUF": ([_FakeSibling("flux1-dev-Q4_K_M.gguf", 7 * GB)], "8" * 40),
+            base: (_FLUX_BASE_SIBLINGS, base_sha),
+        },
+    )
+    monkeypatch.setattr("core.inference.diffusion._resolve_base_repo", lambda *a, **k: base)
+    monkeypatch.setattr(
+        DiffusionBackend, "_dense_quant_prefetch_needed", lambda self, fam, kwargs: False
+    )
+    # No mirror swap, so the staged id and the probed commit are the vendor's own.
+    _all_cached(monkeypatch)
+    staged = [
+        name
+        for name in _FLUX_BASE_SIBLINGS_BY_NAME
+        if _base_file_downloaded(name, include_transformer = False)
+    ]
+    assert len(staged) > 1
+    _seed_cache_file(live, base, staged[0], base_sha)
+    for name in staged[1:]:
+        _seed_cache_file(other, base, name, base_sha)
+
+    plan = DiffusionBackend().download_plan(
+        "unsloth/FLUX.1-dev-GGUF", gguf_filename = "flux1-dev-Q4_K_M.gguf"
+    )
+
+    by_repo = {e["repo_id"]: e for e in plan["entries"]}
+    assert base in by_repo, "a split base repo must keep its row"
+    assert by_repo[base]["files"] == staged
+    assert by_repo[base]["bytes"] == sum(_FLUX_BASE_SIBLINGS_BY_NAME[n] for n in staged)
+    assert plan["total_bytes"] == sum(e["bytes"] for e in plan["entries"])
+
+
+def test_download_plan_drops_a_repo_the_fallback_root_holds_whole(monkeypatch, tmp_path):
+    """The other half of the rule, so the split guard cannot become "always stage": a repo left
+    complete in the import-time root after a cache-folder change still leaves the plan."""
+    _live, other = _two_cache_roots(monkeypatch, tmp_path)
+    base_sha, gguf_sha = "9" * 40, "8" * 40
+    base = "black-forest-labs/FLUX.1-dev"
+    _fake_hf_api_with_shas(
+        monkeypatch,
+        {
+            "unsloth/FLUX.1-dev-GGUF": ([_FakeSibling("flux1-dev-Q4_K_M.gguf", 7 * GB)], gguf_sha),
+            base: (_FLUX_BASE_SIBLINGS, base_sha),
+        },
+    )
+    monkeypatch.setattr("core.inference.diffusion._resolve_base_repo", lambda *a, **k: base)
+    monkeypatch.setattr(
+        DiffusionBackend, "_dense_quant_prefetch_needed", lambda self, fam, kwargs: False
+    )
+    _all_cached(monkeypatch)
+    for name in _FLUX_BASE_SIBLINGS_BY_NAME:
+        if _base_file_downloaded(name, include_transformer = False):
+            _seed_cache_file(other, base, name, base_sha)
+    _seed_cache_file(other, "unsloth/FLUX.1-dev-GGUF", "flux1-dev-Q4_K_M.gguf", gguf_sha)
+
+    plan = DiffusionBackend().download_plan(
+        "unsloth/FLUX.1-dev-GGUF", gguf_filename = "flux1-dev-Q4_K_M.gguf"
+    )
+
+    assert plan == {"entries": [], "total_bytes": 0}
 
 
 def test_files_already_cached_survives_an_unreadable_root(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -5056,6 +5056,15 @@ _FLUX_BASE_SIBLINGS = [
 ]
 
 
+@pytest.fixture(autouse = True)
+def _plan_cache_probe_is_empty(monkeypatch):
+    """Plan tests otherwise read the real HF cache, so a dev holding one of these repos
+    would watch its files get dropped. Tests that exercise the skip stub this themselves."""
+    monkeypatch.setattr(
+        DiffusionBackend, "_files_already_cached", staticmethod(lambda repo_id, files: set())
+    )
+
+
 def _fake_hf_api(monkeypatch, repos):
     """Point HfApi.model_info at a canned sibling list per repo id."""
 
@@ -5421,3 +5430,69 @@ def test_a_superseding_load_fences_queued_generations_too(fake_runtime, tmp_path
 
     assert seen == [1]
     assert backend._teardown_waiters == 0
+
+
+def test_download_plan_skips_files_already_in_the_cache(monkeypatch):
+    # A model fully on disk must plan nothing: entries are what the Downloads panel lists, so
+    # staging a cached repo reads as re-downloading a model the user already has.
+    _fake_hf_api(
+        monkeypatch,
+        {
+            "unsloth/FLUX.1-dev-GGUF": [_FakeSibling("flux1-dev-Q4_K_M.gguf", 7 * GB)],
+            "black-forest-labs/FLUX.1-dev": _FLUX_BASE_SIBLINGS,
+        },
+    )
+    monkeypatch.setattr(
+        "core.inference.diffusion._resolve_base_repo",
+        lambda *a, **k: "black-forest-labs/FLUX.1-dev",
+    )
+    monkeypatch.setattr(
+        DiffusionBackend, "_dense_quant_prefetch_needed", lambda self, fam, kwargs: False
+    )
+    _no_cache(monkeypatch)
+    monkeypatch.setattr(
+        DiffusionBackend, "_files_already_cached", staticmethod(lambda repo_id, files: set(files))
+    )
+
+    plan = DiffusionBackend().download_plan(
+        "unsloth/FLUX.1-dev-GGUF", gguf_filename = "flux1-dev-Q4_K_M.gguf"
+    )
+
+    assert plan["entries"] == []
+    assert plan["total_bytes"] == 0
+
+
+def test_download_plan_stages_only_what_the_cache_is_missing(monkeypatch):
+    # The common case after a base repo is shared: the companion is on disk, a new quant is not.
+    _fake_hf_api(
+        monkeypatch,
+        {
+            "unsloth/FLUX.1-dev-GGUF": [_FakeSibling("flux1-dev-Q4_K_M.gguf", 7 * GB)],
+            "black-forest-labs/FLUX.1-dev": _FLUX_BASE_SIBLINGS,
+        },
+    )
+    monkeypatch.setattr(
+        "core.inference.diffusion._resolve_base_repo",
+        lambda *a, **k: "black-forest-labs/FLUX.1-dev",
+    )
+    monkeypatch.setattr(
+        DiffusionBackend, "_dense_quant_prefetch_needed", lambda self, fam, kwargs: False
+    )
+    _no_cache(monkeypatch)
+    # Everything but the checkpoint repo is cached.
+    monkeypatch.setattr(
+        DiffusionBackend,
+        "_files_already_cached",
+        staticmethod(
+            lambda repo_id, files: set() if repo_id.endswith("-GGUF") else set(files)
+        ),
+    )
+
+    plan = DiffusionBackend().download_plan(
+        "unsloth/FLUX.1-dev-GGUF", gguf_filename = "flux1-dev-Q4_K_M.gguf"
+    )
+
+    assert [e["repo_id"] for e in plan["entries"]] == ["unsloth/FLUX.1-dev-GGUF"]
+    assert plan["entries"][0]["files"] == ["flux1-dev-Q4_K_M.gguf"]
+    # The cached base is gone from the total too, or the progress bar waits on bytes nobody fetches.
+    assert plan["total_bytes"] == 7 * GB

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -5056,15 +5056,6 @@ _FLUX_BASE_SIBLINGS = [
 ]
 
 
-@pytest.fixture(autouse = True)
-def _plan_cache_probe_is_empty(monkeypatch):
-    """Plan tests otherwise read the real HF cache, so a dev holding one of these repos
-    would watch its files get dropped. Tests that exercise the skip stub this themselves."""
-    monkeypatch.setattr(
-        DiffusionBackend, "_files_already_cached", staticmethod(lambda repo_id, files: set())
-    )
-
-
 def _fake_hf_api(monkeypatch, repos):
     """Point HfApi.model_info at a canned sibling list per repo id."""
 
@@ -5451,7 +5442,9 @@ def test_download_plan_skips_files_already_in_the_cache(monkeypatch):
     )
     _no_cache(monkeypatch)
     monkeypatch.setattr(
-        DiffusionBackend, "_files_already_cached", staticmethod(lambda repo_id, files: set(files))
+        DiffusionBackend,
+        "_files_already_cached",
+        staticmethod(lambda repo_id, files, revision = None: set(files)),
     )
 
     plan = DiffusionBackend().download_plan(
@@ -5483,7 +5476,11 @@ def test_download_plan_stages_only_what_the_cache_is_missing(monkeypatch):
     monkeypatch.setattr(
         DiffusionBackend,
         "_files_already_cached",
-        staticmethod(lambda repo_id, files: set() if repo_id.endswith("-GGUF") else set(files)),
+        staticmethod(
+            lambda repo_id, files, revision = None: (
+                set() if repo_id.endswith("-GGUF") else set(files)
+            )
+        ),
     )
 
     plan = DiffusionBackend().download_plan(
@@ -5494,3 +5491,272 @@ def test_download_plan_stages_only_what_the_cache_is_missing(monkeypatch):
     assert plan["entries"][0]["files"] == ["flux1-dev-Q4_K_M.gguf"]
     # The cached base is gone from the total too, or the progress bar waits on bytes nobody fetches.
     assert plan["total_bytes"] == 7 * GB
+
+
+def _seed_cache_file(
+    root,
+    repo_id,
+    filename,
+    sha,
+    *,
+    dangling = False,
+):
+    """Write ``filename`` into a real HF cache layout at ``sha``, refs/main pointing there."""
+    import os as _os
+
+    repo = root / f"models--{repo_id.replace('/', '--')}"
+    (repo / "refs").mkdir(parents = True, exist_ok = True)
+    (repo / "refs" / "main").write_text(sha)
+    target = repo / "snapshots" / sha / filename
+    target.parent.mkdir(parents = True, exist_ok = True)
+    if dangling:
+        # A snapshot entry is a symlink into blobs/; a pruned blob leaves the link but no bytes.
+        _os.symlink(repo / "blobs" / "gone", target)
+    else:
+        target.write_bytes(b"x")
+    return target
+
+
+def _two_cache_roots(monkeypatch, tmp_path):
+    """(live, other) roots wired up the way a mid-session cache-folder change leaves them."""
+    from huggingface_hub import constants as hf_constants
+
+    live = tmp_path / "live"
+    other = tmp_path / "other"
+    live.mkdir()
+    other.mkdir()
+    monkeypatch.setattr("core.inference.diffusion.hub_cache_dir", lambda: str(live))
+    monkeypatch.setattr(hf_constants, "HF_HUB_CACHE", str(other))
+    return live, other
+
+
+def test_files_already_cached_needs_a_revision_to_drop_anything(monkeypatch, tmp_path):
+    """No commit, no verdict. try_to_load_from_cache would otherwise resolve the cache's OWN
+    refs/main, which a republished repo leaves on the superseded commit: the stale blob reads as
+    cached, the file leaves the plan, and the loader pulls the new one outside the panel."""
+    live, _other = _two_cache_roots(monkeypatch, tmp_path)
+    sha = "a" * 40
+    _seed_cache_file(live, "unsloth/FLUX.1-dev-GGUF", "flux1-dev-Q4_K_M.gguf", sha)
+
+    probe = DiffusionBackend._files_already_cached
+    assert probe("unsloth/FLUX.1-dev-GGUF", ["flux1-dev-Q4_K_M.gguf"]) == set()
+    assert probe("unsloth/FLUX.1-dev-GGUF", ["flux1-dev-Q4_K_M.gguf"], sha) == {
+        "flux1-dev-Q4_K_M.gguf"
+    }
+
+
+def test_files_already_cached_ignores_a_superseded_revision(monkeypatch, tmp_path):
+    """The blob is on disk under the old commit and refs/main still names it, but the plan asked
+    about the commit the Hub just reported, so the file stays staged."""
+    live, _other = _two_cache_roots(monkeypatch, tmp_path)
+    _seed_cache_file(live, "unsloth/FLUX.1-dev-GGUF", "flux1-dev-Q4_K_M.gguf", "a" * 40)
+
+    assert (
+        DiffusionBackend._files_already_cached(
+            "unsloth/FLUX.1-dev-GGUF", ["flux1-dev-Q4_K_M.gguf"], "b" * 40
+        )
+        == set()
+    )
+
+
+def test_files_already_cached_reads_both_roots_and_skips_unusable_hits(monkeypatch, tmp_path):
+    """Both roots count: every diffusion fetch passes reuse_other_cache_root, so bytes left in the
+    pre-change root really do satisfy the load. A dangling symlink is a path but not usable bytes,
+    and an absent file is simply missing."""
+    live, other = _two_cache_roots(monkeypatch, tmp_path)
+    sha = "c" * 40
+    repo = "black-forest-labs/FLUX.1-dev"
+    _seed_cache_file(live, repo, "model_index.json", sha)
+    _seed_cache_file(other, repo, "vae/diffusion_pytorch_model.safetensors", sha)
+    _seed_cache_file(live, repo, "text_encoder/model.safetensors", sha, dangling = True)
+
+    assert DiffusionBackend._files_already_cached(
+        repo,
+        [
+            "model_index.json",
+            "vae/diffusion_pytorch_model.safetensors",
+            "text_encoder/model.safetensors",
+            "scheduler/scheduler_config.json",
+        ],
+        sha,
+    ) == {"model_index.json", "vae/diffusion_pytorch_model.safetensors"}
+
+
+def test_files_already_cached_survives_an_unreadable_root(monkeypatch, tmp_path):
+    """A cache we cannot read is not a verdict: the first root raising must not lose the second
+    root's hit, nor abort the files after it."""
+    live, other = _two_cache_roots(monkeypatch, tmp_path)
+    sha = "d" * 40
+    _seed_cache_file(other, "unsloth/FLUX.1-dev-GGUF", "flux1-dev-Q4_K_M.gguf", sha)
+    import huggingface_hub
+
+    real = huggingface_hub.try_to_load_from_cache
+
+    def _boom(
+        repo_id,
+        filename,
+        cache_dir = None,
+        **kwargs,
+    ):
+        if str(cache_dir) == str(live):
+            raise OSError("unreadable")
+        return real(repo_id, filename, cache_dir = cache_dir, **kwargs)
+
+    monkeypatch.setattr(huggingface_hub, "try_to_load_from_cache", _boom)
+
+    assert DiffusionBackend._files_already_cached(
+        "unsloth/FLUX.1-dev-GGUF", ["flux1-dev-Q4_K_M.gguf"], sha
+    ) == {"flux1-dev-Q4_K_M.gguf"}
+
+
+def test_download_plan_stages_only_the_missing_file_of_a_half_cached_repo(monkeypatch):
+    """The delicate case the entry-level tests miss: some files of ONE repo on disk and some not.
+    The entry must survive carrying only what is missing, sized to only what is missing."""
+    _fake_hf_api(
+        monkeypatch,
+        {
+            "unsloth/FLUX.1-dev-GGUF": [_FakeSibling("flux1-dev-Q4_K_M.gguf", 7 * GB)],
+            "black-forest-labs/FLUX.1-dev": _FLUX_BASE_SIBLINGS,
+        },
+    )
+    monkeypatch.setattr(
+        "core.inference.diffusion._resolve_base_repo",
+        lambda *a, **k: "black-forest-labs/FLUX.1-dev",
+    )
+    monkeypatch.setattr(
+        DiffusionBackend, "_dense_quant_prefetch_needed", lambda self, fam, kwargs: False
+    )
+    _no_cache(monkeypatch)
+    # The manifest is on disk, the VAE is not; the checkpoint repo is untouched.
+    monkeypatch.setattr(
+        DiffusionBackend,
+        "_files_already_cached",
+        staticmethod(
+            lambda repo_id, files, revision = None: (
+                set()
+                if repo_id.endswith("-GGUF")
+                else {n for n in files if n != "vae/diffusion_pytorch_model.safetensors"}
+            )
+        ),
+    )
+
+    plan = DiffusionBackend().download_plan(
+        "unsloth/FLUX.1-dev-GGUF", gguf_filename = "flux1-dev-Q4_K_M.gguf"
+    )
+
+    by_repo = {e["repo_id"]: e for e in plan["entries"]}
+    # Staged from the ungated mirror, as every other plan test here: nothing is cached, so
+    # prefer_ungated_mirror swaps the gated vendor id for the one the fetch will really name.
+    assert set(by_repo) == {"unsloth/FLUX.1-dev-GGUF", "unsloth/FLUX.1-dev"}
+    base = by_repo["unsloth/FLUX.1-dev"]
+    assert base["files"] == ["vae/diffusion_pytorch_model.safetensors"]
+    assert base["bytes"] == 300
+    # Derived, so the panel's rows and the bar it drives can never disagree.
+    assert plan["total_bytes"] == sum(e["bytes"] for e in plan["entries"]) == 7 * GB + 300
+    assert all(e["files"] for e in plan["entries"])
+
+
+class _ShaInfo(_FakeInfo):
+    """A model_info that carries a commit, as the real one does."""
+
+    def __init__(self, siblings, sha):
+        super().__init__(siblings)
+        self.sha = sha
+
+
+def _fake_hf_api_with_shas(monkeypatch, repos):
+    """_fake_hf_api, but each repo also reports the commit its listing describes."""
+
+    class _Api:
+        def model_info(
+            self,
+            repo_id,
+            files_metadata = False,
+            token = None,
+        ):
+            siblings, sha = repos[repo_id]
+            return _ShaInfo(siblings, sha)
+
+    monkeypatch.setattr("huggingface_hub.HfApi", lambda *a, **k: _Api())
+
+
+def test_download_plan_pins_each_probe_to_the_commit_it_just_read(monkeypatch):
+    """The sha every model_info reported must reach that repo's own probe, and the MIRROR must be
+    probed at ITS commit: a mirror is a separate repo with its own history, so the vendor's sha
+    would never hit and a cached mirror would re-stage in full."""
+    gguf_sha, vendor_sha, mirror_sha = "f" * 40, "d" * 40, "e" * 40
+    _fake_hf_api_with_shas(
+        monkeypatch,
+        {
+            "unsloth/FLUX.1-dev-GGUF": ([_FakeSibling("flux1-dev-Q4_K_M.gguf", 7 * GB)], gguf_sha),
+            "black-forest-labs/FLUX.1-dev": (_FLUX_BASE_SIBLINGS, vendor_sha),
+            "unsloth/FLUX.1-dev": (_FLUX_BASE_SIBLINGS, mirror_sha),
+        },
+    )
+    monkeypatch.setattr(
+        "core.inference.diffusion._resolve_base_repo",
+        lambda *a, **k: "black-forest-labs/FLUX.1-dev",
+    )
+    monkeypatch.setattr(
+        DiffusionBackend, "_dense_quant_prefetch_needed", lambda self, fam, kwargs: False
+    )
+    _no_cache(monkeypatch)
+    seen: list = []
+    monkeypatch.setattr(
+        DiffusionBackend,
+        "_files_already_cached",
+        staticmethod(
+            lambda repo_id, files, revision = None: seen.append((repo_id, revision)) or set()
+        ),
+    )
+
+    DiffusionBackend().download_plan(
+        "unsloth/FLUX.1-dev-GGUF", gguf_filename = "flux1-dev-Q4_K_M.gguf"
+    )
+
+    assert ("unsloth/FLUX.1-dev-GGUF", gguf_sha) in seen
+    # Nothing is cached, so the swap fired and the base is staged from the mirror.
+    assert ("unsloth/FLUX.1-dev", mirror_sha) in seen
+    assert vendor_sha not in [rev for _repo, rev in seen]
+
+
+def test_download_plan_skips_nothing_when_the_hub_reports_no_commit(monkeypatch):
+    """An old huggingface_hub, or a listing without a sha, must not fall back to the cache's own
+    refs/main: no commit is no verdict, so the pick stages exactly as it did before #8154."""
+    _fake_hf_api(
+        monkeypatch,
+        {
+            "unsloth/FLUX.1-dev-GGUF": [_FakeSibling("flux1-dev-Q4_K_M.gguf", 7 * GB)],
+            "black-forest-labs/FLUX.1-dev": _FLUX_BASE_SIBLINGS,
+        },
+    )
+    monkeypatch.setattr(
+        "core.inference.diffusion._resolve_base_repo",
+        lambda *a, **k: "black-forest-labs/FLUX.1-dev",
+    )
+    monkeypatch.setattr(
+        DiffusionBackend, "_dense_quant_prefetch_needed", lambda self, fam, kwargs: False
+    )
+    _no_cache(monkeypatch)
+    revisions: list = []
+    real = DiffusionBackend._files_already_cached
+
+    def _spy(
+        repo_id,
+        files,
+        revision = None,
+    ):
+        revisions.append(revision)
+        return real(repo_id, files, revision)
+
+    monkeypatch.setattr(DiffusionBackend, "_files_already_cached", staticmethod(_spy))
+
+    plan = DiffusionBackend().download_plan(
+        "unsloth/FLUX.1-dev-GGUF", gguf_filename = "flux1-dev-Q4_K_M.gguf"
+    )
+
+    assert revisions and all(rev is None for rev in revisions)
+    assert {e["repo_id"] for e in plan["entries"]} == {
+        "unsloth/FLUX.1-dev-GGUF",
+        "unsloth/FLUX.1-dev",
+    }

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -5054,6 +5054,7 @@ _FLUX_BASE_SIBLINGS = [
     _FakeSibling("assets/gallery.pdf", 5000),
     _FakeSibling("README.md", 200),
 ]
+_FLUX_BASE_SIBLINGS_BY_NAME = {s.rfilename: s.size for s in _FLUX_BASE_SIBLINGS}
 
 
 def _fake_hf_api(monkeypatch, repos):
@@ -5511,7 +5512,11 @@ def _seed_cache_file(
     target.parent.mkdir(parents = True, exist_ok = True)
     if dangling:
         # A snapshot entry is a symlink into blobs/; a pruned blob leaves the link but no bytes.
-        _os.symlink(repo / "blobs" / "gone", target)
+        # Windows without developer mode cannot make one, and hub writes plain files there too.
+        try:
+            _os.symlink(repo / "blobs" / "gone", target)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this host")
     else:
         target.write_bytes(b"x")
     return target
@@ -5609,9 +5614,10 @@ def test_files_already_cached_survives_an_unreadable_root(monkeypatch, tmp_path)
     ) == {"flux1-dev-Q4_K_M.gguf"}
 
 
-def test_download_plan_stages_only_the_missing_file_of_a_half_cached_repo(monkeypatch):
-    """The delicate case the entry-level tests miss: some files of ONE repo on disk and some not.
-    The entry must survive carrying only what is missing, sized to only what is missing."""
+def test_download_plan_stages_a_half_cached_repo_whole(monkeypatch):
+    """A repo is dropped only when ALL of it is cached. A shrinking file list would 409 a second
+    pick sharing this base, since every diffusion entry rides the one "@diffusion" scope slot and
+    download_registry refuses a claim whose scoped_files differ from the live job's."""
     _fake_hf_api(
         monkeypatch,
         {
@@ -5649,11 +5655,65 @@ def test_download_plan_stages_only_the_missing_file_of_a_half_cached_repo(monkey
     # prefer_ungated_mirror swaps the gated vendor id for the one the fetch will really name.
     assert set(by_repo) == {"unsloth/FLUX.1-dev-GGUF", "unsloth/FLUX.1-dev"}
     base = by_repo["unsloth/FLUX.1-dev"]
-    assert base["files"] == ["vae/diffusion_pytorch_model.safetensors"]
-    assert base["bytes"] == 300
+    # The whole scoped list, not just the missing VAE: the cached file is still staged.
+    assert "vae/diffusion_pytorch_model.safetensors" in base["files"]
+    assert "model_index.json" in base["files"]
+    assert base["bytes"] == sum(
+        size for name, size in _FLUX_BASE_SIBLINGS_BY_NAME.items() if name in base["files"]
+    )
     # Derived, so the panel's rows and the bar it drives can never disagree.
-    assert plan["total_bytes"] == sum(e["bytes"] for e in plan["entries"]) == 7 * GB + 300
+    assert plan["total_bytes"] == sum(e["bytes"] for e in plan["entries"])
     assert all(e["files"] for e in plan["entries"])
+
+
+def test_download_plan_files_do_not_shrink_as_a_repo_warms(monkeypatch):
+    """The scope-slot invariant, stated directly: for one pick, a repo's staged file list is the
+    same whether none or some of it is on disk. Only all-cached removes the entry."""
+
+    def _plan(cached_for_base):
+        mp = pytest.MonkeyPatch()
+        try:
+            _fake_hf_api(
+                mp,
+                {
+                    "unsloth/FLUX.1-dev-GGUF": [_FakeSibling("flux1-dev-Q4_K_M.gguf", 7 * GB)],
+                    "black-forest-labs/FLUX.1-dev": _FLUX_BASE_SIBLINGS,
+                },
+            )
+            mp.setattr(
+                "core.inference.diffusion._resolve_base_repo",
+                lambda *a, **k: "black-forest-labs/FLUX.1-dev",
+            )
+            mp.setattr(
+                DiffusionBackend, "_dense_quant_prefetch_needed", lambda self, fam, kwargs: False
+            )
+            _no_cache(mp)
+            mp.setattr(
+                DiffusionBackend,
+                "_files_already_cached",
+                staticmethod(
+                    lambda repo_id, files, revision = None: (
+                        set() if repo_id.endswith("-GGUF") else set(cached_for_base(files))
+                    )
+                ),
+            )
+            return DiffusionBackend().download_plan(
+                "unsloth/FLUX.1-dev-GGUF", gguf_filename = "flux1-dev-Q4_K_M.gguf"
+            )
+        finally:
+            mp.undo()
+
+    cold = _plan(lambda files: [])
+    half = _plan(lambda files: files[:1])
+    most = _plan(lambda files: files[:-1])
+    warm = _plan(lambda files: files)
+
+    base_files = {e["repo_id"]: e["files"] for e in cold["entries"]}["unsloth/FLUX.1-dev"]
+    for plan in (half, most):
+        staged = {e["repo_id"]: e["files"] for e in plan["entries"]}
+        assert staged["unsloth/FLUX.1-dev"] == base_files
+    # Fully cached is the one state that removes the row.
+    assert "unsloth/FLUX.1-dev" not in {e["repo_id"] for e in warm["entries"]}
 
 
 class _ShaInfo(_FakeInfo):


### PR DESCRIPTION
Picking an image or video model that is already on device staged its repos anyway and listed them in the Downloads panel, which reads as re-downloading a model you already have.

## Cause

`download_plan` names every file the pick needs, and the only thing it skips is a repo that is a **local filesystem path**:

```python
if gguf_filename and not Path(repo_id).expanduser().exists():
if base_files and not Path(base).expanduser().exists():
```

A cached hub repo is neither, so it was planned in full. For `unsloth/Z-Image-Turbo-GGUF` with both repos complete on disk:

```
models--unsloth--Z-Image-Turbo-GGUF   present, 4.4G, blobs: 1,  incomplete: 0
models--Tongyi-MAI--Z-Image-Turbo     present, 7.7G, blobs: 15, incomplete: 0
```

the plan still asked for all 12.9 GB across both entries. Two entries is correct on its own, a GGUF is the transformer only and needs the base repo for the text encoder, VAE, tokenizer and scheduler. Listing them when they are already on disk is not.

The bytes were not actually re-transferred, since each file is found in cache and the job closes immediately, but the entries still appear in the panel and each file is still resolved against the Hub.

## Fix

Drop files already on disk, probed across both roots a load resolves through, the same way `_already_downloaded` and `_resolve_gguf_path` already do it. Cached bytes come off the total too, or the progress bar waits on bytes nobody fetches.

A pick whose files are all cached now yields no entries, and `loadOrStage` already falls through to a direct load when the plan is empty, so nothing is staged and the panel stays clean.

`_estimate_download_bytes` gains an optional per-file size breakdown so a filtered entry can still be sized. Existing callers are unaffected.

## Verification

Live, against a Studio holding both repos in full:

```
before:  entries: unsloth/Z-Image-Turbo-GGUF (4.71 GB) + Tongyi-MAI/Z-Image-Turbo (8.23 GB)
         total_bytes: 12.94 GB
after:   {"entries": [], "total_bytes": 0}
```

Partial caching, which is the common case once a base repo is shared. Requesting an uncached quant with the companion already on disk:

```
unsloth/Z-Image-Turbo-GGUF: 1 file(s), 7.22 GB
total_bytes: 7.22 GB
```

Only the missing checkpoint is staged, the cached 8.2 GB base is dropped, and the total is 7.22 GB rather than 15.4 GB.

Tests, run per file:

```
tests/test_diffusion_backend.py     191 passed
tests/test_diffusion_routes.py       62 passed
tests/test_diffusion_gated_base.py   39 passed
tests/test_video_backend.py          79 passed
tests/test_video_routes.py           40 passed
tests/test_sd_cpp_backend.py         66 passed
```

Two new tests cover fully cached (no entries, zero total) and partially cached (only the missing file, total excludes the cached repo).

The existing plan tests read the real HF cache once a probe exists, so a dev holding FLUX.1-dev would have watched its files get dropped. They now get an autouse fixture reporting nothing cached, and the two new tests stub the probe themselves.

## Notes

Independent of #8149 and #8153. Backend only, and it changes what is staged, never what is loaded: the loader already resolved these files from cache.

Related and not addressed here: the scoped manifest a diffusion load writes is left behind afterwards. #8153 stops that leftover from corrupting the quantization list. Cleaning it up on completion is still worth doing separately.
