### PR TITLE
Fix broken Linux .deb download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Download the native Unsloth desktop app for your operating system:
   </tr>
   <tr>
     <td><b>Linux (deb)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.60-beta/Unsloth-Desktop-0_1_60_beta-Linux.deb'>Download</a></td>
+    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.60-beta/Unsloth-Desktop-0_1_60_beta-Ubuntu.deb'>Download</a></td>
   </tr>
   <tr>
     <td><b>Linux (AppImage)</b></td>


### PR DESCRIPTION
The README's "Linux (deb)" link 404s  it points at -Linux.deb, but the release publishes -Ubuntu.deb.