### PR TITLE
feat(studio): add stop button for image generation

### DIFF
--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -3994,6 +3994,15 @@ class DiffusionBackend:
             "eta_seconds": gen.eta_seconds,
         }
 
+    def cancel_generate(self) -> bool:
+        """Signal the in-flight generation to stop at its next step callback."""
+        with self._lock:
+            cancel = self._active_generate_cancel
+            if cancel is None:
+                return False
+            cancel.set()
+            return True
+
     def unload(self) -> dict[str, Any]:
         with self._lock:
             # Abort an in-flight (lock-free) download so unload returns promptly. Under the lock, like video.py: begin_load

--- a/studio/backend/core/inference/sd_cpp_backend.py
+++ b/studio/backend/core/inference/sd_cpp_backend.py
@@ -1397,6 +1397,15 @@ class SdCppDiffusionBackend:
             "eta_seconds": gen.eta_seconds,
         }
 
+    def cancel_generate(self) -> bool:
+        """Signal the in-flight generation to stop at its next step callback."""
+        with self._lock:
+            cancel = self._active_generate_cancel
+            if cancel is None:
+                return False
+            cancel.set()
+            return True
+
     # ── Unload / status ──────────────────────────────────────────────────────
 
     def unload(self) -> dict[str, Any]:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -20563,6 +20563,14 @@ async def diffusion_generate_progress(current_subject: str = Depends(get_current
     return DiffusionGenerateProgressResponse(**progress)
 
 
+@studio_router.post("/images/generate/cancel")
+async def cancel_diffusion_generation(current_subject: str = Depends(get_current_subject)):
+    from core.inference.diffusion_engine_router import get_active_diffusion_engine
+
+    cancelled = await asyncio.to_thread(get_active_diffusion_engine().cancel_generate)
+    return {"cancelled": cancelled}
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # OpenAI-compatible images API (POST /v1/images/generations). The inference router is mounted at both /api/inference and /v1, so this
 # also answers /v1/images/generations for OpenAI clients. The Studio Image tab uses the richer /images/generate above; this is the spec shape.

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -20566,7 +20566,6 @@ async def diffusion_generate_progress(current_subject: str = Depends(get_current
 @studio_router.post("/images/generate/cancel")
 async def cancel_diffusion_generation(current_subject: str = Depends(get_current_subject)):
     from core.inference.diffusion_engine_router import get_active_diffusion_engine
-
     cancelled = await asyncio.to_thread(get_active_diffusion_engine().cancel_generate)
     return {"cancelled": cancelled}
 

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -2543,6 +2543,73 @@ def test_callback_cancellation_interrupts_denoise(fake_runtime):
     assert "exc" in out and "cancelled" in str(out["exc"]).lower()
 
 
+def test_cancel_generate_idle_returns_false(fake_runtime):
+    backend = DiffusionBackend()
+    assert backend.cancel_generate() is False
+
+
+def test_cancel_generate_via_public_api_interrupts_denoise(fake_runtime):
+    import threading
+
+    backend = DiffusionBackend()
+    at_step0 = threading.Event()
+    resume = threading.Event()
+
+    class _SteppingPipe:
+        def __init__(self) -> None:
+            self._interrupt = False
+            self.steps_run = 0
+
+        def __call__(
+            self,
+            *,
+            callback_on_step_end = None,
+            num_inference_steps = 8,
+            **kwargs,
+        ):
+            for i in range(num_inference_steps):
+                if self._interrupt:
+                    break
+                if callback_on_step_end is not None:
+                    callback_on_step_end(self, i, 0.0, {})
+                self.steps_run = i + 1
+                if i == 0:
+                    at_step0.set()
+                    resume.wait(5)
+            return types.SimpleNamespace(images = [_FakeImage()])
+
+    pipe = _SteppingPipe()
+    fam = detect_family("unsloth/Z-Image-GGUF")
+    backend._state = _LoadState(
+        pipe = pipe,
+        family = fam,
+        repo_id = "r",
+        base_repo = "b",
+        device = "cpu",
+        dtype = "float32",
+        cpu_offload = False,
+    )
+
+    out: dict = {}
+
+    def _run():
+        try:
+            out["res"] = backend.generate(prompt = "p", steps = 8)
+        except Exception as exc:  # noqa: BLE001
+            out["exc"] = exc
+
+    t = threading.Thread(target = _run)
+    t.start()
+    assert at_step0.wait(5)
+    assert backend.cancel_generate() is True
+    resume.set()
+    t.join(5)
+    assert pipe._interrupt is True
+    assert pipe.steps_run < 8
+    assert "exc" in out and "cancelled" in str(out["exc"]).lower()
+    assert backend._active_generate_cancel is None
+
+
 def test_validate_load_request(tmp_path):
     backend = DiffusionBackend()
     # No filename + unsloth repo -> a full-pipeline load (allowed for unsloth/*).

--- a/studio/backend/tests/test_diffusion_routes.py
+++ b/studio/backend/tests/test_diffusion_routes.py
@@ -134,6 +134,9 @@ class _FakeBackend:
         # Idle by default; the persist-window override lives in the route, not here.
         return {"active": False, "step": 0, "total_steps": 0, "fraction": 0.0, "eta_seconds": None}
 
+    def cancel_generate(self):
+        return False
+
     def unload(self):
         self.loaded = False
         return _unloaded_status()
@@ -304,6 +307,43 @@ def test_generate_holds_progress_active_during_persist(client, monkeypatch):
     assert seen["during"] >= 1
     assert inf._diffusion_persist_active == 0
     assert client.get("/api/inference/images/generate-progress").json()["active"] is False
+
+
+def test_cancel_generation_route(client):
+    resp = client.post("/api/inference/images/generate/cancel")
+    assert resp.status_code == 200
+    assert resp.json()["cancelled"] is False
+
+
+def test_cancel_running_generation(client):
+    import threading
+
+    from core.inference.diffusion_families import DIFFUSION_CANCELLED_MSG
+
+    backend = diffusion_module.get_diffusion_backend()
+    backend.loaded = True
+    cancel = threading.Event()
+
+    def _blocking_generate(**kwargs):
+        assert cancel.wait(5)
+        raise RuntimeError(DIFFUSION_CANCELLED_MSG)
+
+    backend.generate = _blocking_generate
+    backend.cancel_generate = lambda: cancel.set() or True
+
+    result: dict = {}
+
+    def _run_generate():
+        result["resp"] = client.post("/api/inference/images/generate", json = {"prompt": "p"})
+
+    worker = threading.Thread(target = _run_generate)
+    worker.start()
+    cancelled = client.post("/api/inference/images/generate/cancel")
+    assert cancelled.status_code == 200 and cancelled.json()["cancelled"] is True
+    worker.join(10)
+    resp = result["resp"]
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == DIFFUSION_CANCELLED_MSG
 
 
 def test_load_rejects_untrusted_base_repo(client):

--- a/studio/backend/tests/test_diffusion_routes.py
+++ b/studio/backend/tests/test_diffusion_routes.py
@@ -346,6 +346,76 @@ def test_cancel_running_generation(client):
     assert resp.json()["detail"] == DIFFUSION_CANCELLED_MSG
 
 
+def test_cancel_after_generation_completes_returns_false(client):
+    client.post(
+        "/api/inference/images/load",
+        json = {
+            "model_path": "unsloth/Z-Image-Turbo-GGUF",
+            "gguf_filename": "z-image-turbo-Q4_K_S.gguf",
+            "base_repo": "unsloth/Z-Image-base",
+        },
+    )
+    gen = client.post("/api/inference/images/generate", json = {"prompt": "a sloth", "seed": 7})
+    assert gen.status_code == 200
+    resp = client.post("/api/inference/images/generate/cancel")
+    assert resp.status_code == 200
+    assert resp.json()["cancelled"] is False
+
+
+def test_double_cancel_during_running_generation(client):
+    import threading
+
+    from core.inference.diffusion_families import DIFFUSION_CANCELLED_MSG
+
+    backend = diffusion_module.get_diffusion_backend()
+    backend.loaded = True
+    cancel = threading.Event()
+    started = threading.Event()
+
+    def _blocking_generate(**kwargs):
+        started.set()
+        assert cancel.wait(5)
+        raise RuntimeError(DIFFUSION_CANCELLED_MSG)
+
+    backend.generate = _blocking_generate
+    backend.cancel_generate = lambda: cancel.set() or True
+
+    result: dict = {}
+
+    def _run_generate():
+        result["resp"] = client.post("/api/inference/images/generate", json = {"prompt": "p"})
+
+    worker = threading.Thread(target = _run_generate)
+    worker.start()
+    assert started.wait(5)
+    first = client.post("/api/inference/images/generate/cancel")
+    second = client.post("/api/inference/images/generate/cancel")
+    assert first.status_code == 200 and first.json()["cancelled"] is True
+    # Second call is harmless: nothing active to cancel anymore once the event is set.
+    assert second.status_code == 200
+    worker.join(10)
+    assert result["resp"].status_code == 409
+
+
+def test_cancel_route_requires_auth_when_enforced():
+    from auth.authentication import get_current_subject
+    from fastapi import FastAPI, HTTPException
+    from fastapi.testclient import TestClient
+
+    import routes.inference as inf
+
+    app = FastAPI()
+    app.include_router(inf.studio_router, prefix = "/api/inference")
+
+    def _deny():
+        raise HTTPException(status_code = 401, detail = "nope")
+
+    app.dependency_overrides[get_current_subject] = _deny
+    guarded = TestClient(app)
+    resp = guarded.post("/api/inference/images/generate/cancel")
+    assert resp.status_code == 401
+
+
 def test_load_rejects_untrusted_base_repo(client):
     # A trusted GGUF paired with an untrusted remote base_repo is rejected at the route, so a client cannot make the server fetch an arbitrary companion repo.
     r = client.post(

--- a/studio/backend/tests/test_diffusion_training.py
+++ b/studio/backend/tests/test_diffusion_training.py
@@ -1284,6 +1284,7 @@ def test_keepwarm_tracks_image_video_generation_paths():
     assert _is_inference_path("/v1/images/generations")
     assert _is_inference_path("/api/inference/video/generate")
     assert not _is_inference_path("/api/inference/images/generate-progress")
+    assert not _is_inference_path("/api/inference/images/generate/cancel")
     assert not _is_inference_path("/api/inference/video/generate-progress")
     assert not _is_inference_path("/api/inference/video/generate/cancel")
 

--- a/studio/backend/tests/test_sd_cpp_backend.py
+++ b/studio/backend/tests/test_sd_cpp_backend.py
@@ -524,6 +524,48 @@ def test_generate_cancellation_raises_cancelled_not_failure():
         b.generate(prompt = "x", steps = 8, seed = 5)
 
 
+def test_cancel_generate_idle_returns_false():
+    b = SdCppDiffusionBackend(engine = _FakeEngine())
+    assert b.cancel_generate() is False
+
+
+def test_cancel_generate_via_public_api_interrupts_generation():
+    import threading
+
+    eng = _FakeEngine()
+    b = _loaded_backend(engine = eng)
+    started = threading.Event()
+    release = threading.Event()
+
+    original_generate = eng.generate
+
+    def _blocking_generate(*args, **kwargs):
+        started.set()
+        assert release.wait(5)
+        cancel = kwargs.get("cancel_event")
+        if cancel is not None and cancel.is_set():
+            raise SdCppCancelled("cancelled")
+        return original_generate(*args, **kwargs)
+
+    eng.generate = _blocking_generate
+    out: dict = {}
+
+    def _run():
+        try:
+            out["res"] = b.generate(prompt = "x", steps = 8, seed = 5)
+        except Exception as exc:  # noqa: BLE001
+            out["exc"] = exc
+
+    t = threading.Thread(target = _run)
+    t.start()
+    assert started.wait(5)
+    assert b.cancel_generate() is True
+    release.set()
+    t.join(10)
+    assert "exc" in out and "cancelled" in str(out["exc"]).lower()
+    assert b._active_generate_cancel is None
+
+
 def test_generate_progress_tracks_parsed_steps():
     b = _loaded_backend()
     b._gen = bk._SdGen(total_steps = 8)

--- a/studio/frontend/src/features/images/api.ts
+++ b/studio/frontend/src/features/images/api.ts
@@ -221,6 +221,13 @@ export async function getGenerateProgress(): Promise<DiffusionGenerateProgress> 
   return parseJson(await authFetch("/api/inference/images/generate-progress"));
 }
 
+/** Request a cancel. Best-effort: the backend stops at the next step boundary and raises the cancelled sentinel, which the caller maps to a 409. */
+export async function cancelImageGeneration(): Promise<{ cancelled: boolean }> {
+  return parseJson(
+    await authFetch("/api/inference/images/generate/cancel", { method: "POST" }),
+  );
+}
+
 export async function loadDiffusionModel(body: DiffusionLoadRequest): Promise<DiffusionStatus> {
   // Announced so the loaded models indicator shows the load for as long as the
   // toast does, rather than up to one 5s poll later. This POST only starts the

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -95,6 +95,7 @@ import {
   type GalleryImage,
   type LoraSpecInput,
   GenerateResponseLostError,
+  cancelImageGeneration,
   deleteGalleryImage,
   fetchGalleryObjectUrl,
   generateDiffusionImage,
@@ -2281,6 +2282,14 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     }
   }, [refreshStatus, dropResidentState]);
 
+  const handleCancelGenerate = useCallback(async () => {
+    try {
+      await cancelImageGeneration();
+    } catch {
+      // The generation may have already finished; the poll/finally clears the UI.
+    }
+  }, []);
+
   const handleGenerate = useCallback(async () => {
     if (!prompt.trim()) {
       toast.error("Prompt is empty");
@@ -2483,7 +2492,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       // so without a refresh the LoRA picker stays enabled and the next LoRA run fails. Cheap status GET.
       if (isMounted.current) void refreshStatus();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Image generation failed");
+      const msg = err instanceof Error ? err.message : "Image generation failed";
+      // The user's own Cancel surfaces as the backend's cancelled sentinel; not an error.
+      if (!msg.toLowerCase().includes("cancelled")) toast.error(msg);
     } finally {
       if (genPollTimer.current) clearInterval(genPollTimer.current);
       genPollTimer.current = null;
@@ -3277,16 +3288,24 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           </div>
           {/* Floats over the settings so it needs no bar of its own. */}
           <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-7 pl-8 pr-8">
-            <Button
-              className="btn-float-action pointer-events-auto h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
-              onClick={handleGenerate}
-              disabled={busy !== null || !status?.loaded}
-            >
-              {busy === "generating" ? <Spinner className="mr-2 size-4" /> : null}
-              {busy === "generating" && genDone != null && count > 1
-                ? `Generating ${genDone}/${count}…`
-                : "Generate"}
-            </Button>
+            {busy === "generating" ? (
+              <Button
+                className="pointer-events-auto h-11 px-8 hover:bg-muted dark:hover:bg-muted"
+                variant="outline"
+                onClick={handleCancelGenerate}
+              >
+                <Spinner className="mr-2 size-4" />
+                Cancel
+              </Button>
+            ) : (
+              <Button
+                className="btn-float-action pointer-events-auto h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
+                onClick={handleGenerate}
+                disabled={busy !== null || !status?.loaded}
+              >
+                Generate
+              </Button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Fixes #8187

## Summary

Video generation already had a **Cancel** button and `POST /api/inference/video/generate/cancel`. Image generation had internal cancel plumbing (`_active_generate_cancel`, `DIFFUSION_CANCELLED_MSG`) but no public route or UI — users had to shut down Studio to escape a long run.

This PR mirrors the video pattern for images.

## Changes

- **`cancel_generate()`** on both diffusion engines (diffusers + native sd.cpp)
- **`POST /api/inference/images/generate/cancel`** → `{"cancelled": true|false}`
- **Images tab UI**: Generate swaps to Cancel while generating; cancelled runs do not toast an error
- **Tests**: route wiring + mid-run cancel (409 with cancelled sentinel); keepwarm path exclusion

## Testing

```bash
pytest studio/backend/tests/test_diffusion_routes.py::test_cancel_generation_route \
       studio/backend/tests/test_diffusion_routes.py::test_cancel_running_generation \
       studio/backend/tests/test_diffusion_training.py::test_keepwarm_tracks_image_video_generation_paths -q
```

All three pass locally on this VM (no GPU; backend route tests with fake engine).