### PR TITLE
fix(mlx): report unsloth's own version instead of unsloth-zoo's

### DIFF
--- a/tests/studio/test_is_mlx_dispatch_gate.py
+++ b/tests/studio/test_is_mlx_dispatch_gate.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 UNSLOTH_INIT = REPO_ROOT / "unsloth" / "__init__.py"
+MODELS_UTILS = REPO_ROOT / "unsloth" / "models" / "_utils.py"
 
 
 # 1. Source-level structure check on _IS_MLX (no platform dependencies).
@@ -199,3 +200,107 @@ def test_detect_hardware_picks_cuda_on_real_host():
     hw = _import_studio_hardware()
     detected = hw.detect_hardware()
     assert detected == hw.DeviceType.CUDA, f"CUDA host must dispatch to CUDA, got {detected!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4. The MLX branch must report unsloth's OWN version, not unsloth-zoo's.
+#    unsloth-zoo is a separately released distribution pinned with `>=`, so its
+#    version routinely trails the core's; aliasing it made `unsloth.__version__`
+#    disagree with `pip show unsloth` on every Apple Silicon install (#8171).
+#    Executed straight out of the source so the test exercises the real
+#    statements, not a reimplementation, and needs no torch/mlx to run.
+# ---------------------------------------------------------------------------
+
+
+_ZOO_SENTINEL = "0.0.0+zoo-sentinel"
+
+
+def _mlx_branch(tree):
+    """The body of the module-level ``if _IS_MLX:`` dispatch branch."""
+    for node in tree.body:
+        if (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Name)
+            and node.test.id == "_IS_MLX"
+        ):
+            return node
+    raise AssertionError("`if _IS_MLX:` dispatch branch not found in unsloth/__init__.py")
+
+
+def _assigns_version(node):
+    return isinstance(node, ast.Assign) and any(
+        isinstance(t, ast.Name) and t.id == "__version__" for t in node.targets
+    )
+
+
+def _resolve_mlx_version(zoo_version):
+    """Run the MLX branch's ``__version__`` resolution with a spoofed zoo.
+
+    Executes the real source statements (plus any module-level helper they
+    call) in an isolated namespace whose ``unsloth_zoo.__version__`` is a
+    sentinel, so borrowing the zoo's version is directly observable.
+    """
+    tree = ast.parse(UNSLOTH_INIT.read_text(encoding = "utf-8"))
+
+    version_stmts = [node for node in _mlx_branch(tree).body if _assigns_version(node)]
+    assert version_stmts, "MLX branch does not assign __version__"
+
+    called = {
+        child.func.id
+        for stmt in version_stmts
+        for child in ast.walk(stmt)
+        if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+    }
+    helpers = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in called
+    ]
+
+    fake_zoo = types.ModuleType("unsloth_zoo")
+    fake_zoo.__version__ = zoo_version
+    namespace = {"__file__": str(UNSLOTH_INIT), "unsloth_zoo": fake_zoo}
+    for node in helpers + version_stmts:
+        exec(compile(ast.Module(body = [node], type_ignores = []), "<mlx-branch>", "exec"), namespace)
+    return namespace["__version__"]
+
+
+def _packaging_version_literal():
+    """The literal pyproject.toml resolves the distribution version from."""
+    tree = ast.parse(MODELS_UTILS.read_text(encoding = "utf-8"))
+    for node in tree.body:
+        if _assigns_version(node) and isinstance(node.value, ast.Constant):
+            return node.value.value
+    raise AssertionError("__version__ literal not found in unsloth/models/_utils.py")
+
+
+def _installed_unsloth_version():
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("unsloth")
+    except PackageNotFoundError:
+        return None
+
+
+def test_mlx_branch_reports_unsloth_version_not_zoo():
+    """Apple Silicon must report unsloth's version, not whatever zoo resolved to."""
+    resolved = _resolve_mlx_version(zoo_version = _ZOO_SENTINEL)
+
+    assert resolved != _ZOO_SENTINEL, (
+        "unsloth.__version__ is aliased to unsloth_zoo.__version__ on the MLX path; "
+        "unsloth-zoo is pinned '>=' and trails the core, so this misreports the "
+        "installed unsloth (issue #8171)"
+    )
+    expected = _installed_unsloth_version() or _packaging_version_literal()
+    assert resolved == expected, f"MLX reported {resolved!r}, expected {expected!r}"
+
+
+def test_gpu_branch_still_sources_version_from_gpu_init():
+    """Canary: the GPU path was already correct; don't 'fix' the MLX path by breaking it."""
+    tree = ast.parse(UNSLOTH_INIT.read_text(encoding = "utf-8"))
+
+    gpu_branch = ast.Module(body = _mlx_branch(tree).orelse, type_ignores = [])
+    assert "from ._gpu_init import __version__" in ast.unparse(gpu_branch), (
+        "GPU path must keep resolving __version__ through _gpu_init -> models._utils"
+    )

