### PR TITLE
Hold the sd.cpp managed tree for the whole install, not just the check

### DIFF
--- a/studio/backend/core/inference/sd_cpp_backend.py
+++ b/studio/backend/core/inference/sd_cpp_backend.py
@@ -86,6 +86,12 @@ _STEP_RE = re.compile(r"(\d+)\s*/\s*(\d+)")
 # Serialises the one-time binary install so concurrent first-loads don't race.
 _install_lock = threading.Lock()
 
+# Admission control over the managed install tree. _install_lock keeps two installs apart, but the
+# conflict that actually corrupts the tree is an install against a native process EXECUTING out of
+# it, and those two never share a lock. See _claim_managed_tree_for_install.
+_tree_admission = threading.Condition()
+_tree_installing = False
+
 # Max images per img_gen job; larger Studio batches (up to 32) are split into these chunks.
 _MAX_SERVER_BATCH = 8
 
@@ -338,6 +344,47 @@ def _managed_tree_in_use() -> bool:
     return _tree_in_use(_sd_cpp_backend)
 
 
+def _claim_managed_tree_for_install() -> bool:
+    """Reserve the managed tree for an install, or return False to leave it alone.
+
+    _managed_tree_in_use() on its own is a point-in-time sample, and the install it admits then
+    spends seconds resolving the release and streaming tens of MB before it extracts anything.
+    A one-shot generate() starting inside that window sets _active_generate_cancel and execs the
+    very sd-cli the installer is about to replace: Linux refuses to write a running executable
+    (ETXTBSY) and Windows locks it, so the install fails or leaves the tree half-written, and the
+    generation can die under it either way.
+
+    So the probe and the reservation happen together, under _tree_admission, and the flag stays up
+    for the whole install span. Refusing rather than waiting keeps the existing contract: the
+    caller holds on to whatever usable binary it already had, and the next load retries the
+    upgrade after its own teardown."""
+    global _tree_installing
+    with _tree_admission:
+        if _tree_installing or _managed_tree_in_use():
+            return False
+        _tree_installing = True
+        return True
+
+
+def _release_managed_tree() -> None:
+    """Drop the reservation and wake anything waiting to run out of the tree."""
+    global _tree_installing
+    with _tree_admission:
+        _tree_installing = False
+        _tree_admission.notify_all()
+
+
+def _await_managed_tree(timeout: float = 900.0) -> None:
+    """Block until no install is rewriting the managed binaries.
+
+    Waiting, not refusing, because the caller is a user's generation: a delay of one download is
+    better than a failure, and better than the corrupt tree this exists to prevent. The timeout is
+    a backstop against a release that never lands, not a policy -- an install that overruns it
+    leaves the caller no worse off than before this gate existed."""
+    with _tree_admission:
+        _tree_admission.wait_for(lambda: not _tree_installing, timeout = timeout)
+
+
 def _accelerator_changed(binary: str, accelerator: str) -> bool:
     """True when ``binary`` is a managed install built for a DIFFERENT accelerator than the one
     now asked for, so reusing it would silently run the wrong build.
@@ -401,22 +448,27 @@ def ensure_sd_cpp_binary(*, allow_install: bool = True, accelerator: str = "cpu"
         # mismatch, but "no binary found" never reaches it: a legacy serverless install has no
         # sd-server at all, while its sd-cli may be mid-generation. Nothing can be in use before
         # anything is installed, so a first install is unaffected. The load retries after teardown.
-        if _managed_tree_in_use():
+        # Reserved, not merely probed: the reservation has to outlast the download, or a
+        # generation admitted meanwhile execs the binary this is about to overwrite.
+        if not _claim_managed_tree_for_install():
             return fallback
         try:
-            _install = _installer_module().install
-        except Exception as exc:  # noqa: BLE001 -- import path / module issues are non-fatal
-            logger.warning("sd-cli installer import failed: %s", exc)
-            return fallback
-        try:
-            path = _install(accelerator = accelerator)
-            logger.info("sd-cli installed at %s", path)
-            return str(path)
-        except Exception as exc:  # noqa: BLE001 -- download/extract failure -> fall back
-            logger.warning("sd-cli auto-install failed: %s", exc)
-            if fallback is not None:
-                _note_failed_upgrade(accelerator)
-            return fallback
+            try:
+                _install = _installer_module().install
+            except Exception as exc:  # noqa: BLE001 -- import path / module issues are non-fatal
+                logger.warning("sd-cli installer import failed: %s", exc)
+                return fallback
+            try:
+                path = _install(accelerator = accelerator)
+                logger.info("sd-cli installed at %s", path)
+                return str(path)
+            except Exception as exc:  # noqa: BLE001 -- download/extract failure -> fall back
+                logger.warning("sd-cli auto-install failed: %s", exc)
+                if fallback is not None:
+                    _note_failed_upgrade(accelerator)
+                return fallback
+        finally:
+            _release_managed_tree()
 
 
 def ensure_sd_server_binary(
@@ -448,24 +500,29 @@ def ensure_sd_server_binary(
         # mismatch, but "no binary found" never reaches it: a legacy serverless install has no
         # sd-server at all, while its sd-cli may be mid-generation. Nothing can be in use before
         # anything is installed, so a first install is unaffected. The load retries after teardown.
-        if _managed_tree_in_use():
+        # Reserved for the whole span, as in ensure_sd_cpp_binary: this archive carries the sd-cli
+        # too, so a generation admitted mid-download is executing a file this will overwrite.
+        if not _claim_managed_tree_for_install():
             return fallback
         try:
-            _install = _installer_module().install
-        except Exception as exc:  # noqa: BLE001 -- import path / module issues are non-fatal
-            logger.warning("sd-server installer import failed: %s", exc)
-            return fallback
-        try:
-            _install(accelerator = accelerator)  # extracts sd-cli AND sd-server
-        except Exception as exc:  # noqa: BLE001 -- download/extract failure -> fall back
-            logger.warning("sd-server auto-install failed: %s", exc)
-            # Also when only the CLI survives (a legacy server-less tree): the router probes
-            # ensure_sd_cpp_binary immediately after this, and without the record that probe
-            # resolves and downloads the same bundle a second time inside one selection.
-            if fallback is not None or find_sd_cpp_binary() is not None:
-                _note_failed_upgrade(accelerator)
-            return fallback
-        return find_sd_server_binary() or fallback
+            try:
+                _install = _installer_module().install
+            except Exception as exc:  # noqa: BLE001 -- import path / module issues are non-fatal
+                logger.warning("sd-server installer import failed: %s", exc)
+                return fallback
+            try:
+                _install(accelerator = accelerator)  # extracts sd-cli AND sd-server
+            except Exception as exc:  # noqa: BLE001 -- download/extract failure -> fall back
+                logger.warning("sd-server auto-install failed: %s", exc)
+                # Also when only the CLI survives (a legacy server-less tree): the router probes
+                # ensure_sd_cpp_binary immediately after this, and without the record that probe
+                # resolves and downloads the same bundle a second time inside one selection.
+                if fallback is not None or find_sd_cpp_binary() is not None:
+                    _note_failed_upgrade(accelerator)
+                return fallback
+            return find_sd_server_binary() or fallback
+        finally:
+            _release_managed_tree()
 
 
 @dataclass(frozen = True)
@@ -1420,21 +1477,33 @@ class SdCppDiffusionBackend:
 
         cancel = threading.Event()
         with self._generate_lock:
-            with self._lock:
-                state = self._state
-                if state is None:
-                    raise RuntimeError(DIFFUSION_NOT_LOADED_MSG)
-                # A resident server can exit while idle; drop stale state and report not-loaded so the client gets the reload path, not a 500.
-                if (
-                    state.mode == "server"
-                    and state.server is not None
-                    and not state.server.is_alive()
-                ):
-                    self._state = None
-                    raise RuntimeError(DIFFUSION_NOT_LOADED_MSG)
-                self._active_generate_cancel = cancel
-                # Publish an active (step 0) state before the slow pre-generate setup so a reload probe does not read idle while this holds _generate_lock.
-                self._gen = _SdGen(total_steps = int(steps))
+            # Under _tree_admission for the whole publish, not merely before it: an installer that
+            # sampled the tree as idle is about to overwrite the binary this generation will exec,
+            # and only holding the same lock across both the wait and the _active_generate_cancel
+            # store makes the claim and the publish unable to interleave. An install already under
+            # way is waited out; one that has not started yet now sees this generation and defers.
+            # Lock order is _generate_lock -> _tree_admission -> self._lock, and nothing takes
+            # _tree_admission while holding self._lock, so there is no cycle.
+            with _tree_admission:
+                _tree_admission.wait_for(lambda: not _tree_installing, timeout = 900.0)
+                with self._lock:
+                    state = self._state
+                    if state is None:
+                        raise RuntimeError(DIFFUSION_NOT_LOADED_MSG)
+                    # A resident server can exit while idle; drop stale state and report not-loaded so the client gets the reload path, not a 500.
+                    if (
+                        state.mode == "server"
+                        and state.server is not None
+                        and not state.server.is_alive()
+                    ):
+                        self._state = None
+                        raise RuntimeError(DIFFUSION_NOT_LOADED_MSG)
+                    self._active_generate_cancel = cancel
+                    # Publish an active (step 0) state before the slow pre-generate setup so a reload probe does not read idle while this holds _generate_lock.
+                    self._gen = _SdGen(total_steps = int(steps))
+            # _tree_admission is dropped here: the generation itself runs for minutes, and holding
+            # it that long would block every upgrade rather than the window that corrupts the tree.
+            # _active_generate_cancel is published now, so _managed_tree_in_use answers for the rest.
             try:
                 if seed is None:
                     seed = int.from_bytes(os.urandom(6), "big") & ((1 << 53) - 1)

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -1614,7 +1614,11 @@ def test_a_generation_waits_out_an_install_before_publishing_itself(monkeypatch)
     waited: list = []
     real_wait_for = threading.Condition.wait_for
 
-    def _record_wait(self, predicate, timeout = None):
+    def _record_wait(
+        self,
+        predicate,
+        timeout = None,
+    ):
         if self is bk._tree_admission:
             waited.append(bool(predicate()))
             # Let the "install" finish, so the generation proceeds instead of hanging the test.

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -1555,6 +1555,82 @@ def test_an_archive_that_does_ship_a_server_keeps_it(tmp_path):
         assert sdmod._archive_ships_sd_server(zf) is True
 
 
+def test_the_install_holds_the_tree_for_its_whole_span(tmp_path, monkeypatch):
+    """A point-in-time _managed_tree_in_use() sample admits the install, and the install then
+    spends seconds resolving and downloading before it writes anything. A generation starting in
+    that window execs the very sd-cli about to be replaced: ETXTBSY on Linux, a locked file on
+    Windows, a half-written tree either way. The reservation must outlast the download."""
+    import core.inference.sd_cpp_backend as bk
+
+    monkeypatch.setattr(bk, "_tree_installing", False)
+    monkeypatch.setattr(bk, "_sd_cpp_backend", None)
+    monkeypatch.setattr(bk, "find_sd_cpp_binary", lambda: None)
+    monkeypatch.setattr(bk, "_failed_accelerator_upgrades", set())
+
+    during: list = []
+
+    def _slow_install(**_kwargs):
+        # Mid-download. Nothing may claim the tree from under us here.
+        during.append(bk._claim_managed_tree_for_install())
+        return tmp_path / "sd-cli"
+
+    monkeypatch.setattr(sdmod, "install", _slow_install)
+
+    assert bk.ensure_sd_cpp_binary(accelerator = "cuda") == str(tmp_path / "sd-cli")
+    assert during == [False], "the tree was claimable while an install was writing it"
+    # And the reservation is dropped once the install returns, or nothing could ever run again.
+    assert bk._tree_installing is False
+    assert bk._claim_managed_tree_for_install() is True
+    bk._release_managed_tree()
+
+
+def test_a_failed_install_still_releases_the_tree(monkeypatch):
+    """Held through the failure path too. A download that dies leaving the flag up would wedge
+    every later generation on the wait below until its timeout."""
+    import core.inference.sd_cpp_backend as bk
+
+    monkeypatch.setattr(bk, "_tree_installing", False)
+    monkeypatch.setattr(bk, "_sd_cpp_backend", None)
+    monkeypatch.setattr(bk, "find_sd_cpp_binary", lambda: None)
+    monkeypatch.setattr(bk, "_failed_accelerator_upgrades", set())
+
+    def _boom(**_kwargs):
+        raise RuntimeError("network died mid-download")
+
+    monkeypatch.setattr(sdmod, "install", _boom)
+
+    assert bk.ensure_sd_cpp_binary(accelerator = "cuda") is None
+    assert bk._tree_installing is False
+
+
+def test_a_generation_waits_out_an_install_before_publishing_itself(monkeypatch):
+    """The other half of the same gate, and the reason the wait and the publish share one lock.
+    An install that has already claimed the tree must hold the generation until it is done;
+    waiting rather than refusing, because the caller is a user's request and one download's delay
+    beats a failure."""
+    import core.inference.sd_cpp_backend as bk
+
+    monkeypatch.setattr(bk, "_tree_installing", True)
+    waited: list = []
+    real_wait_for = threading.Condition.wait_for
+
+    def _record_wait(self, predicate, timeout = None):
+        if self is bk._tree_admission:
+            waited.append(bool(predicate()))
+            # Let the "install" finish, so the generation proceeds instead of hanging the test.
+            bk._tree_installing = False
+        return real_wait_for(self, predicate, timeout = timeout)
+
+    monkeypatch.setattr(threading.Condition, "wait_for", _record_wait)
+
+    backend = bk.SdCppDiffusionBackend()
+    # No state: the generation raises not-loaded straight after the gate, which is all this needs.
+    with pytest.raises(RuntimeError):
+        backend.generate(prompt = "x", steps = 1)
+
+    assert waited == [False], "the generation did not wait on an install that held the tree"
+
+
 def test_the_stop_is_reserved_before_the_server_is_unpublished(tmp_path, monkeypatch):
     """The count has to be claimed in the SAME lock block that clears _state/_pending_server. Doing
     it inside the stop leaves a gap where the resident, pending, stopping and generating fields are


