### PR TITLE
Make the diffusion training tests describe the host they run on

### DIFF
--- a/studio/backend/tests/test_diffusion_checkpoint_resume.py
+++ b/studio/backend/tests/test_diffusion_checkpoint_resume.py
@@ -165,6 +165,29 @@ def test_kill_mid_write_leaves_no_valid_looking_checkpoint(run_dir, monkeypatch)
     assert not list(run_dir.glob("checkpoint-*"))
 
 
+def _cosine_schedule(optimizer, num_training_steps: int, num_warmup_steps: int = 0):
+    """The zero-warmup cosine ``LambdaLR`` that ``diffusers.optimization.get_scheduler("cosine")``
+    builds, written out here rather than imported.
+
+    Byte-for-byte the same lambda diffusers uses (half a cosine period, ``num_cycles = 0.5``,
+    floored at 0), so what the trainers get from get_scheduler and what this returns step
+    identically. Rebuilt locally because this file is CPU-and-stdlib only by design -- diffusers
+    is not in the backend requirements and is not installed on the CI runners, so importing it
+    here would turn the assertion below into a skip on exactly the machines that gate merges,
+    which is the one place this regression has to be caught."""
+    import math
+
+    def lr_lambda(current_step: int) -> float:
+        if current_step < num_warmup_steps:
+            return float(current_step) / float(max(1, num_warmup_steps))
+        progress = float(current_step - num_warmup_steps) / float(
+            max(1, num_training_steps - num_warmup_steps)
+        )
+        return max(0.0, 0.5 * (1.0 + math.cos(math.pi * 0.5 * 2.0 * progress)))
+
+    return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+
+
 def _STREAMS() -> dict:
     """The two random.Random streams both trainers own. A bundle without them cannot restore the
     crop/flip and variant draws, and the preflight refuses it."""
@@ -418,23 +441,68 @@ def test_bundle_round_trips_optimizer_scheduler_sampler_and_rng(run_dir):
     assert resumed.lr_sched.get_last_lr() == reference.lr_sched.get_last_lr()
 
 
-def test_a_foreign_optimizers_state_is_refused_instead_of_key_erroring(run_dir):
-    # The trainers choose their optimizer from the HOST (bitsandbytes present, a fused kernel
-    # available, UNSLOTH_DIFFUSION_FP32_OPTIM), not the config, so a checkpoint can arrive with
-    # moments from a different implementation. Shapes and counts match, so load_state_dict
-    # accepts them and the first step dies on a bare KeyError deep in the optimizer.
-    run = _Run(run_dir)
-    run.save(3)
+def _forge_8bit_optimizer_class(run_dir) -> None:
+    """Rewrite a just-written bundle's manifest so it claims bitsandbytes moments."""
     manifest_path = run_dir / "checkpoint-3" / dc.TRAINER_STATE_FILENAME
     manifest = json.loads(manifest_path.read_text(encoding = "utf-8"))
     assert manifest["optimizer_class"] == "torch.optim.adamw.AdamW"
     manifest["optimizer_class"] = "bitsandbytes.optim.adamw.AdamW8bit"
     manifest_path.write_text(json.dumps(manifest), encoding = "utf-8")
 
