### PR TITLE
add folder picking and drag-drop for paired image and caption datasets

### DIFF
--- a/studio/frontend/src/features/images/train/dataset-files.ts
+++ b/studio/frontend/src/features/images/train/dataset-files.ts
@@ -16,9 +16,9 @@ const METADATA_SCAN_BYTES = 1024 * 1024;
 export const DATASET_UPLOAD_CHUNK = 500;
 
 /** slice `files` so no request exceeds the part cap or `maxBytes`, keeping casefold-equal
- *  names together: a repeat upload replaces a same-name destination, and the backend can only
- *  compare names inside one request. A single group over `maxBytes` still ships whole, since
- *  splitting it is exactly what lets the second request overwrite the first. */
+ *  names together: the backend can only compare names inside one request, and splitting a
+ *  group is exactly what lets the second request overwrite the first. Such a group ships
+ *  whole even when it is over `maxBytes`; `oversizedChunk` catches that before any upload. */
 export function chunkDatasetUpload(files: File[], maxBytes: number): File[][] {
   const groups = new Map<string, File[]>();
   for (const file of files) {
@@ -46,10 +46,18 @@ export function chunkDatasetUpload(files: File[], maxBytes: number): File[][] {
   return chunks;
 }
 
-/** the first metadata file whose captions are keyed on a subfolder path, or null.
+/** the destination name in the first chunk no split can fit under `maxBytes`, or null.
  *
- *  a folder pick flattens the tree to basenames, so rows keyed "images/001.png" stop matching
- *  and every caption in the file silently resolves to none. */
+ *  uploads accumulate, so a chunk the endpoint 413s leaves every chunk before it on disk. */
+export function oversizedChunk(chunks: File[][], maxBytes: number): string | null {
+  for (const chunk of chunks) {
+    if (chunk.reduce((sum, f) => sum + f.size, 0) > maxBytes) return destinationName(chunk[0]);
+  }
+  return null;
+}
+
+/** the first metadata file whose captions are keyed on a subfolder path, or null. a folder pick
+ *  flattens the tree, so rows keyed "images/001.png" silently resolve to no caption at all. */
 export async function metadataKeyedOnSubfolders(files: File[]): Promise<string | null> {
   for (const file of files) {
     if (!file.name.toLowerCase().endsWith(".jsonl")) continue;
@@ -104,8 +112,7 @@ function isHidden(name: string): boolean {
 // a dataset folder holds a .thumbs cache whose jpegs would re-upload as training images.
 function inHiddenPath(file: File): boolean {
   const relative = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
-  // no relative path means the file was named in a dialog, so it was chosen deliberately;
-  // otherwise segment 0 is the picked folder, whose own dot is likewise the user's choice.
+  // a name typed into a dialog, and segment 0 (the picked folder itself), are the user's choice.
   return relative ? relative.split("/").slice(1).some(isHidden) : false;
 }
 
@@ -154,9 +161,9 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
       continue;
     }
     const isImage = DATASET_IMAGE_EXTS.includes(ext);
-    // two images sharing a stem resolve to one <stem>.txt caption, which the backend refuses;
-    // _shares_sidecar clashes when the stems match exactly, or when the full names differ once
-    // casefolded, so only a pure extension-case pair of one stem spelling is exempt.
+    // two images sharing a stem resolve to one <stem>.txt caption, which the backend refuses.
+    // _shares_sidecar clashes on an exact stem match or a differing casefolded name, so only an
+    // extension-case pair of one stem spelling is exempt.
     const stem = isImage ? dest.slice(0, dest.length - ext.length) : null;
     if (stem !== null) {
       const key = stem.toLowerCase();

--- a/studio/frontend/src/features/images/train/dataset-files.ts
+++ b/studio/frontend/src/features/images/train/dataset-files.ts
@@ -12,6 +12,36 @@ const ACCEPTED = new Set([...DATASET_IMAGE_EXTS, ...DATASET_TEXT_EXTS]);
 // selection is sent in slices; the endpoint accumulates repeat uploads into the same folder.
 export const DATASET_UPLOAD_CHUNK = 500;
 
+/** slice `files` so no request exceeds the part cap or `maxBytes`, keeping casefold-equal
+ *  names together: a repeat upload replaces a same-name destination, and the backend can only
+ *  compare names inside one request. */
+export function chunkDatasetUpload(files: File[], maxBytes: number): File[][] {
+  const groups = new Map<string, File[]>();
+  for (const file of files) {
+    const key = file.name.toLowerCase();
+    const group = groups.get(key);
+    if (group) group.push(file);
+    else groups.set(key, [file]);
+  }
+  const chunks: File[][] = [];
+  let current: File[] = [];
+  let bytes = 0;
+  for (const group of groups.values()) {
+    const groupBytes = group.reduce((sum, f) => sum + f.size, 0);
+    const overCount = current.length + group.length > DATASET_UPLOAD_CHUNK;
+    const overBytes = current.length > 0 && bytes + groupBytes > maxBytes;
+    if (current.length > 0 && (overCount || overBytes)) {
+      chunks.push(current);
+      current = [];
+      bytes = 0;
+    }
+    current.push(...group);
+    bytes += groupBytes;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
 /** the first metadata file whose captions are keyed on a subfolder path, or null.
  *
  *  a folder pick flattens the tree to basenames, so rows keyed "images/001.png" stop matching
@@ -37,7 +67,9 @@ export async function metadataKeyedOnSubfolders(files: File[]): Promise<string |
       if (!row || typeof row !== "object") continue;
       const record = row as Record<string, unknown>;
       const key = record.file_name ?? record.image ?? record.file;
-      if (typeof key === "string" && key.includes("/")) return file.name;
+      if (typeof key === "string" && (key.includes("/") || key.includes("\\"))) {
+        return file.name;
+      }
     }
   }
   return null;
@@ -87,7 +119,7 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
   const files: File[] = [];
   const collisions: DatasetCollision[] = [];
   const seen = new Map<string, string>();
-  const imageStems = new Map<string, { name: string; path: string }>();
+  const imageStems = new Map<string, { name: string; stem: string; path: string }>();
   let imageCount = 0;
   let captionCount = 0;
   let skipped = 0;
@@ -109,17 +141,20 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
     }
     const isImage = DATASET_IMAGE_EXTS.includes(ext);
     // two images sharing a stem resolve to one <stem>.txt caption, which the backend refuses;
-    // it casefolds the stem whatever the filesystem does, but exempts case-variants of one name.
-    const stem = isImage
-      ? file.name.slice(0, file.name.length - ext.length).toLowerCase()
-      : null;
+    // _shares_sidecar clashes when the stems match exactly, or when the full names differ once
+    // casefolded, so only a pure extension-case pair of one stem spelling is exempt.
+    const stem = isImage ? file.name.slice(0, file.name.length - ext.length) : null;
     if (stem !== null) {
-      const clash = imageStems.get(stem);
-      if (clash !== undefined && clash.name.toLowerCase() !== file.name.toLowerCase()) {
+      const key = stem.toLowerCase();
+      const clash = imageStems.get(key);
+      if (
+        clash !== undefined &&
+        (clash.stem === stem || clash.name.toLowerCase() !== file.name.toLowerCase())
+      ) {
         collisions.push({ kind: "stem", first: clash.path, second: path });
         continue;
       }
-      if (clash === undefined) imageStems.set(stem, { name: file.name, path });
+      if (clash === undefined) imageStems.set(key, { name: file.name, stem, path });
     }
     seen.set(file.name, path);
     files.push(file);

--- a/studio/frontend/src/features/images/train/dataset-files.ts
+++ b/studio/frontend/src/features/images/train/dataset-files.ts
@@ -8,17 +8,21 @@ export const DATASET_FILE_ACCEPT = [...DATASET_IMAGE_EXTS, ...DATASET_TEXT_EXTS]
 
 const ACCEPTED = new Set([...DATASET_IMAGE_EXTS, ...DATASET_TEXT_EXTS]);
 
+// a caption jsonl runs to kilobytes, so scan a prefix rather than decoding the whole upload.
+const METADATA_SCAN_BYTES = 1024 * 1024;
+
 // starlette caps a multipart body at 1000 file parts and fastapi does not raise it, so a larger
 // selection is sent in slices; the endpoint accumulates repeat uploads into the same folder.
 export const DATASET_UPLOAD_CHUNK = 500;
 
 /** slice `files` so no request exceeds the part cap or `maxBytes`, keeping casefold-equal
  *  names together: a repeat upload replaces a same-name destination, and the backend can only
- *  compare names inside one request. */
+ *  compare names inside one request. A single group over `maxBytes` still ships whole, since
+ *  splitting it is exactly what lets the second request overwrite the first. */
 export function chunkDatasetUpload(files: File[], maxBytes: number): File[][] {
   const groups = new Map<string, File[]>();
   for (const file of files) {
-    const key = file.name.toLowerCase();
+    const key = destinationName(file).toLowerCase();
     const group = groups.get(key);
     if (group) group.push(file);
     else groups.set(key, [file]);
@@ -51,7 +55,7 @@ export async function metadataKeyedOnSubfolders(files: File[]): Promise<string |
     if (!file.name.toLowerCase().endsWith(".jsonl")) continue;
     let text: string;
     try {
-      text = await file.text();
+      text = await file.slice(0, METADATA_SCAN_BYTES).text();
     } catch {
       continue; // unreadable here is the backend's problem, not a reason to block the upload
     }
@@ -66,13 +70,20 @@ export async function metadataKeyedOnSubfolders(files: File[]): Promise<string |
       }
       if (!row || typeof row !== "object") continue;
       const record = row as Record<string, unknown>;
-      const key = record.file_name ?? record.image ?? record.file;
+      const key = record.file_name || record.image || record.file;
       if (typeof key === "string" && (key.includes("/") || key.includes("\\"))) {
         return file.name;
       }
     }
   }
   return null;
+}
+
+/** the name the upload stores this file under, matching the normalisation in training.py. */
+export function destinationName(file: File): string {
+  const base = file.name.replace(/\\/g, "/").split("/").pop() ?? "";
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: the backend strips nulls here too
+  return base.trim().replace(/\0/g, "");
 }
 
 function extensionOf(name: string): string {
@@ -126,7 +137,9 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
 
   for (const file of input) {
     if (inHiddenPath(file)) continue;
-    const ext = extensionOf(file.name);
+    // keyed on the stored name, so " cat.png" and "cat.png" are seen as one destination
+    const dest = destinationName(file);
+    const ext = extensionOf(dest);
     if (!ACCEPTED.has(ext)) {
       skipped += 1;
       continue;
@@ -134,7 +147,7 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
     // a dataset folder is flat, so two tree paths sharing a basename are one destination.
     // matched exactly: only the backend knows whether the dataset filesystem folds case.
     const path = displayPath(file);
-    const previous = seen.get(file.name);
+    const previous = seen.get(dest);
     if (previous !== undefined) {
       collisions.push({ kind: "name", first: previous, second: path });
       continue;
@@ -143,20 +156,20 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
     // two images sharing a stem resolve to one <stem>.txt caption, which the backend refuses;
     // _shares_sidecar clashes when the stems match exactly, or when the full names differ once
     // casefolded, so only a pure extension-case pair of one stem spelling is exempt.
-    const stem = isImage ? file.name.slice(0, file.name.length - ext.length) : null;
+    const stem = isImage ? dest.slice(0, dest.length - ext.length) : null;
     if (stem !== null) {
       const key = stem.toLowerCase();
       const clash = imageStems.get(key);
       if (
         clash !== undefined &&
-        (clash.stem === stem || clash.name.toLowerCase() !== file.name.toLowerCase())
+        (clash.stem === stem || clash.name.toLowerCase() !== dest.toLowerCase())
       ) {
         collisions.push({ kind: "stem", first: clash.path, second: path });
         continue;
       }
-      if (clash === undefined) imageStems.set(key, { name: file.name, stem, path });
+      if (clash === undefined) imageStems.set(key, { name: dest, stem, path });
     }
-    seen.set(file.name, path);
+    seen.set(dest, path);
     files.push(file);
     if (isImage) imageCount += 1;
     else captionCount += 1;
@@ -207,13 +220,19 @@ async function walkEntry(entry: FileSystemEntry, out: File[], prefix = ""): Prom
 /** every file in a drop, descending into any dropped folders; throws if the walk cannot finish. */
 export async function filesFromDataTransfer(transfer: DataTransfer): Promise<File[]> {
   const entries: FileSystemEntry[] = [];
+  let fileItems = 0;
   for (const item of Array.from(transfer.items ?? [])) {
     if (item.kind !== "file") continue;
+    fileItems += 1;
     const entry = item.webkitGetAsEntry?.();
     if (entry) entries.push(entry);
   }
   // still synchronous here, so the drag data store is readable; it is protected once drop yields.
   if (entries.length === 0) return Array.from(transfer.files ?? []);
+  if (entries.length < fileItems) {
+    // some items resolved and some did not, so the walk would quietly upload part of the drop.
+    throw new Error("Some dropped items could not be read.");
+  }
   const out: File[] = [];
   // no partial result: a half-walked folder would upload as if it were the whole dataset.
   for (const entry of entries) await walkEntry(entry, out);

--- a/studio/frontend/src/features/images/train/dataset-files.ts
+++ b/studio/frontend/src/features/images/train/dataset-files.ts
@@ -86,9 +86,10 @@ export function destinationName(file: File): string {
   return base.trim().replace(/\0/g, "");
 }
 
+// mirrors Path(name).suffix.lower(): a leading dot starts the stem, so ".png" has no suffix.
 function extensionOf(name: string): string {
   const dot = name.lastIndexOf(".");
-  return dot < 0 ? "" : name.slice(dot).toLowerCase();
+  return dot < 1 ? "" : name.slice(dot).toLowerCase();
 }
 
 /** where a picked file sat: the folder-relative path when a folder pick supplied one. */
@@ -130,7 +131,7 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
   const files: File[] = [];
   const collisions: DatasetCollision[] = [];
   const seen = new Map<string, string>();
-  const imageStems = new Map<string, { name: string; stem: string; path: string }>();
+  const imageStems = new Map<string, Array<{ name: string; stem: string; path: string }>>();
   let imageCount = 0;
   let captionCount = 0;
   let skipped = 0;
@@ -140,7 +141,7 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
     // keyed on the stored name, so " cat.png" and "cat.png" are seen as one destination
     const dest = destinationName(file);
     const ext = extensionOf(dest);
-    if (!ACCEPTED.has(ext)) {
+    if (!dest || dest.includes("..") || !ACCEPTED.has(ext)) {
       skipped += 1;
       continue;
     }
@@ -159,15 +160,16 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
     const stem = isImage ? dest.slice(0, dest.length - ext.length) : null;
     if (stem !== null) {
       const key = stem.toLowerCase();
-      const clash = imageStems.get(key);
-      if (
-        clash !== undefined &&
-        (clash.stem === stem || clash.name.toLowerCase() !== dest.toLowerCase())
-      ) {
+      const variants = imageStems.get(key) ?? [];
+      const clash = variants.find(
+        (v) => v.stem === stem || v.name.toLowerCase() !== dest.toLowerCase(),
+      );
+      if (clash !== undefined) {
         collisions.push({ kind: "stem", first: clash.path, second: path });
         continue;
       }
-      if (clash === undefined) imageStems.set(key, { name: dest, stem, path });
+      variants.push({ name: dest, stem, path });
+      imageStems.set(key, variants);
     }
     seen.set(dest, path);
     files.push(file);

--- a/studio/frontend/src/features/images/train/dataset-files.ts
+++ b/studio/frontend/src/features/images/train/dataset-files.ts
@@ -116,6 +116,17 @@ function inHiddenPath(file: File): boolean {
   return relative ? relative.split("/").slice(1).some(isHidden) : false;
 }
 
+/** whether two image names resolve to one `<stem>.txt` sidecar, as `_shares_sidecar` does:
+ *  the stems clash on an exact match, so only an extension-case pair of one spelling is exempt. */
+function sharesSidecar(other: string, name: string): boolean {
+  const otherExt = extensionOf(other);
+  if (other === name || !DATASET_IMAGE_EXTS.includes(otherExt)) return false;
+  const otherStem = other.slice(0, other.length - otherExt.length);
+  const stem = name.slice(0, name.length - extensionOf(name).length);
+  if (otherStem.toLowerCase() !== stem.toLowerCase()) return false;
+  return otherStem === stem || other.toLowerCase() !== name.toLowerCase();
+}
+
 /** two picked paths the flat dataset folder cannot hold apart; `kind` picks the wording. */
 export interface DatasetCollision {
   kind: "name" | "stem";
@@ -138,7 +149,7 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
   const files: File[] = [];
   const collisions: DatasetCollision[] = [];
   const seen = new Map<string, string>();
-  const imageStems = new Map<string, Array<{ name: string; stem: string; path: string }>>();
+  const imageStems = new Map<string, Array<{ name: string; path: string }>>();
   let imageCount = 0;
   let captionCount = 0;
   let skipped = 0;
@@ -162,20 +173,16 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
     }
     const isImage = DATASET_IMAGE_EXTS.includes(ext);
     // two images sharing a stem resolve to one <stem>.txt caption, which the backend refuses.
-    // _shares_sidecar clashes on an exact stem match or a differing casefolded name, so only an
-    // extension-case pair of one stem spelling is exempt.
-    const stem = isImage ? dest.slice(0, dest.length - ext.length) : null;
-    if (stem !== null) {
-      const key = stem.toLowerCase();
+    // every accepted variant is kept and compared, since the exemption is not transitive.
+    if (isImage) {
+      const key = dest.slice(0, dest.length - ext.length).toLowerCase();
       const variants = imageStems.get(key) ?? [];
-      const clash = variants.find(
-        (v) => v.stem === stem || v.name.toLowerCase() !== dest.toLowerCase(),
-      );
+      const clash = variants.find((v) => sharesSidecar(v.name, dest));
       if (clash !== undefined) {
         collisions.push({ kind: "stem", first: clash.path, second: path });
         continue;
       }
-      variants.push({ name: dest, stem, path });
+      variants.push({ name: dest, path });
       imageStems.set(key, variants);
     }
     seen.set(dest, path);
@@ -185,6 +192,19 @@ export function selectDatasetFiles(input: File[]): DatasetFileSelection {
   }
 
   return { files, imageCount, captionCount, skipped, collisions };
+}
+
+/** the first selected image the dataset folder already holds under a sidecar-sharing name, or
+ *  null. the backend compares each upload against the folder, so on a chunked top-up that 400
+ *  lands with the slices before it already written. `existing` is the folder's image names. */
+export function existingStemClash(files: File[], existing: string[]): DatasetCollision | null {
+  for (const file of files) {
+    const dest = destinationName(file);
+    if (!DATASET_IMAGE_EXTS.includes(extensionOf(dest))) continue;
+    const clash = existing.find((name) => sharesSidecar(name, dest));
+    if (clash !== undefined) return { kind: "stem", first: clash, second: displayPath(file) };
+  }
+  return null;
 }
 
 // readEntries yields at most 100 entries per call and ends with an empty batch.

--- a/studio/frontend/src/features/images/train/dataset-files.ts
+++ b/studio/frontend/src/features/images/train/dataset-files.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// mirrors _DIFFUSION_DATASET_IMAGE_EXTS and _DIFFUSION_DATASET_TEXT_EXTS in backend/routes/training.py.
+export const DATASET_IMAGE_EXTS = [".png", ".jpg", ".jpeg", ".webp", ".bmp"];
+export const DATASET_TEXT_EXTS = [".txt", ".caption", ".jsonl"];
+export const DATASET_FILE_ACCEPT = [...DATASET_IMAGE_EXTS, ...DATASET_TEXT_EXTS].join(",");
+
+const ACCEPTED = new Set([...DATASET_IMAGE_EXTS, ...DATASET_TEXT_EXTS]);
+
+// starlette caps a multipart body at 1000 file parts and fastapi does not raise it, so a larger
+// selection is sent in slices; the endpoint accumulates repeat uploads into the same folder.
+export const DATASET_UPLOAD_CHUNK = 500;
+
+/** the first metadata file whose captions are keyed on a subfolder path, or null.
+ *
+ *  a folder pick flattens the tree to basenames, so rows keyed "images/001.png" stop matching
+ *  and every caption in the file silently resolves to none. */
+export async function metadataKeyedOnSubfolders(files: File[]): Promise<string | null> {
+  for (const file of files) {
+    if (!file.name.toLowerCase().endsWith(".jsonl")) continue;
+    let text: string;
+    try {
+      text = await file.text();
+    } catch {
+      continue; // unreadable here is the backend's problem, not a reason to block the upload
+    }
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let row: unknown;
+      try {
+        row = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (!row || typeof row !== "object") continue;
+      const record = row as Record<string, unknown>;
+      const key = record.file_name ?? record.image ?? record.file;
+      if (typeof key === "string" && key.includes("/")) return file.name;
+    }
+  }
+  return null;
+}
+
+function extensionOf(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot < 0 ? "" : name.slice(dot).toLowerCase();
+}
+
+/** where a picked file sat: the folder-relative path when a folder pick supplied one. */
+function displayPath(file: File): string {
+  return (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name;
+}
+
+function isHidden(name: string): boolean {
+  return name.startsWith(".");
+}
+
+// a dataset folder holds a .thumbs cache whose jpegs would re-upload as training images.
+function inHiddenPath(file: File): boolean {
+  const relative = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+  // no relative path means the file was named in a dialog, so it was chosen deliberately;
+  // otherwise segment 0 is the picked folder, whose own dot is likewise the user's choice.
+  return relative ? relative.split("/").slice(1).some(isHidden) : false;
+}
+
+/** two picked paths the flat dataset folder cannot hold apart; `kind` picks the wording. */
+export interface DatasetCollision {
+  kind: "name" | "stem";
+  first: string;
+  second: string;
+}
+
+export interface DatasetFileSelection {
+  /** the files to upload, in picked order. */
+  files: File[];
+  imageCount: number;
+  captionCount: number;
+  /** files left out because the endpoint does not accept their extension. */
+  skipped: number;
+  collisions: DatasetCollision[];
+}
+
+/** filters a picked or dropped batch down to what the dataset endpoint accepts. */
+export function selectDatasetFiles(input: File[]): DatasetFileSelection {
+  const files: File[] = [];
+  const collisions: DatasetCollision[] = [];
+  const seen = new Map<string, string>();
+  const imageStems = new Map<string, { name: string; path: string }>();
+  let imageCount = 0;
+  let captionCount = 0;
+  let skipped = 0;
+
+  for (const file of input) {
+    if (inHiddenPath(file)) continue;
+    const ext = extensionOf(file.name);
+    if (!ACCEPTED.has(ext)) {
+      skipped += 1;
+      continue;
+    }
+    // a dataset folder is flat, so two tree paths sharing a basename are one destination.
+    // matched exactly: only the backend knows whether the dataset filesystem folds case.
+    const path = displayPath(file);
+    const previous = seen.get(file.name);
+    if (previous !== undefined) {
+      collisions.push({ kind: "name", first: previous, second: path });
+      continue;
+    }
+    const isImage = DATASET_IMAGE_EXTS.includes(ext);
+    // two images sharing a stem resolve to one <stem>.txt caption, which the backend refuses;
+    // it casefolds the stem whatever the filesystem does, but exempts case-variants of one name.
+    const stem = isImage
+      ? file.name.slice(0, file.name.length - ext.length).toLowerCase()
+      : null;
+    if (stem !== null) {
+      const clash = imageStems.get(stem);
+      if (clash !== undefined && clash.name.toLowerCase() !== file.name.toLowerCase()) {
+        collisions.push({ kind: "stem", first: clash.path, second: path });
+        continue;
+      }
+      if (clash === undefined) imageStems.set(stem, { name: file.name, path });
+    }
+    seen.set(file.name, path);
+    files.push(file);
+    if (isImage) imageCount += 1;
+    else captionCount += 1;
+  }
+
+  return { files, imageCount, captionCount, skipped, collisions };
+}
+
+// readEntries yields at most 100 entries per call and ends with an empty batch.
+function readAllEntries(reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> {
+  return new Promise((resolve, reject) => {
+    const all: FileSystemEntry[] = [];
+    const next = () =>
+      reader.readEntries((batch) => {
+        if (batch.length === 0) {
+          resolve(all);
+          return;
+        }
+        all.push(...batch);
+        next();
+      }, reject);
+    next();
+  });
+}
+
+function fileOf(entry: FileSystemFileEntry): Promise<File> {
+  return new Promise((resolve, reject) => entry.file(resolve, reject));
+}
+
+async function walkEntry(entry: FileSystemEntry, out: File[], prefix = ""): Promise<void> {
+  const path = prefix + entry.name;
+  if (entry.isFile) {
+    const file = await fileOf(entry as FileSystemFileEntry);
+    // a dropped File has no webkitRelativePath, so stand one in and messages can name the tree.
+    Object.defineProperty(file, "webkitRelativePath", { value: path, configurable: true });
+    out.push(file);
+    return;
+  }
+  if (!entry.isDirectory) return;
+  const reader = (entry as FileSystemDirectoryEntry).createReader();
+  for (const child of await readAllEntries(reader)) {
+    // a dropped entry carries no relative path, so nested hidden names are filtered here.
+    if (isHidden(child.name)) continue;
+    await walkEntry(child, out, `${path}/`);
+  }
+}
+
+/** every file in a drop, descending into any dropped folders; throws if the walk cannot finish. */
+export async function filesFromDataTransfer(transfer: DataTransfer): Promise<File[]> {
+  const entries: FileSystemEntry[] = [];
+  for (const item of Array.from(transfer.items ?? [])) {
+    if (item.kind !== "file") continue;
+    const entry = item.webkitGetAsEntry?.();
+    if (entry) entries.push(entry);
+  }
+  // still synchronous here, so the drag data store is readable; it is protected once drop yields.
+  if (entries.length === 0) return Array.from(transfer.files ?? []);
+  const out: File[] = [];
+  // no partial result: a half-walked folder would upload as if it were the whole dataset.
+  for (const entry of entries) await walkEntry(entry, out);
+  return out;
+}

--- a/studio/frontend/src/features/images/train/dataset-files.ts
+++ b/studio/frontend/src/features/images/train/dataset-files.ts
@@ -91,11 +91,20 @@ export async function metadataKeyedOnSubfolders(files: File[]): Promise<string |
   return null;
 }
 
+// str.strip() is not trim(): Python keeps U+FEFF and strips U+001C-001F and U+0085. trim() read
+// a name ending in U+FEFF as an accepted "cat.png", but the multipart part carries the name
+// whole, so the endpoint saw a suffix with the U+FEFF still on it and refused the slice.
+// This class is exactly str.isspace() over the BMP; NUL is stripped separately, as it is there.
+const PY_SPACE_CLASS =
+  "\\t\\n\\v\\f\\r\\u001c-\\u001f\\u0020\\u0085\\u00a0\\u1680" +
+  "\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000";
+const PY_STRIP = new RegExp(`^[${PY_SPACE_CLASS}]+|[${PY_SPACE_CLASS}]+$`, "g");
+
 /** the name the upload stores this file under, matching the normalisation in training.py. */
 export function destinationName(file: File): string {
   const base = file.name.replace(/\\/g, "/").split("/").pop() ?? "";
   // biome-ignore lint/suspicious/noControlCharactersInRegex: the backend strips nulls here too
-  return base.trim().replace(/\0/g, "");
+  return base.replace(PY_STRIP, "").replace(/\0/g, "");
 }
 
 // mirrors Path(name).suffix.lower(): a leading dot starts the stem, so ".png" has no suffix.

--- a/studio/frontend/src/features/images/train/dataset-files.ts
+++ b/studio/frontend/src/features/images/train/dataset-files.ts
@@ -16,9 +16,9 @@ const METADATA_SCAN_BYTES = 1024 * 1024;
 export const DATASET_UPLOAD_CHUNK = 500;
 
 /** slice `files` so no request exceeds the part cap or `maxBytes`, keeping casefold-equal
- *  names together: the backend can only compare names inside one request, and splitting a
- *  group is exactly what lets the second request overwrite the first. Such a group ships
- *  whole even when it is over `maxBytes`; `oversizedChunk` catches that before any upload. */
+ *  names together and sending those groups first: the backend can only compare names inside
+ *  one request, and splitting a group is exactly what lets the second request overwrite the
+ *  first. Such a group ships whole even over `maxBytes`; `oversizedChunk` catches that. */
 export function chunkDatasetUpload(files: File[], maxBytes: number): File[][] {
   const groups = new Map<string, File[]>();
   for (const file of files) {
@@ -27,10 +27,14 @@ export function chunkDatasetUpload(files: File[], maxBytes: number): File[][] {
     if (group) group.push(file);
     else groups.set(key, [file]);
   }
+  // a group of more than one is a case-variant set, which the backend refuses outright on a
+  // case-insensitive dataset folder. Send those first so that refusal lands while there is
+  // still nothing committed, rather than behind slices that have already been written.
+  const all = [...groups.values()];
   const chunks: File[][] = [];
   let current: File[] = [];
   let bytes = 0;
-  for (const group of groups.values()) {
+  for (const group of [...all.filter((g) => g.length > 1), ...all.filter((g) => g.length === 1)]) {
     const groupBytes = group.reduce((sum, f) => sum + f.size, 0);
     const overCount = current.length + group.length > DATASET_UPLOAD_CHUNK;
     const overBytes = current.length > 0 && bytes + groupBytes > maxBytes;

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -72,6 +72,7 @@ import {
   getDiffusionTrainingRun,
   getDiffusionTrainingStatus,
   listDiffusionDatasetExamples,
+  listDiffusionDatasetImages,
   listDiffusionTrainingRuns,
   startDiffusionTraining,
   stopDiffusionTraining,
@@ -82,6 +83,7 @@ import {
   DATASET_FILE_ACCEPT,
   DATASET_IMAGE_EXTS,
   chunkDatasetUpload,
+  existingStemClash,
   filesFromDataTransfer,
   metadataKeyedOnSubfolders,
   oversizedChunk,
@@ -795,6 +797,21 @@ export function DiffusionTrainPanel({
               "uploaded. Raise the limit in Settings, or leave that file out.",
           );
           return;
+        }
+        // one request is all-or-nothing on the backend, so only a split top-up needs the folder
+        // checked as well: there a stem it already holds would 400 a later slice, mid-commit.
+        if (chunks.length > 1 && (info?.datasets ?? []).some((d) => d.name === name)) {
+          const held = await listDiffusionDatasetImages(name).catch(() => null);
+          const clash =
+            held && existingStemClash(files, held.images.map((i) => i.filename));
+          if (clash) {
+            toast.error(
+              `"${clash.second}" and "${clash.first}", already in "${name}", differ only by ` +
+                "extension, so they would share one caption file. Nothing was uploaded; rename " +
+                "it and try again.",
+            );
+            return;
+          }
         }
         let res = await uploadDiffusionDataset(name, chunks[0]);
         let sent = res.uploaded;

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -53,6 +53,10 @@ import type { TrainingSeriesPoint } from "@/features/training";
 // eslint-disable-next-line no-restricted-imports -- matches images-page.tsx's token access
 import { getHfToken, hfApiToken } from "@/features/hub/stores/hf-token-store";
 import { cn } from "@/lib/utils";
+import {
+  DEFAULT_UPLOAD_LIMIT_BYTES,
+  loadUploadLimitSettings,
+} from "@/features/settings/api/upload-limit";
 import { isTauri } from "@/lib/api-base";
 import { toast } from "@/lib/toast";
 
@@ -76,7 +80,7 @@ import { DatasetLabelingGrid, LabelingGridToggle } from "./dataset-labeling-grid
 import {
   DATASET_FILE_ACCEPT,
   DATASET_IMAGE_EXTS,
-  DATASET_UPLOAD_CHUNK,
+  chunkDatasetUpload,
   filesFromDataTransfer,
   metadataKeyedOnSubfolders,
   selectDatasetFiles,
@@ -768,14 +772,19 @@ export function DiffusionTrainPanel({
       const misKeyed = await metadataKeyedOnSubfolders(files);
       setUploading(true);
       try {
-        // the endpoint accumulates into the same folder, so a tree past the multipart part cap
-        // goes up in slices rather than being refused outright.
-        let res = await uploadDiffusionDataset(name, files.slice(0, DATASET_UPLOAD_CHUNK));
+        // the endpoint accumulates into the same folder, so a tree past the multipart part or
+        // byte cap goes up in slices rather than being refused outright.
+        const limit = await loadUploadLimitSettings().catch(() => null);
+        const chunks = chunkDatasetUpload(
+          files,
+          limit?.maxUploadSizeBytes ?? DEFAULT_UPLOAD_LIMIT_BYTES,
+        );
+        let res = await uploadDiffusionDataset(name, chunks[0]);
         let sent = res.uploaded;
         let stopped: string | null = null;
-        for (let at = DATASET_UPLOAD_CHUNK; at < files.length; at += DATASET_UPLOAD_CHUNK) {
+        for (const chunk of chunks.slice(1)) {
           try {
-            res = await uploadDiffusionDataset(name, files.slice(at, at + DATASET_UPLOAD_CHUNK));
+            res = await uploadDiffusionDataset(name, chunk);
             sent += res.uploaded;
           } catch (e) {
             stopped = e instanceof Error ? e.message : "upload failed";

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -407,6 +407,8 @@ export function DiffusionTrainPanel({
   const folderInputRef = useRef<HTMLInputElement | null>(null);
   const folderTarget = useRef("");
   const [dropActive, setDropActive] = useState(false);
+  // the authoritative in-flight guard: `uploading` is render state and reads stale in a closure.
+  const uploadInFlight = useRef(false);
   const [gridOpen, setGridOpen] = useState(false);
   const [gridRefresh, setGridRefresh] = useState(0);
   const [examples, setExamples] = useState<DiffusionDatasetExample[]>([]);
@@ -769,9 +771,14 @@ export function DiffusionTrainPanel({
       // appear yet rather than refusing a captions-first upload.
       const newCaptionsOnly =
         imageCount === 0 && !(info?.datasets ?? []).some((d) => d.name === name);
-      const misKeyed = await metadataKeyedOnSubfolders(files);
+      if (uploadInFlight.current) {
+        toast.error("An upload is already running. Wait for it to finish, then try again.");
+        return;
+      }
+      uploadInFlight.current = true;
       setUploading(true);
       try {
+        const misKeyed = await metadataKeyedOnSubfolders(files);
         // the endpoint accumulates into the same folder, so a tree past the multipart part or
         // byte cap goes up in slices rather than being refused outright.
         const limit = await loadUploadLimitSettings().catch(() => null);
@@ -828,6 +835,7 @@ export function DiffusionTrainPanel({
       } catch (e) {
         toast.error(e instanceof Error ? e.message : "Upload failed");
       } finally {
+        uploadInFlight.current = false;
         setUploading(false);
       }
     },
@@ -848,12 +856,13 @@ export function DiffusionTrainPanel({
       if (!event.dataTransfer.types.includes("Files")) return;
       event.preventDefault();
       setDropActive(false);
-      if (uploading) {
+      if (uploadInFlight.current) {
         toast.error("An upload is already running. Wait for it to finish, then drop again.");
         return;
       }
       let dropped: File[];
       // held across the walk too: a big tree takes seconds, and every control is live until then.
+      uploadInFlight.current = true;
       setUploading(true);
       try {
         dropped = await filesFromDataTransfer(event.dataTransfer);
@@ -864,6 +873,8 @@ export function DiffusionTrainPanel({
         );
         return;
       } finally {
+        // uploadTo re-takes it synchronously below, so no await sits in the gap.
+        uploadInFlight.current = false;
         setUploading(false);
       }
       if (dropped.length === 0) {
@@ -872,7 +883,7 @@ export function DiffusionTrainPanel({
       }
       await uploadTo(dropTarget, dropped);
     },
-    [dropTarget, uploadTo, uploading],
+    [dropTarget, uploadTo],
   );
 
   const onStart = useCallback(async () => {

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -55,6 +55,7 @@ import { getHfToken, hfApiToken } from "@/features/hub/stores/hf-token-store";
 import { cn } from "@/lib/utils";
 import {
   DEFAULT_UPLOAD_LIMIT_BYTES,
+  getCachedUploadLimitLabel,
   loadUploadLimitSettings,
 } from "@/features/settings/api/upload-limit";
 import { isTauri } from "@/lib/api-base";
@@ -83,6 +84,7 @@ import {
   chunkDatasetUpload,
   filesFromDataTransfer,
   metadataKeyedOnSubfolders,
+  oversizedChunk,
   selectDatasetFiles,
 } from "./dataset-files";
 import { DatasetShowcase } from "./dataset-showcase";
@@ -782,10 +784,18 @@ export function DiffusionTrainPanel({
         // the endpoint accumulates into the same folder, so a tree past the multipart part or
         // byte cap goes up in slices rather than being refused outright.
         const limit = await loadUploadLimitSettings().catch(() => null);
-        const chunks = chunkDatasetUpload(
-          files,
-          limit?.maxUploadSizeBytes ?? DEFAULT_UPLOAD_LIMIT_BYTES,
-        );
+        const maxBytes = limit?.maxUploadSizeBytes ?? DEFAULT_UPLOAD_LIMIT_BYTES;
+        const chunks = chunkDatasetUpload(files, maxBytes);
+        // a slice no split can fit under the cap 413s, so refuse before the first request:
+        // otherwise the slices ahead of it are already committed.
+        const over = oversizedChunk(chunks, maxBytes);
+        if (over) {
+          toast.error(
+            `"${over}" is over the ${getCachedUploadLimitLabel()} upload limit, so nothing was ` +
+              "uploaded. Raise the limit in Settings, or leave that file out.",
+          );
+          return;
+        }
         let res = await uploadDiffusionDataset(name, chunks[0]);
         let sent = res.uploaded;
         let stopped: string | null = null;

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1,9 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type DragEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
-import { Settings02Icon, Upload01Icon } from "@hugeicons/core-free-icons";
+import {
+  FolderAddIcon,
+  Settings02Icon,
+  Upload01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { TestTubeOutlineIcon } from "@/lib/hugeicons-derived";
 
@@ -24,6 +36,11 @@ import { useScrollFades } from "@/hooks/use-scroll-fades";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   Select,
   SelectContent,
   SelectGroup,
@@ -36,6 +53,7 @@ import type { TrainingSeriesPoint } from "@/features/training";
 // eslint-disable-next-line no-restricted-imports -- matches images-page.tsx's token access
 import { getHfToken, hfApiToken } from "@/features/hub/stores/hf-token-store";
 import { cn } from "@/lib/utils";
+import { isTauri } from "@/lib/api-base";
 import { toast } from "@/lib/toast";
 
 import {
@@ -55,6 +73,14 @@ import {
   uploadDiffusionDataset,
 } from "../api";
 import { DatasetLabelingGrid, LabelingGridToggle } from "./dataset-labeling-grid";
+import {
+  DATASET_FILE_ACCEPT,
+  DATASET_IMAGE_EXTS,
+  DATASET_UPLOAD_CHUNK,
+  filesFromDataTransfer,
+  metadataKeyedOnSubfolders,
+  selectDatasetFiles,
+} from "./dataset-files";
 import { DatasetShowcase } from "./dataset-showcase";
 import { DiffusionCharts } from "./diffusion-charts";
 import {
@@ -135,7 +161,6 @@ function repoIsPrequantized(baseModel: string): boolean {
 }
 // Dataset-select option value prefix for a not-yet-imported example; picking it imports.
 const EXAMPLE_PREFIX = "example:";
-const DATASET_FILE_ACCEPT = ".png,.jpg,.jpeg,.webp,.bmp,.txt,.caption,.jsonl";
 // min-w-0 + a truncating value: a long option would otherwise set the grid column min width and push into its neighbour.
 const selectClass =
   "h-8 w-full min-w-0 text-xs *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:truncate";
@@ -144,6 +169,34 @@ const selectClass =
 // implicit column auto-sized, so the track froze at its widest child's min-content
 // (150px for the run-length pair) and the cell painted over the next column.
 const fieldClass = "grid grid-cols-1 min-w-0 gap-2";
+
+/** opens the folder picker; icon-only because the 416px rail already holds the select and the file-pick button. */
+function FolderPickButton({
+  disabled,
+  onPick,
+}: {
+  disabled: boolean;
+  onPick: () => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild={true}>
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          aria-label="Add a folder of images"
+          className="size-8 shrink-0"
+          onClick={onPick}
+          disabled={disabled}
+        >
+          <HugeiconsIcon icon={FolderAddIcon} className="size-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Add a whole folder of images</TooltipContent>
+    </Tooltip>
+  );
+}
 
 /** A field's label with its guidance behind an "i" tooltip, keeping the grid scannable.
  *  Only facts a user must act on stay on the page as text. */
@@ -346,6 +399,10 @@ export function DiffusionTrainPanel({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   // Adds to the selected set; the other input creates a new one.
   const addInputRef = useRef<HTMLInputElement | null>(null);
+  // one folder picker serves both targets, so the destination is captured when it opens.
+  const folderInputRef = useRef<HTMLInputElement | null>(null);
+  const folderTarget = useRef("");
+  const [dropActive, setDropActive] = useState(false);
   const [gridOpen, setGridOpen] = useState(false);
   const [gridRefresh, setGridRefresh] = useState(0);
   const [examples, setExamples] = useState<DiffusionDatasetExample[]>([]);
@@ -673,20 +730,89 @@ export function DiffusionTrainPanel({
   }, [viewRun?.metric_history]);
 
   // Uploads accumulate, so the same call both creates a folder and adds to an existing one.
+  // `picked` can come from a file pick, a folder pick or a drop, so it is filtered here.
   const uploadTo = useCallback(
-    async (name: string, files: File[]) => {
-      if (files.length === 0) return; // the picker was cancelled
+    async (name: string, picked: File[]) => {
+      if (picked.length === 0) return; // the picker was cancelled
       if (!name) {
         toast.error("Give the dataset a folder name, e.g. my-style-photos.");
         return;
       }
+      const { files, imageCount, skipped, collisions } = selectDatasetFiles(picked);
+      if (collisions.length > 0) {
+        const { kind, first, second } = collisions[0];
+        const more =
+          collisions.length > 1
+            ? ` ${collisions.length - 1} other pair${collisions.length === 2 ? "" : "s"} clash too.`
+            : "";
+        toast.error(
+          (kind === "name"
+            ? `"${first}" and "${second}" have the same file name, and a dataset folder is ` +
+              "flat, so one would overwrite the other."
+            : `"${first}" and "${second}" differ only by extension, so they would share one ` +
+              "caption file.") + `${more} Rename them and upload again.`,
+        );
+        return;
+      }
+      if (files.length === 0) {
+        toast.error(
+          `Nothing to upload. Pick images (${DATASET_IMAGE_EXTS.join(", ")}) and, ` +
+            "optionally, a caption file beside each one.",
+        );
+        return;
+      }
+      // /diffusion/info only lists folders holding an image, so say why the set will not
+      // appear yet rather than refusing a captions-first upload.
+      const newCaptionsOnly =
+        imageCount === 0 && !(info?.datasets ?? []).some((d) => d.name === name);
+      const misKeyed = await metadataKeyedOnSubfolders(files);
       setUploading(true);
       try {
-        const res = await uploadDiffusionDataset(name, files);
-        toast.success(
-          `Uploaded ${res.uploaded} file${res.uploaded === 1 ? "" : "s"} - ` +
-            `"${res.name}" now has ${res.image_count} images`,
-        );
+        // the endpoint accumulates into the same folder, so a tree past the multipart part cap
+        // goes up in slices rather than being refused outright.
+        let res = await uploadDiffusionDataset(name, files.slice(0, DATASET_UPLOAD_CHUNK));
+        let sent = res.uploaded;
+        let stopped: string | null = null;
+        for (let at = DATASET_UPLOAD_CHUNK; at < files.length; at += DATASET_UPLOAD_CHUNK) {
+          try {
+            res = await uploadDiffusionDataset(name, files.slice(at, at + DATASET_UPLOAD_CHUNK));
+            sent += res.uploaded;
+          } catch (e) {
+            stopped = e instanceof Error ? e.message : "upload failed";
+            break;
+          }
+        }
+        // caption_count is the folder total the backend resolves over sidecars and metadata alike.
+        if (stopped) {
+          toast.error(
+            `Uploaded ${sent} of ${files.length} files into "${res.name}", then stopped: ` +
+              `${stopped}`,
+          );
+        } else {
+          toast.success(
+            `Uploaded ${sent} file${sent === 1 ? "" : "s"} - ` +
+              `"${res.name}" now has ${res.image_count} images, ` +
+              `${res.caption_count} captioned`,
+          );
+        }
+        if (skipped > 0) {
+          toast.info(
+            `Skipped ${skipped} file${skipped === 1 ? "" : "s"} that ` +
+              `${skipped === 1 ? "was" : "were"} neither an image nor a caption.`,
+          );
+        }
+        if (newCaptionsOnly) {
+          toast.info(
+            `"${res.name}" holds captions but no images yet, so it stays out of the dataset ` +
+              "picker until you add some.",
+          );
+        }
+        if (misKeyed) {
+          toast.info(
+            `${misKeyed} keys its captions on subfolder paths, and a dataset folder is flat, ` +
+              "so those rows will not match. A .txt beside each image always will.",
+          );
+        }
         await refreshInfo();
         setDataset(res.name);
         setGridRefresh((k) => k + 1);
@@ -696,7 +822,48 @@ export function DiffusionTrainPanel({
         setUploading(false);
       }
     },
-    [refreshInfo],
+    [info?.datasets, refreshInfo],
+  );
+
+  const pickFolder = useCallback((name: string) => {
+    folderTarget.current = name;
+    folderInputRef.current?.click();
+  }, []);
+
+  // a drop lands on whichever set the field is showing, filling a new folder or topping up the selected one.
+  const dropTarget = uploadMode ? uploadName.trim() : dataset;
+  const onDrop = useCallback(
+    async (event: DragEvent) => {
+      if (isTauri) return;
+      // only claim file drops: preventDefault on a text drag kills editing in the caption boxes.
+      if (!event.dataTransfer.types.includes("Files")) return;
+      event.preventDefault();
+      setDropActive(false);
+      if (uploading) {
+        toast.error("An upload is already running. Wait for it to finish, then drop again.");
+        return;
+      }
+      let dropped: File[];
+      // held across the walk too: a big tree takes seconds, and every control is live until then.
+      setUploading(true);
+      try {
+        dropped = await filesFromDataTransfer(event.dataTransfer);
+      } catch {
+        toast.error(
+          "Could not read every file in that folder, so nothing was uploaded. Try the folder " +
+            "button instead.",
+        );
+        return;
+      } finally {
+        setUploading(false);
+      }
+      if (dropped.length === 0) {
+        toast.error("That drop had no files in it.");
+        return;
+      }
+      await uploadTo(dropTarget, dropped);
+    },
+    [dropTarget, uploadTo, uploading],
   );
 
   const onStart = useCallback(async () => {
@@ -1202,7 +1369,29 @@ export function DiffusionTrainPanel({
           </div>
 
           {/* Dataset */}
-          <div className={fieldClass}>
+          {/* the whole field is the drop zone, so a folder can land on the picker, the thumbnails or the caption grid. */}
+          <div
+            className={cn(
+              fieldClass,
+              "rounded-lg transition-colors",
+              dropActive && "outline-2 outline-dashed outline-offset-4 outline-primary/60",
+            )}
+            onDragOver={(e) => {
+              // tauri consumes os drags before the webview, as the chat composer notes.
+              if (isTauri) return;
+              // files only: without this a text-selection drag also arms the zone.
+              if (!e.dataTransfer.types.includes("Files")) return;
+              e.preventDefault();
+              setDropActive(true);
+            }}
+            onDragLeave={(e) => {
+              // dragging onto a child fires leave on the parent, so ignore inner moves.
+              if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+                setDropActive(false);
+              }
+            }}
+            onDrop={(e) => void onDrop(e)}
+          >
             <FieldLabel hint="The set the LoRA learns from. 10-50 images is plenty, and captions are optional.">
               Training images
             </FieldLabel>
@@ -1270,9 +1459,24 @@ export function DiffusionTrainPanel({
                     <HugeiconsIcon icon={Upload01Icon} className="size-3.5" />
                     {uploading ? "Uploading..." : "Add"}
                   </Button>
+                  <FolderPickButton disabled={uploading} onPick={() => pickFolder(dataset)} />
                 </>
               )}
             </div>
+            {/* a folder pick carries the whole tree, so an images-plus-captions set arrives paired in one go. */}
+            <input
+              ref={folderInputRef}
+              type="file"
+              multiple
+              {...({ webkitdirectory: "", directory: "" } as object)}
+              className="hidden"
+              aria-label="Training image folder"
+              onChange={(e) => {
+                const files = Array.from(e.target.files ?? []);
+                e.target.value = "";
+                void uploadTo(folderTarget.current, files);
+              }}
+            />
             {importingId && (
               <p className="text-ui-11 text-muted-foreground">
                 Importing {examples.find((e) => e.id === importingId)?.label ?? "example"}...
@@ -1325,7 +1529,22 @@ export function DiffusionTrainPanel({
                     <HugeiconsIcon icon={Upload01Icon} className="size-3.5" />
                     {uploading ? "Uploading..." : "Upload"}
                   </Button>
+                  <FolderPickButton
+                    disabled={uploading}
+                    onPick={() => {
+                      if (!uploadName.trim()) {
+                        toast.error("Give the dataset a folder name, e.g. my-style-photos.");
+                        return;
+                      }
+                      pickFolder(uploadName.trim());
+                    }}
+                  />
                 </div>
+                <p className="text-ui-11 leading-snug text-muted-foreground">
+                  {isTauri ? "Pick files or a folder." : "Pick files or a folder, or drop them here."}{" "}
+                  A caption file beside an image (cat.png and cat.txt) is read as that image's
+                  caption.
+                </p>
               </div>
             ) : (
               selectedDataset && (

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -54,7 +54,6 @@ import type { TrainingSeriesPoint } from "@/features/training";
 import { getHfToken, hfApiToken } from "@/features/hub/stores/hf-token-store";
 import { cn } from "@/lib/utils";
 import {
-  DEFAULT_UPLOAD_LIMIT_BYTES,
   getCachedUploadLimitLabel,
   loadUploadLimitSettings,
 } from "@/features/settings/api/upload-limit";
@@ -785,8 +784,18 @@ export function DiffusionTrainPanel({
         const misKeyed = await metadataKeyedOnSubfolders(files);
         // the endpoint accumulates into the same folder, so a tree past the multipart part or
         // byte cap goes up in slices rather than being refused outright.
-        const limit = await loadUploadLimitSettings().catch(() => null);
-        const maxBytes = limit?.maxUploadSizeBytes ?? DEFAULT_UPLOAD_LIMIT_BYTES;
+        // the cap decides where the slices fall, so guessing it makes the refusal below either
+        // too strict or useless. A limit that cannot be read stops the upload.
+        let maxBytes: number;
+        try {
+          maxBytes = (await loadUploadLimitSettings()).maxUploadSizeBytes;
+        } catch (e) {
+          toast.error(
+            "Could not read the upload size limit, so nothing was uploaded: " +
+              `${e instanceof Error ? e.message : "the limit could not be read"}. Try again.`,
+          );
+          return;
+        }
         const chunks = chunkDatasetUpload(files, maxBytes);
         // a slice no split can fit under the cap 413s, so refuse before the first request:
         // otherwise the slices ahead of it are already committed.

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -810,9 +810,11 @@ export function DiffusionTrainPanel({
         // one request is all-or-nothing on the backend, so only a split top-up needs the folder
         // checked as well: there a stem it already holds would 400 a later slice, mid-commit.
         if (chunks.length > 1) {
-          // whether the folder already exists decides whether it needs checking, so absent
-          // dataset info is not proof that it is new: fetch it, and stop rather than assume.
-          const known = info ?? (await refreshInfo());
+          // whether the folder already exists decides whether it needs checking, and the list
+          // held here is the one from mount, so neither its absence nor a name missing from it
+          // proves the folder is new. Only a fresh list can, and one more GET is nothing
+          // against a selection already going up in several requests.
+          const known = await refreshInfo();
           if (!known) {
             toast.error(
               "Could not read the dataset list, so nothing was uploaded. Try again.",

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -788,7 +788,9 @@ export function DiffusionTrainPanel({
         // too strict or useless. A limit that cannot be read stops the upload.
         let maxBytes: number;
         try {
-          maxBytes = (await loadUploadLimitSettings()).maxUploadSizeBytes;
+          // forced: the cached value is from whenever this tab first asked, and the setting can
+          // be changed elsewhere, which would put the slices out of step with the server.
+          maxBytes = (await loadUploadLimitSettings({ force: true })).maxUploadSizeBytes;
         } catch (e) {
           toast.error(
             "Could not read the upload size limit, so nothing was uploaded: " +
@@ -821,15 +823,21 @@ export function DiffusionTrainPanel({
             );
             return;
           }
-          if (known.datasets.some((d) => d.name === name)) {
+          // a case-insensitive dataset root resolves "photos" onto an existing "Photos", so an
+          // exact match would call that folder new and skip the check. Fall back to a folded
+          // match and list the folder under the name the backend reports.
+          const folder =
+            known.datasets.find((d) => d.name === name) ??
+            known.datasets.find((d) => d.name.toLowerCase() === name.toLowerCase());
+          if (folder) {
             // no listing, no guarantee: skipping the check would upload the slices it exists to
             // hold back, so a failure here stops the upload rather than proceeding blind.
             let held: Awaited<ReturnType<typeof listDiffusionDatasetImages>>;
             try {
-              held = await listDiffusionDatasetImages(name);
+              held = await listDiffusionDatasetImages(folder.name);
             } catch (e) {
               toast.error(
-                `Could not read what "${name}" already holds, so nothing was uploaded: ` +
+                `Could not read what "${folder.name}" already holds, so nothing was uploaded: ` +
                   `${e instanceof Error ? e.message : "the dataset could not be listed"}. Try again.`,
               );
               return;
@@ -837,7 +845,7 @@ export function DiffusionTrainPanel({
             const clash = existingStemClash(files, held.images.map((i) => i.filename));
             if (clash) {
               toast.error(
-                `"${clash.second}" and "${clash.first}", already in "${name}", differ only by ` +
+                `"${clash.second}" and "${clash.first}", already in "${folder.name}", differ only by ` +
                   "extension, so they would share one caption file. Nothing was uploaded; " +
                   "rename it and try again.",
               );

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -801,9 +801,19 @@ export function DiffusionTrainPanel({
         // one request is all-or-nothing on the backend, so only a split top-up needs the folder
         // checked as well: there a stem it already holds would 400 a later slice, mid-commit.
         if (chunks.length > 1 && (info?.datasets ?? []).some((d) => d.name === name)) {
-          const held = await listDiffusionDatasetImages(name).catch(() => null);
-          const clash =
-            held && existingStemClash(files, held.images.map((i) => i.filename));
+          // no listing, no guarantee: skipping the check would upload the slices it exists to
+          // hold back, so a failure here stops the upload rather than proceeding blind.
+          let held: Awaited<ReturnType<typeof listDiffusionDatasetImages>>;
+          try {
+            held = await listDiffusionDatasetImages(name);
+          } catch (e) {
+            toast.error(
+              `Could not read what "${name}" already holds, so nothing was uploaded: ` +
+                `${e instanceof Error ? e.message : "the dataset could not be listed"}. Try again.`,
+            );
+            return;
+          }
+          const clash = existingStemClash(files, held.images.map((i) => i.filename));
           if (clash) {
             toast.error(
               `"${clash.second}" and "${clash.first}", already in "${name}", differ only by ` +

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -784,12 +784,11 @@ export function DiffusionTrainPanel({
         const misKeyed = await metadataKeyedOnSubfolders(files);
         // the endpoint accumulates into the same folder, so a tree past the multipart part or
         // byte cap goes up in slices rather than being refused outright.
-        // the cap decides where the slices fall, so guessing it makes the refusal below either
-        // too strict or useless. A limit that cannot be read stops the upload.
+        // the cap decides where the slices fall, so a guess makes the refusal below either too
+        // strict or useless. Forced past the cache, which another tab can leave behind, and a
+        // cap that cannot be read stops the upload.
         let maxBytes: number;
         try {
-          // forced: the cached value is from whenever this tab first asked, and the setting can
-          // be changed elsewhere, which would put the slices out of step with the server.
           maxBytes = (await loadUploadLimitSettings({ force: true })).maxUploadSizeBytes;
         } catch (e) {
           toast.error(
@@ -812,10 +811,8 @@ export function DiffusionTrainPanel({
         // one request is all-or-nothing on the backend, so only a split top-up needs the folder
         // checked as well: there a stem it already holds would 400 a later slice, mid-commit.
         if (chunks.length > 1) {
-          // whether the folder already exists decides whether it needs checking, and the list
-          // held here is the one from mount, so neither its absence nor a name missing from it
-          // proves the folder is new. Only a fresh list can, and one more GET is nothing
-          // against a selection already going up in several requests.
+          // the list held here is the one from mount, so it cannot say the folder is new.
+          // One more GET is nothing against a selection already going up in several requests.
           const known = await refreshInfo();
           if (!known) {
             toast.error(

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -809,27 +809,38 @@ export function DiffusionTrainPanel({
         }
         // one request is all-or-nothing on the backend, so only a split top-up needs the folder
         // checked as well: there a stem it already holds would 400 a later slice, mid-commit.
-        if (chunks.length > 1 && (info?.datasets ?? []).some((d) => d.name === name)) {
-          // no listing, no guarantee: skipping the check would upload the slices it exists to
-          // hold back, so a failure here stops the upload rather than proceeding blind.
-          let held: Awaited<ReturnType<typeof listDiffusionDatasetImages>>;
-          try {
-            held = await listDiffusionDatasetImages(name);
-          } catch (e) {
+        if (chunks.length > 1) {
+          // whether the folder already exists decides whether it needs checking, so absent
+          // dataset info is not proof that it is new: fetch it, and stop rather than assume.
+          const known = info ?? (await refreshInfo());
+          if (!known) {
             toast.error(
-              `Could not read what "${name}" already holds, so nothing was uploaded: ` +
-                `${e instanceof Error ? e.message : "the dataset could not be listed"}. Try again.`,
+              "Could not read the dataset list, so nothing was uploaded. Try again.",
             );
             return;
           }
-          const clash = existingStemClash(files, held.images.map((i) => i.filename));
-          if (clash) {
-            toast.error(
-              `"${clash.second}" and "${clash.first}", already in "${name}", differ only by ` +
-                "extension, so they would share one caption file. Nothing was uploaded; rename " +
-                "it and try again.",
-            );
-            return;
+          if (known.datasets.some((d) => d.name === name)) {
+            // no listing, no guarantee: skipping the check would upload the slices it exists to
+            // hold back, so a failure here stops the upload rather than proceeding blind.
+            let held: Awaited<ReturnType<typeof listDiffusionDatasetImages>>;
+            try {
+              held = await listDiffusionDatasetImages(name);
+            } catch (e) {
+              toast.error(
+                `Could not read what "${name}" already holds, so nothing was uploaded: ` +
+                  `${e instanceof Error ? e.message : "the dataset could not be listed"}. Try again.`,
+              );
+              return;
+            }
+            const clash = existingStemClash(files, held.images.map((i) => i.filename));
+            if (clash) {
+              toast.error(
+                `"${clash.second}" and "${clash.first}", already in "${name}", differ only by ` +
+                  "extension, so they would share one caption file. Nothing was uploaded; " +
+                  "rename it and try again.",
+              );
+              return;
+            }
           }
         }
         let res = await uploadDiffusionDataset(name, chunks[0]);
@@ -885,7 +896,7 @@ export function DiffusionTrainPanel({
         setUploading(false);
       }
     },
-    [info?.datasets, refreshInfo],
+    [info, refreshInfo],
   );
 
   const pickFolder = useCallback((name: string) => {

--- a/studio/frontend/src/features/settings/api/upload-limit.ts
+++ b/studio/frontend/src/features/settings/api/upload-limit.ts
@@ -87,8 +87,11 @@ async function fetchUploadLimitSettings(): Promise<UploadLimitSettings> {
   return fromApi(await res.json());
 }
 
-export async function loadUploadLimitSettings() {
-  if (cachedUploadLimit) {
+/** The cached limit, fetching it once if needed. `force` refetches instead of reading the
+ *  cache, for a caller that must agree with the server rather than merely show a number: the
+ *  setting can be changed from another tab or process, which no event here reaches. */
+export async function loadUploadLimitSettings({ force = false } = {}) {
+  if (cachedUploadLimit && !force) {
     return cachedUploadLimit;
   }
   inFlightUploadLimit ??= fetchUploadLimitSettings()

--- a/studio/frontend/tests/dataset-file-selection.test.ts
+++ b/studio/frontend/tests/dataset-file-selection.test.ts
@@ -8,10 +8,16 @@ import test from "node:test";
 import {
   DATASET_IMAGE_EXTS,
   DATASET_TEXT_EXTS,
+  chunkDatasetUpload,
   filesFromDataTransfer,
   metadataKeyedOnSubfolders,
   selectDatasetFiles,
 } from "../src/features/images/train/dataset-files.ts";
+
+/** a picked file of a given byte size, for the chunking tests. */
+function sized(name: string, bytes: number): File {
+  return new File([new Uint8Array(bytes)], name);
+}
 
 /** a picked file; `path` stands in for the webkitRelativePath a folder pick carries. */
 function picked(name: string, path?: string): File {
@@ -101,6 +107,15 @@ test("folds case on the stem rule, which training.py applies whatever the filesy
   const result = selectDatasetFiles([picked("Cat.png"), picked("cat.jpg")]);
 
   assert.deepEqual(result.collisions, [{ kind: "stem", first: "Cat.png", second: "cat.jpg" }]);
+});
+
+test("clashes an extension-case pair of one stem spelling, as _shares_sidecar does", () => {
+  // cat.png and cat.PNG share the exact stem, so both resolve to cat.txt and the backend
+  // rejects them on every filesystem. Cat.png and cat.PNG differ in stem case and are exempt.
+  assert.deepEqual(selectDatasetFiles([picked("cat.png"), picked("cat.PNG")]).collisions, [
+    { kind: "stem", first: "cat.png", second: "cat.PNG" },
+  ]);
+  assert.deepEqual(selectDatasetFiles([picked("Cat.png"), picked("cat.PNG")]).collisions, []);
 });
 
 test("keeps a dotfile named in the file dialog, where the user chose it deliberately", () => {
@@ -209,6 +224,34 @@ test("gives dropped files their folder path, so a collision names both sides", a
   ]);
 });
 
+test("keeps casefold-equal names in one request, which the backend can only compare there", () => {
+  const files = [
+    ...Array.from({ length: 499 }, (_, i) => sized(`img_${i}.png`, 1)),
+    sized("Cat.png", 1),
+    sized("cat.png", 1),
+  ];
+  const chunks = chunkDatasetUpload(files, 1024 * 1024 * 1024);
+
+  // a plain 500-file slice would put Cat.png and cat.png in separate repeat uploads, where the
+  // second silently replaces the first on a case-insensitive dataset folder.
+  const holding = chunks.filter((c) => c.some((f) => f.name.toLowerCase() === "cat.png"));
+  assert.equal(holding.length, 1);
+  assert.equal(holding[0].filter((f) => f.name.toLowerCase() === "cat.png").length, 2);
+  for (const chunk of chunks) assert.ok(chunk.length <= 500 + 1);
+});
+
+test("splits on the byte cap too, not only the part count", () => {
+  const mb = 1024 * 1024;
+  const files = Array.from({ length: 300 }, (_, i) => sized(`img_${i}.png`, 2 * mb));
+  const chunks = chunkDatasetUpload(files, 500 * mb);
+
+  assert.ok(chunks.length > 1, "600MB under the part cap must still be split");
+  for (const chunk of chunks) {
+    assert.ok(chunk.reduce((n, f) => n + f.size, 0) <= 500 * mb);
+  }
+  assert.equal(chunks.flat().length, 300);
+});
+
 test("flags metadata keyed on a subfolder, which flattening would silently unmatch", async () => {
   const meta = new File(
     ['{"file_name": "images/001.png", "text": "a cat"}\n{"file_name": "images/002.png"}\n'],
@@ -218,6 +261,10 @@ test("flags metadata keyed on a subfolder, which flattening would silently unmat
 
   const flat = new File(['{"file_name": "001.png", "text": "a cat"}\n'], "metadata.jsonl");
   assert.equal(await metadataKeyedOnSubfolders([flat]), null);
+
+  // metadata written on windows keys rows with a backslash
+  const win = new File(['{"file_name": "images\\\\001.png"}\n'], "metadata.jsonl");
+  assert.equal(await metadataKeyedOnSubfolders([win]), "metadata.jsonl");
 });
 
 test("refuses a partly read folder instead of uploading it as complete", async () => {

--- a/studio/frontend/tests/dataset-file-selection.test.ts
+++ b/studio/frontend/tests/dataset-file-selection.test.ts
@@ -9,6 +9,7 @@ import {
   DATASET_IMAGE_EXTS,
   DATASET_TEXT_EXTS,
   chunkDatasetUpload,
+  existingStemClash,
   filesFromDataTransfer,
   metadataKeyedOnSubfolders,
   oversizedChunk,
@@ -316,6 +317,25 @@ test("names a chunk no split can fit, so the slices before it are never committe
   );
   assert.equal(oversizedChunk(chunks, 500 * mb), "huge.png");
   assert.equal(oversizedChunk(chunks.slice(0, 1), 500 * mb), null);
+});
+
+test("reports a stem the dataset folder already holds, which a split top-up would 400", () => {
+  const held = ["cat.png", "dog.png"];
+
+  assert.deepEqual(existingStemClash([picked("cat.jpg", "top-up/cat.jpg")], held), {
+    kind: "stem",
+    first: "cat.png",
+    second: "top-up/cat.jpg",
+  });
+  // a repeat upload of the same name is how the endpoint accumulates, so it must stay allowed
+  assert.equal(existingStemClash([picked("cat.png")], held), null);
+  // an exact stem match still clashes, extension case notwithstanding
+  assert.equal(existingStemClash([picked("cat.PNG")], held)?.first, "cat.png");
+  // only a differing stem case is exempt, which is where _shares_sidecar stops
+  assert.equal(existingStemClash([picked("Cat.png")], held), null);
+  // a caption never shares a sidecar with an image
+  assert.equal(existingStemClash([picked("cat.txt")], held), null);
+  assert.equal(existingStemClash([picked("bird.png")], held), null);
 });
 
 test("flags metadata keyed on a subfolder, which flattening would silently unmatch", async () => {

--- a/studio/frontend/tests/dataset-file-selection.test.ts
+++ b/studio/frontend/tests/dataset-file-selection.test.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  DATASET_IMAGE_EXTS,
+  DATASET_TEXT_EXTS,
+  filesFromDataTransfer,
+  metadataKeyedOnSubfolders,
+  selectDatasetFiles,
+} from "../src/features/images/train/dataset-files.ts";
+
+/** a picked file; `path` stands in for the webkitRelativePath a folder pick carries. */
+function picked(name: string, path?: string): File {
+  const file = new File(["x"], name);
+  if (path !== undefined) {
+    Object.defineProperty(file, "webkitRelativePath", { value: path });
+  }
+  return file;
+}
+
+test("accepts exactly the extensions the backend accepts", async () => {
+  const source = await readFile(
+    new URL("../../backend/routes/training.py", import.meta.url),
+    "utf8",
+  );
+  const literals = (name: string) => {
+    const match = new RegExp(`${name}\\s*=\\s*\\{([^}]+)\\}`).exec(source);
+    assert.ok(match, `${name} not found in training.py`);
+    return [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]).sort();
+  };
+
+  // .caption sidecars and metadata/captions .jsonl are older caption formats the trainer
+  // still reads, so a backend that widens either list must widen the picker with it.
+  assert.deepEqual([...DATASET_IMAGE_EXTS].sort(), literals("_DIFFUSION_DATASET_IMAGE_EXTS"));
+  assert.deepEqual([...DATASET_TEXT_EXTS].sort(), literals("_DIFFUSION_DATASET_TEXT_EXTS"));
+});
+
+test("keeps images alongside the caption files paired to them", () => {
+  const result = selectDatasetFiles([
+    picked("cat.png"),
+    picked("cat.txt"),
+    picked("dog.JPEG"),
+    picked("dog.caption"),
+    picked("metadata.jsonl"),
+  ]);
+
+  assert.equal(result.files.length, 5);
+  assert.equal(result.imageCount, 2);
+  assert.equal(result.captionCount, 3);
+  assert.equal(result.skipped, 0);
+  assert.deepEqual(result.collisions, []);
+});
+
+test("drops files the upload endpoint would reject, and counts them", () => {
+  const result = selectDatasetFiles([
+    picked("cat.png"),
+    picked("notes.pdf"),
+    picked("clip.mp4"),
+    picked("README"),
+  ]);
+
+  assert.deepEqual(result.files.map((f) => f.name), ["cat.png"]);
+  assert.equal(result.skipped, 3);
+});
+
+test("reports basenames a folder pick would flatten together", () => {
+  // a dataset folder is flat, so both of these would be stored as cat.png.
+  const result = selectDatasetFiles([
+    picked("cat.png", "set/train/cat.png"),
+    picked("cat.png", "set/val/cat.png"),
+  ]);
+
+  assert.equal(result.files.length, 1);
+  assert.deepEqual(result.collisions, [
+    { kind: "name", first: "set/train/cat.png", second: "set/val/cat.png" },
+  ]);
+});
+
+test("reports two images sharing a stem, which would share one caption sidecar", () => {
+  // training.py refuses the whole batch on this; catching it here keeps the upload honest.
+  const result = selectDatasetFiles([picked("cat.png"), picked("cat.jpg"), picked("cat.txt")]);
+
+  assert.deepEqual(result.files.map((f) => f.name), ["cat.png", "cat.txt"]);
+  assert.deepEqual(result.collisions, [{ kind: "stem", first: "cat.png", second: "cat.jpg" }]);
+});
+
+test("leaves case-variant names to the backend, which knows if the filesystem folds case", () => {
+  // on ext4 these are two distinct files the upload accepts; refusing here would block a
+  // legitimate dataset and give a reason that is false for that filesystem.
+  const result = selectDatasetFiles([picked("Cat.png"), picked("cat.PNG")]);
+
+  assert.equal(result.files.length, 2);
+  assert.deepEqual(result.collisions, []);
+});
+
+test("folds case on the stem rule, which training.py applies whatever the filesystem does", () => {
+  const result = selectDatasetFiles([picked("Cat.png"), picked("cat.jpg")]);
+
+  assert.deepEqual(result.collisions, [{ kind: "stem", first: "Cat.png", second: "cat.jpg" }]);
+});
+
+test("keeps a dotfile named in the file dialog, where the user chose it deliberately", () => {
+  // no webkitRelativePath means a plain multi-select, unlike a tree walk that surfaces .thumbs.
+  const result = selectDatasetFiles([picked(".cover.png"), picked("cat.png")]);
+
+  assert.deepEqual(result.files.map((f) => f.name), [".cover.png", "cat.png"]);
+  assert.equal(result.skipped, 0);
+});
+
+test("ignores dot-directories, so re-picking a dataset folder skips its .thumbs cache", () => {
+  const result = selectDatasetFiles([
+    picked("cat.png", "my-photos/cat.png"),
+    picked("cat.png_256.jpg", "my-photos/.thumbs/cat.png_256.jpg"),
+    picked(".DS_Store", "my-photos/.DS_Store"),
+  ]);
+
+  assert.deepEqual(result.files.map((f) => f.name), ["cat.png"]);
+  // hidden entries are not "unsupported", so they are not reported as skipped.
+  assert.equal(result.skipped, 0);
+  assert.deepEqual(result.collisions, []);
+});
+
+test("keeps a picked folder whose own name starts with a dot", () => {
+  // webkitRelativePath is rooted at the folder the user chose, so its name is not a reason to skip.
+  const result = selectDatasetFiles([
+    picked("cat.png", ".photos/cat.png"),
+    picked("dog.png", ".photos/nested/dog.png"),
+  ]);
+
+  assert.deepEqual(result.files.map((f) => f.name), ["cat.png", "dog.png"]);
+});
+
+test("an empty or fully rejected pick yields no files", () => {
+  assert.equal(selectDatasetFiles([]).files.length, 0);
+  assert.equal(selectDatasetFiles([picked("notes.pdf")]).files.length, 0);
+});
+
+// -- drop handling -------------------------------------------------------------------------
+
+/** a FileSystemFileEntry over one File. */
+function fileEntry(name: string, onFile?: () => void) {
+  return {
+    isFile: true,
+    isDirectory: false,
+    name,
+    file(resolve: (f: File) => void, reject: (e: Error) => void) {
+      onFile?.();
+      if (name === "explode.png") reject(new Error("unreadable"));
+      else resolve(new File(["x"], name));
+    },
+  } as unknown as FileSystemEntry;
+}
+
+/** a FileSystemDirectoryEntry whose reader hands back `children` in 100-entry batches. */
+function dirEntry(name: string, children: FileSystemEntry[]) {
+  return {
+    isFile: false,
+    isDirectory: true,
+    name,
+    createReader() {
+      let cursor = 0;
+      return {
+        readEntries(resolve: (batch: FileSystemEntry[]) => void) {
+          // mirrors Chrome, which never returns more than 100 entries per call.
+          const batch = children.slice(cursor, cursor + 100);
+          cursor += batch.length;
+          resolve(batch);
+        },
+      };
+    },
+  } as unknown as FileSystemEntry;
+}
+
+function transfer(entries: FileSystemEntry[], files: File[] = []): DataTransfer {
+  return {
+    items: entries.map((entry) => ({ kind: "file", webkitGetAsEntry: () => entry })),
+    files,
+  } as unknown as DataTransfer;
+}
+
+test("reads a dropped folder past the 100-entry readEntries batch limit", async () => {
+  const children = Array.from({ length: 250 }, (_, i) => fileEntry(`img_${i}.png`));
+  const out = await filesFromDataTransfer(transfer([dirEntry("set", children)]));
+
+  // a single readEntries call would stop at 100 and silently drop the rest.
+  assert.equal(out.length, 250);
+});
+
+test("gives dropped files their folder path, so a collision names both sides", async () => {
+  const out = await filesFromDataTransfer(
+    transfer([
+      dirEntry("set", [
+        dirEntry("train", [fileEntry("cat.png")]),
+        dirEntry("val", [fileEntry("cat.png")]),
+      ]),
+    ]),
+  );
+
+  assert.deepEqual(
+    out.map((f) => (f as File & { webkitRelativePath?: string }).webkitRelativePath),
+    ["set/train/cat.png", "set/val/cat.png"],
+  );
+  assert.deepEqual(selectDatasetFiles(out).collisions, [
+    { kind: "name", first: "set/train/cat.png", second: "set/val/cat.png" },
+  ]);
+});
+
+test("flags metadata keyed on a subfolder, which flattening would silently unmatch", async () => {
+  const meta = new File(
+    ['{"file_name": "images/001.png", "text": "a cat"}\n{"file_name": "images/002.png"}\n'],
+    "metadata.jsonl",
+  );
+  assert.equal(await metadataKeyedOnSubfolders([meta]), "metadata.jsonl");
+
+  const flat = new File(['{"file_name": "001.png", "text": "a cat"}\n'], "metadata.jsonl");
+  assert.equal(await metadataKeyedOnSubfolders([flat]), null);
+});
+
+test("refuses a partly read folder instead of uploading it as complete", async () => {
+  await assert.rejects(
+    filesFromDataTransfer(
+      transfer([dirEntry("set", [fileEntry("ok.png"), fileEntry("explode.png")])], []),
+    ),
+    /unreadable/,
+  );
+});
+
+test("uses the flat list when the entries API is unavailable", async () => {
+  const flat = [new File(["x"], "a.png"), new File(["x"], "b.png")];
+  const out = await filesFromDataTransfer({
+    items: [{ kind: "file", webkitGetAsEntry: () => null }],
+    files: flat,
+  } as unknown as DataTransfer);
+
+  assert.deepEqual(out.map((f) => f.name), ["a.png", "b.png"]);
+});

--- a/studio/frontend/tests/dataset-file-selection.test.ts
+++ b/studio/frontend/tests/dataset-file-selection.test.ts
@@ -224,6 +224,31 @@ test("gives dropped files their folder path, so a collision names both sides", a
   ]);
 });
 
+test("normalizes to the stored name, so a leading space is not a second destination", () => {
+  // training.py stores Path(name).name.strip(), so " cat.png" and "cat.png" are one file.
+  const result = selectDatasetFiles([picked(" cat.png"), picked("cat.png")]);
+
+  assert.equal(result.files.length, 1);
+  assert.equal(result.collisions.length, 1);
+
+  // and the same normalisation groups them into one request rather than two repeat uploads.
+  const chunks = chunkDatasetUpload([sized(" cat.png", 1), sized("cat.png", 1)], 1024 * 1024);
+  assert.equal(chunks.length, 1);
+});
+
+test("rejects a drop whose items do not all resolve to entries", async () => {
+  // a partly resolvable drop would otherwise upload a subset under an all-or-nothing contract.
+  const dt = {
+    items: [
+      { kind: "file", webkitGetAsEntry: () => fileEntry("ok.png") },
+      { kind: "file", webkitGetAsEntry: () => null },
+    ],
+    files: [new File(["x"], "ok.png"), new File(["x"], "ghost.png")],
+  } as unknown as DataTransfer;
+
+  await assert.rejects(filesFromDataTransfer(dt), /could not be read/);
+});
+
 test("keeps casefold-equal names in one request, which the backend can only compare there", () => {
   const files = [
     ...Array.from({ length: 499 }, (_, i) => sized(`img_${i}.png`, 1)),
@@ -265,6 +290,13 @@ test("flags metadata keyed on a subfolder, which flattening would silently unmat
   // metadata written on windows keys rows with a backslash
   const win = new File(['{"file_name": "images\\\\001.png"}\n'], "metadata.jsonl");
   assert.equal(await metadataKeyedOnSubfolders([win]), "metadata.jsonl");
+
+  // _load_metadata_captions falls back on the first TRUTHY key, so an empty file_name defers
+  const blank = new File(
+    ['{"file_name": "", "image": "images/001.png"}\n'],
+    "metadata.jsonl",
+  );
+  assert.equal(await metadataKeyedOnSubfolders([blank]), "metadata.jsonl");
 });
 
 test("refuses a partly read folder instead of uploading it as complete", async () => {

--- a/studio/frontend/tests/dataset-file-selection.test.ts
+++ b/studio/frontend/tests/dataset-file-selection.test.ts
@@ -118,6 +118,29 @@ test("clashes an extension-case pair of one stem spelling, as _shares_sidecar do
   assert.deepEqual(selectDatasetFiles([picked("Cat.png"), picked("cat.PNG")]).collisions, []);
 });
 
+test("compares every accepted variant, since the stem exemption is not transitive", () => {
+  // Cat.png exempts cat.PNG and cat.png individually, but those two share an exact stem and
+  // training.py compares each new name against every earlier one.
+  const result = selectDatasetFiles([picked("Cat.png"), picked("cat.PNG"), picked("cat.png")]);
+
+  assert.deepEqual(result.collisions, [
+    { kind: "stem", first: "cat.PNG", second: "cat.png" },
+  ]);
+});
+
+test("skips names the upload refuses outright, before any slice is committed", () => {
+  // Path(".png").suffix is empty and the endpoint rejects any name holding "..", so accepting
+  // either here would commit earlier slices and then fail on a later one.
+  const result = selectDatasetFiles([
+    picked("cat.png"),
+    picked(".png"),
+    picked("photo..png"),
+  ]);
+
+  assert.deepEqual(result.files.map((f) => f.name), ["cat.png"]);
+  assert.equal(result.skipped, 2);
+});
+
 test("keeps a dotfile named in the file dialog, where the user chose it deliberately", () => {
   // no webkitRelativePath means a plain multi-select, unlike a tree walk that surfaces .thumbs.
   const result = selectDatasetFiles([picked(".cover.png"), picked("cat.png")]);

--- a/studio/frontend/tests/dataset-file-selection.test.ts
+++ b/studio/frontend/tests/dataset-file-selection.test.ts
@@ -11,6 +11,7 @@ import {
   chunkDatasetUpload,
   filesFromDataTransfer,
   metadataKeyedOnSubfolders,
+  oversizedChunk,
   selectDatasetFiles,
 } from "../src/features/images/train/dataset-files.ts";
 
@@ -298,6 +299,23 @@ test("splits on the byte cap too, not only the part count", () => {
     assert.ok(chunk.reduce((n, f) => n + f.size, 0) <= 500 * mb);
   }
   assert.equal(chunks.flat().length, 300);
+});
+
+test("names a chunk no split can fit, so the slices before it are never committed", () => {
+  const mb = 1024 * 1024;
+  const files = [
+    ...Array.from({ length: 20 }, (_, i) => sized(`img_${i}.png`, 2 * mb)),
+    sized("huge.png", 600 * mb),
+  ];
+  const chunks = chunkDatasetUpload(files, 500 * mb);
+
+  assert.deepEqual(
+    chunks.map((c) => c.length),
+    [20, 1],
+    "the oversized file must sit in a slice the endpoint would 413",
+  );
+  assert.equal(oversizedChunk(chunks, 500 * mb), "huge.png");
+  assert.equal(oversizedChunk(chunks.slice(0, 1), 500 * mb), null);
 });
 
 test("flags metadata keyed on a subfolder, which flattening would silently unmatch", async () => {

--- a/studio/frontend/tests/dataset-file-selection.test.ts
+++ b/studio/frontend/tests/dataset-file-selection.test.ts
@@ -16,9 +16,12 @@ import {
   selectDatasetFiles,
 } from "../src/features/images/train/dataset-files.ts";
 
-/** a picked file of a given byte size, for the chunking tests. */
+/** a picked file of a given byte size. chunking reads only `size`, so the payload is stubbed:
+ *  materializing it made these cases allocate over a gigabyte between them. */
 function sized(name: string, bytes: number): File {
-  return new File([new Uint8Array(bytes)], name);
+  const file = new File([], name);
+  Object.defineProperty(file, "size", { value: bytes });
+  return file;
 }
 
 /** a picked file; `path` stands in for the webkitRelativePath a folder pick carries. */

--- a/studio/frontend/tests/dataset-file-selection.test.ts
+++ b/studio/frontend/tests/dataset-file-selection.test.ts
@@ -305,6 +305,25 @@ test("splits on the byte cap too, not only the part count", () => {
   assert.equal(chunks.flat().length, 300);
 });
 
+test("strips what Python strips, so a name the endpoint refuses is not read as accepted", () => {
+  // trim() also removes U+FEFF, which str.strip() keeps: the part carries "cat.png﻿" and
+  // the endpoint reads its suffix as ".png﻿", so the client must not see a plain image.
+  const bom = selectDatasetFiles([picked("cat.png\ufeff")]);
+  assert.deepEqual(bom.files, []);
+  assert.equal(bom.skipped, 1);
+
+  // ...and the other direction: str.strip() removes these, trim() does not, so the endpoint
+  // stores a plain "cat.png" and the client must not drop the file as unsupported.
+  for (const ch of ["\u001c", "\u001d", "\u001e", "\u001f", "\u0085"]) {
+    const sel = selectDatasetFiles([picked(`cat.png${ch}`)]);
+    assert.equal(sel.imageCount, 1, `U+${ch.codePointAt(0)?.toString(16)} must be stripped`);
+    assert.equal(sel.skipped, 0);
+  }
+
+  // ordinary whitespace both agree on, still folded onto one destination
+  assert.equal(selectDatasetFiles([picked(" cat.png\t")]).imageCount, 1);
+});
+
 test("sends case-variant groups first, so their refusal lands before anything commits", () => {
   const mb = 1024 * 1024;
   const files = [

--- a/studio/frontend/tests/dataset-file-selection.test.ts
+++ b/studio/frontend/tests/dataset-file-selection.test.ts
@@ -305,6 +305,28 @@ test("splits on the byte cap too, not only the part count", () => {
   assert.equal(chunks.flat().length, 300);
 });
 
+test("sends case-variant groups first, so their refusal lands before anything commits", () => {
+  const mb = 1024 * 1024;
+  const files = [
+    ...Array.from({ length: 499 }, (_, i) => sized(`img_${i}.png`, mb)),
+    sized("Cat.png", mb),
+    sized("cat.png", mb),
+  ];
+  const chunks = chunkDatasetUpload(files, 500 * mb);
+
+  // a case-insensitive dataset folder refuses the pair, so it must ride in the first request:
+  // refused there, nothing has been committed. Keeping it whole is what lets the backend
+  // compare both names at all.
+  assert.deepEqual(
+    chunks[0].slice(0, 2).map((f) => f.name),
+    ["Cat.png", "cat.png"],
+    "the case-variant group must lead the first chunk",
+  );
+  assert.ok(chunks.length > 1, "501 files must still split on the part cap");
+  assert.equal(chunks.flat().length, 501);
+  assert.equal(new Set(chunks.flat()).size, 501);
+});
+
 test("names a chunk no split can fit, so the slices before it are never committed", () => {
   const mb = 1024 * 1024;
   const files = [

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -63,12 +63,12 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     # publish on a leg that did not succeed, and refuse to publish a leg whose
     # job record never appeared, rather than defaulting to "finished".
     assert publish["needs"] == ["prepare-version"]
-    wait = next(step for step in publish["steps"] if step.get("name") == "Wait for the build matrix")
+    wait = next(
+        step for step in publish["steps"] if step.get("name") == "Wait for the build matrix"
+    )
     wait_run = wait["run"]
 
-    matrix_legs = {
-        f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]
-    }
+    matrix_legs = {f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]}
     assert len(matrix_legs) == len(tauri_steps)
     for leg in matrix_legs:
         assert f"'{leg}'" in wait_run, leg


### PR DESCRIPTION
## What this adds

The Images Train tab could only take training images through a multi-select file dialog. A LoRA dataset is normally a folder of images with a `.txt` caption beside each one, and a file dialog cannot span subdirectories, so pairing them meant selecting everything by hand.

This adds a folder picker next to Add and Upload, and makes the whole Training images field a drop zone. Both carry the full tree, so an images-plus-captions set arrives paired in one go. The success toast reports how many images the folder now holds and how many of them resolved a caption, using the backend's own `caption_count`, which covers `.txt` and `.caption` sidecars and `metadata.jsonl` alike.

Nothing changes on the backend. Existing caption formats keep working, and a test pins the picker's accept list to `_DIFFUSION_DATASET_IMAGE_EXTS` and `_DIFFUSION_DATASET_TEXT_EXTS` parsed out of `routes/training.py`, so widening either list on the server without widening the picker fails.

## Mirroring the upload's own rules

`upload_diffusion_dataset` fails a whole batch on several conditions, and a folder pick makes each far easier to hit than a manual selection did. `selectDatasetFiles` in the new `dataset-files.ts` checks them before anything is streamed:

- A dataset folder is flat, so two tree paths sharing a basename are one destination. Reported as a collision naming both paths.
- Two images sharing a stem resolve to one `<stem>.txt` sidecar. `training.py` casefolds that comparison whatever the filesystem does, but exempts pure case-variants of one filename. Both halves of that rule are matched, verified by porting `_shares_sidecar` and running client and server logic over the same six cases.
- The plain filename duplicate check is left to the server, which gates it on `_dataset_folder_is_case_insensitive`. Folding case here would refuse `IMG_01.png` alongside `img_01.png` on ext4, where the upload accepts both.
- Extensions outside the accept list are dropped and counted, and the count is reported.

Every collision is listed, not just the first, so a train/val split does not take one rename per attempt.

## Constraints the browser and the server impose

`readEntries` returns at most 100 entries per call and signals the end with an empty batch, so the walk loops until it drains. A single call would silently truncate any folder past 100 files.

Starlette caps a multipart body at 1000 file parts and FastAPI does not raise it, so a captioned folder of 501 images would fail with an opaque 400. Uploads go up in 500-file slices instead; the endpoint already accumulates repeat uploads into the same folder. A slice that fails reports how many files landed before it stopped.

A dataset folder carries a `.thumbs` cache, so dot-directories are skipped when walking a tree. A dotfile named directly in the file dialog is kept, because choosing it there is deliberate.

A dropped `File` carries no `webkitRelativePath`, so the walk stamps one, which lets a collision message name both sides of the tree rather than the same basename twice.

The drag data store enters protected mode once the drop handler yields, so `webkitGetAsEntry()` and the flat file list are both read before the first `await`. A folder that cannot be walked to completion throws rather than returning a partial list, since a half-read folder uploaded as if whole would train a LoRA on a silently truncated dataset.

Tauri consumes OS drags before the webview, as `features/chat/shared-composer.tsx` already notes, so the drop path is gated on `isTauri` and the help text omits the drop sentence there. The folder button works everywhere.

The drop zone wraps the caption textareas, so it claims a drop only when `dataTransfer.types` contains `Files`. Dragging text between caption boxes still edits them.

## Tests

16 tests in `dataset-file-selection.test.ts` cover the accept-list parity, both collision rules and the case-variant exemption, extension and hidden-path filtering, the 100-entry batching, dropped-file paths, the all-or-nothing walk, and metadata keyed on subfolder paths. Three were mutation tested against the bugs they guard: reading the flat list late, collapsing `readEntries` to one call, and dropping the stem check each fail exactly one test.

## Verification

Manually verified in the running web UI: folder picking, drag and drop, and paired `.txt` captions against a real dataset.

Typecheck, 1326/1326 frontend tests, production build and i18n parity all pass. No Python source changed. No GPU work is involved, so no training or CUDA checks were run.
