### PR TITLE
Fix the four test failures currently red on main

### DIFF
--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -2725,6 +2725,7 @@ def test_load_refines_component_placement_after_text_encoder_quantization(
     fake_runtime, tmp_path, monkeypatch
 ):
     from core.inference import diffusion as dmod
+    from core.inference.diffusion_precision import TEQuantOutcome
 
     (tmp_path / "m.gguf").write_bytes(b"x")
     backend = DiffusionBackend()
@@ -2733,7 +2734,9 @@ def test_load_refines_component_placement_after_text_encoder_quantization(
 
     def _quantize(*args, **kwargs):
         seen["quantized"] = True
-        return None
+        # A bare None predates #8165: the pass now reports what it did, and the loader
+        # reads .mode off it. None mode keeps this stub's meaning, encoders stayed dense.
+        return TEQuantOutcome(None)
 
     def _refine(pipe, plan):
         assert seen["quantized"] is True

--- a/studio/backend/tests/test_saved_image_metadata_precision_contract.py
+++ b/studio/backend/tests/test_saved_image_metadata_precision_contract.py
@@ -265,6 +265,9 @@ def test_a_declined_quant_request_is_not_reported_as_engaged(
 ):
     """The user asked for fp8; the host has no dense source, so the GGUF loaded as-is.
     The recipe must say "GGUF, no quant", not "fp8"."""
+    # A declined explicit precision refuses by default (#8165). This contract is about what
+    # the recipe records once a fallback is allowed, so opt into the fallback path.
+    monkeypatch.setenv("UNSLOTH_DIFFUSION_ALLOW_PRECISION_FALLBACK", "1")
     monkeypatch.setattr(diffusion_module, "dense_transformer_supported", lambda target: False)
     status = _load(backend, tmp_path, monkeypatch, stub_runtime, transformer_quant = "fp8")
 
@@ -274,7 +277,8 @@ def test_a_declined_quant_request_is_not_reported_as_engaged(
     # request was explicit, the engaged value is "off".
     resolved = status["resolved"]["transformer_quant"]
     assert resolved["value"] == "off" and resolved["source"] == "explicit"
-    assert "GGUF transformer loaded" in resolved["reason"]
+    # #8165 records why the request was declined rather than what loaded instead.
+    assert "dense torchao quant" in resolved["reason"]
 
     result = _generate(backend)
     assert result["transformer_quant"] is None, (
@@ -350,6 +354,11 @@ class _EngagedBackend:
         return detect_family(model_path, kwargs.get("family_override"))
 
     def preflight_base_access(self, model_path, fam, **kwargs):
+        return None
+
+    def assert_precision_available(self, fam, **kwargs) -> None:
+        # #8165 added this host-level gate ahead of the load. This backend engages a
+        # precision rather than declining one, so it has nothing to refuse.
         return None
 
     def begin_load(self, model_path, **kwargs):

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -41,10 +41,19 @@ def declared_floor():
 
 
 def package_files(root = PACKAGE_ROOT, minimum = 50):
+    """Our own packaged sources. Vendored third-party trees are excluded.
+
+    `studio/backend/vendor/` is checked in byte-identical to upstream, with a sha256
+    manifest and the linters configured to leave it alone, so the floor cannot be
+    fixed there by editing it. Those packages carry their own floor anyway -- vendored
+    truststore is `requires-python >=3.10` -- and their import sites guard for it.
+    """
     files = sorted(
         p
         for p in root.rglob("*.py")
-        if "__pycache__" not in p.parts and "node_modules" not in p.parts
+        if "__pycache__" not in p.parts
+        and "node_modules" not in p.parts
+        and "vendor" not in p.parts
     )
     assert len(files) >= minimum, f"only found {len(files)} files under {root}, glob is wrong"
     return files
@@ -276,6 +285,26 @@ def test_every_packaged_module_compiles():
             except SyntaxError as error:
                 broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
     assert not broken, "these modules do not compile:\n  " + "\n  ".join(broken)
+
+
+def test_vendored_third_party_source_is_outside_the_floor_scan():
+    """Vendored trees are upstream's code on upstream's floor, so the scan skips them.
+
+    truststore is checked in byte-identical to the wheel and hash-pinned by
+    `vendor/truststore_manifest.json`, so converting its PEP 604 aliases would break the
+    invariant the vendor README exists to defend. It is `requires-python >=3.10` upstream
+    and its import site swallows the failure, so the floor holds without editing it.
+    """
+    vendor = REPO_ROOT / "studio" / "backend" / "vendor"
+    if not vendor.is_dir():
+        pytest.skip("no vendored third-party source in this checkout")
+    # The tree really would be flagged: these aliases are values, not annotations,
+    # so `from __future__ import annotations` would not defer them either.
+    assert "typing.TypeAlias = str | bytes" in (
+        vendor / "truststore" / "_api.py"
+    ).read_text(encoding = "utf-8")
+    scanned = [p for root in packaged_roots() for p in package_files(root, minimum = 1)]
+    assert not [p for p in scanned if "vendor" in p.parts]
 
 
 def test_studio_evaluated_unions_do_not_grow():


### PR DESCRIPTION
Four tests fail on a clean checkout of main, independent of any PR, so every branch
cut from it inherits them. Two separate causes, both semantic merge conflicts where
each PR was green on its own base.

## 1. The 3.9 floor guards vs vendored truststore (#8108)

`test_no_pep604_unions_are_evaluated_on_the_declared_floor` and
`test_studio_evaluated_unions_do_not_grow`. Vendoring truststore 0.10.4 added two
`typing.TypeAlias` values that are PEP 604 unions, which `from __future__ import
annotations` does not defer, and three platform modules that pushed the studio
union-debt ratchet from 35 to 38.

Neither is fixable where it is flagged. The tree is checked in byte-identical to the
wheel and hash-pinned by `vendor/truststore_manifest.json`, with ruff and the kwargs
formatter configured to skip it so it keeps matching upstream, so converting those
aliases breaks the invariant the vendor README exists to defend. truststore is
`requires-python >=3.10` upstream, so it cannot run on our floor either way, and
`prebuilt_core.py` already imports it inside `try/except`.

So the scan is scoped to our own sources, next to the existing `__pycache__` and
`node_modules` exclusions, with a test pinning the reasoning.

## 2. The image precision contracts vs the refusal behaviour (#8162 vs #8165)

`test_saved_image_metadata_precision_contract.py` x3 and
`test_diffusion_backend.py::test_load_refines_component_placement_after_text_encoder_quantization`.

#8162 pinned the saved-recipe contracts against a tree where a declined explicit
precision fell back silently; #8165 landed the fail-closed refusal beside it. Both were
green on their own base and main got a combination neither ran.

Fixed on the test side, since #8165 is the newer intent:

- opt into `UNSLOTH_DIFFUSION_ALLOW_PRECISION_FALLBACK` where the contract is about what
  the recipe records once a fallback is allowed, matching how `test_diffusion_routes.py`
  and `test_diffusion_backend.py` were already adapted for #8165
- assert the decline reason #8165 records instead of the old "GGUF transformer loaded"
  wording. The substantive assertions are untouched: the resolved value is still `off`
  from an `explicit` source, and generate() still must not echo the declined request
- give the `_EngagedBackend` stub the `assert_precision_available` gate the route now
  calls, and return a `TEQuantOutcome` rather than a bare `None` from the stubbed
  text-encoder pass, which the loader now reads `.mode` off

## Verification

Before: 4 tests red on a clean detached checkout of main. After: `tests/test_python39_compatibility.py`
5 passed, `tests/test_saved_image_metadata_precision_contract.py` 10 passed,
`tests/test_diffusion_backend.py` 226 passed. Ruff clean. No production code changed.