### PR TITLE
Repo tests: pin the post-publish VirusTotal contract instead of the old pre-flight one

### DIFF
--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Unit tests for the advisory VirusTotal pre-flight scan.
+"""Unit tests for the advisory VirusTotal post-publish scan.
+
+The scan is a sweep of the bundles a release has already published, run in the
+`virustotal-scan` job after `publish-release`. It is not a gate and cannot hold
+a release back; Defender in the build job is the fail-closed check.
 
 Offline by design: every test injects a fake transport, so the suite never spends
 the account's 500/day quota and never uploads a build. The two behaviours worth
@@ -808,13 +812,28 @@ class TestRetryBackoffRespectsTheDeadline:
 
 
 class TestWorkflowOrdering:
-    """The scan must not disclose bundles for a release that cannot be published."""
+    """The scan is a post-publish sweep, and the wiring that makes it run must hold.
 
-    def _publish_step_list(self):
+    There is no pre-publish gate here and there never was one that could block a
+    release: the scan is advisory by design (Defender in the build job is the
+    fail-closed check for Windows), and since #8194 it runs in its own
+    `virustotal-scan` job after `publish-release` rather than inline before the
+    upload. The bundles are already public by the time it runs.
+
+    What is still worth pinning is that the sweep cannot be quietly lost. A
+    deleted job, a dropped `needs`, an `if:` that never fires, a missing script
+    checkout or a `|| true` around the invocation would each leave the release
+    scanned by nothing while the workflow stayed green. The tests below assert
+    each of those against the workflow YAML.
+    """
+
+    def _workflow(self):
         yaml = pytest.importorskip("yaml")
         workflow = REPO_ROOT / ".github" / "workflows" / "release-desktop.yml"
-        data = yaml.safe_load(workflow.read_text(encoding = "utf-8"))
-        return data["jobs"]["publish-release"]["steps"]
+        return yaml.safe_load(workflow.read_text(encoding = "utf-8"))
+
+    def _publish_step_list(self):
+        return self._workflow()["jobs"]["publish-release"]["steps"]
 
     def _publish_steps(self):
         return [step.get("name") for step in self._publish_step_list()]
@@ -822,33 +841,91 @@ class TestWorkflowOrdering:
     def _publish_step_map(self):
         return {step.get("name"): step for step in self._publish_step_list()}
 
-    def test_scan_runs_after_the_release_is_validated(self):
-        names = self._publish_steps()
-        assert names.index("Validate versioned release state") < names.index(
-            "VirusTotal pre-flight scan"
+    def _scan_job(self):
+        jobs = self._workflow()["jobs"]
+        assert "virustotal-scan" in jobs, (
+            "the virustotal-scan job is gone; the release would ship unscanned by "
+            "anything but Defender"
         )
+        return jobs["virustotal-scan"]
 
-    def test_release_creation_is_deferred_until_after_the_scan(self):
-        # `gh release create` without `--draft` publishes at once, so creating a
-        # new release before the scan would expose an empty release for its
-        # duration, and leave it empty for good if the run were cancelled.
+    def _scan_step_map(self):
+        return {step.get("name"): step for step in self._scan_job()["steps"]}
+
+    def _scan_step_names(self):
+        return [step.get("name") for step in self._scan_job()["steps"]]
+
+    def test_the_scan_is_its_own_job_gated_on_publish_release(self):
+        # Pins the post-publish ordering rather than merely tolerating it: the
+        # job must exist and must be downstream of publish-release, so dropping
+        # either the job or the `needs` turns this red.
+        job = self._scan_job()
+        assert job["needs"] == ["publish-release"]
+
+    def test_the_scan_job_is_not_conditioned_away(self):
+        # A job-level `if:` is the quiet way to disable a scan without deleting
+        # it, so the job carries none: reaching it is decided by `needs` alone.
+        job = self._scan_job()
+        assert "if" not in job
+
+        # Nor may the individual steps be skipped, except the summary, which is
+        # `if: always()` precisely so the evidence survives a failed scan.
+        for step in job["steps"]:
+            condition = step.get("if")
+            if step.get("name") == "Publish VirusTotal summary":
+                assert condition == "always()"
+            else:
+                assert condition is None, step.get("name")
+
+    def test_the_scan_scans_the_bundles_that_were_published(self):
+        # The job has no build outputs of its own, so it re-downloads the very
+        # artifacts the build matrix uploaded and publish-release shipped. A
+        # pattern that matched nothing would scan an empty directory and still
+        # report success.
+        upload_names = {
+            step.get("with", {}).get("name")
+            for step in self._workflow()["jobs"]["build"]["steps"]
+            if step.get("uses", "").startswith("actions/upload-artifact@")
+        }
+        assert "desktop-release-${{ matrix.artifact }}" in upload_names
+
+        download = self._scan_step_map()["Download published assets"]
+        assert download["uses"].startswith("actions/download-artifact@")
+        assert download["with"]["pattern"] == "desktop-release-*"
+        assert download["with"]["merge-multiple"] is True
+
+        names = self._scan_step_names()
+        assert names.index("Download published assets") < names.index("VirusTotal scan")
+
+    def test_the_publish_job_no_longer_runs_the_scan(self):
+        # #8194 moved the scan out wholesale. Re-inlining it would put ~9 minutes
+        # back into the critical path of every release for a check that cannot
+        # block one, and would leave two scans burning the same 4/min quota.
+        for step in self._publish_step_list():
+            assert "virustotal" not in (step.get("name") or "").lower()
+            assert "virustotal_scan.py" not in (step.get("run") or "")
+
+    def test_release_creation_stays_immediately_before_the_upload(self):
+        # `gh release create` without `--draft` publishes at once, so the window
+        # between reserving the tag and uploading the assets is when a release is
+        # publicly empty. Nothing slow may be inserted between the two; the scan
+        # used to sit there and is why the window existed at all.
         names = self._publish_steps()
-        assert names.index("VirusTotal pre-flight scan") < names.index("Create versioned release")
-        assert names.index("Create versioned release") < names.index(
-            "Publish versioned release assets"
-        )
+        create = names.index("Create versioned release")
+        assert names.index("Validate versioned release state") < create
+        assert names[create + 1] == "Publish versioned release assets"
 
     def test_release_notes_are_written_unconditionally(self):
-        # Validation writes the notes before the advisory scan; metadata and
-        # provenance consume that same file before the release is created.
+        # Validation writes the notes; metadata and provenance consume that same
+        # file before the release is created.
         steps = self._publish_step_map()
         assert "desktop-release-notes.md" in steps["Validate versioned release state"]["run"]
         metadata = steps["Generate versioned updater metadata and provenance"]["run"]
         assert "desktop-release-notes.md" in metadata
 
     def test_a_failed_lookup_is_not_treated_as_a_missing_release(self):
-        # A transient GraphQL/auth failure must stop before the workflow marks
-        # the version clean and discloses its bundles to VirusTotal.
+        # A transient GraphQL/auth failure must stop rather than let the workflow
+        # conclude the version is unused and overwrite an existing release.
         run = self._publish_step_map()["Validate versioned release state"]["run"]
         assert "if ! gh release list" in run
         failed_lookup = run.split("if ! gh release list", 1)[1].split("release_state=", 1)[0]
@@ -868,13 +945,78 @@ class TestWorkflowOrdering:
             == "steps.versioned_release_state.outputs.create == 'true'"
         )
 
-    def test_scan_runs_before_the_assets_are_published(self):
-        names = self._publish_steps()
-        assert names.index("VirusTotal pre-flight scan") < names.index(
-            "Publish versioned release assets"
-        )
+    def test_the_scan_step_does_not_swallow_its_own_failure(self):
+        # The advisory posture is a property of the job, not of the step. The job
+        # carries `continue-on-error` so a missing secret or a VirusTotal outage
+        # cannot retroactively fail a release that already published; the step
+        # must still surface its exit status, or a broken invocation reads as a
+        # clean scan.
+        step = self._scan_step_map()["VirusTotal scan"]
+        assert "continue-on-error" not in step
 
-    def test_the_scan_script_is_checked_out_first(self):
-        # publish-release otherwise has no source tree, so the script would be missing.
-        names = self._publish_steps()
-        assert names.index("Check out the scan script") < names.index("VirusTotal pre-flight scan")
+        run = step["run"]
+        assert "set -euo pipefail" in run
+
+        invocation = run.split("python3 scripts/virustotal_scan.py", 1)[1]
+        for swallow in ("|| true", "|| :", "exit 0", "; true"):
+            assert swallow not in invocation, swallow
+
+        # The script signals a detection by returning 1 from main() once
+        # `--fail-threshold` is met (see TestThreshold), so the workflow must not
+        # pin the threshold to something the script treats as "never fail" while
+        # claiming to gate. It passes no threshold at all today, which leaves the
+        # script's advisory default in force and the verdict in the annotations.
+        assert "--fail-threshold" not in run
+
+    def test_the_advisory_escape_hatch_is_confined_to_the_scan_job(self):
+        # `continue-on-error` anywhere else would let a genuine release failure
+        # pass as success. Exactly one in the file, on virustotal-scan itself.
+        jobs = self._workflow()["jobs"]
+        assert self._scan_job()["continue-on-error"] is True
+
+        tolerant_jobs = [name for name, job in jobs.items() if "continue-on-error" in job]
+        assert tolerant_jobs == ["virustotal-scan"]
+
+        # free-capacity only asks CI to release runners and is allowed to fail;
+        # every job that touches a bundle must not be.
+        tolerant_steps = [
+            (name, step.get("name"))
+            for name, job in jobs.items()
+            if name != "free-capacity"
+            for step in job.get("steps", [])
+            if "continue-on-error" in step
+        ]
+        assert tolerant_steps == []
+
+    def test_the_scan_job_makes_the_scan_script_available(self):
+        # The job publishes nothing and so has no source tree of its own; the
+        # sparse checkout is the only thing that puts scripts/virustotal_scan.py
+        # on disk. Assert the mechanism, not a step name: a checkout that stops
+        # fetching the script leaves the scan unable to run at all.
+        checkouts = [
+            step
+            for step in self._scan_job()["steps"]
+            if step.get("uses", "").startswith("actions/checkout@")
+        ]
+        assert len(checkouts) == 1
+        checkout = checkouts[0]
+        assert checkout["with"]["sparse-checkout"] == "scripts/virustotal_scan.py"
+        assert checkout["with"]["persist-credentials"] is False
+
+        names = self._scan_step_names()
+        assert names.index(checkout["name"]) < names.index("VirusTotal scan")
+
+        # And if it ever does not, the scan step says so loudly and exits 1
+        # rather than reporting a clean sweep of nothing.
+        guard = self._scan_step_map()["VirusTotal scan"]["run"]
+        assert "if [ ! -f scripts/virustotal_scan.py ]; then" in guard
+        assert "exit 1" in guard.split("if [ ! -f scripts/virustotal_scan.py ]; then", 1)[1]
+
+    def test_the_scan_verdict_is_always_reported(self):
+        # continue-on-error means nobody is forced to look at the job result, so
+        # the step summary is the report. It must be written even when the scan
+        # itself failed, which is exactly the case worth reading.
+        summary = self._scan_step_map()["Publish VirusTotal summary"]
+        assert summary["if"] == "always()"
+        assert "$GITHUB_STEP_SUMMARY" in summary["run"]
+        assert "virustotal-summary.md" in summary["run"]

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -27,6 +27,16 @@ def test_only_publish_job_can_write_repository_contents():
 
 
 def test_build_matrix_hands_off_assets_without_release_credentials():
+    """The build matrix signs bundles; only publish-release may release them.
+
+    The handoff is one-way and credential-free: the matrix uploads artifacts and
+    holds no release token, and publish-release downloads them. Since #8193 the
+    ordering is no longer expressed as `needs: build` (publish-release starts
+    alongside the matrix to queue for its runner in parallel) but by the "Wait
+    for the build matrix" step, which must be at least as strict. Both halves
+    are asserted below, so removing the wait does not silently reintroduce
+    publishing a partial release.
+    """
     jobs = _workflow()["jobs"]
     build = jobs["build"]
     publish = jobs["publish-release"]
@@ -48,11 +58,31 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     assert any(
         step.get("uses", "").startswith("actions/download-artifact@") for step in publish["steps"]
     )
-    assert "build" in publish["needs"]
+    # publish-release deliberately does not `needs: build`, so the wait step is
+    # the whole of the gate. It must cover every matrix leg by name, refuse to
+    # publish on a leg that did not succeed, and refuse to publish a leg whose
+    # job record never appeared, rather than defaulting to "finished".
+    assert publish["needs"] == ["prepare-version"]
+    wait = next(step for step in publish["steps"] if step.get("name") == "Wait for the build matrix")
+    wait_run = wait["run"]
 
-    # The guard moved into a validation step that runs ahead of the VirusTotal
-    # scan; creating a missing release is deferred to a separate step so a
-    # non-draft release is never published empty for the length of the scan.
+    matrix_legs = {
+        f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]
+    }
+    assert len(matrix_legs) == len(tauri_steps)
+    for leg in matrix_legs:
+        assert f"'{leg}'" in wait_run, leg
+
+    assert "refusing to publish, these build jobs did not succeed" in wait_run
+    assert "refusing to publish without confirming they ran" in wait_run
+    # Every one of those refusals has to be terminal.
+    assert wait_run.count("exit 1") >= 3
+
+    names = [step.get("name") for step in publish["steps"]]
+    assert names.index("Wait for the build matrix") < names.index("Create versioned release")
+
+    # Creating a missing release is a separate step gated on validation, so a
+    # non-draft release is never reserved before its assets are ready to upload.
     release_step = next(
         step for step in publish["steps"] if step.get("name") == "Validate versioned release state"
     )
@@ -64,6 +94,38 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     )
     assert "gh release create" in create_step["run"]
     assert create_step["if"] == "steps.versioned_release_state.outputs.create == 'true'"
+
+
+def test_post_publish_scan_job_holds_no_release_credentials():
+    """#8194 added a job that handles release bundles; it must not be able to release.
+
+    virustotal-scan downloads the published assets and uploads them to a third
+    party. It declares no `permissions` block, so it inherits the workflow's
+    `contents: read`, and it carries no repository token of any kind: the only
+    secret it sees is the VirusTotal key.
+    """
+    scan = _workflow()["jobs"]["virustotal-scan"]
+
+    assert "permissions" not in scan
+    assert "GITHUB_TOKEN" not in scan.get("env", {})
+    assert "GH_TOKEN" not in scan.get("env", {})
+
+    for step in scan["steps"]:
+        env = step.get("env", {})
+        assert "GITHUB_TOKEN" not in env, step.get("name")
+        assert "GH_TOKEN" not in env, step.get("name")
+        if step.get("uses", "").startswith("actions/checkout@"):
+            assert step["with"]["persist-credentials"] is False
+        # No `gh` calls: the job has no token to make them with.
+        assert "gh release" not in (step.get("run") or "")
+
+    secrets = {
+        value
+        for step in scan["steps"]
+        for value in step.get("env", {}).values()
+        if isinstance(value, str) and "secrets." in value
+    }
+    assert secrets == {"${{ secrets.VIRUS_TOTAL_API_TOKEN }}"}
 
 
 def test_versioned_release_hides_updater_signature_assets():


### PR DESCRIPTION
## What is red

On a pristine `origin/main` worktree, `python3 -m pytest tests/security tests/python/test_virustotal_scan.py -q` gives **5 failed, 299 passed**. This is main's own red, so every PR running `Repo tests (CPU)` inherits it.

Two workflow changes landed without their tests:

- **#8194** (`b8dac29fa`) moved the VirusTotal scan out of `publish-release` into its own `virustotal-scan` job that runs *after* the release is published. Four `TestWorkflowOrdering` tests look up steps named `VirusTotal pre-flight scan` and `Check out the scan script` inside `publish-release` and raise `ValueError: ... is not in list`.
- **#8193** (`ae59a9cf7`) replaced `publish-release`'s `needs: build` with a `Wait for the build matrix` step so the job can queue for its runner during the build. `test_build_matrix_hands_off_assets_without_release_credentials` still asserts `"build" in publish["needs"]`.

Scan-after-publish is the intended posture, so this updates the tests rather than reverting either workflow change.

## What the rewritten tests pin

The assertions are re-expressed against the new layout, not dropped. The scan is advisory by design (Defender in the build job is the fail-closed check for Windows), so the control worth keeping is that the sweep cannot be quietly lost:

| Pinned | Test |
| --- | --- |
| `virustotal-scan` exists and `needs: [publish-release]` | `test_the_scan_is_its_own_job_gated_on_publish_release` |
| No job-level `if:`, and no step-level `if:` except the summary's `always()` | `test_the_scan_job_is_not_conditioned_away` |
| The downloaded artifact pattern matches what the build matrix uploads, and lands before the scan step | `test_the_scan_scans_the_bundles_that_were_published` |
| The scan step does not swallow the script's exit status: no `continue-on-error`, no `\|\| true`, no `\|\| :`, no `exit 0`, and no `--fail-threshold` pinned to a value the script treats as never-fail | `test_the_scan_step_does_not_swallow_its_own_failure` |
| `continue-on-error` appears on exactly one job and on no step of any job that handles a bundle | `test_the_advisory_escape_hatch_is_confined_to_the_scan_job` |
| The sparse checkout of `scripts/virustotal_scan.py`, asserted by mechanism rather than by the old step name, plus the guard that exits 1 when the script is absent | `test_the_scan_job_makes_the_scan_script_available` |
| The step summary is written on `always()`, since nothing forces a look at a `continue-on-error` job result | `test_the_scan_verdict_is_always_reported` |
| `publish-release` does not re-inline the scan | `test_the_publish_job_no_longer_runs_the_scan` |
| `Create versioned release` still sits immediately before the upload, so the release is never publicly empty | `test_release_creation_stays_immediately_before_the_upload` |
| The build-to-publish handoff gate: the waiter covers every matrix leg by name, refuses a leg that did not succeed, and refuses a leg whose job record never appeared | `test_build_matrix_hands_off_assets_without_release_credentials` |
| The new scan job holds no release credentials: no `permissions` block, no `GITHUB_TOKEN`/`GH_TOKEN`, `persist-credentials: false`, VirusTotal key only | `test_post_publish_scan_job_holds_no_release_credentials` (new) |

Docstrings now say plainly that this is a post-publish sweep, so a future reader does not go looking for a pre-publish gate that is not there.

## One correction to the record

The old step-level comment claimed the scan gated the release. It never did. `DEFAULT_FAIL_THRESHOLD = 0` disables the gate in `scripts/virustotal_scan.py`, and the workflow passes no `--fail-threshold`, so detections have always surfaced as `::warning` annotations and a step-summary table while the script exits 0. #8194 did not weaken this; it moved a step-level `continue-on-error: true` up to the job. The tests reflect what is actually enforceable instead of asserting a gate that does not exist.

## Sabotage matrix

Every rewritten and new test was checked by breaking the thing it is supposed to catch, then restoring. `sabotaged` and `restored` are pytest exit codes for the named test.

| Sabotage | sabotaged | restored |
| --- | --- | --- |
| Delete the `virustotal-scan` job | 1 | 0 |
| `needs: [publish-release]` to `[prepare-version]` | 1 | 0 |
| Condition the job away with `if: ${{ false }}` | 1 | 0 |
| `continue-on-error: true` on the scan step | 1 | 0 |
| Swallow the script exit with `\|\| true` | 1 | 0 |
| Pin `--fail-threshold 0` while claiming to gate | 1 | 0 |
| Remove the sparse checkout from the scan job | 1 | 0 |
| Sparse-checkout a different path | 1 | 0 |
| Drop the missing-script guard | 1 | 0 |
| Download a pattern that matches no bundle | 1 | 0 |
| Drop `if: always()` from the summary step | 1 | 0 |
| Re-inline a VirusTotal step into `publish-release` | 1 | 0 |
| Remove the `Wait for the build matrix` gate | 1 | 0 |
| Drop a leg from the waiter's `LEGS` list | 1 | 0 |
| Let the waiter tolerate a missing job record | 1 | 0 |
| Persist credentials in the scan job checkout | 1 | 0 |
| Hand the scan job a repository token | 1 | 0 |

The workflow was restored byte-for-byte afterwards; this PR touches no workflow file.

## Test run

Before, on `origin/main`:

```
5 failed, 299 passed
EXIT=1
```

After:

```
310 passed
EXIT=0
```

