### PR TITLE
Restore SFT loss_type='nll' default over TRL 1.7.0 chunked_nll

### DIFF
--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -360,6 +360,7 @@ jobs:
             tests/version_compat/test_trl_grpo_fake_run.py \
             tests/version_compat/test_trl_fake_train_cpu.py \
             tests/version_compat/test_trl_padding_free_max_length.py \
+            tests/version_compat/test_trl_loss_normalization_contract.py \
             -v --tb=short
       # `main` is scheduled/dispatch-only so PR jobs stay fast and a bleeding-edge
       # TRL break does not red every PR. github.event_name is valid in a step if.
@@ -379,6 +380,7 @@ jobs:
             tests/version_compat/test_trl_grpo_fake_run.py \
             tests/version_compat/test_trl_fake_train_cpu.py \
             tests/version_compat/test_trl_padding_free_max_length.py \
+            tests/version_compat/test_trl_loss_normalization_contract.py \
             -v --tb=short
 
   # Daily-only: same suites but with --strict on importable upstream

--- a/tests/version_compat/test_trl_loss_normalization_contract.py
+++ b/tests/version_compat/test_trl_loss_normalization_contract.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
+"""Guard the grad-accumulation loss-normalisation contract across TRL versions.
+
+Three components each decide "is this loss already token-count normalised?", and
+they must agree:
+
+  * unsloth_zoo `_unsloth_get_batch_samples` decides from the forward signature.
+  * The loss divides by num_items_in_batch when it is not None. Both
+    `unsloth_fused_ce_loss` and TRL's `_chunked_cross_entropy_loss` do this
+    without consulting `model_accepts_loss_kwargs`.
+  * transformers `training_step` divides by grad-accum when
+    `not self.model_accepts_loss_kwargs or num_items_in_batch is None`.
+
+When a model class sets `accepts_loss_kwargs = False` (gemma3, qwen-vl,
+paligemma, glm4v) and the loss still divides by the token count, loss and grads
+are silently scaled 1/GA. Nothing raises; the effective LR is just GA times too
+small. Regressed when TRL 1.7.0 defaulted SFT to "chunked_nll" (trl#5846):
+clean on 0.22.2-1.6.0, reproducible from 1.4.0 by opting in explicitly.
+
+Source/AST checks only, no GPU and no downloads, so they run in the CPU job that
+already exercises TRL latest and TRL git main.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import inspect
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+
+os.environ.setdefault("UNSLOTH_COMPILE_DISABLE", "1")
+os.environ.setdefault("TORCHDYNAMO_DISABLE", "1")
+os.environ.setdefault("TORCH_COMPILE_DISABLE", "1")
+
+import pytest
+
+
+# daily-fresh-fetch collects this directory with only pytest installed.
+if importlib.util.find_spec("torch") is None:
+    pytest.skip("torch not installed", allow_module_level = True)
+
+# Unsloth refuses to import without a torch accelerator, so the GPU-less runner
+# needs the same spoof the sibling CPU canaries use. Must precede any unsloth
+# import, which is why it sits at module scope rather than in a fixture.
+_SPOOF_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_SPOOF_DIR))
+import _zoo_aggressive_cuda_spoof as _spoof  # noqa: E402
+
+_spoof.apply()
+
+
+# --------------------------------------------------------------------------
+# 1. TRL's SFT loss default
+# --------------------------------------------------------------------------
+def test_sft_loss_type_default_is_nll_after_unsloth_patch():
+    """chunked_nll bypasses the forward (fused CE never runs) and double-divides."""
+    import unsloth  # noqa: F401  must precede trl
+    import trl
+
+    if not hasattr(trl.SFTConfig, "loss_type"):
+        pytest.skip("this TRL has no SFTConfig.loss_type")
+
+    cfg = trl.SFTConfig(output_dir="unused")
+    assert cfg.loss_type == "nll", (
+        f"SFTConfig.loss_type resolved to {cfg.loss_type!r}, expected 'nll'. "
+        "If TRL changed its default again, update the sft_trainer replacement in "
+        "unsloth/models/rl.py -- do NOT add loss_type to the global replacements "
+        "dict, it is an unrelated field in DPO/KTO/GRPO."
+    )
+
+
+def test_loss_type_replacement_did_not_leak_to_other_trainers():
+    """loss_type is an unrelated field in DPO/KTO/GRPO; the global dict hits all."""
+    import unsloth  # noqa: F401
+    import trl
+
+    expected = {"DPOConfig": ["sigmoid"], "KTOConfig": "kto", "GRPOConfig": "bnpo"}
+    for name, want in expected.items():
+        cfg_cls = getattr(trl, name, None)
+        if cfg_cls is None or not hasattr(cfg_cls, "loss_type"):
+            continue
+        got = cfg_cls(output_dir="unused").loss_type
+        assert got == want, (
+            f"{name}.loss_type is {got!r}, expected {want!r}. A loss_type "
+            "replacement leaked out of the sft_trainer branch in rl.py."
+        )
+
+
+def test_explicit_loss_type_still_wins():
+    """Pinning a default must not take the choice away from the user."""
+    import unsloth  # noqa: F401
+    import trl
+
+    if not hasattr(trl.SFTConfig, "loss_type"):
+        pytest.skip("this TRL has no SFTConfig.loss_type")
+    cfg = trl.SFTConfig(output_dir="unused", loss_type="chunked_nll")
+    assert cfg.loss_type == "chunked_nll", "explicit loss_type was clobbered"
+
+
+# --------------------------------------------------------------------------
+# 2. The normalisation predicates themselves
+# --------------------------------------------------------------------------
+def _divides_by_num_items(fn) -> bool:
+    """True when the source contains a division by num_items_in_batch/n_items."""
+    try:
+        source = textwrap.dedent(inspect.getsource(fn))
+    except (OSError, TypeError):
+        return False
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+
+    names = {"num_items_in_batch", "n_items"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            for sub in ast.walk(node.right):
+                if isinstance(sub, ast.Name) and sub.id in names:
+                    return True
+    return False
+
+
+def test_transformers_training_step_still_keys_off_model_accepts_loss_kwargs():
+    """If upstream changes this predicate, our whole reconciliation is stale."""
+    from transformers import Trainer
+
+    try:
+        source = inspect.getsource(Trainer.training_step)
+    except (OSError, TypeError):
+        pytest.skip("Trainer.training_step source unavailable")
+
+    assert "model_accepts_loss_kwargs" in source, (
+        "transformers' training_step no longer references model_accepts_loss_kwargs. "
+        "The grad-accum normalisation contract changed upstream; re-check "
+        "unsloth_zoo's _unsloth_get_batch_samples against the new predicate."
+    )
+    assert "num_items_in_batch" in source, (
+        "transformers' training_step no longer references num_items_in_batch."
+    )
+
+
+def test_trl_chunked_ce_divides_by_num_items_without_consulting_the_flag():
+    """Fires if TRL starts gating this, at which point the pin can be dropped."""
+    trl_sft = pytest.importorskip("trl.trainer.sft_trainer")
+
+    fn = getattr(trl_sft, "_chunked_cross_entropy_loss", None)
+    if fn is None:
+        pytest.skip("this TRL has no _chunked_cross_entropy_loss")
+
+    assert _divides_by_num_items(fn), (
+        "TRL's _chunked_cross_entropy_loss no longer divides by num_items_in_batch. "
+        "If TRL now gates this on model_accepts_loss_kwargs, the loss_type pin in "
+        "unsloth/models/rl.py may no longer be needed -- re-measure before removing."
+    )
+
+    try:
+        source = inspect.getsource(fn)
+    except (OSError, TypeError):
+        return
+    assert "model_accepts_loss_kwargs" not in source, (
+        "TRL's chunked CE now consults model_accepts_loss_kwargs. Good news: "
+        "re-evaluate whether unsloth still needs to pin loss_type='nll'."
+    )
+
+
+def test_unsloth_fused_ce_has_the_same_num_items_contract():
+    """Ours divides by n_items too, which is why the compiled-path flag matters."""
+    ce = pytest.importorskip("unsloth_zoo.fused_losses.cross_entropy_loss")
+
+    fn = getattr(ce, "unsloth_fused_ce_loss", None)
+    if fn is None:
+        pytest.skip("unsloth_fused_ce_loss not present")
+    source = inspect.getsource(fn)
+    assert "n_items" in source, (
+        "unsloth_fused_ce_loss no longer takes n_items; the normalisation "
+        "contract changed on our side and rl.py's loss_type pin should be re-checked."
+    )
+
+
+def test_unsloth_get_batch_samples_is_installed_and_shaped_as_expected():
+    """_utils.py raises NotImplementedError on this shape; catch it before train()."""
+    from transformers import Trainer
+
+    fn = getattr(Trainer, "get_batch_samples", None)
+    if fn is None:
+        pytest.skip("Trainer has no get_batch_samples")
+
+    try:
+        source = inspect.getsource(fn).strip()
+    except (OSError, TypeError):
+        pytest.skip("get_batch_samples source unavailable")
+
+    assert source.endswith("return batch_samples, num_items_in_batch"), (
+        "get_batch_samples no longer ends in the expected 2-tuple return. "
+        "unsloth/models/_utils.py raises NotImplementedError on this exact check."
+    )
+
+
+# --------------------------------------------------------------------------
+# 3. rl.py's own scoping
+# --------------------------------------------------------------------------
+def test_rl_py_scopes_loss_type_to_sft_trainer():
+    """AST guard: no loss_type replacement outside an `if trainer_file ==` branch."""
+    from unsloth.models import rl
+
+    source = inspect.getsource(rl)
+    tree = ast.parse(source)
+
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "replacements" for t in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Dict):
+            continue
+        keys = [k.value for k in node.value.keys if isinstance(k, ast.Constant)]
+        if "loss_type" not in keys:
+            continue
+        # A loss_type entry is only legitimate inside an `if trainer_file == ...`
+        # branch. Find the nearest enclosing If and check its test.
+        guarded = False
+        for parent in ast.walk(tree):
+            if not isinstance(parent, ast.If):
+                continue
+            if node not in [n for b in (parent.body, parent.orelse) for n in ast.walk(ast.Module(body=b, type_ignores=[]))]:
+                continue
+            if "trainer_file" in ast.dump(parent.test):
+                guarded = True
+                break
+        if not guarded:
+            offenders.append(keys)
+
+    assert not offenders, (
+        f"found an unguarded `loss_type` replacement: {offenders}. It must live "
+        "inside an `if trainer_file == \"...\":` branch -- the global replacements "
+        "dict is applied by regex to every generated config, and loss_type is a "
+        "real field in DPOConfig, KTOConfig and GRPOConfig."
+    )

--- a/tests/version_compat/test_trl_loss_normalization_contract.py
+++ b/tests/version_compat/test_trl_loss_normalization_contract.py
@@ -145,6 +145,33 @@ def test_pristine_trl_sft_config_keeps_an_explicit_loss_type():
         assert got == wanted, f"explicit loss_type {wanted!r} was clobbered to {got!r}"
 
 
+def test_dataclass_field_default_is_nll_for_hfargumentparser():
+    """`HfArgumentParser` reads the field, not the `__init__` default.
+
+    It builds one argparse argument per `dataclasses.fields()` entry and always
+    passes the value through, so a field left at TRL's unresolved `None` sends
+    `loss_type = None` into `__post_init__` and comes back out as chunked_nll
+    however the `__init__` default reads.
+    """
+    import dataclasses
+
+    import unsloth  # noqa: F401
+
+    pristine = _pristine_sft_config_cls()
+    if not hasattr(pristine, "loss_type"):
+        pytest.skip("this TRL has no SFTConfig.loss_type")
+
+    import trl
+
+    for cls in (pristine, trl.SFTConfig):
+        field = {f.name: f for f in dataclasses.fields(cls)}["loss_type"]
+        assert field.default == "nll", (
+            f"{cls.__name__}.loss_type field default is {field.default!r}, "
+            "expected 'nll'. HfArgumentParser and any other dataclass-driven "
+            "entry point would pass that default through and land on chunked_nll."
+        )
+
+
 # --------------------------------------------------------------------------
 # 2. The normalisation predicates themselves
 # --------------------------------------------------------------------------

--- a/tests/version_compat/test_trl_loss_normalization_contract.py
+++ b/tests/version_compat/test_trl_loss_normalization_contract.py
@@ -65,7 +65,7 @@ def test_sft_loss_type_default_is_nll_after_unsloth_patch():
     if not hasattr(trl.SFTConfig, "loss_type"):
         pytest.skip("this TRL has no SFTConfig.loss_type")
 
-    cfg = trl.SFTConfig(output_dir="unused")
+    cfg = trl.SFTConfig(output_dir = "unused")
     assert cfg.loss_type == "nll", (
         f"SFTConfig.loss_type resolved to {cfg.loss_type!r}, expected 'nll'. "
         "If TRL changed its default again, update the sft_trainer replacement in "
@@ -84,7 +84,7 @@ def test_loss_type_replacement_did_not_leak_to_other_trainers():
         cfg_cls = getattr(trl, name, None)
         if cfg_cls is None or not hasattr(cfg_cls, "loss_type"):
             continue
-        got = cfg_cls(output_dir="unused").loss_type
+        got = cfg_cls(output_dir = "unused").loss_type
         assert got == want, (
             f"{name}.loss_type is {got!r}, expected {want!r}. A loss_type "
             "replacement leaked out of the sft_trainer branch in rl.py."
@@ -98,7 +98,7 @@ def test_explicit_loss_type_still_wins():
 
     if not hasattr(trl.SFTConfig, "loss_type"):
         pytest.skip("this TRL has no SFTConfig.loss_type")
-    cfg = trl.SFTConfig(output_dir="unused", loss_type="chunked_nll")
+    cfg = trl.SFTConfig(output_dir = "unused", loss_type = "chunked_nll")
     assert cfg.loss_type == "chunked_nll", "explicit loss_type was clobbered"
 
 
@@ -139,9 +139,9 @@ def test_transformers_training_step_still_keys_off_model_accepts_loss_kwargs():
         "The grad-accum normalisation contract changed upstream; re-check "
         "unsloth_zoo's _unsloth_get_batch_samples against the new predicate."
     )
-    assert "num_items_in_batch" in source, (
-        "transformers' training_step no longer references num_items_in_batch."
-    )
+    assert (
+        "num_items_in_batch" in source
+    ), "transformers' training_step no longer references num_items_in_batch."
 
 
 def test_trl_chunked_ce_divides_by_num_items_without_consulting_the_flag():
@@ -215,9 +215,7 @@ def test_rl_py_scopes_loss_type_to_sft_trainer():
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assign):
             continue
-        if not any(
-            isinstance(t, ast.Name) and t.id == "replacements" for t in node.targets
-        ):
+        if not any(isinstance(t, ast.Name) and t.id == "replacements" for t in node.targets):
             continue
         if not isinstance(node.value, ast.Dict):
             continue
@@ -230,7 +228,11 @@ def test_rl_py_scopes_loss_type_to_sft_trainer():
         for parent in ast.walk(tree):
             if not isinstance(parent, ast.If):
                 continue
-            if node not in [n for b in (parent.body, parent.orelse) for n in ast.walk(ast.Module(body=b, type_ignores=[]))]:
+            if node not in [
+                n
+                for b in (parent.body, parent.orelse)
+                for n in ast.walk(ast.Module(body = b, type_ignores = []))
+            ]:
                 continue
             if "trainer_file" in ast.dump(parent.test):
                 guarded = True
@@ -240,7 +242,7 @@ def test_rl_py_scopes_loss_type_to_sft_trainer():
 
     assert not offenders, (
         f"found an unguarded `loss_type` replacement: {offenders}. It must live "
-        "inside an `if trainer_file == \"...\":` branch -- the global replacements "
+        'inside an `if trainer_file == "...":` branch -- the global replacements '
         "dict is applied by regex to every generated config, and loss_type is a "
         "real field in DPOConfig, KTOConfig and GRPOConfig."
     )

--- a/tests/version_compat/test_trl_loss_normalization_contract.py
+++ b/tests/version_compat/test_trl_loss_normalization_contract.py
@@ -102,6 +102,49 @@ def test_explicit_loss_type_still_wins():
     assert cfg.loss_type == "chunked_nll", "explicit loss_type was clobbered"
 
 
+def _pristine_sft_config_cls():
+    """TRL's own SFTConfig, not the generated subclass patching rebinds over it."""
+    import trl
+
+    cls = trl.SFTConfig
+    return cls.__mro__[1] if cls.__name__.startswith("Unsloth") else cls
+
+
+def test_pristine_trl_sft_config_default_is_nll_too():
+    """`from trl import SFTConfig` before `import unsloth` keeps TRL's own class.
+
+    Patching only rebinds the module aliases, so that caller never sees the
+    generated subclass and would still build a chunked_nll config and hand it to
+    the patched trainer. The same ordering is covered by the padding-free tests.
+    """
+    import unsloth  # noqa: F401  must precede trl
+
+    pristine = _pristine_sft_config_cls()
+    if not hasattr(pristine, "loss_type"):
+        pytest.skip("this TRL has no SFTConfig.loss_type")
+
+    got = pristine(output_dir = "unused").loss_type
+    assert got == "nll", (
+        f"pristine {pristine.__name__}.loss_type resolved to {got!r}, expected "
+        "'nll'. _pin_pristine_sft_loss_type in unsloth/models/rl.py stopped "
+        "reaching TRL's own class, so a pre-unsloth `from trl import SFTConfig` "
+        "still double-normalises the loss by 1/GA."
+    )
+
+
+def test_pristine_trl_sft_config_keeps_an_explicit_loss_type():
+    """Pinning the pristine default must not take the choice away either."""
+    import unsloth  # noqa: F401
+
+    pristine = _pristine_sft_config_cls()
+    if not hasattr(pristine, "loss_type"):
+        pytest.skip("this TRL has no SFTConfig.loss_type")
+
+    for wanted in ("chunked_nll", "dft"):
+        got = pristine(output_dir = "unused", loss_type = wanted).loss_type
+        assert got == wanted, f"explicit loss_type {wanted!r} was clobbered to {got!r}"
+
+
 # --------------------------------------------------------------------------
 # 2. The normalisation predicates themselves
 # --------------------------------------------------------------------------

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -2915,6 +2915,23 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
             y = f"{k} = {y},\n"
             arguments = re.sub(x, y, arguments)
 
