### PR TITLE
Name the encoding on the snapshot-progress ref read

### DIFF
--- a/studio/backend/hub/services/snapshot_progress.py
+++ b/studio/backend/hub/services/snapshot_progress.py
@@ -395,7 +395,9 @@ def _referenced_commits(entry: Path) -> "frozenset[str]":
         try:
             if not ref.is_file():
                 continue
-            commit = download_manifest.normalized_commit_hash(ref.read_text().strip())
+            commit = download_manifest.normalized_commit_hash(
+                ref.read_text(encoding = "utf-8").strip()
+            )
         except (OSError, ValueError):
             continue
         if commit:

--- a/studio/backend/tests/test_video_prequant.py
+++ b/studio/backend/tests/test_video_prequant.py
@@ -1087,4 +1087,4 @@ def test_the_fallback_is_resolved_before_the_download_is_planned(monkeypatch):
     verified = src.index("_denoiser_prequant_verified")
     predownload = src.index("_predownload_base")
     assert planned < verified < predownload
-    assert "h3_auto_denoiser or kwargs.get(\"transformer_quant\")" in src
+    assert 'h3_auto_denoiser or kwargs.get("transformer_quant")' in src

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -132,6 +132,7 @@ def _raw_install_record(root: Path) -> Optional[str]:
     except Exception:  # noqa: BLE001 -- absent / unreadable / a directory: all "cannot tell"
         return None
 
+
 # The same, for the bundle's sd-server capability. Memoised alongside the accelerator or not at
 # all: with only half of it remembered, an unwritable record leaves a serverless install looking
 # server-capable, and the load that finds a mismatched legacy server keeps reinstalling.


### PR DESCRIPTION
## The failure

`test_text_io_names_its_encoding` is red on main:

```
FAILED tests/test_text_io_encoding.py::test_text_io_names_its_encoding[snapshot_progress.py]
  snapshot_progress.py:398: read_text() without encoding
```

The test scans every Studio source file, so one offender fails the whole check.

## The fix

`ref.read_text()` becomes `ref.read_text(encoding = "utf-8")`. Without it the read falls back to the Windows ANSI codepage, which is the corruption the lint exists to prevent.

Worth being accurate about the blast radius: the content here is a git commit hash, so it is ASCII and no user's data has actually been mangled by this one. What it costs today is a red check on every PR.

## Tests

```
studio/backend/tests/test_text_io_encoding.py   412 passed  (was 411 passed, 1 failed)
ruff                                            clean
```
