### PR TITLE
Make the desktop release contract tests fail when the contract breaks

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -2072,7 +2072,7 @@ jobs:
               sys.exit(f'desktop-latest latest.json URL mismatch: expected {expected_url}, got {actual_url}')
           PY
 
-  # ── Advisory multi-engine scan of the bundles just published ──
+  # ── Advisory multi-engine scan of the bundles just uploaded ──
   # Defender (build job) is one vendor and gates only Windows. VirusTotal
   # aggregates ~70 engines across all four bundles, which is how a false
   # positive from some other vendor gets noticed here rather than in a user bug
@@ -2086,11 +2086,14 @@ jobs:
   # job it was ~9 minutes of the ~9.5 the job took, delaying every release by its
   # full length while being unable to block one.
   virustotal-scan:
-    name: VirusTotal post-publish scan
+    # Not "post-publish": `inputs.draft` defaults to true and the release is
+    # created with `--draft` on that input, so the ordinary run has uploaded the
+    # assets to a draft. The name has to read true for both dispatches.
+    name: VirusTotal release asset scan
     needs: [publish-release]
     runs-on: ubuntu-latest
     # A missing secret, a VirusTotal outage or quota exhaustion must not fail
-    # the release that already published.
+    # the release whose assets are already uploaded.
     continue-on-error: true
     timeout-minutes: 30
     steps:
@@ -2137,7 +2140,10 @@ jobs:
           if [ -f "$summary" ]; then
             cat "$summary" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo '### VirusTotal post-publish scan' >> "$GITHUB_STEP_SUMMARY"
+            # Must stay byte-identical to SUMMARY_HEADING in
+            # scripts/virustotal_scan.py, or a run that produced no summary shows
+            # a second, unrelated section. A test ties the two together.
+            echo '### VirusTotal release asset scan' >> "$GITHUB_STEP_SUMMARY"
             echo '' >> "$GITHUB_STEP_SUMMARY"
             echo 'The scan step produced no summary.' >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/scripts/virustotal_scan.py
+++ b/scripts/virustotal_scan.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Advisory VirusTotal pre-flight scan of the built desktop release bundles.
+"""Advisory VirusTotal scan of the published desktop release bundles.
 
 Stdlib only on purpose: this runs on a bare `ubuntu-latest` runner right after the
 artifacts are downloaded, before any Python environment is provisioned, so it cannot
@@ -185,10 +185,15 @@ def _md_text(text: str) -> str:
     return escaped.replace("<", "&lt;").replace(">", "&gt;")
 
 
+# Matched by the workflow step that writes a placeholder when the scan
+# produced no summary, so a reader sees one heading either way.
+SUMMARY_HEADING = "### VirusTotal post-publish scan"
+
+
 def render_markdown(reports: Sequence[FileReport], threshold: int) -> str:
     """Render the job-summary table. Kept pure so it is unit testable."""
     lines = [
-        "### VirusTotal pre-flight scan",
+        SUMMARY_HEADING,
         "",
         "| Asset | Malicious | Suspicious | Undetected | Harmless | Timeout | Source |",
         "| --- | ---: | ---: | ---: | ---: | ---: | --- |",

--- a/scripts/virustotal_scan.py
+++ b/scripts/virustotal_scan.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Advisory VirusTotal scan of the published desktop release bundles.
+"""Advisory VirusTotal scan of the desktop release bundles.
+
+Runs after `publish-release` has uploaded the assets, which for the default
+`draft: true` dispatch means they are attached to a draft rather than published.
 
 Stdlib only on purpose: this runs on a bare `ubuntu-latest` runner right after the
 artifacts are downloaded, before any Python environment is provisioned, so it cannot
@@ -187,7 +190,14 @@ def _md_text(text: str) -> str:
 
 # Matched by the workflow step that writes a placeholder when the scan
 # produced no summary, so a reader sees one heading either way.
-SUMMARY_HEADING = "### VirusTotal post-publish scan"
+#
+# Deliberately says neither "pre-flight" nor "post-publish". The scan runs after
+# `publish-release`, but `inputs.draft` defaults to true and the release is
+# created with `--draft` on that input, so the ordinary run has uploaded the
+# assets to a draft rather than published them. Either heading would tell a
+# release operator the opposite of what the run actually did in one of the two
+# cases; naming the assets covers both.
+SUMMARY_HEADING = "### VirusTotal release asset scan"
 
 
 def render_markdown(reports: Sequence[FileReport], threshold: int) -> str:
@@ -714,15 +724,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             "virustotal_scan: VT_API_KEY is unset or empty; skipping the scan.",
             flush = True,
         )
-        _write_markdown(
-            "### VirusTotal pre-flight scan\n\nSkipped: no API key configured for this run.\n"
-        )
+        _write_markdown(f"{SUMMARY_HEADING}\n\nSkipped: no API key configured for this run.\n")
         return 0
 
     targets = collect_paths(args.paths)
     if not targets:
         print("virustotal_scan: no scannable bundles found.", flush = True)
-        _write_markdown("### VirusTotal pre-flight scan\n\nSkipped: no scannable bundles found.\n")
+        _write_markdown(f"{SUMMARY_HEADING}\n\nSkipped: no scannable bundles found.\n")
         return 0
 
     client = VirusTotalClient(api_key, request_interval = args.request_interval)

--- a/scripts/virustotal_scan.py
+++ b/scripts/virustotal_scan.py
@@ -188,15 +188,13 @@ def _md_text(text: str) -> str:
     return escaped.replace("<", "&lt;").replace(">", "&gt;")
 
 
-# Matched by the workflow step that writes a placeholder when the scan
-# produced no summary, so a reader sees one heading either way.
+# Also written by the workflow's placeholder step, so a reader sees one heading
+# whether or not the scan produced a summary.
 #
-# Deliberately says neither "pre-flight" nor "post-publish". The scan runs after
-# `publish-release`, but `inputs.draft` defaults to true and the release is
-# created with `--draft` on that input, so the ordinary run has uploaded the
-# assets to a draft rather than published them. Either heading would tell a
-# release operator the opposite of what the run actually did in one of the two
-# cases; naming the assets covers both.
+# Says neither "pre-flight" nor "post-publish": the scan runs after
+# `publish-release`, but `inputs.draft` defaults to true, so the ordinary run
+# has uploaded the assets to a draft rather than published them. Naming the
+# assets is the only wording true of both dispatches.
 SUMMARY_HEADING = "### VirusTotal release asset scan"
 
 

