### PR TITLE
Studio: ship the loaded models indicator off by default

### DIFF
--- a/studio/frontend/src/features/loaded-models/show-loaded-models-pref.ts
+++ b/studio/frontend/src/features/loaded-models/show-loaded-models-pref.ts
@@ -4,7 +4,7 @@
 // Whether the corner indicator may appear. Off by default; only an explicit
 // "true" (Settings -> General -> Notifications) enables it. An older explicit
 // "false" still reads as off, so anyone who already turned it down stays that
-// way.
+// way. Tri-state on purpose: see setShowLoadedModels.
 
 import { useSyncExternalStore } from "react";
 
@@ -38,12 +38,11 @@ export function getShowLoadedModels(): boolean {
 
 export function setShowLoadedModels(show: boolean): void {
   try {
-    if (show) {
-      localStorage.setItem(STORAGE_KEY, "true");
-    } else {
-      // Remove rather than store "false" so the default stays off.
-      localStorage.removeItem(STORAGE_KEY);
-    }
+    // Both values written, never removed: "false" is the one an older reader
+    // also treats as off, so a pre-update tab does not flip the card back on
+    // through the storage event. Absent still means off here, so the default
+    // is unaffected.
+    localStorage.setItem(STORAGE_KEY, show ? "true" : "false");
   } catch {
     // storage unavailable
   }

--- a/studio/frontend/src/features/loaded-models/show-loaded-models-pref.ts
+++ b/studio/frontend/src/features/loaded-models/show-loaded-models-pref.ts
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Whether the corner indicator may appear. On by default; only an explicit
-// "false" (Settings -> General -> Notifications) disables it. Same shape as the
-// llama.cpp update banner pref.
+// Whether the corner indicator may appear. Off by default; only an explicit
+// "true" (Settings -> General -> Notifications) enables it. An older explicit
+// "false" still reads as off, so anyone who already turned it down stays that
+// way.
 
 import { useSyncExternalStore } from "react";
 
@@ -29,19 +30,19 @@ function notify(): void {
 
 export function getShowLoadedModels(): boolean {
   try {
-    return localStorage.getItem(STORAGE_KEY) !== "false";
+    return localStorage.getItem(STORAGE_KEY) === "true";
   } catch {
-    return true;
+    return false;
   }
 }
 
 export function setShowLoadedModels(show: boolean): void {
   try {
     if (show) {
-      // Remove rather than store "true" so the default stays on.
-      localStorage.removeItem(STORAGE_KEY);
+      localStorage.setItem(STORAGE_KEY, "true");
     } else {
-      localStorage.setItem(STORAGE_KEY, "false");
+      // Remove rather than store "false" so the default stays off.
+      localStorage.removeItem(STORAGE_KEY);
     }
   } catch {
     // storage unavailable

--- a/studio/frontend/tests/loaded-models-dismiss.test.ts
+++ b/studio/frontend/tests/loaded-models-dismiss.test.ts
@@ -30,20 +30,30 @@ test("the indicator is off until it is switched on", () => {
   assert.equal(getShowLoadedModels(), false);
 });
 
-test("switching on stores the key, switching off removes it", () => {
+// Written either way, never removed. A pre-update tab reads a missing key as
+// on, so removing it on disable would let the storage event flip the card back
+// on over there.
+test("both toggles store a value the older reader also honours", () => {
   reset();
   setShowLoadedModels(true);
   assert.equal(store.get(LOADED_MODELS_PREFERENCE_KEYS.show), "true");
   setShowLoadedModels(false);
-  // Removed, not stored as "false", so the default stays off.
-  assert.equal(store.has(LOADED_MODELS_PREFERENCE_KEYS.show), false);
+  assert.equal(store.get(LOADED_MODELS_PREFERENCE_KEYS.show), "false");
   assert.equal(getShowLoadedModels(), false);
 });
 
-// What the old default wrote when it was turned down. It must not now read as on.
+// What the old build wrote when it was turned down. It must not now read as on.
 test("an older explicit false still reads as off", () => {
   reset();
   store.set(LOADED_MODELS_PREFERENCE_KEYS.show, "false");
+  assert.equal(getShowLoadedModels(), false);
+});
+
+// Reset all local preferences removes the key, and the default must survive it.
+test("a cleared key falls back to off, not on", () => {
+  reset();
+  setShowLoadedModels(true);
+  store.delete(LOADED_MODELS_PREFERENCE_KEYS.show);
   assert.equal(getShowLoadedModels(), false);
 });
 

--- a/studio/frontend/tests/loaded-models-dismiss.test.ts
+++ b/studio/frontend/tests/loaded-models-dismiss.test.ts
@@ -25,6 +25,28 @@ function reset(): void {
   store.clear();
 }
 
+test("the indicator is off until it is switched on", () => {
+  reset();
+  assert.equal(getShowLoadedModels(), false);
+});
+
+test("switching on stores the key, switching off removes it", () => {
+  reset();
+  setShowLoadedModels(true);
+  assert.equal(store.get(LOADED_MODELS_PREFERENCE_KEYS.show), "true");
+  setShowLoadedModels(false);
+  // Removed, not stored as "false", so the default stays off.
+  assert.equal(store.has(LOADED_MODELS_PREFERENCE_KEYS.show), false);
+  assert.equal(getShowLoadedModels(), false);
+});
+
+// What the old default wrote when it was turned down. It must not now read as on.
+test("an older explicit false still reads as off", () => {
+  reset();
+  store.set(LOADED_MODELS_PREFERENCE_KEYS.show, "false");
+  assert.equal(getShowLoadedModels(), false);
+});
+
 test("the card is open until something closes it", () => {
   reset();
   assert.equal(getLoadedModelsDismissed(), false);
@@ -44,6 +66,7 @@ test("closing it stores the dismissal, reopening removes the key", () => {
 // The point of keeping them apart.
 test("closing the card does not switch the setting off", () => {
   reset();
+  setShowLoadedModels(true);
   setLoadedModelsDismissed(true);
   assert.equal(getShowLoadedModels(), true);
 });

--- a/tests/studio/playwright_loaded_models_indicator.py
+++ b/tests/studio/playwright_loaded_models_indicator.py
@@ -233,16 +233,22 @@ def boot(
     state: Runtime,
     *,
     seed: dict | None = None,
+    show: bool = True,
 ) -> None:
     """Reload with a known localStorage, then wait for the card to settle."""
     page.goto(BASE, wait_until = "domcontentloaded")
+    # The indicator ships off, so every check that wants the card has to switch
+    # it on. Pass show = False to exercise the default.
+    seeded = dict(seed or {})
+    if show:
+        seeded.setdefault(SHOW_KEY, "true")
     page.evaluate(
         """([seed, keys]) => {
             for (const k of keys) localStorage.removeItem(k);
             for (const [k, v] of Object.entries(seed || {}))
                 localStorage.setItem(k, v);
         }""",
-        [seed or {}, [POSITION_KEY, COLLAPSED_KEY, SHOW_KEY]],
+        [seeded, [POSITION_KEY, COLLAPSED_KEY, SHOW_KEY]],
     )
     page.reload(wait_until = "domcontentloaded")
     page.wait_for_timeout(SETTLE_MS // 2)
@@ -705,15 +711,19 @@ def run(page, state: Runtime) -> None:
     # ── The preference ──────────────────────────────────────────────────
     state.reset()
     state.chat = chat(active_model = "unsloth/Qwen3-4B", loaded = ["unsloth/Qwen3-4B"])
-    boot(page, state, seed = {SHOW_KEY: "false"})
-    check("the preference hides the card", page.locator(CARD).count() == 0)
+    # Nothing stored: a fresh install shows no card even with a model resident.
+    boot(page, state, show = False)
+    check("the card is off by default", page.locator(CARD).count() == 0)
     state.status_reads = 0
     page.wait_for_timeout(SETTLE_MS)
     check(
-        "the preference stops the poll",
+        "the default stops the poll",
         state.status_reads <= 1,
         f"{state.status_reads} status reads while off",
     )
+    # What the old default wrote when it was turned down; still off.
+    boot(page, state, seed = {SHOW_KEY: "false"}, show = False)
+    check("an older explicit false still hides the card", page.locator(CARD).count() == 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The loaded models indicator shipped on. It should ship off.

## Before

`getShowLoadedModels` read "on unless explicitly disabled":

```ts
return localStorage.getItem(STORAGE_KEY) !== "false";
```

An absent key means a fresh install, so every install got the corner card and its 5s status poll without asking for either.

## After

The same key, read the other way round, so absent reads as off:

```ts
return localStorage.getItem(STORAGE_KEY) === "true";
```

The writer stores both values rather than removing the key on disable:

```ts
localStorage.setItem(STORAGE_KEY, show ? "true" : "false");
```

That matters for a tab still running the old bundle during an update, or for a rollback. The old reader treats a missing key as enabled and there is a `storage` listener on this key, so removing it on disable would let the old tab take the event and turn the card back on. `"false"` is off under both readers. Absent still means off under the new one, so the default is unaffected.

## Existing installs

The only value the old code ever wrote was `"false"`, on disable. `"false" === "true"` is false, so anyone who already turned it down stays off and sees no change. Nobody has `"true"` stored, since the old enable path removed the key rather than writing it, so there is no half-migrated state to handle.

The one intended change: an install that left it alone now has it off. That is the point of the PR.

## Where the toggle is

Settings > General > Notifications, first row, "Loaded models indicator". Unchanged, and the labels are unchanged.

## Testing

`tests/loaded-models-dismiss.test.ts`, four new cases: the default is off, both toggles store a value the older reader honours, an older explicit `"false"` still reads as off, and a cleared key falls back to off rather than on. Confirmed the first two fail against the old module, and the second also fails against the first draft of this PR, which removed the key on disable. The other two pass either way, which is the point of them: they are the migration and reset invariants, and they have to hold on both sides.

One existing case asserted the old default indirectly ("closing the card does not switch the setting off" read `getShowLoadedModels()` as true on a clear store). It now switches the setting on first, so it tests what its name says instead of leaning on the default.

`tests/studio/playwright_loaded_models_indicator.py`: `boot()` takes `show` and seeds the key on by default, so every existing check still exercises the card. The preference section now covers both off paths, the default and an older explicit `"false"`.

- `tsc --noEmit` clean
- `npm test`, 1603 passing
- `i18n:check:strict` clean
- `npm run build` clean
- `py_compile` clean on the smoke suite
- Biome on both touched frontend files: 21 warnings and 0 errors, before and after, identical

