### PR TITLE
Studio: confirm a web_search call that fetches a url in auto mode

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -4477,12 +4477,10 @@ def has_text_only_provisional_card(name: str) -> bool:
 def _web_search_fetches_url(name: str, arguments: dict) -> bool:
     """web_search carrying a ``url`` fetches that exact page instead of searching.
 
-    Searching hands a query to a search engine; a direct fetch is an outbound request
-    to a host the *call* names, which is the one unprompted egress in the built-in set,
-    so it asks even though plain search stays always-safe. The name-only
-    ``is_always_safe_tool`` is deliberately unchanged: it gates the streaming
-    provisional card and the non-streaming stream requirement before arguments exist,
-    where a query-only search must keep running without a prompt."""
+    That fetch is egress to a host the *call* names, the one such case in the built-in
+    set, so it asks even though plain search stays always-safe. Name-only
+    ``is_always_safe_tool`` is deliberately unchanged: it runs before arguments exist
+    (provisional card, stream requirement), where a query-only search must not prompt."""
     return name == "web_search" and bool(str(arguments.get("url", "") or "").strip())
 
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -4474,6 +4474,18 @@ def has_text_only_provisional_card(name: str) -> bool:
     return name in _TEXT_PREVIEW_TOOLS
 
 
+def _web_search_fetches_url(name: str, arguments: dict) -> bool:
+    """web_search carrying a ``url`` fetches that exact page instead of searching.
+
+    Searching hands a query to a search engine; a direct fetch is an outbound request
+    to a host the *call* names, which is the one unprompted egress in the built-in set,
+    so it asks even though plain search stays always-safe. The name-only
+    ``is_always_safe_tool`` is deliberately unchanged: it gates the streaming
+    provisional card and the non-streaming stream requirement before arguments exist,
+    where a query-only search must keep running without a prompt."""
+    return name == "web_search" and bool(str(arguments.get("url", "") or "").strip())
+
+
 def is_potentially_unsafe_tool_call(name: str, arguments: dict) -> bool:
     """Whether a tool call must still pause for approval in auto mode.
 
@@ -4481,6 +4493,8 @@ def is_potentially_unsafe_tool_call(name: str, arguments: dict) -> bool:
     auto-run, anything that can mutate state, execute arbitrary code, or is
     simply unrecognized asks first. Unknown tools fail closed.
     """
+    if _web_search_fetches_url(name, arguments):
+        return True
     if name in _ALWAYS_SAFE_TOOLS:
         return False
     # render_html auto-runs a static canvas but asks once its HTML/JS reaches the
@@ -6464,6 +6478,8 @@ def is_high_risk_tool_call(name: str, arguments: dict) -> bool:
     set, rlimits and secret-env stripping remain in force underneath. Unknown tools
     fail closed (prompt).
     """
+    if _web_search_fetches_url(name, arguments):
+        return True
     if name in _ALWAYS_SAFE_TOOLS:
         return False
     if name == "render_html":

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2597,7 +2597,12 @@ def _confirm_gate_needs_stream(payload) -> bool:
         return False
     from core.inference.tools import is_always_safe_tool
 
-    return not all(is_always_safe_tool(t) for t in enabled)
+    # web_search prompts once the model supplies a ``url`` (it fetches that page rather
+    # than searching), and the gate can only prompt while streaming, so it no longer
+    # qualifies for the safe-only exception: without this a non-streaming auto request
+    # is admitted, then blocks in wait_tool_decision with the approval id stranded in a
+    # stream event the client never reads.
+    return not all(is_always_safe_tool(t) and t != "web_search" for t in enabled)
 
 
 # Cancel registry. Proxies (e.g. Colab) can swallow client fetch aborts so

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2597,11 +2597,9 @@ def _confirm_gate_needs_stream(payload) -> bool:
         return False
     from core.inference.tools import is_always_safe_tool
 
-    # web_search prompts once the model supplies a ``url`` (it fetches that page rather
-    # than searching), and the gate can only prompt while streaming, so it no longer
-    # qualifies for the safe-only exception: without this a non-streaming auto request
-    # is admitted, then blocks in wait_tool_decision with the approval id stranded in a
-    # stream event the client never reads.
+    # web_search prompts once the model supplies a ``url`` (it fetches that page), and the
+    # gate can only prompt while streaming. Without this a non-streaming auto request is
+    # admitted, then blocks in wait_tool_decision on an approval the client never reads.
     return not all(is_always_safe_tool(t) and t != "web_search" for t in enabled)
 
 

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -2960,7 +2960,7 @@ def test_confirm_gate_needs_stream():
         is False
     )
     # web_search prompts once the model supplies a ``url``, so it needs a stream to deliver
