### PR TITLE
Studio: stop two lines repeating in the server log for the whole session

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -12088,8 +12088,7 @@ def _volume_timestamps_finely(workdir: str) -> bool:
     if stat.st_dev in _fine_mtime_devices:
         return True
     if not any(
-        stamp % 1_000_000_000
-        for stamp in (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_atime_ns)
+        stamp % 1_000_000_000 for stamp in (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_atime_ns)
     ):
         return False
     _fine_mtime_devices.add(stat.st_dev)

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -178,12 +178,15 @@ class _CaptureLoadReport(logging.Filter):
     BertModel does not expect, which is benign and identical every time.
 
     Nothing is lost: the caller re-emits the report (see ``_quiet_transformers_load``)
-    at debug when it only reports UNEXPECTED keys, and at warning when it mentions
-    anything that could change the model's behaviour.
+    at debug when it only reports that known legacy key, and at warning when it
+    mentions anything that could change the model's behaviour.
     """
 
-    _BENIGN = ("UNEXPECTED",)
     _SERIOUS = ("MISSING", "MISMATCH", "CONVERSION")
+    # The only UNEXPECTED key worth downgrading is the legacy buffer every BERT-era
+    # sentence-transformer ships. Any other discarded weight can genuinely change
+    # retrieval quality, so it stays a warning.
+    _KNOWN_BENIGN_UNEXPECTED = "position_ids"
 
     def __init__(self) -> None:
         super().__init__()
@@ -206,12 +209,20 @@ class _CaptureLoadReport(logging.Filter):
         return False
 
     def is_serious(self) -> bool:
-        return any(tag in r for r in self.reports for tag in self._SERIOUS)
+        for report in self.reports:
+            if any(tag in report for tag in self._SERIOUS):
+                return True
+            if "UNEXPECTED" in report and self._KNOWN_BENIGN_UNEXPECTED not in report:
+                return True
+        return False
 
 
 _LOAD_REPORT_LOGGERS = (
     "transformers.utils.loading_report",
     "transformers.modeling_utils",
+    # An adapter-backed embedding model reports through the PEFT integration's own
+    # logger, which is not a descendant of either of the above.
+    "transformers.integrations.peft",
 )
 
 

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -212,8 +212,11 @@ class _CaptureLoadReport(logging.Filter):
         for report in self.reports:
             if any(tag in report for tag in self._SERIOUS):
                 return True
-            if "UNEXPECTED" in report and self._KNOWN_BENIGN_UNEXPECTED not in report:
-                return True
+            # Row by row: a report can list the legacy buffer AND a discarded learned
+            # weight, and only the second one matters.
+            for row in report.splitlines():
+                if "UNEXPECTED" in row and self._KNOWN_BENIGN_UNEXPECTED not in row:
+                    return True
         return False
 
 

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import threading
 from contextlib import contextmanager
 from functools import lru_cache
@@ -297,6 +298,20 @@ def _quiet_transformers_load():
                     pass
 
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _one_line(text: str) -> str:
+    """The report as a single plain-text line.
+
+    This module logs through the stdlib logger, not structlog, so re-emitting the
+    captured table verbatim would put the ANSI escapes and embedded newlines straight
+    back into the server log, which is the thing being fixed.
+    """
+    plain = _ANSI_RE.sub("", text)
+    return " | ".join(part.strip() for part in plain.splitlines() if part.strip())
+
+
 def _emit_load_reports(report) -> None:
     """Re-emit what the filter swallowed, as one record on our own logger: debug for
     the expected legacy-key notice, warning for anything that could change the
@@ -304,9 +319,9 @@ def _emit_load_reports(report) -> None:
     serious = report.is_serious()
     for text in report.reports:
         if serious:
-            logger.warning("embedding model load report: %s", text)
+            logger.warning("embedding model load report: %s", _one_line(text))
         else:
-            logger.debug("embedding model load report: %s", text)
+            logger.debug("embedding model load report: %s", _one_line(text))
     report.reports.clear()
 
 

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -212,9 +212,12 @@ class _CaptureLoadReport(logging.Filter):
         for report in self.reports:
             if any(tag in report for tag in self._SERIOUS):
                 return True
-            # Row by row: a report can list the legacy buffer AND a discarded learned
-            # weight, and only the second one matters.
-            for row in report.splitlines():
+            # Row by row over the table only. transformers appends a "Notes:" section
+            # explaining each status ("- UNEXPECTED: can be ignored when loading from
+            # a different task/architecture"), and reading that as a key row would make
+            # every unexpected report serious, including the benign one.
+            table = report.split("Notes:", 1)[0]
+            for row in table.splitlines():
                 if "UNEXPECTED" in row and self._KNOWN_BENIGN_UNEXPECTED not in row:
                     return True
         return False

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from contextlib import contextmanager
 from functools import lru_cache
 from typing import Callable
 
@@ -167,6 +168,95 @@ def _guard_model_security(name: str, local_only: bool = False) -> None:
         )
 
 
