### PR TITLE
Studio: stop reporting the run's mean loss as the final step's loss

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -12088,8 +12088,7 @@ def _volume_timestamps_finely(workdir: str) -> bool:
     if stat.st_dev in _fine_mtime_devices:
         return True
     if not any(
-        stamp % 1_000_000_000
-        for stamp in (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_atime_ns)
+        stamp % 1_000_000_000 for stamp in (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_atime_ns)
     ):
         return False
     _fine_mtime_devices.add(stat.st_dev)

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -307,7 +307,10 @@ class UnslothTrainer:
                 # last step and became `final_loss` on /api/train/runs, disagreeing with the
                 # checkpoint. Keep reporting it, as the summary it is.
                 loss_value = logs.get("loss")
-                if loss_value is None and logs.get("train_loss") is not None:
+                is_run_summary = loss_value is None and (
+                    logs.get("train_loss") is not None or logs.get("train_runtime") is not None
+                )
+                if is_run_summary:
                     logger.info(
                         "training finished: mean train_loss=%s over %s steps",
                         logs.get("train_loss"),
@@ -340,6 +343,7 @@ class UnslothTrainer:
                     grad_norm = grad_norm,
                     num_tokens = num_tokens,
                     eval_loss = logs.get("eval_loss", None),
+                    is_run_summary = is_run_summary,
                     status_message = "",
                 )
 

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -310,7 +310,8 @@ class UnslothTrainer:
                 if loss_value is None and logs.get("train_loss") is not None:
                     logger.info(
                         "training finished: mean train_loss=%s over %s steps",
-                        logs.get("train_loss"), state.global_step,
+                        logs.get("train_loss"),
+                        state.global_step,
                     )
                 current_step = state.global_step
                 grad_norm = logs.get("grad_norm", None)

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -300,7 +300,18 @@ class UnslothTrainer:
             ):
                 if not logs:
                     return
-                loss_value = logs.get("loss", logs.get("train_loss", None))
+                # HF logs the end-of-run summary as {"train_runtime": ..., "train_loss": ...}
+                # with no "loss" key, and `train_loss` is the MEAN loss over the whole run,
+                # not a step loss. Falling back to it reported the average as the final
+                # step's value: it landed on the chart at the same global_step as the real
+                # last step and became `final_loss` on /api/train/runs, disagreeing with the
+                # checkpoint. Keep reporting it, as the summary it is.
+                loss_value = logs.get("loss")
+                if loss_value is None and logs.get("train_loss") is not None:
+                    logger.info(
+                        "training finished: mean train_loss=%s over %s steps",
+                        logs.get("train_loss"), state.global_step,
+                    )
                 current_step = state.global_step
                 grad_norm = logs.get("grad_norm", None)
 

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -627,6 +627,10 @@ class TrainingProgress:
     eval_loss: Optional[float] = None
     peak_memory_gb: Optional[float] = None
     output_dir: Optional[str] = None
+    # Set on the end-of-run record HF emits after leaving the training loop. It has no
+    # step loss, so the progress filter would drop it, and with it the only elapsed
+    # time that includes the final evaluation, checkpoint save and best-model reload.
+    is_run_summary: bool = False
 
 
 class _MLXTrainerAdapter:

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -2854,7 +2854,11 @@ class TrainingBackend:
                 step = event.get("step", 0)
                 loss = _safe_loss
                 lr = _safe_lr
