### PR TITLE
test(studio): stop the backend suite depending on a live Hub

### DIFF
--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -357,9 +357,7 @@ def _outbound_network_guard():
     """
     import socket
 
-    real = _RealSocketCalls(
-        socket.socket.connect, socket.socket.connect_ex, socket.getaddrinfo
-    )
+    real = _RealSocketCalls(socket.socket.connect, socket.socket.connect_ex, socket.getaddrinfo)
     patch = pytest.MonkeyPatch()
 
     def blocked_connect(self, address, *args, **kwargs):
@@ -420,7 +418,6 @@ def _outbound_network_guard():
         hf_http = None
     if hf_http is not None and getattr(hf_http, "time", None) is not None:
         import time as _time
-
         class _NoBackoffClock:
             def __getattr__(self, name):
                 return getattr(_time, name)

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -209,11 +209,19 @@ _PROXY_ENV_VARS = (
 )
 
 
-def no_proxy_with_test_servers(existing) -> str:
-    """*existing* NO_PROXY, plus every server this suite has to reach directly."""
+def no_proxy_with_test_servers(*existing) -> str:
+    """Every *existing* NO_PROXY value, plus the servers this suite must reach directly.
+
+    Takes all the spellings at once rather than one at a time. A host that exports only
+    ``NO_PROXY`` would otherwise have its entries read for that variable and dropped
+    from the ``no_proxy`` written beside it, and most clients read the lowercase one
+    first -- so a bypass the developer had configured would quietly stop applying.
+    """
     bypass = list(_LOOPBACK_PROXY_BYPASS) + sorted(_configured_server_hosts())
-    parts = [part.strip() for part in (existing or "").split(",")]
-    return ",".join(dict.fromkeys([part for part in parts if part] + bypass))
+    parts = [
+        part.strip() for value in existing for part in (value or "").split(",") if part.strip()
+    ]
+    return ",".join(dict.fromkeys(parts + bypass))
 
 
 # Server URLs the suite is explicitly configured to talk to. Both documented external-server
@@ -375,6 +383,13 @@ def _outbound_network_guard():
     and module-scoped fixtures are setting up, and those are as able to dial out as any
     test body. A fixture that wants out says so with ``allow_outbound()``, since by then
     it is too late for a marker on the test to reach back and lift anything.
+
+    Reaches this interpreter only. A test that spawns a Python process gets a child with
+    ordinary sockets, which is deliberate for the one fixture that does it: ``studio_server``
+    starts a real server in managed mode, and that server is supposed to fetch the GGUF
+    it serves. Blocking the child would break the e2e tests this suite runs on rather
+    than remove a dependency they do not want. Those tests live in ``test_studio_api.py``,
+    which CI skips, and are the only place a child is spawned.
     """
     import socket
 
@@ -461,13 +476,22 @@ def _outbound_network_guard():
     # (test_providers_api's auth_headers and public_key_pem) are session-scoped, so a
     # per-test version would be set up long after they had already tried and failed.
     if any(os.environ.get(name) for name in _PROXY_ENV_VARS):
+        # Both spellings merged once and written back identically, so neither variable
+        # loses what the other one carried.
+        combined = no_proxy_with_test_servers(os.environ.get("NO_PROXY"), os.environ.get("no_proxy"))
         for name in ("NO_PROXY", "no_proxy"):
-            patch.setenv(name, no_proxy_with_test_servers(os.environ.get(name)))
+            patch.setenv(name, combined)
 
     try:
         yield real
     finally:
         patch.undo()
+
+
+@pytest.fixture
+def forget_resolved_servers():
+    """Drop the addresses resolved so far, so a test can check something is refused."""
+    return _RESOLVED_SERVER_ADDRESSES.clear
 
 
 @pytest.fixture(scope = "session")

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -218,6 +218,14 @@ def _configured_server_hosts() -> frozenset:
     return frozenset(hosts)
 
 
+# What those hostnames resolved to during this test. socket.create_connection looks the
+# name up and then dials the numeric result, so allowing the name alone still refuses the
+# connect that follows: by then the destination is an address that matches no name rule.
+# Filled in at resolution time, and only for names the rules already allowed, so the
+# address-literal exemption below cannot widen anything through it.
+_RESOLVED_SERVER_ADDRESSES: set = set()
+
+
 def _host_is_allowed(host) -> bool:
     """True for loopback and for any host the suite was explicitly pointed at."""
     if not isinstance(host, str):
@@ -227,6 +235,7 @@ def _host_is_allowed(host) -> bool:
         lowered.startswith("127.")
         or lowered in _LOOPBACK_HOSTS
         or lowered in _configured_server_hosts()
+        or lowered in _RESOLVED_SERVER_ADDRESSES
     )
 
 
@@ -278,6 +287,10 @@ def _no_outbound_network(request, monkeypatch):
     needs to dial out; the e2e ``studio_server`` tests reach their server on loopback
     and are unaffected.
     """
+    # Per test, so a name a test pointed the env vars at itself does not stay dialable
+    # for the rest of the run.
+    _RESOLVED_SERVER_ADDRESSES.clear()
+
     if request.node.get_closest_marker("allow_network") is not None:
         return
 
@@ -311,13 +324,24 @@ def _no_outbound_network(request, monkeypatch):
         # An address literal consults no resolver, so it cannot stall and is left alone;
         # the SSRF guards resolve private literals on purpose to prove they reject them,
         # and connect() still refuses anything non-loopback afterwards.
-        if _host_is_allowed(host) or _is_ip_literal(host):
-            return real_getaddrinfo(host, port, *args, **kwargs)
-        raise socket.gaierror(
-            socket.EAI_NONAME,
-            f"name resolution blocked in tests ({host!r}); "
-            f"stub the call, or mark the test with @pytest.mark.allow_network",
-        )
+        allowed_by_name = _host_is_allowed(host)
+        if not (allowed_by_name or _is_ip_literal(host)):
+            raise socket.gaierror(
+                socket.EAI_NONAME,
+                f"name resolution blocked in tests ({host!r}); "
+                f"stub the call, or mark the test with @pytest.mark.allow_network",
+            )
+        infos = real_getaddrinfo(host, port, *args, **kwargs)
+        if allowed_by_name:
+            # Carry the permission across the lookup, so the numeric address this hands
+            # back is still dialable. Deliberately not done on the literal branch: that
+            # one exists so a private literal can be resolved and then refused.
+            for info in infos:
+                try:
+                    _RESOLVED_SERVER_ADDRESSES.add(str(info[4][0]).lower())
+                except Exception:
+                    continue
+        return infos
 
     monkeypatch.setattr(socket, "getaddrinfo", guarded_getaddrinfo)
 

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -11,6 +11,7 @@ Model/variant for the managed mode resolve from ``--unsloth-model`` /
 ``--unsloth-gguf-variant``, then env vars, then ``test_studio_api.py`` defaults.
 """
 
