### PR TITLE
Studio: keep the overlay stack off a maximised Live monitor

### DIFF
--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -97,10 +97,12 @@ export function stackBottomInset(
   const lowEnough = frame.bottom > viewportHeight / 2;
   if (!(inStackColumn(frame, viewportWidth) && lowEnough)) return STACK_INSET;
   const lifted = viewportHeight - frame.top + STACK_GAP;
-  return Math.max(
-    STACK_INSET,
-    Math.min(lifted, viewportHeight - MIN_STACK_ROOM),
-  );
+  // Too tall to lift over. Clamping the lift instead of dropping it parks the
+  // stack across the box's own top edge, over the controls it is dodging: a
+  // monitor resized to fill the viewport had its Close button swallowed by the
+  // loaded models card. Nothing above it is free, so stay in the corner.
+  if (lifted > viewportHeight - MIN_STACK_ROOM) return STACK_INSET;
+  return Math.max(STACK_INSET, lifted);
 }
 
 /**

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -71,6 +71,15 @@ const STACK_GAP = 8;
 const STACK_WIDTH = 448;
 // Never lift so far that the stack itself is pushed off the top.
 const MIN_STACK_ROOM = 120;
+// The monitor's own controls, measured from its top edge: 12px of panel
+// padding, a 24px control row (the drag handle and the size-6 Close button),
+// an 8px rule and an 8px margin come to 54. Rounded up so a font or a border
+// cannot eat the margin.
+const MONITOR_HEADER = 64;
+// Its native `resize` grip, in the opposite corner. Chromium's hit area
+// reaches 15px in from the bottom-right corner and Firefox's 12px, so one
+// STACK_INSET of clearance takes the stack off all of it.
+const MONITOR_GRIP = 16;
 
 /**
  * How far above the bottom edge the overlay stack must sit to clear the Live
@@ -86,6 +95,20 @@ function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
   );
 }
 
+/** The lift that clears the monitor's top edge, and whether it fits. */
+function liftOver(frame: MonitorFrame, viewportHeight: number): number {
+  return viewportHeight - frame.top + STACK_GAP;
+}
+
+function liftFits(frame: MonitorFrame, viewportHeight: number): boolean {
+  return liftOver(frame, viewportHeight) <= viewportHeight - MIN_STACK_ROOM;
+}
+
+/** Room for the stack underneath the monitor, sitting at its own inset. */
+function roomBelow(frame: MonitorFrame, viewportHeight: number): number {
+  return viewportHeight - STACK_INSET - frame.bottom - STACK_GAP;
+}
+
 export function stackBottomInset(
   frame: MonitorFrame | null,
   viewportWidth: number,
@@ -96,13 +119,26 @@ export function stackBottomInset(
   // enough to be in its way; one dragged elsewhere leaves the corner free.
   const lowEnough = frame.bottom > viewportHeight / 2;
   if (!(inStackColumn(frame, viewportWidth) && lowEnough)) return STACK_INSET;
-  const lifted = viewportHeight - frame.top + STACK_GAP;
+  if (liftFits(frame, viewportHeight)) {
+    return Math.max(STACK_INSET, liftOver(frame, viewportHeight));
+  }
   // Too tall to lift over. Clamping the lift instead of dropping it parks the
   // stack across the box's own top edge, over the controls it is dodging: a
   // monitor resized to fill the viewport had its Close button swallowed by the
-  // loaded models card. Nothing above it is free, so stay in the corner.
-  if (lifted > viewportHeight - MIN_STACK_ROOM) return STACK_INSET;
-  return Math.max(STACK_INSET, lifted);
+  // loaded models card.
+  //
+  // If it still ends above the bottom edge there is room underneath it, so the
+  // corner is free and `stackMaxHeight` keeps the stack short enough to stay
+  // there.
+  if (roomBelow(frame, viewportHeight) >= MIN_STACK_ROOM) return STACK_INSET;
+  // Otherwise it fills the viewport and there is no free space at all. Sit
+  // inside it, off its resize grip; `stackMaxHeight` keeps the top of the stack
+  // below its header. Taking the corner instead buries the grip, which is the
+  // only way back to a smaller monitor.
+  return Math.max(
+    STACK_INSET,
+    viewportHeight - frame.bottom + MONITOR_GRIP + STACK_GAP,
+  );
 }
 
 /**
@@ -114,6 +150,15 @@ export function stackBottomInset(
  * space is underneath it. It still has to be dodged: the stack grows upwards
  * from the bottom, and a full download list plus the card is easily tall enough
  * to reach it. Cap the height at the gap below it instead.
+ *
+ * The same applies to a monitor too tall to lift over: the bottom inset alone
+ * decides where the stack starts, and an expanded download list plus the loaded
+ * models card is easily tall enough to grow from there back over the monitor's
+ * header, which is what the inset was dodging.
+ *
+ * The branch is decided on the frame's own inset, not the one passed in, so it
+ * agrees with `stackBottomInset`; only the height it returns uses the inset the
+ * stack actually sits at, which folds in every other box.
  */
 export function stackMaxHeight(
   frame: MonitorFrame | null,
@@ -123,9 +168,21 @@ export function stackMaxHeight(
 ): number {
   const ownMargin = viewportHeight - bottomInset - STACK_INSET;
   if (!frame || !inStackColumn(frame, viewportWidth)) return ownMargin;
-  if (frame.bottom > viewportHeight / 2) return ownMargin;
   const belowMonitor = viewportHeight - bottomInset - frame.bottom - STACK_GAP;
-  return Math.max(MIN_STACK_ROOM, Math.min(ownMargin, belowMonitor));
+  if (frame.bottom <= viewportHeight / 2) {
+    return Math.max(MIN_STACK_ROOM, Math.min(ownMargin, belowMonitor));
+  }
+  // Lifted clear of it: the space above the monitor is its own limit.
+  if (liftFits(frame, viewportHeight)) return ownMargin;
+  // Too tall to lift over but still leaving room underneath: stay under it.
+  if (roomBelow(frame, viewportHeight) >= MIN_STACK_ROOM) {
+    return Math.max(MIN_STACK_ROOM, Math.min(ownMargin, belowMonitor));
+  }
+  // Sitting inside it. Stop below its header, or the Close button goes back
+  // under the stack the inset just moved off it.
+  const belowHeader =
+    viewportHeight - bottomInset - frame.top - MONITOR_HEADER - STACK_GAP;
+  return Math.max(MIN_STACK_ROOM, Math.min(ownMargin, belowHeader));
 }
 
 export type StackGeometry = { bottom: number; maxHeight: number };

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -113,23 +113,51 @@ test("the cap never shrinks the stack below its floor", () => {
 // the stack across the monitor's own top edge, which is where its Close and
 // collapse controls are. The chat UI suite maximises the monitor and then
 // clicks Close, and the card swallowed the click.
-test("a monitor too tall to lift over is left in the corner", () => {
+//
+// Nothing above such a monitor is free, so the stack goes inside it, and the
+// two things it may not bury are the header at the top and the native resize
+// grip in the bottom-right corner (Chromium's hit area reaches 15px in from
+// that corner, Firefox's 12px). Both edges are checked, because the inset
+// alone does not hold the top: an expanded download list plus the loaded
+// models card grows from the bottom right back over the header.
+/** Where the stack's own edges land, given everything it dodges. */
+function stackEdges(frame: MonitorFrame) {
+  const { bottom, maxHeight } = stackGeometry(frame, W, H);
+  return { bottom, top: H - bottom - maxHeight, edge: H - bottom };
+}
+
+test("a monitor too tall to lift over keeps its header and grip clear", () => {
   const frame: MonitorFrame = {
     left: W - 272,
     top: 16,
     right: W - 16,
     bottom: H - 16,
   };
-  const inset = stackBottomInset(frame, W, H);
-  assert.equal(inset, 16, "no lift can clear it, so do not half-lift");
-  // The monitor's own controls sit just inside its top edge; the stack must
-  // stay well below them.
-  assert.ok(H - inset > frame.top + 64, "the stack stays off the top bar");
+  const { top, edge } = stackEdges(frame);
+  assert.ok(edge <= frame.bottom - 16, "the stack sits clear of the resize grip");
+  assert.ok(top >= frame.top + 64, "and stops below the header controls");
 });
 
-test("a monitor resized to fill the viewport is left in the corner", () => {
+test("a monitor resized to fill the viewport keeps its header and grip clear", () => {
   const frame: MonitorFrame = { left: 16, top: 16, right: W - 16, bottom: H - 16 };
-  assert.equal(stackBottomInset(frame, W, H), 16);
+  const { top, edge } = stackEdges(frame);
+  assert.ok(edge <= frame.bottom - 16, "the stack sits clear of the resize grip");
+  assert.ok(top >= frame.top + 64, "and stops below the header controls");
+});
+
+// Too tall to lift over, but it stops short of the bottom edge. The corner is
+// free after all, so the stack keeps it and is capped to the room underneath
+// rather than being pushed up inside the monitor.
+test("a monitor too tall to lift over but clear of the bottom is sat under", () => {
+  const frame: MonitorFrame = {
+    left: W - 272,
+    top: 16,
+    right: W - 16,
+    bottom: H / 2 + 100,
+  };
+  const { bottom, top } = stackEdges(frame);
+  assert.equal(bottom, 16, "the corner is free, so stay in it");
+  assert.ok(top >= frame.bottom, "and the stack stays underneath the monitor");
 });
 
 // The lift is dropped only when it cannot clear; one that fits still applies.

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -109,14 +109,41 @@ test("the cap never shrinks the stack below its floor", () => {
   assert.ok(stackGeometry(frame, W, H).maxHeight >= 120);
 });
 
-test("a monitor filling the height still leaves the stack room", () => {
+// Clamping the lift to the stack's floor was worse than not lifting: it put
+// the stack across the monitor's own top edge, which is where its Close and
+// collapse controls are. The chat UI suite maximises the monitor and then
+// clicks Close, and the card swallowed the click.
+test("a monitor too tall to lift over is left in the corner", () => {
   const frame: MonitorFrame = {
     left: W - 272,
     top: 16,
     right: W - 16,
     bottom: H - 16,
   };
-  assert.ok(stackBottomInset(frame, W, H) <= H - 120);
+  const inset = stackBottomInset(frame, W, H);
+  assert.equal(inset, 16, "no lift can clear it, so do not half-lift");
+  // The monitor's own controls sit just inside its top edge; the stack must
+  // stay well below them.
+  assert.ok(H - inset > frame.top + 64, "the stack stays off the top bar");
+});
+
+test("a monitor resized to fill the viewport is left in the corner", () => {
+  const frame: MonitorFrame = { left: 16, top: 16, right: W - 16, bottom: H - 16 };
+  assert.equal(stackBottomInset(frame, W, H), 16);
+});
+
+// The lift is dropped only when it cannot clear; one that fits still applies.
+test("a tall monitor that can still be cleared is lifted over", () => {
+  const frame: MonitorFrame = {
+    left: W - 272,
+    top: 200,
+    right: W - 16,
+    bottom: H - 16,
+  };
+  const inset = stackBottomInset(frame, W, H);
+  assert.ok(inset > 16, "the stack must move");
+  assert.ok(H - inset <= frame.top, "no vertical overlap remains");
+  assert.ok(H - inset - 16 >= 120, "and it keeps its floor");
 });
 
 // The union was the trap. A tall monitor and the wide docked composer share
@@ -154,7 +181,15 @@ test("two obstacles are folded one at a time, not as their bounding box", () => 
     unioned.bottom,
     "folding must not agree with the bounding box, or nothing was fixed",
   );
-  assert.ok(both.bottom < unioned.bottom, "and it must lift less, not more");
+  // The union is wrong in whichever direction the clamp happens to send it:
+  // it used to lift to the cap and land on the monitor, and now that a box too
+  // tall to clear is left alone it drops the composer's dodge instead, putting
+  // the card back over the Send button. Folding just gives each box its own.
+  assert.equal(
+    both.bottom,
+    composerOnly.bottom,
+    "the composer still gets the lift it asked for",
+  );
 });
 
 test("an empty list behaves exactly like nothing published", () => {


### PR DESCRIPTION
Follow-up to #8082. Rebased onto current `main`, which now has #8210.

### What is left after #8210

#8210 replaced the two-line "is it near the bottom" boolean with `reachesStack`, derived from `stackMaxHeight`, and made `stackGeometry` settle rather than take a single max. That is a better spine than the one this branch was written against, and this branch is now rewritten on top of it.

What #8210 did not change is the clamp:

```ts
function liftOver(frame, viewportHeight) {
  return Math.max(
    STACK_INSET,
    Math.min(viewportHeight - frame.top + STACK_GAP, viewportHeight - MIN_STACK_ROOM),
  );
}
```

`liftOver` clamps rather than refuses. For a box whose top edge is above that clamp the clamp does not clear the box, it parks the stack across the box's own top edge, which is where the monitor's collapse and Close buttons are.

### The geometry

A monitor dragged to the top left and resized to fill the window, which is what `tests/studio/playwright_chat_ui.py:exercise_floating_monitor_geometry` does immediately before it clicks Close. Viewport 1280x900, frame `{left: 16, top: 16, right: 1264, bottom: 884}`. The header band, from the panel border down past the Close button, is y 16..80.

| | inset | cap | stack occupies | header y 16..80 | grip y 868..884 |
| --- | --- | --- | --- | --- | --- |
| `main` today | 780 | 104 | y 16..120 | covered | clear |
| this branch | 40 | 772 | y 88..860 | clear | clear |

`main` reaches inset 780 as `viewportHeight - MIN_STACK_ROOM`, and the loaded models card is the first persistent overlay in the stack, so it lands on the Close button and swallows the click. Same result at 1280x720: inset 600, cap 104, stack at y 16..120.

### After

A box the lift cannot clear is sat inside rather than lifted over. The inset clears the native resize grip in the opposite corner, which is the only way back to a smaller monitor, and the cap holds the top of the stack below the header.

The predicate is asked at the inset in force rather than a fixed one, so it composes with #8210's settling loop: a box that has room at the corner on its own, but that the composer's lift walks the stack into, is sat inside too rather than clamped onto. That case is new here and was found by extending #8210's own sweep, where it showed up as `bottom=530 height=600 n=2`.

### Constants

Both are checked against `floating-monitor.tsx` rather than carried over from the previous revision, which had the arithmetic slightly wrong.

- `MONITOR_HEADER = 64`. The panel's 1px border, `p-3`, the 24px control row (`size-6` Close button, per `button.tsx`), `pb-2` plus its 1px rule, and `mb-2` come to 54, rounded up.
- `MONITOR_GRIP = 16`. The panel carries `resize` once it has been dragged or resized. Every engine that paints a grip draws it at the platform resizer's 15px; iOS Safari paints none. The previous revision said Firefox was 12px, which was wrong.

### Tests

Added to `monitor-stack-inset.test.ts`, alongside #8210's cases rather than replacing them:

- `a monitor too tall to lift over keeps its header and grip clear`
- `a monitor resized to fill the viewport keeps its header and grip clear`
- `a maximised monitor keeps its header clear under a shared lift`
- `a monitor too tall to lift over but clear of the bottom is sat under`
- `a tall monitor that can still be cleared is lifted over`

#8210's `no pairing produces an overlap or an unusable cap` sweep is extended with heights 600 and 814, which reach boxes that fill the column. For those the contract cannot be "no overlap", since the stack is inside the box, so it becomes "clears above, clears below, or keeps the header and the grip usable".

`two obstacles are folded one at a time` had a direction assertion, `both.bottom < unioned.bottom`, that only held under the old clamp. It is repinned on the consequence: folding clears both boxes, and the bounding box cannot clear both. That is now true whichever way the union errs, so it guards folding rather than this change.

Each new assertion was checked by breaking the fix three ways and confirming it goes red:

| sabotage | exit | red |
| --- | --- | --- |
| `tooTallToClear` forced false, ie. `main`'s behaviour | 1 | the 3 header/grip tests plus the sweep, 1317 pass |
| header cap replaced by `ownMargin` | 1 | the same 4, 1317 pass |
| `MONITOR_GRIP` set to 0 | 1 | the 2 grip tests plus the sweep, 1318 pass |
| restored | 0 | 1321 pass |

### Gates

`npm test` 1321 pass, exit 0. `npm run typecheck` exit 0 on both projects. `biome check` exit 0 on both files.

The change is integer arithmetic on numbers already measured by the caller, with no equality comparisons against them and margins of 8px or more, so nothing in it is engine-dependent. The two browser-facing quantities are the constants above.