--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -892,9 +892,7 @@ class TestWorkflowOrdering:
         # Scanning a different directory would report on nothing at all.
         steps = self._job("virustotal-scan")["steps"]
         download = next(
-            step
-            for step in steps
-            if step.get("uses", "").startswith("actions/download-artifact@")
+            step for step in steps if step.get("uses", "").startswith("actions/download-artifact@")
         )
         # The two spell the runner temp dir differently, so compare the leaf.
         target = download["with"]["path"].rstrip("/").rsplit("/", 1)[-1]
@@ -920,8 +918,6 @@ class TestWorkflowOrdering:
             if step.get("uses", "").startswith("actions/checkout@")
         )
         scan = next(
-            index
-            for index, step in enumerate(steps)
-            if "virustotal_scan.py" in step.get("run", "")
+            index for index, step in enumerate(steps) if "virustotal_scan.py" in step.get("run", "")
         )
         assert checkout < scan, [step.get("name") for step in steps]

--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Unit tests for the advisory VirusTotal pre-flight scan.
+"""Unit tests for the advisory VirusTotal post-publish scan.
 
 Offline by design: every test injects a fake transport, so the suite never spends
 the account's 500/day quota and never uploads a build. The two behaviours worth
@@ -442,7 +442,7 @@ class TestDeadlineEnforcement:
             ]
         )
         assert rc == 0
-        assert "VirusTotal pre-flight scan" in summary.read_text()
+        assert vt.SUMMARY_HEADING in summary.read_text()
 
 
 class TestRenderMarkdown:
@@ -808,13 +808,20 @@ class TestRetryBackoffRespectsTheDeadline:
 
 
 class TestWorkflowOrdering:
-    """The scan must not disclose bundles for a release that cannot be published."""
+    """The scan must cover the bundles a published release actually ships."""
 
-    def _publish_step_list(self):
+    def _jobs(self):
         yaml = pytest.importorskip("yaml")
         workflow = REPO_ROOT / ".github" / "workflows" / "release-desktop.yml"
-        data = yaml.safe_load(workflow.read_text(encoding = "utf-8"))
-        return data["jobs"]["publish-release"]["steps"]
+        return yaml.safe_load(workflow.read_text(encoding = "utf-8"))["jobs"]
+
+    def _job(self, name = "publish-release"):
+        jobs = self._jobs()
+        assert name in jobs, f"no {name!r} job in: {sorted(jobs)}"
+        return jobs[name]
+
+    def _publish_step_list(self):
+        return self._job()["steps"]
 
     def _publish_steps(self):
         return [step.get("name") for step in self._publish_step_list()]
@@ -822,20 +829,33 @@ class TestWorkflowOrdering:
     def _publish_step_map(self):
         return {step.get("name"): step for step in self._publish_step_list()}
 
-    def test_scan_runs_after_the_release_is_validated(self):
-        names = self._publish_steps()
-        assert names.index("Validate versioned release state") < names.index(
-            "VirusTotal pre-flight scan"
-        )
+    def _in_order(self, steps, *names):
+        """Assert `names` appear in this order, naming any that are missing."""
+        present = [step.get("name") for step in steps]
+        missing = [name for name in names if name not in present]
+        assert not missing, f"missing step(s) {missing} in: {present}"
+        found = [present.index(name) for name in names]
+        assert found == sorted(found), f"expected {list(names)} in order, got: {present}"
 
-    def test_release_creation_is_deferred_until_after_the_scan(self):
+    def test_the_scan_runs_once_the_release_is_published(self):
+        # The scan moved out of publish-release into its own job (#8194), so the
+        # ordering guarantee is now the dependency edge rather than step order.
+        scan = self._job("virustotal-scan")
+        assert "publish-release" in (scan.get("needs") or []), scan.get("needs")
+
+    def test_the_scan_job_cannot_write_to_the_repository(self):
+        # It only reads published bundles, so it must not inherit release rights.
+        assert self._job("virustotal-scan").get("permissions", {}).get("contents") != "write"
+
+    def test_release_creation_is_deferred_until_the_state_is_validated(self):
         # `gh release create` without `--draft` publishes at once, so creating a
-        # new release before the scan would expose an empty release for its
-        # duration, and leave it empty for good if the run were cancelled.
-        names = self._publish_steps()
-        assert names.index("VirusTotal pre-flight scan") < names.index("Create versioned release")
-        assert names.index("Create versioned release") < names.index(
-            "Publish versioned release assets"
+        # release before its state is validated would expose an empty release,
+        # and leave it empty for good if the run were cancelled.
+        self._in_order(
+            self._publish_step_list(),
+            "Validate versioned release state",
+            "Create versioned release",
+            "Publish versioned release assets",
         )
 
     def test_release_notes_are_written_unconditionally(self):
@@ -868,13 +888,40 @@ class TestWorkflowOrdering:
             == "steps.versioned_release_state.outputs.create == 'true'"
         )
 
-    def test_scan_runs_before_the_assets_are_published(self):
-        names = self._publish_steps()
-        assert names.index("VirusTotal pre-flight scan") < names.index(
-            "Publish versioned release assets"
+    def test_the_scan_covers_the_same_bundles_that_were_published(self):
+        # Scanning a different directory would report on nothing at all.
+        steps = self._job("virustotal-scan")["steps"]
+        download = next(
+            step
+            for step in steps
+            if step.get("uses", "").startswith("actions/download-artifact@")
         )
+        # The two spell the runner temp dir differently, so compare the leaf.
+        target = download["with"]["path"].rstrip("/").rsplit("/", 1)[-1]
+        scan = next(step for step in steps if "virustotal_scan.py" in step.get("run", ""))
+        assert f"/{target}" in scan["run"], scan["run"]
+
+    def test_the_placeholder_summary_matches_the_real_one(self):
+        # The fallback runs when the scan produced nothing, so a differing
+        # heading would show up as a second, unrelated summary section.
+        publish = next(
+            step
+            for step in self._job("virustotal-scan")["steps"]
+            if step.get("name") == "Publish VirusTotal summary"
+        )
+        assert vt.SUMMARY_HEADING in publish["run"], publish["run"]
 
     def test_the_scan_script_is_checked_out_first(self):
-        # publish-release otherwise has no source tree, so the script would be missing.
-        names = self._publish_steps()
-        assert names.index("Check out the scan script") < names.index("VirusTotal pre-flight scan")
+        # The scan job otherwise has no source tree, so the script would be missing.
+        steps = self._job("virustotal-scan")["steps"]
+        checkout = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("uses", "").startswith("actions/checkout@")
+        )
+        scan = next(
+            index
+            for index, step in enumerate(steps)
+            if "virustotal_scan.py" in step.get("run", "")
+        )
+        assert checkout < scan, [step.get("name") for step in steps]

--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -890,35 +890,24 @@ class TestWorkflowOrdering:
         assert job["needs"] == ["publish-release"]
 
     def test_the_scan_job_is_not_conditioned_away(self):
-        # `needs:` alone carries GitHub's default `success()` gating, which is
-        # what stops the scan from shipping build artifacts to a third party
-        # after a publish-release that failed. A job-level `if:` replaces that
-        # gating, so the job may carry none, as it does today, or one that keeps
-        # `success()` conjunctively. Conjunctively is the point: a substring
-        # check would wave through `success() || inputs.scan_anyway`, which
-        # still runs on a failed publish. Requiring no `||` and a leading
-        # `success() &&` keeps every accepted form narrower than the default.
+        # `needs:` alone carries GitHub's default `success()` gating, so whether
+        # the scan runs is decided by publish-release and nothing else. The job
+        # therefore carries no `if:` at all, and this rejects every one rather
+        # than trying to sort the safe conditions from the unsafe.
+        #
+        # Sorting them does not work. A job-level `if:` fails in both directions:
+        # `always()` or `success() || inputs.scan_anyway` sends build artifacts
+        # to a third party after a publish that failed, while `${{ false }}` or
+        # `success() && <anything falsey>` silently skips the sweep after a
+        # publish that succeeded. Any rule permissive enough to admit an
+        # arbitrary trailing predicate admits the second kind, so the contract
+        # is simply that reaching this job is `needs:`'s decision alone.
         job = self._scan_job()
-        condition = job.get("if")
-        if condition is not None:
-            normalised = str(condition).strip()
-            if normalised.startswith("${{") and normalised.endswith("}}"):
-                normalised = normalised[3:-2]
-            normalised = "".join(normalised.split())
-            assert "||" not in normalised, (
-                f"virustotal-scan carries `if: {condition}`; a disjunction can run the "
-                "scan on a branch where publish-release did not succeed"
-            )
-            assert normalised == "success()" or normalised.startswith("success()&&"), (
-                f"virustotal-scan carries `if: {condition}`, which does not require "
-                "success() conjunctively and so drops the gating that "
-                "needs: [publish-release] provides by default"
-            )
-            for override in ("always()", "failure()", "cancelled()"):
-                assert override not in normalised, (
-                    f"virustotal-scan carries `if: {condition}`, which runs the scan "
-                    "for outcomes other than a successful publish-release"
-                )
+        assert "if" not in job, (
+            f"virustotal-scan carries `if: {job.get('if')}`; a job-level condition "
+            "either runs the scan without a successful publish-release or skips it "
+            "after one, and `needs:` already gates it correctly"
+        )
 
         # Nor may the individual steps be skipped, except the summary, which is
         # `if: always()` precisely so the evidence survives a failed scan.

--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -24,7 +24,9 @@ from __future__ import annotations
 
 import fnmatch
 import importlib.util
+import itertools
 import pathlib
+import shlex
 import sys
 import time
 
@@ -859,8 +861,27 @@ class TestWorkflowOrdering:
         return [step.get("name") for step in self._scan_job()["steps"]]
 
     @staticmethod
-    def _leaf(path):
-        return path.rstrip("/").rsplit("/", 1)[-1]
+    def _runner_temp(path):
+        """Normalise the three spellings of the runner temp dir to one token.
+
+        `with:` uses the `${{ runner.temp }}` expression and `run:` uses the
+        `RUNNER_TEMP` env var, so two paths can name the same directory and
+        still compare unequal as strings.
+        """
+        normalised = " ".join(str(path).split())
+        for spelling in ("${{ runner.temp }}", "${RUNNER_TEMP}", "$RUNNER_TEMP"):
+            normalised = normalised.replace(spelling, "<RUNNER_TEMP>")
+        return normalised.rstrip("/")
+
+    def _scan_script_argv(self):
+        """The argv the `VirusTotal scan` step hands to virustotal_scan.py."""
+        run = self._scan_step_map()["VirusTotal scan"]["run"]
+        command = run.replace("\\\n", " ")
+        line = next(
+            text for text in command.split("\n") if "python3 scripts/virustotal_scan.py" in text
+        )
+        argv = shlex.split(line)
+        return argv[argv.index("scripts/virustotal_scan.py") + 1 :]
 
     def test_the_scan_is_its_own_job_gated_on_publish_release(self):
         # Pins the post-publish ordering rather than merely tolerating it: the
@@ -876,15 +897,29 @@ class TestWorkflowOrdering:
         # `failure()` or `cancelled()` would upload build artifacts to a third
         # party on the strength of a failed publish-release, and `${{ false }}`
         # would disable the scan without deleting the job. So the job may either
-        # carry no `if:` at all, as it does today, or one that still requires
-        # `success()` and adds to it.
+        # carry no `if:` at all, as it does today, or one that requires
+        # `success()` *conjunctively* and only narrows it further.
+        #
+        # Conjunctively is the whole point: `success() || inputs.scan_anyway`
+        # mentions success() while still running the scan after publish-release
+        # failed, so a substring check would wave it through. Requiring the
+        # condition to open with `success() &&` and to contain no `||` keeps
+        # every accepted form strictly narrower than the default gate.
         job = self._scan_job()
         condition = job.get("if")
         if condition is not None:
-            normalised = str(condition).replace(" ", "")
-            assert "success()" in normalised, (
-                f"virustotal-scan carries `if: {condition}`, which drops the success() "
-                "gating that needs: [publish-release] provides by default"
+            normalised = str(condition).strip()
+            if normalised.startswith("${{") and normalised.endswith("}}"):
+                normalised = normalised[3:-2]
+            normalised = "".join(normalised.split())
+            assert "||" not in normalised, (
+                f"virustotal-scan carries `if: {condition}`; a disjunction can run the "
+                "scan on a branch where publish-release did not succeed"
+            )
+            assert normalised == "success()" or normalised.startswith("success()&&"), (
+                f"virustotal-scan carries `if: {condition}`, which does not require "
+                "success() conjunctively and so drops the gating that "
+                "needs: [publish-release] provides by default"
             )
             for override in ("always()", "failure()", "cancelled()"):
                 assert override not in normalised, (
@@ -934,8 +969,21 @@ class TestWorkflowOrdering:
                 download["with"].get(key),
                 publish_download["with"].get(key),
             )
-        # The two spell the runner temp directory differently, so compare leaves.
-        assert self._leaf(download["with"]["path"]) == self._leaf(publish_download["with"]["path"])
+        assert self._runner_temp(download["with"]["path"]) == self._runner_temp(
+            publish_download["with"]["path"]
+        ), (download["with"]["path"], publish_download["with"]["path"])
+
+        # And the scan has to be pointed at that same directory. Comparing the
+        # two download steps alone leaves the gap this test exists to close: the
+        # script takes its target as an argument, so moving both downloads under
+        # a new parent, or repointing the argument at another `$RUNNER_TEMP`
+        # path, would scan an empty directory and still report a clean sweep.
+        argv = self._scan_script_argv()
+        scan_paths = list(itertools.takewhile(lambda argument: not argument.startswith("-"), argv))
+        assert scan_paths, argv
+        assert [self._runner_temp(path) for path in scan_paths] == [
+            self._runner_temp(download["with"]["path"])
+        ], (argv, download["with"]["path"])
 
         # And that shared pattern has to match what the matrix actually uploads,
         # or both jobs would agree on a set that does not exist.

--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -864,9 +864,8 @@ class TestWorkflowOrdering:
     def _runner_temp(path):
         """Normalise the three spellings of the runner temp dir to one token.
 