+class _CaptureLoadReport(logging.Filter):
+    """Swallow transformers' multi-line "<Model> LOAD REPORT" table, keeping the text.
+
+    transformers >= 5 emits the report through ``logger.warning`` with embedded ANSI
+    colour codes, so it lands in the server log as ~7 unstructured lines that break
+    every JSON consumer. It fires on every boot for the RAG embedder because
+    bge-small-en-v1.5 ships a legacy ``embeddings.position_ids`` key that the current
+    BertModel does not expect, which is benign and identical every time.
+
+    Nothing is lost: the caller re-emits the report (see ``_quiet_transformers_load``)
+    at debug when it only reports UNEXPECTED keys, and at warning when it mentions
+    anything that could change the model's behaviour.
+    """
+
+    _BENIGN = ("UNEXPECTED",)
+    _SERIOUS = ("MISSING", "MISMATCH", "CONVERSION")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reports: list[str] = []
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:  # noqa: BLE001 - a broken record must not break loading
+            return True
+        if "LOAD REPORT" not in msg:
+            return True
+        self.reports.append(msg)
+        return False
+
+    def is_serious(self) -> bool:
+        return any(tag in r for r in self.reports for tag in self._SERIOUS)
+
+
+_LOAD_REPORT_LOGGERS = (
+    "transformers.utils.loading_report",
+    "transformers.modeling_utils",
+)
+
+
+@contextmanager
+def _quiet_transformers_load():
+    """Keep a transformers weight load from writing raw ANSI/tqdm output to stdout.
+
+    Scoped to the embedder load only, so a user-visible model load keeps its normal
+    progress bar and report. Restores the progress-bar setting exactly as found, so
+    a caller that had already disabled bars stays disabled.
+    """
+    capture = _CaptureLoadReport()
+    attached = []
+    for name in _LOAD_REPORT_LOGGERS:
+        log = logging.getLogger(name)
+        log.addFilter(capture)
+        attached.append(log)
+
+    # The weight-load bar is transformers.utils.logging.tqdm, so disable_progress_bar()
+    # reaches it. The "is it on right now" probe has been spelled both ways across
+    # versions (is_progress_bar_enabled in 4.x/5.x, are_progress_bars_disabled in
+    # some builds), so accept either and skip the restore when neither exists rather
+    # than re-enabling a bar the caller had deliberately turned off.
+    reenable = False
+    hf_logging = None
+    try:
+        from transformers.utils import logging as hf_logging
+        if hasattr(hf_logging, "is_progress_bar_enabled"):
+            was_on = bool(hf_logging.is_progress_bar_enabled())
+        elif hasattr(hf_logging, "are_progress_bars_disabled"):
+            was_on = not bool(hf_logging.are_progress_bars_disabled())
+        else:
+            was_on = False
+        if was_on:
+            hf_logging.disable_progress_bar()
+            reenable = True
+    except Exception:  # noqa: BLE001 - older/absent transformers: nothing to disable
+        hf_logging = None
+
+    try:
+        yield capture
+    finally:
+        for log in attached:
+            log.removeFilter(capture)
+        if reenable and hf_logging is not None:
+            try:
+                hf_logging.enable_progress_bar()
+            except Exception:  # noqa: BLE001
+                pass
+
+
 def _st_accepts_local_files_only(st_cls) -> bool:
     """Whether this SentenceTransformer version accepts local_files_only; passing it to an
     older constructor raises, so gate on the signature."""
@@ -210,7 +300,16 @@ def _get(model_name: str | None = None):
                     load_target = str(snapshot)
                 elif _st_accepts_local_files_only(SentenceTransformer):
                     st_kwargs["local_files_only"] = True
