### PR TITLE
tests: make `pytest tests` collect cleanly and drop the deleted QVQ registry mirror

### DIFF
--- a/tests/saving/gpt-oss-merge/test_merged_model.py
+++ b/tests/saving/gpt-oss-merge/test_merged_model.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 # inference_on_merged.py
 from unsloth import FastLanguageModel
 from transformers import TextStreamer

--- a/tests/saving/language_models/test_merge_4bit_validation.py
+++ b/tests/saving/language_models/test_merge_4bit_validation.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel
 from unsloth.chat_templates import get_chat_template
 from trl import SFTTrainer, SFTConfig

--- a/tests/saving/language_models/test_merge_model_perplexity_llama_3_2.py
+++ b/tests/saving/language_models/test_merge_model_perplexity_llama_3_2.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastVisionModel, UnslothVisionDataCollator
 from unsloth.chat_templates import get_chat_template
 from trl import SFTTrainer, SFTConfig

--- a/tests/saving/language_models/test_merge_model_perplexity_mistral.py
+++ b/tests/saving/language_models/test_merge_model_perplexity_mistral.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastVisionModel, UnslothVisionDataCollator
 from unsloth.chat_templates import get_chat_template
 from trl import SFTTrainer, SFTConfig

--- a/tests/saving/language_models/test_merge_model_perplexity_phi_4.py
+++ b/tests/saving/language_models/test_merge_model_perplexity_phi_4.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastVisionModel, UnslothVisionDataCollator
 from unsloth.chat_templates import get_chat_template
 from trl import SFTTrainer, SFTConfig

--- a/tests/saving/language_models/test_merged_model_perplexity_llama_3_1_8b.py
+++ b/tests/saving/language_models/test_merged_model_perplexity_llama_3_1_8b.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastVisionModel, UnslothVisionDataCollator
 from unsloth.chat_templates import get_chat_template
 from trl import SFTTrainer, SFTConfig
@@ -30,48 +43,13 @@ from tests.utils.perplexity_eval import (
 )
 
 
-alpaca_prompt = """Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
-
-### Instruction:
-{}
-
-### Input:
-{}
-
-### Response:
-{}"""
-
-
 def formatting_prompts_func(examples):
-    instructions = []
-    inputs = []
-    outputs = []
-    texts = []
-
-    for conversation in examples["messages"]:
-        user_message = ""
-        assistant_message = ""
-
-        for turn in conversation:
-            if turn["role"] == "user":
-                user_message = turn["content"]
-            elif turn["role"] == "assistant":
-                assistant_message = turn["content"]
-
-        instruction = "Complete the statement"
-        instructions.append(instruction)
-        inputs.append(user_message)
-        outputs.append(assistant_message)
-
-        text = alpaca_prompt.format(instruction, user_message, assistant_message)
-        texts.append(text)
-
-    return {
-        "instruction": instructions,
-        "input": inputs,
-        "output": outputs,
-        "text": texts,
-    }
+    convos = examples["messages"]
+    texts = [
+        tokenizer.apply_chat_template(convo, tokenize = False, add_generation_prompt = False)
+        for convo in convos
+    ]
+    return {"text": texts}
 
 
 def load_and_compute_8bit_ppl(
@@ -79,71 +57,38 @@ def load_and_compute_8bit_ppl(
     load_in_4bit = False,
     load_in_8bit = False,
 ):
-    """Load model and compute perplexity in subprocess."""
+    """Load model and compute perplexity in subprocess"""
     from unsloth import FastLanguageModel
+    from unsloth.chat_templates import get_chat_template
     from tests.utils.perplexity_eval import ppl_model
 
     merged_model, merged_tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "./unsloth_out/merged_qwen_text_model",
+        model_name = "./unsloth_out/merged_llama_text_model",
         max_seq_length = 2048,
         load_in_4bit = load_in_4bit,
         load_in_8bit = load_in_8bit,
     )
-    # Set up tokenizer
-    # merged_tokenizer = get_chat_template(
-    #     merged_tokenizer,
-    #     chat_template="llama-3.1",
-    # )
+    merged_tokenizer = get_chat_template(
+        merged_tokenizer,
+        chat_template = "llama-3.1",
+    )
 
+    # Load dataset fresh in subprocess
     dataset_ppl = load_dataset("allenai/openassistant-guanaco-reformatted", split = "eval")
 
-    alpaca_prompt = """Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
-
-    ### Instruction:
-    {}
-
-    ### Input:
-    {}
-
-    ### Response:
-    {}"""
-
     def formatting_prompts_func(examples):
-        instructions = []
-        inputs = []
-        outputs = []
-        texts = []
-
-        for conversation in examples["messages"]:
-            user_message = ""
-            assistant_message = ""
-
-            for turn in conversation:
-                if turn["role"] == "user":
-                    user_message = turn["content"]
-                elif turn["role"] == "assistant":
-                    assistant_message = turn["content"]
-
-            instruction = "Complete the statement"
-            instructions.append(instruction)
-            inputs.append(user_message)
-            outputs.append(assistant_message)
-
-            text = alpaca_prompt.format(instruction, user_message, assistant_message)
-            texts.append(text)
-
-        return {
-            "instruction": instructions,
-            "input": inputs,
-            "output": outputs,
-            "text": texts,
-        }
+        convos = examples["messages"]
+        texts = [
+            merged_tokenizer.apply_chat_template(convo, tokenize = False, add_generation_prompt = False)
+            for convo in convos
+        ]
+        return {"text": texts}
 
     dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched = True)
 
     ppl_value = ppl_model(merged_model, merged_tokenizer, dataset_ppl)
 
