### PR TITLE
Ship desktop bundles on the v{version} release instead of desktop-v{version}

### DIFF
--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -35,7 +35,7 @@ on:
         # Empty, not a pinned tag. desktop-v0.1.50-beta predates #7547, so with the
         # outcome pins retired a dispatch that took this default would fail all four
         # POSIX legs at the installer step -- on a bundle nobody meant to test. Empty
-        # falls through to the same newest-desktop-v* resolution the schedule uses.
+        # falls through to the same desktop-latest resolution the schedule uses.
         default: ''
       release_repo:
         description: 'owner/name hosting the desktop release'
@@ -58,9 +58,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
-  # Drafts are listed only to a token with push access, and every desktop-v* release here
-  # is a draft, so `contents: read` cannot see the bundle under test at all.
-  contents: write
+  # Bundles ship on the public v{version} release and the desktop-latest channel that
+  # resolves it is public too, so read access is enough; this workflow writes nothing.
+  contents: read
 
 env:
   # release-desktop.yml publishes into github.repository, so a nightly aimed anywhere else
@@ -69,9 +69,8 @@ env:
   REL_REPO: ${{ inputs.release_repo || github.repository }}
   # Empty unless dispatched: a pinned tag is an immutable fixture, so a nightly against it
   # could never catch a newly published broken bundle. Each download step then resolves
-  # the newest desktop-v* release, drafts included -- they are all cut as drafts, so
-  # --exclude-drafts matched nothing and every leg died resolving. releases/tags/<tag>
-  # 404s for a draft, but gh resolves drafts over GraphQL, so the download still works.
+  # the release the desktop-latest channel currently points at, which is by definition
+  # the v{version} release carrying the bundles under test.
   REL_TAG: ${{ inputs.release_tag || '' }}
   UNSLOTH_STUDIO_HOME: ${{ github.workspace }}/.studio-home
   UNSLOTH_STUDIO_DISABLE_PUBLIC_CHECK: '1'
@@ -79,9 +78,9 @@ env:
 jobs:
   # ── macOS: .dmg, Apple Silicon ────────────────────────────────────────────
   macos:
-    # A fork PR's token is read-only whatever this workflow declares, so it cannot list
-    # the drafts every desktop-v* bundle is published as. Skip rather than fail: a
-    # property of the trigger, not a broken release.
+    # Fork PRs get a token with no access to this repo's release downloads, so the
+    # bundle under test cannot be fetched. Skip rather than fail: a property of the
+    # trigger, not a broken release.
     if: github.event.pull_request.head.repo.fork != true
     name: desktop macOS ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -104,16 +103,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p dl logs
-          # Desktop releases are prereleases (never repo-wide "latest") and drafts, so the
-          # newest desktop-v* tag has to be resolved explicitly. See REL_TAG above.
+          # Desktop releases are prereleases and never the repo-wide "latest", so the
+          # target tag has to be resolved explicitly. See REL_TAG above.
           if [ -z "$REL_TAG" ]; then
-            REL_TAG="$(gh release list --repo "$REL_REPO" --limit 100 \
-              --json tagName,createdAt \
-              --jq '[.[] | select(.tagName | startswith("desktop-v"))]
-                    | sort_by(.createdAt) | reverse | .[0].tagName // empty')"
+            # Bundles ship on the ordinary v{version} release, and only some of those
+            # carry them, so resolve the active one from the updater channel rather
+            # than by tag shape.
+            manifest_dir="$(mktemp -d)"
+            gh release download desktop-latest --repo "$REL_REPO" \
+              --pattern latest.json --dir "$manifest_dir" 2>/dev/null || true
+            if [ -s "$manifest_dir/latest.json" ]; then
+              REL_TAG="$(jq -r '"v" + (.version | sub("^v"; ""))' "$manifest_dir/latest.json")"
+            else
+              REL_TAG=""
+            fi
             # Loud on purpose: there is no bundle to test, so passing would prove nothing.
             [ -n "$REL_TAG" ] || {
-              echo "::error::no desktop-v* release visible in $REL_REPO -- either none has been cut, or this token cannot list drafts (needs contents: write)"
+              echo "::error::no desktop release resolvable from desktop-latest in $REL_REPO -- either the channel has never been published, or this token cannot read it"
               exit 1
             }
             echo "resolved release tag: $REL_TAG"
@@ -321,12 +327,19 @@ jobs:
           mkdir -p dl logs
           # See the macOS job. Loud on purpose: no bundle means nothing to prove.
           if [ -z "$REL_TAG" ]; then
-            REL_TAG="$(gh release list --repo "$REL_REPO" --limit 100 \
-              --json tagName,createdAt \
-              --jq '[.[] | select(.tagName | startswith("desktop-v"))]
-                    | sort_by(.createdAt) | reverse | .[0].tagName // empty')"
+            # Bundles ship on the ordinary v{version} release, and only some of those
+            # carry them, so resolve the active one from the updater channel rather
+            # than by tag shape.
+            manifest_dir="$(mktemp -d)"
+            gh release download desktop-latest --repo "$REL_REPO" \
+              --pattern latest.json --dir "$manifest_dir" 2>/dev/null || true
+            if [ -s "$manifest_dir/latest.json" ]; then
+              REL_TAG="$(jq -r '"v" + (.version | sub("^v"; ""))' "$manifest_dir/latest.json")"
+            else
+              REL_TAG=""
+            fi
             [ -n "$REL_TAG" ] || {
-              echo "::error::no desktop-v* release visible in $REL_REPO -- either none has been cut, or this token cannot list drafts (needs contents: write)"
+              echo "::error::no desktop release resolvable from desktop-latest in $REL_REPO -- either the channel has never been published, or this token cannot read it"
               exit 1
             }
             echo "resolved release tag: $REL_TAG"
@@ -536,12 +549,19 @@ jobs:
           mkdir -p dl logs
           # See the macOS job. Loud on purpose: no bundle means nothing to prove.
           if [ -z "$REL_TAG" ]; then
-            REL_TAG="$(gh release list --repo "$REL_REPO" --limit 100 \
-              --json tagName,createdAt \
-              --jq '[.[] | select(.tagName | startswith("desktop-v"))]
-                    | sort_by(.createdAt) | reverse | .[0].tagName // empty')"
+            # Bundles ship on the ordinary v{version} release, and only some of those
+            # carry them, so resolve the active one from the updater channel rather
+            # than by tag shape.
+            manifest_dir="$(mktemp -d)"
+            gh release download desktop-latest --repo "$REL_REPO" \
+              --pattern latest.json --dir "$manifest_dir" 2>/dev/null || true
+            if [ -s "$manifest_dir/latest.json" ]; then
+              REL_TAG="$(jq -r '"v" + (.version | sub("^v"; ""))' "$manifest_dir/latest.json")"
+            else
+              REL_TAG=""
+            fi
             [ -n "$REL_TAG" ] || {
-              echo "::error::no desktop-v* release visible in $REL_REPO -- either none has been cut, or this token cannot list drafts (needs contents: write)"
+              echo "::error::no desktop release resolvable from desktop-latest in $REL_REPO -- either the channel has never been published, or this token cannot read it"
               exit 1
             }
             echo "resolved release tag: $REL_TAG"

