### PR TITLE
Repin six UI contracts on what they guard, not how it was spelled

### DIFF
--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1075,9 +1075,9 @@ def test_a_routed_curated_pick_uses_the_same_load_spec_as_a_direct_one():
         # once; the load-bearing part is the third, so do not pin the second.
         call = re.search(r"diffusionRoutePick\(\s*wanted,\s*(.*?),?\s*\);", src, re.S)
         assert call, f"{rel}: the routed pick does not go through diffusionRoutePick"
-        assert f"loadSpecFor(wanted, {catalog})" in call.group(1), (
-            f"{rel}: the routed pick passes no catalog spec"
-        )
+        assert f"loadSpecFor(wanted, {catalog})" in call.group(
+            1
+        ), f"{rel}: the routed pick passes no catalog spec"
 
 
 def test_a_quantized_load_drops_a_lora_selection_it_cannot_bake():
@@ -1110,9 +1110,9 @@ def test_diffusion_pages_never_drop_a_gguf_pick_silently():
         )
         assert branch, f"{rel}: gguf extension guard not found"
         body = branch.group(0)
-        assert "toast.error(" in body or "loadGgufRepoPick(" in body, (
-            f"{rel}: guard returns silently"
-        )
+        assert (
+            "toast.error(" in body or "loadGgufRepoPick(" in body
+        ), f"{rel}: guard returns silently"
 
 
 def test_diffusion_pages_stage_downloads_through_the_manager():
@@ -1154,15 +1154,15 @@ def test_a_hidden_diffusion_page_does_not_load_when_its_download_lands():
         assert flush, f"{rel}: nothing flushes the deferred load when the page is shown"
         # Either the flush calls the loader itself or it calls the same helper the visible
         # path uses. What it may not do is clear the flag and stop there.
-        assert "runStagedLoad()" in flush.group(0) or "handleLoadRef.current(" in flush.group(0), (
-            f"{rel}: deferred load never runs"
-        )
+        assert "runStagedLoad()" in flush.group(0) or "handleLoadRef.current(" in flush.group(
+            0
+        ), f"{rel}: deferred load never runs"
         if "runStagedLoad()" in flush.group(0):
             runner = re.search(r"const runStagedLoad = useCallback\(.*?\n  \}, \[", src, re.S)
             assert runner, f"{rel}: runStagedLoad not found"
-            assert "handleLoadRef.current(" in runner.group(0), (
-                f"{rel}: runStagedLoad loads nothing"
-            )
+            assert "handleLoadRef.current(" in runner.group(
+                0
+            ), f"{rel}: runStagedLoad loads nothing"
 
 
 def test_staged_downloads_always_scope_their_files():

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1145,19 +1145,26 @@ def test_a_hidden_diffusion_page_does_not_load_when_its_download_lands():
         # Deferred, not dropped: something has to fire the held pick when the page returns.
         assert "stagedLoadDeferred" in ready.group(0), f"{rel}: the pick is discarded"
         # The dependency array grew when the load body moved into runStagedLoad, so match
-        # the effect by its guard and let the deps be whatever they need to be.
+        # the effect by its guard and let the deps be whatever they need to be. Stop at the
+        # first effect boundary and check the deps separately: keying the boundary on
+        # `[active` instead lets a reordered array run the match on into the next hook,
+        # where loadOrStage's own handleLoadRef call would satisfy the loader assertion
+        # below for a flush that loads nothing.
         flush = re.search(
-            r"if \(!active \|\| !stagedLoadDeferred\.current\) return;.*?\n  \}, \[active[^\]]*\]\);",
+            r"if \(!active \|\| !stagedLoadDeferred\.current\) return;(.*?)\n  \}, \[([^\]]*)\]\);",
             src,
             re.S,
         )
         assert flush, f"{rel}: nothing flushes the deferred load when the page is shown"