+
+def _pretend_bitsandbytes(monkeypatch, installed: bool) -> None:
+    """Pin what ``_assert_optimizer_buildable`` sees, instead of inheriting it from the host.
+
+    That guard asks ``importlib.util.find_spec("bitsandbytes")``, so which of the two foreign
+    optimizer refusals fires depends on whether the machine running the tests happens to have
+    bitsandbytes -- the CPU CI runners do not, developer boxes with a GPU stack do. Both
+    refusals are correct and both need covering, so each test states the host it is about.
+    ``UNSLOTH_DIFFUSION_FP32_OPTIM`` is cleared for the same reason: set in the environment, it
+    short-circuits the guard before find_spec is ever consulted."""
+    import importlib.util as _importlib_util
+
+    monkeypatch.delenv("UNSLOTH_DIFFUSION_FP32_OPTIM", raising = False)
+    real_find_spec = _importlib_util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "bitsandbytes":
+            return object() if installed else None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(_importlib_util, "find_spec", fake_find_spec)
+
+
+def test_a_foreign_optimizers_state_is_refused_instead_of_key_erroring(run_dir, monkeypatch):
+    # The trainers choose their optimizer from the HOST (bitsandbytes present, a fused kernel
+    # available, UNSLOTH_DIFFUSION_FP32_OPTIM), not the config, so a checkpoint can arrive with
+    # moments from a different implementation. Shapes and counts match, so load_state_dict
+    # accepts them and the first step dies on a bare KeyError deep in the optimizer.
+    #
+    # bitsandbytes present, so the preflight's "this host cannot build that optimizer at all"
+    # refusal does NOT fire and the comparison against the optimizer this run actually built is
+    # what has to catch it.
+    _pretend_bitsandbytes(monkeypatch, installed = True)
+    run = _Run(run_dir)
+    run.save(3)
+    _forge_8bit_optimizer_class(run_dir)
+
     fresh = _Run(run_dir)
     fresh.cfg = __import__("dataclasses").replace(fresh.cfg, resume_from_checkpoint = str(run_dir))
     with pytest.raises(dc.ResumeError, match = "AdamW8bit"):
         fresh.restore()
+
+
+def test_8bit_moments_are_refused_up_front_on_a_host_without_bitsandbytes(run_dir, monkeypatch):
+    # The other half of the same problem, and the one a CPU host hits: with no bitsandbytes to
+    # load the 8-bit moments, preflight_resume refuses BEFORE the route evicts the resident GPU
+    # models, rather than letting the child get as far as building an optimizer it cannot fill.
+    _pretend_bitsandbytes(monkeypatch, installed = False)
+    run = _Run(run_dir)
+    run.save(3)
+    _forge_8bit_optimizer_class(run_dir)
+
+    with pytest.raises(dc.ResumeError, match = "bitsandbytes is not installed"):
+        dc.preflight_resume(str(run_dir), identity = _identity(), target_steps = 500)
 
 
 def test_a_partial_adapter_restore_is_refused(run_dir):
@@ -467,19 +535,11 @@ def test_resuming_reapplies_the_live_lr_schedule(run_dir):
     # load_state_dict restores the rate the checkpoint was written with and never re-evaluates
     # the lambda, so without the re-apply the first resumed step runs at the OLD schedule's
     # value -- lr 0.0 when continuing a finished cosine run by raising the step count.
-    from diffusers.optimization import get_scheduler
-
     def build(total: int):
         torch.manual_seed(0)
         model = torch.nn.Linear(4, 4, bias = False)
         optimizer = torch.optim.AdamW(model.parameters(), lr = 1e-3)
-        return (
-            model,
-            optimizer,
-            get_scheduler(
-                "cosine", optimizer = optimizer, num_warmup_steps = 0, num_training_steps = total
-            ),
-        )
+        return model, optimizer, _cosine_schedule(optimizer, total)
 
     model, optimizer, lr_sched = build(6)
     for _ in range(6):
@@ -747,12 +807,36 @@ def client(monkeypatch):
     return c
 
 
