### PR TITLE
Fix Studio loaded-model GGUF quant label

### DIFF
--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -4386,6 +4386,7 @@ class DiffusionBackend:
                 "device": None,
                 "dtype": None,
                 "model_kind": None,
+                "gguf_variant": None,
                 "cpu_offload": False,
                 "offload_policy": None,
                 "vae_tiling": False,
@@ -4402,6 +4403,7 @@ class DiffusionBackend:
                 "resolved": None,
             }
         from core.inference import diffusion_controlnet, diffusion_lora
+        from hub.utils.gguf import extract_quant_token
 
         return {
             "loaded": True,
@@ -4411,6 +4413,11 @@ class DiffusionBackend:
             "device": state.device,
             "dtype": state.dtype,
             "model_kind": state.kind,
+            "gguf_variant": (
+                extract_quant_token(state.gguf_filename)
+                if state.kind == "gguf" and state.gguf_filename
+                else None
+            ),
             "cpu_offload": state.cpu_offload,
             "offload_policy": state.offload_policy,
             "vae_tiling": state.vae_tiling,

--- a/studio/backend/core/inference/sd_cpp_backend.py
+++ b/studio/backend/core/inference/sd_cpp_backend.py
@@ -1480,7 +1480,9 @@ class SdCppDiffusionBackend:
             "base_repo": state.base_repo,
             "device": state.device,
             "dtype": "gguf",
-            "gguf_variant": extract_quant_token(state.gguf_filename) if state.gguf_filename else None,
+            "gguf_variant": extract_quant_token(state.gguf_filename)
+            if state.gguf_filename
+            else None,
             # Reflect the offload flags actually passed to sd-cli (empty on CPU -> "none").
             "cpu_offload": bool(state.offload_flags),
             "offload_policy": "active" if state.offload_flags else "none",

--- a/studio/backend/core/inference/sd_cpp_backend.py
+++ b/studio/backend/core/inference/sd_cpp_backend.py
@@ -1453,6 +1453,7 @@ class SdCppDiffusionBackend:
                 "base_repo": None,
                 "device": None,
                 "dtype": None,
+                "gguf_variant": None,
                 "cpu_offload": False,
                 "offload_policy": None,
                 "vae_tiling": False,
@@ -1470,6 +1471,7 @@ class SdCppDiffusionBackend:
                 "workflows": [],
             }
         from core.inference import diffusion_lora
+        from hub.utils.gguf import extract_quant_token
 
         return {
             "loaded": True,
@@ -1478,6 +1480,7 @@ class SdCppDiffusionBackend:
             "base_repo": state.base_repo,
             "device": state.device,
             "dtype": "gguf",
+            "gguf_variant": extract_quant_token(state.gguf_filename) if state.gguf_filename else None,
             # Reflect the offload flags actually passed to sd-cli (empty on CPU -> "none").
             "cpu_offload": bool(state.offload_flags),
             "offload_policy": "active" if state.offload_flags else "none",

--- a/studio/backend/core/inference/video.py
+++ b/studio/backend/core/inference/video.py
@@ -2351,6 +2351,7 @@ class VideoBackend:
                 "device": None,
                 "dtype": None,
                 "model_kind": None,
+                "gguf_variant": None,
                 "offload_policy": None,
                 "vae_tiling": False,
                 "memory_mode": None,
@@ -2364,6 +2365,8 @@ class VideoBackend:
                 "defaults": None,
                 "resolved": None,
             }
