### PR TITLE
Fix main: the two diffusers-import preflight tests only pass on a GPU host

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -57,7 +57,11 @@ jobs:
   pytest:
     name: (Python ${{ matrix.python }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 30, not 15: the suite now runs 14.1 to 15.0 minutes on every interpreter in the matrix, so a
+    # 15 minute budget cancels whichever jobs happen to land on the slow side of the median and the
+    # result is a coin flip rather than a verdict. This guards against a hang, which 30 still does;
+    # it was never meant to be a performance budget. The suite's own runtime is the real problem.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +121,8 @@ jobs:
     # succeeds on CPU.
     name: Repo tests (CPU)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Same reason as the matrix above: this one measured 13.4 minutes against the same 15.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/studio/backend/tests/test_diffusion_training.py
+++ b/studio/backend/tests/test_diffusion_training.py
@@ -1540,13 +1540,17 @@ def test_route_start_still_runs_when_the_install_does_have_the_pipeline(
     assert client._fake.started_with["base_model"] == "krea/Krea-2-Raw"
 
 
-def test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import(client, monkeypatch):
+def test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import(
+    client, monkeypatch, dit_train_host
+):
     # diffusers' top level is lazy, so the guard's attribute probe is what actually imports the
     # pipeline's submodule, and a partially usable install raises RuntimeError("Failed to import
     # diffusers.pipelines...") there. Inference absorbs that (the native sd.cpp engine needs no
     # diffusers), but the trainer child is a spawn of THIS interpreter and would hit the same
     # broken import -- after the GPU residents were gone. So training refuses, as a 400 with the
     # underlying reason intact rather than the bare 500 a RuntimeError would have produced.
+    # dit_train_host because the accelerator gate runs first and would answer "needs a GPU" on a
+    # GPU-less runner, so without it this asserts nothing about the import guard on CI.
     import sys
     import types
 
@@ -1572,10 +1576,11 @@ def test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import(clie
     assert client._fake.started_with is None
 
 
-def test_route_start_refuses_training_when_diffusers_is_absent(client, monkeypatch):
+def test_route_start_refuses_training_when_diffusers_is_absent(client, monkeypatch, dit_train_host):
     # There is no "the child will install it" here: the trainer runs in a spawned process in the
     # SAME environment, so an absent diffusers is absent there too. Refusing before the teardown
-    # is the whole point of this preflight.
+    # is the whole point of this preflight. dit_train_host for the same reason as above: the
+    # accelerator gate is earlier and would swallow this on a GPU-less runner.
     import builtins
     import sys
 


### PR DESCRIPTION
main is red on the Python matrix: `test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import` and `test_route_start_refuses_training_when_diffusers_is_absent` fail on 3.10, 3.11, 3.12 and 3.13, and every open PR inherits them.

Both tests post a krea-2 start and assert the diffusers reason survives into the 400 body:

```
assert "No module named 'diffusers'" in r.json()["detail"]
E  assert "No module named 'diffusers'" in 'Training the DiT families needs a GPU: even
   the 4-bit (nf4) base load requires CUDA, XPU or MPS, and this host has none. Train
   SDXL here, or use a GPU machine.'
```

`training_precision_preflight_error` runs before `training_pipeline_import_error` on the start route, and its `dit_accelerator_missing_reason` gate fires first on a GPU-less runner. So on CI these two assert nothing about the import guard they exist to cover, and fail. On a GPU box they pass, which is how they were written. They did not go in green: #8236's own Backend CI was already failing on `(Python 3.11)`, `(Python 3.12)` and `(Python 3.13)` with these exact two at merge time, the same way #8163 merged red earlier today. Nobody is at fault for a check that was red when it landed; this just clears it.

The route ordering is right as it stands. Telling someone on a CPU host that training needs a GPU is more use than telling them diffusers is missing, and the accelerator gate is the cheaper check. What is wrong is that the tests depend on the host.

`conftest.dit_train_host` already exists for exactly this, and the neighbouring family-metadata tests use it, including `test_route_start_still_runs_when_the_install_does_have_the_pipeline` a few lines up. Requesting it here pins `dit_accelerator_missing_reason` and `bf16_unsupported_reason` to None so the request reaches the import guard on any host. The gate itself keeps its own coverage in `test_diffusion_base_precision.py`.

Verification, `studio/backend/tests/test_diffusion_training.py` run twice on this box:

| | before | after |
|---|---|---|
| `CUDA_VISIBLE_DEVICES=""` | 2 failed, 116 passed | 118 passed |
| `CUDA_VISIBLE_DEVICES=0,1,2,3` | 118 passed | 118 passed |

