### PR TITLE
Studio: skip redundant packaged frontend rebuilds

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3037,11 +3037,20 @@ function Get-NodeDecision {
 
 
 function Test-PackagedFrontend {
-    param([string]$LocalInstall, [string]$IndexPath)
+    param([string]$LocalInstall, [string]$IndexPath, [string]$ProjectFilePath)
     # install.ps1 and `unsloth studio update` explicitly pass 0 for PyPI
     # installs. Wheel extraction mtimes do not preserve build ordering, so use
     # the release-built dist whenever its entry point is present.
-    return $LocalInstall -eq "0" -and (Test-Path -LiteralPath $IndexPath -PathType Leaf)
+    #
+    # $ProjectFilePath is the pyproject.toml beside studio/. The mode records
+    # where the Python package came from, not which tree this script runs out
+    # of, and an editable overlay separates the two: it leaves the mode at 0
+    # while $ScriptDir is a checkout, whose dist is a stale build artifact
+    # rather than a release one. A wheel ships no top-level files, so that file
+    # existing means source tree -- keep the mtime rebuild there.
+    if ($LocalInstall -ne "0") { return $false }
+    if ($ProjectFilePath -and (Test-Path -LiteralPath $ProjectFilePath -PathType Leaf)) { return $false }
+    return (Test-Path -LiteralPath $IndexPath -PathType Leaf)
 }
 
 $SkipFrontend = ($env:SKIP_STUDIO_FRONTEND -eq "1")
@@ -3287,16 +3296,19 @@ Write-StudioLine ""
 $DistDir = Join-Path $FrontendDir "dist"
 $PackagedFrontend = Test-PackagedFrontend `
     -LocalInstall "$($env:STUDIO_LOCAL_INSTALL)" `
-    -IndexPath (Join-Path $DistDir "index.html")
+    -IndexPath (Join-Path $DistDir "index.html") `
+    -ProjectFilePath (Join-Path $PackageDir "pyproject.toml")
 # Wheel extraction mtimes are not a source-freshness signal. Standard PyPI
 # installs use the release-built dist; local/source installs retain mtime checks.
+# Tauri is checked first so the reported reason matches setup.sh on a desktop
+# update, where both this and the packaged branch would otherwise apply.
 $NeedFrontendBuild = $true
-if ($IsPipInstall -or $PackagedFrontend) {
-    $NeedFrontendBuild = $false
-    step "frontend" "bundled (pip install)"
-} elseif ($SkipFrontend) {
+if ($SkipFrontend) {
     $NeedFrontendBuild = $false
     step "frontend" "bundled (Tauri)"
+} elseif ($IsPipInstall -or $PackagedFrontend) {
+    $NeedFrontendBuild = $false
+    step "frontend" "bundled (pip install)"
 } elseif (Test-Path $DistDir) {
     $DistTime = (Get-Item $DistDir).LastWriteTime
     $NewerFile = $null

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3035,6 +3035,15 @@ function Get-NodeDecision {
     return "bundled"
 }
 
+
+function Test-PackagedFrontend {
+    param([string]$LocalInstall, [string]$IndexPath)
+    # install.ps1 and `unsloth studio update` explicitly pass 0 for PyPI
+    # installs. Wheel extraction mtimes do not preserve build ordering, so use
+    # the release-built dist whenever its entry point is present.
+    return $LocalInstall -eq "0" -and (Test-Path -LiteralPath $IndexPath -PathType Leaf)
+}
+
 $SkipFrontend = ($env:SKIP_STUDIO_FRONTEND -eq "1")
 $NodeOverride = $null
 $NodeParent = $null
@@ -3276,10 +3285,13 @@ Write-StudioLine ""
 #  PHASE 2: Frontend build (skip if pip-installed -- already bundled)
 # ==========================================================================
 $DistDir = Join-Path $FrontendDir "dist"
-# Skip build if dist/ exists and no tracked input is newer than dist/.
-# Checks src/, public/, package.json, config files -- not just src/.
+$PackagedFrontend = Test-PackagedFrontend `
+    -LocalInstall "$($env:STUDIO_LOCAL_INSTALL)" `
+    -IndexPath (Join-Path $DistDir "index.html")
+# Wheel extraction mtimes are not a source-freshness signal. Standard PyPI
+# installs use the release-built dist; local/source installs retain mtime checks.
 $NeedFrontendBuild = $true
-if ($IsPipInstall) {
+if ($IsPipInstall -or $PackagedFrontend) {
     $NeedFrontendBuild = $false
     step "frontend" "bundled (pip install)"
 } elseif ($SkipFrontend) {

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1071,13 +1071,27 @@ _assert_studio_owned_or_absent() {
     fi
 }
 
+
+_packaged_frontend_available() {
+    # install.sh and `unsloth studio update` explicitly set 0 for PyPI installs.
+    # Wheel extraction mtimes do not preserve build ordering, so source files can
+    # appear newer than the release-built dist even though both came from the
+    # same wheel. Trust the packaged artifact when its entry point is present;
+    # local/source installs set 1 (or leave the mode unset) and still rebuild.
+    [ "${STUDIO_LOCAL_INSTALL:-}" = "0" ] &&
+        [ -f "$SCRIPT_DIR/frontend/dist/index.html" ]
+}
+
 if [ "$_LLAMA_ONLY" != "1" ]; then
 # ── Detect whether frontend needs building ──
-# Skip if SKIP_STUDIO_FRONTEND=1 (Tauri desktop app bundles its own frontend),
-# or if dist/ exists AND no tracked input is newer than dist/.
+# Tauri owns its frontend bundle. Standard PyPI installs use the release-built
+# dist shipped in the wheel. Only local/source installs use mtime-based rebuilds.
 if [ "${SKIP_STUDIO_FRONTEND:-0}" = "1" ]; then
     _NEED_FRONTEND_BUILD=false
     step "frontend" "bundled (Tauri)"
+elif _packaged_frontend_available; then
+    _NEED_FRONTEND_BUILD=false
+    step "frontend" "bundled (pip install)"
 else
 _NEED_FRONTEND_BUILD=true
 if [ -d "$SCRIPT_DIR/frontend/dist" ]; then
@@ -1090,7 +1104,7 @@ if [ -d "$SCRIPT_DIR/frontend/dist" ]; then
     fi
     [ -z "$_changed" ] && _NEED_FRONTEND_BUILD=false
 fi
-fi  # end SKIP_STUDIO_FRONTEND guard
+fi  # end packaged/Tauri guard
 
 # OXC validator runtime (below) needs node/npm whenever its dir exists, regardless
 # of dist staleness; provision Node when the frontend builds OR the OXC dir exists.

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1078,7 +1078,16 @@ _packaged_frontend_available() {
     # appear newer than the release-built dist even though both came from the
     # same wheel. Trust the packaged artifact when its entry point is present;
     # local/source installs set 1 (or leave the mode unset) and still rebuild.
+    #
+    # The mode alone is not enough. It records where the Python package came
+    # from, not which tree this script is running out of, and an editable
+    # overlay separates the two: UNSLOTH_CI_SOURCE_OVERLAY (and a venv left
+    # editable by an earlier --local run) leaves the mode at 0 while
+    # $SCRIPT_DIR is a checkout, whose dist is a stale build artifact rather
+    # than a release one. A wheel ships no top-level files, so a pyproject.toml
+    # next to studio/ means source tree -- keep the mtime rebuild there.
     [ "${STUDIO_LOCAL_INSTALL:-}" = "0" ] &&
+        [ ! -f "$REPO_ROOT/pyproject.toml" ] &&
         [ -f "$SCRIPT_DIR/frontend/dist/index.html" ]
 }
 

--- a/studio/src-tauri/src/update.rs
+++ b/studio/src-tauri/src/update.rs
@@ -47,7 +47,15 @@ fn build_update_command(bin: &std::path::Path) -> Result<Command, String> {
         // -X utf8, not PYTHONUTF8: -I implies -E, so this process ignores every
         // PYTHON* variable and its own output would reach read_lossy_lines in
         // the locale encoding. The env vars still apply to descendants.
-        cmd.args(["-X", "utf8", "-I", "-c", WINDOWS_CLI_ENTRYPOINT, "studio", "update"]);
+        cmd.args([
+            "-X",
+            "utf8",
+            "-I",
+            "-c",
+            WINDOWS_CLI_ENTRYPOINT,
+            "studio",
+            "update",
+        ]);
         cmd.env_remove("PYTHONHOME");
         cmd.env_remove("PYTHONPATH");
         Ok(cmd)
@@ -59,6 +67,15 @@ fn build_update_command(bin: &std::path::Path) -> Result<Command, String> {
         cmd.args(["studio", "update"]);
         Ok(cmd)
     }
+}
+
+fn configure_tauri_update_environment(cmd: &mut Command) {
+    // The desktop owns both its shortcuts and its frontend bundle. The managed
+    // Python update only needs backend dependencies and native helpers.
+    cmd.env_remove("UNSLOTH_STUDIO_HOME");
+    cmd.env_remove("STUDIO_HOME");
+    cmd.env("UNSLOTH_TAURI_UPDATE", "1");
+    cmd.env("SKIP_STUDIO_FRONTEND", "1");
 }
 
 fn spawn_update(
@@ -83,14 +100,9 @@ fn spawn_update(
     #[cfg(target_os = "linux")]
     crate::process::scrub_appimage_python_env(&mut cmd);
 
-    // Tauri manages the legacy root; scrub so 'unsloth studio update' targets
-    // the same install the desktop app uses, not an inherited custom root.
-    cmd.env_remove("UNSLOTH_STUDIO_HOME");
-    cmd.env_remove("STUDIO_HOME");
-    // Signal to unsloth_cli that this update was initiated by the Tauri
-    // desktop bundle so it skips re-creating CLI launchers/.app/.desktop
-    // shortcuts (Tauri owns its own bundle entries).
-    cmd.env("UNSLOTH_TAURI_UPDATE", "1");
+    // Keep the update on the desktop-managed install and avoid rebuilding assets
+    // that are already compiled into the signed Tauri bundle.
+    configure_tauri_update_environment(&mut cmd);
     #[cfg(windows)]
     cmd.env(crate::process::STUDIO_RUNTIME_GATE_HANDOFF_ENV, "1");
 
@@ -472,6 +484,25 @@ pub fn stop_update(state: &UpdateState) -> Result<(), String> {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    #[test]
+    fn tauri_backend_update_skips_the_web_frontend_build() {
+        use std::ffi::OsStr;
+
+        let mut cmd = Command::new("unused");
+        configure_tauri_update_environment(&mut cmd);
+
+        for name in ["UNSLOTH_STUDIO_HOME", "STUDIO_HOME"] {
+            assert!(cmd
+                .get_envs()
+                .any(|(key, value)| key == OsStr::new(name) && value.is_none()));
+        }
+        for (name, expected) in [("UNSLOTH_TAURI_UPDATE", "1"), ("SKIP_STUDIO_FRONTEND", "1")] {
+            assert!(cmd.get_envs().any(|(key, value)| {
+                key == OsStr::new(name) && value == Some(OsStr::new(expected))
+            }));
+        }
+    }
 
     #[test]
     fn lossy_reader_keeps_invalid_utf8_and_later_lines() {

--- a/tests/python/test_windows_setup_output_encoding.py
+++ b/tests/python/test_windows_setup_output_encoding.py
@@ -453,7 +453,9 @@ def test_update_command_uses_the_utf8_switch_not_just_env() -> None:
     https://docs.python.org/3/using/cmdline.html#cmdoption-I
     """
     source = (REPO_ROOT / "studio" / "src-tauri" / "src" / "update.rs").read_text(encoding = "utf-8")
-    assert re.search(r'"-X"\s*,\s*"utf8"', source), "isolated Python child needs -X utf8, env vars are ignored"
+    assert re.search(
+        r'"-X"\s*,\s*"utf8"', source
+    ), "isolated Python child needs -X utf8, env vars are ignored"
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_windows_setup_output_encoding.py
+++ b/tests/python/test_windows_setup_output_encoding.py
@@ -453,7 +453,7 @@ def test_update_command_uses_the_utf8_switch_not_just_env() -> None:
     https://docs.python.org/3/using/cmdline.html#cmdoption-I
     """
     source = (REPO_ROOT / "studio" / "src-tauri" / "src" / "update.rs").read_text(encoding = "utf-8")
-    assert '"-X", "utf8"' in source, "isolated Python child needs -X utf8, env vars are ignored"
+    assert re.search(r'"-X"\s*,\s*"utf8"', source), "isolated Python child needs -X utf8, env vars are ignored"
 
 
 @pytest.mark.parametrize(

--- a/tests/sh/test_packaged_frontend_skip.sh
+++ b/tests/sh/test_packaged_frontend_skip.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# The PyPI wheel already contains the release-built frontend. Wheel extraction
+# mtimes can make its source files appear newer than dist, so packaged installs
+# must not fall through to the source-build freshness check.
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+SETUP_SH="$ROOT/studio/setup.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+sed -n '/^_packaged_frontend_available() {/,/^}/p' "$SETUP_SH" > "$WORK/helper.sh"
+grep -q '^_packaged_frontend_available() {' "$WORK/helper.sh" || {
+    echo "FAIL: packaged frontend helper not found"
+    exit 1
+}
+# shellcheck disable=SC1090
+. "$WORK/helper.sh"
+
+SCRIPT_DIR="$WORK/studio"
+mkdir -p "$SCRIPT_DIR/frontend/dist"
+printf '<!doctype html>\n' > "$SCRIPT_DIR/frontend/dist/index.html"
+
+STUDIO_LOCAL_INSTALL=0
+_packaged_frontend_available || {
+    echo "FAIL: PyPI install with packaged index should skip the build"
+    exit 1
+}
+
+STUDIO_LOCAL_INSTALL=1
+if _packaged_frontend_available; then
+    echo "FAIL: local/source install must retain frontend rebuilds"
+    exit 1
+fi
+
+unset STUDIO_LOCAL_INSTALL
+if _packaged_frontend_available; then
+    echo "FAIL: unspecified setup mode must retain frontend rebuilds"
+    exit 1
+fi
+
+STUDIO_LOCAL_INSTALL=0
+rm -f "$SCRIPT_DIR/frontend/dist/index.html"
+if _packaged_frontend_available; then
+    echo "FAIL: missing packaged index must fall back to a frontend build"
+    exit 1
+fi
+
+echo "All packaged frontend checks passed"

--- a/tests/sh/test_packaged_frontend_skip.sh
+++ b/tests/sh/test_packaged_frontend_skip.sh
@@ -2,6 +2,12 @@
 # The PyPI wheel already contains the release-built frontend. Wheel extraction
 # mtimes can make its source files appear newer than dist, so packaged installs
 # must not fall through to the source-build freshness check.
+#
+# The setup mode alone does not identify a packaged tree: an editable overlay
+# (UNSLOTH_CI_SOURCE_OVERLAY, or a venv left editable by an earlier --local
+# run) keeps the mode at 0 while setup.sh runs out of a checkout. A wheel ships
+# no top-level files, so pyproject.toml beside studio/ marks the tree as source
+# and has to keep the mtime rebuild.
 set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
@@ -17,7 +23,9 @@ grep -q '^_packaged_frontend_available() {' "$WORK/helper.sh" || {
 # shellcheck disable=SC1090
 . "$WORK/helper.sh"
 
-SCRIPT_DIR="$WORK/studio"
+# The layout a wheel produces: studio/ under site-packages, nothing above it.
+SCRIPT_DIR="$WORK/site-packages/studio"
+REPO_ROOT="$WORK/site-packages"
 mkdir -p "$SCRIPT_DIR/frontend/dist"
 printf '<!doctype html>\n' > "$SCRIPT_DIR/frontend/dist/index.html"
 
@@ -43,6 +51,29 @@ STUDIO_LOCAL_INSTALL=0
 rm -f "$SCRIPT_DIR/frontend/dist/index.html"
 if _packaged_frontend_available; then
     echo "FAIL: missing packaged index must fall back to a frontend build"
+    exit 1
+fi
+printf '<!doctype html>\n' > "$SCRIPT_DIR/frontend/dist/index.html"
+
+# Editable overlay: PyPI mode, but $SCRIPT_DIR is a checkout carrying a dist
+# left by some earlier build. The mtime check owns this tree, not the skip.
+SCRIPT_DIR="$WORK/checkout/studio"
+REPO_ROOT="$WORK/checkout"
+mkdir -p "$SCRIPT_DIR/frontend/dist"
+printf '<!doctype html>\n' > "$SCRIPT_DIR/frontend/dist/index.html"
+printf '[project]\nname = "unsloth"\n' > "$REPO_ROOT/pyproject.toml"
+
+STUDIO_LOCAL_INSTALL=0
+if _packaged_frontend_available; then
+    echo "FAIL: source checkout in PyPI mode must retain frontend rebuilds"
+    exit 1
+fi
+
+# The same tree without the marker is indistinguishable from a packaged one,
+# which is what makes the marker load-bearing rather than incidental.
+rm -f "$REPO_ROOT/pyproject.toml"
+if ! _packaged_frontend_available; then
+    echo "FAIL: packaged layout should skip once no source marker remains"
     exit 1
 fi
 

--- a/tests/studio/test_node_decision.ps1
+++ b/tests/studio/test_node_decision.ps1
@@ -19,6 +19,13 @@ $fn = $ast.FindAll({ param($n)
 if ($fn.Count -ne 1) { throw "expected exactly one Get-NodeDecision in setup.ps1, found $($fn.Count)" }
 Invoke-Expression $fn[0].Extent.Text
 
+
+$packagedFn = $ast.FindAll({ param($n)
+    $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq "Test-PackagedFrontend"
+}, $true)
+if ($packagedFn.Count -ne 1) { throw "expected exactly one Test-PackagedFrontend in setup.ps1, found $($packagedFn.Count)" }
+Invoke-Expression $packagedFn[0].Extent.Text
+
 $failures = 0
 function Check($name, $cond) {
     if ($cond) { Write-Host "  PASS  $name" }
@@ -26,6 +33,21 @@ function Check($name, $cond) {
 }
 
 function D($node, $npm, $skip) { Get-NodeDecision -NodeVersion $node -NpmVersion $npm -SkipInstall $skip }
+
+
+$packagedRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("unsloth-packaged-frontend-" + [guid]::NewGuid())
+$packagedIndex = Join-Path $packagedRoot "frontend\dist\index.html"
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $packagedIndex) | Out-Null
+Set-Content -Path $packagedIndex -Value "<!doctype html>" -Encoding Ascii
+try {
+    Check "PyPI install uses packaged frontend" (Test-PackagedFrontend -LocalInstall "0" -IndexPath $packagedIndex)
+    Check "local install rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "1" -IndexPath $packagedIndex))
+    Check "unset install mode rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "" -IndexPath $packagedIndex))
+    Remove-Item -LiteralPath $packagedIndex -Force
+    Check "missing packaged index rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "0" -IndexPath $packagedIndex))
+} finally {
+    Remove-Item -LiteralPath $packagedRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 Write-Host "Get-NodeDecision"
 # system

--- a/tests/studio/test_node_decision.ps1
+++ b/tests/studio/test_node_decision.ps1
@@ -37,14 +37,25 @@ function D($node, $npm, $skip) { Get-NodeDecision -NodeVersion $node -NpmVersion
 
 $packagedRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("unsloth-packaged-frontend-" + [guid]::NewGuid())
 $packagedIndex = Join-Path $packagedRoot "frontend\dist\index.html"
+# The pyproject.toml beside studio/ that only a source checkout has. Absent
+# below unless a case is specifically about the editable-overlay tree.
+$packagedProject = Join-Path $packagedRoot "pyproject.toml"
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $packagedIndex) | Out-Null
 Set-Content -Path $packagedIndex -Value "<!doctype html>" -Encoding Ascii
 try {
-    Check "PyPI install uses packaged frontend" (Test-PackagedFrontend -LocalInstall "0" -IndexPath $packagedIndex)
-    Check "local install rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "1" -IndexPath $packagedIndex))
-    Check "unset install mode rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "" -IndexPath $packagedIndex))
+    Check "PyPI install uses packaged frontend" (Test-PackagedFrontend -LocalInstall "0" -IndexPath $packagedIndex -ProjectFilePath $packagedProject)
+    Check "local install rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "1" -IndexPath $packagedIndex -ProjectFilePath $packagedProject))
+    Check "unset install mode rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "" -IndexPath $packagedIndex -ProjectFilePath $packagedProject))
+
+    # Editable overlay: PyPI mode over a checkout, whose dist is a stale build
+    # artifact rather than a release one.
+    Set-Content -Path $packagedProject -Value "[project]" -Encoding Ascii
+    Check "source checkout in PyPI mode rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "0" -IndexPath $packagedIndex -ProjectFilePath $packagedProject))
+    Remove-Item -LiteralPath $packagedProject -Force
+    Check "packaged layout skips once no source marker remains" (Test-PackagedFrontend -LocalInstall "0" -IndexPath $packagedIndex -ProjectFilePath $packagedProject)
+
     Remove-Item -LiteralPath $packagedIndex -Force
-    Check "missing packaged index rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "0" -IndexPath $packagedIndex))
+    Check "missing packaged index rebuilds frontend" (-not (Test-PackagedFrontend -LocalInstall "0" -IndexPath $packagedIndex -ProjectFilePath $packagedProject))
 } finally {
     Remove-Item -LiteralPath $packagedRoot -Recurse -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
## Summary

- mark desktop-initiated backend updates with `SKIP_STUDIO_FRONTEND=1`
- use the release-built `frontend/dist` already shipped in normal PyPI installs and updates instead of rebuilding it from wheel-extracted sources
- retain frontend builds for `--local`/source installs and when the packaged `index.html` is missing
- keep backend dependencies and native helpers updating, with POSIX, Windows, and Rust regression coverage

## Why

Both update paths were rebuilding a frontend that already has an authoritative release artifact:

- Tauri installs a signed application bundle containing its own frontend.
- The PyPI wheel ships `studio/frontend/dist`, which browser-based Studio serves directly from `site-packages`.

Wheel extraction timestamps do not preserve source/build ordering. As a result, setup could consider a wheel source file newer than the packaged `dist` and unnecessarily run npm/Vite again. The new policy trusts the packaged artifact only when the installer/update explicitly selected PyPI mode (`STUDIO_LOCAL_INSTALL=0`) and `dist/index.html` exists. Local/source installs still use the existing freshness-based build, and damaged packages fall back to rebuilding.

Node may still be provisioned for the OXC validator; this change skips only the redundant frontend compilation.

## Validation

- `bash tests/sh/test_packaged_frontend_skip.sh`
- `bash -n studio/setup.sh tests/sh/test_packaged_frontend_skip.sh`
- `bash tests/sh/test_system_node_readonly.sh`
- `bash tests/sh/test_setup_http_get.sh` (15 passed)
- `python -m pytest -q tests/test_studio_install_workspace_guard.py tests/studio/test_ci_shell_suite_coverage.py` (78 passed)
- `cargo test --manifest-path studio/src-tauri/Cargo.toml update::tests` (3 passed)
- updater UTF-8 source contract and Python syntax checks
- `git diff --check`

The PowerShell policy test is included and will execute in Windows CI; PowerShell was unavailable in the local Linux environment.
