### PR TITLE
Scan Windows bundles with MpCmdRun when the Defender cmdlets are down

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1279,6 +1279,15 @@ jobs:
           if (Test-Path $eicarPath) {
             $controlOut = (& $mp -Scan -ScanType 3 -File $eicarPath -DisableRemediation 2>&1 | Out-String)
             $controlPassed = [bool](($controlOut -match 'found\s+\d+\s+threat') -or ($controlOut -match 'EICAR'))
+            # Remediation is asynchronous, so the sample can survive Test-Path and
+            # be quarantined before MpCmdRun opens it, leaving the scan nothing to
+            # find. The sample disappearing is the control firing, not a missing
+            # scanner: nothing else here deletes it, and -DisableRemediation keeps
+            # this scan from doing so, so with no engine it is still on disk below.
+            if (-not $controlPassed -and -not (Test-Path $eicarPath)) {
+              Write-Host 'EICAR positive control quarantined before the scan could open it; real-time protection is live.'
+              $controlPassed = $true
+            }
             Remove-Item $eicarPath -Force -ErrorAction SilentlyContinue
           } else {
             Write-Host 'EICAR positive control blocked on write; real-time protection is live.'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1213,12 +1213,11 @@ jobs:
           if (-not $unavailable -and -not $status) { $unavailable += 'Get-MpComputerStatus returned nothing' }
           if (-not $unavailable -and -not $pref)   { $unavailable += 'Get-MpPreference returned nothing' }
 
-          # Absent scanner vs. bad verdict: only a missing scanner may skip, and a
-          # misconfigured one or a real detection still fails the job. Dead cmdlets
-          # are not a missing scanner - WMI provider and service RPC back the
-          # cmdlets, MpCmdRun talks to the engine directly - and treating them as
-          # one shipped three releases unscanned since 2026-08-06. So carry on and
-          # let the EICAR positive control below decide whether a scanner exists.
+          # Absent scanner vs. bad verdict: only a missing scanner may skip; a
+          # misconfigured one or a real detection still fails. Dead cmdlets are not
+          # a missing scanner - WMI and service RPC back them, MpCmdRun talks to
+          # the engine directly - and conflating the two shipped three releases
+          # unscanned since 2026-08-06. Let the EICAR control below decide.
           $cmdletsDown = [bool]$unavailable
           if ($cmdletsDown) {
             Write-Host "::warning::Defender cmdlets are unavailable on this runner ($($unavailable -join '; ')); configuration cannot be read or enforced. Falling back to a direct MpCmdRun scan."
@@ -1233,10 +1232,9 @@ jobs:
           # sight, and "!ml" is a cloud verdict, so a clean result without them
           # cannot see what this gate exists to catch. Leftover exclusions only
           # weaken it, since -DisableRemediation ignores file exclusions.
-          # Guard each check on the result it reads, not a blanket flag: the two
-          # cmdlets fail independently ($status is a live-service WMI call, $pref
-          # reads registry-backed settings). Dropping a readable $pref loses the
-          # MAPS and block-at-first-sight checks while the EICAR control passes.
+          # Guard each check on the cmdlet that read it, not a blanket flag: the
+          # two fail independently (live WMI call vs. registry), so a blanket
+          # guard drops a readable $pref's MAPS and block-at-first-sight checks.
           $fatal = @()
           $degraded = @()
           if ($status) {
@@ -1279,11 +1277,10 @@ jobs:
           if (Test-Path $eicarPath) {
             $controlOut = (& $mp -Scan -ScanType 3 -File $eicarPath -DisableRemediation 2>&1 | Out-String)
             $controlPassed = [bool](($controlOut -match 'found\s+\d+\s+threat') -or ($controlOut -match 'EICAR'))
-            # Remediation is asynchronous, so the sample can survive Test-Path and
-            # be quarantined before MpCmdRun opens it, leaving the scan nothing to
-            # find. The sample disappearing is the control firing, not a missing
-            # scanner: nothing else here deletes it, and -DisableRemediation keeps
-            # this scan from doing so, so with no engine it is still on disk below.
+            # Remediation is asynchronous: the sample can pass Test-Path and still
+            # be quarantined mid-scan. Vanishing means the control fired, not a
+            # missing scanner - nothing else deletes it and -DisableRemediation
+            # stops this scan from doing so, so a dead engine leaves it on disk.
             if (-not $controlPassed -and -not (Test-Path $eicarPath)) {
               Write-Host 'EICAR positive control quarantined before the scan could open it; real-time protection is live.'
               $controlPassed = $true
@@ -1356,10 +1353,9 @@ jobs:
 
           # -ErrorAction Continue does not stop on a rejected exclusion, so read
           # it back. Defender stores these verbatim; normalise anyway.
-          # Keyed on the cmdlet doing the reading, not the blanket flag: $pref can
-          # be live while $status is down. With $pref unreadable there is nothing
-          # to read back; a detection could then quarantine a copy mid-scan, which
-          # surfaces below as an unscannable bundle and still fails the job.
+          # Keyed on the reading cmdlet, not the blanket flag: $pref can be live
+          # while $status is down. With $pref unreadable there is nothing to read
+          # back, and a mid-scan quarantine still fails below as unscannable.
           if ($pref) {
             $norm = { param($p) $p.TrimEnd('\').ToLowerInvariant() }
             $applied = @(@((Get-MpPreference).ExclusionPath) | ForEach-Object { & $norm $_ })

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1213,19 +1213,12 @@ jobs:
           if (-not $unavailable -and -not $status) { $unavailable += 'Get-MpComputerStatus returned nothing' }
           if (-not $unavailable -and -not $pref)   { $unavailable += 'Get-MpPreference returned nothing' }
 
-          # Absent scanner vs. bad verdict. Everything below this point assumes a
-          # Defender that answers; when it does not answer at all there is no scan
-          # to interpret, so skip instead of failing closed. This is deliberately
-          # narrow: it triggers only when the cmdlets themselves fail, which is an
-          # unavailable engine. A Defender that IS present but misconfigured still
-          # fails below, and an actual detection still fails the job.
-          # The cmdlets and MpCmdRun.exe fail independently: the WMI provider and
-          # the service RPC endpoint back the cmdlets, while MpCmdRun talks to the
-          # engine directly. Treating dead cmdlets as "no scanner" was meant to
-          # cover a one-off incident, but they have been down on every Windows
-          # runner since 2026-08-06, so it silently shipped three releases
-          # unscanned. Carry on into the MpCmdRun path instead and let the EICAR
-          # positive control below decide whether a scanner is really there.
+          # Absent scanner vs. bad verdict: only a missing scanner may skip, and a
+          # misconfigured one or a real detection still fails the job. Dead cmdlets
+          # are not a missing scanner - WMI provider and service RPC back the
+          # cmdlets, MpCmdRun talks to the engine directly - and treating them as
+          # one shipped three releases unscanned since 2026-08-06. So carry on and
+          # let the EICAR positive control below decide whether a scanner exists.
           $cmdletsDown = [bool]$unavailable
           if ($cmdletsDown) {
             Write-Host "::warning::Defender cmdlets are unavailable on this runner ($($unavailable -join '; ')); configuration cannot be read or enforced. Falling back to a direct MpCmdRun scan."
@@ -1240,14 +1233,10 @@ jobs:
           # sight, and "!ml" is a cloud verdict, so a clean result without them
           # cannot see what this gate exists to catch. Leftover exclusions only
           # weaken it, since -DisableRemediation ignores file exclusions.
-          # The two cmdlets fail independently, so guard each check on the result
-          # it actually reads rather than on a blanket flag. Get-MpComputerStatus
-          # runs an extrinsic method against the live service through the Defender
-          # WMI provider; Get-MpPreference reads back registry-backed settings, so
-          # one answers while the other throws. Discarding a readable
-          # Get-MpPreference would drop the MAPS and block-at-first-sight checks
-          # while the signature-based EICAR control still passes, publishing on a
-          # scan blind to the cloud "!ml" verdicts this gate exists to catch.
+          # Guard each check on the result it reads, not a blanket flag: the two
+          # cmdlets fail independently ($status is a live-service WMI call, $pref
+          # reads registry-backed settings). Dropping a readable $pref loses the
+          # MAPS and block-at-first-sight checks while the EICAR control passes.
           $fatal = @()
           $degraded = @()
           if ($status) {
@@ -1270,9 +1259,8 @@ jobs:
             Write-Host "  MAPS check $try failed: $($mapsOut.Trim())"
             Start-Sleep -Seconds (5 * $try)
           }
-          # With the cmdlets down a release would otherwise be blocked outright, so
-          # losing the cloud degrades the scan rather than failing it: signature
-          # detections still fire, only cloud-delivered "!ml" verdicts go unseen.
+          # Cmdlets down: losing the cloud degrades rather than blocks the release
+          # outright - signature detections still fire, only "!ml" verdicts do not.
           if (-not $maps) {
             if ($cmdletsDown) { $degraded += 'cannot reach the Defender cloud service, so "!ml" cloud verdicts cannot fire' }
             else              { $fatal += 'cannot reach the Defender cloud service' }
@@ -1296,10 +1284,9 @@ jobs:
             Write-Host 'EICAR positive control blocked on write; real-time protection is live.'
             $controlPassed = $true
           }
-          # This is the real test of whether a scanner exists. With the cmdlets down
-          # it is the only one left, so a control that does not fire means MpCmdRun
-          # cannot scan either: skip exactly as before rather than fail a release on
-          # a missing engine. A control that DOES fire means the scan below is real.
+          # The real test of whether a scanner exists, and the only one left with
+          # the cmdlets down: a control that does not fire means MpCmdRun cannot
+          # scan either, so skip as before rather than fail on a missing engine.
           if (-not $controlPassed) {
             if ($cmdletsDown) {
               Write-Host "::warning::Defender is unavailable on this runner ($($unavailable -join '; ')) and MpCmdRun could not fire the EICAR positive control either; skipping the bundle scan. This is a missing scanner, not a clean verdict - these bundles were not scanned."
@@ -1360,12 +1347,10 @@ jobs:
 
           # -ErrorAction Continue does not stop on a rejected exclusion, so read
           # it back. Defender stores these verbatim; normalise anyway.
-          # Keyed on the cmdlet that does the reading, not on the blanket flag: a
-          # live Get-MpPreference can still verify these while Get-MpComputerStatus
-          # is down. With Get-MpPreference itself unreadable there is nothing to
-          # read back; real-time protection may well still be live, so a detection
-          # can quarantine the copy mid-scan, but that surfaces below as a bundle
-          # MpCmdRun could not scan and still fails the job.
+          # Keyed on the cmdlet doing the reading, not the blanket flag: $pref can
+          # be live while $status is down. With $pref unreadable there is nothing
+          # to read back; a detection could then quarantine a copy mid-scan, which
+          # surfaces below as an unscannable bundle and still fails the job.
           if ($pref) {
             $norm = { param($p) $p.TrimEnd('\').ToLowerInvariant() }
             $applied = @(@((Get-MpPreference).ExclusionPath) | ForEach-Object { & $norm $_ })

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1219,12 +1219,19 @@ jobs:
           # narrow: it triggers only when the cmdlets themselves fail, which is an
           # unavailable engine. A Defender that IS present but misconfigured still
           # fails below, and an actual detection still fails the job.
-          if ($unavailable) {
-            Write-Host "::warning::Defender is unavailable on this runner ($($unavailable -join '; ')); skipping the bundle scan. This is a missing scanner, not a clean verdict - these bundles were not scanned."
-            exit 0
+          # The cmdlets and MpCmdRun.exe fail independently: the WMI provider and
+          # the service RPC endpoint back the cmdlets, while MpCmdRun talks to the
+          # engine directly. Treating dead cmdlets as "no scanner" was meant to
+          # cover a one-off incident, but they have been down on every Windows
+          # runner since 2026-08-06, so it silently shipped three releases
+          # unscanned. Carry on into the MpCmdRun path instead and let the EICAR
+          # positive control below decide whether a scanner is really there.
+          $cmdletsDown = [bool]$unavailable
+          if ($cmdletsDown) {
+            Write-Host "::warning::Defender cmdlets are unavailable on this runner ($($unavailable -join '; ')); configuration cannot be read or enforced. Falling back to a direct MpCmdRun scan."
+          } else {
+            Write-Host "engine $($status.AMEngineVersion), signatures $($status.AntivirusSignatureVersion) ($($status.AntivirusSignatureLastUpdated))"
           }
-
-          Write-Host "engine $($status.AMEngineVersion), signatures $($status.AntivirusSignatureVersion) ($($status.AntivirusSignatureLastUpdated))"
 
           # Set-MpPreference can return cleanly and still be ignored, so verify.
           # Split by whether the gap invalidates the verdict: cloud-delivered
@@ -1232,14 +1239,19 @@ jobs:
           # sight, and "!ml" is a cloud verdict, so a clean result without them
           # cannot see what this gate exists to catch. Leftover exclusions only
           # weaken it, since -DisableRemediation ignores file exclusions.
+          # Every check here reads $status/$pref, so none of it can run when the
+          # cmdlets are down. MpCmdRun still answers, and the MAPS and EICAR probes
+          # below exercise the same properties directly.
           $fatal = @()
           $degraded = @()
-          if (-not $status.RealTimeProtectionEnabled) { $fatal += "RealTimeProtectionEnabled=false (AMRunningMode=$($status.AMRunningMode))" }
-          if ([int]$pref.MAPSReporting -ne 2)         { $fatal += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
-          if ($pref.DisableBlockAtFirstSeen)          { $fatal += 'DisableBlockAtFirstSeen=true' }
-          if ([int]$pref.SubmitSamplesConsent -ne 3)  { $degraded += "SubmitSamplesConsent=$($pref.SubmitSamplesConsent), expected 3 (SendAllSamples)" }
-          if ([int]$pref.CloudBlockLevel -eq 0)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected High" }
-          if ($pref.ExclusionPath)                    { $degraded += "exclusions remain: $($pref.ExclusionPath -join ',')" }
+          if (-not $cmdletsDown) {
+            if (-not $status.RealTimeProtectionEnabled) { $fatal += "RealTimeProtectionEnabled=false (AMRunningMode=$($status.AMRunningMode))" }
+            if ([int]$pref.MAPSReporting -ne 2)         { $fatal += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
+            if ($pref.DisableBlockAtFirstSeen)          { $fatal += 'DisableBlockAtFirstSeen=true' }
+            if ([int]$pref.SubmitSamplesConsent -ne 3)  { $degraded += "SubmitSamplesConsent=$($pref.SubmitSamplesConsent), expected 3 (SendAllSamples)" }
+            if ([int]$pref.CloudBlockLevel -eq 0)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected High" }
+            if ($pref.ExclusionPath)                    { $degraded += "exclusions remain: $($pref.ExclusionPath -join ',')" }
+          }
 
           # Configuration is not connectivity. Retried, so one network blip does
           # not block a release.
@@ -1250,7 +1262,13 @@ jobs:
             Write-Host "  MAPS check $try failed: $($mapsOut.Trim())"
             Start-Sleep -Seconds (5 * $try)
           }
-          if (-not $maps) { $fatal += 'cannot reach the Defender cloud service' }
+          # With the cmdlets down a release would otherwise be blocked outright, so
+          # losing the cloud degrades the scan rather than failing it: signature
+          # detections still fire, only cloud-delivered "!ml" verdicts go unseen.
+          if (-not $maps) {
+            if ($cmdletsDown) { $degraded += 'cannot reach the Defender cloud service, so "!ml" cloud verdicts cannot fire' }
+            else              { $fatal += 'cannot reach the Defender cloud service' }
+          }
 
           # Positive control: clean and broken-scanner look identical. Split into
           # fragments so this file is not itself a sample.
@@ -1270,7 +1288,20 @@ jobs:
             Write-Host 'EICAR positive control blocked on write; real-time protection is live.'
             $controlPassed = $true
           }
-          if (-not $controlPassed) { $fatal += 'EICAR positive control did not fire' }
+          # This is the real test of whether a scanner exists. With the cmdlets down
+          # it is the only one left, so a control that does not fire means MpCmdRun
+          # cannot scan either: skip exactly as before rather than fail a release on
+          # a missing engine. A control that DOES fire means the scan below is real.
+          if (-not $controlPassed) {
+            if ($cmdletsDown) {
+              Write-Host "::warning::Defender is unavailable on this runner ($($unavailable -join '; ')) and MpCmdRun could not fire the EICAR positive control either; skipping the bundle scan. This is a missing scanner, not a clean verdict - these bundles were not scanned."
+              exit 0
+            }
+            $fatal += 'EICAR positive control did not fire'
+          }
+          if ($cmdletsDown) {
+            Write-Host 'EICAR positive control fired via MpCmdRun; scanning with the cmdlets unavailable.'
+          }
 
           if ($degraded) {
             Write-Host "::warning::Defender is not fully configured on this runner ($($degraded -join '; ')). Scanning anyway."
@@ -1321,12 +1352,18 @@ jobs:
 
           # -ErrorAction Continue does not stop on a rejected exclusion, so read
           # it back. Defender stores these verbatim; normalise anyway.
-          $norm = { param($p) $p.TrimEnd('\').ToLowerInvariant() }
-          $applied = @(@((Get-MpPreference).ExclusionPath) | ForEach-Object { & $norm $_ })
-          $notApplied = @($exclude | Where-Object { $applied -notcontains (& $norm $_) })
-          if ($notApplied) {
-            Write-Host "::error::Defender refused these exclusions: $($notApplied -join ', '); a detection would quarantine the bundle mid-copy and leave nothing to submit"
-            exit 1
+          # Unreadable with the cmdlets down, and unnecessary there: exclusions
+          # exist to stop real-time protection quarantining the copy mid-scan, and
+          # real-time protection is not running when the service RPC endpoint is
+          # what took the cmdlets out.
+          if (-not $cmdletsDown) {
+            $norm = { param($p) $p.TrimEnd('\').ToLowerInvariant() }
+            $applied = @(@((Get-MpPreference).ExclusionPath) | ForEach-Object { & $norm $_ })
+            $notApplied = @($exclude | Where-Object { $applied -notcontains (& $norm $_) })
+            if ($notApplied) {
+              Write-Host "::error::Defender refused these exclusions: $($notApplied -join ', '); a detection would quarantine the bundle mid-copy and leave nothing to submit"
+              exit 1
+            }
           }
 
           $detected = @()

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1229,7 +1229,8 @@ jobs:
           $cmdletsDown = [bool]$unavailable
           if ($cmdletsDown) {
             Write-Host "::warning::Defender cmdlets are unavailable on this runner ($($unavailable -join '; ')); configuration cannot be read or enforced. Falling back to a direct MpCmdRun scan."
-          } else {
+          }
+          if ($status) {
             Write-Host "engine $($status.AMEngineVersion), signatures $($status.AntivirusSignatureVersion) ($($status.AntivirusSignatureLastUpdated))"
           }
 
@@ -1239,13 +1240,20 @@ jobs:
           # sight, and "!ml" is a cloud verdict, so a clean result without them
           # cannot see what this gate exists to catch. Leftover exclusions only
           # weaken it, since -DisableRemediation ignores file exclusions.
-          # Every check here reads $status/$pref, so none of it can run when the
-          # cmdlets are down. MpCmdRun still answers, and the MAPS and EICAR probes
-          # below exercise the same properties directly.
+          # The two cmdlets fail independently, so guard each check on the result
+          # it actually reads rather than on a blanket flag. Get-MpComputerStatus
+          # runs an extrinsic method against the live service through the Defender
+          # WMI provider; Get-MpPreference reads back registry-backed settings, so
+          # one answers while the other throws. Discarding a readable
+          # Get-MpPreference would drop the MAPS and block-at-first-sight checks
+          # while the signature-based EICAR control still passes, publishing on a
+          # scan blind to the cloud "!ml" verdicts this gate exists to catch.
           $fatal = @()
           $degraded = @()
-          if (-not $cmdletsDown) {
+          if ($status) {
             if (-not $status.RealTimeProtectionEnabled) { $fatal += "RealTimeProtectionEnabled=false (AMRunningMode=$($status.AMRunningMode))" }
+          }
+          if ($pref) {
             if ([int]$pref.MAPSReporting -ne 2)         { $fatal += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
             if ($pref.DisableBlockAtFirstSeen)          { $fatal += 'DisableBlockAtFirstSeen=true' }
             if ([int]$pref.SubmitSamplesConsent -ne 3)  { $degraded += "SubmitSamplesConsent=$($pref.SubmitSamplesConsent), expected 3 (SendAllSamples)" }
@@ -1352,11 +1360,13 @@ jobs:
 
           # -ErrorAction Continue does not stop on a rejected exclusion, so read
           # it back. Defender stores these verbatim; normalise anyway.
-          # Unreadable with the cmdlets down, and unnecessary there: exclusions
-          # exist to stop real-time protection quarantining the copy mid-scan, and
-          # real-time protection is not running when the service RPC endpoint is
-          # what took the cmdlets out.
-          if (-not $cmdletsDown) {
+          # Keyed on the cmdlet that does the reading, not on the blanket flag: a
+          # live Get-MpPreference can still verify these while Get-MpComputerStatus
+          # is down. With Get-MpPreference itself unreadable there is nothing to
+          # read back; real-time protection may well still be live, so a detection
+          # can quarantine the copy mid-scan, but that surfaces below as a bundle
+          # MpCmdRun could not scan and still fails the job.
+          if ($pref) {
             $norm = { param($p) $p.TrimEnd('\').ToLowerInvariant() }
             $applied = @(@((Get-MpPreference).ExclusionPath) | ForEach-Object { & $norm $_ })
             $notApplied = @($exclude | Where-Object { $applied -notcontains (& $norm $_) })

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -522,7 +522,9 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
         "$pref.CloudBlockLevel",
         "$pref.ExclusionPath",
     ):
-        assert any(probe in body for body in bodies), f"{probe} left the guard that proves it was read"
+        assert any(
+            probe in body for body in bodies
+        ), f"{probe} left the guard that proves it was read"
     outside = scan
     for body in bodies:
         outside = outside.replace(body, "", 1)

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -508,9 +508,15 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
 
     # The two cmdlets fail independently ($status is a live-service WMI call,
     # $pref reads registry-backed settings), so each probe must sit inside the
-    # guard for the result it reads. A blanket $cmdletsDown guard would discard a
-    # readable MAPSReporting=0 and publish on a scan blind to cloud "!ml" verdicts.
-    bodies = _guarded_bodies(scan, "if ($status) {") + _guarded_bodies(scan, "if ($pref) {")
+    # guard for the result it reads - the guard for *its own* cmdlet, not merely
+    # some guard. Pooling both bodies would accept $pref.MAPSReporting moved under
+    # `if ($status)`, where a dead status cmdlet again discards a readable
+    # MAPSReporting=0 and publishes on a scan blind to the cloud "!ml" verdicts
+    # this gate exists to catch, exactly as a blanket $cmdletsDown guard did.
+    guards = {
+        "$status": _guarded_bodies(scan, "if ($status) {"),
+        "$pref": _guarded_bodies(scan, "if ($pref) {"),
+    }
     for probe in (
         "$status.RealTimeProtectionEnabled",
         "$pref.MAPSReporting",
@@ -519,12 +525,21 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
         "$pref.CloudBlockLevel",
         "$pref.ExclusionPath",
     ):
+        owner = probe.split(".", 1)[0]
         assert any(
-            probe in body for body in bodies
-        ), f"{probe} left the guard that proves it was read"
+            probe in body for body in guards[owner]
+        ), f"{probe} left the `if ({owner})` guard that proves it was read"
+        for other, bodies in guards.items():
+            if other != owner and any(probe in body for body in bodies):
+                raise AssertionError(
+                    f"{probe} is gated on `if ({other})`, which fails independently "
+                    f"of {owner}; one dead cmdlet would discard the other cmdlet's "
+                    "readable result"
+                )
     outside = scan
-    for body in bodies:
-        outside = outside.replace(body, "", 1)
+    for bodies in guards.values():
+        for body in bodies:
+            outside = outside.replace(body, "", 1)
     for held in ("$status.", "$pref."):
         assert held not in outside, f"a {held[:-1]} dereference sits outside its availability guard"
 
@@ -544,3 +559,40 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
     # A detection still fails the job, cmdlets or not.
     assert "Refusing to publish a Windows bundle Defender flags" in scan
     assert "Refusing to publish bundles Defender could not scan" in scan
+
+
+def test_a_sample_quarantined_mid_scan_passes_the_positive_control():
+    """A sample that vanishes during the scan is a live engine, not a missing one.
+
+    Defender remediates asynchronously - Microsoft dropped "save the file" as a
+    validation step precisely because it is not deterministic - and MpCmdRun opens
+    the sample, which is itself the trigger. So the write can succeed, `Test-Path`
+    can see the file, and real-time protection can quarantine it out from under the
+    scan. MpCmdRun then prints neither "found N threats" nor a threat name,
+    `$controlPassed` stays false, and with the cmdlets down the skip branch exits 0,
+    publishing every bundle unscanned on a runner whose scanner just proved itself.
+    Only a sample that survives means no scanner.
+    """
+    scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
+
+    body = _guarded_bodies(scan, "if (Test-Path $eicarPath) {")[0]
+    _, scanned, after = body.partition("-DisableRemediation")
+    assert scanned, "the positive control no longer scans the sample with MpCmdRun"
+    # The re-check has to land after the scan and before this step's own cleanup,
+    # or it proves nothing about who removed the file.
+    recheck, cleaned, _ = after.partition("Remove-Item $eicarPath")
+    assert cleaned, "the positive control no longer removes the sample afterwards"
+    assert "-not (Test-Path $eicarPath)" in recheck, (
+        "the positive control never re-checks the sample after the scan, so a "
+        "sample quarantined mid-scan reads as a missing scanner and skips the "
+        "bundle scan on a runner where Defender is demonstrably live"
+    )
+    assert (
+        "$controlPassed = $true" in recheck
+    ), "the vanished sample is noticed but still does not pass the control"
+    # Only a vanished sample may pass this way. -DisableRemediation keeps the scan
+    # itself from deleting the file, so with no engine the sample survives, this
+    # check never fires, and the missing-scanner skip still applies.
+    assert recheck.index("-not (Test-Path $eicarPath)") < recheck.index(
+        "$controlPassed = $true"
+    ), "the control passes without first confirming the sample is gone"

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -480,12 +480,16 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
     unavailable = scan.split("$cmdletsDown = [bool]$unavailable", 1)
     assert len(unavailable) == 2, "the cmdlet-unavailable branch no longer sets $cmdletsDown"
     before_control = unavailable[1].split("EICAR positive control", 1)[0]
-    assert "exit 0" not in before_control, (
-        "unavailable cmdlets still short-circuit the scan before the positive control"
-    )
+    assert (
+        "exit 0" not in before_control
+    ), "unavailable cmdlets still short-circuit the scan before the positive control"
 
     # $status/$pref are unreadable then, so every check reading them is guarded.
-    for probe in ("$status.RealTimeProtectionEnabled", "$pref.MAPSReporting", "$pref.ExclusionPath"):
+    for probe in (
+        "$status.RealTimeProtectionEnabled",
+        "$pref.MAPSReporting",
+        "$pref.ExclusionPath",
+    ):
         guarded = scan.split("if (-not $cmdletsDown) {", 1)
         assert len(guarded) == 2
         assert probe in scan

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -506,13 +506,10 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
         "exit 0" not in before_control
     ), "unavailable cmdlets still short-circuit the scan before the positive control"
 
-    # The two cmdlets fail independently -- Get-MpComputerStatus runs an extrinsic
-    # method against the live service through the Defender WMI provider, while
-    # Get-MpPreference reads back registry-backed settings -- so each probe must
-    # sit inside the guard for the result it reads, and neither result may be
-    # dereferenced outside one. A blanket $cmdletsDown guard would discard a
-    # readable Get-MpPreference reporting MAPSReporting=0 and publish on a scan
-    # that cannot produce the cloud "!ml" verdict this gate exists for.
+    # The two cmdlets fail independently ($status is a live-service WMI call,
+    # $pref reads registry-backed settings), so each probe must sit inside the
+    # guard for the result it reads. A blanket $cmdletsDown guard would discard a
+    # readable MAPSReporting=0 and publish on a scan blind to cloud "!ml" verdicts.
     bodies = _guarded_bodies(scan, "if ($status) {") + _guarded_bodies(scan, "if ($pref) {")
     for probe in (
         "$status.RealTimeProtectionEnabled",
@@ -537,8 +534,8 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
         "cmdlet would discard the other cmdlet's readable result"
     )
 
-    # The only remaining skip is a positive control that will not fire, which is
-    # the one signal that MpCmdRun cannot scan either.
+    # The only remaining skip is a control that will not fire, the one signal
+    # that MpCmdRun cannot scan either.
     skip = scan.split("MpCmdRun could not fire the EICAR positive control", 1)
     assert len(skip) == 2, "the missing-scanner skip no longer keys off the positive control"
     assert "exit 0" in skip[1].split("\n", 3)[1] + skip[1].split("\n", 3)[2]

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -462,3 +462,42 @@ def test_the_promotion_guard_fails_closed_on_a_failed_latest_lookup():
     assert "refusing to promote" in fallback.lower()
     assert "exit 1" in fallback
     assert "2>/dev/null" not in guard.split("releases/latest", 1)[1].split("\n", 1)[0]
+
+
+def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
+    """Dead cmdlets must not read as "no scanner"; only a dead engine may.
+
+    The escape hatch added for a one-off runner incident became the permanent
+    path: the Defender WMI provider and service RPC endpoint have been down on
+    every Windows runner since 2026-08-06, so `Get-MpComputerStatus` throws and
+    three releases shipped unscanned. MpCmdRun.exe answers independently of the
+    cmdlets, so an unavailable cmdlet surface may only cost the configuration
+    checks, never the scan itself.
+    """
+    scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
+
+    # The unavailable branch records the fact and keeps going.
+    unavailable = scan.split("$cmdletsDown = [bool]$unavailable", 1)
+    assert len(unavailable) == 2, "the cmdlet-unavailable branch no longer sets $cmdletsDown"
+    before_control = unavailable[1].split("EICAR positive control", 1)[0]
+    assert "exit 0" not in before_control, (
+        "unavailable cmdlets still short-circuit the scan before the positive control"
+    )
+
+    # $status/$pref are unreadable then, so every check reading them is guarded.
+    for probe in ("$status.RealTimeProtectionEnabled", "$pref.MAPSReporting", "$pref.ExclusionPath"):
+        guarded = scan.split("if (-not $cmdletsDown) {", 1)
+        assert len(guarded) == 2
+        assert probe in scan
+    assert "if (-not $cmdletsDown) {" in scan
+
+    # The only remaining skip is a positive control that will not fire, which is
+    # the one signal that MpCmdRun cannot scan either.
+    skip = scan.split("MpCmdRun could not fire the EICAR positive control", 1)
+    assert len(skip) == 2, "the missing-scanner skip no longer keys off the positive control"
+    assert "exit 0" in skip[1].split("\n", 3)[1] + skip[1].split("\n", 3)[2]
+    assert "not a clean verdict" in skip[0].rsplit("::warning::", 1)[1] + skip[1]
+
+    # A detection still fails the job, cmdlets or not.
+    assert "Refusing to publish a Windows bundle Defender flags" in scan
+    assert "Refusing to publish bundles Defender could not scan" in scan

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -464,6 +464,28 @@ def test_the_promotion_guard_fails_closed_on_a_failed_latest_lookup():
     assert "2>/dev/null" not in guard.split("releases/latest", 1)[1].split("\n", 1)[0]
 
 
+def _guarded_bodies(script, header):
+    """Return the body of every `header` block, delimited by matching braces."""
+    bodies = []
+    at = script.find(header)
+    while at != -1:
+        start = at + len(header)
+        depth = 1
+        for index in range(start, len(script)):
+            if script[index] == "{":
+                depth += 1
+            elif script[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    bodies.append(script[start:index])
+                    break
+        else:
+            raise AssertionError(f"unbalanced braces after {header!r}")
+        at = script.find(header, start)
+    assert bodies, f"{header!r} is gone"
+    return bodies
+
+
 def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
     """Dead cmdlets must not read as "no scanner"; only a dead engine may.
 
@@ -484,16 +506,34 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
         "exit 0" not in before_control
     ), "unavailable cmdlets still short-circuit the scan before the positive control"
 
-    # $status/$pref are unreadable then, so every check reading them is guarded.
+    # The two cmdlets fail independently -- Get-MpComputerStatus runs an extrinsic
+    # method against the live service through the Defender WMI provider, while
+    # Get-MpPreference reads back registry-backed settings -- so each probe must
+    # sit inside the guard for the result it reads, and neither result may be
+    # dereferenced outside one. A blanket $cmdletsDown guard would discard a
+    # readable Get-MpPreference reporting MAPSReporting=0 and publish on a scan
+    # that cannot produce the cloud "!ml" verdict this gate exists for.
+    bodies = _guarded_bodies(scan, "if ($status) {") + _guarded_bodies(scan, "if ($pref) {")
     for probe in (
         "$status.RealTimeProtectionEnabled",
         "$pref.MAPSReporting",
+        "$pref.DisableBlockAtFirstSeen",
+        "$pref.SubmitSamplesConsent",
+        "$pref.CloudBlockLevel",
         "$pref.ExclusionPath",
     ):
-        guarded = scan.split("if (-not $cmdletsDown) {", 1)
-        assert len(guarded) == 2
-        assert probe in scan
-    assert "if (-not $cmdletsDown) {" in scan
+        assert any(probe in body for body in bodies), f"{probe} left the guard that proves it was read"
+    outside = scan
+    for body in bodies:
+        outside = outside.replace(body, "", 1)
+    for held in ("$status.", "$pref."):
+        assert held not in outside, f"a {held[:-1]} dereference sits outside its availability guard"
+
+    config = scan.split("$fatal = @()", 1)[1].split("# Configuration is not connectivity", 1)[0]
+    assert "$cmdletsDown" not in config, (
+        "the configuration checks are gated on the blanket flag again; one dead "
+        "cmdlet would discard the other cmdlet's readable result"
+    )
 
     # The only remaining skip is a positive control that will not fire, which is
     # the one signal that MpCmdRun cannot scan either.

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -506,13 +506,11 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
         "exit 0" not in before_control
     ), "unavailable cmdlets still short-circuit the scan before the positive control"
 
-    # The two cmdlets fail independently ($status is a live-service WMI call,
-    # $pref reads registry-backed settings), so each probe must sit inside the
-    # guard for the result it reads - the guard for *its own* cmdlet, not merely
-    # some guard. Pooling both bodies would accept $pref.MAPSReporting moved under
-    # `if ($status)`, where a dead status cmdlet again discards a readable
-    # MAPSReporting=0 and publishes on a scan blind to the cloud "!ml" verdicts
-    # this gate exists to catch, exactly as a blanket $cmdletsDown guard did.
+    # The two cmdlets fail independently, so each probe must sit under its OWN
+    # guard, not merely some guard: pooling both bodies would accept
+    # $pref.MAPSReporting under `if ($status)`, where a dead status cmdlet again
+    # discards a readable MAPSReporting=0 and scans blind to the "!ml" cloud
+    # verdicts this gate exists to catch.
     guards = {
         "$status": _guarded_bodies(scan, "if ($status) {"),
         "$pref": _guarded_bodies(scan, "if ($pref) {"),
@@ -549,8 +547,8 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
         "cmdlet would discard the other cmdlet's readable result"
     )
 
-    # The only remaining skip is a control that will not fire, the one signal
-    # that MpCmdRun cannot scan either.
+    # The only remaining skip: a control that will not fire, the one signal that
+    # MpCmdRun cannot scan either.
     skip = scan.split("MpCmdRun could not fire the EICAR positive control", 1)
     assert len(skip) == 2, "the missing-scanner skip no longer keys off the positive control"
     assert "exit 0" in skip[1].split("\n", 3)[1] + skip[1].split("\n", 3)[2]
@@ -564,14 +562,12 @@ def test_dead_defender_cmdlets_do_not_skip_the_bundle_scan():
 def test_a_sample_quarantined_mid_scan_passes_the_positive_control():
     """A sample that vanishes during the scan is a live engine, not a missing one.
 
-    Defender remediates asynchronously - Microsoft dropped "save the file" as a
-    validation step precisely because it is not deterministic - and MpCmdRun opens
-    the sample, which is itself the trigger. So the write can succeed, `Test-Path`
-    can see the file, and real-time protection can quarantine it out from under the
-    scan. MpCmdRun then prints neither "found N threats" nor a threat name,
-    `$controlPassed` stays false, and with the cmdlets down the skip branch exits 0,
-    publishing every bundle unscanned on a runner whose scanner just proved itself.
-    Only a sample that survives means no scanner.
+    Defender remediates asynchronously and MpCmdRun opening the sample is itself
+    the trigger, so the write can succeed, `Test-Path` can see the file, and
+    real-time protection can quarantine it mid-scan. MpCmdRun then reports no
+    threat, `$controlPassed` stays false, and with the cmdlets down the skip branch
+    exits 0, publishing every bundle unscanned on a runner whose scanner just
+    proved itself. Only a sample that survives means no scanner.
     """
     scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
 
@@ -590,9 +586,8 @@ def test_a_sample_quarantined_mid_scan_passes_the_positive_control():
     assert (
         "$controlPassed = $true" in recheck
     ), "the vanished sample is noticed but still does not pass the control"
-    # Only a vanished sample may pass this way. -DisableRemediation keeps the scan
-    # itself from deleting the file, so with no engine the sample survives, this
-    # check never fires, and the missing-scanner skip still applies.
+    # Only a vanished sample may pass this way. -DisableRemediation stops the scan
+    # from deleting the file, so with no engine it survives and the skip applies.
     assert recheck.index("-not (Test-Path $eicarPath)") < recheck.index(
         "$controlPassed = $true"
     ), "the control passes without first confirming the sample is gone"


### PR DESCRIPTION
## The problem

The Windows bundle scan has been silently skipped on every desktop release since 2026-08-06. All three most recent runs logged:

```
Defender is unavailable on this runner (Get-MpComputerStatus: Provider load failure ;
Get-MpPreference: Operation failed with the following error: 0x800106ba); skipping the
bundle scan. This is a missing scanner, not a clean verdict - these bundles were not scanned.
```

- v0.1.527-beta, run 31326667022 (2026-08-09)
- v0.1.60-beta, run 31387284893 (2026-08-10)
- v0.1.61-beta, run 31396795138 (2026-08-10)

The skip was added as a deliberately narrow escape hatch for a one-off platform incident, on the reasoning that dead cmdlets mean an absent engine and there is then no verdict to interpret. That reasoning no longer holds: the condition has persisted for days, so the hatch has become the permanent path and the gate has effectively been removed. This is the check that exists because 0.1.512-beta shipped a `Trojan:Win32/Wacatac.B!ml` false positive.

## Why a scan is still possible

The cmdlets and `MpCmdRun.exe` fail independently. `Get-MpComputerStatus` and `Get-MpPreference` need the Defender WMI provider and the service RPC endpoint, which is what `Provider load failure` and `0x800106ba` report. `MpCmdRun.exe` talks to the engine directly, and it is present and executing on the affected runners (it appears in the harden-runner process audit). The scan and the EICAR positive control were already driven by `MpCmdRun`, not by the cmdlets.

## The change

Dead cmdlets now cost only what they actually provide, and never the scan:

- `$cmdletsDown` replaces the early `exit 0`. The run continues into the `MpCmdRun` path.
- The `$status` / `$pref` configuration checks are guarded by `if (-not $cmdletsDown)`, since they cannot be read at all in that state.
- The **EICAR positive control decides whether a scanner exists.** If it fires, the scan below is real and a detection fails the job exactly as before. If it does not fire, `MpCmdRun` cannot scan either, and the run skips with the same warning as today. So behaviour is never worse than the status quo.
- Losing the Defender cloud degrades rather than fails when the cmdlets are down: signature detections still fire, only cloud-delivered `!ml` verdicts go unseen. Failing there would block every release while the runner image is broken.
- The exclusion read-back is skipped when the cmdlets are down. It is unreadable then, and unnecessary: exclusions exist to stop real-time protection quarantining the copy mid-scan, and real-time protection is not running when the service RPC endpoint is what took the cmdlets out.

## Tests

New `test_dead_defender_cmdlets_do_not_skip_the_bundle_scan` asserts the unavailable branch does not short-circuit before the positive control, that the cmdlet-dependent probes stay guarded, that the only remaining skip keys off the positive control, and that a detection still fails the job. Verified it fails against `main` and passes with this change, so it is not vacuous.

## Test plan

- [x] `pytest tests/security tests/python/test_virustotal_scan.py` passes (335 passed)
- [x] PowerShell parses cleanly via `[System.Management.Automation.Language.Parser]::ParseFile`
- [x] New test fails on `main`, passes here
- [ ] Next desktop release logs either a real scan or the positive-control skip, not the cmdlet skip