### PR TITLE
Studio: keep sidebar logo visible during training

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1892,7 +1892,7 @@ export function AppSidebar() {
                   className={cn(
                     // min-w-0 so a narrow sidebar truncates the wordmark instead of pushing the search icon over.
                     "flex min-w-0 items-center gap-[6px] select-none transition-opacity",
-                    chatDisabled && "pointer-events-none opacity-50",
+                    chatDisabled && "pointer-events-none",
                   )}
                   aria-label={t("shell.aria.home")}
                   aria-disabled={chatDisabled}

--- a/tests/studio/test_tauri_branding_contract.py
+++ b/tests/studio/test_tauri_branding_contract.py
@@ -98,6 +98,8 @@ def test_desktop_artwork_uses_plain_unsloth_lockups() -> None:
     sidebar = read(FRONTEND / "src/components/app-sidebar.tsx")
     assert "/circle-logo-small.png" in sidebar
     assert "unsloth" in sidebar
+
+    assert 'chatDisabled && "pointer-events-none opacity-50"' not in sidebar
     assert not (FRONTEND / "public/studio.png").exists()
 
     branding = TAURI / "windows/branding"


### PR DESCRIPTION
## Summary
- keep the Unsloth sidebar logo lockup at full opacity while training is active
- retain the existing disabled navigation behavior
- add a branding regression assertion preventing the dimming class from returning

## Validation
- `cd studio/frontend && npm run typecheck`
- `cd studio/frontend && npm test` (1,571 passed)
- `python -m py_compile tests/studio/test_tauri_branding_contract.py`
- `git diff --check`