+import errno
 import itertools
 import os
 import sys
@@ -56,6 +57,13 @@ def _isolate_studio_home(_studio_home_root, monkeypatch):
 
 
 # Pytest CLI options
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "allow_network: let this test make non-loopback connections (see _no_outbound_network)",
+    )
 
 
 def pytest_addoption(parser):
@@ -181,6 +189,113 @@ def _assume_bare_metal(monkeypatch):
         return
     monkeypatch.setattr(
         routes_inference, "_metal_device_is_paravirtual", lambda: False, raising = False
+    )
+
+
+def _is_local_endpoint(sock, address) -> bool:
+    """True for anything the suite may dial: local IPC and loopback addresses.
+
+    Family first, because AF_UNIX carries a filesystem path rather than a host and
+    multiprocessing's pools connect over exactly that -- reading ``address[0]`` there
+    yields a directory name that matches no host rule and blocks process pools.
+    """
+    import socket as _socket
+
+    if getattr(sock, "family", None) not in (_socket.AF_INET, _socket.AF_INET6):
+        return True
+    try:
+        host = address[0]
+    except Exception:
+        return True
+    if not isinstance(host, str):
+        return True
+    return host.startswith("127.") or host in ("::1", "localhost", "0.0.0.0", "::", "")
+
+
+@pytest.fixture(autouse = True)
+def _no_outbound_network(request, monkeypatch):
+    """Refuse every non-loopback connect, so no test depends on a live Hub.
+
+    Several routes probe huggingface.co on paths these tests exercise, and every one
+    of them fails open, so the traffic never showed up as a failure -- it only showed
+    up as time. When the Hub answers slowly rather than refusing (a rate-limited CI
+    egress IP is the usual way), huggingface_hub retries with backoff and a file that
+    normally runs in six seconds sits there for minutes, until the job hits its cap
+    and is killed having reported nothing.
+
+    Blocking the socket keeps the online code path intact -- unlike HF_HUB_OFFLINE,
+    which flips the branch and changes what is under test -- while making the call
+    fail immediately instead of hanging. Mark a test ``allow_network`` if it genuinely
+    needs to dial out; the e2e ``studio_server`` tests reach their server on loopback
+    and are unaffected.
+    """
+    if request.node.get_closest_marker("allow_network") is not None:
+        return
+
+    import socket
+
+    real_connect = socket.socket.connect
+    real_connect_ex = socket.socket.connect_ex
+
+    def _guard(wrapped):
+        def blocked(self, address, *args, **kwargs):
+            if _is_local_endpoint(self, address):
+                return wrapped(self, address, *args, **kwargs)
+            raise OSError(
+                errno.ENETUNREACH,
+                f"outbound network blocked in tests (tried {address!r}); "
+                f"stub the call, or mark the test with @pytest.mark.allow_network",
+            )
+        return blocked
+
+    monkeypatch.setattr(socket.socket, "connect", _guard(real_connect))
+    monkeypatch.setattr(socket.socket, "connect_ex", _guard(real_connect_ex))
+
+    # A refused connection still looks retryable to huggingface_hub, which backs off
+    # 1+2+4+8+8s over five attempts before giving up -- so blocking the socket without
+    # this turns a fast failure back into a ~23s one per call. Swap the clock only
+    # inside that module, since `time` is shared and real sleeps elsewhere matter.
+    try:
+        from huggingface_hub.utils import _http as hf_http
+    except Exception:
+        return
+    import time as _time
+
+    class _NoBackoffClock:
+        def __getattr__(self, name):
+            return getattr(_time, name)
+
+        @staticmethod
+        def sleep(_seconds):
+            return None
+
+    if getattr(hf_http, "time", None) is not None:
+        monkeypatch.setattr(hf_http, "time", _NoBackoffClock())
+
+
+@pytest.fixture(autouse = True)
+def _hub_reachable_without_probing(monkeypatch):
+    """Report the Hub as reachable without dialling it.
+
+    The reachability probes are themselves network calls, so with outbound traffic
+    blocked they would report the Hub down and send every caller into its offline
+    branch -- which is a different code path from the one these tests mean to cover.
+    Pinning them to "reachable" keeps the online path selected; the individual
+    request that follows is still blocked, and the callers already fail open on it.
+    Tests about offline behaviour patch these back.
+
+    Seeded through the memo rather than by patching ``hf_dns_dead`` /
+    ``hf_unreachable``: callers ``from utils.utils import`` those names, so patching
+    the source module leaves already-imported bindings pointing at the real probes.
+    Every caller reaches the memo through a function that reads the module global at
+    call time, so seeding it covers them all regardless of import style.
+    """
+    import time
+
+    from utils import utils as utils_utils
+
+    monkeypatch.setattr(
+        utils_utils, "_hf_reachability", (time.monotonic(), False), raising = False
     )
 
 

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -478,7 +478,9 @@ def _outbound_network_guard():
     if any(os.environ.get(name) for name in _PROXY_ENV_VARS):
         # Both spellings merged once and written back identically, so neither variable
         # loses what the other one carried.
