### PR TITLE
CLI: verify-install reports a healthy install as broken around an editable checkout

### DIFF
--- a/tests/studio/install/test_studio_deps_cli.py
+++ b/tests/studio/install/test_studio_deps_cli.py
@@ -277,3 +277,40 @@ def test_a_torn_tree_without_the_manifest_helper_is_incomplete(tmp_path, monkeyp
 
     assert state["ok"] is False, state
     assert state["reason"] == "studio_install_manifest_missing"
+
+
+# ── which prefix owns the manifest module ────────────────────────────
+
+
+def test_a_manifest_inside_a_venv_site_packages_is_owned_by_that_venv(tmp_path, deps):
+    """The wheel case: studio/ really is installed into that prefix."""
+    venv = tmp_path / "venv"
+    site_packages = venv / "lib" / "python3.11" / "site-packages"
+    (site_packages / "studio").mkdir(parents = True)
+    (venv / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding = "utf-8")
+    module_path = site_packages / "studio" / "install_manifest.py"
+    shutil.copy(MANIFEST_PATH, module_path)
+
+    module = _load(module_path, "manifest_in_site_packages")
+
+    assert deps._venv_root_for_module(module) == venv
+
+
+def test_an_editable_checkout_is_not_owned_by_a_surrounding_venv(tmp_path, deps):
+    """`./install.sh --local` leaves studio/install_manifest.py in the repo. When the
+    clone happens to live inside some other virtualenv's directory, the first
+    pyvenv.cfg above it belongs to a venv the managed install has nothing to do
+    with. Claiming it there made verify-install walk that venv's site-packages and
+    report every managed dependency as missing, so `unsloth studio verify-install`
+    exited 1 on a healthy install and setup.sh could never take its fast path."""
+    surrounding = tmp_path / "unrelated_venv"
+    (surrounding / "lib" / "python3.11" / "site-packages").mkdir(parents = True)
+    (surrounding / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding = "utf-8")
+    repo = surrounding / "repo"
+    (repo / "studio").mkdir(parents = True)
+    module_path = repo / "studio" / "install_manifest.py"
+    shutil.copy(MANIFEST_PATH, module_path)
+
+    module = _load(module_path, "manifest_in_editable_checkout")
+
+    assert deps._venv_root_for_module(module) is None

--- a/unsloth_cli/_studio_deps.py
+++ b/unsloth_cli/_studio_deps.py
@@ -72,11 +72,26 @@ def load_install_manifest_module(extra_roots: Sequence[Path] = ()):
 
 
 def _venv_root_for_module(module) -> Optional[Path]:
-    """Prefix owning a manifest module, which may be a venv other than ours."""
-    path = Path(getattr(module, "__file__", "") or "")
+    """Prefix owning a manifest module, which may be a venv other than ours.
+
+    A prefix only owns the module when the module actually lives in that
+    prefix's site-packages. An editable checkout (`./install.sh --local`) keeps
+    studio/install_manifest.py in the repo, so the first pyvenv.cfg above it is
+    whatever venv the clone happens to sit inside -- frequently an unrelated one
+    when the repo is cloned into a directory that is itself a virtualenv. Owning
+    it there would verify that venv's packages instead of the managed install and
+    report every managed dependency as missing.
+    """
+    path = _resolved(Path(getattr(module, "__file__", "") or ""))
     for parent in path.parents:
         if (parent / "pyvenv.cfg").is_file():
-            return parent
+            for site_packages in _venv_site_packages(parent):
+                try:
+                    path.relative_to(_resolved(site_packages))
+                except ValueError:
+                    continue
+                return parent
+            return None
     return None
 
 


### PR DESCRIPTION
### Summary

`unsloth studio verify-install` can report a perfectly healthy install as broken, listing every managed dependency as missing, because it verifies the wrong virtualenv.

### Repro

After a developer install (`./install.sh --local`) where the clone happens to sit inside another virtualenv:

```
$ UNSLOTH_STUDIO_HOME=/path/to/home unsloth studio verify-install
Unsloth Studio install is incomplete (studio_install_incomplete).
  missing packages: matplotlib, nest_asyncio, datasets, huggingface-hub, structlog,
  diceware, ddgs, boto3, fastmcp, av, sqlite-vec, pymupdf, pymupdf4llm, python-docx
  repair with: unsloth studio update
```

All fourteen import fine in the managed venv that the CLI is running from:

```
$ home/unsloth_studio/bin/python -c "import matplotlib, datasets, structlog, av, sqlite_vec, pymupdf, docx"
$
```

### Why

`_venv_root_for_module` (`unsloth_cli/_studio_deps.py:74`) decides which prefix owns the manifest module by walking up from the module file to the first `pyvenv.cfg`:

```python
path = Path(getattr(module, "__file__", "") or "")
for parent in path.parents:
    if (parent / "pyvenv.cfg").is_file():
        return parent
```

That holds for a normal wheel install, where the module really does live under that prefix's `site-packages`. It does not hold for an editable install: `./install.sh --local` leaves `studio/install_manifest.py` in the repo, so the first `pyvenv.cfg` above it is whatever venv the clone happens to be nested inside, which has nothing to do with the managed install. The check then walks that unrelated venv's `site-packages` and finds none of the managed packages.

### Impact beyond the message

- `verify_install()`'s own docstring (`unsloth_cli/commands/studio.py:3971`) notes that `setup.sh` and `setup.ps1` gate their "already up to date" fast path on this exit code, so every install re-runs the full dependency pass.
- The desktop preflight reads the same `studio_install_incomplete` reason string.
- Anyone debugging a real install problem is told fourteen packages are missing when they are not.

### Fix

A prefix only owns the module when the module is actually inside that prefix's `site-packages`. An editable checkout then resolves to no owner, which falls back to `sys.prefix`, the venv the CLI is running in, which is the managed one.

Both paths are resolved before comparison so a symlinked venv or repo does not defeat the containment check.

After:

```
$ UNSLOTH_STUDIO_HOME=/path/to/home unsloth studio verify-install
Unsloth Studio install is complete.
$ echo $?
0
```

### Tests

`tests/studio/install/test_studio_deps_cli.py` gains cases for the editable-checkout layout (module inside a repo nested in an unrelated venv resolves to no owner) alongside the existing wheel-install layout (module inside the prefix's site-packages still resolves to that prefix).

`tests/studio/install/`: 1723 passed, 2 skipped, 1 failed. The failure is `test_managed_node_runtime.py::test_managed_dir_uses_legacy_sibling_by_default`, which fails identically on an untouched checkout of main in this environment.
