### PR TITLE
CI: prune superseded Actions caches

### DIFF
--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -13,10 +13,11 @@ name: Cache janitor
 #   codeql-overlay-base-database-*  keys embed commit SHA + run id
 #   v0-rust-*                       Swatinem/rust-cache
 #
-# Everything else is left alone. The hf-* / *-gguf-* model caches use exact keys
-# with no restore-keys, so an entry that looks superseded is the only one its key
-# will ever match and deleting it costs a multi-GB re-download. Hence the
-# allowlist rather than a newest-N-per-prefix heuristic.
+# Everything else is left alone. The hf-* / *-gguf-* model caches use exact keys,
+# so an entry that looks superseded is the only one its key will ever match and
+# deleting it costs a multi-GB re-download. setup-python does resolve by
+# restore-keys, but its hash is over the dependency file: one generation is live
+# at a time, and a superseded one expires by itself after 7 days unused.
 
 on:
   schedule:

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -70,11 +70,12 @@ jobs:
           all="$RUNNER_TEMP/caches.tsv"
           grouped="$RUNNER_TEMP/grouped.tsv"
 
-          # A non-numeric keep makes `[ n -le KEEP ]` exit 2, and since that test
-          # is the left operand of `&&` set -e does not fire: the `continue` is
-          # skipped and every generation gets deleted, exit 0. Clamp instead.
-          case "$KEEP" in ""|*[!0-9]*) echo "::warning::invalid keep=$KEEP, using 2"; KEEP=2 ;; esac
-          [ "$KEEP" -lt 1 ] && KEEP=1
+          # Whitelist 1..99. Anything `[ n -le KEEP ]` cannot compare exits 2,
+          # and since that test is the left operand of `&&` set -e does not
+          # fire: the `continue` is skipped and every generation gets deleted,
+          # exit 0. All-digit is not enough, since a value past bash's integer
+          # range fails the same way.
+          case "$KEEP" in [1-9]|[1-9][0-9]) ;; *) echo "::warning::invalid keep=$KEEP, using 2"; KEEP=2 ;; esac
 
           # Report a failed inventory. Deleting nothing is the safe direction,
           # but silence means a broken janitor looks identical to a clean repo

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -63,8 +63,14 @@ jobs:
           all="$RUNNER_TEMP/caches.tsv"
           grouped="$RUNNER_TEMP/grouped.tsv"
 
+          # A non-numeric keep makes `[ n -le KEEP ]` exit 2, and since that test
+          # is the left operand of `&&` set -e does not fire: the `continue` is
+          # skipped and every generation gets deleted, exit 0. Clamp instead.
+          case "$KEEP" in ""|*[!0-9]*) echo "::warning::invalid keep=$KEEP, using 2"; KEEP=2 ;; esac
+          [ "$KEEP" -lt 1 ] && KEEP=1
+
           gh api --paginate "repos/$repo/actions/caches?per_page=100" \
-            -q '.actions_caches[] | [.id, .created_at, .size_in_bytes, .key] | @tsv' \
+            -q '.actions_caches[] | [.id, .created_at, .size_in_bytes, .ref, .key] | @tsv' \
             > "$all" || true
 
           total=$(awk -F'\t' '{s+=$3} END {printf "%d", s+0}' "$all")
@@ -72,7 +78,7 @@ jobs:
           echo "$count caches, $(( total / 1073741824 )) GiB, delete=$DELETE keep=$KEEP"
 
           : > "$grouped"
-          while IFS=$'\t' read -r id created size key; do
+          while IFS=$'\t' read -r id created size ref key; do
             [ -z "${id:-}" ] && continue
             case "$key" in
               codeql-overlay-base-database-*)
@@ -84,7 +90,11 @@ jobs:
             # Unshortened means the suffix did not match, which would make
             # generation 1 look like generation N. Skip rather than guess.
             [ "$pre" = "$key" ] && continue
