### PR TITLE
Fix two macOS installer bugs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1568,6 +1568,11 @@ DESKTOP_EOF
             echo "[ERROR] $_css_app exists but is not a directory; remove manually and re-run install" >&2
             return 1
         fi
+        # Older installs linked the Desktop shortcut with `ln -sf`, which followed the
+        # existing link and planted a self-referential copy one level inside the bundle.
+        if [ -L "$_css_app/Unsloth Studio.app" ]; then
+            rm -f "$_css_app/Unsloth Studio.app" 2>/dev/null || true
+        fi
         mkdir -p "$_css_macos_dir" "$_css_res_dir"
 
         # Info.plist
@@ -1646,9 +1651,10 @@ STUB_EOF
         # Touch so Finder indexes it
         touch "$_css_app"
 
-        # Symlink on Desktop
+        # Symlink on Desktop. -n is required: without it a re-run follows the existing
+        # link into the bundle and creates the new one inside it, as the CLI shim guards.
         if [ -d "$HOME/Desktop" ]; then
-            ln -sf "$_css_app" "$HOME/Desktop/Unsloth Studio" 2>/dev/null || true
+            ln -sfn "$_css_app" "$HOME/Desktop/Unsloth Studio" 2>/dev/null || true
         fi
         _css_created=1
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -561,9 +561,11 @@ _unsloth_uninstall_main() {
             # writes this data; the shell launcher just opens a browser. This script never
             # removes that app, so it must not reset it either.
             _bid="ai.unsloth.studio"
+            # Overridable so tests can point the scan at a fixture dir.
+            _bid_apps="${UNSLOTH_APPLICATIONS_DIR:-/Applications}"
             _bid_owner=""
-            for _bid_cand in "/Applications/Unsloth.app" \
-                             "/Applications/Unsloth Studio (Desktop).app" \
+            for _bid_cand in "$_bid_apps/Unsloth.app" \
+                             "$_bid_apps/Unsloth Studio (Desktop).app" \
                              "$HOME/Applications/Unsloth.app"; do
                 if [ -x "$_bid_cand/Contents/MacOS/unsloth-studio" ]; then
                     _bid_owner="$_bid_cand"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -557,22 +557,38 @@ _unsloth_uninstall_main() {
                 "$_lsr" -u "$HOME/Applications/Unsloth Studio.app" 2>/dev/null || true
             fi
             # WKWebView data, keyed by bundle id. Created at first launch, not by install.sh.
+            # The packaged desktop app shares this bundle id and is the only thing that
+            # writes this data; the shell launcher just opens a browser. This script never
+            # removes that app, so it must not reset it either.
             _bid="ai.unsloth.studio"
-            echo "Removing WebView caches and app data ($_bid)..."
-            _remove_path "$HOME/Library/Caches/$_bid"
-            _remove_path "$HOME/Library/WebKit/$_bid"
-            _remove_path "$HOME/Library/Application Support/$_bid"
-            _remove_path "$HOME/Library/HTTPStorages/$_bid"
-            _remove_path "$HOME/Library/HTTPStorages/$_bid.binarycookies"
-            _remove_path "$HOME/Library/Cookies/$_bid.binarycookies"
-            _remove_path "$HOME/Library/Saved Application State/$_bid.savedState"
-            # defaults, not rm: cfprefsd rewrites the plist from memory. ByHost is a separate
-            # domain. As the home's owner, or under sudo root just edits root's own domain.
-            if command -v defaults >/dev/null 2>&1; then
-                _run_as_home_owner defaults delete "$_bid" >/dev/null 2>&1 || true
-                _run_as_home_owner defaults -currentHost delete "$_bid" >/dev/null 2>&1 || true
+            _bid_owner=""
+            for _bid_cand in "/Applications/Unsloth.app" \
+                             "/Applications/Unsloth Studio (Desktop).app" \
+                             "$HOME/Applications/Unsloth.app"; do
+                if [ -x "$_bid_cand/Contents/MacOS/unsloth-studio" ]; then
+                    _bid_owner="$_bid_cand"
+                    break
+                fi
+            done
+            if [ -n "$_bid_owner" ]; then
+                echo "Keeping app data ($_bid): it belongs to $_bid_owner"
+            else
+                echo "Removing WebView caches and app data ($_bid)..."
+                _remove_path "$HOME/Library/Caches/$_bid"
+                _remove_path "$HOME/Library/WebKit/$_bid"
+                _remove_path "$HOME/Library/Application Support/$_bid"
+                _remove_path "$HOME/Library/HTTPStorages/$_bid"
+                _remove_path "$HOME/Library/HTTPStorages/$_bid.binarycookies"
+                _remove_path "$HOME/Library/Cookies/$_bid.binarycookies"
+                _remove_path "$HOME/Library/Saved Application State/$_bid.savedState"
+                # defaults, not rm: cfprefsd rewrites the plist from memory. ByHost is a separate
+                # domain. As the home's owner, or under sudo root just edits root's own domain.
+                if command -v defaults >/dev/null 2>&1; then
+                    _run_as_home_owner defaults delete "$_bid" >/dev/null 2>&1 || true
+                    _run_as_home_owner defaults -currentHost delete "$_bid" >/dev/null 2>&1 || true
+                fi
+                _remove_path "$HOME/Library/Preferences/$_bid.plist"
             fi
-            _remove_path "$HOME/Library/Preferences/$_bid.plist"
             ;;
         Linux)
             if [ "$_is_wsl" = "1" ]; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -461,8 +461,9 @@ _bundle_id_owner() {
             return 0
         fi
     fi
-    # Spotlight can be off or still indexing, so walk the usual roots too.
-    find "$_bio_apps" "$HOME/Applications" -maxdepth 3 -name '*.app' -type d 2>/dev/null |
+    # Spotlight can be off or still indexing, so walk the usual roots too. No depth cap:
+    # -prune stops the walk at each bundle, so nesting is free and bundles are never entered.
+    find "$_bio_apps" "$HOME/Applications" -name '*.app' -type d -prune -print 2>/dev/null |
     while IFS= read -r _bio_app; do
         if _owns_bundle_id "$_bio_app" "$1"; then
             printf '%s\n' "$_bio_app"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -424,6 +424,53 @@ _remove_cli_shim() {
     esac
 }
 
+# Print key $2 from the Info.plist $1. PlistBuddy also reads binary plists;
+# the awk fallback covers XML on hosts without it.
+_plist_string() {
+    [ -f "$1" ] || return 1
+    if [ -x /usr/libexec/PlistBuddy ]; then
+        /usr/libexec/PlistBuddy -c "Print :$2" "$1" 2>/dev/null && return 0
+    fi
+    awk -v k="<key>$2</key>" 'index($0, k) { f = 1; next }
+         f && /<string>/ { sub(/.*<string>/, ""); sub(/<\/string>.*/, ""); print; exit }' "$1"
+}
+
+# True when the bundle $1 is the packaged desktop app carrying bundle id $2.
+# install.sh's shell launcher shares that id, so exclude it by its executable.
+_owns_bundle_id() {
+    [ -d "$1" ] || return 1
+    [ "$(_plist_string "$1/Contents/Info.plist" CFBundleIdentifier)" = "$2" ] || return 1
+    [ "$(_plist_string "$1/Contents/Info.plist" CFBundleExecutable)" != "launch-studio" ]
+}
+
+# Path of the installed app owning bundle id $1, empty if there is none. A renamed
+# bundle or a subdirectory such as "/Applications/AI & ML/Unsloth.app" is a supported
+# layout, so match on the identifier rather than on a fixed set of paths.
+_bundle_id_owner() {
+    # Overridable so tests can point the scan at a fixture dir.
+    _bio_apps="${UNSLOTH_APPLICATIONS_DIR:-/Applications}"
+    # Spotlight finds it anywhere on disk. Skipped for a fixture scan: a real
+    # install on the machine running the tests must not change the result.
+    if [ -z "${UNSLOTH_APPLICATIONS_DIR:-}" ] && command -v mdfind >/dev/null 2>&1; then
+        _bio_hit=$(mdfind "kMDItemCFBundleIdentifier == '$1'" 2>/dev/null |
+                   while IFS= read -r _bio_app; do
+                       _owns_bundle_id "$_bio_app" "$1" && { printf '%s\n' "$_bio_app"; break; }
+                   done | head -n 1)
+        if [ -n "$_bio_hit" ]; then
+            printf '%s\n' "$_bio_hit"
+            return 0
+        fi
+    fi
+    # Spotlight can be off or still indexing, so walk the usual roots too.
+    find "$_bio_apps" "$HOME/Applications" -maxdepth 3 -name '*.app' -type d 2>/dev/null |
+    while IFS= read -r _bio_app; do
+        if _owns_bundle_id "$_bio_app" "$1"; then
+            printf '%s\n' "$_bio_app"
+            break
+        fi
+    done | head -n 1
+}
+
 _unsloth_uninstall_main() {
     # Reject unknown arguments before destructive work.
     for _arg in "$@"; do
@@ -561,17 +608,7 @@ _unsloth_uninstall_main() {
             # writes this data; the shell launcher just opens a browser. This script never
             # removes that app, so it must not reset it either.
             _bid="ai.unsloth.studio"
-            # Overridable so tests can point the scan at a fixture dir.
-            _bid_apps="${UNSLOTH_APPLICATIONS_DIR:-/Applications}"
-            _bid_owner=""
-            for _bid_cand in "$_bid_apps/Unsloth.app" \
-                             "$_bid_apps/Unsloth Studio (Desktop).app" \
-                             "$HOME/Applications/Unsloth.app"; do
-                if [ -x "$_bid_cand/Contents/MacOS/unsloth-studio" ]; then
-                    _bid_owner="$_bid_cand"
-                    break
-                fi
-            done
+            _bid_owner=$(_bundle_id_owner "$_bid")
             if [ -n "$_bid_owner" ]; then
                 echo "Keeping app data ($_bid): it belongs to $_bid_owner"
             else

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -69,6 +69,24 @@ done
 APPS_DIR="$_TMP_ROOT/Applications"
 mkdir -p "$APPS_DIR"
 
+# make_app <bundle> <executable> : an .app the identifier scan can read.
+make_app() {
+    mkdir -p "$1/Contents/MacOS"
+    printf '#!/bin/sh\nexit 0\n' > "$1/Contents/MacOS/$2"
+    chmod +x "$1/Contents/MacOS/$2"
+    cat > "$1/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>$BID</string>
+    <key>CFBundleExecutable</key>
+    <string>$2</string>
+</dict>
+</plist>
+EOF
+}
+
 # run_uninstall <home> <uname_output> [apps_dir] : run the full script with a stubbed OS.
 run_uninstall() {
     printf '#!/bin/sh\necho %s\n' "$2" > "$STUB_BIN/uname"
@@ -119,19 +137,20 @@ assert_present "macOS: unrelated app cache kept"             "$H/Library/Caches/
 # The shell launcher is a /bin/sh stub with no WebView; only the packaged app writes these.
 # This script never removes that app, so it must not reset it either.
 OWNED_APPS="$_TMP_ROOT/Applications-owned"
-mkdir -p "$OWNED_APPS/Unsloth.app/Contents/MacOS"
-printf '#!/bin/sh\nexit 0\n' > "$OWNED_APPS/Unsloth.app/Contents/MacOS/unsloth-studio"
-chmod +x "$OWNED_APPS/Unsloth.app/Contents/MacOS/unsloth-studio"
+make_app "$OWNED_APPS/Unsloth.app" unsloth-studio
 H=$(new_home)
-mkdir -p "$H/Library/Caches/$BID" "$H/Library/WebKit/$BID" \
-         "$H/Library/Application Support/$BID" "$H/Library/HTTPStorages" \
-         "$H/Library/Saved Application State/$BID.savedState" \
-         "$H/Library/Preferences" "$H/Library/Cookies" \
-         "$H/Applications/Unsloth Studio.app/Contents/MacOS"
-: > "$H/Library/HTTPStorages/$BID.binarycookies"
-: > "$H/Library/Cookies/$BID.binarycookies"
-: > "$H/Library/Preferences/$BID.plist"
-: > "$H/Applications/Unsloth Studio.app/Contents/MacOS/launch-studio"
+# seed_app_data <home> : the ~/Library paths the packaged app owns, plus the shell launcher.
+seed_app_data() {
+    mkdir -p "$1/Library/Caches/$BID" "$1/Library/WebKit/$BID" \
+             "$1/Library/Application Support/$BID" "$1/Library/HTTPStorages" \
+             "$1/Library/Saved Application State/$BID.savedState" \
+             "$1/Library/Preferences" "$1/Library/Cookies"
+    : > "$1/Library/HTTPStorages/$BID.binarycookies"
+    : > "$1/Library/Cookies/$BID.binarycookies"
+    : > "$1/Library/Preferences/$BID.plist"
+    make_app "$1/Applications/Unsloth Studio.app" launch-studio
+}
+seed_app_data "$H"
 run_uninstall "$H" Darwin "$OWNED_APPS"
 assert_present "macOS: Caches/$BID kept when the app owns it"              "$H/Library/Caches/$BID"
 assert_present "macOS: WebKit/$BID kept when the app owns it"              "$H/Library/WebKit/$BID"
@@ -141,6 +160,31 @@ assert_present "macOS: Preferences/$BID.plist kept when the app owns it"   "$H/L
 assert_present "macOS: Cookies kept when the app owns it"                  "$H/Library/Cookies/$BID.binarycookies"
 # The shell launcher is still this script's to remove, app present or not.
 assert_gone    "macOS: shell launcher bundle still removed"                "$H/Applications/Unsloth Studio.app"
+
+# ── 1c. macOS: the app is found by bundle id, not by path ──
+# Renaming the bundle or keeping it in a subfolder is a supported layout, so the
+# data must survive there too.
+for _case in "Unsloth Studio Beta.app" "AI & ML/Unsloth.app"; do
+    MOVED_APPS="$_TMP_ROOT/Applications-moved"
+    rm -rf "$MOVED_APPS"
+    make_app "$MOVED_APPS/$_case" unsloth-studio
+    H=$(new_home)
+    seed_app_data "$H"
+    run_uninstall "$H" Darwin "$MOVED_APPS"
+    assert_present "macOS: app data kept for $_case"         "$H/Library/Caches/$BID"
+    assert_present "macOS: prefs kept for $_case"            "$H/Library/Preferences/$BID.plist"
+done
+
+# ── 1d. macOS: a launcher-style bundle does not count as the owner ──
+# install.sh's launcher carries the same bundle id but only opens a browser, so
+# finding one must not spare data the packaged app would have written.
+LAUNCHER_APPS="$_TMP_ROOT/Applications-launcher"
+make_app "$LAUNCHER_APPS/Unsloth Studio.app" launch-studio
+H=$(new_home)
+seed_app_data "$H"
+run_uninstall "$H" Darwin "$LAUNCHER_APPS"
+assert_gone "macOS: Caches/$BID removed when only a launcher is present" "$H/Library/Caches/$BID"
+assert_gone "macOS: prefs removed when only a launcher is present"       "$H/Library/Preferences/$BID.plist"
 
 # ── 2. Linux: bundle-id-keyed XDG default paths are removed ──
 H=$(new_home)

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -63,12 +63,19 @@ for _tool in powershell.exe sudo; do
     chmod +x "$STUB_BIN/$_tool"
 done
 
-# run_uninstall <home> <uname_output> : run the full script with a stubbed OS.
+# The macOS branch keeps the bundle-id data when the packaged desktop app owns it, so point
+# the scan at an empty fixture: these cases are a shell-only install, and a real /Applications
+# /Unsloth.app on the machine running the tests must not change the result.
+APPS_DIR="$_TMP_ROOT/Applications"
+mkdir -p "$APPS_DIR"
+
+# run_uninstall <home> <uname_output> [apps_dir] : run the full script with a stubbed OS.
 run_uninstall() {
     printf '#!/bin/sh\necho %s\n' "$2" > "$STUB_BIN/uname"
     chmod +x "$STUB_BIN/uname"
     env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
         -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+        UNSLOTH_APPLICATIONS_DIR="${3:-$APPS_DIR}" \
         HOME="$1" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" >/dev/null 2>&1
 }
 
@@ -78,6 +85,7 @@ run_uninstall_out() {
     chmod +x "$STUB_BIN/uname"
     env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
         -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+        UNSLOTH_APPLICATIONS_DIR="${3:-$APPS_DIR}" \
         HOME="$1" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" 2>/dev/null
 }
 
@@ -106,6 +114,33 @@ assert_gone "macOS: Cookies/$BID.binarycookies removed"      "$H/Library/Cookies
 assert_gone "macOS: Saved Application State removed"         "$H/Library/Saved Application State/$BID.savedState"
 assert_gone "macOS: Preferences/$BID.plist removed"          "$H/Library/Preferences/$BID.plist"
 assert_present "macOS: unrelated app cache kept"             "$H/Library/Caches/com.other.app/keepme"
+
+# ── 1b. macOS: the packaged desktop app owns this bundle id, so its data survives ──
+# The shell launcher is a /bin/sh stub with no WebView; only the packaged app writes these.
+# This script never removes that app, so it must not reset it either.
+OWNED_APPS="$_TMP_ROOT/Applications-owned"
+mkdir -p "$OWNED_APPS/Unsloth.app/Contents/MacOS"
+printf '#!/bin/sh\nexit 0\n' > "$OWNED_APPS/Unsloth.app/Contents/MacOS/unsloth-studio"
+chmod +x "$OWNED_APPS/Unsloth.app/Contents/MacOS/unsloth-studio"
+H=$(new_home)
+mkdir -p "$H/Library/Caches/$BID" "$H/Library/WebKit/$BID" \
+         "$H/Library/Application Support/$BID" "$H/Library/HTTPStorages" \
+         "$H/Library/Saved Application State/$BID.savedState" \
+         "$H/Library/Preferences" "$H/Library/Cookies" \
+         "$H/Applications/Unsloth Studio.app/Contents/MacOS"
+: > "$H/Library/HTTPStorages/$BID.binarycookies"
+: > "$H/Library/Cookies/$BID.binarycookies"
+: > "$H/Library/Preferences/$BID.plist"
+: > "$H/Applications/Unsloth Studio.app/Contents/MacOS/launch-studio"
+run_uninstall "$H" Darwin "$OWNED_APPS"
+assert_present "macOS: Caches/$BID kept when the app owns it"              "$H/Library/Caches/$BID"
+assert_present "macOS: WebKit/$BID kept when the app owns it"              "$H/Library/WebKit/$BID"
+assert_present "macOS: Application Support/$BID kept when the app owns it" "$H/Library/Application Support/$BID"
+assert_present "macOS: Saved Application State kept when the app owns it"  "$H/Library/Saved Application State/$BID.savedState"
+assert_present "macOS: Preferences/$BID.plist kept when the app owns it"   "$H/Library/Preferences/$BID.plist"
+assert_present "macOS: Cookies kept when the app owns it"                  "$H/Library/Cookies/$BID.binarycookies"
+# The shell launcher is still this script's to remove, app present or not.
+assert_gone    "macOS: shell launcher bundle still removed"                "$H/Applications/Unsloth Studio.app"
 
 # ── 2. Linux: bundle-id-keyed XDG default paths are removed ──
 H=$(new_home)

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -162,9 +162,9 @@ assert_present "macOS: Cookies kept when the app owns it"                  "$H/L
 assert_gone    "macOS: shell launcher bundle still removed"                "$H/Applications/Unsloth Studio.app"
 
 # ── 1c. macOS: the app is found by bundle id, not by path ──
-# Renaming the bundle or keeping it in a subfolder is a supported layout, so the
-# data must survive there too.
-for _case in "Unsloth Studio Beta.app" "AI & ML/Unsloth.app"; do
+# Renaming the bundle or filing it under subfolders is a supported layout, at any
+# depth, so the data must survive there too.
+for _case in "Unsloth Studio Beta.app" "AI & ML/Unsloth.app" "Development/AI/Local/Unsloth.app"; do
     MOVED_APPS="$_TMP_ROOT/Applications-moved"
     rm -rf "$MOVED_APPS"
     make_app "$MOVED_APPS/$_case" unsloth-studio


### PR DESCRIPTION
1. install.sh planted a symlink inside its own bundle. The Desktop shortcut used ln -sf, so every run after the first followed the existing link into the bundle and created the new one inside it eaving Unsloth Studio.app/Unsloth Studio.app -> itself. That makes the bundle infinitely deep for Spotlight, Finder, backups and codesign. Now uses ln -sfn, same as the CLI shim already does, and clears the stray link on bundles that already have one.. 
2. scripts/uninstall.sh deleted the desktop app's data. It wiped ~/Library/*/ai.unsloth.studio, which the packaged app owns the shell launcher only opens a browser and never writes it. The script never removes that app, so it shouldn't reset it either. Now skipped when the app is installed.