### PR DESCRIPTION
The third agreed item from the #8208 review, and the last of them. The other two went in #8282; this one is a concurrency change in a different file, so it is separate.

## The race

`ensure_sd_cpp_binary` and `ensure_sd_server_binary` decide an install is safe like this:

```python
if _managed_tree_in_use():
    return fallback
...
path = _install(accelerator = accelerator)
```

That is a point-in-time sample, and `_install()` then resolves the release, streams tens of MB and only extracts at the end. A one-shot `generate()` entering during the download sets `_active_generate_cancel` and execs the sd-cli the installer is about to replace. Linux refuses to open a running executable for writing (ETXTBSY), Windows locks it, so the install fails or leaves a half-replaced tree, and the generation can die under it either way.

`_install_lock` does not cover this. It keeps two installs apart; the conflict here is an install against a native process executing out of the tree, and those two paths never shared a lock.

## The fix

A `_tree_admission` condition with a `_tree_installing` flag.

`_claim_managed_tree_for_install()` runs the `_managed_tree_in_use()` probe and sets the flag in the same critical section, and the flag stays up until the install returns. It still refuses rather than waits, so the existing contract is unchanged: the caller keeps whatever usable binary it already had, and the next load retries the upgrade after its own teardown. Released in a `finally`, so a failed or interrupted download cannot wedge it.