-            printf '%s\t%s\t%s\t%s\n' "$pre" "$created" "$id" "$size" >> "$grouped"
+            # Group per ref, not per key. Caches are ref-scoped: a branch cannot
+            # restore a sibling's, but every branch can restore the default
+            # branch's. Ranking all refs together lets two branch-scoped copies
+            # rank newest and evict the default-branch copy everyone shares.
+            printf '%s\t%s\t%s\t%s\n' "$ref|$pre" "$created" "$id" "$size" >> "$grouped"
           done < "$all"
 
           sort -t"$(printf '\t')" -k1,1 -k2,2r -o "$grouped" "$grouped"

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -80,7 +80,7 @@ jobs:
           # but silence means a broken janitor looks identical to a clean repo
           # and nothing notices until the ceiling does.
           if ! gh api --paginate "repos/$repo/actions/caches?per_page=100" \
-                 -q '.actions_caches[] | [.id, .created_at, .size_in_bytes, .ref, .key] | @tsv' \
+                 -q '.actions_caches[] | [.id, .created_at, .size_in_bytes, .ref, .version, .key] | @tsv' \
                  > "$all"; then
             echo "::warning::could not list caches for $repo; nothing pruned this run"
             exit 0
@@ -91,7 +91,7 @@ jobs:
           echo "$count caches, $(( total / 1073741824 )) GiB, delete=$DELETE keep=$KEEP"
 
           : > "$grouped"
-          while IFS=$'\t' read -r id created size ref key; do
+          while IFS=$'\t' read -r id created size ref ver key; do
             [ -z "${id:-}" ] && continue
             case "$key" in
               codeql-overlay-base-database-*)
@@ -103,11 +103,12 @@ jobs:
             # Unshortened means the suffix did not match, which would make
             # generation 1 look like generation N. Skip rather than guess.
             [ "$pre" = "$key" ] && continue
-            # Group per ref, not per key. Caches are ref-scoped: a branch cannot
-            # restore a sibling's, but every branch can restore the default
-            # branch's. Ranking all refs together lets two branch-scoped copies
-            # rank newest and evict the default-branch copy everyone shares.
-            printf '%s\t%s\t%s\t%s\n' "$ref|$pre" "$created" "$id" "$size" >> "$grouped"
+            # Group per (ref, version), not per key. Lookup is scoped by all
+            # three: a branch cannot restore a sibling's cache, and a path or
+            # compression change mints a new version that is restored
+            # independently. Ranking them together lets two entries from one
+            # scope evict every usable entry of another.
+            printf '%s\t%s\t%s\t%s\n' "$ref|$ver|$pre" "$created" "$id" "$size" >> "$grouped"
           done < "$all"
 
           sort -t"$(printf '\t')" -k1,1 -k2,2r -o "$grouped" "$grouped"

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -9,9 +9,15 @@ name: Cache janitor
 # nothing failing.
 #
 # Deletes only families that resolve via restore-keys, where GitHub returns the
-# most recent match and older generations are already unreachable:
+# most recent prefix match so older generations serve no routine build:
 #   codeql-overlay-base-database-*  keys embed commit SHA + run id
 #   v0-rust-*                       Swatinem/rust-cache
+#
+# "Older" is not the same as unreachable. rust-cache passes its full key to
+# restoreCache, which tries an exact match first, so a build returning to an
+# earlier dependency state (a re-run of an old commit, a lockfile revert) can
+# still hit an older generation exactly. Pruning trades those rare exact hits
+# for headroom, which is the point; keep is the dial.
 #
 # Everything else is left alone. The hf-* / *-gguf-* model caches use exact keys,
 # so an entry that looks superseded is the only one its key will ever match and
@@ -70,9 +76,15 @@ jobs:
           case "$KEEP" in ""|*[!0-9]*) echo "::warning::invalid keep=$KEEP, using 2"; KEEP=2 ;; esac
           [ "$KEEP" -lt 1 ] && KEEP=1
 
