### PR TITLE
Studio: remeasure the overlay stack when its content resizes in place

### DIFF
--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -340,13 +340,10 @@ export function useStackGeometry(): StackPlacement {
       setNeededRoom((current) => (current === natural ? current : natural));
     };
     measure();
-    // Every box inside the stack, not just the stack itself. Capped, the container's own
-    // border box does not move when its content grows: an expanded release note whose
-    // Markdown image finishes loading pushes the content taller inside a root that stays
-    // at exactly the cap, so a root-only observer never fires. The child list does not
-    // change either, so the MutationObserver below says nothing. `neededRoom` would keep
-    // the pre-load height and the banner would stay clipped under an obstacle it was
-    // tall enough to be lifted over.
+    // Every box inside the stack, not just the stack itself. At its cap the container's
+    // border box does not move when its content grows, so a root-only observer never
+    // fires for a release-note image finishing its load, and childList says nothing
+    // either: the stack would keep the pre-load height and stay clipped.
     const observer = new ResizeObserver(measure);
     const observed = new Set<Element>();
     const syncObserved = () => {
@@ -366,7 +363,7 @@ export function useStackGeometry(): StackPlacement {
     };
     syncObserved();
     // A 0-height stack stays 0 as children come and go, so watch the child list too, and
-    // take the chance to observe whatever just arrived.
+    // observe whatever just arrived.
     const mutations = new MutationObserver(() => {
       syncObserved();
       measure();

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -344,7 +344,23 @@ export function useStackGeometry(): StackPlacement {
     // border box does not move when its content grows, so a root-only observer never
     // fires for a release-note image finishing its load, and childList says nothing
     // either: the stack would keep the pre-load height and stay clipped.
-    const observer = new ResizeObserver(measure);
+    // Height only. The llama.cpp update banner animates its progress bar's width on every
+    // frame, and that bar is inside this stack, so an unfiltered observer would remeasure
+    // at ~60Hz for a stack whose height never moved, each one forcing a synchronous layout
+    // to read scrollHeight with the cap lifted.
+    const heights = new WeakMap<Element, number>();
+    const observer = new ResizeObserver((entries) => {
+      let moved = false;
+      for (const entry of entries) {
+        const height =
+          entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+        if (heights.get(entry.target) !== height) {
+          heights.set(entry.target, height);
+          moved = true;
+        }
+      }
+      if (moved) measure();
+    });
     const observed = new Set<Element>();
     const syncObserved = () => {
       const wanted = new Set<Element>([node, ...node.querySelectorAll("*")]);

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -340,13 +340,41 @@ export function useStackGeometry(): StackPlacement {
       setNeededRoom((current) => (current === natural ? current : natural));
     };
     measure();
+    // Every box inside the stack, not just the stack itself. Capped, the container's own
+    // border box does not move when its content grows: an expanded release note whose
+    // Markdown image finishes loading pushes the content taller inside a root that stays
+    // at exactly the cap, so a root-only observer never fires. The child list does not
+    // change either, so the MutationObserver below says nothing. `neededRoom` would keep
+    // the pre-load height and the banner would stay clipped under an obstacle it was
+    // tall enough to be lifted over.
     const observer = new ResizeObserver(measure);
-    observer.observe(node);
-    // A 0-height stack stays 0 as children come and go, so watch the child list too.
-    const mutations = new MutationObserver(measure);
+    const observed = new Set<Element>();
+    const syncObserved = () => {
+      const wanted = new Set<Element>([node, ...node.querySelectorAll("*")]);
+      for (const element of observed) {
+        if (!wanted.has(element)) {
+          observer.unobserve(element);
+          observed.delete(element);
+        }
+      }
+      for (const element of wanted) {
+        if (!observed.has(element)) {
+          observer.observe(element);
+          observed.add(element);
+        }
+      }
+    };
+    syncObserved();
+    // A 0-height stack stays 0 as children come and go, so watch the child list too, and
+    // take the chance to observe whatever just arrived.
+    const mutations = new MutationObserver(() => {
+      syncObserved();
+      measure();
+    });
     mutations.observe(node, { childList: true, subtree: true });
     return () => {
       observer.disconnect();
+      observed.clear();
       mutations.disconnect();
     };
   }, []);

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -435,10 +435,9 @@ test("no pairing produces an overlap or an unusable cap", () => {
   }
 });
 
-// Capped, the stack's own border box does not move when its content grows, so a root-only
-// ResizeObserver never fires for an image that finishes loading inside an expanded release
-// note. The child list does not change either, so neither observer speaks and the stack
-// keeps the pre-load height and stays clipped.
+// At its cap the stack's border box does not move when its content grows, so neither a
+// root-only ResizeObserver nor a childList watcher hears an image finish loading inside an
+// expanded release note, and the stack keeps the pre-load height and stays clipped.
 test("every box inside the stack is observed, not just the stack", async () => {
   const source = await readFile(
     new URL(
@@ -457,8 +456,7 @@ test("every box inside the stack is observed, not just the stack", async () => {
     /querySelectorAll\("\*"\)/,
     "the descendants are never enumerated, so none of them is observed",
   );
-  // A subtree that changes has to be re-observed, or a banner that arrives after mount is
-  // watched only until its first paint.
+  // A changed subtree has to be re-observed, or a banner arriving after mount is missed.
   const onMutation = wiring.slice(wiring.indexOf("new MutationObserver"));
   assert.match(onMutation, /syncObserved\(\)/, "the observed set is not resynced");
   // And unobserved on the way out, or a detached node keeps the observer alive.

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -462,3 +462,31 @@ test("every box inside the stack is observed, not just the stack", async () => {
   // And unobserved on the way out, or a detached node keeps the observer alive.
   assert.match(wiring, /observer\.unobserve\(/, "nothing is ever unobserved");
 });
+
+// The llama.cpp update banner animates its progress bar's width every frame, inside this
+// same stack. Observing descendants without filtering therefore remeasures at ~60Hz for a
+// stack whose height never moved, and each remeasure lifts the cap and reads scrollHeight,
+// which forces a synchronous layout.
+test("a width-only animation does not remeasure the stack", async () => {
+  const source = await readFile(
+    new URL(
+      "../src/features/settings/stores/monitor-frame-store.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const wiring = source.slice(
+    source.indexOf("const observer = new ResizeObserver"),
+    source.indexOf("const observed = new Set<Element>()"),
+  );
+  assert.ok(
+    !/new ResizeObserver\(measure\)/.test(wiring),
+    "every observed resize remeasures, width-only ones included",
+  );
+  assert.match(wiring, /blockSize/, "the entry's height is never read");
+  assert.match(
+    wiring,
+    /if \(moved\) measure\(\)/,
+    "measure runs whether or not a height moved",
+  );
+});

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -317,7 +317,7 @@ test("the height is measured with the hook's own cap lifted", async () => {
   );
   const measure = source.slice(
     source.indexOf("const measure = () => {"),
-    source.indexOf("observer.observe(node)"),
+    source.indexOf("const observer = new ResizeObserver"),
   );
   assert.ok(measure, "the measure callback moved");
   assert.match(
@@ -433,4 +433,34 @@ test("no pairing produces an overlap or an unusable cap", () => {
       }
     }
   }
+});
+
+// Capped, the stack's own border box does not move when its content grows, so a root-only
+// ResizeObserver never fires for an image that finishes loading inside an expanded release
+// note. The child list does not change either, so neither observer speaks and the stack
+// keeps the pre-load height and stays clipped.
+test("every box inside the stack is observed, not just the stack", async () => {
+  const source = await readFile(
+    new URL(
+      "../src/features/settings/stores/monitor-frame-store.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const wiring = source.slice(source.indexOf("const observer = new ResizeObserver"));
+  assert.ok(
+    !/observer\.observe\(node\)/.test(wiring),
+    "the root alone is observed, so an intrinsic descendant resize is missed",
+  );
+  assert.match(
+    wiring,
+    /querySelectorAll\("\*"\)/,
+    "the descendants are never enumerated, so none of them is observed",
+  );
+  // A subtree that changes has to be re-observed, or a banner that arrives after mount is
+  // watched only until its first paint.
+  const onMutation = wiring.slice(wiring.indexOf("new MutationObserver"));
+  assert.match(onMutation, /syncObserved\(\)/, "the observed set is not resynced");
+  // And unobserved on the way out, or a detached node keeps the observer alive.
+  assert.match(wiring, /observer\.unobserve\(/, "nothing is ever unobserved");
 });


### PR DESCRIPTION
Follow-up to #8301, which landed before this came up in review.

`useStackGeometry` measures how much room the bottom-right overlay stack needs and observes the stack container so the measurement keeps up. That observer only fires when the container's own border box moves, and the container is capped: when its content grows inside a `max-height` it is already at, the border box does not change. The `MutationObserver` beside it watches `childList` only, so it says nothing either.

The case that reaches it is an expanded release note whose Markdown image finishes loading. Nothing is inserted and nothing at the root resizes, so neither observer calls `measure()`, `neededRoom` keeps the pre-load height, and the banner stays clipped under an obstacle it is now tall enough to be lifted over.

The `ResizeObserver` now watches the container and every element inside it, and the mutation callback resyncs that set before remeasuring so a banner arriving after mount is watched too. Elements that leave are unobserved rather than left attached.

Tests: `monitor-stack-inset.test.ts` gains a check that the root is not the only observed box, that the descendants are enumerated, that the observed set is resynced on mutation and that anything leaving is unobserved. The existing cap-lifted test's slice boundary moved with the code. 1525 frontend tests pass, `npm run typecheck` clean.
