### PR TITLE
Read rl.py with an explicit encoding in the TRL config compat test

### DIFF
--- a/tests/test_rl_config_compat.py
+++ b/tests/test_rl_config_compat.py
@@ -208,7 +208,7 @@ def test_a_default_factory_field_is_compared_not_crashed_on():
 # every test above green. rl.py is read as text because importing it pulls in
 # torch, trl and unsloth_zoo.
 
-RL_SOURCE = (REPO_ROOT / "unsloth" / "models" / "rl.py").read_text()
+RL_SOURCE = (REPO_ROOT / "unsloth" / "models" / "rl.py").read_text(encoding = "utf-8")
 
 
 def test_the_generated_config_routes_super_through_the_filter():


### PR DESCRIPTION
Follow-up to #8330.

`tests/test_rl_config_compat.py` reads `unsloth/models/rl.py` to assert the generated `Unsloth<X>Config.__init__` template still routes through the compatibility filter. That read used `Path.read_text()` with no encoding, which resolves to the platform default and therefore breaks on Windows the moment `rl.py` gains a non-ASCII byte.

The repo already guards against exactly this, and `tests/test_source_read_encoding.py` is currently red on `main`:

```
FAILED tests/test_source_read_encoding.py::test_checked_in_file_reads_name_an_encoding
AssertionError: 1 file reads in the test trees touch a checked-in file with the
platform default encoding, so they break on Windows as soon as that file gains a
non-ASCII byte. Pass encoding = "utf-8":
["tests/test_rl_config_compat.py:211: read_text()"]
```

The fix is the one line the guard asks for.

Verified locally on the current `main` tree:

- before: `tests/test_source_read_encoding.py` -> 1 failed
- after: `tests/test_source_read_encoding.py` + `tests/test_rl_config_compat.py` -> 17 passed
- `ruff check tests/test_rl_config_compat.py` -> clean