### PR TITLE
GRPO: wrap the model that owns the head when falling back to hidden states

### DIFF
--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -63,12 +63,12 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     # publish on a leg that did not succeed, and refuse to publish a leg whose
     # job record never appeared, rather than defaulting to "finished".
     assert publish["needs"] == ["prepare-version"]
-    wait = next(step for step in publish["steps"] if step.get("name") == "Wait for the build matrix")
+    wait = next(
+        step for step in publish["steps"] if step.get("name") == "Wait for the build matrix"
+    )
     wait_run = wait["run"]
 
-    matrix_legs = {
-        f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]
-    }
+    matrix_legs = {f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]}
     assert len(matrix_legs) == len(tauri_steps)
     for leg in matrix_legs:
         assert f"'{leg}'" in wait_run, leg

--- a/tests/test_grpo_hidden_states_wrap_target.py
+++ b/tests/test_grpo_hidden_states_wrap_target.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""The GRPO hidden-states fallback must wrap the module that owns the head.
+
+`_install_grpo_hidden_states_forward_wrapper` is the safety net for a model
+whose forward does not honour UNSLOTH_RETURN_HIDDEN_STATES. TRL builds GRPO's
+`ref_model` with a plain `architecture.from_pretrained(model_id)`, so on every
+non-PEFT (full finetuning) GRPO run the net has to catch a bare
+`*ForCausalLM`.
+
+`_grpo_hidden_states_wrap_target` walked `("base_model", "model")` to find the
+adapter's wrapped model. A bare `*ForCausalLM` also has `.model` -- its decoder
+body -- so the wrapper landed on the decoder. The decoder returns no `.logits`
+at all, the head above it then ran untouched, and the caller got
+[B, T, vocab] where it expects [B, T, hidden]. No warning was emitted, because
+from the wrapper's point of view nothing had failed.
+
+Downstream that is the lm_head matmul in
+`chunked_hidden_states_selective_log_softmax`:
+
+    a and b must have same reduction dim, but got
+    [((s47*s87 + 255)//256), s33] X [1536, 151936]
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+if not torch.cuda.is_available():                       # unsloth needs an accelerator to import
+    pytest.skip("needs an accelerator to import unsloth", allow_module_level = True)
+
+import os
+
+import unsloth  # noqa: F401  (must be imported before transformers)
+from transformers import AutoConfig
+from unsloth.models.rl import (
+    _grpo_hidden_states_wrap_target,
+    _install_grpo_hidden_states_forward_wrapper,
+    _module_returns_logits,
+)
+
+
+def _tiny_causal_lm():
+    """A real transformers `*ForCausalLM`, shaped like TRL's `ref_model`."""
+    from transformers.models.qwen2.modeling_qwen2 import Qwen2ForCausalLM
+
+    config = AutoConfig.from_pretrained("unsloth/Qwen2.5-0.5B-Instruct")
+    config.num_hidden_layers   = 2
+    config.hidden_size         = 64
+    config.intermediate_size   = 128
+    config.num_attention_heads = 4
+    config.num_key_value_heads = 2
+    config.vocab_size          = 128
+    config.pad_token_id        = None
+    config.tie_word_embeddings = False
+    torch.manual_seed(0)
+    return Qwen2ForCausalLM(config).eval(), config
+
+
+class _Wrapper(torch.nn.Module):
+    """An adapter-shaped wrapper: `.model` is itself a head-owning model."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def get_output_embeddings(self):
+        return self.model.get_output_embeddings()
+
+    def forward(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
+
+
+def test_decoder_body_is_not_a_wrap_target():
+    model, _ = _tiny_causal_lm()
+    assert _module_returns_logits(model)
+    assert not _module_returns_logits(model.model)
+    assert _grpo_hidden_states_wrap_target(model) is model
+
+
+def test_adapter_style_wrapper_is_still_unwrapped():
+    model, _ = _tiny_causal_lm()
+    wrapper = _Wrapper(model)
+    assert _grpo_hidden_states_wrap_target(wrapper) is model
+
+
+def test_plain_causal_lm_returns_hidden_states_after_the_wrapper():
+    model, config = _tiny_causal_lm()
+    assert _install_grpo_hidden_states_forward_wrapper(model) is True
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 6))
+
+    previous = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0")
+    os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "1"
+    try:
+        with torch.no_grad():
+            wrapped = model(input_ids = input_ids).logits
+    finally:
+        os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = previous
+
+    assert wrapped.shape == (2, 6, config.hidden_size), (
+        f"expected hidden states of width {config.hidden_size}, got {tuple(wrapped.shape)}"
+    )
+
+    # The hidden states must be the ones the head consumes, or every logprob
+    # computed from them is wrong rather than merely differently shaped.
+    with torch.no_grad():
+        reference = model(input_ids = input_ids).logits
+    lm_head = model.get_output_embeddings().weight
+    assert reference.shape == (2, 6, config.vocab_size)
+    assert torch.allclose(wrapped @ lm_head.t(), reference, atol = 1e-4)
+
+
+def test_the_switch_is_still_honoured():
+    """Off means off: the wrapper must not change the default output."""
+    model, config = _tiny_causal_lm()
+    _install_grpo_hidden_states_forward_wrapper(model)
+
+    input_ids = torch.randint(0, config.vocab_size, (1, 4))
+    previous = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0")
+    os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "0"
+    try:
+        with torch.no_grad():
+            out = model(input_ids = input_ids).logits
+    finally:
+        os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = previous
+    assert out.shape == (1, 4, config.vocab_size)

--- a/tests/test_grpo_hidden_states_wrap_target.py
+++ b/tests/test_grpo_hidden_states_wrap_target.py
@@ -26,7 +26,7 @@ Downstream that is the lm_head matmul in
 import pytest
 
 torch = pytest.importorskip("torch")
-if not torch.cuda.is_available():                       # unsloth needs an accelerator to import
+if not torch.cuda.is_available():  # unsloth needs an accelerator to import
     pytest.skip("needs an accelerator to import unsloth", allow_module_level = True)
 
 import os
@@ -45,13 +45,13 @@ def _tiny_causal_lm():
     from transformers.models.qwen2.modeling_qwen2 import Qwen2ForCausalLM
 
     config = AutoConfig.from_pretrained("unsloth/Qwen2.5-0.5B-Instruct")
-    config.num_hidden_layers   = 2
-    config.hidden_size         = 64
-    config.intermediate_size   = 128
+    config.num_hidden_layers = 2
+    config.hidden_size = 64
+    config.intermediate_size = 128
     config.num_attention_heads = 4
     config.num_key_value_heads = 2
-    config.vocab_size          = 128
-    config.pad_token_id        = None
+    config.vocab_size = 128
+    config.pad_token_id = None
     config.tie_word_embeddings = False
     torch.manual_seed(0)
     return Qwen2ForCausalLM(config).eval(), config
@@ -98,9 +98,11 @@ def test_plain_causal_lm_returns_hidden_states_after_the_wrapper():
     finally:
         os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = previous
 
-    assert wrapped.shape == (2, 6, config.hidden_size), (
-        f"expected hidden states of width {config.hidden_size}, got {tuple(wrapped.shape)}"
-    )
+    assert wrapped.shape == (
+        2,
+        6,
+        config.hidden_size,
+    ), f"expected hidden states of width {config.hidden_size}, got {tuple(wrapped.shape)}"
 
     # The hidden states must be the ones the head consumes, or every logprob
     # computed from them is wrong rather than merely differently shaped.

--- a/tests/test_grpo_hidden_states_wrap_target.py
+++ b/tests/test_grpo_hidden_states_wrap_target.py
@@ -23,17 +23,17 @@ Downstream that is the lm_head matmul in
     [((s47*s87 + 255)//256), s33] X [1536, 151936]
 """
 
+import contextlib
+import os
+from types import MethodType
+
 import pytest
 
 torch = pytest.importorskip("torch")
-if not torch.cuda.is_available():  # unsloth needs an accelerator to import
-    pytest.skip("needs an accelerator to import unsloth", allow_module_level = True)
 
-import os
-
-import unsloth  # noqa: F401  (must be imported before transformers)
-from transformers import AutoConfig
-from unsloth.models.rl import (
+import unsloth  # noqa: F401,E402  (must be imported before transformers)
+from transformers import Qwen2Config  # noqa: E402
+from unsloth.models.rl import (  # noqa: E402
     _grpo_hidden_states_wrap_target,
     _install_grpo_hidden_states_forward_wrapper,
     _module_returns_logits,
@@ -44,17 +44,34 @@ def _tiny_causal_lm():
     """A real transformers `*ForCausalLM`, shaped like TRL's `ref_model`."""
     from transformers.models.qwen2.modeling_qwen2 import Qwen2ForCausalLM
 
-    config = AutoConfig.from_pretrained("unsloth/Qwen2.5-0.5B-Instruct")
-    config.num_hidden_layers = 2
-    config.hidden_size = 64
-    config.intermediate_size = 128
-    config.num_attention_heads = 4
-    config.num_key_value_heads = 2
-    config.vocab_size = 128
-    config.pad_token_id = None
-    config.tie_word_embeddings = False
+    config = Qwen2Config(
+        num_hidden_layers = 2,
+        hidden_size = 64,
+        intermediate_size = 128,
+        num_attention_heads = 4,
+        num_key_value_heads = 2,
+        vocab_size = 128,
+        max_position_embeddings = 64,
+        pad_token_id = None,
+        tie_word_embeddings = False,
+    )
     torch.manual_seed(0)
     return Qwen2ForCausalLM(config).eval(), config
+
+
+@contextlib.contextmanager
+def _return_hidden_states(value):
+    """Pin the switch for the block, then restore the caller's environment
+    exactly -- including having had it unset."""
+    previous = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES")
+    os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = value
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("UNSLOTH_RETURN_HIDDEN_STATES", None)
+        else:
+            os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = previous
 
 
 class _Wrapper(torch.nn.Module):
@@ -89,14 +106,8 @@ def test_plain_causal_lm_returns_hidden_states_after_the_wrapper():
     assert _install_grpo_hidden_states_forward_wrapper(model) is True
 
     input_ids = torch.randint(0, config.vocab_size, (2, 6))
-
-    previous = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0")
-    os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "1"
-    try:
-        with torch.no_grad():
-            wrapped = model(input_ids = input_ids).logits
-    finally:
-        os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = previous
+    with _return_hidden_states("1"), torch.no_grad():
+        wrapped = model(input_ids = input_ids).logits
 
     assert wrapped.shape == (
         2,
@@ -106,7 +117,7 @@ def test_plain_causal_lm_returns_hidden_states_after_the_wrapper():
 
     # The hidden states must be the ones the head consumes, or every logprob
     # computed from them is wrong rather than merely differently shaped.
-    with torch.no_grad():
+    with _return_hidden_states("0"), torch.no_grad():
         reference = model(input_ids = input_ids).logits
     lm_head = model.get_output_embeddings().weight
     assert reference.shape == (2, 6, config.vocab_size)
@@ -119,11 +130,26 @@ def test_the_switch_is_still_honoured():
     _install_grpo_hidden_states_forward_wrapper(model)
 
     input_ids = torch.randint(0, config.vocab_size, (1, 4))
-    previous = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0")
-    os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "0"
-    try:
-        with torch.no_grad():
-            out = model(input_ids = input_ids).logits
-    finally:
-        os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = previous
+    with _return_hidden_states("0"), torch.no_grad():
+        out = model(input_ids = input_ids).logits
     assert out.shape == (1, 4, config.vocab_size)
+
+
+def test_survives_the_accelerate_forward_rebind():
+    """accelerate's `extract_model_from_parallel(keep_fp32_wrapper = False)`
+    rebinds an instance-level forward as `MethodType(forward, model)`, and the
+    GRPO loop unwraps that way on every step. The wrapper then arrives with the
+    module as its leading positional argument, which the head owner forwards on
+    as `input_ids`."""
+    model, config = _tiny_causal_lm()
+    assert _install_grpo_hidden_states_forward_wrapper(model) is True
+    model.forward = MethodType(model.forward, model)
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 6))
+    with _return_hidden_states("1"), torch.no_grad():
+        wrapped = model(input_ids = input_ids).logits
+    assert wrapped.shape == (2, 6, config.hidden_size)
+
+    with _return_hidden_states("0"), torch.no_grad():
+        reference = model(input_ids = input_ids).logits
+    assert reference.shape == (2, 6, config.vocab_size)

--- a/tests/test_grpo_hidden_states_wrap_target.py
+++ b/tests/test_grpo_hidden_states_wrap_target.py
@@ -3,24 +3,11 @@
 
 """The GRPO hidden-states fallback must wrap the module that owns the head.
 
-`_install_grpo_hidden_states_forward_wrapper` is the safety net for a model
-whose forward does not honour UNSLOTH_RETURN_HIDDEN_STATES. TRL builds GRPO's
-`ref_model` with a plain `architecture.from_pretrained(model_id)`, so on every
-non-PEFT (full finetuning) GRPO run the net has to catch a bare
-`*ForCausalLM`.
-
-`_grpo_hidden_states_wrap_target` walked `("base_model", "model")` to find the
-adapter's wrapped model. A bare `*ForCausalLM` also has `.model` -- its decoder
-body -- so the wrapper landed on the decoder. The decoder returns no `.logits`
-at all, the head above it then ran untouched, and the caller got
-[B, T, vocab] where it expects [B, T, hidden]. No warning was emitted, because
-from the wrapper's point of view nothing had failed.
-
-Downstream that is the lm_head matmul in
-`chunked_hidden_states_selective_log_softmax`:
-
-    a and b must have same reduction dim, but got
-    [((s47*s87 + 255)//256), s33] X [1536, 151936]
+TRL builds GRPO's `ref_model` as a bare `*ForCausalLM`, and that also has a
+`.model`, so walking `("base_model", "model")` landed the wrapper on the decoder
+body. Nothing raised: the head above ran untouched and the caller silently got
+[B, T, vocab] where it expects [B, T, hidden], which blows up later as a reduction
+dim mismatch in `chunked_hidden_states_selective_log_softmax`.
 """
 
 import contextlib
@@ -61,8 +48,7 @@ def _tiny_causal_lm():
 
 @contextlib.contextmanager
 def _return_hidden_states(value):
-    """Pin the switch for the block, then restore the caller's environment
-    exactly -- including having had it unset."""
+    """Pin the switch, then restore the caller's environment exactly, unset included."""
     previous = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES")
     os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = value
     try:
@@ -115,8 +101,8 @@ def test_plain_causal_lm_returns_hidden_states_after_the_wrapper():
         config.hidden_size,
     ), f"expected hidden states of width {config.hidden_size}, got {tuple(wrapped.shape)}"
 
-    # The hidden states must be the ones the head consumes, or every logprob
-    # computed from them is wrong rather than merely differently shaped.
+    # Must be the hidden states the head consumes, or the logprobs are wrong rather
+    # than merely mis-shaped.
     with _return_hidden_states("0"), torch.no_grad():
         reference = model(input_ids = input_ids).logits
     lm_head = model.get_output_embeddings().weight
@@ -136,11 +122,9 @@ def test_the_switch_is_still_honoured():
 
 
 def test_survives_the_accelerate_forward_rebind():
-    """accelerate's `extract_model_from_parallel(keep_fp32_wrapper = False)`
-    rebinds an instance-level forward as `MethodType(forward, model)`, and the
-    GRPO loop unwraps that way on every step. The wrapper then arrives with the
-    module as its leading positional argument, which the head owner forwards on
-    as `input_ids`."""
+    """accelerate's `extract_model_from_parallel(keep_fp32_wrapper = False)`, which the
+    GRPO loop calls every step, rebinds an instance forward as `MethodType(forward,
+    model)`, so the module arrives as a leading positional argument."""
     model, config = _tiny_causal_lm()
     assert _install_grpo_hidden_states_forward_wrapper(model) is True
     model.forward = MethodType(model.forward, model)

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -579,6 +579,22 @@ _UNSLOTH_GRPO_HIDDEN_STATES_WRAPPED_ATTR = "_unsloth_grpo_hidden_states_forward_
 _UNSLOTH_GRPO_HIDDEN_STATES_WARNING_ATTR = "_unsloth_grpo_hidden_states_warning_issued"
 
 
+def _module_returns_logits(module):
+    # A module whose forward produces `.logits`, i.e. one that owns an output
+    # head. PreTrainedModel.get_output_embeddings returns None for the decoder
+    # bodies (Qwen2Model, LlamaModel, ...) and the head module for the
+    # *ForCausalLM wrappers, so it separates the two without a name list.
+    if module is None:
+        return False
+    get_output_embeddings = getattr(module, "get_output_embeddings", None)
+    if not callable(get_output_embeddings):
+        return False
+    try:
+        return get_output_embeddings() is not None
+    except Exception:
+        return False
+
+
 def _grpo_hidden_states_wrap_target(model):
     if model is None:
         return None
@@ -589,8 +605,18 @@ def _grpo_hidden_states_wrap_target(model):
             return base_model
     for attr in ("base_model", "model"):
         child = getattr(model, attr, None)
-        if child is not None and child is not model and hasattr(child, "forward"):
-            return child
+        if child is None or child is model or not hasattr(child, "forward"):
+            continue
+        # Only descend into an adapter/wrapper that still owns the output head.
+        # A bare *ForCausalLM also has a `.model`, but that is its decoder body:
+        # it returns hidden states and no `.logits` at all, so wrapping it lets
+        # the head above run untouched and the fallback becomes a silent no-op.
+        # TRL builds GRPO's `ref_model` with a plain
+        # `architecture.from_pretrained(...)`, which is exactly that shape, and
+        # the caller then receives [B, T, vocab] where it expects [B, T, hidden].
+        if not _module_returns_logits(child):
+            continue
+        return child
     return model
 
 

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1469,10 +1469,9 @@ _UNSLOTH_GRPO_HIDDEN_STATES_WARNING_ATTR = "_unsloth_grpo_hidden_states_warning_
 
 
 def _module_returns_logits(module):
-    # A module whose forward produces `.logits`, i.e. one that owns an output
-    # head. PreTrainedModel.get_output_embeddings returns None for the decoder
-    # bodies (Qwen2Model, LlamaModel, ...) and the head module for the
-    # *ForCausalLM wrappers, so it separates the two without a name list.
+    # get_output_embeddings() is None on the decoder bodies (Qwen2Model, ...) and the
+    # head module on the *ForCausalLM wrappers, so it finds the head owner by behaviour
+    # rather than by a model-name list.
     if module is None:
         return False
     get_output_embeddings = getattr(module, "get_output_embeddings", None)
@@ -1496,13 +1495,10 @@ def _grpo_hidden_states_wrap_target(model):
         child = getattr(model, attr, None)
         if child is None or child is model or not hasattr(child, "forward"):
             continue
-        # Only descend into an adapter/wrapper that still owns the output head.
-        # A bare *ForCausalLM also has a `.model`, but that is its decoder body:
-        # it returns hidden states and no `.logits` at all, so wrapping it lets
-        # the head above run untouched and the fallback becomes a silent no-op.
-        # TRL builds GRPO's `ref_model` with a plain
-        # `architecture.from_pretrained(...)`, which is exactly that shape, and
-        # the caller then receives [B, T, vocab] where it expects [B, T, hidden].
+        # Descend only into an adapter that still owns the head. A bare *ForCausalLM
+        # (what TRL builds GRPO's ref_model as) also has a `.model`, but that is its
+        # decoder body, and wrapping it leaves the head above running untouched: the
+        # fallback becomes a silent no-op returning [B, T, vocab], not [B, T, hidden].
         if not _module_returns_logits(child):
             continue
         return child
@@ -1612,10 +1608,10 @@ def _install_grpo_hidden_states_forward_wrapper(model):
     model_name = type(target_model).__name__
 
     def wrapped_forward(*args, **kwargs):
-        # accelerate's extract_model_from_parallel(keep_fp32_wrapper = False) rebinds an
-        # instance-level forward as MethodType(forward, model), so this plain function is
-        # re-entered with the module as its leading positional argument. TRL's GRPO loop
-        # unwraps exactly that way on every step, and `original_forward` is already bound.
+        # accelerate's extract_model_from_parallel(keep_fp32_wrapper = False), which the
+        # GRPO loop calls every step, rebinds an instance-level forward as
+        # MethodType(forward, model), so the module arrives as a leading positional
+        # argument. `original_forward` is already bound, so drop it.
         while len(args) != 0 and args[0] is target_model:
             args = args[1:]
         if os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") != "1":

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1612,6 +1612,12 @@ def _install_grpo_hidden_states_forward_wrapper(model):
     model_name = type(target_model).__name__
 
     def wrapped_forward(*args, **kwargs):
+        # accelerate's extract_model_from_parallel(keep_fp32_wrapper = False) rebinds an
+        # instance-level forward as MethodType(forward, model), so this plain function is
+        # re-entered with the module as its leading positional argument. TRL's GRPO loop
+        # unwraps exactly that way on every step, and `original_forward` is already bound.
+        while len(args) != 0 and args[0] is target_model:
+            args = args[1:]
         if os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") != "1":
             return original_forward(*args, **kwargs)
 


### PR DESCRIPTION
## Problem

Any GRPO run that is not PEFT (`full_finetuning = True`) dies at the first reference-logprob computation:

```
TorchRuntimeError: RuntimeError when making fake tensor call
Dynamo failed to run FX node with fake tensors: call_function <built-in function matmul>(
  FakeTensor(device='cuda:0', size=(((s47*s87 + 255)//256), s33), dtype=torch.bfloat16),
  FakeTensor(device='cuda:0', size=(1536, 151936), dtype=torch.bfloat16, requires_grad=True))
got RuntimeError('a and b must have same reduction dim, but got [((s47*s87 + 255)//256), s33] X [1536, 151936].')

from user code:
  File "unsloth_compiled_cache/UnslothGRPOTrainer.py", line 161,
    in chunked_hidden_states_selective_log_softmax
      chunk_logits = chunk_hidden_states.to(lm_head.dtype) @ lm_head.t()
```

This is what the `NeMo-Gym-Sudoku` and `NeMo-Gym-Multi-Environment` notebooks hit. Both load `unsloth/Qwen2.5-1.5B-Instruct` with `full_finetuning = True`, and `models/rl.py` sets GRPO's `beta` default to `0.001`, so TRL builds a reference model.

## Root cause

TRL builds `ref_model` with a plain

```python
architecture = getattr(transformers, config.architectures[0])
self.ref_model = architecture.from_pretrained(model_id, **model_init_kwargs)
```

That model's forward is a stock transformers one, so it does not honour `UNSLOTH_RETURN_HIDDEN_STATES` and `.logits` is a real `[B, T, vocab]` tensor. `_install_grpo_hidden_states_forward_wrapper` exists exactly to cover this, and `_wrap_grpo_hidden_states_fallback` does install it on `ref_model`.

It never took effect. `_grpo_hidden_states_wrap_target` walked `("base_model", "model")` to find an adapter's wrapped model, and a bare `*ForCausalLM` also has a `.model` -- its decoder body. So the wrapper landed on `Qwen2Model`, which returns no `.logits` at all; the head above it then ran untouched and the caller still got vocab-width logits. Nothing raised, so neither of the two "using logits directly" warnings fired either.

Measured on the model TRL actually builds:

```
REF class           : Qwen2ForCausalLM | transformers.models.qwen2.modeling_qwen2
REF supports marker : False
REF wrap target     : Qwen2Model          <- the decoder, not the head owner
REF wrapped attr    : True
lm_head             : (151936, 896)
REF .logits width   : (1, 6, 151936)      <- expected (1, 6, 896)
```

`s33` in the error is the backed symbol the hidden-size dim collapses to once the policy call (896) and the reference call (151936) have made Dynamo mark that axis dynamic; the mismatch is a plain width mismatch underneath.

## Fix

Descend only into a child that still owns an output head. `PreTrainedModel.get_output_embeddings()` returns `None` for the decoder bodies and the head module for the `*ForCausalLM` wrappers, so it separates the two without a model-name list, and adapter wrappers (PEFT `base_model` / `model`) are unaffected because they proxy the head through.

## Test

`tests/test_grpo_hidden_states_wrap_target.py` builds a real tiny `Qwen2ForCausalLM`, the same shape TRL hands over, and pins:

- the decoder body is not a wrap target, an adapter-shaped wrapper still is
- with the switch on, the model returns hidden states of the head's input width
- those hidden states are the ones the head consumes: `hidden @ lm_head.t()` matches the model's own logits
- with the switch off, the output is unchanged

Reverting the one-line predicate turns tests 1 and 3 red.

## Verification

Qwen2.5-0.5B-Instruct, `full_finetuning = True`, GRPO, 1 step, one A100. Same tree, only this commit differing:

| tree | result |
| --- | --- |
| `origin/main` | exit 1, `a and b must have same reduction dim, but got [((s47*s87 + 7)//8), s33] X [896, 151936]` |
| this branch | exit 0, `TRAIN_OK` |

On `main` the sequence-packing and PrefixGrouper no-grad paths also log the same mismatch and fall back before the padded loop raises for real. With this commit none of them appear: the reference model now returns hidden states, so the memory-efficient chunked path is used rather than being fallen back off.

Related: #8204 adds the missing width dispatch at the remaining call sites, which turns the same input into a correct-but-slower `chunked_selective_log_softmax` call. That is the safety net; this is the reason the wrong-width input reached them.
