### PR TITLE
Only trust the adjacent ROCm-on-WSL helper for a real checkout run

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2642,19 +2642,16 @@ TORCHAUDIO_CONSTRAINT="torchaudio>=2.4,<2.11.0"
 
 # ── Resolve repo root (for --local installs) ──
 _REPO_ROOT="$(cd "$(dirname "$0" 2>/dev/null || echo ".")" && pwd)"
-# A piped install (curl ... | sh) has $0 = "sh", so _REPO_ROOT is whatever directory the
-# user happened to be in, not a checkout. Only a real checkout may be trusted for the
-# scripts sitting next to it, or an install run from a writable or shared directory would
-# execute that directory's copy instead of ours. Run as a file AND surrounded by the repo
-# itself: install.sh downloaded on its own into such a directory is not a checkout.
+# Whether _REPO_ROOT may be trusted for the scripts sitting next to install.sh. A piped
+# install (curl ... | sh) has $0 = "sh", so _REPO_ROOT is whatever directory the user
+# happened to be in; running from a writable or shared one would execute that directory's
+# copy instead of ours. Marker files cannot decide this (anyone who can plant a helper can
+# plant those too), so require the user to have asked for a local install AND to have run
+# install.sh as a file. Everything else fetches the official helper.
 _REPO_IS_CHECKOUT=0
 case "$0" in
     */install.sh|install.sh)
-        if [ -r "$0" ] && [ -f "$_REPO_ROOT/pyproject.toml" ] \
-           && [ -f "$_REPO_ROOT/unsloth/__init__.py" ]; then
-            _REPO_IS_CHECKOUT=1
-        fi
-        ;;
+        [ "$STUDIO_LOCAL_INSTALL" = true ] && [ -r "$0" ] && _REPO_IS_CHECKOUT=1 ;;
 esac
 
 # ── Helper: find no-torch-runtime.txt (local repo or site-packages) ──
@@ -3515,10 +3512,10 @@ _maybe_bootstrap_rocm_wsl() {
     substep "One-time, uses sudo and a large download. (skip: re-run with UNSLOTH_SKIP_ROCM_WSL_SETUP=1)"
 
     # Locate the helper: prefer the copy shipped beside install.sh, else fetch it. The
-    # local copy counts only for a real checkout run: this executes automatically with no
-    # prompt, so on a piped install _REPO_ROOT is the caller's cwd and a file planted
-    # there would run instead. Fetching the official helper is the same code path that
-    # already runs whenever the local copy is absent.
+    # local copy counts only for a --local checkout run: this executes automatically with
+    # no prompt, so otherwise _REPO_ROOT may be the caller's cwd and a file planted there
+    # would run instead. Fetching the official helper is the same code path that already
+    # runs whenever the local copy is absent, and pulls the same script.
     _rw_helper="${_REPO_ROOT:-.}/scripts/install_rocm_wsl_strixhalo.sh"
     _rw_tmp=""
     if [ "$_REPO_IS_CHECKOUT" != "1" ] || [ ! -r "$_rw_helper" ]; then

--- a/install.sh
+++ b/install.sh
@@ -2643,12 +2643,18 @@ TORCHAUDIO_CONSTRAINT="torchaudio>=2.4,<2.11.0"
 # ── Resolve repo root (for --local installs) ──
 _REPO_ROOT="$(cd "$(dirname "$0" 2>/dev/null || echo ".")" && pwd)"
 # A piped install (curl ... | sh) has $0 = "sh", so _REPO_ROOT is whatever directory the
-# user happened to be in, not a checkout. Only a run from the script file itself may
-# trust scripts sitting next to it, or an install from a writable/shared cwd would run
-# that directory's copy instead of ours.
+# user happened to be in, not a checkout. Only a real checkout may be trusted for the
+# scripts sitting next to it, or an install run from a writable or shared directory would
+# execute that directory's copy instead of ours. Run as a file AND surrounded by the repo
+# itself: install.sh downloaded on its own into such a directory is not a checkout.
 _REPO_IS_CHECKOUT=0
 case "$0" in
-    */install.sh|install.sh) [ -r "$0" ] && _REPO_IS_CHECKOUT=1 ;;
+    */install.sh|install.sh)
+        if [ -r "$0" ] && [ -f "$_REPO_ROOT/pyproject.toml" ] \
+           && [ -f "$_REPO_ROOT/unsloth/__init__.py" ]; then
+            _REPO_IS_CHECKOUT=1
+        fi
+        ;;
 esac
 
 # ── Helper: find no-torch-runtime.txt (local repo or site-packages) ──

