### PR TITLE
Studio: match the loaded models card to the update banners

### DIFF
--- a/studio/frontend/src/features/loaded-models/loaded-models-indicator.tsx
+++ b/studio/frontend/src/features/loaded-models/loaded-models-indicator.tsx
@@ -299,7 +299,7 @@ export function LoadedModelsIndicator({
         </Tooltip>
       ) : (
         <div className="menu-soft-surface menu-soft-edgeless pointer-events-auto flex min-h-0 w-[268px] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-[20px] p-1.5 font-heading">
-          <div className="flex items-center gap-1.5 px-1.5 pb-1 pt-0.5">
+          <div className="flex items-center gap-1.5 px-1.5 pb-2.5 pt-0.5">
             <HugeiconsIcon
               icon={SparkleIcon}
               strokeWidth={1.75}

--- a/studio/frontend/src/features/loaded-models/loaded-models-indicator.tsx
+++ b/studio/frontend/src/features/loaded-models/loaded-models-indicator.tsx
@@ -281,7 +281,7 @@ export function LoadedModelsIndicator({
               onClick={() => {
                 if (!justDragged()) setCollapsed(false);
               }}
-              className="menu-soft-surface pointer-events-auto flex h-9 cursor-grab touch-none items-center gap-1.5 rounded-full pl-2.5 pr-3 font-heading text-muted-foreground transition-colors hover:text-foreground active:cursor-grabbing"
+              className="menu-soft-surface menu-soft-edgeless pointer-events-auto flex h-9 cursor-grab touch-none items-center gap-1.5 rounded-full pl-2.5 pr-3 font-heading text-muted-foreground transition-colors hover:text-foreground active:cursor-grabbing"
             >
               <HugeiconsIcon
                 icon={SparkleIcon}
@@ -298,7 +298,7 @@ export function LoadedModelsIndicator({
           </TooltipContent>
         </Tooltip>
       ) : (
-        <div className="menu-soft-surface pointer-events-auto flex min-h-0 w-[268px] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-[20px] p-1.5 font-heading">
+        <div className="menu-soft-surface menu-soft-edgeless pointer-events-auto flex min-h-0 w-[268px] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-[20px] p-1.5 font-heading">
           <div className="flex items-center gap-1.5 px-1.5 pb-1 pt-0.5">
             <HugeiconsIcon
               icon={SparkleIcon}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1581,6 +1581,13 @@ html[data-chat-font] .aui-root {
 		--menu-soft-spread: -8px;
 	}
 
+	/* Same surface without the inset edge ring: the update banners' look.
+	   Reuses the vars above, so both themes stay in step. */
+	.menu-soft-surface.menu-soft-edgeless {
+		box-shadow: 0 var(--menu-soft-offset-y) var(--menu-soft-blur)
+			var(--menu-soft-spread) var(--menu-soft-shadow);
+	}
+
 	/* Model selector: drop the inset edge ring, keep the soft drop shadow.
 	   Pin --radius to the light value so the corners match in both themes. */
 	.unsloth-model-selector-menu.menu-soft-surface {

--- a/studio/frontend/tests/loaded-models-surface.test.ts
+++ b/studio/frontend/tests/loaded-models-surface.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The card wore menu-soft-surface's inset edge ring, which the update banners
+// do not. Read from the source: the node suite has no DOM to compute styles in.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const CSS = readFileSync(new URL("../src/index.css", import.meta.url), "utf8");
+const INDICATOR = readFileSync(
+  new URL(
+    "../src/features/loaded-models/loaded-models-indicator.tsx",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const BANNER = readFileSync(
+  new URL("../src/components/llama-update-banner.tsx", import.meta.url),
+  "utf8",
+);
+
+function surface(source: string, anchor: string): string {
+  const at = source.indexOf(anchor);
+  assert.notEqual(at, -1, `${anchor} not found`);
+  return source.slice(at, source.indexOf('"', at));
+}
+
+/** The CSS rule opened by `selector`, up to its closing brace. */
+function rule(selector: string): string {
+  const at = CSS.indexOf(selector);
+  assert.notEqual(at, -1, `${selector} not found`);
+  return CSS.slice(at, CSS.indexOf("}", at));
+}
+
+test("both card states drop the edge ring", () => {
+  const pill = surface(INDICATOR, "menu-soft-surface menu-soft-edgeless");
+  assert.match(pill, /menu-soft-edgeless/);
+  // Two: the collapsed pill and the expanded card.
+  assert.equal(
+    INDICATOR.split("menu-soft-edgeless").length - 1,
+    2,
+    "the pill and the card are one surface, so both or neither",
+  );
+  assert.doesNotMatch(
+    INDICATOR,
+    /"menu-soft-surface pointer-events-auto/,
+    "a bare menu-soft-surface still carries the ring",
+  );
+});
+
+// The modifier keeps the drop shadow. Dropping both would flatten the card
+// into the page.
+test("the modifier removes only the inset, not the shadow", () => {
+  const modifier = rule(".menu-soft-surface.menu-soft-edgeless");
+  assert.doesNotMatch(modifier, /inset/);
+  assert.match(modifier, /var\(--menu-soft-offset-y\)/);
+  assert.match(modifier, /var\(--menu-soft-blur\)/);
+  assert.match(modifier, /var\(--menu-soft-spread\)/);
+  assert.match(modifier, /var\(--menu-soft-shadow\)/);
+});
+
+// Written against the vars rather than literals, so the dark override at
+// .dark .menu-soft-surface still reaches it.
+test("the modifier hardcodes neither theme", () => {
+  const modifier = rule(".menu-soft-surface.menu-soft-edgeless");
+  assert.doesNotMatch(modifier, /rgba|#[0-9a-f]{3}/i);
+});
+
+// The point of the change: the card and the banners are the same surface.
+// menu-soft-surface's vars already carry the banner's geometry, so once the
+// inset is gone the two agree. If the banner is restyled, this fails.
+test("the shared vars still match the update banner's shadow", () => {
+  assert.match(BANNER, /shadow-\[0_2px_8px_-2px_rgba\(0,0,0,0\.16\)\]/);
+  assert.match(BANNER, /dark:shadow-\[0_8px_28px_-6px_rgba\(0,0,0,0\.28\)\]/);
+  const light = rule(".menu-soft-surface,");
+  assert.match(light, /--menu-soft-shadow: rgba\(0, 0, 0, 0\.16\)/);
+  assert.match(light, /--menu-soft-offset-y: 2px/);
+  assert.match(light, /--menu-soft-blur: 8px/);
+  assert.match(light, /--menu-soft-spread: -2px/);
+  const dark = rule(".dark .menu-soft-surface,");
+  assert.match(dark, /--menu-soft-shadow: rgba\(0, 0, 0, 0\.28\)/);
+  assert.match(dark, /--menu-soft-offset-y: 8px/);
+  assert.match(dark, /--menu-soft-blur: 28px/);
+  assert.match(dark, /--menu-soft-spread: -6px/);
+});
+
+// The banner paints bg-white/dark:bg-card, the card bg-popover. Same colour in
+// every theme, so the surfaces match; this pins that they stay equal.
+test("popover and card resolve to the same colour in every theme", () => {
+  const popover = [...CSS.matchAll(/^\t*--popover:\s*([^;]+);/gm)].map((m) =>
+    m[1].trim(),
+  );
+  const card = [...CSS.matchAll(/^\t*--card:\s*([^;]+);/gm)].map((m) =>
+    m[1].trim(),
+  );
+  assert.ok(popover.length > 0);
+  assert.deepEqual(popover, card);
+});


### PR DESCRIPTION
Two changes to the loaded models card, both making it sit better next to the update banners in the same corner.

## 1. Remove the border

The card had a hairline border. The llama.cpp and app update banners, which share its corner, do not.

### Where it came from

The card and its collapsed pill use `menu-soft-surface`, whose `box-shadow` is two layers:

```css
box-shadow:
	inset 0 0 0 1px var(--menu-soft-edge),
	0 var(--menu-soft-offset-y) var(--menu-soft-blur)
		var(--menu-soft-spread) var(--menu-soft-shadow);
```

The inset layer is the ring. It is not a `border`, which is why it survives every `border-0` in the tree.

### Why nothing else had to change

The two surfaces already agreed on everything except that ring:

| | banner | card |
|---|---|---|
| light shadow | `0 2px 8px -2px rgba(0,0,0,0.16)` | same, via the vars |
| dark shadow | `0 8px 28px -6px rgba(0,0,0,0.28)` | same, via the vars |
| light fill | `bg-white` | `bg-popover`, `oklch(1 0 0)` |
| dark fill | `dark:bg-card`, `#212121` | `bg-popover`, `#212121` |

`--popover` and `--card` are the same value in all four themes, so the fills already matched. Dropping the inset is the whole difference.

### Change

New modifier in `index.css`, next to the base rule:

```css
/* Same surface without the inset edge ring: the update banners' look.
   Reuses the vars above, so both themes stay in step. */
.menu-soft-surface.menu-soft-edgeless {
	box-shadow: 0 var(--menu-soft-offset-y) var(--menu-soft-blur)
		var(--menu-soft-spread) var(--menu-soft-shadow);
}
```

Written against the custom properties rather than literals, so `.dark .menu-soft-surface` still reaches it and light and dark cannot drift apart. Same trick `.unsloth-model-selector-menu.menu-soft-surface` and `.app-user-menu.menu-soft-surface` already use, now named once instead of copied a third time.

Applied to both states of the indicator, the expanded card and the collapsed pill, since they are one surface.

## 2. More room under the header

The header row sat 4px off the first model, which read as cramped against the 8px above the title. `pb-1` to `pb-2.5`, so the gap to the first row is 14px once that row's own `py-1` is counted. Top spacing is unchanged.

## Scope

The CSS modifier is opt-in, so every other `menu-soft-surface` consumer keeps its ring. Two class attributes and one CSS rule. No layout beyond the card's own header gap, no behaviour, no backend.

## Testing

New `studio/frontend/tests/loaded-models-surface.test.ts`, five cases: both card states carry the modifier and no bare `menu-soft-surface` is left, the modifier drops the inset but keeps all four shadow vars, it hardcodes no colour, the vars still equal the banner's literal shadow, and `--popover` still equals `--card` in every theme. The last two fail if the banner or the palette is restyled out from under this.

Confirmed three of the five fail against the pre-change files. The other two are invariants that hold either way, which is the point of them. The header gap is a spacing value with no cross-component contract behind it, so it is not pinned.

- `tsc --noEmit` clean
- `npm test`, 1497 passing
- `i18n:check:strict` clean
- `npm run build` clean
- Biome: `index.css` 1 error and `loaded-models-indicator.tsx` 7 warnings, before and after, identical. New test file adds no errors.
- Built CSS emits `.menu-soft-surface.menu-soft-edgeless{box-shadow:0 var(--menu-soft-offset-y) var(--menu-soft-blur) var(--menu-soft-spread) var(--menu-soft-shadow)}`, so the modifier resolves and outranks the base rule.