-    # Coerce to a Python float.
+    # Convert to a Python float (tensor / numpy / other)
     if torch.is_tensor(ppl_value):
         ppl_value = ppl_value.cpu().item()
     elif hasattr(ppl_value, "item"):
@@ -153,12 +98,11 @@ def load_and_compute_8bit_ppl(
 
     result_queue.put(ppl_value)
 
-    # Clean up
-    # del merged_model
-    # del merged_tokenizer
-    # del dataset_ppl
-    # torch.cuda.empty_cache()
-    # gc.collect()
+    del merged_model
+    del merged_tokenizer
+    del dataset_ppl
+    torch.cuda.empty_cache()
+    gc.collect()
 
 
 if __name__ == "__main__":
@@ -171,7 +115,7 @@ if __name__ == "__main__":
     attn_implementation = "flash_attention_2" if HAS_FLASH_ATTENTION else "sdpa"
 
     model, tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "unsloth/Qwen2.5-7B-Instruct",
+        model_name = "unsloth/Llama-3.1-8B-Instruct",
         max_seq_length = 2048,
         dtype = compute_dtype,
         load_in_4bit = True,
@@ -180,11 +124,21 @@ if __name__ == "__main__":
         attn_implementation = attn_implementation,
     )
 
+    tokenizer = get_chat_template(
+        tokenizer,
+        chat_template = "llama-3.1",
+    )
+
+    from unsloth.chat_templates import standardize_sharegpt
+
     dataset_train = load_dataset("allenai/openassistant-guanaco-reformatted", split = "train")
     dataset_ppl = load_dataset("allenai/openassistant-guanaco-reformatted", split = "eval")
 
     dataset_train = dataset_train.map(formatting_prompts_func, batched = True)
     dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched = True)
+
+    print("\n dataset sample [0]")
+    print(dataset_train[0])
 
     add_to_comparison("Base model 4 bits", ppl_model(model, tokenizer, dataset_ppl))
 
@@ -208,6 +162,8 @@ if __name__ == "__main__":
         use_rslora = False,
         loftq_config = None,
     )
+
+    from unsloth import is_bfloat16_supported
 
     trainer = SFTTrainer(
         model = model,
@@ -235,13 +191,24 @@ if __name__ == "__main__":
         ),
     )
 
+    from unsloth.chat_templates import train_on_responses_only
+
+    trainer = train_on_responses_only(
+        trainer,
+        instruction_part = "<|start_header_id|>user<|end_header_id|>\n\n",
+        response_part = "<|start_header_id|>assistant<|end_header_id|>\n\n",
+    )
+
+    tokenizer.decode(trainer.train_dataset[0]["input_ids"])
+
     trainer_stats = trainer.train()
 
     add_to_comparison("Qlora model", ppl_model(model, tokenizer, dataset_ppl))
 
+    # save and merge the model to local disk
     print("merge and save to local disk")
     model.save_pretrained_merged(
-        save_directory = "./unsloth_out/merged_qwen_text_model", tokenizer = tokenizer
+        save_directory = "./unsloth_out/merged_llama_text_model", tokenizer = tokenizer
     )
 
     # print("cleaning")
@@ -252,7 +219,7 @@ if __name__ == "__main__":
 
     print("Loading merged model in 4 bit for perplexity test")
     merged_model, merged_tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "./unsloth_out/merged_qwen_text_model",
+        model_name = "./unsloth_out/merged_llama_text_model",
         max_seq_length = 2048,
         load_in_4bit = True,
         load_in_8bit = False,
@@ -273,7 +240,7 @@ if __name__ == "__main__":
 
     print("Loading merged model in 16 bit for perplexity test")
     merged_model, merged_tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "./unsloth_out/merged_qwen_text_model",
+        model_name = "./unsloth_out/merged_llama_text_model",
         max_seq_length = 2048,
         load_in_4bit = False,
         load_in_8bit = False,

--- a/tests/saving/language_models/test_merged_model_perplexity_qwen_2_5.py
+++ b/tests/saving/language_models/test_merged_model_perplexity_qwen_2_5.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastVisionModel, UnslothVisionDataCollator
 from unsloth.chat_templates import get_chat_template
 from trl import SFTTrainer, SFTConfig
@@ -30,13 +43,48 @@ from tests.utils.perplexity_eval import (
 )
 
 
+alpaca_prompt = """Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
+
+### Instruction:
+{}
+
+### Input:
+{}
+
+### Response:
+{}"""
+
+
 def formatting_prompts_func(examples):
-    convos = examples["messages"]
-    texts = [
-        tokenizer.apply_chat_template(convo, tokenize = False, add_generation_prompt = False)
-        for convo in convos
-    ]
-    return {"text": texts}
+    instructions = []
+    inputs = []
+    outputs = []
+    texts = []
+
+    for conversation in examples["messages"]:
+        user_message = ""
+        assistant_message = ""
+
+        for turn in conversation:
+            if turn["role"] == "user":
+                user_message = turn["content"]
+            elif turn["role"] == "assistant":
+                assistant_message = turn["content"]
+
+        instruction = "Complete the statement"
+        instructions.append(instruction)
+        inputs.append(user_message)
+        outputs.append(assistant_message)
+
+        text = alpaca_prompt.format(instruction, user_message, assistant_message)
+        texts.append(text)
+
+    return {
+        "instruction": instructions,
+        "input": inputs,
+        "output": outputs,
+        "text": texts,
+    }
 
 
 def load_and_compute_8bit_ppl(
@@ -44,38 +92,71 @@ def load_and_compute_8bit_ppl(
     load_in_4bit = False,
     load_in_8bit = False,
 ):
-    """Load model and compute perplexity in subprocess"""
+    """Load model and compute perplexity in subprocess."""
     from unsloth import FastLanguageModel
-    from unsloth.chat_templates import get_chat_template
     from tests.utils.perplexity_eval import ppl_model
 
     merged_model, merged_tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "./unsloth_out/merged_llama_text_model",
+        model_name = "./unsloth_out/merged_qwen_text_model",
         max_seq_length = 2048,
         load_in_4bit = load_in_4bit,
         load_in_8bit = load_in_8bit,
     )
