### PR TITLE
Desktop release: build the three platform legs in parallel

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -418,7 +418,8 @@ jobs:
   build:
     strategy:
       fail-fast: false
-      max-parallel: 1
+      # Legs run in parallel: they share no state, only upload per-platform
+      # artifacts, and publish-release does every release mutation once.
       matrix:
         include:
           - platform: macos-latest
@@ -949,9 +950,8 @@ jobs:
         if: matrix.platform == 'macos-latest'
         shell: bash
         # `--timeout` below caps the polling, but not the upload that precedes
-        # it. Without a step-level backstop a stuck Notary service would hold
-        # `max-parallel: 1` for the whole job budget and discard the Linux and
-        # Windows builds with it, so cap it tighter than the job here.
+        # it. Without a step-level backstop a stuck Notary service would burn
+        # the whole job budget, so cap it tighter than the job here.
         timeout-minutes: 45
         env:
           ARTIFACT_PATHS: ${{ steps.build_macos.outputs.artifactPaths }}


### PR DESCRIPTION
## Summary

Removes `max-parallel: 1` from the `build` matrix in `release-desktop.yml`, so the macOS, Linux and Windows legs build concurrently instead of one after another.

## Why it was serial, and why that no longer applies

`max-parallel: 1` arrived with the original Tauri PR (#5144, commit a5eb2e3d5). At that point all three legs each invoked `tauri-apps/tauri-action` with `tagName`, `releaseName` and `releaseDraft`, so every leg independently ran find-or-create-release against the same tag. Run them concurrently and more than one leg creates the release, then artifacts scatter across the duplicates. That is [tauri-action#914](https://github.com/tauri-apps/tauri-action/issues/914), still open. Serializing the legs was a correct fix for the workflow as it stood, and it explains the intermittent one-in-three failures seen back then.

That structure is gone. The legs now call `tauri-action` with no `tagName`, no `releaseName` and no `releaseDraft`; they only build and then `upload-artifact` under per-platform names (`desktop-release-macos-aarch64`, `-linux-x64`, `-windows-x64`). Every release mutation happens exactly once, in the separate `publish-release` job. Grepping the whole `build` job body for `git push`, `git tag`, `gh api` or any `GITHUB_TOKEN` use returns nothing, so the legs share no state at all. This is the "decouple build from upload" remedy that tauri-action#914 recommends, and it is strictly stronger than pre-creating the release and passing `releaseId`, because our legs never touch the release API.

For comparison, janhq/jan builds all three platforms fully in parallel (`build-macos`, `build-windows-x64`, `build-linux-x64` all declare the same `needs`), with no retry wrappers anywhere. Their legs still write to the release API concurrently, guarded only by a pre-created draft release. Ours do not even do that.

## What this fixes

Under `max-parallel: 1` a leg only requests a runner once the previous leg ends, so each leg re-enters its pool's queue mid-release. On the in-flight `v0.1.526-beta` release all three legs were created at 15:57:51, but Windows sat with `runner_name=null` while macOS ran and Linux only started at 16:06:40. With a busy queue that requeue can cost far more than the 28 seconds it happened to cost there.

Wall clock for a release drops to roughly the slowest single leg. Runner minutes are unchanged. The legs use three different runner pools, so they do not compete with each other.

This also removes the hazard the workflow itself documented at the notarize step, where a stuck Notary service could burn the job budget and take the Linux and Windows builds down with it. That comment is updated here since the reasoning no longer holds.

## Notes

- `fail-fast: false` is unchanged, so one failing leg still lets the other two finish, and GitHub's "Re-run failed jobs" re-runs only that leg plus `publish-release`. That is retry on demand without paying for it on every release.
- No retry wrapper is added deliberately. The historical failure was a deterministic race, not a transient, and a retry would have re-entered the duplicate-release state rather than clearing it. Blanket retries on a 7 to 21 minute signed and notarized build would also mask genuine Apple notarization and Azure Trusted Signing failures.
- Verified by parsing both workflow versions and diffing them structurally: the only semantic change is the removal of `max-parallel`. Everything else in the diff is comments.

## Test plan

- [ ] Dispatch a minimal unsigned copy on a staging repo and confirm all three legs start concurrently and `publish-release` still collects all artifacts
- [ ] Confirm the next real desktop release produces all nine assets and a correct updater manifest