### PR TITLE
fix(studio): wire llama's OpenMP runtime into slim whisper installs

### DIFF
--- a/studio/backend/core/inference/stt_ggml_sidecar.py
+++ b/studio/backend/core/inference/stt_ggml_sidecar.py
@@ -244,8 +244,12 @@ def slim_runtime_intact(binary: str) -> bool:
         )
     if intact and marker.get("backend") == "rocm":
         expected_runtime_dirs = set() if sys.platform == "win32" else {"hipblaslt", "rocblas"}
+        # Any wiring from version 2 on records linked_runtime_directories, so
+        # pin the floor, not one version, or an installer bump strands installs.
+        wiring_version = marker.get("runtime_wiring_version")
         intact = (
-            marker.get("runtime_wiring_version") == 2
+            isinstance(wiring_version, int)
+            and wiring_version >= 2
             and isinstance(runtime_dirs, list)
             and set(runtime_dirs) == expected_runtime_dirs
         )

--- a/studio/backend/tests/test_stt_ggml_sidecar.py
+++ b/studio/backend/tests/test_stt_ggml_sidecar.py
@@ -255,6 +255,35 @@ def test_slim_guard_rejects_missing_rocm_catalog(tmp_path):
     assert ggml_module.slim_runtime_intact(binary) is False
 
 
