### PR TITLE
CI: avoid blocking Windows releases on cache saves

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -744,6 +744,10 @@ jobs:
         with:
           workspaces: 'studio/src-tauri -> target'
 
+          # Windows release builds can spend many minutes uploading the target cache
+          # after signed artifacts are ready, which blocks the publisher for no release benefit.
+          save-if: ${{ matrix.platform != 'windows-latest' }}
+
       # ── macOS: fail before the build if notarization cannot run ──
       - name: Check Apple notarization credentials
         if: matrix.platform == 'macos-latest'

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -37,6 +37,12 @@ def _step(workflow, job, name):
     return _steps(workflow, job)[_step_index(workflow, job, name)]
 
 
+def test_windows_release_build_restores_but_does_not_save_rust_cache():
+    cache = _step(_workflow(), "build", "Rust cache")
+    assert cache["with"]["workspaces"] == "studio/src-tauri -> target"
+    assert cache["with"]["save-if"] == "${{ matrix.platform != 'windows-latest' }}"
+
+
 def _write_fake_gh(path: Path):
     """Record gh arguments and return configured statuses."""
     path.write_text(


### PR DESCRIPTION
## Summary

- keep restoring the Rust cache for every desktop release platform
- stop the Windows release leg from saving `studio/src-tauri/target` after its signed artifacts are ready
- add a workflow contract test for the platform-specific `save-if` guard

## Why

During fork validation of the all-platform desktop release workflow, the Windows build completed successfully but remained blocked in `Post Rust cache` for more than 13 minutes. Because the publisher waits for every matrix job to finish, that cache upload also prevented otherwise-ready Linux, macOS, and Windows artifacts from being published.

Observed stalled run: https://github.com/wasimysaid/unsloth/actions/runs/31370630056

A subsequent fork run with release cache writes disabled completed successfully, including Windows and publication:
https://github.com/wasimysaid/unsloth/actions/runs/31372448036

This PR narrows that workaround to Windows only. Existing caches can still be restored, and Linux/macOS continue saving caches normally.

## Verification

- `uvx --with pyyaml pytest -q tests/security/test_release_desktop_integrity.py` — 17 passed
- workflow YAML parsed and `save-if` resolved to `${{ matrix.platform != 'windows-latest' }}`
- `git diff --check`