-          gh api --paginate "repos/$repo/actions/caches?per_page=100" \
-            -q '.actions_caches[] | [.id, .created_at, .size_in_bytes, .ref, .key] | @tsv' \
-            > "$all" || true
+          # Report a failed inventory. Deleting nothing is the safe direction,
+          # but silence means a broken janitor looks identical to a clean repo
+          # and nothing notices until the ceiling does.
+          if ! gh api --paginate "repos/$repo/actions/caches?per_page=100" \
+                 -q '.actions_caches[] | [.id, .created_at, .size_in_bytes, .ref, .key] | @tsv' \
+                 > "$all"; then
+            echo "::warning::could not list caches for $repo; nothing pruned this run"
+            exit 0
+          fi
 
           total=$(awk -F'\t' '{s+=$3} END {printf "%d", s+0}' "$all")
           count=$(grep -c . "$all" || true)

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+name: Cache janitor
+
+# Keeps Actions cache usage clear of the 50 GB ceiling. At the ceiling GitHub
+# evicts by LRU regardless of reachability, and a partially evicted cache still
+# restores, then misses on the evicted objects: the hit rate collapses with
+# nothing failing.
+#
+# Deletes only families that resolve via restore-keys, where GitHub returns the
+# most recent match and older generations are already unreachable:
+#   codeql-overlay-base-database-*  keys embed commit SHA + run id
+#   v0-rust-*                       Swatinem/rust-cache
+#
+# Everything else is left alone. The hf-* / *-gguf-* model caches use exact keys
+# with no restore-keys, so an entry that looks superseded is the only one its key
+# will ever match and deleting it costs a multi-GB re-download. Hence the
+# allowlist rather than a newest-N-per-prefix heuristic.
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'report = list candidates, delete nothing. delete = prune.'
+        type: choice
+        options: [report, delete]
+        default: report
+      keep:
+        description: 'Generations kept per prefix. 2 so an in-flight run cannot lose the cache it just resolved.'
+        type: string
+        default: '2'
+
+# Two sweeps would race on the same ids and spend their DELETEs on 404s.
+concurrency:
+  group: cache-janitor-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  prune:
+    name: Prune superseded caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: write
+    steps:
+      - name: Prune
+        continue-on-error: true  # housekeeping must never page anyone
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Opt-in string, not a boolean: GitHub coerces an absent input and
+          # `false` alike, so `inputs.mode == false` is true when unset.
+          DELETE: ${{ (github.event_name == 'schedule' || inputs.mode == 'delete') && 'yes' || 'no' }}
+          KEEP: ${{ inputs.keep || '2' }}
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          all="$RUNNER_TEMP/caches.tsv"
+          grouped="$RUNNER_TEMP/grouped.tsv"
+
+          gh api --paginate "repos/$repo/actions/caches?per_page=100" \
+            -q '.actions_caches[] | [.id, .created_at, .size_in_bytes, .key] | @tsv' \
+            > "$all" || true
+
+          total=$(awk -F'\t' '{s+=$3} END {printf "%d", s+0}' "$all")
+          count=$(grep -c . "$all" || true)
+          echo "$count caches, $(( total / 1073741824 )) GiB, delete=$DELETE keep=$KEEP"
+
+          : > "$grouped"
+          while IFS=$'\t' read -r id created size key; do
+            [ -z "${id:-}" ] && continue
+            case "$key" in
+              codeql-overlay-base-database-*)
+                pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{40}-[0-9]+-[0-9]+$//') ;;
+              v0-rust-*)
+                pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{8,}$//') ;;
+              *) continue ;;
+            esac
+            # Unshortened means the suffix did not match, which would make
+            # generation 1 look like generation N. Skip rather than guess.
+            [ "$pre" = "$key" ] && continue
+            printf '%s\t%s\t%s\t%s\n' "$pre" "$created" "$id" "$size" >> "$grouped"
+          done < "$all"
+
+          sort -t"$(printf '\t')" -k1,1 -k2,2r -o "$grouped" "$grouped"
+
+          prev=""; n=0; freed=0; deleted=0
+          while IFS=$'\t' read -r pre created id size; do
+            [ -z "${pre:-}" ] && continue
+            if [ "$pre" != "$prev" ]; then prev="$pre"; n=1; else n=$(( n + 1 )); fi
+            [ "$n" -le "$KEEP" ] && continue
+            if [ "$DELETE" != "yes" ]; then
+              freed=$(( freed + size )); deleted=$(( deleted + 1 )); continue
+            fi
+            # </dev/null or gh eats the loop's stdin and the sweep stops after one.
+            if gh api -X DELETE "repos/$repo/actions/caches/$id" --silent < /dev/null 2>/dev/null; then
+              freed=$(( freed + size )); deleted=$(( deleted + 1 ))
+            fi
+          done < "$grouped"
+
+          after=$(( total - freed ))
+          verb="pruned"; [ "$DELETE" = "yes" ] || verb="would prune"
+          echo "$verb $deleted caches, $(( freed / 1073741824 )) GiB"
+          {
+            echo "### Cache janitor"
+            echo ""
+            echo "| metric | value |"
+            echo "| --- | --- |"
+            echo "| mode | $([ "$DELETE" = yes ] && echo delete || echo 'report only') |"
+            echo "| kept per prefix | $KEEP |"
+            echo "| caches total | $count |"
+            echo "| candidates $verb | $deleted |"
+            echo "| freed | $(( freed / 1073741824 )) GiB |"
+            echo "| usage before | $(( total / 1073741824 )) GiB of 50 GB |"
+            echo "| usage after | $(( after / 1073741824 )) GiB of 50 GB |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$after" -gt 42949672960 ]; then
+            echo "::warning::Cache usage is $(( after / 1073741824 )) GiB of 50 GB after pruning. Lower keep to 1, or find the family that grew."
+          fi


