### PR TITLE
Fix resume button missing after stop-and-save (#8150)

### DIFF
--- a/studio/backend/core/training/provenance.py
+++ b/studio/backend/core/training/provenance.py
@@ -840,6 +840,26 @@ def validate_exact_resource_pins(config: dict[str, Any]) -> tuple[str, str]:
     return model_snapshot, dataset_snapshot
 
 
+def _provenance_awaiting_attestation(
+    marker: dict[str, Any], config: dict[str, Any]
+) -> bool:
+    """Training stopped before the worker attested loaded hub resources.
+
+    Stop-and-save can finish while provenance is still the initial ``pending`` marker
+    written at run start. Those runs have a valid checkpoint but no attested revision
+    pins yet; resume should behave like a legacy run without exact resource requirements.
+    """
+    if marker.get("status") != "pending":
+        return False
+    if marker.get("model_status") is not None or marker.get("dataset_status") is not None:
+        return False
+    if config.get("actual_model_repo_id"):
+        return False
+    if config.get("model_snapshot_path") or config.get("dataset_snapshot_path"):
+        return False
+    return True
+
+
 def exact_resume_resource_requirements(config: dict[str, Any]) -> tuple[bool, bool]:
     marker = config.get(RESOURCE_PROVENANCE_KEY)
     if marker is None:
@@ -850,6 +870,8 @@ def exact_resume_resource_requirements(config: dict[str, Any]) -> tuple[bool, bo
         or marker.get("status") not in {"pending", "incomplete", "complete"}
     ):
         raise ExactResumeResourcesUnavailable("The resource provenance is invalid.")
+    if _provenance_awaiting_attestation(marker, config):
+        return False, False
 
     from utils.paths import is_local_path
 
@@ -891,6 +913,8 @@ def resource_provenance_resume_blocker(config: dict[str, Any]) -> Optional[str]:
     """
     marker = config.get(RESOURCE_PROVENANCE_KEY)
     if marker is None:
+        return None
+    if isinstance(marker, dict) and _provenance_awaiting_attestation(marker, config):
         return None
     try:
         exact_resume_resource_requirements(config)

--- a/studio/backend/core/training/provenance.py
+++ b/studio/backend/core/training/provenance.py
@@ -840,9 +840,7 @@ def validate_exact_resource_pins(config: dict[str, Any]) -> tuple[str, str]:
     return model_snapshot, dataset_snapshot
 
 
-def _provenance_awaiting_attestation(
-    marker: dict[str, Any], config: dict[str, Any]
-) -> bool:
+def _provenance_awaiting_attestation(marker: dict[str, Any], config: dict[str, Any]) -> bool:
     """Training stopped before the worker attested loaded hub resources.
 
     Stop-and-save can finish while provenance is still the initial ``pending`` marker

--- a/studio/backend/core/training/provenance.py
+++ b/studio/backend/core/training/provenance.py
@@ -912,8 +912,6 @@ def resource_provenance_resume_blocker(config: dict[str, Any]) -> Optional[str]:
     marker = config.get(RESOURCE_PROVENANCE_KEY)
     if marker is None:
         return None
-    if isinstance(marker, dict) and _provenance_awaiting_attestation(marker, config):
-        return None
     try:
         exact_resume_resource_requirements(config)
     except ExactResumeResourcesUnavailable as exc:

--- a/studio/backend/tests/test_resume_blocker_reason.py
+++ b/studio/backend/tests/test_resume_blocker_reason.py
@@ -60,6 +60,21 @@ def test_resumable_statuses_report_no_blocker(status, resources_available):
     assert resource_provenance_allows_resume(config) is True
 
 
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"status": "pending"},
+        {"version": 2, "status": "pending"},
+    ],
+    ids = ["missing-version", "wrong-version"],
+)
+def test_malformed_pending_marker_reports_validation_blocker(marker):
+    config = _config(**{RESOURCE_PROVENANCE_KEY: marker})
+
+    assert resource_provenance_resume_blocker(config) == "The resource provenance is invalid."
+    assert resource_provenance_allows_resume(config) is False
+
+
 def test_an_unresumable_status_explains_itself(resources_available):
     config = _config(**{RESOURCE_PROVENANCE_KEY: {"version": 1, "status": "failed"}})
 

