### PR TITLE
Studio: make the two diffusers-guard training tests host-independent

### DIFF
--- a/studio/backend/tests/test_diffusion_training.py
+++ b/studio/backend/tests/test_diffusion_training.py
@@ -1552,7 +1552,6 @@ def _clear_the_hardware_preflight(monkeypatch):
     direction.
     """
     import core.training.diffusion_train_common as dtc
-
     monkeypatch.setattr(dtc, "training_precision_preflight_error", lambda *a, **k: None)
 
 

--- a/studio/backend/tests/test_diffusion_training.py
+++ b/studio/backend/tests/test_diffusion_training.py
@@ -1540,6 +1540,22 @@ def test_route_start_still_runs_when_the_install_does_have_the_pipeline(
     assert client._fake.started_with["base_model"] == "krea/Krea-2-Raw"
 
 
+def _clear_the_hardware_preflight(monkeypatch):
+    """Clear the host-capability gate, which answers BEFORE the diffusers guards below.
+
+    Those guards are what the two tests after this one are about, and the host gate runs first:
+    on a GPU-less runner it refuses with "needs a GPU", so the assertions read a message that has
+    nothing to do with them, and the tests passed only on a machine that happened to have a
+    bf16 GPU. Stubbing the preflight the route actually calls -- rather than faking torch, where
+    a present CUDA device then trips the bf16 probe -- makes them describe the host they run on,
+    the way test_route_start_refuses_a_dit_family_without_a_gpu_before_freeing pins the other
+    direction.
+    """
+    import core.training.diffusion_train_common as dtc
+
+    monkeypatch.setattr(dtc, "training_precision_preflight_error", lambda *a, **k: None)
+
+
 def test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import(client, monkeypatch):
     # diffusers' top level is lazy, so the guard's attribute probe is what actually imports the
     # pipeline's submodule, and a partially usable install raises RuntimeError("Failed to import
@@ -1559,6 +1575,7 @@ def test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import(clie
             raise RuntimeError(f"Failed to import diffusers.pipelines.{name.lower()}")
 
     freed = []
+    _clear_the_hardware_preflight(monkeypatch)
     monkeypatch.setattr(tr, "_free_gpu_for_diffusion_training", lambda: freed.append(1))
     monkeypatch.setitem(sys.modules, "diffusers", _LazyModule("diffusers"))
 
@@ -1589,6 +1606,7 @@ def test_route_start_refuses_training_when_diffusers_is_absent(client, monkeypat
         return real_import(name, *args, **kwargs)
 
     freed = []
+    _clear_the_hardware_preflight(monkeypatch)
     monkeypatch.setattr(tr, "_free_gpu_for_diffusion_training", lambda: freed.append(1))
     monkeypatch.delitem(sys.modules, "diffusers", raising = False)
     monkeypatch.setattr(builtins, "__import__", _no_diffusers)


### PR DESCRIPTION
Two tests in `studio/backend/tests/test_diffusion_training.py` fail on Backend CI (Python 3.10-3.13) and pass locally, because they depend on the machine they run on rather than on the behaviour they assert.

`test_route_start_refuses_a_diffusers_whose_lazy_submodule_cannot_import` and `test_route_start_refuses_training_when_diffusers_is_absent` both assert on the message `/api/train/diffusion/start` produces from its diffusers preflight. The host-capability preflight answers first, so on a GPU-less runner the request never reaches the guard under test:

```
assert 'Krea2Pipeline' in 'Training the DiT families needs a GPU: even the 4-bit (nf4) base load
requires CUDA, XPU or MPS, and this host has none. Train SDXL here, or use a GPU machine.'
```

Nothing in the product changed. Reproduced on a pristine `origin/main` checkout under `CUDA_VISIBLE_DEVICES=""`, and on every intermediate main commit back through #7989 and #8208 to well before either, so this predates them.

The fix stubs `training_precision_preflight_error`, which is the preflight the route actually calls, rather than faking `torch.cuda.is_available`: with a CUDA device claimed present the bf16 probe fires instead and swaps one host message for another. `test_route_start_refuses_a_dit_family_without_a_gpu_before_freeing` already pins the same gate in the opposite direction, so the pair now describes both hosts explicitly.

`studio/backend/tests/test_diffusion_training.py` is 118 passed under `CUDA_VISIBLE_DEVICES=0,1,2,3` and 118 passed under an empty mask.