--- a/tests/studio/test_is_mlx_dispatch_gate.py
+++ b/tests/studio/test_is_mlx_dispatch_gate.py
@@ -252,9 +252,7 @@ def _resolve_mlx_version(zoo_version):
         if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
     }
     helpers = [
-        node
-        for node in tree.body
-        if isinstance(node, ast.FunctionDef) and node.name in called
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name in called
     ]
 
     fake_zoo = types.ModuleType("unsloth_zoo")
@@ -276,7 +274,6 @@ def _packaging_version_literal():
 
 def _installed_unsloth_version():
     from importlib.metadata import PackageNotFoundError, version
-
     try:
         return version("unsloth")
     except PackageNotFoundError:
@@ -301,6 +298,6 @@ def test_gpu_branch_still_sources_version_from_gpu_init():
     tree = ast.parse(UNSLOTH_INIT.read_text(encoding = "utf-8"))
 
     gpu_branch = ast.Module(body = _mlx_branch(tree).orelse, type_ignores = [])
-    assert "from ._gpu_init import __version__" in ast.unparse(gpu_branch), (
-        "GPU path must keep resolving __version__ through _gpu_init -> models._utils"
-    )
+    assert "from ._gpu_init import __version__" in ast.unparse(
+        gpu_branch
+    ), "GPU path must keep resolving __version__ through _gpu_init -> models._utils"

--- a/tests/studio/test_is_mlx_dispatch_gate.py
+++ b/tests/studio/test_is_mlx_dispatch_gate.py
@@ -233,12 +233,17 @@ def _assigns_version(node):
     )
 
 
-def _resolve_mlx_version(zoo_version):
+def _resolve_mlx_version(zoo_version, package_init = None):
     """Run the MLX branch's ``__version__`` resolution with a spoofed zoo.
 
     Executes the real source statements (plus any module-level helper they
     call) in an isolated namespace whose ``unsloth_zoo.__version__`` is a
     sentinel, so borrowing the zoo's version is directly observable.
+
+    ``package_init`` re-points the executed helper at another package tree,
+    which is how the source-literal precedence test distinguishes "read the
+    literal next to me" from "ask importlib.metadata". The namespace carries
+    no module globals on purpose: the helper must be self-contained.
     """
     tree = ast.parse(UNSLOTH_INIT.read_text(encoding = "utf-8"))
 
@@ -257,7 +262,10 @@ def _resolve_mlx_version(zoo_version):
 
     fake_zoo = types.ModuleType("unsloth_zoo")
     fake_zoo.__version__ = zoo_version
-    namespace = {"__file__": str(UNSLOTH_INIT), "unsloth_zoo": fake_zoo}
+    namespace = {
+        "__file__": str(package_init or UNSLOTH_INIT),
+        "unsloth_zoo": fake_zoo,
+    }
     for node in helpers + version_stmts:
         exec(compile(ast.Module(body = [node], type_ignores = []), "<mlx-branch>", "exec"), namespace)
     return namespace["__version__"]
@@ -272,14 +280,6 @@ def _packaging_version_literal():
     raise AssertionError("__version__ literal not found in unsloth/models/_utils.py")
 
 
-def _installed_unsloth_version():
-    from importlib.metadata import PackageNotFoundError, version
-    try:
-        return version("unsloth")
-    except PackageNotFoundError:
-        return None
-
-
 def test_mlx_branch_reports_unsloth_version_not_zoo():
     """Apple Silicon must report unsloth's version, not whatever zoo resolved to."""
     resolved = _resolve_mlx_version(zoo_version = _ZOO_SENTINEL)
@@ -289,8 +289,31 @@ def test_mlx_branch_reports_unsloth_version_not_zoo():
         "unsloth-zoo is pinned '>=' and trails the core, so this misreports the "
         "installed unsloth (issue #8171)"
     )