-    # that prompt, else the request is admitted then blocks in wait_tool_decision forever.
+    # that prompt, else the request is admitted then blocks out the decision timeout.
     assert (
         _confirm_gate_needs_stream(req(permission_mode = "auto", enabled_tools = ["web_search"]))
         is True

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -2954,10 +2954,25 @@ def test_confirm_gate_needs_stream():
 
     safe = ["web_search", "search_knowledge_base"]
     # auto + a safe-only selection never prompts -> no stream needed.
-    assert _confirm_gate_needs_stream(req(permission_mode = "auto", enabled_tools = safe)) is False
+    assert (
+        _confirm_gate_needs_stream(
+            req(permission_mode = "auto", enabled_tools = ["search_knowledge_base"])
+        )
+        is False
+    )
+    # web_search prompts once the model supplies a ``url`` (it fetches that page instead
+    # of searching), so it needs a stream to deliver that prompt. Without this the request
+    # is admitted and then blocks in wait_tool_decision on an approval the non-streaming
+    # client can never answer.
     assert (
         _confirm_gate_needs_stream(req(permission_mode = "auto", enabled_tools = ["web_search"]))
-        is False
+        is True
+    )
+    assert (
+        _confirm_gate_needs_stream(
+            req(permission_mode = "auto", enabled_tools = ["web_search", "search_knowledge_base"])
+        )
+        is True
     )
     # render_html can prompt when its canvas reaches the network, so a selection
     # that includes it needs a stream to deliver that prompt.

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -2278,8 +2278,7 @@ def test_builtin_readonly_tools_are_safe():
 
 
 def test_web_search_gated_only_when_it_fetches_a_url():
-    # Searching stays always-safe; a ``url`` makes the same tool fetch that exact page,
-    # an outbound request to a host the call names, so it asks in auto mode too.
+    # Searching stays always-safe; a ``url`` fetches that named host, so it asks in auto too.
     for gate in (is_potentially_unsafe_tool_call, is_high_risk_tool_call):
         assert gate("web_search", {"query": "hi"}) is False
         assert gate("web_search", {}) is False
@@ -2291,8 +2290,8 @@ def test_web_search_gated_only_when_it_fetches_a_url():
 
 
 def test_web_search_name_only_gate_is_unchanged():
-    # is_always_safe_tool runs before arguments exist (streaming provisional card, the
-    # non-streaming stream requirement), so a query-only search must not start prompting.
+    # Runs before arguments exist (provisional card, stream requirement), so a query-only
+    # search must not start prompting.
     from core.inference.tools import is_always_safe_tool
     assert is_always_safe_tool("web_search") is True
 
@@ -2960,10 +2959,8 @@ def test_confirm_gate_needs_stream():
         )
         is False
     )
