### PR TITLE
MiniMax-H3: build the ConvRot Linear class once, not once per projection

### DIFF
--- a/studio/backend/core/inference/diffusion_convrot.py
+++ b/studio/backend/core/inference/diffusion_convrot.py
@@ -52,6 +52,7 @@ reading the metadata contract costs no import.
 
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import Any, Iterable, Optional
 
 # ── the metadata contract, carried in the prequant checkpoint's own ``metadata`` dict ──────────
@@ -163,9 +164,18 @@ def rotate_convrot_weight_(module: Any, group_size: int) -> None:
     module.weight.data = rotated.to(weight.dtype)
 
 
+@lru_cache(maxsize = None)
 def convrot_linear_class() -> Any:
     """The ``nn.Linear`` subclass that rotates its input, built lazily so importing this module
-    never imports torch.
+    never imports torch, and built exactly ONCE.
+
+    The cache is not a micro-optimisation, it is the difference between one compiled graph and
+    dozens. A class defined inside a function is a NEW class object on every call, and
+    ``torch.compile`` guards each frame on ``___check_type_id`` of the modules it closes over. So
+    handing every rotated projection its own ConvRotLinear made each one look like a different
+    type and retraced the block it lives in: measured 23 recompiles against bfloat16's 1 on the
+    same job, 178 s of first-call compile against 14 s, on a denoiser with 350 rotated
+    projections. Sharing one class collapses that back to a single trace.
 
     A CLASS SWAP rather than a wrapper module, and that is load-bearing twice over: the module
     stays an ``nn.Linear``, so torchao's filter and ``quantize_`` treat it exactly as they treat

--- a/studio/backend/core/inference/video_minimax_h3_te.py
+++ b/studio/backend/core/inference/video_minimax_h3_te.py
@@ -47,6 +47,7 @@ nothing configured.
 
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import Any, Optional
 
 # The ConvRot primitives, shared with the denoiser's hosted INT8 checkpoint. Re-exported below
@@ -155,8 +156,15 @@ def h3_te_resident_gb(scheme: Optional[str], *, bf16_gb: float) -> float:
 # exactly how they would stop agreeing. Both stay importable from here.
 
 
+@lru_cache(maxsize = None)
 def _int8_convrot_linear_class() -> Any:
-    """The ConvRot INT8 ``nn.Linear`` stand-in, built lazily so importing this module never imports torch."""
+    """The ConvRot INT8 ``nn.Linear`` stand-in, built lazily so importing this module never imports
+    torch, and built exactly ONCE.
+
+    One load already shares a single class across every projection, so the cache is about the
+    SECOND load in a process: a fresh class there is a fresh ``___check_type_id`` guard, which
+    retraces every compiled block that survived the first one. Same reason the denoiser's
+    ``convrot_linear_class`` is cached."""
     import torch
     from torch import nn
 

--- a/studio/backend/hub/services/snapshot_progress.py
+++ b/studio/backend/hub/services/snapshot_progress.py
@@ -395,7 +395,9 @@ def _referenced_commits(entry: Path) -> "frozenset[str]":
         try:
             if not ref.is_file():
                 continue
-            commit = download_manifest.normalized_commit_hash(ref.read_text().strip())
+            commit = download_manifest.normalized_commit_hash(
+                ref.read_text(encoding = "utf-8").strip()
+            )
         except (OSError, ValueError):
             continue
         if commit:

--- a/studio/backend/tests/test_diffusion_convrot.py
+++ b/studio/backend/tests/test_diffusion_convrot.py
@@ -398,3 +398,32 @@ def test_loader_refuses_a_rotation_it_cannot_apply(monkeypatch, tmp_path, fmt, m
     # None means "fall back to the dense download": slower and bigger, but never wrong. The
     # alternative -- loading it anyway -- has no symptom at all.
     assert _load_rotated(monkeypatch, tmp_path, _ckpt(fmt, metadata)) is None
+
+
+def test_every_rotated_projection_shares_one_class():
+    """The rotation is a class SWAP, so the class has to be a singleton.
+
+    ``torch.compile`` guards each frame on ``___check_type_id`` of the modules it closes over. A
+    class defined inside a function is a new class object per call, so giving each of the 350
+    rotated projections its own ConvRotLinear made every one of them look like a different type
+    and retraced the block it lives in: 23 recompiles against bfloat16's 1, and 178 s of
+    first-call compile against 14 s. Identity, not equality: two classes with identical bodies
+    still fail the guard."""
+    import torch
+    from torch import nn
+
+    from core.inference.diffusion_convrot import _install_rotation, convrot_linear_class
+
+    first, second = nn.Linear(256, 8, bias = False), nn.Linear(256, 8, bias = False)
+    _install_rotation(first, 256)
+    _install_rotation(second, 256)
+    assert type(first) is type(second)
+    assert type(first) is convrot_linear_class()
+    # Still an nn.Linear, which is what keeps torchao's filter and the checkpoint keys working.
+    assert isinstance(first, nn.Linear)
+    assert is_rotated_linear(first) and is_rotated_linear(second)
+    # And the swap is per instance, so a shared class must not leak one module's group to another.
+    third = nn.Linear(512, 8, bias = False)
+    _install_rotation(third, 128)
+    assert (first.convrot_groupsize, third.convrot_groupsize) == (256, 128)
+    assert torch.is_tensor(first.weight)


### PR DESCRIPTION
## The bug

`convrot_linear_class()` defines `ConvRotLinear` inside the function, so every call returns a new class object. `_install_rotation` called it once per rotated module, and the hosted int8 denoiser has 350 rotated projections, so 350 modules ended up with 350 distinct types.

`torch.compile` guards each frame on `___check_type_id` of the modules it closes over, so distinct types retrace the block they live in. All 23 recompile records read the same way, with a different type id each time:

```
Recompiling function forward in transformer_minimax_h3.py:344
  triggered by: ___check_type_id(... _modules['proj'], 1112338640),
                type=<class convrot_linear_class.<locals>.ConvRotLinear>
```

## The fix

Cache the factory so the class is a singleton. The text encoder's `_int8_convrot_linear_class` gets the same treatment: it already shares one class within a load, so that one is about the second load in a process, where a fresh class re-guards every block the first load compiled.

## Measured

B200, 960x544, 124 frames, 8 steps, same prompt and seed, three generations per run.

| int8 pinned denoiser | recompiles | gen 1 | gen 2 | gen 3 | steady peak VRAM |
| --- | --- | --- | --- | --- | --- |
| before | 23 | 178.15 s | 17.32 s | 17.27 s | 59.0 GB |
| after | 1 | **31.44 s** | **11.80 s** | **11.77 s** | 57.8 GB |

The one remaining recompile is the legitimate one, classifier-free guidance taking the `temb` batch from 1 to 2, and the released bfloat16 denoiser has always had exactly that one.

Two things worth drawing out.

First, the steady state moved, not just the warm-up. 17.3 s to 11.8 s, so the guard overhead was being paid on every call, not only while tracing.

Second, this changes what we know about int8. Against the released bfloat16 denoiser on the same card (26.64 / 12.71 / 12.79 s, 102.8 GB steady), the int8 checkpoint is now slightly faster per generation and uses a little over half the VRAM. It was previously measured as the slower of the two, and that measurement was this bug rather than the scheme.

That does not change the auto policy in #8347, and should not: the hosted denoisers re-roll the sample (mean SSIM 0.49 against the released weights), so keeping the released weights wherever they fit is still right. What changes is the cost of the fallback on the cards that need it, which is the case this was all for.

## Tests

`test_every_rotated_projection_shares_one_class` asserts class identity rather than equality, because two classes with identical bodies still fail the guard, and checks that a shared class does not leak one module's rotation group into another. Mutation checked: removing the cache fails it and only it.

```
test_diffusion_convrot.py test_video_h3_te_quant.py test_video_prequant.py   131 passed
ruff                                                                         clean
```
