### PR TITLE
Studio: read ?model= from the diffusion page's own route match

### DIFF
--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -191,8 +191,9 @@ function RootLayout() {
   const chatSearch = isChatRoute ? liveChatSearch : frozenChatSearch;
   const shouldMountChat = isChatRoute || chatMounted;
 
-  // Same persistent mount for /images so a long batch keeps generating off-tab (ImagesPage reads no URL search, so it needs
-  // only the mount latch). Mounts lazily on first visit, then stays mounted, hidden+inert while off-route.
+  // Same persistent mount for /images so a long batch keeps generating off-tab. Mounts lazily on first visit, then stays
+  // mounted, hidden+inert while off-route. `active` is a visibility flag only: it lags the matches by a render, so ImagesPage
+  // reads ?model= from its own match instead of trusting it.
   const isImagesRoute = pathname === "/images";
   const [imagesMounted, setImagesMounted] = useState(isImagesRoute);
   if (isImagesRoute && !imagesMounted) {

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2206,18 +2206,15 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   }, [active, pickGuard]);
 
   // A diffusion model picked from the chat picker arrives as ?model= on this route. Load it once, then clear the params.
-  const routeSearch = useSearch({ strict: false }) as {
-    model?: string;
-    quant?: string;
-    ggufQuant?: string;
-  };
+  // This route's own match, never `strict: false`: that resolves to the ROOT match, whose search is whatever route is live, and
+  // /hub names its selection with the same param. `active` cannot fence that off, since it lags the matches by a render.
+  const routeSearch = useSearch({ from: "/images", shouldThrow: false });
   const navigateSelf = useNavigate();
   const handledRouteModel = useRef<string | null>(null);
   useEffect(() => {
-    // Only the page being shown consumes the query: this hook is loose and both diffusion pages stay mounted, so the hidden one
-    // saw /video?model= too and raced this one, loading the other page's checkpoint as its own kind of model.
+    // A hidden page owns no query: both diffusion pages stay mounted.
     if (!active) return;
-    const wanted = routeSearch.model;
+    const wanted = routeSearch?.model;
     // Key on the model AND the quant, and release the marker once the query is gone: this page stays mounted, so a marker that
     // outlived the query made re-picking the same checkpoint a click that neither loaded nor cleared the URL.
     if (!wanted) {
@@ -2226,10 +2223,10 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     }
     // `quant` is used verbatim as a filename; a label there (a hand-built link, an older producer) is resolved instead.
     // The two fields, not the object: `routeSearch` is rebuilt every render, so it would churn the deps.
-    const routed = { quant: routeSearch.quant, ggufQuant: routeSearch.ggufQuant };
+    const routed = { quant: routeSearch?.quant, ggufQuant: routeSearch?.ggufQuant };
     const routedFilename = routedGgufFilename(routed);
     const routedLabel = routedGgufLabel(routed);
-    const key = `${wanted}|${routeSearch.quant ?? ""}|${routeSearch.ggufQuant ?? ""}`;
+    const key = `${wanted}|${routeSearch?.quant ?? ""}|${routeSearch?.ggufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
     // This arrival owns the page like a direct pick, so a download staged by an earlier one cannot land on top.
@@ -2258,9 +2255,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     void loadOrStage(pick.repoId, pick.opts, false, token);
   }, [
     active,
-    routeSearch.model,
-    routeSearch.quant,
-    routeSearch.ggufQuant,
+    routeSearch?.model,
+    routeSearch?.quant,
+    routeSearch?.ggufQuant,
     loadOrStage,
     loadGgufRepoPick,
     navigateSelf,

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -1556,18 +1556,15 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
   }, [active, pickGuard]);
 
   // A diffusion model picked from the chat picker arrives as ?model= on this route. Load it once, then clear the params.
-  const routeSearch = useSearch({ strict: false }) as {
-    model?: string;
-    quant?: string;
-    ggufQuant?: string;
-  };
+  // This route's own match, never `strict: false`: that resolves to the ROOT match, whose search is whatever route is live, and
+  // /hub names its selection with the same param. `active` cannot fence that off, since it lags the matches by a render.
+  const routeSearch = useSearch({ from: "/video", shouldThrow: false });
   const navigateSelf = useNavigate();
   const handledRouteModel = useRef<string | null>(null);
   useEffect(() => {
-    // Only the page being shown consumes the query: this hook is loose and both diffusion pages stay mounted, so the hidden one
-    // saw /images?model= too and raced that page, trying to load an image checkpoint as a video model.
+    // A hidden page owns no query: both diffusion pages stay mounted.
     if (!active) return;
-    const wanted = routeSearch.model;
+    const wanted = routeSearch?.model;
     // Model AND quant, released once the query is gone: this page stays mounted, so a marker that outlived the query made re-picking a dead click.
     if (!wanted) {
       handledRouteModel.current = null;
@@ -1575,10 +1572,10 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     }
     // `quant` is used verbatim as a filename; a label there (a hand-built link, an older producer) is resolved instead.
     // The two fields, not the object: `routeSearch` is rebuilt every render, so it would churn the deps.
-    const routed = { quant: routeSearch.quant, ggufQuant: routeSearch.ggufQuant };
+    const routed = { quant: routeSearch?.quant, ggufQuant: routeSearch?.ggufQuant };
     const routedFilename = routedGgufFilename(routed);
     const routedLabel = routedGgufLabel(routed);
-    const key = `${wanted}|${routeSearch.quant ?? ""}|${routeSearch.ggufQuant ?? ""}`;
+    const key = `${wanted}|${routeSearch?.quant ?? ""}|${routeSearch?.ggufQuant ?? ""}`;
     if (handledRouteModel.current === key) return;
     handledRouteModel.current = key;
     // This arrival owns the page like a direct pick, so a download staged by an earlier one cannot land on top.
@@ -1607,9 +1604,9 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
     void loadOrStage(pick.repoId, pick.opts, false, token);
   }, [
     active,
-    routeSearch.model,
-    routeSearch.quant,
-    routeSearch.ggufQuant,
+    routeSearch?.model,
+    routeSearch?.quant,
+    routeSearch?.ggufQuant,
     loadOrStage,
     loadGgufRepoPick,
     navigateSelf,

--- a/studio/frontend/tests/diffusion-route-model-scope.test.ts
+++ b/studio/frontend/tests/diffusion-route-model-scope.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The Images and Video pages stay mounted off-route and read ?model= to load a pick handed over by the chat picker. /hub names
+// its selection with the same param, so these pin both halves of keeping them apart: the trap (location runs ahead of the
+// matches, so `active` alone lets the hub's id through) and the fix (no /images match to read one from until it commits).
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+
+// What the hub puts in the URL for a downloaded row: an inventory id, not a repo id. Loading it as a diffusion model fails.
+const HUB_INVENTORY_ID = "cache:safetensors:mlx-community%2FQwen3-0.6B-4bit";
+
+function buildRouter() {
+  const rootRoute = createRootRoute({
+    // The real root awaits fetchDeviceType before its chat-only guard.
+    beforeLoad: async () => {
+      await Promise.resolve();
+    },
+    component: () => null,
+  });
+  const page = (path: "/chat" | "/hub" | "/images") =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path,
+      validateSearch: (search: Record<string, unknown>) => ({
+        ...(typeof search.model === "string" ? { model: search.model } : {}),
+      }),
+      component: () => null,
+    });
+  return createRouter({
+    routeTree: rootRoute.addChildren([
+      page("/chat"),
+      page("/hub"),
+      page("/images"),
+    ]),
+    history: createMemoryHistory({ initialEntries: ["/chat"] }),
+  });
+}
+
+function matchFor(router: ReturnType<typeof buildRouter>, routeId: string) {
+  return router.state.matches.find((match) => match.routeId === routeId);
+}
+
+async function settleOnHub(router: ReturnType<typeof buildRouter>) {
+  await router.load();
+  await router.navigate({ to: "/hub", search: { model: HUB_INVENTORY_ID } });
+  await router.invalidate();
+}
+
+test("the root match hands the hub's selection to every persistently mounted page", async () => {
+  const router = buildRouter();
+  await settleOnHub(router);
+
+  // A `strict: false` read from a page mounted under the root resolves here.
+  assert.equal(router.state.matches[0]?.routeId, "__root__");
+  assert.equal(
+    (router.state.matches[0]?.search as { model?: string }).model,
+    HUB_INVENTORY_ID,
+  );
+});
+
+test("location.pathname reaches /images while the hub's search is still committed", async () => {
+  const router = buildRouter();
+  await settleOnHub(router);
+
+  const navigation = router.navigate({ to: "/images" });
+  await Promise.resolve();
+
+  // `active` is derived from this, so mid-navigation the Images page believes it is the visible one...
+  assert.equal(router.state.location.pathname, "/images");
+  // ...while the committed matches still describe /hub. Reading the model here is what loaded an inventory id.
+  assert.equal(
+    (router.state.matches[0]?.search as { model?: string }).model,
+    HUB_INVENTORY_ID,
+  );
+
+  await navigation;
+});
+
+test("no /images match exists to read a model from until the navigation commits", async () => {
+  const router = buildRouter();
+  await settleOnHub(router);
+  assert.equal(matchFor(router, "/images"), undefined);
+
+  const navigation = router.navigate({ to: "/images" });
+  await Promise.resolve();
+  assert.equal(matchFor(router, "/images"), undefined);
+
+  await navigation;
+  assert.notEqual(matchFor(router, "/images"), undefined);
+  // Sidebar navigation carries no search, so the settled route asks for nothing.
+  assert.deepEqual(matchFor(router, "/images")?.search, {});
+});
+
+test("a chat-picker handoff still arrives on the /images match", async () => {
+  const router = buildRouter();
+  await router.load();
+  await router.navigate({
+    to: "/images",
+    search: { model: "unsloth/Z-Image-Turbo" },
+  });
+  await router.invalidate();
+
+  assert.deepEqual(matchFor(router, "/images")?.search, {
+    model: "unsloth/Z-Image-Turbo",
+  });
+});


### PR DESCRIPTION
The Images and Video pages stay mounted off-route and read `?model=` with `useSearch({ strict: false })`, which resolves to the root match. `/hub` names its selection with the same param, so Hub > Images tried to load the hub's inventory id as a diffusion model:

> 'cache:safetensors:mlx-community%2FQwen3-0.6B-4bit' is not a supported diffusion
> image model. Supported families: …

The `active` guard doesn't stop it, since it lags the matches by a render. Both pages now read `useSearch({ from: "/images" | "/video", shouldThrow: false })`.