+        from hub.utils.gguf import extract_quant_token
+
         fam = state.family
         default_steps, default_guidance = default_video_generation_params(
             state.gguf_filename,
@@ -2379,6 +2382,12 @@ class VideoBackend:
             "device": state.device,
             "dtype": state.dtype,
             "model_kind": state.kind,
+            # As on the image runtime: dtype is compute precision, which labelled a Q4_K_M BF16.
+            "gguf_variant": (
+                extract_quant_token(state.gguf_filename)
+                if state.kind == "gguf" and state.gguf_filename
+                else None
+            ),
             "offload_policy": state.offload_policy,
             "vae_tiling": state.vae_tiling,
             "memory_mode": state.memory_mode,

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -3420,6 +3420,9 @@ class VideoStatusResponse(BaseModel):
     model_kind: Optional[str] = Field(
         None, description = "Resolved load kind: gguf | single_file | pipeline (gates GGUF-only UI)"
     )
+    gguf_variant: Optional[str] = Field(
+        None, description = "Selected GGUF quantisation variant (for example Q8_0)"
+    )
     offload_policy: Optional[str] = Field(
         None, description = "Resolved offload policy: none | group | model | sequential"
     )

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -2969,6 +2969,9 @@ class DiffusionStatusResponse(BaseModel):
     model_kind: Optional[str] = Field(
         None, description = "Resolved load kind: gguf | single_file | pipeline (gates GGUF-only UI)"
     )
+    gguf_variant: Optional[str] = Field(
+        None, description = "Selected GGUF quantisation variant (for example Q8_0)"
+    )
     cpu_offload: bool = Field(False, description = "Whether CPU offload is engaged")
     offload_policy: Optional[str] = Field(
         None, description = "Resolved offload policy: none | group | model | streaming | sequential"

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -693,6 +693,23 @@ def test_load_generate_unload_gguf(fake_runtime, tmp_path):
     assert backend.is_loaded is False
 
 
+def test_gguf_status_reports_selected_quant_instead_of_only_compute_dtype(fake_runtime, tmp_path):
+    filename = "z-image-turbo-Q8_0.gguf"
+    (tmp_path / filename).write_bytes(b"weights")
+    backend = DiffusionBackend()
+
+    status = backend.load_pipeline(
+        str(tmp_path),
+        gguf_filename = filename,
+        base_repo = "base/repo",
+        family_override = "z-image",
+    )
+
+    assert status["dtype"] == "float32"  # compute dtype is a separate concern
+    assert status["gguf_variant"] == "Q8_0"
+    assert backend.unload()["gguf_variant"] is None
+
+
 def test_generate_progress_active_during_setup(fake_runtime, tmp_path, monkeypatch):
     # Active must be published the moment the lock is held, before the slow setup that _apply_loras runs in.
     (tmp_path / "model.gguf").write_bytes(b"weights")
@@ -4469,6 +4486,11 @@ def test_diffusion_status_response_carries_requested_precision():
     }
     resp = DiffusionStatusResponse(loaded = True, resolved = rec)
     assert resp.model_dump()["resolved"] == rec
+
+
+def test_diffusion_status_response_carries_gguf_variant():
+    from models.inference import DiffusionStatusResponse
+    assert DiffusionStatusResponse(loaded = True, gguf_variant = "Q8_0").gguf_variant == "Q8_0"
 
 
 def test_companion_cache_bytes_local_dir_excludes_transformer(tmp_path):

--- a/studio/backend/tests/test_sd_cpp_backend.py
+++ b/studio/backend/tests/test_sd_cpp_backend.py
@@ -469,6 +469,7 @@ def test_status_loaded_shape():
     assert st["engine"] == "sd_cpp"
     assert st["family"] == "z-image"
     assert st["device"] == "cpu"
+    assert st["gguf_variant"] is None
     # diffusers-only fields are present (route response parity) but null.
     for k in ("transformer_quant", "attention_backend", "transformer_cache", "text_encoder_quant"):
         assert st[k] is None
@@ -750,6 +751,7 @@ def _run_server_load(
     servers,
     fam_name = "z-image",
     device = "cpu",
+    gguf_filename = "z.gguf",
 ):
     fam = detect_family(fam_name)
     monkeypatch.setattr(bk, "find_sd_server_binary", lambda: "/x/sd-server")
@@ -775,7 +777,7 @@ def _run_server_load(
     b._load_token = 1
     b._run_load(
         repo_id = "unsloth/Z-Image-Turbo-GGUF",
-        gguf_filename = "z.gguf",
+        gguf_filename = gguf_filename,
         base = fam.base_repo,
         fam = fam,
         hf_token = None,
@@ -791,6 +793,13 @@ def test_server_load_spawns_once_and_status_reports_mode(monkeypatch):
     assert servers[0].started is not None  # the model is loaded once, at spawn
     assert b._state is not None and b._state.mode == "server" and b._state.server is servers[0]
     assert b.status()["native_mode"] == "server"
+
+
+def test_server_status_reports_selected_gguf_quant(monkeypatch):
+    b = SdCppDiffusionBackend()
+    servers: list = []
+    _run_server_load(monkeypatch, b, servers, gguf_filename = "z-image-turbo-Q8_0.gguf")
+    assert b.status()["gguf_variant"] == "Q8_0"
 
 
 def test_server_generate_uses_one_request_for_whole_batch(monkeypatch):

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -1383,6 +1383,37 @@ def test_video_step_cache_auto_from_default_schedule(fake_runtime, tmp_path):
     backend.unload()
 
 
+def test_video_gguf_status_reports_selected_quant_instead_of_only_compute_dtype(
+    fake_runtime, tmp_path
+):
+    filename = "ltx-2.3-22b-distilled-1.1-Q4_K_M.gguf"
+    (tmp_path / filename).write_bytes(b"w")
+    backend = VideoBackend()
+
+    status = backend.load_pipeline(
+        str(tmp_path),
+        gguf_filename = filename,
+        base_repo = "Lightricks/LTX-2",
+        family_override = "ltx-2",
+    )
+
+    assert status["gguf_variant"] == "Q4_K_M"
+    assert backend.unload()["gguf_variant"] is None
+    # A pipeline load has no checkpoint quant to name.
+    assert (
+        backend.load_pipeline("Wan-AI/Wan2.2-TI2V-5B-Diffusers", model_kind = "pipeline")[
+            "gguf_variant"
+        ]
+        is None
+    )
+    backend.unload()
+
+
+def test_video_status_response_carries_gguf_variant():
+    from models.inference import VideoStatusResponse
+    assert VideoStatusResponse(loaded = True, gguf_variant = "Q4_K_M").gguf_variant == "Q4_K_M"
+
+
 def test_video_step_cache_auto_toggles_on_actual_steps(fake_runtime):
     # The AUTO decision follows each generation's ACTUAL step count; an explicit "off" never toggles.
     backend = VideoBackend()

--- a/studio/frontend/src/features/images/api.ts
+++ b/studio/frontend/src/features/images/api.ts
@@ -27,6 +27,8 @@ export interface DiffusionStatus {
   dtype: string | null;
   // Resolved load kind: "gguf" | "single_file" | "pipeline". Gates GGUF-only controls. Null when not loaded.
   model_kind?: string | null;
+  // Selected GGUF quant. Newer backends report this separately from the compute dtype.
+  gguf_variant?: string | null;
   cpu_offload: boolean;
   // The ENGAGED runtime build. The backend has always sent these; declaring them is what lets the UI
   // report what actually ran instead of echoing the load request back at the user.

--- a/studio/frontend/src/features/loaded-models/loaded-models-sources.ts
+++ b/studio/frontend/src/features/loaded-models/loaded-models-sources.ts
@@ -236,10 +236,11 @@ export function describeVideoStatus(
       name: status.repo_id,
       detail: joinDetail(
         status.family,
-        status.model_kind === "gguf" ? "GGUF" : null,
-        // The dense transformer's own precision when one engaged, since that is
-        // what distinguishes the build; otherwise the pipeline dtype.
-        precisionLabel(status.transformer_quant) ??
+        status.model_kind === "gguf" || status.gguf_variant ? "GGUF" : null,
+        // The checkpoint quant identifies a GGUF build; else the dense transformer's own
+        // precision when one engaged; else the pipeline dtype (only compute precision).
+        status.gguf_variant ??
+          precisionLabel(status.transformer_quant) ??
           precisionLabel(status.dtype),
         status.device,
       ),

--- a/studio/frontend/src/features/loaded-models/loaded-models-sources.ts
+++ b/studio/frontend/src/features/loaded-models/loaded-models-sources.ts
@@ -215,9 +215,10 @@ export function describeDiffusionStatus(
       detail: joinDetail(
         status.family,
         isGguf ? "GGUF" : null,
-        // The checkpoint quant identifies a GGUF build. dtype is only its
-        // compute precision, and calling that BF16 made a Q8_0 pick look wrong.
-        status.gguf_variant ?? precisionLabel(status.dtype),
+        // The checkpoint quant identifies a GGUF build. dtype is only its compute
+        // precision, and calling that BF16 made a Q8_0 pick look wrong. Through
+        // precisionLabel so a lowercase q8_0 filename still reads Q8_0.
+        precisionLabel(status.gguf_variant) ?? precisionLabel(status.dtype),
         status.device,
       ),
     },
@@ -239,7 +240,7 @@ export function describeVideoStatus(
         status.model_kind === "gguf" || status.gguf_variant ? "GGUF" : null,
         // The checkpoint quant identifies a GGUF build; else the dense transformer's own
         // precision when one engaged; else the pipeline dtype (only compute precision).
-        status.gguf_variant ??
+        precisionLabel(status.gguf_variant) ??
           precisionLabel(status.transformer_quant) ??
           precisionLabel(status.dtype),
         status.device,

--- a/studio/frontend/src/features/loaded-models/loaded-models-sources.ts
+++ b/studio/frontend/src/features/loaded-models/loaded-models-sources.ts
@@ -202,6 +202,10 @@ export function describeDiffusionStatus(
   status: DiffusionStatus | null,
 ): LoadedModelEntry[] {
   if (!status?.loaded || !status.repo_id) return [];
+  const isGguf =
+    status.model_kind === "gguf" ||
+    status.dtype?.toLowerCase() === "gguf" ||
+    Boolean(status.gguf_variant);
   return [
     {
       id: `image:${status.repo_id}`,
@@ -210,9 +214,10 @@ export function describeDiffusionStatus(
       name: status.repo_id,
       detail: joinDetail(
         status.family,
-        status.model_kind === "gguf" ? "GGUF" : null,
-        // A GGUF load reports "gguf" here too; joinDetail drops the repeat.
-        precisionLabel(status.dtype),
+        isGguf ? "GGUF" : null,
+        // The checkpoint quant identifies a GGUF build. dtype is only its
+        // compute precision, and calling that BF16 made a Q8_0 pick look wrong.
+        status.gguf_variant ?? precisionLabel(status.dtype),
         status.device,
       ),
     },

--- a/studio/frontend/src/features/loaded-models/loaded-models-sources.ts
+++ b/studio/frontend/src/features/loaded-models/loaded-models-sources.ts
@@ -215,9 +215,8 @@ export function describeDiffusionStatus(
       detail: joinDetail(
         status.family,
         isGguf ? "GGUF" : null,
-        // The checkpoint quant identifies a GGUF build. dtype is only its compute
-        // precision, and calling that BF16 made a Q8_0 pick look wrong. Through
-        // precisionLabel so a lowercase q8_0 filename still reads Q8_0.
+        // The checkpoint quant, not dtype: dtype is the compute precision, which called
+        // a Q8_0 pick BF16. Via precisionLabel so a lowercase q8_0 still reads Q8_0.
         precisionLabel(status.gguf_variant) ?? precisionLabel(status.dtype),
         status.device,
       ),
@@ -238,8 +237,8 @@ export function describeVideoStatus(
       detail: joinDetail(
         status.family,
         status.model_kind === "gguf" || status.gguf_variant ? "GGUF" : null,
-        // The checkpoint quant identifies a GGUF build; else the dense transformer's own
-        // precision when one engaged; else the pipeline dtype (only compute precision).
+        // Checkpoint quant, else the dense transformer's own precision when one
+        // engaged, else the pipeline dtype (compute precision, so it called Q4_K_M BF16).
         precisionLabel(status.gguf_variant) ??
           precisionLabel(status.transformer_quant) ??
           precisionLabel(status.dtype),

--- a/studio/frontend/src/features/video/api.ts
+++ b/studio/frontend/src/features/video/api.ts
@@ -44,6 +44,8 @@ export interface VideoStatus {
   dtype: string | null;
   // Resolved load kind: "gguf" | "single_file" | "pipeline". Null when not loaded.
   model_kind?: string | null;
+  // Selected GGUF quant. Newer backends report this separately from the compute dtype.
+  gguf_variant?: string | null;
   // Resolved offload policy: none | group | model | sequential.
   offload_policy?: string | null;
   vae_tiling: boolean;

--- a/studio/frontend/tests/loaded-models-q8-precision-repro.test.ts
+++ b/studio/frontend/tests/loaded-models-q8-precision-repro.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeDiffusionStatus } from "../src/features/loaded-models/loaded-models-sources.ts";
+
+test("fixed: a Q8 Z-Image GGUF row names Q8 instead of its BF16 compute dtype", () => {
+  const [row] = describeDiffusionStatus({
+    loaded: true,
+    repo_id: "unsloth/Z-Image-Turbo-GGUF",
+    family: "z-image",
+    device: "cuda",
+    dtype: "bfloat16",
+    model_kind: "gguf",
+    gguf_variant: "Q8_0",
+  } as never);
+
+  assert.equal(row.detail, "z-image · GGUF · Q8_0 · cuda");
+  assert.equal(row.detail.includes("BF16"), false);
+  console.log(
+    "PASS selected=z-image-turbo-Q8_0.gguf indicator=z-image · GGUF · Q8_0 · cuda",
+  );
+});

--- a/studio/frontend/tests/loaded-models-sources.test.ts
+++ b/studio/frontend/tests/loaded-models-sources.test.ts
@@ -219,6 +219,31 @@ test("a GGUF image load does not print GGUF twice", () => {
   assert.equal(image.detail, "flux · GGUF · cuda");
 });
 
+test("a GGUF image row names its selected quant instead of its compute dtype", () => {
+  const [image] = describeDiffusionStatus({
+    loaded: true,
+    repo_id: "unsloth/Z-Image-Turbo-GGUF",
+    family: "z-image",
+    model_kind: "gguf",
+    gguf_variant: "Q8_0",
+    dtype: "bfloat16",
+    device: "cuda",
+  } as never);
+  assert.equal(image.detail, "z-image · GGUF · Q8_0 · cuda");
+});
+
+test("a native GGUF image row names its selected quant without model_kind", () => {
+  const [image] = describeDiffusionStatus({
+    loaded: true,
+    repo_id: "unsloth/Z-Image-Turbo-GGUF",
+    family: "z-image",
+    gguf_variant: "Q8_0",
+    dtype: "gguf",
+    device: "cpu",
+  } as never);
+  assert.equal(image.detail, "z-image · GGUF · Q8_0 · cpu");
+});
+
 // Gemma 3n and friends take audio in but answer as chat. Every backend sets
 // is_audio from `audio_type is not None and audio_type != "audio_vlm"`
 // (model_config.py, mlx_inference.py; llama_cpp.py keeps _is_audio False for

--- a/studio/frontend/tests/loaded-models-sources.test.ts
+++ b/studio/frontend/tests/loaded-models-sources.test.ts
@@ -207,6 +207,19 @@ test("a bf16 video load falls back to the pipeline dtype", () => {
   assert.equal(video.detail, "wan · BF16 · cuda");
 });
 
+test("a GGUF video row names its selected quant instead of its compute dtype", () => {
+  const [video] = describeVideoStatus({
+    loaded: true,
+    repo_id: "unsloth/Wan2.2-T2V-A14B-GGUF",
+    family: "wan",
+    model_kind: "gguf",
+    gguf_variant: "Q4_K_M",
+    dtype: "bfloat16",
+    device: "cuda",
+  } as never);
+  assert.equal(video.detail, "wan · GGUF · Q4_K_M · cuda");
+});
+
 test("a GGUF image load does not print GGUF twice", () => {
   const [image] = describeDiffusionStatus({
     loaded: true,

--- a/studio/frontend/tests/loaded-models-sources.test.ts
+++ b/studio/frontend/tests/loaded-models-sources.test.ts
@@ -220,6 +220,21 @@ test("a GGUF video row names its selected quant instead of its compute dtype", (
   assert.equal(video.detail, "wan · GGUF · Q4_K_M · cuda");
 });
 
+test("a lowercase quant filename still reads as an upper-case quant", () => {
+  // Plenty of Hub repos ship z-image-turbo-q8_0.gguf; every other quant label in the
+  // UI is upper-cased, so the row must not be the one place that shows q8_0.
+  const [image] = describeDiffusionStatus({
+    loaded: true,
+    repo_id: "unsloth/Z-Image-Turbo-GGUF",
+    family: "z-image",
+    model_kind: "gguf",
+    gguf_variant: "q8_0",
+    dtype: "bfloat16",
+    device: "cuda",
+  } as never);
+  assert.equal(image.detail, "z-image · GGUF · Q8_0 · cuda");
+});
+
 test("a GGUF image load does not print GGUF twice", () => {
   const [image] = describeDiffusionStatus({
     loaded: true,

--- a/studio/frontend/tests/loaded-models-sources.test.ts
+++ b/studio/frontend/tests/loaded-models-sources.test.ts
@@ -221,8 +221,7 @@ test("a GGUF video row names its selected quant instead of its compute dtype", (
 });
 
 test("a lowercase quant filename still reads as an upper-case quant", () => {
-  // Plenty of Hub repos ship z-image-turbo-q8_0.gguf; every other quant label in the
-  // UI is upper-cased, so the row must not be the one place that shows q8_0.
+  // Hub repos ship q8_0 filenames, and every other quant label in the UI is upper-cased.
   const [image] = describeDiffusionStatus({
     loaded: true,
     repo_id: "unsloth/Z-Image-Turbo-GGUF",


### PR DESCRIPTION
## Summary

- report the selected image GGUF quantization in diffusion status
- show that quantization in the Loaded models indicator instead of the pipeline compute dtype
- cover both diffusers and native `sd.cpp` paths, with a fallback for older backends

## Root cause

The image runtime retained the selected GGUF filename internally, but `/api/inference/images/status` exposed only `model_kind: "gguf"` and `dtype: "bfloat16"`. The Loaded models indicator consequently rendered `GGUF · BF16` when `Q8_0` was selected. BF16 described the pipeline compute precision, not the GGUF checkpoint quantization.

## User impact

A Z-Image `Q8_0` load now displays `GGUF · Q8_0 · cuda` rather than `GGUF · BF16 · cuda`.

## Validation

- [Targeted GitHub Actions repro and fix-verification run](https://github.com/Imagineer99/unsloth/actions/runs/31303306098)
  - fixed output: `PASS selected=z-image-turbo-Q8_0.gguf indicator=z-image · GGUF · Q8_0 · cuda`
- 72 loaded-model frontend tests passed
- 5 focused backend tests passed, covering diffusers and native `sd.cpp` status producers
- frontend TypeScript typecheck passed
- `git diff --check` passed
