### PR TITLE
Studio: align desktop details chevrons

### DIFF
--- a/studio/frontend/src/components/tauri/startup-screen.tsx
+++ b/studio/frontend/src/components/tauri/startup-screen.tsx
@@ -10,6 +10,9 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import type { BackendStatus } from "@/hooks/use-tauri-backend";
 import type { CopySupportDiagnosticsResult } from "@/lib/tauri-diagnostics";
+
+import { ChevronDown as ChevronDownIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
 import { type ReactNode, useEffect, useState } from "react";
 
@@ -217,9 +220,15 @@ function InstallingContent({
         <p className="text-sm text-muted-foreground">{message.subtitle}</p>
         {detailLines.length > 0 && (
           <details className="group mt-2 w-full max-w-sm text-left">
-            <summary className="mx-auto w-fit cursor-pointer select-none rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
               <span className="group-open:hidden">Show installation details</span>
               <span className="hidden group-open:inline">Hide installation details</span>
+              <HugeiconsIcon
+                icon={ChevronDownIcon}
+                aria-hidden="true"
+                strokeWidth={1.5}
+                className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
+              />
             </summary>
             <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
               {detailLines.join("\n")}
@@ -253,9 +262,15 @@ function RepairingContent({
         <p className="text-sm text-muted-foreground">This won’t take long.</p>
         {detailLines.length > 0 && (
           <details className="group mt-2 w-full max-w-sm text-left">
-            <summary className="mx-auto w-fit cursor-pointer select-none rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
               <span className="group-open:hidden">Show setup details</span>
               <span className="hidden group-open:inline">Hide setup details</span>
+              <HugeiconsIcon
+                icon={ChevronDownIcon}
+                aria-hidden="true"
+                strokeWidth={1.5}
+                className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
+              />
             </summary>
             <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
               {detailLines.join("\n")}

--- a/studio/frontend/src/components/tauri/update-screen.tsx
+++ b/studio/frontend/src/components/tauri/update-screen.tsx
@@ -4,6 +4,9 @@
 import { Spinner } from "@/components/ui/spinner";
 import type { UpdateStatus } from "@/hooks/use-tauri-update";
 import type { CopySupportDiagnosticsResult } from "@/lib/tauri-diagnostics";
+
+import { ChevronDown as ChevronDownIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 
@@ -75,9 +78,15 @@ function UpdateDetails({ logs }: { logs: string[] }) {
 
   return (
     <details className="group mt-2 w-full max-w-sm text-left">
-      <summary className="mx-auto w-fit cursor-pointer select-none rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+      <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
         <span className="group-open:hidden">Show update details</span>
         <span className="hidden group-open:inline">Hide update details</span>
+        <HugeiconsIcon
+          icon={ChevronDownIcon}
+          aria-hidden="true"
+          strokeWidth={1.5}
+          className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
+        />
       </summary>
       <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
         {logs.join("\n")}

--- a/studio/frontend/tests/tauri-details-toggle.test.ts
+++ b/studio/frontend/tests/tauri-details-toggle.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+async function source(path: string): Promise<string> {
+  return readFile(
+    new URL(`../src/components/tauri/${path}`, import.meta.url),
+    "utf8",
+  );
+}
+
+function summaryForLabel(sourceText: string, label: string): string {
+  const labelOffset = sourceText.indexOf(label);
+  assert.notEqual(labelOffset, -1, `${label} toggle is missing`);
+  const start = sourceText.lastIndexOf("<summary", labelOffset);
+  const end = sourceText.indexOf("</summary>", labelOffset);
+  assert.notEqual(start, -1, `${label} is not inside a summary`);
+  assert.notEqual(end, -1, `${label} summary is not closed`);
+  return sourceText.slice(start, end);
+}
+
+test("Tauri detail toggles put a custom down chevron after their labels", async () => {
+  const startup = await source("startup-screen.tsx");
+  const update = await source("update-screen.tsx");
+
+  for (const [sourceText, label] of [
+    [startup, "Show installation details"],
+    [startup, "Show setup details"],
+    [update, "Show update details"],
+  ] as const) {
+    const summary = summaryForLabel(sourceText, label);
+    assert.match(summary, /\blist-none\b/);
+    assert.match(summary, /\[&::\-webkit-details-marker\]:hidden/);
+    assert.match(summary, /\bflex\b/);
+    assert.ok(
+      summary.indexOf("<HugeiconsIcon") > summary.indexOf(label) &&
+        summary.includes("icon={ChevronDownIcon}"),
+      `${label} chevron must be on the right`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- replace the browser-native left disclosure marker on Tauri setup/install/update detail toggles
- render a 13px Hugeicons down chevron after the label and rotate it when expanded
- cover all three desktop lifecycle toggles with a regression test

## Validation

- `npm run typecheck`
- `npm test` (1,579 passed)
- `git diff --check`

The Tauri-only lifecycle screens were not visually exercised locally because Playwright is unavailable; layout and icon placement are covered by the focused source contract test.
