### PR TITLE
Studio: exempt shared top-level trees from the integrity check for our own wheels too

### DIFF
--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -1894,6 +1894,28 @@ class TestVenvDirFileIntegrity:
         )
         assert _venv_dir_is_valid_and_undamaged(str(venv_dir), ("transformers==5.3.0",))
 
+    def test_shared_non_runtime_rows_are_ignored_for_our_own_wheels_too(self, tmp_path: Path):
+        """Unreliable ownership is a property of the path, not of the claimant.
+        unsloth_zoo <= 2026.8.5 shipped a top-level tests/ into the same squatted
+        namespace, so exempting only third parties left it reported forever."""
+        venv_dir = self._make_venv(
+            tmp_path / "venv",
+            pkg = "unsloth_zoo",
+            record_extra = ["tests/conftest.py,sha256=deadbeef,11429"],
+        )
+        assert _venv_dir_is_valid_and_undamaged(str(venv_dir), ("unsloth_zoo==5.3.0",))
+
+    def test_our_own_runtime_tree_is_still_checked(self, tmp_path: Path):
+        """Only the shared roots are exempt. A tests/ tree inside our package is
+        ours alone, so damage there still forces the wipe-and-reinstall."""
+        venv_dir = self._make_venv(
+            tmp_path / "venv",
+            pkg = "unsloth_zoo",
+            files = {"unsloth_zoo/__init__.py": "x" * 40, "unsloth_zoo/tests/h.py": "y" * 10},
+        )
+        (venv_dir / "unsloth_zoo" / "tests" / "h.py").unlink()
+        assert not _venv_dir_is_valid_and_undamaged(str(venv_dir), ("unsloth_zoo==5.3.0",))
+
     def test_an_installer_rewritten_file_keeps_its_existence_check(self, tmp_path: Path):
         """setup.ps1 runs npm install in the installed tree, so the lockfile's
         recorded size drifts. npm never deletes it, so only the size is dropped."""

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2000,7 +2000,6 @@ _SHARED_NON_RUNTIME_ROOTS = frozenset(
     )
 )
 _INSTALLER_REWRITTEN_NAMES = frozenset(("package-lock.json",))
-_OUR_DISTRIBUTIONS = frozenset(("unsloth", "unsloth-zoo", "unsloth-studio"))
 
 
 def _sidecar_damaged_files(venv_dir: str, limit: int = 3) -> list[str]:
@@ -2096,14 +2095,10 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
                 or (parts and parts[0] in ("bin", "Scripts"))
             ):
                 continue
-            # Third-party top-level dirs several wheels write into, so one uninstall
-            # deletes another's files. Never applied to what we ship: a missing
-            # __init__.py does not make a directory unimportable (PEP 420).
-            if (
-                len(parts) > 1
-                and parts[0] in _SHARED_NON_RUNTIME_ROOTS
-                and name.replace("_", "-").lower() not in _OUR_DISTRIBUTIONS
-            ):
+            # Top-level dirs several wheels write into, so one uninstall deletes
+            # another's files. Unreliable ownership is a property of the path, so
+            # this covers what we ship too; see _shared_non_runtime in _studio_deps.
+            if len(parts) > 1 and parts[0] in _SHARED_NON_RUNTIME_ROOTS:
                 continue
             # The size field is optional and real wheels do leave it blank. Keep the row with an
             # unknown size: existence is still checkable, and dropping it hides a deletion.

--- a/unsloth_cli/_studio_deps.py
+++ b/unsloth_cli/_studio_deps.py
@@ -220,7 +220,8 @@ def _scan_paths() -> Dict[str, list]:
 # Top-level dirs several wheels write into, so one uninstall deletes another's
 # files and the survivor's RECORD describes a file nothing recreates. einx and
 # torchao both ship test/conftest.py, and install_python_stack.py