-    merged_tokenizer = get_chat_template(
-        merged_tokenizer,
-        chat_template = "llama-3.1",
-    )
+    # Set up tokenizer
+    # merged_tokenizer = get_chat_template(
+    #     merged_tokenizer,
+    #     chat_template="llama-3.1",
+    # )
 
-    # Load dataset fresh in subprocess
     dataset_ppl = load_dataset("allenai/openassistant-guanaco-reformatted", split = "eval")
 
+    alpaca_prompt = """Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
+
+    ### Instruction:
+    {}
+
+    ### Input:
+    {}
+
+    ### Response:
+    {}"""
+
     def formatting_prompts_func(examples):
-        convos = examples["messages"]
-        texts = [
-            merged_tokenizer.apply_chat_template(convo, tokenize = False, add_generation_prompt = False)
-            for convo in convos
-        ]
-        return {"text": texts}
+        instructions = []
+        inputs = []
+        outputs = []
+        texts = []
+
+        for conversation in examples["messages"]:
+            user_message = ""
+            assistant_message = ""
+
+            for turn in conversation:
+                if turn["role"] == "user":
+                    user_message = turn["content"]
+                elif turn["role"] == "assistant":
+                    assistant_message = turn["content"]
+
+            instruction = "Complete the statement"
+            instructions.append(instruction)
+            inputs.append(user_message)
+            outputs.append(assistant_message)
+
+            text = alpaca_prompt.format(instruction, user_message, assistant_message)
+            texts.append(text)
+
+        return {
+            "instruction": instructions,
+            "input": inputs,
+            "output": outputs,
+            "text": texts,
+        }
 
     dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched = True)
 
     ppl_value = ppl_model(merged_model, merged_tokenizer, dataset_ppl)
 
-    # Convert to a Python float (tensor / numpy / other)
+    # Coerce to a Python float.
     if torch.is_tensor(ppl_value):
         ppl_value = ppl_value.cpu().item()
     elif hasattr(ppl_value, "item"):
@@ -85,11 +166,12 @@ def load_and_compute_8bit_ppl(
 
     result_queue.put(ppl_value)
 
-    del merged_model
-    del merged_tokenizer
-    del dataset_ppl
-    torch.cuda.empty_cache()
-    gc.collect()
+    # Clean up
+    # del merged_model
+    # del merged_tokenizer
+    # del dataset_ppl
+    # torch.cuda.empty_cache()
+    # gc.collect()
 
 
 if __name__ == "__main__":
@@ -102,7 +184,7 @@ if __name__ == "__main__":
     attn_implementation = "flash_attention_2" if HAS_FLASH_ATTENTION else "sdpa"
 
     model, tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "unsloth/Llama-3.1-8B-Instruct",
+        model_name = "unsloth/Qwen2.5-7B-Instruct",
         max_seq_length = 2048,
         dtype = compute_dtype,
         load_in_4bit = True,
@@ -111,21 +193,11 @@ if __name__ == "__main__":
         attn_implementation = attn_implementation,
     )
 
-    tokenizer = get_chat_template(
-        tokenizer,
-        chat_template = "llama-3.1",
-    )
-
-    from unsloth.chat_templates import standardize_sharegpt
-
     dataset_train = load_dataset("allenai/openassistant-guanaco-reformatted", split = "train")
     dataset_ppl = load_dataset("allenai/openassistant-guanaco-reformatted", split = "eval")
 
     dataset_train = dataset_train.map(formatting_prompts_func, batched = True)
     dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched = True)
-
-    print("\n dataset sample [0]")
-    print(dataset_train[0])
 
     add_to_comparison("Base model 4 bits", ppl_model(model, tokenizer, dataset_ppl))
 
@@ -149,8 +221,6 @@ if __name__ == "__main__":
         use_rslora = False,
         loftq_config = None,
     )
-
-    from unsloth import is_bfloat16_supported
 
     trainer = SFTTrainer(
         model = model,
@@ -178,24 +248,13 @@ if __name__ == "__main__":
         ),
     )
 
-    from unsloth.chat_templates import train_on_responses_only
-
-    trainer = train_on_responses_only(
-        trainer,
-        instruction_part = "<|start_header_id|>user<|end_header_id|>\n\n",
-        response_part = "<|start_header_id|>assistant<|end_header_id|>\n\n",
-    )
-
-    tokenizer.decode(trainer.train_dataset[0]["input_ids"])
-
     trainer_stats = trainer.train()
 
     add_to_comparison("Qlora model", ppl_model(model, tokenizer, dataset_ppl))
 