--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -15,7 +15,11 @@ concurrency:
 jobs:
   publish-updater:
     name: Advance desktop updater channel
-    if: startsWith(github.event.release.tag_name, 'desktop-v')
+    # Desktop bundles now ship on the ordinary `v{version}` release. Those releases are
+    # published before the bundles are copied onto them, so the precise SemVer shape and
+    # the presence of latest.json are re-checked in "Check for desktop bundles" below;
+    # a release without them is skipped rather than failed.
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,7 +33,33 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Check for desktop bundles
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.][0-9A-Za-z.-]*)?$ ]]; then
+            echo "${RELEASE_TAG} is not a v{SemVer} release; nothing to advance."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Fail closed on an API error: an unreadable release must not look like one
+          # that simply carries no bundles.
+          asset_names="$RUNNER_TEMP/release-asset-names.txt"
+          if ! gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' > "$asset_names"; then
+            echo "Could not list assets on ${RELEASE_TAG}; refusing to advance the channel." >&2
+            exit 1
+          fi
+          if grep -Fxq 'latest.json' "$asset_names"; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "${RELEASE_TAG} carries no latest.json; the desktop bundles have not landed yet."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download updater metadata
+        if: steps.gate.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -65,20 +95,25 @@ jobs:
             exit 1
           fi
 
+      # Scoped to the desktop bundle names: this release is shared with whatever else
+      # the version release carries, so deleting every *.sig on it would reach beyond
+      # the desktop artifacts.
       - name: Remove standalone signature assets
+        if: steps.gate.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           signature_assets="$(
             gh release view "$RELEASE_TAG" --json assets \
-              --jq '.assets[].name | select(endswith(".sig"))'
+              --jq '.assets[].name | select(startswith("Unsloth-Desktop-")) | select(endswith(".sig"))'
           )"
           while IFS= read -r asset_name; do
             [[ -z "$asset_name" ]] || gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
           done <<< "$signature_assets"
 
       - name: Validate updater metadata
+        if: steps.gate.outputs.proceed == 'true'
         run: |
           python3 <<'PY'
           import json
@@ -138,7 +173,7 @@ jobs:
               return (len(left_parts) > len(right_parts)) - (len(left_parts) < len(right_parts))
 
           release_tag = os.environ['RELEASE_TAG']
-          tag_match = re.fullmatch(r'desktop-v(.+)', release_tag)
+          tag_match = re.fullmatch(r'v(.+)', release_tag)
           if not tag_match:
               sys.exit(f'Not a desktop version release: {release_tag}')
 
@@ -191,6 +226,7 @@ jobs:
           PY
 
       - name: Ensure updater channel release
+        if: steps.gate.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -222,6 +258,7 @@ jobs:
           PY
 
       - name: Publish updater channel metadata
+        if: steps.gate.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
     # Both version inputs are free text in the dispatch UI, and studio_version
     # alone decides the release tag, all nine asset filenames and the updater
-    # manifest version together. Near-miss tags are the failure mode worth
+    # manifest version together. studio_version must name a `v{version}` release
+    # that already exists: the bundles are copied onto it rather than into a
+    # release of their own. Near-miss tags are the failure mode worth
     # guarding, because they look right at a glance:
     #
     #   studio_version   v0.1.52-beta     correct
@@ -27,7 +29,7 @@ on:
         type: string
         required: false
       draft:
-        description: 'Create as draft; publishing it later advances desktop-latest without rebuilding'
+        description: 'Stage the bundles on a draft release only; nothing is copied to the v{version} release and desktop-latest is left untouched'
         type: boolean
         default: true
 
@@ -99,6 +101,7 @@ jobs:
       app_version: ${{ steps.prepare.outputs.app_version }}
       asset_version: ${{ steps.prepare.outputs.asset_version }}
       desktop_release_tag: ${{ steps.prepare.outputs.desktop_release_tag }}
+      staging_release_tag: ${{ steps.prepare.outputs.staging_release_tag }}
       prerelease: ${{ steps.prepare.outputs.prerelease }}
       pypi_version: ${{ steps.prepare.outputs.pypi_version }}
 
@@ -148,7 +151,11 @@ jobs:
 
           app_version = studio_version.removeprefix('v')
           asset_version = re.sub(r'[^0-9A-Za-z]+', '_', app_version).strip('_')
-          desktop_release_tag = f'desktop-v{app_version}'
+          # Desktop bundles ship on the ordinary `v{version}` release, which the
+          # maintainer publishes when main is tagged. `desktop-v{version}` survives only
+          # as a private staging draft that is deleted once the bundles are copied over.
+          desktop_release_tag = f'v{app_version}'
+          staging_release_tag = f'desktop-v{app_version}'
           prerelease = 'true' if '-' in app_version.split('+', 1)[0] else 'false'
 
           def parse_backend_version(version):
@@ -212,47 +219,61 @@ jobs:
               print(f'app_version={app_version}', file=output)
               print(f'asset_version={asset_version}', file=output)
               print(f'desktop_release_tag={desktop_release_tag}', file=output)
+              print(f'staging_release_tag={staging_release_tag}', file=output)
               print(f'prerelease={prerelease}', file=output)
               print(f'pypi_version={pypi_version}', file=output)
           PY
 
       # Fail before building and notarizing a version publish-release will reject.
+      # The bundles land on the pre-existing `v{version}` release, so unlike the old
+      # `desktop-v{version}` scheme the target is required to exist and the thing that
+      # must be absent is the desktop asset set, not the tag.
       - name: Guard against republishing an existing version
         shell: bash
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           DESKTOP_RELEASE_TAG: ${{ steps.prepare.outputs.desktop_release_tag }}
+          ASSET_VERSION: ${{ steps.prepare.outputs.asset_version }}
         run: |
           set -euo pipefail
-          print_retry_hint() {
-            echo "To retry a failed publish of this version:" >&2
-            echo "  If a release exists, delete it and its tag: gh release delete ${DESKTOP_RELEASE_TAG} --cleanup-tag" >&2
-            echo "  If release creation failed after reserving only the tag, delete the orphan tag: gh api --method DELETE repos/${GH_REPO}/git/refs/tags/${DESKTOP_RELEASE_TAG}" >&2
-          }
-          resource_exists() {
-            local response
-            if response="$(gh api --include "$1" 2>&1)"; then
-              return 0
-            fi
+          release_json="$RUNNER_TEMP/target-release.json"
+          if ! response="$(gh api --include "repos/${GH_REPO}/releases/tags/${DESKTOP_RELEASE_TAG}" 2>&1)"; then
             if [[ "$response" =~ ^HTTP/[0-9.]+\ 404\  ]]; then
-              return 1
+              echo "Release ${DESKTOP_RELEASE_TAG} does not exist." >&2
+              echo "  Tag main and publish the ${DESKTOP_RELEASE_TAG} release first, then re-dispatch this workflow." >&2
+              exit 1
             fi
-            echo "Could not verify that ${2} is absent; refusing to publish." >&2
+            echo "Could not read release ${DESKTOP_RELEASE_TAG}; refusing to publish." >&2
             printf '%s\n' "$response" >&2
             exit 1
-          }
-          if resource_exists "repos/${GH_REPO}/git/ref/tags/${DESKTOP_RELEASE_TAG}" "tag ${DESKTOP_RELEASE_TAG}"; then
-            echo "Tag ${DESKTOP_RELEASE_TAG} already exists. Release a new studio_version instead of rebuilding a shipped one." >&2
-            print_retry_hint
-            exit 1
           fi
