### PR TITLE
fix overlay banners floating mid-screen on an empty chat

### DIFF
--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -71,6 +71,7 @@ const STACK_GAP = 8;
 const STACK_WIDTH = 448;
 // Never lift so far that the stack itself is pushed off the top.
 const MIN_STACK_ROOM = 120;
+const STACK_BOTTOM_ZONE = MIN_STACK_ROOM + STACK_INSET + STACK_GAP;
 
 /**
  * How far above the bottom edge the overlay stack must sit to clear the Live
@@ -86,6 +87,10 @@ function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
   );
 }
 
+function inStackCorner(frame: MonitorFrame, viewportHeight: number): boolean {
+  return viewportHeight - frame.bottom < STACK_BOTTOM_ZONE;
+}
+
 export function stackBottomInset(
   frame: MonitorFrame | null,
   viewportWidth: number,
@@ -94,7 +99,7 @@ export function stackBottomInset(
   if (!frame) return STACK_INSET;
   // Only dodge a monitor that is actually in the stack's column and low
   // enough to be in its way; one dragged elsewhere leaves the corner free.
-  const lowEnough = frame.bottom > viewportHeight / 2;
+  const lowEnough = inStackCorner(frame, viewportHeight);
   if (!(inStackColumn(frame, viewportWidth) && lowEnough)) return STACK_INSET;
   const lifted = viewportHeight - frame.top + STACK_GAP;
   return Math.max(
@@ -121,7 +126,7 @@ export function stackMaxHeight(
 ): number {
   const ownMargin = viewportHeight - bottomInset - STACK_INSET;
   if (!frame || !inStackColumn(frame, viewportWidth)) return ownMargin;
-  if (frame.bottom > viewportHeight / 2) return ownMargin;
+  if (inStackCorner(frame, viewportHeight)) return ownMargin;
   const belowMonitor = viewportHeight - bottomInset - frame.bottom - STACK_GAP;
   return Math.max(MIN_STACK_ROOM, Math.min(ownMargin, belowMonitor));
 }

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -71,7 +71,6 @@ const STACK_GAP = 8;
 const STACK_WIDTH = 448;
 // Never lift so far that the stack itself is pushed off the top.
 const MIN_STACK_ROOM = 120;
-const STACK_BOTTOM_ZONE = MIN_STACK_ROOM + STACK_INSET + STACK_GAP;
 
 /**
  * How far above the bottom edge the overlay stack must sit to clear the Live
@@ -87,19 +86,30 @@ function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
   );
 }
 
-function inStackCorner(frame: MonitorFrame, viewportHeight: number): boolean {
-  return viewportHeight - frame.bottom < STACK_BOTTOM_ZONE;
+// Whether so little room is left under the box, with the stack sitting on
+// `bottomInset`, that capping beneath it would leave less than the stack's own
+// floor. Such a box has to be lifted over instead. A lift another box asked for
+// comes out of the same room, so it counts against this too.
+function inStackCorner(
+  frame: MonitorFrame,
+  viewportHeight: number,
+  bottomInset: number,
+): boolean {
+  return (
+    viewportHeight - frame.bottom - bottomInset - STACK_GAP < MIN_STACK_ROOM
+  );
 }
 
 export function stackBottomInset(
   frame: MonitorFrame | null,
   viewportWidth: number,
   viewportHeight: number,
+  bottomInset: number = STACK_INSET,
 ): number {
   if (!frame) return STACK_INSET;
   // Only dodge a monitor that is actually in the stack's column and low
   // enough to be in its way; one dragged elsewhere leaves the corner free.
-  const lowEnough = inStackCorner(frame, viewportHeight);
+  const lowEnough = inStackCorner(frame, viewportHeight, bottomInset);
   if (!(inStackColumn(frame, viewportWidth) && lowEnough)) return STACK_INSET;
   const lifted = viewportHeight - frame.top + STACK_GAP;
   return Math.max(
@@ -126,7 +136,7 @@ export function stackMaxHeight(
 ): number {
   const ownMargin = viewportHeight - bottomInset - STACK_INSET;
   if (!frame || !inStackColumn(frame, viewportWidth)) return ownMargin;
-  if (inStackCorner(frame, viewportHeight)) return ownMargin;
+  if (inStackCorner(frame, viewportHeight, bottomInset)) return ownMargin;
   const belowMonitor = viewportHeight - bottomInset - frame.bottom - STACK_GAP;
   return Math.max(MIN_STACK_ROOM, Math.min(ownMargin, belowMonitor));
 }
@@ -156,9 +166,19 @@ export function stackGeometry(
       maxHeight: stackMaxHeight(null, viewportWidth, viewportHeight, bottom),
     };
   }
-  const bottom = Math.max(
-    ...list.map((f) => stackBottomInset(f, viewportWidth, viewportHeight)),
-  );
+  // Lifting over one box eats the room left under another, which can leave a
+  // box that looked high enough to sit under too low to sit under after all.
+  // Re-ask at the lift agreed so far until it stops growing.
+  let bottom = STACK_INSET;
+  for (let pass = 0; pass <= list.length; pass += 1) {
+    const next = Math.max(
+      ...list.map((f) =>
+        stackBottomInset(f, viewportWidth, viewportHeight, bottom),
+      ),
+    );
+    if (next === bottom) break;
+    bottom = next;
+  }
   return {
     bottom,
     maxHeight: Math.min(

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -213,6 +213,48 @@ test("no box in the column is ever overlapped, on either branch", () => {
   }
 });
 
+// The lift one box asks for comes out of the room left under another, so a box
+// that was high enough to sit under on its own may not be once the stack has
+// moved up. Capping it there falls through to the stack's floor and lands the
+// stack back on top of it. Both of these need no dragging beyond opening the
+// monitor where it opens by default.
+test("a box is not capped under using room another box's lift took", () => {
+  const monitorCorner = corner(300);
+  const both = stackGeometry([welcomeComposer, monitorCorner], W, H);
+  const stackTop = H - both.bottom - both.maxHeight;
+  for (const frame of [welcomeComposer, monitorCorner]) {
+    assert.ok(
+      H - both.bottom <= frame.top || stackTop >= frame.bottom,
+      `stack ${stackTop}..${H - both.bottom} overlaps ${frame.top}..${frame.bottom}`,
+    );
+  }
+});
+
+test("the monitor dragged up the column is not overlapped either", () => {
+  const docked: MonitorFrame = {
+    left: 300,
+    top: H - 141,
+    right: W - 340,
+    bottom: H - 29,
+  };
+  for (let bottom = 0; bottom <= H; bottom += 1) {
+    const monitor: MonitorFrame = {
+      left: W - 272,
+      top: Math.max(0, bottom - 300),
+      right: W - 16,
+      bottom,
+    };
+    const { bottom: inset, maxHeight } = stackGeometry([monitor, docked], W, H);
+    const stackTop = H - inset - maxHeight;
+    for (const frame of [monitor, docked]) {
+      assert.ok(
+        H - inset <= frame.top || stackTop >= frame.bottom,
+        `monitor at bottom=${bottom}: stack ${stackTop}..${H - inset} overlaps ${frame.top}..${frame.bottom}`,
+      );
+    }
+  }
+});
+
 test("an empty list behaves exactly like nothing published", () => {
   assert.deepEqual(stackGeometry([], W, H), stackGeometry(null, W, H));
 });

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -157,6 +157,62 @@ test("two obstacles are folded one at a time, not as their bounding box", () => 
   assert.ok(both.bottom < unioned.bottom, "and it must lift less, not more");
 });
 
+const welcomeComposer: MonitorFrame = {
+  left: 492,
+  top: 376,
+  right: 1228,
+  bottom: 488,
+};
+
+test("the centred welcome composer does not lift the stack", () => {
+  assert.equal(stackBottomInset(welcomeComposer, W, H), 16);
+});
+
+test("a centred composer just past the midline still does not lift", () => {
+  const frame: MonitorFrame = { ...welcomeComposer, top: 417, bottom: 529 };
+  assert.equal(stackBottomInset(frame, W, 1050), 16);
+});
+
+test("the centred composer caps the stack instead of lifting it", () => {
+  const geometry = stackGeometry(welcomeComposer, W, H);
+  assert.equal(geometry.bottom, 16);
+  assert.ok(
+    H - geometry.bottom - geometry.maxHeight >= welcomeComposer.bottom,
+    "the stack's top edge stays below the composer",
+  );
+  assert.ok(geometry.maxHeight < H - 32, "it must actually be capped");
+});
+
+test("the docked composer still lifts the stack", () => {
+  const docked: MonitorFrame = {
+    left: 300,
+    top: H - 141,
+    right: W - 340,
+    bottom: H - 29,
+  };
+  const inset = stackBottomInset(docked, W, H);
+  assert.ok(inset > 16, "the stack must move");
+  assert.ok(H - inset <= docked.top, "no vertical overlap remains");
+});
+
+test("no box in the column is ever overlapped, on either branch", () => {
+  for (let fromBottom = 0; fromBottom <= 400; fromBottom += 1) {
+    const frame: MonitorFrame = {
+      left: W - 272,
+      top: Math.max(0, H - fromBottom - 300),
+      right: W - 16,
+      bottom: H - fromBottom,
+    };
+    const { bottom, maxHeight } = stackGeometry(frame, W, H);
+    const stackTop = H - bottom - maxHeight;
+    const liftedClear = H - bottom <= frame.top;
+    assert.ok(
+      liftedClear || stackTop >= frame.bottom,
+      `overlap at ${fromBottom}px off the bottom`,
+    );
+  }
+});
+
 test("an empty list behaves exactly like nothing published", () => {
   assert.deepEqual(stackGeometry([], W, H), stackGeometry(null, W, H));
 });


### PR DESCRIPTION
On a new chat, the llama.cpp update banner, the desktop update banner, the download panel and the loaded models card all float in the middle of the window instead of sitting in the bottom-right corner.

The stack lifts itself clear of any box published in its column, and treats a box as being in the way when `frame.bottom > viewportHeight / 2`. The chat composer publishes its box even while it is centred on an empty thread, and centred it clears the midline in any window shorter than ~1050px  so the stack lifts over a box in the middle of the screen. Every default desktop window is in that range.

Fixed by only counting a box as blocking the corner if it actually reaches the bottom edge. `inStackCorner` replaces the midline test in both `stackBottomInset` and `stackMaxHeight` so they cannot disagree. The centred composer now takes the existing "parked high" branch: the stack stays in its corner, capped short of the composer.

Measured on an empty chat at 1440x900, the stack inset goes from 532px to 16px. The docked composer still lifts it, as before.