### PR TITLE
Pin the auto-load success toast by its branch, not by one spelling

### DIFF
--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -107,7 +107,13 @@ def test_chat_autoload_toast_is_persistent_and_dismissible():
     assert "onDismiss:" in auto_load
     # Terminal success uses a fresh finite toast after manual progress dismissal.
     assert "showAutoLoadSuccess" in auto_load
-    assert "description: undefined" in auto_load
+    # No description on the ordinary path. It stopped being the literal
+    # `description: undefined` when the CPU-fallback branch was added, so pin the
+    # branch and its undefined arm rather than one spelling of the old constant.
+    success_toast = auto_load.split("const showAutoLoadSuccess", 1)[1]
+    success_toast = success_toast.split("};", 1)[0]
+    assert "description: cpuFallbackReason" in success_toast
+    assert ": undefined," in success_toast
     assert "icon: undefined" in auto_load
     assert "duration: 5000" in auto_load
     assert "duration: 30000" not in auto_load


### PR DESCRIPTION
## What breaks

`main` at `b0ea23bbf`, which already has #8182:

```
FAILED tests/studio/test_model_picker_contracts.py::test_chat_autoload_toast_is_persistent_and_dismissible
    assert "description: undefined" in auto_load
1 failed, 161 passed
```

## Why

#8050, `738413ab0`, gave the auto-load success toast a CPU-fallback description:

```diff
-  const showAutoLoadSuccess = (message: string): void => {
+  const showAutoLoadSuccess = (
+    message: string,
+    cpuFallbackReason?: CpuFallbackReason | null,
+  ): void => {
     const options = {
-      description: undefined,
+      description: cpuFallbackReason
+        ? "The auto-selected Vulkan backend crashed during startup, so GPU acceleration is disabled for this model session."
+        : undefined,
```

The behaviour this contract guards did not change. An ordinary auto-load still shows a success toast with no description. What changed is that the value stopped being written as the literal `description: undefined`, and the assertion was a substring search for exactly that spelling.

So this is a stale test, not a regression, and the guarded property is still true.

## The fix

Slice out `showAutoLoadSuccess` and assert the branch instead of one spelling of one arm:

```python
assert "description: cpuFallbackReason" in success_toast
assert ": undefined," in success_toast
```

That keeps both halves pinned: an ordinary auto-load carries no description, and a Vulkan-crash fallback explains itself. It survives the next rewording of the fallback copy, which the old form would not have.

I checked it still discriminates rather than passing on anything: replacing the ternary with an unconditional `description: "always something"` turns it red and leaves the other 161 green.

## Result

```
262 passed, 1 skipped
```

for this file plus `tests/studio/install/test_install_llama_prebuilt_logic.py`. Test-only change; no production file is touched, so nothing moves at runtime on any platform or in any browser.

Worth noting alongside #8182: both reds were a source-grep contract test left behind by a legitimate refactor in another PR. That is now three in a row, so the pattern is worth watching.