-        combined = no_proxy_with_test_servers(os.environ.get("NO_PROXY"), os.environ.get("no_proxy"))
+        combined = no_proxy_with_test_servers(
+            os.environ.get("NO_PROXY"), os.environ.get("no_proxy")
+        )
         for name in ("NO_PROXY", "no_proxy"):
             patch.setenv(name, combined)
 

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -11,6 +11,7 @@ Model/variant for the managed mode resolve from ``--unsloth-model`` /
 ``--unsloth-gguf-variant``, then env vars, then ``test_studio_api.py`` defaults.
 """
 
+import contextlib
 import errno
 import itertools
 import os
@@ -225,12 +226,63 @@ def _configured_server_hosts() -> frozenset:
 # address-literal exemption below cannot widen anything through it.
 _RESOLVED_SERVER_ADDRESSES: set = set()
 
+# Lifted only by allow_outbound(), below. A module global rather than something a
+# fixture holds, because the callers that need it run before any per-test fixture
+# exists to hold it for them.
+_outbound_permitted = False
+
+
+@contextlib.contextmanager
+def allow_outbound():
+    """Permit real outbound traffic for the duration of the block.
+
+    For a session- or module-scoped fixture that has to fetch something for real. Those
+    are built before the per-test fixtures, so ``@pytest.mark.allow_network`` on the
+    test that happens to trigger one cannot reach back and lift the guard in time; the
+    fixture has to say so itself. A test body should still use the marker.
+    """
+    global _outbound_permitted
+
+    previous = _outbound_permitted
+    _outbound_permitted = True
+    try:
+        yield
+    finally:
+        _outbound_permitted = previous
+
+
+def _decoded_host(host):
+    """*host* as a comparable string, or None when it is not a name these rules can read.
+
+    The socket API takes a hostname as ``str`` or ``bytes``. Comparing the bytes form
+    against a set of strings matches nothing, so it has to be decoded before the rules
+    see it, or every rule below silently says no and the caller-facing default decides.
+    """
+    if isinstance(host, (bytes, bytearray)):
+        try:
+            return bytes(host).decode("ascii")
+        except UnicodeDecodeError:
+            return None
+    if isinstance(host, str):
+        return host
+    return None
+
 
 def _host_is_allowed(host) -> bool:
-    """True for loopback and for any host the suite was explicitly pointed at."""
-    if not isinstance(host, str):
+    """True for loopback and for any host the suite was explicitly pointed at.
+
+    Anything that is not a readable hostname is refused rather than allowed. Defaulting
+    the other way made ``getaddrinfo(b"huggingface.co", 443)`` a complete way around the
+    guard: the byte string missed every rule, the non-string default let it through to
+    the real resolver, and the address it returned was then dialable.
+    """
+    if host is None:
+        # getaddrinfo(None, port) asks for a local address to bind, not a destination.
         return True
-    lowered = host.lower()
+    decoded = _decoded_host(host)
+    if decoded is None:
+        return False
+    lowered = decoded.strip().lower()
     return (
         lowered.startswith("127.")
         or lowered in _LOOPBACK_HOSTS
@@ -243,10 +295,11 @@ def _is_ip_literal(host) -> bool:
     """True when *host* is already an address, so resolving it consults no resolver."""
     import ipaddress
 
-    if not isinstance(host, str):
+    decoded = _decoded_host(host)
+    if decoded is None:
         return False
     try:
-        ipaddress.ip_address(host.strip("[]"))
+        ipaddress.ip_address(decoded.strip().strip("[]"))
     except ValueError:
         return False
     return True
@@ -270,8 +323,17 @@ def _is_local_endpoint(sock, address) -> bool:
     return _host_is_allowed(host)
 
 
-@pytest.fixture(autouse = True)
-def _no_outbound_network(request, monkeypatch):
+class _RealSocketCalls:
+    """The unpatched socket entry points, kept so a test can hand them back out."""
+
+    def __init__(self, connect, connect_ex, getaddrinfo):
+        self.connect = connect
+        self.connect_ex = connect_ex
+        self.getaddrinfo = getaddrinfo
+
+
+@pytest.fixture(scope = "session", autouse = True)
+def _outbound_network_guard():
     """Refuse every non-loopback connect, so no test depends on a live Hub.
 
     Several routes probe huggingface.co on paths these tests exercise, and every one
@@ -286,53 +348,54 @@ def _no_outbound_network(request, monkeypatch):
     fail immediately instead of hanging. Mark a test ``allow_network`` if it genuinely
     needs to dial out; the e2e ``studio_server`` tests reach their server on loopback
     and are unaffected.
