### PR TITLE
Studio: stop keeping download partials no huggingface_hub can resume

### DIFF
--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -1099,6 +1099,22 @@ def register_worker(
                     )
             except Exception:
                 logger.exception("post-finalize marker cleanup failed for %s", key)
+            try:
+                # The second look for anything prepare_cache_for_transport spared as too
+                # recently written. A download runs for long enough that a partial orphaned
+                # before it started is well past the grace by now, and the peer set still
+                # shields a same-repo variant writing a shared companion right now.
+                swept = download_registry.sweep_abandoned_partials(
+                    repo_type,
+                    repo_id,
+                    protected_blob_hashes = registry.peer_blob_hashes(key),
+                )
+                if swept:
+                    logger.info(
+                        "%sswept %d unresumable partial blob(s) for %s", log_prefix, swept, repo_id
+                    )
+            except Exception:
+                logger.exception("abandoned-partial sweep failed for %s", key)
             finally:
                 hf_cache_scan.invalidate_hf_cache_scans()
 

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -1115,6 +1115,9 @@ def register_worker(
                     repo_id,
                     protected_blob_hashes = registry.peer_blob_hashes(key),
                     owned_blob_hashes = _own_blob_hashes if terminal else None,
+                    # _own_blob_hashes is None for a job with no variant, and claim() refuses a
+                    # concurrent sibling for those, so such a job owns the whole repo dir.
+                    owns_all_blobs = terminal and _own_blob_hashes is None,
                     # The cache this worker actually wrote to. Resolving the live one instead
                     # would miss the orphan whenever the download location changed mid-run,
                     # and sweep a cache this job never touched.

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -1108,6 +1108,10 @@ def register_worker(
                     repo_type,
                     repo_id,
                     protected_blob_hashes = registry.peer_blob_hashes(key),
+                    # The cache this worker actually wrote to. Resolving the live one instead
+                    # would miss the orphan whenever the download location changed mid-run,
+                    # and sweep a cache this job never touched.
+                    root = _cache_dir,
                 )
                 if swept:
                     logger.info(

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -776,6 +776,34 @@ def _repo_bytes_on_disk(repo_type, repo_id: str, cache_dir) -> "Optional[int]":
     return None if state is None else int(state[0])
 
 
+def _sweep_ownership(metadata, own_blob_hashes, owned_for_sweep, repo_type: str, repo_id: str):
+    """(owned hashes, owns-everything) for a job that has just reached a terminal state.
+
+    A variant job whose API-side hash pre-resolution failed carries a non-null variant with an
+    EMPTY hash set, so neither claim applies and its own fresh partial waits out a grace that
+    exists to guess at a writer we already know is dead. The worker wrote a manifest naming the
+    files it fetched, so read the ownership back off that.
+    """
+    if own_blob_hashes is None:
+        return None, True
+    if owned_for_sweep:
+        return frozenset(owned_for_sweep), False
+    from hub.utils import download_manifest
+
+    manifest = download_manifest.read_manifest(
+        repo_type,
+        repo_id,
+        getattr(metadata, "variant", None),
+        hub_cache = getattr(metadata, "hub_cache", None),
+    )
+    recovered = {
+        expected.sha256
+        for expected in getattr(manifest, "expected_files", ()) or ()
+        if getattr(expected, "sha256", None)
+    }
+    return frozenset(recovered), False
+
+
 def _job_bytes_on_disk(repo_type, repo_id: str, cache_dir, blob_hashes) -> "Optional[int]":
     """Bytes THIS job owns, or None when unmeasurable.
 
@@ -926,6 +954,8 @@ def register_worker(
         if getattr(_metadata, "variant", None)
         else None
     )
+    # Companions (a shared mmproj) live only in the progress set, and this worker was writing
+    # one when it died just as much as it was writing the main quant.
     _owned_for_sweep = (
         getattr(_metadata, "progress_blob_hashes", None) or _own_blob_hashes
         if _own_blob_hashes is not None
@@ -1115,18 +1145,21 @@ def register_worker(
                 # been reaped, which is the very thing the wait is there to guess at. A retry
                 # relaunched above leaves the job active, and then it is not ours to assume.
                 terminal = registry.get_job(key).state not in ("running", "cancelling")
+                _owned, _owns_all = (
+                    _sweep_ownership(
+                        _metadata, _own_blob_hashes, _owned_for_sweep, repo_type, repo_id
+                    )
+                    if terminal
+                    else (None, False)
+                )
                 swept = download_registry.sweep_abandoned_partials(
                     repo_type,
                     repo_id,
                     protected_blob_hashes = registry.peer_blob_hashes(key),
-                    # The PROGRESS set, not _own_blob_hashes: companions (a shared mmproj) live
-                    # only there, and this worker was writing one when it died just as much as
-                    # it was writing the main quant. A companion a sibling is writing right now
-                    # is still held back by peer_blob_hashes above.
-                    owned_blob_hashes = _owned_for_sweep if terminal else None,
-                    # No variant means no resolved hashes, and claim() refuses a concurrent
-                    # sibling for those, so such a job owns the whole repo dir.
-                    owns_all_blobs = terminal and _own_blob_hashes is None,
+                    # A companion a sibling is writing right now is still held back by
+                    # peer_blob_hashes above, whatever this job believes it owns.
+                    owned_blob_hashes = _owned,
+                    owns_all_blobs = _owns_all,
                     # The cache this worker actually wrote to. Resolving the live one instead
                     # would miss the orphan whenever the download location changed mid-run,
                     # and sweep a cache this job never touched.

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -926,6 +926,11 @@ def register_worker(
         if getattr(_metadata, "variant", None)
         else None
     )
+    _owned_for_sweep = (
+        getattr(_metadata, "progress_blob_hashes", None) or _own_blob_hashes
+        if _own_blob_hashes is not None
+        else None
+    )
     # Sampled before the worker can write, so "did this job move bytes over Xet" is answerable on
     # exit. launch_worker samples BEFORE spawn(); sampling here would race a fast child that already
     # finalized its blobs, making a real transfer look like a no-op and leaving the streak uncleared.
@@ -1114,9 +1119,13 @@ def register_worker(
                     repo_type,
                     repo_id,
                     protected_blob_hashes = registry.peer_blob_hashes(key),
-                    owned_blob_hashes = _own_blob_hashes if terminal else None,
-                    # _own_blob_hashes is None for a job with no variant, and claim() refuses a
-                    # concurrent sibling for those, so such a job owns the whole repo dir.
+                    # The PROGRESS set, not _own_blob_hashes: companions (a shared mmproj) live
+                    # only there, and this worker was writing one when it died just as much as
+                    # it was writing the main quant. A companion a sibling is writing right now
+                    # is still held back by peer_blob_hashes above.
+                    owned_blob_hashes = _owned_for_sweep if terminal else None,
+                    # No variant means no resolved hashes, and claim() refuses a concurrent
+                    # sibling for those, so such a job owns the whole repo dir.
                     owns_all_blobs = terminal and _own_blob_hashes is None,
                     # The cache this worker actually wrote to. Resolving the live one instead
                     # would miss the orphan whenever the download location changed mid-run,

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -1104,10 +1104,17 @@ def register_worker(
                 # recently written. A download runs for long enough that a partial orphaned
                 # before it started is well past the grace by now, and the peer set still
                 # shields a same-repo variant writing a shared companion right now.
+                # This job's own blobs skip the abandonment wait, but ONLY once the job is
+                # genuinely finished. A cancelled worker's partial was written seconds ago, so
+                # the wait would strand it for the rest of the session; and its writer has just
+                # been reaped, which is the very thing the wait is there to guess at. A retry
+                # relaunched above leaves the job active, and then it is not ours to assume.
+                terminal = registry.get_job(key).state not in ("running", "cancelling")
                 swept = download_registry.sweep_abandoned_partials(
                     repo_type,
                     repo_id,
                     protected_blob_hashes = registry.peer_blob_hashes(key),
+                    owned_blob_hashes = _own_blob_hashes if terminal else None,
                     # The cache this worker actually wrote to. Resolving the live one instead
                     # would miss the orphan whenever the download location changed mid-run,
                     # and sweep a cache this job never touched.

--- a/studio/backend/hub/services/models/downloads.py
+++ b/studio/backend/hub/services/models/downloads.py
@@ -452,14 +452,23 @@ def _variant_transport_status(repo_id: str, variant: str, hf_token: Optional[str
             repo_id,
             variant,
         )
-    has_matching_incomplete = bool(
-        incomplete_hashes and variant_hashes and incomplete_hashes.intersection(variant_hashes)
+    # A partial only counts toward "resumable" while a writer that reopens it is installed,
+    # since the UI turns the flag into "Resume with HTTP to keep the progress you already
+    # have" and the next download start sweeps whatever cannot be reopened.
+    resumable_hashes = download_registry.incomplete_blob_hashes(
+        "model",
+        repo_id,
+        active_only = True,
+        resumable_only = True,
+    )
+    has_resumable_incomplete = bool(
+        resumable_hashes and variant_hashes and resumable_hashes.intersection(variant_hashes)
     )
     return {
         "has_partial": has_partial,
         "last_transport": last_transport,
         "resumable": (
-            has_matching_incomplete and last_transport == download_registry.TRANSPORT_HTTP
+            has_resumable_incomplete and last_transport == download_registry.TRANSPORT_HTTP
         ),
     }
 

--- a/studio/backend/hub/services/snapshot_progress.py
+++ b/studio/backend/hub/services/snapshot_progress.py
@@ -533,9 +533,7 @@ def compute_snapshot_progress(
         completed_bytes = 0
         # Keyed by logical blob: a broken advisory lock leaves several process-unique writers
         # racing on one etag, and each downloads the WHOLE file, so summing them overshoots.
-        # Each reading carries its mtime, because "largest" alone cannot tell a racer apart
-        # from the corpse of a killed attempt (see the reduction below the scan).
-        partial_readings: dict[str, list[tuple[float, int]]] = {}
+        partial_bytes: dict[str, int] = {}
         completed_hashes: set[str] = set()
         # A partial this reading could not attribute to any target. It is not evidence FOR this
         # variant -- it may be a sibling quant's -- but with the hashes unresolved it is not
@@ -576,8 +574,8 @@ def compute_snapshot_progress(
                         elif not count_unscoped:
                             unattributable_partial = True
                             continue
-                        partial_readings.setdefault(partial_hash, []).append(
-                            (f.stat().st_mtime, blob_bytes_present(f))
+                        partial_bytes[partial_hash] = max(
+                            partial_bytes.get(partial_hash, 0), blob_bytes_present(f)
                         )
                     else:
                         if expected_hashes:
@@ -599,19 +597,18 @@ def compute_snapshot_progress(
         # no bytes in flight, pinned a fully downloaded variant at 0.99 until the orphan was
         # swept -- and an orphan outlives the process that would have unlinked it on the way out.
         for blob_hash in completed_hashes:
-            partial_readings.pop(blob_hash, None)
-        # Among writers for one blob, the most recently touched one IS the reading. A retry
-        # leaves the killed attempt's partial beside the replacement's, both unresumable and
-        # both named for the same etag, and taking the larger reported the corpse -- freezing
-        # the bar at the dead attempt's high-water mark until the live transfer overtook it.
-        # Size cannot separate them, and neither can the gap between their mtimes, which is
-        # smallest exactly when the retry was quickest. Only "which one is still being
-        # written" can, and huggingface_hub writes continuously, so that is the newest mtime.
-        # Genuine concurrent racers are all advancing within a chunk of each other, so
-        # preferring the freshest over the largest costs at most a chunk there.
-        partial_bytes: dict[str, int] = {}
-        for blob_hash, writers in partial_readings.items():
-            partial_bytes[blob_hash] = max(writers)[1]
+            partial_bytes.pop(blob_hash, None)
+        # Largest wins, deliberately, even though a killed attempt's partial can sit beside its
+        # replacement's under the same etag. Preferring the freshest mtime reads better against
+        # a corpse but oscillates between two GENUINELY live writers, which is what a broken
+        # advisory lock produces: each write makes a different one newest, so the bar would
+        # jump between the leader and the straggler.
+        #
+        # A corpse is not this reading's problem to solve, because it should not outlive the
+        # job that made it: a terminal job sweeps its own blobs without waiting out the
+        # abandonment grace, and a backend that died before it could is caught at boot. If one
+        # survives both (an unrelated client holding the blob lock over it) the bar over-reads
+        # until the next sweep, which is a smaller wrong than a reading that will not sit still.
         in_progress_bytes = sum(partial_bytes.values())
         snapshot_dirs: "_Lazy[list[Path]]" = _Lazy(
             lambda entry = entry: _retained_snapshot_dirs(entry)

--- a/studio/backend/hub/services/snapshot_progress.py
+++ b/studio/backend/hub/services/snapshot_progress.py
@@ -25,7 +25,6 @@ from hub.utils import download_registry
 from hub.utils import inventory_scan as hf_cache_scan
 from hub.utils.state_dir import RepoType
 from hub.utils.hf_cache_state import (
-    ABANDONED_PARTIAL_SECONDS,
     blob_bytes_present,
     incomplete_blob_hash,
     preferred_repo_cache_dirs,
@@ -601,18 +600,18 @@ def compute_snapshot_progress(
         # swept -- and an orphan outlives the process that would have unlinked it on the way out.
         for blob_hash in completed_hashes:
             partial_readings.pop(blob_hash, None)
-        # Among writers for one blob, only those still keeping pace with the freshest count.
-        # A retry inside the sweep's grace leaves the killed attempt's partial next to the
-        # replacement's, both unresumable and both named for the same etag, and taking the
-        # larger reported the corpse -- freezing the bar at the dead attempt's high-water mark
-        # until the live transfer overtook it. Genuine concurrent writers are all advancing, so
-        # they stay in and the largest of them still wins.
+        # Among writers for one blob, the most recently touched one IS the reading. A retry
+        # leaves the killed attempt's partial beside the replacement's, both unresumable and
+        # both named for the same etag, and taking the larger reported the corpse -- freezing
+        # the bar at the dead attempt's high-water mark until the live transfer overtook it.
+        # Size cannot separate them, and neither can the gap between their mtimes, which is
+        # smallest exactly when the retry was quickest. Only "which one is still being
+        # written" can, and huggingface_hub writes continuously, so that is the newest mtime.
+        # Genuine concurrent racers are all advancing within a chunk of each other, so
+        # preferring the freshest over the largest costs at most a chunk there.
         partial_bytes: dict[str, int] = {}
         for blob_hash, writers in partial_readings.items():
-            freshest = max(mtime for mtime, _ in writers)
-            partial_bytes[blob_hash] = max(
-                size for mtime, size in writers if freshest - mtime <= ABANDONED_PARTIAL_SECONDS
-            )
+            partial_bytes[blob_hash] = max(writers)[1]
         in_progress_bytes = sum(partial_bytes.values())
         snapshot_dirs: "_Lazy[list[Path]]" = _Lazy(
             lambda entry = entry: _retained_snapshot_dirs(entry)

--- a/studio/backend/hub/services/snapshot_progress.py
+++ b/studio/backend/hub/services/snapshot_progress.py
@@ -25,6 +25,7 @@ from hub.utils import download_registry
 from hub.utils import inventory_scan as hf_cache_scan
 from hub.utils.state_dir import RepoType
 from hub.utils.hf_cache_state import (
+    ABANDONED_PARTIAL_SECONDS,
     blob_bytes_present,
     incomplete_blob_hash,
     preferred_repo_cache_dirs,
@@ -504,9 +505,11 @@ def compute_snapshot_progress(
     variant_file_set_unknown = variant is not None and not expected_hashes
     # Resolved at most once, and only if a reading gets far enough to need it.
     metadata_files: "_Lazy[tuple[download_manifest.ExpectedFile, ...]]" = _Lazy(
-        lambda: tuple(expected_files_resolver(repo_id, hf_token))
-        if expected_files_resolver is not None
-        else ()
+        lambda: (
+            tuple(expected_files_resolver(repo_id, hf_token))
+            if expected_files_resolver is not None
+            else ()
+        )
     )
 
     readings: list[tuple[int, int, Optional[str], bool, Optional[bool]]] = []
@@ -531,7 +534,9 @@ def compute_snapshot_progress(
         completed_bytes = 0
         # Keyed by logical blob: a broken advisory lock leaves several process-unique writers
         # racing on one etag, and each downloads the WHOLE file, so summing them overshoots.
-        partial_bytes: dict[str, int] = {}
+        # Each reading carries its mtime, because "largest" alone cannot tell a racer apart
+        # from the corpse of a killed attempt (see the reduction below the scan).
+        partial_readings: dict[str, list[tuple[float, int]]] = {}
         completed_hashes: set[str] = set()
         # A partial this reading could not attribute to any target. It is not evidence FOR this
         # variant -- it may be a sibling quant's -- but with the hashes unresolved it is not
@@ -572,8 +577,8 @@ def compute_snapshot_progress(
                         elif not count_unscoped:
                             unattributable_partial = True
                             continue
-                        partial_bytes[partial_hash] = max(
-                            partial_bytes.get(partial_hash, 0), blob_bytes_present(f)
+                        partial_readings.setdefault(partial_hash, []).append(
+                            (f.stat().st_mtime, blob_bytes_present(f))
                         )
                     else:
                         if expected_hashes:
@@ -595,7 +600,19 @@ def compute_snapshot_progress(
         # no bytes in flight, pinned a fully downloaded variant at 0.99 until the orphan was
         # swept -- and an orphan outlives the process that would have unlinked it on the way out.
         for blob_hash in completed_hashes:
-            partial_bytes.pop(blob_hash, None)
+            partial_readings.pop(blob_hash, None)
+        # Among writers for one blob, only those still keeping pace with the freshest count.
+        # A retry inside the sweep's grace leaves the killed attempt's partial next to the
+        # replacement's, both unresumable and both named for the same etag, and taking the
+        # larger reported the corpse -- freezing the bar at the dead attempt's high-water mark
+        # until the live transfer overtook it. Genuine concurrent writers are all advancing, so
+        # they stay in and the largest of them still wins.
+        partial_bytes: dict[str, int] = {}
+        for blob_hash, writers in partial_readings.items():
+            freshest = max(mtime for mtime, _ in writers)
+            partial_bytes[blob_hash] = max(
+                size for mtime, size in writers if freshest - mtime <= ABANDONED_PARTIAL_SECONDS
+            )
         in_progress_bytes = sum(partial_bytes.values())
         snapshot_dirs: "_Lazy[list[Path]]" = _Lazy(
             lambda entry = entry: _retained_snapshot_dirs(entry)

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -1371,9 +1371,9 @@ def test_cached_gguf_scan_degrades_when_the_shared_index_cannot_be_built(monkeyp
         )
 
     rows = cache_inventory._scan_cached_gguf()
-    assert "Org/Good" in {
-        row["repo_id"] for row in rows
-    }, "one unhashable repo identity emptied the whole GGUF inventory"
+    assert "Org/Good" in {row["repo_id"] for row in rows}, (
+        "one unhashable repo identity emptied the whole GGUF inventory"
+    )
 
 
 def test_state_scan_survives_a_state_filename_with_an_undecodable_byte(monkeypatch, tmp_path):
@@ -4850,7 +4850,9 @@ def test_prepare_cache_for_transport_purges_cross_transport_companion(monkeypatc
 
 def test_prepare_cache_for_transport_preserves_same_transport_companion(monkeypatch, tmp_path):
     """Only a hub that can still append to the partial earns the same-transport reprieve."""
-    monkeypatch.setattr(download_registry, "hf_partials_are_resumable", lambda: True)
+    # The purge asks partial_is_resumable, so patching the hub-version helper it wraps would
+    # be a no-op here.
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: True)
     blobs = _vision_cache_root(monkeypatch, tmp_path)
     companion = frozenset({"shared-mmproj"})
 
@@ -4862,7 +4864,11 @@ def test_prepare_cache_for_transport_preserves_same_transport_companion(monkeypa
         only_blob_hashes = frozenset({"q4-main"}),
         companion_blob_hashes = companion,
     )
-    (blobs / "shared-mmproj.incomplete").write_bytes(b"resumable")
+    partial = blobs / "shared-mmproj.incomplete"
+    partial.write_bytes(b"resumable")
+    # Aged past the abandonment grace, so the reprieve is what preserves it, not its freshness.
+    old = time.time() - download_registry._ABANDONED_PARTIAL_SECONDS - 60
+    os.utime(partial, (old, old))
 
     purged = download_registry.prepare_cache_for_transport(
         "model",
@@ -4874,7 +4880,7 @@ def test_prepare_cache_for_transport_preserves_same_transport_companion(monkeypa
     )
 
     assert purged == 0
-    assert (blobs / "shared-mmproj.incomplete").exists()
+    assert partial.exists()
 
 
 def test_prepare_cache_for_transport_protects_peer_companion(monkeypatch, tmp_path):
@@ -5724,9 +5730,9 @@ def test_a_root_that_will_not_resolve_is_a_scan_error(monkeypatch, tmp_path):
     monkeypatch.setattr(Path, "resolve", _boom)
     errors: list = []
     assert state.hf_cache_roots(errors) == []
-    assert any(
-        "network mount unavailable" in str(e) for e in errors
-    ), "the unreadable root has to be reported, not silently dropped"
+    assert any("network mount unavailable" in str(e) for e in errors), (
+        "the unreadable root has to be reported, not silently dropped"
+    )
 
 
 def test_a_partial_scan_cannot_report_the_target_as_gone(monkeypatch, tmp_path):

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -1371,9 +1371,9 @@ def test_cached_gguf_scan_degrades_when_the_shared_index_cannot_be_built(monkeyp
         )
 
     rows = cache_inventory._scan_cached_gguf()
-    assert "Org/Good" in {row["repo_id"] for row in rows}, (
-        "one unhashable repo identity emptied the whole GGUF inventory"
-    )
+    assert "Org/Good" in {
+        row["repo_id"] for row in rows
+    }, "one unhashable repo identity emptied the whole GGUF inventory"
 
 
 def test_state_scan_survives_a_state_filename_with_an_undecodable_byte(monkeypatch, tmp_path):
@@ -5724,9 +5724,9 @@ def test_a_root_that_will_not_resolve_is_a_scan_error(monkeypatch, tmp_path):
     monkeypatch.setattr(Path, "resolve", _boom)
     errors: list = []
     assert state.hf_cache_roots(errors) == []
-    assert any("network mount unavailable" in str(e) for e in errors), (
-        "the unreadable root has to be reported, not silently dropped"
-    )
+    assert any(
+        "network mount unavailable" in str(e) for e in errors
+    ), "the unreadable root has to be reported, not silently dropped"
 
 
 def test_a_partial_scan_cannot_report_the_target_as_gone(monkeypatch, tmp_path):

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -4867,7 +4867,7 @@ def test_prepare_cache_for_transport_preserves_same_transport_companion(monkeypa
     partial = blobs / "shared-mmproj.incomplete"
     partial.write_bytes(b"resumable")
     # Aged past the abandonment grace, so the reprieve is what preserves it, not its freshness.
-    old = time.time() - download_registry._ABANDONED_PARTIAL_SECONDS - 60
+    old = time.time() - download_registry.ABANDONED_PARTIAL_SECONDS - 60
     os.utime(partial, (old, old))
 
     purged = download_registry.prepare_cache_for_transport(

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -1371,9 +1371,9 @@ def test_cached_gguf_scan_degrades_when_the_shared_index_cannot_be_built(monkeyp
         )
 
     rows = cache_inventory._scan_cached_gguf()
-    assert "Org/Good" in {row["repo_id"] for row in rows}, (
-        "one unhashable repo identity emptied the whole GGUF inventory"
-    )
+    assert "Org/Good" in {
+        row["repo_id"] for row in rows
+    }, "one unhashable repo identity emptied the whole GGUF inventory"
 
 
 def test_state_scan_survives_a_state_filename_with_an_undecodable_byte(monkeypatch, tmp_path):
@@ -5730,9 +5730,9 @@ def test_a_root_that_will_not_resolve_is_a_scan_error(monkeypatch, tmp_path):
     monkeypatch.setattr(Path, "resolve", _boom)
     errors: list = []
     assert state.hf_cache_roots(errors) == []
-    assert any("network mount unavailable" in str(e) for e in errors), (
-        "the unreadable root has to be reported, not silently dropped"
-    )
+    assert any(
+        "network mount unavailable" in str(e) for e in errors
+    ), "the unreadable root has to be reported, not silently dropped"
 
 
 def test_a_partial_scan_cannot_report_the_target_as_gone(monkeypatch, tmp_path):

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -1371,9 +1371,9 @@ def test_cached_gguf_scan_degrades_when_the_shared_index_cannot_be_built(monkeyp
         )
 
     rows = cache_inventory._scan_cached_gguf()
-    assert "Org/Good" in {
-        row["repo_id"] for row in rows
-    }, "one unhashable repo identity emptied the whole GGUF inventory"
+    assert "Org/Good" in {row["repo_id"] for row in rows}, (
+        "one unhashable repo identity emptied the whole GGUF inventory"
+    )
 
 
 def test_state_scan_survives_a_state_filename_with_an_undecodable_byte(monkeypatch, tmp_path):
@@ -4849,6 +4849,8 @@ def test_prepare_cache_for_transport_purges_cross_transport_companion(monkeypatc
 
 
 def test_prepare_cache_for_transport_preserves_same_transport_companion(monkeypatch, tmp_path):
+    """Only a hub that can still append to the partial earns the same-transport reprieve."""
+    monkeypatch.setattr(download_registry, "hf_partials_are_resumable", lambda: True)
     blobs = _vision_cache_root(monkeypatch, tmp_path)
     companion = frozenset({"shared-mmproj"})
 
@@ -5722,9 +5724,9 @@ def test_a_root_that_will_not_resolve_is_a_scan_error(monkeypatch, tmp_path):
     monkeypatch.setattr(Path, "resolve", _boom)
     errors: list = []
     assert state.hf_cache_roots(errors) == []
-    assert any(
-        "network mount unavailable" in str(e) for e in errors
-    ), "the unreadable root has to be reported, not silently dropped"
+    assert any("network mount unavailable" in str(e) for e in errors), (
+        "the unreadable root has to be reported, not silently dropped"
+    )
 
 
 def test_a_partial_scan_cannot_report_the_target_as_gone(monkeypatch, tmp_path):

--- a/studio/backend/hub/tests/test_process_unique_incomplete_repro.py
+++ b/studio/backend/hub/tests/test_process_unique_incomplete_repro.py
@@ -377,15 +377,19 @@ def test_finalized_blob_supersedes_an_orphaned_partial(monkeypatch, tmp_path):
 
 
 def test_progress_reports_the_live_writer_not_the_killed_attempt(monkeypatch, tmp_path):
-    """A retry inside the sweep's grace leaves the corpse next to the replacement."""
+    """The immediate retry: both partials written seconds apart, the corpse the larger."""
     entry = tmp_path / "models--Org--Model-GGUF"
     blobs = entry / "blobs"
     blobs.mkdir(parents = True)
     corpse = blobs / f"{_BLOB_HASH}.11111111.incomplete"
     corpse.write_bytes(b"x" * 80)
-    stale = time.time() - snapshot_progress.ABANDONED_PARTIAL_SECONDS - 60
-    os.utime(corpse, (stale, stale))
-    (blobs / f"{_BLOB_HASH}.22222222.incomplete").write_bytes(b"x" * 10)
+    live = blobs / f"{_BLOB_HASH}.22222222.incomplete"
+    live.write_bytes(b"x" * 10)
+    # A retry seconds after the kill, so the two mtimes are far closer together than any
+    # abandonment threshold. Only which one is still advancing separates them.
+    now = time.time()
+    os.utime(corpse, (now - 8, now - 8))
+    os.utime(live, (now, now))
 
     monkeypatch.setattr(
         snapshot_progress,

--- a/studio/backend/hub/tests/test_process_unique_incomplete_repro.py
+++ b/studio/backend/hub/tests/test_process_unique_incomplete_repro.py
@@ -376,36 +376,36 @@ def test_finalized_blob_supersedes_an_orphaned_partial(monkeypatch, tmp_path):
     assert result["progress"] == 1.0
 
 
-def test_progress_reports_the_live_writer_not_the_killed_attempt(monkeypatch, tmp_path):
-    """The immediate retry: both partials written seconds apart, the corpse the larger."""
+def test_progress_is_stable_across_which_racer_wrote_last(monkeypatch, tmp_path):
+    """Two genuinely live writers must not make the bar jump between leader and straggler."""
     entry = tmp_path / "models--Org--Model-GGUF"
     blobs = entry / "blobs"
     blobs.mkdir(parents = True)
-    corpse = blobs / f"{_BLOB_HASH}.11111111.incomplete"
-    corpse.write_bytes(b"x" * 80)
-    live = blobs / f"{_BLOB_HASH}.22222222.incomplete"
-    live.write_bytes(b"x" * 10)
-    # A retry seconds after the kill, so the two mtimes are far closer together than any
-    # abandonment threshold. Only which one is still advancing separates them.
-    now = time.time()
-    os.utime(corpse, (now - 8, now - 8))
-    os.utime(live, (now, now))
+    leader = blobs / f"{_BLOB_HASH}.11111111.incomplete"
+    leader.write_bytes(b"x" * 80)
+    straggler = blobs / f"{_BLOB_HASH}.22222222.incomplete"
+    straggler.write_bytes(b"x" * 10)
 
     monkeypatch.setattr(
         snapshot_progress,
         "preferred_repo_cache_dirs",
         lambda *_args, **_kwargs: [entry],
     )
-    result = snapshot_progress.compute_snapshot_progress(
-        repo_type = "model",
-        repo_id = "Org/Model-GGUF",
-        job_key = "model:org/model-gguf#q4_k_m",
-        expected_bytes = 100,
-        hf_token = None,
-        registry = _running_registry(),
-        metadata_resolver = lambda *_args: (100, frozenset({_BLOB_HASH})),
-        variant = "Q4_K_M",
-    )
 
-    # Before: 80, the dead attempt's high-water mark, until the live one overtook it.
-    assert result["downloaded_bytes"] == 10
+    def _read():
+        return snapshot_progress.compute_snapshot_progress(
+            repo_type = "model",
+            repo_id = "Org/Model-GGUF",
+            job_key = "model:org/model-gguf#q4_k_m",
+            expected_bytes = 100,
+            hf_token = None,
+            registry = _running_registry(),
+            metadata_resolver = lambda *_args: (100, frozenset({_BLOB_HASH})),
+            variant = "Q4_K_M",
+        )
+
+    now = time.time()
+    for newest in (leader, straggler):
+        # Whichever of them happened to write last, the answer has to be the same one.
+        os.utime(newest, (now, now))
+        assert _read()["downloaded_bytes"] == 80

--- a/studio/backend/hub/tests/test_process_unique_incomplete_repro.py
+++ b/studio/backend/hub/tests/test_process_unique_incomplete_repro.py
@@ -3,6 +3,8 @@
 
 """Focused reproduction for Hugging Face's process-unique partial filenames."""
 
+import os
+import time
 from types import SimpleNamespace
 
 from hub.services import snapshot_progress
@@ -372,3 +374,34 @@ def test_finalized_blob_supersedes_an_orphaned_partial(monkeypatch, tmp_path):
     assert result["downloaded_bytes"] == 100
     assert result["complete_on_disk"] is True
     assert result["progress"] == 1.0
+
+
+def test_progress_reports_the_live_writer_not_the_killed_attempt(monkeypatch, tmp_path):
+    """A retry inside the sweep's grace leaves the corpse next to the replacement."""
+    entry = tmp_path / "models--Org--Model-GGUF"
+    blobs = entry / "blobs"
+    blobs.mkdir(parents = True)
+    corpse = blobs / f"{_BLOB_HASH}.11111111.incomplete"
+    corpse.write_bytes(b"x" * 80)
+    stale = time.time() - snapshot_progress.ABANDONED_PARTIAL_SECONDS - 60
+    os.utime(corpse, (stale, stale))
+    (blobs / f"{_BLOB_HASH}.22222222.incomplete").write_bytes(b"x" * 10)
+
+    monkeypatch.setattr(
+        snapshot_progress,
+        "preferred_repo_cache_dirs",
+        lambda *_args, **_kwargs: [entry],
+    )
+    result = snapshot_progress.compute_snapshot_progress(
+        repo_type = "model",
+        repo_id = "Org/Model-GGUF",
+        job_key = "model:org/model-gguf#q4_k_m",
+        expected_bytes = 100,
+        hf_token = None,
+        registry = _running_registry(),
+        metadata_resolver = lambda *_args: (100, frozenset({_BLOB_HASH})),
+        variant = "Q4_K_M",
+    )
+
+    # Before: 80, the dead attempt's high-water mark, until the live one overtook it.
+    assert result["downloaded_bytes"] == 10

--- a/studio/backend/hub/tests/test_process_unique_incomplete_repro.py
+++ b/studio/backend/hub/tests/test_process_unique_incomplete_repro.py
@@ -46,6 +46,19 @@ def test_registry_groups_duplicate_process_unique_writers_by_blob(monkeypatch, t
     )
 
     assert download_registry.incomplete_blob_hashes("model", "Org/Model") == {_BLOB_HASH}
+    # Nonce partials are refetched rather than resumed, so none of those bytes are bytes the
+    # next attempt gets to skip. Their grouping is still asserted, one blob not two.
+    assert (
+        download_registry.existing_blob_bytes(
+            "model",
+            "Org/Model",
+            frozenset({_BLOB_HASH}),
+        )
+        == 0
+    )
+
+    # The same grouping where the bytes DO count: a legacy partial under a writer that appends.
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: True)
     assert (
         download_registry.existing_blob_bytes(
             "model",

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -472,3 +472,52 @@ def test_the_boot_sweep_runs_after_the_orphan_is_killed(monkeypatch, tmp_path, b
 
     assert order[0] == "kill"
     assert not partial.exists()
+
+
+def test_a_companion_the_dead_worker_was_writing_is_owned_too(monkeypatch, blobs):
+    """A shared mmproj lives in progress_blob_hashes, never in the main blob_hashes set."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    companion = blobs / f"{_PEER}.feedface{hf_cache_state.INCOMPLETE_SUFFIX}"
+    companion.write_bytes(b"x" * 25)  # fresh, as a just-cancelled worker's companion would be
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    # Ownership limited to the variant's own quant leaves the companion waiting out the grace.
+    assert (
+        download_registry.sweep_abandoned_partials(
+            "model",
+            "Org/Model",
+            owned_blob_hashes = frozenset({_MAIN}),
+        )
+        == 0
+    )
+    assert companion.exists()
+
+    assert (
+        download_registry.sweep_abandoned_partials(
+            "model",
+            "Org/Model",
+            owned_blob_hashes = frozenset({_MAIN, _PEER}),
+        )
+        == 1
+    )
+    assert not companion.exists()
+
+
+def test_the_reaper_waits_for_the_worker_to_actually_die(monkeypatch):
+    """SIGKILL only schedules the death; the lock outlives the signal by a moment."""
+    alive = {"n": 3}
+
+    def _still_alive(_pid):
+        alive["n"] -= 1
+        return alive["n"] > 0
+
+    monkeypatch.setattr(download_registry.os, "kill", lambda *_a: None)
+    monkeypatch.setattr(download_registry, "_process_alive", _still_alive)
+
+    download_registry._kill_orphan(4242)
+
+    assert alive["n"] == 0  # returned only once the process was gone, not straight after kill

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""A partial no huggingface_hub can append to is litter, not resume state."""
+"""A partial no writer can reopen is litter, but only once nothing is writing it."""
+
+import os
+import time
 
 import pytest
 
@@ -10,17 +13,27 @@ from hub.utils import download_registry, hf_cache_state
 
 _MAIN = "a" * 64
 _PEER = "b" * 64
+_LEGACY_PARTIAL = f"{_MAIN}{hf_cache_state.INCOMPLETE_SUFFIX}"
+_NONCE_PARTIAL = f"{_MAIN}.deadbeef{hf_cache_state.INCOMPLETE_SUFFIX}"
 
 
 @pytest.fixture
 def blobs(monkeypatch, tmp_path):
     root = tmp_path / "hub"
-    entry = root / "models--Org--Model"
-    blobs_dir = entry / "blobs"
+    blobs_dir = root / "models--Org--Model" / "blobs"
     blobs_dir.mkdir(parents = True)
     monkeypatch.setenv("HF_HUB_CACHE", str(root))
     monkeypatch.setattr(download_registry, "hf_cache_root", lambda **_kwargs: root)
+    # iter_active_repo_cache_dirs resolves the root through hf_cache_state, not the caller.
+    monkeypatch.setattr(hf_cache_state, "hf_cache_root", lambda **_kwargs: root)
     return blobs_dir
+
+
+def _abandon(path):
+    """Backdate a partial past the grace, as an abandoned one would be."""
+    old = time.time() - download_registry._ABANDONED_PARTIAL_SECONDS - 60
+    os.utime(path, (old, old))
+    return path
 
 
 def _prepare(**kwargs):
@@ -46,7 +59,7 @@ def _prepare(**kwargs):
         ("not-a-version", True),
     ],
 )
-def test_resumability_tracks_the_installed_writer(monkeypatch, hf_version, resumable):
+def test_writer_resumability_tracks_the_installed_version(monkeypatch, hf_version, resumable):
     """1.18 is the line: before it a partial is appended to, after it a new file is written."""
     monkeypatch.setattr("huggingface_hub.__version__", hf_version, raising = False)
     hf_cache_state.hf_partials_are_resumable.cache_clear()
@@ -56,12 +69,21 @@ def test_resumability_tracks_the_installed_writer(monkeypatch, hf_version, resum
         hf_cache_state.hf_partials_are_resumable.cache_clear()
 
 
+def test_a_nonce_partial_is_unresumable_even_under_a_legacy_writer(monkeypatch):
+    """The nonce path is private to the process that made it; nothing reopens it by name."""
+    monkeypatch.setattr(hf_cache_state, "hf_partials_are_resumable", lambda: True)
+
+    assert hf_cache_state.partial_is_resumable(_LEGACY_PARTIAL) is True
+    assert hf_cache_state.partial_is_resumable(_NONCE_PARTIAL) is False
+
+
 def test_unresumable_partial_is_purged_despite_a_matching_marker(monkeypatch, blobs):
     """The marker vouches for provenance, which is worth nothing with no resumer left."""
-    monkeypatch.setattr(download_registry, "hf_partials_are_resumable", lambda: False)
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
     _prepare()  # writes the http marker
-    partial = blobs / f"{_MAIN}.deadbeef.incomplete"
+    partial = blobs / _NONCE_PARTIAL
     partial.write_bytes(b"x" * 25)
+    _abandon(partial)
 
     assert _prepare() == 1
     assert not partial.exists()
@@ -69,23 +91,54 @@ def test_unresumable_partial_is_purged_despite_a_matching_marker(monkeypatch, bl
 
 def test_resumable_partial_survives_a_matching_marker(monkeypatch, blobs):
     """Older hubs still append to it, so deleting it would throw away real bytes."""
-    monkeypatch.setattr(download_registry, "hf_partials_are_resumable", lambda: True)
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: True)
     _prepare()
-    partial = blobs / f"{_MAIN}{hf_cache_state.INCOMPLETE_SUFFIX}"
+    partial = blobs / _LEGACY_PARTIAL
     partial.write_bytes(b"x" * 25)
+    _abandon(partial)
 
     assert _prepare() == 0
     assert partial.exists()
 
 
+def test_a_partial_still_being_written_is_left_alone(monkeypatch, blobs):
+    """It may belong to a client this backend's peer registry cannot see."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    _prepare()
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)  # mtime is now, as a live writer's would be
+
+    assert _prepare() == 0
+    assert partial.exists()
+
+
+def test_a_mismatched_marker_still_purges_without_waiting(monkeypatch, blobs):
+    """That purge stops a corrupt append, so it cannot defer to a grace period."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: True)
+    download_registry.prepare_cache_for_transport(
+        "model",
+        "Org/Model",
+        download_registry.TRANSPORT_XET,
+        "Q4_K_M",
+        only_blob_hashes = frozenset({_MAIN}),
+    )
+    partial = blobs / _LEGACY_PARTIAL
+    partial.write_bytes(b"x" * 25)
+
+    assert _prepare() == 1
+    assert not partial.exists()
+
+
 def test_a_peer_being_written_is_still_protected(monkeypatch, blobs):
     """Unresumable is not a licence to delete a blob another download is writing now."""
-    monkeypatch.setattr(download_registry, "hf_partials_are_resumable", lambda: False)
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
     _prepare()
-    mine = blobs / f"{_MAIN}.deadbeef.incomplete"
+    mine = blobs / _NONCE_PARTIAL
     mine.write_bytes(b"x" * 25)
-    peer = blobs / f"{_PEER}.feedface.incomplete"
+    _abandon(mine)
+    peer = blobs / f"{_PEER}.feedface{hf_cache_state.INCOMPLETE_SUFFIX}"
     peer.write_bytes(b"x" * 25)
+    _abandon(peer)
 
     purged = download_registry.prepare_cache_for_transport(
         "model",
@@ -99,3 +152,15 @@ def test_a_peer_being_written_is_still_protected(monkeypatch, blobs):
     assert purged == 1
     assert not mine.exists()
     assert peer.exists()
+
+
+def test_transport_status_does_not_promise_a_resume_it_cannot_keep(monkeypatch, blobs):
+    """``resumable`` drives a dialog offering to keep existing progress."""
+    monkeypatch.setattr(download_registry, "read_active_transport_marker", lambda *_a, **_k: "http")
+    (blobs / _NONCE_PARTIAL).write_bytes(b"x" * 25)
+
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: True)
+    assert download_registry.is_resumable_partial("model", "Org/Model") is True
+
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    assert download_registry.is_resumable_partial("model", "Org/Model") is False

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -374,3 +374,101 @@ def test_ownership_never_overrides_peer_protection(monkeypatch, blobs):
 
     assert swept == 0
     assert partial.exists()
+
+
+def test_the_sweep_accepts_the_string_root_the_metadata_holds(monkeypatch, tmp_path):
+    """DownloadMetadata.hub_cache is a str, and the caller hands it straight through.
+
+    Deliberately not using the ``blobs`` fixture: patching hf_cache_root would hand the
+    resolver a Path and hide the very conversion under test.
+    """
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    blobs = tmp_path / "hub" / "models--Org--Model" / "blobs"
+    blobs.mkdir(parents = True)
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+    _abandon(partial)
+
+    # A Path-only signature raised AttributeError here, and the caller's broad except
+    # swallowed it, so the terminal sweep silently did nothing for every real download.
+    swept = download_registry.sweep_abandoned_partials(
+        "model",
+        "Org/Model",
+        root = str(blobs.parent.parent),
+    )
+
+    assert swept == 1
+    assert not partial.exists()
+
+
+def test_a_job_owning_its_whole_repo_needs_no_hash_list(monkeypatch, blobs):
+    """A download with no variant resolves no blob hashes, and claim() gives it the repo."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)  # fresh, as a just-cancelled snapshot download's would be
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    assert download_registry.sweep_abandoned_partials("model", "Org/Model") == 0
+    assert (
+        download_registry.sweep_abandoned_partials("model", "Org/Model", owns_all_blobs = True) == 1
+    )
+    assert not partial.exists()
+
+
+def test_the_boot_sweep_runs_after_the_orphan_is_killed(monkeypatch, tmp_path, blobs):
+    """Sweeping first reads the doomed worker's still-held lock and spares its partial."""
+    workers = tmp_path / "workers"
+    workers.mkdir()
+    (workers / "job.json").write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "repo_type": "model",
+                "repo_id": "Org/Model",
+                "variant": None,
+                "transport": "http",
+                "hub_cache": str(blobs.parent.parent),
+            }
+        ),
+        encoding = "utf-8",
+    )
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+
+    order = []
+    locked = {"held": True}
+    monkeypatch.setattr(download_registry.state_dir, "workers_dir", lambda: workers)
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    monkeypatch.setattr(download_registry, "_process_alive", lambda _pid: True)
+    monkeypatch.setattr(download_registry, "_is_our_worker", lambda *_a: True)
+    monkeypatch.setattr(download_registry, "_settle_orphaned_download", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        download_registry,
+        "hf_cache_roots",
+        lambda *_a, **_k: [blobs.parent.parent],
+    )
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    def _kill(_pid):
+        order.append("kill")
+        locked["held"] = False  # the lock dies with the process
+
+    monkeypatch.setattr(download_registry, "_kill_orphan", _kill)
+    monkeypatch.setattr(
+        download_registry,
+        "blob_download_lock_held",
+        lambda *_a: order.append("sweep") or locked["held"],
+    )
+
+    download_registry.reap_orphan_workers()
+
+    assert order[0] == "kill"
+    assert not partial.exists()

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import threading
 import time
 
 import pytest
@@ -25,9 +26,17 @@ def blobs(monkeypatch, tmp_path):
     blobs_dir.mkdir(parents = True)
     monkeypatch.setenv("HF_HUB_CACHE", str(root))
     monkeypatch.setattr(download_registry, "hf_cache_root", lambda **_kwargs: root)
-    # iter_active_repo_cache_dirs resolves the root through hf_cache_state, not the caller.
+    # The cache-dir iterators resolve the root through hf_cache_state, not the caller.
     monkeypatch.setattr(hf_cache_state, "hf_cache_root", lambda **_kwargs: root)
+    monkeypatch.setattr(hf_cache_state, "hf_cache_roots", lambda *_a, **_k: [root])
     return blobs_dir
+
+
+def _join_background_sweep():
+    """The all-caches pass is threaded so it cannot delay startup; wait for it here."""
+    for thread in threading.enumerate():
+        if thread.name == "hf-abandoned-partial-sweep":
+            thread.join(10)
 
 
 def _abandon(path):
@@ -243,7 +252,7 @@ def test_unresumable_bytes_are_not_credited_against_the_disk_check(monkeypatch, 
     (blobs / _NONCE_PARTIAL).write_bytes(b"x" * 25)
     monkeypatch.setattr(
         download_registry,
-        "iter_active_repo_cache_dirs",
+        "iter_destructive_repo_cache_dirs",
         lambda *_a, **_k: [blobs.parent],
     )
 
@@ -259,7 +268,7 @@ def test_a_finalized_blob_still_counts_against_the_disk_check(monkeypatch, blobs
     (blobs / _MAIN).write_bytes(b"x" * 25)
     monkeypatch.setattr(
         download_registry,
-        "iter_active_repo_cache_dirs",
+        "iter_destructive_repo_cache_dirs",
         lambda *_a, **_k: [blobs.parent],
     )
     monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
@@ -282,6 +291,7 @@ def test_startup_sweep_does_not_depend_on_a_breadcrumb(monkeypatch, tmp_path, bl
     )
 
     download_registry.reap_orphan_workers()
+    _join_background_sweep()
 
     assert not partial.exists()
 
@@ -301,6 +311,7 @@ def test_startup_sweep_leaves_a_resumable_partial_alone(monkeypatch, tmp_path, b
     )
 
     download_registry.reap_orphan_workers()
+    _join_background_sweep()
 
     assert partial.exists()
 
@@ -312,7 +323,7 @@ def test_a_reaped_job_does_not_wait_out_the_grace_on_its_own_blobs(monkeypatch, 
     partial.write_bytes(b"x" * 25)  # freshly written, as a just-cancelled download's would be
     monkeypatch.setattr(
         download_registry,
-        "iter_active_repo_cache_dirs",
+        "iter_destructive_repo_cache_dirs",
         lambda *_a, **_k: [blobs.parent],
     )
 
@@ -340,7 +351,7 @@ def test_ownership_never_overrides_the_lock(monkeypatch, blobs):
     _abandon(partial)
     monkeypatch.setattr(
         download_registry,
-        "iter_active_repo_cache_dirs",
+        "iter_destructive_repo_cache_dirs",
         lambda *_a, **_k: [blobs.parent],
     )
 
@@ -361,7 +372,7 @@ def test_ownership_never_overrides_peer_protection(monkeypatch, blobs):
     partial.write_bytes(b"x" * 25)
     monkeypatch.setattr(
         download_registry,
-        "iter_active_repo_cache_dirs",
+        "iter_destructive_repo_cache_dirs",
         lambda *_a, **_k: [blobs.parent],
     )
 
@@ -408,7 +419,7 @@ def test_a_job_owning_its_whole_repo_needs_no_hash_list(monkeypatch, blobs):
     partial.write_bytes(b"x" * 25)  # fresh, as a just-cancelled snapshot download's would be
     monkeypatch.setattr(
         download_registry,
-        "iter_active_repo_cache_dirs",
+        "iter_destructive_repo_cache_dirs",
         lambda *_a, **_k: [blobs.parent],
     )
 
@@ -453,13 +464,14 @@ def test_the_boot_sweep_runs_after_the_orphan_is_killed(monkeypatch, tmp_path, b
     )
     monkeypatch.setattr(
         download_registry,
-        "iter_active_repo_cache_dirs",
+        "iter_destructive_repo_cache_dirs",
         lambda *_a, **_k: [blobs.parent],
     )
 
     def _kill(_pid):
         order.append("kill")
         locked["held"] = False  # the lock dies with the process
+        return True
 
     monkeypatch.setattr(download_registry, "_kill_orphan", _kill)
     monkeypatch.setattr(
@@ -469,6 +481,7 @@ def test_the_boot_sweep_runs_after_the_orphan_is_killed(monkeypatch, tmp_path, b
     )
 
     download_registry.reap_orphan_workers()
+    _join_background_sweep()
 
     assert order[0] == "kill"
     assert not partial.exists()
@@ -481,7 +494,7 @@ def test_a_companion_the_dead_worker_was_writing_is_owned_too(monkeypatch, blobs
     companion.write_bytes(b"x" * 25)  # fresh, as a just-cancelled worker's companion would be
     monkeypatch.setattr(
         download_registry,
-        "iter_active_repo_cache_dirs",
+        "iter_destructive_repo_cache_dirs",
         lambda *_a, **_k: [blobs.parent],
     )
 
@@ -521,3 +534,110 @@ def test_the_reaper_waits_for_the_worker_to_actually_die(monkeypatch):
     download_registry._kill_orphan(4242)
 
     assert alive["n"] == 0  # returned only once the process was gone, not straight after kill
+
+
+def test_a_worker_that_will_not_die_keeps_its_breadcrumb_and_its_partial(
+    monkeypatch, tmp_path, blobs
+):
+    """An unreapable worker is still running, so nothing about it is ours to claim."""
+    workers = tmp_path / "workers"
+    workers.mkdir()
+    crumb = workers / "job.json"
+    crumb.write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "repo_type": "model",
+                "repo_id": "Org/Model",
+                "variant": None,
+                "transport": "http",
+                "hub_cache": str(blobs.parent.parent),
+            }
+        ),
+        encoding = "utf-8",
+    )
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+
+    monkeypatch.setattr(download_registry.state_dir, "workers_dir", lambda: workers)
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    monkeypatch.setattr(download_registry, "_process_alive", lambda _pid: True)
+    monkeypatch.setattr(download_registry, "_is_our_worker", lambda *_a: True)
+    monkeypatch.setattr(download_registry, "_kill_orphan", lambda _pid: False)  # would not die
+    monkeypatch.setattr(download_registry, "hf_cache_roots", lambda *_a, **_k: [tmp_path / "none"])
+
+    download_registry.reap_orphan_workers()
+    _join_background_sweep()
+
+    assert partial.exists()
+    assert crumb.exists()  # still tracked, so the next boot tries again
+
+
+def test_a_locked_peer_partial_still_counts_against_the_disk_check(monkeypatch, blobs):
+    """A sibling variant is finishing the shared companion, so we need no room for it."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    (blobs / _NONCE_PARTIAL).write_bytes(b"x" * 25)
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    monkeypatch.setattr(download_registry, "blob_download_lock_held", lambda *_a: False)
+    assert download_registry.existing_blob_bytes("model", "Org/Model", frozenset({_MAIN})) == 0
+
+    monkeypatch.setattr(download_registry, "blob_download_lock_held", lambda *_a: True)
+    assert download_registry.existing_blob_bytes("model", "Org/Model", frozenset({_MAIN})) == 25
+
+
+def test_the_sweep_will_not_cross_a_case_variant_directory(monkeypatch, tmp_path):
+    """owns_all_blobs plus a case-insensitive collision could otherwise reach a neighbour."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    root = tmp_path / "hub"
+    mine = root / "models--Org--Model" / "blobs"
+    other = root / "models--org--model" / "blobs"
+    mine.mkdir(parents = True)
+    other.mkdir(parents = True)
+    for blobs_dir in (mine, other):
+        partial = blobs_dir / _NONCE_PARTIAL
+        partial.write_bytes(b"x" * 25)
+        _abandon(partial)
+
+    download_registry.sweep_abandoned_partials(
+        "model",
+        "Org/Model",
+        owns_all_blobs = True,
+        root = str(root),
+    )
+
+    assert not (mine / _NONCE_PARTIAL).exists()
+    assert (other / _NONCE_PARTIAL).exists()
+
+
+def test_ownership_is_recovered_from_the_manifest_when_hashes_never_resolved(monkeypatch):
+    """A variant job whose API-side pre-resolution failed carries an EMPTY hash set."""
+    from types import SimpleNamespace
+
+    from hub.services import download_lifecycle
+    from hub.utils import download_manifest
+
+    metadata = SimpleNamespace(
+        variant = "Q4_K_M",
+        hub_cache = None,
+        progress_blob_hashes = frozenset(),
+    )
+    manifest = download_manifest.Manifest(
+        repo_type = "model",
+        repo_id = "Org/Model",
+        variant = "Q4_K_M",
+        started_at = "",
+        expected_files = (download_manifest.ExpectedFile(path = "m.gguf", size = 5, sha256 = _MAIN),),
+    )
+    monkeypatch.setattr(download_manifest, "read_manifest", lambda *_a, **_k: manifest)
+
+    owned, owns_all = download_lifecycle._sweep_ownership(
+        metadata, frozenset(), frozenset(), "model", "Org/Model"
+    )
+
+    assert owns_all is False  # a variant job never owns its siblings' blobs
+    assert owned == frozenset({_MAIN})

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -3,6 +3,7 @@
 
 """A partial no writer can reopen is litter, but only once nothing is writing it."""
 
+import json
 import os
 import time
 
@@ -201,3 +202,101 @@ def test_the_sweep_still_spares_a_live_writer_and_a_peer(monkeypatch, blobs):
     assert swept == 0
     assert live.exists()
     assert peer.exists()
+
+
+def test_a_locked_blob_is_spared_however_stale_it_looks(monkeypatch, blobs):
+    """A writer stalled past the grace still holds the lock, and still owns the file."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    _prepare()
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+    _abandon(partial)
+
+    monkeypatch.setattr(download_registry, "blob_download_lock_held", lambda *_a: True)
+    assert _prepare() == 0
+    assert partial.exists()
+
+    monkeypatch.setattr(download_registry, "blob_download_lock_held", lambda *_a: False)
+    assert _prepare() == 1
+    assert not partial.exists()
+
+
+def test_the_lock_probe_reads_the_layout_hf_writes(tmp_path):
+    """<hub cache>/.locks/<repo dir>/<etag>.lock, and no lock file means nobody is writing."""
+    from filelock import FileLock
+
+    entry = tmp_path / "models--Org--Model"
+    lock_path = tmp_path / ".locks" / "models--Org--Model" / f"{_MAIN}.lock"
+    lock_path.parent.mkdir(parents = True)
+
+    assert hf_cache_state.blob_download_lock_held(entry, _MAIN) is False
+
+    lock_path.touch()
+    assert hf_cache_state.blob_download_lock_held(entry, _MAIN) is False
+
+    with FileLock(str(lock_path), timeout = 0):
+        assert hf_cache_state.blob_download_lock_held(entry, _MAIN) is True
+
+
+def test_unresumable_bytes_are_not_credited_against_the_disk_check(monkeypatch, blobs):
+    """_preflight_disk_space subtracts this, so crediting a refetch can approve a full disk."""
+    (blobs / _NONCE_PARTIAL).write_bytes(b"x" * 25)
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    assert download_registry.existing_blob_bytes("model", "Org/Model", frozenset({_MAIN})) == 0
+
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: True)
+    assert download_registry.existing_blob_bytes("model", "Org/Model", frozenset({_MAIN})) == 25
+
+
+def test_a_finalized_blob_still_counts_against_the_disk_check(monkeypatch, blobs):
+    """Only partials are in question; a finished blob is bytes nobody refetches."""
+    (blobs / _MAIN).write_bytes(b"x" * 25)
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+
+    assert download_registry.existing_blob_bytes("model", "Org/Model", frozenset({_MAIN})) == 25
+
+
+def test_startup_reaping_sweeps_a_previous_run_orphan(monkeypatch, tmp_path, blobs):
+    """The guaranteed revisit: by the next boot the writer is a process that no longer exists."""
+    workers = tmp_path / "workers"
+    workers.mkdir()
+    (workers / "job.json").write_text(
+        json.dumps(
+            {
+                "pid": 999999999,
+                "repo_type": "model",
+                "repo_id": "Org/Model",
+                "variant": None,
+                "transport": "http",
+                "hub_cache": str(blobs.parent.parent),
+            }
+        ),
+        encoding = "utf-8",
+    )
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+    _abandon(partial)
+
+    monkeypatch.setattr(download_registry.state_dir, "workers_dir", lambda: workers)
+    monkeypatch.setattr(download_registry, "_settle_orphaned_download", lambda *_a, **_k: None)
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    download_registry.reap_orphan_workers()
+
+    assert not partial.exists()

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A partial no huggingface_hub can append to is litter, not resume state."""
+
+import pytest
+
+from hub.utils import download_registry, hf_cache_state
+
+
+_MAIN = "a" * 64
+_PEER = "b" * 64
+
+
+@pytest.fixture
+def blobs(monkeypatch, tmp_path):
+    root = tmp_path / "hub"
+    entry = root / "models--Org--Model"
+    blobs_dir = entry / "blobs"
+    blobs_dir.mkdir(parents = True)
+    monkeypatch.setenv("HF_HUB_CACHE", str(root))
+    monkeypatch.setattr(download_registry, "hf_cache_root", lambda **_kwargs: root)
+    return blobs_dir
+
+
+def _prepare(**kwargs):
+    return download_registry.prepare_cache_for_transport(
+        "model",
+        "Org/Model",
+        download_registry.TRANSPORT_HTTP,
+        "Q4_K_M",
+        only_blob_hashes = frozenset({_MAIN}),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    "hf_version, resumable",
+    [
+        ("0.36.2", True),
+        ("1.17.0", True),
+        ("1.18.0", False),
+        ("1.23.0", False),
+        ("1.27.0", False),
+        ("2.0.0.dev0", False),
+        ("not-a-version", True),
+    ],
+)
+def test_resumability_tracks_the_installed_writer(monkeypatch, hf_version, resumable):
+    """1.18 is the line: before it a partial is appended to, after it a new file is written."""
+    monkeypatch.setattr("huggingface_hub.__version__", hf_version, raising = False)
+    hf_cache_state.hf_partials_are_resumable.cache_clear()
+    try:
+        assert hf_cache_state.hf_partials_are_resumable() is resumable
+    finally:
+        hf_cache_state.hf_partials_are_resumable.cache_clear()
+
+
+def test_unresumable_partial_is_purged_despite_a_matching_marker(monkeypatch, blobs):
+    """The marker vouches for provenance, which is worth nothing with no resumer left."""
+    monkeypatch.setattr(download_registry, "hf_partials_are_resumable", lambda: False)
+    _prepare()  # writes the http marker
+    partial = blobs / f"{_MAIN}.deadbeef.incomplete"
+    partial.write_bytes(b"x" * 25)
+
+    assert _prepare() == 1
+    assert not partial.exists()
+
+
+def test_resumable_partial_survives_a_matching_marker(monkeypatch, blobs):
+    """Older hubs still append to it, so deleting it would throw away real bytes."""
+    monkeypatch.setattr(download_registry, "hf_partials_are_resumable", lambda: True)
+    _prepare()
+    partial = blobs / f"{_MAIN}{hf_cache_state.INCOMPLETE_SUFFIX}"
+    partial.write_bytes(b"x" * 25)
+
+    assert _prepare() == 0
+    assert partial.exists()
+
+
+def test_a_peer_being_written_is_still_protected(monkeypatch, blobs):
+    """Unresumable is not a licence to delete a blob another download is writing now."""
+    monkeypatch.setattr(download_registry, "hf_partials_are_resumable", lambda: False)
+    _prepare()
+    mine = blobs / f"{_MAIN}.deadbeef.incomplete"
+    mine.write_bytes(b"x" * 25)
+    peer = blobs / f"{_PEER}.feedface.incomplete"
+    peer.write_bytes(b"x" * 25)
+
+    purged = download_registry.prepare_cache_for_transport(
+        "model",
+        "Org/Model",
+        download_registry.TRANSPORT_HTTP,
+        "Q4_K_M",
+        only_blob_hashes = frozenset({_MAIN, _PEER}),
+        protected_blob_hashes = frozenset({_PEER}),
+    )
+
+    assert purged == 1
+    assert not mine.exists()
+    assert peer.exists()

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -641,3 +641,82 @@ def test_ownership_is_recovered_from_the_manifest_when_hashes_never_resolved(mon
 
     assert owns_all is False  # a variant job never owns its siblings' blobs
     assert owned == frozenset({_MAIN})
+
+
+def test_a_filesystem_without_flock_does_not_escape_the_probe(monkeypatch, tmp_path):
+    """NotImplementedError used to travel out and fail the download on every retry."""
+    import filelock
+
+    entry = tmp_path / "models--Org--Model"
+    lock_path = tmp_path / ".locks" / "models--Org--Model" / f"{_MAIN}.lock"
+    lock_path.parent.mkdir(parents = True)
+
+    class _NoFlock:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def __enter__(self):
+            raise NotImplementedError(
+                "FileSystem does not appear to support flock; use SoftFileLock instead"
+            )
+
+        def __exit__(self, *_a):
+            return False
+
+    monkeypatch.setattr(filelock, "FileLock", _NoFlock)
+
+    # No lock file: nobody has locked this blob, whatever the filesystem supports.
+    assert hf_cache_state.blob_download_lock_held(entry, _MAIN) is False
+
+    # With one, the answer is "held" rather than an exception -- which is also what a
+    # SoftFileLock would say, since its file IS the lock and that file is present.
+    lock_path.touch()
+    assert hf_cache_state.blob_download_lock_held(entry, _MAIN) is True
+
+
+def test_an_unprobeable_lock_reads_as_held(monkeypatch, tmp_path):
+    """Ownership can skip the staleness gate, so a wrong 'free' deletes a live writer's file."""
+    import filelock
+
+    entry = tmp_path / "models--Org--Model"
+    lock_path = tmp_path / ".locks" / "models--Org--Model" / f"{_MAIN}.lock"
+    lock_path.parent.mkdir(parents = True)
+    lock_path.touch()
+
+    class _Broken:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def __enter__(self):
+            raise RuntimeError("something unforeseen")
+
+        def __exit__(self, *_a):
+            return False
+
+    monkeypatch.setattr(filelock, "FileLock", _Broken)
+
+    assert hf_cache_state.blob_download_lock_held(entry, _MAIN) is True
+
+
+def test_unreadable_breadcrumbs_do_not_cancel_the_cache_sweep(monkeypatch, tmp_path, blobs):
+    """The workers dir and the HF caches are separate trees; one failing is not the other."""
+    workers = tmp_path / "workers"
+    workers.mkdir()
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+    _abandon(partial)
+
+    class _UnreadableDir:
+        def iterdir(self):
+            raise OSError("permission denied")
+
+    monkeypatch.setattr(download_registry.state_dir, "workers_dir", lambda: _UnreadableDir())
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    monkeypatch.setattr(
+        download_registry, "hf_cache_roots", lambda *_a, **_k: [blobs.parent.parent]
+    )
+
+    download_registry.reap_orphan_workers()
+    _join_background_sweep()
+
+    assert not partial.exists()

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -164,3 +164,40 @@ def test_transport_status_does_not_promise_a_resume_it_cannot_keep(monkeypatch, 
 
     monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
     assert download_registry.is_resumable_partial("model", "Org/Model") is False
+
+
+def test_a_skipped_partial_is_swept_once_it_ages_out(monkeypatch, blobs):
+    """The start-of-download skip is not the last word on an orphan."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    _prepare()
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+
+    # Too fresh at download start, so prepare leaves it alone.
+    assert _prepare() == 0
+    assert partial.exists()
+
+    # By the time that download reaches a terminal state the grace has elapsed.
+    _abandon(partial)
+    assert download_registry.sweep_abandoned_partials("model", "Org/Model") == 1
+    assert not partial.exists()
+
+
+def test_the_sweep_still_spares_a_live_writer_and_a_peer(monkeypatch, blobs):
+    """A terminal state for one job says nothing about what another is writing."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    live = blobs / _NONCE_PARTIAL
+    live.write_bytes(b"x" * 25)
+    peer = blobs / f"{_PEER}.feedface{hf_cache_state.INCOMPLETE_SUFFIX}"
+    peer.write_bytes(b"x" * 25)
+    _abandon(peer)
+
+    swept = download_registry.sweep_abandoned_partials(
+        "model",
+        "Org/Model",
+        protected_blob_hashes = frozenset({_PEER}),
+    )
+
+    assert swept == 0
+    assert live.exists()
+    assert peer.exists()

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -720,3 +720,95 @@ def test_unreadable_breadcrumbs_do_not_cancel_the_cache_sweep(monkeypatch, tmp_p
     _join_background_sweep()
 
     assert not partial.exists()
+
+
+def test_an_owned_partial_that_is_still_growing_is_spared(monkeypatch, blobs):
+    """Ownership proves OUR writer died, never that no other process shares the cache."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    monkeypatch.setattr(download_registry, "blob_download_lock_held", lambda *_a: False)  # lies
+    monkeypatch.setattr(download_registry, "_STILLNESS_PROBE_SECONDS", 0.05)
+    monkeypatch.setattr(
+        download_registry,
+        "iter_destructive_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+
+    real_sleep = time.sleep
+
+    def _write_while_we_watch(_seconds):
+        real_sleep(_seconds)
+        with partial.open("ab") as handle:
+            handle.write(b"y" * 10)  # an external writer, mid-transfer
+
+    monkeypatch.setattr(download_registry.time, "sleep", _write_while_we_watch)
+
+    swept = download_registry.sweep_abandoned_partials(
+        "model",
+        "Org/Model",
+        owns_all_blobs = True,
+    )
+
+    assert swept == 0
+    assert partial.exists()
+
+
+def test_an_owned_partial_that_never_moves_is_swept_without_the_full_grace(monkeypatch, blobs):
+    """The corpse of a cancelled download must not outlive the retry that follows it."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    monkeypatch.setattr(download_registry, "_STILLNESS_PROBE_SECONDS", 0.05)
+    monkeypatch.setattr(
+        download_registry,
+        "iter_destructive_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)  # written seconds ago, far inside the abandonment grace
+
+    swept = download_registry.sweep_abandoned_partials(
+        "model",
+        "Org/Model",
+        owns_all_blobs = True,
+    )
+
+    assert swept == 1
+    assert not partial.exists()
+
+
+def test_a_breadcrumb_whose_worker_already_exited_is_claimed(monkeypatch, tmp_path, blobs):
+    """A container restart leaves the crumb behind and the pid long gone."""
+    workers = tmp_path / "workers"
+    workers.mkdir()
+    (workers / "job.json").write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "repo_type": "model",
+                "repo_id": "Org/Model",
+                "variant": None,
+                "transport": "http",
+                "hub_cache": str(blobs.parent.parent),
+            }
+        ),
+        encoding = "utf-8",
+    )
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)  # fresh, so only an ownership claim reaches it
+
+    monkeypatch.setattr(download_registry.state_dir, "workers_dir", lambda: workers)
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    monkeypatch.setattr(download_registry, "_process_alive", lambda _pid: False)  # already dead
+    monkeypatch.setattr(download_registry, "_STILLNESS_PROBE_SECONDS", 0.05)
+    monkeypatch.setattr(download_registry, "_settle_orphaned_download", lambda *_a, **_k: None)
+    monkeypatch.setattr(download_registry, "hf_cache_roots", lambda *_a, **_k: [tmp_path / "none"])
+    monkeypatch.setattr(
+        download_registry,
+        "iter_destructive_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    download_registry.reap_orphan_workers()
+    _join_background_sweep()
+
+    assert not partial.exists()

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -303,3 +303,74 @@ def test_startup_sweep_leaves_a_resumable_partial_alone(monkeypatch, tmp_path, b
     download_registry.reap_orphan_workers()
 
     assert partial.exists()
+
+
+def test_a_reaped_job_does_not_wait_out_the_grace_on_its_own_blobs(monkeypatch, blobs):
+    """Cancelling writes the partial seconds before the sweep, so waiting strands it."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)  # freshly written, as a just-cancelled download's would be
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    # Without the ownership claim it has to wait, which is what stranded it for the session.
+    assert download_registry.sweep_abandoned_partials("model", "Org/Model") == 0
+    assert partial.exists()
+
+    assert (
+        download_registry.sweep_abandoned_partials(
+            "model",
+            "Org/Model",
+            owned_blob_hashes = frozenset({_MAIN}),
+        )
+        == 1
+    )
+    assert not partial.exists()
+
+
+def test_ownership_never_overrides_the_lock(monkeypatch, blobs):
+    """hf locks before it creates the temp file, so a locked blob has a live writer."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    monkeypatch.setattr(download_registry, "blob_download_lock_held", lambda *_a: True)
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+    _abandon(partial)
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    swept = download_registry.sweep_abandoned_partials(
+        "model",
+        "Org/Model",
+        owned_blob_hashes = frozenset({_MAIN}),
+    )
+
+    assert swept == 0
+    assert partial.exists()
+
+
+def test_ownership_never_overrides_peer_protection(monkeypatch, blobs):
+    """A shared companion a sibling variant is writing stays out of reach."""
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
+    partial = blobs / _NONCE_PARTIAL
+    partial.write_bytes(b"x" * 25)
+    monkeypatch.setattr(
+        download_registry,
+        "iter_active_repo_cache_dirs",
+        lambda *_a, **_k: [blobs.parent],
+    )
+
+    swept = download_registry.sweep_abandoned_partials(
+        "model",
+        "Org/Model",
+        protected_blob_hashes = frozenset({_MAIN}),
+        owned_blob_hashes = frozenset({_MAIN}),
+    )
+
+    assert swept == 0
+    assert partial.exists()

--- a/studio/backend/hub/tests/test_unresumable_partial_purge.py
+++ b/studio/backend/hub/tests/test_unresumable_partial_purge.py
@@ -32,7 +32,7 @@ def blobs(monkeypatch, tmp_path):
 
 def _abandon(path):
     """Backdate a partial past the grace, as an abandoned one would be."""
-    old = time.time() - download_registry._ABANDONED_PARTIAL_SECONDS - 60
+    old = time.time() - download_registry.ABANDONED_PARTIAL_SECONDS - 60
     os.utime(path, (old, old))
     return path
 
@@ -267,36 +267,39 @@ def test_a_finalized_blob_still_counts_against_the_disk_check(monkeypatch, blobs
     assert download_registry.existing_blob_bytes("model", "Org/Model", frozenset({_MAIN})) == 25
 
 
-def test_startup_reaping_sweeps_a_previous_run_orphan(monkeypatch, tmp_path, blobs):
-    """The guaranteed revisit: by the next boot the writer is a process that no longer exists."""
+def test_startup_sweep_does_not_depend_on_a_breadcrumb(monkeypatch, tmp_path, blobs):
+    """finalize_worker_exit drops the breadcrumb, so the boot sweep cannot be driven off one."""
     workers = tmp_path / "workers"
-    workers.mkdir()
-    (workers / "job.json").write_text(
-        json.dumps(
-            {
-                "pid": 999999999,
-                "repo_type": "model",
-                "repo_id": "Org/Model",
-                "variant": None,
-                "transport": "http",
-                "hub_cache": str(blobs.parent.parent),
-            }
-        ),
-        encoding = "utf-8",
-    )
+    workers.mkdir()  # deliberately empty, as it is once drop_process has run
     partial = blobs / _NONCE_PARTIAL
     partial.write_bytes(b"x" * 25)
     _abandon(partial)
 
     monkeypatch.setattr(download_registry.state_dir, "workers_dir", lambda: workers)
-    monkeypatch.setattr(download_registry, "_settle_orphaned_download", lambda *_a, **_k: None)
     monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: False)
     monkeypatch.setattr(
-        download_registry,
-        "iter_active_repo_cache_dirs",
-        lambda *_a, **_k: [blobs.parent],
+        download_registry, "hf_cache_roots", lambda *_a, **_k: [blobs.parent.parent]
     )
 
     download_registry.reap_orphan_workers()
 
     assert not partial.exists()
+
+
+def test_startup_sweep_leaves_a_resumable_partial_alone(monkeypatch, tmp_path, blobs):
+    """Walking every cache at boot is not a licence to widen what gets deleted."""
+    workers = tmp_path / "workers"
+    workers.mkdir()
+    partial = blobs / _LEGACY_PARTIAL
+    partial.write_bytes(b"x" * 25)
+    _abandon(partial)
+
+    monkeypatch.setattr(download_registry.state_dir, "workers_dir", lambda: workers)
+    monkeypatch.setattr(download_registry, "partial_is_resumable", lambda _name: True)
+    monkeypatch.setattr(
+        download_registry, "hf_cache_roots", lambda *_a, **_k: [blobs.parent.parent]
+    )
+
+    download_registry.reap_orphan_workers()
+
+    assert partial.exists()

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -73,7 +73,7 @@ from hub.utils.hf_cache_state import (
     repo_cache_dir_name,
     target_dir_name,
     hf_cache_root,
-    hf_partials_are_resumable,
+    blob_download_lock_held,
     incomplete_blob_hash,
     partial_is_resumable,
 )
@@ -327,11 +327,12 @@ def reap_orphan_workers() -> None:
 
     Verifies each breadcrumb's PID is alive AND its command line is one of our
     workers before terminating, so a recycled PID can't take down an unrelated
-    process. Partial blobs are never touched, so a reaped download stays
+    process. A resumable partial is never touched, so a reaped download stays
     resumable; an interrupted one with bytes on disk is settled to a cancelled
     marker (see :func:`_settle_orphaned_download`) so its resume affordance
-    survives a hard crash like a graceful shutdown's does. Runs once at startup
-    and never raises."""
+    survives a hard crash like a graceful shutdown's does. A partial nothing can
+    resume has no affordance to preserve and is swept
+    (see :func:`sweep_abandoned_partials`). Runs once at startup and never raises."""
     parent = state_dir.workers_dir()
     if parent is None:
         return
@@ -368,6 +369,23 @@ def reap_orphan_workers() -> None:
                 data.get("cancel_marker_transport") or data.get("transport"),
                 data.get("hub_cache"),
             )
+            # The guaranteed revisit. A terminal-state sweep can still find an orphan too
+            # freshly written to judge, and if the user never returns to that repo nothing
+            # else looks again. Here the writer is a process from a previous run, so the
+            # question is settled -- and a partial an unrelated client is holding right now
+            # is still spared by the lock and staleness gates inside the sweep.
+            swept = sweep_abandoned_partials(
+                data.get("repo_type") or "model",
+                repo_id,
+                root = Path(data["hub_cache"]) if data.get("hub_cache") else None,
+            )
+            if swept:
+                logger.info(
+                    "Swept %d unresumable partial blob(s) for %s left by a previous "
+                    "backend instance.",
+                    swept,
+                    repo_id,
+                )
         except Exception as exc:
             logger.debug("Reaper failed for breadcrumb %s: %s", entry, exc)
         _safe_unlink(entry)
@@ -428,6 +446,12 @@ def _purge_incomplete_blobs(
                 continue
             if unresumable_only:
                 if partial_is_resumable(blob.name):
+                    continue
+                # Two independent ways to spot a live writer, because neither is sufficient
+                # alone: the lock is the precise signal but upstream calls it best-effort and
+                # some filesystems grant it to everyone, while mtime cannot tell a dead writer
+                # from one stalled on a slow network for longer than the grace.
+                if blob_download_lock_held(entry, blob_hash):
                     continue
                 if now - blob.stat().st_mtime < _ABANDONED_PARTIAL_SECONDS:
                     continue
@@ -873,10 +897,10 @@ def completed_blob_bytes(
 
 
 def existing_blob_bytes(repo_type: str, repo_id: str, blob_hashes: frozenset[str]) -> int:
-    """Bytes already on disk (finalized + ``.incomplete``) for *blob_hashes* in
-    the active HF cache root. A blob is in exactly one state, so summing both
-    candidate names never double-counts. Used to size what a (possibly resumed)
-    download still needs to write before the run starts."""
+    """Bytes a download will NOT have to fetch again for *blob_hashes*, in the active HF cache
+    root: finalized blobs, plus partials something can still resume from. A blob is in exactly
+    one state, so summing both candidate names never double-counts. Used to size what a
+    (possibly resumed) download still needs to write before the run starts."""
     if not blob_hashes:
         return 0
     total = 0
@@ -896,6 +920,12 @@ def existing_blob_bytes(repo_type: str, repo_id: str, blob_hashes: frozenset[str
                 partial_hash = incomplete_blob_hash(blob.name)
                 blob_hash = partial_hash if partial_hash is not None else blob.name
                 if blob_hash not in present:
+                    continue
+                if partial_hash is not None and not partial_is_resumable(blob.name):
+                    # Callers spend this on "bytes we will not have to fetch again", and
+                    # _preflight_disk_space subtracts it from the space a download needs. An
+                    # unresumable partial is refetched in full into a new path, so counting it
+                    # would clear a download for a disk that cannot hold it.
                     continue
                 # Broken advisory locks can leave several process-unique writers for one etag.
                 # They are duplicate attempts, not additive completion, so keep the largest.

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -363,6 +363,9 @@ def reap_orphan_workers() -> None:
     try:
         entries = list(parent.iterdir())
     except OSError:
+        # Unreadable breadcrumbs means no worker can be claimed as reaped, not that the caches
+        # go unswept: they are a separate tree and may well be readable.
+        _boot_sweep(reaped)
         return
     for entry in entries:
         if not entry.is_file() or not entry.name.endswith(".json"):

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -402,6 +402,7 @@ def _purge_incomplete_blobs(
     protected_hashes: Optional[frozenset[str]] = None,
     *,
     unresumable_only: bool = False,
+    owned_hashes: Optional[frozenset[str]] = None,
 ) -> _PurgeOutcome:
     """Delete selected partials while preserving protected concurrent writes.
 
@@ -411,6 +412,12 @@ def _purge_incomplete_blobs(
     has touched for ``ABANDONED_PARTIAL_SECONDS``. Unlinking a live partial does not stop its
     writer on POSIX; it keeps filling an unlinked inode and then fails at the rename, so the
     cost of that mistake is another client's whole download.
+
+    ``owned_hashes`` are blobs whose only Studio-side writer has just been reaped, so the wait
+    buys nothing: the staleness check exists to infer a live writer, and here the answer is
+    known. The lock check still runs, which is what makes this safe -- hf takes the per-blob
+    lock BEFORE creating its temporary file, so any partial belonging to a live writer
+    (including a retry for this same job) is necessarily locked.
     """
     now = time.time()
     blobs_dir = entry / "blobs"
@@ -443,8 +450,9 @@ def _purge_incomplete_blobs(
                 # from one stalled on a slow network for longer than the grace.
                 if blob_download_lock_held(entry, blob_hash):
                     continue
-                if now - blob.stat().st_mtime < ABANDONED_PARTIAL_SECONDS:
-                    continue
+                if not (owned_hashes and blob_hash in owned_hashes):
+                    if now - blob.stat().st_mtime < ABANDONED_PARTIAL_SECONDS:
+                        continue
             blob.unlink()
             removed += 1
         except FileNotFoundError:
@@ -778,6 +786,7 @@ def sweep_abandoned_partials(
     *,
     only_blob_hashes: Optional[frozenset[str]] = None,
     protected_blob_hashes: Optional[frozenset[str]] = None,
+    owned_blob_hashes: Optional[frozenset[str]] = None,
     root: Optional[Path] = None,
 ) -> int:
     """Remove partials nothing can resume and nothing has touched. Returns how many went.
@@ -795,6 +804,7 @@ def sweep_abandoned_partials(
             only_blob_hashes,
             protected_blob_hashes,
             unresumable_only = True,
+            owned_hashes = owned_blob_hashes,
         )
         removed += outcome.removed
     return removed

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -9,9 +9,13 @@ machine plus the cache/marker inspection those workers depend on.
 
 Resume model
 ------------
-Only the HTTP transport supports true partial-file resume:
-huggingface_hub's HTTP resumer opens ``<etag>.incomplete`` in append mode
-and sends ``Range: bytes={resume_size}-`` to continue from disk.
+Up to huggingface_hub 1.17 the HTTP transport supported true partial-file
+resume: the resumer opened ``<etag>.incomplete`` in append mode and sent
+``Range: bytes={resume_size}-`` to continue from disk. 1.18 replaced that with
+a process-unique ``<etag>.<nonce>.incomplete`` opened ``"wb"`` and unlinked on
+the way out, so no transport resumes within a file any more and a surviving
+partial is litter (see :func:`hf_partials_are_resumable`). Resume is now
+whole-file only: ``snapshot_download`` skips shards already materialized.
 
 The XET transport CANNOT resume from a ``.incomplete`` partial:
 ``hf_xet.download_files`` rewrites the destination from scratch.
@@ -69,6 +73,7 @@ from hub.utils.hf_cache_state import (
     repo_cache_dir_name,
     target_dir_name,
     hf_cache_root,
+    hf_partials_are_resumable,
     incomplete_blob_hash,
 )
 
@@ -561,7 +566,10 @@ def prepare_cache_for_transport(
     - HTTP mode: a partial is trusted ONLY when its governing marker equals
       ``"http"``. Any other case (missing/unreadable/mismatched marker) purges,
       since the HTTP resumer would otherwise append to a sparse
-      XET/parallel-Range partial and silently produce a corrupt blob.
+      XET/parallel-Range partial and silently produce a corrupt blob. On
+      huggingface_hub >= 1.18 there is no resumer left to trust a partial for
+      (see ``hf_partials_are_resumable``), so the marker is bypassed and every
+      selected partial purges.
     - XET mode: incomplete blobs are purged (``hf_xet.download_files`` rewrites
       from scratch, so this only fixes UI accounting — bytes already in CAS are
       reused via the chunk-cache). Scoped to ``only_blob_hashes``: companion
@@ -617,9 +625,15 @@ def prepare_cache_for_transport(
         if mode == TRANSPORT_XET:
             main_purge = _purge_incomplete_blobs(entry, only_blob_hashes, protected)
         else:
-            if _read_marker(entry, variant) != mode:
+            # A trusted marker only buys something if the next attempt can append to the
+            # partial it vouches for, and since huggingface_hub 1.18 nothing can. What
+            # survives is dead weight that holds the disk the refetch needs and, carrying the
+            # etag of the blob being refetched, pins the bar to its own stale high-water mark
+            # until the new attempt overtakes it. Peers writing right now are still protected.
+            resumable = hf_partials_are_resumable()
+            if not resumable or _read_marker(entry, variant) != mode:
                 main_purge = _purge_incomplete_blobs(entry, only_blob_hashes, protected)
-            if companion_blob_hashes and _read_companion_marker(entry) != mode:
+            if companion_blob_hashes and (not resumable or _read_companion_marker(entry) != mode):
                 companion_purge = _purge_incomplete_blobs(
                     entry,
                     companion_blob_hashes,

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -259,10 +259,27 @@ def _is_our_worker(pid: int, repo_id: Optional[str]) -> bool:
 
 
 def _kill_orphan(pid: int) -> None:
+    """Signal the process and wait for it to actually be gone.
+
+    The wait is what makes the boot sweep meaningful: the signal only schedules the death, and
+    a sweep that runs a microsecond later still sees the worker's Hugging Face blob lock and
+    spares a partial nothing will ever finish. Bounded, because a pid we cannot reap is not a
+    reason to hold up startup.
+    """
     try:
         os.kill(pid, signal.SIGTERM if sys.platform == "win32" else signal.SIGKILL)
     except OSError:
-        pass
+        return
+    deadline = time.monotonic() + _ORPHAN_REAP_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if not _process_alive(pid):
+            return
+        time.sleep(0.05)
+    logger.debug("Orphan worker pid=%s still alive after the reap timeout.", pid)
+
+
+# Long enough for a SIGKILLed worker to be torn down, short enough not to delay a boot.
+_ORPHAN_REAP_TIMEOUT_SECONDS = 5.0
 
 
 def _settle_orphaned_download(

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -381,7 +381,11 @@ def reap_orphan_workers() -> None:
             _safe_unlink(entry)
             continue
         try:
-            if _process_alive(pid) and _is_our_worker(pid, repo_id):
+            if not _process_alive(pid):
+                # Already gone, which is better proof than killing it ourselves. Its partial
+                # is ours to sweep even though this invocation reaped nothing.
+                reaped.append((data.get("repo_type") or "model", repo_id, data.get("hub_cache")))
+            elif _is_our_worker(pid, repo_id):
                 if not _kill_orphan(pid):
                     # Still running. Keeping the breadcrumb keeps it tracked for the next boot,
                     # and claiming no ownership keeps its live partial out of the sweep.
@@ -487,10 +491,12 @@ def _purge_incomplete_blobs(
 
     ``owned_hashes``, or ``owns_all_blobs`` for a job that owns its whole repo dir (one with no
     variant, which claim() will not let a sibling share), are blobs whose only Studio-side
-    writer has just been reaped, so the wait buys nothing: the staleness check exists to infer a live writer, and here the answer is
-    known. The lock check still runs, which is what makes this safe -- hf takes the per-blob
-    lock BEFORE creating its temporary file, so any partial belonging to a live writer
-    (including a retry for this same job) is necessarily locked.
+    writer has just been reaped. Those do not wait out the full grace -- the corpse would
+    outlive the retry that follows a cancel, which is the frozen bar this whole change is
+    about -- but they are not simply trusted either: registry ownership proves OUR writer is
+    gone, never that no independent process shares the cache. They go through a stillness
+    probe instead, which is the one liveness test that survives a filesystem where flock is
+    granted to every caller and the lock therefore reads free while somebody writes.
     """
     now = time.time()
     blobs_dir = entry / "blobs"
@@ -498,6 +504,7 @@ def _purge_incomplete_blobs(
         return _PurgeOutcome(0, 0)
     removed = 0
     failed = 0
+    watched: list[tuple[Path, str, int, float]] = []
     try:
         candidates = list(blobs_dir.iterdir())
     except OSError:
@@ -527,6 +534,10 @@ def _purge_incomplete_blobs(
                 if not owned:
                     if now - blob.stat().st_mtime < ABANDONED_PARTIAL_SECONDS:
                         continue
+                elif now - blob.stat().st_mtime < ABANDONED_PARTIAL_SECONDS:
+                    stat = blob.stat()
+                    watched.append((blob, blob_hash, stat.st_size, stat.st_mtime))
+                    continue
             blob.unlink()
             removed += 1
         except FileNotFoundError:
@@ -536,6 +547,38 @@ def _purge_incomplete_blobs(
         except OSError:
             failed += 1
             continue
+    watched_outcome = _purge_still_partials(watched)
+    return _PurgeOutcome(removed + watched_outcome.removed, failed + watched_outcome.failed)
+
+
+# One shared pause is enough to tell a frozen corpse from a writer mid-transfer: hf writes a
+# partial continuously, so anything untouched across it is not being written by anyone.
+_STILLNESS_PROBE_SECONDS = 2.0
+
+
+def _purge_still_partials(watched: "Sequence[tuple[Path, str, int, float]]") -> _PurgeOutcome:
+    """Delete the owned partials that do not move while we watch them.
+
+    Sampled once before, once after a single shared sleep, so the cost is one pause per sweep
+    rather than one per file. Anything that grew or was touched in between has a live writer,
+    whatever the advisory lock had to say about it.
+    """
+    if not watched:
+        return _PurgeOutcome(0, 0)
+    time.sleep(_STILLNESS_PROBE_SECONDS)
+    removed = 0
+    failed = 0
+    for blob, _blob_hash, size, mtime in watched:
+        try:
+            stat = blob.stat()
+            if stat.st_size != size or stat.st_mtime != mtime:
+                continue  # it moved, so somebody owns it after all
+            blob.unlink()
+            removed += 1
+        except FileNotFoundError:
+            continue
+        except OSError:
+            failed += 1
     return _PurgeOutcome(removed, failed)
 
 

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -335,17 +335,10 @@ def reap_orphan_workers() -> None:
     survives a hard crash like a graceful shutdown's does. A partial nothing can
     resume has no affordance to preserve and is swept
     (see :func:`sweep_abandoned_partials`). Runs once at startup and never raises."""
-    try:
-        swept = sweep_abandoned_partials_in_all_caches()
-        if swept:
-            logger.info(
-                "Swept %d unresumable partial blob(s) left by a previous backend instance.",
-                swept,
-            )
-    except Exception as exc:
-        logger.debug("Boot sweep of abandoned partials failed: %s", exc)
+    reaped: list[tuple[str, str, Optional[str]]] = []
     parent = state_dir.workers_dir()
     if parent is None:
+        _boot_sweep(reaped)
         return
     try:
         entries = list(parent.iterdir())
@@ -367,6 +360,10 @@ def reap_orphan_workers() -> None:
         try:
             if _process_alive(pid) and _is_our_worker(pid, repo_id):
                 _kill_orphan(pid)
+                # Its partial is unreadable now and its writer is gone, but only as of this
+                # line. The sweep has to come after the kill, not before, or it reads the
+                # still-held blob lock and spares a file nothing will ever finish.
+                reaped.append((data.get("repo_type") or "model", repo_id, data.get("hub_cache")))
                 logger.warning(
                     "Reaped orphaned download worker pid=%s repo=%s from a "
                     "previous backend instance.",
@@ -383,6 +380,28 @@ def reap_orphan_workers() -> None:
         except Exception as exc:
             logger.debug("Reaper failed for breadcrumb %s: %s", entry, exc)
         _safe_unlink(entry)
+    _boot_sweep(reaped)
+
+
+def _boot_sweep(reaped: "Sequence[tuple[str, str, Optional[str]]]") -> None:
+    """Startup cleanup, run only once every surviving worker above has been killed."""
+    swept = 0
+    try:
+        for repo_type, repo_id, hub_cache in reaped:
+            # We killed this one ourselves a moment ago, so it need not look abandoned yet.
+            swept += sweep_abandoned_partials(
+                repo_type,
+                repo_id,
+                owns_all_blobs = True,
+                root = hub_cache,
+            )
+        swept += sweep_abandoned_partials_in_all_caches()
+    except Exception as exc:
+        logger.debug("Boot sweep of abandoned partials failed: %s", exc)
+    if swept:
+        logger.info(
+            "Swept %d unresumable partial blob(s) left by a previous backend instance.", swept
+        )
 
 
 class _PurgeOutcome(NamedTuple):
@@ -403,6 +422,7 @@ def _purge_incomplete_blobs(
     *,
     unresumable_only: bool = False,
     owned_hashes: Optional[frozenset[str]] = None,
+    owns_all_blobs: bool = False,
 ) -> _PurgeOutcome:
     """Delete selected partials while preserving protected concurrent writes.
 
@@ -413,8 +433,9 @@ def _purge_incomplete_blobs(
     writer on POSIX; it keeps filling an unlinked inode and then fails at the rename, so the
     cost of that mistake is another client's whole download.
 
-    ``owned_hashes`` are blobs whose only Studio-side writer has just been reaped, so the wait
-    buys nothing: the staleness check exists to infer a live writer, and here the answer is
+    ``owned_hashes``, or ``owns_all_blobs`` for a job that owns its whole repo dir (one with no
+    variant, which claim() will not let a sibling share), are blobs whose only Studio-side
+    writer has just been reaped, so the wait buys nothing: the staleness check exists to infer a live writer, and here the answer is
     known. The lock check still runs, which is what makes this safe -- hf takes the per-blob
     lock BEFORE creating its temporary file, so any partial belonging to a live writer
     (including a retry for this same job) is necessarily locked.
@@ -450,7 +471,8 @@ def _purge_incomplete_blobs(
                 # from one stalled on a slow network for longer than the grace.
                 if blob_download_lock_held(entry, blob_hash):
                     continue
-                if not (owned_hashes and blob_hash in owned_hashes):
+                owned = owns_all_blobs or bool(owned_hashes and blob_hash in owned_hashes)
+                if not owned:
                     if now - blob.stat().st_mtime < ABANDONED_PARTIAL_SECONDS:
                         continue
             blob.unlink()
@@ -787,7 +809,8 @@ def sweep_abandoned_partials(
     only_blob_hashes: Optional[frozenset[str]] = None,
     protected_blob_hashes: Optional[frozenset[str]] = None,
     owned_blob_hashes: Optional[frozenset[str]] = None,
-    root: Optional[Path] = None,
+    owns_all_blobs: bool = False,
+    root: Optional[str | Path] = None,
 ) -> int:
     """Remove partials nothing can resume and nothing has touched. Returns how many went.
 
@@ -797,6 +820,10 @@ def sweep_abandoned_partials(
     this when a download reaches a terminal state and every file skipped then gets a second
     look, by which point the grace has long since elapsed.
     """
+    # DownloadMetadata.hub_cache is a str, and every caller hands its captured root straight
+    # through, so normalize here rather than trusting each one to remember.
+    if isinstance(root, str):
+        root = Path(root) if root else None
     removed = 0
     for entry in iter_active_repo_cache_dirs(repo_type, repo_id, root = root):
         outcome = _purge_incomplete_blobs(
@@ -805,6 +832,7 @@ def sweep_abandoned_partials(
             protected_blob_hashes,
             unresumable_only = True,
             owned_hashes = owned_blob_hashes,
+            owns_all_blobs = owns_all_blobs,
         )
         removed += outcome.removed
     return removed

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -75,6 +75,7 @@ from hub.utils.hf_cache_state import (
     hf_cache_root,
     hf_partials_are_resumable,
     incomplete_blob_hash,
+    partial_is_resumable,
 )
 
 
@@ -379,15 +380,31 @@ class _PurgeOutcome(NamedTuple):
     failed: int
 
 
+# How long a partial must sit untouched before an unresumable-purge treats it as abandoned.
+# huggingface_hub writes to a partial continuously, so anything still advancing is a live
+# writer -- possibly another Studio or another client entirely, which this backend's peer
+# registry cannot see. Only the unresumable sweep waits: it reclaims disk, while a
+# marker-mismatch purge exists to stop a corrupt append and cannot defer.
+_ABANDONED_PARTIAL_SECONDS = 120
+
+
 def _purge_incomplete_blobs(
     entry: Path,
     only_hashes: Optional[frozenset[str]] = None,
     protected_hashes: Optional[frozenset[str]] = None,
+    *,
+    unresumable_only: bool = False,
 ) -> _PurgeOutcome:
     """Delete selected partials while preserving protected concurrent writes.
 
     Report failed deletions so sparse partials cannot receive an HTTP marker.
+
+    ``unresumable_only`` restricts the sweep to partials no writer can reuse AND that nothing
+    has touched for ``_ABANDONED_PARTIAL_SECONDS``. Unlinking a live partial does not stop its
+    writer on POSIX; it keeps filling an unlinked inode and then fails at the rename, so the
+    cost of that mistake is another client's whole download.
     """
+    now = time.time()
     blobs_dir = entry / "blobs"
     if not blobs_dir.is_dir():
         return _PurgeOutcome(0, 0)
@@ -409,6 +426,11 @@ def _purge_incomplete_blobs(
                 continue
             if only_hashes is not None and blob_hash not in only_hashes:
                 continue
+            if unresumable_only:
+                if partial_is_resumable(blob.name):
+                    continue
+                if now - blob.stat().st_mtime < _ABANDONED_PARTIAL_SECONDS:
+                    continue
             blob.unlink()
             removed += 1
         except FileNotFoundError:
@@ -625,20 +647,34 @@ def prepare_cache_for_transport(
         if mode == TRANSPORT_XET:
             main_purge = _purge_incomplete_blobs(entry, only_blob_hashes, protected)
         else:
-            # A trusted marker only buys something if the next attempt can append to the
-            # partial it vouches for, and since huggingface_hub 1.18 nothing can. What
+            # A matching marker vouches for provenance, which is only worth something if
+            # something can still append to the partial it vouches for. When nothing can, what
             # survives is dead weight that holds the disk the refetch needs and, carrying the
             # etag of the blob being refetched, pins the bar to its own stale high-water mark
-            # until the new attempt overtakes it. Peers writing right now are still protected.
-            resumable = hf_partials_are_resumable()
-            if not resumable or _read_marker(entry, variant) != mode:
+            # until the new attempt overtakes it. Sweep it, but only once abandoned.
+            if _read_marker(entry, variant) != mode:
                 main_purge = _purge_incomplete_blobs(entry, only_blob_hashes, protected)
-            if companion_blob_hashes and (not resumable or _read_companion_marker(entry) != mode):
-                companion_purge = _purge_incomplete_blobs(
+            else:
+                main_purge = _purge_incomplete_blobs(
                     entry,
-                    companion_blob_hashes,
+                    only_blob_hashes,
                     protected,
+                    unresumable_only = True,
                 )
+            if companion_blob_hashes:
+                if _read_companion_marker(entry) != mode:
+                    companion_purge = _purge_incomplete_blobs(
+                        entry,
+                        companion_blob_hashes,
+                        protected,
+                    )
+                else:
+                    companion_purge = _purge_incomplete_blobs(
+                        entry,
+                        companion_blob_hashes,
+                        protected,
+                        unresumable_only = True,
+                    )
         total_purged += main_purge.removed + companion_purge.removed
         record_unconditionally = mode == TRANSPORT_XET
         if record_unconditionally or not main_purge.failed:
@@ -727,12 +763,16 @@ def is_resumable_partial(
     repo_id: str,
     variant: Optional[str] = None,
 ) -> bool:
-    """True only when a partial exists AND was produced by a byte-resumable
-    writer (the HTTP transport). XET partials exist on disk but are discarded on
-    the next download attempt."""
-    if not has_active_incomplete_blobs(repo_type, repo_id):
+    """True only when a partial exists AND something can still resume from it.
+
+    Two ways to fail that. XET partials exist on disk but ``hf_xet`` rewrites the destination
+    from scratch, so the marker has to say HTTP. And an HTTP partial is only resumable while a
+    writer that reopens it is installed; the UI turns this flag into "Resume with HTTP to keep
+    the progress you already have", which must not be promised for bytes about to be swept.
+    """
+    if read_active_transport_marker(repo_type, repo_id, variant) != TRANSPORT_HTTP:
         return False
-    return read_active_transport_marker(repo_type, repo_id, variant) == TRANSPORT_HTTP
+    return bool(incomplete_blob_hashes(repo_type, repo_id, active_only = True, resumable_only = True))
 
 
 def incomplete_blob_hashes(
@@ -740,8 +780,14 @@ def incomplete_blob_hashes(
     repo_id: str,
     *,
     active_only: bool = False,
+    resumable_only: bool = False,
     root: Optional[Path] = None,
 ) -> set[str]:
+    """Logical blob hashes with a partial on disk.
+
+    ``resumable_only`` keeps just the ones a later attempt could actually append to, which is
+    what a "resume and keep your progress" claim has to be built on.
+    """
     out: set[str] = set()
     entries = (
         iter_active_repo_cache_dirs(repo_type, repo_id, root = root)
@@ -757,8 +803,11 @@ def incomplete_blob_hashes(
                 if not blob.is_file():
                     continue
                 blob_hash = incomplete_blob_hash(blob.name)
-                if blob_hash is not None:
-                    out.add(blob_hash)
+                if blob_hash is None:
+                    continue
+                if resumable_only and not partial_is_resumable(blob.name):
+                    continue
+                out.add(blob_hash)
         except OSError:
             continue
     return out

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -77,6 +77,7 @@ from hub.utils.hf_cache_state import (
     blob_download_lock_held,
     hf_cache_roots,
     incomplete_blob_hash,
+    iter_destructive_repo_cache_dirs,
     partial_is_resumable,
 )
 
@@ -258,24 +259,26 @@ def _is_our_worker(pid: int, repo_id: Optional[str]) -> bool:
     return True
 
 
-def _kill_orphan(pid: int) -> None:
-    """Signal the process and wait for it to actually be gone.
+def _kill_orphan(pid: int) -> bool:
+    """Signal the process and wait for it to actually be gone. True once it is.
 
     The wait is what makes the boot sweep meaningful: the signal only schedules the death, and
     a sweep that runs a microsecond later still sees the worker's Hugging Face blob lock and
     spares a partial nothing will ever finish. Bounded, because a pid we cannot reap is not a
-    reason to hold up startup.
+    reason to hold up startup -- and answering False there matters: a survivor must keep its
+    breadcrumb and must not have its live partial claimed as ours to delete.
     """
     try:
         os.kill(pid, signal.SIGTERM if sys.platform == "win32" else signal.SIGKILL)
     except OSError:
-        return
+        return not _process_alive(pid)
     deadline = time.monotonic() + _ORPHAN_REAP_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         if not _process_alive(pid):
-            return
+            return True
         time.sleep(0.05)
-    logger.debug("Orphan worker pid=%s still alive after the reap timeout.", pid)
+    logger.warning("Orphan worker pid=%s is still alive after the reap timeout.", pid)
+    return False
 
 
 # Long enough for a SIGKILLed worker to be torn down, short enough not to delay a boot.
@@ -376,7 +379,16 @@ def reap_orphan_workers() -> None:
             continue
         try:
             if _process_alive(pid) and _is_our_worker(pid, repo_id):
-                _kill_orphan(pid)
+                if not _kill_orphan(pid):
+                    # Still running. Keeping the breadcrumb keeps it tracked for the next boot,
+                    # and claiming no ownership keeps its live partial out of the sweep.
+                    logger.warning(
+                        "Could not reap download worker pid=%s repo=%s; leaving its "
+                        "breadcrumb and partial in place.",
+                        pid,
+                        repo_id,
+                    )
+                    continue
                 # Its partial is unreadable now and its writer is gone, but only as of this
                 # line. The sweep has to come after the kill, not before, or it reads the
                 # still-held blob lock and spares a file nothing will ever finish.
@@ -401,7 +413,13 @@ def reap_orphan_workers() -> None:
 
 
 def _boot_sweep(reaped: "Sequence[tuple[str, str, Optional[str]]]") -> None:
-    """Startup cleanup, run only once every surviving worker above has been killed."""
+    """Startup cleanup, run only once every surviving worker above has been killed.
+
+    The reaped repos are swept inline: that work is bounded by the breadcrumbs and it settles
+    the caches a returning user is most likely to look at. The all-caches pass is not bounded
+    by anything -- it walks every repo dir, stats every partial and probes locks -- so it goes
+    to a thread rather than holding the lifespan open ahead of the first request.
+    """
     swept = 0
     try:
         for repo_type, repo_id, hub_cache in reaped:
@@ -412,13 +430,27 @@ def _boot_sweep(reaped: "Sequence[tuple[str, str, Optional[str]]]") -> None:
                 owns_all_blobs = True,
                 root = hub_cache,
             )
-        swept += sweep_abandoned_partials_in_all_caches()
     except Exception as exc:
-        logger.debug("Boot sweep of abandoned partials failed: %s", exc)
+        logger.debug("Boot sweep of reaped downloads failed: %s", exc)
     if swept:
         logger.info(
             "Swept %d unresumable partial blob(s) left by a previous backend instance.", swept
         )
+
+    def _sweep_all_caches() -> None:
+        try:
+            removed = sweep_abandoned_partials_in_all_caches()
+        except Exception as exc:
+            logger.debug("Background sweep of abandoned partials failed: %s", exc)
+            return
+        if removed:
+            logger.info("Swept %d unresumable partial blob(s) from the HF caches.", removed)
+
+    threading.Thread(
+        target = _sweep_all_caches,
+        name = "hf-abandoned-partial-sweep",
+        daemon = True,
+    ).start()
 
 
 class _PurgeOutcome(NamedTuple):
@@ -842,7 +874,10 @@ def sweep_abandoned_partials(
     if isinstance(root, str):
         root = Path(root) if root else None
     removed = 0
-    for entry in iter_active_repo_cache_dirs(repo_type, repo_id, root = root):
+    # The destructive iterator, not the active one: this deletes, and on a case-insensitive
+    # collision the active iterator yields every spelling while this one resolves to the exact
+    # directory or refuses. A job owning "its" repo does not own a differently-cased neighbour.
+    for entry in iter_destructive_repo_cache_dirs(repo_type, repo_id, root = root):
         outcome = _purge_incomplete_blobs(
             entry,
             only_blob_hashes,
@@ -988,11 +1023,18 @@ def existing_blob_bytes(repo_type: str, repo_id: str, blob_hashes: frozenset[str
                 blob_hash = partial_hash if partial_hash is not None else blob.name
                 if blob_hash not in present:
                     continue
-                if partial_hash is not None and not partial_is_resumable(blob.name):
+                if (
+                    partial_hash is not None
+                    and not partial_is_resumable(blob.name)
+                    and not blob_download_lock_held(entry, blob_hash)
+                ):
                     # Callers spend this on "bytes we will not have to fetch again", and
                     # _preflight_disk_space subtracts it from the space a download needs. An
                     # unresumable partial is refetched in full into a new path, so counting it
-                    # would clear a download for a disk that cannot hold it.
+                    # would clear a download for a disk that cannot hold it. A LOCKED one is
+                    # different: a live peer is finishing it and snapshot_download will block
+                    # on that lock and reuse the result, so those bytes are not ours to find
+                    # room for. Two GGUF variants sharing an mmproj hit this every time.
                     continue
                 # Broken advisory locks can leave several process-unique writers for one etag.
                 # They are duplicate attempts, not additive completion, so keep the largest.

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -73,7 +73,9 @@ from hub.utils.hf_cache_state import (
     repo_cache_dir_name,
     target_dir_name,
     hf_cache_root,
+    ABANDONED_PARTIAL_SECONDS,
     blob_download_lock_held,
+    hf_cache_roots,
     incomplete_blob_hash,
     partial_is_resumable,
 )
@@ -333,6 +335,15 @@ def reap_orphan_workers() -> None:
     survives a hard crash like a graceful shutdown's does. A partial nothing can
     resume has no affordance to preserve and is swept
     (see :func:`sweep_abandoned_partials`). Runs once at startup and never raises."""
+    try:
+        swept = sweep_abandoned_partials_in_all_caches()
+        if swept:
+            logger.info(
+                "Swept %d unresumable partial blob(s) left by a previous backend instance.",
+                swept,
+            )
+    except Exception as exc:
+        logger.debug("Boot sweep of abandoned partials failed: %s", exc)
     parent = state_dir.workers_dir()
     if parent is None:
         return
@@ -369,23 +380,6 @@ def reap_orphan_workers() -> None:
                 data.get("cancel_marker_transport") or data.get("transport"),
                 data.get("hub_cache"),
             )
-            # The guaranteed revisit. A terminal-state sweep can still find an orphan too
-            # freshly written to judge, and if the user never returns to that repo nothing
-            # else looks again. Here the writer is a process from a previous run, so the
-            # question is settled -- and a partial an unrelated client is holding right now
-            # is still spared by the lock and staleness gates inside the sweep.
-            swept = sweep_abandoned_partials(
-                data.get("repo_type") or "model",
-                repo_id,
-                root = Path(data["hub_cache"]) if data.get("hub_cache") else None,
-            )
-            if swept:
-                logger.info(
-                    "Swept %d unresumable partial blob(s) for %s left by a previous "
-                    "backend instance.",
-                    swept,
-                    repo_id,
-                )
         except Exception as exc:
             logger.debug("Reaper failed for breadcrumb %s: %s", entry, exc)
         _safe_unlink(entry)
@@ -398,12 +392,8 @@ class _PurgeOutcome(NamedTuple):
     failed: int
 
 
-# How long a partial must sit untouched before an unresumable-purge treats it as abandoned.
-# huggingface_hub writes to a partial continuously, so anything still advancing is a live
-# writer -- possibly another Studio or another client entirely, which this backend's peer
-# registry cannot see. Only the unresumable sweep waits: it reclaims disk, while a
+# Only the unresumable sweep waits out ABANDONED_PARTIAL_SECONDS: it reclaims disk, while a
 # marker-mismatch purge exists to stop a corrupt append and cannot defer.
-_ABANDONED_PARTIAL_SECONDS = 120
 
 
 def _purge_incomplete_blobs(
@@ -418,7 +408,7 @@ def _purge_incomplete_blobs(
     Report failed deletions so sparse partials cannot receive an HTTP marker.
 
     ``unresumable_only`` restricts the sweep to partials no writer can reuse AND that nothing
-    has touched for ``_ABANDONED_PARTIAL_SECONDS``. Unlinking a live partial does not stop its
+    has touched for ``ABANDONED_PARTIAL_SECONDS``. Unlinking a live partial does not stop its
     writer on POSIX; it keeps filling an unlinked inode and then fails at the rename, so the
     cost of that mistake is another client's whole download.
     """
@@ -453,7 +443,7 @@ def _purge_incomplete_blobs(
                 # from one stalled on a slow network for longer than the grace.
                 if blob_download_lock_held(entry, blob_hash):
                     continue
-                if now - blob.stat().st_mtime < _ABANDONED_PARTIAL_SECONDS:
+                if now - blob.stat().st_mtime < ABANDONED_PARTIAL_SECONDS:
                     continue
             blob.unlink()
             removed += 1
@@ -807,6 +797,28 @@ def sweep_abandoned_partials(
             unresumable_only = True,
         )
         removed += outcome.removed
+    return removed
+
+
+def sweep_abandoned_partials_in_all_caches() -> int:
+    """Boot-time sweep across every known HF cache root. Returns how many partials went.
+
+    Not driven off worker breadcrumbs, because ``drop_process`` removes a breadcrumb during
+    ``finalize_worker_exit`` -- before the terminal-state sweep runs -- so a partial that sweep
+    skips for being freshly written has no breadcrumb left to be found by. Walking the caches
+    instead needs no record to survive, and every deletion still has to clear the same
+    unresumable, unlocked and abandoned gates.
+    """
+    removed = 0
+    for root in hf_cache_roots():
+        try:
+            entries = list(root.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if "--" not in entry.name or not (entry / "blobs").is_dir():
+                continue
+            removed += _purge_incomplete_blobs(entry, None, None, unresumable_only = True).removed
     return removed
 
 

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -758,6 +758,34 @@ def read_active_transport_marker(
     return None
 
 
+def sweep_abandoned_partials(
+    repo_type: str,
+    repo_id: str,
+    *,
+    only_blob_hashes: Optional[frozenset[str]] = None,
+    protected_blob_hashes: Optional[frozenset[str]] = None,
+    root: Optional[Path] = None,
+) -> int:
+    """Remove partials nothing can resume and nothing has touched. Returns how many went.
+
+    ``prepare_cache_for_transport`` runs once, before a download, and skips anything still
+    inside the abandonment grace. That skip lands on the common case: the orphan is the file a
+    hard kill left behind, and the user restarts within seconds of the kill that made it. Run
+    this when a download reaches a terminal state and every file skipped then gets a second
+    look, by which point the grace has long since elapsed.
+    """
+    removed = 0
+    for entry in iter_active_repo_cache_dirs(repo_type, repo_id, root = root):
+        outcome = _purge_incomplete_blobs(
+            entry,
+            only_blob_hashes,
+            protected_blob_hashes,
+            unresumable_only = True,
+        )
+        removed += outcome.removed
+    return removed
+
+
 def is_resumable_partial(
     repo_type: str,
     repo_id: str,

--- a/studio/backend/hub/utils/hf_cache_state.py
+++ b/studio/backend/hub/utils/hf_cache_state.py
@@ -107,19 +107,28 @@ def blob_download_lock_held(entry: Path, blob_hash: str) -> bool:
     """
     lock_path = entry.parent / ".locks" / entry.name / f"{blob_hash}.lock"
     if not lock_path.exists():
+        # hf creates the lock file before taking the lock, so no file means no writer. It is
+        # also the answer for a SoftFileLock, whose file IS the lock (see below).
         return False
     try:
         from filelock import FileLock, Timeout
-    except Exception:  # noqa: BLE001 - no filelock means no opinion
+    except Exception:  # noqa: BLE001 - no filelock at all means no opinion
         return False
     try:
-        lock = FileLock(str(lock_path), timeout = 0)
-        with lock:
+        with FileLock(str(lock_path), timeout = 0):
             return False
     except Timeout:
         return True
-    except OSError:
-        return False
+    except Exception:  # noqa: BLE001 - deliberately broad, see below
+        # A filesystem without flock raises NotImplementedError here, and upstream's
+        # WeakFileLock answers it by retrying as a SoftFileLock (huggingface_hub
+        # utils/_fixes.py). Retrying is pointless for a PROBE: a soft lock is its file, and we
+        # only reach this line because that file exists, so the soft answer is "held" too.
+        # What matters is that the exception does not escape -- it used to travel out through
+        # the purge and fail the download on every retry. Any other unprobeable error answers
+        # the same way, because the caller's remaining guard is a staleness check that an
+        # ownership claim may skip, and a wrong "free" there deletes a live writer's file.
+        return True
 
 
 def partial_is_resumable(name: str) -> bool:

--- a/studio/backend/hub/utils/hf_cache_state.py
+++ b/studio/backend/hub/utils/hf_cache_state.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import stat as stat_module
 import sys
+from functools import lru_cache
 from pathlib import Path, PureWindowsPath
 from typing import Iterable, Iterator, Optional
 
@@ -46,6 +47,40 @@ def incomplete_blob_hash(name: str) -> Optional[str]:
         return None
     process_unique = _PROCESS_UNIQUE_PARTIAL_RE.fullmatch(stem)
     return process_unique.group("blob_hash") if process_unique else stem
+
+
+# The last huggingface_hub line whose partials a later attempt can append to.
+_LAST_RESUMABLE_PARTIAL_VERSION = (1, 17)
+
+
+@lru_cache(maxsize = 1)
+def hf_partials_are_resumable() -> bool:
+    """Whether an interrupted download leaves bytes the next attempt can reuse.
+
+    Up to 1.17 huggingface_hub appended to a shared ``<etag>.incomplete`` and restarted from
+    its length over a Range request. 1.18 moved the writer to a process-unique
+    ``<etag>.<nonce>.incomplete``, opened ``"wb"`` and unlinked in a ``finally``
+    (huggingface/huggingface_hub#4228), so an interrupted file is refetched from zero and
+    whatever partial survives a hard kill can never be read again.
+
+    An unreadable version answers True: not knowing which writer is installed is not grounds
+    for deleting bytes that may still be resumable.
+    """
+    try:
+        from huggingface_hub import __version__ as hf_version
+    except Exception:  # noqa: BLE001 - an unimportable hub is the caller's problem, not ours
+        return True
+    release = []
+    for chunk in str(hf_version).split(".")[:2]:
+        digits = ""
+        for char in chunk:
+            if not char.isdigit():
+                break
+            digits += char
+        if not digits:
+            return True
+        release.append(int(digits))
+    return tuple(release) <= _LAST_RESUMABLE_PARTIAL_VERSION
 
 
 def _safe_is_dir(path: Path, scan_errors: Optional[list] = None) -> bool:

--- a/studio/backend/hub/utils/hf_cache_state.py
+++ b/studio/backend/hub/utils/hf_cache_state.py
@@ -83,6 +83,26 @@ def hf_partials_are_resumable() -> bool:
     return tuple(release) <= _LAST_RESUMABLE_PARTIAL_VERSION
 
 
+def partial_is_process_unique(name: str) -> bool:
+    """Whether a partial filename carries the 1.18+ per-process nonce."""
+    if not name.endswith(INCOMPLETE_SUFFIX):
+        return False
+    return _PROCESS_UNIQUE_PARTIAL_RE.fullmatch(name[: -len(INCOMPLETE_SUFFIX)]) is not None
+
+
+def partial_is_resumable(name: str) -> bool:
+    """Whether any later attempt could append to this particular partial.
+
+    Two conditions, and the layout half matters on its own: a nonce partial is private to the
+    process that created it, so even a legacy writer will not reopen it. That combination is
+    reachable whenever caches are shared across environments, which this repo's own pins
+    produce (Python 3.10+ takes hub >= 1.23, older takes 0.36.2, one cache between them).
+    """
+    if partial_is_process_unique(name):
+        return False
+    return hf_partials_are_resumable()
+
+
 def _safe_is_dir(path: Path, scan_errors: Optional[list] = None) -> bool:
     """``Path.is_dir()`` returning False instead of raising when the path or a
     parent is unreadable (e.g. a restricted ``~/.cache/huggingface/hub``), so

--- a/studio/backend/hub/utils/hf_cache_state.py
+++ b/studio/backend/hub/utils/hf_cache_state.py
@@ -90,6 +90,32 @@ def partial_is_process_unique(name: str) -> bool:
     return _PROCESS_UNIQUE_PARTIAL_RE.fullmatch(name[: -len(INCOMPLETE_SUFFIX)]) is not None
 
 
+def blob_download_lock_held(entry: Path, blob_hash: str) -> bool:
+    """Whether some process holds huggingface_hub's per-blob download lock right now.
+
+    hf takes ``<hub cache>/.locks/<repo dir>/<etag>.lock`` for the whole of a file download, so
+    a lock we cannot take means a live writer -- including a client in another process that no
+    peer registry here can see. It answers False when the lock cannot be probed at all, since
+    upstream calls the lock best-effort and some filesystems grant it to everyone; callers pair
+    it with a staleness check rather than trusting it alone.
+    """
+    lock_path = entry.parent / ".locks" / entry.name / f"{blob_hash}.lock"
+    if not lock_path.exists():
+        return False
+    try:
+        from filelock import FileLock, Timeout
+    except Exception:  # noqa: BLE001 - no filelock means no opinion
+        return False
+    try:
+        lock = FileLock(str(lock_path), timeout = 0)
+        with lock:
+            return False
+    except Timeout:
+        return True
+    except OSError:
+        return False
+
+
 def partial_is_resumable(name: str) -> bool:
     """Whether any later attempt could append to this particular partial.
 

--- a/studio/backend/hub/utils/hf_cache_state.py
+++ b/studio/backend/hub/utils/hf_cache_state.py
@@ -52,6 +52,12 @@ def incomplete_blob_hash(name: str) -> Optional[str]:
 # The last huggingface_hub line whose partials a later attempt can append to.
 _LAST_RESUMABLE_PARTIAL_VERSION = (1, 17)
 
+# How long a partial must sit untouched before it reads as abandoned rather than in flight.
+# huggingface_hub writes to one continuously, so anything still advancing has a live writer --
+# possibly a client in another process that no registry here can see. Shared by the sweep that
+# deletes abandoned partials and the progress scan that must not report one as current.
+ABANDONED_PARTIAL_SECONDS = 120
+
 
 @lru_cache(maxsize = 1)
 def hf_partials_are_resumable() -> bool:


### PR DESCRIPTION
## Summary

- add `hf_partials_are_resumable()`, which answers whether the installed huggingface_hub still appends to a partial
- purge `.incomplete` partials on HTTP downloads when it cannot, instead of preserving them on the strength of a transport marker
- keep the existing behaviour intact on hubs that can still resume, and keep protecting blobs a concurrent peer is writing

## Root cause

`prepare_cache_for_transport` preserves an HTTP partial whose transport marker says `http`, on the premise that "the HTTP resumer would otherwise append to a sparse XET partial and silently produce a corrupt blob". That premise assumes a resumer exists.

huggingface_hub 1.17 and earlier opened `<etag>.incomplete` in append mode and continued from its length with `Range: bytes={resume_size}-`. 1.18 replaced that with a process-unique `<etag>.<nonce>.incomplete`, opened `"wb"` and unlinked in a `finally` (huggingface/huggingface_hub#4228). I bisected the tags to confirm the boundary: 1.17.0 does not have the new writer, 1.18.0 does. Since `studio.txt` pins `huggingface-hub>=1.23.0,<2.0` for Python 3.10+, every current Studio install is past it.

So on the pinned hub there is no within-file resume left. A partial that survives a hard kill (the `finally` does not run on SIGKILL) is never read again, and the marker vouches for provenance nobody will use.

## User impact

The orphan is not merely wasted disk, though a cancelled 30GB GGUF leaves 30GB of it. It also carries the same etag as the blob the next attempt is refetching, so the progress reading takes it as this download's high-water mark. Restarting that download shows the bar parked at wherever the previous attempt died, unmoving, until the fresh attempt overtakes it. Purging at download start is what makes the bar start at zero and climb honestly.

This is the follow-up I flagged in #8288, which fixed the reading side of the same upstream change.

## Scope

Deliberately narrow. Whole-file resume is unaffected: `snapshot_download` still skips shards already materialized, so an interrupted multi-shard model still keeps its completed shards. What is gone upstream, and not something Studio can restore here, is resuming within a single large file.

XET already purged unconditionally, so nothing changes there. `protected_blob_hashes` still shields a blob a same-repo peer is writing right now, since unresumable is not a licence to delete a file another download has open.

An unreadable or unparseable hub version answers "resumable", because not knowing which writer is installed is not grounds for deleting bytes that may still be reusable.

## Validation

- `hub/tests`: 501 passed, against the installed hub and again with `huggingface_hub.__version__` forced to `1.27.0` for the whole suite, which is the condition CI runs on Python 3.10+.
- `test_prepare_cache_for_transport_preserves_same_transport_companion` asserted the old contract unconditionally and fails on a modern hub. It now pins the capability to `True`, so it still covers the reprieve where the reprieve is real.
- New `test_unresumable_partial_purge.py`: the version boundary across 0.36.2 / 1.17 / 1.18 / 1.23 / 1.27 / a dev version / an unparseable one, the purge despite a matching marker, the preserved partial on a resumable hub, and the protected peer.
- Ruff check and format clean, `git diff --check` clean.
