### PR TITLE
Studio: realign the image precision contracts with the fail-closed refusal

### DIFF
--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -2813,6 +2813,7 @@ def test_load_refines_component_placement_after_text_encoder_quantization(
     fake_runtime, tmp_path, monkeypatch
 ):
     from core.inference import diffusion as dmod
+    from core.inference.diffusion_precision import TEQuantOutcome
 
     (tmp_path / "m.gguf").write_bytes(b"x")
     backend = DiffusionBackend()
@@ -2821,7 +2822,10 @@ def test_load_refines_component_placement_after_text_encoder_quantization(
 
     def _quantize(*args, **kwargs):
         seen["quantized"] = True
-        return None
+        # The real pass reports what it did and the loader reads `.mode` off that report, so a
+        # bare None here is a shape the production function can no longer return. A None mode
+        # keeps this stub's meaning: the encoders were left dense.
+        return TEQuantOutcome(None)
 
     def _refine(pipe, plan):
         assert seen["quantized"] is True

--- a/studio/backend/tests/test_saved_image_metadata_precision_contract.py
+++ b/studio/backend/tests/test_saved_image_metadata_precision_contract.py
@@ -265,6 +265,10 @@ def test_a_declined_quant_request_is_not_reported_as_engaged(
 ):
     """The user asked for fp8; the host has no dense source, so the GGUF loaded as-is.
     The recipe must say "GGUF, no quant", not "fp8"."""
+    # A declined explicit precision now refuses the load outright unless the fallback is opted
+    # into. This contract is about what the recipe records for a build that DID fall back, so it
+    # has to ask for that build, the same way the routes and backend suites do.
+    monkeypatch.setenv("UNSLOTH_DIFFUSION_ALLOW_PRECISION_FALLBACK", "1")
     monkeypatch.setattr(diffusion_module, "dense_transformer_supported", lambda target: False)
     status = _load(backend, tmp_path, monkeypatch, stub_runtime, transformer_quant = "fp8")
 
@@ -274,7 +278,9 @@ def test_a_declined_quant_request_is_not_reported_as_engaged(
     # request was explicit, the engaged value is "off".
     resolved = status["resolved"]["transformer_quant"]
     assert resolved["value"] == "off" and resolved["source"] == "explicit"
-    assert "GGUF transformer loaded" in resolved["reason"]
+    # The reason now names why the request was declined rather than what loaded in its place,
+    # which is the half a user can act on. The substantive contract is the pair above.
+    assert "dense torchao quant" in resolved["reason"]
 
     result = _generate(backend)
     assert result["transformer_quant"] is None, (
@@ -350,6 +356,11 @@ class _EngagedBackend:
         return detect_family(model_path, kwargs.get("family_override"))
 
     def preflight_base_access(self, model_path, fam, **kwargs):
+        return None
+
+    def assert_precision_available(self, fam, **kwargs) -> None:
+        # The route's pre-eviction refusal for a precision this host can never honor. This
+        # backend exists to ENGAGE one, so it has nothing to refuse.
         return None
 
     def begin_load(self, model_path, **kwargs):


### PR DESCRIPTION
Four tests are red on a clean checkout of main, so every branch cut from it inherits them:

```
FAILED studio/backend/tests/test_saved_image_metadata_precision_contract.py::test_a_declined_quant_request_is_not_reported_as_engaged
FAILED studio/backend/tests/test_saved_image_metadata_precision_contract.py::test_the_persisted_recipe_records_the_engaged_build_not_the_load_request
FAILED studio/backend/tests/test_saved_image_metadata_precision_contract.py::test_the_openai_route_persists_the_same_build
FAILED studio/backend/tests/test_diffusion_backend.py::test_load_refines_component_placement_after_text_encoder_quantization
```

## Root cause

#8165 ("Report the precision actually in use, and refuse an explicit one we cannot honor", merged 01:15) changed two things: a declined EXPLICIT precision now refuses the load instead of falling back silently, and `quantize_text_encoders` returns a `TEQuantOutcome` the loader reads `.mode` off rather than a bare mode string.

Two squash merges that landed after it carried branches cut before it, so main got combinations neither PR ever ran:

- #8162 (merged 01:24, nine minutes later) added `test_saved_image_metadata_precision_contract.py` whole, pinned against a tree where a declined explicit precision fell back silently and where the load route had no `assert_precision_available` gate.
- #8141 (merged 01:32) added `test_load_refines_component_placement_after_text_encoder_quantization`, whose stubbed text-encoder pass returns a bare `None`. The loader then does `te_quant = te_outcome.mode` and raises `AttributeError: 'NoneType' object has no attribute 'mode'`.

## Test side or product side?

Test side, and the two symptoms were checked separately.

`AttributeError: 'NoneType' object has no attribute 'mode'` at `diffusion.py:3113` looks like a live crash users could hit, so it is the one worth being sure about. `quantize_text_encoders` is annotated `-> TEQuantOutcome` and every one of its seven return statements constructs one; there is no bare `return` and no path that falls off the end. Nothing in production wraps or rebinds it, and `video.py:1562` reads `.mode` off the same call with no guard for the same reason. The only object that ever reaches line 3113 as `None` is the stub a test monkeypatches in. A `if te_outcome is None` guard would be unreachable code that also weakens the return contract the outcome type exists to state.

`AttributeError: '_EngagedBackend' object has no attribute 'assert_precision_available'` is the same shape. The route only makes that call under `pending_name == ENGINE_DIFFUSERS`, and `engine_for(ENGINE_DIFFUSERS)` returns `get_diffusion_backend()`, i.e. `DiffusionBackend`, which defines the method at `diffusion.py:917`. Reaching for `getattr(backend, "assert_precision_available", None)` there would be strictly worse than the status quo: it would turn a loud failure into a silently skipped fail-closed gate.

So no production code changes and no regression test, because there is no product behaviour change to regress. #8165's refusal is the newer intent and the tests simply encode the older one.

## Changes

- opt into `UNSLOTH_DIFFUSION_ALLOW_PRECISION_FALLBACK` in the declined-request contract. That test is about what the recipe records once a fallback is allowed, so it has to ask for the build it is describing, the same way `test_diffusion_routes.py`, `test_diffusion_backend.py`, `test_video_routes.py` and `test_video_backend.py` were already adapted for #8165
- assert the decline reason #8165 records rather than the old wording naming what loaded instead. The substantive pair is untouched: the resolved value is still `off` from an `explicit` source, and `generate()` still must not echo the declined request
- give `_EngagedBackend` the `assert_precision_available` gate the route now calls, matching the fake in `test_diffusion_routes.py`
- return a `TEQuantOutcome(None)` from the stubbed text-encoder pass, which preserves the stub's meaning (the encoders stayed dense) in the shape the function now returns

## Verification

Before, on a clean detached checkout of `c7ffee7bc`: 4 failed, 233 passed.

After: `test_saved_image_metadata_precision_contract.py`, `test_diffusion_backend.py`, `test_diffusion_routes.py` and `test_diffusion_precision.py` together are 347 passed, 0 failed. Both runs with `python3 -B` on a cleared `__pycache__`. Ruff linter and the pinned kwargs formatter are clean.

## Relationship to #8254

#8254 proposed this same Studio fix first, and the two Studio files here are its approach, reviewed on their merits rather than copied. This PR exists only because #8254's head branch lives on the org repo, so I cannot push to it, and because #8254 additionally carries a change to `tests/test_python39_compatibility.py` that is now obsolete: that floor red was fixed by the merged #8252, and the change conflicts with main as it stands. #8254 is left open for its author to close.
