### PR TITLE
Studio: use Muse Glimmer's published sampling defaults

### DIFF
--- a/studio/backend/assets/configs/inference_defaults.json
+++ b/studio/backend/assets/configs/inference_defaults.json
@@ -137,6 +137,13 @@
       "min_p": 0.0,
       "repetition_penalty": 1.0
     },
+    "muse-glimmer": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64,
+      "min_p": 0.0,
+      "repetition_penalty": 1.0
+    },
     "llama-4": {
       "temperature": 1.0,
       "top_p": 0.9,
@@ -404,6 +411,7 @@
     "qwen2-vl", "qwen2",
     "qwq",
     "gemma-4", "gemma-3n", "gemma-3", "medgemma", "gemma-2",
+    "muse-glimmer",
     "llama-4", "llama-3.3", "llama-3.2", "llama-3.1", "llama-3",
     "phi-4", "phi-3",
     "mistral-nemo", "mistral-small", "mistral-large", "magistral", "ministral",

--- a/studio/backend/tests/test_muse_glimmer_sampling_defaults.py
+++ b/studio/backend/tests/test_muse_glimmer_sampling_defaults.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Muse Glimmer resolves to its published sampling defaults.
+
+Muse Glimmer recommends temperature 1.0, top_p 0.95, top_k 64. Without a family
+entry every id fell through to ``default.yaml`` at 0.7 / 0.95 / -1 / 0.01, so
+top_k was disabled outright and min_p was applied where the model asks for none.
+
+The defaults live in ``inference_defaults.json`` rather than a ``model_defaults``
+YAML, for the reason #7619 moved Kimi-K3's there: a YAML is reached only by exact
+alias or a one/two-component path suffix, so it would match the bare repo id and
+miss ``repo:variant``, the cache snapshot path and a plain ``.gguf`` path. Family
+patterns are substring-matched against the id with the org stripped, so one entry
+covers the GGUF, 4-bit and bf16 repos and every path shape they arrive as.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_backend_root = Path(__file__).resolve().parent.parent
+if str(_backend_root) not in sys.path:
+    sys.path.insert(0, str(_backend_root))
+
+
+EXPECTED = {"temperature": 1.0, "top_p": 0.95, "top_k": 64, "min_p": 0.0}
+
+# Every shape an id reaches load_inference_config as. The snapshot path is not
+# hypothetical: _repo_gguf_load_id publishes a snapshot filesystem path as the
+# load_id for a GGUF repo in a non-active cache root.
+MUSE_GLIMMER_IDS = [
+    "unsloth/Muse-Glimmer-30B-GGUF",
+    "unsloth/Muse-Glimmer-30B",
+    "unsloth/Muse-Glimmer-30B-unsloth-bnb-4bit",
+    "meta-models/Muse-Glimmer-30B",
+    "unsloth/Muse-Glimmer-30B-GGUF:UD-Q4_K_XL",
+    "/home/u/.cache/huggingface/hub/models--unsloth--Muse-Glimmer-30B-GGUF/snapshots/deadbeef",
+    "/data/models/Muse-Glimmer-30B-GGUF/Muse-Glimmer-30B-UD-Q4_K_XL.gguf",
+]
+
+
+def _resolve(model_id):
+    from utils.inference.inference_config import load_inference_config
+    return load_inference_config(model_id)
+
+
+@pytest.mark.parametrize("model_id", MUSE_GLIMMER_IDS)
+def test_every_id_shape_resolves_to_published_sampling(model_id):
+    config = _resolve(model_id)
+    for key, want in EXPECTED.items():
+        assert config[key] == want, f"{model_id}: {key} was {config[key]}, expected {want}"
+
+
+def test_family_entry_is_registered_in_patterns():
+    """A family dict with no matching pattern never resolves: get_family_inference_params
+    iterates ``patterns``, not ``families``."""
+    import json
+
+    path = _backend_root / "assets" / "configs" / "inference_defaults.json"
+    data = json.loads(path.read_text(encoding = "utf-8"))
+    assert "muse-glimmer" in data["families"]
+    assert "muse-glimmer" in data["patterns"]
+
+
+def test_family_lookup_is_case_insensitive_and_org_stripped():
+    from utils.inference.inference_config import get_family_inference_params
+
+    params = get_family_inference_params("unsloth/MUSE-GLIMMER-30B-GGUF")
+    assert params.get("top_k") == 64
+    assert params.get("temperature") == 1.0
+
+
+def test_top_k_is_within_the_api_bound():
+    """InferenceRequest bounds top_k at 100, so a family default above it would be
+    rejected by validation before it ever reached llama-server."""
+    from models.inference import ChatCompletionRequest
+
+    field = ChatCompletionRequest.model_fields["top_k"]
+    bounds = [m for m in field.metadata if hasattr(m, "le")]
+    assert bounds, "top_k lost its upper bound"
+    assert EXPECTED["top_k"] <= bounds[0].le
+
+
+def test_unrelated_families_are_untouched():
+    """The pattern is distinctive, but substring matching means a new entry can
+    shadow an existing one. Spot-check the neighbours it sits between."""
+    assert _resolve("unsloth/gemma-2-9b-it")["top_k"] == 64
+    assert _resolve("unsloth/Llama-4-Scout-17B-16E-Instruct")["top_k"] == -1
+    assert _resolve("unsloth/Qwen3-8B")["temperature"] == 0.6
+    assert _resolve("unsloth/Kimi-K3-GGUF")["temperature"] == 1.0


### PR DESCRIPTION
## Problem

Muse Glimmer recommends temperature 1.0, top_p 0.95, top_k 64. Studio had no family entry for it, so every id fell through to `default.yaml`:

| | temperature | top_p | top_k | min_p |
|---|---|---|---|---|
| before | 0.7 | 0.95 | -1 | 0.01 |
| after | 1.0 | 0.95 | 64 | 0.0 |

So top_k was disabled outright, and min_p was applied where the model asks for none.

## Fix

Adds a `muse-glimmer` family to `inference_defaults.json`, and registers it in the `patterns` list. Both are needed: `get_family_inference_params` iterates `patterns`, so a family dict with no matching pattern never resolves. There is a test for exactly that, since it is a silent failure.

## Why here and not a model_defaults YAML

Following #7619, which moved Kimi-K3's defaults the same way. `load_model_defaults` reaches a YAML only by exact alias or a one/two-component path suffix, so a YAML would match the bare repo id and miss everything else. Family patterns are substring-matched against the id with the org stripped, so one entry covers all three repos and every path shape they arrive as:

| id shape | YAML | family entry |
|---|---|---|
| `unsloth/Muse-Glimmer-30B-GGUF` | matches | matches |
| `unsloth/Muse-Glimmer-30B-GGUF:UD-Q4_K_XL` | misses | matches |
| `unsloth/Muse-Glimmer-30B-unsloth-bnb-4bit` | misses | matches |
| `.../models--unsloth--Muse-Glimmer-30B-GGUF/snapshots/<sha>` | misses | matches |
| `/data/models/Muse-Glimmer-30B-GGUF/....gguf` | misses | matches |

The snapshot path is not hypothetical: `_repo_gguf_load_id` publishes a snapshot filesystem path as the `load_id` for a GGUF repo in a non-active cache root.

## Blast radius

Resolved the inference config for 185 model ids before and after, covering every existing family pattern in three id shapes each, the five Muse Glimmer shapes above, and a spread of real repos. Exactly 11 change, and all 11 are Muse Glimmer. `gemma-2` stays at top_k 64, `llama-4` at -1, `qwen3` at temperature 0.6, `kimi` at 1.0.

The pattern is distinctive, but substring matching means a new entry can shadow an existing one, so those neighbours are asserted in the tests rather than just eyeballed.

## Tests

11 new tests in `test_muse_glimmer_sampling_defaults.py`: all seven id shapes, the families/patterns registration guard, case-insensitive and org-stripped lookup, a check that top_k 64 sits inside the API's upper bound of 100 (a family default above it would be rejected by validation before reaching llama-server), and the unrelated-family spot checks.

`test_muse_glimmer_sampling_defaults.py`, `test_kimi_k3_reasoning_defaults.py`, `test_sampling_resolution.py`, `test_defaults_refresh_after_redetect.py`, `test_model_defaults_log_once.py` and `test_model_defaults_none_guard.py`: 55 passed.