### PR TITLE
Pin the accelerator gates in the DiT precision preflight test

### DIFF
--- a/studio/backend/tests/test_xformers_stub_diffusion_parity.py
+++ b/studio/backend/tests/test_xformers_stub_diffusion_parity.py
@@ -253,10 +253,11 @@ def test_dit_training_refuses_dense_precision_under_the_stub(on_windows_rocm, mo
 
 
 @pytest.mark.parametrize("mode", ["fp8", "mxfp8"])
-def test_the_preflight_refuses_the_stub_too(on_windows_rocm, mode):
+def test_the_preflight_refuses_the_stub_too(on_windows_rocm, mode, monkeypatch):
     """The child's guard fires after _free_gpu_for_diffusion_training() has already unloaded residents, so the preflight must reject it first."""
     pytest.importorskip("torch")
     from core.training.diffusion_dit_trainer import _resolve_base_precision
+    from core.training import diffusion_train_common as dtc
     from core.training.diffusion_train_common import training_precision_preflight_error
 
     install_torchao_windows_rocm_stub()
@@ -264,6 +265,14 @@ def test_the_preflight_refuses_the_stub_too(on_windows_rocm, mode):
     with pytest.raises(ValueError, match = "Windows-ROCm stub"):
         _resolve_base_precision(cfg, None, "cuda")
 
+    # Pin the earlier gates: on a CPU-only runner they answer first and correctly,
+    # so without this the assertion below reads their message and the stub gate is
+    # never exercised (it passes only on a GPU host).
+    import torch
+
+    monkeypatch.setattr(dtc, "bf16_unsupported_reason", lambda _f: None)
+    monkeypatch.setattr(dtc, "dit_accelerator_missing_reason", lambda _f: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     # A real DiT family name, or the gate block is skipped and the test proves nothing.
     reason = training_precision_preflight_error("flux.1", mode)
     assert reason and "Windows-ROCm stub" in reason, (


### PR DESCRIPTION
`test_the_preflight_refuses_the_stub_too` has been failing on every Backend CI job since #7981 merged, on all four Python versions. It is a host-dependent test, not a product bug.

The test asserts that `training_precision_preflight_error("flux.1", mode)` names the Windows-ROCm torchao stub. But the preflight checks the gates in the order a real start hits them, and on a runner with no CUDA, XPU or MPS the accelerator gate answers first and correctly:

```
Training the DiT families needs a GPU: even the 4-bit (nf4) base load requires
CUDA, XPU or MPS, and this host has none. Train SDXL here, or use a GPU machine.
```

So the test passes on a GPU box and fails on CI. Reproduced both ways locally: green with GPUs visible, red with `CUDA_VISIBLE_DEVICES=""`, matching the CI output exactly.

The preflight itself is right, and the module docstring already says the behaviour tests are meant to fake the platform probe. This one just missed the accelerator probe, so it pins the two earlier gates and `torch.cuda.is_available` before asserting on the stub gate.

Verified:
- 27/27 in the file with GPUs visible, and 27/27 with `CUDA_VISIBLE_DEVICES=""`.
- Mutation-checked: removing the preflight's `fp8`/`mxfp8` stub gate still fails the test under CPU-only conditions, so it keeps the protection it was written for rather than being defanged.