+        deps = [dep.strip() for dep in flush.group(2).split(",")]
+        assert "active" in deps, f"{rel}: the flush does not re-run when the page is shown"
+        body = flush.group(1)
         # Either the flush calls the loader itself or it calls the same helper the visible
         # path uses. What it may not do is clear the flag and stop there.
-        assert "runStagedLoad()" in flush.group(0) or "handleLoadRef.current(" in flush.group(
-            0
+        assert (
+            "runStagedLoad()" in body or "handleLoadRef.current(" in body
         ), f"{rel}: deferred load never runs"
-        if "runStagedLoad()" in flush.group(0):
+        if "runStagedLoad()" in body:
             runner = re.search(r"const runStagedLoad = useCallback\(.*?\n  \}, \[", src, re.S)
             assert runner, f"{rel}: runStagedLoad not found"
             assert "handleLoadRef.current(" in runner.group(

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -27,8 +27,7 @@ def _read(rel: str) -> str:
 
 
 def _split_args(captured: str) -> list[str]:
-    """A call's argument list, split on its own commas only. Splitting on every
-    comma would cut nested calls such as `loadSpecFor(wanted, CATALOG)` in two."""
+    """Split on top-level commas only, so `loadSpecFor(wanted, CATALOG)` survives."""
     args, depth, current = [], 0, ""
     for char in captured:
         if char in "([{":
@@ -1089,16 +1088,14 @@ def test_a_routed_curated_pick_uses_the_same_load_spec_as_a_direct_one():
         ("features/video/video-page.tsx", "VIDEO_CATALOG"),
     ):
         src = _read(rel)
-        # The middle argument is the routed filename and has been respelled more than
-        # once; the load-bearing part is the third, so do not pin the second.
+        # The middle argument, the routed filename, has been respelled more than once;
+        # only the third is load-bearing, so do not pin the second.
         call = re.search(r"diffusionRoutePick\(\s*wanted,\s*(.*?),?\s*\);", src, re.S)
         assert call, f"{rel}: the routed pick does not go through diffusionRoutePick"
-        # By position, not by presence: the capture is every argument after `wanted`,
-        # and the helper reads `quant` before `spec`. `diffusionRoutePick(wanted,
-        # routedFilename ?? loadSpecFor(wanted, IMAGE_CATALOG)?.filename)` type-checks,
-        # passes the catalog filename as the quant, drops the spec entirely, and would
-        # otherwise satisfy a plain substring check while curated single-file artifacts
-        # load as GGUF.
+        # By position, not by presence: `diffusionRoutePick(wanted, routedFilename ??
+        # loadSpecFor(wanted, IMAGE_CATALOG)?.filename)` type-checks, passes the spec's
+        # filename as the quant, drops the spec, and would pass a substring check while
+        # curated single-file artifacts load as GGUF.
         args = _split_args(call.group(1))
         assert len(args) >= 2, f"{rel}: the routed pick passes no spec argument"
         assert (
@@ -1125,10 +1122,9 @@ def test_a_quantized_load_drops_a_lora_selection_it_cannot_bake():
 
 
 def test_diffusion_pages_never_drop_a_gguf_pick_silently():
-    """The fallback branch splits a local path; a repo pick reaching it has no
-    filename. It used to error out there. It now resolves the repo's own .gguf
-    instead, which is the better answer, but either way the branch must do
-    something: returning with no request and no toast drops the pick in silence."""
+    """The fallback branch splits a local path, so a repo pick reaching it has no
+    filename. It used to error; it now resolves the repo's own .gguf. Either way the
+    branch must act: returning with no request and no toast drops the pick."""
     for rel in ("features/images/images-page.tsx", "features/video/video-page.tsx"):
         src = _read(rel)
         branch = re.search(
@@ -1170,12 +1166,11 @@ def test_a_hidden_diffusion_page_does_not_load_when_its_download_lands():
         assert "if (!active)" in ready.group(0), f"{rel}: a hidden page still takes the GPU"
         # Deferred, not dropped: something has to fire the held pick when the page returns.
         assert "stagedLoadDeferred" in ready.group(0), f"{rel}: the pick is discarded"
-        # The dependency array grew when the load body moved into runStagedLoad, so match
-        # the effect by its guard and let the deps be whatever they need to be. Stop at the
-        # first effect boundary and check the deps separately: keying the boundary on
+        # The deps array grew when the load body moved into runStagedLoad, so match the
+        # effect by its guard and check the deps separately. Keying the boundary on
         # `[active` instead lets a reordered array run the match on into the next hook,
-        # where loadOrStage's own handleLoadRef call would satisfy the loader assertion
-        # below for a flush that loads nothing.
+        # where loadOrStage's own handleLoadRef call satisfies the loader assertion below
+        # for a flush that loads nothing.
         flush = re.search(
             r"if \(!active \|\| !stagedLoadDeferred\.current\) return;(.*?)\n  \}, \[([^\]]*)\]\);",
             src,
@@ -1185,8 +1180,8 @@ def test_a_hidden_diffusion_page_does_not_load_when_its_download_lands():
         deps = [dep.strip() for dep in flush.group(2).split(",")]
         assert "active" in deps, f"{rel}: the flush does not re-run when the page is shown"
         body = flush.group(1)
-        # Either the flush calls the loader itself or it calls the same helper the visible
-        # path uses. What it may not do is clear the flag and stop there.
+        # Loading directly or through the visible path's helper is fine; clearing the
+        # flag and stopping is not.
         assert (
             "runStagedLoad()" in body or "handleLoadRef.current(" in body
         ), f"{rel}: deferred load never runs"

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -26,6 +26,24 @@ def _read(rel: str) -> str:
     return path.read_text(encoding = "utf-8")
 
 
+def _split_args(captured: str) -> list[str]:
+    """A call's argument list, split on its own commas only. Splitting on every
+    comma would cut nested calls such as `loadSpecFor(wanted, CATALOG)` in two."""
+    args, depth, current = [], 0, ""
+    for char in captured:
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        if char == "," and depth == 0:
+            args.append(current)
+            current = ""
+        else:
+            current += char
+    args.append(current)
+    return args
+
+
 def _read_backend(rel: str) -> str:
     path = WORKDIR / "studio" / "backend" / rel
     assert path.exists(), f"missing backend source file: {path}"
@@ -1075,8 +1093,16 @@ def test_a_routed_curated_pick_uses_the_same_load_spec_as_a_direct_one():
         # once; the load-bearing part is the third, so do not pin the second.
         call = re.search(r"diffusionRoutePick\(\s*wanted,\s*(.*?),?\s*\);", src, re.S)
         assert call, f"{rel}: the routed pick does not go through diffusionRoutePick"
-        assert f"loadSpecFor(wanted, {catalog})" in call.group(
-            1
+        # By position, not by presence: the capture is every argument after `wanted`,
+        # and the helper reads `quant` before `spec`. `diffusionRoutePick(wanted,
+        # routedFilename ?? loadSpecFor(wanted, IMAGE_CATALOG)?.filename)` type-checks,
+        # passes the catalog filename as the quant, drops the spec entirely, and would
+        # otherwise satisfy a plain substring check while curated single-file artifacts
+        # load as GGUF.
+        args = _split_args(call.group(1))
+        assert len(args) >= 2, f"{rel}: the routed pick passes no spec argument"
+        assert (
+            f"loadSpecFor(wanted, {catalog})" in args[1]
         ), f"{rel}: the routed pick passes no catalog spec"
 
 

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1071,11 +1071,13 @@ def test_a_routed_curated_pick_uses_the_same_load_spec_as_a_direct_one():
         ("features/video/video-page.tsx", "VIDEO_CATALOG"),
     ):
         src = _read(rel)
-        call = re.search(
-            r"diffusionRoutePick\(\s*wanted,\s*routeSearch\.quant,\s*(.*?),?\s*\);", src, re.S
+        # The middle argument is the routed filename and has been respelled more than
+        # once; the load-bearing part is the third, so do not pin the second.
+        call = re.search(r"diffusionRoutePick\(\s*wanted,\s*(.*?),?\s*\);", src, re.S)
+        assert call, f"{rel}: the routed pick does not go through diffusionRoutePick"
+        assert f"loadSpecFor(wanted, {catalog})" in call.group(1), (
+            f"{rel}: the routed pick passes no catalog spec"
         )
-        assert call, f"{rel}: the routed pick passes no spec"
-        assert f"loadSpecFor(wanted, {catalog})" in call.group(1), rel
 
 
 def test_a_quantized_load_drops_a_lora_selection_it_cannot_bake():
@@ -1098,14 +1100,19 @@ def test_a_quantized_load_drops_a_lora_selection_it_cannot_bake():
 
 def test_diffusion_pages_never_drop_a_gguf_pick_silently():
     """The fallback branch splits a local path; a repo pick reaching it has no
-    filename. It must say so instead of returning with no request and no toast."""
+    filename. It used to error out there. It now resolves the repo's own .gguf
+    instead, which is the better answer, but either way the branch must do
+    something: returning with no request and no toast drops the pick in silence."""
     for rel in ("features/images/images-page.tsx", "features/video/video-page.tsx"):
         src = _read(rel)
         branch = re.search(
-            r'if \(!filename\.toLowerCase\(\)\.endsWith\("\.gguf"\)\) \{.*?\}', src, re.S
+            r'if \(!filename\.toLowerCase\(\)\.endsWith\("\.gguf"\)\) \{.*?\n        \}', src, re.S
         )
         assert branch, f"{rel}: gguf extension guard not found"
-        assert "toast.error(" in branch.group(0), f"{rel}: guard returns silently"
+        body = branch.group(0)
+        assert "toast.error(" in body or "loadGgufRepoPick(" in body, (
+            f"{rel}: guard returns silently"
+        )
 
 
 def test_diffusion_pages_stage_downloads_through_the_manager():
@@ -1137,13 +1144,25 @@ def test_a_hidden_diffusion_page_does_not_load_when_its_download_lands():
         assert "if (!active)" in ready.group(0), f"{rel}: a hidden page still takes the GPU"
         # Deferred, not dropped: something has to fire the held pick when the page returns.
         assert "stagedLoadDeferred" in ready.group(0), f"{rel}: the pick is discarded"
+        # The dependency array grew when the load body moved into runStagedLoad, so match
+        # the effect by its guard and let the deps be whatever they need to be.
         flush = re.search(
-            r"if \(!active \|\| !stagedLoadDeferred\.current\) return;.*?\n  \}, \[active\]\);",
+            r"if \(!active \|\| !stagedLoadDeferred\.current\) return;.*?\n  \}, \[active[^\]]*\]\);",
             src,
             re.S,
         )
         assert flush, f"{rel}: nothing flushes the deferred load when the page is shown"
-        assert "handleLoadRef.current(" in flush.group(0), f"{rel}: deferred load never runs"
+        # Either the flush calls the loader itself or it calls the same helper the visible
+        # path uses. What it may not do is clear the flag and stop there.
+        assert "runStagedLoad()" in flush.group(0) or "handleLoadRef.current(" in flush.group(0), (
+            f"{rel}: deferred load never runs"
+        )
+        if "runStagedLoad()" in flush.group(0):
+            runner = re.search(r"const runStagedLoad = useCallback\(.*?\n  \}, \[", src, re.S)
+            assert runner, f"{rel}: runStagedLoad not found"
+            assert "handleLoadRef.current(" in runner.group(0), (
+                f"{rel}: runStagedLoad loads nothing"
+            )
 
 
 def test_staged_downloads_always_scope_their_files():

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -1113,20 +1113,15 @@ def test_code_span_closers_ignore_backslashes():
 
 
 def test_the_overlay_stack_fits_the_viewport():
-    """The update card's own cap does not account for a long download list
-    stacked beneath it.
-
-    The cap used to be the literal class `max-h-[calc(100dvh_-_2rem)]`. It is now
-    computed by `stackGeometry`, which subtracts the same 2rem when nothing is in
-    the way and subtracts more when the Live monitor is. The arithmetic is checked
-    numerically in studio/frontend/tests/monitor-stack-inset.test.ts, including
-    `stackGeometry(null, W, H).maxHeight === H - 32`; what has to hold here is that
+    """The update card's own cap does not account for a long download list stacked
+    beneath it. The cap is no longer the literal class `max-h-[calc(100dvh_-_2rem)]`
+    but `stackGeometry`, whose arithmetic is checked numerically in
+    studio/frontend/tests/monitor-stack-inset.test.ts; what has to hold here is that
     the stack reads it rather than growing unbounded."""
     provider = (FRONTEND / "app/provider.tsx").read_text(encoding = "utf-8")
     stacks = provider.count("z-[9998] flex flex-col items-end gap-2")
     assert stacks, "the bottom-right overlay stack is gone"
-    # Counted, not merely present: there is more than one stack element and capping
-    # only one of them is exactly the bug this guards.
+    # Counted, not merely present: capping only one of the stacks is the bug here.
     assert provider.count("maxHeight: stack.maxHeight") == stacks, "every stack is capped"
     panel = (FRONTEND / "features/hub/download-manager/download-manager-panel.tsx").read_text(
         encoding = "utf-8"
@@ -1137,9 +1132,8 @@ def test_the_overlay_stack_fits_the_viewport():
 
 
 def test_the_desktop_stack_is_capped_like_the_browser_one():
-    """The download panel shares the desktop stack, so the update card's own
-    cap is not enough there either. Two stacks, two caps: the desktop branch is a
-    separate element and has been left uncapped before."""
+    """The download panel shares the desktop stack, so the update card's own cap is
+    not enough there either, and the desktop branch has been left uncapped before."""
     provider = (FRONTEND / "app/provider.tsx").read_text(encoding = "utf-8")
     assert provider.count("useStackGeometry()") == 2, "both stacks measure themselves"
     assert provider.count("maxHeight: stack.maxHeight") == 2, "both stacks are capped"
@@ -1147,8 +1141,8 @@ def test_the_desktop_stack_is_capped_like_the_browser_one():
 
 
 def test_the_stack_geometry_is_checked_numerically():
-    """The cap is arithmetic now, not a class name, so the test that owns it is the
-    node one. Named here so deleting it does not quietly leave the cap unchecked."""
+    """The cap is arithmetic now, not a class name, so the node test owns it. Named
+    here so deleting it does not quietly leave the cap unchecked."""
     geometry = REPO / "studio/frontend/tests/monitor-stack-inset.test.ts"
     src = geometry.read_text(encoding = "utf-8")
     assert (

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -1114,9 +1114,20 @@ def test_code_span_closers_ignore_backslashes():
 
 def test_the_overlay_stack_fits_the_viewport():
     """The update card's own cap does not account for a long download list
-    stacked beneath it."""
+    stacked beneath it.
+
+    The cap used to be the literal class `max-h-[calc(100dvh_-_2rem)]`. It is now
+    computed by `stackGeometry`, which subtracts the same 2rem when nothing is in
+    the way and subtracts more when the Live monitor is. The arithmetic is checked
+    numerically in studio/frontend/tests/monitor-stack-inset.test.ts, including
+    `stackGeometry(null, W, H).maxHeight === H - 32`; what has to hold here is that
+    the stack reads it rather than growing unbounded."""
     provider = (FRONTEND / "app/provider.tsx").read_text(encoding = "utf-8")
-    assert "max-h-[calc(100dvh_-_2rem)]" in provider
+    stacks = provider.count("z-[9998] flex flex-col items-end gap-2")
+    assert stacks, "the bottom-right overlay stack is gone"
+    # Counted, not merely present: there is more than one stack element and capping
+    # only one of them is exactly the bug this guards.
+    assert provider.count("maxHeight: stack.maxHeight") == stacks, "every stack is capped"
     panel = (FRONTEND / "features/hub/download-manager/download-manager-panel.tsx").read_text(
         encoding = "utf-8"
     )
@@ -1127,10 +1138,22 @@ def test_the_overlay_stack_fits_the_viewport():
 
 def test_the_desktop_stack_is_capped_like_the_browser_one():
     """The download panel shares the desktop stack, so the update card's own
-    cap is not enough there either."""
+    cap is not enough there either. Two stacks, two caps: the desktop branch is a
+    separate element and has been left uncapped before."""
     provider = (FRONTEND / "app/provider.tsx").read_text(encoding = "utf-8")
-    assert provider.count("max-h-[calc(100dvh_-_2rem)]") == 2, "both stacks are capped"
+    assert provider.count("useStackGeometry()") == 2, "both stacks measure themselves"
+    assert provider.count("maxHeight: stack.maxHeight") == 2, "both stacks are capped"
     assert "flex min-h-0" in TAURI_BANNER.read_text(encoding = "utf-8")
+
+
+def test_the_stack_geometry_is_checked_numerically():
+    """The cap is arithmetic now, not a class name, so the test that owns it is the
+    node one. Named here so deleting it does not quietly leave the cap unchecked."""
+    geometry = REPO / "studio/frontend/tests/monitor-stack-inset.test.ts"
+    src = geometry.read_text(encoding = "utf-8")
+    assert "stackGeometry(null, W, H).maxHeight, H - 32" in src, (
+        "nothing pins the no-obstacle cap to the 2rem the class used to spell"
+    )
 
 
 def test_desktop_notes_are_looked_up_by_the_backend_version():
@@ -1360,7 +1383,8 @@ def test_the_download_panel_can_shrink_inside_the_capped_stack():
     )
     assert 'positioned ? "fixed bottom-4 right-4 z-50" : "flex min-h-0 justify-end"' in panel
     provider = (FRONTEND / "app/provider.tsx").read_text(encoding="utf-8")
-    assert "max-h-[calc(100dvh_-_2rem)]" in provider, "the cap this has to absorb"
+    stacks = provider.count("z-[9998] flex flex-col items-end gap-2")
+    assert provider.count("maxHeight: stack.maxHeight") == stacks, "the cap this has to absorb"
 
 
 @pytest.fixture(scope="module")

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -1151,9 +1151,9 @@ def test_the_stack_geometry_is_checked_numerically():
     node one. Named here so deleting it does not quietly leave the cap unchecked."""
     geometry = REPO / "studio/frontend/tests/monitor-stack-inset.test.ts"
     src = geometry.read_text(encoding = "utf-8")
-    assert "stackGeometry(null, W, H).maxHeight, H - 32" in src, (
-        "nothing pins the no-obstacle cap to the 2rem the class used to spell"
-    )
+    assert (
+        "stackGeometry(null, W, H).maxHeight, H - 32" in src
+    ), "nothing pins the no-obstacle cap to the 2rem the class used to spell"
 
 
 def test_desktop_notes_are_looked_up_by_the_backend_version():


### PR DESCRIPTION
`Repo tests (CPU)` is red on `main`. Six failures, all in source-shape contract tests, all caused by their subject being rewritten under them:

```
tests/studio/test_model_picker_contracts.py::test_a_hidden_diffusion_page_does_not_load_when_its_download_lands
tests/studio/test_model_picker_contracts.py::test_a_routed_curated_pick_uses_the_same_load_spec_as_a_direct_one
tests/studio/test_model_picker_contracts.py::test_diffusion_pages_never_drop_a_gguf_pick_silently
tests/studio/test_update_release_notes.py::test_the_desktop_stack_is_capped_like_the_browser_one
tests/studio/test_update_release_notes.py::test_the_download_panel_can_shrink_inside_the_capped_stack
tests/studio/test_update_release_notes.py::test_the_overlay_stack_fits_the_viewport
```

I checked each one against the code before touching the test. In every case the behaviour the test exists to protect is intact, and in two cases it is better than what the assertion described. Nothing in `studio/` changes here.

## The overlay stack cap

The three release-notes tests asserted the literal class `max-h-[calc(100dvh_-_2rem)]`. #8082 replaced that fixed cap with `stackGeometry`, which subtracts the same 2rem when nothing is in the way and subtracts more when the Live monitor is, so the stack dodges the monitor instead of sitting under it.

The arithmetic is already checked numerically, in `studio/frontend/tests/monitor-stack-inset.test.ts`, fourteen cases including the exact successor of the old class:

```ts
assert.equal(stackGeometry(null, W, H).maxHeight, H - 32);
```

So the python test should not try to re-check the number. What it can still add is that every stack element reads the geometry, which it now does by counting:

```python
stacks = provider.count("z-[9998] flex flex-col items-end gap-2")
assert stacks, "the bottom-right overlay stack is gone"
assert provider.count("maxHeight: stack.maxHeight") == stacks, "every stack is capped"
```

Counting rather than checking presence is the point. There are two such elements, browser and desktop, and capping one and forgetting the other is precisely the mistake worth catching; a substring check cannot see it. A fourth, new test names the node test by path, so deleting the numeric check does not quietly leave the cap unguarded.

## The three picker contracts

**Routed pick.** The test pinned `diffusionRoutePick`'s second argument, which was respelled from `routeSearch.quant` to `routedFilename ?? undefined`. The catalog spec is the third argument and is the thing the test is named for. The regex no longer pins the second; the `loadSpecFor(wanted, IMAGE_CATALOG)` assertion is unchanged.

**GGUF guard.** The test required a `toast.error` in the branch that used to reject a repo-id pick outright. #8149 made that branch resolve the repo's own `.gguf` through `loadGgufRepoPick` instead, which is the better answer for the user. The invariant that survives the rewrite is that the branch does something: a bare `return` there drops the pick with no request and no message, which is the failure the test is named for.

**Deferred load.** The test required the flush effect to end with `}, [active]);` and to call `handleLoadRef` directly. The load body moved into `runStagedLoad`, now shared with the visible path, so the dependency array grew to `[active, runStagedLoad]`. The test accepts either spelling and, when the helper is used, follows through into it to confirm it actually loads.

## Mutation results

Eight mutations, all caught. Each breaks one thing an assertion claims to guard; the tree was restored and re-run green after each.

| mutation | caught by |
| --- | --- |
| browser stack loses its cap | overlay-stack, desktop-stack, download-panel |
| desktop stack alone loses its cap | desktop-stack |
| desktop stack stops measuring itself | desktop-stack |
| node test stops pinning `H - 32` | the new geometry-is-checked test |
| repo-id GGUF pick returns bare | gguf-guard |
| routed pick drops its catalog spec | routed-pick |
| deferred flush clears the flag and stops | deferred-load |
| `runStagedLoad` loads nothing | deferred-load |

The first two survived an earlier draft that used a plain `in` check on the provider source, since the other stack still carried the string. That is why the counting form is there rather than a substring test.

## Verification

`tests/studio/`: 3 failed, 2795 passed, 4 skipped, 1 error. The three are `test_studio_gguf_export_script_pin.py` and the error is `test_rocm_rdna_routing.py`; both fail identically on a clean `main` worktree and are outside this job's scope.

I did not run the frontend node suite locally: this worktree has no `node_modules`, and without it every test fails to resolve `react`. Frontend CI is green on `main` and covers `monitor-stack-inset.test.ts`, and no frontend source changes here.