### PR TITLE
Studio: eliminate Cargo and Clippy warnings

### DIFF
--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -653,6 +653,7 @@ pub async fn start_managed_repair(
     Err(msg)
 }
 
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -335,7 +335,7 @@ fn write_private_file(path: &Path, body: &[u8]) -> Result<(), String> {
             .map_err(|e| e.to_string())?;
         file.write_all(body).map_err(|e| e.to_string())?;
         file.sync_all().map_err(|e| e.to_string())?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]

--- a/studio/src-tauri/src/diagnostics/phase_log.rs
+++ b/studio/src-tauri/src/diagnostics/phase_log.rs
@@ -298,8 +298,7 @@ pub(crate) fn ensure_logs_dir_at(dir: &Path) -> std::io::Result<()> {
         .map(|metadata| metadata.file_type().is_symlink())
         .unwrap_or(false)
     {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        return Err(std::io::Error::other(
             "refusing diagnostics logs dir symlink",
         ));
     }

--- a/studio/src-tauri/src/install.rs
+++ b/studio/src-tauri/src/install.rs
@@ -10,6 +10,7 @@ use tauri::{AppHandle, Emitter, Manager};
 
 // ── Types ──
 
+#[derive(Default)]
 pub struct InstallProcess {
     /// Process group handle — killing this kills the entire subprocess tree.
     pub child: Option<Box<dyn ChildWrapper + Send>>,
@@ -18,17 +19,6 @@ pub struct InstallProcess {
     pub needed_packages: Vec<String>,
     /// Current diagnostics attempt; kept after NEEDS_ELEVATION so apt output can be linked.
     pub current_attempt: Option<AttemptLog>,
-}
-
-impl Default for InstallProcess {
-    fn default() -> Self {
-        Self {
-            child: None,
-            intentional_stop: false,
-            needed_packages: Vec::new(),
-            current_attempt: None,
-        }
-    }
 }
 
 pub type InstallState = Arc<Mutex<InstallProcess>>;

--- a/studio/src-tauri/src/native_backend_lease.rs
+++ b/studio/src-tauri/src/native_backend_lease.rs
@@ -101,38 +101,42 @@ pub fn random_nonce() -> String {
     hex_bytes(&rand::random::<[u8; 16]>())
 }
 
+pub struct NativePathLeaseRequest {
+    pub operation: NativePathOperation,
+    pub canonical_path: String,
+    pub path_kind: NativePathKind,
+    pub path_type: NativePathType,
+    pub source_kind: NativePathSourceKind,
+    pub token: String,
+    pub display_label: String,
+    pub size_bytes: Option<u64>,
+    pub modified_ms: Option<u64>,
+}
+
 pub fn sign_path_lease(
     secret: &[u8],
-    operation: NativePathOperation,
-    canonical_path: String,
-    path_kind: NativePathKind,
-    path_type: NativePathType,
-    source_kind: NativePathSourceKind,
-    token: &str,
-    display_label: String,
-    size_bytes: Option<u64>,
-    modified_ms: Option<u64>,
+    request: NativePathLeaseRequest,
 ) -> Result<NativePathLeaseResponse, String> {
     let issued_at_ms = now_ms();
     let expires_at_ms = issued_at_ms + LEASE_TTL.as_millis() as u64;
     let payload = NativePathLeasePayload {
         version: LEASE_VERSION,
-        operation,
-        canonical_path,
-        path_kind,
-        path_type,
-        source_kind,
-        token_id_hash: token_hash(token),
+        operation: request.operation,
+        canonical_path: request.canonical_path,
+        path_kind: request.path_kind,
+        path_type: request.path_type,
+        source_kind: request.source_kind,
+        token_id_hash: token_hash(&request.token),
         issued_at_ms,
         expires_at_ms,
         nonce: random_nonce(),
-        display_label: display_label.clone(),
-        size_bytes,
-        modified_ms,
+        display_label: request.display_label.clone(),
+        size_bytes: request.size_bytes,
+        modified_ms: request.modified_ms,
     };
     sign_payload(secret, &payload).map(|native_path_lease| NativePathLeaseResponse {
         native_path_lease,
-        display_label,
+        display_label: request.display_label,
         expires_at_ms,
     })
 }
@@ -180,15 +184,17 @@ mod tests {
     fn signed_lease_has_two_base64url_parts() {
         let lease = sign_path_lease(
             b"01234567890123456789012345678901",
-            NativePathOperation::ValidateModel,
-            "/tmp/model.gguf".to_string(),
-            NativePathKind::Model,
-            NativePathType::File,
-            NativePathSourceKind::Dialog,
-            "token",
-            "model.gguf".to_string(),
-            Some(123),
-            Some(456),
+            NativePathLeaseRequest {
+                operation: NativePathOperation::ValidateModel,
+                canonical_path: "/tmp/model.gguf".to_string(),
+                path_kind: NativePathKind::Model,
+                path_type: NativePathType::File,
+                source_kind: NativePathSourceKind::Dialog,
+                token: "token".to_string(),
+                display_label: "model.gguf".to_string(),
+                size_bytes: Some(123),
+                modified_ms: Some(456),
+            },
         )
         .unwrap();
         let parts: Vec<&str> = lease.native_path_lease.split('.').collect();

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -1,6 +1,7 @@
 use crate::native_backend_lease::{
     encode_secret_env, now_ms, random_token, sign_path_lease, NativePathKind,
-    NativePathLeaseResponse, NativePathOperation, NativePathSourceKind, NativePathType,
+    NativePathLeaseRequest, NativePathLeaseResponse, NativePathOperation, NativePathSourceKind,
+    NativePathType,
 };
 use crate::native_path_policy::{
     classify_artifact_path, classify_native_attachment_path, classify_native_dataset_path,
@@ -18,6 +19,7 @@ const TOKEN_TTL: Duration = Duration::from_secs(15 * 60);
 // How long after the OS reports a drop the renderer may still register those paths.
 const DROP_GRACE: Duration = Duration::from_secs(2 * 60);
 
+#[cfg(any(windows, test))]
 fn normalize_windows_verbatim_path(path: String) -> String {
     if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
         return format!(r"\\{rest}");
@@ -271,15 +273,17 @@ impl NativeIntakeState {
         validate_entry_path(&entry, operation)?;
         sign_path_lease(
             &self.lease_secret,
-            operation,
-            entry.canonical_path.to_string_lossy().to_string(),
-            entry.path_kind,
-            entry.path_type,
-            entry.source_kind,
-            &entry.token,
-            entry.display_label,
-            entry.size_bytes,
-            entry.modified_ms,
+            NativePathLeaseRequest {
+                operation,
+                canonical_path: entry.canonical_path.to_string_lossy().to_string(),
+                path_kind: entry.path_kind,
+                path_type: entry.path_type,
+                source_kind: entry.source_kind,
+                token: entry.token,
+                display_label: entry.display_label,
+                size_bytes: entry.size_bytes,
+                modified_ms: entry.modified_ms,
+            },
         )
     }
 
@@ -615,7 +619,7 @@ mod tests {
             .unwrap_err();
         assert!(err.contains("dropped on the window"));
 
-        state.note_dropped_paths(&[path.clone()]);
+        state.note_dropped_paths(std::slice::from_ref(&path));
         let intent = state
             .register_attachment_path(&path, NativePathSourceKind::Drop)
             .unwrap();
@@ -637,7 +641,7 @@ mod tests {
         fs::write(&dropped, b"dropped").unwrap();
         fs::write(&sibling, b"sibling").unwrap();
 
-        state.note_dropped_paths(&[dropped.clone()]);
+        state.note_dropped_paths(std::slice::from_ref(&dropped));
         assert!(state
             .register_attachment_path(&sibling, NativePathSourceKind::Drop)
             .is_err());

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -13,9 +13,10 @@ use managed::probe_managed_install;
 use std::path::PathBuf;
 use types::{BackendProbe, ManagedProbe};
 pub use types::{DesktopPreflightDisposition, DesktopPreflightResult, ExternalBackendConflict};
+#[cfg(test)]
+pub(crate) use version::DESKTOP_MANAGEABILITY_VERSION;
 pub(crate) use version::{
-    backend_version_stale_reason, DESKTOP_BACKEND_MANAGEABILITY_VERSION,
-    DESKTOP_MANAGEABILITY_VERSION, DESKTOP_PROTOCOL_VERSION,
+    backend_version_stale_reason, DESKTOP_BACKEND_MANAGEABILITY_VERSION, DESKTOP_PROTOCOL_VERSION,
 };
 
 #[cfg(test)]

--- a/studio/src-tauri/src/preflight/managed.rs
+++ b/studio/src-tauri/src/preflight/managed.rs
@@ -369,9 +369,7 @@ async fn probe_cli_capability(bin: &Path) -> Option<DesktopCapability> {
         );
         return None;
     };
-    let Some(mut stdout) = child.stdout.take() else {
-        return None;
-    };
+    let mut stdout = child.stdout.take()?;
 
     match tokio::time::timeout(Duration::from_secs(10), child.wait()).await {
         Ok(Ok(status)) if status.success() => {}

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -244,7 +244,7 @@ pub(crate) fn clear_adopted_backend_if_current(
     let matches_adopted = matches!(
         proc.owned.as_ref(),
         Some(OwnedBackendHandle::Adopted { port: current_port, .. })
-            if port.map_or(true, |port| port == *current_port)
+            if port.is_none_or(|port| port == *current_port)
     );
     if !matches_adopted {
         return false;

--- a/studio/src-tauri/src/update.rs
+++ b/studio/src-tauri/src/update.rs
@@ -13,20 +13,11 @@ const WINDOWS_CLI_ENTRYPOINT: &str =
 
 // ── Types ──
 
+#[derive(Default)]
 pub struct UpdateProcess {
     pub child: Option<Box<dyn ChildWrapper + Send>>,
     pub intentional_stop: bool,
     pub current_attempt: Option<AttemptLog>,
-}
-
-impl Default for UpdateProcess {
-    fn default() -> Self {
-        Self {
-            child: None,
-            intentional_stop: false,
-            current_attempt: None,
-        }
-    }
 }
 
 pub type UpdateState = Arc<Mutex<UpdateProcess>>;


### PR DESCRIPTION
## Summary

- remove Rust compiler warnings from the Studio Tauri crate
- apply behavior-preserving Clippy recommendations across process, diagnostics, preflight, and native path handling
- group native path lease parameters into a request type to keep the signer API clean

## Testing

- `RUSTFLAGS='-D warnings' cargo check --all-targets --all-features --message-format=short`
- `cargo clippy --all-targets --all-features --message-format=short -- -D warnings`
- `cargo test --all-features --no-fail-fast` (135 passed)
