### PR TITLE
studio: serve the deep research event stream over post so proxies stop buffering it

### DIFF
--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -427,7 +427,8 @@ async def retry_research_run(
     return run
 
 
-@router.get("/{run_id}/events")
+# POST too: proxies that stream /v1/chat/completions still buffer a streamed GET until it closes.
+@router.api_route("/{run_id}/events", methods = ["GET", "POST"])
 async def research_events(
     run_id: str,
     request: Request,

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -428,7 +428,9 @@ async def retry_research_run(
 
 
 # POST too: proxies that stream /v1/chat/completions still buffer a streamed GET until it closes.
-@router.api_route("/{run_id}/events", methods = ["GET", "POST"])
+@router.post("/{run_id}/events")
+# Separate registration, out of the schema: one api_route would give both verbs one operationId.
+@router.get("/{run_id}/events", include_in_schema = False)
 async def research_events(
     run_id: str,
     request: Request,

--- a/studio/backend/tests/test_research_progress_events.py
+++ b/studio/backend/tests/test_research_progress_events.py
@@ -279,5 +279,24 @@ def test_event_stream_is_reachable_over_post_as_well_as_get():
     from routes.research_runs import router
 
     events = [route for route in router.routes if route.path == "/{run_id}/events"]
-    assert len(events) == 1
-    assert {"GET", "POST"} <= events[0].methods
+    assert {method for route in events for method in route.methods} >= {"GET", "POST"}
+
+
+def test_event_stream_verbs_do_not_share_one_operation_id():
+    # A single api_route for both verbs gave them one operationId, which FastAPI warns about and
+    # OpenAPI generators resolve by dropping one of the two operations.
+    import warnings
+
+    from fastapi import FastAPI
+    from fastapi.openapi.utils import get_openapi
+
+    from routes.research_runs import router
+
+    app = FastAPI()
+    app.include_router(router, prefix = "/api/chat/research-runs")
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        spec = get_openapi(title = "t", version = "1", routes = app.routes)
+    assert not [w for w in caught if "Duplicate Operation ID" in str(w.message)]
+    operations = spec["paths"]["/api/chat/research-runs/{run_id}/events"]
+    assert list(operations) == ["post"]

--- a/studio/backend/tests/test_research_progress_events.py
+++ b/studio/backend/tests/test_research_progress_events.py
@@ -272,3 +272,12 @@ def test_decision_phase_bracket_carries_its_step_position(research_home, monkeyp
     started = next(e for e in _events("run-1") if e["type"] == "phase.started")
     assert started["data"]["stepPosition"] == 3
     assert started["data"]["phase"] == "decision"
+
+
+def test_event_stream_is_reachable_over_post_as_well_as_get():
+    # Proxies that stream POST /v1/chat/completions still hold a streamed GET until it closes.
+    from routes.research_runs import router
+
+    events = [route for route in router.routes if route.path == "/{run_id}/events"]
+    assert len(events) == 1
+    assert {"GET", "POST"} <= events[0].methods

--- a/studio/backend/tests/test_research_progress_events.py
+++ b/studio/backend/tests/test_research_progress_events.py
@@ -277,7 +277,6 @@ def test_decision_phase_bracket_carries_its_step_position(research_home, monkeyp
 def test_event_stream_is_reachable_over_post_as_well_as_get():
     # Proxies that stream POST /v1/chat/completions still hold a streamed GET until it closes.
     from routes.research_runs import router
-
     events = [route for route in router.routes if route.path == "/{run_id}/events"]
     assert {method for route in events for method in route.methods} >= {"GET", "POST"}
 

--- a/studio/frontend/src/features/chat/api/research-api.ts
+++ b/studio/frontend/src/features/chat/api/research-api.ts
@@ -146,9 +146,10 @@ export async function* streamResearchEvents(
   after: number,
   signal?: AbortSignal,
 ): AsyncGenerator<StreamResearchEvent> {
+  // POST, not GET: proxies hold a streamed GET until it closes. The route accepts both.
   const response = await authFetch(
     `/api/chat/research-runs/${id}/events?after=${Math.max(0, after)}`,
-    { headers: { accept: "text/event-stream" }, signal },
+    { method: "POST", headers: { accept: "text/event-stream" }, signal },
   );
   if (!response.ok) {
     await json(response);

--- a/tests/studio/test_deep_research_frontend_contract.py
+++ b/tests/studio/test_deep_research_frontend_contract.py
@@ -21,7 +21,8 @@ def test_research_api_is_isolated_and_cursor_based() -> None:
     assert "runs.at(-1) ?? null" in api
     assert "getResearchThreadState" in api
     assert "/events?after=${Math.max(0, after)}" in api
-    assert 'headers: { accept: "text/event-stream" }' in api
+    # POST, not GET: proxies that buffer a streamed GET leave the activity panel empty.
+    assert 'method: "POST", headers: { accept: "text/event-stream" }' in api
     assert "export async function* followResearchRun" in api
     assert "Math.min(8_000, 500 * 2 ** (failures - 1))" in api
     assert "for await (const event of streamResearchEvents" in api


### PR DESCRIPTION
Follow-up to #8129. That PR fixed the event stream on the backend and in the store; this fixes the transport it travels over.

## What happens

Behind a Cloudflare quick tunnel, a Deep Research run looks dead. The activity panel sits on "Loading research activity…" and the card reads "Building a rigorous research plan…" for the whole run, while the backend is working normally.

Captured from a stuck run: the supervisor wrote all 14 events, `phase.started` through `plan.ready`, and the run reached `awaiting_approval`. The events request stayed open 281 seconds and ended only when the page was reloaded. Nothing rendered in between.

## Why

cloudflared buffers a streamed **GET** until the connection closes, then flushes the whole body at once. A streamed **POST** passes through. See [cloudflared#1449](https://github.com/cloudflare/cloudflared/issues/1449) and [cloudflared#199](https://github.com/cloudflare/cloudflared/issues/199).

That asymmetry is why chat works and research does not on the same host: chat streams over `POST /v1/chat/completions`, and `/api/chat/research-runs/{id}/events` was the one streaming endpoint served over GET.

Not specific to Cloudflare. Any proxy that buffers `text/event-stream` on GET produces the same dead panel, so this is not a workaround for one vendor.

## The change

`research_events` is registered with `api_route(methods=["GET", "POST"])` instead of `router.get`. The generator, cursor handling, `Last-Event-ID` support and headers are untouched.

`streamResearchEvents` sends POST. It uses `fetch`, not `EventSource`, so no client rewrite is needed. GET stays for any external client that does use `EventSource`.

## Verification

- `test_event_stream_is_reachable_over_post_as_well_as_get` asserts the route exposes both verbs, so a revert to `router.get` fails the suite
- `test_deep_research_frontend_contract` pins the client to POST
- 352 backend tests pass across the research and middleware suites; 1310 frontend tests pass; `tsc -b` and eslint clean on the changed files
- ruff format and `ruff check studio/backend` clean

The buffering itself is not reproduced by any automated test here, since it needs a real tunnel in front of the server. It is documented in the cloudflared issues linked above, and the GET/POST asymmetry matches what this host already sees: chat streams, research does not.

No GPU is present on this machine, so CUDA, Triton, quantisation and model training checks were not run.
