### PR TITLE
Stop the vLLM CUDA mismatch hint printing a wheel URL that 404s

### DIFF
--- a/tests/test_vllm_cuda_mismatch_wheel_url.py
+++ b/tests/test_vllm_cuda_mismatch_wheel_url.py
@@ -1,0 +1,307 @@
+# Unsloth - 2x faster, 60% less VRAM LLM training and finetuning
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+"""The CUDA-mismatch hint used to hand-build a wheel filename as
+``vllm-{v}+cu{system_cuda}-cp38-abi3-manylinux_2_35_{arch}.whl``. No vLLM release
+has ever published a ``+cu128`` asset and the manylinux tag moved
+manylinux1 -> 2_31 -> 2_35 -> 2_34 -> 2_24 -> 2_28, so on a CUDA 12.8 box the hint
+was a 404 (the same broken pattern as vllm-project/vllm#37847).
+
+Every URL the hint prints is checked against ``_RELEASE_ASSETS`` below, a snapshot of
+the real GitHub release assets (``gh api repos/vllm-project/vllm/releases/tags/vX -q
+'.assets[].name'``) that is independent of the table in ``import_fixes.py``. GPU-free.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import urllib.request
+
+import pytest
+
+from unsloth.import_fixes import (
+    _get_vllm_cuda_mismatch_message,
+    _get_vllm_wheel_url,
+    _VLLM_WHEEL_ASSETS,
+)
+
+
+# Real CUDA wheel assets per release (the ``+cpu`` and macOS assets are dropped).
+# Ground truth: the GitHub releases API, not Unsloth's own table.
+_RELEASE_ASSETS = {
+    "0.11.0": (
+        "vllm-0.11.0+cu129-cp38-abi3-manylinux1_x86_64.whl",
+        "vllm-0.11.0-cp38-abi3-manylinux1_x86_64.whl",
+        "vllm-0.11.0-cp38-abi3-manylinux2014_aarch64.whl",
+    ),
+    "0.11.1": (
+        "vllm-0.11.1+cu129-cp38-abi3-manylinux1_x86_64.whl",
+        "vllm-0.11.1+cu130-cp38-abi3-manylinux1_x86_64.whl",
+        "vllm-0.11.1-cp38-abi3-manylinux1_x86_64.whl",
+        "vllm-0.11.1-cp38-abi3-manylinux2014_aarch64.whl",
+    ),
+    "0.11.2": (
+        "vllm-0.11.2+cu129-cp38-abi3-manylinux1_x86_64.whl",
+        "vllm-0.11.2+cu130-cp38-abi3-manylinux1_x86_64.whl",
+        "vllm-0.11.2-cp38-abi3-manylinux1_x86_64.whl",
+        "vllm-0.11.2-cp38-abi3-manylinux2014_aarch64.whl",
+    ),
+    "0.12.0": (
+        "vllm-0.12.0+cu130-cp38-abi3-manylinux_2_31_x86_64.whl",
+        "vllm-0.12.0-cp38-abi3-manylinux_2_31_aarch64.whl",
+        "vllm-0.12.0-cp38-abi3-manylinux_2_31_x86_64.whl",
+    ),
+    "0.13.0": (
+        "vllm-0.13.0+cu130-cp38-abi3-manylinux_2_35_aarch64.whl",
+        "vllm-0.13.0+cu130-cp38-abi3-manylinux_2_35_x86_64.whl",
+        "vllm-0.13.0-cp38-abi3-manylinux_2_31_aarch64.whl",
+        "vllm-0.13.0-cp38-abi3-manylinux_2_31_x86_64.whl",
+    ),
+    "0.14.1": (
+        "vllm-0.14.1+cu130-cp38-abi3-manylinux_2_35_aarch64.whl",
+        "vllm-0.14.1+cu130-cp38-abi3-manylinux_2_35_x86_64.whl",
+        "vllm-0.14.1-cp38-abi3-manylinux_2_31_aarch64.whl",
+        "vllm-0.14.1-cp38-abi3-manylinux_2_31_x86_64.whl",
+    ),
+    "0.17.1": (
+        "vllm-0.17.1+cu130-cp38-abi3-manylinux_2_35_aarch64.whl",
+        "vllm-0.17.1+cu130-cp38-abi3-manylinux_2_35_x86_64.whl",
+        "vllm-0.17.1-cp38-abi3-manylinux_2_31_aarch64.whl",
+        "vllm-0.17.1-cp38-abi3-manylinux_2_31_x86_64.whl",
+    ),
+    "0.18.0": (
+        "vllm-0.18.0+cu130-cp38-abi3-manylinux_2_35_aarch64.whl",
+        "vllm-0.18.0+cu130-cp38-abi3-manylinux_2_35_x86_64.whl",
+        "vllm-0.18.0-cp38-abi3-manylinux_2_31_aarch64.whl",
+        "vllm-0.18.0-cp38-abi3-manylinux_2_31_x86_64.whl",
+    ),
+    "0.19.1": (
+        "vllm-0.19.1+cu130-cp38-abi3-manylinux_2_35_aarch64.whl",
+        "vllm-0.19.1+cu130-cp38-abi3-manylinux_2_35_x86_64.whl",
+        "vllm-0.19.1-cp38-abi3-manylinux_2_31_aarch64.whl",
+        "vllm-0.19.1-cp38-abi3-manylinux_2_31_x86_64.whl",
+    ),
+    "0.20.0": (
+        "vllm-0.20.0+cu129-cp38-abi3-manylinux_2_31_aarch64.whl",
+        "vllm-0.20.0+cu129-cp38-abi3-manylinux_2_31_x86_64.whl",
+        "vllm-0.20.0-cp38-abi3-manylinux_2_35_aarch64.whl",
+        "vllm-0.20.0-cp38-abi3-manylinux_2_35_x86_64.whl",
+    ),
+    "0.20.2": (
+        "vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl",
+        "vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_x86_64.whl",
+        "vllm-0.20.2-cp38-abi3-manylinux_2_35_aarch64.whl",
+        "vllm-0.20.2-cp38-abi3-manylinux_2_35_x86_64.whl",
+    ),
+    "0.21.0": (
+        "vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_aarch64.whl",
+        "vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_x86_64.whl",
+        "vllm-0.21.0-cp38-abi3-manylinux_2_24_aarch64.whl",
+        "vllm-0.21.0-cp38-abi3-manylinux_2_24_x86_64.whl",
+    ),
+    "0.22.0": (
+        "vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl",
+        "vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl",
+        "vllm-0.22.0-cp38-abi3-manylinux_2_28_aarch64.whl",
+        "vllm-0.22.0-cp38-abi3-manylinux_2_28_x86_64.whl",
+    ),
+    "0.23.0": (
+        "vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl",
+        "vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl",
+        "vllm-0.23.0-cp38-abi3-manylinux_2_28_aarch64.whl",
+        "vllm-0.23.0-cp38-abi3-manylinux_2_28_x86_64.whl",
+    ),
+    "0.25.1": (
+        "vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_aarch64.whl",
+        "vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_x86_64.whl",
+        "vllm-0.25.1-cp38-abi3-manylinux_2_28_aarch64.whl",
+        "vllm-0.25.1-cp38-abi3-manylinux_2_28_x86_64.whl",
+    ),
+    "0.26.0": (
+        "vllm-0.26.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl",
+        "vllm-0.26.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl",
+        "vllm-0.26.0-cp38-abi3-manylinux_2_28_aarch64.whl",
+        "vllm-0.26.0-cp38-abi3-manylinux_2_28_x86_64.whl",
+    ),
+}
+
+# Which CUDA major each snapshot asset is built for. The "+cuXXX" local tag names it
+# outright; the unsuffixed default wheel is CUDA 13 from 0.20.0 on ("CUDA 13.0 default"
+# in the v0.20.0 release notes) and CUDA 12 before that.
+_LOCAL_TAG_RE = re.compile(r"^vllm-[0-9.]+\+cu(\d\d)\d")
+
+_ARCHES = ("x86_64", "aarch64")
+_CUDA_MAJORS = (12, 13)
+
+
+def _cuda_major_of(asset, version):
+    match = _LOCAL_TAG_RE.match(asset)
+    if match:
+        return int(match.group(1))
+    from packaging.version import Version
+
+    return 13 if Version(version) >= Version("0.20.0") else 12
+
+
+def _assets_for(version, cuda_major, arch):
+    return {
+        asset
+        for asset in _RELEASE_ASSETS[version]
+        if asset.endswith(f"_{arch}.whl") and _cuda_major_of(asset, version) == cuda_major
+    }
+
+
+@pytest.mark.parametrize("version", sorted(_RELEASE_ASSETS))
+@pytest.mark.parametrize("arch", _ARCHES)
+@pytest.mark.parametrize("cuda_major", _CUDA_MAJORS)
+def test_wheel_url_names_a_published_asset(version, arch, cuda_major):
+    """Any URL we print must be a file that actually exists in that release."""
+    url = _get_vllm_wheel_url(version, cuda_major, arch)
+    published = _assets_for(version, cuda_major, arch)
+    if url is None:
+        return  # Not naming a wheel is always allowed; naming a wrong one is not.
+    assert url.startswith(
+        f"https://github.com/vllm-project/vllm/releases/download/v{version}/"
+    ), url
+    filename = url.rsplit("/", 1)[-1]
+    assert filename in published, (
+        f"vLLM {version} CUDA {cuda_major} {arch}: {filename} is not a published "
+        f"release asset. Published: {sorted(published) or 'none'}"
+    )
+
+
+@pytest.mark.parametrize("version", sorted(_RELEASE_ASSETS))
+def test_cuda12_wheel_is_resolved_for_every_known_release(version):
+    """The table must actually resolve, or the check above passes vacuously."""
+    url = _get_vllm_wheel_url(version, 12, "x86_64")
+    assert url is not None, f"no CUDA 12 x86_64 wheel resolved for vLLM {version}"
+    assert url.endswith(".whl")
+
+
+def test_no_release_ever_published_a_cu128_wheel():
+    """The old code built '+cu128' from torch.version.cuda; that asset never existed."""
+    for version, assets in _RELEASE_ASSETS.items():
+        for asset in assets:
+            assert "+cu128" not in asset, (version, asset)
+
+
+def _mismatch_message(monkeypatch, *, cuda = "12.8", vllm = "0.23.0",
+                      machine = "x86_64", system = "Linux",
+                      soname = 13):
+    import platform as _platform
+    import unsloth.import_fixes as import_fixes
+
+    monkeypatch.setattr(_platform, "machine", lambda: machine)
+    monkeypatch.setattr(_platform, "system", lambda: system)
+    monkeypatch.setattr(import_fixes, "importlib_version", lambda name: vllm)
+
+    class _FakeTorchVersion:
+        pass
+
+    _FakeTorchVersion.cuda = cuda
+    fake_torch = type("torch", (), {"version": _FakeTorchVersion})
+    monkeypatch.setitem(__import__("sys").modules, "torch", fake_torch)
+
+    error = ImportError(
+        f"libcudart.so.{soname}: cannot open shared object file: No such file or directory"
+    )
+    return _get_vllm_cuda_mismatch_message(error)
+
+
+def test_message_recommends_the_real_cu129_wheel_on_a_cuda12_system(monkeypatch):
+    message = _mismatch_message(monkeypatch)
+    assert (
+        "https://github.com/vllm-project/vllm/releases/download/v0.23.0/"
+        "vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" in message
+    ), message
+    assert "cu128" not in message
+    assert "manylinux_2_35" not in message
+
+
+def test_message_is_arch_correct_on_aarch64(monkeypatch):
+    message = _mismatch_message(monkeypatch, machine = "aarch64")
+    assert "manylinux_2_28_aarch64.whl" in message, message
+    assert "x86_64" not in message
+
+
+def test_message_recommends_the_default_wheel_on_a_cuda13_system(monkeypatch):
+    """Reverse direction: CUDA 13 host, vLLM built for CUDA 12."""
+    message = _mismatch_message(monkeypatch, cuda = "13.0", soname = 12)
+    assert "vllm-0.23.0-cp38-abi3-manylinux_2_28_x86_64.whl" in message, message
+    assert "+cu" not in message
+
+
+def test_older_release_uses_its_own_manylinux_tag(monkeypatch):
+    message = _mismatch_message(monkeypatch, vllm = "0.18.0")
+    assert "vllm-0.18.0-cp38-abi3-manylinux_2_31_x86_64.whl" in message, message
+
+
+def test_unmapped_newer_release_points_at_the_release_page(monkeypatch):
+    message = _mismatch_message(monkeypatch, vllm = "0.99.0")
+    assert ".whl" not in message, message
+    assert "https://github.com/vllm-project/vllm/releases/tag/v0.99.0" in message
+    assert "+cu129" in message  # still says which variant to pick
+
+
+def test_non_release_version_never_fabricates_a_filename(monkeypatch):
+    message = _mismatch_message(monkeypatch, vllm = "0.24.0rc1")
+    assert ".whl" not in message, message
+    assert "https://github.com/vllm-project/vllm/releases" in message
+
+
+@pytest.mark.parametrize("system,machine", [("Windows", "AMD64"), ("Darwin", "arm64")])
+def test_non_linux_never_recommends_a_manylinux_wheel(monkeypatch, system, machine):
+    message = _mismatch_message(monkeypatch, system = system, machine = machine)
+    assert "manylinux" not in message, message
+    assert ".whl" not in message, message
+
+
+def test_matching_cuda_is_not_reported_as_a_mismatch(monkeypatch):
+    assert _mismatch_message(monkeypatch, cuda = "12.8", soname = 12) is None
+
+
+def test_unrelated_error_is_not_reported_as_a_mismatch(monkeypatch):
+    import unsloth.import_fixes as import_fixes
+
+    assert import_fixes._get_vllm_cuda_mismatch_message(
+        ImportError("vllm._C: undefined symbol: _ZN3c108ListType3ofTsEv")
+    ) is None
+
+
+def test_table_ranges_are_ordered_and_disjoint():
+    from packaging.version import Version
+
+    previous_high = None
+    for low, high, by_cuda in _VLLM_WHEEL_ASSETS:
+        assert Version(low) <= Version(high), (low, high)
+        if previous_high is not None:
+            assert Version(previous_high) < Version(low), (previous_high, low)
+        previous_high = high
+        assert by_cuda, (low, high)
+
+
+@pytest.mark.skipif(
+    os.environ.get("UNSLOTH_TEST_NETWORK", "0") not in ("1", "true", "True"),
+    reason = "set UNSLOTH_TEST_NETWORK=1 to check the URLs against GitHub",
+)
+@pytest.mark.parametrize("version", sorted(_RELEASE_ASSETS))
+def test_wheel_urls_resolve_live(version):
+    for cuda_major in _CUDA_MAJORS:
+        for arch in _ARCHES:
+            url = _get_vllm_wheel_url(version, cuda_major, arch)
+            if url is None:
+                continue
+            request = urllib.request.Request(url, method = "HEAD")
+            with urllib.request.urlopen(request, timeout = 30) as response:
+                assert response.status == 200, (url, response.status)

--- a/tests/test_vllm_cuda_mismatch_wheel_url.py
+++ b/tests/test_vllm_cuda_mismatch_wheel_url.py
@@ -196,9 +196,15 @@ def test_no_release_ever_published_a_cu128_wheel():
             assert "+cu128" not in asset, (version, asset)
 
 
-def _mismatch_message(monkeypatch, *, cuda = "12.8", vllm = "0.23.0",
-                      machine = "x86_64", system = "Linux",
-                      soname = 13):
+def _mismatch_message(
+    monkeypatch,
+    *,
+    cuda = "12.8",
+    vllm = "0.23.0",
+    machine = "x86_64",
+    system = "Linux",
+    soname = 13,
+):
     import platform as _platform
     import unsloth.import_fixes as import_fixes
 
@@ -273,15 +279,16 @@ def test_matching_cuda_is_not_reported_as_a_mismatch(monkeypatch):
 
 def test_unrelated_error_is_not_reported_as_a_mismatch(monkeypatch):
     import unsloth.import_fixes as import_fixes
-
-    assert import_fixes._get_vllm_cuda_mismatch_message(
-        ImportError("vllm._C: undefined symbol: _ZN3c108ListType3ofTsEv")
-    ) is None
+    assert (
+        import_fixes._get_vllm_cuda_mismatch_message(
+            ImportError("vllm._C: undefined symbol: _ZN3c108ListType3ofTsEv")
+        )
+        is None
+    )
 
 
 def test_table_ranges_are_ordered_and_disjoint():
     from packaging.version import Version
-
     previous_high = None
     for low, high, by_cuda in _VLLM_WHEEL_ASSETS:
         assert Version(low) <= Version(high), (low, high)

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -2968,9 +2968,7 @@ def _is_broken_vllm_error(error) -> bool:
 
 
 _VLLM_RELEASES_URL = "https://github.com/vllm-project/vllm/releases"
-_VLLM_INSTALL_DOCS_URL = (
-    "https://docs.vllm.ai/en/latest/getting_started/installation/gpu/"
-)
+_VLLM_INSTALL_DOCS_URL = "https://docs.vllm.ai/en/latest/getting_started/installation/gpu/"
 
 # A plain release version, e.g. "0.23.0". Anything else (rc / dev / post builds)
 # has no matching GitHub release asset, so we never name a wheel for it.

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -2967,10 +2967,148 @@ def _is_broken_vllm_error(error) -> bool:
     return False
 
 
+_VLLM_RELEASES_URL = "https://github.com/vllm-project/vllm/releases"
+_VLLM_INSTALL_DOCS_URL = (
+    "https://docs.vllm.ai/en/latest/getting_started/installation/gpu/"
+)
+
+# A plain release version, e.g. "0.23.0". Anything else (rc / dev / post builds)
+# has no matching GitHub release asset, so we never name a wheel for it.
+_VLLM_RELEASE_VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+)*$")
+
+# Normalises platform.machine() onto the arch spelling used in wheel names.
+_VLLM_WHEEL_ARCHES = {
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+    "x64": "x86_64",
+    "aarch64": "aarch64",
+    "arm64": "aarch64",
+}
+
+
+def _both_arches(manylinux_tag):
+    return {"x86_64": manylinux_tag, "aarch64": manylinux_tag}
+
+
+# vLLM ships exactly one CUDA build per release as the unsuffixed "default" wheel
+# and the other under a "+cuXXX" local version tag. Which CUDA major is the default
+# flipped at 0.20.0 (release notes: "CUDA 13.0 default"), the "+cuXXX" tag has been
+# cu130 and then cu129, and the manylinux tag has moved manylinux1 -> 2_31 -> 2_35 ->
+# 2_34 -> 2_24 -> 2_28, differing between the two wheels of the same release. So the
+# asset name cannot be derived from a formula: vLLM's own docs document a
+# "+cu${CUDA_VERSION}" pattern that 404s (vllm-project/vllm#37847), and no release
+# has ever published a "+cu128" wheel.
+#
+# Each entry is (min_version, max_version, {cuda_major: (local_tag, {arch: manylinux})}),
+# transcribed from the actual release assets. A CUDA major or arch that is absent was
+# never published for that range. Extend the table when a new vLLM release lands; until
+# then newer versions fall back to the release page instead of a fabricated filename.
+_VLLM_WHEEL_ASSETS = (
+    (
+        "0.11.0",
+        "0.11.0",
+        {12: ("", {"x86_64": "manylinux1", "aarch64": "manylinux2014"})},
+    ),
+    (
+        "0.11.1",
+        "0.11.2",
+        {
+            12: ("", {"x86_64": "manylinux1", "aarch64": "manylinux2014"}),
+            13: ("cu130", {"x86_64": "manylinux1"}),
+        },
+    ),
+    (
+        "0.12.0",
+        "0.12.0",
+        {
+            12: ("", _both_arches("manylinux_2_31")),
+            13: ("cu130", {"x86_64": "manylinux_2_31"}),
+        },
+    ),
+    (
+        "0.13.0",
+        "0.19.1",
+        {
+            12: ("", _both_arches("manylinux_2_31")),
+            13: ("cu130", _both_arches("manylinux_2_35")),
+        },
+    ),
+    (
+        "0.20.0",
+        "0.20.2",
+        {
+            12: ("cu129", _both_arches("manylinux_2_31")),
+            13: ("", _both_arches("manylinux_2_35")),
+        },
+    ),
+    (
+        "0.21.0",
+        "0.21.0",
+        {
+            12: ("cu129", _both_arches("manylinux_2_34")),
+            13: ("", _both_arches("manylinux_2_24")),
+        },
+    ),
+    (
+        "0.22.0",
+        "0.26.0",
+        {
+            12: ("cu129", _both_arches("manylinux_2_28")),
+            13: ("", _both_arches("manylinux_2_28")),
+        },
+    ),
+)
+
+# From this release on, the default (unsuffixed) wheel is the CUDA 13 build and the
+# CUDA 12 build carries "+cu129", so we can still name the right variant for a release
+# newer than the table above even though its manylinux tag is unknown.
+_VLLM_CUDA13_DEFAULT_SINCE = "0.20.0"
+
+
+def _get_vllm_wheel_url(vllm_version, cuda_major, cpu_arch):
+    """URL of the published vLLM wheel for this release/CUDA/arch, else None."""
+    if not _VLLM_RELEASE_VERSION_RE.match(vllm_version or ""):
+        return None
+    arch = _VLLM_WHEEL_ARCHES.get(str(cpu_arch).lower())
+    if arch is None:
+        return None
+    try:
+        wanted = TrueVersion(vllm_version)
+    except Exception:
+        return None
+    for low, high, by_cuda in _VLLM_WHEEL_ASSETS:
+        if not TrueVersion(low) <= wanted <= TrueVersion(high):
+            continue
+        local_tag, manylinux_by_arch = by_cuda.get(cuda_major, (None, {}))
+        manylinux = manylinux_by_arch.get(arch)
+        if manylinux is None:
+            return None
+        local = f"+{local_tag}" if local_tag else ""
+        return (
+            f"{_VLLM_RELEASES_URL}/download/v{vllm_version}/"
+            f"vllm-{vllm_version}{local}-cp38-abi3-{manylinux}_{arch}.whl"
+        )
+    return None
+
+
+def _get_vllm_wheel_variant_hint(vllm_version, cuda_major):
+    """Which wheel of a release to pick, when we cannot name the exact file."""
+    if not _VLLM_RELEASE_VERSION_RE.match(vllm_version or ""):
+        return None
+    try:
+        if TrueVersion(vllm_version) < TrueVersion(_VLLM_CUDA13_DEFAULT_SINCE):
+            return None
+    except Exception:
+        return None
+    if cuda_major >= 13:
+        return "the default wheel (the one with no `+cuXXX` suffix)"
+    if cuda_major == 12:
+        return "the `+cu129` wheel"
+    return None
+
+
 def _get_vllm_cuda_mismatch_message(error):
     """If the error is a CUDA version mismatch, return a helpful install message."""
-    import re as _re
-
     checked = set()
     current = error
     wanted_cuda = None
@@ -2978,9 +3116,9 @@ def _get_vllm_cuda_mismatch_message(error):
         checked.add(id(current))
         message = str(current)
         # Extract the CUDA version vllm was built for, e.g. "libcudart.so.12"
-        match = _re.search(r"libcudart\.so\.(\d+)", message)
+        match = re.search(r"libcudart\.so\.(\d+)", message)
         if match:
-            wanted_cuda = match.group(1)
+            wanted_cuda = int(match.group(1))
             break
         current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
     if wanted_cuda is None:
@@ -2988,38 +3126,64 @@ def _get_vllm_cuda_mismatch_message(error):
 
     # Detect what CUDA version is actually available on the system
     system_cuda_display = None  # Human-readable, e.g. "13.0"
-    system_cuda_tag = None  # For wheel URL, e.g. "130"
+    system_cuda_major = None
     try:
         import torch
         cuda_version = torch.version.cuda  # e.g. "13.0" or "12.8"
         if cuda_version:
             system_cuda_display = cuda_version
-            system_cuda_tag = cuda_version.replace(".", "")[:3]  # "130" or "128"
+            system_cuda_major = int(str(cuda_version).split(".")[0])
     except Exception:
         pass
 
-    if system_cuda_tag is None or system_cuda_tag.startswith(wanted_cuda):
+    if system_cuda_major is None or system_cuda_major == wanted_cuda:
         return None  # Not a mismatch or can't determine
 
     try:
         vllm_version = importlib_version("vllm").split("+")[0]
     except Exception:
-        vllm_version = "VLLM_VERSION"
+        vllm_version = None
 
+    system = ""
     cpu_arch = "x86_64"
     try:
         import platform
+        system = platform.system()
         cpu_arch = platform.machine()
     except Exception:
         pass
 
-    return (
+    header = (
         f"Unsloth: vLLM was built for CUDA {wanted_cuda} but this system has "
-        f"CUDA {system_cuda_display}. Please reinstall vLLM with the correct CUDA version:\n"
-        f"\n"
-        f"  uv pip install https://github.com/vllm-project/vllm/releases/download/"
-        f"v{vllm_version}/vllm-{vllm_version}+cu{system_cuda_tag}-cp38-abi3-"
-        f"manylinux_2_35_{cpu_arch}.whl"
+        f"CUDA {system_cuda_display}. "
+    )
+
+    # vLLM only publishes CUDA wheels for Linux (Windows users go through WSL).
+    if system and system != "Linux":
+        return (
+            f"{header}Please reinstall a vLLM build for CUDA {system_cuda_major}; "
+            f"vLLM publishes CUDA wheels for Linux only, so see\n\n  "
+            f"{_VLLM_INSTALL_DOCS_URL}"
+        )
+
+    wheel_url = _get_vllm_wheel_url(vllm_version, system_cuda_major, cpu_arch)
+    if wheel_url is not None:
+        return (
+            f"{header}Please reinstall vLLM with the correct CUDA version:\n\n  "
+            f"uv pip install {wheel_url}"
+        )
+
+    # Unknown / unmapped release: never invent a filename, point at the real assets.
+    hint = _get_vllm_wheel_variant_hint(vllm_version, system_cuda_major)
+    hint = f"Download {hint} for your platform" if hint else "Pick the wheel for your platform"
+    release_page = (
+        f"{_VLLM_RELEASES_URL}/tag/v{vllm_version}"
+        if _VLLM_RELEASE_VERSION_RE.match(vllm_version or "")
+        else _VLLM_RELEASES_URL
+    )
+    return (
+        f"{header}Please reinstall a vLLM build for CUDA {system_cuda_major}. "
+        f"{hint} from\n\n  {release_page}"
     )
 
 


### PR DESCRIPTION
When a vLLM wheel built for a different CUDA major fails to load, `_get_vllm_cuda_mismatch_message` prints a reinstall command. It built the filename by hand:

```
vllm-{version}+cu{torch.version.cuda}-cp38-abi3-manylinux_2_35_{arch}.whl
```

That pattern is copied from vLLM's own install docs, which are stale, and it is wrong twice.

**No vLLM release has ever published a `+cu128` asset.** Checking every release from 0.10.0 to 0.26.0, the CUDA variants published are `+cu118`, `+cu126`, `+cu129`, `+cu130` and the unsuffixed default; `cu128` appears nowhere. So on any CUDA 12.8 machine the URL is a guaranteed 404. Someone hit the identical URL from the vLLM docs in vllm-project/vllm#37847.

**The manylinux tag is not `manylinux_2_35`.** It has moved `manylinux1` -> `manylinux_2_31` -> `manylinux_2_35` -> `manylinux_2_34` -> `manylinux_2_24` -> `manylinux_2_28`, and it differs between the two wheels of the *same* release (0.20.0 ships `+cu129` as `manylinux_2_31` and the default as `manylinux_2_35`).

Observed on a Colab L4, torch 2.11.0+cu128, vLLM 0.23.0: the hint fires and prints a 404, and because vLLM is then blocked the next error the user sees is the misleading `Unsloth: Please install vLLM before enabling fast_inference!`.

## What actually exists

Each release ships one CUDA build as the unsuffixed default wheel and the other under a `+cuXXX` local version tag. Which major is the default flipped at 0.20.0 (its release notes: "CUDA 13.0 default: Default CUDA wheel on PyPI ... switched to CUDA 13.0"):

| vLLM | CUDA 12 wheel | CUDA 13 wheel |
|---|---|---|
| 0.11.0 - 0.11.2 | default, `manylinux1` / `manylinux2014` | `+cu130`, `manylinux1`, x86_64 only (0.11.1+) |
| 0.12.0 | default, `manylinux_2_31` | `+cu130`, `manylinux_2_31`, x86_64 only |
| 0.13.0 - 0.19.1 | default, `manylinux_2_31` | `+cu130`, `manylinux_2_35` |
| 0.20.0 - 0.20.2 | `+cu129`, `manylinux_2_31` | default, `manylinux_2_35` |
| 0.21.0 | `+cu129`, `manylinux_2_34` | default, `manylinux_2_24` |
| 0.22.0 - 0.26.0 | `+cu129`, `manylinux_2_28` | default, `manylinux_2_28` |

There is no formula here, so the fix is a lookup table transcribed from the release assets.

## The change

- Resolve the wheel from that table. On the reported case it now prints the real asset:
  `https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl`. `+cu129` is the right recommendation for a CUDA 12.8 host: its soname is the major-versioned `libcudart.so.12`, and CUDA minor version compatibility covers a 12.9-built binary on a 12.x runtime.
- Never fabricate a filename for an unknown or unmapped version. A release newer than the table, or an rc/dev build, gets the release page plus which variant to pick.
- No network call at error-reporting time.
- `aarch64` (and `arm64`) resolve to the aarch64 asset, and a version/arch combination that was never published falls back rather than guessing.
- Windows and macOS get the vLLM install docs instead of a manylinux wheel. WSL is Linux and takes the normal path.
- Mismatch detection now compares CUDA majors as integers instead of a string prefix on a 3-char tag.

## Tests

`tests/test_vllm_cuda_mismatch_wheel_url.py`, GPU-free, 92 tests. Every URL the hint can emit is checked against a snapshot of the real release assets taken from the GitHub releases API, which is independent of the table in `import_fixes.py`, plus end-to-end message tests for CUDA 12 host, CUDA 13 host, aarch64, an older release, an unmapped release, an rc version, Windows, macOS, and the two no-mismatch cases. An opt-in `UNSLOTH_TEST_NETWORK=1` pass HEADs all 16 resolvable URLs against GitHub; all return 200.

Sabotage-checked, since a green test proves nothing on its own:

| reintroduced defect | result |
|---|---|
| the old `+cu128` / `manylinux_2_35` construction | 60 failed, 32 passed |
| `manylinux_2_24` -> `manylinux_2_28` for 0.21.0 only | 2 failed, exactly the 0.21.0 CUDA 13 cases |
| `+cu129` -> `+cu128` for 0.22.0 - 0.26.0 | 9 failed |
| resolver always returns `None` (vacuity check) | 20 failed |

`tests/test_vllm_broken_detection.py`, `tests/test_import_fixes_drift.py` and the new file: 123 passed, 17 skipped. Ruff clean.