### PR TITLE
Guard the diffusers and torchao paths the backend pytest matrix cannot install

### DIFF
--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -804,7 +804,11 @@ def healthy_diffusers(monkeypatch):
                     return getattr(_real, name)
                 except Exception:  # noqa: BLE001 -- the lazy submodule is what may be broken
                     pass
-            if name.endswith("Pipeline"):
+            # "Model" as well as "Pipeline": the gate probes whatever class a family names,
+            # and the video families name a transformer (MiniMaxH3Transformer3DModel), not a
+            # pipeline. Answering only pipelines let that probe miss and turned routing tests
+            # into the 400 about diffusers this proxy exists to prevent.
+            if name.endswith("Pipeline") or name.endswith("Model"):
                 return object
             raise AttributeError(name)
 

--- a/studio/backend/tests/test_diffusion_training.py
+++ b/studio/backend/tests/test_diffusion_training.py
@@ -629,7 +629,7 @@ def test_route_start_preflights_gated_base_off_the_coroutine_thread(client, monk
     assert threads["preflight"] is not threads["inline"]  # offloaded to a worker, not run inline
 
 
-def test_a_clip_trained_family_is_not_turned_away_by_the_clip_refusal(client, monkeypatch):
+def test_a_clip_trained_family_is_not_turned_away_by_the_clip_refusal(client, monkeypatch, dit_train_host):
     """The refusal exists to protect the IMAGE discovery, so it must not outrank a clip family.
 
     It ran unconditionally and fires on any folder with a clip in it, above the discovery that
@@ -665,7 +665,7 @@ def test_a_clip_trained_family_is_not_turned_away_by_the_clip_refusal(client, mo
     assert len(consulted) == 1
 
 
-def test_a_clip_family_still_refuses_a_folder_holding_stills(client, monkeypatch):
+def test_a_clip_family_still_refuses_a_folder_holding_stills(client, monkeypatch, dit_train_host):
     """Exempting a clip family from the clip refusal must not exempt it from the mixed case.
 
     discover_clip_caption_pairs enumerates video extensions only, so a still in a clip folder

--- a/studio/backend/tests/test_diffusion_training.py
+++ b/studio/backend/tests/test_diffusion_training.py
@@ -629,7 +629,9 @@ def test_route_start_preflights_gated_base_off_the_coroutine_thread(client, monk
     assert threads["preflight"] is not threads["inline"]  # offloaded to a worker, not run inline
 
 
-def test_a_clip_trained_family_is_not_turned_away_by_the_clip_refusal(client, monkeypatch, dit_train_host):
+def test_a_clip_trained_family_is_not_turned_away_by_the_clip_refusal(
+    client, monkeypatch, dit_train_host
+):
     """The refusal exists to protect the IMAGE discovery, so it must not outrank a clip family.
 
     It ran unconditionally and fires on any folder with a clip in it, above the discovery that

--- a/studio/backend/tests/test_video_prequant.py
+++ b/studio/backend/tests/test_video_prequant.py
@@ -796,11 +796,26 @@ def test_the_planned_sizing_matches_the_measured_one_it_stands_in_for():
 
     fam = _h3_family()
 
+    class _Weight:
+        """The released denoiser's size WITHOUT the 66.3 GB it would take to hold it.
+
+        The measurement reads numel(), element_size() and is_meta and nothing else, so a real
+        tensor buys no fidelity here and costs more RAM than a CI runner has: the allocation
+        raised, ``_h3_dense_denoiser_resident_bytes`` swallowed it as an unanswerable estimate,
+        and the test failed on a None that says nothing about the arithmetic under test.
+        """
+
+        is_meta = False
+
+        def numel(self):
+            return int(fam.bf16_components_gb[0] * 1000**3 // 2)
+
+        def element_size(self):
+            return torch.finfo(torch.bfloat16).bits // 8
+
     class _Dense:
         def parameters(self):
-            # The released denoiser, at the size the family table quotes for it.
-            n = int(fam.bf16_components_gb[0] * 1000**3 // 2)
-            return [torch.zeros(n, dtype = torch.bfloat16)]
+            return [_Weight()]
 
         def buffers(self):
             return []

--- a/studio/backend/tests/test_video_routes.py
+++ b/studio/backend/tests/test_video_routes.py
@@ -209,6 +209,18 @@ class _FakeBackend(video_module.VideoBackend):
         }
 
 
+@pytest.fixture(autouse = True)
+def _healthy_diffusers(healthy_diffusers):
+    """These tests are about the route, not about the runner's diffusers.
+
+    The module docstring promises they run without diffusers, and most do, but the
+    MiniMax-H3 download plan reaches `import diffusers` in video.py's modular-workflow
+    branch. Backend CI installs no diffusers (it lives in requirements/diffusers-pin.txt,
+    which only install_python_stack.py applies), so without the proxy that one test dies
+    on ModuleNotFoundError. Same fixture the diffusion test modules already use.
+    """
+
+
 @pytest.fixture
 def client(monkeypatch, tmp_path):
     backend = _FakeBackend()
@@ -1273,6 +1285,11 @@ def test_video_download_plan_judges_a_quantized_reference_pick_per_partition(cli
     # pick rather than a keyframe checkpoint wearing the wrong name. A scheme with no checkpoint
     # at all is still refused BEFORE staging, which is the failure this route check was added for
     # -- a 200 plan carrying 20 GB for a request the load then answered with a 400.
+    #
+    # The int8 half needs a torchao that can actually run a dense quant scheme; without one the
+    # route answers 409 and is RIGHT to. Backend CI installs no torchao, so assert nothing there
+    # rather than assert the wrong thing. Same guard as tests/test_diffusion_quant_pad.py.
+    pytest.importorskip("torchao")
     backend = video_module.get_video_backend()
     monkeypatch.setattr(
         backend,

--- a/studio/backend/tests/test_video_routes.py
+++ b/studio/backend/tests/test_video_routes.py
@@ -1286,10 +1286,14 @@ def test_video_download_plan_judges_a_quantized_reference_pick_per_partition(cli
     # at all is still refused BEFORE staging, which is the failure this route check was added for
     # -- a 200 plan carrying 20 GB for a request the load then answered with a 400.
     #
-    # The int8 half needs a torchao that can actually run a dense quant scheme; without one the
-    # route answers 409 and is RIGHT to. Backend CI installs no torchao, so assert nothing there
-    # rather than assert the wrong thing. Same guard as tests/test_diffusion_quant_pad.py.
-    pytest.importorskip("torchao")
+    # The host-level precision gate is a DIFFERENT question from the one under test, and on a
+    # box with no CUDA and no torchao it answers 409 before the partition check is ever reached.
+    # Stubbing it keeps the availability refusal (a 400, raised by validate_load_request below)
+    # under test everywhere, including the Backend CI matrix that installs no torchao. Same stub
+    # the neighbouring route tests use; test_video_h3_te_quant.py covers the gate itself.
+    monkeypatch.setattr(
+        video_module, "assert_video_precision_available", lambda fam, **kw: None, raising = False
+    )
     backend = video_module.get_video_backend()
     monkeypatch.setattr(
         backend,


### PR DESCRIPTION
Three tests fail on `main` in an environment shaped like the `studio-backend-ci.yml`
pytest matrix. That job installs neither `diffusers` (it lives in
`requirements/diffusers-pin.txt`, applied only by `install_python_stack.py`) nor
`torchao`. Nothing reported it: until #8342 the job died at collection before any test
ran, and the org Actions queue cancels runs rather than failing them.

### What was wrong

**`healthy_diffusers` answered only pipeline classes.** The fixture proxies an absent
diffusers so routing and config tests are not turned into a 400 about diffusers, which
is its stated purpose. It answered any name ending in `Pipeline`, but the video families
name a transformer, `MiniMaxH3Transformer3DModel`, so the availability probe in
`diffusion_families` missed and the request was refused with "needs a newer diffusers"
before it could reach the assertion under test. Answer `Model` as well.

**`test_video_routes.py` had no proxy at all.** Its own module docstring says the file
runs "without torch, diffusers, weights, or a GPU", but the MiniMax-H3 download plan
reaches a bare `import diffusers` in `video.py`'s modular-workflow branch. Added the
autouse wrapper that `test_diffusion_training.py` and `test_diffusion_checkpoint_resume.py`
already use.

**That exposed a second missing dependency.** The same test's int8 half needs a `torchao`
that can run a dense quant scheme; without one the route answers 409 and is right to.
Asserting 200 there would be asserting the wrong thing, so it now skips with the
`pytest.importorskip("torchao")` guard `tests/test_diffusion_quant_pad.py` already uses.

### Verification

Against a venv built to match the workflow's pytest matrix job, using its own ignore and
deselect flags.

| tree | result |
|---|---|
| `test_video_routes.py` + `test_diffusion_training.py` on `main` | 3 failed |
| the same two files with this change | **189 passed, 1 skipped** |
| full backend suite with this change | 3 failed, **21259 passed**, 130 skipped |

The 3 remaining failures are the `test_research_runs_storage.py` ones fixed by #8351,
which is not in this branch. With both applied the suite is green.
