### PR TITLE
fix(studio): release the inference subprocess's VRAM when its last model unloads

### DIFF
--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -1581,20 +1581,13 @@ class InferenceOrchestrator:
                     self.active_model_name = None
 
                 logger.info("Model '%s' unloaded from subprocess", model_name)
-                # The child's unload frees the model and calls empty_cache, but the
-                # caching allocator can only return blocks nothing still references,
-                # and the accelerator context is never returned while the process
-                # lives. An idle worker therefore keeps its high-water mark -- VRAM
-                # the GGUF backend cannot see, since it probes its own process. Both
-                # are chat-owned, so gpu_arbiter never evicts between them. Nothing
-                # left to serve means nothing worth keeping warm: drop it.
+                # empty_cache in the child cannot return the accelerator context, so an
+                # idle worker keeps its high-water mark -- VRAM the GGUF backend cannot
+                # see and gpu_arbiter never evicts (both are chat-owned). Nothing left
+                # to serve, so drop it; load_model respawns a fresh worker regardless.
                 if not self.models and not self.loading_models:
-                    logger.info(
-                        "No models left resident; shutting the inference subprocess "
-                        "down to return its GPU memory"
-                    )
-                    # The unload already succeeded, so a teardown that fails must not
-                    # report it as failed: the next load respawns the worker anyway.
+                    logger.info("No models left resident; shutting the inference subprocess down")
+                    # The unload already succeeded: a failed teardown must not report it failed.
                     try:
                         self._shutdown_subprocess(timeout = 5)
                     except Exception as exc:

--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -1581,6 +1581,24 @@ class InferenceOrchestrator:
                     self.active_model_name = None
 
                 logger.info("Model '%s' unloaded from subprocess", model_name)
+                # The child's unload frees the model and calls empty_cache, but the
+                # caching allocator can only return blocks nothing still references,
+                # and the accelerator context is never returned while the process
+                # lives. An idle worker therefore keeps its high-water mark -- VRAM
+                # the GGUF backend cannot see, since it probes its own process. Both
+                # are chat-owned, so gpu_arbiter never evicts between them. Nothing
+                # left to serve means nothing worth keeping warm: drop it.
+                if not self.models and not self.loading_models:
+                    logger.info(
+                        "No models left resident; shutting the inference subprocess "
+                        "down to return its GPU memory"
+                    )
+                    # The unload already succeeded, so a teardown that fails must not
+                    # report it as failed: the next load respawns the worker anyway.
+                    try:
+                        self._shutdown_subprocess(timeout = 5)
+                    except Exception as exc:
+                        logger.warning("Could not shut the idle inference subprocess down: %s", exc)
                 return True
 
             except Exception as exc:

--- a/studio/backend/tests/test_orchestrator_idle_subprocess_teardown.py
+++ b/studio/backend/tests/test_orchestrator_idle_subprocess_teardown.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Unloading the last model tears the inference subprocess down.
+
+The child's unload frees the model and calls empty_cache, but the caching
+allocator only returns blocks nothing still references and the accelerator
+context outlives every model, so an idle worker sat on its high-water mark.
+gpu_arbiter never evicts between the transformers and GGUF backends (both are
+chat-owned), so that memory stayed stranded for the rest of the session.
+"""
+
+import threading
+
+from core.inference.orchestrator import InferenceOrchestrator
+
+
+def _idle_orchestrator(models, loading = ()):
+    """An orchestrator whose unload round-trip is stubbed to succeed."""
+    o = InferenceOrchestrator.__new__(InferenceOrchestrator)
+    o._gen_lock = threading.Lock()
+    o._dispatcher_lifecycle_lock = threading.Lock()
+    o._drain_event = threading.Event()
+    o._unload_pending = False
+    o.models = dict(models)
+    o.loading_models = set(loading)
+    o.active_model_name = next(iter(models), None)
+
+    o.shutdowns = []
+    o.cancel_load = lambda _name: False
+    o._ensure_subprocess_alive = lambda: True
+    o._cancel_generation = lambda: None
+    o._wait_dispatcher_idle = lambda: True
+    o._drain_queue = lambda: None
+    o._send_cmd = lambda _cmd: None
+    o._wait_response = lambda _token: None
+    o._shutdown_subprocess = lambda timeout = 10.0: o.shutdowns.append(timeout)
+    return o
+
+
+def test_last_unload_shuts_the_subprocess_down():
+    o = _idle_orchestrator({"m": {}})
+
+    assert o.unload_model("m") is True
+    assert o.models == {}
+    assert o.shutdowns, "idle worker kept its VRAM after the last model unloaded"
+
+
+def test_unload_keeps_the_worker_while_a_model_is_still_resident():
+    o = _idle_orchestrator({"m": {}, "other": {}})
+
+    assert o.unload_model("m") is True
+    assert o.models == {"other": {}}
+    assert o.shutdowns == []
+
+
+def test_unload_keeps_the_worker_while_a_load_is_in_flight():
+    # Tearing down here would kill the load that is about to reuse the worker.
+    o = _idle_orchestrator({"m": {}}, loading = ("incoming",))
+
+    assert o.unload_model("m") is True
+    assert o.shutdowns == []

--- a/studio/backend/tests/test_orchestrator_idle_subprocess_teardown.py
+++ b/studio/backend/tests/test_orchestrator_idle_subprocess_teardown.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 """Unloading the last model tears the inference subprocess down.
 
