### PR TITLE
Stop writing the desktop build provenance section onto the release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1722,18 +1722,10 @@ jobs:
               sys.exit(1)
           PY
 
-      - name: Generate versioned updater metadata and provenance
+      - name: Generate versioned updater metadata
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # The build checked out the tag, so provenance records the tag's commit
-          # rather than this job's dispatch-scoped GITHUB_SHA.
-          # commits/{tag} resolves annotated and lightweight tags alike, so this is
-          # the commit the build compiled, not an intermediate tag object.
-          RELEASE_TAG_SHA="$(gh api "repos/${GH_REPO}/commits/${DESKTOP_RELEASE_TAG}" --jq '.sha')"
-          export RELEASE_TAG_SHA
           python3 <<'PY'
           import base64
           import binascii
@@ -1799,31 +1791,9 @@ jobs:
           output.write_text(json.dumps(metadata, indent=2) + '\n')
           PY
 
-          # Keep provenance out of the notes displayed in the updater popup. This is
-          # appended to the existing release body, so it carries no copy of the notes.
-          body_file="$RUNNER_TEMP/desktop-release-body.md"
-          {
-            printf '### Desktop build provenance\n\n'
-            printf 'Source commit: %s\n\n' "$RELEASE_TAG_SHA"
-            printf 'Asset SHA-256:\n\n```\n'
-            (
-              cd "$RUNNER_TEMP/desktop-release-assets"
-              for asset in *; do
-                [[ "$asset" == *.sig ]] || sha256sum -- "$asset"
-              done
-            )
-            (
-              cd "$RUNNER_TEMP"
-              sha256sum -- latest.json
-            )
-            printf '```\n'
-          } > "$body_file"
-          cat "$body_file"
-
-      # The release body is the maintainer's changelog, so provenance is appended
-      # rather than replacing it.
-      # The target release is already public, so a validation-only run must not
-      # upload to it.
+      # The release body is the maintainer's changelog and this workflow never
+      # rewrites it. The target release is already public, so a validation-only
+      # run must not upload to it.
       - name: Publish versioned release assets
         if: ${{ !inputs.draft }}
         shell: bash
@@ -1848,30 +1818,6 @@ jobs:
           # --clobber only for latest.json: it may already hold an older version's
           # pointer. The bundles above are still uploaded without it.
           gh release upload "$DESKTOP_RELEASE_TAG" "$RUNNER_TEMP/latest.json" --clobber
-
-      # After the uploads, so a retry that follows a partial upload records the
-      # digests actually published. Any earlier section is replaced, never kept.
-      - name: Record desktop build provenance on the release
-        if: ${{ !inputs.draft }}
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          current="$RUNNER_TEMP/current-release-body.md"
-          merged="$RUNNER_TEMP/merged-release-body.md"
-          gh release view "$DESKTOP_RELEASE_TAG" --json body --jq '.body // ""' > "$current"
-          python3 - "$current" "$RUNNER_TEMP/desktop-release-body.md" "$merged" <<'PY'
-          import pathlib
-          import sys
-
-          heading = '### Desktop build provenance'
-          current, provenance, merged = (pathlib.Path(p) for p in sys.argv[1:4])
-          body = current.read_text(encoding = 'utf-8')
-          body = body.split(heading, 1)[0].rstrip()
-          merged.write_text(f'{body}\n\n{provenance.read_text(encoding = "utf-8")}', encoding = 'utf-8')
-          PY
-          gh release edit "$DESKTOP_RELEASE_TAG" --notes-file "$merged"
 
       - name: Download versioned updater metadata
         if: ${{ !inputs.draft }}

--- a/tests/python/test_virustotal_scan.py
+++ b/tests/python/test_virustotal_scan.py
@@ -992,15 +992,15 @@ class TestWorkflowOrdering:
         # used to sit there and is why the window existed at all.
         names = self._publish_steps()
         validate = names.index("Validate versioned release state")
-        assert names[validate + 1] == "Generate versioned updater metadata and provenance"
+        assert names[validate + 1] == "Generate versioned updater metadata"
         assert names[validate + 2] == "Publish versioned release assets"
 
     def test_release_notes_are_written_unconditionally(self):