+def _resolved_request_precision() -> str:
+    """The mixed precision a run started from ``_RESUME_BODY`` on THIS host actually trains in.
+
+    ``identity_for_config`` records the EFFECTIVE precision, not the requested one, and it is
+    resolved from the live hardware: a CUDA Ampere-or-newer box resolves the default bf16
+    request to "bf16", a pre-Ampere card to "fp16", and a machine with no CUDA at all -- every
+    CPU CI runner -- to "no". Hard-coding one of those into the fixtures below made the route
+    tests pass on a GPU developer box and fail on CI with a mixed-precision refusal that was
+    the guard working correctly on a bundle claiming a precision the run could not have used.
+    Resolved through the same helper the route reaches, so the fixture describes the host it is
+    running on instead of guessing."""
+    from core.training.diffusion_lora_trainer import _config_from_dict
+    from core.training.diffusion_train_common import effective_mixed_precision
+
+    return effective_mixed_precision(_config_from_dict(dict(_RESUME_BODY)).normalized())
+
+
+def _other_precision() -> str:
+    """A mixed precision this host will NOT resolve to, so a bundle recording it is a genuine
+    mismatch rather than an artefact of which machine the tests run on."""
+    return "fp16" if _resolved_request_precision() != "fp16" else "bf16"
+
+
 def _request_identity(**overrides) -> dc.CheckpointIdentity:
     """The identity the start route computes for ``_RESUME_BODY`` + the stubbed dataset."""
     return _identity(
         **{
             "base_revision": "unresolved",
             "dataset_fingerprint": dc.dataset_fingerprint(_PAIRS),
+            "precision": _resolved_request_precision(),
             **overrides,
         }
     )
@@ -802,6 +886,23 @@ def test_route_resume_mismatch_400s_without_evicting_the_gpu(client, run_dir):
     assert r.status_code == 400, r.text
     assert "different model family" in r.json()["detail"]
     # The whole point of preflighting here: the user's loaded Images pipeline survives a refusal.
+    assert client._freed == []
+    assert "start" not in client._fake.calls
+
+
+def test_route_resume_precision_mismatch_400s_without_evicting_the_gpu(client, run_dir):
+    # The guard the fixture above must not be allowed to defeat. Restoring moments produced
+    # under one set of frozen-base numerics into a run using another continues the trajectory at
+    # a different precision while reporting a clean resume, so a bundle recording a precision
+    # this host does not resolve to has to be refused -- and refused HERE, before the resident
+    # Images pipeline is torn down. Written against a precision picked to differ from whatever
+    # this machine resolves, so it is a real mismatch on a GPU box and on a CPU runner alike.
+    mismatched = _other_precision()
+    assert mismatched != _resolved_request_precision()
+    _write_bundle(run_dir, 11, _request_identity(precision = mismatched))
+    r = client.post("/api/train/diffusion/start", json = _RESUME_BODY)
+    assert r.status_code == 400, r.text
+    assert "different mixed precision" in r.json()["detail"]
     assert client._freed == []
     assert "start" not in client._fake.calls
 