+def test_slim_guard_accepts_newer_rocm_wiring_version(tmp_path):
+    # The guard pins a floor, not one version: an installer bump must not strand
+    # ROCm installs as unavailable when every wired library is present.
+    names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
+    binary = _slim_install(
+        tmp_path,
+        linked_libraries = names,
+        backend = "rocm",
+        linked_runtime_directories = ["hipblaslt", "rocblas"],
+        runtime_wiring_version = 3,
+    )
+    (Path(binary).parent / "libggml-hip.so").write_bytes(b"ggml")
+    assert ggml_module.slim_runtime_intact(binary) is True
+
+
+def test_slim_guard_rejects_pre_catalog_rocm_wiring_version(tmp_path):
+    # Version 1 predates linked_runtime_directories, so it stays rejected.
+    names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
+    binary = _slim_install(
+        tmp_path,
+        linked_libraries = names,
+        backend = "rocm",
+        linked_runtime_directories = ["hipblaslt", "rocblas"],
+        runtime_wiring_version = 1,
+    )
+    (Path(binary).parent / "libggml-hip.so").write_bytes(b"ggml")
+    assert ggml_module.slim_runtime_intact(binary) is False
+
+
 def test_slim_guard_accepts_windows_rocm_dll_overlay(monkeypatch, tmp_path):
     monkeypatch.setattr(ggml_module.sys, "platform", "win32")
     names = ["ggml.dll", "ggml-base.dll", "ggml-hip.dll", "amdhip64.dll"]

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -166,17 +166,11 @@ SLIM_BACKEND_MODULE_GLOBS = {
 
 # Everything the slim wiring mirrors from the llama bin dir: the core ggml
 # sonames plus every dlopen'd backend module (CPU variants included). libggml*
-# matches .so and .dylib alike; ggml*.dll covers Windows.
-#
-# The libomp* globs are not optional. Wherever llama's slice is clang-built, its
-# ggml links the LLVM OpenMP runtime and SHIPS it in the bundle, so it is never
-# resolvable from the host:
-#   windows x64/arm64  ggml-base.dll imports libomp140.<arch>.dll
-#   linux arm64        libggml-base.so NEEDS libomp.so.5 (RUNPATH $ORIGIN)
-# Missing it, whisper-server dies at load with DLL_NOT_FOUND / "cannot open
-# shared object file", which is what shipped until whisper.cpp#18. Linux x64 is
-# gcc-built and takes libgomp.so.1 from the host, as llama's own binaries do, and
-# Apple clang builds no OpenMP at all, so the globs simply match nothing there.
+# matches .so and .dylib alike; ggml*.dll covers Windows. libomp* rides along
+# because llama's clang-built slices (windows x64/arm64, linux arm64) link ggml
+# against the LLVM OpenMP runtime and ship it in the bundle, so the loader can
+# never find it on the host. Linux x64 (gcc, host libgomp.so.1) and macOS (Apple
+# clang, no OpenMP) ship none, so the globs match nothing there.
 SLIM_GGML_LIBRARY_GLOBS = (
     "libggml*",
     "ggml*.dll",
@@ -191,8 +185,8 @@ SLIM_ROCM_LIBRARY_GLOBS = (
     "libroc*.so*",
 )
 SLIM_ROCM_RUNTIME_DIRS = ("hipblaslt", "rocblas")
-# 3: libomp*.so* / libomp*.dylib joined the wiring, so slim installs made
-# under version 2 are missing libomp.so.5 on linux arm64 and must re-wire.
+# 3: libomp*.so*/dylib joined the wiring, so version 2 installs are missing
+# libomp.so.5 on linux arm64 and must re-wire.
 SLIM_RUNTIME_WIRING_VERSION = 3
 
 INSTALL_STAGING_ROOT_NAME = ".staging"

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -178,7 +178,11 @@ SLIM_BACKEND_MODULE_GLOBS = {
 # gcc-built and takes libgomp.so.1 from the host, as llama's own binaries do, and
 # Apple clang builds no OpenMP at all, so the globs simply match nothing there.
 SLIM_GGML_LIBRARY_GLOBS = (
-    "libggml*", "ggml*.dll", "libomp*.dll", "libomp*.so*", "libomp*.dylib",
+    "libggml*",
+    "ggml*.dll",
+    "libomp*.dll",
+    "libomp*.so*",
+    "libomp*.dylib",
 )
 SLIM_ROCM_LIBRARY_GLOBS = (
     "libamd*.so*",

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -166,12 +166,20 @@ SLIM_BACKEND_MODULE_GLOBS = {
 
 # Everything the slim wiring mirrors from the llama bin dir: the core ggml
 # sonames plus every dlopen'd backend module (CPU variants included). libggml*
-# matches .so and .dylib alike; ggml*.dll covers Windows. libomp*.dll rides along
-# because llama's clang-built windows-arm64 ggml-base.dll imports
-# libomp140.aarch64.dll, shipped in the llama bundle but never a system DLL, so
-# the loader needs it next to whisper-server.exe (MSVC x64 uses System32
-# vcomp140.dll; Linux ggml needs system libgomp.so.1, which llama already requires).
-SLIM_GGML_LIBRARY_GLOBS = ("libggml*", "ggml*.dll", "libomp*.dll")
+# matches .so and .dylib alike; ggml*.dll covers Windows.
+#
+# The libomp* globs are not optional. Wherever llama's slice is clang-built, its
+# ggml links the LLVM OpenMP runtime and SHIPS it in the bundle, so it is never
+# resolvable from the host:
+#   windows x64/arm64  ggml-base.dll imports libomp140.<arch>.dll
+#   linux arm64        libggml-base.so NEEDS libomp.so.5 (RUNPATH $ORIGIN)
+# Missing it, whisper-server dies at load with DLL_NOT_FOUND / "cannot open
+# shared object file", which is what shipped until whisper.cpp#18. Linux x64 is
+# gcc-built and takes libgomp.so.1 from the host, as llama's own binaries do, and
+# Apple clang builds no OpenMP at all, so the globs simply match nothing there.
+SLIM_GGML_LIBRARY_GLOBS = (
+    "libggml*", "ggml*.dll", "libomp*.dll", "libomp*.so*", "libomp*.dylib",
+)
 SLIM_ROCM_LIBRARY_GLOBS = (
     "libamd*.so*",
     "libhip*.so*",
@@ -179,7 +187,9 @@ SLIM_ROCM_LIBRARY_GLOBS = (
     "libroc*.so*",
 )
 SLIM_ROCM_RUNTIME_DIRS = ("hipblaslt", "rocblas")
-SLIM_RUNTIME_WIRING_VERSION = 2
+# 3: libomp*.so* / libomp*.dylib joined the wiring, so slim installs made
+# under version 2 are missing libomp.so.5 on linux arm64 and must re-wire.
+SLIM_RUNTIME_WIRING_VERSION = 3
 
 INSTALL_STAGING_ROOT_NAME = ".staging"
 

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -989,9 +989,8 @@ def test_link_ggml_runtime_wires_windows_libomp(tmp_path):
 
 
 def test_link_ggml_runtime_wires_linux_libomp(tmp_path):
-    # llama's clang-built linux-arm64 libggml-base.so NEEDS libomp.so.5, shipped
-    # in the llama bundle and never on the host: without it beside whisper-server
-    # the loader fails with "libomp.so.5: cannot open shared object file".
+    # llama's clang-built linux-arm64 libggml-base.so NEEDS libomp.so.5, bundled
+    # and never on the host: without it whisper-server fails to load.
     bin_dir = tmp_path / "llama_bin"
     bin_dir.mkdir()
     for name in ("libggml.so.0", "libggml-base.so.0", "libggml-cpu-armv8.0_1.so", "libomp.so.5"):
@@ -1010,8 +1009,8 @@ def test_link_ggml_runtime_wires_linux_libomp(tmp_path):
 
 
 def test_link_ggml_runtime_linux_libomp_alone_is_not_a_pairing(tmp_path):
-    # Same fail-closed rule as the Windows libomp case: OpenMP without ggml is
-    # not a usable llama runtime.
+    # Same fail-closed rule as the Windows case: OpenMP without ggml is not a
+    # usable llama runtime.
     bin_dir = tmp_path / "llama_bin"
     bin_dir.mkdir()
     (bin_dir / "libomp.so.5").write_bytes(b"x")

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -994,14 +994,17 @@ def test_link_ggml_runtime_wires_linux_libomp(tmp_path):
     # the loader fails with "libomp.so.5: cannot open shared object file".
     bin_dir = tmp_path / "llama_bin"
     bin_dir.mkdir()
-    for name in ("libggml.so.0", "libggml-base.so.0", "libggml-cpu-armv8.0_1.so",
-                 "libomp.so.5"):
+    for name in ("libggml.so.0", "libggml-base.so.0", "libggml-cpu-armv8.0_1.so", "libomp.so.5"):
         (bin_dir / name).write_bytes(b"x")
     (bin_dir / "libllama.so").write_bytes(b"x")  # never wired
     whisper_bin = tmp_path / "whisper_bin"
     linked = M.link_ggml_runtime(bin_dir, whisper_bin)
-    assert linked == ["libggml-base.so.0", "libggml-cpu-armv8.0_1.so",
-                      "libggml.so.0", "libomp.so.5"]
+    assert linked == [
+        "libggml-base.so.0",
+        "libggml-cpu-armv8.0_1.so",
+        "libggml.so.0",
+        "libomp.so.5",
+    ]
     assert (whisper_bin / "libomp.so.5").is_file()
     assert not (whisper_bin / "libllama.so").exists()
 

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -988,6 +988,34 @@ def test_link_ggml_runtime_wires_windows_libomp(tmp_path):
     assert not (whisper_bin / "llama.dll").exists()
 
 
+def test_link_ggml_runtime_wires_linux_libomp(tmp_path):
+    # llama's clang-built linux-arm64 libggml-base.so NEEDS libomp.so.5, shipped
+    # in the llama bundle and never on the host: without it beside whisper-server
+    # the loader fails with "libomp.so.5: cannot open shared object file".
+    bin_dir = tmp_path / "llama_bin"
+    bin_dir.mkdir()
+    for name in ("libggml.so.0", "libggml-base.so.0", "libggml-cpu-armv8.0_1.so",
+                 "libomp.so.5"):
+        (bin_dir / name).write_bytes(b"x")
+    (bin_dir / "libllama.so").write_bytes(b"x")  # never wired
+    whisper_bin = tmp_path / "whisper_bin"
+    linked = M.link_ggml_runtime(bin_dir, whisper_bin)
+    assert linked == ["libggml-base.so.0", "libggml-cpu-armv8.0_1.so",
+                      "libggml.so.0", "libomp.so.5"]
+    assert (whisper_bin / "libomp.so.5").is_file()
+    assert not (whisper_bin / "libllama.so").exists()
+
+
+def test_link_ggml_runtime_linux_libomp_alone_is_not_a_pairing(tmp_path):
+    # Same fail-closed rule as the Windows libomp case: OpenMP without ggml is
+    # not a usable llama runtime.
+    bin_dir = tmp_path / "llama_bin"
+    bin_dir.mkdir()
+    (bin_dir / "libomp.so.5").write_bytes(b"x")
+    with pytest.raises(PrebuiltFallback):
+        M.link_ggml_runtime(bin_dir, tmp_path / "whisper_bin")
+
+
 def test_rocm_runtime_wires_complete_windows_dll_overlay(tmp_path):
     bin_dir = tmp_path / "llama_bin"
     bin_dir.mkdir()


### PR DESCRIPTION
Companion to unslothai/whisper.cpp#18 and unslothai/whisper.cpp#19. Those fix the build and the published contract; this fixes what the installer actually wires, which is what users run.

## The bug

`SLIM_GGML_LIBRARY_GLOBS` mirrors `libggml*` / `ggml*.dll` / `libomp*.dll` from the paired llama bin dir into the whisper bin dir. The DLL glob was added for llama's clang-built windows-arm64 `ggml-base.dll`; the ELF side was skipped on the stated assumption that Linux ggml takes `libgomp.so.1` from the host.

That holds for the gcc-built x64 slice, but not for arm64. From the published `app-b10327-mix-b1e9972-linux-arm64-cpu.tar.gz`:

```
libggml-base.so         NEEDED libomp.so.5   RUNPATH $ORIGIN
libggml-cpu-armv8.0_1   NEEDED libomp.so.5   RUNPATH $ORIGIN
```

`libomp.so.5` ships **inside** the llama bundle and is not a host library. So on linux arm64 every slim install wired a ggml stack the loader could not bring up:

```
whisper-server: error while loading shared libraries: libomp.so.5:
cannot open shared object file: no such file or directory
```

`whisper-server` never starts and dictation silently falls back to Transformers. The same defect broke the whisper.cpp release CI, which is how it surfaced.

## Changes

- `libomp*.so*` and `libomp*.dylib` join `SLIM_GGML_LIBRARY_GLOBS`. Linux x64 (gcc, `libgomp.so.1` from the host, exactly as llama's own binaries resolve it) and macOS (Apple clang, no OpenMP) ship no libomp, so the globs match nothing and those platforms are byte-identical.
- `SLIM_RUNTIME_WIRING_VERSION` 2 -> 3. Without this, an install made under the old wiring reports itself current forever: the missing-library repair check only looks at names in its own marker, and the old marker never listed `libomp.so.5`. The bump is what actually repairs the broken arm64 installs already out there.

The fail-closed rule is unchanged: OpenMP without any ggml library still raises `PrebuiltFallback`, now covered for the ELF case too.

## On the manifest side

whisper.cpp#19 adds `libomp.so.5` to `requires_ggml_sonames` on linux/arm64 and `libomp140.<arch>.dll` on Windows. `slim_pairing_for_artifact` checks those names against the **llama bin dir**, where they are real files, so the new manifests pair correctly with both the old and the new installer. No coordinated rollout is needed; this PR is what makes the wiring match the contract.

## Verification

Against the real published llama.cpp bundles, not fixtures:

- Wiring the arm64 cpu bundle now places `libomp.so.5` beside `whisper-server` (16 libs) and pulls in no `libllama*`.
- Every soname the new whisper manifests require exists as a file in the paired llama bin dir, on both arches, so the pairing gate passes.
- An x64 `whisper-server` from the published `v1.9.2-unsloth.5` slim bundle, wired through `link_ggml_runtime` and launched with `--no-gpu`, returns a real transcription of `samples/jfk.wav`.
- Two new regression tests mirroring the existing Windows libomp pair: the ELF wiring includes `libomp.so.5` and excludes `libllama.so`, and libomp alone still fails closed.
- 350 passed, 1 skipped across the whisper, llama, prebuilt-core, setup-status and checksum install suites.