-# force-reinstalls torchao every update.
+# force-reinstalls torchao every update; unsloth_zoo <= 2026.8.5 shipped
+# tests/ and scripts/ into the same squatted namespace.
 _SHARED_NON_RUNTIME_ROOTS = frozenset(
     (
         "test",
@@ -243,26 +244,21 @@ _SHARED_NON_RUNTIME_ROOTS = frozenset(
 _INSTALLER_REWRITTEN_NAMES = frozenset(("package-lock.json",))
 
 
-def _shared_non_runtime(rel: str, name: str) -> bool:
-    """A third-party row under a top-level dir several wheels write into.
+def _shared_non_runtime(rel: str) -> bool:
+    """A row under a top-level dir several wheels write into.
 
     Ownership of these is unreliable: whichever wheel installed last wins, and
-    any of them uninstalling takes the others' files with it. Never applied to
-    what we ship, because a missing __init__.py does NOT make a directory
-    unimportable (PEP 420) and this repo imports scripts.* itself, so our own
-    top-level trees stay checked. Applied while reading RECORD, not when
-    reporting, so the row also stays out of the ownership tally and the `limit`
-    budget.
+    any of them uninstalling takes the others' files with it. That is a property
+    of the path, not of the distribution claiming it, so it holds for what we
+    ship too: unsloth_zoo <= 2026.8.5 packaged a top-level tests/ and scripts/,
+    nothing imports either at runtime, and a clobbered copy wedged every update
+    with `unsloth_zoo: tests/conftest.py is 8107 bytes, expected 11429`. Our
+    runtime trees are unaffected, since none of them is named for a shared root.
+    Applied while reading RECORD, not when reporting, so the row also stays out
+    of the ownership tally and the `limit` budget.
     """
-    if _canonical(name) in _OUR_DISTRIBUTIONS:
-        return False
     parts = tuple(p for p in rel.replace("\\", "/").split("/") if p and p != ".")
     return len(parts) > 1 and parts[0] in _SHARED_NON_RUNTIME_ROOTS
-
-
-# What Unsloth ships. Its top-level trees are ours to guarantee, so they are
-# never exempted however they are named.
-_OUR_DISTRIBUTIONS = frozenset(("unsloth", "unsloth-zoo", "unsloth-studio"))
 
 
 def _installer_rewritten(rel: str) -> bool:
@@ -335,7 +331,7 @@ def damaged_installed_files(limit: int = 8) -> List[str]:
             # size recorded inside itself; .pyc is regenerated from source.
             if ".dist-info/" in rel or ".egg-info/" in rel or rel.endswith(".pyc"):
                 continue
-            if _shared_non_runtime(rel, name):
+            if _shared_non_runtime(rel):
                 continue
             # The size field is optional and real wheels do leave it blank. Keep
             # the row anyway with an unknown size: existence is still checkable,

--- a/unsloth_cli/tests/test_studio_update_verify.py
+++ b/unsloth_cli/tests/test_studio_update_verify.py
@@ -689,13 +689,40 @@ def test_ignored_rows_do_not_consume_the_finding_budget(site):
     assert len(found) == 1 and "tau/__init__.py is missing" in found[0]
 
 
-def test_our_own_top_level_trees_are_still_checked(site):
-    # A missing __init__.py does not make a directory unimportable (PEP 420),
-    # and this repo imports scripts.* itself, so the shared-namespace exemption
-    # must never apply to what Unsloth ships.
+def test_our_own_shared_top_level_trees_are_exempt_too(site):
+    # Reported as `unsloth_zoo: tests/conftest.py is 8107 bytes, expected 11429`
+    # on an install that was already current, so the update failed on every
+    # retry. 11429 is the size in the 2026.8.5 wheel, which shipped a top-level
+    # tests/ that any other wheel using that name overwrites. Squatting the
+    # namespace does not make it ours, and nothing imports it at runtime.
+    conftest = "tests/conftest.py"
+    _make_dist(
+        site,
+        "unsloth_zoo",
+        {"unsloth_zoo/__init__.py": b"z\n", conftest: b"c" * 8107},
+        record_sizes = {conftest: 11429},
+    )
+    assert _deps().damaged_installed_files() == []
+
+
+def test_our_own_shared_top_level_trees_may_also_vanish(site):
+    # Same path, deleted rather than overwritten: the einx shape, but claimed by
+    # a distribution of ours. No reinstall repairs it either.
     _make_dist(site, "unsloth_zoo", {"unsloth_zoo/__init__.py": b"z\n"})
     (site / "unsloth_zoo-1.0.dist-info" / "RECORD").write_text(
         "unsloth_zoo/__init__.py,sha256=x,2\nscripts/helper.py,sha256=x,99\n"
     )
+    assert _deps().damaged_installed_files() == []
+
+
+def test_our_own_runtime_trees_are_still_checked(site):
+    # The exemption is scoped to the shared roots. Everything Unsloth actually
+    # imports lives outside them and must still fail an update when damaged.
+    _make_dist(
+        site,
+        "unsloth_zoo",
+        {"unsloth_zoo/__init__.py": b"z\n", "unsloth_zoo/tests/helper.py": b"h\n"},
+    )
+    (site / "unsloth_zoo" / "tests" / "helper.py").unlink()
     found = _deps().damaged_installed_files()
-    assert len(found) == 1 and "scripts/helper.py is missing" in found[0]
+    assert len(found) == 1 and "unsloth_zoo/tests/helper.py is missing" in found[0]


### PR DESCRIPTION
## Summary

Apply the shared-top-level-tree exemption in Studio's post-update integrity check to Unsloth's own distributions as well. Without it, `unsloth studio update` fails on every attempt with a finding no reinstall can clear.

## Motivation

#8092 added `_SHARED_NON_RUNTIME_ROOTS` so a row under a squatted top-level namespace (`test/`, `tests/`, `docs/`, `scripts/`, ...) no longer counts as damage. Ownership of those paths is unreliable: whichever wheel installs last wins, and any of them uninstalling takes the others' files with it.

It exempted third parties only. The reasoning was that a missing `__init__.py` does not make a directory unimportable and that the repo imports `scripts.*` itself, so our own top-level trees should stay guaranteed. That does not hold in practice. Nothing under `unsloth/`, `unsloth_cli/` or `studio/` imports a top-level `scripts` or `tests` at runtime, and unsloth ships neither. unsloth_zoo did: every release from 2026.5.2 to 2026.8.5 packaged the repo's `tests/` and `scripts/` trees into site-packages, straight into the same shared namespace.

So the carve-out singled out the one distribution of ours that was actually exposed to the collision:

```
Update finished, but some installed files are damaged:
  unsloth_zoo: tests/conftest.py is 8107 bytes, expected 11429
```

11429 is exactly `tests/conftest.py` in the 2026.8.5 wheel, so the recorded size is ours and the file on disk is not. This was reported on 2026.8.8, which already carries #8092, on an install that was otherwise up to date. The `einx` and `package-lock.json` findings were gone and only this one remained, on every retry. The printed remedy cannot help, because pip sees intact metadata and nothing is really damaged.

Ownership being unreliable is a property of the path, not of the distribution claiming it. unsloth-zoo#1016 stops shipping the two trees, but anyone who already has unsloth_zoo 2026.5.2 through 2026.8.5 installed keeps the polluted site-packages, so the check has to tolerate it.

## Changes

- `unsloth_cli/_studio_deps.py`: drop the `_OUR_DISTRIBUTIONS` carve-out from `_shared_non_runtime`, which no longer needs the distribution name.
- `studio/backend/utils/transformers_version.py`: same carve-out removed from the sidecar scan, keeping the two implementations in sync.
- Tests for the reported shrinkage, for the deletion shape, and for our runtime trees still being checked.

The exemption stays scoped to the shared roots. `unsloth_zoo/tests/helper.py` is inside a package we own and is still reported when it goes missing, as is every other runtime path.

## How to test

```bash
python -m pytest unsloth_cli/tests/test_studio_update_verify.py studio/backend/tests/test_transformers_version.py tests/python/test_windows_studio_update_launcher.py unsloth_cli/tests/test_studio_update_local_repo.py -q
```

413 passed. Full `unsloth_cli/tests`: 942 passed, 4 skipped. Reverting only the two source files while keeping the new tests fails all three of the added cases and passes both "still checked" guards.

## Related

- unslothai/unsloth-zoo#1016 removes the top-level `tests/` and `scripts/` from the wheel, which fixes the cause for new installs.
- #8092 introduced the exemption this widens.
