### PR TITLE
Studio: require verified desktop ownership before attaching to a backend

### DIFF
--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -80,6 +80,12 @@ function externalConflictMessage(preflight: DesktopPreflightResult) {
       : "A desktop-owned Unsloth server for this install is already running. Quit the other desktop app instance, then try again.";
   }
 
+  if (preflight.reason === "desktop_ownership_unverified") {
+    return preflight.port
+      ? `An unverified Unsloth server claiming this install is running on port ${preflight.port}. It did not prove desktop ownership, so the desktop app will not attach to it or send it credentials. Stop that server, then try again.`
+      : "An unverified Unsloth server claiming this install is running. It did not prove desktop ownership, so the desktop app will not attach to it or send it credentials. Stop that server, then try again.";
+  }
+
   if (preflight.reason === "desktop_owned_backend_starting") {
     return "The desktop-owned Unsloth backend is still starting. Wait a moment, then try again.";
   }

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -876,8 +876,11 @@ mod tests {
 
     #[tokio::test]
     async fn mutation_guard_blocks_second_external_backend_when_owned_child_is_ignored() {
-        crate::desktop_backend_owner::install_test_owner(ROOT_ID, OWNER_TOKEN);
+        let _owner_guard = crate::test_support::OWNER_METADATA_LOCK.lock().await;
         let owned_port = command_test_backend(ready_health(true)).await;
+        // Ownership proof binds to the recorded port, so install the owner
+        // metadata for the owned backend's actual port.
+        crate::desktop_backend_owner::install_test_owner_on_port(ROOT_ID, OWNER_TOKEN, owned_port);
         let external_port = command_test_backend(ready_health(false)).await;
 
         let err = super::block_external_conflict(&[owned_port])

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -61,6 +61,11 @@ fn external_conflict_message(conflict: &crate::preflight::ExternalBackendConflic
             "An Unsloth server is already running on port {}, and this app cannot confirm which install it belongs to. Stop that server, then try again.",
             conflict.port
         ),
+        "desktop_ownership_unverified" => format!(
+            "An unverified Unsloth server claiming this install is running on port {}. It did not prove desktop ownership, so the desktop app will not attach to it or send it credentials. Stop that server, then try again.",
+            conflict.port
+        ),
+
         _ => format!(
             "An Unsloth server for this install is already running from a terminal on port {}. Stop that server, or run `unsloth studio update` from that terminal before using desktop repair/update.",
             conflict.port
@@ -819,40 +824,12 @@ mod tests {
     }
 
     async fn command_test_backend(health_body: String) -> u16 {
-        let mut listener = None;
-        for port in 8888u16..=8908 {
-            if let Ok(bound) = TcpListener::bind(("127.0.0.1", port)).await {
-                listener = Some(bound);
-                break;
-            }
-        }
-        let listener = listener.expect("test needs a free desktop preflight port");
-        let port = listener.local_addr().unwrap().port();
-        tokio::spawn(async move {
-            for _ in 0..2 {
-                let Ok((mut stream, _)) = listener.accept().await else {
-                    return;
-                };
-                let mut buffer = [0; 2048];
-                let Ok(n) = stream.read(&mut buffer).await else {
-                    return;
-                };
-                let request = String::from_utf8_lossy(&buffer[..n]);
-                let (status, body) = if request.starts_with("GET /api/health ") {
-                    ("200 OK", health_body.as_str())
-                } else if request.starts_with("POST /api/auth/desktop-login ") {
-                    ("401 Unauthorized", "")
-                } else {
-                    ("404 Not Found", "")
-                };
-                let response = format!(
-                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                    body.len()
-                );
-                let _ = stream.write_all(response.as_bytes()).await;
-            }
-        });
-        port
+        crate::test_support::LoopbackTestServer::bind_candidate_port(
+            health_body,
+            "401 Unauthorized",
+        )
+        .await
+        .port
     }
 
     #[test]
@@ -908,7 +885,10 @@ mod tests {
             .expect_err("external non-owned backend should block mutation");
 
         assert!(err.contains(&format!("port {external_port}")));
-        assert!(err.contains("Stop that server"));
+        // An ownerless same-root responder is no longer trusted as an
+        // attachable backend: the unauthenticated root id is not a secret and
+        // no ownership was proven, so it is reported as an unverified server.
+        assert!(err.contains("did not prove desktop ownership"));
     }
 
     /// Stub backend for the launcher probe. `liveness` of `None` models a backend older

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -659,6 +659,41 @@ pub(crate) fn classify_health_desktop_owner(
     )
 }
 
+/// Binds a health-classified `CurrentApp` owner claim to the spawned backend
+/// recorded in the owner metadata.
+///
+/// `studio_root_id` and `desktop_owner.token_sha256` are both exposed by the
+/// unauthenticated health endpoint, so a local spoof can replay them. The
+/// claim is only accepted when the responder also sits on the port recorded
+/// for the backend this app spawned, and that backend process is still alive:
+/// a spoof cannot occupy the recorded port while the legitimate backend holds
+/// it, and cannot keep a dead backend pid alive.
+pub(crate) fn owner_metadata_binds_responder(
+    port: u16,
+    studio_root_id: Option<&str>,
+    owner_kind: Option<&str>,
+    token_sha256_value: Option<&str>,
+) -> bool {
+    let Some(metadata) = current_owner_metadata() else {
+        return false;
+    };
+    let expected = read_expected_studio_root_id();
+    if !(metadata_is_well_formed(&metadata)
+        && expected.as_deref() == Some(metadata.studio_root_id.as_str())
+        && metadata.app_pid == std::process::id()
+        && owner_matches_metadata(&metadata, studio_root_id, owner_kind, token_sha256_value))
+    {
+        return false;
+    }
+    if port != metadata.port.unwrap_or(metadata.requested_port) {
+        return false;
+    }
+    matches!(
+        previous_app_pid_status(metadata.backend_pid),
+        PreviousAppPidStatus::AliveOrCurrent
+    )
+}
+
 fn current_owner_metadata() -> Option<DesktopBackendMetadata> {
     #[cfg(test)]
     if let Ok(guard) = TEST_METADATA.lock() {
@@ -673,16 +708,23 @@ fn current_owner_metadata() -> Option<DesktopBackendMetadata> {
 
 #[cfg(test)]
 pub(crate) fn install_test_owner(root_id: &str, token: &str) {
+    install_test_owner_on_port(root_id, token, 8888);
+}
+
+#[cfg(test)]
+pub(crate) fn install_test_owner_on_port(root_id: &str, token: &str, port: u16) {
     let metadata = DesktopBackendMetadata {
         schema_version: METADATA_SCHEMA_VERSION,
         kind: OWNER_KIND_TAURI.to_string(),
         token: token.to_string(),
         token_sha256: token_sha256(token),
         app_pid: std::process::id(),
-        backend_pid: 2,
+        // The process-binding leg of the ownership check needs a live backend
+        // pid; the test process itself is alive for the whole test.
+        backend_pid: std::process::id(),
         generation: 3,
-        requested_port: 8888,
-        port: Some(8888),
+        requested_port: port,
+        port: Some(port),
         studio_root_id: root_id.to_string(),
         started_at_ms: 1,
         updated_at_ms: 1,

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -18,6 +18,8 @@ mod native_intents;
 mod native_path_policy;
 mod preflight;
 mod process;
+#[cfg(test)]
+mod test_support;
 mod update;
 mod windows_job;
 mod x11_threads;

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -805,13 +805,9 @@ exit 1
 
         let client = crate::loopback_http::client(std::time::Duration::from_secs(2)).unwrap();
         let health = backend_health(&client, server.port).await.unwrap();
-        let probe = backend_desktop_auth_status(
-            &client,
-            server.port,
-            &health,
-            Some(EXPECTED_ROOT_ID),
-        )
-        .await;
+        let probe =
+            backend_desktop_auth_status(&client, server.port, &health, Some(EXPECTED_ROOT_ID))
+                .await;
 
         assert!(matches!(
             probe,

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -767,11 +767,64 @@ exit 1
         health_body: impl Into<String>,
         route_status: &'static str,
     ) -> BackendProbe {
-        install_test_owner();
+        let _owner_guard = crate::test_support::OWNER_METADATA_LOCK.lock().await;
         let port = backend_server(health_body, route_status).await;
+        // Ownership proof binds to the responder's port, so record the
+        // server's actual port in the test owner metadata.
+        crate::desktop_backend_owner::install_test_owner_on_port(
+            EXPECTED_ROOT_ID,
+            OWNER_TOKEN,
+            port,
+        );
         let client = crate::loopback_http::client(std::time::Duration::from_secs(2)).unwrap();
         let health = backend_health(&client, port).await.unwrap();
         backend_desktop_auth_status(&client, port, &health, Some(EXPECTED_ROOT_ID)).await
+    }
+
+    #[tokio::test]
+    async fn replayed_owner_fields_are_rejected_without_process_binding() {
+        // studio_root_id and desktop_owner.token_sha256 are both exposed by
+        // the unauthenticated health endpoint, so a spoof can replay them. A
+        // CurrentApp claim is only proven when the responder also matches the
+        // spawned backend's recorded port and live pid; a responder on any
+        // other port stays unverified and must not receive the desktop-login
+        // probe.
+        let _owner_guard = crate::test_support::OWNER_METADATA_LOCK.lock().await;
+        let server = crate::test_support::LoopbackTestServer::bind(
+            desktop_ready_health(EXPECTED_ROOT_ID),
+            "401 Unauthorized",
+        )
+        .await;
+        // Metadata records a different port than the responder's, so the
+        // replayed owner fields cannot bind to this responder.
+        crate::desktop_backend_owner::install_test_owner_on_port(
+            EXPECTED_ROOT_ID,
+            OWNER_TOKEN,
+            8888,
+        );
+
+        let client = crate::loopback_http::client(std::time::Duration::from_secs(2)).unwrap();
+        let health = backend_health(&client, server.port).await.unwrap();
+        let probe = backend_desktop_auth_status(
+            &client,
+            server.port,
+            &health,
+            Some(EXPECTED_ROOT_ID),
+        )
+        .await;
+
+        assert!(matches!(
+            probe,
+            BackendProbe::ExternalConflict { reason, .. }
+                if reason == "desktop_ownership_unverified"
+        ));
+        let seen = server.requests.lock().unwrap();
+        assert_eq!(
+            seen.len(),
+            1,
+            "replayed owner fields must not earn a desktop-login probe"
+        );
+        assert!(seen[0].starts_with("GET /api/health "));
     }
 
     #[tokio::test]
@@ -911,6 +964,7 @@ exit 1
         // responder that echoes the expected root id must be rejected from the
         // unauthenticated health body alone, before preflight sends anything
         // to /api/auth/desktop-login.
+        let _owner_guard = crate::test_support::OWNER_METADATA_LOCK.lock().await;
         install_test_owner();
         let server = crate::test_support::LoopbackTestServer::bind(
             desktop_ready_health_with_owner(EXPECTED_ROOT_ID, false),
@@ -971,6 +1025,7 @@ exit 1
 
     #[tokio::test]
     async fn backend_expected_root_id_missing_is_external_conflict_before_auth_probe() {
+        let _owner_guard = crate::test_support::OWNER_METADATA_LOCK.lock().await;
         install_test_owner();
         let port = backend_server(desktop_ready_health(EXPECTED_ROOT_ID), "401 Unauthorized").await;
         let client = crate::loopback_http::client(std::time::Duration::from_secs(2)).unwrap();

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -297,8 +297,6 @@ pub async fn desktop_preflight_result_with_state(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpListener;
 
     #[test]
     fn choose_preflight_classifies_core_cases() {
@@ -760,32 +758,9 @@ exit 1
     }
 
     async fn backend_server(health_body: impl Into<String>, route_status: &'static str) -> u16 {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let health_body = health_body.into();
-
-        tokio::spawn(async move {
-            for _ in 0..2 {
-                let (mut stream, _) = listener.accept().await.unwrap();
-                let mut buffer = [0; 2048];
-                let n = stream.read(&mut buffer).await.unwrap();
-                let request = String::from_utf8_lossy(&buffer[..n]);
-                let (status, body) = if request.starts_with("GET /api/health ") {
-                    ("200 OK", health_body.as_str())
-                } else if request.starts_with("POST /api/auth/desktop-login ") {
-                    (route_status, "")
-                } else {
-                    ("404 Not Found", "")
-                };
-                let response = format!(
-                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                    body.len()
-                );
-                stream.write_all(response.as_bytes()).await.unwrap();
-            }
-        });
-
-        port
+        crate::test_support::LoopbackTestServer::bind(health_body.into(), route_status)
+            .await
+            .port
     }
 
     async fn probe_test_backend(
@@ -869,18 +844,50 @@ exit 1
     }
 
     #[tokio::test]
-    async fn compatible_same_root_without_desktop_owner_is_ready() {
+    async fn compatible_same_root_without_desktop_owner_is_external_conflict() {
+        // The health root id is exposed to unauthenticated callers, so a
+        // same-root responder without ownership metadata could be a local
+        // spoof. It must be a conflict, never a backend that receives the
+        // desktop secret.
         let probe = probe_test_backend(
             desktop_ready_health_with_owner(EXPECTED_ROOT_ID, false),
             "401 Unauthorized",
         )
         .await;
 
-        assert!(matches!(probe, BackendProbe::Ready { .. }));
+        assert!(matches!(
+            probe,
+            BackendProbe::ExternalConflict { reason, .. }
+                if reason == "desktop_ownership_unverified"
+        ));
+    }
+
+    #[tokio::test]
+    async fn other_owner_same_root_backend_is_desktop_owned_conflict() {
+        // A responder asserting ownership by a different desktop app instance
+        // keeps the desktop-owned conflict reason: unlike an ownerless
+        // responder, it provably belongs to another owner, so the guidance is
+        // to quit the other instance.
+        let probe = probe_test_backend(
+            format!(
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}", "desktop_owner":{{"kind":"tauri","token_sha256":"{}"}}}}"#,
+                crate::desktop_backend_owner::token_sha256("another-desktop-owner-token")
+            ),
+            "401 Unauthorized",
+        )
+        .await;
+
+        assert!(matches!(
+            probe,
+            BackendProbe::ExternalConflict { reason, .. }
+                if reason == "desktop_owned_backend_active"
+        ));
     }
 
     #[tokio::test]
     async fn stale_same_root_without_desktop_owner_is_external_conflict() {
+        // Ownership verification runs before the capability gate: an unproven
+        // same-root responder is a conflict no matter which version it claims.
         let probe = probe_test_backend(
             format!(
                 r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.1","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
@@ -894,8 +901,41 @@ exit 1
             BackendProbe::ExternalConflict {
                 reason,
                 ..
-            } if reason == "desktop_backend_version_too_old"
+            } if reason == "desktop_ownership_unverified"
         ));
+    }
+
+    #[tokio::test]
+    async fn ownerless_same_root_conflict_is_decided_before_any_auth_probe() {
+        // Regression for the backend-spoof phishing path: an ownerless
+        // responder that echoes the expected root id must be rejected from the
+        // unauthenticated health body alone, before preflight sends anything
+        // to /api/auth/desktop-login.
+        install_test_owner();
+        let server = crate::test_support::LoopbackTestServer::bind(
+            desktop_ready_health_with_owner(EXPECTED_ROOT_ID, false),
+            "401 Unauthorized",
+        )
+        .await;
+        let port = server.port;
+
+        let client = crate::loopback_http::client(std::time::Duration::from_secs(2)).unwrap();
+        let health = backend_health(&client, port).await.unwrap();
+        let probe =
+            backend_desktop_auth_status(&client, port, &health, Some(EXPECTED_ROOT_ID)).await;
+
+        assert!(matches!(
+            probe,
+            BackendProbe::ExternalConflict { reason, .. }
+                if reason == "desktop_ownership_unverified"
+        ));
+        let seen = server.requests.lock().unwrap();
+        assert_eq!(
+            seen.len(),
+            1,
+            "ownerless same-root responders must be rejected before any desktop-login probe"
+        );
+        assert!(seen[0].starts_with("GET /api/health "));
     }
 
     #[tokio::test]

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -228,12 +228,26 @@ pub(super) async fn backend_desktop_auth_status(
     // The root id is intentionally exposed by the unauthenticated health
     // endpoint, so matching it alone cannot prove that a responder is safe to
     // receive the desktop secret. Only ownership metadata tied to this app
-    // instance provides that proof. Any other same-root responder is a
-    // conflict and never receives the desktop-login probe or the secret: one
-    // asserting ownership belongs to another desktop app instance; one
-    // asserting none cannot be verified at all and could be a local spoof.
+    // instance provides that proof, and even that metadata's health fields
+    // (root id, owner kind, token hash) are public and replayable — so a
+    // CurrentApp claim additionally has to bind to the backend this app
+    // actually spawned (recorded port plus live backend pid). Any responder
+    // that fails this gate is a conflict and never receives the desktop-login
+    // probe or the secret: one asserting ownership belongs to another desktop
+    // app instance; one asserting none, or replaying unbound owner fields,
+    // cannot be verified at all and could be a local spoof.
+    let owner = health.desktop_owner.as_ref();
+    let current_app_bound = owner_match
+        == crate::desktop_backend_owner::HealthOwnerMatch::CurrentApp
+        && crate::desktop_backend_owner::owner_metadata_binds_responder(
+            port,
+            health.studio_root_id.as_deref(),
+            owner.and_then(|o| o.kind.as_deref()),
+            owner.and_then(|o| o.token_sha256.as_deref()),
+        );
+
     match owner_match {
-        crate::desktop_backend_owner::HealthOwnerMatch::CurrentApp => {}
+        crate::desktop_backend_owner::HealthOwnerMatch::CurrentApp if current_app_bound => {}
         crate::desktop_backend_owner::HealthOwnerMatch::PreviousApp
         | crate::desktop_backend_owner::HealthOwnerMatch::OtherDesktopOwner => {
             return BackendProbe::ExternalConflict {
@@ -241,7 +255,8 @@ pub(super) async fn backend_desktop_auth_status(
                 reason: "desktop_owned_backend_active".to_string(),
             };
         }
-        crate::desktop_backend_owner::HealthOwnerMatch::None => {
+        crate::desktop_backend_owner::HealthOwnerMatch::CurrentApp
+        | crate::desktop_backend_owner::HealthOwnerMatch::None => {
             return BackendProbe::ExternalConflict {
                 port,
                 reason: "desktop_ownership_unverified".to_string(),

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -208,8 +208,6 @@ pub(super) async fn backend_desktop_auth_status(
 ) -> BackendProbe {
     let root_status = backend_root_status(health, expected_studio_root_id);
     let owner_match = backend_desktop_owner_match(health);
-    let verified_owner = owner_match == crate::desktop_backend_owner::HealthOwnerMatch::CurrentApp;
-    let same_root_external = root_status == BackendRootStatus::SameRoot && !verified_owner;
 
     match root_status {
         BackendRootStatus::AmbiguousRoot | BackendRootStatus::ExpectedUnavailable => {
@@ -227,25 +225,32 @@ pub(super) async fn backend_desktop_auth_status(
         BackendRootStatus::SameRoot => {}
     }
 
-    if same_root_external
-        && matches!(
-            owner_match,
-            crate::desktop_backend_owner::HealthOwnerMatch::PreviousApp
-                | crate::desktop_backend_owner::HealthOwnerMatch::OtherDesktopOwner
-        )
-    {
-        return BackendProbe::ExternalConflict {
-            port,
-            reason: "desktop_owned_backend_active".to_string(),
-        };
+    // The root id is intentionally exposed by the unauthenticated health
+    // endpoint, so matching it alone cannot prove that a responder is safe to
+    // receive the desktop secret. Only ownership metadata tied to this app
+    // instance provides that proof. Any other same-root responder is a
+    // conflict and never receives the desktop-login probe or the secret: one
+    // asserting ownership belongs to another desktop app instance; one
+    // asserting none cannot be verified at all and could be a local spoof.
+    match owner_match {
+        crate::desktop_backend_owner::HealthOwnerMatch::CurrentApp => {}
+        crate::desktop_backend_owner::HealthOwnerMatch::PreviousApp
+        | crate::desktop_backend_owner::HealthOwnerMatch::OtherDesktopOwner => {
+            return BackendProbe::ExternalConflict {
+                port,
+                reason: "desktop_owned_backend_active".to_string(),
+            };
+        }
+        crate::desktop_backend_owner::HealthOwnerMatch::None => {
+            return BackendProbe::ExternalConflict {
+                port,
+                reason: "desktop_ownership_unverified".to_string(),
+            };
+        }
     }
 
     if let Some(reason) = backend_capability_stale_reason(health) {
-        return if same_root_external {
-            BackendProbe::ExternalConflict { port, reason }
-        } else {
-            BackendProbe::Old { port, reason }
-        };
+        return BackendProbe::Old { port, reason };
     }
 
     let url = format!("http://127.0.0.1:{port}/api/auth/desktop-login");
@@ -260,31 +265,19 @@ pub(super) async fn backend_desktop_auth_status(
     let Ok(response) = response else {
         let reason = backend_capability_stale_reason(health)
             .unwrap_or_else(|| "desktop_login_probe_failed".to_string());
-        return if same_root_external {
-            BackendProbe::ExternalConflict { port, reason }
-        } else {
-            BackendProbe::Old { port, reason }
-        };
+        return BackendProbe::Old { port, reason };
     };
 
     match response.status() {
         reqwest::StatusCode::UNAUTHORIZED => BackendProbe::Ready { port },
-        reqwest::StatusCode::NOT_FOUND => {
-            let reason = "desktop_login_not_found".to_string();
-            if same_root_external {
-                BackendProbe::ExternalConflict { port, reason }
-            } else {
-                BackendProbe::Old { port, reason }
-            }
-        }
+        reqwest::StatusCode::NOT_FOUND => BackendProbe::Old {
+            port,
+            reason: "desktop_login_not_found".to_string(),
+        },
         _ => {
             let reason = backend_capability_stale_reason(health)
                 .unwrap_or_else(|| "desktop_login_probe_failed".to_string());
-            if same_root_external {
-                BackendProbe::ExternalConflict { port, reason }
-            } else {
-                BackendProbe::Old { port, reason }
-            }
+            BackendProbe::Old { port, reason }
         }
     }
 }

--- a/studio/src-tauri/src/test_support.rs
+++ b/studio/src-tauri/src/test_support.rs
@@ -1,0 +1,81 @@
+//! Shared loopback HTTP test doubles for desktop preflight tests.
+//!
+//! Every server records the request line of each accepted connection so tests
+//! can assert not just the classification result but which probes the app
+//! actually sent (e.g. that an unverified responder never receives the
+//! desktop-login probe).
+
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Request line (e.g. `"GET /api/health HTTP/1.1"`) of every accepted connection.
+pub(crate) type RequestLog = Arc<Mutex<Vec<String>>>;
+
+/// A canned-response loopback backend: `GET /api/health` answers `health_body`,
+/// `POST /api/auth/desktop-login` answers `login_status`, anything else 404s.
+pub(crate) struct LoopbackTestServer {
+    pub port: u16,
+    pub requests: RequestLog,
+}
+
+impl LoopbackTestServer {
+    /// Bind an ephemeral 127.0.0.1 port.
+    pub(crate) async fn bind(health_body: String, login_status: &'static str) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        Self::serve(listener, health_body, login_status)
+    }
+
+    /// Bind the first free desktop candidate port: `probe_existing_backends`
+    /// only scans the candidate range, so mutation-guard tests need a port in it.
+    pub(crate) async fn bind_candidate_port(
+        health_body: String,
+        login_status: &'static str,
+    ) -> Self {
+        let mut listener = None;
+        for port in crate::desktop_backend_owner::desktop_candidate_ports() {
+            if let Ok(bound) = TcpListener::bind(("127.0.0.1", port)).await {
+                listener = Some(bound);
+                break;
+            }
+        }
+        let listener = listener.expect("test needs a free desktop preflight port");
+        Self::serve(listener, health_body, login_status)
+    }
+
+    fn serve(listener: TcpListener, health_body: String, login_status: &'static str) -> Self {
+        let port = listener.local_addr().unwrap().port();
+        let requests: RequestLog = Arc::new(Mutex::new(Vec::new()));
+        let log = requests.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buffer = [0; 2048];
+                let Ok(count) = stream.read(&mut buffer).await else {
+                    continue;
+                };
+                let request = String::from_utf8_lossy(&buffer[..count]);
+                log.lock()
+                    .unwrap()
+                    .push(request.lines().next().unwrap_or("").to_string());
+                let (status, body) = if request.starts_with("GET /api/health ") {
+                    ("200 OK", health_body.as_str())
+                } else if request.starts_with("POST /api/auth/desktop-login ") {
+                    (login_status, "")
+                } else {
+                    ("404 Not Found", "")
+                };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                if stream.write_all(response.as_bytes()).await.is_err() {
+                    break;
+                }
+            }
+        });
+        Self { port, requests }
+    }
+}

--- a/studio/src-tauri/src/test_support.rs
+++ b/studio/src-tauri/src/test_support.rs
@@ -9,6 +9,11 @@ use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
+/// The owner-metadata test hooks are process-global, and ownership proof now
+/// binds to the recorded port, so tests that install owner metadata must not
+/// interleave: hold this lock from the install through the final probe.
+pub(crate) static OWNER_METADATA_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Request line (e.g. `"GET /api/health HTTP/1.1"`) of every accepted connection.
 pub(crate) type RequestLog = Arc<Mutex<Vec<String>>>;
 


### PR DESCRIPTION
## Motivation

Desktop preflight classified a loopback backend as attachable (`BackendProbe::Ready` → `AttachedReady`) when its **unauthenticated** `/api/health` response echoed the expected `studio_root_id` and it answered `401` to the invalid desktop-login probe — even when it asserted no desktop ownership at all (`desktop_owner` absent).

`studio_root_id` is intentionally exposed to unauthenticated callers by `/api/health` (that is how launchers detect sibling installs), so it is not a secret authenticator. A same-host process can:

1. read the victim's `studio_root_id` from the legitimate running backend's unauthenticated `/api/health`,
2. bind one of the desktop candidate ports (127.0.0.1:8888–8908),
3. spoof an ownerless health response carrying that root id and answer `401` to the invalid preflight probe,

and desktop auth then POSTs the persistent `.desktop_secret` to the selected port. The real backend's `/api/auth/desktop-login` accepts that same secret in exchange for admin JWT/refresh tokens.

## Fix

`backend_desktop_auth_status` now requires a verified desktop-owner match before a same-root responder can proceed:

- Only `HealthOwnerMatch::CurrentApp` — ownership metadata tied to this app instance (root id + owner kind + `token_sha256` + own pid) — may continue to the desktop-login probe and reach `Ready`.
- Responders asserting ownership by another app instance (`PreviousApp` / `OtherDesktopOwner`) remain a `desktop_owned_backend_active` conflict.
- Ownerless same-root responders are rejected **before any `/api/auth/desktop-login` traffic** as a new `desktop_ownership_unverified` conflict, with matching messages in the desktop app (`commands.rs`) and the frontend.

Legitimate flows are unchanged: token-hash-verified owned backend adoption (`OwnedReady`) and backends spawned by the current app instance.

## Tests

- `compatible_same_root_without_desktop_owner_is_ready` renamed to `..._is_external_conflict`; the stale-ownerless test now pins the ownership gate ahead of the version gate.
- New regression test proving an ownerless same-root responder receives only the health probe and never any desktop-login traffic.
- New test locking in that a different-owner responder keeps the `desktop_owned_backend_active` reason.
- The three hand-rolled loopback test servers were consolidated into a shared `test_support::LoopbackTestServer` that records request lines.

`cargo test --no-fail-fast` (studio/src-tauri): 224 passed, 0 failed.