-        # Validation writes the notes; metadata and provenance consume that same
-        # file before the release is created.
+        # Validation writes the notes; the metadata step consumes that same file
+        # before the assets land on the release.
         steps = self._publish_step_map()
         assert "desktop-release-notes.md" in steps["Validate versioned release state"]["run"]
-        metadata = steps["Generate versioned updater metadata and provenance"]["run"]
+        metadata = steps["Generate versioned updater metadata"]["run"]
         assert "desktop-release-notes.md" in metadata
 
     def test_a_missing_release_stops_the_publish(self):

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -197,23 +197,21 @@ def _run_create_release(
     }
     env.update(kwargs.pop("extra_env", None) or {})
 
-    # Execute the production publish sequence in one shell so the notes,
-    # metadata and provenance files cross the same step boundaries as Actions.
+    # Execute the production publish sequence in one shell so the notes and
+    # metadata files cross the same step boundaries as Actions.
     names = (
         "Validate versioned release state",
-        "Generate versioned updater metadata and provenance",
-        "Record desktop build provenance on the release",
+        "Generate versioned updater metadata",
     )
-    create_step = _step(
-        workflow, "publish-release", "Record desktop build provenance on the release"
-    )
+    host = "Generate versioned updater metadata"
+    create_step = _step(workflow, "publish-release", host)
     create_step["run"] = "\n".join(
         _step(workflow, "publish-release", name)["run"] for name in names
     )
     return _run_step(
         workflow,
         "publish-release",
-        "Record desktop build provenance on the release",
+        host,
         tmp_path,
         extra_env = env,
         **kwargs,
@@ -323,37 +321,31 @@ def test_publish_rejects_signer_diagnostics_as_updater_signatures(tmp_path):
     assert not [line for line in commands if line.startswith("gh release create")]
 
 
-def test_release_body_records_provenance_the_updater_notes_do_not_carry(tmp_path):
+def test_the_publish_sequence_never_rewrites_the_release_body(tmp_path):
     workflow = _workflow()
-    digests = _stage_assets(tmp_path)
     result, commands = _run_create_release(workflow, tmp_path)
     assert result.returncode == 0, result.stderr
 
     # The release already exists, so nothing is created and no tag is reserved.
     assert not [line for line in commands if line.startswith("gh release create")]
     assert not [line for line in commands if "git/refs" in line]
-    assert any(line.startswith("gh release edit") for line in commands)
+    # The body is the maintainer's changelog. Assets are uploaded beside it and
+    # the notes are never edited, so nothing this workflow does can clobber it.
+    assert not [line for line in commands if line.startswith("gh release edit")]
+    assert not (tmp_path / "desktop-release-body.md").exists()
 
-    body_file = tmp_path / "desktop-release-body.md"
-    body = body_file.read_text(encoding = "utf-8")
-    assert SOURCE_SHA in body
-    for name, digest in digests.items():
-        assert f"{digest}  {name}" in body
     latest = tmp_path / "latest.json"
+    assert latest.is_file()
     metadata = yaml.safe_load(latest.read_text(encoding = "utf-8"))
     for platform in metadata["platforms"].values():
         decoded = base64.b64decode(platform["signature"], validate = True)
         assert decoded.startswith(b"untrusted comment:")
         assert b"\ntrusted comment:" in decoded
-    assert latest.is_file()
-    assert f"{hashlib.sha256(latest.read_bytes()).hexdigest()}  latest.json" in body
-    assert ".sig" not in body
 
-    # Keep digests out of updater notes, and out of the changelog we append to.
+    # The updater popup shows the maintainer notes, never build metadata.
     notes = (tmp_path / "desktop-release-notes.md").read_text(encoding = "utf-8")
     assert "Build provenance" not in notes
     assert "Desktop app for Unsloth." in notes
-    assert "Desktop app for Unsloth." not in body
 
 
 def test_versioned_uploads_never_clobber_or_mutate_the_legacy_channel():
@@ -389,14 +381,14 @@ def test_a_validation_only_run_touches_nothing_public():
     mutating = (
         "Publish versioned release assets",
         "Publish versioned updater metadata",
-        "Record desktop build provenance on the release",
         "Promote normal release to GitHub latest",
     )
     for name in mutating:
         step = steps[names.index(name)]
         assert step.get("if") == "${{ !inputs.draft }}", name
 
-    # Provenance last, so a retry after a partial upload records what shipped.
+    # Promotion last, so latest only moves once the assets are actually on the
+    # release and a partial upload cannot leave latest pointing at an empty one.
     for upload in mutating[:2]:
         assert names.index(upload) < names.index(mutating[2])
 

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -129,7 +129,7 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
 
     names = [step.get("name") for step in publish["steps"]]
     assert names.index("Wait for the build matrix") < names.index(
-        "Record desktop build provenance on the release"
+        "Publish versioned release assets"
     )
     # And it has to clear before the assets are pulled, or the download races the
     # legs and publish-release dies on artifacts that do not exist yet.
@@ -148,14 +148,10 @@ def test_build_matrix_hands_off_assets_without_release_credentials():
     assert 'gh api "repos/${GH_REPO}/releases/tags/${DESKTOP_RELEASE_TAG}"' in release_step["run"]
     assert "already carries desktop assets" in release_step["run"]
 
-    # The release is the maintainer's, so provenance is appended, never created.
-    provenance = next(
-        step
-        for step in publish["steps"]
-        if step.get("name") == "Record desktop build provenance on the release"
-    )
-    assert "gh release edit" in provenance["run"]
+    # The release is the maintainer's: assets are uploaded onto it, but the
+    # release itself is never created and its notes are never rewritten.
     assert not any("gh release create" in step.get("run", "") for step in publish["steps"])
+    assert not any("gh release edit" in step.get("run", "") for step in publish["steps"])
 
 
 def test_post_publish_scan_job_holds_no_release_credentials():


### PR DESCRIPTION
## Summary

`release-desktop.yml` appended a `### Desktop build provenance` section (source commit plus a SHA-256 table for every bundle and `latest.json`) to the release body on each publish. It is noise on the release page, so this removes it. See [v0.1.60-beta](https://github.com/unslothai/unsloth/releases/tag/v0.1.60-beta), where it was stripped by hand.

## Changes

- Drops the provenance block that wrote `desktop-release-body.md`, and the `Record desktop build provenance on the release` step that merged it into the body with `gh release edit`.
- Renames `Generate versioned updater metadata and provenance` to `Generate versioned updater metadata`, since that is all it does now.
- Removes the now-unused `RELEASE_TAG_SHA` lookup, and with it the `GH_TOKEN` that step needed only for that `gh api` call.

`publish-release` no longer runs `gh release edit` at all, so the workflow can only upload assets onto the release, never rewrite the maintainer changelog. It already never ran `gh release create`.

Nothing about update integrity changes: the Tauri updater verifies bundles against the `.sig` files and the public key in `latest.json`, not this table. Asset digests remain available from the GitHub API and from the VirusTotal scan job.

## Tests

Three suites asserted the provenance step existed and were updated:

- `test_release_desktop_integrity.py`: the publish-sequence helper now chains the two remaining steps. `test_release_body_records_provenance_the_updater_notes_do_not_carry` becomes `test_the_publish_sequence_never_rewrites_the_release_body`, asserting no `gh release edit`, no `gh release create` and no body file, while keeping the updater signature and notes checks. The validation-only test drops the step from its mutating list and now anchors ordering on promotion to latest.
- `test_release_desktop_permissions.py`: asserts `publish-release` runs neither `gh release create` nor `gh release edit`; the build-matrix ordering check anchors on `Publish versioned release assets`.
- `test_virustotal_scan.py`: step-name updates.

## Test plan

- [x] `pytest tests/security` passes (258 passed)
- [x] `pytest tests/security/test_release_desktop_integrity.py tests/security/test_release_desktop_permissions.py tests/python/test_virustotal_scan.py` passes (99 passed)
- [x] Workflow parses as YAML and no `provenance` / `RELEASE_TAG_SHA` / `desktop-release-body` references remain
- [ ] Confirm on the next desktop release that the body is left untouched