### PR TITLE
Tell users to upgrade the dependency, not transformers, when a --no-deps install leaves a floor unmet

### DIFF
--- a/tests/test_transformers_dependency_floor.py
+++ b/tests/test_transformers_dependency_floor.py
@@ -15,6 +15,7 @@ Runs under the GPU-free ``tests/conftest.py``.
 from __future__ import annotations
 
 import importlib.metadata
+import importlib.util
 import logging
 
 import pytest
@@ -380,3 +381,20 @@ def test_check_warns_rather_than_raises_on_a_violation(monkeypatch, caplog):
     )
     IF.check_transformers_dependency_versions()  # no exception
     assert len(_run_check(caplog)) == 1
+
+
+def test_a_transformers_stub_in_sys_modules_does_not_break_the_import(monkeypatch, caplog):
+    """`find_spec` RAISES on a module in sys.modules whose `__spec__` is None or unset,
+    rather than returning None (documented behaviour, CPython Lib/importlib/util.py).
+    An unguarded probe there turns a warn-only check into a failed `import unsloth`.
+    """
+    import sys
+    import types
+
+    _install_env(monkeypatch, ["safetensors>=0.8.0"], {"transformers": "5.15.0.dev0"})
+    for stub in (types.ModuleType("transformers"), types.SimpleNamespace()):
+        monkeypatch.setitem(sys.modules, "transformers", stub)
+        with pytest.raises(ValueError):
+            importlib.util.find_spec("transformers")   # __spec__ None / not set
+        IF.check_transformers_dependency_versions()    # must not raise
+        assert _warnings(caplog) == []

--- a/tests/test_transformers_dependency_floor.py
+++ b/tests/test_transformers_dependency_floor.py
@@ -96,24 +96,37 @@ def _run_check(caplog):
 
 # ---------------------------------------------------------------- satisfied
 
+
 @pytest.mark.parametrize(
     "requires, installed",
     [
         (
             REQUIRES_4_57_6,
             {
-                "filelock": "3.16.1", "huggingface-hub": "0.36.2", "numpy": "2.1.3",
-                "packaging": "24.2", "pyyaml": "6.0.2", "regex": "2025.11.3",
-                "requests": "2.32.4", "tokenizers": "0.22.2",
-                "safetensors": "0.7.0", "tqdm": "4.67.3",
+                "filelock": "3.16.1",
+                "huggingface-hub": "0.36.2",
+                "numpy": "2.1.3",
+                "packaging": "24.2",
+                "pyyaml": "6.0.2",
+                "regex": "2025.11.3",
+                "requests": "2.32.4",
+                "tokenizers": "0.22.2",
+                "safetensors": "0.7.0",
+                "tqdm": "4.67.3",
             },
         ),
         (
             REQUIRES_5_14_1,
             {
-                "huggingface-hub": "1.27.0", "numpy": "2.1.3", "packaging": "24.2",
-                "pyyaml": "6.0.2", "regex": "2025.11.3", "tokenizers": "0.22.2",
-                "typer": "0.15.1", "safetensors": "0.8.0", "tqdm": "4.67.3",
+                "huggingface-hub": "1.27.0",
+                "numpy": "2.1.3",
+                "packaging": "24.2",
+                "pyyaml": "6.0.2",
+                "regex": "2025.11.3",
+                "tokenizers": "0.22.2",
+                "typer": "0.15.1",
+                "safetensors": "0.8.0",
+                "tqdm": "4.67.3",
             },
         ),
     ],
@@ -128,21 +141,25 @@ def test_satisfied_requirements_are_silent(monkeypatch, caplog, requires, instal
 
 # ----------------------------------------------------------------- violated
 
+
 def test_violated_floor_is_reported_and_names_the_dependency(monkeypatch, caplog):
     """The Kaggle LFM2 break: transformers main wants safetensors>=0.8.0, the
     image ships 0.7.0. The remedy must upgrade safetensors, not transformers."""
     installed = {
-        "transformers": "5.15.0.dev0", "huggingface-hub": "1.27.0", "numpy": "2.1.3",
-        "packaging": "24.2", "pyyaml": "6.0.2", "regex": "2025.11.3",
-        "tokenizers": "0.22.2", "typer": "0.15.1",
+        "transformers": "5.15.0.dev0",
+        "huggingface-hub": "1.27.0",
+        "numpy": "2.1.3",
+        "packaging": "24.2",
+        "pyyaml": "6.0.2",
+        "regex": "2025.11.3",
+        "tokenizers": "0.22.2",
+        "typer": "0.15.1",
         "safetensors": "0.7.0",  # the violation
         "tqdm": "4.67.3",
     }
     _install_env(monkeypatch, REQUIRES_5_14_1, installed)
 
-    assert IF._unsatisfied_transformers_requirements() == [
-        ("safetensors", ">=0.8.0", "0.7.0")
-    ]
+    assert IF._unsatisfied_transformers_requirements() == [("safetensors", ">=0.8.0", "0.7.0")]
 
     warnings = _run_check(caplog)
     assert len(warnings) == 1
@@ -177,8 +194,10 @@ def test_multiple_violations_are_all_listed_in_one_command(monkeypatch, caplog):
         monkeypatch,
         ["huggingface-hub<2.0,>=1.5.0", "safetensors>=0.8.0", "tqdm>=4.60"],
         {
-            "transformers": "5.15.0.dev0", "huggingface-hub": "0.36.2",
-            "safetensors": "0.7.0", "tqdm": "4.67.3",
+            "transformers": "5.15.0.dev0",
+            "huggingface-hub": "0.36.2",
+            "safetensors": "0.7.0",
+            "tqdm": "4.67.3",
         },
     )
     reported = {name for name, _, _ in IF._unsatisfied_transformers_requirements()}
@@ -200,6 +219,7 @@ def test_prerelease_dependency_satisfying_the_floor_is_not_reported(monkeypatch,
 
 # ------------------------------------------------------- environment markers
 
+
 def test_inapplicable_environment_markers_are_skipped(monkeypatch, caplog):
     """Extras and python_version gates that do not apply must not be checked,
     even when a violating version of the named package is installed."""
@@ -213,8 +233,12 @@ def test_inapplicable_environment_markers_are_skipped(monkeypatch, caplog):
             'requests>=99.0; sys_platform == "definitely-not-a-real-platform"',
         ],
         {
-            "transformers": "5.15.0.dev0", "torch": "2.9.0", "accelerate": "1.2.0",
-            "fugashi": "1.3.0", "numpy": "2.1.3", "requests": "2.32.4",
+            "transformers": "5.15.0.dev0",
+            "torch": "2.9.0",
+            "accelerate": "1.2.0",
+            "fugashi": "1.3.0",
+            "numpy": "2.1.3",
+            "requests": "2.32.4",
         },
     )
     assert IF._unsatisfied_transformers_requirements() == []