+
+    Installed for the session rather than per test. pytest builds a test's fixtures
+    widest scope first, so a function-scoped guard is not in place yet while session-
+    and module-scoped fixtures are setting up, and those are as able to dial out as any
+    test body. A fixture that wants out says so with ``allow_outbound()``, since by then
+    it is too late for a marker on the test to reach back and lift anything.
     """
-    # Per test, so a name a test pointed the env vars at itself does not stay dialable
-    # for the rest of the run.
-    _RESOLVED_SERVER_ADDRESSES.clear()
-
-    if request.node.get_closest_marker("allow_network") is not None:
-        return
-
     import socket
 
-    real_connect = socket.socket.connect
-    real_connect_ex = socket.socket.connect_ex
+    real = _RealSocketCalls(
+        socket.socket.connect, socket.socket.connect_ex, socket.getaddrinfo
+    )
+    patch = pytest.MonkeyPatch()
 
-    def _guard(wrapped):
-        def blocked(self, address, *args, **kwargs):
-            if _is_local_endpoint(self, address):
-                return wrapped(self, address, *args, **kwargs)
-            raise OSError(
-                errno.ENETUNREACH,
-                f"outbound network blocked in tests (tried {address!r}); "
-                f"stub the call, or mark the test with @pytest.mark.allow_network",
-            )
+    def blocked_connect(self, address, *args, **kwargs):
+        if _outbound_permitted or _is_local_endpoint(self, address):
+            return real.connect(self, address, *args, **kwargs)
+        raise OSError(
+            errno.ENETUNREACH,
+            f"outbound network blocked in tests (tried {address!r}); "
+            f"stub the call, or mark the test with @pytest.mark.allow_network",
+        )
 
-        return blocked
-
-    monkeypatch.setattr(socket.socket, "connect", _guard(real_connect))
-    monkeypatch.setattr(socket.socket, "connect_ex", _guard(real_connect_ex))
+    def blocked_connect_ex(self, address, *args, **kwargs):
+        if _outbound_permitted or _is_local_endpoint(self, address):
+            return real.connect_ex(self, address, *args, **kwargs)
+        # Returned, not raised: connect_ex reports failure with an errno and callers
+        # branch on it (run.py probes a port that way). Raising here would send code
+        # that only handles a non-zero result down a path a real failure never takes.
+        return errno.ENETUNREACH
 
     # Resolution runs before either of those: socket.create_connection, which is what the
     # Hub's HTTP stack ends up in, calls getaddrinfo first. Left live, an uncached request
     # still hits the host resolver and can stall there, so the dependency is not actually
     # gone. Refuse the lookup too, which is also where a real resolver would fail.
-    real_getaddrinfo = socket.getaddrinfo
-
     def guarded_getaddrinfo(host, port, *args, **kwargs):
         # An address literal consults no resolver, so it cannot stall and is left alone;
         # the SSRF guards resolve private literals on purpose to prove they reject them,
         # and connect() still refuses anything non-loopback afterwards.
-        allowed_by_name = _host_is_allowed(host)
+        allowed_by_name = _outbound_permitted or _host_is_allowed(host)
         if not (allowed_by_name or _is_ip_literal(host)):
             raise socket.gaierror(
                 socket.EAI_NONAME,
                 f"name resolution blocked in tests ({host!r}); "
                 f"stub the call, or mark the test with @pytest.mark.allow_network",
             )
-        infos = real_getaddrinfo(host, port, *args, **kwargs)
-        if allowed_by_name:
+        infos = real.getaddrinfo(host, port, *args, **kwargs)
+        if allowed_by_name and not _outbound_permitted:
             # Carry the permission across the lookup, so the numeric address this hands
             # back is still dialable. Deliberately not done on the literal branch: that
             # one exists so a private literal can be resolved and then refused.
@@ -343,7 +406,9 @@ def _no_outbound_network(request, monkeypatch):
                     continue
         return infos
 
-    monkeypatch.setattr(socket, "getaddrinfo", guarded_getaddrinfo)
+    patch.setattr(socket.socket, "connect", blocked_connect)
+    patch.setattr(socket.socket, "connect_ex", blocked_connect_ex)
+    patch.setattr(socket, "getaddrinfo", guarded_getaddrinfo)
 
     # A refused connection still looks retryable to huggingface_hub, which backs off
     # 1+2+4+8+8s over five attempts before giving up -- so blocking the socket without
@@ -352,19 +417,64 @@ def _no_outbound_network(request, monkeypatch):
     try:
         from huggingface_hub.utils import _http as hf_http
     except Exception:
-        return
-    import time as _time
+        hf_http = None
+    if hf_http is not None and getattr(hf_http, "time", None) is not None:
+        import time as _time
 
-    class _NoBackoffClock:
-        def __getattr__(self, name):
-            return getattr(_time, name)
+        class _NoBackoffClock:
+            def __getattr__(self, name):
+                return getattr(_time, name)
 
-        @staticmethod
-        def sleep(_seconds):
-            return None
+            @staticmethod
+            def sleep(_seconds):
+                return None
 
-    if getattr(hf_http, "time", None) is not None:
-        monkeypatch.setattr(hf_http, "time", _NoBackoffClock())
+        patch.setattr(hf_http, "time", _NoBackoffClock())
+
+    try:
+        yield real
+    finally:
+        patch.undo()
+
+
+@pytest.fixture(scope = "session")
+def allow_outbound_network(_outbound_network_guard):
+    """Hand a fixture the context manager that lifts the guard around a real fetch."""
+    return allow_outbound
+
+
+@pytest.fixture(autouse = True)
+def _no_outbound_network(request, monkeypatch, _outbound_network_guard):
+    """Per-test half of the guard: reset what the last test was allowed to reach.
+
+    Also lifts the guard for the whole of an ``allow_network`` test, which is where a
+    marker can still do the job: the test body has not started yet.
+    """
+    # Per test, so a name a test pointed the env vars at itself does not stay dialable
+    # for the rest of the run.
+    _RESOLVED_SERVER_ADDRESSES.clear()
+
+    # A proxy, where one is configured, is dialled instead of the server -- and it is
+    # not what the suite was pointed at, so the guard refuses it and the configured
+    # endpoint is unreachable after all. Bypass the proxy for those hosts rather than
+    # allowing it, since the same proxy would otherwise carry Hub traffic straight
+    # through. Only ever touches hosts the run named itself.
+    configured = _configured_server_hosts()
+    if configured and any(
+        os.environ.get(name) for name in ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
+    ):
+        for name in ("NO_PROXY", "no_proxy"):
+            existing = [part.strip() for part in (os.environ.get(name) or "").split(",")]
+            merged = [part for part in existing if part] + sorted(configured)
+            monkeypatch.setenv(name, ",".join(dict.fromkeys(merged)))
+
+    if request.node.get_closest_marker("allow_network") is not None:
+        import socket
+
+        real = _outbound_network_guard
+        monkeypatch.setattr(socket.socket, "connect", real.connect)
+        monkeypatch.setattr(socket.socket, "connect_ex", real.connect_ex)
+        monkeypatch.setattr(socket, "getaddrinfo", real.getaddrinfo)
 
 
 @pytest.fixture(autouse = True)

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -199,7 +199,14 @@ _LOOPBACK_HOSTS = frozenset({"::1", "localhost", "localhost.localdomain", "0.0.0
 # the empty string, which mean "every interface" to bind() and nothing to a proxy rule.
 _LOOPBACK_PROXY_BYPASS = ("localhost", "localhost.localdomain", "127.0.0.1", "::1")
 
-_PROXY_ENV_VARS = ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy")
+_PROXY_ENV_VARS = (
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+)
 
 
 def no_proxy_with_test_servers(existing) -> str:
@@ -207,6 +214,7 @@ def no_proxy_with_test_servers(existing) -> str:
     bypass = list(_LOOPBACK_PROXY_BYPASS) + sorted(_configured_server_hosts())
     parts = [part.strip() for part in (existing or "").split(",")]
     return ",".join(dict.fromkeys([part for part in parts if part] + bypass))
+
 
 # Server URLs the suite is explicitly configured to talk to. Both documented external-server
 # modes may name a remote host, and neither suite carries the allow_network marker, so

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -192,6 +192,57 @@ def _assume_bare_metal(monkeypatch):
     )
 
 
+_LOOPBACK_HOSTS = frozenset({"::1", "localhost", "localhost.localdomain", "0.0.0.0", "::", ""})
+
+# Server URLs the suite is explicitly configured to talk to. Both documented external-server
+# modes may name a remote host, and neither suite carries the allow_network marker, so
+# blocking them would make a deliberately configured integration run unusable.
+_EXTERNAL_SERVER_ENV_VARS = ("UNSLOTH_E2E_BASE_URL", "STUDIO_TEST_URL")
+
+
+def _configured_server_hosts() -> frozenset:
+    """Hostnames from the external-server env vars, so a configured endpoint stays dialable."""
+    from urllib.parse import urlsplit
+
+    hosts = set()
+    for name in _EXTERNAL_SERVER_ENV_VARS:
+        raw = (os.environ.get(name) or "").strip()
+        if not raw:
+            continue
+        try:
+            host = urlsplit(raw).hostname
+        except ValueError:
+            continue
+        if host:
+            hosts.add(host.lower())
+    return frozenset(hosts)
+
+
+def _host_is_allowed(host) -> bool:
+    """True for loopback and for any host the suite was explicitly pointed at."""
+    if not isinstance(host, str):
+        return True
+    lowered = host.lower()
+    return (
+        lowered.startswith("127.")
+        or lowered in _LOOPBACK_HOSTS
+        or lowered in _configured_server_hosts()
+    )
+
+
+def _is_ip_literal(host) -> bool:
+    """True when *host* is already an address, so resolving it consults no resolver."""
+    import ipaddress
+
+    if not isinstance(host, str):
+        return False
+    try:
+        ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return False
+    return True
+
+
 def _is_local_endpoint(sock, address) -> bool:
     """True for anything the suite may dial: local IPC and loopback addresses.
 
@@ -207,9 +258,7 @@ def _is_local_endpoint(sock, address) -> bool:
         host = address[0]
     except Exception:
         return True
-    if not isinstance(host, str):
-        return True
-    return host.startswith("127.") or host in ("::1", "localhost", "0.0.0.0", "::", "")
+    return _host_is_allowed(host)
 
 
 @pytest.fixture(autouse = True)
@@ -252,6 +301,26 @@ def _no_outbound_network(request, monkeypatch):
     monkeypatch.setattr(socket.socket, "connect", _guard(real_connect))
     monkeypatch.setattr(socket.socket, "connect_ex", _guard(real_connect_ex))
 
