### PR TITLE
Count a RECORD path claim before the row is filtered out

### DIFF
--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2097,8 +2097,7 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
                 continue
             target = root / rel
             key = os.path.normcase(str(target))
-            # Count every real claim before filtering, or a dropped row's file is
-            # measured against a retained row's RECORD.
+            # Before the filter: a dropped row still owns the path it claims.
             owners[key] = owners.get(key, 0) + 1
             # Top-level dirs several wheels write into, so one uninstall deletes
             # another's files. Unreliable ownership is a property of the path, so

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2095,6 +2095,11 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
                 or (parts and parts[0] in ("bin", "Scripts"))
             ):
                 continue
+            target = root / rel
+            key = os.path.normcase(str(target))
+            # Count every real claim before filtering, or a dropped row's file is
+            # measured against a retained row's RECORD.
+            owners[key] = owners.get(key, 0) + 1
             # Top-level dirs several wheels write into, so one uninstall deletes
             # another's files. Unreliable ownership is a property of the path, so
             # this covers what we ship too; see _shared_non_runtime in _studio_deps.
@@ -2110,9 +2115,6 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
                     recorded = int(row[2])
                 except ValueError:
                     recorded = None
-            target = root / rel
-            key = os.path.normcase(str(target))
-            owners[key] = owners.get(key, 0) + 1
             entries.append((name, rel, recorded, target, key))
 
     found: list[str] = []

--- a/unsloth_cli/_studio_deps.py
+++ b/unsloth_cli/_studio_deps.py
@@ -255,7 +255,10 @@ def _shared_non_runtime(rel: str) -> bool:
     with `unsloth_zoo: tests/conftest.py is 8107 bytes, expected 11429`. Our
     runtime trees are unaffected, since none of them is named for a shared root.
     Applied while reading RECORD, not when reporting, so the row also stays out
-    of the ownership tally and the `limit` budget.
+    of the `limit` budget. Its ownership claim is still counted: dropping a
+    colliding row before the tally is what made a retained row look singly
+    owned, which is how the size of somebody else's file got compared against
+    unsloth_zoo's RECORD.
     """
     parts = tuple(p for p in rel.replace("\\", "/").split("/") if p and p != ".")
     return len(parts) > 1 and parts[0] in _SHARED_NON_RUNTIME_ROOTS
@@ -331,6 +334,15 @@ def damaged_installed_files(limit: int = 8) -> List[str]:
             # size recorded inside itself; .pyc is regenerated from source.
             if ".dist-info/" in rel or ".egg-info/" in rel or rel.endswith(".pyc"):
                 continue
+            try:
+                target = dist.locate_file(rel)
+            except Exception:
+                continue
+            key = os.path.normcase(str(target))
+            # Every real claim counts, including one about to be filtered out.
+            # Filtering first is what let a dropped row's file be measured
+            # against a retained row's RECORD.
+            owners[key] = owners.get(key, 0) + 1
             if _shared_non_runtime(rel):
                 continue
             # The size field is optional and real wheels do leave it blank. Keep
@@ -342,12 +354,6 @@ def damaged_installed_files(limit: int = 8) -> List[str]:
                     recorded = int(row[2])
                 except ValueError:
                     recorded = None
-            try:
-                target = dist.locate_file(rel)
-            except Exception:
-                continue
-            key = os.path.normcase(str(target))
-            owners[key] = owners.get(key, 0) + 1
             entries.append((name, rel, recorded, target, key))
 
     found: List[str] = []

--- a/unsloth_cli/_studio_deps.py
+++ b/unsloth_cli/_studio_deps.py
@@ -255,10 +255,9 @@ def _shared_non_runtime(rel: str) -> bool:
     with `unsloth_zoo: tests/conftest.py is 8107 bytes, expected 11429`. Our
     runtime trees are unaffected, since none of them is named for a shared root.
     Applied while reading RECORD, not when reporting, so the row also stays out
-    of the `limit` budget. Its ownership claim is still counted: dropping a
-    colliding row before the tally is what made a retained row look singly
-    owned, which is how the size of somebody else's file got compared against
-    unsloth_zoo's RECORD.
+    of the `limit` budget. Its claim is still counted: dropping a colliding row
+    before the tally is what made a retained row look singly owned, so another
+    distribution's file got measured against unsloth_zoo's RECORD.
     """
     parts = tuple(p for p in rel.replace("\\", "/").split("/") if p and p != ".")
     return len(parts) > 1 and parts[0] in _SHARED_NON_RUNTIME_ROOTS
