### PR TITLE
Stop the CPU fake-train tests from spoofing torch for the whole session

### DIFF
--- a/tests/version_compat/test_import_leaves_torch_globals_alone.py
+++ b/tests/version_compat/test_import_leaves_torch_globals_alone.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
+"""The CPU-only fake-train modules must not spoof torch for the whole session.
+
+`test_trl_fake_train_cpu.py` and `test_trl_padding_free_max_length.py` pretend
+this process has no GPU: eager `torch.compile`, `torch.accelerator.is_available`
+answering False, and every `device = "cuda"` allocation rewritten to CPU. Done at
+module scope that outlives the module, and pytest imports every selected file
+during collection, so a GPU test running later in the same process gets CPU
+tensors out of `torch.randn(..., device = "cuda")`, its CUDA autocast never
+applies, and it passes without having tested anything. CI runners have no GPU, so
+they skip such tests and never notice; local GPU verification is what breaks.
+
+Both checks below fail against the import-time version of those patches.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve().parent
+_GUARDED = ("test_trl_fake_train_cpu.py", "test_trl_padding_free_max_length.py")
+
+# Imported in a subprocess: the whole point is that importing these modules must
+# not touch torch, and doing it in this process would be the damage itself.
+_PROBE = r"""
+import importlib.util, sys
+from pathlib import Path
+
+import torch
+
+before = {
+    "compile": torch.compile,
+    "Tensor.to": torch.Tensor.to,
+    "Tensor.cuda": torch.Tensor.cuda,
+}
+if hasattr(torch, "accelerator"):
+    before["accelerator.is_available"] = torch.accelerator.is_available
+has_cuda = torch.cuda.is_available()
+
+for path in sys.argv[1:]:
+    spec = importlib.util.spec_from_file_location(Path(path).stem, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException as e:  # a module-level pytest.skip is not an error here
+        print("skipped %s: %s" % (path, type(e).__name__))
+
+failures = []
+for name, original in before.items():
+    obj = torch
+    for part in name.split(".")[:-1]:
+        obj = getattr(obj, part)
+    if getattr(obj, name.split(".")[-1]) is not original:
+        failures.append("torch.%s was replaced" % name)
+
+if has_cuda:
+    # The allocator rewrite is the one that makes a GPU test pass vacuously.
+    if not torch.randn(4, 4, device = "cuda").is_cuda:
+        failures.append('torch.randn(device = "cuda") returned a CPU tensor')
+    if not torch.zeros(4).to("cuda").is_cuda:
+        failures.append('Tensor.to("cuda") returned a CPU tensor')
+
+print("FAILURES:" + "|".join(failures))
+sys.exit(1 if failures else 0)
+"""
+
+
+def test_importing_the_cpu_modules_leaves_torch_globals_alone():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch not installed; there is no global state to protect")
+
+    proc = subprocess.run(
+        [sys.executable, "-B", "-c", _PROBE, *[str(_HERE / name) for name in _GUARDED]],
+        capture_output = True,
+        text = True,
+        timeout = 600,
+    )
+    assert proc.returncode == 0, proc.stdout[-4000:] + proc.stderr[-4000:]
+
+
+def _module_level_nodes(node):
+    """Everything that runs on import: loops and try blocks included, function
+    and class bodies excluded, since those only run when something calls them."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+            continue
+        yield child
+        yield from _module_level_nodes(child)
+
+
+def _rooted_at_torch(node):
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return isinstance(node, ast.Name) and node.id == "torch"
+
+
+def test_no_version_compat_module_patches_torch_at_import_time():
+    """The static half, so a new module cannot reintroduce the leak.
+
+    Cheap and GPU-free, unlike the subprocess above, and it covers every file in
+    the directory rather than the two known offenders.
+    """
+    offenders = []
+    for path in sorted(_HERE.glob("test_*.py")):
+        if path.name == Path(__file__).name:
+            continue
+        for node in _module_level_nodes(ast.parse(path.read_text(encoding = "utf-8"))):
+            targets = []
+            if isinstance(node, ast.Assign):
+                targets = node.targets
+            elif isinstance(node, ast.AnnAssign):
+                targets = [node.target]
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "setattr"
+                and node.args
+            ):
+                targets = [node.args[0]]
+            for target in targets:
+                if isinstance(target, (ast.Attribute, ast.Name)) and _rooted_at_torch(target):
+                    offenders.append(f"{path.name}:{node.lineno} {ast.unparse(target)}")
+
+    assert not offenders, (
+        "patch torch from a fixture instead, so it is undone for the rest of the "
+        f"session: {offenders}"
+    )