-        `with:` uses the `${{ runner.temp }}` expression and `run:` uses the
-        `RUNNER_TEMP` env var, so two paths can name the same directory and
-        still compare unequal as strings.
+        `with:` uses `${{ runner.temp }}` and `run:` uses `$RUNNER_TEMP`, so two
+        paths can name one directory and still compare unequal.
         """
         normalised = " ".join(str(path).split())
         for spelling in ("${{ runner.temp }}", "${RUNNER_TEMP}", "$RUNNER_TEMP"):
@@ -891,20 +890,14 @@ class TestWorkflowOrdering:
         assert job["needs"] == ["publish-release"]
 
     def test_the_scan_job_is_not_conditioned_away(self):
-        # `needs:` alone gives ordering plus GitHub's default `success()` gating,
-        # which is what keeps the scan from running after a publication that
-        # never happened. A job-level `if:` overrides that gating: `always()`,
-        # `failure()` or `cancelled()` would upload build artifacts to a third
-        # party on the strength of a failed publish-release, and `${{ false }}`
-        # would disable the scan without deleting the job. So the job may either
-        # carry no `if:` at all, as it does today, or one that requires
-        # `success()` *conjunctively* and only narrows it further.
-        #
-        # Conjunctively is the whole point: `success() || inputs.scan_anyway`
-        # mentions success() while still running the scan after publish-release
-        # failed, so a substring check would wave it through. Requiring the
-        # condition to open with `success() &&` and to contain no `||` keeps
-        # every accepted form strictly narrower than the default gate.
+        # `needs:` alone carries GitHub's default `success()` gating, which is
+        # what stops the scan from shipping build artifacts to a third party
+        # after a publish-release that failed. A job-level `if:` replaces that
+        # gating, so the job may carry none, as it does today, or one that keeps
+        # `success()` conjunctively. Conjunctively is the point: a substring
+        # check would wave through `success() || inputs.scan_anyway`, which
+        # still runs on a failed publish. Requiring no `||` and a leading
+        # `success() &&` keeps every accepted form narrower than the default.
         job = self._scan_job()
         condition = job.get("if")
         if condition is not None:
@@ -953,11 +946,10 @@ class TestWorkflowOrdering:
         assert download["uses"].startswith("actions/download-artifact@")
         assert download["with"]["merge-multiple"] is True
 
-        # Tie the scan's input to publish-release's own artifact download rather
-        # than to a literal repeated in both places. What has to hold is that the
-        # scan covers the set that was released: if publish-release ever ships a
-        # different artifact set, a scan still pulling the old pattern would
-        # leave the shipped installers unscanned while reporting a clean sweep.
+        # Tie the scan's input to publish-release's own download rather than to
+        # a literal repeated in both places: if publish ever ships a different
+        # artifact set, a scan still pulling the old pattern leaves the shipped
+        # installers unscanned and still reports a clean sweep.
         publish_download = next(
             step
             for step in self._publish_step_list()
@@ -973,11 +965,9 @@ class TestWorkflowOrdering:
             publish_download["with"]["path"]
         ), (download["with"]["path"], publish_download["with"]["path"])
 
-        # And the scan has to be pointed at that same directory. Comparing the
-        # two download steps alone leaves the gap this test exists to close: the
-        # script takes its target as an argument, so moving both downloads under
-        # a new parent, or repointing the argument at another `$RUNNER_TEMP`
-        # path, would scan an empty directory and still report a clean sweep.
+        # And the scan has to be pointed at that same directory. The script takes
+        # its target as an argument, so comparing only the two download steps
+        # lets a repointed argument scan an empty directory and report clean.
         argv = self._scan_script_argv()
         scan_paths = list(itertools.takewhile(lambda argument: not argument.startswith("-"), argv))
         assert scan_paths, argv
@@ -1123,9 +1113,9 @@ class TestWorkflowOrdering:
         assert "virustotal-summary.md" in summary["run"]
 
     def test_the_placeholder_summary_matches_the_real_one(self):
-        # The placeholder is written when the scan produced no summary at all, so
-        # a heading that differs from the script's would render as a second,
-        # unrelated section rather than as the report the reader is looking for.
+        # The placeholder stands in when the scan produced no summary, so a
+        # heading that drifts from the script's renders as a second, unrelated
+        # section instead of the report the reader came for.
         summary = self._scan_step_map()["Publish VirusTotal summary"]
         assert vt.SUMMARY_HEADING in summary["run"], summary["run"]
 

--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Unit tests for the advisory VirusTotal post-publish scan.
+"""Unit tests for the advisory VirusTotal release asset scan.
 