@@ -228,13 +252,12 @@ def test_applicable_environment_marker_is_still_checked(monkeypatch, caplog):
         ['safetensors>=0.8.0; python_version >= "3.0"'],
         {"transformers": "5.15.0.dev0", "safetensors": "0.7.0"},
     )
-    assert IF._unsatisfied_transformers_requirements() == [
-        ("safetensors", ">=0.8.0", "0.7.0")
-    ]
+    assert IF._unsatisfied_transformers_requirements() == [("safetensors", ">=0.8.0", "0.7.0")]
     assert "safetensors" in _run_check(caplog)[0]
 
 
 # ------------------------------------------------------------ absent package
+
 
 def test_an_absent_base_requirement_is_reported_like_a_stale_one(monkeypatch, caplog):
     """`--no-deps` leaves a dependency missing as often as it leaves it old.
@@ -289,6 +312,7 @@ def test_unreadable_metadata_is_still_silent(monkeypatch, caplog):
 
 # --------------------------------------------------------- defensive silence
 
+
 @pytest.mark.parametrize(
     "requires, installed",
     [
@@ -301,12 +325,9 @@ def test_unreadable_metadata_is_still_silent(monkeypatch, caplog):
         # Undecidable marker.
         (['safetensors>=0.8.0; nonexistent_marker == "x"'], {"safetensors": "0.7.0"}),
     ],
-    ids = ["bad-specifier", "garbage-line", "bad-marker", "bad-installed-version",
-           "unknown-marker"],
+    ids = ["bad-specifier", "garbage-line", "bad-marker", "bad-installed-version", "unknown-marker"],
 )
-def test_unparseable_input_is_silent_and_never_raises(
-    monkeypatch, caplog, requires, installed
-):
+def test_unparseable_input_is_silent_and_never_raises(monkeypatch, caplog, requires, installed):
     installed = {"transformers": "5.15.0.dev0", **installed}
     _install_env(monkeypatch, requires, installed)
     assert IF._unsatisfied_transformers_requirements() == []
@@ -317,14 +338,12 @@ def test_unparseable_input_is_silent_and_never_raises(
     "requires",
     [
         importlib.metadata.PackageNotFoundError("transformers"),
-        None,   # dist-info present but declares nothing
+        None,  # dist-info present but declares nothing
         [],
     ],
     ids = ["metadata-missing", "requires-none", "requires-empty"],
 )
-def test_missing_transformers_metadata_is_silent_and_never_raises(
-    monkeypatch, caplog, requires
-):
+def test_missing_transformers_metadata_is_silent_and_never_raises(monkeypatch, caplog, requires):
     _install_env(monkeypatch, requires, {})
     assert IF._unsatisfied_transformers_requirements() == []
     assert _run_check(caplog) == []
@@ -352,6 +371,7 @@ def test_env_var_silences_the_check(monkeypatch, caplog):
 
 
 # --------------------------------------------------------------- live + wiring
+
 
 def test_runs_against_the_real_environment_without_raising(caplog):
     """No monkeypatching: the real installed transformers, read from real metadata."""
@@ -395,8 +415,8 @@ def test_a_transformers_stub_in_sys_modules_does_not_break_the_import(monkeypatc
     for stub in (types.ModuleType("transformers"), types.SimpleNamespace()):
         monkeypatch.setitem(sys.modules, "transformers", stub)
         with pytest.raises(ValueError):
-            importlib.util.find_spec("transformers")   # __spec__ None / not set
-        IF.check_transformers_dependency_versions()    # must not raise
+            importlib.util.find_spec("transformers")  # __spec__ None / not set
+        IF.check_transformers_dependency_versions()  # must not raise
         assert _warnings(caplog) == []
 
 
@@ -414,7 +434,8 @@ def test_check_also_runs_on_the_mlx_branch():
 
     source = Path(IF.__file__).with_name("__init__.py").read_text(encoding = "utf-8")
     branch = next(
-        node for node in ast.parse(source).body
+        node
+        for node in ast.parse(source).body
         if isinstance(node, ast.If) and ast.unparse(node.test) == "_IS_MLX"
     )
     body = ast.unparse(ast.Module(body = branch.body, type_ignores = []))

--- a/tests/test_transformers_dependency_floor.py
+++ b/tests/test_transformers_dependency_floor.py
@@ -423,11 +423,10 @@ def test_a_transformers_stub_in_sys_modules_does_not_break_the_import(monkeypatc
 def test_check_also_runs_on_the_mlx_branch():
     """Apple Silicon never reaches `_gpu_init`.
 
-    `unsloth/__init__.py` splits on `_IS_MLX`; only the `else` arm imports
-    `_gpu_init`, and the MLX arm imports transformers itself. Registering the check
-    on one arm only leaves every MLX user with transformers' own wrong remedy, so
-    the call has to sit inside the `if _IS_MLX:` body, next to the torchao fixes
-    that are there for exactly this reason.
+    `unsloth/__init__.py` splits on `_IS_MLX` and only the `else` arm imports
+    `_gpu_init`, while the MLX arm imports transformers itself, so registering on one
+    arm leaves MLX users with transformers' own wrong remedy. The call belongs in the
+    `if _IS_MLX:` body, next to the torchao fixes that are there for the same reason.
     """
     import ast
     from pathlib import Path

--- a/tests/test_transformers_dependency_floor.py
+++ b/tests/test_transformers_dependency_floor.py
@@ -3,12 +3,10 @@
 
 """``check_transformers_dependency_versions`` in ``unsloth/import_fixes.py``.
 
-Notebooks that need a bleeding-edge model install transformers from git with
-``--no-deps`` on purpose, so pip never enforces what that transformers requires.
-The break lands later at import, and transformers' own remedy
-(``pip install transformers -U``) is the wrong one for someone who is
-deliberately on main. These tests drive the real functions and pin: the
-requirement set is read from the installed distribution's metadata, only genuine
+A ``--no-deps`` install of transformers from git main leaves pip enforcing nothing,
+so the break lands at import with the wrong remedy (``pip install transformers -U``)
+for someone deliberately on main. These tests drive the real functions and pin: the
+requirement set comes from the installed distribution's metadata, only genuine
 violations are reported, the remedy names the DEPENDENCY, and nothing raises.
 
 Runs under the GPU-free ``tests/conftest.py``.
@@ -238,13 +236,11 @@ def test_applicable_environment_marker_is_still_checked(monkeypatch, caplog):
 # ------------------------------------------------------------ absent package
 
 def test_an_absent_base_requirement_is_reported_like_a_stale_one(monkeypatch, caplog):
-    """`--no-deps` leaves a dependency missing at least as often as it leaves it old.
+    """`--no-deps` leaves a dependency missing as often as it leaves it old.
 
