### PR TITLE
Fix API monitor token counts for clients that omit stream usage

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1228,6 +1228,34 @@ def _cmpl_stream_event_out(event: bytes, include_usage: bool) -> Optional[bytes]
     return _rewrite_cmpl_id(b"\n".join(lines) if changed else event)
 
 
+def _chat_passthrough_sse_out(raw_line: str, include_usage: bool) -> Optional[str]:
+    """Filter one chat-completion SSE ``data:`` line for the downstream client.
+
+    The API monitor always records usage from llama-server (we request
+    ``stream_options.include_usage`` upstream even when the client omits it).
+    Clients that did not opt in must not see a trailing ``choices: []`` usage
+    chunk or an inline ``usage`` field on a content chunk.
+    """
+    if include_usage:
+        return raw_line
+    if not raw_line.startswith("data:"):
+        return raw_line
+    payload = raw_line[5:].strip()
+    if not payload or payload == "[DONE]":
+        return raw_line
+    try:
+        obj = json.loads(payload)
+    except Exception:
+        return raw_line
+    if not isinstance(obj, dict) or obj.get("usage") is None:
+        return raw_line
+    if obj.get("choices") == []:
+        return None
+    stripped = dict(obj)
+    stripped.pop("usage", None)
+    return "data: " + json.dumps(stripped, separators = (",", ":"), ensure_ascii = False)
+
+
 def _classify_llama_generation_error(exc: Exception) -> Optional[bool]:
     """Classify an error raised while consuming the GGUF generator.
 
@@ -21832,6 +21860,12 @@ def _build_openai_passthrough_body(
         stream_options = payload.stream_options,
         markup = getattr(llama_backend, "markup_profile", None),
     )
+    if payload.stream:
+        # External OpenAI clients (e.g. Tencent Code Buddy) often stream without
+        # stream_options.include_usage, which leaves the API monitor's token
+        # columns blank. Always ask llama-server for the trailing usage chunk;
+        # _chat_passthrough_sse_out withholds it from clients that did not opt in.
+        body["stream_options"] = {"include_usage": True}
     if _continue_final_message(payload):
         # llama-server rejects both flags set true.
         body["continue_final_message"] = True
@@ -22252,6 +22286,7 @@ async def _openai_passthrough_stream_admitted(
                 StreamToolCallHealer(_allowed_tools, body.get("tools")) if _allowed_tools else None
             )
             healed_call_index = 0
+            relay_include_usage = _wants_stream_usage(payload)
 
             def _synthetic_finish_line() -> str:
                 healed = healer is not None and healer.healed
@@ -22604,8 +22639,14 @@ async def _openai_passthrough_stream_admitted(
                         if monitor_event == "error":
                             saw_stream_error = True
                         # Relay to preserve llama-server's native id,
-                        # finish_reason, delta.tool_calls, and usage chunks.
-                        yield out_line + "\n\n"
+                        # finish_reason, and delta.tool_calls; usage is withheld
+                        # unless the client opted in (monitor still saw it above).
+                        client_line = _chat_passthrough_sse_out(
+                            out_line,
+                            relay_include_usage,
+                        )
+                        if client_line is not None:
+                            yield client_line + "\n\n"
                         if monitor_event == "done":
                             monitor_done = True
                             break
@@ -22614,9 +22655,7 @@ async def _openai_passthrough_stream_admitted(
                             if out_line is raw_line
                             else _openai_passthrough_sse_line_terminal_state(out_line)
                         )
-                        if terminal_state == "usage" or (
-                            terminal_state == "finish" and not _wants_stream_usage(payload)
-                        ):
+                        if terminal_state == "usage":
                             done_line = _SSE_DONE_LINE
                             _monitor_openai_sse_line(
                                 monitor_id,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1216,7 +1216,7 @@ def _cmpl_stream_event_out(event: bytes, include_usage: bool) -> Optional[bytes]
             obj = json.loads(payload)
         except Exception:
             continue
-        if not isinstance(obj, dict) or obj.get("usage") is None:
+        if not isinstance(obj, dict) or "usage" not in obj:
             continue
         # Standalone usage-only chunk (chat-style) -> drop the whole event.
         if obj.get("choices") == []:
@@ -1247,7 +1247,7 @@ def _chat_passthrough_sse_out(raw_line: str, include_usage: bool) -> Optional[st
         obj = json.loads(payload)
     except Exception:
         return raw_line
-    if not isinstance(obj, dict) or obj.get("usage") is None:
+    if not isinstance(obj, dict) or "usage" not in obj:
         return raw_line
     if obj.get("choices") == []:
         return None

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -1779,6 +1779,15 @@ class TestOpenAICompatibilityHelpers:
         assert _chat_passthrough_sse_out(line, include_usage = False) is None
         assert _chat_passthrough_sse_out(line, include_usage = True) == line
 
+        content_with_null_usage = (
+            'data: {"id":"chatcmpl-test","choices":[{"index":0,"delta":{"content":"hi"},'
+            '"finish_reason":null}],"usage":null}'
+        )
+        stripped = _chat_passthrough_sse_out(content_with_null_usage, include_usage = False)
+        assert stripped is not None
+        assert '"usage"' not in stripped
+        assert '"content":"hi"' in stripped.replace(" ", "")
+
     def test_developer_message_preserves_existing_system_prompt(self):
         payload = ChatCompletionRequest(
             messages = [

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -45,6 +45,7 @@ from routes.inference import (
     _build_openai_passthrough_body,
     _build_passthrough_payload,
     _clamp_finish_reason,
+    _chat_passthrough_sse_out,
     _cmpl_stream_event_out,
     _coalesce_consecutive_user_turns,
     _drop_empty_assistant_sentinels,
@@ -1256,11 +1257,14 @@ class TestBuildPassthroughPayloadToolChoice:
         assert schema["properties"]["nested"]["items"]["anyOf"][0]["pattern"] == "token"
         assert schema["properties"]["largeScript"]["maxLength"] == 65536
 
-    def test_stream_omits_usage_options_when_client_did_not_request_them(self):
-        args = self._args()
-        args["stream"] = True
-        body = _build_passthrough_payload(**args)
-        assert "stream_options" not in body
+    def test_stream_requests_usage_upstream_even_when_client_omits_it(self):
+        payload = ChatCompletionRequest(
+            model = "default",
+            messages = [ChatMessage(role = "user", content = "hi")],
+            stream = True,
+        )
+        passthrough_body = _build_openai_passthrough_body(payload, backend_ctx = 4096)
+        assert passthrough_body["stream_options"] == {"include_usage": True}
 
     def test_stream_forwards_include_usage_when_client_requests_it(self):
         args = self._args()
@@ -1271,7 +1275,7 @@ class TestBuildPassthroughPayloadToolChoice:
         )
         assert body.get("stream_options") == {"include_usage": True}
 
-    def test_stream_forwards_include_usage_false_when_client_requests_it(self):
+    def test_stream_upstream_usage_requested_even_when_client_sets_false(self):
         args = self._args()
         args["stream"] = True
         body = _build_passthrough_payload(
@@ -1279,6 +1283,15 @@ class TestBuildPassthroughPayloadToolChoice:
             stream_options = {"include_usage": False},
         )
         assert body.get("stream_options") == {"include_usage": False}
+
+        payload = ChatCompletionRequest(
+            model = "default",
+            messages = [ChatMessage(role = "user", content = "hi")],
+            stream = True,
+            stream_options = {"include_usage": False},
+        )
+        passthrough_body = _build_openai_passthrough_body(payload, backend_ctx = 4096)
+        assert passthrough_body["stream_options"] == {"include_usage": True}
 
     def test_response_format_without_tools_omits_tool_fields(self):
         args = self._args()
@@ -1757,6 +1770,14 @@ class TestOpenAICompatibilityHelpers:
         assert entry["completion_tokens"] == 6
         assert entry["total_tokens"] == 10
         assert entry["context_usage"] == 0.1
+
+    def test_chat_passthrough_monitor_reads_usage_before_client_strip(self):
+        line = (
+            'data: {"id":"chatcmpl-test","choices":[],"usage":{"prompt_tokens":4,'
+            '"completion_tokens":6,"total_tokens":10}}'
+        )
+        assert _chat_passthrough_sse_out(line, include_usage = False) is None
+        assert _chat_passthrough_sse_out(line, include_usage = True) == line
 
     def test_developer_message_preserves_existing_system_prompt(self):
         payload = ChatCompletionRequest(
@@ -5733,6 +5754,27 @@ class TestApiMonitorProviderAndCompletionStreams:
 
         asyncio.run(_run())
 
+    def test_passthrough_monitor_records_usage_when_client_omits_include_usage(self, monkeypatch):
+        async def _run():
+            result = await self._run_passthrough_stream(
+                monkeypatch,
+                [
+                    'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}',
+                    'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+                    'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}',
+                ],
+                stream_options = None,
+            )
+
+            assert '"usage"' not in result.body
+            [entry] = result.monitor.snapshot()
+            assert entry["prompt_tokens"] == 11
+            assert entry["completion_tokens"] == 7
+            assert entry["total_tokens"] == 18
+            assert entry["reply"] == "hello"
+
+        asyncio.run(_run())
+
     def test_passthrough_stream_queued_request_sends_keepalive_before_upstream(self, monkeypatch):
         async def _run():
             import routes.inference as inf_mod
@@ -6499,7 +6541,7 @@ class TestApiMonitorProviderAndCompletionStreams:
         asyncio.run(_run())
 
     def test_passthrough_finish_without_done_closes_stream_early(self, monkeypatch):
-        # Some llama-server builds emit the finish chunk and then hold the HTTP
+        # Some llama-server builds emit finish + usage and then hold the HTTP
         # stream open without sending [DONE]; the terminal classifier must end
         # the client stream promptly instead of hanging on the open socket.
         async def _run():
@@ -6515,7 +6557,8 @@ class TestApiMonitorProviderAndCompletionStreams:
             async def fake_items(*_args, **_kwargs):
                 yield 'data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}'
                 yield 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
-                await asyncio.Event().wait()  # upstream never closes
+                yield 'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}'
+                await asyncio.Event().wait()  # upstream never closes after usage
 
             monitor = ApiMonitor(max_entries = 3)
             monkeypatch.setattr(inf_mod, "api_monitor", monitor)
@@ -6563,8 +6606,11 @@ class TestApiMonitorProviderAndCompletionStreams:
             body = "".join(chunks)
 
             assert '"finish_reason":"stop"' in body.replace(" ", "")
+            assert '"usage"' not in body.replace(" ", "")
             assert body.endswith("data: [DONE]\n\n")
             [entry] = monitor.snapshot()
+            assert entry["prompt_tokens"] == 1
+            assert entry["completion_tokens"] == 1
             assert entry["status"] == "completed"
             assert monitor.active_count() == 0
 


### PR DESCRIPTION
## Summary

Fixes #8142

External OpenAI clients (e.g. Tencent Code Buddy) often call `/v1/chat/completions` with streaming enabled but without `stream_options.include_usage`. In that case llama-server never emitted a trailing usage chunk, so the Studio API monitor showed `–` for prompt/completion/total tokens even though the request completed successfully.

## Changes

- Always request `stream_options.include_usage` on the upstream llama-server passthrough body for streaming chat completions
- Record usage in the API monitor from the upstream trailing usage chunk
- Strip usage from the downstream SSE stream unless the client opted in (`_chat_passthrough_sse_out`)
- Wait for the trailing usage chunk before closing the client stream (instead of closing immediately on `finish_reason` when usage was not requested)

## Test plan

- [x] `pytest studio/backend/tests/test_openai_tool_passthrough.py` (364 tests with `test_api_monitor.py`)
- [x] New test: monitor records usage when client omits `include_usage` but client body has no usage chunk