### PR TITLE
Resolve latest mlx-vlm and route its new processors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1874,7 +1874,9 @@ if [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
         # truncates it and aborts every later uv call (issue #6503). Hand uv a copy.
         case "$_OVERRIDES_FILE" in
             *[[:space:]]*)
-                _UV_OVERRIDE_TMPDIR=$(mktemp -d 2>/dev/null) || _UV_OVERRIDE_TMPDIR=""
+                _UV_OVERRIDE_TMP_ROOT=${TMPDIR:-/tmp}
+                case "$_UV_OVERRIDE_TMP_ROOT" in *[[:space:]]*) _UV_OVERRIDE_TMP_ROOT=/tmp ;; esac
+                _UV_OVERRIDE_TMPDIR=$(mktemp -d "$_UV_OVERRIDE_TMP_ROOT/unsloth_uv.XXXXXX" 2>/dev/null) || _UV_OVERRIDE_TMPDIR=""
                 case "$_UV_OVERRIDE_TMPDIR" in
                     "") ;;
                     *[[:space:]]*) rm -rf "$_UV_OVERRIDE_TMPDIR" 2>/dev/null || true; _UV_OVERRIDE_TMPDIR="" ;;
@@ -4065,6 +4067,49 @@ esac
 # ── Install unsloth directly into the venv (no activation needed) ──
 tauri_log "STEP" "Installing PyTorch"
 _VENV_PY="$VENV_DIR/bin/python"
+
+# A piped/standalone install.sh has no sibling requirements tree. Bootstrap only
+# the Unsloth wheel so its canonical Darwin override becomes available before
+# the first with-dependencies resolution; this avoids backtracking mlx-vlm and
+# then repairing it in a later phase. No-torch has no such resolve; repository,
+# local, and caller-configured installs already have an override and skip this.
+_bootstrap_packaged_mlx_override() {
+    [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ] || return 0
+    [ "$SKIP_TORCH" = false ] || return 0
+    [ -f "${_OVERRIDES_FILE:-}" ] && return 0
+    [ -n "${UV_OVERRIDE:-}" ] && return 0
+
+    substep "preparing Apple Silicon model support..."
+    run_install_cmd_retry "prepare Apple Silicon dependencies" \
+        uv pip install --python "$_VENV_PY" --no-deps \
+        --upgrade-package "$PACKAGE_NAME" -- "$PACKAGE_NAME"
+
+    _PACKAGED_MLX_OVERRIDES=$("$_VENV_PY" -I -c "
+import importlib.resources
+path = importlib.resources.files('studio') / 'backend' / 'requirements' / 'single-env' / 'overrides-darwin-arm64.txt'
+print(path if path.is_file() else '')
+" 2>/dev/null || true)
+    if [ ! -f "$_PACKAGED_MLX_OVERRIDES" ]; then
+        substep "[WARN] Latest Apple Silicon model support could not be enabled. Installation will continue, but some newer models may be unavailable." "$C_WARN"
+        return 0
+    fi
+
+    _MLX_OVERRIDE_TMP_ROOT=${TMPDIR:-/tmp}
+    case "$_MLX_OVERRIDE_TMP_ROOT" in *[[:space:]]*) _MLX_OVERRIDE_TMP_ROOT=/tmp ;; esac
+    _UV_OVERRIDE_TMPDIR=$(mktemp -d "$_MLX_OVERRIDE_TMP_ROOT/unsloth_uv.XXXXXX" 2>/dev/null) \
+        || _UV_OVERRIDE_TMPDIR=""
+    if [ -z "$_UV_OVERRIDE_TMPDIR" ] \
+       || ! cp "$_PACKAGED_MLX_OVERRIDES" "$_UV_OVERRIDE_TMPDIR/overrides-darwin-arm64.txt"; then
+        [ -n "$_UV_OVERRIDE_TMPDIR" ] && rm -rf "$_UV_OVERRIDE_TMPDIR" 2>/dev/null || true
+        _UV_OVERRIDE_TMPDIR=""
+        substep "[WARN] Latest Apple Silicon model support could not be enabled. Installation will continue, but some newer models may be unavailable." "$C_WARN"
+        return 0
+    fi
+    _OVERRIDES_FILE="$_UV_OVERRIDE_TMPDIR/overrides-darwin-arm64.txt"
+    export UV_OVERRIDE="$_OVERRIDES_FILE"
+}
+
+_bootstrap_packaged_mlx_override
 
 # A released unsloth wheel can pin an older torch (unsloth 2026.7.2 declares
 # torch<2.11.0); a with-deps PyPI resolve then downgrades the whole trio,

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -493,6 +493,31 @@ class TestCheckConfigNeeds550:
 
         assert _check_config_needs_550(str(tmp_path)) is True
 
