### PR TITLE
Stub the trainer's heavy imports so Backend CI can collect the studio tree again

### DIFF
--- a/studio/backend/tests/test_backend_tests_stub_heavy_imports.py
+++ b/studio/backend/tests/test_backend_tests_stub_heavy_imports.py
@@ -97,15 +97,9 @@ def test_the_guard_would_catch_an_unstubbed_module(tmp_path):
     assert _imports_trainer_at_module_scope(tree)
     assert not _stubs_before_that_import(unstubbed.read_text(encoding = "utf-8"), tree)
 
-    stubbed_source = (
-        '_stub_if_missing("unsloth", ())\n'
-        "from core.training import trainer as t\n"
-    )
+    stubbed_source = '_stub_if_missing("unsloth", ())\n' "from core.training import trainer as t\n"
     assert _stubs_before_that_import(stubbed_source, ast.parse(stubbed_source))
 
     # And a stub that lands too late does not count.
-    too_late = (
-        "from core.training import trainer as t\n"
-        '_stub_if_missing("unsloth", ())\n'
-    )
+    too_late = "from core.training import trainer as t\n" '_stub_if_missing("unsloth", ())\n'
     assert not _stubs_before_that_import(too_late, ast.parse(too_late))

--- a/studio/backend/tests/test_backend_tests_stub_heavy_imports.py
+++ b/studio/backend/tests/test_backend_tests_stub_heavy_imports.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""No test module in this tree may import the LLM trainer without stubbing its heavy deps first.
+
+``core/training/trainer.py`` imports ``unsloth`` (and through it ``unsloth_zoo``) and ``trl`` at
+module scope. The ``pytest`` matrix in ``.github/workflows/studio-backend-ci.yml`` installs
+studio.txt plus torch and transformers and deliberately stops there. The heavier
+``repo-cpu-tests`` job beside it does install ``unsloth_zoo``, but it runs the REPO-ROOT
+``tests/`` tree, not this one, so nothing here can lean on that.
+
+The consequence is worse than one skipped test: an unstubbed module fails COLLECTION, and a
+collection error takes down the entire job on all four Python versions. That is what happened
+when ``test_trainer_stdout_quiet.py`` landed, and every open PR went red until it was fixed.
+
+Three modules import the trainer today and each stubs first. This asserts the rule so a fourth
+cannot arrive without it, and it is a source check rather than a runtime one because on a box
+where the real packages ARE installed the import succeeds and proves nothing.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_TESTS_DIR = Path(__file__).resolve().parent
+
+# The import that pulls the heavy chain in. Matched on the module path, so
+# `from core.training import trainer` and `import core.training.trainer` both count.
+_TRAINER_MODULE = "core.training.trainer"
+# What a module must stub before that import. Naming `unsloth` is enough to prove intent: a
+# module that stubs it and forgets `trl` fails loudly at collection on CI, whereas a module that
+# stubs nothing is the silent case this guard exists to catch.
+_REQUIRED_STUB = "unsloth"
+
+
+def _imports_trainer_at_module_scope(tree: ast.Module) -> bool:
+    for node in tree.body:  # module scope only: an import inside a test function is already lazy
+        if isinstance(node, ast.Import):
+            if any(a.name == _TRAINER_MODULE for a in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if mod == _TRAINER_MODULE:
+                return True
+            if mod == "core.training" and any(a.name == "trainer" for a in node.names):
+                return True
+    return False
+
+
+def _stubs_before_that_import(source: str, tree: ast.Module) -> bool:
+    """Whether a stub call naming ``unsloth`` appears at module scope BEFORE the trainer import.
+
+    Order is the whole point. A stub registered afterwards is registered after the real import
+    has already been attempted and raised, so it changes nothing."""
+    trainer_line = None
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)) and _imports_trainer_at_module_scope(
+            ast.Module(body = [node], type_ignores = [])
+        ):
+            trainer_line = node.lineno
+            break
+    if trainer_line is None:
+        return True
+    head = "\n".join(source.splitlines()[: trainer_line - 1])
+    return _REQUIRED_STUB in head and ("stub" in head or "sys.modules" in head)
+
+
+def test_no_test_module_imports_the_trainer_unstubbed():
+    offenders = []
+    for path in sorted(_TESTS_DIR.glob("test_*.py")):
+        source = path.read_text(encoding = "utf-8")
+        if _TRAINER_MODULE not in source and "core.training import trainer" not in source:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:  # not this guard's job to report
+            continue
+        if not _imports_trainer_at_module_scope(tree):
+            continue
+        if not _stubs_before_that_import(source, tree):
+            offenders.append(path.name)
+
+    assert not offenders, (
+        f"{len(offenders)} test module(s) import {_TRAINER_MODULE} at module scope without "
+        f"stubbing its heavy deps first, so they fail COLLECTION on the backend pytest matrix "
+        f"(which installs neither unsloth nor trl) and take the whole job down: {offenders}. "
+        f"Copy the _stub_if_missing block from test_trainer_stdout_quiet.py, above the import."
+    )
+
+
+def test_the_guard_would_catch_an_unstubbed_module(tmp_path):
+    """The guard above passes trivially if its matching is wrong, so pin both answers here."""
+    unstubbed = tmp_path / "test_unstubbed.py"
+    unstubbed.write_text("from core.training import trainer as t\n", encoding = "utf-8")
+    tree = ast.parse(unstubbed.read_text(encoding = "utf-8"))
+    assert _imports_trainer_at_module_scope(tree)
+    assert not _stubs_before_that_import(unstubbed.read_text(encoding = "utf-8"), tree)
+
+    stubbed_source = (
+        '_stub_if_missing("unsloth", ())\n'
+        "from core.training import trainer as t\n"
+    )
+    assert _stubs_before_that_import(stubbed_source, ast.parse(stubbed_source))
+
+    # And a stub that lands too late does not count.
+    too_late = (
+        "from core.training import trainer as t\n"
+        '_stub_if_missing("unsloth", ())\n'
+    )
+    assert not _stubs_before_that_import(too_late, ast.parse(too_late))