-            _model = SentenceTransformer(load_target, **st_kwargs)
+            with _quiet_transformers_load() as report:
+                _model = SentenceTransformer(load_target, **st_kwargs)
+            for text in report.reports:
+                # Re-emit what the filter swallowed, as one record on our own logger:
+                # debug for the expected legacy-key notice, warning for anything that
+                # could actually change the embeddings.
+                if report.is_serious():
+                    logger.warning("embedding model load report: %s", text)
+                else:
+                    logger.debug("embedding model load report: %s", text)
             _name = name
         return _model
 

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -169,6 +169,9 @@ def _guard_model_security(name: str, local_only: bool = False) -> None:
         )
 
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
 class _CaptureLoadReport(logging.Filter):
     """Swallow transformers' multi-line "<Model> LOAD REPORT" table, keeping the text.
 
@@ -186,8 +189,9 @@ class _CaptureLoadReport(logging.Filter):
     _SERIOUS = ("MISSING", "MISMATCH", "CONVERSION")
     # The only UNEXPECTED key worth downgrading is the legacy buffer every BERT-era
     # sentence-transformer ships. Any other discarded weight can genuinely change
-    # retrieval quality, so it stays a warning.
-    _KNOWN_BENIGN_UNEXPECTED = "position_ids"
+    # retrieval quality, so it stays a warning. Matched on the whole key, not as a
+    # substring: "encoder.position_ids_projection.weight" is a real discarded weight.
+    _KNOWN_BENIGN_UNEXPECTED = "embeddings.position_ids"
 
     def __init__(self) -> None:
         super().__init__()
@@ -219,7 +223,12 @@ class _CaptureLoadReport(logging.Filter):
             # every unexpected report serious, including the benign one.
             table = report.split("Notes:", 1)[0]
             for row in table.splitlines():
-                if "UNEXPECTED" in row and self._KNOWN_BENIGN_UNEXPECTED not in row:
+                if "UNEXPECTED" not in row:
+                    continue
+                key = _ANSI_RE.sub("", row).split("|", 1)[0].strip()
+                if key != self._KNOWN_BENIGN_UNEXPECTED and not key.endswith(
+                    "." + self._KNOWN_BENIGN_UNEXPECTED
+                ):
                     return True
         return False
 
@@ -296,9 +305,6 @@ def _quiet_transformers_load():
                     disable_progress_bars()
                 except Exception:  # noqa: BLE001
                     pass
-
-
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 def _one_line(text: str) -> str:

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -188,8 +188,14 @@ class _CaptureLoadReport(logging.Filter):
     def __init__(self) -> None:
         super().__init__()
         self.reports: list[str] = []
+        # These filters sit on process-global loggers, so a concurrent load on another
+        # thread would otherwise have its report swallowed and attributed here. Only
+        # capture what the thread that opened the context emits.
+        self.thread_id = threading.get_ident()
 
     def filter(self, record: logging.LogRecord) -> bool:
+        if threading.get_ident() != self.thread_id:
+            return True
         try:
             msg = record.getMessage()
         except Exception:  # noqa: BLE001 - a broken record must not break loading
@@ -229,6 +235,17 @@ def _quiet_transformers_load():
     # versions (is_progress_bar_enabled in 4.x/5.x, are_progress_bars_disabled in
     # some builds), so accept either and skip the restore when neither exists rather
     # than re-enabling a bar the caller had deliberately turned off.
+    # transformers' enable_progress_bar() also calls the Hub's enable_progress_bars(),
+    # so restoring the transformers flag would clobber a Hub-only disable that someone
+    # else installed (unsloth does exactly that in patch_ipykernel_hf_xet for the
+    # broken hf-xet/ipykernel pair). Snapshot the Hub state separately and put it back.
+    hub_bars_off = None
+    try:
+        from huggingface_hub.utils import are_progress_bars_disabled
+        hub_bars_off = bool(are_progress_bars_disabled())
+    except Exception:  # noqa: BLE001 - no Hub, or a version without the probe
+        hub_bars_off = None
+
     reenable = False
     hf_logging = None
     try:
@@ -255,6 +272,25 @@ def _quiet_transformers_load():
                 hf_logging.enable_progress_bar()
             except Exception:  # noqa: BLE001
                 pass
+            if hub_bars_off:
+                try:
+                    from huggingface_hub.utils import disable_progress_bars
+                    disable_progress_bars()
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+def _emit_load_reports(report) -> None:
+    """Re-emit what the filter swallowed, as one record on our own logger: debug for
+    the expected legacy-key notice, warning for anything that could change the
+    embeddings. Drains the list so a retry does not report the same lines twice."""
+    serious = report.is_serious()
+    for text in report.reports:
+        if serious:
+            logger.warning("embedding model load report: %s", text)
+        else:
+            logger.debug("embedding model load report: %s", text)
+    report.reports.clear()
 
 
 def _st_accepts_local_files_only(st_cls) -> bool:
@@ -301,15 +337,13 @@ def _get(model_name: str | None = None):
                 elif _st_accepts_local_files_only(SentenceTransformer):
                     st_kwargs["local_files_only"] = True
             with _quiet_transformers_load() as report:
-                _model = SentenceTransformer(load_target, **st_kwargs)
-            for text in report.reports:
-                # Re-emit what the filter swallowed, as one record on our own logger:
-                # debug for the expected legacy-key notice, warning for anything that
-                # could actually change the embeddings.
-                if report.is_serious():
-                    logger.warning("embedding model load report: %s", text)
-                else:
-                    logger.debug("embedding model load report: %s", text)
+                # The re-emit runs in finally: a load that raises after transformers
+                # wrote its report is exactly when a MISSING or MISMATCH line matters,
+                # and letting the exception skip the loop would swallow it.
+                try:
+                    _model = SentenceTransformer(load_target, **st_kwargs)
+                finally:
+                    _emit_load_reports(report)
             _name = name
         return _model
 

--- a/studio/backend/tests/test_embedding_load_report_quiet.py
+++ b/studio/backend/tests/test_embedding_load_report_quiet.py
@@ -121,3 +121,67 @@ def test_a_caller_that_already_disabled_bars_stays_disabled():
         assert enabled_probe() is False
     finally:
         hf_logging.enable_progress_bar()
+
+
+def test_a_concurrent_thread_is_not_captured():
+    # The filters sit on process-global loggers; another in-process load must keep
+    # its own report rather than have it swallowed and attributed to the embedder.
+    import threading
+
+    log, sink = _attach_sink()
+    try:
+        with _quiet_transformers_load() as report:
+            t = threading.Thread(target = lambda: log.warning(_SERIOUS))
+            t.start()
+            t.join()
+        assert sink.messages == [_SERIOUS], sink.messages
+        assert report.reports == []
+    finally:
+        log.removeHandler(sink)
+        log.propagate = True
+
+
+def test_reports_are_re_emitted_when_the_load_fails():
+    # A load that raises after transformers wrote its report is exactly when a
+    # MISSING line matters, so it must not be lost with the exception.
+    from core.rag import embeddings as emb
+
+    log, sink = _attach_sink()
+    emitted = []
+    real_warning = emb.logger.warning
+    emb.logger.warning = lambda msg, *a, **k: emitted.append(msg % a if a else msg)
+    try:
+        try:
+            with _quiet_transformers_load() as report:
+                try:
+                    log.warning(_SERIOUS)
+                    raise RuntimeError("weight tying blew up")
+                finally:
+                    emb._emit_load_reports(report)
+        except RuntimeError:
+            pass
+        assert any("MISSING" in m for m in emitted), emitted
+    finally:
+        emb.logger.warning = real_warning
+        log.removeHandler(sink)
+        log.propagate = True
+
+
+def test_a_hub_only_progress_disable_survives():
+    # transformers' enable_progress_bar() also enables the Hub's bars, which would
+    # undo unsloth's patch_ipykernel_hf_xet disable.
+    from huggingface_hub.utils import (
+        are_progress_bars_disabled,
+        disable_progress_bars,
+        enable_progress_bars,
+    )
+    from transformers.utils import logging as hf_logging
+
+    hf_logging.enable_progress_bar()   # transformers on, Hub-only disable after it
+    disable_progress_bars()
+    try:
+        with _quiet_transformers_load():
+            pass
+        assert are_progress_bars_disabled() is True
+    finally:
+        enable_progress_bars()

--- a/studio/backend/tests/test_embedding_load_report_quiet.py
+++ b/studio/backend/tests/test_embedding_load_report_quiet.py
@@ -127,7 +127,6 @@ def test_a_concurrent_thread_is_not_captured():
     # The filters sit on process-global loggers; another in-process load must keep
     # its own report rather than have it swallowed and attributed to the embedder.
     import threading
-
     log, sink = _attach_sink()
     try:
         with _quiet_transformers_load() as report:
@@ -177,7 +176,7 @@ def test_a_hub_only_progress_disable_survives():
     )
     from transformers.utils import logging as hf_logging
 
-    hf_logging.enable_progress_bar()   # transformers on, Hub-only disable after it
+    hf_logging.enable_progress_bar()  # transformers on, Hub-only disable after it
     disable_progress_bars()
     try:
         with _quiet_transformers_load():

--- a/studio/backend/tests/test_embedding_load_report_quiet.py
+++ b/studio/backend/tests/test_embedding_load_report_quiet.py
@@ -184,3 +184,45 @@ def test_a_hub_only_progress_disable_survives():
         assert are_progress_bars_disabled() is True
     finally:
         enable_progress_bars()
+
+
+def test_an_unexpected_key_other_than_the_legacy_one_stays_a_warning():
+    # A discarded encoder weight can genuinely degrade retrieval, so only the
+    # bge-style embeddings.position_ids report is quiet enough for debug.
+    log, sink = _attach_sink()
+    try:
+        with _quiet_transformers_load() as report:
+            log.warning("BertModel LOAD REPORT from: x\nencoder.layer.0.dense | UNEXPECTED")
+        assert report.is_serious() is True
+    finally:
+        log.removeHandler(sink)
+        log.propagate = True
+
+
+def test_the_legacy_position_ids_report_is_still_benign():
+    log, sink = _attach_sink()
+    try:
+        with _quiet_transformers_load() as report:
+            log.warning(_BENIGN)
+        assert report.is_serious() is False
+    finally:
+        log.removeHandler(sink)
+        log.propagate = True
+
+
+def test_the_peft_integration_logger_is_covered():
+    # An adapter-backed embedding model reports through transformers.integrations.peft,
+    # which is not a descendant of the other two loggers.
+    log = logging.getLogger("transformers.integrations.peft")
+    sink = _Sink()
+    log.addHandler(sink)
+    log.propagate = False
+    log.setLevel(logging.DEBUG)
+    try:
+        with _quiet_transformers_load() as report:
+            log.warning(_SERIOUS)
+        assert sink.messages == [], sink.messages
+        assert len(report.reports) == 1
+    finally:
+        log.removeHandler(sink)
+        log.propagate = True

--- a/studio/backend/tests/test_embedding_load_report_quiet.py
+++ b/studio/backend/tests/test_embedding_load_report_quiet.py
@@ -226,3 +226,21 @@ def test_the_peft_integration_logger_is_covered():
     finally:
         log.removeHandler(sink)
         log.propagate = True
+
+
+def test_a_mixed_report_is_serious():
+    # The legacy key and a discarded encoder weight in the same table: the second row
+    # is what matters, so the whole report must stay a warning.
+    log, sink = _attach_sink()
+    mixed = (
+        "BertModel LOAD REPORT from: x\n"
+        "embeddings.position_ids  | UNEXPECTED\n"
+        "encoder.layer.0.dense    | UNEXPECTED"
+    )
+    try:
+        with _quiet_transformers_load() as report:
+            log.warning(mixed)
+        assert report.is_serious() is True
+    finally:
+        log.removeHandler(sink)
+        log.propagate = True

--- a/studio/backend/tests/test_embedding_load_report_quiet.py
+++ b/studio/backend/tests/test_embedding_load_report_quiet.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import logging
 import sys
+
+import pytest
 from pathlib import Path
 
 _BACKEND = Path(__file__).resolve().parent.parent
@@ -41,13 +43,32 @@ class _Sink(logging.Handler):
         self.messages.append(record.getMessage())
 
 
-def _attach_sink():
-    log = logging.getLogger(_REPORT_LOGGER)
+_RESTORE: list = []
+
+
+def _attach_sink(name: str = _REPORT_LOGGER):
+    """Attach a sink to a process-global logger, remembering what to put back.
+
+    getLogger() is process-global, so leaving propagate = False behind would make
+    later tests in the same worker silently drop real records.
+    """
+    log = logging.getLogger(name)
     sink = _Sink()
+    _RESTORE.append((log, sink, log.propagate, log.level))
     log.addHandler(sink)
     log.propagate = False
     log.setLevel(logging.DEBUG)
     return log, sink
+
+
+@pytest.fixture(autouse = True)
+def _restore_loggers():
+    yield
+    while _RESTORE:
+        log, sink, propagate, level = _RESTORE.pop()
+        log.removeHandler(sink)
+        log.propagate = propagate
+        log.setLevel(level)
 
 
 def test_load_report_is_swallowed_and_captured():
@@ -213,11 +234,7 @@ def test_the_legacy_position_ids_report_is_still_benign():
 def test_the_peft_integration_logger_is_covered():
     # An adapter-backed embedding model reports through transformers.integrations.peft,
     # which is not a descendant of the other two loggers.
-    log = logging.getLogger("transformers.integrations.peft")
-    sink = _Sink()
-    log.addHandler(sink)
-    log.propagate = False
-    log.setLevel(logging.DEBUG)
+    log, sink = _attach_sink("transformers.integrations.peft")
     try:
         with _quiet_transformers_load() as report:
             log.warning(_SERIOUS)
@@ -244,3 +261,19 @@ def test_a_mixed_report_is_serious():
     finally:
         log.removeHandler(sink)
         log.propagate = True
+
+
+def test_the_notes_section_is_not_read_as_a_key_row():
+    # transformers appends "Notes:\n- UNEXPECTED: can be ignored ..." to every report
+    # that has unexpected keys; treating that as a row would make the benign bge
+    # report serious and defeat the whole change.
+    log, sink = _attach_sink()
+    with_notes = (
+        "BertModel LOAD REPORT from: unsloth/bge-small-en-v1.5\n"
+        "embeddings.position_ids | UNEXPECTED\n"
+        "\nNotes:\n"
+        "- UNEXPECTED:\tcan be ignored when loading from different task/architecture."
+    )
+    with _quiet_transformers_load() as report:
+        log.warning(with_notes)
+    assert report.is_serious() is False

--- a/studio/backend/tests/test_embedding_load_report_quiet.py
+++ b/studio/backend/tests/test_embedding_load_report_quiet.py
@@ -317,3 +317,23 @@ def test_a_serious_report_is_flattened_to_one_plain_line():
     assert "\x1b" not in emitted[0]
     assert "\n" not in emitted[0]
     assert "MISSING" in emitted[0]
+
+
+def test_a_key_merely_containing_position_ids_is_serious():
+    # "encoder.position_ids_projection.weight" is a real discarded weight, not the
+    # legacy buffer, so a substring match would have hidden it.
+    log, sink = _attach_sink()
+    with _quiet_transformers_load() as report:
+        log.warning(
+            "BertModel LOAD REPORT from: x\nencoder.position_ids_projection.weight | UNEXPECTED"
+        )
+    assert report.is_serious() is True
+
+
+def test_a_prefixed_legacy_buffer_is_still_benign():
+    log, sink = _attach_sink()
+    with _quiet_transformers_load() as report:
+        log.warning(
+            "BertModel LOAD REPORT from: x\n0_Transformer.embeddings.position_ids | UNEXPECTED"
+        )
+    assert report.is_serious() is False

--- a/studio/backend/tests/test_embedding_load_report_quiet.py
+++ b/studio/backend/tests/test_embedding_load_report_quiet.py
@@ -115,7 +115,7 @@ def test_filter_is_removed_after_the_context():
         log.removeHandler(sink)
 
 
-def test_progress_bar_state_is_restored():
+def test_progress_bar_state_is_restored(_progress_bar_state):
     from transformers.utils import logging as hf_logging
 
     enabled_probe = getattr(hf_logging, "is_progress_bar_enabled", None)
@@ -128,7 +128,7 @@ def test_progress_bar_state_is_restored():
     assert enabled_probe() is True
 
 
-def test_a_caller_that_already_disabled_bars_stays_disabled():
+def test_a_caller_that_already_disabled_bars_stays_disabled(_progress_bar_state):
     from transformers.utils import logging as hf_logging
 
     enabled_probe = getattr(hf_logging, "is_progress_bar_enabled", None)
@@ -136,12 +136,9 @@ def test_a_caller_that_already_disabled_bars_stays_disabled():
         return
 
     hf_logging.disable_progress_bar()
-    try:
-        with _quiet_transformers_load():
-            pass
-        assert enabled_probe() is False
-    finally:
-        hf_logging.enable_progress_bar()
+    with _quiet_transformers_load():
+        pass
+    assert enabled_probe() is False
 
 
 def test_a_concurrent_thread_is_not_captured():
@@ -187,9 +184,13 @@ def test_reports_are_re_emitted_when_the_load_fails():
         log.propagate = True
 
 
-def test_a_hub_only_progress_disable_survives():
-    # transformers' enable_progress_bar() also enables the Hub's bars, which would
-    # undo unsloth's patch_ipykernel_hf_xet disable.
+@pytest.fixture
+def _progress_bar_state():
+    """Snapshot and restore the two process-global progress-bar switches.
+
+    Both are global, so a test that leaves them enabled makes later tests in the same
+    worker order-dependent and can undo an environment-specific workaround.
+    """
     from huggingface_hub.utils import (
         are_progress_bars_disabled,
         disable_progress_bars,
@@ -197,14 +198,32 @@ def test_a_hub_only_progress_disable_survives():
     )
     from transformers.utils import logging as hf_logging
 
+    hub_was_off = bool(are_progress_bars_disabled())
+    tf_was_on = bool(hf_logging.is_progress_bar_enabled())
+    try:
+        yield
+    finally:
+        if tf_was_on:
+            hf_logging.enable_progress_bar()
+        else:
+            hf_logging.disable_progress_bar()
+        if hub_was_off:
+            disable_progress_bars()
+        else:
+            enable_progress_bars()
+
+
+def test_a_hub_only_progress_disable_survives(_progress_bar_state):
+    # transformers' enable_progress_bar() also enables the Hub's bars, which would
+    # undo unsloth's patch_ipykernel_hf_xet disable.
+    from huggingface_hub.utils import are_progress_bars_disabled, disable_progress_bars
+    from transformers.utils import logging as hf_logging
+
     hf_logging.enable_progress_bar()  # transformers on, Hub-only disable after it
     disable_progress_bars()
-    try:
-        with _quiet_transformers_load():
-            pass
-        assert are_progress_bars_disabled() is True
-    finally:
-        enable_progress_bars()
+    with _quiet_transformers_load():
+        pass
+    assert are_progress_bars_disabled() is True
 
 
 def test_an_unexpected_key_other_than_the_legacy_one_stays_a_warning():
@@ -277,3 +296,24 @@ def test_the_notes_section_is_not_read_as_a_key_row():
     with _quiet_transformers_load() as report:
         log.warning(with_notes)
     assert report.is_serious() is False
+
+
+def test_a_serious_report_is_flattened_to_one_plain_line():
+    # This module logs through the stdlib logger, so re-emitting the captured table
+    # verbatim would put its ANSI escapes and newlines straight back in the log.
+    from core.rag import embeddings as emb
+
+    emitted = []
+    real_warning = emb.logger.warning
+    emb.logger.warning = lambda msg, *a, **k: emitted.append(msg % a if a else msg)
+    log, sink = _attach_sink()
+    try:
+        with _quiet_transformers_load() as report:
+            log.warning("\x1b[1mBertModel LOAD REPORT\x1b[0m from: x\nencoder.0 | MISSING")
+        emb._emit_load_reports(report)
+    finally:
+        emb.logger.warning = real_warning
+    assert emitted, emitted
+    assert "\x1b" not in emitted[0]
+    assert "\n" not in emitted[0]
+    assert "MISSING" in emitted[0]

--- a/studio/backend/tests/test_embedding_load_report_quiet.py
+++ b/studio/backend/tests/test_embedding_load_report_quiet.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The RAG embedder load must not write raw transformers output to the server log.
+
+transformers >= 5 prints a multi-line, ANSI-coloured "<Model> LOAD REPORT" table
+through logger.warning plus a "Loading weights" tqdm bar. bge-small-en-v1.5 always
+trips it (legacy embeddings.position_ids key), so every Studio boot emitted ~7
+unstructured lines into an otherwise JSON log. They are captured and re-emitted on
+our own logger instead: debug when benign, warning when the report mentions
+anything that could change the model.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from core.rag.embeddings import _quiet_transformers_load  # noqa: E402
+
+_REPORT_LOGGER = "transformers.utils.loading_report"
+_BENIGN = (
+    "\x1b[1mBertModel LOAD REPORT\x1b[0m from: unsloth/bge-small-en-v1.5\n"
+    "Key                     | Status\n"
+    "embeddings.position_ids | UNEXPECTED"
+)
+_SERIOUS = "BertModel LOAD REPORT from: x\nencoder.layer.0.weight | MISSING"
+
+
+class _Sink(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+def _attach_sink():
+    log = logging.getLogger(_REPORT_LOGGER)
+    sink = _Sink()
+    log.addHandler(sink)
+    log.propagate = False
+    log.setLevel(logging.DEBUG)
+    return log, sink
+
+
+def test_load_report_is_swallowed_and_captured():
+    log, sink = _attach_sink()
+    try:
+        with _quiet_transformers_load() as report:
+            log.warning(_BENIGN)
+        assert sink.messages == [], sink.messages
+        assert len(report.reports) == 1
+        assert "LOAD REPORT" in report.reports[0]
+        assert report.is_serious() is False
+    finally:
+        log.removeHandler(sink)
+
+
+def test_unrelated_transformers_warnings_still_pass_through():
+    log, sink = _attach_sink()
+    try:
+        with _quiet_transformers_load():
+            log.warning("something genuinely wrong happened")
+        assert sink.messages == ["something genuinely wrong happened"]
+    finally:
+        log.removeHandler(sink)
+
+
+def test_missing_keys_are_flagged_as_serious():
+    log, sink = _attach_sink()
+    try:
+        with _quiet_transformers_load() as report:
+            log.warning(_SERIOUS)
+        assert report.is_serious() is True
+    finally:
+        log.removeHandler(sink)
+
+
+def test_filter_is_removed_after_the_context():
+    log, sink = _attach_sink()
+    try:
+        with _quiet_transformers_load():
+            pass
+        log.warning(_BENIGN)
+        assert len(sink.messages) == 1
+    finally:
+        log.removeHandler(sink)
+
+
+def test_progress_bar_state_is_restored():
+    from transformers.utils import logging as hf_logging
+
+    enabled_probe = getattr(hf_logging, "is_progress_bar_enabled", None)
+    if enabled_probe is None:
+        return  # nothing to assert on this transformers build
+
+    hf_logging.enable_progress_bar()
+    with _quiet_transformers_load():
+        assert enabled_probe() is False
+    assert enabled_probe() is True
+
+
+def test_a_caller_that_already_disabled_bars_stays_disabled():
+    from transformers.utils import logging as hf_logging
+
+    enabled_probe = getattr(hf_logging, "is_progress_bar_enabled", None)
+    if enabled_probe is None:
+        return
+
+    hf_logging.disable_progress_bar()
+    try:
+        with _quiet_transformers_load():
+            pass
+        assert enabled_probe() is False
+    finally:
+        hf_logging.enable_progress_bar()

--- a/studio/backend/tests/test_model_defaults_log_once.py
+++ b/studio/backend/tests/test_model_defaults_log_once.py
@@ -31,6 +31,7 @@ class _RecordingLogger:
     def _record(self, level: str):
         def log(msg, *args, **kwargs):
             self.calls.append((level, str(msg)))
+
         return log
 
     def __getattr__(self, name: str):
@@ -75,10 +76,7 @@ def test_announced_set_is_bounded(monkeypatch):
     _reset(monkeypatch)
     for i in range(model_config._ANNOUNCED_MODEL_DEFAULTS_MAX + 10):
         model_config._log_model_defaults(f"msg {i}", f"key-{i}")
-    assert (
-        len(model_config._ANNOUNCED_MODEL_DEFAULTS)
-        <= model_config._ANNOUNCED_MODEL_DEFAULTS_MAX
-    )
+    assert len(model_config._ANNOUNCED_MODEL_DEFAULTS) <= model_config._ANNOUNCED_MODEL_DEFAULTS_MAX
     model_config._ANNOUNCED_MODEL_DEFAULTS.clear()
 
 

--- a/studio/backend/tests/test_model_defaults_log_once.py
+++ b/studio/backend/tests/test_model_defaults_log_once.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""load_model_defaults announces a resolution once, then drops to debug.
+
+GET /api/inference/status resolves the defaults on every poll and the UI polls it
+every 5s for as long as a tab is open, so the unconditional info line repeated
+forever. The first resolution still logs at info; repeats stay visible at debug.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from utils.models import model_config  # noqa: E402
+from utils.models.model_config import load_model_defaults  # noqa: E402
+
+
+class _RecordingLogger:
+    """Stand-in for the module's structlog logger; caplog cannot see structlog."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def _record(self, level: str):
+        def log(msg, *args, **kwargs):
+            self.calls.append((level, str(msg)))
+        return log
+
+    def __getattr__(self, name: str):
+        if name in ("debug", "info", "warning", "error"):
+            return self._record(name)
+        raise AttributeError(name)
+
+    def at(self, level: str, needle: str) -> list[str]:
+        return [m for lvl, m in self.calls if lvl == level and needle in m]
+
+
+def _reset(monkeypatch) -> _RecordingLogger:
+    model_config._ANNOUNCED_MODEL_DEFAULTS.clear()
+    rec = _RecordingLogger()
+    monkeypatch.setattr(model_config, "logger", rec)
+    return rec
+
+
+def test_repeat_resolution_logs_once_at_info(monkeypatch):
+    rec = _reset(monkeypatch)
+    for _ in range(5):
+        load_model_defaults("definitely-not-a-real-model-xyz")
+    assert len(rec.at("info", "defaults from")) == 1, rec.calls
+
+
+def test_repeats_still_visible_at_debug(monkeypatch):
+    rec = _reset(monkeypatch)
+    for _ in range(3):
+        load_model_defaults("definitely-not-a-real-model-xyz")
+    # First call is the info line, the other two are debug: nothing is lost.
+    assert len(rec.at("debug", "defaults from")) == 2, rec.calls
+
+
+def test_a_different_model_gets_its_own_announcement(monkeypatch):
+    rec = _reset(monkeypatch)
+    load_model_defaults("definitely-not-a-real-model-xyz")
+    load_model_defaults("also-not-a-real-model-abc")
+    assert len(rec.at("info", "defaults from")) == 2, rec.calls
+
+
+def test_announced_set_is_bounded(monkeypatch):
+    _reset(monkeypatch)
+    for i in range(model_config._ANNOUNCED_MODEL_DEFAULTS_MAX + 10):
+        model_config._log_model_defaults(f"msg {i}", f"key-{i}")
+    assert (
+        len(model_config._ANNOUNCED_MODEL_DEFAULTS)
+        <= model_config._ANNOUNCED_MODEL_DEFAULTS_MAX
+    )
+    model_config._ANNOUNCED_MODEL_DEFAULTS.clear()
+
+
+def test_returned_config_is_unchanged_by_the_dedup(monkeypatch):
+    _reset(monkeypatch)
+    first = load_model_defaults("definitely-not-a-real-model-xyz")
+    second = load_model_defaults("definitely-not-a-real-model-xyz")
+    assert isinstance(first, dict)
+    assert first == second