-The scan is a sweep of the bundles a release has already published, run in the
-`virustotal-scan` job after `publish-release`. It is not a gate and cannot hold
-a release back; Defender in the build job is the fail-closed check.
+The scan is a sweep of the bundles `publish-release` uploaded, run in the
+`virustotal-scan` job after it. Those bundles are attached to a draft on the
+default dispatch and to a published release otherwise, which is why neither the
+job nor the summary heading claims a publication. It is not a gate and cannot
+hold a release back; Defender in the build job is the fail-closed check.
 
 Offline by design: every test injects a fake transport, so the suite never spends
 the account's 500/day quota and never uploads a build. The two behaviours worth
@@ -20,6 +22,7 @@ protecting are the ones a release depends on:
 
 from __future__ import annotations
 
+import fnmatch
 import importlib.util
 import pathlib
 import sys
@@ -446,7 +449,7 @@ class TestDeadlineEnforcement:
             ]
         )
         assert rc == 0
-        assert "VirusTotal pre-flight scan" in summary.read_text()
+        assert vt.SUMMARY_HEADING in summary.read_text()
 
 
 class TestRenderMarkdown:
@@ -855,6 +858,10 @@ class TestWorkflowOrdering:
     def _scan_step_names(self):
         return [step.get("name") for step in self._scan_job()["steps"]]
 
