### PR TITLE
Give Backend CI a timeout that is not the suite's runtime

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -57,7 +57,11 @@ jobs:
   pytest:
     name: (Python ${{ matrix.python }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 30, not 15: the suite now runs 14.1 to 15.0 minutes on every interpreter in the matrix, so a
+    # 15 minute budget cancels whichever jobs happen to land on the slow side of the median and the
+    # result is a coin flip rather than a verdict. This guards against a hang, which 30 still does;
+    # it was never meant to be a performance budget. The suite's own runtime is the real problem.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +121,8 @@ jobs:
     # succeeds on CPU.
     name: Repo tests (CPU)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Same reason as the matrix above: this one measured 13.4 minutes against the same 15.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:


### PR DESCRIPTION
Backend CI jobs have been getting cancelled at a high rate across every open PR, and the cancellations read as `fail` in `gh pr checks`, so PRs look red for reasons that have nothing to do with their diff. #8274 currently shows 52 red checks and not one of them is a real failure.

## The measurement

Every `(Python ...)` job across the last 14 Backend CI runs, by wall time and outcome:

| outcome | durations (minutes) |
|---|---|
| completed (success or failure) | 14.1, 14.3, 14.3, 14.3, 14.4, 14.4, 14.4, 14.5, 14.5, 14.7, 14.8, 15.0, 15.0 |
| cancelled | 1.8 x4, 2.1 x4, 2.7 x4, 2.8 x8, **15.2 x8**, 22.8 x4 |

The cancellations are bimodal. The 20 jobs under 3 minutes are ordinary supersede cancellations, a new push killing an in-flight run, and those are fine. The 8 at 15.2 are the job hitting `timeout-minutes: 15`.

The completed column is the real finding: **every job that finished took between 14.1 and 15.0 minutes against a 15 minute budget.** The median is 14.4. A job that runs 4% slower than the median dies, so which ones survive is close to a coin flip per run, and it is not interpreter-specific: 3.10, 3.11, 3.12 and 3.13 all sit on the same line.

That is why the same PR shows different red checks on each re-run, and why re-running "failed" jobs has not helped: `gh run rerun --failed` does not pick up a cancelled job at all.

## The change

`timeout-minutes: 15` to `30`, on the pytest matrix and on `Repo tests (CPU)`, which measured 13.4 minutes against the same limit.

This is the guard against a hung job, not a performance budget, and 30 minutes still catches a hang inside one CI cycle. Nothing else changes.

## What this does not fix

A unit-test suite that takes 14.5 minutes is the actual problem, and this only stops it being scored as a coin flip. Worth doing properly afterwards: the matrix runs the whole of `studio/backend/tests` four times over, and `pytest-xdist` or splitting the slow modules out would cut it a long way. I did not want to put a behaviour change and a scheduling change in the same PR, and the timeout is what is blocking the queue today.

## Verification

The workflow parses and both jobs read 30:

```
{'pytest': 30, 'repo-cpu-tests': 30}
```

No test or product code is touched, so the evidence that matters is this PR's own Backend CI going green without a cancellation.