-    transformers checks its base requirements during its own root import and raises
-    `PackageNotFoundError: The 'safetensors>=0.8.0' distribution was not found and is
-    required by this application. Try: pip install transformers -U ...` - the same
-    misleading remedy this check exists to correct. Skipping the absent case left the
-    user with only that message, which is the one outcome the feature has to prevent.
+    transformers checks its base requirements at its own root import and raises
+    PackageNotFoundError carrying the same misleading `pip install transformers -U`
+    hint, so skipping the absent case left the user with only that message.
     """
     _install_env(
         monkeypatch,
@@ -278,8 +274,8 @@ def test_an_absent_extras_only_package_is_not_reported(monkeypatch, caplog):
 
 
 def test_unreadable_metadata_is_still_silent(monkeypatch, caplog):
-    """Only a real PackageNotFoundError counts as absent. Any other metadata error
-    means we cannot tell, and guessing would warn about a working install."""
+    """Only PackageNotFoundError counts as absent; any other metadata error means we
+    cannot tell, and guessing would warn about a working install."""
     _install_env(monkeypatch, ["safetensors>=0.8.0"], {"transformers": "5.15.0.dev0"})
 
     def broken_version(name):

--- a/tests/test_transformers_dependency_floor.py
+++ b/tests/test_transformers_dependency_floor.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""``check_transformers_dependency_versions`` in ``unsloth/import_fixes.py``.
+
+Notebooks that need a bleeding-edge model install transformers from git with
+``--no-deps`` on purpose, so pip never enforces what that transformers requires.
+The break lands later at import, and transformers' own remedy
+(``pip install transformers -U``) is the wrong one for someone who is
+deliberately on main. These tests drive the real functions and pin: the
+requirement set is read from the installed distribution's metadata, only genuine
+violations are reported, the remedy names the DEPENDENCY, and nothing raises.
+
+Runs under the GPU-free ``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+
+import pytest
+
+from unsloth import import_fixes as IF
+
+
+# Base (no-extras) requirements as declared by two real transformers releases.
+# The names and floors differ between them, which is why the check reads them
+# from metadata instead of carrying a table that would rot.
+REQUIRES_4_57_6 = [
+    "filelock",
+    "huggingface-hub<1.0,>=0.34.0",
+    "numpy>=1.17",
+    "packaging>=20.0",
+    "pyyaml>=5.1",
+    "regex!=2019.12.17",
+    "requests",
+    "tokenizers<=0.23.0,>=0.22.0",
+    "safetensors>=0.4.3",
+    "tqdm>=4.27",
+    'torch>=2.2; extra == "torch"',
+    'accelerate>=0.26.0; extra == "torch"',
+    'fugashi>=1.0; extra == "ja"',
+]
+REQUIRES_5_14_1 = [
+    "huggingface-hub<2.0,>=1.5.0",
+    "numpy>=1.17",
+    "packaging>=20.0",
+    "pyyaml>=5.1",
+    "regex>=2025.10.22",
+    "tokenizers<=0.23.0,>=0.22.0",
+    "typer",
+    "safetensors>=0.8.0",
+    "tqdm>=4.60",
+]
+
+
+class _Missing(Exception):
+    """Stands in for importlib.metadata.PackageNotFoundError."""
+
+
+def _install_env(monkeypatch, requires, installed):
+    """Point the check at a synthetic environment.
+
+    ``requires`` is what transformers declares (or an exception to raise);
+    ``installed`` maps distribution name -> version, anything absent raises.
+    """
+
+    def fake_requires(name):
+        if name != "transformers":
+            raise importlib.metadata.PackageNotFoundError(name)
+        if isinstance(requires, Exception):
+            raise requires
+        return requires
+
+    def fake_version(name):
+        key = name.lower().replace("_", "-")
+        if key in installed:
+            return installed[key]
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "requires", fake_requires)
+    monkeypatch.setattr(IF, "importlib_version", fake_version)
+    monkeypatch.delenv("UNSLOTH_SKIP_TRANSFORMERS_DEPENDENCY_CHECK", raising = False)
+
+
+def _warnings(caplog):
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def _run_check(caplog):
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger = IF.logger.name):
+        IF.check_transformers_dependency_versions()
+    return _warnings(caplog)
+
+
+# ---------------------------------------------------------------- satisfied
+
+@pytest.mark.parametrize(
+    "requires, installed",
+    [
+        (
+            REQUIRES_4_57_6,
+            {
+                "filelock": "3.16.1", "huggingface-hub": "0.36.2", "numpy": "2.1.3",
+                "packaging": "24.2", "pyyaml": "6.0.2", "regex": "2025.11.3",
+                "requests": "2.32.4", "tokenizers": "0.22.2",
+                "safetensors": "0.7.0", "tqdm": "4.67.3",
+            },
+        ),
+        (
+            REQUIRES_5_14_1,
+            {
+                "huggingface-hub": "1.27.0", "numpy": "2.1.3", "packaging": "24.2",
+                "pyyaml": "6.0.2", "regex": "2025.11.3", "tokenizers": "0.22.2",
+                "typer": "0.15.1", "safetensors": "0.8.0", "tqdm": "4.67.3",
+            },
+        ),
+    ],
+    ids = ["transformers-4.57.6", "transformers-5.14.1"],
+)
+def test_satisfied_requirements_are_silent(monkeypatch, caplog, requires, installed):
+    """A fully satisfied requirement set says nothing, on 4.57.x and on 5.x."""
+    _install_env(monkeypatch, requires, installed)
+    assert IF._unsatisfied_transformers_requirements() == []
+    assert _run_check(caplog) == []
+
+
+# ----------------------------------------------------------------- violated
+
+def test_violated_floor_is_reported_and_names_the_dependency(monkeypatch, caplog):
+    """The Kaggle LFM2 break: transformers main wants safetensors>=0.8.0, the
+    image ships 0.7.0. The remedy must upgrade safetensors, not transformers."""
+    installed = {
+        "transformers": "5.15.0.dev0", "huggingface-hub": "1.27.0", "numpy": "2.1.3",
+        "packaging": "24.2", "pyyaml": "6.0.2", "regex": "2025.11.3",
+        "tokenizers": "0.22.2", "typer": "0.15.1",
+        "safetensors": "0.7.0",  # the violation
+        "tqdm": "4.67.3",
+    }
+    _install_env(monkeypatch, REQUIRES_5_14_1, installed)
+
+    assert IF._unsatisfied_transformers_requirements() == [
+        ("safetensors", ">=0.8.0", "0.7.0")
+    ]
+
+    warnings = _run_check(caplog)
+    assert len(warnings) == 1
+    message = warnings[0]
+
+    # Names the dependency, its floor and what is actually installed.
+    assert "safetensors>=0.8.0 is required, but found safetensors==0.7.0" in message
+    # The remedy upgrades the DEPENDENCY.
+    assert 'pip install --upgrade "safetensors>=0.8.0"' in message
+    assert "Upgrade the dependencies, not transformers" in message
+    # And explicitly contradicts transformers' own misleading advice.
+    assert "pip install transformers -U" in message
+    assert "Ignore that" in message
+    # Nothing satisfied gets dragged in.
+    for satisfied in ("tqdm", "typer", "numpy", "huggingface-hub"):
+        assert f"{satisfied}==" not in message
+
+
+def test_string_comparison_trap_is_not_a_false_positive(monkeypatch, caplog):
+    """``0.10.0`` sorts before ``0.8.0`` as a string but satisfies >=0.8.0."""
+    _install_env(
+        monkeypatch,
+        ["safetensors>=0.8.0"],
+        {"transformers": "5.15.0.dev0", "safetensors": "0.10.0"},
+    )
+    assert IF._unsatisfied_transformers_requirements() == []
+    assert _run_check(caplog) == []
+
+
+def test_multiple_violations_are_all_listed_in_one_command(monkeypatch, caplog):
+    _install_env(
+        monkeypatch,
+        ["huggingface-hub<2.0,>=1.5.0", "safetensors>=0.8.0", "tqdm>=4.60"],
+        {
+            "transformers": "5.15.0.dev0", "huggingface-hub": "0.36.2",
+            "safetensors": "0.7.0", "tqdm": "4.67.3",
+        },
+    )
+    reported = {name for name, _, _ in IF._unsatisfied_transformers_requirements()}
+    assert reported == {"huggingface-hub", "safetensors"}
+
+    message = _run_check(caplog)[0]
+    assert 'pip install --upgrade "huggingface-hub<2.0,>=1.5.0" "safetensors>=0.8.0"' in message
+
+
+def test_prerelease_dependency_satisfying_the_floor_is_not_reported(monkeypatch, caplog):
+    _install_env(
+        monkeypatch,
+        ["safetensors>=0.8.0"],
+        {"transformers": "5.15.0.dev0", "safetensors": "0.9.0rc1"},
+    )
+    assert IF._unsatisfied_transformers_requirements() == []
+    assert _run_check(caplog) == []
+
+
+# ------------------------------------------------------- environment markers
+
+def test_inapplicable_environment_markers_are_skipped(monkeypatch, caplog):
+    """Extras and python_version gates that do not apply must not be checked,
+    even when a violating version of the named package is installed."""
+    _install_env(
+        monkeypatch,
+        [
+            'torch>=99.0; extra == "torch"',
+            'accelerate>=99.0; extra == "accelerate"',
+            'fugashi>=99.0; extra == "ja"',
+            'numpy>=99.0; python_version < "3.0"',
+            'requests>=99.0; sys_platform == "definitely-not-a-real-platform"',
+        ],
+        {
+            "transformers": "5.15.0.dev0", "torch": "2.9.0", "accelerate": "1.2.0",
+            "fugashi": "1.3.0", "numpy": "2.1.3", "requests": "2.32.4",
+        },
+    )
+    assert IF._unsatisfied_transformers_requirements() == []
+    assert _run_check(caplog) == []
+
+
+def test_applicable_environment_marker_is_still_checked(monkeypatch, caplog):
+    """The marker filter must not swallow requirements whose marker DOES apply."""
+    _install_env(
+        monkeypatch,
+        ['safetensors>=0.8.0; python_version >= "3.0"'],
+        {"transformers": "5.15.0.dev0", "safetensors": "0.7.0"},
+    )
+    assert IF._unsatisfied_transformers_requirements() == [
+        ("safetensors", ">=0.8.0", "0.7.0")
+    ]
+    assert "safetensors" in _run_check(caplog)[0]
+
+
+# ------------------------------------------------------------ absent package
+
+def test_absent_optional_package_is_not_reported(monkeypatch, caplog):
+    """transformers imports these lazily; a package the user simply does not have
+    is not a floor violation and must not be warned about."""
+    _install_env(
+        monkeypatch,
+        ["safetensors>=0.8.0", "typer", "typer-slim>=1.0"],
+        {"transformers": "5.15.0.dev0", "safetensors": "0.9.0"},
+    )
+    assert IF._unsatisfied_transformers_requirements() == []
+    assert _run_check(caplog) == []
+
+
+# --------------------------------------------------------- defensive silence
+
+@pytest.mark.parametrize(
+    "requires, installed",
+    [
+        # Unparseable requirement line.
+        (["safetensors>=@@@not-a-specifier"], {"safetensors": "0.7.0"}),
+        (["=== nonsense ==="], {"safetensors": "0.7.0"}),
+        (["safetensors>=0.8.0; extra ==="], {"safetensors": "0.7.0"}),
+        # Parseable specifier, but the installed version is not PEP 440.
+        (["safetensors>=0.8.0"], {"safetensors": "not-a-version"}),
+        # Undecidable marker.
+        (['safetensors>=0.8.0; nonexistent_marker == "x"'], {"safetensors": "0.7.0"}),
+    ],
+    ids = ["bad-specifier", "garbage-line", "bad-marker", "bad-installed-version",
+           "unknown-marker"],
+)
+def test_unparseable_input_is_silent_and_never_raises(
+    monkeypatch, caplog, requires, installed
+):
+    installed = {"transformers": "5.15.0.dev0", **installed}
+    _install_env(monkeypatch, requires, installed)
+    assert IF._unsatisfied_transformers_requirements() == []
+    assert _run_check(caplog) == []
+
+
+@pytest.mark.parametrize(
+    "requires",
+    [
+        importlib.metadata.PackageNotFoundError("transformers"),
+        None,   # dist-info present but declares nothing
+        [],
+    ],
+    ids = ["metadata-missing", "requires-none", "requires-empty"],
+)
+def test_missing_transformers_metadata_is_silent_and_never_raises(
+    monkeypatch, caplog, requires
+):
+    _install_env(monkeypatch, requires, {})
+    assert IF._unsatisfied_transformers_requirements() == []
+    assert _run_check(caplog) == []
+
+
+def test_transformers_not_installed_is_silent(monkeypatch, caplog):
+    real_find_spec = IF.importlib.util.find_spec
+    monkeypatch.setattr(
+        IF.importlib.util,
+        "find_spec",
+        lambda name, *a, **kw: None if name == "transformers" else real_find_spec(name, *a, **kw),
+    )
+    _install_env(monkeypatch, REQUIRES_5_14_1, {})
+    assert _run_check(caplog) == []
+
+
+def test_env_var_silences_the_check(monkeypatch, caplog):
+    _install_env(
+        monkeypatch,
+        ["safetensors>=0.8.0"],
+        {"transformers": "5.15.0.dev0", "safetensors": "0.7.0"},
+    )
+    monkeypatch.setenv("UNSLOTH_SKIP_TRANSFORMERS_DEPENDENCY_CHECK", "1")
+    assert _run_check(caplog) == []
+
+
+# --------------------------------------------------------------- live + wiring
+
+def test_runs_against_the_real_environment_without_raising(caplog):
+    """No monkeypatching: the real installed transformers, read from real metadata."""
+    result = IF._unsatisfied_transformers_requirements()
+    assert isinstance(result, list)
+    for entry in result:
+        assert len(entry) == 3
+    IF.check_transformers_dependency_versions()  # must not raise
+
+
+def test_check_is_registered_in_gpu_init():
+    """The check is worthless if nothing calls it at import time."""
+    from pathlib import Path
+
+    source = Path(IF.__file__).with_name("_gpu_init.py").read_text(encoding = "utf-8")
+    assert "check_transformers_dependency_versions," in source, "not imported"
+    assert "check_transformers_dependency_versions()" in source, "imported but never called"
+
+
+def test_check_warns_rather_than_raises_on_a_violation(monkeypatch, caplog):
+    """Deliberate contract: transformers' own (misleading) message still reaches the
+    user, ours lands just before it. A metadata floor must not become a hard stop."""
+    _install_env(
+        monkeypatch,
+        ["safetensors>=0.8.0"],
+        {"transformers": "5.15.0.dev0", "safetensors": "0.7.0"},
+    )
+    IF.check_transformers_dependency_versions()  # no exception
+    assert len(_run_check(caplog)) == 1

--- a/tests/test_transformers_dependency_floor.py
+++ b/tests/test_transformers_dependency_floor.py
@@ -398,3 +398,26 @@ def test_a_transformers_stub_in_sys_modules_does_not_break_the_import(monkeypatc
             importlib.util.find_spec("transformers")   # __spec__ None / not set
         IF.check_transformers_dependency_versions()    # must not raise
         assert _warnings(caplog) == []
+
+
+def test_check_also_runs_on_the_mlx_branch():
+    """Apple Silicon never reaches `_gpu_init`.
+
+    `unsloth/__init__.py` splits on `_IS_MLX`; only the `else` arm imports
+    `_gpu_init`, and the MLX arm imports transformers itself. Registering the check
+    on one arm only leaves every MLX user with transformers' own wrong remedy, so
+    the call has to sit inside the `if _IS_MLX:` body, next to the torchao fixes
+    that are there for exactly this reason.
+    """
+    import ast
+    from pathlib import Path
+
+    source = Path(IF.__file__).with_name("__init__.py").read_text(encoding = "utf-8")
+    branch = next(
+        node for node in ast.parse(source).body
+        if isinstance(node, ast.If) and ast.unparse(node.test) == "_IS_MLX"
+    )
+    body = ast.unparse(ast.Module(body = branch.body, type_ignores = []))
+    assert "check_transformers_dependency_versions" in body, "not called on the MLX path"
+    # And the GPU arm still reaches it through _gpu_init.
+    assert "_gpu_init" in ast.unparse(ast.Module(body = branch.orelse, type_ignores = []))

--- a/tests/test_transformers_dependency_floor.py
+++ b/tests/test_transformers_dependency_floor.py
@@ -237,14 +237,55 @@ def test_applicable_environment_marker_is_still_checked(monkeypatch, caplog):
 
 # ------------------------------------------------------------ absent package
 
-def test_absent_optional_package_is_not_reported(monkeypatch, caplog):
-    """transformers imports these lazily; a package the user simply does not have
-    is not a floor violation and must not be warned about."""
+def test_an_absent_base_requirement_is_reported_like_a_stale_one(monkeypatch, caplog):
+    """`--no-deps` leaves a dependency missing at least as often as it leaves it old.
+
+    transformers checks its base requirements during its own root import and raises
+    `PackageNotFoundError: The 'safetensors>=0.8.0' distribution was not found and is
+    required by this application. Try: pip install transformers -U ...` - the same
+    misleading remedy this check exists to correct. Skipping the absent case left the
+    user with only that message, which is the one outcome the feature has to prevent.
+    """
     _install_env(
         monkeypatch,
-        ["safetensors>=0.8.0", "typer", "typer-slim>=1.0"],
-        {"transformers": "5.15.0.dev0", "safetensors": "0.9.0"},
+        ["safetensors>=0.8.0", "typer", "tqdm>=4.27", 'fugashi>=1.0; extra == "ja"'],
+        {"transformers": "5.15.0.dev0", "tqdm": "4.67.3"},
     )
+    assert IF._unsatisfied_transformers_requirements() == [
+        ("safetensors", ">=0.8.0", None),
+        ("typer", "", None),
+    ]
+    warning = "\n".join(_run_check(caplog))
+    assert "safetensors>=0.8.0 is required, but it is not installed" in warning
+    assert "typer is required, but it is not installed" in warning
+    assert 'pip install --upgrade "safetensors>=0.8.0" "typer"' in warning
+    assert "Install or upgrade the dependencies, not transformers" in warning
+    # An extras-only requirement stays out of it: not having it is correct.
+    assert "fugashi" not in warning
+    # Satisfied requirements stay out of it too.
+    assert "tqdm" not in warning
+
+
+def test_an_absent_extras_only_package_is_not_reported(monkeypatch, caplog):
+    """Optional extras are opt-in; a package the user is right not to have is silent."""
+    _install_env(
+        monkeypatch,
+        ['torch>=2.2; extra == "torch"', 'jax>=0.4.1; extra == "flax"'],
+        {"transformers": "5.15.0.dev0"},
+    )
+    assert IF._unsatisfied_transformers_requirements() == []
+    assert _run_check(caplog) == []
+
+
+def test_unreadable_metadata_is_still_silent(monkeypatch, caplog):
+    """Only a real PackageNotFoundError counts as absent. Any other metadata error
+    means we cannot tell, and guessing would warn about a working install."""
+    _install_env(monkeypatch, ["safetensors>=0.8.0"], {"transformers": "5.15.0.dev0"})
+
+    def broken_version(name):
+        raise OSError("dist-info unreadable")
+
+    monkeypatch.setattr(IF, "importlib_version", broken_version)
     assert IF._unsatisfied_transformers_requirements() == []
     assert _run_check(caplog) == []
 

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -98,8 +98,8 @@ if _IS_MLX:
     except Exception:
         pass
     try:
-        # Same reason again: this branch imports transformers itself further down,
-        # so a --no-deps floor miss surfaces here with the same wrong remedy.
+        # Same reason: this branch imports transformers itself further down, so a
+        # --no-deps floor miss surfaces here with the same wrong remedy.
         from .import_fixes import check_transformers_dependency_versions as _check_tf_deps
         _check_tf_deps()
         del _check_tf_deps

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -98,6 +98,14 @@ if _IS_MLX:
     except Exception:
         pass
     try:
+        # Same reason again: this branch imports transformers itself further down,
+        # so a --no-deps floor miss surfaces here with the same wrong remedy.
+        from .import_fixes import check_transformers_dependency_versions as _check_tf_deps
+        _check_tf_deps()
+        del _check_tf_deps
+    except Exception:
+        pass
+    try:
         import unsloth_zoo
     except ImportError as _e:
         raise ImportError(

--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -30,6 +30,7 @@ from .import_fixes import (
     fix_torchao_torch_symbol_skew,
     propagate_torchao_fix_to_subprocesses,
     check_fbgemm_gpu_version,
+    check_transformers_dependency_versions,
     disable_broken_causal_conv1d,
     disable_broken_vllm,
     configure_amdgpu_asic_id_table_path,
@@ -80,6 +81,12 @@ fix_torchao_torch_symbol_skew()
 # The above fixes THIS process only; vLLM's model-architecture inspector
 # is a subprocess that imports torchao itself and hits the same ImportError.
 propagate_torchao_fix_to_subprocesses()
+# Warn, do not raise: by the time transformers is imported the mismatch is
+# already fatal and transformers prints its own (misleading) remedy. A warning
+# landing just before that message adds the correct one without taking a
+# metadata-derived floor - which may be advisory for a given code path - and
+# turning it into a hard import failure.
+check_transformers_dependency_versions()
 check_fbgemm_gpu_version()
 torchvision_compatibility_check()
 fix_diffusers_warnings()
@@ -93,6 +100,7 @@ del fix_torch_check_is_size
 del fix_torchao_torch_symbol_skew
 del propagate_torchao_fix_to_subprocesses
 del check_fbgemm_gpu_version
+del check_transformers_dependency_versions
 del torchvision_compatibility_check
 del fix_diffusers_warnings
 del fix_huggingface_hub

--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -81,11 +81,9 @@ fix_torchao_torch_symbol_skew()
 # The above fixes THIS process only; vLLM's model-architecture inspector
 # is a subprocess that imports torchao itself and hits the same ImportError.
 propagate_torchao_fix_to_subprocesses()
-# Warn, do not raise: by the time transformers is imported the mismatch is
-# already fatal and transformers prints its own (misleading) remedy. A warning
-# landing just before that message adds the correct one without taking a
-# metadata-derived floor - which may be advisory for a given code path - and
-# turning it into a hard import failure.
+# Warn, do not raise: this only adds the correct remedy just before transformers
+# prints its misleading one, without turning a metadata-derived floor into a hard
+# import failure of our own.
 check_transformers_dependency_versions()
 check_fbgemm_gpu_version()
 torchvision_compatibility_check()

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -20,6 +20,7 @@ import importlib.machinery
 import importlib.util
 from pathlib import Path
 from importlib.metadata import version as importlib_version
+from importlib.metadata import PackageNotFoundError
 from packaging.version import Version as TrueVersion
 import re
 import logging
@@ -1076,6 +1077,7 @@ def torchvision_compatibility_check():
 def _unsatisfied_transformers_requirements():
     """Return [(name, specifier, installed_version), ...] for the base (no-extras)
     requirements transformers itself declares that the environment does not satisfy.