--- a/studio/backend/tests/test_resume_reason_matches_cause.py
+++ b/studio/backend/tests/test_resume_reason_matches_cause.py
@@ -79,7 +79,23 @@ def test_an_intact_checkpoint_still_gets_the_provenance_reason(tmp_path, unresum
 
     monkeypatch.setattr(resume_mod, "has_resume_state", lambda output_dir: True)
 
-    summary = training_history._summary_from_row(_row(tmp_path), False)
+    summary = training_history._summary_from_row(
+        _row(
+            tmp_path,
+            config_json = json.dumps(
+                {
+                    "model_name": "unsloth/Llama-3.2-1B-Instruct",
+                    "hf_dataset": "yahma/alpaca-cleaned",
+                    RESOURCE_PROVENANCE_KEY: {
+                        "version": 1,
+                        "status": "incomplete",
+                        "model_status": "incomplete",
+                    },
+                }
+            ),
+        ),
+        False,
+    )
 
     assert summary.resume_blocked_reason == _ATTESTATION
 

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -1793,7 +1793,7 @@ def test_legacy_resume_config_cannot_inject_cache_pins():
     assert resource_provenance_is_complete(source_config) is False
 
 
-@pytest.mark.parametrize("status", ["pending", "incomplete"])
+@pytest.mark.parametrize("status", ["incomplete"])
 def test_unattested_current_hub_model_resume_is_rejected(status):
     route = _load_route_module(f"training_route_unattested_hub_model_{status}")
     request = _request(hf_dataset = None)
@@ -1811,6 +1811,28 @@ def test_unattested_current_hub_model_resume_is_rejected(status):
         route._prepare_resume_resource_provenance(request, resume_run)
 
     assert exc_info.value.status_code == 409
+
+
+def test_pending_hub_model_resume_before_attestation_is_allowed():
+    route = _load_route_module("training_route_pending_hub_model_resume")
+    request = _request(hf_dataset = None)
+    resume_run = {
+        "model_name": "unsloth/test",
+        "config_json": {
+            "model_name": "unsloth/test",
+            "training_type": "LoRA/QLoRA",
+            "hf_dataset": "",
+            "resource_provenance": {"version": 1, "status": "pending"},
+        },
+    }
+
+    actual_repo_id, requires_exact_model, requires_exact_dataset, _, _ = (
+        route._prepare_resume_resource_provenance(request, resume_run)
+    )
+
+    assert actual_repo_id is None
+    assert requires_exact_model is False
+    assert requires_exact_dataset is False
 
 
 def test_foreign_absolute_resume_paths_are_rejected_on_native_host():

--- a/studio/backend/tests/test_training_provenance.py
+++ b/studio/backend/tests/test_training_provenance.py
@@ -1193,6 +1193,30 @@ def test_pending_current_hub_pins_are_not_treated_as_attested(tmp_path):
     assert resource_provenance_allows_resume(config) is False
 
 
+def test_stop_and_save_before_attestation_allows_resume(monkeypatch):
+    """Regression for #8150: Resume hidden after Stop and Save on hub models."""
+    from core.training import resume
+
+    monkeypatch.setattr(resume, "has_resume_state", lambda _path: True)
+    config = {
+        "model_name": "unsloth/Qwen3.5-0.8B",
+        "hf_dataset": "org/dataset",
+        RESOURCE_PROVENANCE_KEY: {"version": 1, "status": "pending"},
+    }
+    run = {
+        "status": "stopped",
+        "final_step": 10,
+        "total_steps": 100,
+        "output_dir": "/outputs/run-8150",
+        "resumed_later": False,
+        "config_json": json.dumps(config),
+    }
+
+    assert exact_resume_resource_requirements(config) == (False, False)
+    assert resource_provenance_allows_resume(config) is True
+    assert resume.can_resume_run(run) is True
+
+
 @pytest.mark.parametrize(
     "marker",
     [
@@ -1206,7 +1230,7 @@ def test_malformed_provenance_is_rejected_while_legacy_is_unchanged(marker):
     assert resource_provenance_allows_resume({"model_name": "legacy/model"}) is True
 
 
-def test_resume_eligibility_rejects_unpinned_current_hub_and_preserves_legacy(monkeypatch):
+def test_resume_eligibility_allows_pending_before_attestation_and_preserves_legacy(monkeypatch):
     from core.training import resume
 
     monkeypatch.setattr(resume, "has_resume_state", lambda _path: True)
@@ -1230,7 +1254,7 @@ def test_resume_eligibility_rejects_unpinned_current_hub_and_preserves_legacy(mo
                 ),
             }
         )
-        is False
+        is True
     )
     assert (
         resume.can_resume_run(

--- a/studio/backend/tests/test_training_provenance.py
+++ b/studio/backend/tests/test_training_provenance.py
@@ -1110,12 +1110,26 @@ def test_embedding_hf_loader_attests_first_remote_dataset_load(tmp_path):
 
 @pytest.mark.parametrize("status", ["pending", "incomplete"])
 def test_unattested_current_provenance_without_hub_resources_can_resume(status):
-    assert (
-        resource_provenance_allows_resume(
-            {RESOURCE_PROVENANCE_KEY: {"version": 1, "status": status}}
-        )
-        is True
-    )
+    config = {RESOURCE_PROVENANCE_KEY: {"version": 1, "status": status}}
+
+    assert exact_resume_resource_requirements(config) == (False, False)
+    assert resource_provenance_allows_resume(config) is True
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"status": "pending"},
+        {"version": 2, "status": "pending"},
+    ],
+    ids = ["missing-version", "wrong-version"],
+)
+def test_malformed_pending_provenance_is_rejected_consistently(marker):
+    config = {RESOURCE_PROVENANCE_KEY: marker}
+
+    with pytest.raises(ExactResumeResourcesUnavailable, match = "provenance is invalid"):
+        exact_resume_resource_requirements(config)
+    assert resource_provenance_allows_resume(config) is False
 
 
 def test_unattested_current_hub_dataset_cannot_resume_mutable_revision(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #8150 — the Resume button was hidden after Stop and Save on hub-model training runs when the worker had not yet attested model/dataset revisions.

## Root cause

`initialize_resource_provenance()` writes `{"version": 1, "status": "pending"}` at run start. If the user stops before the worker attests loaded resources, provenance stays `pending`. `exact_resume_resource_requirements()` treated that as "model revision not attested" and blocked both `can_resume_run` (UI) and resume start.

## Fix

Introduce `_provenance_awaiting_attestation()` to detect the initial pending state (no `model_status`/`dataset_status`, no snapshot paths). Those runs resume like legacy runs without exact resource pins. Unattested snapshot paths and `incomplete` provenance remain blocked.

## Test plan

- [x] `test_stop_and_save_before_attestation_allows_resume` — regression for #8150
- [x] `test_pending_hub_model_resume_before_attestation_is_allowed` — resume start path
- [x] `test_pending_current_hub_pins_are_not_treated_as_attested` — still blocks untrusted snapshot paths
- [x] 153 resume/provenance-related tests pass