### PR DESCRIPTION
Actions cache usage in this repo is **36.6 GiB of the 50 GB limit** (73%). This adds a scheduled janitor that holds it near 24 GiB.

### Why it matters

At the ceiling GitHub evicts by least-recently-used, and LRU does not respect reachability. A partially evicted cache still *restores*, then misses on the objects that were evicted, so the hit rate collapses with nothing failing and nothing logged. That is exactly the shape of the 6.2% ccache hit rate we chased in llama.cpp before raising its cap.

### What it deletes, and what it deliberately does not

Only families that resolve through `restore-keys` prefix matching. GitHub returns just the most recent match for a prefix, so every older generation is already unreachable: deleting it frees space and changes no hit.

| family | caches | size | why superseded entries are dead |
| --- | --- | --- | --- |
| `codeql-overlay-base-database-*` | 46 | 8.26 GiB | key embeds the analysed commit SHA and run id, so each run mints a fresh entry |
| `v0-rust-*` | 21 | 11.60 GiB | `Swatinem/rust-cache` prefix scheme |

Everything else is held back by an allowlist rather than a heuristic, and that distinction is the whole design. Our hand-written `hf-*` and `*-gguf-*` model caches use **exact keys with no restore-keys at all**, so "older generation" is not a meaningful notion for them: an entry that looks superseded is the one and only entry its key will ever match, and deleting it costs a multi-GB model re-download. A generic newest-N-per-prefix sweep would eat precisely those.

`keep=2` rather than 1 so a run that has already resolved a cache id cannot have it deleted out from under it.

### Measured against the live cache list

Ran the generated script against the real API output with deletes stubbed:

```
235 caches, 36 GiB, delete=no keep=2
would prune 51 caches, 12 GiB
```

- 36 GiB -> 24 GiB, i.e. 73% -> 48% of the limit
- candidate set contained zero `gguf` / `hf-` / `setup-python` / `trusted-signing` / `harden-runner` entries
- kept generations confirmed to be the newest two by `created_at`; everything selected was older
- delete mode issued one DELETE per candidate rather than stopping after the first, confirming the `< /dev/null` guard against `gh` consuming the loop's stdin

Checks: `yaml.safe_load` parses, `bash -n` clean, `shellcheck -S warning` clean.

### Safety

- manual runs **report only** unless `mode=delete` is passed explicitly; only the schedule prunes unattended
- the gate is an opt-in string, not a boolean, because GitHub coerces an absent input and `false` to the same value, which makes `inputs.mode == false` true when the input is unset
- `continue-on-error`, so housekeeping never pages anyone
- `concurrency` group, so two sweeps cannot race on the same ids
- `actions: write` is scoped to the single job, not the workflow

The file is generated by `scripts/make_cache_janitor.py` so the workflow holding delete permissions is reviewable as one diff against a known input. The same file applies unchanged to unsloth-zoo (separate PR).
