### PR TITLE
Point the release-desktop ordering tests at the job graph the workflow now has

### DIFF
--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -810,11 +810,16 @@ class TestRetryBackoffRespectsTheDeadline:
 class TestWorkflowOrdering:
     """The scan must not disclose bundles for a release that cannot be published."""
 
-    def _publish_step_list(self):
+    def _jobs(self):
         yaml = pytest.importorskip("yaml")
         workflow = REPO_ROOT / ".github" / "workflows" / "release-desktop.yml"
-        data = yaml.safe_load(workflow.read_text(encoding = "utf-8"))
-        return data["jobs"]["publish-release"]["steps"]
+        return yaml.safe_load(workflow.read_text(encoding = "utf-8"))["jobs"]
+
+    def _publish_step_list(self):
+        return self._jobs()["publish-release"]["steps"]
+
+    def _scan_steps(self):
+        return [step.get("name") for step in self._jobs()["virustotal-scan"]["steps"]]
 
     def _publish_steps(self):
         return [step.get("name") for step in self._publish_step_list()]
@@ -823,17 +828,18 @@ class TestWorkflowOrdering:
         return {step.get("name"): step for step in self._publish_step_list()}
 
     def test_scan_runs_after_the_release_is_validated(self):
-        names = self._publish_steps()
-        assert names.index("Validate versioned release state") < names.index(
-            "VirusTotal pre-flight scan"
-        )
+        # The scan is its own job downstream of publish-release, so everything
+        # publish-release validates is already settled before it starts.
+        assert "publish-release" in self._jobs()["virustotal-scan"]["needs"]
+        assert "Validate versioned release state" in self._publish_steps()
 
-    def test_release_creation_is_deferred_until_after_the_scan(self):
-        # `gh release create` without `--draft` publishes at once, so creating a
-        # new release before the scan would expose an empty release for its
-        # duration, and leave it empty for good if the run were cancelled.
+    def test_release_creation_is_deferred_until_the_assets_are_ready(self):
+        # `gh release create` without `--draft` publishes at once, so the release
+        # is created only once its assets are in hand, and never left empty.
         names = self._publish_steps()
-        assert names.index("VirusTotal pre-flight scan") < names.index("Create versioned release")
+        assert names.index("Download signed release assets") < names.index(
+            "Create versioned release"
+        )
         assert names.index("Create versioned release") < names.index(
             "Publish versioned release assets"
         )
@@ -868,13 +874,13 @@ class TestWorkflowOrdering:
             == "steps.versioned_release_state.outputs.create == 'true'"
         )
 
-    def test_scan_runs_before_the_assets_are_published(self):
-        names = self._publish_steps()
-        assert names.index("VirusTotal pre-flight scan") < names.index(
-            "Publish versioned release assets"
-        )
+    def test_the_scan_reads_the_assets_that_were_published(self):
+        # The scan job holds no build of its own, so it has to pull the same
+        # artifacts publish-release released rather than rebuild them.
+        names = self._scan_steps()
+        assert names.index("Download published assets") < names.index("VirusTotal scan")
 
     def test_the_scan_script_is_checked_out_first(self):
-        # publish-release otherwise has no source tree, so the script would be missing.
-        names = self._publish_steps()
-        assert names.index("Check out the scan script") < names.index("VirusTotal pre-flight scan")
+        # virustotal-scan otherwise has no source tree, so the script would be missing.
+        names = self._scan_steps()
+        assert names.index("Check out the scan script") < names.index("VirusTotal scan")

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -48,11 +48,19 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     assert any(
         step.get("uses", "").startswith("actions/download-artifact@") for step in publish["steps"]
     )
-    assert "build" in publish["needs"]
 
-    # The guard moved into a validation step that runs ahead of the VirusTotal
-    # scan; creating a missing release is deferred to a separate step so a
-    # non-draft release is never published empty for the length of the scan.
+    # publish-release starts alongside the build matrix rather than after it, so
+    # the hand-off is an explicit wait step that has to precede the download.
+    publish_names = [step.get("name") for step in publish["steps"]]
+    download_index = next(
+        index
+        for index, step in enumerate(publish["steps"])
+        if step.get("uses", "").startswith("actions/download-artifact@")
+    )
+    assert publish_names.index("Wait for the build matrix") < download_index
+
+    # The guard lives in a validation step; creating a missing release is deferred
+    # to a separate step so a non-draft release is never published empty.
     release_step = next(
         step for step in publish["steps"] if step.get("name") == "Validate versioned release state"
     )


### PR DESCRIPTION
`Repo tests (CPU)` and `pytest tests/security` are red on `main` and on every open PR branched from it. Five assertions still describe the release-desktop workflow as it was before #8193 and #8194 restructured it.

```
FAILED tests/security/test_release_desktop_permissions.py::test_build_matrix_hands_off_assets_without_release_credentials - AssertionError: assert 'build' in ['prepare-version']
FAILED tests/python/test_virustotal_scan.py::TestWorkflowOrdering::test_scan_runs_after_the_release_is_validated - ValueError: 'VirusTotal pre-flight scan' is not in list
FAILED tests/python/test_virustotal_scan.py::TestWorkflowOrdering::test_release_creation_is_deferred_until_after_the_scan - ValueError: 'VirusTotal pre-flight scan' is not in list
FAILED tests/python/test_virustotal_scan.py::TestWorkflowOrdering::test_scan_runs_before_the_assets_are_published - ValueError: 'VirusTotal pre-flight scan' is not in list
FAILED tests/python/test_virustotal_scan.py::TestWorkflowOrdering::test_the_scan_script_is_checked_out_first - ValueError: 'Check out the scan script' is not in list
```

What changed under them:

- #8193 started `publish-release` alongside the build matrix, so it needs `prepare-version` and waits on an explicit `Wait for the build matrix` step instead of `needs: build`.
- #8194 moved the VirusTotal scan out of `publish-release` into its own `virustotal-scan` job that needs `publish-release`, and renamed its steps (`VirusTotal pre-flight scan` -> `VirusTotal scan`, plus a `Download published assets` step).

The workflow is untouched here. The tests now assert the same properties against the current graph:

- the build hand-off is the `Wait for the build matrix` step, and it precedes the `download-artifact` step;
- `virustotal-scan` needs `publish-release`, so everything `publish-release` validates is settled before the scan starts;
- the release is created only after its assets are downloaded, and before they are published;
- inside `virustotal-scan`, the script checkout and the asset download both precede `VirusTotal scan`.

Verified by sabotage, each against the restored workflow:

| mutation | result |
|---|---|
| baseline | 73 passed |
| rename `Wait for the build matrix` | `test_build_matrix_hands_off_assets_without_release_credentials` fails |
| `virustotal-scan` needs `build` instead of `publish-release` | `test_scan_runs_after_the_release_is_validated` fails |
| move `Check out the scan script` after the scan | `test_the_scan_script_is_checked_out_first` fails |
| restored | 73 passed |
