### PR TITLE
Studio: only dodge an overlay box that reaches the corner stack

### DIFF
--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -96,13 +96,31 @@ function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
  * the corner underneath them empty.
  *
  * Derived from the cap rather than guessed, so the two cannot disagree: the
- * space below the box is what stackMaxHeight allows, and it refuses to go below
- * MIN_STACK_ROOM. Read as a bare "is it near the bottom" instead, boxes ending
- * just above the cutoff were left in the capped branch with a floor that did
- * not fit under them, and the stack overlapped them by up to 24px.
+ * space below the box is what stackMaxHeight allows. Read as a bare "is it near
+ * the bottom" instead, boxes ending just above the cutoff were left in the
+ * capped branch with a cap that did not fit under them.
+ *
+ * Asked against the inset in force, never a fixed one: lifting over one box
+ * moves the stack up into the next, and a box that had room at the corner may
+ * have none there.
  */
-function reachesStack(frame: MonitorFrame, viewportHeight: number): boolean {
-  return roomBelow(frame, viewportHeight, STACK_INSET) < MIN_STACK_ROOM;
+function reachesStack(
+  frame: MonitorFrame,
+  viewportHeight: number,
+  bottomInset: number,
+): boolean {
+  return roomBelow(frame, viewportHeight, bottomInset) < MIN_STACK_ROOM;
+}
+
+/** The inset that clears this box entirely, bounded so the stack stays on screen. */
+function liftOver(frame: MonitorFrame, viewportHeight: number): number {
+  return Math.max(
+    STACK_INSET,
+    Math.min(
+      viewportHeight - frame.top + STACK_GAP,
+      viewportHeight - MIN_STACK_ROOM,
+    ),
+  );
 }
 
 /** Height available between the box and the stack sitting on `bottomInset`. */
@@ -120,16 +138,12 @@ export function stackBottomInset(
   viewportHeight: number,
 ): number {
   if (!frame) return STACK_INSET;
-  // Only dodge a box that is in the stack's column and reaches its strip; one
-  // parked anywhere else leaves the corner free.
+  // Only dodge a box that is in the stack's column and crowds its corner; one
+  // parked anywhere else leaves that corner free.
   const inTheWay =
-    inStackColumn(frame, viewportWidth) && reachesStack(frame, viewportHeight);
-  if (!inTheWay) return STACK_INSET;
-  const lifted = viewportHeight - frame.top + STACK_GAP;
-  return Math.max(
-    STACK_INSET,
-    Math.min(lifted, viewportHeight - MIN_STACK_ROOM),
-  );
+    inStackColumn(frame, viewportWidth) &&
+    reachesStack(frame, viewportHeight, STACK_INSET);
+  return inTheWay ? liftOver(frame, viewportHeight) : STACK_INSET;
 }
 
 /**
@@ -150,10 +164,9 @@ export function stackMaxHeight(
 ): number {
   const ownMargin = viewportHeight - bottomInset - STACK_INSET;
   if (!frame || !inStackColumn(frame, viewportWidth)) return ownMargin;
-  // The lifted case: already accounted for by bottomInset.
-  if (reachesStack(frame, viewportHeight)) return ownMargin;
-  // At least MIN_STACK_ROOM by construction: anything tighter reaches, and was
-  // lifted instead of capped.
+  // Lifted over: bottomInset already cleared it.
+  if (reachesStack(frame, viewportHeight, bottomInset)) return ownMargin;
+  // At least MIN_STACK_ROOM, since anything tighter reaches at this inset.
   return Math.min(ownMargin, roomBelow(frame, viewportHeight, bottomInset));
 }
 
@@ -182,9 +195,21 @@ export function stackGeometry(
       maxHeight: stackMaxHeight(null, viewportWidth, viewportHeight, bottom),
     };
   }
-  const bottom = Math.max(
-    ...list.map((f) => stackBottomInset(f, viewportWidth, viewportHeight)),
-  );
+  // Settled, not summed. Lifting over one box moves the stack up into the next,
+  // which may then need a lift of its own, so keep going until nothing more
+  // asks. Each pass can only promote a box once, so this bounds at their count.
+  const column = list.filter((f) => inStackColumn(f, viewportWidth));
+  let bottom = STACK_INSET;
+  for (let pass = 0; pass <= column.length; pass += 1) {
+    let next = bottom;
+    for (const frame of column) {
+      if (reachesStack(frame, viewportHeight, bottom)) {
+        next = Math.max(next, liftOver(frame, viewportHeight));
+      }
+    }
+    if (next === bottom) break;
+    bottom = next;
+  }
   return {
     bottom,
     maxHeight: Math.min(

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -71,9 +71,6 @@ const STACK_GAP = 8;
 const STACK_WIDTH = 448;
 // Never lift so far that the stack itself is pushed off the top.
 const MIN_STACK_ROOM = 120;
-// Shortest the stack ever is: the collapsed card on its own. An obstacle above
-// this strip is not covering the stack, whatever else it overlaps.
-const MIN_STACK_HEIGHT = 96;
 
 /**
  * How far above the bottom edge the overlay stack must sit to clear the Live
@@ -88,17 +85,33 @@ function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
 }
 
 /**
- * Whether the box reaches down into the strip the stack sits in. Anything
- * higher leaves the corner free, however far down the screen it starts.
+ * Whether the box leaves the stack too little room to sit under it, in which
+ * case the stack has to go over it instead. Anything higher leaves the corner
+ * usable, however far down the screen it starts.
  *
  * This is the whole difference between the two composer layouts. Docked under a
- * thread it reaches the corner and has to be dodged, or the card covers Send.
- * On an empty chat the welcome layout pads it well clear of the bottom, and
+ * thread it crowds the corner and has to be dodged, or the card covers Send. On
+ * an empty chat the welcome layout pads it well clear of the bottom, and
  * lifting over it there is what put the banners in the middle of the page with
  * the corner underneath them empty.
+ *
+ * Derived from the cap rather than guessed, so the two cannot disagree: the
+ * space below the box is what stackMaxHeight allows, and it refuses to go below
+ * MIN_STACK_ROOM. Read as a bare "is it near the bottom" instead, boxes ending
+ * just above the cutoff were left in the capped branch with a floor that did
+ * not fit under them, and the stack overlapped them by up to 24px.
  */
 function reachesStack(frame: MonitorFrame, viewportHeight: number): boolean {
-  return frame.bottom > viewportHeight - STACK_INSET - MIN_STACK_HEIGHT;
+  return roomBelow(frame, viewportHeight, STACK_INSET) < MIN_STACK_ROOM;
+}
+
+/** Height available between the box and the stack sitting on `bottomInset`. */
+function roomBelow(
+  frame: MonitorFrame,
+  viewportHeight: number,
+  bottomInset: number,
+): number {
+  return viewportHeight - bottomInset - frame.bottom - STACK_GAP;
 }
 
 export function stackBottomInset(
@@ -139,8 +152,9 @@ export function stackMaxHeight(
   if (!frame || !inStackColumn(frame, viewportWidth)) return ownMargin;
   // The lifted case: already accounted for by bottomInset.
   if (reachesStack(frame, viewportHeight)) return ownMargin;
-  const belowMonitor = viewportHeight - bottomInset - frame.bottom - STACK_GAP;
-  return Math.max(MIN_STACK_ROOM, Math.min(ownMargin, belowMonitor));
+  // At least MIN_STACK_ROOM by construction: anything tighter reaches, and was
+  // lifted instead of capped.
+  return Math.min(ownMargin, roomBelow(frame, viewportHeight, bottomInset));
 }
 
 export type StackGeometry = { bottom: number; maxHeight: number };

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -71,6 +71,9 @@ const STACK_GAP = 8;
 const STACK_WIDTH = 448;
 // Never lift so far that the stack itself is pushed off the top.
 const MIN_STACK_ROOM = 120;
+// Shortest the stack ever is: the collapsed card on its own. An obstacle above
+// this strip is not covering the stack, whatever else it overlaps.
+const MIN_STACK_HEIGHT = 96;
 
 /**
  * How far above the bottom edge the overlay stack must sit to clear the Live
@@ -81,9 +84,21 @@ const MIN_STACK_ROOM = 120;
 /** Whether the monitor overlaps the column the stack's overlays occupy. */
 function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
   const columnLeft = viewportWidth - STACK_INSET - STACK_WIDTH;
-  return (
-    frame.right > columnLeft && frame.left < viewportWidth - STACK_INSET
-  );
+  return frame.right > columnLeft && frame.left < viewportWidth - STACK_INSET;
+}
+
+/**
+ * Whether the box reaches down into the strip the stack sits in. Anything
+ * higher leaves the corner free, however far down the screen it starts.
+ *
+ * This is the whole difference between the two composer layouts. Docked under a
+ * thread it reaches the corner and has to be dodged, or the card covers Send.
+ * On an empty chat the welcome layout pads it well clear of the bottom, and
+ * lifting over it there is what put the banners in the middle of the page with
+ * the corner underneath them empty.
+ */
+function reachesStack(frame: MonitorFrame, viewportHeight: number): boolean {
+  return frame.bottom > viewportHeight - STACK_INSET - MIN_STACK_HEIGHT;
 }
 
 export function stackBottomInset(
@@ -92,10 +107,11 @@ export function stackBottomInset(
   viewportHeight: number,
 ): number {
   if (!frame) return STACK_INSET;
-  // Only dodge a monitor that is actually in the stack's column and low
-  // enough to be in its way; one dragged elsewhere leaves the corner free.
-  const lowEnough = frame.bottom > viewportHeight / 2;
-  if (!(inStackColumn(frame, viewportWidth) && lowEnough)) return STACK_INSET;
+  // Only dodge a box that is in the stack's column and reaches its strip; one
+  // parked anywhere else leaves the corner free.
+  const inTheWay =
+    inStackColumn(frame, viewportWidth) && reachesStack(frame, viewportHeight);
+  if (!inTheWay) return STACK_INSET;
   const lifted = viewportHeight - frame.top + STACK_GAP;
   return Math.max(
     STACK_INSET,
@@ -121,7 +137,8 @@ export function stackMaxHeight(
 ): number {
   const ownMargin = viewportHeight - bottomInset - STACK_INSET;
   if (!frame || !inStackColumn(frame, viewportWidth)) return ownMargin;
-  if (frame.bottom > viewportHeight / 2) return ownMargin;
+  // The lifted case: already accounted for by bottomInset.
+  if (reachesStack(frame, viewportHeight)) return ownMargin;
   const belowMonitor = viewportHeight - bottomInset - frame.bottom - STACK_GAP;
   return Math.max(MIN_STACK_ROOM, Math.min(ownMargin, belowMonitor));
 }

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -165,3 +165,40 @@ test("one box in a list matches passing it on its own", () => {
   const frame = corner(300);
   assert.deepEqual(stackGeometry([frame], W, H), stackGeometry(frame, W, H));
 });
+
+// The two composer layouts, which are what this gate exists for. Boxes taken
+// from a 1280x830 window: the docked one has to be dodged, or the card covers
+// Send, which below a 1584px viewport it does. The welcome one must not be,
+// because it sits high on the page and lifting over it stranded the banners in
+// the middle of the screen with the corner underneath them empty.
+const CHAT_W = 1280;
+const CHAT_H = 830;
+
+test("a docked composer is dodged, so the card cannot cover Send", () => {
+  const docked = { left: 412, top: 664, right: 1148, bottom: 814 };
+  const inset = stackBottomInset(docked, CHAT_W, CHAT_H);
+  assert.ok(inset > 16, "it reaches the stack's strip, so the stack lifts");
+  assert.ok(
+    inset >= CHAT_H - docked.top,
+    "and lifts clear of it, not part way",
+  );
+  // Still the bottom of the screen, which is the point: above the composer,
+  // not adrift in the middle.
+  assert.ok(inset < CHAT_H / 2);
+});
+
+test("the welcome composer is left alone, and the stack stays in the corner", () => {
+  const welcome = { left: 412, top: 435, right: 1148, bottom: 660 };
+  assert.equal(stackBottomInset(welcome, CHAT_W, CHAT_H), 16);
+});
+
+// Same rule, applied to the other publisher: a monitor dragged up the screen
+// leaves the corner free, so the stack belongs in it.
+test("a monitor away from the corner no longer lifts the stack", () => {
+  const middle = { left: 996, top: 300, right: 1264, bottom: 560 };
+  const geometry = stackGeometry(middle, CHAT_W, CHAT_H);
+  assert.equal(geometry.bottom, 16);
+  // It is still in the column, so the stack is capped short of it instead.
+  assert.ok(geometry.maxHeight < CHAT_H - 16 - 16);
+  assert.ok(geometry.maxHeight <= CHAT_H - 16 - middle.bottom);
+});

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -225,3 +225,51 @@ test("a capped stack always fits under the box it is capped by", () => {
     );
   }
 });
+
+// Reachability has to be asked at the inset actually in force. Folding each box
+// against the default one, a monitor with room at the corner kept the capped
+// branch after the composer had already lifted the stack into it, and the cap
+// came out negative. Browsers drop an invalid max-height, so the cap vanished
+// exactly where it was needed.
+test("a box the shared lift moves the stack into is lifted over too", () => {
+  const composer = { left: 412, top: 664, right: 1148, bottom: 814 };
+  const monitor = { left: 996, top: 400, right: 1264, bottom: 660 };
+  assert.equal(
+    stackGeometry(monitor, CHAT_W, CHAT_H).bottom,
+    16,
+    "on its own the monitor leaves the corner free",
+  );
+  const both = stackGeometry([monitor, composer], CHAT_W, CHAT_H);
+  assert.ok(both.maxHeight > 0, "a negative cap is dropped by the browser");
+  assert.ok(
+    CHAT_H - both.bottom <= monitor.top,
+    "the stack has to clear the monitor, not just the composer",
+  );
+});
+
+// The same, swept: no arrangement may leave the stack overlapping a box, and no
+// cap may come out at zero or below.
+test("no pairing produces an overlap or an unusable cap", () => {
+  const composer = { left: 412, top: 664, right: 1148, bottom: 814 };
+  for (let bottom = 60; bottom <= CHAT_H - 16; bottom += 2) {
+    for (const height of [80, 180, 280, 400]) {
+      const box = {
+        left: 996,
+        top: Math.max(0, bottom - height),
+        right: 1264,
+        bottom,
+      };
+      for (const boxes of [[box], [box, composer]]) {
+        const geometry = stackGeometry(boxes, CHAT_W, CHAT_H);
+        const label = `bottom=${bottom} height=${height} n=${boxes.length}`;
+        assert.ok(geometry.maxHeight > 0, `non-positive cap for ${label}`);
+        const stackTop = CHAT_H - geometry.bottom - geometry.maxHeight;
+        for (const each of boxes) {
+          const clearsAbove = CHAT_H - geometry.bottom <= each.top;
+          const clearsBelow = stackTop >= each.bottom;
+          assert.ok(clearsAbove || clearsBelow, `overlap for ${label}`);
+        }
+      }
+    }
+  }
+});

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -202,3 +202,26 @@ test("a monitor away from the corner no longer lifts the stack", () => {
   assert.ok(geometry.maxHeight < CHAT_H - 16 - 16);
   assert.ok(geometry.maxHeight <= CHAT_H - 16 - middle.bottom);
 });
+
+// The capped branch used to be reachable with a floor that did not fit: a box
+// ending just above the old cutoff was left uncapped-in-practice, and the
+// stack's guaranteed MIN_STACK_ROOM put its top back over the box by up to
+// 24px. The cutoff is derived from the cap now, so the two cannot disagree.
+test("a capped stack always fits under the box it is capped by", () => {
+  for (let bottom = 100; bottom <= CHAT_H - 16; bottom += 1) {
+    const frame = {
+      left: 996,
+      top: Math.max(0, bottom - 260),
+      right: 1264,
+      bottom,
+    };
+    const geometry = stackGeometry(frame, CHAT_W, CHAT_H);
+    // Lifted boxes sit under the stack by design; only the capped ones apply.
+    if (geometry.bottom !== 16) continue;
+    const stackTop = CHAT_H - geometry.bottom - geometry.maxHeight;
+    assert.ok(
+      stackTop >= bottom,
+      `a box ending at ${bottom} left the stack top at ${stackTop}`,
+    );
+  }
+});


### PR DESCRIPTION
## The problem

On a chat page the update banners, the download panel and the loaded models card sit a few hundred pixels up the middle of the page instead of in the bottom-right corner.

The corner stack lifts over anything published to the frame store whose bottom is past the halfway line. The chat composer publishes, and on an empty chat `ThreadWelcome` pads it down from the top with `pt-[27.5dvh]` rather than docking it, so its bottom clears the halfway line while the corner underneath it stays free. The stack lifted anyway, and it is one container, so all four overlays went with it.

## The change

Dodge only a box that reaches the strip the stack occupies: its own inset plus the shortest the stack ever is, which is the collapsed card. One predicate, applied to both publishers.

| box | before | after |
| --- | --- | --- |
| Welcome composer, sits high | lifted | corner |
| Docked composer | lifted | lifted |
| Monitor at its default corner | lifted | lifted |
| Monitor dragged up the screen | lifted | corner, height capped below it |

## Why the docked composer still has to be dodged

Not cosmetic. The composer column is `max-w-[46rem]` centred in the content area, the card is `w-[268px]` at `right-4`, and `SIDEBAR_WIDTH_DEFAULT` is 280, so the card's left edge is `viewport - 284` and the composer's right edge is `(viewport + sidebar + 736) / 2`. They overlap while the viewport is under **1584px**:

| viewport | composer right | card left | overlap |
| --- | --- | --- | --- |
| 1280 (`playwright_chat_ui.py`) | 1148 | 996 | 152px |
| 1440 | 1228 | 1156 | 72px |
| 1512 | 1264 | 1228 | 36px |
| 1728 | 1372 | 1444 | clear |

With a model loaded the card lands on Send and eats the click, which is what the chat UI suite caught as a 60s timeout on a visible button. So the docked case keeps its lift, and lifting over a docked composer still leaves the stack at the bottom of the screen, roughly 170px up on a 830px window, not adrift in the middle.

## Checks

- `npm run typecheck` clean
- `npm test`: 1313 passing, 0 failing
- `npm run i18n:check:strict` passes
- `npm run build` succeeds
- Biome on the changed file: identical findings to `main`, none new

Three tests added, using boxes measured from a 1280x830 window: the docked composer is dodged, the welcome composer is not, and a monitor away from the corner no longer lifts the stack. All three fail against the old halfway-line rule.