-          # A read token cannot see drafts, so publish-release repeats this check.
-          if resource_exists "repos/${GH_REPO}/releases/tags/${DESKTOP_RELEASE_TAG}" "release ${DESKTOP_RELEASE_TAG}"; then
-            echo "Release ${DESKTOP_RELEASE_TAG} already exists. Release a new studio_version instead of rebuilding a shipped one." >&2
-            print_retry_hint
-            exit 1
-          fi
+          gh api "repos/${GH_REPO}/releases/tags/${DESKTOP_RELEASE_TAG}" > "$release_json"
+
+          python3 <<'PY'
+          import json
+          import os
+          import pathlib
+          import sys
+
+          release = json.loads(pathlib.Path(os.environ['RUNNER_TEMP'], 'target-release.json').read_text())
+          tag = os.environ['DESKTOP_RELEASE_TAG']
+          if release.get('draft'):
+              sys.exit(f'Release {tag} is a draft; publish it before shipping desktop bundles to it.')
+
+          prefix = f'Unsloth-Desktop-{os.environ["ASSET_VERSION"]}'
+          clashing = sorted(
+              asset['name']
+              for asset in release.get('assets', [])
+              if asset.get('name') == 'latest.json' or str(asset.get('name', '')).startswith(prefix)
+          )
+          if clashing:
+              print(f'Release {tag} already carries desktop assets: {", ".join(clashing)}', file=sys.stderr)
+              print('Release a new studio_version, or delete those assets to retry a failed publish:', file=sys.stderr)
+              for name in clashing:
+                  print(f'  gh release delete-asset {tag} {name} --yes', file=sys.stderr)
+              sys.exit(1)
+          PY
 
       - name: Verify PyPI package and Unsloth stamp
         shell: bash
@@ -1477,6 +1498,7 @@ jobs:
       PYPI_VERSION: ${{ needs.prepare-version.outputs.pypi_version }}
       STUDIO_VERSION: ${{ needs.prepare-version.outputs.studio_version }}
       DESKTOP_RELEASE_TAG: ${{ needs.prepare-version.outputs.desktop_release_tag }}
+      STAGING_RELEASE_TAG: ${{ needs.prepare-version.outputs.staging_release_tag }}
       DESKTOP_PRERELEASE: ${{ needs.prepare-version.outputs.prerelease }}
 
     steps:
@@ -1604,8 +1626,10 @@ jobs:
           PY
 
       # Validation runs before the scan so an already-used version is rejected
-      # before any bundle is disclosed to VirusTotal. Creation remains deferred
-      # until after the scan so a non-draft release is never left public and empty.
+      # before any bundle is disclosed to VirusTotal. Bundles reach the public
+      # `v{version}` release only after every validation step has passed; until then
+      # they live on the staging draft, so a failed run leaves nothing public behind.
+      # (The VirusTotal job is advisory and runs after this one either way.)
       - name: Validate versioned release state
         id: versioned_release_state
         shell: bash
@@ -1613,35 +1637,50 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          resource_exists() {
-            local response
-            if response="$(gh api --include "$1" 2>&1)"; then
-              return 0
-            fi
-            if [[ "$response" =~ ^HTTP/[0-9.]+\ 404\  ]]; then
-              return 1
-            fi
-            echo "Could not verify that ${2} is absent; refusing to publish." >&2
-            printf '%s\n' "$response" >&2
-            exit 1
-          }
-          print_retry_hint() {
-            echo "Release a new studio_version, or recover the failed publish before retrying:" >&2
-            echo "  If a release exists, delete it and its tag: gh release delete ${DESKTOP_RELEASE_TAG} --cleanup-tag" >&2
-            echo "  If only a tag exists, delete it: gh api --method DELETE repos/${GH_REPO}/git/refs/tags/${DESKTOP_RELEASE_TAG}" >&2
-          }
-
           notes_file="$RUNNER_TEMP/desktop-release-notes.md"
           printf '%s\n' "$DESKTOP_RELEASE_NOTES" > "$notes_file"
 
+          release_json="$RUNNER_TEMP/target-release-publish.json"
+          if ! gh api "repos/${GH_REPO}/releases/tags/${DESKTOP_RELEASE_TAG}" > "$release_json" 2>/dev/null; then
+            echo "Release ${DESKTOP_RELEASE_TAG} does not exist." >&2
+            echo "  Tag main and publish the ${DESKTOP_RELEASE_TAG} release first, then re-dispatch this workflow." >&2
+            exit 1
+          fi
+
+          python3 <<'PY'
+          import json
+          import os
+          import pathlib
+          import sys
+
+          release = json.loads(
+              pathlib.Path(os.environ['RUNNER_TEMP'], 'target-release-publish.json').read_text()
+          )
+          tag = os.environ['DESKTOP_RELEASE_TAG']
+          if release.get('draft'):
+              sys.exit(f'Release {tag} is a draft; publish it before shipping desktop bundles to it.')
+
+          prefix = f'Unsloth-Desktop-{os.environ["ASSET_VERSION"]}'
+          clashing = sorted(
+              asset['name']
+              for asset in release.get('assets', [])
+              if asset.get('name') == 'latest.json' or str(asset.get('name', '')).startswith(prefix)
+          )
+          if clashing:
+              print(f'Refusing to republish {tag}: it already carries desktop assets.', file=sys.stderr)
+              for name in clashing:
+                  print(f'  gh release delete-asset {tag} {name} --yes', file=sys.stderr)
+              sys.exit(1)
+          PY
+
+          # Drafts are invisible to the REST tag lookup, so use the draft-aware
+          # GraphQL path to catch a staging release left behind by a failed run.
           releases_file="$RUNNER_TEMP/desktop-releases.json"
-          # Both release REST endpoints omit drafts. `gh release list` uses the
-          # draft-aware GraphQL path and fails nonzero on API/auth errors.
           if ! gh release list --limit 10000 --json tagName > "$releases_file"; then
             echo "Could not list releases, including drafts; refusing to publish." >&2
             exit 1
           fi
-          release_state="$(python3 - "$releases_file" "$DESKTOP_RELEASE_TAG" <<'PY'
+          staging_state="$(python3 - "$releases_file" "$STAGING_RELEASE_TAG" <<'PY'
           import json
           import pathlib
           import sys