-    expected = _installed_unsloth_version() or _packaging_version_literal()
+    expected = _packaging_version_literal()
     assert resolved == expected, f"MLX reported {resolved!r}, expected {expected!r}"
+
+
+def test_mlx_version_reads_the_source_beside_it_not_installed_metadata(tmp_path):
+    """The version must track the imported tree, so it agrees with the GPU path.
+
+    An editable install that has moved on, or this checkout on PYTHONPATH beside
+    another installed unsloth, both leave `importlib.metadata` describing a
+    different tree. Point the helper at a package whose literal is a sentinel:
+    reading distribution metadata returns the real version and fails here.
+    """
+    package = tmp_path / "unsloth"
+    (package / "models").mkdir(parents = True)
+    (package / "models" / "_utils.py").write_text('__version__ = "9999.1.2"\n', encoding = "utf-8")
+    init = package / "__init__.py"
+    init.write_text("", encoding = "utf-8")
+
+    resolved = _resolve_mlx_version(zoo_version = _ZOO_SENTINEL, package_init = init)
+
+    assert resolved == "9999.1.2", (
+        f"expected the literal beside the imported package, got {resolved!r}; "
+        "resolving through installed distribution metadata makes the MLX path "
+        "disagree with the GPU path, which reads models/_utils.py"
+    )
 
 
 def test_gpu_branch_still_sources_version_from_gpu_init():
@@ -298,6 +321,6 @@ def test_gpu_branch_still_sources_version_from_gpu_init():
     tree = ast.parse(UNSLOTH_INIT.read_text(encoding = "utf-8"))
 
     gpu_branch = ast.Module(body = _mlx_branch(tree).orelse, type_ignores = [])
-    assert "from ._gpu_init import __version__" in ast.unparse(
-        gpu_branch
-    ), "GPU path must keep resolving __version__ through _gpu_init -> models._utils"
+    assert "from ._gpu_init import __version__" in ast.unparse(gpu_branch), (
+        "GPU path must keep resolving __version__ through _gpu_init -> models._utils"
+    )

--- a/tests/studio/test_is_mlx_dispatch_gate.py
+++ b/tests/studio/test_is_mlx_dispatch_gate.py
@@ -321,6 +321,6 @@ def test_gpu_branch_still_sources_version_from_gpu_init():
     tree = ast.parse(UNSLOTH_INIT.read_text(encoding = "utf-8"))
 
     gpu_branch = ast.Module(body = _mlx_branch(tree).orelse, type_ignores = [])
-    assert "from ._gpu_init import __version__" in ast.unparse(gpu_branch), (
-        "GPU path must keep resolving __version__ through _gpu_init -> models._utils"
-    )
+    assert "from ._gpu_init import __version__" in ast.unparse(
+        gpu_branch
+    ), "GPU path must keep resolving __version__ through _gpu_init -> models._utils"

--- a/tests/studio/test_is_mlx_dispatch_gate.py
+++ b/tests/studio/test_is_mlx_dispatch_gate.py
@@ -17,6 +17,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 UNSLOTH_INIT = REPO_ROOT / "unsloth" / "__init__.py"
@@ -293,17 +295,22 @@ def test_mlx_branch_reports_unsloth_version_not_zoo():
     assert resolved == expected, f"MLX reported {resolved!r}, expected {expected!r}"
 
 
-def test_mlx_version_reads_the_source_beside_it_not_installed_metadata(tmp_path):
+@pytest.mark.parametrize("literal", ['__version__ = "9999.1.2"', "__version__ = '9999.1.2'"])
+def test_mlx_version_reads_the_source_beside_it_not_installed_metadata(tmp_path, literal):
     """The version must track the imported tree, so it agrees with the GPU path.
 
     An editable install that has moved on, or this checkout on PYTHONPATH beside
     another installed unsloth, both leave `importlib.metadata` describing a
     different tree. Point the helper at a package whose literal is a sentinel:
     reading distribution metadata returns the real version and fails here.
+
+    Both quote styles are valid Python and the packaging metadata reads either,
+    so recognising only one turns a reformat of that single line into a silent
+    fall-through to installed metadata.
     """
     package = tmp_path / "unsloth"
     (package / "models").mkdir(parents = True)
-    (package / "models" / "_utils.py").write_text('__version__ = "9999.1.2"\n', encoding = "utf-8")
+    (package / "models" / "_utils.py").write_text(literal + "\n", encoding = "utf-8")
     init = package / "__init__.py"
     init.write_text("", encoding = "utf-8")
 

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -77,6 +77,29 @@ def _is_mlx_available():
     return is_mlx_available()
 
 
