### PR TITLE
MiniMax-H3: make the hosted int8 denoiser the default, not a fallback

### DIFF
--- a/studio/backend/core/inference/video.py
+++ b/studio/backend/core/inference/video.py
@@ -723,21 +723,23 @@ def _h3_auto_denoiser_scheme(
 ) -> Optional[str]:
     """The hosted scheme an UNSET ``transformer_quant`` resolves to, or None to keep bfloat16.
 
-    None whenever the released denoiser can stay resident, so a card with room gets exactly what
-    it got before: the released weights, bit-identical output, and the pin plus regional compile
-    that make it fast.
+    int8 wherever the hosted checkpoint exists for this partition and fits, which is now the
+    DEFAULT rather than a fallback. Measured on an H200 (141 GB) and a B200 (183 GB), 960x544,
+    124 frames, 8 steps, every component resident in both rows:
 
-    The fallback exists because the alternative on a smaller card is not "a bit slower". A denoiser
-    that does not fit stays in the CPU-offload rotation, and a module that moves cannot be compiled
-    either, so the regional compile is dropped with it: 194 s against 23.7 s on the same 8-step job,
-    every step paying 66.3 GB across the bus. The hosted checkpoint is 20.3 GB resident, which pins,
-    which restores the compile.
+        released bf16   20.06 / 12.76 / 12.77 s    102.8 GB steady
+        hosted int8     23.08 / 11.74 / 11.84 s     57.8 GB steady
 
-    The cost is real and is why this is a fallback rather than the default everywhere: the hosted
-    denoisers RE-ROLL the sample (mean SSIM 0.49 against the released weights, where that config
-    against itself scores 0.99). Different is not worse -- no NaN, no black frames, no visible
-    degradation at the model's own 30-step schedule -- but it is not the same picture, so it is
-    taken only when the choice is against a configuration nobody would pick knowingly.
+    So int8 is faster per generation and needs 45 GB less, which is what makes it the better
+    default on a card of any size. On a card that cannot hold the released denoiser the margin is
+    not 8% but the difference between running and crawling: bf16 there rides the CPU-offload
+    rotation and a module that moves cannot be compiled either, 194 s against 23.7 s.
+
+    What it costs is the picture, and that is the whole of the trade: the hosted denoisers RE-ROLL
+    the sample (mean SSIM 0.49 against the released weights, where that config against itself
+    scores 0.99). No NaN, no black frames, no visible degradation at the model's own 30-step
+    schedule, but the same seed and prompt render a different video. ``transformer_quant='none'``
+    keeps the released weights, and speed_mode="off" declines this on its own below.
 
     ``free_reader`` is how the device is measured: live free memory by default, and CAPACITY for
     the pre-download decision, which runs while the previous pipeline is still resident.
@@ -767,8 +769,6 @@ def _h3_auto_denoiser_scheme(
     if sizes is None or free_bytes is None:
         # No reading is not evidence of a shortfall, and guessing wrong here changes the picture a
         # user gets. Keep the released denoiser, which is what happens today.
-        return None
-    if _h3_dense_denoiser_fits(sizes, free_bytes):
         return None
     if not video_family_prequant_available(
         fam, H3_AUTO_FALLBACK_SCHEME, task = task, base_repo = base_repo

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -2958,8 +2958,10 @@ def test_the_h3_loader_optimises_the_partition_it_denoises_with():
         ), f"{helper} is handed {ast.dump(first)}, not the denoiser view"
 
 
-def test_download_plan_adds_no_prequant_entry_without_a_scheme(monkeypatch):
-    # bf16 keeps the dense shards, so there is nothing to replace and no third repo to stage.
+def test_download_plan_adds_no_prequant_entry_when_bfloat16_is_pinned(monkeypatch):
+    # transformer_quant="none" keeps the dense shards, so there is nothing to replace and no
+    # third repo to stage. An UNSET request resolves to int8 now and stages the hosted
+    # checkpoint instead, which is a different case; this one is the explicit opt-out.
     _cuda_bf16_target(monkeypatch)
     _plan_api(
         monkeypatch,
@@ -2973,6 +2975,7 @@ def test_download_plan_adds_no_prequant_entry_without_a_scheme(monkeypatch):
         "MiniMaxAI/MiniMax-H3",
         family_override = "minimax-h3",
         model_kind = "pipeline",
+        transformer_quant = "none",
     )
 
     by_repo = {entry["repo_id"]: entry for entry in plan["entries"]}
@@ -4974,6 +4977,9 @@ def test_h3_modular_load_restricts_the_components_not_the_blocks(monkeypatch, tm
 
     backend = VideoBackend()
     status = backend._load_h3_modular_pipeline(
+        # Precision is not what this covers, and an unset request resolves to int8 now,
+        # which sends the load down the hosted-checkpoint path instead of this one.
+        transformer_quant = "none",
         diffusers = diffusers,
         torch = torch,
         fam = fam,
@@ -5073,8 +5079,9 @@ def test_h3_modular_load_pins_a_hosted_prequant_denoiser_out_of_the_offload_rota
     assert calls["pinned"]["manager"] is manager
     assert calls["pinned"]["device"] == "cuda"
 
-    # No hosted checkpoint engaged -> released bfloat16 components, which the manager moves fine.
-    status = load(None)
+    # No hosted checkpoint engaged -> released bfloat16 components, which the manager moves
+    # fine. Asked for EXPLICITLY: an unset request resolves to int8 now.
+    status = load("none")
     assert status["transformer_quant"] is None
     assert "pinned" not in calls
 
@@ -5622,6 +5629,9 @@ def test_h3_modular_load_brings_up_the_requested_partition(monkeypatch):
 
     backend = VideoBackend()
     status = backend._load_h3_modular_pipeline(
+        # Precision is not what this covers, and an unset request resolves to int8 now,
+        # which sends the load down the hosted-checkpoint path instead of this one.
+        transformer_quant = "none",
         diffusers = diffusers,
         torch = torch,
         fam = fam,

--- a/studio/backend/tests/test_video_prequant.py
+++ b/studio/backend/tests/test_video_prequant.py
@@ -821,10 +821,18 @@ def test_the_planned_sizing_matches_the_measured_one_it_stands_in_for():
     assert fp32 is not None and bf16 is not None and fp32[0] == bf16[0] * 2
 
 
-def test_auto_keeps_the_released_denoiser_on_a_card_that_can_hold_it(monkeypatch):
-    """The whole point of making this conditional. A card with room gets exactly what it got
-    before: the released weights and the same picture, because the pin plus the regional compile
-    make it fast without changing a single value."""
+def test_auto_takes_the_hosted_denoiser_even_on_a_card_with_room_to_spare(monkeypatch):
+    """int8 is the DEFAULT, not a fallback, so having room for the released denoiser is not a
+    reason to load it.
+
+    It is not a tie broken on memory. Measured on an H200 and a B200, every component resident in
+    both rows, the hosted checkpoint is faster per generation AND 45 GB smaller:
+
+        released bf16   20.06 / 12.76 / 12.77 s   102.8 GB steady
+        hosted int8     23.08 / 11.74 / 11.84 s    57.8 GB steady
+
+    What it costs is the picture (mean SSIM 0.49 against the released weights), which is a choice
+    ``transformer_quant='none'`` reverses and which no amount of free VRAM changes."""
     import torch
 
     from core.inference import video as vid
@@ -844,7 +852,7 @@ def test_auto_keeps_the_released_denoiser_on_a_card_that_can_hold_it(monkeypatch
             task = "fl2va",
             base_repo = fam.base_repo,
         )
-        is None
+        == "int8"
     )
 
 


### PR DESCRIPTION
## Depends on #8357

Do not merge this before #8357. Without it the hosted int8 denoiser pays 23 dynamo recompiles, so making it the default would take the FIRST generation from 23 s to 178 s for everyone. #8357 collapses that to one recompile. Merge order matters here, so I have kept them as separate PRs rather than one.

## Why

int8 is faster per generation and needs 45 GB less than the released bfloat16 denoiser, so there is no card size on which bf16 is the better performance choice. Measured 960x544, 124 frames, 8 steps, same prompt and seed, every component resident in both rows, three generations each:

| card | denoiser | generations | steady VRAM |
| --- | --- | --- | --- |
| H200, 141 GB | released bf16 | 20.06 / 12.76 / 12.77 s | 102.8 GB |
| H200, 141 GB | **hosted int8** | 23.08 / **11.74** / **11.84** s | **57.8 GB** |
| B200, 183 GB | released bf16 | 19.89 / 12.68 / 12.65 s | 102.8 GB |
| B200, 183 GB | **hosted int8** | 31.44 / **11.80** / **11.77** s | **57.8 GB** |

The first generation is a few seconds slower because the int8 graph takes longer to compile; every generation after it is faster, and the resident footprint is a little over half.

On a card that cannot hold the released denoiser the margin is not 8% but the difference between running and crawling, which is what the fallback in #8347 was for: bf16 there rides the CPU-offload rotation, a module that moves cannot be regionally compiled either, and the same job goes 23.7 s to 194 s.

## What changed

One line of policy. The chooser no longer returns early when the released denoiser happens to fit. Every gate it already had still stands, and each one still declines to bfloat16:

- exact base identity, so a derivative never gets upstream's denoiser
- a hosted checkpoint for THIS partition, asked per (scheme, partition)
- the replacement itself has to fit resident
- `speed_mode="off"`, which is a bit-exact contract
- any reading that cannot be taken

## What it costs, stated plainly

The hosted denoisers re-roll the sample: mean SSIM 0.49 against the released weights, where that config against itself scores 0.99. No NaN, no black frames, no visible degradation at the model's own 30-step schedule, but the same seed and prompt render a different video. Anyone comparing renders across a Studio update will see their outputs change.

`transformer_quant='none'` keeps the released weights.

This is the one part of this PR that is a product decision rather than a measurement, and it is the reason int8 was previously a fallback rather than the default.

## Tests

Four existing tests encoded the old default. They are retargeted, not relaxed:

- the one asserting auto keeps bfloat16 on a roomy card now asserts the opposite, and carries the measurements as its reason
- the other three were never about precision (a download plan, a component restriction, a partition selection) and now pin `transformer_quant="none"` so they keep testing what they name

Mutation checked: restoring the early-out fails the new test.

```
test_video_prequant.py test_video_backend.py test_video_routes.py
test_video_families.py test_video_h3_te_quant.py     402 passed
ruff                                                 clean
```
