### PR TITLE
Let the pipeline gate survive a diffusers whose lazy submodule cannot import

### DIFF
--- a/studio/backend/core/inference/diffusion_families.py
+++ b/studio/backend/core/inference/diffusion_families.py
@@ -761,15 +761,22 @@ def assert_pipeline_class_available(pipeline_class: str, family_name: str) -> No
     500 with the message lost."""
     try:
         import diffusers
-    except ImportError:
+        present = hasattr(diffusers, pipeline_class)
+    except Exception:  # noqa: BLE001 -- see below: this check must never raise anything but its own ValueError
         # Not this check's business: it answers "is the installed diffusers new enough for this family", and with
-        # nothing installed there is no version to judge. Refusing would also break the native sd.cpp engine, which
+        # nothing importable there is no version to judge. Refusing would also break the native sd.cpp engine, which
         # serves GGUF picks on a CPU or Apple host without diffusers. A pick that really needs it fails later, in
         # the loader. The one thing that must not happen is a raise: ModuleNotFoundError is not the ValueError the
         # routes map to 400, so it escapes /images/download-plan as a bare 500 with the message lost.
+        #
+        # The attribute probe is inside the try for the same reason. diffusers' top level is a lazy module, so
+        # ``hasattr`` is what actually imports the pipeline's submodule, and when that submodule's own dependencies
+        # are unsatisfiable it raises RuntimeError ("Failed to import diffusers.pipelines...") -- which hasattr does
+        # NOT swallow, since it only absorbs AttributeError. A partially usable diffusers install therefore escaped
+        # this guard exactly the way a missing one used to.
         return
 
-    if hasattr(diffusers, pipeline_class):
+    if present:
         return
     raise ValueError(
         f"'{family_name}' needs diffusers >= 0.39.0 ({pipeline_class}); this environment has "

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -3291,6 +3291,28 @@ def test_pipeline_class_guard_is_silent_when_diffusers_is_absent(monkeypatch):
     assert assert_pipeline_class_available("ZImagePipeline", "z-image") is None
 
 
+def test_pipeline_class_guard_is_silent_when_a_lazy_submodule_cannot_import(monkeypatch):
+    # Same contract as the absent-diffusers case, for the install that is PRESENT but only
+    # partially usable. diffusers' top level is a lazy module, so the attribute probe is what
+    # actually imports the pipeline's submodule, and when that submodule's own dependencies are
+    # unsatisfiable it raises RuntimeError ("Failed to import diffusers.pipelines..."). hasattr
+    # absorbs AttributeError only, so the RuntimeError escaped this guard exactly the way a
+    # missing diffusers used to: not the ValueError the routes map to 400, so a bare 500 with the
+    # message lost.
+    import types
+
+    from core.inference.diffusion_families import assert_pipeline_class_available
+
+    class _LazyModule(types.ModuleType):
+        __version__ = "0.40.0"
+
+        def __getattr__(self, name):
+            raise RuntimeError(f"Failed to import diffusers.pipelines.{name.lower()}")
+
+    monkeypatch.setitem(sys.modules, "diffusers", _LazyModule("diffusers"))
+    assert assert_pipeline_class_available("ZImagePipeline", "z-image") is None
+
+
 def test_cached_pipeline_needs_a_detectable_image_family(monkeypatch):
     # A top-level model_index.json only proves the repo is a diffusers pipeline: an unsloth-hosted pipeline of a class this backend
     # cannot assemble cleared the trust gate, was advertised, then failed validate_load_request. Both gates now, like the video branch.


### PR DESCRIPTION
## The bug

`hasattr` absorbs `AttributeError` and nothing else.

`diffusers`' top level is a lazy module, so in `assert_pipeline_class_available` the attribute probe is what actually imports the pipeline's submodule. When that submodule's own dependencies are unsatisfiable it raises `RuntimeError("Failed to import diffusers.pipelines...")`, which walks straight out of the guard.

That is precisely the escape the existing `ImportError` catch was written to prevent. The docstring already says it: the one thing that must not happen is a raise, because anything other than `ValueError` is not what the routes map to 400, so it leaves `/images/download-plan` as a bare 500 with the message lost. A **partially usable** diffusers install hit that path exactly the way a missing one used to.

## Effect

Ten tests are red on `main` because of it. Same command, same tree, with only this guard swapped:

```
main's guard   10 failed, 204 passed
this branch             214 passed
```

```
FAILED tests/test_video_backend.py::test_validate_rejects_unknown_and_untrusted
FAILED tests/test_video_backend.py::test_validate_gates_base_repo_and_local_paths
FAILED tests/test_video_backend.py::test_validate_rejects_kind_extension_mismatch
FAILED tests/test_video_backend.py::test_validate_rejects_local_file_suffix_kind_mismatch
FAILED tests/test_video_backend.py::test_validate_rejects_windows_shaped_missing_checkpoint
FAILED tests/test_video_backend.py::test_validate_rejects_local_pipeline_without_model_index
FAILED tests/test_video_backend.py::test_validate_rejects_local_file_picked_as_pipeline
FAILED tests/test_video_backend.py::test_validate_rejects_local_base_repo_without_model_index
FAILED tests/test_cached_gguf_routes.py::test_pipeline_class_guard_passes_every_shipped_family
```

The eight `test_video_backend.py` ones have been carried as an environment problem for a while. They are not.

## Change

Move the attribute probe inside the `try` and widen the catch, so the guard cannot raise anything but its own `ValueError`. Eight lines, plus a test that fails when either half is reverted.