-    # save and merge the model to local disk
     print("merge and save to local disk")
     model.save_pretrained_merged(
-        save_directory = "./unsloth_out/merged_llama_text_model", tokenizer = tokenizer
+        save_directory = "./unsloth_out/merged_qwen_text_model", tokenizer = tokenizer
     )
 
     # print("cleaning")
@@ -206,7 +265,7 @@ if __name__ == "__main__":
 
     print("Loading merged model in 4 bit for perplexity test")
     merged_model, merged_tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "./unsloth_out/merged_llama_text_model",
+        model_name = "./unsloth_out/merged_qwen_text_model",
         max_seq_length = 2048,
         load_in_4bit = True,
         load_in_8bit = False,
@@ -227,7 +286,7 @@ if __name__ == "__main__":
 
     print("Loading merged model in 16 bit for perplexity test")
     merged_model, merged_tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "./unsloth_out/merged_llama_text_model",
+        model_name = "./unsloth_out/merged_qwen_text_model",
         max_seq_length = 2048,
         load_in_4bit = False,
         load_in_8bit = False,

--- a/tests/saving/language_models/test_push_to_hub_merged.py
+++ b/tests/saving/language_models/test_push_to_hub_merged.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastVisionModel, UnslothVisionDataCollator
 from unsloth.chat_templates import get_chat_template
 from trl import SFTTrainer, SFTConfig

--- a/tests/saving/language_models/test_push_to_hub_merged_sharded_index_file.py
+++ b/tests/saving/language_models/test_push_to_hub_merged_sharded_index_file.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastVisionModel, UnslothVisionDataCollator
 from unsloth.chat_templates import get_chat_template
 from trl import SFTTrainer, SFTConfig

