### PR TITLE
Format the release-permissions test so pre-commit.ci stops failing on main

### DIFF
--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -63,12 +63,12 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     # publish on a leg that did not succeed, and refuse to publish a leg whose
     # job record never appeared, rather than defaulting to "finished".
     assert publish["needs"] == ["prepare-version"]
-    wait = next(step for step in publish["steps"] if step.get("name") == "Wait for the build matrix")
+    wait = next(
+        step for step in publish["steps"] if step.get("name") == "Wait for the build matrix"
+    )
     wait_run = wait["run"]
 
-    matrix_legs = {
-        f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]
-    }
+    matrix_legs = {f"Build {entry['label']}" for entry in build["strategy"]["matrix"]["include"]}
     assert len(matrix_legs) == len(tauri_steps)
     for leg in matrix_legs:
         assert f"'{leg}'" in wait_run, leg


### PR DESCRIPTION
## Summary

- run the `ruff-format-with-kwargs` hook over `tests/security/test_release_desktop_permissions.py` so `main` is formatted again

## Why

`pre-commit.ci - push` is red on `main`, and every open PR inherits it as a red `pre-commit.ci - pr`. The hook wants two reflows in that file, so it reports "files were modified by this hook" on every run and its autofix push then conflicts on PR branches.

The file arrived with #8240. `pre-commit.ci` only pushes autofixes to PR branches, not to `main`, so nothing heals this on its own.

## Change

Two hunks, formatting only, no assertion or behaviour touched: one `next(...)` call wrapped, one set comprehension unwrapped back onto a single line now that it fits.

## Validation

- `pre-commit run --all-files`: all three hooks pass, and a second run is a no-op, so the tree is now a fixed point of the formatter
- `pytest tests/security/test_release_desktop_permissions.py -q`: 5 passed
