### PR TITLE
Video: verify the H3 denoiser artifact before the pull drops its dense shards

### DIFF
--- a/studio/backend/core/inference/video.py
+++ b/studio/backend/core/inference/video.py
@@ -669,6 +669,40 @@ class _SecondDiTView:
         setattr(pipe, "transformer_2" if name == "transformer" else name, value)
 
 
+class _NamedDiTView:
+    """``_SecondDiTView`` for an arbitrary attribute: presents ``pipe.<attr>`` as
+    ``pipe.transformer`` to the helpers that hardcode that name, reading everything else through.
+
+    MiniMax-H3 keeps one denoiser per workflow partition, so a reference load's DiT is
+    ``transformer_ref``. ``_denoiser_dits`` / ``_attention_dits`` enumerate only ``transformer``,
+    ``transformer_2`` and ``unconditional_transformer``, so without this the partition that load
+    actually denoises with gets neither the selected attention backend nor the regional compile,
+    while the resolved record still reports the profile that was asked for -- exactly the
+    over-reporting those two helpers' docstrings exist to rule out.
+    """
+
+    def __init__(self, pipe: Any, attr: str) -> None:
+        object.__setattr__(self, "_pipe", pipe)
+        object.__setattr__(self, "_attr", attr)
+
+    @property
+    def transformer(self) -> Any:
+        return getattr(self._pipe, object.__getattribute__(self, "_attr"), None)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_pipe"), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        pipe = object.__getattribute__(self, "_pipe")
+        attr = object.__getattribute__(self, "_attr")
+        setattr(pipe, attr if name == "transformer" else name, value)
+
+
+def _denoiser_view(pipe: Any, component: str) -> Any:
+    """``pipe`` itself for the usual ``transformer``; a view onto ``component`` otherwise."""
+    return pipe if component == "transformer" else _NamedDiTView(pipe, component)
+
+
 def _views_for(pipe: Any, fam: VideoFamily) -> tuple[Any, ...]:
     """The pipe view(s) to pass through the ``getattr(pipe, "transformer")`` helpers so
     they cover every denoiser: the real pipe (its ``transformer``), plus a
@@ -1099,9 +1133,16 @@ class VideoBackend:
             # An fp8 encoder request loads a hosted pre-cast checkpoint, so neither the estimate nor the pull includes those dense shards.
             te_sources = self._te_prequant_sources(fam, kwargs.get("text_encoder_quant"))
             # The same deal for the denoiser: a hosted pre-quantized checkpoint replaces the dense
-            # DiT shards, so the estimate and the scoped pull below both drop them.
-            skip_transformer_weights = self._denoiser_prequant_covered(
-                fam, kwargs.get("transformer_quant"), base, kwargs.get("h3_task")
+            # DiT shards, so the estimate and the scoped pull below both drop them. VERIFIED, like
+            # the conditioner below and like the plan: this flag both REMOVES 66 GB from the pull
+            # and is never re-checked, so an artifact that does not resolve has to keep the dense
+            # shards rather than strand the load's own bf16 fallback with nothing to open.
+            skip_transformer_weights = self._denoiser_prequant_verified(
+                fam,
+                kwargs.get("transformer_quant"),
+                base,
+                kwargs.get("h3_task"),
+                kwargs.get("hf_token"),
             )
             # And for MiniMax-H3's conditioner, whose hosted quantized artifact replaces the base
             # repo's 62 GB dense text_encoder/ shards outright.
@@ -1555,6 +1596,46 @@ class VideoBackend:
             return source if isinstance(source, str) and source else None
         except Exception:  # noqa: BLE001 -- unanswerable keeps the dense shards
             return None
+
+    def _denoiser_prequant_verified(
+        self,
+        fam: Any,
+        transformer_quant: Optional[str],
+        base: Optional[str],
+        h3_task: Optional[str],
+        hf_token: Optional[str],
+    ) -> bool:
+        """``_denoiser_prequant_covered`` plus the Hub check, for the decisions that COMMIT.
+
+        The pure probe answers from the registry, which is right where it must not raise or touch
+        the network. It is NOT enough to drop the dense shards from the pull: a task-specific row
+        gets no filename fallback, so a Ref2VA artifact that is renamed, unpublished or gated
+        resolves to nothing while the registry still says the scheme is covered. Skipping on that
+        word alone stages neither denoiser, and the bf16 fallback the loader documents then has
+        nothing to open offline (or pulls 66 GB inline, outside this load's progress, cancel and
+        disk budget).
+
+        Same rule as ``_h3_te_quant_scheme_verified`` next door, and the same fail-closed
+        direction: unanswerable keeps the dense shards."""
+        if not self._denoiser_prequant_covered(fam, transformer_quant, base, h3_task):
+            return False
+        try:
+            from huggingface_hub import HfApi
+
+            repo, _files = self._denoiser_prequant_hub_files(
+                fam, transformer_quant, base, HfApi(token = hf_token), h3_task
+            )
+        except Exception:  # noqa: BLE001 -- an unanswerable probe keeps the dense shards
+            return False
+        if repo is None:
+            logger.info(
+                "video.denoiser_prequant: no hosted %s checkpoint resolved for %s %s; keeping its "
+                "dense denoiser shards",
+                transformer_quant,
+                getattr(fam, "name", None),
+                h3_task or getattr(fam, "modular_workflow", None),
+            )
+        return repo is not None
 
     def _h3_te_quant_scheme_verified(
         self,
@@ -3744,9 +3825,15 @@ class VideoBackend:
         self._precommit_globals = (_load_token, backend_flags)
         attention_engaged = None
         speed_optims: tuple = ()
+        # Both helpers reach the denoiser through ``pipe.transformer``, and a reference load's DiT
+        # is ``transformer_ref``. Handed the bare pipe they would enumerate no denoiser at all, so
+        # the partition this run denoises with would keep native attention and stay uncompiled
+        # while the resolved record below still reported the requested profile -- and the pin
+        # above is what removes the eager downgrade that used to hide it.
+        speed_view = _denoiser_view(pipe, denoiser_component)
         try:
             attention_engaged = apply_attention_backend(
-                pipe,
+                speed_view,
                 select_attention_backend(
                     umem_target, attention_backend, speed_active = effective_speed != SPEED_OFF
                 ),
@@ -3755,7 +3842,7 @@ class VideoBackend:
                 target = types.SimpleNamespace(device = device, dtype = dtype),
             )
             applied = apply_speed_optims(
-                pipe,
+                speed_view,
                 types.SimpleNamespace(
                     device = device,
                     dtype = dtype,

--- a/studio/backend/core/inference/video.py
+++ b/studio/backend/core/inference/video.py
@@ -1621,7 +1621,6 @@ class VideoBackend:
             return False
         try:
             from huggingface_hub import HfApi
-
             repo, _files = self._denoiser_prequant_hub_files(
                 fam, transformer_quant, base, HfApi(token = hf_token), h3_task
             )

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -2812,6 +2812,132 @@ def test_download_plan_still_drops_the_reference_shards_its_artifact_replaces(mo
     assert plan["total_bytes"] == sum(e["bytes"] for e in plan["entries"])
 
 
+def test_the_verified_probe_keeps_the_dense_shards_when_the_artifact_is_absent(monkeypatch):
+    # The load path drops 66 GB from the pull and never re-checks, so the registry's word is not
+    # enough: only an artifact that really resolves on the Hub earns that skip. Same rule the
+    # conditioner already follows through _h3_te_quant_scheme_verified.
+    from core.inference.video import _detect_load_family as _fam
+
+    fam = _fam("MiniMaxAI/MiniMax-H3", None, "minimax-h3")
+    backend = VideoBackend()
+
+    class _Api:
+        def __init__(self, names):
+            self._names = names
+
+        def model_info(self, repo_id, files_metadata = False, token = None):
+            return _PlanInfo([_PlanSibling(n, 20) for n in self._names])
+
+    def _use(names):
+        monkeypatch.setattr("huggingface_hub.HfApi", lambda *a, **k: _Api(names))
+
+    # The keyframe artifacts exist, the reference one does not.
+    _use(["MiniMax-H3-FP8.pt", "MiniMax-H3-INT8-ConvRot.pt"])
+    assert backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "ref2va", None) is False
+    assert backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "fl2va", None) is True
+
+    # Once the reference artifact is published the skip is earned again.
+    _use(["MiniMax-H3-FP8.pt", "MiniMax-H3-Ref2VA-FP8.pt"])
+    assert backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "ref2va", None) is True
+
+    # An unreadable repo is a refusal, not a pass: the dense shards stay.
+    class _Boom:
+        def model_info(self, *a, **k):
+            raise RuntimeError("404 gated")
+
+    monkeypatch.setattr("huggingface_hub.HfApi", lambda *a, **k: _Boom())
+    assert backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "ref2va", None) is False
+    # And bf16 never asks in the first place.
+    assert backend._denoiser_prequant_verified(fam, None, "MiniMaxAI/MiniMax-H3", "ref2va", None) is False
+
+
+def test_the_load_path_gates_its_dense_skip_on_the_verified_probe():
+    """``_run_load`` must ask the VERIFIED probe, not the registry-only one.
+
+    This is the flag that removes the dense denoiser from the actual pull, so a registry-only
+    answer stages neither denoiser and leaves the loader's documented bf16 fallback with nothing
+    to open offline.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from core.inference.video import VideoBackend as _VB
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(_VB._run_load)))
+    assigned = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Assign)
+        and any(getattr(t, "id", None) == "skip_transformer_weights" for t in n.targets)
+    ]
+    assert assigned, "skip_transformer_weights is no longer assigned in _run_load"
+    called = {
+        n.func.attr
+        for a in assigned
+        for n in ast.walk(a)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+    }
+    assert "_denoiser_prequant_verified" in called
+    assert "_denoiser_prequant_covered" not in called
+
+
+def test_a_named_dit_view_presents_the_reference_denoiser_as_the_transformer():
+    # The speed and attention helpers enumerate transformer / transformer_2 /
+    # unconditional_transformer only. H3 keeps one denoiser per partition, so a reference load's
+    # DiT is invisible to both without this view.
+    from core.inference.diffusion_attention import _attention_dits
+    from core.inference.diffusion_speed import _denoiser_dits
+    from core.inference.video import _denoiser_view
+
+    ref = object()
+    pipe = types.SimpleNamespace(transformer_ref = ref, vae = "vae")
+
+    assert _denoiser_dits(pipe) == [] and _attention_dits(pipe) == []
+
+    view = _denoiser_view(pipe, "transformer_ref")
+    assert view.transformer is ref
+    assert _denoiser_dits(view) == [ref]
+    assert _attention_dits(view) == [ref]
+    # Everything else reads through, and a helper's reassignment lands on the real partition.
+    assert view.vae == "vae"
+    replacement = object()
+    view.transformer = replacement
+    assert pipe.transformer_ref is replacement
+    assert not hasattr(pipe, "transformer")
+
+    # A keyframe load is handed the pipe itself, so its behaviour is byte-for-byte unchanged.
+    keyframe = types.SimpleNamespace(transformer = ref)
+    assert _denoiser_view(keyframe, "transformer") is keyframe
+
+
+def test_the_h3_loader_optimises_the_partition_it_denoises_with():
+    """``apply_attention_backend`` / ``apply_speed_optims`` must see this workflow's denoiser.
+
+    The pre-quantized reference pin keeps the profile out of the eager downgrade, so handing these
+    the bare pipe leaves the reference DiT native and uncompiled while the resolved record still
+    reports the requested profile.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from core.inference.video import VideoBackend as _VB
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(_VB._load_h3_modular_pipeline)))
+    for helper in ("apply_attention_backend", "apply_speed_optims"):
+        calls = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and getattr(n.func, "id", None) == helper
+        ]
+        assert len(calls) == 1, f"{helper} is called {len(calls)} times"
+        first = calls[0].args[0]
+        assert getattr(first, "id", None) == "speed_view", (
+            f"{helper} is handed {ast.dump(first)}, not the denoiser view"
+        )
+
+
 def test_download_plan_adds_no_prequant_entry_without_a_scheme(monkeypatch):
     # bf16 keeps the dense shards, so there is nothing to replace and no third repo to stage.
     _cuda_bf16_target(monkeypatch)

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -2825,7 +2825,12 @@ def test_the_verified_probe_keeps_the_dense_shards_when_the_artifact_is_absent(m
         def __init__(self, names):
             self._names = names
 
-        def model_info(self, repo_id, files_metadata = False, token = None):
+        def model_info(
+            self,
+            repo_id,
+            files_metadata = False,
+            token = None,
+        ):
             return _PlanInfo([_PlanSibling(n, 20) for n in self._names])
 
     def _use(names):
@@ -2833,12 +2838,21 @@ def test_the_verified_probe_keeps_the_dense_shards_when_the_artifact_is_absent(m
 
     # The keyframe artifacts exist, the reference one does not.
     _use(["MiniMax-H3-FP8.pt", "MiniMax-H3-INT8-ConvRot.pt"])
-    assert backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "ref2va", None) is False
-    assert backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "fl2va", None) is True
+    assert (
+        backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "ref2va", None)
+        is False
+    )
+    assert (
+        backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "fl2va", None)
+        is True
+    )
 
     # Once the reference artifact is published the skip is earned again.
     _use(["MiniMax-H3-FP8.pt", "MiniMax-H3-Ref2VA-FP8.pt"])
-    assert backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "ref2va", None) is True
+    assert (
+        backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "ref2va", None)
+        is True
+    )
 
     # An unreadable repo is a refusal, not a pass: the dense shards stay.
     class _Boom:
@@ -2846,9 +2860,15 @@ def test_the_verified_probe_keeps_the_dense_shards_when_the_artifact_is_absent(m
             raise RuntimeError("404 gated")
 
     monkeypatch.setattr("huggingface_hub.HfApi", lambda *a, **k: _Boom())
-    assert backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "ref2va", None) is False
+    assert (
+        backend._denoiser_prequant_verified(fam, "fp8", "MiniMaxAI/MiniMax-H3", "ref2va", None)
+        is False
+    )
     # And bf16 never asks in the first place.
-    assert backend._denoiser_prequant_verified(fam, None, "MiniMaxAI/MiniMax-H3", "ref2va", None) is False
+    assert (
+        backend._denoiser_prequant_verified(fam, None, "MiniMaxAI/MiniMax-H3", "ref2va", None)
+        is False
+    )
 
 
 def test_the_load_path_gates_its_dense_skip_on_the_verified_probe():
@@ -2933,9 +2953,9 @@ def test_the_h3_loader_optimises_the_partition_it_denoises_with():
         ]
         assert len(calls) == 1, f"{helper} is called {len(calls)} times"
         first = calls[0].args[0]
-        assert getattr(first, "id", None) == "speed_view", (
-            f"{helper} is handed {ast.dump(first)}, not the denoiser view"
-        )
+        assert (
+            getattr(first, "id", None) == "speed_view"
+        ), f"{helper} is handed {ast.dump(first)}, not the denoiser view"
 
 
 def test_download_plan_adds_no_prequant_entry_without_a_scheme(monkeypatch):


### PR DESCRIPTION
Follow-up to #8329, which merged before the last review round landed. Two fixes, both on the reference (ref2va) denoiser path.

## The pull can drop the dense shards for an artifact that does not exist

`_run_load` set `skip_transformer_weights` from `_denoiser_prequant_covered`, a registry-only probe. The plan already gates its own skip on the artifact resolving (`dq_repo`), and both encoder skips next to it gate on the checkpoint actually landing, but the load path had no equivalent.

A task-specific `prequant_filenames` row gets no filename fallback, so a Ref2VA checkpoint that is renamed, unpublished or gated resolves to nothing while the registry still reports the scheme as covered. `_predownload_base` then removed every dense `transformer_ref` weight before `load_prequantized_transformer` had established a replacement, so the documented bf16 fallback ran against a snapshot without them: an offline or pre-staged load fails, and an online one pulls ~66 GB inline, outside the load progress, the cancel path and the disk preflight.

`_denoiser_prequant_verified` is the registry probe plus the Hub check, in the same shape as `_h3_te_quant_scheme_verified` beside it and with the same fail-closed direction: unanswerable keeps the dense shards.

## The reference partition never reached the optimisation helpers

`apply_attention_backend` and `apply_speed_optims` reach the denoiser through `pipe.transformer`, and both enumerate only `transformer`, `transformer_2` and `unconditional_transformer`. A reference load denoises out of `transformer_ref`, so neither helper found a DiT at all.

This used to be hidden: the pin read `getattr(pipe, "transformer")`, found nothing on a reference load, and the profile was downgraded to eager. #8329 correctly pinned the partition the load opens, which removed that downgrade and left the reference DiT native and uncompiled while the resolved record still reported the requested profile - the exact over-reporting `_denoiser_dits` and `_attention_dits` document as the thing to avoid.

`_NamedDiTView` generalises the existing `_SecondDiTView` seam: it presents `pipe.<component>` as `pipe.transformer` and reads everything else through. A keyframe load is handed the pipe itself, so its behaviour is unchanged.

## Tests

Four added in `studio/backend/tests/test_video_backend.py`, two of them AST-based:

- the verified probe refuses an absent reference artifact, accepts it once published, treats an unreadable repo as a refusal, and never asks for bf16;
- `_run_load` gates its dense skip on the verified probe, not the registry-only one;
- `_denoiser_view` makes the reference DiT visible to `_denoiser_dits` / `_attention_dits`, passes writes through to the real partition, and returns the pipe unchanged for a keyframe load;
- the H3 loader hands both helpers the denoiser view.

Each was mutation-checked: reverting either fix fails its tests, restoring it passes.

414 passed across the prequant, video, routes and speed test files; backend and hub suites show no new failures against main.