### PR TITLE
Desktop: prevent a white sidebar corner over modals

### DIFF
--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -347,6 +347,30 @@ export function WindowTitlebar({
 
   return (
     <>
+      {showSidebarSurface && (
+        <div
+          data-slot="window-titlebar-decoration"
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-[var(--studio-custom-titlebar-height)] z-[45] h-3"
+        >
+          {pinned && (
+            <div
+              className="absolute top-0 size-3 -translate-x-px bg-sidebar"
+              style={{ left: sidebarWidth }}
+            />
+          )}
+          <div
+            className="absolute top-0 h-px bg-sidebar-border"
+            style={{ left: contentBorderLeft, right: 0 }}
+          />
+          {pinned && (
+            <div
+              className="absolute top-0 size-3 -translate-x-px rounded-tl-[12px] border-l border-t border-sidebar-border bg-background"
+              style={{ left: sidebarWidth }}
+            />
+          )}
+        </div>
+      )}
       <header
         className={cn(
           "pointer-events-none absolute inset-x-0 top-0 z-[70] h-[var(--studio-custom-titlebar-height)] select-none text-foreground",
@@ -354,27 +378,6 @@ export function WindowTitlebar({
         )}
         aria-label="Window titlebar"
       >
-        {showSidebarSurface && pinned && (
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute top-full size-3 -translate-x-px bg-sidebar"
-            style={{ left: sidebarWidth }}
-          />
-        )}
-        {showSidebarSurface && (
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute top-full h-px bg-sidebar-border"
-            style={{ left: contentBorderLeft, right: 0 }}
-          />
-        )}
-        {showSidebarSurface && pinned && (
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute top-full size-3 -translate-x-px rounded-tl-[12px] border-l border-t border-sidebar-border bg-background"
-            style={{ left: sidebarWidth }}
-          />
-        )}
         {showSidebarSurface && (
           <div
             className={cn(

--- a/studio/frontend/tests/titlebar-modal-layering.test.ts
+++ b/studio/frontend/tests/titlebar-modal-layering.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = (path: string) =>
+  readFile(new URL(`../src/${path}`, import.meta.url), "utf8");
+
+const Z_INDEX_PATTERN = /z-\[(\d+)\]|\bz-(\d+)\b/;
+const DECORATION_PATTERN =
+  /data-slot="window-titlebar-decoration"[\s\S]*?className="([^"]+)"/;
+const TITLEBAR_PATTERN = /<header\s+className=\{cn\(\s*"([^"]+)"/;
+const DIALOG_OVERLAY_PATTERN =
+  /data-slot="dialog-overlay"[\s\S]*?"([^"]*\bz-50\b[^"]*)"/;
+const ALERT_DIALOG_OVERLAY_PATTERN =
+  /data-slot="alert-dialog-overlay"[\s\S]*?"([^"]*\bz-50\b[^"]*)"/;
+const TOP_FULL_PATTERN = /top-full/;
+const CLOSED_DECORATION_PATTERN = /<\/div>\s*\)\}\s*$/;
+
+function zIndex(block: string): number {
+  const match = block.match(Z_INDEX_PATTERN);
+  if (!match) throw new Error(`no z-index class in ${block}`);
+  return Number(match[1] ?? match[2]);
+}
+
+test("titlebar decoration stays below modal backdrops and window controls", async () => {
+  const [titlebar, dialog, alertDialog] = await Promise.all([
+    source("components/tauri/window-titlebar.tsx"),
+    source("components/ui/dialog.tsx"),
+    source("components/ui/alert-dialog.tsx"),
+  ]);
+
+  const decoration = titlebar.match(DECORATION_PATTERN);
+  const titlebarHeader = titlebar.match(TITLEBAR_PATTERN);
+  const dialogOverlay = dialog.match(DIALOG_OVERLAY_PATTERN);
+  const alertDialogOverlay = alertDialog.match(ALERT_DIALOG_OVERLAY_PATTERN);
+
+  assert.ok(decoration);
+  assert.ok(titlebarHeader);
+  assert.ok(dialogOverlay);
+  assert.ok(alertDialogOverlay);
+
+  const decorationLayer = zIndex(decoration[1]);
+  const titlebarLayer = zIndex(titlebarHeader[1]);
+  for (const overlay of [dialogOverlay[1], alertDialogOverlay[1]]) {
+    const overlayLayer = zIndex(overlay);
+    assert.ok(decorationLayer < overlayLayer);
+    assert.ok(overlayLayer < titlebarLayer);
+  }
+});
+
+test("below-titlebar decoration is not trapped in the titlebar stacking context", async () => {
+  const titlebar = await source("components/tauri/window-titlebar.tsx");
+  const decorationIndex = titlebar.indexOf(
+    'data-slot="window-titlebar-decoration"',
+  );
+  const headerIndex = titlebar.indexOf("<header", decorationIndex);
+
+  assert.notEqual(decorationIndex, -1);
+  assert.notEqual(headerIndex, -1);
+  assert.ok(decorationIndex < headerIndex);
+  assert.match(
+    titlebar.slice(decorationIndex, headerIndex),
+    CLOSED_DECORATION_PATTERN,
+  );
+
+  const headerEnd = titlebar.indexOf("</header>", headerIndex);
+  assert.notEqual(headerEnd, -1);
+  const header = titlebar.slice(headerIndex, headerEnd);
+  assert.doesNotMatch(header, TOP_FULL_PATTERN);
+});

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -509,9 +509,7 @@ def test_expanded_titlebar_button_and_corner_match_sidebar_edge():
 
     # Keep the decoration below z-50 modals and outside the z-[70] header.
     assert 'data-slot="window-titlebar-decoration"' in source
-    decoration = source.split('data-slot="window-titlebar-decoration"', 1)[1].split(
-        "<header", 1
-    )[0]
+    decoration = source.split('data-slot="window-titlebar-decoration"', 1)[1].split("<header", 1)[0]
     assert (
         'className="pointer-events-none absolute inset-x-0 '
         'top-[var(--studio-custom-titlebar-height)] z-[45] h-3"' in decoration

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -506,15 +506,24 @@ def test_expanded_titlebar_button_and_corner_match_sidebar_edge():
     assert "<DesktopTitlebarNavigation" in source
     assert "const contentBorderLeft = pinned" in source
     assert ': "0px";' in source
-    # The curved transition and sidebar-colored backing are expanded-only.
-    assert source.count("{showSidebarSurface && pinned && (") == 2
+
+    # Keep the decoration below z-50 modals and outside the z-[70] header.
+    assert 'data-slot="window-titlebar-decoration"' in source
+    decoration = source.split('data-slot="window-titlebar-decoration"', 1)[1].split(
+        "<header", 1
+    )[0]
     assert (
-        'className="pointer-events-none absolute top-full size-3 -translate-x-px bg-sidebar"'
-        in source
+        'className="pointer-events-none absolute inset-x-0 '
+        'top-[var(--studio-custom-titlebar-height)] z-[45] h-3"' in decoration
     )
+    # The border is always visible.
+    assert 'className="absolute top-0 h-px bg-sidebar-border"' in decoration
+    # The backing and corner only appear when pinned.
+    assert decoration.count("{pinned && (") == 2
+    assert 'className="absolute top-0 size-3 -translate-x-px bg-sidebar"' in decoration
     assert (
-        'className="pointer-events-none absolute top-full size-3 -translate-x-px rounded-tl-[12px] border-l border-t border-sidebar-border bg-background"'
-        in source
+        'className="absolute top-0 size-3 -translate-x-px rounded-tl-[12px] border-l border-t border-sidebar-border bg-background"'
+        in decoration
     )
 
 


### PR DESCRIPTION
## Problem

Opening a modal in the light desktop app leaves a bright 12x12 square below the titlebar at the pinned sidebar boundary. The rest of the page is dimmed by the modal backdrop, so the square reads as a detached frontend artifact.

## Root cause

The custom titlebar stays at `z-70` so its window controls remain usable above modal surfaces. Its rounded sidebar-corner decoration was nested inside that stacking context even though it extends below the titlebar. Modal backdrops use `z-50`, so they could not dim the overflowing decoration.

## Fix

Move the below-titlebar border and corner into a sibling `z-45` layer. The decoration remains above the page chrome, modal backdrops now cover it, and the draggable titlebar and window controls remain at `z-70`.

Regression coverage enforces `decoration < modal backdrop < titlebar` for both dialogs and alert dialogs, and prevents the decoration from moving back inside the titlebar stacking context.

## Testing

- `npm test` (1,425 passed)
- `npm run typecheck`
- `npm run build`
- Focused ESLint and formatting checks
- `git diff --check`

## Runtime validation

Ran the production Studio frontend in Chromium through Playwright with the desktop window layout and a pinned 360px sidebar, then opened the alert-dialog backdrop over the page.

- Main reproduced the white square. Its sampled luminance was 253.67 against 176.67 on the adjacent backdrop, a 77.00-point mismatch.
- This branch measured 176.00 against 176.67, reducing the mismatch to 0.67 while keeping the window controls above the backdrop.

## Screenshots

### Before

<img width="1440" height="900" alt="before" src="https://github.com/user-attachments/assets/23ce319a-76a8-4858-9137-c2ff570d925c" />


### After
<img width="1440" height="900" alt="after" src="https://github.com/user-attachments/assets/1257605f-ede8-448d-8979-f9f190941765" />


