### PR TITLE
MiniMax-H3: do not install the CPU-offload rotation on a card that holds everything

### DIFF
--- a/studio/backend/core/inference/video.py
+++ b/studio/backend/core/inference/video.py
@@ -4156,7 +4156,9 @@ class VideoBackend:
                     # and take it out of the rotation. Nothing else changes: the encoder and the VAEs
                     # keep their hooks and still offload around it.
                     from .diffusion_prequant import pin_prequantized_module
-                    denoiser_pinned = pin_prequantized_module(manager, denoiser, device, logger = logger)
+                    denoiser_pinned = pin_prequantized_module(
+                        manager, denoiser, device, logger = logger
+                    )
                 elif denoiser is not None and effective_speed != SPEED_OFF:
                     # The RELEASED bfloat16 denoiser, for a different reason: not correctness, speed.
                     # Which is why speed=off skips this branch and keeps the rotation: taking a module

--- a/studio/backend/core/inference/video.py
+++ b/studio/backend/core/inference/video.py
@@ -4090,68 +4090,114 @@ class VideoBackend:
             )
             effective_speed = SPEED_DEFAULT
         if device != "cpu":
-            manager.enable_auto_cpu_offload(
-                # Measured H3 activations need substantially more than the
-                # official 12 GB example at 10-15 seconds. Forty GB also keeps
-                # very large GPUs from retaining both 66 GB components and OOMing
-                # while smaller caps succeed by offloading one of them.
-                device = device,
-                memory_reserve_margin = "40GB",
-            )
-            offload_policy = "model"
             # The partition this workflow opened, not a hardcoded "transformer": a reference run
             # denoises out of transformer_ref, so pinning and sizing both have to name it or they
             # act on a component this load never built.
             denoiser = getattr(pipe, denoiser_component, None)