@@ -1659,11 +1698,9 @@ jobs:
           print('exists' if matches else 'absent')
           PY
           )"
-
-          if resource_exists "repos/${GH_REPO}/git/ref/tags/${DESKTOP_RELEASE_TAG}" "tag ${DESKTOP_RELEASE_TAG}" \
-            || [ "$release_state" = "exists" ]; then
-            echo "Refusing to republish ${DESKTOP_RELEASE_TAG}: a release or tag for this version already exists." >&2
-            print_retry_hint
+          if [ "$staging_state" = "exists" ]; then
+            echo "Staging release ${STAGING_RELEASE_TAG} already exists from an earlier run." >&2
+            echo "  Delete it before retrying: gh release delete ${STAGING_RELEASE_TAG} --yes" >&2
             exit 1
           fi
           echo "create=true" >> "$GITHUB_OUTPUT"
@@ -1728,11 +1765,12 @@ jobs:
           output.write_text(json.dumps(metadata, indent=2) + '\n')
           PY
 
-          # Keep provenance out of the notes displayed in the updater popup.
+          # Keep provenance out of the notes displayed in the updater popup. The
+          # v{version} release body belongs to the maintainer's changelog, so this is
+          # appended to it rather than replacing it.
           body_file="$RUNNER_TEMP/desktop-release-body.md"
           {
-            cat "$RUNNER_TEMP/desktop-release-notes.md"
-            printf '\n### Build provenance\n\n'
+            printf '### Desktop build provenance\n\n'
             printf 'Source commit: %s\n\n' "$GITHUB_SHA"
             printf 'Asset SHA-256:\n\n```\n'
             (
@@ -1749,74 +1787,29 @@ jobs:
           } > "$body_file"
           cat "$body_file"
 
-      # Kept immediately before upload so the release is never left empty for
-      # long, and the absence checks are repeated here to reserve the tag
-      # atomically.
-      - name: Create versioned release
+      # The bundles are staged on a draft `desktop-v{version}` release first so they are
+      # never publicly visible before the scan. No git tag is reserved: a draft release
+      # does not create one, which keeps the staging tag out of the repository entirely.
+      - name: Stage desktop bundles on a draft release
         if: steps.versioned_release_state.outputs.create == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_DRAFT: ${{ inputs.draft }}
         run: |
           set -euo pipefail
-          resource_exists() {
-            local response
-            if response="$(gh api --include "$1" 2>&1)"; then
-              return 0
-            fi
-            if [[ "$response" =~ ^HTTP/[0-9.]+\ 404\  ]]; then
-              return 1
-            fi
-            echo "Could not verify that ${2} is absent; refusing to publish." >&2
-            printf '%s\n' "$response" >&2
-            exit 1
-          }
+          gh release create "$STAGING_RELEASE_TAG" \
+            --title "Unsloth ${STUDIO_VERSION} (staging)" \
+            --notes "Internal staging release for ${DESKTOP_RELEASE_TAG}; deleted once the bundles are copied over." \
+            --draft
 
-          releases_file="$RUNNER_TEMP/desktop-releases-before-create.json"
-          if ! gh release list --limit 10000 --json tagName > "$releases_file"; then
-            echo "Could not list releases, including drafts; refusing to publish." >&2
-            exit 1
-          fi
-          release_state="$(python3 - "$releases_file" "$DESKTOP_RELEASE_TAG" <<'PY'
-          import json
-          import pathlib
-          import sys
-
-          releases = json.loads(pathlib.Path(sys.argv[1]).read_text())
-          if not isinstance(releases, list):
-              sys.exit('Unexpected response while listing desktop releases')
-          print('exists' if any(
-              isinstance(release, dict) and release.get('tagName') == sys.argv[2]
-              for release in releases
-          ) else 'absent')
-          PY
-          )"
-          if resource_exists "repos/${GH_REPO}/git/ref/tags/${DESKTOP_RELEASE_TAG}" "tag ${DESKTOP_RELEASE_TAG}" \
-            || [ "$release_state" = "exists" ]; then
-            echo "Refusing to republish ${DESKTOP_RELEASE_TAG}: a release or tag appeared during the pre-flight scan." >&2
-            exit 1
-          fi
-
-          # Reserve the tag at this source commit before creating the release.
-          gh api --method POST "repos/${GH_REPO}/git/refs" \
-            -f "ref=refs/tags/${DESKTOP_RELEASE_TAG}" \
-            -f "sha=${GITHUB_SHA}"
-
-          release_flags=(
-            --title "Unsloth ${STUDIO_VERSION}"
-            --notes-file "$RUNNER_TEMP/desktop-release-body.md"
-            --verify-tag
-          )
-          if [ "$RELEASE_DRAFT" = "true" ]; then
-            release_flags+=(--draft)
-          fi
-          if [ "$DESKTOP_PRERELEASE" = "true" ]; then
-            release_flags+=(--prerelease)
-          fi
-          gh release create "$DESKTOP_RELEASE_TAG" "${release_flags[@]}"
+          staged_assets=()
+          for asset in "$RUNNER_TEMP/desktop-release-assets"/*; do
+            [[ "$asset" == *.sig ]] || staged_assets+=("$asset")
+          done
+          gh release upload "$STAGING_RELEASE_TAG" "${staged_assets[@]}" "$RUNNER_TEMP/latest.json"
 
       - name: Publish versioned release assets
+        if: ${{ !inputs.draft }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1830,12 +1823,36 @@ jobs:
           gh release upload "$DESKTOP_RELEASE_TAG" "${release_assets[@]}"
 
       - name: Publish versioned updater metadata
+        if: ${{ !inputs.draft }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           gh release upload "$DESKTOP_RELEASE_TAG" "$RUNNER_TEMP/latest.json"
+
+      # Appended, never replaced: the release body is the maintainer's changelog and
+      # only the desktop provenance section belongs to this workflow.
+      - name: Record desktop build provenance on the release
+        if: ${{ !inputs.draft }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current_body="$RUNNER_TEMP/current-release-body.md"
+          merged_body="$RUNNER_TEMP/merged-release-body.md"
+          gh release view "$DESKTOP_RELEASE_TAG" --json body --jq '.body // ""' > "$current_body"
+          if grep -Fq '### Desktop build provenance' "$current_body"; then
+            echo "Release ${DESKTOP_RELEASE_TAG} already records desktop provenance; leaving it alone."
+            exit 0
+          fi
+          {
+            cat "$current_body"
+            printf '\n\n'
+            cat "$RUNNER_TEMP/desktop-release-body.md"
+          } > "$merged_body"
+          gh release edit "$DESKTOP_RELEASE_TAG" --notes-file "$merged_body"
 
       - name: Download versioned updater metadata
         if: ${{ !inputs.draft }}
@@ -2072,6 +2089,18 @@ jobs:
               sys.exit(f'desktop-latest latest.json URL mismatch: expected {expected_url}, got {actual_url}')
           PY
 
+      # Only once the bundles are on the public release and the channel points at
+      # them. A failed run deliberately leaves the staging draft behind for triage;
+      # the pre-flight check tells the next run how to remove it.
+      - name: Remove the staging release
+        if: ${{ !inputs.draft }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release delete "$STAGING_RELEASE_TAG" --yes
+
   # ── Advisory multi-engine scan of the bundles just uploaded ──
   # Defender (build job) is one vendor and gates only Windows. VirusTotal
   # aggregates ~70 engines across all four bundles, which is how a false
@@ -2086,9 +2115,9 @@ jobs:
   # job it was ~9 minutes of the ~9.5 the job took, delaying every release by its
   # full length while being unable to block one.
   virustotal-scan:
-    # Not "post-publish": `inputs.draft` defaults to true and the release is
-    # created with `--draft` on that input, so the ordinary run has uploaded the
-    # assets to a draft. The name has to read true for both dispatches.
+    # Not "post-publish": `inputs.draft` defaults to true, and on that input the
+    # bundles only ever reach the staging draft. The name has to read true for both
+    # dispatches.
     name: VirusTotal release asset scan
     needs: [publish-release]
     runs-on: ubuntu-latest

--- a/studio/frontend/src/hooks/use-tauri-update.ts
+++ b/studio/frontend/src/hooks/use-tauri-update.ts
@@ -63,10 +63,12 @@ export interface RetainedUpdateFailure {
   logs: string[];
 }
 
+// Mirrors the constants in src-tauri/src/desktop_update_policy.rs; used when the
+// desktop_update_policy invoke fails.
 const DEFAULT_UPDATE_POLICY: DesktopUpdatePolicy = {
   mode: "in_app",
   releasePageBaseUrl: "https://github.com/unslothai/unsloth/releases/tag/",
-  releaseTagPrefix: "desktop-v",
+  releaseTagPrefix: "v",
 };
 
 // Desktop quit never fires beforeunload, and only the renderer sees the shell installer.

--- a/studio/src-tauri/src/desktop_update_policy.rs
+++ b/studio/src-tauri/src/desktop_update_policy.rs
@@ -2,7 +2,11 @@ use serde::Serialize;
 use std::collections::HashMap;
 
 const DESKTOP_RELEASE_PAGE_BASE_URL: &str = "https://github.com/unslothai/unsloth/releases/tag/";
-const DESKTOP_RELEASE_TAG_PREFIX: &str = "desktop-v";
+// Desktop bundles ship on the ordinary `v{version}` release rather than a separate
+// `desktop-v{version}` one, so the release page link and the bundle URLs share a tag.
+const DESKTOP_RELEASE_TAG_PREFIX: &str = "v";
+const DESKTOP_RELEASE_DOWNLOAD_BASE_URL: &str =
+    "https://github.com/unslothai/unsloth/releases/download/";
 const DESKTOP_UPDATER_CHANNEL_URL: &str =
     "https://github.com/unslothai/unsloth/releases/download/desktop-latest/latest.json";
 
@@ -120,8 +124,10 @@ fn validate_channel_metadata(
         return Err("Desktop updater metadata has no platforms".to_string());
     }
 
+    // Derived from the shared constants so the accepted prefix cannot drift away from
+    // the tag the release page link is built from.
     let expected_prefix = format!(
-        "https://github.com/unslothai/unsloth/releases/download/desktop-v{normalized_version}/"
+        "{DESKTOP_RELEASE_DOWNLOAD_BASE_URL}{DESKTOP_RELEASE_TAG_PREFIX}{normalized_version}/"
     );
     for (platform, entry) in &metadata.platforms {
         if entry.url.trim().is_empty() {
@@ -379,6 +385,92 @@ fn split_alpha_numeric(value: &str) -> Option<(&str, u64)> {
 
 #[cfg(test)]
 mod tests {
+    use super::{ChannelMetadata, ChannelPlatform};
+    use std::collections::HashMap;
+
+    fn metadata_with_url(url: &str) -> ChannelMetadata {
+        let mut platforms = HashMap::new();
+        platforms.insert(
+            "windows-x86_64".to_string(),
+            ChannelPlatform {
+                url: url.to_string(),
+                signature: "dW50cnVzdGVk".to_string(),
+            },
+        );
+        ChannelMetadata {
+            version: "0.1.527-beta".to_string(),
+            pypi_version: None,
+            notes: None,
+            pub_date: None,
+            platforms,
+        }
+    }
+
+    const VERSION: &str = "0.1.527-beta";
+
+    #[test]
+    fn validate_channel_metadata_accepts_version_tag_urls() {
+        let metadata = metadata_with_url(
+            "https://github.com/unslothai/unsloth/releases/download/v0.1.527-beta/Unsloth-Desktop-0_1_527_beta-Windows.exe",
+        );
+        assert!(super::validate_channel_metadata(&metadata, VERSION).is_ok());
+    }
+
+    #[test]
+    fn validate_channel_metadata_rejects_legacy_desktop_tag_urls() {
+        let metadata = metadata_with_url(
+            "https://github.com/unslothai/unsloth/releases/download/desktop-v0.1.527-beta/Unsloth-Desktop-0_1_527_beta-Windows.exe",
+        );
+        assert!(super::validate_channel_metadata(&metadata, VERSION).is_err());
+    }
+
+    #[test]
+    fn validate_channel_metadata_rejects_moving_channel_urls() {
+        for url in [
+            "https://github.com/unslothai/unsloth/releases/download/desktop-latest/Unsloth-Desktop-0_1_527_beta-Windows.exe",
+            "https://github.com/unslothai/unsloth/releases/latest/Unsloth-Desktop-0_1_527_beta-Windows.exe",
+        ] {
+            let metadata = metadata_with_url(url);
+            assert!(
+                super::validate_channel_metadata(&metadata, VERSION).is_err(),
+                "expected {url} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_channel_metadata_rejects_foreign_hosts_and_other_versions() {
+        for url in [
+            "https://example.com/unslothai/unsloth/releases/download/v0.1.527-beta/Unsloth-Desktop-0_1_527_beta-Windows.exe",
+            "https://github.com/unslothai/unsloth/releases/download/v0.1.526-beta/Unsloth-Desktop-0_1_526_beta-Windows.exe",
+        ] {
+            let metadata = metadata_with_url(url);
+            assert!(
+                super::validate_channel_metadata(&metadata, VERSION).is_err(),
+                "expected {url} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_channel_metadata_requires_url_signature_and_platforms() {
+        let mut empty = metadata_with_url("");
+        assert!(super::validate_channel_metadata(&empty, VERSION).is_err());
+
+        empty.platforms.clear();
+        assert!(super::validate_channel_metadata(&empty, VERSION).is_err());
+
+        let mut unsigned = metadata_with_url(
+            "https://github.com/unslothai/unsloth/releases/download/v0.1.527-beta/Unsloth-Desktop-0_1_527_beta-Windows.exe",
+        );
+        unsigned
+            .platforms
+            .get_mut("windows-x86_64")
+            .expect("platform present")
+            .signature = "   ".to_string();
+        assert!(super::validate_channel_metadata(&unsigned, VERSION).is_err());
+    }
+
     #[test]
     fn compare_versions_orders_supported_suffixes() {
         assert!(super::compare_versions("2026.5.3", "2026.5.3-rc1") > 0);

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -13,7 +13,8 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-desktop.yml"
 
-RELEASE_TAG = "desktop-v0.1.50-beta"
+RELEASE_TAG = "v0.1.50-beta"
+STAGING_TAG = "desktop-v0.1.50-beta"
 SOURCE_SHA = "1f02275b86f0e0d3a5b1c9f2a4d6e8b0c2a4e6f8"
 
 
@@ -43,26 +44,39 @@ def _write_fake_gh(path: Path):
 set -eu
 printf 'gh %s\\n' "$*" >> "$COMMAND_LOG"
 if [ "$1" = "api" ]; then
+  include=0
   endpoint=""
   for argument in "$@"; do
-    case "$argument" in repos/*) endpoint="$argument" ;; esac
+    case "$argument" in
+      --include) include=1 ;;
+      repos/*) endpoint="$argument" ;;
+    esac
   done
   case "$endpoint" in
-    */git/ref/tags/*) status="$TAG_HTTP_STATUS" ;;
-    */releases/tags/*) status="$RELEASE_HTTP_STATUS" ;;
+    */releases/tags/desktop-latest) status=404 ;;
+    */releases/tags/*) status="$TARGET_HTTP_STATUS" ;;
     *) exit 0 ;;
   esac
-  printf 'HTTP/2.0 %s Test Response\n' "$status"
-  if [ "$status" = "200" ]; then exit 0; fi
+  if [ "$include" = "1" ]; then
+    printf 'HTTP/2.0 %s Test Response\n' "$status"
+  fi
+  if [ "$status" = "200" ]; then
+    if [ "$TARGET_HAS_DESKTOP_ASSETS" = "1" ]; then
+      printf '{"tag_name":"%s","draft":false,"assets":[{"name":"latest.json"}]}\n' "$DESKTOP_RELEASE_TAG"
+    else
+      printf '{"tag_name":"%s","draft":false,"assets":[]}\n' "$DESKTOP_RELEASE_TAG"
+    fi
+    exit 0
+  fi
   exit 1
 fi
 if [ "$1" = "release" ] && [ "$2" = "list" ]; then
-  if [ "$RELEASE_HTTP_STATUS" = "500" ]; then
+  if [ "$STAGING_LIST_STATUS" = "500" ]; then
     printf 'GraphQL test failure\n' >&2
     exit 1
   fi
-  if [ "$RELEASE_HTTP_STATUS" = "200" ]; then
-    printf '[{"tagName":"%s"}]\n' "$DESKTOP_RELEASE_TAG"
+  if [ "$STAGING_EXISTS" = "1" ]; then
+    printf '[{"tagName":"%s"}]\n' "$STAGING_RELEASE_TAG"
   else
     printf '[]\n'
   fi
@@ -82,8 +96,10 @@ def _run_step(
     name: str,
     tmp_path: Path,
     *,
-    tag_http_status: int = 404,
-    release_http_status: int = 404,
+    target_http_status: int = 200,
+    target_has_desktop_assets: bool = False,
+    staging_exists: bool = False,
+    staging_list_status: int = 200,
     extra_env: dict[str, str] | None = None,
 ):
     fake_bin = tmp_path / "bin"
@@ -95,15 +111,19 @@ def _run_step(
     env = os.environ.copy()
     env.update(
         {
+            "ASSET_VERSION": "0_1_50_beta",
             "COMMAND_LOG": str(log),
             "DESKTOP_RELEASE_TAG": RELEASE_TAG,
             "GH_REPO": "unslothai/unsloth",
             "GITHUB_OUTPUT": str(tmp_path / "github-output"),
             "GH_TOKEN": "masked-token",
             "PATH": f"{fake_bin}:{env['PATH']}",
-            "RELEASE_HTTP_STATUS": str(release_http_status),
             "RUNNER_TEMP": str(tmp_path),
-            "TAG_HTTP_STATUS": str(tag_http_status),
+            "STAGING_EXISTS": "1" if staging_exists else "0",
+            "STAGING_LIST_STATUS": str(staging_list_status),
+            "STAGING_RELEASE_TAG": STAGING_TAG,
+            "TARGET_HAS_DESKTOP_ASSETS": "1" if target_has_desktop_assets else "0",
+            "TARGET_HTTP_STATUS": str(target_http_status),
         }
     )
     env.update(extra_env or {})
@@ -148,7 +168,6 @@ def _run_create_release(workflow, tmp_path: Path, **kwargs):
         "GITHUB_SHA": SOURCE_SHA,
         "GITHUB_REPOSITORY": "unslothai/unsloth",
         "PYPI_VERSION": "2026.8.7",
-        "RELEASE_DRAFT": "true",
         "STUDIO_VERSION": "v0.1.50-beta",
     }
     env.update(kwargs.pop("extra_env", None) or {})
@@ -158,14 +177,19 @@ def _run_create_release(workflow, tmp_path: Path, **kwargs):
     names = (
         "Validate versioned release state",
         "Generate versioned updater metadata and provenance",
-        "Create versioned release",
+        "Stage desktop bundles on a draft release",
     )
-    create_step = _step(workflow, "publish-release", "Create versioned release")
+    create_step = _step(workflow, "publish-release", "Stage desktop bundles on a draft release")
     create_step["run"] = "\n".join(
         _step(workflow, "publish-release", name)["run"] for name in names
     )
     return _run_step(
-        workflow, "publish-release", "Create versioned release", tmp_path, extra_env = env, **kwargs
+        workflow,
+        "publish-release",
+        "Stage desktop bundles on a draft release",
+        tmp_path,
+        extra_env = env,
+        **kwargs,
     )
 
 
@@ -189,8 +213,8 @@ def test_a_used_version_fails_the_guard_before_any_build_work(tmp_path):
     assert workflow["jobs"]["build"]["needs"] == "prepare-version"
 
     for case, expected in (
-        ({"tag_http_status": 200}, 1),
-        ({"release_http_status": 200}, 1),
+        ({"target_has_desktop_assets": True}, 1),
+        ({"target_http_status": 404}, 1),
         ({}, 0),
     ):
         case_dir = tmp_path / ("-".join(case) or "unused-version")
@@ -202,15 +226,36 @@ def test_a_used_version_fails_the_guard_before_any_build_work(tmp_path):
             case_dir,
             **case,
         )
-        assert result.returncode == expected, (case, result.stderr)
+        assert result.returncode == expected, (case, result.stderr, result.stdout)
         if expected:
             assert RELEASE_TAG in result.stderr
-            # Avoid leaving a tag that fails the next attempt.
-            assert f"gh release delete {RELEASE_TAG} --cleanup-tag" in result.stderr
-            assert (
-                f"gh api --method DELETE repos/unslothai/unsloth/git/refs/tags/{RELEASE_TAG}"
-                in result.stderr
-            )
+
+
+def test_a_missing_target_release_says_how_to_create_it(tmp_path):
+    workflow = _workflow()
+    result, _ = _run_step(
+        workflow,
+        "prepare-version",
+        "Guard against republishing an existing version",
+        tmp_path,
+        target_http_status = 404,
+    )
+    assert result.returncode == 1
+    assert f"Release {RELEASE_TAG} does not exist." in result.stderr
+    assert "Tag main and publish" in result.stderr
+
+
+def test_existing_desktop_assets_name_the_cleanup_command(tmp_path):
+    workflow = _workflow()
+    result, _ = _run_step(
+        workflow,
+        "prepare-version",
+        "Guard against republishing an existing version",
+        tmp_path,
+        target_has_desktop_assets = True,
+    )
+    assert result.returncode == 1
+    assert f"gh release delete-asset {RELEASE_TAG} latest.json --yes" in result.stderr
 
 
 def test_a_failed_guard_probe_fails_closed_before_any_build_work(tmp_path):
@@ -220,40 +265,41 @@ def test_a_failed_guard_probe_fails_closed_before_any_build_work(tmp_path):
         "prepare-version",
         "Guard against republishing an existing version",
         tmp_path,
-        tag_http_status = 500,
+        target_http_status = 500,
     )
     assert result.returncode == 1
-    assert "Could not verify that tag" in result.stderr
+    assert "Could not read release" in result.stderr
 
 
 def test_publish_refuses_to_reuse_an_existing_release(tmp_path):
     workflow = _workflow()
-    # The write-scoped publish job can see drafts that prepare-version cannot.
-    for case in ({"tag_http_status": 200}, {"release_http_status": 200}):
-        case_dir = tmp_path / "-".join(case)
-        case_dir.mkdir()
-        result, commands = _run_create_release(workflow, case_dir, **case)
-        assert result.returncode == 1, case
-        assert "Refusing to republish" in result.stderr
-        assert f"gh release delete {RELEASE_TAG} --cleanup-tag" in result.stderr
-        assert (
-            f"gh api --method DELETE repos/unslothai/unsloth/git/refs/tags/{RELEASE_TAG}"
-            in result.stderr
-        )
-        assert not [line for line in commands if line.startswith("gh release create")]
-
-
-def test_publish_fails_closed_when_a_guard_probe_errors(tmp_path):
-    workflow = _workflow()
-    result, commands = _run_create_release(workflow, tmp_path, tag_http_status = 500)
+    result, commands = _run_create_release(workflow, tmp_path, target_has_desktop_assets = True)
     assert result.returncode == 1
-    assert "Could not verify that tag" in result.stderr
+    assert "Refusing to republish" in result.stderr
+    assert f"gh release delete-asset {RELEASE_TAG} latest.json --yes" in result.stderr
+    assert not [line for line in commands if line.startswith("gh release create")]
+
+
+def test_publish_refuses_when_a_staging_release_is_left_over(tmp_path):
+    workflow = _workflow()
+    result, commands = _run_create_release(workflow, tmp_path, staging_exists = True)
+    assert result.returncode == 1
+    assert f"Staging release {STAGING_TAG} already exists" in result.stderr
+    assert f"gh release delete {STAGING_TAG} --yes" in result.stderr
+    assert not [line for line in commands if line.startswith("gh release create")]
+
+
+def test_publish_fails_closed_when_the_target_release_is_missing(tmp_path):
+    workflow = _workflow()
+    result, commands = _run_create_release(workflow, tmp_path, target_http_status = 404)
+    assert result.returncode == 1
+    assert f"Release {RELEASE_TAG} does not exist." in result.stderr
     assert not [line for line in commands if line.startswith("gh release create")]
 
 
 def test_publish_fails_closed_when_draft_listing_errors(tmp_path):
     workflow = _workflow()
-    result, commands = _run_create_release(workflow, tmp_path, release_http_status = 500)
+    result, commands = _run_create_release(workflow, tmp_path, staging_list_status = 500)
     assert result.returncode == 1
     assert "Could not list releases, including drafts" in result.stderr
     assert not [line for line in commands if line.startswith("gh release create")]
@@ -265,14 +311,15 @@ def test_release_body_records_provenance_the_updater_notes_do_not_carry(tmp_path
     result, commands = _run_create_release(workflow, tmp_path)
     assert result.returncode == 0, result.stderr
 
+    # Staging is a draft with no tag reserved, so no desktop-v* tag survives a release.
     create = next(line for line in commands if line.startswith("gh release create"))
-    assert RELEASE_TAG in create
+    assert STAGING_TAG in create
+    assert "--draft" in create
+    assert "--verify-tag" not in create
     assert "--target" not in create
-    assert "--verify-tag" in create
-    assert any("git/refs" in line and f"sha={SOURCE_SHA}" in line for line in commands)
+    assert not [line for line in commands if "git/refs" in line]
 
     body_file = tmp_path / "desktop-release-body.md"
-    assert f"--notes-file {body_file}" in create
     body = body_file.read_text(encoding = "utf-8")
     assert SOURCE_SHA in body
     for name, digest in digests.items():
@@ -286,19 +333,23 @@ def test_release_body_records_provenance_the_updater_notes_do_not_carry(tmp_path
     notes = (tmp_path / "desktop-release-notes.md").read_text(encoding = "utf-8")
     assert "Build provenance" not in notes
     assert "Desktop app for Unsloth." in notes
-    create_step = _step(workflow, "publish-release", "Create versioned release")
-    assert "'desktop-release-notes.md'" in create_step["run"]
-    assert "latest.json" in create_step["run"]
+
+    # The maintainer's changelog is appended to, never replaced.
+    provenance = _step(workflow, "publish-release", "Record desktop build provenance on the release")
+    assert "gh release edit" in provenance["run"]
+    assert "--json body" in provenance["run"]
 
 
 def test_versioned_uploads_never_clobber_but_the_channel_pointer_does():
     uploads = _upload_commands(_workflow())
     versioned = [line for line in uploads if "$DESKTOP_RELEASE_TAG" in line]
+    staging = [line for line in uploads if "$STAGING_RELEASE_TAG" in line]
     channel = [line for line in uploads if "desktop-latest" in line]
     assert len(versioned) == 2, uploads
+    assert len(staging) == 1, uploads
     assert len(channel) == 1, uploads
 
-    for line in versioned:
+    for line in versioned + staging:
         assert "--clobber" not in line, line
     # The channel pointer is intentionally mutable.
     assert "--clobber" in channel[0]

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -335,7 +335,9 @@ def test_release_body_records_provenance_the_updater_notes_do_not_carry(tmp_path
     assert "Desktop app for Unsloth." in notes
 
     # The maintainer's changelog is appended to, never replaced.
-    provenance = _step(workflow, "publish-release", "Record desktop build provenance on the release")
+    provenance = _step(
+        workflow, "publish-release", "Record desktop build provenance on the release"
+    )
     assert "gh release edit" in provenance["run"]
     assert "--json body" in provenance["run"]
 

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -128,7 +128,9 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     assert re.search(r"^\s*break\b", loop_body, re.MULTILINE), wait_run
 
     names = [step.get("name") for step in publish["steps"]]
-    assert names.index("Wait for the build matrix") < names.index("Create versioned release")
+    assert names.index("Wait for the build matrix") < names.index(
+        "Stage desktop bundles on a draft release"
+    )
     # And it has to clear before the assets are pulled, or the download races the
     # legs and publish-release dies on artifacts that do not exist yet.
     download = next(
@@ -138,18 +140,23 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     )
     assert names.index("Wait for the build matrix") < download, names
 
-    # Creating a missing release is a separate step gated on validation, so a
-    # non-draft release is never reserved before its assets are ready to upload.
+    # Staging is a separate step gated on validation, so nothing reaches the public
+    # v{version} release before its assets are ready to upload.
     release_step = next(
         step for step in publish["steps"] if step.get("name") == "Validate versioned release state"
     )
+    # Draft-aware listing catches a leftover staging release; the REST lookup checks
+    # the target release exists and is not already carrying desktop assets.
     assert "gh release list" in release_step["run"]
-    assert "resource_exists" in release_step["run"]
+    assert 'gh api "repos/${GH_REPO}/releases/tags/${DESKTOP_RELEASE_TAG}"' in release_step["run"]
 
     create_step = next(
-        step for step in publish["steps"] if step.get("name") == "Create versioned release"
+        step
+        for step in publish["steps"]
+        if step.get("name") == "Stage desktop bundles on a draft release"
     )
     assert "gh release create" in create_step["run"]
+    assert "--draft" in create_step["run"]
     assert create_step["if"] == "steps.versioned_release_state.outputs.create == 'true'"
 
 
@@ -203,7 +210,7 @@ def test_publishing_draft_advances_updater_without_rebuilding():
     job = workflow["jobs"]["publish-updater"]
     assert "build" not in workflow["jobs"]
     assert job["permissions"] == {"contents": "write"}
-    assert "startsWith(github.event.release.tag_name, 'desktop-v')" in job["if"]
+    assert "startsWith(github.event.release.tag_name, 'v')" in job["if"]
     assert not any("actions/checkout" in step.get("uses", "") for step in job["steps"])
     assert any("desktop-latest" in step.get("run", "") for step in job["steps"])
     assert any("gh release delete-asset" in step.get("run", "") for step in job["steps"])

--- a/tests/studio/test_tauri_branding_contract.py
+++ b/tests/studio/test_tauri_branding_contract.py
@@ -157,5 +157,5 @@ def test_desktop_surfaces_do_not_restore_studio_branding() -> None:
 
     workflow = read(REPO / ".github/workflows/release-desktop.yml")
     assert "Desktop app for Unsloth." in workflow
-    assert '--title "Unsloth ${STUDIO_VERSION}"' in workflow
+    assert '--title "Unsloth ${STUDIO_VERSION} (staging)"' in workflow
     assert '--title "Unsloth Desktop updater channel"' in workflow


### PR DESCRIPTION
## Why

0.1.526 users never saw an update prompt for 0.1.527. Tracing it end to end:

- Every installed client polls one compiled-in endpoint, `desktop-latest/latest.json` (`studio/src-tauri/tauri.conf.json`, `desktop_update_policy.rs:6-7`). That URL returns **404** -- the `desktop-latest` release has never existed.
- Every step that creates or advances it is gated on `if: ${{ !inputs.draft }}`, and desktop releases have always been dispatched with `draft=true`.
- The fallback promotion never fired either: `publish-desktop-updater.yml` was gated on `startsWith(tag_name, 'desktop-v')`, so publishing the ordinary `v0.1.527-beta` release produced a skipped run.
- Copying the manifest by hand would not have helped: its URLs pointed into the still-draft `desktop-v0.1.527-beta`, whose assets are 404 to anonymous users.

Two releases per version, one of them permanently draft, is what made all of this possible. This collapses them into one.

## What changes

Desktop bundles and `latest.json` now ship on the ordinary `v{version}` release that main tagging already publishes, so the release page link, the bundle URLs and the changelog share a tag.

| Tag | Role | Visibility |
|---|---|---|
| `v{version}` | the bundles and `latest.json` | public, must already exist |
| `desktop-v{version}` | build/notarize staging only | draft, deleted after the copy |
| `desktop-latest` | moving updater channel | **unchanged** -- compiled into every client |

`desktop-v{version}` no longer reserves a git tag, so nothing survives a release. The guards invert with the scheme: the target release is now required to *exist*, and what must be absent is the desktop asset set rather than the tag, since `v{version}` is always tagged before dispatch. A leftover staging draft is detected and named in the error.

Provenance is appended to the release body rather than replacing it, since that body is the maintainer's changelog.

## Breaking change

Linux `.deb`/`.rpm` installs of 0.1.527 and earlier stop updating. Their compiled-in `validate_channel_metadata` accepts only `desktop-v` URLs and will reject the new ones as an untrusted URL, visible under Settings -> General.

**Windows, macOS and Linux AppImage are unaffected**, including already-installed 0.1.526: those run in `InApp` mode, where `check_desktop_update` delegates to the Tauri updater plugin, which applies no prefix rule and verifies only the minisign signature.

## Also fixed along the way

- `publish-desktop-updater.yml` deleted *every* `.sig` asset on the triggering release. Harmless on a dedicated release, not on a shared one -- now scoped to `Unsloth-Desktop-*`.
- The new bundle-presence gate fails closed on an API error, so an unreadable release cannot look like one that simply carries no bundles.
- `desktop-app-clean-machine-ci.yml` resolved the newest `desktop-v*` release by tag shape; it now resolves whatever `desktop-latest` points at, which is by definition the release under test. Its `contents: write` existed only to list drafts, so it drops to `contents: read`.
- `validate_channel_metadata` re-spelled the prefix inline instead of using the constant; it is now derived, and has unit tests for the first time.

## Test plan

- [x] `cargo test --bins desktop_update_policy` -- 8 passed, including 5 new `validate_channel_metadata` cases (accepts `v{version}`, rejects legacy `desktop-v`, rejects `desktop-latest` and `/releases/latest/`, rejects foreign hosts and other versions, requires url/signature/platforms)
- [x] `pytest tests/security tests/studio` -- 3075 passed; the only failures are 8 `test_chat_thread_title_cas.py` errors that reproduce unchanged on `main`
- [x] `actionlint` on all three workflows -- same 3 findings as the base commit (`queue: max`, `macos-26`), none introduced
- [ ] Dispatch on a staging repo and confirm unauthenticated 200 on every `latest.json` URL and on `desktop-latest/latest.json`, and that no `desktop-v*` tag or release remains