--- a/studio/backend/tests/test_diffusion_training.py
+++ b/studio/backend/tests/test_diffusion_training.py
@@ -1540,6 +1540,22 @@ def test_route_start_still_runs_when_the_install_does_have_the_pipeline(
     assert client._fake.started_with["base_model"] == "krea/Krea-2-Raw"
 
 
+def _pretend_this_host_has_an_accelerator(monkeypatch) -> None:
+    """Let a DiT start reach the pipeline-import guard on a machine with no GPU.
+
+    ``training_precision_preflight_error`` runs first and refuses every DiT family outright
+    when the host has no CUDA / XPU / MPS, because nf4 is not a CPU fallback. That refusal is
+    correct and has its own test (test_route_start_refuses_a_dit_family_without_a_gpu_before_
+    freeing), but on a GPU-less runner it fires before the import guard and swallows the
+    assertion the tests below are about. MPS rather than CUDA: ``bf16_unsupported_reason``
+    only consults compute capability when CUDA reports available, and a spoofed CUDA on a
+    CPU-only wheel has no capability to report, so it would trade one masking refusal for
+    another."""
+    import torch
+
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+
+
 def test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import(client, monkeypatch):
     # diffusers' top level is lazy, so the guard's attribute probe is what actually imports the
     # pipeline's submodule, and a partially usable install raises RuntimeError("Failed to import
@@ -1559,6 +1575,7 @@ def test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import(clie
             raise RuntimeError(f"Failed to import diffusers.pipelines.{name.lower()}")
 
     freed = []
+    _pretend_this_host_has_an_accelerator(monkeypatch)
     monkeypatch.setattr(tr, "_free_gpu_for_diffusion_training", lambda: freed.append(1))
     monkeypatch.setitem(sys.modules, "diffusers", _LazyModule("diffusers"))
 
@@ -1589,6 +1606,7 @@ def test_route_start_refuses_training_when_diffusers_is_absent(client, monkeypat
         return real_import(name, *args, **kwargs)
 
     freed = []
+    _pretend_this_host_has_an_accelerator(monkeypatch)
     monkeypatch.setattr(tr, "_free_gpu_for_diffusion_training", lambda: freed.append(1))
     monkeypatch.delitem(sys.modules, "diffusers", raising = False)
     monkeypatch.setattr(builtins, "__import__", _no_diffusers)


### PR DESCRIPTION
Backend CI is red on `main`, so every open PR shows the same six failures regardless of its own diff.

`#8163` (Resume diffusion training from a stop-and-save checkpoint, merged as `4e7755b7a`) landed with its own checks already failing on its head `abe2ce3b3`: `(Python 3.10)`, `(Python 3.11)`, `(Python 3.12)`, `(Python 3.13)`, `Repo tests (CPU)` and three `Core` checks. `#8236` (Assert the image family's pipeline class in the training preflight, merged as `bcfc62657`) then added two more failures of the same shape. Nobody is at fault for a check that was red at merge time; this just clears it.

The six, all in the `Backend CI` pytest matrix:

- `test_diffusion_checkpoint_resume.py::test_a_foreign_optimizers_state_is_refused_instead_of_key_erroring`
- `test_diffusion_checkpoint_resume.py::test_resuming_reapplies_the_live_lr_schedule`
- `test_diffusion_checkpoint_resume.py::test_route_resume_accepts_a_matching_checkpoint_and_pins_it`
- `test_diffusion_checkpoint_resume.py::test_route_resume_dataset_change_400s_without_evicting_the_gpu`
- `test_diffusion_training.py::test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import`
- `test_diffusion_training.py::test_route_start_refuses_training_when_diffusers_is_absent`

Every one of them is a test that assumes a GPU developer box with `diffusers` and `bitsandbytes` present. In each case the production guard is doing exactly what it was written to do, so no guard is changed: only the tests move.

## Per failure

**1. `test_a_foreign_optimizers_state_is_refused_instead_of_key_erroring`** wants the refusal that compares a bundle's recorded optimizer class against the one this run actually built (`... written by bitsandbytes.optim.adamw.AdamW8bit, but this machine builds ...`). On a host without bitsandbytes an earlier guard fires first: `_assert_optimizer_buildable` refuses 8-bit moments a host provably cannot load, before the route evicts the resident GPU models. That is the better error, and it is correct. Which of the two fires is decided by `importlib.util.find_spec("bitsandbytes")`, that is, by the machine. `find_spec` is now pinned per test, so this test states the bitsandbytes-present host it is about, and a new `test_8bit_moments_are_refused_up_front_on_a_host_without_bitsandbytes` covers the other side deterministically. The existing test only exercised the find_spec path conditionally, `if find_spec(...) is not None`, so the absent case had no coverage anywhere.

**2. `test_resuming_reapplies_the_live_lr_schedule`** did `from diffusers.optimization import get_scheduler`. `diffusers` is not in `studio/backend/requirements/studio.txt` and the workflow does not install it, and the file's own docstring says it is CPU-and-stdlib only. A skip would have been the easy fix, but it would leave the regression this test exists for (a resumed finished cosine run taking its first step at lr 0.0) unverified on exactly the machines that gate merges. It now builds the same zero-warmup cosine `LambdaLR` locally. Verified step for step against `get_scheduler("cosine")` over several step counts and warmup values before replacing it.

**3 and 4. the two route tests.** `identity_for_config` records the EFFECTIVE mixed precision, not the requested one, via `effective_mixed_precision`: bf16 on Ampere or newer, fp16 on an older card, and `"no"` on a host with no CUDA. The fixtures hard-coded `bf16`, so a CPU runner met a bundle claiming a precision the run could not have used and the identity gate refused it, correctly, with `different mixed precision (bf16 vs no)`. Test 4 failed for the same reason: the route's first preflight pass runs before dataset discovery and skips the dataset field as unknown, so the precision refusal was reported before the dataset refusal it asserts on. The fixture now resolves precision through the same helper the route reaches.

Deliberately **not** done: adding `precision` to `_OPTIONAL_IDENTITY_FIELDS`, or dropping it from `_IDENTITY_LABELS`. The field is a hard identity for a real reason spelled out in that file, restoring optimizer moments produced under one set of frozen-base numerics into a run using another continues the trajectory at a different precision while reporting a clean resume. (For the record, the optional set would not have helped anyway: it skips a field only when one side is `None` or empty, and `"bf16"` against `"no"` is neither.) A new `test_route_resume_precision_mismatch_400s_without_evicting_the_gpu` asserts the route still 400s on a genuine mismatch and still does not evict the GPU, written against a precision chosen to differ from whatever the host resolves so it is a real mismatch on a GPU box and on a CPU runner alike.

**5 and 6. the two `#8236` tests.** Both start a DiT family (`krea/Krea-2-Raw`). On a host with no CUDA, XPU or MPS, `dit_accelerator_missing_reason` refuses every DiT start before the pipeline-import guard is reached, because nf4 is not a CPU fallback. Correct, and it has its own test (`test_route_start_refuses_a_dit_family_without_a_gpu_before_freeing`), which is untouched. These two now spoof an accelerator so the import refusal they assert on is the one exercised. MPS rather than CUDA: `bf16_unsupported_reason` consults compute capability once CUDA reports available, and a CPU-only wheel has none to report, which would just trade one masking refusal for another.

## Verification

Reproduced rather than assumed. Two throwaway venvs built from the workflow's own install steps, neither with `diffusers` or `bitsandbytes`; the CI-shaped one uses the CPU-only torch wheel so `torch.version.cuda` is `None`, which two of these failures are sensitive to.

Full backend suite, `studio/backend/tests/`, on that venv, FAILED line sets compared rather than counts:

Before, pristine `origin/main` at `749437314` - 6 failed, 19821 passed:

```
FAILED tests/test_diffusion_checkpoint_resume.py::test_a_foreign_optimizers_state_is_refused_instead_of_key_erroring
FAILED tests/test_diffusion_checkpoint_resume.py::test_resuming_reapplies_the_live_lr_schedule
FAILED tests/test_diffusion_checkpoint_resume.py::test_route_resume_accepts_a_matching_checkpoint_and_pins_it
FAILED tests/test_diffusion_checkpoint_resume.py::test_route_resume_dataset_change_400s_without_evicting_the_gpu
FAILED tests/test_diffusion_training.py::test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import
FAILED tests/test_diffusion_training.py::test_route_start_refuses_training_when_diffusers_is_absent
```

After, this branch - 0 failed, 19829 passed. Empty FAILED set, nothing added.

`studio/backend/hub/tests/` run as its own invocation: 417 passed on both sides. Both touched files are also green with a CUDA GPU visible, so this is not a fix that only works on CPU.

Each new and adjusted test was checked to fail when the guard it covers is removed:

- delete `("precision", "mixed precision")` from `_IDENTITY_LABELS` and the new route test fails, along with the existing parametrized case and `test_the_identity_records_the_precision_the_run_will_actually_use`
- neuter `_assert_optimizer_buildable` and both 8-bit tests fail
- neuter the `training_pipeline_import_error` branch in the start route and both `#8236` tests fail

Tests only. No production file is touched.