+    @staticmethod
+    def _leaf(path):
+        return path.rstrip("/").rsplit("/", 1)[-1]
+
     def test_the_scan_is_its_own_job_gated_on_publish_release(self):
         # Pins the post-publish ordering rather than merely tolerating it: the
         # job must exist and must be downstream of publish-release, so dropping
@@ -863,10 +870,27 @@ class TestWorkflowOrdering:
         assert job["needs"] == ["publish-release"]
 
     def test_the_scan_job_is_not_conditioned_away(self):
-        # A job-level `if:` is the quiet way to disable a scan without deleting
-        # it, so the job carries none: reaching it is decided by `needs` alone.
+        # `needs:` alone gives ordering plus GitHub's default `success()` gating,
+        # which is what keeps the scan from running after a publication that
+        # never happened. A job-level `if:` overrides that gating: `always()`,
+        # `failure()` or `cancelled()` would upload build artifacts to a third
+        # party on the strength of a failed publish-release, and `${{ false }}`
+        # would disable the scan without deleting the job. So the job may either
+        # carry no `if:` at all, as it does today, or one that still requires
+        # `success()` and adds to it.
         job = self._scan_job()
-        assert "if" not in job
+        condition = job.get("if")
+        if condition is not None:
+            normalised = str(condition).replace(" ", "")
+            assert "success()" in normalised, (
+                f"virustotal-scan carries `if: {condition}`, which drops the success() "
+                "gating that needs: [publish-release] provides by default"
+            )
+            for override in ("always()", "failure()", "cancelled()"):
+                assert override not in normalised, (
+                    f"virustotal-scan carries `if: {condition}`, which runs the scan "
+                    "for outcomes other than a successful publish-release"
+                )
 
         # Nor may the individual steps be skipped, except the summary, which is
         # `if: always()` precisely so the evidence survives a failed scan.
@@ -882,17 +906,46 @@ class TestWorkflowOrdering:
         # artifacts the build matrix uploaded and publish-release shipped. A
         # pattern that matched nothing would scan an empty directory and still
         # report success.
+        build = self._workflow()["jobs"]["build"]
         upload_names = {
             step.get("with", {}).get("name")
-            for step in self._workflow()["jobs"]["build"]["steps"]
+            for step in build["steps"]
             if step.get("uses", "").startswith("actions/upload-artifact@")
         }
         assert "desktop-release-${{ matrix.artifact }}" in upload_names
 
         download = self._scan_step_map()["Download published assets"]
         assert download["uses"].startswith("actions/download-artifact@")
-        assert download["with"]["pattern"] == "desktop-release-*"
         assert download["with"]["merge-multiple"] is True
+
+        # Tie the scan's input to publish-release's own artifact download rather
+        # than to a literal repeated in both places. What has to hold is that the
+        # scan covers the set that was released: if publish-release ever ships a
+        # different artifact set, a scan still pulling the old pattern would
+        # leave the shipped installers unscanned while reporting a clean sweep.
+        publish_download = next(
+            step
+            for step in self._publish_step_list()
+            if step.get("uses", "").startswith("actions/download-artifact@")
+        )
+        for key in ("pattern", "merge-multiple"):
+            assert download["with"][key] == publish_download["with"][key], (
+                key,
+                download["with"].get(key),
+                publish_download["with"].get(key),
+            )
+        # The two spell the runner temp directory differently, so compare leaves.
+        assert self._leaf(download["with"]["path"]) == self._leaf(publish_download["with"]["path"])
+
+        # And that shared pattern has to match what the matrix actually uploads,
+        # or both jobs would agree on a set that does not exist.
+        template = "desktop-release-${{ matrix.artifact }}"
+        for entry in build["strategy"]["matrix"]["include"]:
+            artifact = template.replace("${{ matrix.artifact }}", entry["artifact"])
+            assert fnmatch.fnmatch(artifact, download["with"]["pattern"]), (
+                artifact,
+                download["with"]["pattern"],
+            )
 
         names = self._scan_step_names()
         assert names.index("Download published assets") < names.index("VirusTotal scan")
@@ -1020,3 +1073,28 @@ class TestWorkflowOrdering:
         assert summary["if"] == "always()"
         assert "$GITHUB_STEP_SUMMARY" in summary["run"]
         assert "virustotal-summary.md" in summary["run"]
