### PR TITLE
Desktop: keep probing the announced backend port instead of discarding it

### DIFF
--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -1395,9 +1395,16 @@ async fn generic_backend_health_ok(port: u16) -> bool {
     live && service
 }
 
-/// Gap between port-verification probes. Each probe already costs up to
-/// LOCAL_HTTP_TIMEOUT, so this only paces a backend that is busy, not stuck.
-const PORT_VALIDATION_RETRY_DELAY: Duration = Duration::from_secs(2);
+/// Backoff between port-verification probes, doubling from min to max.
+///
+/// A probe is not free: it costs a liveness request plus a desktop-login
+/// request, each up to LOCAL_HTTP_TIMEOUT, against a backend that is by
+/// definition busy. Polling at a fixed short interval would add load to the
+/// slow start it is waiting on. Starting small still wins the common race,
+/// where the backend is a few hundred ms from ready, while the cap keeps a
+/// long torch import down to a handful of probes rather than dozens.
+const PORT_VALIDATION_RETRY_MIN: Duration = Duration::from_millis(250);
+const PORT_VALIDATION_RETRY_MAX: Duration = Duration::from_secs(5);
 
 async fn validate_candidate_port(
     app: AppHandle,
@@ -1433,6 +1440,7 @@ async fn validate_candidate_port(
     // port the backend had already reported it could not bind. Keep probing
     // until the backend answers or that same deadline passes.
     let deadline = std::time::Instant::now() + BACKEND_START_DEADLINE;
+    let mut delay = PORT_VALIDATION_RETRY_MIN;
     let mut attempts = 0u32;
     let valid = loop {
         attempts += 1;
@@ -1453,7 +1461,8 @@ async fn validate_candidate_port(
         if std::time::Instant::now() >= deadline {
             break false;
         }
-        tokio::time::sleep(PORT_VALIDATION_RETRY_DELAY).await;
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(PORT_VALIDATION_RETRY_MAX);
         // Stop once this generation is gone or another path claimed the port,
         // so a restarted backend does not keep an old probe alive. Bound the
         // guard to this statement: the future must stay Send across the await.

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -1395,6 +1395,10 @@ async fn generic_backend_health_ok(port: u16) -> bool {
     live && service
 }
 
+/// Gap between port-verification probes. Each probe already costs up to
+/// LOCAL_HTTP_TIMEOUT, so this only paces a backend that is busy, not stuck.
+const PORT_VALIDATION_RETRY_DELAY: Duration = Duration::from_secs(2);
+
 async fn validate_candidate_port(
     app: AppHandle,
     state: BackendState,
@@ -1421,19 +1425,52 @@ async fn validate_candidate_port(
         }
     };
 
-    let valid = if let Some(owner) = owner {
-        matches!(
-            crate::desktop_backend_owner::probe_owned_backend_state(owner, Some(port), false).await,
-            crate::desktop_backend_owner::OwnedBackendProbe::Verified(
-                crate::desktop_backend_owner::VerifiedOwnedBackend { port: verified_port, .. }
-            ) if verified_port == port
-        )
-    } else {
-        generic_backend_health_ok(port).await
+    // The backend announces its port once. That line arrives while it is still
+    // importing torch, so a single probe races a backend that cannot answer
+    // inside LOCAL_HTTP_TIMEOUT yet: on a cold CPU-only machine /api/liveness
+    // has been seen taking 2.1 s against a 2 s budget. Discarding the only
+    // announcement left the window waiting out BACKEND_START_DEADLINE on the
+    // port the backend had already reported it could not bind. Keep probing
+    // until the backend answers or that same deadline passes.
+    let deadline = std::time::Instant::now() + BACKEND_START_DEADLINE;
+    let mut attempts = 0u32;
+    let valid = loop {
+        attempts += 1;
+        let ok = if let Some(owner) = owner.clone() {
+            matches!(
+                crate::desktop_backend_owner::probe_owned_backend_state(owner, Some(port), false)
+                    .await,
+                crate::desktop_backend_owner::OwnedBackendProbe::Verified(
+                    crate::desktop_backend_owner::VerifiedOwnedBackend { port: verified_port, .. }
+                ) if verified_port == port
+            )
+        } else {
+            generic_backend_health_ok(port).await
+        };
+        if ok {
+            break true;
+        }
+        if std::time::Instant::now() >= deadline {
+            break false;
+        }
+        tokio::time::sleep(PORT_VALIDATION_RETRY_DELAY).await;
+        // Stop once this generation is gone or another path claimed the port,
+        // so a restarted backend does not keep an old probe alive. Bound the
+        // guard to this statement: the future must stay Send across the await.
+        let still_current = match state.lock() {
+            Ok(proc) => proc.generation == generation && proc.port.is_none(),
+            Err(_) => false,
+        };
+        if !still_current {
+            return;
+        }
     };
 
     if !valid {
-        warn!("Ignoring unverified TAURI_PORT candidate {}", port);
+        warn!(
+            "Ignoring unverified TAURI_PORT candidate {} after {} attempts",
+            port, attempts
+        );
         return;
     }
 

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -1448,7 +1448,14 @@ async fn validate_candidate_port(
     // the backend answers or that deadline, shared with the watchdog, passes.
     let mut delay = PORT_VALIDATION_RETRY_MIN;
     let mut attempts = 0u32;
+    let mut verified_late = false;
     let valid = loop {
+        // Before the probe, not just after a failed one: the announcement
+        // itself can arrive past the deadline on a very slow start, and the
+        // watchdog does not kill the backend when it times out.
+        if std::time::Instant::now() >= deadline {
+            break false;
+        }
         attempts += 1;
         let ok = if let Some(owner) = owner.clone() {
             matches!(
@@ -1462,12 +1469,20 @@ async fn validate_candidate_port(
             generic_backend_health_ok(port).await
         };
         if ok {
-            break true;
-        }
-        if std::time::Instant::now() >= deadline {
+            // A probe that started in time can still finish late. Emitting
+            // server-port after the watchdog's server-start-timeout strands the
+            // window in an error state it has no handler to leave.
+            if std::time::Instant::now() < deadline {
+                break true;
+            }
+            verified_late = true;
             break false;
         }
-        tokio::time::sleep(delay).await;
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break false;
+        }
+        tokio::time::sleep(delay.min(remaining)).await;
         delay = (delay * 2).min(PORT_VALIDATION_RETRY_MAX);
         // Stop once this generation is gone or another path claimed the port,
         // so a restarted backend does not keep an old probe alive. Bound the
@@ -1482,10 +1497,22 @@ async fn validate_candidate_port(
     };
 
     if !valid {
-        warn!(
-            "Ignoring unverified TAURI_PORT candidate {} after {} attempts",
-            port, attempts
-        );
+        if verified_late {
+            warn!(
+                "Backend port {} verified after the start deadline; not emitting",
+                port
+            );
+        } else if attempts == 0 {
+            warn!(
+                "TAURI_PORT candidate {} arrived after the start deadline",
+                port
+            );
+        } else {
+            warn!(
+                "Ignoring unverified TAURI_PORT candidate {} after {} attempts",
+                port, attempts
+            );
+        }
         return;
     }
 

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -652,6 +652,11 @@ pub struct BackendProcess {
     pub generation: u64,
     pub diagnostics_session: Option<BackendLog>,
     pub adopted_watchdog_generation: Option<u64>,
+    /// Set by the start watchdog, under this mutex, once it has committed to
+    /// emitting server-start-timeout for the current generation. Port
+    /// validation refuses to claim afterwards, so the window never receives
+    /// server-port behind an error it has no handler to clear.
+    pub start_timed_out: bool,
 }
 
 impl BackendProcess {
@@ -703,6 +708,7 @@ pub(crate) fn adopt_verified_backend(
     proc.intentional_stop = false;
     proc.diagnostics_session = None;
     proc.adopted_watchdog_generation = None;
+    proc.start_timed_out = false;
     proc.owned = Some(OwnedBackendHandle::adopted(
         verified.owner,
         verified.port,
@@ -836,6 +842,7 @@ impl Default for BackendProcess {
             generation: 0,
             diagnostics_session: None,
             adopted_watchdog_generation: None,
+            start_timed_out: false,
         }
     }
 }
@@ -1182,6 +1189,7 @@ pub fn start_backend(
         proc.intentional_stop = false;
         proc.diagnostics_session = None;
         proc.adopted_watchdog_generation = None;
+        proc.start_timed_out = false;
         proc.owned = None;
         let generation = proc.generation;
 
@@ -1524,7 +1532,9 @@ async fn validate_candidate_port(
                 return;
             }
         };
-        if proc.generation != generation || proc.port.is_some() {
+        // start_timed_out is the watchdog's claim, taken under this same lock,
+        // so exactly one of the two outcomes reaches the window.
+        if proc.generation != generation || proc.port.is_some() || proc.start_timed_out {
             false
         } else if matches!(proc.owned, Some(OwnedBackendHandle::Spawned { .. })) {
             proc.port = Some(port);
@@ -1610,7 +1620,7 @@ fn start_watchdog(
         }
 
         let (still_ours, tail) = match state.lock() {
-            Ok(proc) => {
+            Ok(mut proc) => {
                 // Same three conditions as the loop. Dropping has_owned_backend here
                 // would let a crash in the last second be overwritten by a message
                 // claiming the backend is still running.
@@ -1618,6 +1628,11 @@ fn start_watchdog(
                 {
                     (false, String::new())
                 } else {
+                    // Claim the outcome while still holding the lock. Deciding
+                    // here and emitting after the unlock would otherwise let a
+                    // port validation that succeeded in between emit
+                    // server-port on top of this timeout.
+                    proc.start_timed_out = true;
                     let skip = proc.logs.len().saturating_sub(20);
                     let tail: Vec<String> = proc.logs.iter().skip(skip).cloned().collect();
                     (true, tail.join("\n"))

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -1274,6 +1274,10 @@ pub fn start_backend(
 
     info!("{}", start_line);
     diagnostics::append_phase_line(&backend_log.handle, "meta", &start_line);
+    // One deadline for this start, shared with the watchdog below. Port
+    // validation must not outlive it: the watchdog's server-start-timeout puts
+    // the window in an error state that a later server-port does not clear.
+    let start_deadline = std::time::Instant::now() + BACKEND_START_DEADLINE;
     start_watchdog(app, state, shutdown, generation, &backend_log);
 
     if let Some(stdout) = stdout {
@@ -1290,6 +1294,7 @@ pub fn start_backend(
                 &backend_log_clone,
                 false,
                 generation,
+                start_deadline,
             );
         });
     }
@@ -1308,6 +1313,7 @@ pub fn start_backend(
                 &backend_log_clone,
                 true,
                 generation,
+                start_deadline,
             );
         });
     }
@@ -1413,6 +1419,7 @@ async fn validate_candidate_port(
     session_id: String,
     generation: u64,
     port: u16,
+    deadline: std::time::Instant,
 ) {
     let started = std::time::Instant::now();
     let owner = {
@@ -1436,10 +1443,9 @@ async fn validate_candidate_port(
     // importing torch, so a single probe races a backend that cannot answer
     // inside LOCAL_HTTP_TIMEOUT yet: on a cold CPU-only machine /api/liveness
     // has been seen taking 2.1 s against a 2 s budget. Discarding the only
-    // announcement left the window waiting out BACKEND_START_DEADLINE on the
-    // port the backend had already reported it could not bind. Keep probing
-    // until the backend answers or that same deadline passes.
-    let deadline = std::time::Instant::now() + BACKEND_START_DEADLINE;
+    // announcement left the window waiting out the start deadline on the port
+    // the backend had already reported it could not bind. Keep probing until
+    // the backend answers or that deadline, shared with the watchdog, passes.
     let mut delay = PORT_VALIDATION_RETRY_MIN;
     let mut attempts = 0u32;
     let valid = loop {
@@ -1625,6 +1631,7 @@ fn read_output_stream<R: std::io::Read>(
     backend_log: &BackendLog,
     is_stderr: bool,
     generation: u64,
+    start_deadline: std::time::Instant,
 ) {
     let mut reader = std::io::BufReader::new(stream);
     let port_re = Regex::new(r"TAURI_PORT=(\d+)").unwrap();
@@ -1699,6 +1706,7 @@ fn read_output_stream<R: std::io::Read>(
                             session_id,
                             generation,
                             port,
+                            start_deadline,
                         )
                         .await;
                     });


### PR DESCRIPTION
## Symptom

The desktop app hangs on the "Nearly done..." splash and eventually fails with:

```
The Unsloth backend did not start within 300 seconds.
```

The backend is up and serving the whole time. Reported on 0.1.526-beta, Windows 11, CPU-only.

## Root cause

The backend announces its port once, on a `TAURI_PORT=` stdout line, and `validate_candidate_port` in `process.rs` probed it exactly **once**:

```rust
if !valid {
    warn!("Ignoring unverified TAURI_PORT candidate {}", port);
    return;
}
```

That line arrives while the backend is still importing torch. `probe_owned_backend_state` gives each request `LOCAL_HTTP_TIMEOUT`, which is 2 s. If the backend cannot answer inside that window, the only announcement it will ever make is discarded and the window keeps waiting for a backend on the port it originally requested, which the backend has already reported it could not bind. Nothing retries, so it waits out the full `BACKEND_START_DEADLINE`.

From the reporter's log, with 8888 held by an unrelated process so the backend moved to 8889:

```
16:51:56 [backend] Port 8888 is already in use by ssh.exe (PID 5092).
16:51:56 [backend] Unsloth Studio will use port 8889 instead.
16:51:59 [backend] TAURI_PORT=8889
16:52:01 [WARN]    Ignoring unverified TAURI_PORT candidate 8889
16:56:37 [error]   The Unsloth backend did not start within 300 seconds
```

The backend's own log for 16:52:01 records the probe that lost:

```json
{"event": "request_completed", "path": "/api/liveness", "process_time_ms": 2156.02}
```

2156 ms against a 2000 ms budget. This is a race, not a hard failure. Three healthy runs in the same log validated in 735 ms, 792 ms and 2295 ms. The fast path wins it most of the time and loses it on a cold start, which is why it looks intermittent.

Note the port fallback itself is working correctly and is not the bug. The same fallback happens in every healthy run in these logs. What is wrong is discarding the announcement after one attempt.

## Fix

Retry until the backend answers or `BACKEND_START_DEADLINE` passes, instead of giving the slowest moment of startup a single attempt. The deadline is the one the window is already waiting on, so this cannot extend a hang, only avoid one.

The loop bails early if the generation changes or another path claims the port, so a restarted backend does not leave an old probe running. The re-check binds its `MutexGuard` to a single statement rather than a `match` arm, keeping the future `Send` for `tauri::async_runtime::spawn`.

The rejection warning now carries the attempt count, so a genuine "wrong port announced" case still reports and is distinguishable from this race.

## Why it surfaced now

Two conditions have to coincide: the requested port must already be taken, so the backend has to announce a different one; and that announcement must land during a slow patch of startup.

Anything that makes the first backend start colder makes the second more likely. A fresh package upgrade does exactly that, and in this log the run that failed is the one immediately after a successful `desktop_backend_version_outdated` repair, where torch warm took 99 s. The repair itself completed cleanly.

## Related hazard, not addressed here

Worth a separate look. In the same diagnostics, `runtime_health` reports `port=8888 status=healthy service=Unsloth UI Backend`, but 8888 is held by `ssh.exe`. That machine is forwarding 8888 to a remote host that is also running Unsloth, so a health probe on the requested port can be answered by a **different** Unsloth instance. `validate_candidate_port` calls `probe_owned_backend_state` with `require_desktop_secret: false`, so identity rests on the service name rather than on the desktop secret. That did not cause this hang, but adopting someone else's backend is a worse failure than waiting for your own.

## Testing

No Rust toolchain on the machine this was written on, so this relies on the Tauri CI build for compilation. `tokio` is already a direct dependency with `features = ["full"]`, so `tokio::time::sleep` needs no manifest change. No test or doc asserted the old single-probe behaviour or the warning text. Brace and paren balance across `process.rs` verified against `origin/main`.

I have not reproduced the hang deterministically. It needs the requested port occupied plus a backend slow enough to miss the 2 s window, and the fix is aimed at the mechanism the logs show rather than at a reproduction.
