### PR TITLE
Let the floating monitor paint over the notification stack

### DIFF
--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -467,10 +467,17 @@ function FloatingMonitorPanel({
 
   const hasGpu = (displayedGpu?.available ?? false) && devices.length > 0;
 
+  // The container's z sits above the bottom-right overlay stack (z-[9998]). That
+  // stack normally dodges this monitor, but the dodge has a floor: drag the monitor
+  // to the corner and resize it to fill the viewport and there is nowhere left to
+  // dodge to, so stackBottomInset clamps at MIN_STACK_ROOM and parks the stack at
+  // the top of the screen, directly over this monitor's title bar and Close button.
+  // The stack is passive status; this is a window the user is dragging, resizing and
+  // closing, so it wins. Still below the startup screen and tooltips.
   return (
     <div
       ref={setConstraintsElement}
-      className="pointer-events-none fixed inset-4 z-50"
+      className="pointer-events-none fixed inset-4 z-[9999]"
     >
       <motion.div
         ref={monitorRef}

--- a/tests/studio/test_overlay_layering.py
+++ b/tests/studio/test_overlay_layering.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Who paints over whom in the bottom-right corner.
+
+The floating API monitor and the notification stack both live there. The stack
+tries to dodge the monitor (see stackGeometry and monitor-stack-inset.test.ts),
+but the dodge has a floor: a monitor dragged to the corner and resized to fill
+the viewport leaves nowhere to dodge to, and the stack is parked at the top of
+the screen, on top of the monitor's own title bar. At that point z-order is the
+only thing deciding whether the monitor's Close button can be clicked.
+
+The Windows UI smoke does exactly that drag-and-resize and then clicks Close, so
+it catches a regression here for real. It takes about twenty minutes and needs a
+Windows runner. These read the numbers straight out of the source instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+FRONTEND = REPO / "studio/frontend/src"
+MONITOR = FRONTEND / "components/floating-monitor.tsx"
+PROVIDER = FRONTEND / "app/provider.tsx"
+STARTUP = FRONTEND / "components/tauri/startup-screen.tsx"
+TOOLTIP = FRONTEND / "components/ui/tooltip.tsx"
+
+_Z = re.compile(r"z-\[(\d+)\]")
+
+
+def _z_indexes(path: Path) -> list[int]:
+    return [int(m) for m in _Z.findall(path.read_text(encoding = "utf-8"))]
+
+
+def _monitor_root_z() -> int:
+    """The z on the monitor's constraints container, which is what stacks it."""
+    src = MONITOR.read_text(encoding = "utf-8")
+    root = re.search(r"ref=\{setConstraintsElement\}\s*\n\s*className=\"([^\"]+)\"", src)
+    assert root, "the monitor's constraints container was not found"
+    found = _Z.search(root.group(1))
+    assert found, f"the monitor's container carries no z-\\[n\\]: {root.group(1)!r}"
+    return int(found.group(1))
+
+
+def _stack_z() -> int:
+    """The bottom-right overlay stack. Both copies, browser and desktop."""
+    src = PROVIDER.read_text(encoding = "utf-8")
+    stacks = re.findall(r'className="pointer-events-none fixed right-4 z-\[(\d+)\]', src)
+    assert stacks, "the bottom-right overlay stack was not found"
+    assert len(set(stacks)) == 1, f"the two stacks disagree on z-index: {stacks}"
+    return int(stacks[0])
+
+
+def test_the_monitor_paints_over_the_notification_stack():
+    """A full-viewport monitor parks the stack over its own title bar. The stack is
+    passive status; the monitor is a window being dragged, resized and closed."""
+    assert _monitor_root_z() > _stack_z(), (
+        "the notification stack paints over the floating monitor, so its Close "
+        "button cannot be clicked once the monitor fills the viewport"
+    )
+
+
+@pytest.mark.parametrize("path", [STARTUP, TOOLTIP])
+def test_the_monitor_stays_under_the_layers_that_outrank_it(path: Path):
+    """Raising the monitor must not put it over the startup screen, which blocks
+    the app while the backend comes up, or over tooltips, which are transient and
+    have to be readable above whatever spawned them."""
+    above = [z for z in _z_indexes(path) if z >= _monitor_root_z()]
+    assert above, f"{path.name} no longer outranks the floating monitor"


### PR DESCRIPTION
`Windows Unsloth UI CI` is red on `main`. The smoke drags the API monitor to the corner, resizes it to fill the viewport, then clicks Close. The click never lands:

```
waiting for get_by_test_id("floating-monitor").get_by_role("button", name="Close")
  - element is visible, enabled and stable
  - scrolling into view if needed
  - done scrolling
  - <div class="menu-soft-surface pointer-events-auto flex min-h-0 w-[268px] ...">
    from <div class="pointer-events-none fixed right-4 z-[9998] ...">
  - retrying click action
  ... 113 x
```

The interceptor is the loaded models card, inside the bottom-right overlay stack. It is not a test flake: with a model loaded and the monitor maximised, a user cannot close the monitor.

## Why the dodge did not save it

The stack is supposed to dodge this monitor, and normally does. `stackBottomInset` lifts it clear of a monitor in its column, and `monitor-stack-inset.test.ts` covers that in fourteen cases.

The dodge has a floor. A monitor filling the viewport leaves nowhere to lift to, so the lift is clamped:

```ts
return Math.max(STACK_INSET, Math.min(lifted, viewportHeight - MIN_STACK_ROOM));
```

which parks the stack 120px from the top of the screen. That is exactly where a maximised monitor's title bar and Close button are. The clamp itself is correct, since a stack pushed off screen would be worse. The problem is what decides the outcome once they do overlap: the monitor's container is `z-50` and the stack is `z-[9998]`, so a passive status card paints over a window the user is dragging, resizing and closing.

## The fix

Raise the monitor's constraints container to `z-[9999]`.

Ordering afterwards, highest first: tooltips `z-[999999]`, startup screen `z-[9999]`, floating monitor `z-[9999]`, overlay stack `z-[9998]`. The monitor stays under the startup screen, which blocks the app while the backend comes up, and under tooltips, which have to stay readable above whatever spawned them. It never coexists with the startup screen, so sharing that number is not a real contest.

I considered the alternative of collapsing or hiding the stack when there is no room to dodge. That leaves banners visible in more cases, but it makes the loaded models indicator disappear exactly when a model is loaded, which is when it is meant to be there. Window beats status card.

## Tests

`tests/studio/test_overlay_layering.py` reads the z-indexes out of the source and compares them, rather than pinning any single value, so renumbering a layer does not break it. It also catches the browser and desktop stacks drifting apart from each other.

Six mutations, all caught:

| mutation | caught |
| --- | --- |
| monitor back under the stack | yes |
| stack raised over the monitor | yes |
| the two stacks disagree on z | yes |
| monitor container loses its z entirely | yes |
| startup screen drops below the monitor | yes |
| tooltips drop below the monitor | yes |

The real check is the Windows smoke, which does the drag, the resize and the click for real. It takes about twenty minutes and needs a Windows runner, so these read the numbers instead and fail in milliseconds.

## Expected CI noise

`Repo tests (CPU)` will be red on this PR until #8197 lands. Those are the six stale contract tests that are already red on `main` and have nothing to do with this change; three of them live in `test_update_release_notes.py`, which this branch also touches nothing in.