+
+    def test_the_placeholder_summary_matches_the_real_one(self):
+        # The placeholder is written when the scan produced no summary at all, so
+        # a heading that differs from the script's would render as a second,
+        # unrelated section rather than as the report the reader is looking for.
+        summary = self._scan_step_map()["Publish VirusTotal summary"]
+        assert vt.SUMMARY_HEADING in summary["run"], summary["run"]
+
+    def test_the_summary_heading_holds_for_a_draft_release_too(self):
+        # `inputs.draft` defaults to true and "Create versioned release" only
+        # adds --draft when it is set, so the ordinary dispatch leaves a draft
+        # behind and nothing is published. A heading calling this a post-publish
+        # scan would tell a release operator the opposite of what happened, so
+        # the wording has to cover an upload to a draft as well as a publication.
+        workflow = self._workflow()
+        draft = workflow.get("on", workflow.get(True))["workflow_dispatch"]["inputs"]["draft"]
+        assert draft["default"] is True
+
+        create = self._publish_step_map()["Create versioned release"]["run"]
+        assert 'release_flags+=(--draft)' in create
+        assert '"$RELEASE_DRAFT" = "true"' in create
+
+        heading = vt.SUMMARY_HEADING.lower()
+        for claim in ("post-publish", "published", "pre-flight"):
+            assert claim not in heading, (vt.SUMMARY_HEADING, claim)

--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -1092,7 +1092,7 @@ class TestWorkflowOrdering:
         assert draft["default"] is True
 
         create = self._publish_step_map()["Create versioned release"]["run"]
-        assert 'release_flags+=(--draft)' in create
+        assert "release_flags+=(--draft)" in create
         assert '"$RELEASE_DRAFT" = "true"' in create
 
         heading = vt.SUMMARY_HEADING.lower()

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -1,5 +1,6 @@
 """Permission-boundary checks for the desktop release workflow."""
 
+import re
 from pathlib import Path
 
 import yaml
@@ -45,10 +46,30 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     assert any(
         step.get("uses", "").startswith("actions/upload-artifact@") for step in build["steps"]
     )
-    assert any(
-        step.get("uses", "").startswith("actions/download-artifact@") for step in publish["steps"]
+    download = next(
+        (
+            index
+            for index, step in enumerate(publish["steps"])
+            if step.get("uses", "").startswith("actions/download-artifact@")
+        ),
+        None,
     )
-    assert "build" in publish["needs"]
+    assert download is not None, [step.get("name") for step in publish["steps"]]
+
+    # The publish job starts alongside the build matrix rather than through
+    # `needs: build`, so the hand-off is a wait step that has to clear before
+    # the assets are downloaded. Either shape keeps the ordering guarantee.
+    if "build" not in (publish.get("needs") or []):
+        wait = next(
+            (
+                index
+                for index, step in enumerate(publish["steps"])
+                if "GITHUB_RUN_ID" in step.get("run", "")
+            ),
+            None,
+        )
+        assert wait is not None, "publish-release neither needs build nor waits for it"
+        assert wait < download, [step.get("name") for step in publish["steps"]]
 
     # The guard moved into a validation step that runs ahead of the VirusTotal
     # scan; creating a missing release is deferred to a separate step so a
@@ -64,6 +85,30 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     )
     assert "gh release create" in create_step["run"]
     assert create_step["if"] == "steps.versioned_release_state.outputs.create == 'true'"
+
+
+def test_the_wait_step_polls_every_build_matrix_leg_by_its_real_name():
+    # The wait step matches jobs by name. Renaming a matrix label, or adding a
+    # leg, would otherwise leave it waiting on a job that never reports, or
+    # publishing while a leg is still building.
+    jobs = _workflow()["jobs"]
+    build = jobs["build"]
+    if "build" in (jobs["publish-release"].get("needs") or []):
+        return
+
+    wait = next(
+        step
+        for step in jobs["publish-release"]["steps"]
+        if "GITHUB_RUN_ID" in step.get("run", "")
+    )
+    # Leg names carry their own parentheses, so take the LEGS line, not to `)`.
+    legs = re.findall(r"'([^']+)'", wait["run"].split("LEGS=(", 1)[1].split("\n", 1)[0])
+    template = build["name"]
+    expected = [
+        template.replace("${{ matrix.label }}", entry["label"])
+        for entry in build["strategy"]["matrix"]["include"]
+    ]
+    assert sorted(legs) == sorted(expected), (legs, expected)
 
 
 def test_versioned_release_hides_updater_signature_assets():

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -97,9 +97,7 @@ def test_the_wait_step_polls_every_build_matrix_leg_by_its_real_name():
         return
 
     wait = next(
-        step
-        for step in jobs["publish-release"]["steps"]
-        if "GITHUB_RUN_ID" in step.get("run", "")
+        step for step in jobs["publish-release"]["steps"] if "GITHUB_RUN_ID" in step.get("run", "")
     )
     # Leg names carry their own parentheses, so take the LEGS line, not to `)`.
     legs = re.findall(r"'([^']+)'", wait["run"].split("LEGS=(", 1)[1].split("\n", 1)[0])

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -28,15 +28,24 @@ def test_only_publish_job_can_write_repository_contents():
 
 
 def _poll_loop_body(script):
-    """Return the body of the first `while ...; do ... done` loop in `script`.
+    """Return the body of the first live `while ...; do ... done` loop.
 
     Assertions about a wait have to land inside the loop that waits, not