+    ``installed_version`` is None when the package is absent altogether.
 
     The requirement set is read from the installed distribution's own metadata, so
     it is always whatever the installed transformers actually asks for - a git-main
@@ -1114,15 +1116,22 @@ def _unsatisfied_transformers_requirements():
             except Exception:
                 continue  # Undecidable marker - assume it does not apply.
 
-        if not requirement.specifier:
-            continue  # Bare dependency with no floor, e.g. `filelock`.
-
         try:
             installed = importlib_version(requirement.name)
-        except Exception:
-            # Not installed. transformers only imports these lazily for the code
-            # paths that need them, so an absent package is not our warning to give.
+        except PackageNotFoundError:
+            # Absent entirely, which `--no-deps` causes just as readily as a stale
+            # version. transformers checks its base requirements during its own root
+            # import and raises `PackageNotFoundError: The 'safetensors>=0.4.3'
+            # distribution was not found ...` carrying the very hint this warning
+            # exists to correct, so an absent one belongs in the list. Floor or no
+            # floor: a base requirement is not optional to transformers.
+            unsatisfied.append((requirement.name, str(requirement.specifier), None))
             continue
+        except Exception:
+            continue  # Metadata unreadable - we cannot judge it, so stay quiet.
+
+        if not requirement.specifier:
+            continue  # Installed, and no floor it could fall below.
 
         try:
             # Parse explicitly: SpecifierSet.contains() reports a non-PEP440 version