--- a/tests/version_compat/test_trl_fake_train_cpu.py
+++ b/tests/version_compat/test_trl_fake_train_cpu.py
@@ -68,24 +68,6 @@ def _eager_compile(
     return lambda fn: fn
 
 
-torch.compile = _eager_compile
-
-# Belt-and-suspenders: if any @torch.compile still routes through dynamo, let it
-# fall back to eager instead of crashing, and stop its stream-capture probe from
-# reaching torch.accelerator -> real CUDA on a GPU-less box.
-try:
-    import torch._dynamo  # noqa: E402
-    torch._dynamo.config.suppress_errors = True
-except Exception:
-    pass
-if hasattr(torch, "accelerator"):
-    torch.accelerator.is_available = lambda *a, **k: False
-
-
-# Redirect any `device="cuda"` tensor allocation / `.to("cuda")` / `.cuda()` to
-# CPU. The aggressive spoof deliberately keeps real allocators, but a fake CPU
-# train needs cuda-targeted ops (e.g. inductor's init_gpu_context does
-# `torch.empty(1, device="cuda")`) to land on CPU instead of erroring.
 def _is_cuda_dev(d):
     try:
         return d is not None and torch.device(d).type == "cuda"
@@ -93,64 +75,103 @@ def _is_cuda_dev(d):
         return False
 
 
-for _name in (
-    "empty",
-    "zeros",
-    "ones",
-    "full",
-    "tensor",
-    "arange",
-    "randn",
-    "rand",
-    "randint",
-    "empty_like",
-    "zeros_like",
-    "ones_like",
-):
-    _orig = getattr(torch, _name, None)
-    if _orig is None:
-        continue
+def _fake_cpu_gpu(mp):
+    """Make this process behave like a GPU-less box, undoably.
 
-    def _redir(
-        *args,
-        _orig = _orig,
-        **kwargs,
+    Everything here is a mutation of a global that outlives the module, so it
+    goes through the caller's MonkeyPatch: applied for the duration of this
+    module's tests and reverted afterwards. Applied at import time instead, a
+    GPU test collected from anywhere else in the same session silently gets CPU
+    tensors out of `device = "cuda"` and can pass without testing anything.
+    """
+    mp.setattr(torch, "compile", _eager_compile)
+
+    # Belt-and-suspenders: if any @torch.compile still routes through dynamo,
+    # let it fall back to eager instead of crashing, and stop its stream-capture
+    # probe from reaching torch.accelerator -> real CUDA on a GPU-less box.
+    try:
+        # Aliased: a bare `import torch._dynamo` would rebind `torch` as a local.
+        import torch._dynamo as _dynamo
+        mp.setattr(_dynamo.config, "suppress_errors", True)
+    except Exception:
+        pass
+    # torch.accelerator only exists from torch 2.6 onwards.
+    if hasattr(torch, "accelerator"):
+        mp.setattr(torch.accelerator, "is_available", lambda *a, **k: False)
+
+    # Redirect any `device="cuda"` tensor allocation / `.to("cuda")` / `.cuda()`
+    # to CPU. The aggressive spoof deliberately keeps real allocators, but a fake
+    # CPU train needs cuda-targeted ops (e.g. inductor's init_gpu_context does
+    # `torch.empty(1, device="cuda")`) to land on CPU instead of erroring.
+    for _name in (
+        "empty",
+        "zeros",
+        "ones",
+        "full",
+        "tensor",
+        "arange",
+        "randn",
+        "rand",
+        "randint",
+        "empty_like",
+        "zeros_like",
+        "ones_like",
     ):
+        _orig = getattr(torch, _name, None)
+        if _orig is None:
+            continue
+
+        def _redir(
+            *args,
+            _orig = _orig,
+            **kwargs,
+        ):
+            if _is_cuda_dev(kwargs.get("device")):
+                kwargs["device"] = "cpu"
+            return _orig(*args, **kwargs)
+
+        mp.setattr(torch, _name, _redir)
+
+    _orig_to = torch.Tensor.to
+
+    def _to_cpu(self, *args, **kwargs):
+        args = tuple("cpu" if _is_cuda_dev(a) else a for a in args)
         if _is_cuda_dev(kwargs.get("device")):
             kwargs["device"] = "cpu"
-        return _orig(*args, **kwargs)
+        return _orig_to(self, *args, **kwargs)
 
-    setattr(torch, _name, _redir)
+    mp.setattr(torch.Tensor, "to", _to_cpu)
+    mp.setattr(torch.Tensor, "cuda", lambda self, *a, **k: self)
 
-_orig_to = torch.Tensor.to
+    # Extra CUDA stubs the aggressive spoof lacks, needed to walk a real train():
+    # Adam's _cuda_graph_capture_health_check() probes stream capture.
+    mp.setattr(torch.cuda, "is_current_stream_capturing", lambda *a, **k: False, raising = False)
+    try:
+        import torch.cuda.graphs as _cg
+        mp.setattr(_cg, "_cuda_isCurrentStreamCapturing", lambda *a, **k: False, raising = False)
+    except Exception:
+        pass
+
+    # A broken libmlx.so in the shared site-packages crashes transformers' Mac-only
+    # is_mlx_array probe on Linux; disable it.
+    try:
+        import transformers.utils.generic as _g
+        mp.setattr(_g, "_is_mlx_available", False, raising = False)
+    except Exception:
+        pass
 
 
-def _to_cpu(self, *args, **kwargs):
-    args = tuple("cpu" if _is_cuda_dev(a) else a for a in args)
-    if _is_cuda_dev(kwargs.get("device")):
-        kwargs["device"] = "cpu"
-    return _orig_to(self, *args, **kwargs)
+@pytest.fixture(scope = "module", autouse = True)
+def _cpu_only_torch():
+    """Hold the GPU-less spoof for this module only.
 
-
-torch.Tensor.to = _to_cpu
-torch.Tensor.cuda = lambda self, *a, **k: self
-
-# Extra CUDA stubs the aggressive spoof lacks, needed to walk a real train():
-# Adam's _cuda_graph_capture_health_check() probes stream capture.
-torch.cuda.is_current_stream_capturing = lambda *a, **k: False
-try:
-    import torch.cuda.graphs as _cg  # noqa: E402
-    _cg._cuda_isCurrentStreamCapturing = lambda *a, **k: False
-except Exception:
-    pass
-
-# A broken libmlx.so in the shared site-packages crashes transformers' Mac-only
-# is_mlx_array probe on Linux; disable it.
-try:
-    import transformers.utils.generic as _g  # noqa: E402
-    _g._is_mlx_available = False
-except Exception:
-    pass
+    Module scoped so it is in place before the per-test `_require_stack` imports
+    unsloth and before any trainer is generated, which is the whole reason the
+    patches used to sit at import time.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+        _fake_cpu_gpu(mp)
+        yield mp
 
 
 # Dense (non-MoE) tiny model on purpose: MoE models route through Unsloth's
@@ -212,7 +233,7 @@ def _load_plain():
 
 
 @pytest.fixture(autouse = True)
-def _require_stack():
+def _require_stack(_cpu_only_torch):
     global torch  # the `import torch._dynamo` below would otherwise shadow it as local
     if importlib.util.find_spec("unsloth") is None or importlib.util.find_spec("trl") is None:
         pytest.skip("unsloth or trl not installed")
@@ -225,10 +246,11 @@ def _require_stack():
     # device, crashing on device props (`gcnArchName`). Re-apply the eager
     # passthrough and flip dynamo's call-time kill switch so every @torch.compile
     # runs eager regardless of when it was decorated. CPU eager is what we want.
-    torch.compile = _eager_compile
+    # Through the module's MonkeyPatch, so both are undone with the rest of it.
+    _cpu_only_torch.setattr(torch, "compile", _eager_compile)
     try:
         import torch._dynamo  # noqa: E402
-        torch._dynamo.config.disable = True
+        _cpu_only_torch.setattr(torch._dynamo.config, "disable", True)
     except Exception:
         pass
 

--- a/tests/version_compat/test_trl_padding_free_max_length.py
+++ b/tests/version_compat/test_trl_padding_free_max_length.py
@@ -51,9 +51,22 @@ def _eager_compile(
     return lambda fn: fn
 
 
-torch.compile = _eager_compile
-if hasattr(torch, "accelerator"):
-    torch.accelerator.is_available = lambda *a, **k: False
+@pytest.fixture(scope = "module", autouse = True)
+def _cpu_only_torch():
+    """Hold the eager-compile spoof for this module only.
+
+    `torch.compile` and `torch.accelerator.is_available` are process-wide, and
+    nothing here needs them before the module's own tests start, so scope them:
+    left in place at import time they follow the session into any GPU test
+    collected after this file.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(torch, "compile", _eager_compile)
+        # torch.accelerator only exists from torch 2.6 onwards.
+        if hasattr(torch, "accelerator"):
+            mp.setattr(torch.accelerator, "is_available", lambda *a, **k: False)
+        yield mp
+
 
 _MODEL = "hf-internal-testing/tiny-random-LlamaForCausalLM"
 # Model-level length the trainer resolves from when the user names none.
@@ -63,7 +76,7 @@ _USER_MAX_LENGTH = 64
 
 
 @pytest.fixture(scope = "module", autouse = True)
-def patched_sft():
+def patched_sft(_cpu_only_torch):
     """Import unsloth, and force both halves of the SFT patch on.
 
     `UNSLOTH_ALLOW_CPU=1` (which CPU-only CI sets) skips both, so ask explicitly,
@@ -73,10 +86,12 @@ def patched_sft():
     global torch  # the `import torch._dynamo` below would otherwise shadow it
     import unsloth  # noqa: F401
 
-    torch.compile = _eager_compile
+    # Through the module's MonkeyPatch: `import unsloth` reinstalls the real
+    # torch.compile over the passthrough, and dynamo's kill switch is global too.
+    _cpu_only_torch.setattr(torch, "compile", _eager_compile)
     try:
         import torch._dynamo
-        torch._dynamo.config.disable = True
+        _cpu_only_torch.setattr(torch._dynamo.config, "disable", True)
     except Exception:
         pass
 


### PR DESCRIPTION
### The leak

`tests/version_compat/test_trl_fake_train_cpu.py` makes the process pretend it has no GPU, and it does so with plain module-level statements:

- `torch.compile = _eager_compile`
- `torch.accelerator.is_available = lambda *a, **k: False`
- `torch.cuda.is_current_stream_capturing = lambda *a, **k: False`
- a loop over `("empty", "zeros", "ones", "full", "tensor", "arange", "randn", ...)` that rewrites any `device = "cuda"` request to CPU, plus `torch.Tensor.to` and `torch.Tensor.cuda`

None of it is restored. pytest imports every selected file during collection, so merely selecting this file is enough: from that point on the whole process is a fake CPU box. `tests/version_compat/test_trl_padding_free_max_length.py` does the same for `torch.compile` and `torch.accelerator.is_available`.

### Evidence

On a GPU box, on current main:

```
CUDA_VISIBLE_DEVICES=6 python3 -B -m pytest tests/version_compat tests/test_grpo_autocast_per_trainer.py -q -p no:randomly
1 failed, 1691 passed, 213 skipped
FAILED tests/test_grpo_autocast_per_trainer.py::test_an_outer_autocast_is_inherited_rather_than_overridden
```

The same test passes when run alone. The giveaway is in the failure output: the tensors print with no `device='cuda:0'`, so `torch.randn(4, 4, device = "cuda")` returned a CPU tensor, the CUDA autocast never applied, and the matmul stayed float32.

```
E  assert torch.float32 is torch.bfloat16
E   +  where torch.float32 = (tensor([[-0.6225,  1.0247, ...]]) @ tensor([[-0.6225,  1.0247, ...]])).dtype
```

### Why CI never caught it

CI runners have no GPU. `torch.cuda.is_available()` is False there, every GPU test skips, and the suite stays green. The damage is entirely to local GPU verification, where a test that should fail can pass vacuously.

### Blast radius, measured

27 files under `tests/` gate on CUDA or allocate with `device = "cuda"`. Note that `@pytest.mark.skipif(not torch.cuda.is_available(), ...)` is evaluated at collection time, before the leak, so those tests are selected to run and then silently get CPU tensors.

Measured on this box against main, over the GPU-touching files that need no large download:

```
# the GPU files alone
106 passed, 3 skipped

# the same files with test_trl_fake_train_cpu.py collected first
8 failed, 101 passed, 3 skipped
  tests/test_offload_embedding_hooks.py  (4 tests)
  tests/test_uma_safetensors_load.py     (2 tests)
  tests/utils/test_batched_leftpad_generation_gpu.py
  tests/test_grpo_autocast_per_trainer.py
```

So it is not one test: it is 8 tests across 4 files in that sample alone, and every one of them was a false pass rather than a hard error until the assertions happened to catch it.

In a plain `pytest tests/` run the exposure is smaller, since `tests/version_compat` sorts near the end of collection. It bites when a subset is run in the order given on the command line, which is exactly how GPU verification is done locally.

Nothing else under `tests/` patches torch globally at import time. `tests/test_float32_no_fp16_autocast.py` swaps `torch.cuda` inside a helper and restores it in a `finally`; `tests/test_device_helpers.py` builds a fake torch module rather than mutating the real one.

### The fix

The patches move into module-scoped autouse fixtures driven by `pytest.MonkeyPatch.context()`, which undoes every one of them at module teardown. `_require_stack` (and `patched_sft` in the padding-free module) reuse the same `MonkeyPatch`, so the re-application of the eager `torch.compile` after `import unsloth`, and `torch._dynamo.config.disable`, are unwound too.

Why this over the alternatives:

- **Process isolation.** The strongest guarantee, but the repo has no convention for it: `pytest-forked` is not a dependency, and both `version-compat-ci.yml` jobs deliberately run these modules together in one process (the daily sweep runs the whole directory in one). Adding a dependency plus a CI-invocation change to fix a test-hygiene bug is a lot of moving parts, and it would not stop the next module from doing the same thing.
- **Save and restore at import time.** No new dependency, but it has to enumerate every patched name by hand, including the whole allocator loop, and the next patch added to the file silently escapes it. It also leaves the spoof in place for anything collected between import and the module's own tests.
- **Confine the patches to the tests that need them.** The comments say the spoof has to precede certain imports, so I checked whether that constraint is real: nothing at module scope imports unsloth or trl. Both modules do all of that inside fixtures and test bodies, and `conftest.py` has already imported unsloth before any of this runs. A module-scoped fixture is therefore in place strictly before the first thing that cares, and `pytest.MonkeyPatch` removes the enumeration problem because the undo list builds itself.

`_zoo_aggressive_cuda_spoof.apply()` stays at module scope. It is a shared harness (five modules plus the shims generated by `consolidated-tests-ci.yml`), it is deliberately idempotent and one-way, and it is not restorable in practice since `unsloth_zoo.device_type` caches the spoofed answer permanently at import. It leaks separately, and on this box it is what still makes `test_batched_leftpad_generation_gpu.py` fail after the fake-train module: the spoof reports capability `(8, 0)` on a B200, so Triton compiles an SM80 kernel and gets "no kernel image is available for execution on the device". That is a distinct mechanism from the one fixed here and is left alone on purpose.

### Regression test

`tests/version_compat/test_import_leaves_torch_globals_alone.py`, in two halves:

- a subprocess that imports both modules exactly as collection does, then checks `torch.compile`, `torch.Tensor.to`, `torch.Tensor.cuda` and `torch.accelerator.is_available` are the same objects as before, and, when a real GPU is present, that `torch.randn(4, 4, device = "cuda")` and `.to("cuda")` still land on CUDA. It runs on a GPU-less runner too, where the identity checks alone still catch the leak.
- a static check that no module in `tests/version_compat` assigns to a `torch` attribute (or `setattr`s one) at import time, so a new module cannot reintroduce this.

Both fail on the parent commit and pass here:

```
# on main, with the new file dropped in
2 failed
E  AssertionError: FAILURES:torch.compile was replaced|torch.Tensor.to was replaced|
   torch.Tensor.cuda was replaced|torch.accelerator.is_available was replaced|
   torch.randn(device = "cuda") returned a CPU tensor|Tensor.to("cuda") returned a CPU tensor
E  AssertionError: patch torch from a fixture instead ...:
   ['test_trl_fake_train_cpu.py:71 torch.compile', ..., 'test_trl_padding_free_max_length.py:56 torch.accelerator.is_available']

# with the fix
2 passed
```

### Verification

```
pytest tests/version_compat tests/test_grpo_autocast_per_trainer.py   1694 passed, 213 skipped   (was 1 failed, 1691 passed)
pytest tests/version_compat                                           1660 passed, 213 skipped
pytest tests/test_grpo_autocast_per_trainer.py                          34 passed
```

and the blast-radius sample goes from 8 failed / 101 passed to 1 failed / 108 passed, the remaining one being the separate capability spoof described above.

The fake-CPU environment those tests exist for is unchanged: `tests/version_compat` passes in full on its own, and the three real `trainer.train()` canaries still run the whole loop on CPU. torch 2.6 compatibility is preserved, `torch.accelerator` is still reached only under `hasattr`.