+    # Resolution runs before either of those: socket.create_connection, which is what the
+    # Hub's HTTP stack ends up in, calls getaddrinfo first. Left live, an uncached request
+    # still hits the host resolver and can stall there, so the dependency is not actually
+    # gone. Refuse the lookup too, which is also where a real resolver would fail.
+    real_getaddrinfo = socket.getaddrinfo
+
+    def guarded_getaddrinfo(host, port, *args, **kwargs):
+        # An address literal consults no resolver, so it cannot stall and is left alone;
+        # the SSRF guards resolve private literals on purpose to prove they reject them,
+        # and connect() still refuses anything non-loopback afterwards.
+        if _host_is_allowed(host) or _is_ip_literal(host):
+            return real_getaddrinfo(host, port, *args, **kwargs)
+        raise socket.gaierror(
+            socket.EAI_NONAME,
+            f"name resolution blocked in tests ({host!r}); "
+            f"stub the call, or mark the test with @pytest.mark.allow_network",
+        )
+
+    monkeypatch.setattr(socket, "getaddrinfo", guarded_getaddrinfo)
+
     # A refused connection still looks retryable to huggingface_hub, which backs off
     # 1+2+4+8+8s over five attempts before giving up -- so blocking the socket without
     # this turns a fast failure back into a ~23s one per call. Swap the clock only
@@ -290,12 +359,25 @@ def _hub_reachable_without_probing(monkeypatch):
     the source module leaves already-imported bindings pointing at the real probes.
     Every caller reaches the memo through a function that reads the module global at
     call time, so seeding it covers them all regardless of import style.