-    anywhere in the step. Nesting is tracked by depth; every opener in this
-    workflow ends its line with `do`.
+    anywhere in the step, and that loop has to be one the shell actually
+    enters: `while false; do` keeps a textually perfect body while skipping
+    every API read and status check, and the step falls straight through to a
+    download that races the matrix. So the condition must be the unconditional
+    `:` or `true` that a poll exiting via `break` uses. Nesting is tracked by
+    depth; every opener in this workflow ends its line with `do`.
     """
     lines = script.split("\n")
-    starts = [index for index, line in enumerate(lines) if re.match(r"\s*while\b", line)]
-    assert starts, f"no `while` loop in the wait step:\n{script}"
+    opener = re.compile(r"\s*while\s+(?P<condition>.*?)\s*;\s*do\s*$")
+    starts = [
+        index
+        for index, line in enumerate(lines)
+        if (match := opener.match(line)) and match.group("condition") in (":", "true")
+    ]
+    assert starts, f"no live (`while :` / `while true`) poll loop in the wait step:\n{script}"
 
     start = starts[0]
     depth = 0

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -64,12 +64,12 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     # publish on a leg that did not succeed, and refuse to publish a leg whose
     # job record never appeared, rather than defaulting to "finished".
     assert publish["needs"] == ["prepare-version"]
-    wait = next(step for step in publish["steps"] if step.get("name") == "Wait for the build matrix")
+    wait = next(
+        step for step in publish["steps"] if step.get("name") == "Wait for the build matrix"
+    )
     wait_run = wait["run"]
 
-    matrix_legs = {
-        f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]
-    }
+    matrix_legs = {f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]}
     assert len(matrix_legs) == len(tauri_steps)
     for leg in matrix_legs:
         assert f"'{leg}'" in wait_run, leg

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -1,5 +1,6 @@
 """Permission-boundary checks for the desktop release workflow."""
 
+import re
 from pathlib import Path
 
 import yaml
@@ -78,8 +79,31 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     # Every one of those refusals has to be terminal.
     assert wait_run.count("exit 1") >= 3
 
+    # The wait is a poll of this run's job list, not a mention of an env var.
+    # Assert the mechanism, because the error strings above could survive a step
+    # that no longer loops or no longer reads a conclusion: the jobs API call,
+    # the loop that repeats it, and the two states it decides on. Without these,
+    # deleting the polling loop and the status checks while leaving GITHUB_RUN_ID
+    # and LEGS in place still reads as a wait, and the download races the matrix.
+    assert "actions/runs/${GITHUB_RUN_ID}/jobs" in wait_run
+    assert ".status" in wait_run and ".conclusion" in wait_run
+    # Not finished yet is "keep waiting"; finished but not `success` is a refusal.
+    assert re.search(r'!=\s*"completed"', wait_run), wait_run
+    assert re.search(r'!=\s*"success"', wait_run), wait_run
+    # A single API read is a snapshot, not a wait: it has to loop and sleep.
+    assert re.search(r"^\s*while\b", wait_run, re.MULTILINE), wait_run
+    assert re.search(r"^\s*sleep\b", wait_run, re.MULTILINE), wait_run
+
     names = [step.get("name") for step in publish["steps"]]
     assert names.index("Wait for the build matrix") < names.index("Create versioned release")
+    # And it has to clear before the assets are pulled, or the download races the
+    # legs and publish-release dies on artifacts that do not exist yet.
+    download = next(
+        index
+        for index, step in enumerate(publish["steps"])
+        if step.get("uses", "").startswith("actions/download-artifact@")
+    )
+    assert names.index("Wait for the build matrix") < download, names
 
     # Creating a missing release is a separate step gated on validation, so a
     # non-draft release is never reserved before its assets are ready to upload.

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -27,6 +27,31 @@ def test_only_publish_job_can_write_repository_contents():
     assert write_jobs == ["publish-release"]
 
 
+def _poll_loop_body(script):
+    """Return the body of the first `while ...; do ... done` loop in `script`.
+
+    Assertions about a wait have to land inside the loop that does the waiting,
+    so this brackets it rather than searching the step as a whole. Nested `for`
+    and `while` loops are tracked by depth; the openers here all end their line
+    with `do`, which is what the shell style in this workflow uses.
+    """
+    lines = script.split("\n")
+    starts = [index for index, line in enumerate(lines) if re.match(r"\s*while\b", line)]
+    assert starts, f"no `while` loop in the wait step:\n{script}"
+
+    start = starts[0]
+    depth = 0
+    for index in range(start, len(lines)):
+        line = lines[index]
+        if re.search(r"(?:^|;)\s*do\s*$", line):
+            depth += 1
+        if re.match(r"\s*done\b", line):
+            depth -= 1
+            if depth == 0:
+                return "\n".join(lines[start + 1 : index])
+    raise AssertionError(f"unterminated `while` loop in the wait step:\n{script}")
+
+
 def test_build_matrix_hands_off_assets_without_release_credentials():
     """The build matrix signs bundles; only publish-release may release them.
 
@@ -85,14 +110,20 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     # the loop that repeats it, and the two states it decides on. Without these,
     # deleting the polling loop and the status checks while leaving GITHUB_RUN_ID
     # and LEGS in place still reads as a wait, and the download races the matrix.
-    assert "actions/runs/${GITHUB_RUN_ID}/jobs" in wait_run
-    assert ".status" in wait_run and ".conclusion" in wait_run
+    #
+    # All of it is asserted against the *body of the loop*, not the step as a
+    # whole. Searching the whole script would pass a one-shot `gh api` read
+    # sitting next to an unrelated or dead `while`, which is exactly the shape
+    # that lets publish-release reach the download before the legs finish.
+    loop_body = _poll_loop_body(wait_run)
+    assert "actions/runs/${GITHUB_RUN_ID}/jobs" in loop_body, wait_run
+    assert ".status" in loop_body and ".conclusion" in loop_body, wait_run
     # Not finished yet is "keep waiting"; finished but not `success` is a refusal.
-    assert re.search(r'!=\s*"completed"', wait_run), wait_run
-    assert re.search(r'!=\s*"success"', wait_run), wait_run
-    # A single API read is a snapshot, not a wait: it has to loop and sleep.
-    assert re.search(r"^\s*while\b", wait_run, re.MULTILINE), wait_run
-    assert re.search(r"^\s*sleep\b", wait_run, re.MULTILINE), wait_run
+    assert re.search(r'!=\s*"completed"', loop_body), wait_run
+    assert re.search(r'!=\s*"success"', loop_body), wait_run
+    # A loop that never sleeps is a spin, and one that never breaks never ends.
+    assert re.search(r"^\s*sleep\b", loop_body, re.MULTILINE), wait_run
+    assert re.search(r"^\s*break\b", loop_body, re.MULTILINE), wait_run
 
     names = [step.get("name") for step in publish["steps"]]
     assert names.index("Wait for the build matrix") < names.index("Create versioned release")

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -30,10 +30,9 @@ def test_only_publish_job_can_write_repository_contents():
 def _poll_loop_body(script):
     """Return the body of the first `while ...; do ... done` loop in `script`.
 
-    Assertions about a wait have to land inside the loop that does the waiting,
-    so this brackets it rather than searching the step as a whole. Nested `for`
-    and `while` loops are tracked by depth; the openers here all end their line
-    with `do`, which is what the shell style in this workflow uses.
+    Assertions about a wait have to land inside the loop that waits, not
+    anywhere in the step. Nesting is tracked by depth; every opener in this
+    workflow ends its line with `do`.
     """
     lines = script.split("\n")
     starts = [index for index, line in enumerate(lines) if re.match(r"\s*while\b", line)]