@@ -339,9 +338,7 @@ def damaged_installed_files(limit: int = 8) -> List[str]:
             except Exception:
                 continue
             key = os.path.normcase(str(target))
-            # Every real claim counts, including one about to be filtered out.
-            # Filtering first is what let a dropped row's file be measured
-            # against a retained row's RECORD.
+            # Before the filter: a dropped row still owns the path it claims.
             owners[key] = owners.get(key, 0) + 1
             if _shared_non_runtime(rel):
                 continue

--- a/unsloth_cli/tests/test_studio_update_verify.py
+++ b/unsloth_cli/tests/test_studio_update_verify.py
@@ -705,6 +705,19 @@ def test_our_own_shared_top_level_trees_are_exempt_too(site):
     assert _deps().damaged_installed_files() == []
 
 
+def test_two_distributions_claiming_one_shared_path(site):
+    # The real shape: a third party also ships tests/conftest.py and lands last,
+    # so the bytes on disk match its RECORD and are shorter than unsloth_zoo's.
+    # Neither the drift nor the deletion can affect startup.
+    rel = "tests/conftest.py"
+    _make_dist(site, "unsloth_zoo", {rel: b"u" * 11429})
+    _make_dist(site, "upsilon", {rel: b"c" * 8107})
+    assert (site / rel).stat().st_size == 8107
+    assert _deps().damaged_installed_files() == []
+    (site / rel).unlink()
+    assert _deps().damaged_installed_files() == []
+
+
 def test_our_own_shared_top_level_trees_may_also_vanish(site):
     # Same path, deleted rather than overwritten: the einx shape, but claimed by
     # a distribution of ours. No reinstall repairs it either.


### PR DESCRIPTION
## Summary

Count a RECORD path claim before the row is filtered out of the scan, in both the CLI verifier and the sidecar scanner, and add a two-owner regression test.

## Why

The `unsloth_zoo: tests/conftest.py is 8107 bytes, expected 11429` failure had two halves. This PR carries the second one.

`_shared_non_runtime` dropped a row with `continue`, and that `continue` sat above `owners[key] += 1`. So a filtered row never registered its claim on the path. When two distributions shipped the same top-level `tests/conftest.py` and only one of the rows was filtered, the survivor looked singly owned, and `owners[key] == 1` let its recorded size be compared against a file the other distribution had written. The size on disk was never a statement about the retained RECORD in the first place.

#8179 fixed the reachable half by exempting the shared roots for every distribution rather than third parties only, which is what unblocks the reported installs. Filtering is now root-based and identical for every claimant, so two distributions claiming one path are always both filtered or both retained, and the tally can no longer go stale.

## Scope

**This changes no behavior on current main.** Verified: the added test passes with and without the reordering. It is an invariant, not a fix. The ordering was load-bearing once and would be again the moment the exemption is narrowed by distribution, by path, or by anything else, so it is worth stating in code rather than leaving as a property that happens to hold.

Also corrects the `_shared_non_runtime` docstring, which claimed the row "stays out of the ownership tally" as though that were intended.

## Changes

- `unsloth_cli/_studio_deps.py`: resolve the target and count the claim before the `_shared_non_runtime` filter.
- `studio/backend/utils/transformers_version.py`: the same reordering in `_sidecar_scan_impl`.
- `test_two_distributions_claiming_one_shared_path`: two distributions claim `tests/conftest.py`, the second lands last and shorter, and neither the size drift nor the deletion is damage.

## Dropped from the original version of this PR

Keeping `scripts/` checked for Unsloth-owned distributions, since unsloth_zoo 2026.5.2 through 2026.8.5 shipped four files under a top-level `scripts/`:

```
scripts/enforce_kwargs_spacing.py  scripts/lint_workflow_triggers.py
scripts/scan_packages.py           scripts/verify_comment_only_diff.py
```

Retaining those rows leaves the einx failure shape live for our own wheel: the ownership tally only gates the size comparison, while the missing-file branch reports regardless of how many distributions claim the path. Nothing under `unsloth/`, `unsloth_cli/` or `studio/` imports a top-level `scripts` at runtime, and unsloth's own wheel never shipped one, so there is nothing there to guarantee.

The rest of the original diff is in #8179.

## How to test

```bash
python -m pytest unsloth_cli/tests/test_studio_update_verify.py studio/backend/tests/test_transformers_version.py -q
```

330 passed. Full `unsloth_cli/tests`: 943 passed, 4 skipped.
