### PR TITLE
Make publish-desktop-updater.yml manual-dispatch only

### DIFF
--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -1,14 +1,22 @@
 name: Publish Desktop Release
 
+# Manual dispatch only. Publishing a release must never start this workflow: it
+# shares a concurrency group with release-desktop.yml, so an auto-fired run queues
+# ahead of the desktop build dispatched right after it and stalls the release. It
+# also fired on a release that could not yet carry bundles, because this repo
+# publishes the v... release before release-desktop.yml attaches them.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Unified v... release to expose once to legacy desktop-latest clients'
+        description: 'Unified v... release to validate and expose to clients (for example, v0.1.61-beta)'
         type: string
         required: true
+      repair_pointer:
+        description: 'Release carries no bundles of its own: carry the newest desktop manifest onto it so update checks stop 404ing'
+        type: boolean
+        required: false
+        default: false
       bridge_legacy_channel:
         description: 'One-time migration only: mirror this release manifest to existing desktop-latest'
         type: boolean
@@ -26,15 +34,15 @@ concurrency:
 jobs:
   publish-updater:
     name: Validate published desktop release
-    if: >-
-      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) ||
-      (github.event_name == 'workflow_dispatch' && inputs.bridge_legacy_channel)
+    # A mistakenly flagged prerelease still reaches the job so validation fails
+    # visibly rather than silently skipping.
+    if: ${{ startsWith(inputs.release_tag, 'v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
       GH_REPO: ${{ github.repository }}
-      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
 
     steps:
       - name: Harden runner (audit)
@@ -42,19 +50,15 @@ jobs:
         with:
           egress-policy: audit
 
-      # The v... release is published before release-desktop.yml attaches the
-      # bundles, so this fires first on a release that carries none. Skip cleanly
-      # instead of failing; the desktop run advances the channel itself.
+      # Dispatching against a release that carries no bundles is a normal case, so
+      # decide from the assets rather than failing: with repair_pointer the run
+      # carries a manifest forward, without it there is simply nothing to validate.
       - name: Check for desktop bundles
         id: gate
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" != "release" ]; then
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           asset_names="$RUNNER_TEMP/release-asset-names.txt"
           # Fail closed: an unreadable release must not look like one with no bundles.
           if ! gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' > "$asset_names"; then
@@ -74,8 +78,12 @@ jobs:
       # newest desktop manifest onto this release instead, so discovery follows
       # desktop metadata rather than release order. The manifest keeps its own
       # version and its URLs keep pointing at the immutable release that built it.
+      #
+      # This run stops here: the gate said the release carries nothing of its own,
+      # so validation and promotion below stay skipped. Once the release has its
+      # own bundles, re-dispatch without repair_pointer to validate and promote.
       - name: Carry desktop metadata forward
-        if: ${{ github.event_name == 'release' && steps.gate.outputs.proceed == 'false' }}
+        if: ${{ inputs.repair_pointer && steps.gate.outputs.proceed == 'false' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -145,14 +153,17 @@ jobs:
           PY
           gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/carry-forward/latest.json" --clobber
           echo "Carried ${source_tag} updater metadata onto ${RELEASE_TAG}."
-          # GitHub moves /releases/latest when the release is published, before this
-          # job can start, so update checks 404 from that moment until the upload
-          # above. Record it: a long queue makes the gap worth knowing about.
+          # GitHub moves /releases/latest the moment the release is published, so
+          # update checks 404 from then until the upload above. Nothing fires
+          # automatically now, so that gap runs until someone dispatches this:
+          # record it, because its length is a human response time.
           {
             printf '### Desktop updater pointer\n\n'
             printf '%s carried no desktop bundles, so it now serves the %s manifest.\n\n' \
               "$RELEASE_TAG" "$source_tag"
             printf 'Update checks returned 404 between the release being published and this upload.\n'
+            printf '\nRe-dispatch without repair_pointer once %s carries its own bundles.\n' \
+              "$RELEASE_TAG"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Download updater metadata
@@ -167,7 +178,7 @@ jobs:
           test -s "$RUNNER_TEMP/desktop-updater/latest.json"
 
       - name: Remove standalone signature assets
-        if: ${{ github.event_name == 'release' && steps.gate.outputs.proceed == 'true' }}
+        if: ${{ steps.gate.outputs.proceed == 'true' && !inputs.bridge_legacy_channel }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -238,7 +249,7 @@ jobs:
           PY
 
       - name: Prevent GitHub latest downgrade
-        if: ${{ github.event_name == 'release' && steps.gate.outputs.proceed == 'true' }}
+        if: ${{ steps.gate.outputs.proceed == 'true' && !inputs.bridge_legacy_channel }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -304,7 +315,7 @@ jobs:
 
 
       - name: Mark published release as GitHub latest
-        if: ${{ github.event_name == 'release' && steps.gate.outputs.proceed == 'true' }}
+        if: ${{ steps.gate.outputs.proceed == 'true' && !inputs.bridge_legacy_channel }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -315,7 +326,7 @@ jobs:
           test -n "$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[] | select(.name == "latest.json") | .url')"
 
       - name: Bridge legacy desktop-latest clients once
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.bridge_legacy_channel }}
+        if: ${{ inputs.bridge_legacy_channel }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -325,8 +325,16 @@ jobs:
           test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)" = "$RELEASE_TAG"
           test -n "$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[] | select(.name == "latest.json") | .url')"
 
+      # The gate guard is load-bearing, not decoration: this step reads the
+      # manifest that "Download updater metadata" fetches, and that step is
+      # itself gated on proceed == 'true'. Before this workflow became
+      # dispatch-only the gate short-circuited to 'true' on every dispatch, so
+      # bridge_legacy_channel alone implied the download had run. It no longer
+      # does, and without this conjunct a repair_pointer run that also asks to
+      # bridge would upload a carried manifest and then read a file that was
+      # never downloaded, failing after it had already mutated the release.
       - name: Bridge legacy desktop-latest clients once
-        if: ${{ inputs.bridge_legacy_channel }}
+        if: ${{ steps.gate.outputs.proceed == 'true' && inputs.bridge_legacy_channel }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -1,10 +1,8 @@
 name: Publish Desktop Release
 
-# Manual dispatch only. Publishing a release must never start this workflow: it
-# shares a concurrency group with release-desktop.yml, so an auto-fired run queues
-# ahead of the desktop build dispatched right after it and stalls the release. It
-# also fired on a release that could not yet carry bundles, because this repo
-# publishes the v... release before release-desktop.yml attaches them.
+# Manual dispatch only. This shares a concurrency group with release-desktop.yml,
+# so a run fired by publishing queues ahead of the desktop build dispatched right
+# after it and stalls the release -- and fires before any bundles exist anyway.
 on:
   workflow_dispatch:
     inputs:
@@ -50,9 +48,9 @@ jobs:
         with:
           egress-policy: audit
 
-      # Dispatching against a release that carries no bundles is a normal case, so
-      # decide from the assets rather than failing: with repair_pointer the run
-      # carries a manifest forward, without it there is simply nothing to validate.
+      # A release with no bundles is a normal dispatch, so decide from the assets:
+      # with repair_pointer the run carries a manifest forward, without it there is
+      # nothing to validate.
       - name: Check for desktop bundles
         id: gate
         env:
@@ -78,10 +76,8 @@ jobs:
       # newest desktop manifest onto this release instead, so discovery follows
       # desktop metadata rather than release order. The manifest keeps its own
       # version and its URLs keep pointing at the immutable release that built it.
-      #
-      # This run stops here: the gate said the release carries nothing of its own,
-      # so validation and promotion below stay skipped. Once the release has its
-      # own bundles, re-dispatch without repair_pointer to validate and promote.
+      # The run stops here; validation and promotion below stay skipped. Re-dispatch
+      # without repair_pointer once the release carries its own bundles.
       - name: Carry desktop metadata forward
         if: ${{ inputs.repair_pointer && steps.gate.outputs.proceed == 'false' }}
         env:
@@ -153,10 +149,9 @@ jobs:
           PY
           gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/carry-forward/latest.json" --clobber
           echo "Carried ${source_tag} updater metadata onto ${RELEASE_TAG}."
-          # GitHub moves /releases/latest the moment the release is published, so
-          # update checks 404 from then until the upload above. Nothing fires
-          # automatically now, so that gap runs until someone dispatches this:
-          # record it, because its length is a human response time.
+          # GitHub moves /releases/latest when the release is published, so update
+          # checks 404 from then until the upload above. Nothing fires automatically
+          # now, so record the gap: its length is a human response time.
           {
             printf '### Desktop updater pointer\n\n'
             printf '%s carried no desktop bundles, so it now serves the %s manifest.\n\n' \
@@ -325,14 +320,10 @@ jobs:
           test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)" = "$RELEASE_TAG"
           test -n "$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[] | select(.name == "latest.json") | .url')"
 
-      # The gate guard is load-bearing, not decoration: this step reads the
-      # manifest that "Download updater metadata" fetches, and that step is
-      # itself gated on proceed == 'true'. Before this workflow became
-      # dispatch-only the gate short-circuited to 'true' on every dispatch, so
-      # bridge_legacy_channel alone implied the download had run. It no longer
-      # does, and without this conjunct a repair_pointer run that also asks to
-      # bridge would upload a carried manifest and then read a file that was
-      # never downloaded, failing after it had already mutated the release.
+      # The gate conjunct is load-bearing: this step reads the manifest that
+      # "Download updater metadata" fetches, and that step is itself gated on
+      # proceed == 'true'. Without it a repair_pointer run that also bridges would
+      # upload a carried manifest and then die on a file it never downloaded.
       - name: Bridge legacy desktop-latest clients once
         if: ${{ steps.gate.outputs.proceed == 'true' && inputs.bridge_legacy_channel }}
         env:

--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -100,6 +100,23 @@ jobs:
 
           semver = re.compile(r'^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$')
           releases = json.loads(pathlib.Path(sys.argv[1]).read_text())
+
+          # /releases/latest resolves only to a non-draft, non-prerelease release, so
+          # a manifest carried onto one of those cannot repair the endpoint this step
+          # exists for, however well the upload itself goes. The source filter below
+          # already refuses them; hold the target to the same rule rather than report
+          # a repair it could never deliver. Read from the listing already fetched.
+          target = next(
+              (r for r in releases if r.get('tag_name') == os.environ['RELEASE_TAG']),
+              None,
+          )
+          if target is not None and (target.get('draft') or target.get('prerelease')):
+              state = 'draft' if target.get('draft') else 'prerelease'
+              sys.exit(
+                  f"{os.environ['RELEASE_TAG']} is a {state}, which /releases/latest never "
+                  'resolves to; refusing to carry a manifest that cannot repair the pointer'
+              )
+
           candidates = [
               release for release in releases
               if semver.fullmatch(release.get('tag_name') or '')

--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -172,20 +172,6 @@ jobs:
           gh release download "$RELEASE_TAG" --pattern latest.json --dir "$RUNNER_TEMP/desktop-updater"
           test -s "$RUNNER_TEMP/desktop-updater/latest.json"
 
-      - name: Remove standalone signature assets
-        if: ${{ steps.gate.outputs.proceed == 'true' && !inputs.bridge_legacy_channel }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # Scoped to the desktop bundles: the v... release carries other assets too.
-          signature_assets="$(gh release view "$RELEASE_TAG" --json assets \
-            --jq '.assets[].name | select(startswith("Unsloth-Desktop-")) | select(endswith(".sig"))')"
-          while IFS= read -r asset_name; do
-            [[ -z "$asset_name" ]] || gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
-          done <<< "$signature_assets"
-          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > "$RUNNER_TEMP/source-release.json"
-
       - name: Validate updater metadata
         if: steps.gate.outputs.proceed == 'true'
         run: |
@@ -308,6 +294,25 @@ jobs:
               sys.exit(f'Refusing to replace GitHub latest {current} with older {candidate}')
           PY
 
+
+      # Deletion is permanent, and the tag is now typed by hand rather than
+      # supplied by the release event, so every check that can reject the target
+      # runs above this. Validation only asks whether each manifest bundle is
+      # present, so the .sig assets still being here does not change its verdict.
+      # The re-fetch keeps source-release.json current for the promotion below.
+      - name: Remove standalone signature assets
+        if: ${{ steps.gate.outputs.proceed == 'true' && !inputs.bridge_legacy_channel }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Scoped to the desktop bundles: the v... release carries other assets too.
+          signature_assets="$(gh release view "$RELEASE_TAG" --json assets \
+            --jq '.assets[].name | select(startswith("Unsloth-Desktop-")) | select(endswith(".sig"))')"
+          while IFS= read -r asset_name; do
+            [[ -z "$asset_name" ]] || gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
+          done <<< "$signature_assets"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > "$RUNNER_TEMP/source-release.json"
 
       - name: Mark published release as GitHub latest
         if: ${{ steps.gate.outputs.proceed == 'true' && !inputs.bridge_legacy_channel }}

--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -1,8 +1,7 @@
 name: Publish Desktop Release
 
-# Manual dispatch only. This shares a concurrency group with release-desktop.yml,
-# so a run fired by publishing queues ahead of the desktop build dispatched right
-# after it and stalls the release -- and fires before any bundles exist anyway.
+# Manual dispatch only: sharing release-desktop.yml's concurrency group, a publish-fired
+# run stalls the desktop build queued behind it -- and predates any bundles anyway.
 on:
   workflow_dispatch:
     inputs:
@@ -32,8 +31,8 @@ concurrency:
 jobs:
   publish-updater:
     name: Validate published desktop release
-    # A mistakenly flagged prerelease still reaches the job so validation fails
-    # visibly rather than silently skipping.
+    # A mistakenly flagged prerelease still reaches the job, so validation fails
+    # visibly instead of silently skipping.
     if: ${{ startsWith(inputs.release_tag, 'v') }}
     runs-on: ubuntu-latest
     permissions:
@@ -48,9 +47,8 @@ jobs:
         with:
           egress-policy: audit
 
-      # A release with no bundles is a normal dispatch, so decide from the assets:
-      # with repair_pointer the run carries a manifest forward, without it there is
-      # nothing to validate.
+      # A release with no bundles is a normal dispatch, so decide from the assets: with
+      # repair_pointer the run carries a manifest forward, without it nothing to validate.
       - name: Check for desktop bundles
         id: gate
         env:
@@ -76,8 +74,8 @@ jobs:
       # newest desktop manifest onto this release instead, so discovery follows
       # desktop metadata rather than release order. The manifest keeps its own
       # version and its URLs keep pointing at the immutable release that built it.
-      # The run stops here; validation and promotion below stay skipped. Re-dispatch
-      # without repair_pointer once the release carries its own bundles.
+      # Validation and promotion below stay skipped; re-dispatch without repair_pointer
+      # once the release carries its own bundles.
       - name: Carry desktop metadata forward
         if: ${{ inputs.repair_pointer && steps.gate.outputs.proceed == 'false' }}
         env:
@@ -101,20 +99,18 @@ jobs:
           semver = re.compile(r'^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$')
           releases = json.loads(pathlib.Path(sys.argv[1]).read_text())
 
-          # /releases/latest resolves only to a non-draft, non-prerelease release, so
-          # a manifest carried onto one of those cannot repair the endpoint this step
-          # exists for, however well the upload itself goes. The source filter below
-          # already refuses them; hold the target to the same rule rather than report
-          # a repair it could never deliver. Read from the listing already fetched:
-          # it is the only view that carries the answer, because /releases/tags/{tag}
-          # returns 404 for a draft, which has no git tag until it is published.
+          # /releases/latest never resolves to a draft or prerelease, so a manifest
+          # carried onto one cannot repair the endpoint however well the upload goes;
+          # the source filter below already refuses them. Read the target from the
+          # listing already fetched: /releases/tags/{tag} returns 404 for a draft,
+          # which has no git tag until it is published.
           target = next(
               (r for r in releases if r.get('tag_name') == os.environ['RELEASE_TAG']),
               None,
           )
-          # Fail closed: that listing is one page, so a target beyond it is a state
-          # this step cannot read, not a state it may assume is fine. Skipping the
-          # check below would upload the manifest and report a repair anyway.
+          # Fail closed: the listing is one page, so a target beyond it has a state
+          # this step cannot read; skipping the check below would upload the manifest
+          # and report a repair anyway.
           if target is None:
               sys.exit(
                   f"{os.environ['RELEASE_TAG']} is not among the 100 most recent releases; "
@@ -177,9 +173,9 @@ jobs:
           PY
           gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/carry-forward/latest.json" --clobber
           echo "Carried ${source_tag} updater metadata onto ${RELEASE_TAG}."
-          # GitHub moves /releases/latest when the release is published, so update
-          # checks 404 from then until the upload above. Nothing fires automatically
-          # now, so record the gap: its length is a human response time.
+          # GitHub moved /releases/latest when the release was published, so update
+          # checks 404 from then until the upload above. Nothing is automatic now, so
+          # record that gap: its length is a human response time.
           {
             printf '### Desktop updater pointer\n\n'
             printf '%s carried no desktop bundles, so it now serves the %s manifest.\n\n' \
@@ -323,10 +319,9 @@ jobs:
           PY
 
 
-      # Deletion is permanent, and the tag is now typed by hand rather than
-      # supplied by the release event, so every check that can reject the target
-      # runs above this. Validation only asks whether each manifest bundle is
-      # present, so the .sig assets still being here does not change its verdict.
+      # Deletion is permanent and the tag is now hand-typed, so every check that can
+      # reject the target runs above this. Validation only asks whether each manifest
+      # bundle is present, so the surviving .sig assets do not change its verdict.
       # The re-fetch keeps source-release.json current for the promotion below.
       - name: Remove standalone signature assets
         if: ${{ steps.gate.outputs.proceed == 'true' && !inputs.bridge_legacy_channel }}
@@ -353,10 +348,9 @@ jobs:
           test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)" = "$RELEASE_TAG"
           test -n "$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[] | select(.name == "latest.json") | .url')"
 
-      # The gate conjunct is load-bearing: this step reads the manifest that
-      # "Download updater metadata" fetches, and that step is itself gated on
-      # proceed == 'true'. Without it a repair_pointer run that also bridges would
-      # upload a carried manifest and then die on a file it never downloaded.
+      # The gate conjunct is load-bearing: this step reads the manifest fetched by
+      # "Download updater metadata", itself gated on proceed == 'true'. Without it a
+      # repair_pointer run that also bridges would die on a file it never downloaded.
       - name: Bridge legacy desktop-latest clients once
         if: ${{ steps.gate.outputs.proceed == 'true' && inputs.bridge_legacy_channel }}
         env:

--- a/.github/workflows/publish-desktop-updater.yml
+++ b/.github/workflows/publish-desktop-updater.yml
@@ -105,12 +105,23 @@ jobs:
           # a manifest carried onto one of those cannot repair the endpoint this step
           # exists for, however well the upload itself goes. The source filter below
           # already refuses them; hold the target to the same rule rather than report
-          # a repair it could never deliver. Read from the listing already fetched.
+          # a repair it could never deliver. Read from the listing already fetched:
+          # it is the only view that carries the answer, because /releases/tags/{tag}
+          # returns 404 for a draft, which has no git tag until it is published.
           target = next(
               (r for r in releases if r.get('tag_name') == os.environ['RELEASE_TAG']),
               None,
           )
-          if target is not None and (target.get('draft') or target.get('prerelease')):
+          # Fail closed: that listing is one page, so a target beyond it is a state
+          # this step cannot read, not a state it may assume is fine. Skipping the
+          # check below would upload the manifest and report a repair anyway.
+          if target is None:
+              sys.exit(
+                  f"{os.environ['RELEASE_TAG']} is not among the 100 most recent releases; "
+                  'refusing to carry a manifest onto a target whose draft or '
+                  'prerelease state cannot be checked'
+              )
+          if target.get('draft') or target.get('prerelease'):
               state = 'draft' if target.get('draft') else 'prerelease'
               sys.exit(
                   f"{os.environ['RELEASE_TAG']} is a {state}, which /releases/latest never "

--- a/tests/security/test_desktop_updater_pointer.py
+++ b/tests/security/test_desktop_updater_pointer.py
@@ -50,6 +50,9 @@ def _step_run():
     step = steps[STEP_NAME]
     # Only for a release that arrived without bundles of its own.
     assert "steps.gate.outputs.proceed == 'false'" in step["if"]
+    # Nothing fires this workflow automatically any more, so the repair is
+    # reachable only when a maintainer asks for it by name.
+    assert "inputs.repair_pointer" in step["if"]
     return step["run"]
 
 

--- a/tests/security/test_desktop_updater_pointer.py
+++ b/tests/security/test_desktop_updater_pointer.py
@@ -85,6 +85,7 @@ def _manifest(tag):
 
 
 def _run(tmp_path, *, release_tag, releases, manifest):
+    tmp_path.mkdir(parents = True, exist_ok = True)
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     gh = fake_bin / "gh"
@@ -222,3 +223,22 @@ def test_a_manifest_without_a_usable_version_is_refused(tmp_path):
     )
     assert result.returncode == 1
     assert "refusing to carry it forward" in result.stderr
+
+
+def test_a_draft_or_prerelease_target_is_refused(tmp_path):
+    # /releases/latest resolves only to a non-draft, non-prerelease release, so
+    # carrying a manifest onto one of those cannot repair the endpoint. The source
+    # filter already refuses them; the target is held to the same rule rather than
+    # reporting a repair it could never deliver.
+    for state in ("draft", "prerelease"):
+        target = _release("v0.1.53-beta", has_manifest = False)
+        target[state] = True
+        result, commands = _run(
+            tmp_path / state,
+            release_tag = "v0.1.53-beta",
+            releases = [target, _release("v0.1.52-beta")],
+            manifest = _manifest("v0.1.52-beta"),
+        )
+        assert result.returncode != 0, f"{state} target was accepted"
+        assert f"is a {state}" in result.stderr, result.stderr
+        assert not [line for line in commands if line.startswith("gh release upload")], commands

--- a/tests/security/test_desktop_updater_pointer.py
+++ b/tests/security/test_desktop_updater_pointer.py
@@ -234,10 +234,9 @@ def test_a_manifest_without_a_usable_version_is_refused(tmp_path):
 
 
 def test_a_draft_or_prerelease_target_is_refused(tmp_path):
-    # /releases/latest resolves only to a non-draft, non-prerelease release, so
-    # carrying a manifest onto one of those cannot repair the endpoint. The source
-    # filter already refuses them; the target is held to the same rule rather than
-    # reporting a repair it could never deliver.
+    # /releases/latest never resolves to a draft or prerelease, so carrying a manifest
+    # onto one cannot repair the endpoint. The source filter already refuses them; the
+    # target is held to the same rule.
     for state in ("draft", "prerelease"):
         target = _release("v0.1.53-beta", has_manifest = False)
         target[state] = True
@@ -253,11 +252,10 @@ def test_a_draft_or_prerelease_target_is_refused(tmp_path):
 
 
 def test_a_target_missing_from_the_release_listing_is_refused(tmp_path):
-    # The listing is the only view that shows the target's draft state at all:
-    # /releases/tags/{tag} answers 404 for a draft, which has no git tag until it
-    # is published. So a target absent from the single page fetched above has an
-    # unverifiable state, and the draft/prerelease refusal degrades into no check.
-    # Refuse rather than report a repair /releases/latest may never resolve to.
+    # The listing is the only view of the target's draft state: /releases/tags/{tag}
+    # answers 404 for a draft, which has no git tag until it is published. A target
+    # absent from that single page has an unverifiable state, so the draft/prerelease
+    # refusal above would degrade into no check. Fail closed instead.
     result, commands = _run(
         tmp_path,
         release_tag = "v0.1.53-beta",

--- a/tests/security/test_desktop_updater_pointer.py
+++ b/tests/security/test_desktop_updater_pointer.py
@@ -155,6 +155,7 @@ def test_drafts_prereleases_and_bundleless_releases_are_never_the_source(tmp_pat
         tmp_path,
         release_tag = "v0.1.53-beta",
         releases = [
+            _release("v0.1.53-beta", has_manifest = False, published_at = "2026-04-01T00:00:00Z"),
             _release("v0.1.52-beta", draft = True, published_at = "2026-03-01T00:00:00Z"),
             _release("v0.1.51-beta", prerelease = True, published_at = "2026-02-01T00:00:00Z"),
             _release("v0.1.50-beta", has_manifest = False, published_at = "2026-01-01T00:00:00Z"),
@@ -185,6 +186,7 @@ def test_an_already_carried_manifest_is_carried_forward_again(tmp_path):
         tmp_path,
         release_tag = "v0.1.54-beta",
         releases = [
+            _release("v0.1.54-beta", has_manifest = False, published_at = "2026-05-01T00:00:00Z"),
             _release("v0.1.53-beta", published_at = "2026-04-01T00:00:00Z"),
             _release("v0.1.52-beta", published_at = "2026-03-01T00:00:00Z"),
         ],
@@ -198,7 +200,10 @@ def test_a_manifest_that_is_not_pinned_to_its_own_version_is_refused(tmp_path):
     result, commands = _run(
         tmp_path,
         release_tag = "v0.1.53-beta",
-        releases = [_release("v0.1.52-beta")],
+        releases = [
+            _release("v0.1.53-beta", has_manifest = False),
+            _release("v0.1.52-beta"),
+        ],
         manifest = {
             "version": "v0.1.52-beta",
             "platforms": {
@@ -218,7 +223,10 @@ def test_a_manifest_without_a_usable_version_is_refused(tmp_path):
     result, _ = _run(
         tmp_path,
         release_tag = "v0.1.53-beta",
-        releases = [_release("v0.1.52-beta")],
+        releases = [
+            _release("v0.1.53-beta", has_manifest = False),
+            _release("v0.1.52-beta"),
+        ],
         manifest = {"version": "latest", "platforms": {}},
     )
     assert result.returncode == 1
@@ -242,3 +250,20 @@ def test_a_draft_or_prerelease_target_is_refused(tmp_path):
         assert result.returncode != 0, f"{state} target was accepted"
         assert f"is a {state}" in result.stderr, result.stderr
         assert not [line for line in commands if line.startswith("gh release upload")], commands
+
+
+def test_a_target_missing_from_the_release_listing_is_refused(tmp_path):
+    # The listing is the only view that shows the target's draft state at all:
+    # /releases/tags/{tag} answers 404 for a draft, which has no git tag until it
+    # is published. So a target absent from the single page fetched above has an
+    # unverifiable state, and the draft/prerelease refusal degrades into no check.
+    # Refuse rather than report a repair /releases/latest may never resolve to.
+    result, commands = _run(
+        tmp_path,
+        release_tag = "v0.1.53-beta",
+        releases = [_release("v0.1.52-beta")],
+        manifest = _manifest("v0.1.52-beta"),
+    )
+    assert result.returncode != 0, result.stdout
+    assert "is not among the 100 most recent releases" in result.stderr, result.stderr
+    assert not [line for line in commands if line.startswith("gh release upload")], commands

--- a/tests/security/test_desktop_updater_pointer.py
+++ b/tests/security/test_desktop_updater_pointer.py
@@ -50,8 +50,7 @@ def _step_run():
     step = steps[STEP_NAME]
     # Only for a release that arrived without bundles of its own.
     assert "steps.gate.outputs.proceed == 'false'" in step["if"]
-    # Nothing fires this workflow automatically any more, so the repair is
-    # reachable only when a maintainer asks for it by name.
+    # Nothing fires this workflow automatically, so the repair must be asked for.
     assert "inputs.repair_pointer" in step["if"]
     return step["run"]
 

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -240,6 +240,10 @@ def test_publishing_draft_validates_normal_release_without_rebuilding():
         if step.get("name") == "Bridge legacy desktop-latest clients once"
     )
     assert "inputs.bridge_legacy_channel" in bridge["if"]
+    # The bridge reads the manifest "Download updater metadata" fetches, and that
+    # step is gated on the same output. Dropping this conjunct lets a repair run
+    # that also bridges mutate the release and then die on a file it never got.
+    assert "steps.gate.outputs.proceed == 'true'" in bridge["if"]
     assert "gh release create desktop-latest" not in bridge["run"]
     assert "gh release upload desktop-latest" in bridge["run"]
     assert "--clobber" in bridge["run"]

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -240,8 +240,7 @@ def test_publishing_draft_validates_normal_release_without_rebuilding():
         if step.get("name") == "Bridge legacy desktop-latest clients once"
     )
     assert "inputs.bridge_legacy_channel" in bridge["if"]
-    # The bridge reads the manifest that the download step, gated on this same
-    # output, fetches: without it a bridging repair run dies on a missing file.
+    # Without it the bridge reads a manifest that the gated download step never fetched.
     assert "steps.gate.outputs.proceed == 'true'" in bridge["if"]
     assert "gh release create desktop-latest" not in bridge["run"]
     assert "gh release upload desktop-latest" in bridge["run"]
@@ -292,8 +291,7 @@ def test_the_updater_workflow_validates_the_target_before_deleting_its_assets():
     remove = order.index("Remove standalone signature assets")
     for name in ("Validate updater metadata", "Prevent GitHub latest downgrade"):
         assert order.index(name) < remove, name
-    # Still swept before the release becomes the pointer clients resolve, and
-    # still ahead of the promotion that reads the source-release.json it refreshes.
+    # Still ahead of the promotion, which points clients here and reads the JSON it refreshes.
     assert remove < order.index("Mark published release as GitHub latest")
 
 
@@ -306,14 +304,12 @@ def test_the_updater_workflow_is_manual_dispatch_only():
     assert set(triggers) == {"workflow_dispatch"}, triggers
 
     job = workflow["jobs"]["publish-updater"]
-    # A leftover github.event.release reference is null under dispatch, so every
-    # condition has to resolve against inputs instead of being silently false.
+    # A leftover github.event.release ref is null under dispatch: silently false, not an error.
     conditions = [job["if"]] + [step["if"] for step in job["steps"] if "if" in step]
     for condition in conditions:
         assert "github.event" not in condition, condition
 
-    # Removing the release trigger is only safe while the pointer repair stays
-    # reachable, so it must not become dead code.
+    # Dropping the release trigger is only safe while the pointer repair stays reachable.
     carry = next(
         step for step in job["steps"] if step.get("name") == "Carry desktop metadata forward"
     )

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -198,17 +198,16 @@ def test_versioned_release_hides_updater_signature_assets():
 def test_publishing_draft_validates_normal_release_without_rebuilding():
     workflow = yaml.safe_load(UPDATER_WORKFLOW.read_text(encoding = "utf-8"))
     triggers = workflow.get("on", workflow.get(True))
-    assert triggers["release"] == {"types": ["published"]}
-    assert "workflow_dispatch" in triggers
+    assert set(triggers) == {"workflow_dispatch"}
     assert workflow["permissions"] == {"contents": "read"}
     assert workflow["concurrency"]["queue"] == "max"
 
     job = workflow["jobs"]["publish-updater"]
     assert "build" not in workflow["jobs"]
     assert job["permissions"] == {"contents": "write"}
-    assert "startsWith(github.event.release.tag_name, 'v')" in job["if"]
+    assert "startsWith(inputs.release_tag, 'v')" in job["if"]
     # The job runs for a mistakenly flagged prerelease so validation fails visibly.
-    assert "github.event.release.prerelease" not in job["if"]
+    assert "prerelease" not in job["if"]
     assert not any("actions/checkout" in step.get("uses", "") for step in job["steps"])
     assert any("gh release delete-asset" in step.get("run", "") for step in job["steps"])
 
@@ -240,7 +239,6 @@ def test_publishing_draft_validates_normal_release_without_rebuilding():
         for step in job["steps"]
         if step.get("name") == "Bridge legacy desktop-latest clients once"
     )
-    assert "workflow_dispatch" in bridge["if"]
     assert "inputs.bridge_legacy_channel" in bridge["if"]
     assert "gh release create desktop-latest" not in bridge["run"]
     assert "gh release upload desktop-latest" in bridge["run"]
@@ -271,9 +269,34 @@ def test_the_updater_workflow_skips_releases_without_desktop_bundles():
         "Download updater metadata",
         "Validate updater metadata",
         "Remove standalone signature assets",
+        "Prevent GitHub latest downgrade",
         "Mark published release as GitHub latest",
     ):
         assert "steps.gate.outputs.proceed == 'true'" in steps[name]["if"], name
 
     # The v... release is shared, so the sweep must not reach past desktop assets.
     assert 'startswith("Unsloth-Desktop-")' in steps["Remove standalone signature assets"]["run"]
+
+
+def test_the_updater_workflow_is_manual_dispatch_only():
+    """It shares a concurrency group with release-desktop.yml, so an auto-fired
+    run queues ahead of the desktop build dispatched right after it and stalls
+    the release. Nothing may start this workflow except a maintainer."""
+    workflow = yaml.safe_load(UPDATER_WORKFLOW.read_text(encoding = "utf-8"))
+    triggers = workflow.get("on", workflow.get(True))
+    assert set(triggers) == {"workflow_dispatch"}, triggers
+
+    job = workflow["jobs"]["publish-updater"]
+    # Every condition has to resolve against dispatch inputs: a leftover
+    # github.event.release reference is null under dispatch and silently false.
+    conditions = [job["if"]] + [step["if"] for step in job["steps"] if "if" in step]
+    for condition in conditions:
+        assert "github.event" not in condition, condition
+
+    # The pointer repair is the reason the release trigger could be removed at
+    # all, so it must stay reachable rather than becoming dead code.
+    carry = next(
+        step for step in job["steps"] if step.get("name") == "Carry desktop metadata forward"
+    )
+    assert "inputs.repair_pointer" in carry["if"]
+    assert triggers["workflow_dispatch"]["inputs"]["repair_pointer"]["default"] is False

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -240,9 +240,8 @@ def test_publishing_draft_validates_normal_release_without_rebuilding():
         if step.get("name") == "Bridge legacy desktop-latest clients once"
     )
     assert "inputs.bridge_legacy_channel" in bridge["if"]
-    # The bridge reads the manifest "Download updater metadata" fetches, and that
-    # step is gated on the same output. Dropping this conjunct lets a repair run
-    # that also bridges mutate the release and then die on a file it never got.
+    # The bridge reads the manifest that the download step, gated on this same
+    # output, fetches: without it a bridging repair run dies on a missing file.
     assert "steps.gate.outputs.proceed == 'true'" in bridge["if"]
     assert "gh release create desktop-latest" not in bridge["run"]
     assert "gh release upload desktop-latest" in bridge["run"]
@@ -291,14 +290,14 @@ def test_the_updater_workflow_is_manual_dispatch_only():
     assert set(triggers) == {"workflow_dispatch"}, triggers
 
     job = workflow["jobs"]["publish-updater"]
-    # Every condition has to resolve against dispatch inputs: a leftover
-    # github.event.release reference is null under dispatch and silently false.
+    # A leftover github.event.release reference is null under dispatch, so every
+    # condition has to resolve against inputs instead of being silently false.
     conditions = [job["if"]] + [step["if"] for step in job["steps"] if "if" in step]
     for condition in conditions:
         assert "github.event" not in condition, condition
 
-    # The pointer repair is the reason the release trigger could be removed at
-    # all, so it must stay reachable rather than becoming dead code.
+    # Removing the release trigger is only safe while the pointer repair stays
+    # reachable, so it must not become dead code.
     carry = next(
         step for step in job["steps"] if step.get("name") == "Carry desktop metadata forward"
     )

--- a/tests/security/test_release_desktop_permissions.py
+++ b/tests/security/test_release_desktop_permissions.py
@@ -281,6 +281,22 @@ def test_the_updater_workflow_skips_releases_without_desktop_bundles():
     assert 'startswith("Unsloth-Desktop-")' in steps["Remove standalone signature assets"]["run"]
 
 
+def test_the_updater_workflow_validates_the_target_before_deleting_its_assets():
+    """The tag is typed by hand, so a mistyped or mis-flagged one names a real
+    older release. Deleting release assets cannot be undone, so every check that
+    rejects the target has to run before the sweep, or the rejected release is
+    already missing its signatures by the time the run fails."""
+    job = yaml.safe_load(UPDATER_WORKFLOW.read_text(encoding = "utf-8"))["jobs"]["publish-updater"]
+    order = [step.get("name") for step in job["steps"]]
+
+    remove = order.index("Remove standalone signature assets")
+    for name in ("Validate updater metadata", "Prevent GitHub latest downgrade"):
+        assert order.index(name) < remove, name
+    # Still swept before the release becomes the pointer clients resolve, and
+    # still ahead of the promotion that reads the source-release.json it refreshes.
+    assert remove < order.index("Mark published release as GitHub latest")
+
+
 def test_the_updater_workflow_is_manual_dispatch_only():
     """It shares a concurrency group with release-desktop.yml, so an auto-fired
     run queues ahead of the desktop build dispatched right after it and stalls


### PR DESCRIPTION
## Summary

`publish-desktop-updater.yml` was the only workflow in the repo with an `on: release:` trigger, so publishing a `v...` release auto-fired it. That is now removed: the workflow is `workflow_dispatch` only.

Two concrete problems this fixes:

- It shares `concurrency: group: release-desktop-${{ github.repository }}` with `release-desktop.yml` (`queue: max`, `cancel-in-progress: false`), so the auto-fired run queued **ahead of** the desktop build dispatched right after it. Run 31396795138 sat behind "Publish Desktop Release #4" until that run was cancelled by hand.
- The auto-fired run could not succeed anyway. This repo publishes the `v...` release *before* `release-desktop.yml` attaches bundles (the desktop workflow refuses to run otherwise: "Tag main and publish it first"), so the updater always fired on a release carrying no `latest.json`.

## Why this is not just deleting the trigger

The job branched on `github.event_name == 'release'` in six places. Removing the trigger naively would have left the job running only when `bridge_legacy_channel` was true, silently disabling all validation and promotion. So the conditions are rewired onto dispatch inputs:

- Job `if:` is now `startsWith(inputs.release_tag, 'v')`; `RELEASE_TAG` reads `inputs.release_tag` directly.
- The `Check for desktop bundles` gate no longer short-circuits to `proceed=true` for non-release events, so it now actually inspects the assets on every run. Strictly stronger than before, where a dispatch skipped the check entirely. The fail-closed unreadable-release branch is unchanged.
- `Remove standalone signature assets`, `Prevent GitHub latest downgrade` and `Mark published release as GitHub latest` now key off `steps.gate.outputs.proceed == 'true' && !inputs.bridge_legacy_channel`, preserving today's behaviour where a bridge dispatch validates but never promotes.

## Keeping the pointer repair reachable

Clients poll the deliberately-moving `/releases/latest/download/latest.json`, and GitHub moves that pointer the instant any normal release is published. A release with no `latest.json` therefore 404s every client's update check. `Carry desktop metadata forward` exists to repair that, so rather than deleting it, it is now gated on a new `repair_pointer` dispatch input (default `false`). Dispatch with it when you publish a `v...` release you are not going to build desktop bundles for.

That run stops after the carry-forward, since the gate reported the release carries nothing of its own. Re-dispatch without `repair_pointer` once the release has its own bundles.

## Tests

- `test_publishing_draft_validates_normal_release_without_rebuilding`: asserts the trigger set is exactly `{workflow_dispatch}` and the job `if` keys off `inputs.release_tag`.
- New `test_the_updater_workflow_is_manual_dispatch_only`: locks the invariant, and asserts no `if:` anywhere in the job still references `github.event` (such a reference is `null` under dispatch and silently false), plus that the repair stays reachable.
- `test_the_updater_workflow_skips_releases_without_desktop_bundles`: adds `Prevent GitHub latest downgrade` to the steps asserted to carry the gate guard, closing a pre-existing coverage gap.
- `test_desktop_updater_pointer.py`: the six carry-forward tests execute the step script directly and are unaffected; the shared helper now also asserts `inputs.repair_pointer` gates the step.

## Test plan

- [x] `pytest tests/security` passes (259 passed, was 258)
- [x] `pytest tests/python/test_virustotal_scan.py tests/security` passes (335 passed)
- [x] Workflow parses as YAML; zero `github.event` references remain
- [ ] Publishing a release produces no workflow run at all
- [ ] `release-desktop.yml` starts immediately instead of queueing behind the updater