--- a/studio/backend/tests/test_trainer_stdout_quiet.py
+++ b/studio/backend/tests/test_trainer_stdout_quiet.py
@@ -23,7 +23,46 @@ _BACKEND = Path(__file__).resolve().parent.parent
 if str(_BACKEND) not in sys.path:
     sys.path.insert(0, str(_BACKEND))
 
+import importlib  # noqa: E402
+import types  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
 import pytest  # noqa: E402
+
+
+def _stub_if_missing(name, attrs):
+    """Register a stub module for a dep the backend pytest job does not install.
+
+    Same helper, and the same reason, as in test_training_preflight.py and
+    test_training_progress_callback.py: core.training.trainer imports unsloth (and through it
+    unsloth_zoo) and trl at module scope, while the pytest matrix in studio-backend-ci.yml
+    installs studio.txt plus torch and transformers and stops there. The heavier
+    repo-cpu-tests job beside it is the one that installs unsloth_zoo, and it runs the
+    REPO-ROOT tests/, not this tree -- so nothing here can rely on those packages being
+    present. Unstubbed, this module fails COLLECTION, which fails the whole job rather than
+    one test. Real installs are left alone, so a developer box still exercises the genuine
+    import. __spec__ = None keeps the trainer's own _ensure_real_packages namespace-shadow
+    guard a no-op on the stub."""
+    if name in sys.modules:
+        return
+    try:
+        importlib.import_module(name)
+        return
+    except Exception:  # noqa: BLE001 - any import failure means "not usable here", so stub it
+        pass
+    mod = types.ModuleType(name)
+    mod.__spec__ = None
+    for attr in attrs:
+        setattr(mod, attr, MagicMock())
+    sys.modules[name] = mod
+    parent, _, child = name.rpartition(".")
+    if parent and parent in sys.modules:
+        setattr(sys.modules[parent], child, mod)
+
+
+_stub_if_missing("unsloth", ("FastLanguageModel", "FastVisionModel", "is_bfloat16_supported"))
+_stub_if_missing("unsloth.chat_templates", ("get_chat_template",))
+_stub_if_missing("trl", ("SFTTrainer", "SFTConfig"))
 
 from core.training import trainer as tmod  # noqa: E402
 


### PR DESCRIPTION
`studio/backend/tests/test_trainer_stdout_quiet.py` (added in #8311) imports `core.training.trainer` at module scope. That module imports `unsloth` at line 50, and through it `unsloth_zoo`, plus `trl`.

The `pytest` matrix in `.github/workflows/studio-backend-ci.yml` installs studio.txt plus torch and transformers and deliberately stops there. The `repo-cpu-tests` job beside it does install `unsloth_zoo`, but it runs the REPO-ROOT `tests/` tree, not `studio/backend/tests/`, so nothing here can rely on it.

The result is worse than one failing test: the module fails **collection**, and a collection error fails the whole job. Every open PR has been red on `(Python 3.10/3.11/3.12/3.13)` since it landed:

```
ERROR collecting studio/backend/tests/test_trainer_stdout_quiet.py
ImportError: Unsloth: Please install unsloth_zoo via `pip install unsloth_zoo` then retry!
4 skipped, 36 deselected, 3 warnings, 1 error
```

## The fix

The two other modules in this tree that import the trainer, `test_training_preflight.py` and `test_training_progress_callback.py`, each already register stubs before the import. This adds the same block to the third.

That is preferred over adding `unsloth_zoo` to the matrix job. The matrix is deliberately light, and the heavier job next to it exists precisely to carry the `unsloth_zoo` install (with torchvision and bitsandbytes behind it, plus a three-attempt retry around a git clone). Pulling that into four more jobs to satisfy one module's import is a large cost for no extra coverage. The stubs are no-ops wherever the real packages are installed, so a developer box and the heavier job both still exercise the genuine import.

## Verification

Reproduced under a `meta_path` finder that makes `unsloth`, `unsloth_zoo` and `trl` unimportable, which is the matrix job's dep set:

| | result |
| --- | --- |
| before (`main`'s copy of the file) | `ImportError` ... `1 error during collection` |
| after (this branch) | `8 passed` |

With the real packages present, unchanged: `8 passed`.

Whole tree under the same block: **21280 collected, 0 collection errors** - so this module was the only one affected, and the job should go green rather than merely further along.

The four trainer-importing modules together: **68 passed** both with the real packages and with all three blocked.

## The guard

`test_backend_tests_stub_heavy_imports.py` asserts the rule by AST, so a fourth module cannot arrive without it. Source-based rather than runtime, because on a box where the packages ARE installed the import succeeds and proves nothing.

Mutation-checked: restoring `main`'s unstubbed version of `test_trainer_stdout_quiet.py` fails the guard, and the guard's own matching is pinned by a second test covering the unstubbed case, the stubbed case, and a stub that lands after the import.