### PR TITLE
Format the release permissions test to the kwarg-spacing hook

### DIFF
--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -63,12 +63,12 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     # publish on a leg that did not succeed, and refuse to publish a leg whose
     # job record never appeared, rather than defaulting to "finished".
     assert publish["needs"] == ["prepare-version"]
-    wait = next(step for step in publish["steps"] if step.get("name") == "Wait for the build matrix")
+    wait = next(
+        step for step in publish["steps"] if step.get("name") == "Wait for the build matrix"
+    )
     wait_run = wait["run"]
 
-    matrix_legs = {
-        f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]
-    }
+    matrix_legs = {f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]}
     assert len(matrix_legs) == len(tauri_steps)
     for leg in matrix_legs:
         assert f"'{leg}'" in wait_run, leg


### PR DESCRIPTION
`tests/security/test_release_desktop_permissions.py` as rewritten in #8240 does not match `scripts/run_ruff_format.py`, the `ruff-format-with-kwargs` pre-commit hook (pinned `ruff==0.6.9`).

pre-commit.ci runs `--all-files` against each PR's **merge result**, so this is not confined to #8240: every open PR fails that hook as soon as it merges main. #7867 is the one currently showing it.

Two statements, wrapped the way I typed them rather than the way the hook wants:

- the `Wait for the build matrix` `next(...)` call splits across lines
- the `matrix_legs` set comprehension collapses onto one

Formatting only. The 79 tests in `tests/security/test_release_desktop_permissions.py` and `tests/python/test_virustotal_scan.py` pass unchanged, and re-running the hook afterwards is a no-op.