+    # TRL >= 1.7.0 defaults SFT to loss_type="chunked_nll" (trl#5846), which patches
+    # the lm_head and calls the backbone directly. Two problems:
+    #   1. It bypasses the model forward, so unsloth_fused_ce_loss never runs. Ours
+    #      chunks too and peaks 1.7-3.7GB lower on gemma-3-4b at 141-8192 tokens.
+    #   2. It divides by num_items_in_batch ignoring model_accepts_loss_kwargs, so
+    #      on models setting that flag False (gemma3, qwen-vl, paligemma, glm4v)
+    #      training_step divides by grad-accum again: loss and grads scaled 1/GA.
+    # Explicit loss_type= still wins. Keep scoped to sft_trainer: loss_type is an
+    # unrelated field in DPO/KTO/GRPO and the global dict above is applied to all.
+    if trainer_file == "sft_trainer":
+        replacements = {"loss_type": "nll"}
+        for k, v in replacements.items():
+            x = f"{k}( = [^,\n]{{1,}})?,\n"
+            y = f"'{v}'" if type(v) is str else f"{v}"
+            y = f"{k} = {y},\n"
+            arguments = re.sub(x, y, arguments)
+
     # Warn on too large or too small learning rate
     if "learning_rate" in call_args:
         learning_rate_check = (

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1022,6 +1022,57 @@ def _trl_prepares_late_evals(trainer_cls):
     return False
 
 
+def _pin_pristine_sft_loss_type(config_cls):
+    """Pin `loss_type` to `nll` on TRL's own `SFTConfig`, not just on ours.
+
+    Patching rebinds `trl.SFTConfig` to the generated subclass, so a caller who
+    ran `from trl import SFTConfig` before importing Unsloth keeps the pristine
+    class and would still get TRL >= 1.7.0's `chunked_nll` (that ordering is
+    supported and covered by the padding-free tests). TRL declares the field as
+    `None` and resolves it in `__post_init__`, so seeding `nll` there is enough;
+    an explicit `loss_type = ` still wins, and `use_liger_kernel = True` already
+    resolved to `nll`. Only the unresolved `None` default is touched, which also
+    makes this a no-op on TRL < 1.7.0 and on a second call.
+    """
+    field = getattr(config_cls, "__dataclass_fields__", {}).get("loss_type")
+    if field is None or field.default is not None:
+        return False
+    init = config_cls.__dict__.get("__init__")
+    if init is None:
+        return False
+    try:
+        parameters = inspect.signature(init).parameters
+    except (TypeError, ValueError):
+        return False
+    positional = [
+        name
+        for name, parameter in parameters.items()
+        if parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+        and parameter.default is not inspect.Parameter.empty
+    ]
+    defaults = init.__defaults__ or ()
+    keyword_defaults = init.__kwdefaults__ or {}
+    if "loss_type" in positional and len(defaults) == len(positional):
+        index = positional.index("loss_type")
+        if defaults[index] is not None:
+            return False
+        new_defaults = list(defaults)
+        new_defaults[index] = "nll"
+        init.__defaults__ = tuple(new_defaults)
+    elif "loss_type" in keyword_defaults:
+        if keyword_defaults["loss_type"] is not None:
+            return False
+        keyword_defaults["loss_type"] = "nll"
+    else:
+        return False
+    field.default = "nll"
+    # The class attribute is the other copy of the default: dataclasses seeds it
+    # at class creation and a later subclass reads the field, so leave the two
+    # agreeing rather than half-patched.
+    setattr(config_cls, "loss_type", "nll")
+    return True
+
+
 def _wrap_sft_evaluate_cap(trainer_cls):
     """Cap a pre-tokenized split handed to `evaluate()`/`predict()` later on.
 
@@ -3435,6 +3486,13 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
         pass
 
     if trainer_file == "sft_trainer":
+        try:
+            for _config_base in getattr(created_module, f"Unsloth{RLConfig_name}").__mro__[1:]:
+                if not _config_base.__name__.startswith("Unsloth"):
+                    _pin_pristine_sft_loss_type(_config_base)
+                    break
+        except Exception as e:
+            logger.info(f"Unsloth: Could not pin the {RLConfig_name} loss_type: {e}")
         try:
             _wrap_sft_evaluate_cap(getattr(created_module, f"Unsloth{RLTrainer_name}"))
         except Exception as e:


### PR DESCRIPTION
TRL 1.7.0 ([trl#5846](https://github.com/huggingface/trl/pull/5846)) changed the SFT loss default from `nll` to `chunked_nll`. That path patches the `lm_head` and calls the backbone directly, which causes two problems for us.

**1. Our fused CE stops running.** `chunked_nll` bypasses the model forward, so `unsloth_fused_ce_loss` is never reached. We already detect this bypass in `unsloth/trainer.py::_chunked_loss_bypasses_forward`, but only for hybrid packing. Ours chunks the `lm_head` projection too, and measures cheaper on `gemma-3-4b` (bs1, GA2, LoRA, 4bit):

| real seq len | `chunked_nll` | `nll` | fused CE calls under `nll` |
|---|---|---|---|
| 141 | 8.235 GB | 4.548 GB | 4 |
| 2048 | 8.377 GB | 6.483 GB | 4 |
| 8192 | 8.616 GB | 6.878 GB | 4 |

Counted at three levels including the autograd `UnslothFusedLoss.apply`. Under `chunked_nll` all three read zero.

**2. Silent 1/GA scaling of loss and gradients.** Three components each decide "is this loss already token-count normalised", using different predicates:

| component | predicate |
|---|---|
| `_unsloth_get_batch_samples` | forward signature takes `**kwargs` |
| `_chunked_cross_entropy_loss` | `num_items_in_batch is not None` |
| `Trainer.training_step` | `self.model_accepts_loss_kwargs` |

On a model class with `accepts_loss_kwargs = False` (gemma3, gemma4, qwen-vl, paligemma, glm4v) two of the three normalise, so the effective learning rate ends up GA times too small. Nothing raises.

Measured on real `unsloth/gemma-3-4b-it-unsloth-bnb-4bit` with `UNSLOTH_COMPILE_DISABLE=1` and no other changes:

| | GA=1 | GA=2 | GA=4 |
|---|---|---|---|
| before, grad-norm | 1.041674 | 0.520837 | 0.260419 |
| after, grad-norm | 1.041674 | 1.041674 | 1.041674 |

## Bisection

Held everything else fixed and varied one library at a time:

| library | versions | result |
|---|---|---|
| transformers | 4.57.6, 5.5.0, 5.6.0, 5.14.1 | identical, not the cause |
| accelerate | 1.10.1, 1.14.0 | identical, not the cause |
| TRL | 0.22.2, 0.24.0, 1.0.0, 1.1.0, 1.3.0, 1.5.0, 1.6.0 | correct |
| TRL | 1.7.0, 1.9.0, 1.9.2 | 1/GA scaling |

Boundary is 1.6.0 to 1.7.0. Reproducible from 1.4.0 by setting `loss_type="chunked_nll"` explicitly, since that is when the chunked path landed as opt-in.

## Change

Pin the generated SFT default back to `nll`. Kept scoped to `sft_trainer`: `loss_type` is an unrelated field in `DPOConfig` (`sigmoid`/`ipo`), `KTOConfig` and `GRPOConfig` (`bnpo`/`cispo`), and the global `replacements` dict is applied by regex to every generated config. An explicit `loss_type=` still takes precedence.

Generated config defaults, before and after:

| trainer | before | after |
|---|---|---|
| SFT | `chunked_nll` | `nll` |
| DPO | `['sigmoid']` | `['sigmoid']` |
| KTO | `kto` | `kto` |
| GRPO | `bnpo` | `bnpo` |
| explicit `chunked_nll` | honoured | honoured |

Patching rebinds `trl.SFTConfig` to the generated subclass, so that alone misses a caller who ran `from trl import SFTConfig` before importing Unsloth. That ordering is supported and already covered by the padding-free tests, and the config it builds reaches the patched trainer with the same scaling. TRL declares the field as `None` and resolves it in `__post_init__` (`'nll' if use_liger_kernel else 'chunked_nll'`), so `_pin_pristine_sft_loss_type` seeds `nll` on TRL's own class after the rebind. That also fixes the dataclass-field entry points: `HfArgumentParser` builds one argument per `dataclasses.fields()` entry and passes the value through, so a field left at the unresolved `None` came back out as `chunked_nll` regardless of the generated `__init__` default.

| entry point | before | after | explicit `chunked_nll` |
|---|---|---|---|
| `trl.SFTConfig()` | `chunked_nll` | `nll` | honoured |
| pristine `SFTConfig()` | `chunked_nll` | `nll` | honoured |
| `HfArgumentParser` CLI | `chunked_nll` | `nll` | honoured |

Only an unresolved `None` default is touched, so it is a no-op on TRL 1.6.0 (already `nll`), on TRL 0.22.2 (no such field) and on a second patch pass.

## Tests

New `tests/version_compat/test_trl_loss_normalization_contract.py`, 11 tests, under a second, no GPU and no downloads. Wired into both the TRL latest and TRL git main jobs in `version-compat-ci.yml`, so the next upstream default change surfaces before release rather than after.

Coverage: the SFT default, the DPO/KTO/GRPO leak guard, the user override, the pristine class and the dataclass field default behind `HfArgumentParser`, and four drift checks against `training_step`, TRL's chunked CE, our fused CE `n_items` contract, and the `get_batch_samples` return shape that `_utils.py` already asserts on. Plus an AST guard that fails if `loss_type` is ever moved into the global `replacements` dict.

Several are written to fail when upstream fixes the hazard, so the pin does not outlive its cause.

Verified: 11 new tests pass, and the existing `version_compat` suite stays green at 1700 passed, 182 skipped, including the SFT, GRPO and DPO CPU fake-train canaries. On an unpatched tree the new suite fails, with messages pointing at `rl.py`.

## Not covered

This pins the default but does not reconcile the three predicates, so an explicit `loss_type="chunked_nll"` still double-normalises. Happy to follow up in `unsloth-zoo` if you want that backstop too.

