### PR TITLE
Desktop release: run the VirusTotal scan after publishing, in its own job

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1563,18 +1563,6 @@ jobs:
             sleep "$POLL"
           done
 
-      # This job publishes artifacts built elsewhere, so it historically needed no
-      # source tree. The VirusTotal step runs a repo script, so it does now. Sparse:
-      # a full checkout of this repo to fetch one file would be wasteful, and a
-      # missing script would be swallowed by that step's continue-on-error and
-      # publish the release with no scan at all.
-      - name: Check out the scan script
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-          sparse-checkout: scripts/virustotal_scan.py
-          sparse-checkout-cone-mode: false
-
       - name: Download signed release assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -1680,48 +1668,6 @@ jobs:
           fi
           echo "create=true" >> "$GITHUB_OUTPUT"
 
-      # ── Advisory multi-engine scan of the bundles we are about to publish ──
-      # Defender (build job) is one vendor and gates only Windows. VirusTotal
-      # aggregates ~70 engines across all four bundles, which is how a false
-      # positive from some other vendor gets noticed here rather than in a user
-      # bug report. Advisory on purpose: installers routinely trip one or two
-      # obscure heuristics, so a hard gate here would block releases on noise.
-      # Defender stays the authoritative fail-closed check.
-      #
-      # The step never fails the job: a missing secret, a VirusTotal outage or a
-      # quota exhaustion must not be able to block a release.
-      - name: VirusTotal pre-flight scan
-        continue-on-error: true
-        # Free-tier keys allow 4 requests/minute, and the script paces itself to
-        # match, so four bundles of lookup + upload + polling can take a while.
-        timeout-minutes: 30
-        env:
-          VT_API_KEY: ${{ secrets.VIRUS_TOTAL_API_TOKEN }}
-        run: |
-          set -euo pipefail
-          # continue-on-error means a silent failure here would publish an unscanned
-          # release with only a terse "no summary" note, so name the cause loudly.
-          if [ ! -f scripts/virustotal_scan.py ]; then
-            echo "::error::scripts/virustotal_scan.py is missing; the checkout step in this job must provide it"
-            exit 1
-          fi
-          python3 scripts/virustotal_scan.py \
-            "$RUNNER_TEMP/desktop-release-assets" \
-            --output-markdown "$RUNNER_TEMP/virustotal-summary.md"
-
-      - name: Publish VirusTotal summary
-        if: always()
-        run: |
-          set -euo pipefail
-          summary="$RUNNER_TEMP/virustotal-summary.md"
-          if [ -f "$summary" ]; then
-            cat "$summary" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo '### VirusTotal pre-flight scan' >> "$GITHUB_STEP_SUMMARY"
-            echo '' >> "$GITHUB_STEP_SUMMARY"
-            echo 'The scan step produced no summary.' >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Generate versioned updater metadata and provenance
         shell: bash
         run: |
@@ -1803,9 +1749,9 @@ jobs:
           } > "$body_file"
           cat "$body_file"
 
-      # Deferred until immediately before upload so public releases are not left
-      # empty during the VirusTotal scan. Repeat the absence checks here to close
-      # the race introduced by that scan before atomically reserving the tag.
+      # Kept immediately before upload so the release is never left empty for
+      # long, and the absence checks are repeated here to reserve the tag
+      # atomically.
       - name: Create versioned release
         if: steps.versioned_release_state.outputs.create == 'true'
         shell: bash
@@ -2125,3 +2071,73 @@ jobs:
           if actual_url != expected_url:
               sys.exit(f'desktop-latest latest.json URL mismatch: expected {expected_url}, got {actual_url}')
           PY
