### PR TITLE
tests: build the hub-error fixtures without calling __init__ (huggingface_hub 1.x)

### DIFF
--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -207,9 +207,24 @@ class _FakeApi:
         return object()
 
 
+def _hub_error(cls, message):
+    """Build a hub exception without calling its ``__init__``.
+
+    ``HfHubHTTPError.__init__`` takes ``response`` as an optional positional on
+    huggingface_hub 0.x and as a *required* keyword-only httpx Response on 1.x,
+    and RepositoryNotFoundError inherits it. Bypassing ``__init__`` keeps these
+    fixtures working on both, which the repo supports.
+    """
+    error = cls.__new__(cls)
+    Exception.__init__(error, message)
+    return error
+
+
 def test_missing_repo_is_reported_missing():
     """A repo the Hub says does not exist is a registry error."""
-    api = _FakeApi(RepositoryNotFoundError("404 Client Error. Repository Not Found"))
+    api = _FakeApi(
+        _hub_error(RepositoryNotFoundError, "404 Client Error. Repository Not Found")
+    )
     assert _model_is_missing(api, "unsloth/does-not-exist")
 
 
@@ -218,16 +233,17 @@ def test_present_repo_is_not_reported_missing():
 
 
 @pytest.mark.parametrize(
-    "error",
+    "make_error",
     [
-        HfHubHTTPError("429 Client Error: Too Many Requests"),
-        ConnectionError("Failed to establish a new connection"),
-        TimeoutError("read timed out"),
+        lambda: _hub_error(HfHubHTTPError, "429 Client Error: Too Many Requests"),
+        lambda: ConnectionError("Failed to establish a new connection"),
+        lambda: TimeoutError("read timed out"),
     ],
     ids = ["rate_limited", "connection_refused", "timeout"],
 )
-def test_unreachable_hub_skips_instead_of_reporting_missing(monkeypatch, error):
+def test_unreachable_hub_skips_instead_of_reporting_missing(monkeypatch, make_error):
     """A hub outage must not be reported as every registered model missing."""
+    error = make_error()
     with pytest.raises(HubUnavailable):
         _model_is_missing(_FakeApi(error), "unsloth/Qwen2.5-7B")
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -222,9 +222,7 @@ def _hub_error(cls, message):
 
 def test_missing_repo_is_reported_missing():
     """A repo the Hub says does not exist is a registry error."""
-    api = _FakeApi(
-        _hub_error(RepositoryNotFoundError, "404 Client Error. Repository Not Found")
-    )
+    api = _FakeApi(_hub_error(RepositoryNotFoundError, "404 Client Error. Repository Not Found"))
     assert _model_is_missing(api, "unsloth/does-not-exist")
 
 


### PR DESCRIPTION
Follow-up to #8206, which merged before this landed.

`Repo tests (CPU)` installs huggingface_hub **1.27.0**, where `HfHubHTTPError.__init__` is

```python
def __init__(self, message: str, *, response: httpx.Response, server_message: str | None = None)
```

`response` is a required keyword-only argument, and `RepositoryNotFoundError` inherits that `__init__`. On 0.36.2
(what this workspace has) it is still an optional positional, so #8206's fixtures built the exceptions eagerly at
parametrize time and passed locally while failing collection on CI:

```
ERROR tests/test_model_registry.py - TypeError: HfHubHTTPError.__init__() missing 1
      required keyword-only argument: 'response'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

That is exactly the failure mode #8206 was about: one module's import error interrupts the whole run.

The fixtures now go through `_hub_error()`, which allocates with `cls.__new__(cls)` and calls
`Exception.__init__`, so no version's signature is involved and the instance is still a real
`RepositoryNotFoundError` / `HfHubHTTPError` for the `except` clauses under test.

Verified against the CI version in a throwaway venv:

```
hfh 1.27.0
sig (self, message: str, *, response: httpx.Response, server_message: str | None = None)
eager ctor FAILS as in CI: HfHubHTTPError.__init__() missing 1 required keyword-only argument: 'response'
lazy ctor OK: HfHubHTTPError -> boom
lazy ctor OK: RepositoryNotFoundError -> boom
```

`RepositoryNotFoundError` would have broken `test_missing_repo_is_reported_missing` on 1.x too, so both
constructions are converted. Checked the rest of the suite for the same pattern: the only other eager hub-error
construction is `errors.LocalEntryNotFoundError("missing")` in `tests/test_offline_loading_helpers.py`, whose
`__init__` is still `(self, message: str)` on 1.27.0.

```
tests/test_model_registry.py -k "not registration"   8 passed, exit 0   (huggingface_hub 0.36.2)
ruff check tests/test_model_registry.py              All checks passed!
```
