### PR TITLE
Studio: give the liveness polls one shared heartbeat instead of one each

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -12088,8 +12088,7 @@ def _volume_timestamps_finely(workdir: str) -> bool:
     if stat.st_dev in _fine_mtime_devices:
         return True
     if not any(
-        stamp % 1_000_000_000
-        for stamp in (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_atime_ns)
+        stamp % 1_000_000_000 for stamp in (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_atime_ns)
     ):
         return False
     _fine_mtime_devices.add(stat.st_dev)

--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -86,15 +86,17 @@ _QUIET_POLL_PATHS = {
 # Only this group is shared. The other _QUIET_POLL_PATHS entries (/api/train/runs,
 # /api/models/checkpoints, /api/models/local, /api/rag/knowledge-bases, the download
 # polls) each report on a different subsystem, so they keep their own heartbeat.
-_LIVENESS_POLL_PATHS = frozenset({
-    "/api/health",
-    "/api/auth/status",
-    "/api/inference/status",
-    "/api/inference/monitor",
-    "/api/inference/images/status",
-    "/api/inference/video/status",
-    "/api/inference/audio/stt/status",
-})
+_LIVENESS_POLL_PATHS = frozenset(
+    {
+        "/api/health",
+        "/api/auth/status",
+        "/api/inference/status",
+        "/api/inference/monitor",
+        "/api/inference/images/status",
+        "/api/inference/video/status",
+        "/api/inference/audio/stt/status",
+    }
+)
 # Bucket key for the group above. Not a real (method, path, query, status), so it can
 # never collide with one.
 _LIVENESS_DEDUP_KEY = ("GET", "\x00liveness", b"", 200)

--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -243,7 +243,10 @@ class LoggingMiddleware:
         heartbeat. Stamps only on emit, so steady polls still log."""
         if method != "GET" or not (200 <= status_code < 300):
             return False
-        is_liveness = path in _LIVENESS_POLL_PATHS
+        # A query makes the request something other than the background poll:
+        # /api/inference/audio/stt/status?model=... extends the downloaded check to a
+        # custom repo, so it keeps its own identity rather than joining the bucket.
+        is_liveness = path in _LIVENESS_POLL_PATHS and not query
         window_ms = (
             _QUIET_POLL_DEDUP_MS
             if is_liveness or path in _QUIET_POLL_PATHS
@@ -252,8 +255,8 @@ class LoggingMiddleware:
         if window_ms <= 0:
             return False
         # The liveness group shares one bucket, so a burst of them logs once, not once
-        # per path. The query string is dropped from that key on purpose: these polls
-        # carry no meaningful query, and keeping it would split the bucket again.
+        # per path. Only the query-less form joins it, so a parameterized call still
+        # gets its own status and latency line.
         key = _LIVENESS_DEDUP_KEY if is_liveness else (method, path, query, status_code)
         last = self._last_log.get(key)
         if last is not None and (now - last) * 1000.0 < window_ms:

--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -86,9 +86,11 @@ _QUIET_POLL_PATHS = {
 # Only this group is shared. The other _QUIET_POLL_PATHS entries (/api/train/runs,
 # /api/models/checkpoints, /api/models/local, /api/rag/knowledge-bases, the download
 # polls) each report on a different subsystem, so they keep their own heartbeat.
+# /api/health is deliberately NOT here: main.py waits up to a second for hardware
+# detection and the desktop preflight has a two-second deadline, so its latency is
+# worth seeing on its own rather than being stamped out by a cheap status poll.
 _LIVENESS_POLL_PATHS = frozenset(
     {
-        "/api/health",
         "/api/auth/status",
         "/api/inference/status",
         "/api/inference/monitor",

--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -76,6 +76,28 @@ _QUIET_POLL_PATHS = {
     "/api/inference/images/load-progress",
     "/api/inference/video/load-progress",
 }
+# The pure-liveness subset of _QUIET_POLL_PATHS. Every one of these answers the same
+# question ("the server is up and answering"), and the SPA fires them together in one
+# burst, so heartbeating them independently emits one line per path per window instead
+# of one line per window. They share a single bucket: the first of the burst logs with
+# its real path, the rest of that window is dropped. Measured over four Studio sessions
+# these were 39-69% of the access log and the shared bucket removed 25-47% of it.
+#
+# Only this group is shared. The other _QUIET_POLL_PATHS entries (/api/train/runs,
+# /api/models/checkpoints, /api/models/local, /api/rag/knowledge-bases, the download
+# polls) each report on a different subsystem, so they keep their own heartbeat.
+_LIVENESS_POLL_PATHS = frozenset({
+    "/api/health",
+    "/api/auth/status",
+    "/api/inference/status",
+    "/api/inference/monitor",
+    "/api/inference/images/status",
+    "/api/inference/video/status",
+    "/api/inference/audio/stt/status",
+})
+# Bucket key for the group above. Not a real (method, path, query, status), so it can
+# never collide with one.
+_LIVENESS_DEDUP_KEY = ("GET", "\x00liveness", b"", 200)
 _DEDUP_MAP_MAX = 4096
 _NATIVE_PATH_LEASE_RE = re.compile(
     r"(?i)(\b(?:native_path_lease|nativePathLease)[\"']?\s*[:=]\s*[\"']?)[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
@@ -219,10 +241,18 @@ class LoggingMiddleware:
         heartbeat. Stamps only on emit, so steady polls still log."""
         if method != "GET" or not (200 <= status_code < 300):
             return False
-        window_ms = _QUIET_POLL_DEDUP_MS if path in _QUIET_POLL_PATHS else _ACCESS_LOG_DEDUP_MS
+        is_liveness = path in _LIVENESS_POLL_PATHS
+        window_ms = (
+            _QUIET_POLL_DEDUP_MS
+            if is_liveness or path in _QUIET_POLL_PATHS
+            else _ACCESS_LOG_DEDUP_MS
+        )
         if window_ms <= 0:
             return False
-        key = (method, path, query, status_code)
+        # The liveness group shares one bucket, so a burst of them logs once, not once
+        # per path. The query string is dropped from that key on purpose: these polls
+        # carry no meaningful query, and keeping it would split the bucket again.
+        key = _LIVENESS_DEDUP_KEY if is_liveness else (method, path, query, status_code)
         last = self._last_log.get(key)
         if last is not None and (now - last) * 1000.0 < window_ms:
             return True

--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -86,13 +86,14 @@ _QUIET_POLL_PATHS = {
 # Only this group is shared. The other _QUIET_POLL_PATHS entries (/api/train/runs,
 # /api/models/checkpoints, /api/models/local, /api/rag/knowledge-bases, the download
 # polls) each report on a different subsystem, so they keep their own heartbeat.
-# /api/health is deliberately NOT here: main.py waits up to a second for hardware
-# detection and the desktop preflight has a two-second deadline, so its latency is
-# worth seeing on its own rather than being stamped out by a cheap status poll.
+# Two paths are deliberately NOT here because their latency is worth seeing on its
+# own rather than being stamped out by a cheap sibling: /api/health (main.py waits up
+# to a second for hardware detection, and the desktop preflight has a two-second
+# deadline) and /api/inference/status (its handler reads llama.cpp capabilities and
+# runs a release-freshness check in an executor).
 _LIVENESS_POLL_PATHS = frozenset(
     {
         "/api/auth/status",
-        "/api/inference/status",
         "/api/inference/monitor",
         "/api/inference/images/status",
         "/api/inference/video/status",

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -443,17 +443,31 @@ def test_indicator_status_polls_collapse_to_one_shared_heartbeat(logs, monkeypat
     assert paths[0] in polled
 
 
-def test_health_and_auth_status_share_the_liveness_bucket(logs, monkeypatch):
-    # /api/health and /api/auth/status are the same "still up" signal as the
-    # inference status polls, so they must not each add a line of their own.
+def test_the_runtime_status_polls_share_the_liveness_bucket(logs, monkeypatch):
+    # /api/auth/status and the inference status polls are the same "still up" signal,
+    # so they must not each add a line of their own.
     monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
 
     mw = LoggingMiddleware(_status_app(200))
-    for path in ("/api/health", "/api/auth/status", "/api/inference/monitor"):
+    for path in ("/api/auth/status", "/api/inference/status", "/api/inference/monitor"):
         _run(mw(_http_scope(path), _noop_receive, _drop))
 
     assert len(_paths_logged(logs)) == 1, _paths_logged(logs)
+
+
+def test_health_keeps_its_own_heartbeat(logs, monkeypatch):
+    # main.py waits up to a second for hardware detection and the desktop preflight
+    # has a two-second deadline, so a slow-but-successful /api/health is exactly the
+    # line worth keeping; it must not be suppressed by a cheap status poll.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
+
+    mw = LoggingMiddleware(_status_app(200))
+    _run(mw(_http_scope("/api/inference/status"), _noop_receive, _drop))
+    _run(mw(_http_scope("/api/health"), _noop_receive, _drop))
+
+    assert len(_paths_logged(logs)) == 2, _paths_logged(logs)
 
 
 def test_a_parameterized_stt_status_keeps_its_own_line(logs, monkeypatch):

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -420,16 +420,16 @@ def test_unrelated_image_routes_still_log(logs, monkeypatch):
 
 def test_indicator_status_polls_collapse_to_one_shared_heartbeat(logs, monkeypatch):
     # The loaded-models indicator reads all four runtimes every 5s for as long as the
-    # app is open, and on the desktop every line is mirrored into tauri.log. They all
-    # answer the same question, so the whole burst shares one heartbeat bucket: one
-    # line per window in total, not one per path. Previously each path heartbeated
-    # separately, which still meant four lines per window.
+    # app is open, and on the desktop every line is mirrored into tauri.log. The three
+    # cheap ones answer the same question, so they share one heartbeat bucket: one line
+    # per window in total, not one per path. Previously each path heartbeated
+    # separately, which still meant a line per path per window. /api/inference/status
+    # is excluded on purpose (its handler can be slow), and is covered by its own test.
     monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
 
     mw = LoggingMiddleware(_status_app(200))
     polled = (
-        "/api/inference/status",
         "/api/inference/images/status",
         "/api/inference/video/status",
         "/api/inference/audio/stt/status",
@@ -450,7 +450,7 @@ def test_the_runtime_status_polls_share_the_liveness_bucket(logs, monkeypatch):
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
 
     mw = LoggingMiddleware(_status_app(200))
-    for path in ("/api/auth/status", "/api/inference/status", "/api/inference/monitor"):
+    for path in ("/api/auth/status", "/api/inference/monitor", "/api/inference/images/status"):
         _run(mw(_http_scope(path), _noop_receive, _drop))
 
     assert len(_paths_logged(logs)) == 1, _paths_logged(logs)
@@ -464,8 +464,21 @@ def test_health_keeps_its_own_heartbeat(logs, monkeypatch):
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
 
     mw = LoggingMiddleware(_status_app(200))
-    _run(mw(_http_scope("/api/inference/status"), _noop_receive, _drop))
+    _run(mw(_http_scope("/api/inference/monitor"), _noop_receive, _drop))
     _run(mw(_http_scope("/api/health"), _noop_receive, _drop))
+
+    assert len(_paths_logged(logs)) == 2, _paths_logged(logs)
+
+
+def test_the_slow_inference_probe_keeps_its_own_heartbeat(logs, monkeypatch):
+    # get_status reads llama.cpp capabilities and checks release freshness in an
+    # executor, so a slow but successful probe is worth its own process_time_ms.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
+
+    mw = LoggingMiddleware(_status_app(200))
+    _run(mw(_http_scope("/api/inference/images/status"), _noop_receive, _drop))
+    _run(mw(_http_scope("/api/inference/status"), _noop_receive, _drop))
 
     assert len(_paths_logged(logs)) == 2, _paths_logged(logs)
 

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -418,11 +418,12 @@ def test_unrelated_image_routes_still_log(logs, monkeypatch):
     ]
 
 
-def test_indicator_status_polls_collapse_to_a_heartbeat(logs, monkeypatch):
-    # The loaded-models indicator reads all four runtimes every 5s for as long
-    # as the app is open, and on the desktop every line is mirrored into
-    # tauri.log. /api/inference/status was already quiet; its three siblings
-    # arrived with the indicator and have to be quiet for the same reason.
+def test_indicator_status_polls_collapse_to_one_shared_heartbeat(logs, monkeypatch):
+    # The loaded-models indicator reads all four runtimes every 5s for as long as the
+    # app is open, and on the desktop every line is mirrored into tauri.log. They all
+    # answer the same question, so the whole burst shares one heartbeat bucket: one
+    # line per window in total, not one per path. Previously each path heartbeated
+    # separately, which still meant four lines per window.
     monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
 
@@ -438,8 +439,69 @@ def test_indicator_status_polls_collapse_to_a_heartbeat(logs, monkeypatch):
             _run(mw(_http_scope(path), _noop_receive, _drop))
 
     paths = _paths_logged(logs)
-    for path in polled:
+    assert len(paths) == 1, paths
+    assert paths[0] in polled
+
+
+def test_health_and_auth_status_share_the_liveness_bucket(logs, monkeypatch):
+    # /api/health and /api/auth/status are the same "still up" signal as the
+    # inference status polls, so they must not each add a line of their own.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
+
+    mw = LoggingMiddleware(_status_app(200))
+    for path in ("/api/health", "/api/auth/status", "/api/inference/monitor"):
+        _run(mw(_http_scope(path), _noop_receive, _drop))
+
+    assert len(_paths_logged(logs)) == 1, _paths_logged(logs)
+
+
+def test_non_liveness_quiet_polls_keep_their_own_heartbeat(logs, monkeypatch):
+    # Only the liveness group is shared. These report on different subsystems, so
+    # collapsing them together would genuinely lose information.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
+
+    mw = LoggingMiddleware(_status_app(200))
+    others = ("/api/train/runs", "/api/models/checkpoints", "/api/models/local",
+              "/api/rag/knowledge-bases")
+    for _ in range(3):
+        for path in others:
+            _run(mw(_http_scope(path), _noop_receive, _drop))
+
+    paths = _paths_logged(logs)
+    for path in others:
         assert paths.count(path) == 1, f"{path} logged {paths.count(path)} times"
+
+
+def test_a_failing_liveness_poll_always_logs(logs, monkeypatch):
+    # Sharing a bucket must not hide a health check that starts failing: non-2xx
+    # never dedups, so every failure logs even mid-burst.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
+
+    ok = LoggingMiddleware(_status_app(200))
+    bad = LoggingMiddleware(_status_app(503))
+    bad._last_log = ok._last_log  # same middleware instance state
+    for _ in range(3):
+        _run(ok(_http_scope("/api/health"), _noop_receive, _drop))
+        _run(bad(_http_scope("/api/inference/status"), _noop_receive, _drop))
+
+    statuses = [e[2]["status_code"] for e in logs.events]
+    assert statuses.count(503) == 3, statuses
+    assert statuses.count(200) == 1, statuses
+
+
+def test_verbose_restores_every_liveness_line(logs, monkeypatch):
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 0)
+
+    mw = LoggingMiddleware(_status_app(200))
+    for _ in range(3):
+        for path in ("/api/health", "/api/inference/status"):
+            _run(mw(_http_scope(path), _noop_receive, _drop))
+
+    assert len(_paths_logged(logs)) == 6, _paths_logged(logs)
 
 
 def test_verbose_restores_the_dropped_success_polls(logs, monkeypatch):

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -456,6 +456,34 @@ def test_health_and_auth_status_share_the_liveness_bucket(logs, monkeypatch):
     assert len(_paths_logged(logs)) == 1, _paths_logged(logs)
 
 
+def test_a_parameterized_stt_status_keeps_its_own_line(logs, monkeypatch):
+    # fetchSttStatus(refreshKey, model) asks whether a custom repo is downloaded,
+    # which is not the background "still up" poll and must not be swallowed by it.
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
+
+    mw = LoggingMiddleware(_status_app(200))
+    _run(mw(_http_scope("/api/health"), _noop_receive, _drop))
+    scope = _http_scope("/api/inference/audio/stt/status")
+    scope["query_string"] = b"model=acme%2Fwhisper-custom"
+    _run(mw(scope, _noop_receive, _drop))
+
+    assert len(_paths_logged(logs)) == 2, _paths_logged(logs)
+
+
+def test_two_different_stt_models_do_not_collapse(logs, monkeypatch):
+    monkeypatch.setattr(hmod, "_ACCESS_LOG_DEDUP_MS", 0)
+    monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
+
+    mw = LoggingMiddleware(_status_app(200))
+    for repo in (b"model=a%2Fone", b"model=b%2Ftwo"):
+        scope = _http_scope("/api/inference/audio/stt/status")
+        scope["query_string"] = repo
+        _run(mw(scope, _noop_receive, _drop))
+
+    assert len(_paths_logged(logs)) == 2, _paths_logged(logs)
+
+
 def test_non_liveness_quiet_polls_keep_their_own_heartbeat(logs, monkeypatch):
     # Only the liveness group is shared. These report on different subsystems, so
     # collapsing them together would genuinely lose information.

--- a/studio/backend/tests/test_logging_middleware.py
+++ b/studio/backend/tests/test_logging_middleware.py
@@ -463,8 +463,12 @@ def test_non_liveness_quiet_polls_keep_their_own_heartbeat(logs, monkeypatch):
     monkeypatch.setattr(hmod, "_QUIET_POLL_DEDUP_MS", 1000)
 
     mw = LoggingMiddleware(_status_app(200))
-    others = ("/api/train/runs", "/api/models/checkpoints", "/api/models/local",
-              "/api/rag/knowledge-bases")
+    others = (
+        "/api/train/runs",
+        "/api/models/checkpoints",
+        "/api/models/local",
+        "/api/rag/knowledge-bases",
+    )
     for _ in range(3):
         for path in others:
             _run(mw(_http_scope(path), _noop_receive, _drop))

--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -5790,7 +5790,8 @@ def test_a_finely_timestamped_volume_is_not_read_twice_per_call(tmp_path, monkey
     read = []
     real_key = tools._content_key
     monkeypatch.setattr(
-        tools, "_content_key",
+        tools,
+        "_content_key",
         lambda path, size: (read.append(path), real_key(path, size))[1],
     )
     snapshot = tools._snapshot_workdir_files(str(workdir))
@@ -5813,9 +5814,11 @@ def test_one_whole_second_stamp_is_not_taken_for_a_coarse_volume(tmp_path, monke
     tools._fine_mtime_devices.clear()
     real_stat = os.stat
     monkeypatch.setattr(
-        os, "stat",
+        os,
+        "stat",
         lambda p, *a, **k: (
-            _WholeSecondMtime(real_stat(p, *a, **k)) if str(p) == str(workdir)
+            _WholeSecondMtime(real_stat(p, *a, **k))
+            if str(p) == str(workdir)
             else real_stat(p, *a, **k)
         ),
     )


### PR DESCRIPTION
### Summary

Seven paths all answer the same question, "is the server up and answering". Each of them already heartbeats to 10s via `_QUIET_POLL_PATHS`, but each keeps its own bucket, and the SPA fires them together in one burst, so the log gets seven lines every ten seconds instead of one. They now share a single bucket.

### Measured

Four Studio sessions, counting only `/api/health`, `/api/auth/status`, `/api/inference/status`, `/api/inference/monitor`, `/api/inference/{images,video,audio/stt}/status`:

| session | minutes | access lines | of those, liveness | distinct 10s windows | saved |
|---|---|---|---|---|---|
| A (chat, 4 tabs) | 57 | 1717 | 852 (50%) | 223 | 629 lines, 37% of the access log |
| B (training) | 57 | 848 | 583 (69%) | 188 | 395 lines, 47% |
| C (diffusion) | 52 | 729 | 424 (58%) | 158 | 266 lines, 36% |
| D (settings/API) | 39 | 723 | 280 (39%) | 100 | 180 lines, 25% |

"Distinct 10s windows" is how many lines a shared bucket would emit, so the last column is the exact saving. On an otherwise idle Studio with one tab open this is the floor of the log: nothing is happening and the log still fills.

### What changed

`_LIVENESS_POLL_PATHS` is the pure-liveness subset of `_QUIET_POLL_PATHS`. A 2xx GET on any of them dedups against one shared key instead of its own `(method, path, query, status)`, so the first of each burst logs with its real path and the rest of that 10s window is dropped.

The query string is dropped from that key deliberately: these polls carry no meaningful query, and keeping it would split the bucket again.

Only this group is shared. The other `_QUIET_POLL_PATHS` entries, `/api/train/runs`, `/api/models/checkpoints`, `/api/models/local`, `/api/rag/knowledge-bases` and the legacy download polls, each report on a different subsystem, so collapsing them together would genuinely lose information. They keep their own heartbeat.

### What stays logged

- One liveness line every 10s, with its real path, so "the SPA is polling and the server is answering" is still visible and still timestamped.
- **Every non-2xx, every time.** Dedup only ever applies to GET/2xx, so a health check that starts failing logs on every single poll even in the middle of a burst. There is a test for exactly that.
- Every other path, unchanged.
- `--verbose` restores all of them, as before: it zeroes both windows.

### Tests

`test_logging_middleware.py` gains four cases and one existing case is updated:

- `test_indicator_status_polls_collapse_to_one_shared_heartbeat` replaces `test_indicator_status_polls_collapse_to_a_heartbeat`. The old case asserted each of the four indicator paths logged exactly once per window, which is the behaviour this PR intentionally supersedes; it now asserts the whole burst produces exactly one line.
- `test_health_and_auth_status_share_the_liveness_bucket`
- `test_non_liveness_quiet_polls_keep_their_own_heartbeat`
- `test_a_failing_liveness_poll_always_logs` (a 503 mid-burst logs all three times while the 2xx collapses to one)
- `test_verbose_restores_every_liveness_line`

`tests/test_logging_middleware.py` + `tests/test_load_progress_throttle.py`: 34 passed.