+
+  # ── Advisory multi-engine scan of the bundles just published ──
+  # Defender (build job) is one vendor and gates only Windows. VirusTotal
+  # aggregates ~70 engines across all four bundles, which is how a false
+  # positive from some other vendor gets noticed here rather than in a user bug
+  # report. Advisory on purpose: installers routinely trip one or two obscure
+  # heuristics, so a hard gate would block releases on noise. Defender stays the
+  # authoritative fail-closed check.
+  #
+  # Its own job, after publish-release, because the scan is rate-limit bound and
+  # not parallelisable: the free tier allows 4 requests/minute per key, so the
+  # four bundles share one budget however they are scheduled. Inside the publish
+  # job it was ~9 minutes of the ~9.5 the job took, delaying every release by its
+  # full length while being unable to block one.
+  virustotal-scan:
+    name: VirusTotal post-publish scan
+    needs: [publish-release]
+    runs-on: ubuntu-latest
+    # A missing secret, a VirusTotal outage or quota exhaustion must not fail
+    # the release that already published.
+    continue-on-error: true
+    timeout-minutes: 30
+    steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      # Sparse: a full checkout to fetch one file would be wasteful.
+      - name: Check out the scan script
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: scripts/virustotal_scan.py
+          sparse-checkout-cone-mode: false
+
+      - name: Download published assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: desktop-release-*
+          path: ${{ runner.temp }}/desktop-release-assets
+          merge-multiple: true
+
+      - name: VirusTotal scan
+        env:
+          VT_API_KEY: ${{ secrets.VIRUS_TOTAL_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Name the cause loudly: a silent failure here leaves the release
+          # scanned by nothing but a terse "no summary" note.
+          if [ ! -f scripts/virustotal_scan.py ]; then
+            echo "::error::scripts/virustotal_scan.py is missing; the checkout step in this job must provide it"
+            exit 1
+          fi
+          python3 scripts/virustotal_scan.py \
+            "$RUNNER_TEMP/desktop-release-assets" \
+            --output-markdown "$RUNNER_TEMP/virustotal-summary.md"
+
+      - name: Publish VirusTotal summary
+        if: always()
+        run: |
+          set -euo pipefail
+          summary="$RUNNER_TEMP/virustotal-summary.md"
+          if [ -f "$summary" ]; then
+            cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '### VirusTotal post-publish scan' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo 'The scan step produced no summary.' >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

Moves the VirusTotal scan out of `publish-release` into its own `virustotal-scan` job that runs after it. The release publishes as soon as the bundles are ready; the advisory scan then runs and posts its summary.

## Why

Measured on the `v0.1.526-beta` run, `publish-release` was almost entirely this one step:

| Step | Duration |
| --- | --- |
| Setup, harden, checkout, download, both validations | 13 seconds combined |
| VirusTotal pre-flight scan | ~9 minutes |

So roughly nine and a half minutes of release latency, of which the scan is about nine. The step is `continue-on-error: true` and the workflow already states "The step never fails the job: a missing secret, a VirusTotal outage or a quota exhaustion must not be able to block a release." It could never gate a release, so running it ahead of publication only delayed it.

## Why not parallelise the scan instead

The scan is rate-limit bound, not compute bound. VirusTotal's public API allows [4 requests/minute and 500/day](https://docs.virustotal.com/reference/public-vs-premium-api), and `scripts/virustotal_scan.py` already paces itself to match at `DEFAULT_REQUEST_INTERVAL = 20.0`, whose comment reads "The public API allows 4 requests/minute... A premium key can drop this to ~1s via `--request-interval`."

That budget is per API key, not per connection. The four bundles cost a hash lookup each, an upload for anything VirusTotal has not seen, then analysis polls, and scanning them concurrently issues the same requests against the same cap in bursts. The result is 429s handed to the script's exponential backoff, which is slower than pacing. Concurrency only becomes useful on a premium key, and would then need a rate limiter shared across threads rather than the current per-instance `_last_request_at`.

## Notes

- The job is `continue-on-error: true` so a missing secret, an outage or quota exhaustion cannot fail a release that already published. That preserves the old step-level behaviour.
- `Create versioned release` was previously "Deferred until immediately before upload so public releases are not left empty during the VirusTotal scan". With the scan gone from that job the gap it was working around no longer exists. The deferral and its absence re-checks are kept as they are, since reserving the tag atomically immediately before upload is correct regardless; only the comment is updated.
- The scan now reports on bundles that are already published rather than about to be. It was advisory in both cases, and Defender remains the authoritative fail-closed gate on Windows.
- Scan targets are unchanged: the four installers, with `SKIPPED_SUFFIXES = (".sig",)` filtering signatures.

## Test plan

- Workflow parsed and diffed structurally: the only changes are the three steps moving out of `publish-release` into the new job; `build`, `prepare-version` and `free-capacity` are byte identical.
- Every `run:` block in the new job shell-parsed clean.
- [ ] Confirm on the next release that the release appears without waiting for the scan, and that the summary still posts

## Note

Independent of #8191 and #8193. #8191 shortens the build phase, #8193 removes the publish job's queue wait, this removes the scan from the release path.