-The child's unload frees the model and calls empty_cache, but the caching
-allocator only returns blocks nothing still references and the accelerator
-context outlives every model, so an idle worker sat on its high-water mark.
-gpu_arbiter never evicts between the transformers and GGUF backends (both are
-chat-owned), so that memory stayed stranded for the rest of the session.
+empty_cache in the child cannot return the accelerator context, so an idle
+worker sat on its high-water mark, and gpu_arbiter never evicts between the
+transformers and GGUF backends (both are chat-owned): the memory stayed
+stranded for the rest of the session.
 """
 
+import multiprocessing as mp
 import threading
+import time
 
 from core.inference.orchestrator import InferenceOrchestrator
 
@@ -58,3 +59,71 @@ def test_unload_keeps_the_worker_while_a_load_is_in_flight():
 
     assert o.unload_model("m") is True
     assert o.shutdowns == []
+
+
+# The stubs above cannot see a teardown that deadlocks or raises: the real
+# _shutdown_subprocess runs while unload_model holds _gen_lock and has set
+# _unload_pending, and it nulls the very _drain_event the unload clears in its
+# finally. These drive it for real against a live worker.
+
+
+def _sleeper(cmd_queue, resp_queue):
+    while True:
+        try:
+            msg = cmd_queue.get(timeout = 0.2)
+        except Exception:
+            continue
+        if isinstance(msg, dict) and msg.get("type") == "shutdown":
+            return
+
+
+def _live_orchestrator(models, loading = ()):
+    """A real orchestrator with a live dummy worker; only the round-trip is stubbed."""
+    ctx = mp.get_context("spawn")
+    o = InferenceOrchestrator()
+    o._cmd_queue, o._resp_queue = ctx.Queue(), ctx.Queue()
+    o._cancel_event, o._drain_event = ctx.Event(), ctx.Event()
+    o._proc = ctx.Process(target = _sleeper, args = (o._cmd_queue, o._resp_queue), daemon = True)
+    o._proc.start()
+    o.models = dict(models)
+    o.loading_models = set(loading)
+    o.active_model_name = next(iter(models), None)
+    o._send_cmd = lambda _cmd: None
+    o._wait_response = lambda _token: None
+    return o
+
+
+def test_real_teardown_kills_the_worker_and_leaves_clean_state():
+    o = _live_orchestrator({"m": {}})
+    proc, done, result = o._proc, threading.Event(), {}
+
+    def run():
+        result["ok"] = o.unload_model("m")
+        done.set()
+
+    threading.Thread(target = run, daemon = True).start()
+    assert done.wait(60), "unload_model deadlocked on the real teardown"
+    assert result["ok"] is True
+    assert o.models == {} and o.active_model_name is None
+    time.sleep(0.5)
+    assert not proc.is_alive(), "worker survived the teardown"
+    assert o._proc is None and o._unload_pending is False
+    # _gen_lock must be free for the next load.
+    assert o._gen_lock.acquire(timeout = 1)
+    o._gen_lock.release()
+
+
+def test_real_teardown_failure_still_reports_the_unload_as_succeeded():
+    o = _live_orchestrator({"m": {}})
+    proc = o._proc
+    try:
+        def boom(timeout = 10.0):
+            raise RuntimeError("teardown exploded")
+
+        o._shutdown_subprocess = boom
+        assert o.unload_model("m") is True
+        assert o.models == {}
+    finally:
+        del o._shutdown_subprocess
+        o._shutdown_subprocess(timeout = 5)
+        proc.join(timeout = 5)

--- a/studio/backend/tests/test_orchestrator_idle_subprocess_teardown.py
+++ b/studio/backend/tests/test_orchestrator_idle_subprocess_teardown.py
@@ -117,6 +117,7 @@ def test_real_teardown_failure_still_reports_the_unload_as_succeeded():
     o = _live_orchestrator({"m": {}})
     proc = o._proc
     try:
+
         def boom(timeout = 10.0):
             raise RuntimeError("teardown exploded")
 


### PR DESCRIPTION
Fixes #8220.

The transformers inference subprocess stays alive after its last model unloads, holding several GB of VRAM that nothing reclaims. Measured on a 16 GB card: 3.89 GB stranded, card at 16.12 GB against 16.0 GB dedicated.

`unload_model` already calls `clear_gpu_cache()` in the child and it runs, so this is not a missing `empty_cache()`. The allocator can only return blocks nothing still references, and the accelerator context outlives every model regardless. The surviving reference is unidentified; this change fixes the layer that holds independent of it.

`gpu_arbiter` evicts between owners, and both the transformers orchestrator and the llama.cpp GGUF backend are owner `CHAT`, so switching between them is an intra-owner handoff no evictor covers. Training start and diffusion/video acquisition both already tear the subprocess down; this adds the third case.

The stranded VRAM is also invisible to the GGUF context fit, which probes `torch.cuda.mem_get_info` in the parent process, so the fit budgets against a card it reads as empty (`GPUs free: [(0, 15939)]` with 3.89 GB resident elsewhere). That probe is a separate issue and is not touched here.

## Change

After a successful unload, if no models remain resident and no load is in flight, shut the worker down. The next load respawns it.

A teardown failure is logged, never surfaced: the unload has already succeeded at that point, and letting the exception reach the outer handler would report a successful unload as failed. (My first draft had exactly that bug; it broke four existing tests in `test_orchestrator_unload_cancel.py`, which is how it surfaced.)

Guarded on `loading_models` so a load already reusing the worker isn't killed.

## Verification

```
tests/test_orchestrator_idle_subprocess_teardown.py   3 passed  (new)
tests/test_orchestrator_unload_cancel.py             60 passed
-k "orchestrator or arbiter"                        108 passed, 4 skipped
```

New tests cover the last-model teardown, no teardown while another model is resident, and no teardown while a load is in flight.

`test_inference_orchestrator_crash_message.py::test_subprocess_crash_message_includes_signal_and_oom_hint` fails on this branch and on a clean tree (verified by stashing), so it is pre-existing and unrelated. `test_mcp_server.py` and `test_rag_ocr_fallback.py` fail collection on missing optional deps, also pre-existing.