+    @pytest.mark.parametrize(
+        "cfg",
+        (
+            {"architectures": ["KimiK3ForConditionalGeneration"]},
+            {"model_type": "kimi_k3"},
+            {"architectures": ["LocateAnythingForConditionalGeneration"]},
+            {"model_type": "locateanything"},
+            {"architectures": ["DiffusionGemmaForBlockDiffusion"]},
+            {"model_type": "diffusion_gemma"},
+        ),
+        ids = (
+            "kimi-k3-architecture",
+            "kimi-k3-model-type",
+            "locate-anything-architecture",
+            "locate-anything-model-type",
+            "diffusion-gemma-architecture",
+            "diffusion-gemma-model-type",
+        ),
+    )
+    def test_mlx_vlm_v5_processor_config(self, tmp_path: Path, cfg: dict):
+        """mlx-vlm processors that require Transformers 5 should select 5.5."""
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+        assert _check_config_needs_550(str(tmp_path)) is True
+
     def test_llama_architecture(self, tmp_path: Path):
         """config.json with LlamaForCausalLM should return False."""
         cfg = {"architectures": ["LlamaForCausalLM"], "model_type": "llama"}
@@ -937,6 +962,20 @@ class TestGetTransformersTier:
 
     def test_gemma4_alt_substring_returns_550(self):
         assert get_transformers_tier("unsloth/gemma4-E4B-it") == "550"
+
+    @pytest.mark.parametrize(
+        "model_id",
+        (
+            "moonshotai/Kimi-K3",
+            "mlx-community/KimiK3-4bit",
+            "nvidia/LocateAnything-3B",
+            "mlx-community/locate-anything-3b-4bit",
+            "mlx-community/diffusiongemma-26B-A4B-it-4bit",
+            "mlx-community/diffusion-gemma-26B-A4B-it-4bit",
+        ),
+    )
+    def test_mlx_vlm_v5_processor_name_returns_550(self, model_id: str):
+        assert get_transformers_tier(model_id) == "550"
 
     def test_gemma4_config_json_returns_550(self, tmp_path: Path):
         """Local checkpoint with Gemma4 architecture → 550."""

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -275,11 +275,17 @@ TRANSFORMERS_510_MODEL_SUBSTRINGS: tuple[str, ...] = (
     "gemma4-12b",
 )
 
-# Lowercase substrings for models that require the Gemma 4 transformers 5.5 sidecar.
+# Lowercase substrings for models that require the transformers 5.5 sidecar.
 TRANSFORMERS_550_MODEL_SUBSTRINGS: tuple[str, ...] = (
     "gemma-4",  # Gemma-4 (E2B-it, E4B-it, 31B-it, 26B-A4B-it)
     "gemma4",  # Gemma-4 alternate naming
     "qwen3.6",
+    "kimi-k3",
+    "kimik3",
+    "locate-anything",
+    "locateanything",
+    "diffusion-gemma",
+    "diffusiongemma",
 )
 
 # Architecture classes / model_type values requiring transformers 5.10.x (via config.json).
