### PR TITLE
Studio: grey the sidebar dot a finished chat leaves

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1647,7 +1647,8 @@ export function AppSidebar() {
             )}
             aria-hidden
           >
-            <span className="size-2 rounded-full bg-[#d07a5f] dark:bg-[#df8a6f]" />
+            {/* Neutral: a finished reply is news, not a fault. */}
+            <span className="size-2 rounded-full bg-muted-foreground/60" />
           </span>
         ) : null}
         {variant === "project" && (

--- a/studio/frontend/tests/sidebar-unread-dot.test.ts
+++ b/studio/frontend/tests/sidebar-unread-dot.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The dot a finished reply leaves on a sidebar row. Read from the source: the
+// node suite has no DOM to mount the sidebar in.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const SIDEBAR = readFileSync(
+  new URL("../src/components/app-sidebar.tsx", import.meta.url),
+  "utf8",
+);
+
+test("the unread dot is grey", () => {
+  assert.match(SIDEBAR, /size-2 rounded-full bg-muted-foreground\/60/);
+});
+
+// A literal pair misses the contrast-boost theme, which recomputes
+// --muted-foreground rather than swapping light for dark.
+test("the unread dot carries no hardcoded light/dark pair", () => {
+  assert.doesNotMatch(SIDEBAR, /d07a5f|df8a6f/i);
+});
+
+// Warm there does mean stopped or errored.
+test("training run status dots are untouched", () => {
+  assert.match(SIDEBAR, /runStatusDotClass\(run\.status\)/);
+});


### PR DESCRIPTION
### What

The sidebar shows a small dot on a chat row when its reply finished while you were looking at something else. That dot was terracotta (`#d07a5f`, `#df8a6f` in dark). This makes it neutral grey.

### Why

Warm colours mean something specific everywhere else in the shell. `bg-destructive` is delete, the training run dots are amber for stopped and red for errored. A finished reply sitting in the same palette reads as a problem to go and look at, when it is just news.

It was also the only hardcoded light/dark hex pair in that file. Those miss the contrast-boost theme, which recomputes `--muted-foreground` in `index.css` instead of swapping one literal for another, so a two-hex pair silently gets the wrong value there.

### Change

`studio/frontend/src/components/app-sidebar.tsx`, the `hasUnreadActivity` branch:

```diff
-<span className="size-2 rounded-full bg-[#d07a5f] dark:bg-[#df8a6f]" />
+{/* Neutral: a finished reply is news, not a fault. */}
+<span className="size-2 rounded-full bg-muted-foreground/60" />
```

Nothing else moves. Same size, same position, same show and hide rules, same clear-on-click. Training run status dots are untouched, since warm there does mean stopped or errored.

### Scope

One colour on one decorative element. The dot is `aria-hidden` inside a `pointer-events-none` wrapper, so no behaviour, no layout and no accessible output changes. Backend untouched.

### Testing

New `studio/frontend/tests/sidebar-unread-dot.test.ts`, three cases: the dot is grey, no hardcoded hex pair survives, and the training run dots still resolve through `runStatusDotClass`. Confirmed all three fail against the pre-change file.

- `tsc --noEmit` clean
- `npm test`, 1424 passing
- `i18n:check:strict` clean
- `npm run build` clean
- Biome on `app-sidebar.tsx`: 2 errors and 20 warnings before and after, identical. The new test file adds no errors.
- Built CSS emits `.bg-muted-foreground\/60{background-color:color-mix(in oklab, var(--muted-foreground) 60%, transparent)}` with a plain-colour fallback, so the utility resolves rather than rendering transparent.
