### PR TITLE
Studio: stop the sidebar flashing an icon rail it never collapses to

### DIFF
--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -277,13 +277,10 @@ function Sidebar({
         hasPinMode && !pinned && (collapseToZero ? "w-0" : "w-(--sidebar-width-icon)"),
       )}
       data-state={state}
-      // "zero" rather than the caller's `collapsible` when the panel collapses to nothing.
-      // The icon-rail rules keyed on data-collapsible="icon" re-centre every nav button
-      // (sidebarMenuButtonVariants), hide every label, and repaint the panel white
-      // (index.css --sidebar-surface). A sidebar collapsing to w-0 never renders that rail,
-      // but it did briefly wear its styling, which is the ghost column of icons on white
-      // seen for a frame or two on the way out and back in. No selector matches "zero", so
-      // the intermediate state no longer exists.
+      // "zero" when the panel collapses to nothing: the icon-rail rules keyed on
+      // "icon" centre every button, hide every label and repaint the panel white,
+      // which a w-0 sidebar wore for a frame on its way out. That was the ghost.
+      // No selector matches "zero", so the intermediate state no longer exists.
       data-collapsible={
         state === "collapsed"
           ? hasPinMode && collapseToZero

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -277,7 +277,20 @@ function Sidebar({
         hasPinMode && !pinned && (collapseToZero ? "w-0" : "w-(--sidebar-width-icon)"),
       )}
       data-state={state}
-      data-collapsible={state === "collapsed" ? collapsible : ""}
+      // "zero" rather than the caller's `collapsible` when the panel collapses to nothing.
+      // The icon-rail rules keyed on data-collapsible="icon" re-centre every nav button
+      // (sidebarMenuButtonVariants), hide every label, and repaint the panel white
+      // (index.css --sidebar-surface). A sidebar collapsing to w-0 never renders that rail,
+      // but it did briefly wear its styling, which is the ghost column of icons on white
+      // seen for a frame or two on the way out and back in. No selector matches "zero", so
+      // the intermediate state no longer exists.
+      data-collapsible={
+        state === "collapsed"
+          ? hasPinMode && collapseToZero
+            ? "zero"
+            : collapsible
+          : ""
+      }
       data-variant={variant}
       data-side={side}
       data-slot="sidebar"

--- a/studio/frontend/tests/sidebar-collapse-to-zero.test.ts
+++ b/studio/frontend/tests/sidebar-collapse-to-zero.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+// The desktop sidebar collapses to nothing (collapseToZero), so it never shows
+// the icon rail the web build collapses to. It used to wear the rail's styling
+// on the way there anyway: data-collapsible="icon" re-centres every nav button,
+// hides every label and repaints the panel white, and a frame that landed with
+// those applied but the width not yet collapsed drew a bare column of icons on
+// white. That is the reported collapse ghost.
+
+async function source(path: string): Promise<string> {
+  return readFile(new URL(path, import.meta.url), "utf8");
+}
+
+test("a sidebar that collapses to zero never enters icon-rail mode", async () => {
+  const sidebar = await source("../src/components/ui/sidebar.tsx");
+  const attribute = sidebar.match(/data-collapsible=\{([\s\S]*?)\n\s*\}/);
+  assert.ok(attribute, "data-collapsible is no longer written as an expression");
+  const expression = attribute[1];
+  assert.match(
+    expression,
+    /collapseToZero/,
+    "the value has to depend on collapseToZero",
+  );
+  assert.match(expression, /"zero"/, "and resolve to a value no rule matches");
+});
+
+test("no styling keys off the zero-width collapse value", async () => {
+  // The point of "zero": it is inert. Anything matching it would put the rail
+  // styling back, in a state that renders for at most a frame and is never the
+  // destination.
+  for (const path of [
+    "../src/components/ui/sidebar.tsx",
+    "../src/components/app-sidebar.tsx",
+    "../src/index.css",
+  ]) {
+    const text = await source(path);
+    assert.ok(
+      !text.includes("collapsible=zero"),
+      `${path} styles the zero-width collapse state`,
+    );
+    assert.ok(
+      !text.includes('data-collapsible="zero"]'),
+      `${path} styles the zero-width collapse state`,
+    );
+  }
+});
+
+test("the icon rail styling still exists for the web build", async () => {
+  // The web sidebar really does collapse to the rail, so the rules the desktop
+  // path now skips must stay in place for it.
+  const css = await source("../src/index.css");
+  assert.match(css, /\[data-collapsible="icon"\] \[data-sidebar="sidebar"\]/);
+  const sidebar = await source("../src/components/ui/sidebar.tsx");
+  assert.match(sidebar, /group-data-\[collapsible=icon\]:/);
+});

--- a/studio/frontend/tests/sidebar-collapse-to-zero.test.ts
+++ b/studio/frontend/tests/sidebar-collapse-to-zero.test.ts
@@ -5,12 +5,10 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-// The desktop sidebar collapses to nothing (collapseToZero), so it never shows
-// the icon rail the web build collapses to. It used to wear the rail's styling
-// on the way there anyway: data-collapsible="icon" re-centres every nav button,
-// hides every label and repaints the panel white, and a frame that landed with
-// those applied but the width not yet collapsed drew a bare column of icons on
-// white. That is the reported collapse ghost.
+// The desktop sidebar collapses to nothing, so it never shows the web build's
+// icon rail, but it used to wear that rail's styling on the way there: a frame
+// with the labels hidden, the buttons centred and the panel white but the width
+// not yet gone drew a bare column of icons. That is the reported collapse ghost.
 
 async function source(path: string): Promise<string> {
   return readFile(new URL(path, import.meta.url), "utf8");
@@ -30,9 +28,8 @@ test("a sidebar that collapses to zero never enters icon-rail mode", async () =>
 });
 
 test("no styling keys off the zero-width collapse value", async () => {
-  // The point of "zero": it is inert. Anything matching it would put the rail
-  // styling back, in a state that renders for at most a frame and is never the
-  // destination.
+  // The point of "zero" is that it is inert; anything matching it puts the rail
+  // styling back into a state that is never the destination.
   for (const path of [
     "../src/components/ui/sidebar.tsx",
     "../src/components/app-sidebar.tsx",
@@ -51,8 +48,7 @@ test("no styling keys off the zero-width collapse value", async () => {
 });
 
 test("the icon rail styling still exists for the web build", async () => {
-  // The web sidebar really does collapse to the rail, so the rules the desktop
-  // path now skips must stay in place for it.
+  // The web sidebar really does collapse to the rail, so its rules must stay.
   const css = await source("../src/index.css");
   assert.match(css, /\[data-collapsible="icon"\] \[data-sidebar="sidebar"\]/);
   const sidebar = await source("../src/components/ui/sidebar.tsx");


### PR DESCRIPTION
## The bug

Collapsing the sidebar in the desktop app flashes a ghost: for a frame or two you see a bare column of nav icons floating on a white panel with no sidebar behind them, and expanding does the mirror image. It is short but it is visible on every toggle.

## Why

The desktop sidebar collapses to nothing (`collapseToZero`, `app-sidebar.tsx`), so it never renders the icon rail the web build collapses to. It wore that rail's styling on the way there anyway. `data-collapsible` was set to the caller's `collapsible` for any collapsed state, which on this path is `"icon"`, and that value drives:

- `sidebarMenuButtonVariants` in `sidebar.tsx`: `group-data-[collapsible=icon]:!w-[32px]` plus `mx-auto`, so every nav button shrinks and re-centres
- the same variant's `group-data-[collapsible=icon]:[&>span]:hidden`, so every label disappears
- `index.css`: `[data-collapsible="icon"] [data-sidebar="sidebar"] { --sidebar-surface: #ffffff }`, so the panel repaints white

A frame that lands with those applied and the width not yet collapsed is exactly the reported ghost: centred icons, no labels, white panel at full width.

## The fix

Write `"zero"` instead when the panel collapses to zero width. No selector matches it, so the intermediate state stops existing rather than being raced against. The web rail is untouched: there `"icon"` is the destination, not a state on the way to one.

## Verifying it

The frame is a paint-level race, so it was staged by hand rather than waited for: collapse the sidebar, then put the widths back without touching the attribute the app wrote, and photograph what that combination renders.

- before: `data-collapsible` is `"icon"`, and the staged frame is the ghost, centred icons on a white full-width panel, matching the frame from the report
- after: `data-collapsible` is `"zero"`, and the same staged frame is an ordinary expanded sidebar

`tests/sidebar-collapse-to-zero.test.ts` covers it from the other side: the zero-width collapse never yields `"icon"`, nothing styles `"zero"`, and the rail rules the web build needs are still there.

`npm run typecheck` and `npm test` (1492 tests) pass.