@@ -296,10 +302,16 @@ _TRANSFORMERS_510_MODEL_TYPES: set[str] = {
 
 # Architecture classes / model_type values requiring transformers 5.5.0 (via config.json).
 _TRANSFORMERS_550_ARCHITECTURES: set[str] = {
+    "DiffusionGemmaForBlockDiffusion",
     "Gemma4ForConditionalGeneration",
+    "KimiK3ForConditionalGeneration",
+    "LocateAnythingForConditionalGeneration",
 }
 _TRANSFORMERS_550_MODEL_TYPES: set[str] = {
+    "diffusion_gemma",
     "gemma4",
+    "kimi_k3",
+    "locateanything",
 }
 
 # Architecture classes / model_type values requiring transformers 5.3.0 (via config.json).
@@ -988,7 +1000,7 @@ def _config_needs_530(cfg: dict) -> bool:
 
 
 def _check_config_needs_550(model_name: str, hf_token: str | None = None) -> bool:
-    """True if ``config.json`` needs transformers 5.5.0 (e.g. Gemma 4). Local first, else
+    """True if ``config.json`` needs transformers 5.5.0. Local first, else
     fetched (authenticated with ``hf_token``); cached by (model, token) only for a definitive
     read so a transient miss retries. False on error.
     """
@@ -1683,7 +1695,7 @@ def get_transformers_tier(
     """Return the transformers tier required for *model_name*.
 
     Returns ``"510"`` for models needing transformers 5.10.x (Gemma 4 Unified),
-    ``"550"`` for models needing transformers 5.5.0 (Gemma 4),
+    ``"550"`` for models needing transformers 5.5.0 (e.g. Gemma 4 or mlx-vlm processors),
     ``"530"`` for models needing transformers 5.3.0 (e.g. Ministral-3, Qwen3 MoE),
     or ``"default"`` for everything else (4.57.x).
 

--- a/tests/sh/test_install_uv_override_space.sh
+++ b/tests/sh/test_install_uv_override_space.sh
@@ -64,18 +64,24 @@ run_block "$PSRC"
 [ -z "$_UV_OVERRIDE_TMPDIR" ] && ok "no-space path: no temp dir created" || bad "no-space path: temp dir created"
 rm -rf "$PLAIN"
 
-# 3. TMPDIR itself contains a space -> fall back to the original path, no leak.
+# 3. TMPDIR itself contains a space -> use /tmp for a safe copy, no leak.
 WORK2=$(mktemp -d)
 mkdir -p "$WORK2/Open Source" "$WORK2/tmp dir"
 SRC2="$WORK2/Open Source/overrides-darwin-arm64.txt"
 printf 'transformers>=4.57.6\n' > "$SRC2"
 RES=$( TMPDIR="$WORK2/tmp dir"; export TMPDIR; run_block "$SRC2"
-       printf 'UV_OVERRIDE=%s\nTMPDIR_VAR=%s\n' "$UV_OVERRIDE" "$_UV_OVERRIDE_TMPDIR" )
-echo "$RES" | grep -qx "UV_OVERRIDE=$SRC2" \
-    && ok "spaced TMPDIR: falls back to original path" || bad "spaced TMPDIR: did not fall back ($RES)"
-echo "$RES" | grep -qx "TMPDIR_VAR=" \
-    && ok "spaced TMPDIR: no temp dir tracked" || bad "spaced TMPDIR: temp dir tracked"
-# mktemp may have created a dir under the spaced TMPDIR; it must not be leaked.
+       if printf '%s' "$UV_OVERRIDE" | grep -q '[[:space:]]'; then _safe=no; else _safe=yes; fi
+       [ "$(cat "$UV_OVERRIDE" 2>/dev/null)" = "transformers>=4.57.6" ] && _copy=yes || _copy=no
+       { [ -n "$_UV_OVERRIDE_TMPDIR" ] && [ -d "$_UV_OVERRIDE_TMPDIR" ]; } && _tracked=yes || _tracked=no
+       printf 'SAFE=%s\nCOPY=%s\nTRACKED=%s\n' "$_safe" "$_copy" "$_tracked"
+       [ -n "$_UV_OVERRIDE_TMPDIR" ] && rm -rf "$_UV_OVERRIDE_TMPDIR" 2>/dev/null || true )
+echo "$RES" | grep -qx "SAFE=yes" \
+    && ok "spaced TMPDIR: UV_OVERRIDE is whitespace-free" || bad "spaced TMPDIR: unsafe override path ($RES)"
+echo "$RES" | grep -qx "COPY=yes" \
+    && ok "spaced TMPDIR: safe copy contents identical" || bad "spaced TMPDIR: copy contents differ ($RES)"
+echo "$RES" | grep -qx "TRACKED=yes" \
+    && ok "spaced TMPDIR: temp dir tracked for cleanup" || bad "spaced TMPDIR: temp dir not tracked ($RES)"
+# The unsafe TMPDIR itself must stay unused.
 _leftover=$(find "$WORK2/tmp dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -n1)
 [ -z "$_leftover" ] && ok "spaced TMPDIR: no leaked temp dir" || bad "spaced TMPDIR: leaked $_leftover"
 rm -rf "$WORK2"
@@ -101,6 +107,102 @@ _trap_line=$(grep -n '^trap _on_install_exit EXIT' "$INSTALL_SH" | head -n1 | cu
 { [ -n "$_init_line" ] && [ -n "$_trap_line" ] && [ "$_init_line" -lt "$_trap_line" ]; } \
     && ok "init: _UV_OVERRIDE_TMPDIR cleared before exit trap" \
     || bad "init: _UV_OVERRIDE_TMPDIR not cleared before exit trap (init=$_init_line trap=$_trap_line)"
+
+# 6. Piped/standalone installs bootstrap the wheel without dependencies, then
+# activate its packaged override before any with-dependencies Unsloth resolve.
+BOOTSTRAP=$(sed -n '/^_bootstrap_packaged_mlx_override() {/,/^}/p' "$INSTALL_SH")
+if [ -z "$BOOTSTRAP" ]; then
+    bad "early packaged-override bootstrap is missing"
+else
+    printf '%s' "$BOOTSTRAP" | grep -q 'preparing Apple Silicon model support' \
+        && ok "bootstrap: progress message is user-friendly" \
+        || bad "bootstrap: user-friendly progress message is missing"
+    if printf '%s' "$BOOTSTRAP" | grep -q 'mlx-vlm may be backtracked'; then
+        bad "bootstrap: warning exposes resolver jargon"
+    else
+        ok "bootstrap: warning avoids resolver jargon"
+    fi
+    WORK4=$(mktemp -d)
+    mkdir -p "$WORK4/Packaged Overrides"
+    PACKAGED_OVERRIDE="$WORK4/Packaged Overrides/overrides-darwin-arm64.txt"
+    FAKE_PY="$WORK4/python"
+    CAPTURE="$WORK4/install-command.txt"
+    printf 'transformers>=4.57.6\n' > "$PACKAGED_OVERRIDE"
+    printf '#!/bin/sh\nprintf "%%s\\n" "$FAKE_OVERRIDE_PATH"\n' > "$FAKE_PY"
+    chmod +x "$FAKE_PY"
+    export FAKE_OVERRIDE_PATH="$PACKAGED_OVERRIDE"
+    export CAPTURE
+    OS=macos
+    _ARCH=arm64
+    _VENV_PY="$FAKE_PY"
+    PACKAGE_NAME=unsloth
+    C_WARN=warn
+    SKIP_TORCH=false
+    _OVERRIDES_FILE="$WORK4/missing-repository-override.txt"
+    _UV_OVERRIDE_TMPDIR=""
+    unset UV_OVERRIDE
+    substep() { :; }
+    run_install_cmd_retry() { printf '%s\n' "$*" > "$CAPTURE"; }
+    eval "$BOOTSTRAP"
+    _bootstrap_packaged_mlx_override
+    _bootstrap_cmd=$(cat "$CAPTURE" 2>/dev/null || true)
+    case "$_bootstrap_cmd" in
+        *"uv pip install --python $FAKE_PY --no-deps --upgrade-package unsloth -- unsloth"*)
+            ok "bootstrap: wheel is installed without dependencies" ;;
+        *) bad "bootstrap: no-deps wheel command missing ($_bootstrap_cmd)" ;;
+    esac
+    case "$UV_OVERRIDE" in
+        *[[:space:]]*) bad "bootstrap: UV_OVERRIDE contains whitespace ($UV_OVERRIDE)" ;;
+        *) ok "bootstrap: packaged override path is whitespace-safe" ;;
+    esac
+    [ "$(cat "$UV_OVERRIDE" 2>/dev/null)" = "transformers>=4.57.6" ] \
+        && ok "bootstrap: packaged override contents are preserved" \
+        || bad "bootstrap: packaged override contents differ"
+    printf '%s' "$BOOTSTRAP" | grep -q '"$_VENV_PY" -I -c' \
+        && ok "bootstrap: packaged resource lookup ignores local modules" \
+        || bad "bootstrap: packaged resource lookup is not isolated"
+    [ -n "$_UV_OVERRIDE_TMPDIR" ] && rm -rf "$_UV_OVERRIDE_TMPDIR" 2>/dev/null || true
+
+    EXTERNAL_OVERRIDE="$WORK4/external-override.txt"
+    printf 'transformers==5.5.0\n' > "$EXTERNAL_OVERRIDE"
+    UV_OVERRIDE="$EXTERNAL_OVERRIDE"
+    export UV_OVERRIDE
+    _OVERRIDES_FILE="$WORK4/still-missing.txt"
+    _UV_OVERRIDE_TMPDIR=""
+    : > "$CAPTURE"
+    _bootstrap_packaged_mlx_override
+    { [ ! -s "$CAPTURE" ] && [ "$UV_OVERRIDE" = "$EXTERNAL_OVERRIDE" ]; } \
+        && ok "bootstrap: caller-provided UV_OVERRIDE is preserved" \
+        || bad "bootstrap: caller-provided UV_OVERRIDE was replaced"
+    unset UV_OVERRIDE
+
+    check_bootstrap_skip() {  # label, os, arch, sibling override, skip torch
+        _skip_label="$1"
+        OS="$2"
+        _ARCH="$3"
+        _OVERRIDES_FILE="$4"
+        SKIP_TORCH="$5"
+        _UV_OVERRIDE_TMPDIR=""
+        unset UV_OVERRIDE
+        : > "$CAPTURE"
+        _bootstrap_packaged_mlx_override
+        { [ ! -s "$CAPTURE" ] && [ -z "${UV_OVERRIDE:-}" ]; } \
+            && ok "bootstrap: $_skip_label is unchanged" \
+            || bad "bootstrap: $_skip_label unexpectedly bootstrapped"
+    }
+    check_bootstrap_skip "Linux" linux arm64 "$WORK4/missing.txt" false
+    check_bootstrap_skip "Intel macOS" macos x86_64 "$WORK4/missing.txt" false
+    check_bootstrap_skip "no-torch install" macos arm64 "$WORK4/missing.txt" true
+    check_bootstrap_skip "repository install" macos arm64 "$PACKAGED_OVERRIDE" false
+    rm -rf "$WORK4"
+fi
+
+_bootstrap_line=$(grep -n '^_bootstrap_packaged_mlx_override$' "$INSTALL_SH" | head -n1 | cut -d: -f1)
+_with_deps_line=$(grep -n '^_build_unsloth_torch_overrides()' "$INSTALL_SH" | head -n1 | cut -d: -f1)
+{ [ -n "$_bootstrap_line" ] && [ -n "$_with_deps_line" ] \
+  && [ "$_bootstrap_line" -lt "$_with_deps_line" ]; } \
+    && ok "bootstrap: packaged override activates before dependency resolution" \
+    || bad "bootstrap: activation is not before dependency resolution"
 
 echo ""
 echo "  PASS: $PASS"