`generate()` takes the same condition, waits out an install already in flight, and stores `_active_generate_cancel` while still holding it. Holding across both is the point: it is what makes the installer's claim and the generation's publish unable to interleave, so one of them always sees the other. Generation waits rather than refuses, because the caller is a user's request and one download's delay beats a failure, let alone the corrupt tree this exists to prevent.

The condition is dropped before the generation runs, which takes minutes. By then `_active_generate_cancel` is published, so `_managed_tree_in_use()` answers for the rest and no upgrade is blocked longer than the window that actually matters.

Lock order is `_generate_lock` then `_tree_admission` then `self._lock`, and nothing acquires `_tree_admission` while holding `self._lock`, so there is no cycle.

## What I did not change

`_accelerator_changed()` keeps its plain `_managed_tree_in_use()` probe. It is a predicate, not an admission point, and a stale answer there defers an upgrade to the next load, which is the existing documented behaviour.

## Verification

| | result |
|---|---|
| `tests/test_sd_cpp_install.py` | 80 passed |
| `ruff check` | clean |
| `studio/backend/tests/` vs the same merge base | 86 FAILED/ERROR lines on each, identical sets |

Both suite runs on `CUDA_VISIBLE_DEVICES=2,3`, since `test_amd_apu_unified_memory.py` reads that variable and an unmatched mask makes the two sides look different when they are not.

Three new cases: the tree cannot be claimed from inside a running install; a failed install still releases it; a generation waits on an install that holds it. To be straight about what those prove, they pin the new gate's contract rather than reproducing the original race, which needs a real thread to lose a real download's timing. The argument that the gate closes it is the one above, not the tests.