--- a/install.sh
+++ b/install.sh
@@ -2642,12 +2642,10 @@ TORCHAUDIO_CONSTRAINT="torchaudio>=2.4,<2.11.0"
 
 # ── Resolve repo root (for --local installs) ──
 _REPO_ROOT="$(cd "$(dirname "$0" 2>/dev/null || echo ".")" && pwd)"
-# Whether _REPO_ROOT may be trusted for the scripts sitting next to install.sh. A piped
-# install (curl ... | sh) has $0 = "sh", so _REPO_ROOT is whatever directory the user
-# happened to be in; running from a writable or shared one would execute that directory's
-# copy instead of ours. Marker files cannot decide this (anyone who can plant a helper can
-# plant those too), so require the user to have asked for a local install AND to have run
-# install.sh as a file. Everything else fetches the official helper.
+# Whether the scripts next to install.sh may be trusted. A piped install (curl ... | sh)
+# has $0 = "sh", so _REPO_ROOT is just the caller's cwd and a file planted there would run.
+# Marker files cannot decide this (whoever can plant a helper can plant those), so require
+# the explicit --local intent AND a run from the file itself; else fetch the official copy.
 _REPO_IS_CHECKOUT=0
 case "$0" in
     */install.sh|install.sh)
@@ -3511,11 +3509,9 @@ _maybe_bootstrap_rocm_wsl() {
     substep "Setting up ROCm-on-WSL (ROCm 7.2 + librocdxg) automatically to enable this GPU."
     substep "One-time, uses sudo and a large download. (skip: re-run with UNSLOTH_SKIP_ROCM_WSL_SETUP=1)"
 
-    # Locate the helper: prefer the copy shipped beside install.sh, else fetch it. The
-    # local copy counts only for a --local checkout run: this executes automatically with
-    # no prompt, so otherwise _REPO_ROOT may be the caller's cwd and a file planted there
-    # would run instead. Fetching the official helper is the same code path that already
-    # runs whenever the local copy is absent, and pulls the same script.
+    # Locate the helper: prefer the copy shipped beside install.sh, else fetch it. The local
+    # copy counts only for a --local checkout run, since this executes with no prompt and
+    # _REPO_ROOT may otherwise be the caller's cwd. The fetch pulls the same script.
     _rw_helper="${_REPO_ROOT:-.}/scripts/install_rocm_wsl_strixhalo.sh"
     _rw_tmp=""
     if [ "$_REPO_IS_CHECKOUT" != "1" ] || [ ! -r "$_rw_helper" ]; then

--- a/install.sh
+++ b/install.sh
@@ -2642,6 +2642,14 @@ TORCHAUDIO_CONSTRAINT="torchaudio>=2.4,<2.11.0"
 
 # ── Resolve repo root (for --local installs) ──
 _REPO_ROOT="$(cd "$(dirname "$0" 2>/dev/null || echo ".")" && pwd)"
+# A piped install (curl ... | sh) has $0 = "sh", so _REPO_ROOT is whatever directory the
+# user happened to be in, not a checkout. Only a run from the script file itself may
+# trust scripts sitting next to it, or an install from a writable/shared cwd would run
+# that directory's copy instead of ours.
+_REPO_IS_CHECKOUT=0
+case "$0" in
+    */install.sh|install.sh) [ -r "$0" ] && _REPO_IS_CHECKOUT=1 ;;
+esac
 
 # ── Helper: find no-torch-runtime.txt (local repo or site-packages) ──
 _find_no_torch_runtime() {
@@ -3500,10 +3508,14 @@ _maybe_bootstrap_rocm_wsl() {
     substep "Setting up ROCm-on-WSL (ROCm 7.2 + librocdxg) automatically to enable this GPU."
     substep "One-time, uses sudo and a large download. (skip: re-run with UNSLOTH_SKIP_ROCM_WSL_SETUP=1)"
 
-    # Locate the helper: prefer the copy shipped beside install.sh, else fetch it.
+    # Locate the helper: prefer the copy shipped beside install.sh, else fetch it. The
+    # local copy counts only for a real checkout run: this executes automatically with no
+    # prompt, so on a piped install _REPO_ROOT is the caller's cwd and a file planted
+    # there would run instead. Fetching the official helper is the same code path that
+    # already runs whenever the local copy is absent.
     _rw_helper="${_REPO_ROOT:-.}/scripts/install_rocm_wsl_strixhalo.sh"
     _rw_tmp=""
-    if [ ! -r "$_rw_helper" ]; then
+    if [ "$_REPO_IS_CHECKOUT" != "1" ] || [ ! -r "$_rw_helper" ]; then
         _rw_tmp="$(mktemp 2>/dev/null || echo /tmp/_unsloth_rocm_wsl.sh)"
         if download "https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/install_rocm_wsl_strixhalo.sh" "$_rw_tmp" 2>/dev/null; then
             _rw_helper="$_rw_tmp"


### PR DESCRIPTION
### Summary

`_REPO_ROOT` is derived from `dirname "$0"`:

```sh
_REPO_ROOT="$(cd "$(dirname "$0" 2>/dev/null || echo ".")" && pwd)"
```

In the documented install path, `curl -fsSL https://unsloth.ai/install.sh | sh`, `$0` is `sh`, so `dirname` gives `.` and `_REPO_ROOT` becomes whatever directory the user happened to be in. Confirmed:

```
$ printf 'echo "$0 / $(dirname "$0")"\n' | sh
sh / .
```

`_maybe_bootstrap_rocm_wsl` then prefers the adjacent helper over the official download:

```sh
_rw_helper="${_REPO_ROOT:-.}/scripts/install_rocm_wsl_strixhalo.sh"
if [ ! -r "$_rw_helper" ]; then
    ... download the official copy ...
fi
...
if UNSLOTH_WSL_SMOKE_TEST=0 bash "$_rw_helper"; then
```

That runs automatically with no prompt (deliberately, so it works with no TTY under `curl | sh`). So a piped install started from a shared or writable directory that happens to contain `scripts/install_rocm_wsl_strixhalo.sh` runs that copy instead of ours, as the installing user, at a point where the installer has just told the user to expect a privileged step and a large download.

The unsafe lookup predates this, but the bootstrap now triggers on any Windows-reported AMD/Radeon GPU rather than only Strix CPU strings, so many more hosts reach it.

### Fix

Take the adjacent helper only when `install.sh` was actually run as a file:

```sh
_REPO_IS_CHECKOUT=0
case "$0" in
    */install.sh|install.sh) [ -r "$0" ] && _REPO_IS_CHECKOUT=1 ;;
esac
```

A piped install falls through to the existing download branch, which is the same code path that already runs whenever the local copy is absent. Nothing new to maintain and no new failure mode.

### No behaviour change for real installs

| invocation | `_REPO_IS_CHECKOUT` | helper used |
|---|---|---|
| `./install.sh` | 1 | local |
| `bash install.sh` | 1 | local |
| `sh install.sh` | 1 | local |
| `bash path/to/install.sh` from elsewhere | 1 | local |
| `curl ... \| sh` | 0 | official download |
| `sh < install.sh` | 0 | official download |

Verified each of the six. A `--local` install is unaffected: it is run as `./install.sh --local` from the checkout, which keeps `_REPO_IS_CHECKOUT=1`.

### Scope

Deliberately narrow. The other `_REPO_ROOT` consumers (`uv pip install -e "$_REPO_ROOT"`, `studio/setup.sh`) sit behind `--local`, which the user opts into explicitly from their own checkout, so they are not reachable from a piped install. This changes only the one path that auto-executes a file with no prompt.

`sh -n` and `bash -n` both clean.