### PR DESCRIPTION
## Summary

- activate the packaged Darwin arm64 dependency override before release dependency resolution, so both fresh and upgraded `curl -fsSL https://unsloth.ai/install.sh | sh` installs resolve the latest compatible mlx-vlm release (currently 0.6.10 instead of 0.6.4)
- route Kimi-K3, LocateAnything, and DiffusionGemma through the existing Transformers 5.5 sidecar using Hub-name, architecture, and `model_type` signals
- preserve the existing dependency and routing behavior for other platforms, no-torch installs, repository installs, and unrelated model families

This does not pin mlx-vlm to 0.6.10. It makes the packaged Apple Silicon override available during the resolver phase where it was previously inaccessible to a piped standalone installer.

## Root cause

A piped `install.sh` has no repository sibling requirements tree, so its early Darwin override lookup could not find `overrides-darwin-arm64.txt`. On upgrades, later phases could still appear to honor some existing constraints, but the release dependency solve had already happened without the packaged override and retained mlx-vlm 0.6.4.

mlx-vlm 0.6.10 also adds processors that cannot run in Studio's base Transformers 4.57.6 environment. Kimi-K3 and LocateAnything fail the older concrete-class validation, and a real DiffusionGemma processor also fails to load. All three work with the existing Transformers 5.5 sidecar.

