### PR TITLE
Await the async chat-history routes in the research run tests

### DIFF
--- a/studio/backend/tests/test_research_runs_storage.py
+++ b/studio/backend/tests/test_research_runs_storage.py
@@ -815,10 +815,12 @@ def test_delete_thread_cancels_active_research_run(research_home):
             state = SimpleNamespace(research_supervisor = SimpleNamespace(cancel = cancelled.append))
         )
     )
-    chat_history.delete_threads(
-        chat_history.ChatDeleteRequest(ids = ["thread-1"]),
-        request,
-        current_subject = "alice",
+    asyncio.run(
+        chat_history.delete_threads(
+            chat_history.ChatDeleteRequest(ids = ["thread-1"]),
+            request,
+            current_subject = "alice",
+        )
     )
 
     assert research_db.get_run("run-1") is None
@@ -849,8 +851,10 @@ def test_project_delete_cancels_runs_captured_by_delete_transaction(research_hom
         )
     )
 
-    deleted = chat_history.delete_project(
-        "project-1", request, delete_files = False, current_subject = "alice"
+    deleted = asyncio.run(
+        chat_history.delete_project(
+            "project-1", request, delete_files = False, current_subject = "alice"
+        )
     )
 
     assert deleted.id == "project-1"
@@ -874,7 +878,7 @@ def test_clear_history_cancels_runs_captured_by_delete_transaction(research_home
         )
     )
 
-    chat_history.clear_history(request, current_subject = "alice")
+    asyncio.run(chat_history.clear_history(request, current_subject = "alice"))
 
     assert studio_db.get_chat_thread("thread-1") is None
     assert research_db.get_run("run-1") is None


### PR DESCRIPTION
`delete_threads`, `delete_project` and `clear_history` are all `async def` in
`routes/chat_history.py`. Three tests in `test_research_runs_storage.py` called them
directly rather than awaiting them, so each call returned a coroutine that was never
run: the delete never happened, and the assertions that the research run had been
cancelled failed. Python reported it plainly, in the same output as the failure:

```
RuntimeWarning: coroutine 'delete_threads' was never awaited
```

The fix wraps the three calls in `asyncio.run`, which is what the other ~20 async call
sites in this same file already do, so no new pattern is introduced.

### Why nobody saw these go red

They were failing on `main`, but invisible. `studio/backend/tests/test_trainer_stdout_quiet.py`
was aborting collection for the whole Backend CI job before any test ran (fixed in #8342),
and the org Actions queue has been cancelling runs rather than failing them. The three
failures only became visible once #8342 landed and the job could collect again.

### Verification

Run against a venv built to match the `studio-backend-ci.yml` pytest matrix job
(studio.txt plus the listed extras, CPU torch, transformers), using the workflow's own
ignore and deselect flags.

| tree | result |
|---|---|
| `test_research_runs_storage.py` on `main` | 3 failed, 121 passed |
| `test_research_runs_storage.py` with this fix | **124 passed** |
| full backend suite with this fix | 3 failed, **21260 passed**, 129 skipped |

The 3 remaining failures are unrelated and pre-existing: `test_a_clip_trained_family_is_not_turned_away_by_the_clip_refusal`,
`test_a_clip_family_still_refuses_a_folder_holding_stills` and
`test_video_download_plan_judges_a_quantized_reference_pick_per_partition`. I confirmed
all three fail identically on a pristine checkout of current `main` (`2066f2d8d`) with
this branch's change absent, so they are not caused by it and are left alone here.
