### PR TITLE
Studio: say what the Train row is waiting for while it spins

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -229,6 +229,9 @@ type NavRowDef = {
   // The capability that decides `disabled` has not been measured yet. A row in this state is
   // neither enabled-looking nor blacked out: resolveNavRowState renders it with the spinner.
   pending?: boolean;
+  // What that spinning row says on hover. Detection can take minutes on a cold host, so the
+  // spinner needs to name what it is waiting for.
+  pendingTooltip?: string;
   badge?: string;
   onClick: () => void;
   onIntent?: () => void;
@@ -1097,6 +1100,7 @@ export function AppSidebar() {
       tooltip: trainDisabledHint,
       spinner: trainingInProgress,
       pending: capabilitiesUnknown,
+      pendingTooltip: t("shell.navigation.trainChecking"),
       onClick: () => {
         if (chatOnlyMeasured) return;
         navigate({ to: "/studio" });
@@ -1114,6 +1118,7 @@ export function AppSidebar() {
       disabled: chatOnlyMeasured,
       tooltip: videoDisabledHint,
       pending: capabilitiesUnknown,
+      pendingTooltip: t("shell.navigation.videoChecking"),
       onClick: () => {
         navigate({ to: "/video" });
         closeMobileIfOpen();

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -229,8 +229,7 @@ type NavRowDef = {
   // The capability that decides `disabled` has not been measured yet. A row in this state is
   // neither enabled-looking nor blacked out: resolveNavRowState renders it with the spinner.
   pending?: boolean;
-  // What that spinning row says on hover. Detection can take minutes on a cold host, so the
-  // spinner needs to name what it is waiting for.
+  // What that spinning row says on hover; detection can take minutes on a cold host.
   pendingTooltip?: string;
   badge?: string;
   onClick: () => void;
@@ -369,9 +368,8 @@ function NavItem({
   testId?: string;
   // Overrides the hover tooltip; explains why a disabled item is greyed out.
   tooltip?: string;
-  // Show that tooltip on the expanded row too. An enabled row normally only shows one on
-  // the collapsed rail, where it stands in for the hidden label; a row that is still being
-  // measured has something to say the expanded row cannot show any other way.
+  // Show that tooltip on the expanded row too, not just the collapsed rail where it
+  // stands in for the hidden label.
   alwaysTooltip?: boolean;
   // Trailing "New" pill text.
   badge?: string;
@@ -562,9 +560,8 @@ function MoreMenuItem({
   return (
     <DropdownMenuItem
       disabled={disabled}
-      // Whenever there is one. It used to be gated on `disabled`, on the assumption that a
-      // tooltip only ever explains a grey-out; a row that is still being measured is enabled
-      // and has something to say, and dropped it.
+      // Whenever there is one: gated on `disabled` it dropped the tooltip of a row that is
+      // still being measured, which is enabled and has something to say.
       title={tooltip}
       onSelect={onSelect}
       onPointerEnter={disabled ? undefined : onIntent}

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -348,6 +348,7 @@ function NavItem({
   className,
   spinner,
   tooltip,
+  alwaysTooltip,
   onIntent,
   badge,
   overlay,
@@ -368,6 +369,10 @@ function NavItem({
   testId?: string;
   // Overrides the hover tooltip; explains why a disabled item is greyed out.
   tooltip?: string;
+  // Show that tooltip on the expanded row too. An enabled row normally only shows one on
+  // the collapsed rail, where it stands in for the hidden label; a row that is still being
+  // measured has something to say the expanded row cannot show any other way.
+  alwaysTooltip?: boolean;
   // Trailing "New" pill text.
   badge?: string;
   // Absolutely-positioned extras over the row, e.g. a disclosure chevron.
@@ -378,6 +383,7 @@ function NavItem({
       <div className="relative">
         <SidebarMenuButton
           tooltip={tooltip ?? label}
+          alwaysTooltip={alwaysTooltip && Boolean(tooltip)}
           disabled={disabled}
           onClick={onClick}
           onPointerEnter={disabled ? undefined : onIntent}
@@ -556,7 +562,10 @@ function MoreMenuItem({
   return (
     <DropdownMenuItem
       disabled={disabled}
-      title={disabled ? tooltip : undefined}
+      // Whenever there is one. It used to be gated on `disabled`, on the assumption that a
+      // tooltip only ever explains a grey-out; a row that is still being measured is enabled
+      // and has something to say, and dropped it.
+      title={tooltip}
       onSelect={onSelect}
       onPointerEnter={disabled ? undefined : onIntent}
       onFocus={disabled ? undefined : onIntent}
@@ -2074,6 +2083,7 @@ export function AppSidebar() {
                     }
                     disabled={rowState.disabled}
                     tooltip={rowState.tooltip}
+                    alwaysTooltip={rowState.pending}
                     spinner={rowState.spinner}
                     testId={`nav-row-${id}`}
                     onClick={row.onClick}

--- a/studio/frontend/src/components/nav-row-state.ts
+++ b/studio/frontend/src/components/nav-row-state.ts
@@ -29,9 +29,21 @@ export function resolveNavRowState(row: NavRowState): {
   disabled?: boolean;
   tooltip?: string;
   spinner?: boolean;
+  /** Whether this tooltip belongs to a pending row, which both renderers hide by default. */
+  pending: boolean;
 } {
   if (row.pending) {
-    return { disabled: false, tooltip: row.pendingTooltip, spinner: true };
+    return {
+      disabled: false,
+      tooltip: row.pendingTooltip,
+      spinner: true,
+      pending: true,
+    };
   }
-  return { disabled: row.disabled, tooltip: row.tooltip, spinner: row.spinner };
+  return {
+    disabled: row.disabled,
+    tooltip: row.tooltip,
+    spinner: row.spinner,
+    pending: false,
+  };
 }

--- a/studio/frontend/src/components/nav-row-state.ts
+++ b/studio/frontend/src/components/nav-row-state.ts
@@ -21,9 +21,8 @@ export type NavRowState = {
  * on a page that shows its own loading state. Both render sites (the inline rows and the More
  * flyout) go through here so they cannot drift.
  *
- * The spinner alone does not say what is being waited on, and detection can take minutes on a
- * cold host, so a pending row carries its own tooltip rather than the disabled hint (which
- * would state a verdict that has not been reached) or nothing (which reads as a hung row).
+ * A pending row carries its own tooltip rather than the disabled hint, which would state a
+ * verdict nobody has reached, or nothing, which reads as a hung row.
  */
 export function resolveNavRowState(row: NavRowState): {
   disabled?: boolean;

--- a/studio/frontend/src/components/nav-row-state.ts
+++ b/studio/frontend/src/components/nav-row-state.ts
@@ -9,6 +9,8 @@ export type NavRowState = {
   tooltip?: string;
   spinner?: boolean;
   pending?: boolean;
+  /** What the row says while `pending`. Falls back to the row's own label. */
+  pendingTooltip?: string;
 };
 
 /**
@@ -18,6 +20,10 @@ export type NavRowState = {
  * the row stays enabled and spins instead: the user sees "still checking", and the click lands
  * on a page that shows its own loading state. Both render sites (the inline rows and the More
  * flyout) go through here so they cannot drift.
+ *
+ * The spinner alone does not say what is being waited on, and detection can take minutes on a
+ * cold host, so a pending row carries its own tooltip rather than the disabled hint (which
+ * would state a verdict that has not been reached) or nothing (which reads as a hung row).
  */
 export function resolveNavRowState(row: NavRowState): {
   disabled?: boolean;
@@ -25,7 +31,7 @@ export function resolveNavRowState(row: NavRowState): {
   spinner?: boolean;
 } {
   if (row.pending) {
-    return { disabled: false, tooltip: undefined, spinner: true };
+    return { disabled: false, tooltip: row.pendingTooltip, spinner: true };
   }
   return { disabled: row.disabled, tooltip: row.tooltip, spinner: row.spinner };
 }

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -651,12 +651,15 @@ function SidebarMenuButton({
   variant = "default",
   size = "default",
   tooltip,
+  alwaysTooltip = false,
   className,
   ...props
 }: React.ComponentProps<"button"> & {
   asChild?: boolean
   isActive?: boolean
   tooltip?: string | React.ComponentProps<typeof TooltipContent>
+  /** Show the tooltip while expanded and enabled, not only on the collapsed rail. */
+  alwaysTooltip?: boolean
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const Comp = asChild ? Slot.Root : "button"
   const { isMobile, state } = useSidebar()
@@ -703,7 +706,10 @@ function SidebarMenuButton({
         align="center"
         // Enabled items only show the tooltip when collapsed (icon labels);
         // a disabled item shows it while expanded too, since it explains why.
-        hidden={isMobile || (!isDisabled && state !== "collapsed")}
+        // alwaysTooltip is for the third case: an enabled row whose tooltip is
+        // not a label repeat but a status the expanded row has no other way to
+        // show, e.g. a capability still being measured.
+        hidden={isMobile || (!isDisabled && !alwaysTooltip && state !== "collapsed")}
         {...tooltip}
       />
     </Tooltip>

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -706,9 +706,8 @@ function SidebarMenuButton({
         align="center"
         // Enabled items only show the tooltip when collapsed (icon labels);
         // a disabled item shows it while expanded too, since it explains why.
-        // alwaysTooltip is for the third case: an enabled row whose tooltip is
-        // not a label repeat but a status the expanded row has no other way to
-        // show, e.g. a capability still being measured.
+        // alwaysTooltip is the third case: an enabled row whose tooltip is a
+        // status, not a label repeat, e.g. a capability still being measured.
         hidden={isMobile || (!isDisabled && !alwaysTooltip && state !== "collapsed")}
         {...tooltip}
       />

--- a/studio/frontend/src/features/studio/studio-page.tsx
+++ b/studio/frontend/src/features/studio/studio-page.tsx
@@ -157,10 +157,9 @@ export function StudioPage(): ReactElement {
   // verdict is unknown and writes it to this same store, so no second poll is needed here.
   const showTrainingHydrating =
     capabilitiesUnknown || (!hasHydratedRuntime && isHydratingRuntime);
-  // Two very different waits share this panel. Hardware detection is a cold `import torch`
-  // that can run for minutes, so it says so, the way the Video page does; a hydrating runtime
-  // is quick and keeps the runtime wording. "Loading training runtime..." on a machine that is
-  // still being measured reads as a hang, which is the whole complaint about this wait.
+  // Two waits share this panel. Hardware detection is a cold `import torch` that can run for
+  // minutes and says so, the way the Video page does; a hydrating runtime is quick and keeps
+  // the runtime wording, which on a machine still being measured just reads as a hang.
   const hydratingMessage = capabilitiesUnknown
     ? t("studio.checkingSupport")
     : t("studio.loadingRuntime");

--- a/studio/frontend/src/features/studio/studio-page.tsx
+++ b/studio/frontend/src/features/studio/studio-page.tsx
@@ -157,6 +157,13 @@ export function StudioPage(): ReactElement {
   // verdict is unknown and writes it to this same store, so no second poll is needed here.
   const showTrainingHydrating =
     capabilitiesUnknown || (!hasHydratedRuntime && isHydratingRuntime);
+  // Two very different waits share this panel. Hardware detection is a cold `import torch`
+  // that can run for minutes, so it says so, the way the Video page does; a hydrating runtime
+  // is quick and keeps the runtime wording. "Loading training runtime..." on a machine that is
+  // still being measured reads as a hang, which is the whole complaint about this wait.
+  const hydratingMessage = capabilitiesUnknown
+    ? t("studio.checkingSupport")
+    : t("studio.loadingRuntime");
   const showHistoryBack = activeTab === "history" && !!selectedHistoryRunId;
 
   return (
@@ -217,7 +224,7 @@ export function StudioPage(): ReactElement {
             {showTrainingHydrating ? (
               <div className="flex items-center gap-3 rounded-2xl border border-border/60 p-8 text-sm text-muted-foreground">
                 <Spinner className="size-4 shrink-0" />
-                {t("studio.loadingRuntime")}
+                {hydratingMessage}
               </div>
             ) : (
               <>

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -83,6 +83,8 @@ export const ar = {
       recipes: "الوصفات",
       images: "الصور",
       video: "الفيديو",
+      trainChecking: "جارٍ التحقق من دعم هذا الجهاز للتدريب...",
+      videoChecking: "جارٍ التحقق من دعم هذا الجهاز للفيديو...",
       more: "المزيد",
       customizeSidebar: "تخصيص الشريط الجانبي",
       newBadge: "جديد",
@@ -1363,6 +1365,7 @@ export const ar = {
       history: "السجل",
     },
     loadingRuntime: "جارٍ تحميل بيئة تشغيل التدريب...",
+    checkingSupport: "جارٍ التحقق من دعم هذا الجهاز للتدريب...",
     backToHistory: "العودة إلى السجل",
     sections: {
       model: "النموذج",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -86,6 +86,8 @@ export const de = {
       recipes: "Rezepte",
       images: "Bilder",
       video: "Video",
+      trainChecking: "Dieser Rechner wird auf Trainingsunterstützung geprüft...",
+      videoChecking: "Dieser Rechner wird auf Video-Unterstützung geprüft...",
       more: "Mehr",
       customizeSidebar: "Seitenleiste anpassen",
       newBadge: "Neu",
@@ -1410,6 +1412,7 @@ export const de = {
       history: "Verlauf",
     },
     loadingRuntime: "Trainingsumgebung wird geladen...",
+    checkingSupport: "Dieser Rechner wird auf Trainingsunterstützung geprüft...",
     backToHistory: "Zurück zum Verlauf",
     sections: {
       model: "Modell",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -78,6 +78,11 @@ export const en = {
       recipes: "Recipes",
       images: "Images",
       video: "Video",
+      // Hover text while the row spins, i.e. before this machine's training or video
+      // capability has been measured. A cold host can take minutes, so the spinner has to
+      // say what it is waiting for rather than read as a hung row.
+      trainChecking: "Checking this machine for training support...",
+      videoChecking: "Checking this machine for video support...",
       more: "More",
       // Last entry of the More flyout; opens Settings -> Appearance.
       customizeSidebar: "Customize sidebar",
@@ -1350,6 +1355,7 @@ export const en = {
     imageTraining: "Image training",
     goToImageTraining: "Go to image training",
     loadingRuntime: "Loading training runtime...",
+    checkingSupport: "Checking this machine for training support...",
     backToHistory: "Back to history",
     sections: {
       model: "Model",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -78,9 +78,7 @@ export const en = {
       recipes: "Recipes",
       images: "Images",
       video: "Video",
-      // Hover text while the row spins, i.e. before this machine's training or video
-      // capability has been measured. A cold host can take minutes, so the spinner has to
-      // say what it is waiting for rather than read as a hung row.
+      // Hover text while the row spins, before this machine's capability is measured.
       trainChecking: "Checking this machine for training support...",
       videoChecking: "Checking this machine for video support...",
       more: "More",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -85,6 +85,8 @@ export const es = {
       recipes: "Recetas",
       images: "Imágenes",
       video: "Vídeo",
+      trainChecking: "Comprobando si este equipo admite entrenamiento...",
+      videoChecking: "Comprobando si este equipo admite vídeo...",
       more: "Más",
       customizeSidebar: "Personalizar la barra lateral",
       newBadge: "Nuevo",
@@ -1401,6 +1403,7 @@ export const es = {
       history: "Historial",
     },
     loadingRuntime: "Cargando entorno de entrenamiento...",
+    checkingSupport: "Comprobando si este equipo admite entrenamiento...",
     backToHistory: "Volver al historial",
     sections: {
       model: "Modelo",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -86,6 +86,8 @@ export const fr = {
       recipes: "Recettes",
       images: "Images",
       video: "Vidéo",
+      trainChecking: "Vérification de la prise en charge de l'entraînement sur cette machine...",
+      videoChecking: "Vérification de la prise en charge de la vidéo sur cette machine...",
       more: "Plus",
       customizeSidebar: "Personnaliser la barre latérale",
       newBadge: "Nouveau",
@@ -1412,6 +1414,7 @@ export const fr = {
       history: "Historique",
     },
     loadingRuntime: "Chargement de l'environnement d'entraînement...",
+    checkingSupport: "Vérification de la prise en charge de l'entraînement sur cette machine...",
     backToHistory: "Retour à l'historique",
     sections: {
       model: "Modèle",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -86,6 +86,8 @@ export const hi = {
       recipes: "रेसिपी",
       images: "इमेज",
       video: "वीडियो",
+      trainChecking: "इस मशीन पर ट्रेनिंग सपोर्ट की जाँच हो रही है...",
+      videoChecking: "इस मशीन पर वीडियो सपोर्ट की जाँच हो रही है...",
       more: "अधिक",
       customizeSidebar: "साइडबार कस्टमाइज़ करें",
       newBadge: "नया",
@@ -1372,6 +1374,7 @@ export const hi = {
       history: "इतिहास",
     },
     loadingRuntime: "ट्रेनिंग रनटाइम लोड हो रहा है...",
+    checkingSupport: "इस मशीन पर ट्रेनिंग सपोर्ट की जाँच हो रही है...",
     backToHistory: "इतिहास पर वापस जाएं",
     sections: {
       model: "मॉडल",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -52,6 +52,8 @@ export const it = {
       recipes: "Ricette",
       images: "Immagini",
       video: "Video",
+      trainChecking: "Verifica del supporto all'addestramento su questa macchina...",
+      videoChecking: "Verifica del supporto video su questa macchina...",
       more: "Altro",
       customizeSidebar: "Personalizza la barra laterale",
       newBadge: "Novità",
@@ -1411,6 +1413,7 @@ export const it = {
       history: "Cronologia",
     },
     loadingRuntime: "Caricamento del runtime di addestramento...",
+    checkingSupport: "Verifica del supporto all'addestramento su questa macchina...",
     backToHistory: "Torna alla cronologia",
     sections: {
       model: "Modello",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -85,6 +85,8 @@ export const ja = {
       recipes: "レシピ",
       images: "画像",
       video: "動画",
+      trainChecking: "このマシンのトレーニング対応を確認しています...",
+      videoChecking: "このマシンの動画生成対応を確認しています...",
       more: "その他",
       customizeSidebar: "サイドバーをカスタマイズ",
       newBadge: "新機能",
@@ -1339,6 +1341,7 @@ export const ja = {
       history: "履歴",
     },
     loadingRuntime: "トレーニングランタイムを読み込み中...",
+    checkingSupport: "このマシンのトレーニング対応を確認しています...",
     backToHistory: "履歴に戻る",
     sections: {
       model: "モデル",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -83,6 +83,8 @@ export const ko = {
       recipes: "레시피",
       images: "이미지",
       video: "동영상",
+      trainChecking: "이 컴퓨터의 학습 지원 여부를 확인하는 중...",
+      videoChecking: "이 컴퓨터의 비디오 지원 여부를 확인하는 중...",
       more: "더 보기",
       customizeSidebar: "사이드바 사용자 지정",
       newBadge: "신규",
@@ -1364,6 +1366,7 @@ export const ko = {
       history: "기록",
     },
     loadingRuntime: "학습 런타임을 로딩하는 중...",
+    checkingSupport: "이 컴퓨터의 학습 지원 여부를 확인하는 중...",
     backToHistory: "기록으로 돌아가기",
     sections: {
       model: "모델",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -85,6 +85,8 @@ export const ptBR = {
       recipes: "Receitas",
       images: "Imagens",
       video: "Vídeo",
+      trainChecking: "Verificando se esta máquina oferece suporte a treino...",
+      videoChecking: "Verificando se esta máquina oferece suporte a vídeo...",
       more: "Mais",
       customizeSidebar: "Personalizar barra lateral",
       newBadge: "Novo",
@@ -1382,6 +1384,7 @@ export const ptBR = {
       history: "Histórico",
     },
     loadingRuntime: "Carregando ambiente de execução de treino...",
+    checkingSupport: "Verificando se esta máquina oferece suporte a treino...",
     backToHistory: "Voltar ao histórico",
     sections: {
       model: "Modelo",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -85,6 +85,8 @@ export const ru = {
       recipes: "Рецепты",
       images: "Изображения",
       video: "Видео",
+      trainChecking: "Проверка поддержки обучения на этой машине...",
+      videoChecking: "Проверка поддержки видео на этой машине...",
       more: "Ещё",
       customizeSidebar: "Настроить боковую панель",
       newBadge: "Новое",
@@ -1383,6 +1385,7 @@ export const ru = {
       history: "История",
     },
     loadingRuntime: "Загрузка среды обучения...",
+    checkingSupport: "Проверка поддержки обучения на этой машине...",
     backToHistory: "Назад к истории",
     sections: {
       model: "Модель",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -81,6 +81,8 @@ export const zhCN = {
       recipes: "配方",
       images: "图像",
       video: "视频",
+      trainChecking: "正在检查此设备是否支持训练...",
+      videoChecking: "正在检查此设备是否支持视频生成...",
       more: "更多",
       customizeSidebar: "自定义侧边栏",
       newBadge: "新",
@@ -1317,6 +1319,7 @@ export const zhCN = {
       history: "历史",
     },
     loadingRuntime: "正在加载训练运行时...",
+    checkingSupport: "正在检查此设备是否支持训练...",
     backToHistory: "返回历史",
     sections: {
       model: "模型",

--- a/studio/frontend/tests/sidebar-spinner-column.test.ts
+++ b/studio/frontend/tests/sidebar-spinner-column.test.ts
@@ -120,6 +120,39 @@ test("a pending row spins instead of blacking out", async () => {
   );
 });
 
+// Detection is a cold `import torch` and can run for minutes, which is long enough for a
+// silent spinner to read as a hung row. It says what it is waiting for instead, the way
+// the Video page does; the disabled hint is still withheld, since no verdict is in yet.
+test("a pending row says what it is waiting for", async () => {
+  const { resolveNavRowState } = await import("../src/components/nav-row-state.ts");
+
+  const pending = resolveNavRowState({
+    disabled: true,
+    tooltip: "Training needs an NVIDIA or AMD GPU.",
+    pending: true,
+    pendingTooltip: "Checking this machine for training support...",
+  });
+  assert.equal(pending.spinner, true);
+  assert.equal(pending.disabled, false);
+  assert.equal(pending.tooltip, "Checking this machine for training support...");
+});
+
+test("both capability rows carry a pending tooltip", async () => {
+  const source = await readFile(
+    new URL("../src/components/app-sidebar.tsx", import.meta.url),
+    "utf8",
+  );
+  for (const row of ["train", "video"]) {
+    const block = source.slice(source.indexOf(`    ${row}: {`));
+    const body = block.slice(0, block.indexOf("\n    },"));
+    assert.match(
+      body,
+      /pendingTooltip: t\("shell\.navigation\.\w+Checking"\)/,
+      `the ${row} row spins without saying why`,
+    );
+  }
+});
+
 test("a measured row is left exactly as it was", async () => {
   const { resolveNavRowState } = await import("../src/components/nav-row-state.ts");
 

--- a/studio/frontend/tests/sidebar-spinner-column.test.ts
+++ b/studio/frontend/tests/sidebar-spinner-column.test.ts
@@ -137,6 +137,47 @@ test("a pending row says what it is waiting for", async () => {
   assert.equal(pending.tooltip, "Checking this machine for training support...");
 });
 
+// Having the tooltip is not the same as showing it. Both renderers hide one by default for
+// an enabled row: SidebarMenuButton shows it only on the collapsed rail (it stands in for
+// the hidden label there), and MoreMenuItem used to set `title` only when disabled. A
+// pending row is enabled, so the explanation reached neither the expanded row nor the
+// flyout and the spinner stayed unexplained exactly where it is most visible.
+test("a pending row is marked so both renderers can show its tooltip", async () => {
+  const { resolveNavRowState } = await import("../src/components/nav-row-state.ts");
+
+  assert.equal(
+    resolveNavRowState({ pending: true, pendingTooltip: "Checking..." }).pending,
+    true,
+  );
+  assert.equal(resolveNavRowState({ disabled: true, tooltip: "x" }).pending, false);
+  assert.equal(resolveNavRowState({ spinner: true }).pending, false);
+});
+
+test("the expanded row and the flyout both show a pending tooltip", async () => {
+  const [sidebar, appSidebar] = await Promise.all([
+    readFile(new URL("../src/components/ui/sidebar.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/components/app-sidebar.tsx", import.meta.url), "utf8"),
+  ]);
+
+  // The rail-only rule has to make an exception, or an enabled row is silent while expanded.
+  assert.match(
+    sidebar,
+    /hidden=\{isMobile \|\| \(!isDisabled && !alwaysTooltip && state !== "collapsed"\)\}/,
+    "SidebarMenuButton still hides every enabled row's tooltip while expanded",
+  );
+  assert.match(
+    appSidebar,
+    /alwaysTooltip=\{rowState\.pending\}/,
+    "the inline rows never ask for the exception",
+  );
+  // The flyout's title is not conditional on the grey-out any more.
+  assert.match(appSidebar, /^\s*title=\{tooltip\}$/m, "MoreMenuItem drops a pending title");
+  assert.ok(
+    !appSidebar.includes("title={disabled ? tooltip : undefined}"),
+    "MoreMenuItem still gates its title on disabled",
+  );
+});
+
 test("both capability rows carry a pending tooltip", async () => {
   const source = await readFile(
     new URL("../src/components/app-sidebar.tsx", import.meta.url),

--- a/studio/frontend/tests/sidebar-spinner-column.test.ts
+++ b/studio/frontend/tests/sidebar-spinner-column.test.ts
@@ -120,9 +120,9 @@ test("a pending row spins instead of blacking out", async () => {
   );
 });
 
-// Detection is a cold `import torch` and can run for minutes, which is long enough for a
-// silent spinner to read as a hung row. It says what it is waiting for instead, the way
-// the Video page does; the disabled hint is still withheld, since no verdict is in yet.
+// Detection is a cold `import torch` and can run for minutes, long enough for a silent
+// spinner to read as a hung row, so it says what it is waiting for. The disabled hint is
+// still withheld: no verdict is in yet.
 test("a pending row says what it is waiting for", async () => {
   const { resolveNavRowState } = await import("../src/components/nav-row-state.ts");
 
@@ -137,11 +137,9 @@ test("a pending row says what it is waiting for", async () => {
   assert.equal(pending.tooltip, "Checking this machine for training support...");
 });
 
-// Having the tooltip is not the same as showing it. Both renderers hide one by default for
-// an enabled row: SidebarMenuButton shows it only on the collapsed rail (it stands in for
-// the hidden label there), and MoreMenuItem used to set `title` only when disabled. A
-// pending row is enabled, so the explanation reached neither the expanded row nor the
-// flyout and the spinner stayed unexplained exactly where it is most visible.
+// Having the tooltip is not the same as showing it. Both renderers hid one by default for
+// an enabled row: SidebarMenuButton only on the collapsed rail, MoreMenuItem only when
+// disabled. A pending row is enabled, so the explanation reached neither.
 test("a pending row is marked so both renderers can show its tooltip", async () => {
   const { resolveNavRowState } = await import("../src/components/nav-row-state.ts");
 


### PR DESCRIPTION
## The bug

On a machine that cannot train, the Train row spins for a long time before it greys out. On a slow host that is minutes, and nothing on screen says what is happening, so it reads as a hang. The Video page at least says "Checking this machine for video support..." while it does the same wait.

## Why

`resolveNavRowState` renders an unmeasured row as a spinner rather than a grey-out, which is right: a guessed grey-out reads exactly like a measured one. But it also dropped the tooltip, so hovering the spinning row said "Train" and nothing else. The wait itself is real work, a cold `import torch` inside hardware detection, and it ends when it ends.

The Train page had the same gap from the other side: while the verdict is out it showed "Loading training runtime...", which describes a different and much shorter wait.

## The fix

- a pending row carries its own tooltip, "Checking this machine for training support...". Both render sites already go through `resolveNavRowState`, so they cannot drift. The disabled hint is still withheld while pending: no verdict has been reached to explain.
- the Train page shows the same line while the wait is the hardware verdict, and keeps the runtime wording for a hydrating runtime.
- Video gets the matching tooltip, so the two capability rows say the same kind of thing.

New strings are translated into all eleven locale overlays; `npm run i18n:check:strict` passes.

## Verifying it

Driven against a live Studio with `device_type` stripped from `/api/health`, which is the state a cold host sits in:

- the Train row reports `data-spinner="true"` and its tooltip reads "Checking this machine for training support..."
- clicking through to Train shows the same line in place of "Loading training runtime..."

`npm run typecheck` and `npm test` (1494 tests) pass.

## What this does not change

The length of the wait. Detection is a real import, and on Apple Silicon the verdict is deliberately held while an MLX self-heal may still overturn it (bounded by the torch warm plus a short handoff, under an absolute ceiling). This makes the wait legible, not shorter.