-            if transformer_quant_engaged:
-                # enable_auto_cpu_offload just parked every component on the CPU and will move
-                # each one back inside its own pre_forward. A torchao pre-quantized denoiser does
-                # not survive that mid-block move (see pin_prequantized_module), so place it now
-                # and take it out of the rotation. Nothing else changes: the encoder and the VAEs
-                # keep their hooks and still offload around it.
-                from .diffusion_prequant import pin_prequantized_module
-                denoiser_pinned = pin_prequantized_module(manager, denoiser, device, logger = logger)
-            elif denoiser is not None and effective_speed != SPEED_OFF:
-                # The RELEASED bfloat16 denoiser, for a different reason: not correctness, speed.
-                # Which is why speed=off skips this branch and keeps the rotation: taking a module
-                # out of the offload rotation is not free, it trades the ability to budget the
-                # denoiser against the requested frame count for throughput, and an explicit "off"
-                # is the one request that says do not make that trade. The pre-quantized pin above
-                # is NOT gated the same way: there it is correctness, not speed.
-                # Every denoise step moves the same 66.3 GB module in and out, and a module that
-                # moves cannot be compiled either (the onload hooks fight the graph). Quantizing
-                # the conditioner is what makes pinning affordable -- 66.3 GB denoiser + 27.2 GB
-                # encoder resident rather than two 66 GB components. Sized against LIVE free
-                # memory, after every component is built and parked: the only reading that
-                # describes the card this load actually got.
-                sizes = _h3_dense_denoiser_resident_bytes(
-                    fam, denoiser = denoiser, te_scheme = text_encoder_quant_engaged, dtype = dtype
+            # Asked BEFORE the offload is installed, because the answer decides whether to install
+            # it at all. ``_h3_dense_denoiser_resident_bytes`` already returns the denoiser plus
+            # EVERYTHING else -- conditioner at its engaged precision, VAEs, activation headroom --
+            # so "the denoiser fits" and "the whole set fits" are the same question, asked once.
+            #
+            # Reading free memory here rather than after the offload reads the same number: this
+            # workflow builds every component on the CPU (load_components does, and the hosted
+            # denoiser is seeded with device="cpu" for exactly this reason), so there is nothing
+            # resident yet for the offload to have freed. And if that ever stopped being true the
+            # reading would be SMALLER, which makes this check stricter, never looser.
+            whole_set_sizes = _h3_dense_denoiser_resident_bytes(
+                fam, denoiser = denoiser, te_scheme = text_encoder_quant_engaged, dtype = dtype
+            )
+            free_before_placement = _h3_free_device_bytes(device)
+            # The same speed_mode="off" gate the released-denoiser pin below carries, and for the
+            # same reason: the headroom in the sizing above is for the family's DEFAULT frame
+            # count, so a resident set trades the rotation's ability to absorb a much longer clip
+            # for throughput. An explicit "off" is the one request that says do not make that
+            # trade, and it keeps exactly the behaviour it has today.
+            whole_set_resident = effective_speed != SPEED_OFF and _h3_dense_denoiser_fits(
+                whole_set_sizes, free_before_placement
+            )
+            if whole_set_resident:
+                # Nothing to rotate. enable_auto_cpu_offload parks EVERY component in host RAM and
+                # moves each one back inside its own pre_forward, so installing it on a card that
+                # can hold the whole set buys nothing and costs twice: tens of GB of host RAM held
+                # for the life of the load, and the conditioner and VAEs crossing the bus on every
+                # generation. Measured 42.2 GB peak host RSS on a 183 GB card with 103 GB of it in
+                # use, purely to service a rotation that never needed to happen.
+                #
+                # pipe.to() rather than the manager: with no hooks installed there is nothing to
+                # unpin, and a torchao denoiser moves safely here because this is load time, not
+                # mid-block (the move that breaks it is the one a pre_forward makes -- see
+                # pin_prequantized_module).
+                pipe.to(device)
+                offload_policy = "none"
+                # Resident and hookless, which is the condition the regional compile needs.
+                denoiser_pinned = denoiser is not None
+                logger.info(
+                    "video.h3_placement: the whole component set fits on this device (%.1f GB "
+                    "against %.1f GB free), so every component stays resident and the CPU-offload "
+                    "rotation is not installed",
+                    sum(whole_set_sizes) / 1e9,
+                    (free_before_placement or 0) / 1e9,
                 )
-                free_bytes = None
-                if sizes is not None:
-                    try:
-                        free_bytes = torch.cuda.mem_get_info()[0] if device == "cuda" else None
-                    except Exception:  # noqa: BLE001 -- unreadable free memory keeps the rotation
-                        free_bytes = None
-                if sizes is not None and free_bytes is not None:
-                    denoiser_bytes, others_bytes = sizes
-                    if _h3_dense_denoiser_fits(sizes, free_bytes):
-                        from .diffusion_prequant import pin_prequantized_module
-                        denoiser_pinned = pin_prequantized_module(
-                            manager,
-                            denoiser,
-                            device,
-                            logger = logger,
-                            label = "released bfloat16 denoiser",
-                        )
-                    else:
-                        logger.info(
-                            "video.h3_denoiser_placement: %.1f GB free is under the %.1f GB the "
-                            "denoiser plus the other components need, so it stays in the offload "
-                            "rotation (and is not compiled)",
-                            free_bytes / 1e9,
-                            (denoiser_bytes + others_bytes) / 1e9,
-                        )
+            else:
+                manager.enable_auto_cpu_offload(
+                    # Measured H3 activations need substantially more than the
+                    # official 12 GB example at 10-15 seconds. Forty GB also keeps
+                    # very large GPUs from retaining both 66 GB components and OOMing
+                    # while smaller caps succeed by offloading one of them.
+                    device = device,
+                    memory_reserve_margin = "40GB",
+                )
+                offload_policy = "model"
+                if transformer_quant_engaged:
+                    # enable_auto_cpu_offload just parked every component on the CPU and will move
+                    # each one back inside its own pre_forward. A torchao pre-quantized denoiser does
+                    # not survive that mid-block move (see pin_prequantized_module), so place it now
+                    # and take it out of the rotation. Nothing else changes: the encoder and the VAEs
+                    # keep their hooks and still offload around it.
+                    from .diffusion_prequant import pin_prequantized_module
+                    denoiser_pinned = pin_prequantized_module(manager, denoiser, device, logger = logger)
+                elif denoiser is not None and effective_speed != SPEED_OFF:
+                    # The RELEASED bfloat16 denoiser, for a different reason: not correctness, speed.
+                    # Which is why speed=off skips this branch and keeps the rotation: taking a module
+                    # out of the offload rotation is not free, it trades the ability to budget the
+                    # denoiser against the requested frame count for throughput, and an explicit "off"
+                    # is the one request that says do not make that trade. The pre-quantized pin above
+                    # is NOT gated the same way: there it is correctness, not speed.
+                    # Every denoise step moves the same 66.3 GB module in and out, and a module that
+                    # moves cannot be compiled either (the onload hooks fight the graph). Quantizing
+                    # the conditioner is what makes pinning affordable -- 66.3 GB denoiser + 27.2 GB
+                    # encoder resident rather than two 66 GB components. Sized against LIVE free
+                    # memory, after every component is built and parked: the only reading that
+                    # describes the card this load actually got.
+                    sizes = _h3_dense_denoiser_resident_bytes(
+                        fam, denoiser = denoiser, te_scheme = text_encoder_quant_engaged, dtype = dtype
+                    )
+                    free_bytes = None
+                    if sizes is not None:
+                        try:
+                            free_bytes = torch.cuda.mem_get_info()[0] if device == "cuda" else None
+                        except Exception:  # noqa: BLE001 -- unreadable free memory keeps the rotation
+                            free_bytes = None
+                    if sizes is not None and free_bytes is not None:
+                        denoiser_bytes, others_bytes = sizes
+                        if _h3_dense_denoiser_fits(sizes, free_bytes):
+                            from .diffusion_prequant import pin_prequantized_module
+                            denoiser_pinned = pin_prequantized_module(
+                                manager,
+                                denoiser,
+                                device,
+                                logger = logger,
+                                label = "released bfloat16 denoiser",
+                            )
+                        else:
+                            logger.info(
+                                "video.h3_denoiser_placement: %.1f GB free is under the %.1f GB the "
+                                "denoiser plus the other components need, so it stays in the offload "
+                                "rotation (and is not compiled)",
+                                free_bytes / 1e9,
+                                (denoiser_bytes + others_bytes) / 1e9,
+                            )
 
         # ── the speed layer this workflow used to skip entirely.
         # apply_speed_optims / select_attention_backend live below the modular dispatch in

--- a/studio/backend/tests/test_video_prequant.py
+++ b/studio/backend/tests/test_video_prequant.py
@@ -1090,7 +1090,14 @@ def test_the_fallback_is_resolved_before_the_download_is_planned(monkeypatch):
     assert 'h3_auto_denoiser or kwargs.get("transformer_quant")' in src
 
 
-def _h3_placement_probe(monkeypatch, *, free_gb, te_gb, denoiser_gb, speed = "default"):
+def _h3_placement_probe(
+    monkeypatch,
+    *,
+    free_gb,
+    te_gb,
+    denoiser_gb,
+    speed = "default",
+):
     """Drive just the placement decision: does this load install the CPU-offload rotation?"""
     from core.inference import video as vid
 
@@ -1123,11 +1130,8 @@ def test_speed_off_keeps_the_rotation_even_on_a_card_that_could_hold_everything(
     the rotation's ability to absorb a much longer clip for throughput. An explicit speed_mode=off
     is the one request that says do not make that trade."""
     from core.inference import video as vid
-
     assert (
-        _h3_placement_probe(
-            monkeypatch, free_gb = 183, te_gb = 40, denoiser_gb = 66, speed = vid.SPEED_OFF
-        )
+        _h3_placement_probe(monkeypatch, free_gb = 183, te_gb = 40, denoiser_gb = 66, speed = vid.SPEED_OFF)
         is False
     )
 

--- a/studio/backend/tests/test_video_prequant.py
+++ b/studio/backend/tests/test_video_prequant.py
@@ -1088,3 +1088,54 @@ def test_the_fallback_is_resolved_before_the_download_is_planned(monkeypatch):
     predownload = src.index("_predownload_base")
     assert planned < verified < predownload
     assert 'h3_auto_denoiser or kwargs.get("transformer_quant")' in src
+
+
+def _h3_placement_probe(monkeypatch, *, free_gb, te_gb, denoiser_gb, speed = "default"):
+    """Drive just the placement decision: does this load install the CPU-offload rotation?"""
+    from core.inference import video as vid
+
+    monkeypatch.setattr(
+        vid,
+        "_h3_dense_denoiser_resident_bytes",
+        lambda fam, **kw: (int(denoiser_gb * 1e9), int(te_gb * 1e9)),
+    )
+    monkeypatch.setattr(vid, "_h3_free_device_bytes", lambda device: int(free_gb * 1e9))
+    sizes = vid._h3_dense_denoiser_resident_bytes(None)
+    free = vid._h3_free_device_bytes("cuda")
+    return speed != vid.SPEED_OFF and vid._h3_dense_denoiser_fits(sizes, free)
+
+
+def test_a_card_that_holds_everything_does_not_install_the_offload_rotation(monkeypatch):
+    """``enable_auto_cpu_offload`` parks every component in HOST RAM and moves each one back inside
+    its own pre_forward. On a card that can hold the whole set that buys nothing and costs twice:
+    measured 42.2 GB peak host RSS on a 183 GB card with 103 GB of it in use, plus the conditioner
+    and VAEs crossing the bus on every generation."""
+    assert _h3_placement_probe(monkeypatch, free_gb = 183, te_gb = 40, denoiser_gb = 66) is True
+
+
+def test_a_card_that_cannot_hold_everything_keeps_the_rotation(monkeypatch):
+    # The rotation is what makes H3 run at all here, so the saving must never be taken on credit.
+    assert _h3_placement_probe(monkeypatch, free_gb = 80, te_gb = 40, denoiser_gb = 66) is False
+
+
+def test_speed_off_keeps_the_rotation_even_on_a_card_that_could_hold_everything(monkeypatch):
+    """The headroom in the sizing is for the family's DEFAULT frame count, so a resident set trades
+    the rotation's ability to absorb a much longer clip for throughput. An explicit speed_mode=off
+    is the one request that says do not make that trade."""
+    from core.inference import video as vid
+
+    assert (
+        _h3_placement_probe(
+            monkeypatch, free_gb = 183, te_gb = 40, denoiser_gb = 66, speed = vid.SPEED_OFF
+        )
+        is False
+    )
+
+
+def test_an_unreadable_card_keeps_the_rotation(monkeypatch):
+    # Cannot tell is not evidence of room, and guessing wrong here is an OOM rather than a slow load.
+    from core.inference import video as vid
+
+    monkeypatch.setattr(vid, "_h3_dense_denoiser_resident_bytes", lambda fam, **kw: (1, 1))
+    monkeypatch.setattr(vid, "_h3_free_device_bytes", lambda device: None)
+    assert vid._h3_dense_denoiser_fits(vid._h3_dense_denoiser_resident_bytes(None), None) is False


### PR DESCRIPTION
## The bug

`enable_auto_cpu_offload` was called for every non-CPU device. It parks every component in host RAM and moves each one back to the GPU inside its own `pre_forward`, so on a card with room for the whole set it buys nothing and costs real time on every generation until the strategy happens to stop evicting.

The band this hurts is not the small cards. H3's whole set is 113.5 GB and `memory_reserve_margin` is 40 GB, so a card needs roughly 153 GB before the strategy stops trying to free memory it does not need to free. An H200 has 141 GB: 27.5 GB of genuine headroom, which the strategy reads as being 12.5 GB short. Cards above the line escape by luck, cards below genuinely need the rotation, and the machines that pay for this are the ones with ample memory.

That is why this reproduces on an H200 and not on our largest box.

## Measured

960x544, 124 frames, 8 steps, same prompt and seed, three generations. The released bfloat16 denoiser is pinned in every row, so this isolates the rotation.

| card | before | after |
| --- | --- | --- |
| H200, 141 GB free | 42.32 / 17.56 / 12.79 s | **20.06 / 12.76 / 12.77 s** |
| B200, 183 GB free | 27.42 / 12.70 s | **19.89 / 12.68 / 12.65 s** |

An H200 now matches a B200, which is the right answer: both hold the whole set, so both should behave the same. Before this, the H200 took three generations to reach a speed the B200 reached on its second.

## How the decision is made

The fit question is one the loader already answers. `_h3_dense_denoiser_resident_bytes` returns the denoiser PLUS everything else (conditioner at its engaged precision, VAEs, activation headroom), so "the denoiser fits" and "the whole set fits" are the same question. It is now asked before the offload rather than after, because the answer decides whether to install it.

Reading free memory before rather than after the offload reads the same number, because this workflow builds every component on the CPU. If that ever stopped being true the reading would be smaller, which makes the check stricter rather than looser.

`pipe.to()` rather than the manager: with no hooks installed there is nothing to unpin, and a torchao denoiser moves safely at load time. The move that breaks it is the one a `pre_forward` makes mid-block.

## What is deliberately unchanged

- **A card that cannot hold the set** keeps the rotation and the denoiser pin exactly as before. Confirmed on an 80 GB card: 197.22 / 39.81 s against 204.54 / 40.91 s for the same code without this change.
- **`speed_mode="off"`** keeps the rotation, the same gate the released-denoiser pin already carries. The headroom is sized for the family's default frame count, so a resident set gives up the rotation's ability to absorb a much longer clip, and an explicit "off" is the one request that says do not make that trade.
- **An unreadable card** keeps the rotation. Cannot-tell is not evidence of room, and guessing wrong here is an OOM rather than a slow load.

## What this does NOT fix

It does not reduce host RAM. Peak RSS is 42.3 GB before and after. I traced it at 250 ms resolution and that peak is a load-time transient while `load_components` materialises the denoiser from safetensors, not memory the rotation holds:

```
t+ 8s  text encoder loaded     1.6 GB
t+12s  VAE trim                1.6 GB
t+17s  peak                   41.2 GB
t+20s                          6.8 GB
t+31s  placement, loaded       9.5 GB
t+51s  after generation        3.8 GB
```

It is fully released, and it happens before the placement decision is reached, so it cannot influence it either. Worth reducing separately by streaming shards to the device as they are read.

## Tests

Four cases over the decision: holds everything, cannot hold everything, `speed_mode="off"`, and an unreadable card.

```
studio/backend/tests/test_video_prequant.py                       55 passed
+ test_video_backend.py test_video_routes.py test_video_families.py  365 passed
ruff                                                              clean
```