@@ -1193,10 +1202,12 @@ def check_transformers_dependency_versions():
     ]
     upgrades = []
     for name, specifier, installed in unsatisfied:
-        lines.append(f"    {name}{specifier} is required, but found {name}=={installed}")
+        found = f"found {name}=={installed}" if installed is not None else "it is not installed"
+        lines.append(f"    {name}{specifier} is required, but {found}")
         upgrades.append(f'"{name}{specifier}"')
     lines.append("")
-    lines.append("Upgrade the dependencies, not transformers:")
+    verb = "Upgrade" if all(i is not None for _, _, i in unsatisfied) else "Install or upgrade"
+    lines.append(f"{verb} the dependencies, not transformers:")
     lines.append(f"    pip install --upgrade {' '.join(upgrades)}")
     lines.append("")
     lines.append(

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1073,6 +1073,143 @@ def torchvision_compatibility_check():
     raise ImportError(message)
 
 
+def _unsatisfied_transformers_requirements():
+    """Return [(name, specifier, installed_version), ...] for the base (no-extras)
+    requirements transformers itself declares that the environment does not satisfy.
+
+    The requirement set is read from the installed distribution's own metadata, so
+    it is always whatever the installed transformers actually asks for - a git-main
+    checkout, 4.57.x or 5.x alike - and never a hardcoded table that would rot.
+    Returns [] on anything unexpected; this must never raise.
+    """
+    try:
+        from importlib.metadata import requires as _dist_requires
+        from packaging.requirements import Requirement
+    except Exception:
+        return []
+
+    try:
+        raw_requirements = _dist_requires("transformers")
+    except Exception:
+        # transformers not installed, or its dist-info is missing / unreadable.
+        return []
+    if not raw_requirements:
+        return []
+
+    unsatisfied = []
+    for raw_requirement in raw_requirements:
+        try:
+            requirement = Requirement(raw_requirement)
+        except Exception:
+            continue  # Unparseable requirement line - ignore it, never guess.
+
+        # Environment markers: evaluate with extra = "" so optional-extra
+        # requirements (extra == "torch", extra == "ja", ...) and inapplicable
+        # python_version / sys_platform gates are skipped. Otherwise we would
+        # warn about packages the user is correct not to have.
+        if requirement.marker is not None:
+            try:
+                if not requirement.marker.evaluate({"extra": ""}):
+                    continue
+            except Exception:
+                continue  # Undecidable marker - assume it does not apply.
+
+        if not requirement.specifier:
+            continue  # Bare dependency with no floor, e.g. `filelock`.
+
+        try:
+            installed = importlib_version(requirement.name)
+        except Exception:
+            # Not installed. transformers only imports these lazily for the code
+            # paths that need them, so an absent package is not our warning to give.
+            continue
+
+        try:
+            # Parse explicitly: SpecifierSet.contains() reports a non-PEP440 version
+            # as "not contained" rather than raising, which would be a false positive.
+            installed_version = TrueVersion(installed)
+        except Exception:
+            continue  # Not a PEP 440 version - we cannot judge it, so stay quiet.
+
+        try:
+            # prereleases = True so a legitimate 1.0.0rc1 does not read as a violation.
+            if requirement.specifier.contains(installed_version, prereleases = True):
+                continue
+        except Exception:
+            continue  # Bad specifier - stay quiet.
+
+        unsatisfied.append((requirement.name, str(requirement.specifier), installed))
+
+    return unsatisfied
+
+
+def check_transformers_dependency_versions():
+    """Warn when transformers' own declared dependency floors are unmet.
+
+    Notebooks that need a bleeding-edge model install transformers from git with
+    `--no-deps` on purpose, so pip cannot re-resolve torch:
+
+        pip install --no-deps git+https://github.com/huggingface/transformers.git
+
+    `--no-deps` also means pip never enforces what that transformers actually
+    requires; it prints a WARNING and the install "succeeds". The failure lands
+    later, at import:
+
+        safetensors>=0.8.0 is required for a normal functioning of this module,
+        but found safetensors==0.7.0.
+        Try: `pip install transformers -U` or `pip install -e '.[dev]'` ...
+
+    That remedy is wrong for this situation: the user is deliberately on
+    transformers main, so `pip install transformers -U` either downgrades them off
+    the model support they installed main for, or loops. What they need is to
+    upgrade the dependency. This check runs before transformers is imported and
+    says so, naming the dependency.
+
+    Warns rather than raises - see the note at the call site in _gpu_init.py.
+    """
+    if os.environ.get("UNSLOTH_SKIP_TRANSFORMERS_DEPENDENCY_CHECK", "0").lower() in (
+        "1",
+        "true",
+    ):
+        return
+    if importlib.util.find_spec("transformers") is None:
+        return
+
+    try:
+        unsatisfied = _unsatisfied_transformers_requirements()
+    except Exception:
+        return
+    if not unsatisfied:
+        return
+
+    try:
+        transformers_version = importlib_version("transformers")
+    except Exception:
+        transformers_version = "unknown"
+
+    lines = [
+        f"Unsloth: transformers=={transformers_version} declares dependencies that "
+        f"your environment does not satisfy:"
+    ]
+    upgrades = []
+    for name, specifier, installed in unsatisfied:
+        lines.append(f"    {name}{specifier} is required, but found {name}=={installed}")
+        upgrades.append(f'"{name}{specifier}"')
+    lines.append("")
+    lines.append("Upgrade the dependencies, not transformers:")
+    lines.append(f"    pip install --upgrade {' '.join(upgrades)}")
+    lines.append("")
+    lines.append(
+        "transformers may suggest `pip install transformers -U` instead. Ignore that "
+        "if you installed transformers from git main on purpose (for example with "
+        "`pip install --no-deps git+https://github.com/huggingface/transformers.git` "
+        "for a new model) - upgrading transformers would only undo the install you "
+        "wanted. Set UNSLOTH_SKIP_TRANSFORMERS_DEPENDENCY_CHECK=1 to silence this."
+    )
+
+    logger.warning("\n".join(lines))
+
+
 # Fix TRL OpenEnv 0.26 NameError: name 'SamplingParams' is not defined
 def fix_openenv_no_vllm():
     spec = importlib.util.find_spec("trl")

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1075,14 +1075,11 @@ def torchvision_compatibility_check():
 
 
 def _unsatisfied_transformers_requirements():
-    """Return [(name, specifier, installed_version), ...] for the base (no-extras)
-    requirements transformers itself declares that the environment does not satisfy.
-    ``installed_version`` is None when the package is absent altogether.
-
-    The requirement set is read from the installed distribution's own metadata, so
-    it is always whatever the installed transformers actually asks for - a git-main
-    checkout, 4.57.x or 5.x alike - and never a hardcoded table that would rot.
-    Returns [] on anything unexpected; this must never raise.
+    """Base (no-extras) requirements the environment does not satisfy, as
+    [(name, specifier, installed_version), ...]; installed_version is None when the
+    package is absent. Read from the installed distribution's own metadata, so it is
+    whatever that transformers asks for - git main, 4.57.x or 5.x - rather than a
+    table that would rot. Never raises; returns [] on anything unexpected.
     """
     try:
         from importlib.metadata import requires as _dist_requires
@@ -1105,10 +1102,8 @@ def _unsatisfied_transformers_requirements():
         except Exception:
             continue  # Unparseable requirement line - ignore it, never guess.
 
-        # Environment markers: evaluate with extra = "" so optional-extra
-        # requirements (extra == "torch", extra == "ja", ...) and inapplicable
-        # python_version / sys_platform gates are skipped. Otherwise we would
-        # warn about packages the user is correct not to have.
+        # extra = "" drops optional-extra requirements and inapplicable
+        # python_version / sys_platform gates - packages the user is right not to have.
         if requirement.marker is not None:
             try:
                 if not requirement.marker.evaluate({"extra": ""}):
@@ -1119,12 +1114,10 @@ def _unsatisfied_transformers_requirements():
         try:
             installed = importlib_version(requirement.name)
         except PackageNotFoundError:
-            # Absent entirely, which `--no-deps` causes just as readily as a stale
-            # version. transformers checks its base requirements during its own root
-            # import and raises `PackageNotFoundError: The 'safetensors>=0.4.3'
-            # distribution was not found ...` carrying the very hint this warning
-            # exists to correct, so an absent one belongs in the list. Floor or no
-            # floor: a base requirement is not optional to transformers.
+            # Absent, which `--no-deps` causes as readily as a stale version.
+            # transformers checks its base requirements at its own root import and
+            # raises PackageNotFoundError carrying the same misleading hint, so an
+            # absent one belongs here - floor or no floor, it is not optional.
             unsatisfied.append((requirement.name, str(requirement.specifier), None))
             continue
         except Exception:
@@ -1155,26 +1148,13 @@ def _unsatisfied_transformers_requirements():
 def check_transformers_dependency_versions():
     """Warn when transformers' own declared dependency floors are unmet.
 
-    Notebooks that need a bleeding-edge model install transformers from git with
-    `--no-deps` on purpose, so pip cannot re-resolve torch:
-
-        pip install --no-deps git+https://github.com/huggingface/transformers.git
-
-    `--no-deps` also means pip never enforces what that transformers actually
-    requires; it prints a WARNING and the install "succeeds". The failure lands
-    later, at import:
-
-        safetensors>=0.8.0 is required for a normal functioning of this module,
-        but found safetensors==0.7.0.
-        Try: `pip install transformers -U` or `pip install -e '.[dev]'` ...
-
-    That remedy is wrong for this situation: the user is deliberately on
-    transformers main, so `pip install transformers -U` either downgrades them off
-    the model support they installed main for, or loops. What they need is to
-    upgrade the dependency. This check runs before transformers is imported and
-    says so, naming the dependency.
-
-    Warns rather than raises - see the note at the call site in _gpu_init.py.
+    A notebook needing a bleeding-edge model installs transformers from git with
+    `--no-deps` on purpose, so pip cannot re-resolve torch - and so pip never
+    enforces what that transformers requires either. The install "succeeds" and the
+    failure lands at import, advising `pip install transformers -U`. That remedy is
+    wrong here: the user is deliberately on main, so upgrading undoes the install
+    they wanted, or loops. The dependency is what needs upgrading. This runs first
+    and says so, naming it. Warns rather than raises; see the _gpu_init.py call.
     """
     if os.environ.get("UNSLOTH_SKIP_TRANSFORMERS_DEPENDENCY_CHECK", "0").lower() in (
         "1",

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1161,7 +1161,13 @@ def check_transformers_dependency_versions():
         "true",
     ):
         return
-    if importlib.util.find_spec("transformers") is None:
+    try:
+        # find_spec RAISES ValueError, rather than returning None, for a transformers
+        # in sys.modules whose `__spec__` is None or unset - a stub module, or one
+        # mid-teardown. Nothing here is worth failing `import unsloth` over.
+        if importlib.util.find_spec("transformers") is None:
+            return
+    except Exception:
         return
 
     try:

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1163,8 +1163,8 @@ def check_transformers_dependency_versions():
         return
     try:
         # find_spec RAISES ValueError, rather than returning None, for a transformers
-        # in sys.modules whose `__spec__` is None or unset - a stub module, or one
-        # mid-teardown. Nothing here is worth failing `import unsloth` over.
+        # in sys.modules with `__spec__` None or unset - a stub, or one mid-teardown.
+        # Nothing here is worth failing `import unsloth` over.
         if importlib.util.find_spec("transformers") is None:
             return
     except Exception:


### PR DESCRIPTION
## The problem

Notebooks that need a bleeding-edge model install transformers from git with `--no-deps`, deliberately, so pip cannot re-resolve torch:

```
!pip install --no-deps git+https://github.com/huggingface/transformers.git
```

`--no-deps` also means pip never enforces what that transformers actually requires. pip prints a warning and the install "succeeds":

```
transformers 5.15.0.dev0 requires safetensors>=0.8.0, but you have safetensors 0.7.0 which is incompatible.
Successfully installed click-8.4.2 hf-xet-1.6.0 huggingface_hub-1.27.0
```

The failure lands two cells later, at import:

```
Exception: safetensors>=0.8.0 is required for a normal functioning of this module, but found safetensors==0.7.0.
Try: `pip install transformers -U` or `pip install -e '.[dev]'` if you're working with git main
```

This killed `Liquid_LFM2-Conversational` and `Kaggle-Liquid_LFM2_(1.2B)-Conversational` on Kaggle T4. Kaggle ships safetensors 0.7.0; transformers main wants 0.8.0.

The load-bearing part is the remedy transformers suggests. `pip install transformers -U` is exactly the wrong move for someone who is deliberately on main: it either downgrades them off the model support they installed main for, or it loops. What they actually need is `pip install -U safetensors`. The notebooks were patched to floor hub, safetensors and tokenizers, but that only covers the notebooks we already know broke.

## What this adds

`check_transformers_dependency_versions()` in `unsloth/import_fixes.py`, called from `_gpu_init.py` before anything imports transformers. It compares the installed versions of transformers' own declared requirements against what transformers declares, and reports the shortfalls with the correct remedy:

```
Unsloth: transformers==5.15.0.dev0 declares dependencies that your environment does not satisfy:
    huggingface-hub<2.0,>=1.5.0 is required, but found huggingface-hub==0.36.2
    safetensors>=0.8.0 is required, but found safetensors==0.7.0

Upgrade the dependencies, not transformers:
    pip install --upgrade "huggingface-hub<2.0,>=1.5.0" "safetensors>=0.8.0"

transformers may suggest `pip install transformers -U` instead. Ignore that if you installed
transformers from git main on purpose ... Set UNSLOTH_SKIP_TRANSFORMERS_DEPENDENCY_CHECK=1 to silence this.
```

Design notes:

- The requirement set comes from the installed distribution's own metadata (`importlib.metadata.requires("transformers")`), never a hardcoded table and never the network. A table would rot into a second copy of the bug. It also has to be metadata: the base requirements genuinely differ across the supported range, 4.57.6 declares `huggingface-hub<1.0,>=0.34.0` and `safetensors>=0.4.3`, 5.14.1 declares `huggingface-hub<2.0,>=1.5.0` and `safetensors>=0.8.0` and drops `filelock` and `requests` while adding `typer`.
- Comparison goes through `packaging`, not strings, so `0.10.0` against `>=0.8.0` is a pass and not a false report.
- Environment markers are evaluated with `extra = ""`, so extras (`extra == "torch"`, `extra == "ja"`) and inapplicable `python_version` / `sys_platform` gates are skipped. Otherwise the check would nag about packages the user is right not to have.
- Requirements whose package is absent are skipped; transformers imports those lazily and their absence is not a floor violation.
- Every parse is wrapped: an unparseable requirement line, an undecidable marker, a non-PEP 440 installed version or missing transformers metadata all return quietly. The check must never raise and never be slow, since it runs on every `import unsloth`.
- Pure `importlib.metadata` plus `packaging`, so no shelling out and no path assumptions; correct on Linux, macOS, Windows and WSL.

## Warn, not raise

It warns. By the time transformers is imported the mismatch is already fatal and the user sees transformers' own message anyway, so a warning landing just before it adds the correct remedy rather than replacing an error with another error. The floors are also read generically, and a given floor may be advisory for the code path a particular user is on, so turning any of them into a hard import failure would break environments that work today. This matches `check_fbgemm_gpu_version`, which degrades rather than stops; `torchvision_compatibility_check` raises, but only because it checks a curated (torch, torchvision) table where a stable mismatch guarantees broken operators.

## Verification

- 22 tests in `tests/test_transformers_dependency_floor.py` drive the real functions: satisfied sets for both 4.57.6 and 5.14.1 metadata (silent), the Kaggle violation (reported, naming safetensors as the thing to upgrade, and contradicting `pip install transformers -U`), the `0.10.0` vs `0.8.0` string-comparison trap, multiple violations in one command, prereleases, inapplicable markers skipped, applicable markers still checked, absent optional packages not reported, five flavours of unparseable input, missing transformers metadata, the skip env var, a live run against the real environment, and a guard that the check is actually wired into `_gpu_init.py`.
- Sabotage-checked: reverting the marker filter and the `packaging` comparison to a string compare turns 5 of the new tests red (exit 1); removing the `_gpu_init.py` call turns the registration test red (exit 1). Restored, the file is 22 passed, exit 0.
- Full suite, same selection before and after, on a clean worktree at the same base and on this branch: 18 failed / 4075 passed / 5 errors versus 18 failed / 4098 passed / 5 errors. The failure and error sets are byte-identical; the 23 extra passes are the new tests.
- `import unsloth` still works. The check costs about 22 ms, against a 14.5 s import; median wall time with and without it is 14.55 s and 15.02 s, so it is under the run-to-run noise.