+def _unsloth_version():
+    # unsloth's own version, for the MLX path. The GPU path gets this from
+    # _gpu_init -> models._utils, but that module imports torch, which the MLX
+    # path deliberately never reaches. Read the installed distribution instead
+    # (the string `pip show unsloth` prints), falling back to the literal in
+    # models/_utils.py that pyproject.toml builds the version from, for source
+    # checkouts that were never installed. Do NOT borrow unsloth_zoo.__version__:
+    # the zoo is a separate distribution pinned with `>=` and routinely trails.
+    from importlib.metadata import PackageNotFoundError, version as _dist_version
+    try:
+        return _dist_version("unsloth")
+    except PackageNotFoundError:
+        pass
+    import re
+    _utils = os.path.join(os.path.dirname(__file__), "models", "_utils.py")
+    try:
+        with open(_utils, encoding = "utf-8") as _f:
+            _match = re.search(r'^__version__\s*=\s*"([^"]+)"', _f.read(), re.MULTILINE)
+    except OSError:
+        _match = None
+    return _match.group(1) if _match else "0.0.0+unknown"
+
+
 # Detect Apple Silicon + MLX before any torch/numpy imports
 _IS_MLX = _is_mlx_available()
 
@@ -129,7 +152,7 @@ if _IS_MLX:
     import types as _types
     import warnings as _warnings
 
-    __version__ = unsloth_zoo.__version__
+    __version__ = _unsloth_version()
     DEVICE_TYPE = "mlx"
     _MLX_TRAINER_ACCEPTS_VAR_KWARGS = False
     _MLX_TRAINER_SUPPORTED_KWARGS = frozenset()

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -86,11 +86,13 @@ def _unsloth_version():
     # checkouts that were never installed. Do NOT borrow unsloth_zoo.__version__:
     # the zoo is a separate distribution pinned with `>=` and routinely trails.
     from importlib.metadata import PackageNotFoundError, version as _dist_version
+
     try:
         return _dist_version("unsloth")
     except PackageNotFoundError:
         pass
     import re
+
     _utils = os.path.join(os.path.dirname(__file__), "models", "_utils.py")
     try:
         with open(_utils, encoding = "utf-8") as _f:

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -78,28 +78,35 @@ def _is_mlx_available():
 
 
 def _unsloth_version():
-    # unsloth's own version, for the MLX path. The GPU path gets this from
-    # _gpu_init -> models._utils, but that module imports torch, which the MLX
-    # path deliberately never reaches. Read the installed distribution instead
-    # (the string `pip show unsloth` prints), falling back to the literal in
-    # models/_utils.py that pyproject.toml builds the version from, for source
-    # checkouts that were never installed. Do NOT borrow unsloth_zoo.__version__:
-    # the zoo is a separate distribution pinned with `>=` and routinely trails.
+    # unsloth's own version, for the MLX path. The GPU path reads the literal in
+    # models/_utils.py via _gpu_init, but that module imports torch, which the MLX
+    # path deliberately never reaches — so read the same literal straight off disk.
+    # Reading the literal beside this file, rather than asking importlib.metadata
+    # first, is what keeps the two paths in agreement: metadata describes whichever
+    # unsloth was installed, which is a different tree whenever this checkout is
+    # imported via PYTHONPATH or an editable install that has since moved on.
+    # Distribution metadata is only the fallback, for installs shipped without the
+    # source literal. Do NOT borrow unsloth_zoo.__version__: the zoo is a separate
+    # distribution pinned with `>=` and routinely trails.
+    # Self-contained on purpose: no reliance on this module's globals, so the
+    # helper can be executed in isolation by tests.
+    import os as _os
+    import re as _re
+
+    _utils = _os.path.join(_os.path.dirname(__file__), "models", "_utils.py")
+    try:
+        with open(_utils, encoding = "utf-8") as _f:
+            _match = _re.search(r'^__version__\s*=\s*"([^"]+)"', _f.read(), _re.MULTILINE)
+    except OSError:
+        _match = None
+    if _match:
+        return _match.group(1)
     from importlib.metadata import PackageNotFoundError, version as _dist_version
 
     try:
         return _dist_version("unsloth")
     except PackageNotFoundError:
