### PR TITLE
Drop sd.cpp binaries a new bundle did not overwrite, and stop the memo masking a newer install record

### DIFF
--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -1705,7 +1705,12 @@ def test_a_record_written_elsewhere_takes_the_answer_back_from_the_memo(tmp_path
 
     real_open = builtins.open
 
-    def _readonly_record(file, mode = "r", *a, **k):
+    def _readonly_record(
+        file,
+        mode = "r",
+        *a,
+        **k,
+    ):
         if str(file).endswith(sdmod.INSTALL_RECORD) and "w" in mode:
             raise OSError("permission denied")
         return real_open(file, mode, *a, **k)

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -1535,10 +1535,11 @@ def test_an_archive_without_a_server_drops_the_previous_one(tmp_path, monkeypatc
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr(f"bin/{cli_name}", "new")
     buf.seek(0)
+    before = sdmod._managed_executables(target)
     with zipfile.ZipFile(buf) as zf:
-        assert sdmod._archive_ships_sd_server(zf) is False
+        supplied = sdmod._archive_executables(zf, target)
 
-    sdmod._discard_stale_sd_server(target)
+    sdmod._discard_superseded_executables(target, supplied, before)
     assert not stale.exists()
     assert sdmod._locate_sd_server(target) is None
 
@@ -1546,13 +1547,60 @@ def test_an_archive_without_a_server_drops_the_previous_one(tmp_path, monkeypatc
 def test_an_archive_that_does_ship_a_server_keeps_it(tmp_path):
     """The removal must key on the archive's member list, not on what is on disk: a bundle that
     ships its own sd-server has just written it, and deleting that would break every upgrade."""
+    target = tmp_path / "sd"
     server_name = "sd-server.exe" if sys.platform == "win32" else "sd-server"
+    (target / "bin").mkdir(parents = True)
+    server = target / "bin" / server_name
+    server.write_bytes(b"old-cpu-server")
+
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr(f"bin/{server_name}", "new")
     buf.seek(0)
+    before = sdmod._managed_executables(target)
     with zipfile.ZipFile(buf) as zf:
-        assert sdmod._archive_ships_sd_server(zf) is True
+        supplied = sdmod._archive_executables(zf, target)
+
+    # Same path, so the archive has overwritten it rather than left it behind.
+    sdmod._discard_superseded_executables(target, supplied, before)
+    assert server.exists()
+
+
+def test_a_relaid_out_archive_drops_the_binaries_it_did_not_overwrite(tmp_path):
+    """The case the ships-a-server test above cannot reach. When an upgrade's archive uses a
+    different layout it extracts ALONGSIDE the old binaries, and the stale copy at the
+    higher-priority path keeps winning _layout_candidates: the record then names the new
+    accelerator while the old build is what actually runs, indefinitely. Both binaries, not just
+    the server."""
+    target = tmp_path / "sd"
+    cli_name = "sd-cli.exe" if sys.platform == "win32" else "sd-cli"
+    server_name = "sd-server.exe" if sys.platform == "win32" else "sd-server"
+    old = target / "build" / "bin"
+    old.mkdir(parents = True)
+    (old / cli_name).write_bytes(b"old-cpu-cli")
+    (old / server_name).write_bytes(b"old-cpu-server")
+
+    new_dir = target / "sd-master-813" / "bin"
+    new_dir.mkdir(parents = True)
+    (new_dir / cli_name).write_bytes(b"new-cuda-cli")
+    (new_dir / server_name).write_bytes(b"new-cuda-server")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(f"sd-master-813/bin/{cli_name}", "new")
+        zf.writestr(f"sd-master-813/bin/{server_name}", "new")
+    buf.seek(0)
+    # before is the whole tree here, because the snapshot in install() is taken ahead of the
+    # extract; the two old copies are the ones outside supplied.
+    before = sdmod._managed_executables(target)
+    with zipfile.ZipFile(buf) as zf:
+        supplied = sdmod._archive_executables(zf, target)
+
+    sdmod._discard_superseded_executables(target, supplied, before)
+    assert not (old / cli_name).exists()
+    assert not (old / server_name).exists()
+    assert (new_dir / cli_name).read_bytes() == b"new-cuda-cli"
+    assert (new_dir / server_name).read_bytes() == b"new-cuda-server"
 
 
 def test_the_stop_is_reserved_before_the_server_is_unpublished(tmp_path, monkeypatch):
@@ -1643,6 +1691,37 @@ def test_a_stale_unwritable_record_does_not_outrank_what_was_just_installed(tmp_
     assert sdmod.installed_accelerator(root) == "cuda"
 
 
+def test_a_record_written_elsewhere_takes_the_answer_back_from_the_memo(tmp_path, monkeypatch):
+    """The memo is in-process, the managed root is not. The installer CLI and a second Studio
+    write the same record, and a memo that outranked them unconditionally hid the newer install
+    for the life of this process: after memoising cpu, an external cuda install still read as cpu
+    here, so a later cpu selection called the cuda binaries a match and silently ran the wrong
+    accelerator build. The memo only outranks the file while the file has not moved."""
+    root = tmp_path / "sd"
+    root.mkdir()
+    with open(root / sdmod.INSTALL_RECORD, "w", encoding = "utf-8") as f:
+        json.dump({"accelerator": "cpu", "repo": "r", "tag": "old"}, f)
+    sdmod._INSTALLED_ACCELERATOR_MEMO.clear()
+
+    real_open = builtins.open
+
+    def _readonly_record(file, mode = "r", *a, **k):
+        if str(file).endswith(sdmod.INSTALL_RECORD) and "w" in mode:
+            raise OSError("permission denied")
+        return real_open(file, mode, *a, **k)
+
+    monkeypatch.setattr(builtins, "open", _readonly_record)
+    sdmod._write_install_record(root, accelerator = "cpu", repo = "r", tag = "t")
+    monkeypatch.setattr(builtins, "open", real_open)
+    assert sdmod.installed_accelerator(root) == "cpu"
+
+    # Now somebody else installs cuda into the same root and succeeds where we could not.
+    with open(root / sdmod.INSTALL_RECORD, "w", encoding = "utf-8") as f:
+        json.dump({"accelerator": "cuda", "repo": "r", "tag": "new"}, f)
+
+    assert sdmod.installed_accelerator(root) == "cuda", "the newer on-disk record must win"
+
+
 def test_a_stale_server_that_cannot_be_removed_fails_the_install(tmp_path, monkeypatch):
     """A leftover server is still RUNNABLE, so no downstream probe repairs it, and a record naming
     the new accelerator would make _accelerator_changed trust it forever. Withhold both."""
@@ -1656,5 +1735,5 @@ def test_a_stale_server_that_cannot_be_removed_fails_the_install(tmp_path, monke
 
     monkeypatch.setattr(Path, "unlink", _no_unlink)
     with pytest.raises(RuntimeError) as exc:
-        sdmod._discard_stale_sd_server(root)
-    assert "superseded sd-server" in str(exc.value)
+        sdmod._discard_superseded_executables(root, set(), {stale.resolve()})
+    assert "superseded" in str(exc.value) and stale.name in str(exc.value)

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -355,9 +355,7 @@ def _locate_sd_cli(root: Path) -> Optional[Path]:
 
 
 def _executable_names() -> set[str]:
-    return (
-        {"sd-cli.exe", "sd-server.exe"} if sys.platform == "win32" else {"sd-cli", "sd-server"}
-    )
+    return {"sd-cli.exe", "sd-server.exe"} if sys.platform == "win32" else {"sd-cli", "sd-server"}
 
 
 def _managed_executables(root: Path) -> set[Path]:

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -85,24 +85,45 @@ def read_install_record(root: Path) -> dict:
         return {}
 
 
+def _record_fingerprint(record: dict) -> str:
+    """A stable string for a record, so "has the file changed since we last looked" is one
+    comparison. Content, not mtime: a same-second rewrite is exactly the case that matters."""
+    try:
+        return json.dumps(record, sort_keys = True)
+    except (TypeError, ValueError):
+        return repr(sorted(record.items()))
+
+
 def installed_accelerator(root: Path) -> Optional[str]:
     """The accelerator class the install in ``root`` was built for, or None when unrecorded.
 
-    The memo WINS over the file. It is only ever set by an install that completed in this process,
-    so it is strictly newer than whatever is on disk -- and the case it exists for is precisely a
-    record that could not be overwritten, which then still reads as the PREVIOUS accelerator.
-    Preferring the file there would keep reporting cpu after a successful cuda install, and every
-    later selection would download the bundle again."""
-    val = _INSTALLED_ACCELERATOR_MEMO.get(str(root)) or read_install_record(root).get("accelerator")
+    The memo outranks the file only while the file still reads exactly as it did when the memo was
+    taken. That is the case the memo exists for: a record this process could not overwrite, which
+    then still names the PREVIOUS accelerator, and believing it would report cpu after a
+    successful cuda install and re-download the bundle on every later selection.
+
+    Once the file changes it wins, because the managed root is shared. The installer CLI and a
+    second Studio process write it too, and a memo that outranked them unconditionally would hide
+    a newer install for the life of this process: after memoising cpu, an external cuda install
+    would keep reading as cpu here, a later cpu selection would call the cuda binaries a match,
+    and the wrong accelerator build would run silently."""
+    record = read_install_record(root)
+    memo = _INSTALLED_ACCELERATOR_MEMO.get(str(root))
+    if memo is not None and memo[1] == _record_fingerprint(record):
+        return memo[0] or None
+    val = record.get("accelerator")
     return val if isinstance(val, str) and val else None
 
 
-# What THIS process installed, per install root. The on-disk record is the durable answer, but an
-# unwritable one (read-only file, a directory in its place) used to mean the accelerator was
-# unknown forever, and unknown reads as a mismatch for a GPU target: every later engine selection
-# would re-resolve and re-download the same multi-GB bundle. Remembering it in-process keeps a
-# successful install from being repeated, without failing an install whose binaries are fine.
-_INSTALLED_ACCELERATOR_MEMO: dict[str, str] = {}
+# Per install root: what THIS process installed, paired with the record that was on disk at the
+# moment its write failed. Only ever populated by a FAILED write. The on-disk record is the
+# durable answer, but an unwritable one (read-only file, a directory in its place) used to mean
+# the accelerator was unknown forever, and unknown reads as a mismatch for a GPU target: every
+# later engine selection would re-resolve and re-download the same multi-GB bundle. Remembering it
+# in-process keeps a successful install from being repeated, without failing an install whose
+# binaries are fine. The paired fingerprint is what lets a later external install take the answer
+# back: see installed_accelerator.
+_INSTALLED_ACCELERATOR_MEMO: dict[str, tuple[str, str]] = {}
 
 
 def _write_install_record(root: Path, *, accelerator: str, repo: str, tag: Optional[str]) -> None:
@@ -112,11 +133,19 @@ def _write_install_record(root: Path, *, accelerator: str, repo: str, tag: Optio
     extracted correctly -- but the answer is memoised either way, so this process never re-installs
     what it just installed."""
     klass = accelerator_class(accelerator)
-    _INSTALLED_ACCELERATOR_MEMO[str(root)] = klass
     try:
         with open(root / INSTALL_RECORD, "w", encoding = "utf-8") as f:
             json.dump({"accelerator": klass, "repo": repo, "tag": tag}, f)
+        # The file is the durable answer again, so stop shadowing it with what an EARLIER failed
+        # write remembered: that memo is now older than the record and would outlive its purpose.
+        _INSTALLED_ACCELERATOR_MEMO.pop(str(root), None)
     except OSError as exc:
+        # Pinned to the record as it stands right now, so an install by the CLI or another Studio
+        # process later takes the answer back instead of being masked for the life of this one.
+        _INSTALLED_ACCELERATOR_MEMO[str(root)] = (
+            klass,
+            _record_fingerprint(read_install_record(root)),
+        )
         print(
             f"sd-cli: WARNING could not write the install record in {root}: {exc}; "
             f"remembering {klass} for this process only",
@@ -325,32 +354,61 @@ def _locate_sd_cli(root: Path) -> Optional[Path]:
     return None
 
 
-def _archive_ships_sd_server(zf: zipfile.ZipFile) -> bool:
-    """Whether ``zf`` carries an sd-server binary. Read from the MEMBER LIST, never from the
-    extracted tree: a leftover sd-server from an earlier install looks identical on disk, which is
+def _executable_names() -> set[str]:
+    return (
+        {"sd-cli.exe", "sd-server.exe"} if sys.platform == "win32" else {"sd-cli", "sd-server"}
+    )
+
+
+def _managed_executables(root: Path) -> set[Path]:
+    """Every sd-cli / sd-server under ``root``, not just the first one a locator would return.
+    Finding the extra copies is the whole point: they are the ones a different archive layout
+    leaves in places _layout_candidates ranks ABOVE the bundle we are installing."""
+    out: set[Path] = set()
+    for name in _executable_names():
+        for p in root.rglob(name):
+            if p.is_file():
+                out.add(p.resolve())
+    return out
+
+
+def _archive_executables(zf: zipfile.ZipFile, root: Path) -> set[Path]:
+    """Where ``zf`` puts its sd-cli / sd-server. Read from the MEMBER LIST, never from the
+    extracted tree: a leftover binary from an earlier install looks identical on disk, which is
     exactly the confusion this answers."""
-    name = "sd-server.exe" if sys.platform == "win32" else "sd-server"
-    return any(n.rsplit("/", 1)[-1] == name for n in zf.namelist())
+    names = _executable_names()
+    out: set[Path] = set()
+    for member in zf.namelist():
+        if member.rsplit("/", 1)[-1] in names:
+            out.add((root / member).resolve())
+    return out
 
 
-def _discard_stale_sd_server(root: Path) -> None:
-    """Remove an sd-server left behind by a previous, different bundle.
+def _discard_superseded_executables(root: Path, supplied: set[Path], before: set[Path]) -> None:
+    """Remove the sd-cli / sd-server copies this bundle did not supply at their existing paths.
 
-    Raises when it cannot go. A leftover server is still RUNNABLE, so nothing downstream repairs
-    it: _usable_or_discard_managed only removes binaries that fail to run, and once the record
-    below names the new accelerator, _accelerator_changed trusts it and keeps handing back that
-    stale server. Failing here withholds the record, which is what makes the next load retry."""
-    stale = _locate_sd_server(root)
-    if stale is None:
-        return
-    try:
-        stale.unlink()
-    except OSError as exc:
-        raise RuntimeError(
-            f"could not remove the superseded sd-server {stale}: {exc}. It was built for a "
-            f"different accelerator than this bundle, and leaving it would keep serving it."
-        ) from exc
-    print(f"removed the previous sd-server -> {stale}", flush = True)
+    An archive whose layout differs from the last one extracts alongside the old binaries instead
+    of over them, and a stale copy at a higher-priority path (say ``build/bin/sd-server`` against
+    a new versioned subdirectory) keeps winning _layout_candidates. Once the record below names
+    this accelerator, _accelerator_changed trusts the tree and the previous build runs for good.
+    Both binaries have this problem; the earlier version of this only covered an archive that
+    shipped no server at all, which is the special case where everything on disk is superseded.
+
+    Raises when a copy cannot go. A leftover binary is still RUNNABLE, so nothing downstream
+    repairs it: _usable_or_discard_managed only removes binaries that fail to run. Failing here
+    withholds the record, which is what makes the next load retry."""
+    for stale in sorted(before - supplied):
+        try:
+            stale.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise RuntimeError(
+                f"could not remove the superseded {stale.name} at {stale}: {exc}. This bundle "
+                f"did not supply it at that path, and leaving it would keep serving the previous "
+                f"build."
+            ) from exc
+        print(f"removed the superseded {stale.name} -> {stale}", flush = True)
 
 
 def _locate_sd_server(root: Path) -> Optional[Path]:
@@ -580,15 +638,18 @@ def install(
         # Verify integrity BEFORE extracting + executing.
         _verify_sha256(archive, asset.get("digest"))
         print("extracting ...", flush = True)
+        # Snapshot the binaries already there BEFORE extraction: afterwards this bundle's own are
+        # indistinguishable from what a previous, differently laid out one left behind.
+        before_executables = _managed_executables(target) if _may_own else set()
         with zipfile.ZipFile(archive) as zf:
-            ships_server = _archive_ships_sd_server(zf)
+            supplied_executables = _archive_executables(zf, target)
             _safe_extractall(zf, target)
-        # An archive that carries no sd-server leaves the PREVIOUS accelerator's one in place, and
-        # the record written below would then label the whole tree as this accelerator: the backend
-        # rediscovers that stale server, trusts the record and runs a CUDA request on the old CPU
-        # build forever. Drop what this bundle did not provide, so the tree and its record agree.
-        if _may_own and not ships_server:
-            _discard_stale_sd_server(target)
+        # Whatever this bundle did not supply at its existing path is the PREVIOUS accelerator's,
+        # and the record written below would label the whole tree as this accelerator: the backend
+        # rediscovers the stale binary, trusts the record and runs a CUDA request on the old CPU
+        # build forever. Drop them, so the tree and its record agree.
+        if _may_own:
+            _discard_superseded_executables(target, supplied_executables, before_executables)
         # Windows CUDA builds need the separately-published cudart runtime DLLs.
         _maybe_fetch_windows_cudart(release, chosen, target)
     finally:


### PR DESCRIPTION
Two follow-ups to #8208. Both were raised in its review and I agreed with both, but it merged without the fixes. I re-checked each against current main before writing this.

## Superseded binaries survive an archive layout change

`install()` removed a leftover `sd-server` only when the new archive shipped none at all:

```python
if _may_own and not ships_server:
    _discard_stale_sd_server(target)
```

An archive whose layout differs from the last one does ship a server, just somewhere else, so it extracts alongside the old binaries instead of over them. The leftover at the higher-priority path keeps winning `sd_cpp_engine._layout_candidates()` (an old `build/bin/sd-server` outranks a new versioned subdirectory), the record written below then names the accelerator we just installed, and `_accelerator_changed()` trusts the tree from that point on. The previous build runs indefinitely. `sd-cli` has the same exposure.

Now the tree is snapshotted before extraction, the supplied paths come from the archive's member list, and anything in `before - supplied` goes. The old case falls out as the instance where nothing on disk was supplied. Removal still raises on failure, which withholds the record and is what makes the next load retry.

## The in-process memo hides a record written elsewhere

`installed_accelerator` let the memo beat the file unconditionally. The managed root is shared: the installer CLI and a second Studio process write that record too. Once this process memoised `cpu`, an external `cuda` install stayed invisible here, a later `cpu` selection judged the cuda binaries a match, and the wrong accelerator build ran with nothing to indicate it.

Flipping the precedence outright is wrong, because it breaks the case the memo exists for: a record that is readable but cannot be replaced still names the PREVIOUS accelerator, and believing it reports `cpu` after a successful `cuda` install and re-downloads the bundle on every later selection. So the memo now carries a fingerprint of the record as it stood when the write failed, and outranks the file only while the file has not moved. Both behaviours hold, and the memo is only ever populated by a failed write.

## Verification

| | result |
|---|---|
| `tests/test_sd_cpp_install.py` | 79 passed |
| `ruff check` on both changed files | clean |
| `studio/backend/tests/` vs the same merge base | 86 FAILED/ERROR lines on each, identical sets |

Both suite runs used `CUDA_VISIBLE_DEVICES=2,3`, since `test_amd_apu_unified_memory.py` reads that variable and an unmatched mask makes the two sides look different when they are not.

Three new cases: a relaid-out archive drops both old binaries and keeps both new ones; a same-path overwrite keeps the server; a record written elsewhere takes the answer back from the memo. The two existing tests that called the removed helpers are moved to the new one, and the stale-unwritable-record test is untouched and still passes, which is the half of the memo behaviour that had to survive.

## Not in here

The third agreed item from that review, holding managed-tree admission across the whole install span rather than sampling `_managed_tree_in_use()` once before the download, is a concurrency change in `sd_cpp_backend.py` rather than the installer. It is worth its own PR and its own review, so I have left it out of this one.