-                if step > 0 and loss is not None:
+                # Only ever move forward. HF can log more than one record at the same
+                # global_step around the end of a run, and each one used to add another
+                # point, so a 30-step run charted 33 with the last few stacked on step 30.
+                _last_step = self.step_history[-1] if self.step_history else None
+                if step > 0 and loss is not None and (_last_step is None or step > _last_step):
                     self.loss_history.append(loss)
                     self.lr_history.append(lr if lr is not None else 0.0)
                     self.step_history.append(step)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -4520,7 +4520,17 @@ def _create_trainer_progress_callback(event_queue: Any) -> Callable[[TrainingPro
     def _on_progress(progress: TrainingProgress) -> None:
         has_train_loss = progress.step > 0 and progress.loss is not None
         has_eval_loss = progress.eval_loss is not None
-        if (progress.step == 0 and progress.total_steps > 0) or has_train_loss or has_eval_loss:
+        # The end-of-run summary carries no loss (it is the mean, not a step), but it
+        # does carry the elapsed time including the final evaluation, checkpoint save
+        # and best-model reload. Without this the run's recorded duration stops at the
+        # last step log and under-reports how long the run actually took.
+        is_terminal = progress.total_steps > 0 and progress.step >= progress.total_steps
+        if (
+            (progress.step == 0 and progress.total_steps > 0)
+            or has_train_loss
+            or has_eval_loss
+            or is_terminal
+        ):
             event_queue.put(
                 {
                     "type": "progress",

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -4524,7 +4524,12 @@ def _create_trainer_progress_callback(event_queue: Any) -> Callable[[TrainingPro
         # does carry the elapsed time including the final evaluation, checkpoint save
         # and best-model reload. Without this the run's recorded duration stops at the
         # last step log and under-reports how long the run actually took.
-        is_terminal = progress.total_steps > 0 and progress.step >= progress.total_steps
+        # A run stopped early never reaches total_steps, so the flag the trainer sets
+        # on the summary record is what marks it terminal; the step comparison stays as
+        # a fallback for backends that do not set it.
+        is_terminal = bool(getattr(progress, "is_run_summary", False)) or (
+            progress.total_steps > 0 and progress.step >= progress.total_steps
+        )
         if (
             (progress.step == 0 and progress.total_steps > 0)
             or has_train_loss

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -4579,7 +4579,15 @@ def _create_embedding_progress_callback(
         ):
             if not logs:
                 return
-            loss_value = logs.get("loss", logs.get("train_loss", None))
+            # See the note in trainer.py: "train_loss" in HF's terminal summary record is
+            # the run mean, not a step loss, so it must not become the final step.
+            loss_value = logs.get("loss")
+            if loss_value is None and logs.get("train_loss") is not None:
+                print(
+                    f"Training finished: mean train_loss={logs.get('train_loss')} "
+                    f"over {state.global_step} steps",
+                    flush = True,
+                )
             current_step = state.global_step
 
             elapsed = time.time() - training_start_time

--- a/studio/backend/tests/test_final_loss_not_average.py
+++ b/studio/backend/tests/test_final_loss_not_average.py
@@ -89,3 +89,75 @@ def test_the_shipped_call_sites_no_longer_fall_back_to_train_loss():
     for rel in ("core/training/trainer.py", "core/training/worker.py"):
         text = (_BACKEND / rel).read_text(encoding = "utf-8")
         assert 'logs.get("loss", logs.get("train_loss", None))' not in text, rel
+
+
+def test_the_terminal_summary_still_reports_elapsed_time():
+    # The summary record has no step loss, so the progress filter dropped it; the
+    # elapsed time it carries (final eval, checkpoint save, best-model reload) is the
+    # run's real duration and must still reach the parent.
+    import sys
+    from pathlib import Path
+
+    backend = Path(__file__).resolve().parent.parent
+    if str(backend) not in sys.path:
+        sys.path.insert(0, str(backend))
+    from core.training.worker import _create_trainer_progress_callback
+
+    class _P:
+        step = 30
+        total_steps = 30
+        loss = None
+        eval_loss = None
+        epoch = 3.0
+        learning_rate = 0.0
+        elapsed_seconds = 412.5
+        eta_seconds = None
+        grad_norm = None
+        num_tokens = 12345
+        status_message = ""
+        warnings: list = []
+
+    events = []
+
+    class _Q:
+        def put(self, e):
+            events.append(e)
+
+    _create_trainer_progress_callback(_Q())(_P())
+    progress = [e for e in events if e.get("type") == "progress"]
+    assert progress, events
+    assert progress[0]["elapsed_seconds"] == 412.5
+    assert progress[0]["loss"] is None
+
+
+def test_a_lossless_mid_run_record_is_still_dropped():
+    import sys
+    from pathlib import Path
+
+    backend = Path(__file__).resolve().parent.parent
+    if str(backend) not in sys.path:
+        sys.path.insert(0, str(backend))
+    from core.training.worker import _create_trainer_progress_callback
+
+    class _P:
+        step = 12
+        total_steps = 30
+        loss = None
+        eval_loss = None
+        epoch = 1.0
+        learning_rate = 0.0
+        elapsed_seconds = 40.0
+        eta_seconds = None
+        grad_norm = None
+        num_tokens = 1
+        status_message = ""
+        warnings: list = []
+
+    events = []
+
+    class _Q:
+        def put(self, e):
+            events.append(e)
+
+    _create_trainer_progress_callback(_Q())(_P())
+    assert [e for e in events if e.get("type") == "progress"] == []

--- a/studio/backend/tests/test_final_loss_not_average.py
+++ b/studio/backend/tests/test_final_loss_not_average.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The run's mean loss must not be reported as the final step's loss.
+
+HF logs the end-of-run summary as {"train_runtime": ..., "train_loss": <mean>}
+with no "loss" key. `logs.get("loss", logs.get("train_loss"))` therefore fell back
+to the mean and published it at the same global_step as the real last step, so:
+
+  - the loss chart gained points stacked on the final step, the last of them the
+    run average (a 30 step run charted 33 points, ending 0.3205, 0.3205, 0.3834),
+  - `final_loss` on /api/train/runs became the average while
+    /api/models/checkpoints reported the true last-step loss for the same run,
+  - the UI stat card showed the average, so loss appeared to jump on the last step.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+def _extract_loss(logs: dict):
+    """The corrected reading of an HF on_log record: only a real per-step loss."""
+    return logs.get("loss")
+
+
+def test_a_step_record_still_reports_its_loss():
+    logs = {"loss": 0.3205, "grad_norm": 0.4, "learning_rate": 1e-5, "epoch": 1.0}
+    assert _extract_loss(logs) == 0.3205
+
+
+def test_the_summary_record_reports_no_step_loss():
+    logs = {"train_runtime": 23.18, "train_loss": 0.3834, "train_samples_per_second": 5.2}
+    assert _extract_loss(logs) is None
+
+
+class _History:
+    """The append rule from TrainingManager's event pump."""
+
+    def __init__(self):
+        self.steps: list[int] = []
+        self.loss: list[float] = []
+
+    def offer(self, step, loss):
+        last = self.steps[-1] if self.steps else None
+        if step > 0 and loss is not None and (last is None or step > last):
+            self.steps.append(step)
+            self.loss.append(loss)
+
+
+def test_series_ignores_repeats_at_the_same_step():
+    h = _History()
+    for step, loss in [(28, 0.27), (29, 0.32), (30, 0.3205), (30, 0.3205), (30, None)]:
+        h.offer(step, loss)
+    assert h.steps == [28, 29, 30]
+    assert h.loss[-1] == 0.3205
+
+
+def test_series_never_ends_on_the_average():
+    h = _History()
+    # The exact tail a 30 step run produced before the fix.
+    for step, loss in [(30, 0.3205), (30, 0.3205), (30, 0.3834), (30, 0.3834)]:
+        h.offer(step, loss)
+    assert h.steps == [30]
+    assert h.loss == [0.3205]
+
+
+def test_a_step_zero_record_is_still_ignored():
+    h = _History()
+    h.offer(0, 1.23)
+    assert h.steps == []
+
+
+def test_normal_monotonic_run_is_unchanged():
+    h = _History()
+    for step in range(1, 31):
+        h.offer(step, 1.0 / step)
+    assert h.steps == list(range(1, 31))
+    assert len(h.loss) == 30
+
+
+def test_the_shipped_call_sites_no_longer_fall_back_to_train_loss():
+    # Guard the actual source: the fallback is what caused this.
+    for rel in ("core/training/trainer.py", "core/training/worker.py"):
+        text = (_BACKEND / rel).read_text(encoding = "utf-8")
+        assert 'logs.get("loss", logs.get("train_loss", None))' not in text, rel

--- a/studio/backend/tests/test_final_loss_not_average.py
+++ b/studio/backend/tests/test_final_loss_not_average.py
@@ -161,3 +161,45 @@ def test_a_lossless_mid_run_record_is_still_dropped():
 
     _create_trainer_progress_callback(_Q())(_P())
     assert [e for e in events if e.get("type") == "progress"] == []
+
+
+def test_an_early_stopped_run_still_reports_its_duration():
+    # Stopping at step 12 of 30 still produces HF's lossless summary; the step
+    # comparison alone would discard it and finalize the run with stale timing.
+    import sys
+    from pathlib import Path
+
+    backend = Path(__file__).resolve().parent.parent
+    if str(backend) not in sys.path:
+        sys.path.insert(0, str(backend))
+    from core.training.worker import _create_trainer_progress_callback
+
+    class _P:
+        step = 12
+        total_steps = 30
+        loss = None
+        eval_loss = None
+        epoch = 1.0
+        learning_rate = 0.0
+        elapsed_seconds = 91.0
+        eta_seconds = None
+        grad_norm = None
+        num_tokens = 5
+        status_message = ""
+        is_run_summary = True
+        warnings: list = []
+
+    events = []
+
+    class _Q:
+        def put(self, e):
+            events.append(e)
+
+    _create_trainer_progress_callback(_Q())(_P())
+    progress = [e for e in events if e.get("type") == "progress"]
+    assert progress and progress[0]["elapsed_seconds"] == 91.0
+
+
+def test_the_trainer_marks_the_summary_record():
+    text = (_BACKEND / "core/training/trainer.py").read_text(encoding = "utf-8")
+    assert "is_run_summary = is_run_summary," in text

--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -5790,7 +5790,8 @@ def test_a_finely_timestamped_volume_is_not_read_twice_per_call(tmp_path, monkey
     read = []
     real_key = tools._content_key
     monkeypatch.setattr(
-        tools, "_content_key",
+        tools,
+        "_content_key",
         lambda path, size: (read.append(path), real_key(path, size))[1],
     )
     snapshot = tools._snapshot_workdir_files(str(workdir))
@@ -5813,9 +5814,11 @@ def test_one_whole_second_stamp_is_not_taken_for_a_coarse_volume(tmp_path, monke
     tools._fine_mtime_devices.clear()
     real_stat = os.stat
     monkeypatch.setattr(
-        os, "stat",
+        os,
+        "stat",
         lambda p, *a, **k: (
-            _WholeSecondMtime(real_stat(p, *a, **k)) if str(p) == str(workdir)
+            _WholeSecondMtime(real_stat(p, *a, **k))
+            if str(p) == str(workdir)
             else real_stat(p, *a, **k)
         ),
     )


### PR DESCRIPTION
### Summary

A finished run reports the mean loss over the whole run as if it were the last step's loss. The chart gains points stacked on the final step ending on that average, and `final_loss` on `/api/train/runs` disagrees with `/api/models/checkpoints` for the same run.

### Repro

Any run. A 30-step LoRA on `unsloth/gemma-4-E2B-it`, then `GET /api/train/status`:

```
metric_history.steps  ->  [..., 26, 27, 28, 29, 30, 30, 30, 30]      (33 points for 30 steps)
metric_history.loss   ->  [..., 0.2602, 0.2902, 0.2754, 0.3250,
                                0.3205, 0.3205, 0.3834, 0.3834]
```

`0.3205` is the real step-30 loss; it is also what `checkpoint-30/trainer_state.json` has as the last `log_history` entry. `0.3834` is HF's end-of-run `train_loss`, the mean over the run.

Then:

```
GET /api/train/runs         ->  final_loss = 0.3834      (the mean)
GET /api/models/checkpoints ->  0.3205                   (the real last step)
```

So the two endpoints disagree about the same run, and the UI stat card shows the average, which reads as loss jumping about 20% on the very last step.

### Cause

`transformers` logs the end-of-run summary as `{"train_runtime": ..., "train_loss": <mean>, ...}` with no `"loss"` key. Both `on_log` handlers read:

```python
loss_value = logs.get("loss", logs.get("train_loss", None))
```

(`core/training/trainer.py:354`, `core/training/worker.py:4582`)

so the summary record falls through to `train_loss` and is published as a normal progress update at `state.global_step`, which is still the last step. From there it lands in `loss_history` and overwrites `self._progress.loss`, which is what `final_loss` is read from (`core/training/training.py:2122`).

The duplicate `30, 30` before it has a second cause: the append in the event pump only required `step > 0`, so more than one record at the same `global_step` added more than one point.

### Changes

1. **Both `on_log` handlers read only `logs["loss"]`.** A record without one is not a step. The summary is not thrown away: `trainer.py` logs `training finished: mean train_loss=<x> over <n> steps` at info, and the worker prints the equivalent line, so the average is still reported, as the summary it is rather than as a step.
2. **The event pump only appends when the step strictly advances.** `training.py` keeps the last recorded step and ignores anything that does not move past it, so repeated records at the same `global_step` stop stacking points.

`final_loss` needed no change of its own: with the summary no longer overwriting `self._progress.loss`, it is the real final step, which is what `/api/models/checkpoints` already reported.

### After

Same model, dataset and step count, on a Studio running this branch:

```
metric_history.steps  ->  [..., 23, 24, 25, 26, 27, 28, 29, 30]     (30 points for 30 steps)
metric_history.loss   ->  [..., 0.3216, 0.3070, 0.2346, 0.2597,
                                0.2894, 0.2747, 0.3243, 0.3198]
GET /api/train/runs   ->  final_loss = 0.3198   (the real last step)
```

And the average is still reported, as the summary it is:

```
{"level": "info", "event": "training finished: mean train_loss=0.38329874177773793 over 30 steps"}
```

### Tests

`studio/backend/tests/test_final_loss_not_average.py` (7 cases): a step record still reports its loss, a summary record reports none, the series ignores repeats at the same step, the series never ends on the average (fed the exact tail this run produced), a step-0 record is still ignored, a normal monotonic run is unchanged, and a guard asserting the `logs.get("loss", logs.get("train_loss", None))` fallback is gone from both shipped call sites.

`tests/ -k train`: 1520 passed, 2 skipped.