-        pass
-    import re
-
-    _utils = os.path.join(os.path.dirname(__file__), "models", "_utils.py")
-    try:
-        with open(_utils, encoding = "utf-8") as _f:
-            _match = re.search(r'^__version__\s*=\s*"([^"]+)"', _f.read(), re.MULTILINE)
-    except OSError:
-        _match = None
-    return _match.group(1) if _match else "0.0.0+unknown"
+        return "0.0.0+unknown"
 
 
 # Detect Apple Silicon + MLX before any torch/numpy imports

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -96,11 +96,16 @@ def _unsloth_version():
     _utils = _os.path.join(_os.path.dirname(__file__), "models", "_utils.py")
     try:
         with open(_utils, encoding = "utf-8") as _f:
-            _match = _re.search(r'^__version__\s*=\s*"([^"]+)"', _f.read(), _re.MULTILINE)
+            # Either quote style: matching only one would silently fall through to
+            # metadata the day someone reformats that line, which is the exact
+            # mismatch this function exists to prevent.
+            _match = _re.search(
+                r"""^__version__\s*=\s*(["'])([^"']+)\1""", _f.read(), _re.MULTILINE
+            )
     except OSError:
         _match = None
     if _match:
-        return _match.group(1)
+        return _match.group(2)
     from importlib.metadata import PackageNotFoundError, version as _dist_version
 
     try:


### PR DESCRIPTION
## What

On Apple Silicon, `unsloth.__version__` reported unsloth-zoo's version rather than unsloth's, so it disagreed with `pip show unsloth` on every MLX install

## Why it happened

The MLX branch of `unsloth/__init__.py` set `__version__ = unsloth_zoo.__version__`. unsloth-zoo is a separate distribution pinned `unsloth_zoo>=2026.8.6`, so it routinely trails the core

The GPU path was never affected: it resolves `__version__` through `_gpu_init` into `models/_utils.py`, the same literal `pyproject.toml` builds the distribution version from. One correction to the issue, which presents this as universal: the aliasing line sits inside `if _IS_MLX:`, gated on Darwin plus arm64, so no CUDA or ROCm install ever hit it

## Fix

`_unsloth_version()` in `unsloth/__init__.py` reads the `models/_utils.py` literal sitting beside the package, the same one the GPU path resolves through `_gpu_init`, and falls back to installed distribution metadata. It does not import `models._utils` directly because that pulls in torch, which the MLX path deliberately never reaches

Reading the literal rather than asking `importlib.metadata` first is what keeps the two paths in agreement: metadata describes whichever unsloth was installed, which is a different tree whenever this checkout is imported through PYTHONPATH or an editable install that has since moved on

Closes #8171

## Proof

Apple Silicon M-series, `pip install unsloth mlx mlx-lm mlx-vlm`, then running against this checkout:

```
$ python -c "import unsloth, unsloth_zoo, importlib.metadata as md; \
    print('unsloth.__version__     =', unsloth.__version__); \
    print('pip show unsloth        =', md.version('unsloth')); \
    print('unsloth_zoo.__version__ =', unsloth_zoo.__version__)"

# on main
unsloth.__version__     = 2026.8.6
pip show unsloth        = 2026.8.9
unsloth_zoo.__version__ = 2026.8.6

# on this branch
unsloth.__version__     = 2026.8.9
pip show unsloth        = 2026.8.9
unsloth_zoo.__version__ = 2026.8.6
```

## Tests

`tests/studio/test_is_mlx_dispatch_gate.py` gains three cases, all executing the MLX branch's version statements straight out of the source so they exercise the real code rather than a reimplementation. The first runs them against a spoofed `unsloth_zoo` whose version is a sentinel and asserts the result is neither that sentinel nor anything but the packaging literal, so it fails on main with `assert '0.0.0+zoo-sentinel' != '0.0.0+zoo-sentinel'`. The second points the helper at a throwaway package tree whose literal is `9999.1.2` and asserts it reports that, which fails against a metadata-first implementation with `assert '2026.8.9' == '9999.1.2'`; it is parametrised over both quote styles, since recognising only one would turn a reformat of that upstream line into a silent fall-through to metadata. The third is a canary that the GPU path still resolves through `_gpu_init`. None needs torch or mlx, so all run in the Linux job that already covers this file

Backend CI's hardware-spoof step goes from 56 passed, 2 skipped to 60 passed, 2 skipped with no new failures. The lint gate passes (compileall, ruff, codespell, import-hoist self-test)