+
+    The verdict is also pinned fresh for the whole test. The memo expires after
+    ``_HF_REACHABILITY_TTL_S`` (five seconds), so a seed stamped now would lapse in any
+    test that reaches a Hub-guarded operation later than that, and the real probe would
+    run into the blocked socket and select the offline branch this fixture exists to
+    avoid. The stamp is dated far ahead instead, which keeps it fresh under the real
+    freshness rule rather than disabling that rule for every test.
     """
     import time
 
     from utils import utils as utils_utils
 
-    monkeypatch.setattr(utils_utils, "_hf_reachability", (time.monotonic(), False), raising = False)
+    # Dated far ahead rather than by overriding _reachability_fresh: the freshness rule is
+    # itself under test (test_verdict_expires_so_a_disconnect_is_noticed shortens the TTL and
+    # asserts the verdict lapses), so it has to keep working. A future stamp keeps this seed
+    # fresh under the real rule, and a test that writes its own verdict replaces it.
+    monkeypatch.setattr(
+        utils_utils, "_hf_reachability", (time.monotonic() + 10**6, False), raising = False
+    )
 
 
 @pytest.fixture(scope = "session")

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -246,6 +246,7 @@ def _no_outbound_network(request, monkeypatch):
                 f"outbound network blocked in tests (tried {address!r}); "
                 f"stub the call, or mark the test with @pytest.mark.allow_network",
             )
+
         return blocked
 
     monkeypatch.setattr(socket.socket, "connect", _guard(real_connect))
@@ -294,9 +295,7 @@ def _hub_reachable_without_probing(monkeypatch):
 
     from utils import utils as utils_utils
 
-    monkeypatch.setattr(
-        utils_utils, "_hf_reachability", (time.monotonic(), False), raising = False
-    )
+    monkeypatch.setattr(utils_utils, "_hf_reachability", (time.monotonic(), False), raising = False)
 
 
 @pytest.fixture(scope = "session")

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -195,6 +195,19 @@ def _assume_bare_metal(monkeypatch):
 
 _LOOPBACK_HOSTS = frozenset({"::1", "localhost", "localhost.localdomain", "0.0.0.0", "::", ""})
 
+# The spellings worth writing into NO_PROXY. Same set as above minus the wildcards and
+# the empty string, which mean "every interface" to bind() and nothing to a proxy rule.
+_LOOPBACK_PROXY_BYPASS = ("localhost", "localhost.localdomain", "127.0.0.1", "::1")
+
+_PROXY_ENV_VARS = ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy")
+
+
+def no_proxy_with_test_servers(existing) -> str:
+    """*existing* NO_PROXY, plus every server this suite has to reach directly."""
+    bypass = list(_LOOPBACK_PROXY_BYPASS) + sorted(_configured_server_hosts())
+    parts = [part.strip() for part in (existing or "").split(",")]
+    return ",".join(dict.fromkeys([part for part in parts if part] + bypass))
+
 # Server URLs the suite is explicitly configured to talk to. Both documented external-server
 # modes may name a remote host, and neither suite carries the allow_network marker, so
 # blocking them would make a deliberately configured integration run unusable.
@@ -428,10 +441,31 @@ def _outbound_network_guard():
 
         patch.setattr(hf_http, "time", _NoBackoffClock())
 
+    # A proxy, where one is configured, is dialled instead of the server the request
+    # names -- so the guard sees the proxy, which is not what the run was pointed at,
+    # refuses it, and the server is unreachable after all. That applies to the managed
+    # loopback server as much as to a configured remote one: a proxy with no loopback
+    # entry in NO_PROXY swallows localhost requests too.
+    #
+    # Bypassed rather than allowed, since allowing the proxy host would let that same
+    # proxy carry Hub traffic straight through, which is the thing being stopped here.
+    # Done at session scope with everything else: the fixtures that dial these servers
+    # (test_providers_api's auth_headers and public_key_pem) are session-scoped, so a
+    # per-test version would be set up long after they had already tried and failed.
+    if any(os.environ.get(name) for name in _PROXY_ENV_VARS):
+        for name in ("NO_PROXY", "no_proxy"):
+            patch.setenv(name, no_proxy_with_test_servers(os.environ.get(name)))
+
     try:
         yield real
     finally:
         patch.undo()
+
+
+@pytest.fixture(scope = "session")
+def no_proxy_bypass_value():
+    """Hand out the NO_PROXY builder, which is otherwise only reachable as a fixture."""
+    return no_proxy_with_test_servers
 
 
 @pytest.fixture(scope = "session")
@@ -450,20 +484,6 @@ def _no_outbound_network(request, monkeypatch, _outbound_network_guard):
     # Per test, so a name a test pointed the env vars at itself does not stay dialable
     # for the rest of the run.
     _RESOLVED_SERVER_ADDRESSES.clear()
-
-    # A proxy, where one is configured, is dialled instead of the server -- and it is
-    # not what the suite was pointed at, so the guard refuses it and the configured
-    # endpoint is unreachable after all. Bypass the proxy for those hosts rather than
-    # allowing it, since the same proxy would otherwise carry Hub traffic straight
-    # through. Only ever touches hosts the run named itself.
-    configured = _configured_server_hosts()
-    if configured and any(
-        os.environ.get(name) for name in ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
-    ):
-        for name in ("NO_PROXY", "no_proxy"):
-            existing = [part.strip() for part in (os.environ.get(name) or "").split(",")]
-            merged = [part for part in existing if part] + sorted(configured)
-            monkeypatch.setenv(name, ",".join(dict.fromkeys(merged)))
 
     if request.node.get_closest_marker("allow_network") is not None:
         import socket

--- a/studio/backend/tests/test_outbound_network_guard.py
+++ b/studio/backend/tests/test_outbound_network_guard.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Invariant: the suite's outbound-network guard blocks the Hub without blocking the suite.
+
+``conftest._no_outbound_network`` exists so no test depends on huggingface.co being up and
+fast. It has to hold two things apart that look alike from inside a socket call: traffic
+nobody asked for, which must fail immediately, and the server an integration run was
+deliberately pointed at, which must stay reachable.
+
+The ways it got that wrong were only visible end to end, so this covers it there:
+resolution and connection are separate hooks, and a rule enforced on one of them says
+nothing about the other. CPU-only, and every connection here is to this same machine.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+
+import pytest
+
+
+def _own_routable_address(hostname: str) -> str | None:
+    """This host's own non-loopback IPv4, or None if it does not have a usable one."""
+    try:
+        infos = socket.getaddrinfo(hostname, None, socket.AF_INET, socket.SOCK_STREAM)
+    except OSError:
+        return None
+    for info in infos:
+        address = info[4][0]
+        if not address.startswith("127.") and address != "0.0.0.0":
+            return address
+    return None
+
+
+@pytest.fixture
+def offbox_server(monkeypatch):
+    """Yield ``(hostname, address, port)`` for a listener on this host's routable address.
+
+    That address stands in for a remote server: it is off loopback, so the guard treats
+    it exactly as it would treat somebody else's machine, while no packet leaves the box.
+
+    The name is configured before it is resolved, because the guard blocks resolution of
+    anything unconfigured -- including, correctly, this machine's own name.
+
+    Skips where the stand-in is not available: a runner with only loopback configured, or
+    one whose hostname does not resolve, cannot express "a server that is not local".
+    """
+    hostname = socket.gethostname()
+    monkeypatch.setenv("UNSLOTH_E2E_BASE_URL", f"http://{hostname}")
+
+    address = _own_routable_address(hostname)
+    if address is None:
+        pytest.skip("host has no non-loopback IPv4 to stand in for a remote server")
+
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        server.bind((address, 0))
+    except OSError:
+        server.close()
+        pytest.skip(f"cannot bind {address} on this runner")
+    server.listen(8)
+    port = server.getsockname()[1]
+
+    def _accept_quietly():
+        while True:
+            try:
+                conn, _ = server.accept()
+            except OSError:
+                return
+            conn.close()
+
+    threading.Thread(target = _accept_quietly, daemon = True).start()
+    try:
+        yield hostname, address, port
+    finally:
+        server.close()
+
+
+def test_a_server_configured_by_name_is_reachable(monkeypatch, offbox_server):
+    """The regression: allowing the hostname alone is not enough.
+
+    ``socket.create_connection`` resolves first and then dials the numeric result, so a
+    rule that only knows the name refuses the connect that follows it -- the destination
+    is by then an address that matches nothing. A configured endpoint was unusable.
+    """
+    hostname, _address, port = offbox_server
+    monkeypatch.setenv("UNSLOTH_E2E_BASE_URL", f"http://{hostname}:{port}")
+
+    socket.create_connection((hostname, port), timeout = 10).close()
+
+
+def test_a_server_configured_by_address_is_reachable(monkeypatch, offbox_server):
+    """The same endpoint written as an address, which skips the resolver entirely."""
+    _hostname, address, port = offbox_server
+    monkeypatch.setenv("STUDIO_TEST_URL", f"http://{address}:{port}")
+
+    socket.create_connection((address, port), timeout = 10).close()
+
+
+def test_resolving_an_address_literal_does_not_make_it_dialable():
+    """The literal exemption must not become a way through.
+
+    Literals are exempt from the resolution rule because the SSRF tests resolve private
+    ones on purpose to prove they get rejected. That exemption is about the lookup only:
+    the connect has to stay refused, or those tests would start reaching the address
+    they are asserting is unreachable.
+    """
+    socket.getaddrinfo("169.254.169.254", 80, socket.AF_INET, socket.SOCK_STREAM)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(OSError, match = "outbound network blocked"):
+            sock.connect(("169.254.169.254", 80))
+    finally:
+        sock.close()
+
+
+def test_an_unconfigured_name_fails_at_resolution():
+    """Blocked names fail the way an unresolvable name does, which callers already handle."""
+    with pytest.raises(socket.gaierror, match = "name resolution blocked"):
+        socket.getaddrinfo("huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
+
+
+def test_loopback_stays_open():
+    """The guard must not disturb the in-process servers most of the suite runs on."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    try:
+        socket.create_connection(server.getsockname(), timeout = 10).close()
+    finally:
+        server.close()

--- a/studio/backend/tests/test_outbound_network_guard.py
+++ b/studio/backend/tests/test_outbound_network_guard.py
@@ -182,6 +182,24 @@ def test_a_fixture_can_ask_for_the_traffic_it_needs(allow_outbound_network):
         socket.getaddrinfo("huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
 
 
+def test_the_proxy_bypass_covers_the_local_server_too(monkeypatch, no_proxy_bypass_value):
+    """A proxy swallows loopback requests as readily as remote ones.
+
+    With ``HTTP_PROXY`` set and no loopback entry in ``NO_PROXY``, a request to the
+    managed ``studio_server`` is sent to the proxy instead. The guard then refuses the
+    proxy, correctly, and the server on 127.0.0.1 is unreachable through no fault of
+    its own. Naming only the configured external servers left that case out.
+    """
+    monkeypatch.setenv("UNSLOTH_E2E_BASE_URL", "http://studio.example.internal:8000")
+    bypass = no_proxy_bypass_value("corp.example, 10.0.0.1").split(",")
+
+    assert "127.0.0.1" in bypass
+    assert "localhost" in bypass
+    assert "studio.example.internal" in bypass, "the configured server must still be bypassed"
+    assert bypass[:2] == ["corp.example", "10.0.0.1"], "an existing NO_PROXY must survive"
+    assert len(bypass) == len(set(bypass)), "entries must not be duplicated on re-entry"
+
+
 def test_loopback_stays_open():
     """The guard must not disturb the in-process servers most of the suite runs on."""
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/studio/backend/tests/test_outbound_network_guard.py
+++ b/studio/backend/tests/test_outbound_network_guard.py
@@ -15,6 +15,7 @@ nothing about the other. CPU-only, and every connection here is to this same mac
 
 from __future__ import annotations
 
+import errno
 import socket
 import threading
 
@@ -120,6 +121,63 @@ def test_resolving_an_address_literal_does_not_make_it_dialable():
 
 def test_an_unconfigured_name_fails_at_resolution():
     """Blocked names fail the way an unresolvable name does, which callers already handle."""
+    with pytest.raises(socket.gaierror, match = "name resolution blocked"):
+        socket.getaddrinfo("huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
+
+
+def test_a_byte_hostname_is_read_rather_than_waved_through():
+    """The regression: bytes are a hostname too.
+
+    ``socket`` takes a name as ``str`` or ``bytes``. Compared as-is, the byte form
+    matched no rule and fell through to whatever the non-string case did -- which was
+    to allow it. That made ``getaddrinfo(b"huggingface.co", 443)`` a way straight out:
+    real resolution, and the address it returned dialable afterwards.
+    """
+    with pytest.raises(socket.gaierror, match = "name resolution blocked"):
+        socket.getaddrinfo(b"huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
+
+
+def test_a_byte_hostname_for_a_configured_server_still_works(monkeypatch, offbox_server):
+    """Reading the byte form must mean reading it, not refusing it."""
+    hostname, _address, port = offbox_server
+    monkeypatch.setenv("UNSLOTH_E2E_BASE_URL", f"http://{hostname}:{port}")
+
+    infos = socket.getaddrinfo(hostname.encode(), port, socket.AF_INET, socket.SOCK_STREAM)
+    assert infos
+
+
+def test_connect_ex_reports_the_block_the_way_it_reports_a_failure():
+    """connect_ex answers with an errno; callers branch on it rather than catching.
+
+    ``run.py`` probes a port exactly that way. Raising here would send code that only
+    handles a non-zero result down a path an ordinary failed connect_ex never takes.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        assert sock.connect_ex(("169.254.169.254", 80)) == errno.ENETUNREACH
+    finally:
+        sock.close()
+
+
+def test_a_fixture_can_ask_for_the_traffic_it_needs(allow_outbound_network):
+    """The escape hatch for fixtures built before the per-test guard exists.
+
+    Checked at the resolver, which needs no listener and opens no connection. Inside
+    the block the guard must not be what refuses: a runner with no DNS at all is free
+    to refuse for its own reasons, and saying so is the point of reading the message.
+    """
+    with pytest.raises(socket.gaierror, match = "name resolution blocked"):
+        socket.getaddrinfo("huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
+
+    with allow_outbound_network():
+        try:
+            assert socket.getaddrinfo("huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
+        except socket.gaierror as lifted:
+            assert "name resolution blocked" not in str(lifted), (
+                "allow_outbound() did not lift the guard: the lookup inside the block "
+                "was still refused by the guard rather than by the resolver"
+            )
+
     with pytest.raises(socket.gaierror, match = "name resolution blocked"):
         socket.getaddrinfo("huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
 

--- a/studio/backend/tests/test_outbound_network_guard.py
+++ b/studio/backend/tests/test_outbound_network_guard.py
@@ -159,27 +159,29 @@ def test_connect_ex_reports_the_block_the_way_it_reports_a_failure():
         sock.close()
 
 
-def test_a_fixture_can_ask_for_the_traffic_it_needs(allow_outbound_network):
+def test_a_fixture_can_ask_for_the_traffic_it_needs(
+    monkeypatch, allow_outbound_network, offbox_server, forget_resolved_servers
+):
     """The escape hatch for fixtures built before the per-test guard exists.
 
-    Checked at the resolver, which needs no listener and opens no connection. Inside
-    the block the guard must not be what refuses: a runner with no DNS at all is free
-    to refuse for its own reasons, and saying so is the point of reading the message.
+    Dialled by address, at a listener on this machine: no resolver is consulted and no
+    packet leaves the box. Checking the lift against a real hostname would have meant a
+    live lookup with the guard down, which on a runner with slow or blackholed DNS is
+    the stall this whole change exists to remove.
     """
-    with pytest.raises(socket.gaierror, match = "name resolution blocked"):
-        socket.getaddrinfo("huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
+    _hostname, address, port = offbox_server
+    # Undo what the fixture configured, so the address is a stranger again.
+    monkeypatch.delenv("UNSLOTH_E2E_BASE_URL", raising = False)
+    forget_resolved_servers()
+
+    with pytest.raises(OSError, match = "outbound network blocked"):
+        socket.create_connection((address, port), timeout = 10)
 
     with allow_outbound_network():
-        try:
-            assert socket.getaddrinfo("huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
-        except socket.gaierror as lifted:
-            assert "name resolution blocked" not in str(lifted), (
-                "allow_outbound() did not lift the guard: the lookup inside the block "
-                "was still refused by the guard rather than by the resolver"
-            )
+        socket.create_connection((address, port), timeout = 10).close()
 
-    with pytest.raises(socket.gaierror, match = "name resolution blocked"):
-        socket.getaddrinfo("huggingface.co", 443, socket.AF_INET, socket.SOCK_STREAM)
+    with pytest.raises(OSError, match = "outbound network blocked"):
+        socket.create_connection((address, port), timeout = 10)
 
 
 def test_the_proxy_bypass_covers_the_local_server_too(monkeypatch, no_proxy_bypass_value):
@@ -198,6 +200,21 @@ def test_the_proxy_bypass_covers_the_local_server_too(monkeypatch, no_proxy_bypa
     assert "studio.example.internal" in bypass, "the configured server must still be bypassed"
     assert bypass[:2] == ["corp.example", "10.0.0.1"], "an existing NO_PROXY must survive"
     assert len(bypass) == len(set(bypass)), "entries must not be duplicated on re-entry"
+
+
+def test_neither_no_proxy_spelling_loses_what_the_other_carried(no_proxy_bypass_value):
+    """A host that exports only one spelling must not have the other overwrite it.
+
+    Reading one variable and writing both drops the entries the developer set, and
+    clients generally read the lowercase one first -- so the bypass silently stops
+    applying to the host it was written for.
+    """
+    bypass = no_proxy_bypass_value("only-in-uppercase.example", "").split(",")
+    assert "only-in-uppercase.example" in bypass
+
+    both = no_proxy_bypass_value("upper.example", "lower.example").split(",")
+    assert "upper.example" in both and "lower.example" in both
+    assert len(both) == len(set(both))
 
 
 def test_loopback_stays_open():

--- a/studio/backend/tests/test_providers_api.py
+++ b/studio/backend/tests/test_providers_api.py
@@ -163,13 +163,18 @@ def public_key_pem(auth_headers: dict[str, str]) -> str:
 
 
 @pytest.fixture(scope = "session")
-def vision_image_data_url() -> str:
+def vision_image_data_url(allow_outbound_network) -> str:
     """Download the sloth image once per session as a base64 data URI.
 
     A data URI sends the image inline; Gemini's OpenAI-compatible layer doesn't
     fetch external HTTP URLs, so raw image_url links give empty Gemini replies.
+
+    This one genuinely fetches, so it says so: the suite otherwise blocks outbound
+    traffic, and a session fixture is built before the per-test guard can be told to
+    make an exception for it.
     """
-    resp = requests.get(_VISION_IMAGE_URL, timeout = 30)
+    with allow_outbound_network():
+        resp = requests.get(_VISION_IMAGE_URL, timeout = 30)
     resp.raise_for_status()
     content_type = resp.headers.get("Content-Type", "image/jpeg").split(";")[0].strip()
     b64 = base64.b64encode(resp.content).decode("utf-8")

--- a/studio/backend/tests/test_stt_review_fixes_4.py
+++ b/studio/backend/tests/test_stt_review_fixes_4.py
@@ -182,11 +182,17 @@ def test_status_reads_do_not_block_during_a_llama_cpp_update():
         ), "a status read blocked for the length of the llama.cpp install"
 
 
-def test_ggml_download_drops_its_adopted_pid(monkeypatch):
+def test_ggml_download_drops_its_adopted_pid(monkeypatch, tmp_path):
     """spawn_download() adopts a PID; left adopted it can be reused, and
     terminate_all would then signal whatever inherited it.
     """
     forgotten = []
+
+    # Once metadata resolves, _run() prepares the repo's cache for HTTP before it
+    # reaches the stubbed worker, and that writes: it creates the repo directory and
+    # a .transport marker. The session conftest deliberately pins HF_HUB_CACHE to the
+    # developer's real cache, so without a cache of its own this test edits it.
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "hub"))
 
     class _Finished:
         pid = 7777

--- a/studio/backend/tests/test_stt_review_fixes_4.py
+++ b/studio/backend/tests/test_stt_review_fixes_4.py
@@ -196,6 +196,28 @@ def test_ggml_download_drops_its_adopted_pid(monkeypatch):
             return 0
 
     monkeypatch.setattr(ggml_mod, "_cached_model_path", lambda model_id: None)
+    # _run() opens with a HEAD to the Hub for the size and etag. It is best-effort and
+    # swallows its own errors, but leaving it live makes this test depend on a network
+    # round trip it does not care about, so answer it locally.
+    import huggingface_hub
+
+    class _Metadata:
+        """Stands in for HfFileMetadata; unset fields read as None, as they may on the Hub.
+
+        ``commit_hash`` has to be a real-looking sha: _run() pins the download to an
+        immutable revision and refuses anything that is not one.
+        """
+
+        size = 1
+        etag = "stub"
+        commit_hash = "0" * 40
+
+        def __getattr__(self, _name):
+            return None
+
+    monkeypatch.setattr(
+        huggingface_hub, "get_hf_file_metadata", lambda *a, **k: _Metadata(), raising = False
+    )
     import core.inference.stt_download_worker as worker_mod
 
     monkeypatch.setattr(worker_mod, "spawn_download", lambda *a, **k: _Finished())

--- a/studio/backend/tests/test_training_streaming_mlx_warm.py
+++ b/studio/backend/tests/test_training_streaming_mlx_warm.py
@@ -61,6 +61,27 @@ def hardware_globals():
         hw.DEVICE, hw.CHAT_ONLY, hw.CHAT_ONLY_REASON, hw.IS_ROCM = saved
 
 
+@pytest.fixture(autouse = True)
+def _hub_preflight_passes(monkeypatch):
+    """Let the Hub preflights succeed without asking the Hub.
+
+    This file is about the MLX guard, and its docstring already promises no network,
+    but ``start_training`` verifies the model and dataset against huggingface.co on
+    the way past validation. That call used to reach the real Hub, so the tests were
+    quietly online and would 503 whenever it was slow or unreachable.
+    """
+    monkeypatch.setattr(training_routes, "_preflight_hf_dataset_request", lambda request: None)
+    monkeypatch.setattr(
+        training_routes,
+        "_reject_untrainable_model_request",
+        lambda request, *args, **kwargs: training_routes._ModelPreflightResult(
+            model_name = request.model_name,
+            model_local_path = None,
+            cached_model_pin = None,
+        ),
+    )
+
+
 @pytest.fixture
 def spawn_calls(monkeypatch):
     """Stub the backend so a start past validation is observable without a worker."""


### PR DESCRIPTION
The backend tests reach `huggingface.co`. Attributing every DNS lookup to the test that caused it: **83 tests across 24 files, 178 lookups per run, 161 of them to the Hub.**

Nothing chose this. Routes like the training guard and the diffusion classifier probe the Hub on paths these tests exercise, the tests pass real repo ids such as `unsloth/Qwen3-1.7B`, and no layer stubs the HTTP underneath.

## Why it never showed up as a failure

Those probes fail open. A network error returns `None`, or `"default"`, or "unknown", and the assertion still holds, so the suite is green whether or not the Hub answers. It only showed up as time:

- HF pointed at an address that **refuses** instantly: `test_chat_load_during_training.py` passes in `10.8s`.
- HF pointed at a socket that **accepts and never answers**: the same file, normally `6s`, hangs until it is killed.

That second case is what a rate-limited CI egress IP looks like. `huggingface_hub` retries with backoff, the job burns its 15 minute cap and reports nothing. Several `Backend CI` jobs have been cancelled exactly that way, always going quiet around 5%, which is where that file sits in the run order. The captured stderr from a reproduction:

```
ReadTimeoutError(... Read timed out. (read timeout=10))
  thrown while requesting HEAD .../unsloth/DiffusionGemma-GGUF/resolve/main/adapter_config.json
Retrying in 1s [Retry 1/5].
```

## The change

Block non-loopback connects for every test. **Deliberately not `HF_HUB_OFFLINE=1`**: that flips callers into their offline branch, which is a different path from the one under test, and 46 tests fail under it because they assert online behaviour. A blocked socket keeps the online path selected and only makes the request fail, which the callers already handle.

Three details the guard needs, each found the hard way:

- **Dispatch on socket family, not on the address.** `AF_UNIX` carries a filesystem path and multiprocessing pools connect over it, so an address-only rule blocks process pools (`test_dataset_map_num_proc`).
- **Seed the reachability memo** rather than patch `hf_dns_dead` / `hf_unreachable`. Callers `from utils.utils import` those names, so patching the source module leaves earlier bindings on the real probes.
- **Neutralise huggingface_hub's backoff clock**, scoped to its own module. A refused connection still looks retryable, so without this each blocked call costs `1+2+4+8+8s`. `test_active_generations.py` went `10.4s` to `57.6s` and one test flipped; with it, `11.3s` and green.

Two test files needed their Hub calls stubbed. `test_training_streaming_mlx_warm.py` already promised `"CPU-only, no network, no GPU, no weights"` in its docstring, which it was not.

## Verification

Full suite: **18868 passed, 74 skipped, 0 failed**, no outbound traffic. Runtime unchanged; per file the guard is a touch faster, since nothing waits on a round trip. Also run on a staging replica of this branch.

`@pytest.mark.allow_network` is there for a test that genuinely needs to dial out. **No production code changes.**

Unrelated and pre-existing: `Repo tests (CPU)` fails on `tests/studio/install/test_install_llama_prebuilt_logic.py` with `fake_validate() got an unexpected keyword argument 'rocm_gfx'`. I verified that fails identically on plain `main` at `63bc5aa65`, and it lives under a different conftest that this change does not touch.