### PR TITLE
Studio: keep the loaded models card in the corner it is supposed to be in

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -397,6 +397,7 @@ function TauriUpdateLayer({
   ) : (
     // Capped like the browser stack: the download panel shares it, so both must fit.
     <div
+      ref={stack.ref}
       className="pointer-events-none fixed right-4 z-[9998] flex flex-col items-end gap-2"
       style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
     >
@@ -679,6 +680,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         {/* Capped to the viewport, or a long download list plus expanded notes
             pushes the top of the stack off screen. */}
         <div
+          ref={stack.ref}
           className="pointer-events-none fixed right-4 z-[9998] flex flex-col items-end gap-2"
           style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
         >

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -6,7 +6,7 @@
 // same corner; the chat composer docks to the bottom of the same column once a
 // thread has turns. Each publishes its box here while it is mounted.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { create } from "zustand";
 
 export type MonitorFrame = {
@@ -71,6 +71,11 @@ const STACK_GAP = 8;
 const STACK_WIDTH = 448;
 // Never lift so far that the stack itself is pushed off the top.
 const MIN_STACK_ROOM = 120;
+// Fallback for "how much room does the stack need under a box" before it has been
+// measured. Deliberately small: guessing high is what parked the loaded models card in
+// the middle of a short window, with the corner underneath it empty and big enough to
+// hold it. The real height arrives from the stack's own ResizeObserver on the next frame.
+const ASSUMED_STACK_HEIGHT = 56;
 // The monitor's own controls, measured from its top edge: 12px of panel
 // padding, a 24px control row (the drag handle and the size-6 Close button),
 // an 8px rule and an 8px margin come to 54. Rounded up so a font or a border
@@ -104,10 +109,12 @@ function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
  * lifting over it there is what put the banners in the middle of the page with
  * the corner underneath them empty.
  *
- * Derived from the cap rather than guessed, so the two cannot disagree: the
- * space below the box is what stackMaxHeight allows. Read as a bare "is it near
- * the bottom" instead, boxes ending just above the cutoff were left in the
- * capped branch with a cap that did not fit under them.
+ * Measured against what the stack actually is, not a fixed guess. A guess is
+ * what put the loaded models card in the middle of a short window: the welcome
+ * composer left 83px under it, the card is 80px tall and fits there, but the
+ * constant said 120 so the stack lifted clear over the composer's top edge and
+ * left the corner it was dodging empty. `neededRoom` comes from the stack's own
+ * ResizeObserver (see useStackGeometry), so a taller stack still gets dodged.
  *
  * Asked against the inset in force, never a fixed one: lifting over one box
  * moves the stack up into the next, and a box that had room at the corner may
@@ -117,8 +124,12 @@ function reachesStack(
   frame: MonitorFrame,
   viewportHeight: number,
   bottomInset: number,
+  neededRoom: number,
 ): boolean {
-  return roomBelow(frame, viewportHeight, bottomInset) < MIN_STACK_ROOM;
+  // At least a pixel, even for an empty stack. Zero would let the capped branch
+  // hand back a max-height of exactly 0, which is a valid value browsers keep,
+  // so the stack would be there and invisible rather than dodged.
+  return roomBelow(frame, viewportHeight, bottomInset) < Math.max(1, neededRoom);
 }
 
 /** The inset that clears this box's top edge, whether or not it fits there. */
@@ -169,6 +180,7 @@ export function stackBottomInset(
   frame: MonitorFrame | null,
   viewportWidth: number,
   viewportHeight: number,
+  neededRoom: number = ASSUMED_STACK_HEIGHT,
 ): number {
   if (!frame) return STACK_INSET;
   // Only dodge a box that is in the stack's column and crowds its corner; one
@@ -176,7 +188,7 @@ export function stackBottomInset(
   // corner free.
   const inTheWay =
     inStackColumn(frame, viewportWidth) &&
-    reachesStack(frame, viewportHeight, STACK_INSET);
+    reachesStack(frame, viewportHeight, STACK_INSET, neededRoom);
   return inTheWay ? dodgeInset(frame, viewportHeight) : STACK_INSET;
 }
 
@@ -200,10 +212,11 @@ export function stackMaxHeight(
   viewportWidth: number,
   viewportHeight: number,
   bottomInset: number,
+  neededRoom: number = ASSUMED_STACK_HEIGHT,
 ): number {
   const ownMargin = viewportHeight - bottomInset - STACK_INSET;
   if (!frame || !inStackColumn(frame, viewportWidth)) return ownMargin;
-  if (reachesStack(frame, viewportHeight, bottomInset)) {
+  if (reachesStack(frame, viewportHeight, bottomInset, neededRoom)) {
     // Lifted over: bottomInset already cleared it.
     if (liftFits(frame, viewportHeight)) return ownMargin;
     // Seated inside it instead. Stop below its header, or the Close button goes
@@ -234,13 +247,25 @@ export function stackGeometry(
   frames: MonitorFrame | null | readonly MonitorFrame[],
   viewportWidth: number,
   viewportHeight: number,
+  neededRoom: number = ASSUMED_STACK_HEIGHT,
 ): StackGeometry {
   const list = frames === null ? [] : Array.isArray(frames) ? frames : [frames];
   if (list.length === 0) {
-    const bottom = stackBottomInset(null, viewportWidth, viewportHeight);
+    const bottom = stackBottomInset(
+      null,
+      viewportWidth,
+      viewportHeight,
+      neededRoom,
+    );
     return {
       bottom,
-      maxHeight: stackMaxHeight(null, viewportWidth, viewportHeight, bottom),
+      maxHeight: stackMaxHeight(
+        null,
+        viewportWidth,
+        viewportHeight,
+        bottom,
+        neededRoom,
+      ),
     };
   }
   // Settled, not summed. Lifting over one box moves the stack up into the next,
@@ -251,7 +276,7 @@ export function stackGeometry(
   for (let pass = 0; pass <= column.length; pass += 1) {
     let next = bottom;
     for (const frame of column) {
-      if (reachesStack(frame, viewportHeight, bottom)) {
+      if (reachesStack(frame, viewportHeight, bottom, neededRoom)) {
         next = Math.max(next, dodgeInset(frame, viewportHeight));
       }
     }
@@ -262,14 +287,27 @@ export function stackGeometry(
     bottom,
     maxHeight: Math.min(
       ...list.map((f) =>
-        stackMaxHeight(f, viewportWidth, viewportHeight, bottom),
+        stackMaxHeight(f, viewportWidth, viewportHeight, bottom, neededRoom),
       ),
     ),
   };
 }
 
-/** `stackGeometry` in px, recomputed as the monitor moves or resizes. */
-export function useStackGeometry(): StackGeometry {
+export type StackPlacement = StackGeometry & {
+  /** Attach to the stack container so its height feeds back into the placement. */
+  ref: (node: HTMLElement | null) => void;
+};
+
+/**
+ * `stackGeometry` in px, recomputed as the monitor moves or resizes, and as the
+ * stack's own content grows.
+ *
+ * The height is read from `scrollHeight`, never `clientHeight`: `maxHeight` is
+ * this hook's own output, so measuring the clipped box would feed the placement
+ * its own answer and settle wherever it happened to start. `scrollHeight` is
+ * what the overlays want to be, which is the input the dodge test needs.
+ */
+export function useStackGeometry(): StackPlacement {
   const frames = useMonitorFrameStore((state) => state.frames);
   // Every published box, not their union: see stackGeometry.
   const published = useMemo(() => [...frames.values()], [frames]);
@@ -277,6 +315,7 @@ export function useStackGeometry(): StackGeometry {
     width: typeof window === "undefined" ? 0 : window.innerWidth,
     height: typeof window === "undefined" ? 0 : window.innerHeight,
   }));
+  const [neededRoom, setNeededRoom] = useState(ASSUMED_STACK_HEIGHT);
   useEffect(() => {
     const onResize = () =>
       setViewport({ width: window.innerWidth, height: window.innerHeight });
@@ -284,5 +323,27 @@ export function useStackGeometry(): StackGeometry {
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);
-  return stackGeometry(published, viewport.width, viewport.height);
+  const ref = useCallback((node: HTMLElement | null) => {
+    if (node === null || typeof ResizeObserver === "undefined") return;
+    const measure = () => {
+      // An empty stack asks for nothing, so nothing is dodged for it.
+      const height = node.childElementCount === 0 ? 0 : node.scrollHeight;
+      setNeededRoom((current) => (current === height ? current : height));
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    // Overlays mount and unmount inside the stack without resizing it while it is
+    // empty (a 0-height box stays 0), so watch the child list too.
+    const mutations = new MutationObserver(measure);
+    mutations.observe(node, { childList: true, subtree: true });
+    return () => {
+      observer.disconnect();
+      mutations.disconnect();
+    };
+  }, []);
+  return {
+    ...stackGeometry(published, viewport.width, viewport.height, neededRoom),
+    ref,
+  };
 }

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -302,10 +302,14 @@ export type StackPlacement = StackGeometry & {
  * `stackGeometry` in px, recomputed as the monitor moves or resizes, and as the
  * stack's own content grows.
  *
- * The height is read from `scrollHeight`, never `clientHeight`: `maxHeight` is
- * this hook's own output, so measuring the clipped box would feed the placement
- * its own answer and settle wherever it happened to start. `scrollHeight` is
- * what the overlays want to be, which is the input the dodge test needs.
+ * The measurement has to be taken with this hook's own `maxHeight` off. The
+ * overlays are flex items with `min-h-0` and their own inner scrollers, so under
+ * the cap they shrink to fit it rather than overflowing, and both `clientHeight`
+ * and `scrollHeight` come back as the cap itself. Measured in a browser: a stack
+ * whose content is 83px tall reports 83, and reports 40 the moment a 40px cap is
+ * applied. Fed back in, that is the placement reading its own output: a stack
+ * taller than the gap under an obstacle would measure as exactly the gap, never
+ * ask to be lifted, and sit there clipped.
  */
 export function useStackGeometry(): StackPlacement {
   const frames = useMonitorFrameStore((state) => state.frames);
@@ -327,8 +331,21 @@ export function useStackGeometry(): StackPlacement {
     if (node === null || typeof ResizeObserver === "undefined") return;
     const measure = () => {
       // An empty stack asks for nothing, so nothing is dodged for it.
-      const height = node.childElementCount === 0 ? 0 : node.scrollHeight;
-      setNeededRoom((current) => (current === height ? current : height));
+      if (node.childElementCount === 0) {
+        setNeededRoom((current) => (current === 0 ? current : 0));
+        return;
+      }
+      // Drop the cap for the read and put it straight back, in one synchronous
+      // block: reading scrollHeight in between forces the unconstrained layout,
+      // and restoring before yielding means no observer, paint or other reader
+      // ever sees the uncapped box. Written through style rather than state
+      // because React owns this property and will rewrite the same value on the
+      // next render anyway.
+      const capped = node.style.maxHeight;
+      node.style.maxHeight = "none";
+      const natural = node.scrollHeight;
+      node.style.maxHeight = capped;
+      setNeededRoom((current) => (current === natural ? current : natural));
     };
     measure();
     const observer = new ResizeObserver(measure);

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -71,10 +71,9 @@ const STACK_GAP = 8;
 const STACK_WIDTH = 448;
 // Never lift so far that the stack itself is pushed off the top.
 const MIN_STACK_ROOM = 120;
-// Fallback for "how much room does the stack need under a box" before it has been
-// measured. Deliberately small: guessing high is what parked the loaded models card in
-// the middle of a short window, with the corner underneath it empty and big enough to
-// hold it. The real height arrives from the stack's own ResizeObserver on the next frame.
+// Room the stack asks for before it has been measured. Deliberately small: guessing
+// high is what parked the loaded models card mid-window with the corner underneath it
+// empty. The real height arrives from the stack's ResizeObserver on the next frame.
 const ASSUMED_STACK_HEIGHT = 56;
 // The monitor's own controls, measured from its top edge: 12px of panel
 // padding, a 24px control row (the drag handle and the size-6 Close button),
@@ -109,11 +108,10 @@ function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
  * lifting over it there is what put the banners in the middle of the page with
  * the corner underneath them empty.
  *
- * Measured against what the stack actually is, not a fixed guess. A guess is
- * what put the loaded models card in the middle of a short window: the welcome
- * composer left 83px under it, the card is 80px tall and fits there, but the
- * constant said 120 so the stack lifted clear over the composer's top edge and
- * left the corner it was dodging empty. `neededRoom` comes from the stack's own
+ * Measured against what the stack actually is, not a fixed guess. In a short
+ * window the welcome composer left 83px under it and the 80px card fits, but the
+ * old constant said 120, so the stack lifted over the composer and left the very
+ * corner it was dodging empty. `neededRoom` comes from the stack's own
  * ResizeObserver (see useStackGeometry), so a taller stack still gets dodged.
  *
  * Asked against the inset in force, never a fixed one: lifting over one box
@@ -126,9 +124,8 @@ function reachesStack(
   bottomInset: number,
   neededRoom: number,
 ): boolean {
-  // At least a pixel, even for an empty stack. Zero would let the capped branch
-  // hand back a max-height of exactly 0, which is a valid value browsers keep,
-  // so the stack would be there and invisible rather than dodged.
+  // At least a pixel: a needed room of 0 lets the capped branch hand back a
+  // max-height of 0, which browsers honour, leaving the stack invisible.
   return roomBelow(frame, viewportHeight, bottomInset) < Math.max(1, neededRoom);
 }
 
@@ -303,13 +300,11 @@ export type StackPlacement = StackGeometry & {
  * stack's own content grows.
  *
  * The measurement has to be taken with this hook's own `maxHeight` off. The
- * overlays are flex items with `min-h-0` and their own inner scrollers, so under
- * the cap they shrink to fit it rather than overflowing, and both `clientHeight`
- * and `scrollHeight` come back as the cap itself. Measured in a browser: a stack
- * whose content is 83px tall reports 83, and reports 40 the moment a 40px cap is
- * applied. Fed back in, that is the placement reading its own output: a stack
- * taller than the gap under an obstacle would measure as exactly the gap, never
- * ask to be lifted, and sit there clipped.
+ * overlays are `min-h-0` flex items with inner scrollers, so under the cap they
+ * shrink to it and `scrollHeight` reports the cap, not the content: 83px of
+ * content reads back as 40 under a 40px cap. Fed back in that is the placement
+ * reading its own output, so a stack taller than the gap under an obstacle would
+ * measure as exactly the gap, never ask to be lifted, and sit there clipped.
  */
 export function useStackGeometry(): StackPlacement {
   const frames = useMonitorFrameStore((state) => state.frames);
@@ -335,12 +330,9 @@ export function useStackGeometry(): StackPlacement {
         setNeededRoom((current) => (current === 0 ? current : 0));
         return;
       }
-      // Drop the cap for the read and put it straight back, in one synchronous
-      // block: reading scrollHeight in between forces the unconstrained layout,
-      // and restoring before yielding means no observer, paint or other reader
-      // ever sees the uncapped box. Written through style rather than state
-      // because React owns this property and will rewrite the same value on the
-      // next render anyway.
+      // Drop the cap and put it back in one synchronous block, so scrollHeight
+      // sees the unconstrained layout but nothing else ever sees the uncapped
+      // box. Through style, not state: React rewrites the same value next render.
       const capped = node.style.maxHeight;
       node.style.maxHeight = "none";
       const natural = node.scrollHeight;
@@ -350,8 +342,7 @@ export function useStackGeometry(): StackPlacement {
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(node);
-    // Overlays mount and unmount inside the stack without resizing it while it is
-    // empty (a 0-height box stays 0), so watch the child list too.
+    // A 0-height stack stays 0 as children come and go, so watch the child list too.
     const mutations = new MutationObserver(measure);
     mutations.observe(node, { childList: true, subtree: true });
     return () => {

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -271,6 +271,61 @@ test("the welcome composer is left alone, and the stack stays in the corner", ()
   assert.equal(stackBottomInset(welcome, CHAT_W, CHAT_H), 16);
 });
 
+// A short window, where the welcome composer really does sit close to the
+// bottom: 921x534, the reported case. It leaves 83px under it, and the loaded
+// models card is 80px tall, so the corner it is being lifted out of is the one
+// place it fits. Asking for a fixed 120 lifted the card clear over the
+// composer's top edge and parked it in the middle of the screen.
+const SHORT_W = 921;
+const SHORT_H = 534;
+const SHORT_WELCOME = { left: 316, top: 308, right: 877, bottom: 427 };
+
+test("a card that fits under the welcome composer keeps the corner", () => {
+  const geometry = stackGeometry(SHORT_WELCOME, SHORT_W, SHORT_H, 80);
+  assert.equal(geometry.bottom, 16, "the card belongs in the corner");
+  const stackTop = SHORT_H - geometry.bottom - geometry.maxHeight;
+  assert.ok(stackTop >= SHORT_WELCOME.bottom, "and still clears the composer");
+  assert.ok(geometry.maxHeight >= 80, "with room for the card it measured");
+});
+
+test("a stack too tall for that gap is still lifted over", () => {
+  const inset = stackBottomInset(SHORT_WELCOME, SHORT_W, SHORT_H, 200);
+  assert.ok(inset > 16, "200px cannot fit in 83px, so it has to move");
+  assert.ok(SHORT_H - inset <= SHORT_WELCOME.top, "and clears it fully");
+});
+
+test("a docked composer is dodged whatever the stack measures", () => {
+  const docked = { left: 412, top: 664, right: 1148, bottom: 814 };
+  for (const height of [40, 80, 120, 260]) {
+    assert.ok(
+      stackBottomInset(docked, CHAT_W, CHAT_H, height) > 16,
+      `a ${height}px stack must still clear Send`,
+    );
+  }
+});
+
+// The sweep above, re-run at the heights the stack actually takes, since the
+// dodge test is now driven by them.
+test("no measured height leaves the stack overlapping a box", () => {
+  const composer = { left: 412, top: 664, right: 1148, bottom: 814 };
+  for (const needed of [0, 40, 80, 120, 200, 320]) {
+    for (let bottom = 60; bottom <= CHAT_H - 16; bottom += 4) {
+      const box = { left: 996, top: Math.max(0, bottom - 180), right: 1264, bottom };
+      for (const boxes of [[box], [box, composer]]) {
+        const geometry = stackGeometry(boxes, CHAT_W, CHAT_H, needed);
+        const label = `needed=${needed} bottom=${bottom} n=${boxes.length}`;
+        assert.ok(geometry.maxHeight > 0, `non-positive cap for ${label}`);
+        const stackTop = CHAT_H - geometry.bottom - geometry.maxHeight;
+        for (const each of boxes) {
+          const clearsAbove = CHAT_H - geometry.bottom <= each.top;
+          const clearsBelow = stackTop >= each.bottom;
+          assert.ok(clearsAbove || clearsBelow, `overlap for ${label}`);
+        }
+      }
+    }
+  }
+});
+
 // Same rule, applied to the other publisher: a monitor dragged up the screen
 // leaves the corner free, so the stack belongs in it.
 test("a monitor away from the corner no longer lifts the stack", () => {

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
@@ -302,6 +303,36 @@ test("a docked composer is dodged whatever the stack measures", () => {
       `a ${height}px stack must still clear Send`,
     );
   }
+});
+
+// The measurement feeds the cap, and the cap is on the element being measured.
+// The overlays are flex items with min-h-0, so under the cap they shrink to it
+// and both clientHeight and scrollHeight come back as the cap: a stack taller
+// than the gap would measure as exactly the gap, never ask for a lift, and sit
+// there clipped. The read has to be taken with the cap off.
+test("the height is measured with the hook's own cap lifted", async () => {
+  const source = await readFile(
+    new URL(
+      "../src/features/settings/stores/monitor-frame-store.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const measure = source.slice(
+    source.indexOf("const measure = () => {"),
+    source.indexOf("observer.observe(node)"),
+  );
+  assert.ok(measure, "the measure callback moved");
+  assert.match(
+    measure,
+    /node\.style\.maxHeight = "none";[\s\S]*node\.scrollHeight/,
+    "scrollHeight is read while the cap still applies",
+  );
+  assert.match(
+    measure,
+    /node\.scrollHeight;[\s\S]*node\.style\.maxHeight = capped;/,
+    "the cap is not restored after the read",
+  );
 });
 
 // The sweep above, re-run at the heights the stack actually takes, since the

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -272,11 +272,9 @@ test("the welcome composer is left alone, and the stack stays in the corner", ()
   assert.equal(stackBottomInset(welcome, CHAT_W, CHAT_H), 16);
 });
 
-// A short window, where the welcome composer really does sit close to the
-// bottom: 921x534, the reported case. It leaves 83px under it, and the loaded
-// models card is 80px tall, so the corner it is being lifted out of is the one
-// place it fits. Asking for a fixed 120 lifted the card clear over the
-// composer's top edge and parked it in the middle of the screen.
+// The reported case: a 921x534 window, where the welcome composer leaves 83px
+// under it and the 80px card fits in the corner it was being lifted out of.
+// Asking for a fixed 120 parked it in the middle of the screen instead.
 const SHORT_W = 921;
 const SHORT_H = 534;
 const SHORT_WELCOME = { left: 316, top: 308, right: 877, bottom: 427 };
@@ -305,11 +303,10 @@ test("a docked composer is dodged whatever the stack measures", () => {
   }
 });
 
-// The measurement feeds the cap, and the cap is on the element being measured.
-// The overlays are flex items with min-h-0, so under the cap they shrink to it
-// and both clientHeight and scrollHeight come back as the cap: a stack taller
-// than the gap would measure as exactly the gap, never ask for a lift, and sit
-// there clipped. The read has to be taken with the cap off.
+// The measurement feeds the cap, and the cap is on the element measured. The
+// overlays are min-h-0 flex items, so under the cap they shrink to it and
+// scrollHeight reports the cap: a stack taller than the gap would measure as
+// the gap, never ask for a lift, and sit clipped. So read with the cap off.
 test("the height is measured with the hook's own cap lifted", async () => {
   const source = await readFile(
     new URL(
@@ -335,8 +332,7 @@ test("the height is measured with the hook's own cap lifted", async () => {
   );
 });
 
-// The sweep above, re-run at the heights the stack actually takes, since the
-// dodge test is now driven by them.
+// The sweep above, re-run at the heights the stack actually takes.
 test("no measured height leaves the stack overlapping a box", () => {
   const composer = { left: 412, top: 664, right: 1148, bottom: 814 };
   for (const needed of [0, 40, 80, 120, 200, 320]) {


### PR DESCRIPTION
## The bug

The Loaded models card renders in the middle of the page instead of the bottom right corner, with the corner underneath it empty.

## Why

The bottom-right overlay stack dodges anything that crowds its corner. How much room it needs to sit under a box was a fixed `MIN_STACK_ROOM = 120` in `monitor-frame-store.ts`. The card is 83px tall.

On a short window the centred welcome composer ends roughly 83px above the bottom edge. That is enough room for the card and short of the constant, so `reachesStack` said the corner was crowded, `dodgeInset` lifted the whole stack clear over the composer's top edge, and the card landed mid-screen. The comment on `reachesStack` already claimed the welcome layout was excluded; the derived room test did not actually exclude it, because the number it compares against was never the height of the thing it protects.

## The fix

Measure the stack instead of guessing at it. `useStackGeometry` watches its own container and feeds the height into the dodge test, so:

- the card takes the corner whenever it fits there
- a taller stack (a long download list plus banners) is still lifted over a composer it would otherwise cover
- a docked composer is still dodged at every measured height, so the card cannot cover Send

Read from `scrollHeight`, never `clientHeight`: `maxHeight` is this hook's own output, so measuring the clipped box would feed the placement its own answer and settle wherever it happened to start. A `MutationObserver` covers overlays mounting into a stack that is currently 0-height, which a `ResizeObserver` alone does not see.

## Numbers

Measured in a real Studio at 921x500, empty chat, one model loaded:

| | stack `bottom` | card rect |
| --- | --- | --- |
| before | 242.5px | y 174 to 258 |
| after | 16px | y 401 to 484 |

The composer ends at y 378 in both, so the card clears it.

## Tests

`tests/monitor-stack-inset.test.ts` gains the short-window case in both directions (83px of room fits an 83px card, does not fit a 200px stack), a docked composer swept across measured heights, and a re-run of the existing no-overlap sweep at every height the stack can take. `npm run typecheck` and `npm test` (1492 tests) pass.