## Resolution evidence

A full release-style `uv pip compile` and an actual `uv pip install --dry-run` were run in a disposable empty Python 3.13 environment:

- baseline and branch each resolved 241 packages
- the only package-plan difference was `mlx-vlm 0.6.4 -> 0.6.10`
- the dry-run environment still contained zero installed distributions afterward

Installer regression coverage after rebasing onto current `main`:

- 25 Apple Silicon bootstrap/whitespace tests passed
- 14 torch-override tests passed
- 36 macOS/Python installer compatibility tests passed
- `bash -n install.sh` and `git diff --check` passed

## mlx-vlm 0.6.10 with Transformers 5.5 evidence

Validation used exact [mlx-vlm v0.6.10](https://github.com/Blaizzy/mlx-vlm/tree/c2fe301bb3f21c45985a423d7832bb238987312d) on macOS arm64 with Python 3.13.13 and `transformers==5.5.0`.

| Check | Result |
|---|---:|
| Full upstream mlx-vlm suite | 1,914 passed, 3 skipped, 60 subtests, 1 known unrelated failure |
| Recursive imports of non-test modules | 1,050 imported, 0 failed |
| Real `SmolVLM-256M-Instruct-4bit` image generation | loaded and generated `Red.<end_of_utterance>` |
| Focused processor + DiffusionGemma checks | 188 passed, 3 skipped, 7 subtests |
| Studio Transformers routing module | 294 passed |

The lone upstream-suite failure is an MLX bfloat16 exact-equality mismatch in the quantized speculative test. It reproduced with byte-for-byte identical values under the base Transformers 4.57.6 environment, so it is not caused by the 5.5 sidecar.

Additional real processor checks:

- Kimi-K3: constructor fails under Transformers 4.57.6; passes under 5.5.0
- LocateAnything: constructor fails under Transformers 4.57.6; passes under 5.5.0
- cached `mlx-community/diffusiongemma-26B-A4B-it-4bit`: production `load_processor` fails under 4.57.6 and loads under 5.5.0 as `DiffusionGemma4Processor` with Gemma 4 image/video processors
- per-family routing mutations made exactly that family's architecture, model-type, and name cases fail

Transformers 5.5 is intentionally the lowest validated common sidecar for these processors; this PR does not broaden them to 5.10 or change any sidecar package version.