-    # web_search prompts once the model supplies a ``url`` (it fetches that page instead
-    # of searching), so it needs a stream to deliver that prompt. Without this the request
-    # is admitted and then blocks in wait_tool_decision on an approval the non-streaming
-    # client can never answer.
+    # web_search prompts once the model supplies a ``url``, so it needs a stream to deliver
+    # that prompt, else the request is admitted then blocks in wait_tool_decision forever.
     assert (
         _confirm_gate_needs_stream(req(permission_mode = "auto", enabled_tools = ["web_search"]))
         is True

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -2294,7 +2294,6 @@ def test_web_search_name_only_gate_is_unchanged():
     # is_always_safe_tool runs before arguments exist (streaming provisional card, the
     # non-streaming stream requirement), so a query-only search must not start prompting.
     from core.inference.tools import is_always_safe_tool
-
     assert is_always_safe_tool("web_search") is True
 
 

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -2277,6 +2277,27 @@ def test_builtin_readonly_tools_are_safe():
     assert is_potentially_unsafe_tool_call("render_html", {}) is False
 
 
+def test_web_search_gated_only_when_it_fetches_a_url():
+    # Searching stays always-safe; a ``url`` makes the same tool fetch that exact page,
+    # an outbound request to a host the call names, so it asks in auto mode too.
+    for gate in (is_potentially_unsafe_tool_call, is_high_risk_tool_call):
+        assert gate("web_search", {"query": "hi"}) is False
+        assert gate("web_search", {}) is False
+        assert gate("web_search", {"url": ""}) is False
+        assert gate("web_search", {"url": None}) is False
+        assert gate("web_search", {"url": "   "}) is False
+        assert gate("web_search", {"url": "https://example.com/page"}) is True
+        assert gate("web_search", {"query": "hi", "url": "https://example.com"}) is True
+
+
+def test_web_search_name_only_gate_is_unchanged():
+    # is_always_safe_tool runs before arguments exist (streaming provisional card, the
+    # non-streaming stream requirement), so a query-only search must not start prompting.
+    from core.inference.tools import is_always_safe_tool
+
+    assert is_always_safe_tool("web_search") is True
+
+
 def test_render_html_gated_only_when_networked():
     # A static canvas auto-runs; one whose HTML/JS reaches the network asks.
     def rh(code):


### PR DESCRIPTION
### Summary

`web_search` is in `_ALWAYS_SAFE_TOOLS`, so in `permission_mode="auto"` ("Approve for me") it auto-runs on any arguments without consulting them. But it takes an optional `url` that makes it fetch that exact page instead of searching:

```python
def _web_search(query, max_results = 5, timeout = _EXEC_TIMEOUT, url = None, ...):
    if url and url.strip():
        return _fetch_page_text(url.strip(), ...)
```

Handing a query to a search engine and issuing an outbound request to a host the call names are different risk classes, and the second was the only unprompted egress in the built-in tool set. Every other network path already asks: `curl` piped to a shell, `wget -O- | bash`, `urllib`, `requests`, and a `render_html` canvas whose HTML reaches the network.

### Fix

Gate the two argument-aware classifiers, `is_potentially_unsafe_tool_call` and `is_high_risk_tool_call`, on a non-empty `url`. A direct fetch asks, plain search keeps auto-running.

The name-only `is_always_safe_tool` is deliberately left alone. It runs before arguments exist, for the streaming provisional card and for `_confirm_gate_needs_stream`, and demoting it there would make a query-only `enabled_tools: ["web_search"]` request start requiring `stream=true` and suppress its early card. Keeping the gate on the paths that can actually see `url` avoids that.

### Scope

This is intentionally small. The existing SSRF guard in `_validate_and_resolve_host` already refuses loopback, link-local and private ranges, so this is only about the public-internet case that the guard allows by design:

```
127.0.0.1        Blocked: refusing to fetch non-public address
169.254.169.254  Blocked: refusing to fetch non-public address
192.168.1.1      Blocked: refusing to fetch non-public address
example.com      allowed
```

A domain allowlist would be the natural next step, and `web_access_policy.py` already has `normalize_website_policy` with `allowedDomains` / `blockedDomains` validated and ready. It is currently only wired into `routes/research_runs.py`, not the chat tool loop. Left for a separate change so this one stays reviewable.

### Tests

`test_web_search_gated_only_when_it_fetches_a_url` pins both classifiers across missing, empty, `None`, whitespace and populated `url`, plus the `query` + `url` combination. `test_web_search_name_only_gate_is_unchanged` pins that `is_always_safe_tool("web_search")` stays `True` so the pre-argument paths do not shift.


### Known scope limit

The Anthropic Messages channel (`/v1/messages`) is unchanged by this PR. It runs the tool loop without `confirm_tool_calls`, so neither classifier is consulted there, and `web_search` sits in `_ANTHROPIC_UNPROMPTED_SAFE_TOOLS`, so a `web_search`-only selection under `auto` or an omitted mode is admitted rather than rejected. A model-supplied `url` on that channel therefore still fetches unprompted, exactly as it did before this change.

Closing that would mean dropping `web_search` from that allowlist, the way `render_html` already is, since the channel cannot prompt and cannot know whether a `url` will appear until the model emits one. That turns every `auto` or default-mode Messages request selecting `web_search` into a 400. Query-only search on that channel works today and is safe, so breaking it is not worth closing a fetch that only happens when the model supplies a `url`. Cheap to revisit if that channel gains a real confirmation path.