--- a/tests/saving/language_models/test_save_merged_grpo_model.py
+++ b/tests/saving/language_models/test_save_merged_grpo_model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Llama 3.1 (3B) GRPO LoRA train + merged-model save/eval."""
+
 # tests/saving scripts run their whole body at import, so plain pytest
 # collection would download checkpoints and train. Skip unless opted in.
 import sys as _sys

--- a/tests/saving/language_models/test_save_merged_grpo_model.py
+++ b/tests/saving/language_models/test_save_merged_grpo_model.py
@@ -1,5 +1,18 @@
 # -*- coding: utf-8 -*-
 """Llama 3.1 (3B) GRPO LoRA train + merged-model save/eval."""
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 
 from unsloth import FastLanguageModel
 import torch

--- a/tests/saving/non_peft/test_mistral_non_peft.py
+++ b/tests/saving/non_peft/test_mistral_non_peft.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel
 from transformers import AutoModelForCausalLM
 from peft import PeftModel

--- a/tests/saving/non_peft/test_whisper_non_peft.py
+++ b/tests/saving/non_peft/test_whisper_non_peft.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastModel
 from transformers import AutoModelForCausalLM, WhisperForConditionalGeneration
 from peft import PeftModel

--- a/tests/saving/test_fix_sentencepiece_gguf_robustness.py
+++ b/tests/saving/test_fix_sentencepiece_gguf_robustness.py
@@ -4,7 +4,14 @@ import os
 
 os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
 
-from transformers.utils import sentencepiece_model_pb2
+# Same accessor unsloth.tokenizer_utils uses. The legacy
+# `transformers.utils.sentencepiece_model_pb2` is generated against protobuf
+# 3.x and raises on protobuf >= 4 ("Descriptors cannot be created directly"),
+# or collides with sentencepiece's own copy ("duplicate file name
+# sentencepiece_model.proto") once that one is loaded first.
+from transformers.convert_slow_tokenizer import import_protobuf
+
+sentencepiece_model_pb2 = import_protobuf()
 
 from unsloth.tokenizer_utils import fix_sentencepiece_gguf
 

--- a/tests/saving/test_fix_sentencepiece_tokenizer_guard.py
+++ b/tests/saving/test_fix_sentencepiece_tokenizer_guard.py
@@ -5,7 +5,15 @@ import os
 os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
 
 import transformers
-from transformers.utils import sentencepiece_model_pb2
+
+# Same accessor unsloth.tokenizer_utils uses. The legacy
+# `transformers.utils.sentencepiece_model_pb2` is generated against protobuf
+# 3.x and raises on protobuf >= 4 ("Descriptors cannot be created directly"),
+# or collides with sentencepiece's own copy ("duplicate file name
+# sentencepiece_model.proto") once that one is loaded first.
+from transformers.convert_slow_tokenizer import import_protobuf
+
+sentencepiece_model_pb2 = import_protobuf()
 
 from unsloth.tokenizer_utils import fix_sentencepiece_tokenizer
 

--- a/tests/saving/text_to_speech_models/test_csm.py
+++ b/tests/saving/text_to_speech_models/test_csm.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastModel
 from transformers import CsmForConditionalGeneration
 import torch

--- a/tests/saving/text_to_speech_models/test_lasa.py
+++ b/tests/saving/text_to_speech_models/test_lasa.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastModel
 from transformers import CsmForConditionalGeneration
 import torch

--- a/tests/saving/text_to_speech_models/test_orpheus.py
+++ b/tests/saving/text_to_speech_models/test_orpheus.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastModel
 from transformers import CsmForConditionalGeneration
 import torch

--- a/tests/saving/text_to_speech_models/test_whisper.py
+++ b/tests/saving/text_to_speech_models/test_whisper.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastLanguageModel, FastModel
 from transformers import WhisperForConditionalGeneration, WhisperProcessor
 import torch

--- a/tests/saving/vision_models/test_index_file_sharded_model.py
+++ b/tests/saving/vision_models/test_index_file_sharded_model.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 from unsloth import FastVisionModel, is_bf16_supported
 from unsloth.trainer import UnslothVisionDataCollator
 

--- a/tests/saving/vision_models/test_push_to_hub_merged.py
+++ b/tests/saving/vision_models/test_push_to_hub_merged.py
@@ -1,3 +1,16 @@
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 ## Import required libraries
 
 from unsloth import FastVisionModel, is_bf16_supported

--- a/tests/saving/vision_models/test_save_merge_qwen2_5vl32B_model_ocr_benchmark.py
+++ b/tests/saving/vision_models/test_save_merge_qwen2_5vl32B_model_ocr_benchmark.py
@@ -1,4 +1,17 @@
 # -*- coding: utf-8 -*-
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 
 from unsloth import FastVisionModel
 

--- a/tests/saving/vision_models/test_save_merge_vision_model_ocr_benchmark.py
+++ b/tests/saving/vision_models/test_save_merge_vision_model_ocr_benchmark.py
@@ -1,4 +1,17 @@
 # -*- coding: utf-8 -*-
+# tests/saving scripts run their whole body at import, so plain pytest
+# collection would download checkpoints and train. Skip unless opted in.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
+from tests.utils.os_utils import require_opt_in as _require_opt_in
+
+_require_opt_in(
+    "UNSLOTH_RUN_SAVING_SCRIPTS",
+    "GPU + Hub saving script; its body runs at import.",
+)
+
 
 from unsloth import FastVisionModel
 

--- a/tests/test_collection_hygiene.py
+++ b/tests/test_collection_hygiene.py
@@ -86,7 +86,7 @@ def test_raw_text_does_not_leave_its_datasets_mock_in_sys_modules():
         text = True,
         check = False,
     )
-    assert "DATASETS_OK" in result.stdout, (
-        f"exit {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert (
+        "DATASETS_OK" in result.stdout
+    ), f"exit {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     assert "DATASETS_OK datasets." in result.stdout, result.stdout

--- a/tests/test_collection_hygiene.py
+++ b/tests/test_collection_hygiene.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""`pytest tests` must collect cleanly.
+
+A collection ERROR is not a failing test: pytest reports "Interrupted" and
+never runs the rest of the suite, so one bad module hides thousands of good
+ones. These guard the three ways modules under tests/ used to break collection.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TESTS_DIR.parent
+SAVING_DIR = TESTS_DIR / "saving"
+
+
+def _test_modules() -> list[Path]:
+    return sorted(TESTS_DIR.rglob("test_*.py"))
+
+
+def _has_test_items(tree: ast.Module) -> bool:
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith(
+            "test_"
+        ):
+            return True
+        if isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+            return True
+    return False
+
+
+def test_no_test_module_filename_contains_a_dot():
+    """A dot in the stem is a package separator to pytest's importer.
+
+    tests/saving/language_models/test_merged_model_perplexity_qwen_2.5.py was
+    imported as ...test_merged_model_perplexity_qwen_2.5 and died with
+    "No module named 'test_merged_model_perplexity_qwen_2'".
+    """
+    dotted = [str(p.relative_to(REPO_ROOT)) for p in _test_modules() if "." in p.stem]
+    assert not dotted, f"test module filenames must not contain '.': {dotted}"
+
+
+def test_saving_scripts_opt_in_before_running_at_import():
+    """Files under tests/saving with no test items are standalone GPU scripts.
+
+    Their whole body runs at import, so bare collection downloads checkpoints,
+    trains and pushes to the Hub. Each must call require_opt_in() so it is a
+    visible SKIP instead.
+    """
+    ungated = []
+    for path in sorted(SAVING_DIR.rglob("test_*.py")):
+        source = path.read_text(encoding = "utf-8")
+        if _has_test_items(ast.parse(source)):
+            continue
+        if "require_opt_in(" not in source:
+            ungated.append(str(path.relative_to(REPO_ROOT)))
+    assert not ungated, f"tests/saving scripts missing the require_opt_in gate: {ungated}"
+
+
+def test_raw_text_does_not_leave_its_datasets_mock_in_sys_modules():
+    """tests/test_raw_text.py stubs `datasets` to import unsloth.dataprep.raw_text.
+
+    It used to leave the stub in sys.modules for the rest of the session, so
+    every later `from datasets import IterableDataset` raised ImportError and
+    tests/utils/test_packing.py failed to collect.
+    """
+    pytest.importorskip("datasets")
+    child = (
+        "import runpy, sys\n"
+        f"sys.path.insert(0, {str(REPO_ROOT)!r})\n"
+        f"runpy.run_path({str(TESTS_DIR / 'test_raw_text.py')!r}, run_name='test_raw_text')\n"
+        "from datasets import Dataset, IterableDataset\n"
+        "print('DATASETS_OK', Dataset.__module__)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        capture_output = True,
+        text = True,
+        check = False,
+    )
+    assert "DATASETS_OK" in result.stdout, (
+        f"exit {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "DATASETS_OK datasets." in result.stdout, result.stdout

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -197,7 +197,11 @@ class _FakeApi:
     def __init__(self, error):
         self.error = error
 
-    def model_info(self, model_id, expand = None):
+    def model_info(
+        self,
+        model_id,
+        expand = None,
+    ):
         if self.error is not None:
             raise self.error
         return object()

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -6,7 +6,8 @@ import sys
 from dataclasses import dataclass
 
 import pytest
-from huggingface_hub import ModelInfo as HfModelInfo
+from huggingface_hub import HfApi
+from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError
 
 from unsloth.registry import register_models, search_models
 from unsloth.registry._deepseek import register_deepseek_models
@@ -16,7 +17,6 @@ from unsloth.registry._mistral import register_mistral_models
 from unsloth.registry._phi import register_phi_models
 from unsloth.registry._qwen import register_qwen_models
 from unsloth.registry.registry import MODEL_REGISTRY, QUANT_TAG_MAP, QuantType
-from unsloth.utils.hf_hub import get_model_info
 
 MODEL_NAMES = [
     "llama",
@@ -42,12 +42,41 @@ class ModelTestParam:
     register_models: callable
 
 
+class HubUnavailable(Exception):
+    """The Hub could not answer, so the registry cannot be judged from here."""
+
+
+def _model_is_missing(api: HfApi, model_id: str) -> bool:
+    """True when the Hub says the repo does not exist.
+
+    Only RepositoryNotFoundError means "not on the Hub". The suite runs
+    unauthenticated in CI, where the Hub answers a private/deleted repo with
+    401 "Invalid username or password" and huggingface_hub maps that to
+    RepositoryNotFoundError. A *gated* repo is not in that bucket: its metadata
+    is public, so model_info returns 200 and this returns False.
+
+    Anything else (429 rate limit, 5xx, DNS/TLS/timeouts) is a broken
+    connection to the Hub, not a broken registry, and must not be reported as
+    129 missing models.
+    """
+    try:
+        api.model_info(model_id, expand = ["lastModified"])
+    except RepositoryNotFoundError:
+        return True
+    except Exception as exc:
+        raise HubUnavailable(f"{model_id}: {type(exc).__name__}: {exc}") from exc
+    return False
+
+
 def _test_model_uploaded(model_ids: list[str]):
+    api = HfApi()
     missing_models = []
     for _id in model_ids:
-        model_info: HfModelInfo = get_model_info(_id)
-        if not model_info:
-            missing_models.append(_id)
+        try:
+            if _model_is_missing(api, _id):
+                missing_models.append(_id)
+        except HubUnavailable as exc:
+            pytest.skip(f"Hugging Face Hub unavailable: {exc}")
 
     return missing_models
 
@@ -162,3 +191,42 @@ def test_register_models_registers_no_upstream_originals():
     # Deepseek is still registered via the normal path, just without originals.
     deepseek_lines = [line for line in out.splitlines() if line.startswith("NUM_DEEPSEEK")]
     assert deepseek_lines and int(deepseek_lines[0].split()[1]) > 0, out + result.stderr
+
+
+class _FakeApi:
+    def __init__(self, error):
+        self.error = error
+
+    def model_info(self, model_id, expand = None):
+        if self.error is not None:
+            raise self.error
+        return object()
+
+
+def test_missing_repo_is_reported_missing():
+    """A repo the Hub says does not exist is a registry error."""
+    api = _FakeApi(RepositoryNotFoundError("404 Client Error. Repository Not Found"))
+    assert _model_is_missing(api, "unsloth/does-not-exist")
+
+
+def test_present_repo_is_not_reported_missing():
+    assert not _model_is_missing(_FakeApi(None), "unsloth/Qwen2.5-7B")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        HfHubHTTPError("429 Client Error: Too Many Requests"),
+        ConnectionError("Failed to establish a new connection"),
+        TimeoutError("read timed out"),
+    ],
+    ids = ["rate_limited", "connection_refused", "timeout"],
+)
+def test_unreachable_hub_skips_instead_of_reporting_missing(monkeypatch, error):
+    """A hub outage must not be reported as every registered model missing."""
+    with pytest.raises(HubUnavailable):
+        _model_is_missing(_FakeApi(error), "unsloth/Qwen2.5-7B")
+
+    monkeypatch.setattr(sys.modules[__name__], "HfApi", lambda: _FakeApi(error))
+    with pytest.raises(pytest.skip.Exception):
+        _test_model_uploaded(["unsloth/Qwen2.5-7B"])

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -37,7 +37,6 @@ class MockDataset:
 datasets_mock = type(sys)("datasets")
 datasets_mock.__spec__ = importlib.util.spec_from_loader("datasets", loader = None)
 datasets_mock.Dataset = MockDataset
-sys.modules["datasets"] = datasets_mock
 
 # Import raw_text directly to avoid unsloth/__init__.py dependencies.
 current_dir = os.path.dirname(__file__)
@@ -45,7 +44,20 @@ raw_text_path = os.path.join(os.path.dirname(current_dir), "unsloth", "dataprep"
 
 spec = importlib.util.spec_from_file_location("raw_text", raw_text_path)
 raw_text_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(raw_text_module)
+
+# The mock is only in place while raw_text executes its `from datasets import
+# Dataset`. Leaving it in sys.modules poisoned every later test module in the
+# same session: `from datasets import IterableDataset` then raised ImportError
+# and tests/utils/test_packing.py failed to collect.
+_real_datasets = sys.modules.get("datasets")
+sys.modules["datasets"] = datasets_mock
+try:
+    spec.loader.exec_module(raw_text_module)
+finally:
+    if _real_datasets is None:
+        del sys.modules["datasets"]
+    else:
+        sys.modules["datasets"] = _real_datasets
 
 RawTextDataLoader = raw_text_module.RawTextDataLoader
 TextPreprocessor = raw_text_module.TextPreprocessor

--- a/tests/utils/os_utils.py
+++ b/tests/utils/os_utils.py
@@ -13,6 +13,26 @@ def _missing_dependency(message):
     sys.exit(1)
 
 
+TRUTHY = ("1", "true", "yes", "on")
+
+
+def require_opt_in(env_var, reason):
+    """Gate a module-level script so `pytest` skips it instead of executing it.
+
+    Files under tests/saving are standalone scripts: the whole body runs at
+    import, so pytest *collection* alone downloads checkpoints, trains and
+    pushes to the Hub, and any failure surfaces as a collection ERROR that
+    interrupts the entire run. Call this before the heavy imports so the module
+    is a visible SKIP unless ``env_var`` is truthy. Running the file directly
+    (``python tests/saving/...py``) is unaffected.
+    """
+    if os.environ.get(env_var, "").strip().lower() in TRUTHY:
+        return
+    if "pytest" in sys.modules:
+        import pytest
+        pytest.skip(f"{reason} Set {env_var}=1 to run.", allow_module_level = True)
+
+
 def detect_package_manager():
     """Detect the available package manager"""
     package_managers = {

--- a/unsloth/registry/_qwen.py
+++ b/unsloth/registry/_qwen.py
@@ -70,6 +70,9 @@ QwenQwQMeta = ModelMeta(
 )
 
 # Qwen QVQ Preview Model Meta
+# No QuantType.NONE: the unquantized mirror unsloth/QVQ-72B-Preview was removed
+# from the Hub (only unsloth/QVQ-72B-Preview-bnb-4bit remains). The upstream
+# Qwen/QVQ-72B-Preview is still registered via include_original_model.
 QwenQVQPreviewMeta = ModelMeta(
     org = "Qwen",
     base_name = "QVQ",
@@ -78,7 +81,7 @@ QwenQVQPreviewMeta = ModelMeta(
     model_sizes = ["72"],
     model_info_cls = QwenQVQPreviewModelInfo,
     is_multimodal = True,
-    quant_types = [QuantType.NONE, QuantType.BNB],
+    quant_types = [QuantType.BNB],
 )
 
 


### PR DESCRIPTION
Three standing reds on `main` that no open PR causes. Each one is judged separately: in two of them the test was wrong, in one the thing it tested was wrong.

## Before / after

```
$ python3 -m pytest tests --collect-only -q
before: 7629 tests collected, 17 errors in 213.87s   -> Interrupted, exit 2
after:  7703 tests collected,  0 errors in   3.02s   -> exit 0
```

Collection went from 214s to 3s because it no longer downloads checkpoints and trains.

```
$ python3 -m pytest tests/test_model_registry.py -q     # unauthenticated
before: FAILED test_model_registration[qwen] - Repository Not Found: unsloth/QVQ-72B-Preview
after:  15 passed, exit 0
```

## 1. `test_model_registration[qwen]`: the registry entry is wrong

`unsloth/QVQ-72B-Preview` is gone from the Hub, so the registry entry that names it is stale.

The 401 the unauthenticated API returns does not mean "gated". Evidence:

- 401 is what the Hub returns for *any* repo it will not confirm, including ones that never existed:
  `GET /api/models/unsloth/definitely-does-not-exist-xyz123` also answers `401 {"error":"Invalid username or password."}`.
- A genuinely gated repo answers **200** unauthenticated with its metadata:
  `meta-llama/Llama-3.1-8B-Instruct` and `google/gemma-2-9b-it` both return 200 with `gated: "manual"`.
- Authenticated as an `unsloth` org member (the token sees 18 private repos in that org's listing),
  `GET /api/models/unsloth/QVQ-72B-Preview` returns **404**, and
  `GET /api/models?author=unsloth&search=QVQ` returns only `unsloth/QVQ-72B-Preview-bnb-4bit`.
  So it is neither private nor gated.
- It did exist: the Wayback Machine has a real model page for it captured 2025-06-13.

So `QwenQVQPreviewMeta` loses `QuantType.NONE`. `unsloth/QVQ-72B-Preview-bnb-4bit` (which exists) and the
upstream `Qwen/QVQ-72B-Preview` registered via `include_original_model` are untouched.

**The rest of the registry is healthy.** All 129 registered ids were checked unauthenticated: 94 return 200,
33 return a case-normalisation 307 that resolves to 200 (`unsloth/gemma-3-12B-it` -> `unsloth/gemma-3-12b-it`,
`unsloth/DeepSeek-R1-bf16` -> `unsloth/DeepSeek-R1-BF16`, `unsloth/phi-4-mini-instruct` -> `unsloth/Phi-4-mini-instruct`),
and exactly one, QVQ, is missing. There is no second entry about to rot.

**The test was also wrong**, and that is the part that matters for the next time a repo moves. It went through
`get_model_info`, which swallows every exception and returns `None`, so a 429 or a DNS blip in unauthenticated CI
would have reported all 129 models as missing. The check now treats only `RepositoryNotFoundError` as "not on the
Hub" and raises `HubUnavailable` -> `pytest.skip` for anything else. A gated repo is deliberately not in the missing
bucket: its metadata is public, so `model_info` returns 200.

## 2. The 17 collection errors

`Repo tests (CPU)` `--ignore`s these directories, so they are invisible in CI while breaking `pytest tests`
locally, and a collection error interrupts the whole run. Four distinct causes, none silenced with an ignore:

**a. 15 standalone scripts under `tests/saving` (the bulk of the errors).** They contain zero test items: the
whole file body runs at import, so *collection alone* downloaded checkpoints, trained, merged and pushed to the
Hub, and any failure inside that surfaced as a collection ERROR (`Model is in float16 precision but you want to
use bfloat16`, `Could not find a valid pad token for unsloth/csm-1b`, `'int' object has no attribute 'mean'`,
`PeftConfig error: Can't find 'adapter_config.json'`, ...). They now call
`tests/utils/os_utils.require_opt_in()` before the heavy imports, so `pytest` reports them as visible skips:

```
SKIPPED [20] tests/utils/os_utils.py:33: GPU + Hub saving script; its body runs at import.
             Set UNSLOTH_RUN_SAVING_SCRIPTS=1 to run.
```

All 20 such scripts are gated, not just the erroring ones, so the ones that "passed" collection by silently
running a Mistral perplexity eval stop doing that too. Running a file directly (`python tests/saving/....py`) is
unchanged: the helper is a no-op outside pytest.

**b. 4 filenames contained a dot** (`test_merged_model_perplexity_qwen_2.5.py`, ...). pytest's importer reads the
dot as a package separator, hence `ModuleNotFoundError: No module named 'test_merged_model_perplexity_qwen_2'`.
Renamed to underscores; no references to the old names anywhere in the repo.

**c. `tests/utils/test_packing.py`** was not broken at all: it collects 52 tests in isolation. `tests/test_raw_text.py`
installs a stub `datasets` module in `sys.modules` at import and never removes it, so every later
`from datasets import IterableDataset` in the same session raised
`ImportError: cannot import name 'IterableDataset' from 'datasets' (unknown location)`.
Minimal repro on `main`: `pytest tests/test_raw_text.py tests/utils/test_packing.py --collect-only`.
The stub is now scoped to the `exec_module` call that needs it and the real module is restored in a `finally`.

**d. The two sentencepiece tests** imported the legacy `transformers.utils.sentencepiece_model_pb2`, which is
generated against protobuf 3.x and raises on protobuf >= 4 ("Descriptors cannot be created directly"), or collides
with sentencepiece's own copy ("duplicate file name sentencepiece_model.proto") when that one loads first. This is
a test bug, not an optional dependency: `unsloth/tokenizer_utils.py` gets the module through
`transformers.convert_slow_tokenizer.import_protobuf()`, which works here and still exists in transformers 5.x.
The tests now use the same accessor, and their 14 tests run for the first time instead of erroring.

**The INTERNALERROR at `tests/saving/text_to_speech_models/test_lasa.py:22` no longer reproduces at this base.**
That line is `require_python_package("xcodec2")`, and `_missing_dependency` already prefers
`pytest.skip(allow_module_level=True)` over `sys.exit(1)` on `main` (a bare `SystemExit` during collection is what
pytest reports as an INTERNALERROR). `test_lasa.py` skips cleanly, and it is not among the 17.

**`tests/test_collection_hygiene.py`** guards all three regression classes: no test filename may contain a dot,
every `tests/saving` script with no test items must carry the gate, and `test_raw_text.py` must not leave its
`datasets` stub behind.

## 3. `ruff` E741 in `unslothai/notebooks`: not fixed, deliberately

`tests/test_notebook_vllm_pin.py` does not exist on notebooks `main` (`git ls-tree origin/main` is empty for it).
It exists only on an unmerged branch, where the loop in question has already been rewritten to
`for _index, source in ...`; the one surviving `for p, l in` there is at line 263, not 219. Notebooks CI's ruff gate
is `--select E9,F63,F7,F82`, so E741 is not enforced and this is not a red. Editing it would collide with that
in-flight branch for a style nit CI does not check. The 14 pre-existing E741 hits on notebooks `main` are all in
generated notebook cells carrying upstream model code, and are likewise not CI failures.

## Sabotage checks

Every guard was verified by breaking what it protects and confirming that specific test goes red, then restoring:

| break | result |
|---|---|
| re-add `QuantType.NONE` to the QVQ meta | `test_model_registration[qwen]` FAILED with the original `missing following models: ['unsloth/QVQ-72B-Preview']`, unauthenticated |
| make `_model_is_missing` treat any exception as missing | all 3 `test_unreachable_hub_skips_instead_of_reporting_missing` params FAILED |
| drop the `sys.modules` restore in `test_raw_text.py` | `test_raw_text_does_not_leave_its_datasets_mock_in_sys_modules` FAILED |
| rename the gate call in one `tests/saving` script | `test_saving_scripts_opt_in_before_running_at_import` FAILED |
| add a test file with a dot in its name | `test_no_test_module_filename_contains_a_dot` FAILED |
| restore the legacy sentencepiece import | that file went back to a collection ERROR, exit 2 |

## Test runs

```
tests/test_model_registry.py                     15 passed  (exit 0, also with HF_TOKEN unset)
tests/test_collection_hygiene.py                  3 passed  (exit 0)
tests/saving/test_fix_sentencepiece_*.py         14 passed  (exit 0)
tests/test_raw_text.py + tests/utils/test_packing.py  75 passed  (exit 0)
tests/saving/{non_peft,text_to_speech_models,vision_models,gpt-oss-merge,language_models}
                                                 20 skipped in 0.04s
tests --collect-only                             7703 collected, 0 errors, exit 0
```

`ruff check` is clean on every changed file, `scripts/run_ruff_format.py` is a no-op, and
`tests/test_enforce_kwargs_spacing.py` passes (62).