@@ -104,17 +103,11 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     # Every one of those refusals has to be terminal.
     assert wait_run.count("exit 1") >= 3
 
-    # The wait is a poll of this run's job list, not a mention of an env var.
-    # Assert the mechanism, because the error strings above could survive a step
-    # that no longer loops or no longer reads a conclusion: the jobs API call,
-    # the loop that repeats it, and the two states it decides on. Without these,
-    # deleting the polling loop and the status checks while leaving GITHUB_RUN_ID
-    # and LEGS in place still reads as a wait, and the download races the matrix.
-    #
-    # All of it is asserted against the *body of the loop*, not the step as a
-    # whole. Searching the whole script would pass a one-shot `gh api` read
-    # sitting next to an unrelated or dead `while`, which is exactly the shape
-    # that lets publish-release reach the download before the legs finish.
+    # Assert the mechanism, not just the error strings: those survive a step
+    # that no longer loops or no longer reads a conclusion, and then the
+    # download races the matrix. Everything below is checked inside the loop
+    # body, because a one-shot `gh api` read beside a dead `while` would satisfy
+    # the same substrings while waiting for nothing.
     loop_body = _poll_loop_body(wait_run)
     assert "actions/runs/${GITHUB_RUN_ID}/jobs" in loop_body, wait_run
     assert ".status" in loop_body and ".conclusion" in loop_body, wait_run


### PR DESCRIPTION
## Summary

This started as a fix for the test drift #8193 and #8194 left behind. #8240 landed that fix on `main` first, so none of it remains here. What is left is the part that fix did not cover: the assertions guarding the release workflow passed whether or not the thing they guard was intact.

Three of them were the same defect.

- The scan test proved it read a directory its own step had populated, which is true of any download writing there. It never compared the scan's download `pattern` with `publish-release`'s, so pointing the scan at a different artifact set left the shipped installers unscanned and still reported a clean sweep.
- The wait contract matched on a `GITHUB_RUN_ID` mention plus a `LEGS` assignment. The polling loop and the success-status checks could both be deleted with the test still green, and `publish-release` would then race the build matrix to the artifact download.
- `needs:` gives ordering, not success gating. An `if: always()` would run the scan after a failed publish, sending build artifacts to a third party on the strength of a publication that never happened, with the assertion still passing.

A fourth item was a wording bug rather than a test one. The job was named "post-publish scan", but `inputs.draft` defaults to true and "Create versioned release" passes `--draft` on that input, so the ordinary dispatch uploads the assets to a draft and publishes nothing. The name, the job summary heading and the script's heading now all say "VirusTotal release asset scan", which is true of both dispatches, and the script's `SUMMARY_HEADING` is the single source for the workflow's no-summary placeholder so the two cannot drift.

## What the assertions now pin

- The scan job carries no `if:` at all, so whether it runs is `needs:`'s decision alone. Every job-level condition is rejected rather than sorted into safe and unsafe, because the failure is symmetric: `always()` or `success() || inputs.scan_anyway` runs the scan without a successful publish, while `${{ false }}` or `success() && <anything falsey>` skips the sweep after one, and any rule loose enough to admit an arbitrary trailing predicate admits the second kind.
- The scan's input directory. `${{ runner.temp }}` and `$RUNNER_TEMP` normalise to one token, the two download paths are compared in full rather than by leaf, and the positional argument the scan step hands to `scripts/virustotal_scan.py` is compared against the scan job's own download path. The shared `pattern` is also checked against every `matrix.artifact` the build uploads, so the two jobs cannot agree on a set that does not exist.
- The wait. A helper brackets the body of the first *live* `while ... do ... done` loop by depth, taking only an unconditional `:` or `true` condition, since `while false; do` keeps a textually perfect body while the shell skips every read in it. The jobs API read, `.status`/`.conclusion`, the `!= "completed"` and `!= "success"` decisions, the `sleep` and the `break` are all asserted inside that body. The wait must also clear before the assets are downloaded, not merely before the release is created.
- The draft contract, so the heading and the workflow's default dispatch cannot drift apart again.

## Validation

`pytest tests/security/test_release_desktop_permissions.py tests/python/test_virustotal_scan.py`: 81 passed.

Every assertion was mutation checked on a throwaway copy of the tree, 29 mutants in all. The 27 that violate the contract each turn the intended test red: repointing the scan's pattern, deleting the polling loop and status checks while leaving `GITHUB_RUN_ID` and `LEGS` in place, `if: always()`, `if: failure()`, `if: cancelled()`, `if: ${{ false }}`, `if: ${{ success() || inputs.scan_anyway }}`, `if: ${{ success() && false }}`, `if: ${{ success() && inputs.scan }}`, turning `while :; do` into `while false; do`, a one-shot `gh api` read beside a dead `while`, removing every `sleep` or the `break` from the loop, deleting either the `!= "completed"` or the `!= "success"` decision, repointing `needs`, moving the checkout after the scan or the download after the scan, moving the asset download ahead of the wait, renaming the uploaded artifact out of the pattern, moving both downloads under a new parent with the same leaf, repointing the script argument, dropping `merge-multiple`, drifting the placeholder heading, flipping `inputs.draft` to false, and dropping `--draft`.

Two mutants are legitimate refactors rather than violations and stay green, which is the check that the assertions are not simply over-tight: writing the poll as `while true; do`, and moving the downloads together with the script argument to a new directory.

`studio/backend/tests/` and `studio/backend/hub/tests/` were run on `main` and on this branch: identical FAILED/ERROR line sets (78 lines, all pre-existing on `main`) and 354 passed in the hub suite on both.
