### PR TITLE
Read PSModulePath under the key Windows actually exports

### DIFF
--- a/tests/test_installer_profile_hardening.py
+++ b/tests/test_installer_profile_hardening.py
@@ -1647,6 +1647,11 @@ def _windows_probe_env(monkeypatch, host, module_path):
     return studio_cmd._profile_probe_env(host)
 
 
+# os.environ upper-cases keys on Windows, so a probe env built there carries PSMODULEPATH.
+def _module_path(env):
+    return env[next(k for k in env if k.upper() == "PSMODULEPATH")]
+
+
 _PS7_MODULE_PATH = (
     r"C:\Users\me\Documents\PowerShell\Modules;"
     r"C:\Program Files\PowerShell\7\Modules;"
@@ -1661,7 +1666,7 @@ def test_the_windows_powershell_probe_is_given_its_own_modules_first(monkeypatch
     profile importing one threw while it was dot-sourced and its proxy never reached setup."""
     env = _windows_probe_env(monkeypatch, "powershell.exe", _PS7_MODULE_PATH)
 
-    entries = env["PSModulePath"].split(";")
+    entries = _module_path(env).split(";")
     assert entries[0] == _WINDOWS_PS_MODULES
     # Reordered, not pruned: everything the caller had is still reachable, just second.
     assert entries[1:] == _PS7_MODULE_PATH.split(";")[:2]
@@ -1672,14 +1677,31 @@ def test_a_module_path_already_led_by_windows_powershell_is_left_alone(monkeypat
     already = _WINDOWS_PS_MODULES + r";C:\Program Files\PowerShell\7\Modules"
     env = _windows_probe_env(monkeypatch, "powershell.exe", already)
 
-    assert env["PSModulePath"] == already
+    assert _module_path(env) == already
 
 
 def test_the_pwsh_probe_keeps_the_inherited_module_path(monkeypatch):
     # PowerShell 7 prefixes its own paths at startup, so reordering here would only demote them.
     env = _windows_probe_env(monkeypatch, "pwsh.exe", _PS7_MODULE_PATH)
 
-    assert env["PSModulePath"] == _PS7_MODULE_PATH
+    assert _module_path(env) == _PS7_MODULE_PATH
+
+
+def test_the_probe_reads_the_module_path_windows_actually_exports(monkeypatch):
+    """dict(os.environ) on Windows is keyed PSMODULEPATH, and a plain dict is case-sensitive.
+    Reading "PSModulePath" found nothing, so the repair dropped the caller's entries and handed
+    the child a second key differing only by case."""
+    from unsloth_cli.commands import studio as studio_cmd
+
+    monkeypatch.setattr(studio_cmd.platform, "system", lambda: "Windows")
+    monkeypatch.setenv("SystemRoot", r"C:\Windows")
+    monkeypatch.delenv("PSModulePath", raising = False)
+    monkeypatch.setenv("PSMODULEPATH", _PS7_MODULE_PATH)
+
+    env = studio_cmd._profile_probe_env("powershell.exe")
+
+    assert [k for k in env if k.upper() == "PSMODULEPATH"] == ["PSMODULEPATH"]
+    assert _module_path(env).split(";") == [_WINDOWS_PS_MODULES] + _PS7_MODULE_PATH.split(";")[:2]
 
 
 def test_the_module_path_is_untouched_off_windows(monkeypatch):
@@ -1688,7 +1710,7 @@ def test_the_module_path_is_untouched_off_windows(monkeypatch):
     monkeypatch.setattr(studio_cmd.platform, "system", lambda: "Linux")
     monkeypatch.setenv("PSModulePath", _PS7_MODULE_PATH)
 
-    assert studio_cmd._profile_probe_env("powershell.exe")["PSModulePath"] == _PS7_MODULE_PATH
+    assert _module_path(studio_cmd._profile_probe_env("powershell.exe")) == _PS7_MODULE_PATH
 
 
 def test_each_probed_host_gets_its_own_module_path(monkeypatch):
@@ -1702,7 +1724,7 @@ def test_each_probed_host_gets_its_own_module_path(monkeypatch):
     seen: dict = {}
 
     def _run(argv, **kwargs):
-        seen[argv[0]] = kwargs["env"]["PSModulePath"]
+        seen[argv[0]] = _module_path(kwargs["env"])
         return _Result(_framed('{"Invoke-WebRequest:Proxy": "http://corp:8080"}'))
 
     monkeypatch.setattr(studio_cmd.platform, "system", lambda: "Windows")

--- a/tests/test_installer_profile_hardening.py
+++ b/tests/test_installer_profile_hardening.py
@@ -1688,9 +1688,8 @@ def test_the_pwsh_probe_keeps_the_inherited_module_path(monkeypatch):
 
 
 def test_the_probe_reads_the_module_path_windows_actually_exports(monkeypatch):
-    """dict(os.environ) on Windows is keyed PSMODULEPATH, and a plain dict is case-sensitive.
-    Reading "PSModulePath" found nothing, so the repair dropped the caller's entries and handed
-    the child a second key differing only by case."""
+    """dict(os.environ) on Windows is keyed PSMODULEPATH and a plain dict is case-sensitive, so
+    reading "PSModulePath" dropped the caller's entries and added a second, case-differing key."""
     from unsloth_cli.commands import studio as studio_cmd
 
     monkeypatch.setattr(studio_cmd.platform, "system", lambda: "Windows")

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -2952,9 +2952,13 @@ def _profile_probe_env(host: str = "") -> dict:
     if platform.system() == "Windows" and _fold_module_entry(host).rsplit("\\", 1)[-1] in (
         _WINDOWS_PS_HOSTS
     ):
-        reordered = _windows_powershell_module_path(env.get("PSModulePath", ""))
+        # os.environ upper-cases keys on Windows, so the copy carries PSMODULEPATH. Read and
+        # write the key that is actually there: "PSModulePath" would miss the caller's value
+        # and leave the child two entries differing only by case.
+        key = next((k for k in env if k.upper() == "PSMODULEPATH"), "PSModulePath")
+        reordered = _windows_powershell_module_path(env.get(key, ""))
         if reordered:
-            env["PSModulePath"] = reordered
+            env[key] = reordered
     return env
 
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -2952,9 +2952,8 @@ def _profile_probe_env(host: str = "") -> dict:
     if platform.system() == "Windows" and _fold_module_entry(host).rsplit("\\", 1)[-1] in (
         _WINDOWS_PS_HOSTS
     ):
-        # os.environ upper-cases keys on Windows, so the copy carries PSMODULEPATH. Read and
-        # write the key that is actually there: "PSModulePath" would miss the caller's value
-        # and leave the child two entries differing only by case.
+        # os.environ upper-cases keys on Windows, so the copy is keyed PSMODULEPATH: reading
+        # "PSModulePath" misses the caller's value and adds a second, case-differing entry.
         key = next((k for k in env if k.upper() == "PSMODULEPATH"), "PSModulePath")
         reordered = _windows_powershell_module_path(env.get(key, ""))
         if reordered:


### PR DESCRIPTION
`parity (windows-latest)` has been red on every branch since #8161 merged, with five failures in `tests/test_installer_profile_hardening.py`:

```
assert entries[1:] == _PS7_MODULE_PATH.split(";")[:2]
E   AssertionError: assert [] == ['C:\\Users\\...\\7\\Modules']

assert studio_cmd._profile_probe_env("powershell.exe")["PSModulePath"] == _PS7_MODULE_PATH
E   KeyError: 'PSModulePath'
```

## Cause

`os.environ` upper-cases keys on Windows ([docs](https://docs.python.org/3/library/os.html): "On Windows, the keys are converted to uppercase. This also applies when getting, setting, or deleting an item"). `os.environ` itself stays case-insensitive because it uppercases on both ends, but `dict(os.environ)` is a plain dict holding `PSMODULEPATH`, and a plain dict is not.

So in `_profile_probe_env`:

```python
reordered = _windows_powershell_module_path(env.get("PSModulePath", ""))
if reordered:
    env["PSModulePath"] = reordered
```

1. the `get` always returned the empty default, never the caller's module path;
2. `_windows_powershell_module_path("")` therefore returned just `%SystemRoot%\System32\WindowsPowerShell\v1.0\Modules`;
3. the assignment added a **second** key next to the untouched `PSMODULEPATH`.

That is the "reordered, not pruned" invariant broken in production, not only in the tests: the probe child was handed two entries differing only by case, and the surviving value had the caller's PowerShell 7 module directories dropped rather than demoted. `parity (ubuntu-latest)` stayed green because POSIX `os.environ` preserves case.

`test_the_module_path_is_untouched_off_windows` pins the mechanism down: it forces `platform.system()` to Linux, so `_profile_probe_env` returns `dict(os.environ)` unmodified, and the lookup still raises `KeyError`. The key is `PSMODULEPATH`.

## Fix

Resolve the key case-insensitively and update it in place, so nothing is added:

```python
key = next((k for k in env if k.upper() == "PSMODULEPATH"), "PSModulePath")
reordered = _windows_powershell_module_path(env.get(key, ""))
if reordered:
    env[key] = reordered
```

The five existing assertions read the same key out of a plain dict, so they go through a small `_module_path(env)` helper that does the same lookup.

## Tests

Added `test_the_probe_reads_the_module_path_windows_actually_exports`, which sets only the uppercase key so it reproduces the defect on any platform. Against the old code it fails exactly as Windows CI does:

```
assert [k for k in env if k.upper() == "PSMODULEPATH"] == ["PSMODULEPATH"]
E   AssertionError: assert ['PSMODULEPAT...PSModulePath'] == ['PSMODULEPATH']
```

`tests/test_installer_profile_hardening.py`: 75 passed. Ruff clean on both files.
