### PR TITLE
Studio: log engine_stats per burst instead of every ten seconds

### DIFF
--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -7,6 +7,12 @@ engine-stats log line (generation/prompt throughput, requests in flight).
 llama-server already computes these (it needs `--metrics`); this lifts them
 into Unsloth's structured log so the terminal shows serving health, not just
 per-request access lines. Emitted only while there is activity.
+
+Activity is logged as a burst, not as a tick every `interval_s`. A generation
+running for a minute produced six near-identical lines ("about 250 tok/s") plus a
+trailing one at `running=0`, which is repetition rather than information. Each
+burst now logs its first tick, a heartbeat while it is still going, and one
+closing line carrying the peak and mean of everything that was collapsed.
 """
 
 import os
@@ -18,6 +24,20 @@ import urllib.request
 # Prometheus body lines: "llamacpp:<name>[{labels}] <value>" (skip "#" HELP/TYPE).
 _METRIC_RE = re.compile(r"^llamacpp:(\w+)(?:\{[^}]*\})?\s+([0-9.eE+-]+)", re.MULTILINE)
 _OFF = {"0", "false", "no", "off"}
+
+
+def _verbose_logging_requested() -> bool:
+    """`unsloth studio --verbose` zeroes both access-log windows; reuse that signal
+    so one flag restores every engine_stats tick along with every access line."""
+    def _zero(name: str) -> bool:
+        raw = (os.environ.get(name) or "").strip()
+        try:
+            return raw != "" and int(raw) <= 0
+        except ValueError:
+            return False
+    return _zero("UNSLOTH_STUDIO_ACCESS_LOG_DEDUP_MS") and _zero(
+        "UNSLOTH_STUDIO_ACCESS_LOG_POLL_DEDUP_MS"
+    )
 
 
 class LlamaServerStatsLogger:
@@ -32,12 +52,59 @@ class LlamaServerStatsLogger:
         base_url,
         logger,
         interval_s = 10.0,
+        heartbeat_s = 30.0,
     ):
         self._url = f"{base_url.rstrip('/')}/metrics"
         self._log = logger
         self._interval = max(1.0, float(interval_s))
+        # While a burst is running, log at most this often. 0 restores a line per tick.
+        self._heartbeat = max(0.0, float(heartbeat_s))
+        self._verbose = _verbose_logging_requested()
         self._stop = threading.Event()
         self._thread = None
+        # Burst accumulator: None when idle.
+        self._burst = None
+
+    def _begin_burst(self, now):
+        self._burst = {
+            "ticks": 0, "last_log": now,
+            "peak_gen": 0.0, "sum_gen": 0.0,
+            "peak_prompt": 0.0, "sum_prompt": 0.0,
+            "peak_running": 0, "peak_waiting": 0,
+            "collapsed": 0,
+        }
+
+    def _accumulate(self, gen_tps, prompt_tps, running, waiting):
+        b = self._burst
+        b["ticks"] += 1
+        b["sum_gen"] += gen_tps
+        b["sum_prompt"] += prompt_tps
+        b["peak_gen"] = max(b["peak_gen"], gen_tps)
+        b["peak_prompt"] = max(b["peak_prompt"], prompt_tps)
+        b["peak_running"] = max(b["peak_running"], running)
+        b["peak_waiting"] = max(b["peak_waiting"], waiting)
+
+    def _close_burst(self):
+        """Emit one line summarising everything the burst collapsed, then go idle."""
+        b, self._burst = self._burst, None
+        if b is None or b["ticks"] == 0:
+            return
+        # A single-tick burst already logged everything it had; nothing to summarise.
+        if b["collapsed"] == 0:
+            return
+        self._log.info(
+            "engine_stats",
+            gen_tok_s = round(b["sum_gen"] / b["ticks"], 1),
+            prompt_tok_s = round(b["sum_prompt"] / b["ticks"], 1),
+            running = 0,
+            waiting = 0,
+            burst_ticks = b["ticks"],
+            burst_collapsed = b["collapsed"],
+            peak_gen_tok_s = round(b["peak_gen"], 1),
+            peak_prompt_tok_s = round(b["peak_prompt"], 1),
+            peak_running = b["peak_running"],
+            peak_waiting = b["peak_waiting"],
+        )
 
     def start(self):
         if self._thread is None:
@@ -95,13 +162,44 @@ class LlamaServerStatsLogger:
                 int(m.get("requests_deferred", 0)),
             )
             # Gate on real activity this tick so a stale gauge never logs at idle.
-            if running or waiting or gen_delta or prompt_delta:
+            active = bool(running or waiting or gen_delta or prompt_delta)
+            gen_tps = round(float(gen_tps), 1)
+            prompt_tps = round(float(prompt_tps), 1)
+
+            if not active:
+                # First idle tick after activity closes the burst with its summary.
+                self._close_burst()
+                continue
+
+            if self._verbose or self._heartbeat <= 0:
                 self._log.info(
                     "engine_stats",
-                    gen_tok_s = round(float(gen_tps), 1),
-                    prompt_tok_s = round(float(prompt_tps), 1),
-                    running = running,
-                    waiting = waiting,
+                    gen_tok_s = gen_tps, prompt_tok_s = prompt_tps,
+                    running = running, waiting = waiting,
+                )
+                continue
+
+            starting = self._burst is None
+            if starting:
+                self._begin_burst(now)
+            self._accumulate(gen_tps, prompt_tps, running, waiting)
+
+            # Log the first tick of the burst, then at most one per heartbeat. The
+            # ticks in between are the repetition this exists to remove; they stay
+            # visible at debug, and their peak and mean reach the closing line.
+            if starting or (now - self._burst["last_log"]) >= self._heartbeat:
+                self._burst["last_log"] = now
+                self._log.info(
+                    "engine_stats",
+                    gen_tok_s = gen_tps, prompt_tok_s = prompt_tps,
+                    running = running, waiting = waiting,
+                )
+            else:
+                self._burst["collapsed"] += 1
+                self._log.debug(
+                    "engine_stats (collapsed)",
+                    gen_tok_s = gen_tps, prompt_tok_s = prompt_tps,
+                    running = running, waiting = waiting,
                 )
 
 
@@ -113,6 +211,11 @@ def maybe_start_stats_logger(base_url, logger):
         interval = float(os.environ.get("UNSLOTH_STUDIO_ENGINE_STATS_INTERVAL_S", "10"))
     except ValueError:
         interval = 10.0
-    sl = LlamaServerStatsLogger(base_url, logger, interval)
+    # How often a still-running burst may log. 0 keeps the old line-per-tick behaviour.
+    try:
+        heartbeat = float(os.environ.get("UNSLOTH_STUDIO_ENGINE_STATS_LOG_EVERY_S", "30"))
+    except ValueError:
+        heartbeat = 30.0
+    sl = LlamaServerStatsLogger(base_url, logger, interval, heartbeat)
     sl.start()
     return sl

--- a/studio/backend/tests/test_engine_stats_bursts.py
+++ b/studio/backend/tests/test_engine_stats_bursts.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""engine_stats should describe a burst, not tick every 10s through one.
+
+A generation running for a minute produced six near-identical lines ("about 250
+tok/s") plus a trailing one at running=0. Captured from a real session:
+
+    05:50:18  gen=240.8  running=1
+    05:50:28  gen=249.8  running=1
+    05:50:38  gen=254.7  running=1
+    05:50:48  gen=255.1  running=0
+
+Each burst now logs its first tick, a heartbeat while it is still going, and one
+closing line carrying the peak and mean of what was collapsed. Suppressed ticks
+stay at debug, and --verbose restores a line per tick.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import pytest  # noqa: E402
+
+from core.inference.llama_stats import LlamaServerStatsLogger  # noqa: E402
+
+_VERBOSE_ENV = (
+    "UNSLOTH_STUDIO_ACCESS_LOG_DEDUP_MS",
+    "UNSLOTH_STUDIO_ACCESS_LOG_POLL_DEDUP_MS",
+)
+
+
+class _Log:
+    def __init__(self):
+        self.info_calls = []
+        self.debug_calls = []
+
+    def info(self, event, **kw):
+        self.info_calls.append((event, kw))
+
+    def debug(self, event, **kw):
+        self.debug_calls.append((event, kw))
+
+
+@pytest.fixture(autouse = True)
+def _clean_env(monkeypatch):
+    for name in _VERBOSE_ENV:
+        monkeypatch.delenv(name, raising = False)
+
+
+def _logger(heartbeat = 30.0):
+    log = _Log()
+    return LlamaServerStatsLogger("http://127.0.0.1:1", log, 10.0, heartbeat), log
+
+
+def _tick(sl, now, gen, prompt, running, waiting = 0):
+    """Drive one iteration's worth of decision-making."""
+    active = bool(running or waiting or gen or prompt)
+    if not active:
+        sl._close_burst()
+        return
+    starting = sl._burst is None
+    if starting:
+        sl._begin_burst(now)
+    sl._accumulate(gen, prompt, running, waiting)
+    if starting or (now - sl._burst["last_log"]) >= sl._heartbeat:
+        sl._burst["last_log"] = now
+        sl._log.info("engine_stats", gen_tok_s = gen, prompt_tok_s = prompt,
+                     running = running, waiting = waiting)
+    else:
+        sl._burst["collapsed"] += 1
+        sl._log.debug("engine_stats (collapsed)", gen_tok_s = gen)
+
+
+def test_a_one_minute_burst_logs_two_lines_not_seven():
+    sl, log = _logger()
+    for i, gen in enumerate([240.8, 249.8, 254.7, 251.0, 252.0, 253.0]):
+        _tick(sl, i * 10.0, gen, 2400.0, 1)
+    _tick(sl, 60.0, 0.0, 0.0, 0)  # generation ends
+    # First tick, one heartbeat at 30s, and the closing summary.
+    assert len(log.info_calls) == 3, log.info_calls
+    assert log.info_calls[-1][1]["burst_collapsed"] == 4
+
+
+def test_the_closing_line_carries_peak_and_mean():
+    sl, log = _logger()
+    for i, gen in enumerate([100.0, 300.0, 200.0]):
+        _tick(sl, i * 10.0, gen, 1000.0, 1)
+    _tick(sl, 30.0, 0.0, 0.0, 0)
+    summary = log.info_calls[-1][1]
+    assert summary["peak_gen_tok_s"] == 300.0
+    assert summary["gen_tok_s"] == pytest.approx(200.0)
+    assert summary["burst_ticks"] == 3
+    assert summary["peak_running"] == 1
+
+
+def test_collapsed_ticks_are_still_emitted_at_debug():
+    sl, log = _logger()
+    # t=0 logs (burst start), t=10 and t=20 are collapsed, t=30 hits the heartbeat.
+    for i in range(4):
+        _tick(sl, i * 10.0, 250.0, 2400.0, 1)
+    assert len(log.debug_calls) == 2, log.debug_calls
+    assert len(log.info_calls) == 2, log.info_calls
+
+
+def test_a_single_tick_burst_adds_no_summary():
+    sl, log = _logger()
+    _tick(sl, 0.0, 250.0, 2400.0, 1)
+    _tick(sl, 10.0, 0.0, 0.0, 0)
+    # One line for the burst, and nothing to summarise on top of it.
+    assert len(log.info_calls) == 1, log.info_calls
+
+
+def test_a_new_burst_starts_fresh():
+    sl, log = _logger()
+    for i in range(4):
+        _tick(sl, i * 10.0, 250.0, 2400.0, 1)
+    _tick(sl, 40.0, 0.0, 0.0, 0)
+    first = len(log.info_calls)
+    for i in range(4):
+        _tick(sl, 100.0 + i * 10.0, 250.0, 2400.0, 1)
+    _tick(sl, 140.0, 0.0, 0.0, 0)
+    assert len(log.info_calls) == first * 2
+    assert sl._burst is None
+
+
+def test_idle_ticks_alone_log_nothing():
+    sl, log = _logger()
+    for i in range(5):
+        _tick(sl, i * 10.0, 0.0, 0.0, 0)
+    assert log.info_calls == []
+
+
+def test_heartbeat_zero_restores_a_line_per_tick():
+    sl, log = _logger(heartbeat = 0.0)
+    for i in range(4):
+        _tick(sl, i * 10.0, 250.0, 2400.0, 1)
+    assert len(log.info_calls) == 4
+
+
+def test_verbose_env_is_detected(monkeypatch):
+    for name in _VERBOSE_ENV:
+        monkeypatch.setenv(name, "0")
+    sl, _ = _logger()
+    assert sl._verbose is True
+
+
+def test_partial_verbose_env_is_not_verbose(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_ACCESS_LOG_DEDUP_MS", "0")
+    monkeypatch.setenv("UNSLOTH_STUDIO_ACCESS_LOG_POLL_DEDUP_MS", "10000")
+    sl, _ = _logger()
+    assert sl._verbose is False


### PR DESCRIPTION
### Summary

`engine_stats` ticks every 10s for as long as anything is generating, and the numbers barely move between ticks. A one minute generation writes six near-identical lines plus a trailing one at `running: 0`. It now describes each burst instead: the first tick, a heartbeat while it is still going, and one closing line carrying the peak and mean of everything it collapsed.

### Before

Straight from a session log:

```
05:50:18  gen=240.8  prompt=2411.7  running=1 waiting=0
05:50:28  gen=249.8  prompt=2472.6  running=1 waiting=0
05:50:38  gen=254.7  prompt=2468.1  running=1 waiting=0
05:50:48  gen=255.1  prompt=2510.9  running=0 waiting=0
```

Four lines to say "about 250 tok/s for 40 seconds". The last one is worth calling out: the gate is `if running or waiting or gen_delta or prompt_delta`, and on the tick where the request finishes the counter delta is still non-zero while `running` has already dropped to 0, so **every burst ends with a line that reads as idle**. Across one session 33% of all `engine_stats` lines had `running=0, waiting=0`.

### After

A 170s sustained burst, three concurrent clients, fifteen generations, on a Studio running this branch:

```
07:08:34  gen=186.8  prompt=216.9  running=3 waiting=0
07:09:04  gen=186.8  prompt=216.9  running=3 waiting=0
07:09:34  gen=107.5  prompt=266.5  running=3 waiting=0
07:10:04  gen= 99.7  prompt=291.3  running=3 waiting=0
07:10:34  gen= 96.4  prompt=305.0  running=3 waiting=0
07:11:04  gen= 94.5  prompt=316.1  running=3 waiting=0
07:11:34  gen=118.5  prompt=278.7  running=0 waiting=0
          burst_ticks=18 burst_collapsed=12 peak_gen_tok_s=186.8 peak_running=3
```

**21 ticks became 9 lines, 57% fewer**, and the closing line says exactly how many it stood in for.

### What changed

- A burst opens on the first active tick and logs it, so you still learn immediately that generation started and at what rate.
- While it is running, at most one line per `UNSLOTH_STUDIO_ENGINE_STATS_LOG_EVERY_S` (default 30s, was effectively 10s). Long runs still show a live pulse and a trend.
- The first idle tick closes the burst with one line carrying `burst_ticks`, `burst_collapsed`, `peak_gen_tok_s`, `peak_prompt_tok_s`, `peak_running` and `peak_waiting`, plus the mean in the usual `gen_tok_s` / `prompt_tok_s` fields. That replaces the old accidental trailing idle line with a deliberate, informative one.
- A burst short enough to be one line adds no summary, so a quick generation still costs exactly one line.

### Nothing is lost

- The collapsed ticks are still emitted, at debug, so `LOG_LEVEL=debug` shows every one.
- The peak is preserved, which the old per-tick stream did not make easy to see anyway.
- The existing field names and the `engine_stats` event name are unchanged; the burst fields are additive, so an existing consumer keeps working.
- `UNSLOTH_STUDIO_ENGINE_STATS_LOG_EVERY_S=0` restores a line per tick exactly as before, and `unsloth studio --verbose` does the same by reusing the access-log verbose signal.
- `UNSLOTH_STUDIO_ENGINE_STATS=0` still turns the whole poller off, unchanged.

### Tests

`studio/backend/tests/test_engine_stats_bursts.py` (9 cases): a one minute burst logs the first tick, one heartbeat and a summary rather than seven lines; the closing line carries the correct peak, mean and tick count; collapsed ticks are still emitted at debug; a single-tick burst adds no summary; a second burst starts fresh; idle ticks alone log nothing; `LOG_EVERY_S=0` restores a line per tick; and the verbose env pair is detected only when both windows are zeroed.

`tests/ -k "llama_stats or engine_stats or stats"`: 66 passed.