--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -5790,7 +5790,8 @@ def test_a_finely_timestamped_volume_is_not_read_twice_per_call(tmp_path, monkey
     read = []
     real_key = tools._content_key
     monkeypatch.setattr(
-        tools, "_content_key",
+        tools,
+        "_content_key",
         lambda path, size: (read.append(path), real_key(path, size))[1],
     )
     snapshot = tools._snapshot_workdir_files(str(workdir))
@@ -5813,9 +5814,11 @@ def test_one_whole_second_stamp_is_not_taken_for_a_coarse_volume(tmp_path, monke
     tools._fine_mtime_devices.clear()
     real_stat = os.stat
     monkeypatch.setattr(
-        os, "stat",
+        os,
+        "stat",
         lambda p, *a, **k: (
-            _WholeSecondMtime(real_stat(p, *a, **k)) if str(p) == str(workdir)
+            _WholeSecondMtime(real_stat(p, *a, **k))
+            if str(p) == str(workdir)
             else real_stat(p, *a, **k)
         ),
     )

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -3407,7 +3407,11 @@ _ANNOUNCED_MODEL_DEFAULTS: set = set()
 _ANNOUNCED_MODEL_DEFAULTS_MAX = 4096
 
 
-def _log_model_defaults(message: str, key: str, level: str = "info") -> None:
+def _log_model_defaults(
+    message: str,
+    key: str,
+    level: str = "info",
+) -> None:
     """Log `message` at `level` the first time `key` is seen, then at debug."""
     if key in _ANNOUNCED_MODEL_DEFAULTS:
         logger.debug(message)

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -3397,6 +3397,27 @@ def get_base_model_from_lora_identifier(
 UI_STATUS_INDICATORS = [" (Ready)", " (Loading...)", " (Active)", "↓ "]
 
 
+# Which model defaults have already been announced. GET /api/inference/status is
+# polled every 5s for as long as a tab is open and resolves the defaults on every
+# poll, so without this the same "Loaded ... defaults from <path>" line repeats
+# forever. The first resolution of each (model, path) still logs at info; repeats
+# drop to debug, so --verbose and UNSLOTH_STUDIO_LOG_LEVEL=debug still show every
+# one. Bounded so a long-lived server with many models cannot grow it without end.
+_ANNOUNCED_MODEL_DEFAULTS: set = set()
+_ANNOUNCED_MODEL_DEFAULTS_MAX = 4096
+
+
+def _log_model_defaults(message: str, key: str, level: str = "info") -> None:
+    """Log `message` at `level` the first time `key` is seen, then at debug."""
+    if key in _ANNOUNCED_MODEL_DEFAULTS:
+        logger.debug(message)
+        return
+    if len(_ANNOUNCED_MODEL_DEFAULTS) >= _ANNOUNCED_MODEL_DEFAULTS_MAX:
+        _ANNOUNCED_MODEL_DEFAULTS.clear()
+    _ANNOUNCED_MODEL_DEFAULTS.add(key)
+    getattr(logger, level)(message)
+
+
 def load_model_defaults(model_name: str) -> Dict[str, Any]:
     """Load default training parameters for a model from a YAML file.
 
@@ -3418,7 +3439,10 @@ def load_model_defaults(model_name: str) -> Dict[str, Any]:
                 if config_path.is_file():
                     with open(config_path, "r", encoding = "utf-8") as f:
                         config = yaml.safe_load(f) or {}
-                        logger.info(f"Loaded model defaults from {config_path} (via mapping)")
+                        _log_model_defaults(
+                            f"Loaded model defaults from {config_path} (via mapping)",
+                            f"{model_name}|{config_path}|mapping",
+                        )
                         return config
 
         # For local paths (e.g. .../Spark-TTS-0.5B/LLM from adapter_config.json, or a Windows
@@ -3437,8 +3461,9 @@ def load_model_defaults(model_name: str) -> Dict[str, Any]:
                             if config_path.is_file():
                                 with open(config_path, "r", encoding = "utf-8") as f:
                                     config = yaml.safe_load(f) or {}
-                                    logger.info(
-                                        f"Loaded model defaults from {config_path} (via path suffix '{suffix}')"
+                                    _log_model_defaults(
+                                        f"Loaded model defaults from {config_path} (via path suffix '{suffix}')",
+                                        f"{model_name}|{config_path}|suffix",
                                     )
                                     return config
 
@@ -3450,17 +3475,27 @@ def load_model_defaults(model_name: str) -> Dict[str, Any]:
             if config_path.is_file():
                 with open(config_path, "r", encoding = "utf-8") as f:
                     config = yaml.safe_load(f) or {}
-                    logger.info(f"Loaded model defaults from {config_path}")
+                    _log_model_defaults(
+                        f"Loaded model defaults from {config_path}",
+                        f"{model_name}|{config_path}|exact",
+                    )
                     return config
 
         default_config_path = defaults_dir / "default.yaml"
         if default_config_path.exists():
             with open(default_config_path, "r", encoding = "utf-8") as f:
                 config = yaml.safe_load(f) or {}
-                logger.info(f"Loaded default model defaults from {default_config_path}")
+                _log_model_defaults(
+                    f"Loaded default model defaults from {default_config_path}",
+                    f"{model_name}|{default_config_path}|fallback",
+                )
                 return config
 
-        logger.warning(f"No default config found for model {model_name}")
+        _log_model_defaults(
+            f"No default config found for model {model_name}",
+            f"{model_name}|<missing>",
+            level = "warning",
+        )
         return {}
 
     except Exception as e:

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -3405,6 +3405,9 @@ UI_STATUS_INDICATORS = [" (Ready)", " (Loading...)", " (Active)", "↓ "]
 # one. Bounded so a long-lived server with many models cannot grow it without end.
 _ANNOUNCED_MODEL_DEFAULTS: set = set()
 _ANNOUNCED_MODEL_DEFAULTS_MAX = 4096
+# Two request threads can resolve the same unseen model at once, and a bare
+# check-then-add would let both decide they were first.
+_ANNOUNCED_MODEL_DEFAULTS_LOCK = threading.Lock()
 
 
 def _log_model_defaults(
@@ -3413,12 +3416,13 @@ def _log_model_defaults(
     level: str = "info",
 ) -> None:
     """Log `message` at `level` the first time `key` is seen, then at debug."""
-    if key in _ANNOUNCED_MODEL_DEFAULTS:
-        logger.debug(message)
-        return
-    if len(_ANNOUNCED_MODEL_DEFAULTS) >= _ANNOUNCED_MODEL_DEFAULTS_MAX:
-        _ANNOUNCED_MODEL_DEFAULTS.clear()
-    _ANNOUNCED_MODEL_DEFAULTS.add(key)
+    with _ANNOUNCED_MODEL_DEFAULTS_LOCK:
+        if key in _ANNOUNCED_MODEL_DEFAULTS:
+            logger.debug(message)
+            return
+        if len(_ANNOUNCED_MODEL_DEFAULTS) >= _ANNOUNCED_MODEL_DEFAULTS_MAX:
+            _ANNOUNCED_MODEL_DEFAULTS.clear()
+        _ANNOUNCED_MODEL_DEFAULTS.add(key)
     getattr(logger, level)(message)
 
 


### PR DESCRIPTION
### Summary

Two lines dominate a normal Studio session's log and neither carries information after its first appearance: the model-defaults resolution, which repeats for as long as a browser tab is open, and the raw transformers weight-load output from the RAG embedder, which is unstructured ANSI text in an otherwise JSON log. Both are quieted the way #7087 and #7869 did it: the signal is kept, the repetition is not.

### 1. "Loaded default model defaults from ..." repeats every poll

`GET /api/inference/status` is polled every 5s for as long as the app is open. It calls `load_inference_config` -> `load_model_defaults`, which logs the resolved config path at info on every call. The path never changes, so the line just repeats.

Measured on one machine from `logs/studio_a.log`, counting only that event:

| session | duration | "model defaults" lines | rate |
|---|---|---|---|
| before, one tab | 8.7 min | 22 | 2.5/min |
| before, four tabs | 10.8 min | 206 | 19.0/min |
| after | 18.2 min | 2 | 0.1/min |

The four-tab number is the interesting one: every open tab polls independently, so the line scales with tabs and made up the largest single share of non-access events.

`_log_model_defaults` now announces each `(model, resolved path)` once at info and drops later repeats to debug, so `--verbose` and `LOG_LEVEL=debug` still show every one. The set is bounded (4096 entries, cleared on overflow) so a long-lived server with many models cannot grow it without end. This covers all four resolution branches plus the "No default config found" warning, which had the same repeat problem.

Deliberately not a cache: the returned dict is unchanged and the file is still read every call, so editing a YAML under `assets/configs/model_defaults/` during development still takes effect immediately. Only the logging is deduplicated.

### 2. Raw transformers output on every boot

Loading the RAG embedder (`unsloth/bge-small-en-v1.5`, `core/rag/embeddings.py`) writes this to stdout on every single boot:

```
Loading weights:   0%|          | 0/199 [00:00<?, ?it/s]Loading weights: 100%|...| 199/199 [00:00<00:00, 4297.35it/s]
[1mBertModel LOAD REPORT[0m from: unsloth/bge-small-en-v1.5
Key                     | Status     |  |
------------------------+------------+--+-
embeddings.position_ids | UNEXPECTED |  |

Notes:
- UNEXPECTED:	can be ignored when loading from different task/architecture; not ok if you expect identical arch.
```

That is 7 lines, one of them a tqdm progress bar and one carrying ANSI colour codes, in a log whose every other line is JSON. It fires unconditionally because bge-small-en-v1.5 ships a legacy `embeddings.position_ids` key that the current `BertModel` does not expect, so the report is identical every time. transformers >= 5 emits it through `logger.warning` (`transformers/utils/loading_report.py`), not `print`, so a filter can reach it, the same technique as the existing `_DropTorchDtypeDeprecation` in `loggers/config.py`.

`_quiet_transformers_load()` wraps only that one load and:

- attaches a filter that captures the `LOAD REPORT` record instead of letting it print, then re-emits it on our own logger, at debug when it reports only UNEXPECTED keys and at warning if it ever mentions MISSING, MISMATCH or CONVERSION;
- disables the transformers progress bar for the duration and restores the previous setting exactly, so a caller that had already disabled bars stays disabled, and every other model load keeps its normal bar and report.

Nothing is lost. `embeddings.py` already logs `loading embedding model <name> on <device>` at info, which is the line that actually says what happened, and a report that could change the model's behaviour is promoted rather than hidden.

Measured directly by loading the embedder in a subprocess with and without the change: 7 lines of tqdm and report before, 0 after.

### What stays logged

- The first resolution of every model's defaults, at info.
- Every repeat, at debug.
- The "No default config found for model X" warning, once per model, at warning.
- `loading embedding model ... on ...`, unchanged.
- Any load report mentioning MISSING, MISMATCH or CONVERSION, at warning, on the structured logger.
- All progress bars and load reports for user-visible model loads, untouched.

### Tests

`studio/backend/tests/test_model_defaults_log_once.py` (5 cases): the repeat logs once at info, the repeats are still emitted at debug, a second model gets its own announcement, the announced set stays bounded, and the returned config is unaffected.

`studio/backend/tests/test_embedding_load_report_quiet.py` (6 cases): the report is swallowed and captured, unrelated transformers warnings still pass through, MISSING is flagged serious, the filter is removed after the context, and the progress-bar setting is restored both when it was on and when the caller had already turned it off.

Related suites, all green on this branch: `test_rag_embeddings`, `test_embedding_model_settings`, `test_embedding_model_security_gate`, `test_offline_embedding_minimal`, `test_model_defaults_none_guard`, `test_kimi_k3_reasoning_defaults`, `test_models_get_model_config_case_resolution`, `test_logging_middleware` plus the two new files: 163 passed, 1 skipped.
