### PR TITLE
Studio: keep a rehearsal tool call quoted in markdown code as text

### DIFF
--- a/studio/backend/core/tool_healing.py
+++ b/studio/backend/core/tool_healing.py
@@ -107,6 +107,28 @@ def strip_tool_patterns(text: str, patterns) -> str:
     return text
 
 
+def _rehearsal_strip(m, pat, text, spans, enabled_tool_names) -> str:
+    """Replacement for one rehearsal strip match: "" to remove it, else what to keep.
+
+    An inactive name or a quoted example is kept. The tail pattern runs to EOF, so a match
+    that opens on a quoted example can still cover a later real call; keep the quoted part
+    and strip from that call on, or the truncated markup leaks into the answer."""
+    if enabled_tool_names is not None and m.group(1) not in enabled_tool_names:
+        return m.group(0)
+    if not _in_code(spans, m.start()):
+        return ""
+    pos = m.start()
+    while True:
+        nxt = pat.search(text, pos + 1)
+        if nxt is None or nxt.start() >= m.end():
+            return m.group(0)
+        if not _in_code(spans, nxt.start()) and (
+            enabled_tool_names is None or nxt.group(1) in enabled_tool_names
+        ):
+            return m.group(0)[: nxt.start() - m.start()]
+        pos = nxt.start()
+
+
 def apply_tool_strip_patterns(
     text: str,
     patterns,
@@ -125,13 +147,8 @@ def apply_tool_strip_patterns(
             # Same two gates the parser applies in _iter_bracket_spans, so a rehearsal that
             # is not promoted to a call stays visible instead of vanishing from the answer.
             spans = _code_spans(text)
-            text = pat.sub(
-                lambda m: m.group(0)
-                if (enabled_tool_names is not None and m.group(1) not in enabled_tool_names)
-                or _in_code(spans, m.start())
-                else "",
-                text,
-            )
+            _t = text
+            text = pat.sub(lambda m: _rehearsal_strip(m, pat, _t, spans, enabled_tool_names), text)
         else:
             text = pat.sub("", text)
     return text
@@ -183,11 +200,13 @@ _REHEARSAL_RE = re.compile(r"(?<!\[CALL_ID\])\b([\w-]+)\[ARGS\]\s*(?=\{)")
 # Markdown code: a fenced block (closing fence optional so a streaming block counts) or
 # an inline span. Gates the markerless rehearsal form only, so quoting the syntax as
 # documentation stays text instead of executing. ``>`` container prefixes are allowed so
-# a fence inside a block quote counts, and an inline span closes on a backtick run of its
-# own length (``code`` is one span, not two empty ones).
+# a fence inside a block quote counts. Inline runs are enumerated by length (double before
+# single) rather than backreferenced: ``code`` must be one span and not two empty pairs
+# around live markup, but a ``(`+)..\1`` form backtracks over every candidate length and
+# turned 21 KB of unmatched runs into a 1.8s scan.
 _CODE_SPAN_RE = re.compile(
     r"^[ \t]*(?:>[ \t]*)*(?:```+|~~~+).*?(?:^[ \t]*(?:>[ \t]*)*(?:```+|~~~+)[ \t]*$|\Z)"
-    r"|(`+)(?:(?!\1).)+?\1(?!`)",
+    r"|``[^`]*?``|`[^`\n]*`",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/studio/backend/core/tool_healing.py
+++ b/studio/backend/core/tool_healing.py
@@ -110,14 +110,24 @@ def apply_tool_strip_patterns(
 ) -> str:
     """Apply strip ``patterns`` to ``text``. A bare rehearsal ``name[ARGS]{..}`` pattern
     strips only when ``name`` is an enabled tool (or when ``enabled_tool_names`` is
-    ``None``); every other pattern is removed unconditionally. A closed-pair pattern whose
-    close token is absent is skipped so an unclosed-marker stream stays linear."""
+    ``None``) and the match is not inside markdown code; every other pattern is removed
+    unconditionally. A closed-pair pattern whose close token is absent is skipped so an
+    unclosed-marker stream stays linear."""
     for pat in patterns:
         token = _PAT_REQUIRED_TOKEN.get(pat)
         if token is not None and token not in text:
             continue
-        if enabled_tool_names is not None and pat in _REHEARSAL_STRIP_PATS:
-            text = pat.sub(lambda m: "" if m.group(1) in enabled_tool_names else m.group(0), text)
+        if pat in _REHEARSAL_STRIP_PATS:
+            # Same two gates the parser applies in _iter_bracket_spans, so a rehearsal that
+            # is not promoted to a call stays visible instead of vanishing from the answer.
+            spans = _code_spans(text)
+            text = pat.sub(
+                lambda m: m.group(0)
+                if (enabled_tool_names is not None and m.group(1) not in enabled_tool_names)
+                or any(s <= m.start() < e for s, e in spans)
+                else "",
+                text,
+            )
         else:
             text = pat.sub("", text)
     return text
@@ -165,6 +175,14 @@ _MISTRAL_BRACKET_RE = re.compile(
 # Rehearsal ``name[ARGS]{json}`` (no [TOOL_CALLS]); the lookbehind keeps the v11 call-id
 # from being taken as the function name.
 _REHEARSAL_RE = re.compile(r"(?<!\[CALL_ID\])\b([\w-]+)\[ARGS\]\s*(?=\{)")
+
+# Markdown code: a fenced block (closing fence optional so a streaming block counts) or
+# an inline span. Gates the markerless rehearsal form only, so quoting the syntax as
+# documentation stays text instead of executing.
+_CODE_SPAN_RE = re.compile(
+    r"^[ \t]*(?:```+|~~~+).*?(?:^[ \t]*(?:```+|~~~+)[ \t]*$|\Z)|`[^`\n]*`",
+    re.DOTALL | re.MULTILINE,
+)
 
 # Above this size skip the balanced scan; the linear regex catch-all bounds pathological output.
 _MAX_BRACKET_SCAN_CHARS = 1_000_000
@@ -297,6 +315,18 @@ def _decode_array_items(text: str, body_start: int, body_end: int):
     return objs, ends
 
 
+def _code_spans(text: str) -> list[tuple[int, int]]:
+    """Markdown code spans, used to keep a quoted rehearsal out of the call set.
+
+    A line-start fence cannot occur inside a call's JSON body (a raw newline is
+    invalid JSON there), so no tool-markup exclusion is needed; a stray inline span
+    can at worst hide a same-line rehearsal, which drops a call rather than
+    inventing one."""
+    if "`" not in text and "~~~" not in text:
+        return []
+    return [m.span() for m in _CODE_SPAN_RE.finditer(text)]
+
+
 def _iter_bracket_spans(
     text: str,
     start: int = 0,
@@ -312,6 +342,12 @@ def _iter_bracket_spans(
     prose ``foo[ARGS]{..}`` (foo disabled) is neither parsed nor stripped. Explicit
     [TOOL_CALLS] markers stay unconditional, keeping parse/strip/detection symmetric.
 
+    A rehearsal inside markdown code (fenced block or inline span) is documentation
+    for the same reason -- the syntax has no sentinel, so quoting it would otherwise
+    BE a call -- and is likewise neither parsed nor stripped. Explicit markers stay
+    unconditional there too: a ```json block is still a real call for the templates
+    that emit one.
+
     Balance-only (no JSON validation) so strip and parse share one scan. The cursor
     jumps past each consumed span, so a marker inside consumed JSON is never
     re-matched and each regex re-searches only once its match falls behind: linear."""
@@ -323,6 +359,7 @@ def _iter_bracket_spans(
     )
     nexts = {kind: rx.search(text, start) for kind, rx in specs}
     cursor = start
+    code_spans: list | None = None  # computed on the first rehearsal candidate only
     while cursor < n:
         for kind, rx in specs:
             m = nexts[kind]
@@ -349,6 +386,13 @@ def _iter_bracket_spans(
             # Inactive-name rehearsal is prose: advance past its body without yielding.
             cursor = end + 1
             continue
+        if kind == "rehearsal":
+            if code_spans is None:
+                code_spans = _code_spans(text)
+            if any(s <= m.start() < e for s, e in code_spans):
+                # Quoted syntax, not a call: advance past its body without yielding.
+                cursor = end + 1
+                continue
         yield (m.start(), end + 1, kind, m)
         cursor = end + 1
 

--- a/studio/backend/core/tool_healing.py
+++ b/studio/backend/core/tool_healing.py
@@ -90,6 +90,10 @@ _PAT_REQUIRED_TOKEN = {
     _TC_JSON_CLOSED_PAT: "</tool_call>",
     _TC_GEMMA_CLOSED_PAT: "<tool_call|>",
     _TC_FUNC_CLOSED_PAT: "</function>",
+    # Literal in both rehearsal patterns: skips the sub AND its _code_spans scan on the
+    # common answer that has no rehearsal at all.
+    _REHEARSAL_CLOSED_STRIP_RE: "[ARGS]",
+    _REHEARSAL_TAIL_STRIP_RE: "[ARGS]",
 }
 
 
@@ -124,7 +128,7 @@ def apply_tool_strip_patterns(
             text = pat.sub(
                 lambda m: m.group(0)
                 if (enabled_tool_names is not None and m.group(1) not in enabled_tool_names)
-                or any(s <= m.start() < e for s, e in spans)
+                or _in_code(spans, m.start())
                 else "",
                 text,
             )
@@ -178,9 +182,12 @@ _REHEARSAL_RE = re.compile(r"(?<!\[CALL_ID\])\b([\w-]+)\[ARGS\]\s*(?=\{)")
 
 # Markdown code: a fenced block (closing fence optional so a streaming block counts) or
 # an inline span. Gates the markerless rehearsal form only, so quoting the syntax as
-# documentation stays text instead of executing.
+# documentation stays text instead of executing. ``>`` container prefixes are allowed so
+# a fence inside a block quote counts, and an inline span closes on a backtick run of its
+# own length (``code`` is one span, not two empty ones).
 _CODE_SPAN_RE = re.compile(
-    r"^[ \t]*(?:```+|~~~+).*?(?:^[ \t]*(?:```+|~~~+)[ \t]*$|\Z)|`[^`\n]*`",
+    r"^[ \t]*(?:>[ \t]*)*(?:```+|~~~+).*?(?:^[ \t]*(?:>[ \t]*)*(?:```+|~~~+)[ \t]*$|\Z)"
+    r"|(`+)(?:(?!\1).)+?\1(?!`)",
     re.DOTALL | re.MULTILINE,
 )
 
@@ -321,10 +328,17 @@ def _code_spans(text: str) -> list[tuple[int, int]]:
     A line-start fence cannot occur inside a call's JSON body (a raw newline is
     invalid JSON there), so no tool-markup exclusion is needed; a stray inline span
     can at worst hide a same-line rehearsal, which drops a call rather than
-    inventing one."""
+    inventing one. Spans are ordered and non-overlapping, so ``_in_code`` bisects
+    them instead of rescanning from the front per candidate."""
     if "`" not in text and "~~~" not in text:
         return []
     return [m.span() for m in _CODE_SPAN_RE.finditer(text)]
+
+
+def _in_code(spans, pos: int) -> bool:
+    """Whether ``pos`` falls in one of ``spans`` (ordered, non-overlapping)."""
+    i = bisect.bisect_right(spans, (pos, pos)) - 1
+    return i >= 0 and spans[i][0] <= pos < spans[i][1]
 
 
 def _iter_bracket_spans(
@@ -389,7 +403,7 @@ def _iter_bracket_spans(
         if kind == "rehearsal":
             if code_spans is None:
                 code_spans = _code_spans(text)
-            if any(s <= m.start() < e for s, e in code_spans):
+            if _in_code(code_spans, m.start()):
                 # Quoted syntax, not a call: advance past its body without yielding.
                 cursor = end + 1
                 continue

--- a/studio/backend/core/tool_healing.py
+++ b/studio/backend/core/tool_healing.py
@@ -200,13 +200,17 @@ _REHEARSAL_RE = re.compile(r"(?<!\[CALL_ID\])\b([\w-]+)\[ARGS\]\s*(?=\{)")
 # Markdown code: a fenced block (closing fence optional so a streaming block counts) or
 # an inline span. Gates the markerless rehearsal form only, so quoting the syntax as
 # documentation stays text instead of executing. ``>`` container prefixes are allowed so
-# a fence inside a block quote counts. Inline runs are enumerated by length (double before
+# a fence inside a block quote counts. A backtick fence's info string cannot itself contain
+# backticks, so ```` ```a``` ```` opening a line is an inline span and not a fence running
+# to EOF; the closer tolerates a CR so a CRLF block still closes. Both would otherwise
+# swallow the rest of the message and drop a real call after it. Inline runs are enumerated by length (double before
 # single) rather than backreferenced: ``code`` must be one span and not two empty pairs
 # around live markup, but a ``(`+)..\1`` form backtracks over every candidate length and
 # turned 21 KB of unmatched runs into a 1.8s scan. A lone backtick is valid content inside
 # a doubled span, so only a run of two closes it.
 _CODE_SPAN_RE = re.compile(
-    r"^[ \t]*(?:>[ \t]*)*(?:```+|~~~+).*?(?:^[ \t]*(?:>[ \t]*)*(?:```+|~~~+)[ \t]*$|\Z)"
+    r"^[ \t]*(?:>[ \t]*)*(?:```+[^`\n]*|~~~+[^\n]*)$"
+    r".*?(?:^[ \t]*(?:>[ \t]*)*(?:```+|~~~+)[ \t\r]*$|\Z)"
     r"|``(?:[^`]|`(?!`))*?``|`[^`\n]*`",
     re.DOTALL | re.MULTILINE,
 )

--- a/studio/backend/core/tool_healing.py
+++ b/studio/backend/core/tool_healing.py
@@ -203,10 +203,11 @@ _REHEARSAL_RE = re.compile(r"(?<!\[CALL_ID\])\b([\w-]+)\[ARGS\]\s*(?=\{)")
 # a fence inside a block quote counts. Inline runs are enumerated by length (double before
 # single) rather than backreferenced: ``code`` must be one span and not two empty pairs
 # around live markup, but a ``(`+)..\1`` form backtracks over every candidate length and
-# turned 21 KB of unmatched runs into a 1.8s scan.
+# turned 21 KB of unmatched runs into a 1.8s scan. A lone backtick is valid content inside
+# a doubled span, so only a run of two closes it.
 _CODE_SPAN_RE = re.compile(
     r"^[ \t]*(?:>[ \t]*)*(?:```+|~~~+).*?(?:^[ \t]*(?:>[ \t]*)*(?:```+|~~~+)[ \t]*$|\Z)"
-    r"|``[^`]*?``|`[^`\n]*`",
+    r"|``(?:[^`]|`(?!`))*?``|`[^`\n]*`",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/studio/backend/tests/test_rehearsal_in_code_block.py
+++ b/studio/backend/tests/test_rehearsal_in_code_block.py
@@ -37,6 +37,10 @@ QUOTED = {
     "fenced_indented": f'  {FENCE}\n  terminal[ARGS]{{"command": "id"}}\n  {FENCE}',
     "tilde_fence": '~~~\nterminal[ARGS]{"command": "id"}\n~~~',
     "inline_span": 'Write `terminal[ARGS]{"command": "id"}` to run it.',
+    # A span opened with N backticks closes on a run of N, so it is one span rather
+    # than two empty pairs around live markup.
+    "inline_double_backtick": 'Write ``terminal[ARGS]{"command": "id"}`` as docs.',
+    "blockquoted_fence": f'> {FENCE}\n> terminal[ARGS]{{"command": "id"}}\n> {FENCE}',
     # A block still streaming has no closing fence yet; it must not execute in the
     # window before the fence arrives.
     "unclosed_fence": f'{FENCE}\nterminal[ARGS]{{"command": "id"}}',
@@ -85,6 +89,22 @@ def test_explicit_markers_in_a_fence_still_call(body):
 def test_unrestricted_mode_also_skips_quoted_rehearsal():
     """The code gate does not depend on the enabled-name gate."""
     assert _names(QUOTED["fenced"], enabled_tool_names = None) == []
+
+
+def test_unmatched_backtick_does_not_hide_a_later_call():
+    """An inline span needs a closing run, so a stray backtick stays prose."""
+    assert _names('cost is 5` then terminal[ARGS]{"command": "id"}') == ["terminal"]
+
+
+def test_many_quoted_examples_stay_linear():
+    """Ordered spans are bisected, not rescanned per candidate (264 KB / 8k examples)."""
+    import time
+
+    content = " ".join('`terminal[ARGS]{"command": "id"}`' for _ in range(8000))
+    start = time.perf_counter()
+    assert _names(content) == []
+    assert strip_tool_call_markup(content, enabled_tool_names = ENABLED) == content
+    assert time.perf_counter() - start < 5.0
 
 
 def test_backtick_inside_arguments_does_not_hide_a_later_call():

--- a/studio/backend/tests/test_rehearsal_in_code_block.py
+++ b/studio/backend/tests/test_rehearsal_in_code_block.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Bare rehearsal ``name[ARGS]{json}`` quoted in markdown code stays prose.
+
+The rehearsal form has no sentinel of its own (unlike ``[TOOL_CALLS]`` or the
+XML markup), so an answer that *documents* the syntax used to parse as a real
+call and then vanish from the rendered message. A fenced block or an inline
+span marks the text as an example, so it is neither promoted nor stripped --
+the same contract an inactive tool name already gets.
+
+Explicit markers keep their unconditional behaviour inside code: a ```json
+block is still a real call for the templates that emit one.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.tool_healing import parse_tool_calls_from_text, strip_tool_call_markup
+
+ENABLED = {"terminal", "web_search"}
+FENCE = "`" * 3
+
+
+def _names(content, enabled_tool_names = ENABLED):
+    calls = parse_tool_calls_from_text(content, enabled_tool_names = enabled_tool_names)
+    return [call["function"]["name"] for call in calls]
+
+
+QUOTED = {
+    "fenced": f"Docs:\n{FENCE}\nterminal[ARGS]{{\"command\": \"id\"}}\n{FENCE}",
+    "fenced_with_language": f"{FENCE}json\nterminal[ARGS]{{\"command\": \"id\"}}\n{FENCE}",
+    "fenced_indented": f"  {FENCE}\n  terminal[ARGS]{{\"command\": \"id\"}}\n  {FENCE}",
+    "tilde_fence": "~~~\nterminal[ARGS]{\"command\": \"id\"}\n~~~",
+    "inline_span": "Write `terminal[ARGS]{\"command\": \"id\"}` to run it.",
+    # A block still streaming has no closing fence yet; it must not execute in the
+    # window before the fence arrives.
+    "unclosed_fence": f"{FENCE}\nterminal[ARGS]{{\"command\": \"id\"}}",
+}
+
+
+@pytest.mark.parametrize("case", sorted(QUOTED))
+def test_quoted_rehearsal_is_not_a_call(case):
+    assert _names(QUOTED[case]) == []
+
+
+@pytest.mark.parametrize("case", sorted(QUOTED))
+def test_quoted_rehearsal_stays_visible(case):
+    """Parse and strip must agree: text that is not promoted is not removed."""
+    content = QUOTED[case]
+    assert strip_tool_call_markup(content, enabled_tool_names = ENABLED) == content
+
+
+def test_unquoted_rehearsal_still_calls():
+    content = "Running now. terminal[ARGS]{\"command\": \"id\"}"
+    assert _names(content) == ["terminal"]
+    assert strip_tool_call_markup(content, enabled_tool_names = ENABLED) == "Running now. "
+
+
+def test_rehearsal_after_a_closed_fence_still_calls():
+    content = f"{FENCE}\nx = 1\n{FENCE}\nterminal[ARGS]{{\"command\": \"id\"}}"
+    assert _names(content) == ["terminal"]
+
+
+def test_indented_rehearsal_outside_code_still_calls():
+    """Leading whitespace alone is not a code block."""
+    assert _names("  terminal[ARGS]{\"command\": \"id\"}") == ["terminal"]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "[TOOL_CALLS]web_search{\"query\": \"x\"}",
+        "<tool_call>{\"name\": \"web_search\", \"arguments\": {\"query\": \"x\"}}</tool_call>",
+    ],
+)
+def test_explicit_markers_in_a_fence_still_call(body):
+    assert _names(f"{FENCE}json\n{body}\n{FENCE}") == ["web_search"]
+
+
+def test_unrestricted_mode_also_skips_quoted_rehearsal():
+    """The code gate does not depend on the enabled-name gate."""
+    assert _names(QUOTED["fenced"], enabled_tool_names = None) == []
+
+
+def test_backtick_inside_arguments_does_not_hide_a_later_call():
+    content = (
+        "web_search[ARGS]{\"query\": \"what is `ls`\"}\n"
+        "terminal[ARGS]{\"command\": \"id\"}"
+    )
+    assert _names(content) == ["web_search", "terminal"]

--- a/studio/backend/tests/test_rehearsal_in_code_block.py
+++ b/studio/backend/tests/test_rehearsal_in_code_block.py
@@ -107,6 +107,29 @@ def test_many_quoted_examples_stay_linear():
     assert time.perf_counter() - start < 5.0
 
 
+def test_unmatched_backtick_runs_stay_linear():
+    """Inline runs are enumerated by length; a backreference backtracked over 21 KB."""
+    import time
+
+    body = "".join("`" * n + " text " for n in range(1, 300))
+    content = body + ' terminal[ARGS]{"command": "id"}'
+    start = time.perf_counter()
+    assert _names(content) == ["terminal"]
+    assert time.perf_counter() - start < 2.0
+
+
+def test_truncated_call_after_a_quoted_example_is_still_stripped():
+    """The tail pattern runs to EOF, so a quoted opener must not shield a real call."""
+    content = '`terminal[ARGS]{"command": "doc"}` then terminal[ARGS]{"command": '
+    stripped = strip_tool_call_markup(content, final = True, enabled_tool_names = ENABLED)
+    assert stripped == '`terminal[ARGS]{"command": "doc"}` then'
+
+
+def test_quoted_example_alone_survives_the_final_pass():
+    content = '`terminal[ARGS]{"command": "doc"}`'
+    assert strip_tool_call_markup(content, final = True, enabled_tool_names = ENABLED) == content
+
+
 def test_backtick_inside_arguments_does_not_hide_a_later_call():
     content = 'web_search[ARGS]{"query": "what is `ls`"}\nterminal[ARGS]{"command": "id"}'
     assert _names(content) == ["web_search", "terminal"]

--- a/studio/backend/tests/test_rehearsal_in_code_block.py
+++ b/studio/backend/tests/test_rehearsal_in_code_block.py
@@ -40,6 +40,10 @@ QUOTED = {
     # A span opened with N backticks closes on a run of N, so it is one span rather
     # than two empty pairs around live markup.
     "inline_double_backtick": 'Write ``terminal[ARGS]{"command": "id"}`` as docs.',
+    # A lone backtick is valid content inside a doubled span, so only a run of two closes it.
+    "inline_double_with_inner_backtick": (
+        'Write ``terminal[ARGS]{"command": "id"} and `x` `` as docs.'
+    ),
     "blockquoted_fence": f'> {FENCE}\n> terminal[ARGS]{{"command": "id"}}\n> {FENCE}',
     # A block still streaming has no closing fence yet; it must not execute in the
     # window before the fence arrives.

--- a/studio/backend/tests/test_rehearsal_in_code_block.py
+++ b/studio/backend/tests/test_rehearsal_in_code_block.py
@@ -48,7 +48,23 @@ QUOTED = {
     # A block still streaming has no closing fence yet; it must not execute in the
     # window before the fence arrives.
     "unclosed_fence": f'{FENCE}\nterminal[ARGS]{{"command": "id"}}',
+    "crlf_fence": f'{FENCE}\r\nterminal[ARGS]{{"command": "id"}}\r\n{FENCE}',
 }
+
+
+# A real call must still run when the text around it only looks like a fence. These are the
+# opposite failure: over-suppression silently drops a tool call the user asked for.
+LIVE_AFTER = {
+    # A backtick fence info string cannot contain backticks, so this opens an inline span,
+    # not a fence running to EOF.
+    "line_start_inline_span": f'{FENCE}example{FENCE} then terminal[ARGS]{{"command": "id"}}',
+    "crlf_closed_fence": f'{FENCE}\r\ndocs\r\n{FENCE}\r\nterminal[ARGS]{{"command": "id"}}',
+}
+
+
+@pytest.mark.parametrize("case", sorted(LIVE_AFTER))
+def test_call_after_fence_like_text_still_runs(case):
+    assert _names(LIVE_AFTER[case]) == ["terminal"]
 
 
 @pytest.mark.parametrize("case", sorted(QUOTED))

--- a/studio/backend/tests/test_rehearsal_in_code_block.py
+++ b/studio/backend/tests/test_rehearsal_in_code_block.py
@@ -32,14 +32,14 @@ def _names(content, enabled_tool_names = ENABLED):
 
 
 QUOTED = {
-    "fenced": f"Docs:\n{FENCE}\nterminal[ARGS]{{\"command\": \"id\"}}\n{FENCE}",
-    "fenced_with_language": f"{FENCE}json\nterminal[ARGS]{{\"command\": \"id\"}}\n{FENCE}",
-    "fenced_indented": f"  {FENCE}\n  terminal[ARGS]{{\"command\": \"id\"}}\n  {FENCE}",
-    "tilde_fence": "~~~\nterminal[ARGS]{\"command\": \"id\"}\n~~~",
-    "inline_span": "Write `terminal[ARGS]{\"command\": \"id\"}` to run it.",
+    "fenced": f'Docs:\n{FENCE}\nterminal[ARGS]{{"command": "id"}}\n{FENCE}',
+    "fenced_with_language": f'{FENCE}json\nterminal[ARGS]{{"command": "id"}}\n{FENCE}',
+    "fenced_indented": f'  {FENCE}\n  terminal[ARGS]{{"command": "id"}}\n  {FENCE}',
+    "tilde_fence": '~~~\nterminal[ARGS]{"command": "id"}\n~~~',
+    "inline_span": 'Write `terminal[ARGS]{"command": "id"}` to run it.',
     # A block still streaming has no closing fence yet; it must not execute in the
     # window before the fence arrives.
-    "unclosed_fence": f"{FENCE}\nterminal[ARGS]{{\"command\": \"id\"}}",
+    "unclosed_fence": f'{FENCE}\nterminal[ARGS]{{"command": "id"}}',
 }
 
 
@@ -56,26 +56,26 @@ def test_quoted_rehearsal_stays_visible(case):
 
 
 def test_unquoted_rehearsal_still_calls():
-    content = "Running now. terminal[ARGS]{\"command\": \"id\"}"
+    content = 'Running now. terminal[ARGS]{"command": "id"}'
     assert _names(content) == ["terminal"]
     assert strip_tool_call_markup(content, enabled_tool_names = ENABLED) == "Running now. "
 
 
 def test_rehearsal_after_a_closed_fence_still_calls():
-    content = f"{FENCE}\nx = 1\n{FENCE}\nterminal[ARGS]{{\"command\": \"id\"}}"
+    content = f'{FENCE}\nx = 1\n{FENCE}\nterminal[ARGS]{{"command": "id"}}'
     assert _names(content) == ["terminal"]
 
 
 def test_indented_rehearsal_outside_code_still_calls():
     """Leading whitespace alone is not a code block."""
-    assert _names("  terminal[ARGS]{\"command\": \"id\"}") == ["terminal"]
+    assert _names('  terminal[ARGS]{"command": "id"}') == ["terminal"]
 
 
 @pytest.mark.parametrize(
     "body",
     [
-        "[TOOL_CALLS]web_search{\"query\": \"x\"}",
-        "<tool_call>{\"name\": \"web_search\", \"arguments\": {\"query\": \"x\"}}</tool_call>",
+        '[TOOL_CALLS]web_search{"query": "x"}',
+        '<tool_call>{"name": "web_search", "arguments": {"query": "x"}}</tool_call>',
     ],
 )
 def test_explicit_markers_in_a_fence_still_call(body):
@@ -88,8 +88,5 @@ def test_unrestricted_mode_also_skips_quoted_rehearsal():
 
 
 def test_backtick_inside_arguments_does_not_hide_a_later_call():
-    content = (
-        "web_search[ARGS]{\"query\": \"what is `ls`\"}\n"
-        "terminal[ARGS]{\"command\": \"id\"}"
-    )
+    content = 'web_search[ARGS]{"query": "what is `ls`"}\nterminal[ARGS]{"command": "id"}'
     assert _names(content) == ["web_search", "terminal"]


### PR DESCRIPTION
### Summary

The bare rehearsal tool-call form `name[ARGS]{json}` has no sentinel of its own, unlike `[TOOL_CALLS]` or the XML markup. That means an answer which *documents* the syntax was parsed as a real call: the span got promoted to a tool call and stripped from the rendered message, so the user saw an empty code block where the example used to be.

Before, with `terminal` enabled:

````
Docs:
```
terminal[ARGS]{"command": "id"}
```
````

parsed to `[{"name": "terminal", "arguments": "{\"command\": \"id\"}"}]` and rendered as an empty fence.

### Fix

Gate the markerless form on markdown code the same way it is already gated on the enabled tool list, in the shared `_iter_bracket_spans` scan so parse and strip stay symmetric. A rehearsal inside a fenced block or an inline span is neither promoted nor stripped, which is the same contract an inactive tool name already gets.

Two properties worth calling out:

- Explicit markers are untouched. A `[TOOL_CALLS]` or `<tool_call>` inside a ```` ```json ```` block is still a real call, so templates that emit their calls inside a fence keep working.
- An unclosed fence counts, so a block that is still streaming does not execute in the window before its closing fence arrives.

The display side needed the same gate: `apply_tool_strip_patterns` has its own rehearsal tail pattern that runs outside the scan, so without it the example still vanished from the message even once it stopped being parsed.

### Notes

`_code_spans` deliberately does no tool-markup exclusion. A line-start fence cannot occur inside a call's JSON body because a raw newline is invalid JSON there, and a stray inline span can at worst hide a same-line rehearsal, which drops a call rather than inventing one.

Cost is a single regex pass computed lazily on the first rehearsal candidate, so an answer with no rehearsal in it pays nothing.

### Tests

New `studio/backend/tests/test_rehearsal_in_code_block.py` covers fenced, fenced-with-language, indented, tilde, inline and unclosed-fence quoting; that parse and strip agree on each; that an unquoted rehearsal, one after a closed fence, and a merely indented one all still call; that explicit markers inside a fence still call; and that a backtick inside one call's arguments does not hide a later call.
