### PR TITLE
Turn off embedding offload when the model is dispatched across devices

### DIFF
--- a/tests/test_offload_tied_autodisable.py
+++ b/tests/test_offload_tied_autodisable.py
@@ -38,10 +38,12 @@ def _load(*names):
 _NS = _load(
     "_embeddings_are_tied",
     "_offload_embedding_unsupported_platform",
+    "_embedding_dispatch_device",
     "_resolve_offload_embedding",
 )
 resolve = _NS["_resolve_offload_embedding"]
 unsupported_platform = _NS["_offload_embedding_unsupported_platform"]
+dispatch_device = _NS["_embedding_dispatch_device"]
 
 _WSL_VARS = ("WSL_DISTRO_NAME", "WSL_INTEROP")
 
@@ -164,6 +166,43 @@ def test_resolved_before_multidevice_hooks():
 
 def test_no_tied_embedding_raise_remains():
     assert "is not supported for models with tied word" not in _SRC
+
+
+class _Hook:
+    def __init__(self, execution_device):
+        self.execution_device = execution_device
+
+
+def _dispatched_model(execution_device = torch.device("cuda", 0)):
+    m = _untied_model()
+    m.get_input_embeddings()._hf_hook = _Hook(execution_device)
+    return m
+
+
+def test_dispatch_device_reads_the_accelerate_hook():
+    assert dispatch_device(nn.Embedding(32, 8)) is None          # no hook at all
+    assert dispatch_device(_dispatched_model().get_input_embeddings()) is not None
+    assert dispatch_device(_dispatched_model(None).get_input_embeddings()) is None
+    assert dispatch_device(None) is None                         # embeddings not exposed
+
+
+def test_dispatched_model_disables_offload():
+    # accelerate re-sends the ids to its recorded device after the offload pre-hook has
+    # sent them to the CPU weight, so the lookup gets ids and weight on different devices.
+    with _as_platform("posix"):
+        assert resolve(_dispatched_model(), True) is False
+
+
+def test_hook_without_execution_device_keeps_offload():
+    # A hook that never moves anything cannot undo the offload.
+    with _as_platform("posix"):
+        assert resolve(_dispatched_model(None), True) is True
+
+
+def test_undispatched_model_keeps_offload():
+    # The single-GPU path must not lose the VRAM saving.
+    with _as_platform("posix"):
+        assert resolve(_untied_model(), True) is True
 
 
 if __name__ == "__main__":

--- a/tests/test_offload_tied_autodisable.py
+++ b/tests/test_offload_tied_autodisable.py
@@ -180,10 +180,10 @@ def _dispatched_model(execution_device = torch.device("cuda", 0)):
 
 
 def test_dispatch_device_reads_the_accelerate_hook():
-    assert dispatch_device(nn.Embedding(32, 8)) is None          # no hook at all
+    assert dispatch_device(nn.Embedding(32, 8)) is None  # no hook at all
     assert dispatch_device(_dispatched_model().get_input_embeddings()) is not None
     assert dispatch_device(_dispatched_model(None).get_input_embeddings()) is None
-    assert dispatch_device(None) is None                         # embeddings not exposed
+    assert dispatch_device(None) is None  # embeddings not exposed
 
 
 def test_dispatched_model_disables_offload():

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -320,6 +320,13 @@ def _offload_embedding_unsupported_platform():
     return None
 
 
+def _embedding_dispatch_device(input_embeddings):
+    # accelerate's hook wraps forward and re-sends the ids to the device it recorded, after
+    # our offload pre-hook already sent them to the CPU weight. Returns that device, or None.
+    hook = getattr(input_embeddings, "_hf_hook", None)
+    return None if hook is None else getattr(hook, "execution_device", None)
+
+
 def _resolve_offload_embedding(model, offload_embedding):
     """Report `offload_embedding` as True only when the offload will really run.
 
@@ -346,6 +353,12 @@ def _resolve_offload_embedding(model, offload_embedding):
         print(
             "Unsloth: Not offloading embeddings; this model ties embed_tokens "
             "to lm_head, so offloading saves no VRAM."
+        )
+        return False
+    if _embedding_dispatch_device(in_embed) is not None:
+        print(
+            "Unsloth: Not offloading embeddings; this model is dispatched across devices, "
+            "which overrides the offload."
         )
         return False
     return True


### PR DESCRIPTION
`offload_embedding = True` moves `embed_tokens` to the CPU and installs a forward pre-hook that sends the ids to wherever the weight now lives. When the model was **also** dispatched across devices, accelerate has already wrapped that same module's forward, and its hook re-sends the ids to the execution device it recorded. Ours runs first, accelerate's runs second and wins, so the lookup ends up with the ids on `cuda:0` and the weight on `cpu`:

```
RuntimeError: Expected all tensors to be on the same device, but got index is on cuda:0,
different from other tensors on cpu (when checking argument in method wrapper_CUDA__index_select)
```

Nothing warns. The load looks completely normal, `Unsloth: Offloading embeddings to RAM to save N GB.` prints as usual, and the first forward dies.

This bites precisely when the offload is most wanted: a model too large for one card gets spread over several, which is the same condition that makes people reach for `offload_embedding` in the first place.

## Reproduction

`unsloth/tinyllama-bnb-4bit`, 1.1B, split over two GPUs with an explicit `device_map`, so it needs no large checkpoint:

```python
dm = {"model.embed_tokens": 0, "model.rotary_emb": 0, "lm_head": 1, "model.norm": 1}
for i in range(22): dm[f"model.layers.{i}"] = 0 if i < 11 else 1

model, tok = FastModel.from_pretrained(
    model_name        = "unsloth/tinyllama-bnb-4bit",
    max_seq_length    = 128,
    load_in_4bit      = True,
    offload_embedding = True,
    device_map        = dm,
)
ids = tok("Hello world, this is a test.", return_tensors = "pt").input_ids.to("cuda:0")
model(input_ids = ids)
```

Before: `embed device: cpu | accelerate hook: True`, then the `index_select` error above.
After: `Unsloth: Not offloading embeddings; this model is dispatched across devices, which overrides the offload.` and the forward returns `(1, 9, 32000)`.

## The change

`_resolve_offload_embedding` already exists to answer False for every case where the offload cannot actually run: an unsupported platform, tied embeddings, and vLLM a few lines earlier. Its docstring says it plainly, that this is a VRAM optimisation rather than a correctness switch, so it should turn itself off rather than fail the load. A dispatched model is one more of those cases, so it joins them instead of becoming a new special path.

Detection reads the hook off the embedding module rather than counting devices in `hf_device_map`, because the thing that breaks the offload is specifically an accelerate hook with an execution device attached to *that* module. A single-GPU load attaches no such hook and keeps its saving, which the tests pin.

Two `getattr` calls, no new imports, and no dependency on any accelerate, transformers or torch version.

## Testing

- Multi-GPU repro above: fails on `main`, passes here.
- Single-GPU `offload_embedding = True` still offloads (`embed device: cpu`, hooks installed) and still runs, so the memory saving is not lost.
- `tests/test_offload_tied_autodisable.py` extended with four cases: the hook reader itself, a dispatched model disabling the offload, a hook with no execution device keeping it, and an undispatched model keeping it.
- `tests/test_offload_tied_autodisable.py`, `tests/test_offload_tied_guard.py` and `tests/test_offload_embedding_hooks.py` all pass.
- 31 of the 32 tests mentioning vision, offload, device_map or embed pass; `tests/test_grpo_hidden_states_wrap_target.py` fails identically on a clean checkout of `main`, so it is unrelated to this change.
