### PR TITLE
Desktop release: start the publish job alongside the build matrix

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1458,12 +1458,18 @@ jobs:
   # Draft runs do not advance the public desktop-latest channel.
   publish-release:
     name: Publish desktop release
-    needs: [prepare-version, build]
+    # Only prepare-version, so this starts alongside the build matrix and
+    # queues for its runner during the build instead of after it. "Wait for the
+    # build matrix" below restores the gate `needs: build` gave away. The cost
+    # is one runner slot held for the length of the run.
+    needs: [prepare-version]
     runs-on: ubuntu-latest
-    # Artifact download plus release upload; observed 17-40s.
-    timeout-minutes: 20
+    # Waits out the build (legs cap at 60) then downloads and uploads; the
+    # publish steps themselves are 17-40s.
+    timeout-minutes: 90
     permissions:
       contents: write  # create the versioned Release and replace updater-channel metadata
+      actions: read    # the waiter reads this run's job list
     env:
       GH_REPO: ${{ github.repository }}
       APP_VERSION: ${{ needs.prepare-version.outputs.app_version }}
@@ -1478,6 +1484,84 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
           egress-policy: audit
+
+      # Replaces the `needs: build` gate dropped above, and must be at least as
+      # strict: publishing a partial release is far worse than publishing late.
+      - name: Wait for the build matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+
+          # The three matrix legs, by their `name:` (Build <matrix.label>).
+          LEGS=('Build macOS (Apple Silicon)' 'Build Linux (x64)' 'Build Windows (x64)')
+          POLL=30
+          DEADLINE=$(( $(date +%s) + 75 * 60 ))
+          # Matrix job records appear with the run, so a leg still missing well
+          # after the start is a real problem, not a slow API.
+          STARTUP_DEADLINE=$(( $(date +%s) + 15 * 60 ))
+          API_FAILS=0
+
+          while :; do
+            if ! JOBS="$(gh api --paginate \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
+                  --jq '.jobs[] | [.name, .status, (.conclusion // "none")] | @tsv' 2>/dev/null)"; then
+              # A blip in the jobs API must not throw away a finished build.
+              API_FAILS=$(( API_FAILS + 1 ))
+              if [ "$API_FAILS" -ge 10 ]; then
+                echo "ERROR: jobs API failed 10 times running; cannot confirm the build matrix finished" >&2
+                exit 1
+              fi
+              echo "jobs API call failed (${API_FAILS}/10); retrying in ${POLL}s"
+              sleep "$POLL"
+              continue
+            fi
+            API_FAILS=0
+
+            MISSING=""
+            PENDING=0
+            BAD=""
+            for leg in "${LEGS[@]}"; do
+              ROW="$(printf '%s\n' "$JOBS" | awk -F'\t' -v n="$leg" '$1 == n {print; exit}')"
+              if [ -z "$ROW" ]; then
+                MISSING="${MISSING} '${leg}'"
+                continue
+              fi
+              STATUS="$(printf '%s' "$ROW" | cut -f2)"
+              CONCL="$(printf '%s' "$ROW" | cut -f3)"
+              if [ "$STATUS" != "completed" ]; then
+                PENDING=$(( PENDING + 1 ))
+              elif [ "$CONCL" != "success" ]; then
+                BAD="${BAD}${leg} (${CONCL}); "
+              fi
+            done
+
+            # Fail on the first finished leg that did not succeed rather than
+            # holding a runner to reach the same answer later.
+            if [ -n "$BAD" ]; then
+              echo "ERROR: refusing to publish, these build jobs did not succeed: ${BAD}" >&2
+              exit 1
+            fi
+            if [ -n "$MISSING" ]; then
+              if [ "$(date +%s)" -gt "$STARTUP_DEADLINE" ]; then
+                echo "ERROR: no job record for:${MISSING}; refusing to publish without confirming they ran" >&2
+                exit 1
+              fi
+              echo "waiting for job records to appear for:${MISSING}"
+              sleep "$POLL"
+              continue
+            fi
+            if [ "$PENDING" -eq 0 ]; then
+              echo "all ${#LEGS[@]} build legs finished and succeeded"
+              break
+            fi
+            if [ "$(date +%s)" -gt "$DEADLINE" ]; then
+              echo "ERROR: timed out waiting for the build matrix; ${PENDING} leg(s) still running" >&2
+              exit 1
+            fi
+            echo "${PENDING} of ${#LEGS[@]} build legs still running; polling again in ${POLL}s"
+            sleep "$POLL"
+          done
 
       # This job publishes artifacts built elsewhere, so it historically needed no
       # source tree. The VirusTotal step runs a repo script, so it does now. Sparse:


### PR DESCRIPTION
## Summary

`publish-release` now declares `needs: [prepare-version]` instead of `needs: [prepare-version, build]`, so it starts with the build matrix and spends the build queueing for its runner instead of queueing only after the last leg goes green. A new "Wait for the build matrix" step restores the gate that `needs: build` provided.

## Why

On the `v0.1.526-beta` release, all three legs finished at 16:33:08 and `Publish desktop release` then sat with `runner_name=null` for about two minutes short of half an hour, waiting for an `ubuntu-latest` slot behind 56 queued runs, to then do 17 to 40 seconds of work. The queue wait is pure latency bolted onto the end of every release.

This is the same fix, and the same reasoning, as `assemble` in unslothai/llama.cpp's `unsloth-prebuilt.yml`, which records the problem it solved:

> Only `resolve`, so this job starts alongside the build matrix instead of after it. It used to `needs:` every build child, which meant it began queueing for a runner only once the last leg went green: on the reference run that queue wait was 109 minutes to then run a 10-second job. Starting early overlaps the wait with the build. The cost is one runner slot held for the length of the run.

## The gate

Dropping `needs: build` gives away the success check, so the waiter has to be at least as strict. Publishing a partial release is much worse than publishing late. It polls this run's job list every 30s and:

- blocks until all three legs report `completed`
- exits non-zero the moment any finished leg has a conclusion other than `success`, rather than holding a runner to reach the same answer later
- refuses to publish if a leg has no job record at all after 15 minutes, so a matrix that never started cannot be mistaken for one that passed
- tolerates 10 consecutive jobs-API failures before giving up, so an API blip cannot discard a finished build
- gives up at 75 minutes, inside the job's own 90 minute cap

`timeout-minutes` goes from 20 to 90 because the job now spans the build, whose legs cap at 60. `actions: read` is added because the job-level `permissions` block replaces the workflow-level one and the waiter needs to read the run's job list.

## Behaviour change worth knowing

If a build leg fails, `publish-release` previously showed as skipped. It will now show as failed, with the failing leg named in the log. Nothing is published in either case. llama.cpp made the same trade.

## Test plan

The waiter was extracted and run against a stubbed jobs API:

- all three legs `success` -> exits 0, "all 3 build legs finished and succeeded"
- one leg `failure` -> exits 1, names the leg
- one leg `cancelled` -> exits 1, names the leg
- legs still `in_progress` -> keeps polling, does not proceed
- a leg missing from the job list -> keeps waiting, does not proceed
- jobs API failing -> counts strikes 1/10, 2/10 and keeps retrying

Every `run:` block in the workflow was also shell-parsed; the only parse error is a pre-existing PowerShell step on the Windows leg, untouched here.

- [ ] Confirm on the next release that publish starts with the matrix and that its runner wait overlaps the build

## Note

Independent of #8191 and touches a different part of the file. #8191 shortens the build phase; this removes the queue wait that follows it. Either can merge first.