### PR TITLE
Studio: stop the update banners printing over their own buttons

### DIFF
--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -379,6 +379,13 @@ jobs:
               echo "::add-mask::$STUDIO_OLD_PW"
               echo "::add-mask::$STUDIO_NEW_PW"
               export STUDIO_OLD_PW STUDIO_NEW_PW
+              # Out of this shell as well as into it. The retry deleted the auth
+              # directory and bootstrapped a new password, so the values every
+              # LATER step reads from GITHUB_ENV are now the credentials of a
+              # server that no longer exists, and the next step to log in fails
+              # a job whose retry had otherwise just succeeded.
+              echo "STUDIO_EXTRA_OLD_PW=$STUDIO_OLD_PW" >> "$GITHUB_ENV"
+              echo "STUDIO_EXTRA_NEW_PW=$STUDIO_NEW_PW" >> "$GITHUB_ENV"
               attempt=$((attempt + 1))
               sleep 3
               continue

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -386,6 +386,20 @@ jobs:
             exit "$rc"
           done
 
+      # The same layout regression the Linux job runs, on the platform whose
+      # scrollbars actually take width and whose font metrics are its own: the
+      # card's floor and the action row's wrap threshold are both measurements,
+      # and a measurement taken on one platform is a guess on the others.
+      - name: Update banner layout regression (Playwright)
+        env:
+          BASE_URL: http://127.0.0.1:18897
+          STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
+          STUDIO_NEW_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
+          PW_ART_DIR: logs/playwright_update_banner
+        run: |
+          mkdir -p logs/playwright_update_banner
+          python tests/studio/playwright_update_banner_layout.py
+
       - name: Stop second Unsloth
         if: always()
         run: |
@@ -635,6 +649,7 @@ jobs:
             logs/playwright
             logs/playwright-permissions-*
             logs/playwright_extra
+            logs/playwright_update_banner
             logs/studio-permissions-*.log
             logs/studio_tabs.log
             logs/playwright_mac_tabs

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -57,7 +57,9 @@ jobs:
   ui-smoke:
     name: Chat UI Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # The job was landing at 22m30s of its 25, so the banner layout step below
+    # took it over and the three image-model steps after it never ran.
+    timeout-minutes: 30
     env:
       GGUF_REPO: unsloth/gemma-3-270m-it-GGUF
       GGUF_VARIANT: UD-Q4_K_XL

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -278,6 +278,25 @@ jobs:
           mkdir -p logs/playwright_update_banner
           python tests/studio/playwright_update_banner_layout.py
 
+      # Firefox and WebKit at the viewports that reproduce, and nothing else:
+      # the card's floor and the action row's wrap threshold are measurements,
+      # and the three engines do not agree on font metrics or on whether a
+      # scrollbar takes width out of the box it sits on. WebKit is the closest
+      # this runner gets to Safari. Cut down to `spot` because a third full
+      # pass would spend minutes re-answering the first pass's questions.
+      - name: Update banner layout, other engines (Playwright)
+        env:
+          BASE_URL: http://127.0.0.1:18894
+          STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
+          STUDIO_NEW_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
+          PW_ART_DIR: logs/playwright_update_banner
+          STUDIO_UI_BANNER_SCOPE: spot
+        run: |
+          for engine in firefox webkit; do
+            STUDIO_PLAYWRIGHT_BROWSER="$engine" \
+              python tests/studio/playwright_update_banner_layout.py
+          done
+
       - name: Image model full-footprint selector regression (Playwright)
         env:
           BASE_URL: http://127.0.0.1:18894

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -266,6 +266,16 @@ jobs:
           mkdir -p logs/playwright_fontscale
           python tests/studio/playwright_ui_font_scale.py
 
+      - name: Update banner layout regression (Playwright)
+        env:
+          BASE_URL: http://127.0.0.1:18894
+          STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
+          STUDIO_NEW_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
+          PW_ART_DIR: logs/playwright_update_banner
+        run: |
+          mkdir -p logs/playwright_update_banner
+          python tests/studio/playwright_update_banner_layout.py
+
       - name: Image model full-footprint selector regression (Playwright)
         env:
           BASE_URL: http://127.0.0.1:18894
@@ -402,6 +412,7 @@ jobs:
             logs/playwright-permissions-*
             logs/playwright_extra
             logs/playwright_fontscale
+            logs/playwright_update_banner
             logs/playwright_image_footprint
             logs/playwright_image_cancel_retry
             logs/playwright_image_cancel_retry_cold

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -405,6 +405,20 @@ jobs:
           mkdir -p logs/playwright_extra
           python tests/studio/playwright_extra_ui.py
 
+      # The same layout regression the Linux job runs, on the platform whose
+      # scrollbars actually take width and whose font metrics are its own: the
+      # card's floor and the action row's wrap threshold are both measurements,
+      # and a measurement taken on one platform is a guess on the others.
+      - name: Update banner layout regression (Playwright)
+        env:
+          BASE_URL: http://127.0.0.1:18897
+          STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
+          STUDIO_NEW_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
+          PW_ART_DIR: logs/playwright_update_banner
+        run: |
+          mkdir -p logs/playwright_update_banner
+          python tests/studio/playwright_update_banner_layout.py
+
       - name: Stop second Unsloth
         if: always()
         run: |
@@ -423,6 +437,7 @@ jobs:
             logs/playwright
             logs/playwright-permissions-*
             logs/playwright_extra
+            logs/playwright_update_banner
             logs/studio-permissions-*.log
           # 1 day, matching the repository-wide cap. A larger value here is
           # silently clamped to that cap today, so stating 7 only invites the

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -398,10 +398,13 @@ function TauriUpdateLayer({
     // Capped like the browser stack: the download panel shares it, so both must fit.
     <div
       ref={stack.ref}
-      // Scrolls when the cap is smaller than the cards, rather than
-      // spilling them over the page. The padding, cancelled by the
-      // margin, keeps the card shadows out of the scroller's clip.
-      className="pointer-events-none fixed right-4 z-[9998] -m-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain p-3"
+      // Scrolls when the cap is smaller than the cards, rather than spilling
+      // them over the page. The side gutter, cancelled by the margin, keeps the
+      // card shadows out of the scroller's clip. Horizontal only, because
+      // useStackGeometry measures this node's scrollHeight: vertical padding
+      // there inflates the height the placement thinks the stack needs, so a
+      // card that fits under the composer measures as one that does not.
+      className="pointer-events-none fixed right-4 z-[9998] -mx-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3"
       style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
     >
       <UpdateBanner
@@ -686,9 +689,13 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         <div
           ref={stack.ref}
           // Scrolls when the cap is smaller than the cards, rather than
-          // spilling them over the page. The padding, cancelled by the
+          // spilling them over the page. The side gutter, cancelled by the
           // margin, keeps the card shadows out of the scroller's clip.
-          className="pointer-events-none fixed right-4 z-[9998] -m-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain p-3"
+          // Horizontal only, because useStackGeometry measures this node's
+          // scrollHeight: vertical padding there inflates the height the
+          // placement thinks the stack needs, so a card that fits under the
+          // composer measures as one that does not.
+          className="pointer-events-none fixed right-4 z-[9998] -mx-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3"
           style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
         >
           <WebUpdateBanner

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -399,11 +399,9 @@ function TauriUpdateLayer({
     <div
       ref={stack.ref}
       // Scrolls when the cap is smaller than the cards, rather than spilling
-      // them over the page. The side gutter, cancelled by the margin, keeps the
-      // card shadows out of the scroller's clip. Horizontal only, because
-      // useStackGeometry measures this node's scrollHeight: vertical padding
-      // there inflates the height the placement thinks the stack needs, so a
-      // card that fits under the composer measures as one that does not.
+      // them over the page. The gutter, cancelled by the margin, keeps the card
+      // shadows out of the clip; horizontal only, since useStackGeometry reads
+      // this node's scrollHeight and vertical padding would inflate it.
       className="pointer-events-none fixed right-4 z-[9998] -mx-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3"
       style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
     >
@@ -566,7 +564,6 @@ function TauriWrapper({ children }: { children: ReactNode }) {
     void wasLaunchedHidden().then(async (hiddenAtLaunch) => {
       if (!hiddenAtLaunch || disposed) return;
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
-
       const unlisten = await getCurrentWindow().onFocusChanged(({ payload }) => {
         if (!payload || disposed) return;
         stopListening?.();
@@ -689,12 +686,10 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         <div
           ref={stack.ref}
           // Scrolls when the cap is smaller than the cards, rather than
-          // spilling them over the page. The side gutter, cancelled by the
-          // margin, keeps the card shadows out of the scroller's clip.
-          // Horizontal only, because useStackGeometry measures this node's
-          // scrollHeight: vertical padding there inflates the height the
-          // placement thinks the stack needs, so a card that fits under the
-          // composer measures as one that does not.
+          // spilling them over the page. The gutter, cancelled by the margin,
+          // keeps the card shadows out of the clip; horizontal only, since
+          // useStackGeometry reads this node's scrollHeight and vertical
+          // padding would inflate it.
           className="pointer-events-none fixed right-4 z-[9998] -mx-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3"
           style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
         >

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -398,10 +398,9 @@ function TauriUpdateLayer({
     // Capped like the browser stack: the download panel shares it, so both must fit.
     <div
       ref={stack.ref}
-      // Last resort when the cap is smaller than the cards: the rail scrolls
-      // rather than spilling them over the composer. The padding and the
-      // negative margin that cancels it keep the card shadows out of the
-      // scroller's clip without moving the cards themselves.
+      // Scrolls when the cap is smaller than the cards, rather than
+      // spilling them over the page. The padding, cancelled by the
+      // margin, keeps the card shadows out of the scroller's clip.
       className="pointer-events-none fixed right-4 z-[9998] -m-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain p-3"
       style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
     >
@@ -686,10 +685,9 @@ function TauriWrapper({ children }: { children: ReactNode }) {
             pushes the top of the stack off screen. */}
         <div
           ref={stack.ref}
-          // Last resort when the cap is smaller than the cards: the rail scrolls
-          // rather than spilling them over the composer. The padding and the
-          // negative margin that cancels it keep the card shadows out of the
-          // scroller's clip without moving the cards themselves.
+          // Scrolls when the cap is smaller than the cards, rather than
+          // spilling them over the page. The padding, cancelled by the
+          // margin, keeps the card shadows out of the scroller's clip.
           className="pointer-events-none fixed right-4 z-[9998] -m-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain p-3"
           style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
         >

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -398,7 +398,11 @@ function TauriUpdateLayer({
     // Capped like the browser stack: the download panel shares it, so both must fit.
     <div
       ref={stack.ref}
-      className="pointer-events-none fixed right-4 z-[9998] flex flex-col items-end gap-2"
+      // Last resort when the cap is smaller than the cards: the rail scrolls
+      // rather than spilling them over the composer. The padding and the
+      // negative margin that cancels it keep the card shadows out of the
+      // scroller's clip without moving the cards themselves.
+      className="pointer-events-none fixed right-4 z-[9998] -m-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain p-3"
       style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
     >
       <UpdateBanner
@@ -560,6 +564,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
     void wasLaunchedHidden().then(async (hiddenAtLaunch) => {
       if (!hiddenAtLaunch || disposed) return;
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
+
       const unlisten = await getCurrentWindow().onFocusChanged(({ payload }) => {
         if (!payload || disposed) return;
         stopListening?.();
@@ -681,7 +686,11 @@ function TauriWrapper({ children }: { children: ReactNode }) {
             pushes the top of the stack off screen. */}
         <div
           ref={stack.ref}
-          className="pointer-events-none fixed right-4 z-[9998] flex flex-col items-end gap-2"
+          // Last resort when the cap is smaller than the cards: the rail scrolls
+          // rather than spilling them over the composer. The padding and the
+          // negative margin that cancels it keep the card shadows out of the
+          // scroller's clip without moving the cards themselves.
+          className="pointer-events-none fixed right-4 z-[9998] -m-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain p-3"
           style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
         >
           <WebUpdateBanner

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -33,6 +33,7 @@ import { TauriUpdateContext } from "@/hooks/tauri-update-context";
 import { type BackendStatus, useTauriBackend } from "@/hooks/use-tauri-backend";
 import { useTauriUpdate } from "@/hooks/use-tauri-update";
 import { isTauri } from "@/lib/api-base";
+import { cn } from "@/lib/utils";
 import { useRouterState } from "@tanstack/react-router";
 import { MotionConfig } from "motion/react";
 import {
@@ -402,7 +403,13 @@ function TauriUpdateLayer({
       // them over the page. The gutter, cancelled by the margin, keeps the card
       // shadows out of the clip; horizontal only, since useStackGeometry reads
       // this node's scrollHeight and vertical padding would inflate it.
-      className="pointer-events-none fixed right-4 z-[9998] -mx-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3"
+      // Click-through until it actually scrolls: pointer-events-none also
+      // costs it its scrollbar, and only the cards opt back in, so nothing
+      // would drag the ones below the fold into view.
+      className={cn(
+        "fixed right-4 z-[9998] -mx-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3",
+        stack.overflowing ? "pointer-events-auto" : "pointer-events-none",
+      )}
       style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
     >
       <UpdateBanner
@@ -690,7 +697,13 @@ function TauriWrapper({ children }: { children: ReactNode }) {
           // keeps the card shadows out of the clip; horizontal only, since
           // useStackGeometry reads this node's scrollHeight and vertical
           // padding would inflate it.
-          className="pointer-events-none fixed right-4 z-[9998] -mx-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3"
+          // Click-through until it actually scrolls: pointer-events-none also
+          // costs it its scrollbar, and only the cards opt back in, so nothing
+          // would drag the ones below the fold into view.
+          className={cn(
+            "fixed right-4 z-[9998] -mx-3 flex flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3",
+            stack.overflowing ? "pointer-events-auto" : "pointer-events-none",
+          )}
           style={{ bottom: stack.bottom, maxHeight: stack.maxHeight }}
         >
           <WebUpdateBanner

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3181,7 +3181,12 @@ const Composer: FC<{
   // The composer docks to the bottom of the viewport once a thread has turns,
   // in the same column the corner overlay stack occupies. Published so the
   // stack lifts above it rather than covering the Send button.
-  usePublishedFrame(composerEl);
+  //
+  // Coverable, though: in a window too short to hold the update cards above it
+  // there is no arrangement that dodges the composer AND shows them whole, and
+  // a card clipped at the rail's edge looks like it has slid behind the page.
+  // The stack takes the corner and paints over the composer there instead.
+  usePublishedFrame(composerEl, { coverable: true });
   const dictationBaseTextRef = useRef("");
   const dictationComposerRef = useRef("");
   // Thread switches reuse this composer, so the send has to know where it

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -139,7 +139,10 @@ export function LlamaUpdateBanner({
             "pointer-events-auto w-[calc(100vw-2rem)] max-w-[400px] shrink-0",
       )}
       // See the app update card: dismissible, so it may cover the composer.
-      data-overlay-dismissible="true"
+      // Only while it actually is. The dismiss button goes away for the length
+      // of an update, and the licence has to go with it: a card the reader
+      // cannot get rid of is one the stack must never park on Send.
+      data-overlay-dismissible={applying ? undefined : "true"}
       data-testid="llama-update-banner"
     >
       <div className="relative overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
@@ -176,7 +179,9 @@ export function LlamaUpdateBanner({
           />
           <div className="min-w-0">
             <p className="font-heading text-base font-medium text-foreground">
-              {applying ? `Updating ${component}...` : `New ${component} update`}
+              {applying
+                ? `Updating ${component}...`
+                : `New ${component} update`}
             </p>
             <p className="mt-0.5 text-xs text-muted-foreground">
               {status?.installed_tag ?? "unknown"} &rarr;{" "}

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -134,7 +134,9 @@ export function LlamaUpdateBanner({
       className={cn(
         positioned
           ? "fixed bottom-4 right-4 z-[9998] w-[calc(100vw-2rem)] max-w-[400px]"
-          : "pointer-events-auto w-[calc(100vw-2rem)] max-w-[400px]",
+          : // shrink-0: nothing in this card can give up height, so a capped
+            // stack squeezing it only prints its text over its own buttons.
+            "pointer-events-auto w-[calc(100vw-2rem)] max-w-[400px] shrink-0",
       )}
       data-testid="llama-update-banner"
     >

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -138,6 +138,8 @@ export function LlamaUpdateBanner({
             // stack squeezing it only prints its text over its own buttons.
             "pointer-events-auto w-[calc(100vw-2rem)] max-w-[400px] shrink-0",
       )}
+      // See the app update card: dismissible, so it may cover the composer.
+      data-overlay-dismissible="true"
       data-testid="llama-update-banner"
     >
       <div className="relative overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -111,20 +111,19 @@ export function UpdateBanner({
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
               : cn(
                   "pointer-events-auto flex w-[calc(100vw-2rem)] max-w-[448px] flex-col",
-                  // Floor = this card with its notes closed, measured in a
-                  // browser: 8rem for one row of actions, 12rem once the card
-                  // is narrow enough to wrap them onto a second (184px at a
-                  // 390px viewport). The row wraps below a 404px card, which is
-                  // a 436px viewport, so 480px leaves margin for wider text.
-                  // Under the floor a capped rail takes the height out of the
-                  // notes, which clip; min-height:auto would instead be the
-                  // whole card, so this one would yield nothing and clip the
-                  // banner below it.
+                  // Floor = this card with its notes closed. Written against
+                  // --ui-font-scale so it tracks Settings > Appearance: at the
+                  // 20px maximum the action row wraps at every card width and
+                  // the notes-closed card is 209px, well over the 128px a
+                  // default-font measurement would have pinned. Under the floor
+                  // a capped rail takes the height out of the notes, which
+                  // clip; min-height:auto would instead be the whole card, so
+                  // this one would yield nothing and clip the banner below it.
                   //
                   // The failure card has no notes to give up, so shrinking it
                   // could only clip the diagnostics and the retry button. It
                   // holds its height and the rail scrolls instead.
-                  showFailure ? "shrink-0" : "min-h-48 min-[480px]:min-h-32",
+                  showFailure ? "shrink-0" : "min-h-[calc(12rem*var(--ui-font-scale,1)/0.9375)]",
                 ),
           )}
           data-testid="tauri-update-banner"
@@ -277,18 +276,30 @@ export function UpdateBanner({
                 </div>
               )}
             </div>
-            {manualMessage && (
-              <p className="mt-3 shrink-0 text-xs text-destructive">
-                {manualMessage}
-              </p>
-            )}
-            {manualReport && (
-              <textarea
-                readOnly={true}
-                value={manualReport}
-                onFocus={(event) => event.currentTarget.select()}
-                className="mt-2 h-28 w-full shrink-0 resize-none rounded-lg border border-border/50 bg-muted/30 p-2 font-mono text-ui-10 text-muted-foreground"
-              />
+            {(manualMessage || manualReport) && (
+              // The clipboard fallback, and the one region of the failure card
+              // that may give up height. The card is capped at the viewport and
+              // clips, and the rail cannot scroll to what that cap hides, so
+              // without a scroller here the report the reader is being asked to
+              // select and copy is the part that goes missing in a short window.
+              <div
+                className="hover-scrollbar min-h-0 flex-1 overflow-y-auto overscroll-contain"
+                data-testid="tauri-update-manual-report"
+              >
+                {manualMessage && (
+                  <p className="mt-3 text-xs text-destructive">
+                    {manualMessage}
+                  </p>
+                )}
+                {manualReport && (
+                  <textarea
+                    readOnly={true}
+                    value={manualReport}
+                    onFocus={(event) => event.currentTarget.select()}
+                    className="mt-2 h-28 w-full resize-none rounded-lg border border-border/50 bg-muted/30 p-2 font-mono text-ui-10 text-muted-foreground"
+                  />
+                )}
+              </div>
             )}
           </div>
         </motion.div>

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -126,6 +126,8 @@ export function UpdateBanner({
                   showFailure ? "shrink-0" : "min-h-[calc(12rem*var(--ui-font-scale,1)/0.9375)]",
                 ),
           )}
+          // See the browser card: dismissible, so it may cover the composer.
+          data-overlay-dismissible="true"
           data-testid="tauri-update-banner"
         >
           <div className="relative flex max-h-[calc(100dvh_-_2rem)] min-h-0 flex-col overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -111,20 +111,19 @@ export function UpdateBanner({
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
               : cn(
                   "pointer-events-auto flex w-[calc(100vw-2rem)] max-w-[448px] flex-col",
-                  // The floor is this card with its notes closed, measured in
-                  // a browser: 8rem wide enough for one row of actions, 12rem
-                  // once the card is narrow enough to wrap them onto a second
-                  // row (184px at a 390px viewport). 480px is where the card
-                  // reaches its 448px max width; the row wraps at a 404px card,
-                  // so that leaves margin for wider text. A capped rail takes the
-                  // card's height out of the notes, which clip, and stops at
-                  // the buttons. min-height:auto would be the whole card, so
-                  // the card would give up nothing and the banner below it
-                  // would be the one clipped.
+                  // Floor = this card with its notes closed, measured in a
+                  // browser: 8rem for one row of actions, 12rem once the card
+                  // is narrow enough to wrap them onto a second (184px at a
+                  // 390px viewport). The row wraps below a 404px card, which is
+                  // a 436px viewport, so 480px leaves margin for wider text.
+                  // Under the floor a capped rail takes the height out of the
+                  // notes, which clip; min-height:auto would instead be the
+                  // whole card, so this one would yield nothing and clip the
+                  // banner below it.
                   //
-                  // The failure card has no notes, so there is nothing in it to
-                  // give up: shrinking it only clips the diagnostics and the
-                  // retry button. It holds its height and the rail scrolls.
+                  // The failure card has no notes to give up, so shrinking it
+                  // could only clip the diagnostics and the retry button. It
+                  // holds its height and the rail scrolls instead.
                   showFailure ? "shrink-0" : "min-h-48 min-[480px]:min-h-32",
                 ),
           )}

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -109,11 +109,19 @@ export function UpdateBanner({
             // Wider than the other overlays: notes preview plus three buttons.
             positioned
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
-              : "pointer-events-auto flex min-h-0 w-[calc(100vw-2rem)] max-w-[448px] flex-col",
+              : // min-h-32 is the card with its notes closed: 8rem covers the
+                // header, the buttons and the card's own padding. A capped
+                // stack therefore takes the card's height out of the notes,
+                // which clip, and stops at the row of buttons instead of
+                // squeezing until the notes print over them. min-height:auto
+                // would be the whole card including the notes, so the card
+                // would not give up anything and the banner under it would be
+                // the one clipped instead.
+                "pointer-events-auto flex min-h-32 w-[calc(100vw-2rem)] max-w-[448px] flex-col",
           )}
           data-testid="tauri-update-banner"
         >
-          <div className="relative flex max-h-[calc(100dvh_-_2rem)] flex-col overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
+          <div className="relative flex max-h-[calc(100dvh_-_2rem)] min-h-0 flex-col overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
             <button
               type="button"
               onClick={onDismiss}
@@ -137,7 +145,7 @@ export function UpdateBanner({
               </svg>
             </button>
 
-            <div className="flex min-w-0 items-start gap-4 pr-6">
+            <div className="flex min-w-0 shrink-0 items-start gap-4 pr-6">
               <Icon
                 aria-hidden="true"
                 className="mt-1 size-5 shrink-0 text-foreground"
@@ -168,7 +176,7 @@ export function UpdateBanner({
             </div>
 
             {showFailure && lastFailure && (
-              <p className="mt-3 line-clamp-2 text-xs text-destructive">
+              <p className="mt-3 line-clamp-2 shrink-0 text-xs text-destructive">
                 {lastFailure.error}
               </p>
             )}
@@ -186,7 +194,8 @@ export function UpdateBanner({
 
             <div
               className={cn(
-                "mt-4 flex flex-wrap items-center gap-x-1 gap-y-2",
+                // Wraps on a narrow card, never compresses on a short one.
+                "mt-4 flex shrink-0 flex-wrap items-center gap-x-1 gap-y-2",
                 !showFailure && notesTargetVersion
                   ? "justify-between"
                   : "justify-end",
@@ -261,14 +270,16 @@ export function UpdateBanner({
               )}
             </div>
             {manualMessage && (
-              <p className="mt-3 text-xs text-destructive">{manualMessage}</p>
+              <p className="mt-3 shrink-0 text-xs text-destructive">
+                {manualMessage}
+              </p>
             )}
             {manualReport && (
               <textarea
                 readOnly={true}
                 value={manualReport}
                 onFocus={(event) => event.currentTarget.select()}
-                className="mt-2 h-28 w-full resize-none rounded-lg border border-border/50 bg-muted/30 p-2 font-mono text-ui-10 text-muted-foreground"
+                className="mt-2 h-28 w-full shrink-0 resize-none rounded-lg border border-border/50 bg-muted/30 p-2 font-mono text-ui-10 text-muted-foreground"
               />
             )}
           </div>

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -109,12 +109,19 @@ export function UpdateBanner({
             // Wider than the other overlays: notes preview plus three buttons.
             positioned
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
-              : // min-h-32 is this card with its notes closed. A capped rail
-                // takes its height out of the notes, which clip, and stops at
-                // the buttons. min-height:auto would be the whole card, so the
-                // card would give up nothing and the banner below it would be
-                // the one clipped.
-                "pointer-events-auto flex min-h-32 w-[calc(100vw-2rem)] max-w-[448px] flex-col",
+              : cn(
+                  "pointer-events-auto flex w-[calc(100vw-2rem)] max-w-[448px] flex-col",
+                  // min-h-32 is this card with its notes closed. A capped rail
+                  // takes its height out of the notes, which clip, and stops at
+                  // the buttons. min-height:auto would be the whole card, so
+                  // the card would give up nothing and the banner below it
+                  // would be the one clipped.
+                  //
+                  // The failure card has no notes, so there is nothing in it to
+                  // give up: shrinking it only clips the diagnostics and the
+                  // retry button. It holds its height and the rail scrolls.
+                  showFailure ? "shrink-0" : "min-h-32",
+                ),
           )}
           data-testid="tauri-update-banner"
         >

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -118,18 +118,21 @@ export function UpdateBanner({
                   // one would yield nothing and clip the banner below it.
                   //
                   // Its own constants, not the browser card's: this card
-                  // carries one more status line under the version, worth 19px
-                  // at the default type size and 24px at the largest. Measured
-                  // the same way and exact above the wrap (221px at scale
-                  // 1.125, 227 at 1.1875, 233 at 1.25). See web/update-banner
-                  // for why the floor is split into a fixed and a scaled part.
+                  // carries one more status line under the version, worth about
+                  // 20px at the default type size and 24px at the largest.
+                  // Measured the same way, at every step from 15px to 20px:
+                  // 204, 210, 215, 221, 227, 233 at the widths where the action
+                  // pair holds together, and 204, 210, 262, 269, 277, 304 below
+                  // 384px where it wraps onto a row of its own. See
+                  // web/update-banner for why the floor is split into a fixed
+                  // and a scaled part, and why the narrow regime needs its own.
                   //
                   // The failure card has no notes to give up, so shrinking it
                   // could only clip the diagnostics and the retry button. It
                   // holds its height and the rail scrolls instead.
                   showFailure
                     ? "shrink-0"
-                    : "min-h-[calc(113px+96px*var(--ui-font-scale,1))]",
+                    : "min-h-[calc(117px+93px*var(--ui-font-scale,1))] max-[383px]:min-h-[calc(24px+224px*var(--ui-font-scale,1))]",
                 ),
           )}
           // See the browser card: dismissible, so it may cover the composer.

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -111,8 +111,11 @@ export function UpdateBanner({
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
               : cn(
                   "pointer-events-auto flex w-[calc(100vw-2rem)] max-w-[448px] flex-col",
-                  // min-h-32 is this card with its notes closed. A capped rail
-                  // takes its height out of the notes, which clip, and stops at
+                  // The floor is this card with its notes closed, measured in
+                  // a browser: 8rem wide enough for one row of actions, 12rem
+                  // once the card is narrow enough to wrap them onto a second
+                  // row (184px at a 390px viewport). A capped rail takes the
+                  // card's height out of the notes, which clip, and stops at
                   // the buttons. min-height:auto would be the whole card, so
                   // the card would give up nothing and the banner below it
                   // would be the one clipped.
@@ -120,7 +123,7 @@ export function UpdateBanner({
                   // The failure card has no notes, so there is nothing in it to
                   // give up: shrinking it only clips the diagnostics and the
                   // retry button. It holds its height and the rail scrolls.
-                  showFailure ? "shrink-0" : "min-h-32",
+                  showFailure ? "shrink-0" : "min-h-48 sm:min-h-32",
                 ),
           )}
           data-testid="tauri-update-banner"

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -109,14 +109,11 @@ export function UpdateBanner({
             // Wider than the other overlays: notes preview plus three buttons.
             positioned
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
-              : // min-h-32 is the card with its notes closed: 8rem covers the
-                // header, the buttons and the card's own padding. A capped
-                // stack therefore takes the card's height out of the notes,
-                // which clip, and stops at the row of buttons instead of
-                // squeezing until the notes print over them. min-height:auto
-                // would be the whole card including the notes, so the card
-                // would not give up anything and the banner under it would be
-                // the one clipped instead.
+              : // min-h-32 is this card with its notes closed. A capped rail
+                // takes its height out of the notes, which clip, and stops at
+                // the buttons. min-height:auto would be the whole card, so the
+                // card would give up nothing and the banner below it would be
+                // the one clipped.
                 "pointer-events-auto flex min-h-32 w-[calc(100vw-2rem)] max-w-[448px] flex-col",
           )}
           data-testid="tauri-update-banner"

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -111,19 +111,25 @@ export function UpdateBanner({
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
               : cn(
                   "pointer-events-auto flex w-[calc(100vw-2rem)] max-w-[448px] flex-col",
-                  // Floor = this card with its notes closed. Written against
-                  // --ui-font-scale so it tracks Settings > Appearance: at the
-                  // 20px maximum the action row wraps at every card width and
-                  // the notes-closed card is 209px, well over the 128px a
-                  // default-font measurement would have pinned. Under the floor
-                  // a capped rail takes the height out of the notes, which
-                  // clip; min-height:auto would instead be the whole card, so
-                  // this one would yield nothing and clip the banner below it.
+                  // Floor = the header and the action row, the parts of this
+                  // card that cannot give up height. Under it a capped rail
+                  // takes the height out of the notes, which clip;
+                  // min-height:auto would instead be the whole card, so this
+                  // one would yield nothing and clip the banner below it.
+                  //
+                  // Its own constants, not the browser card's: this card
+                  // carries one more status line under the version, worth 19px
+                  // at the default type size and 24px at the largest. Measured
+                  // the same way and exact above the wrap (221px at scale
+                  // 1.125, 227 at 1.1875, 233 at 1.25). See web/update-banner
+                  // for why the floor is split into a fixed and a scaled part.
                   //
                   // The failure card has no notes to give up, so shrinking it
                   // could only clip the diagnostics and the retry button. It
                   // holds its height and the rail scrolls instead.
-                  showFailure ? "shrink-0" : "min-h-[calc(12rem*var(--ui-font-scale,1)/0.9375)]",
+                  showFailure
+                    ? "shrink-0"
+                    : "min-h-[calc(113px+96px*var(--ui-font-scale,1))]",
                 ),
           )}
           // See the browser card: dismissible, so it may cover the composer.

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -114,7 +114,9 @@ export function UpdateBanner({
                   // The floor is this card with its notes closed, measured in
                   // a browser: 8rem wide enough for one row of actions, 12rem
                   // once the card is narrow enough to wrap them onto a second
-                  // row (184px at a 390px viewport). A capped rail takes the
+                  // row (184px at a 390px viewport). 480px is where the card
+                  // reaches its 448px max width; the row wraps at a 404px card,
+                  // so that leaves margin for wider text. A capped rail takes the
                   // card's height out of the notes, which clip, and stops at
                   // the buttons. min-height:auto would be the whole card, so
                   // the card would give up nothing and the banner below it
@@ -123,7 +125,7 @@ export function UpdateBanner({
                   // The failure card has no notes, so there is nothing in it to
                   // give up: shrinking it only clips the diagnostics and the
                   // retry button. It holds its height and the rail scrolls.
-                  showFailure ? "shrink-0" : "min-h-48 sm:min-h-32",
+                  showFailure ? "shrink-0" : "min-h-48 min-[480px]:min-h-32",
                 ),
           )}
           data-testid="tauri-update-banner"

--- a/studio/frontend/src/components/update/release-notes-panel.tsx
+++ b/studio/frontend/src/components/update/release-notes-panel.tsx
@@ -113,7 +113,9 @@ export function ReleaseNotesPanel({
 
   return (
     <div
-      className={cn("mt-3 flex min-h-0 flex-col", className)}
+      // Clipped, not just capped: this is the one part of the card allowed to
+      // give up height, so its content must not paint over the buttons below.
+      className={cn("mt-3 flex min-h-0 flex-col overflow-hidden", className)}
       data-testid="update-release-notes-panel"
       data-notes-state={state}
       data-notes-version={version}
@@ -145,7 +147,7 @@ export function ReleaseNotesPanel({
               ) : null}
             </section>
           ) : (
-            <ReleaseNotesSummary preview={preview} />
+            <ReleaseNotesSummary preview={preview} version={version} />
           )
         ) : (
           <NotesStatus
@@ -166,8 +168,10 @@ export function ReleaseNotesPanel({
 /** Collapsed view: the first few bullets, one line each where possible. */
 function ReleaseNotesSummary({
   preview,
+  version,
 }: {
   preview: ReturnType<typeof releaseNotesPreview> | null;
+  version: string;
 }): ReactElement | null {
   if (preview === null || preview.items.length === 0) {
     return null;
@@ -176,7 +180,13 @@ function ReleaseNotesSummary({
 
   return (
     <ul
-      className="space-y-1 py-2 pr-1"
+      // Scrolls for the same reason the expanded notes do: in a short window
+      // the card's slot for this list is smaller than the list, and without a
+      // scroller here the bullets are painted straight over the buttons.
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: keyboard-scrollable region
+      tabIndex={0}
+      aria-label={`Release notes summary for version ${version}`}
+      className="hover-scrollbar min-h-0 flex-1 space-y-1 overflow-y-auto overscroll-contain py-2 pr-1"
       data-testid="update-release-notes-summary"
     >
       {items.map((item, index) => (

--- a/studio/frontend/src/components/update/release-notes-panel.tsx
+++ b/studio/frontend/src/components/update/release-notes-panel.tsx
@@ -147,7 +147,7 @@ export function ReleaseNotesPanel({
               ) : null}
             </section>
           ) : (
-            <ReleaseNotesSummary preview={preview} version={version} />
+            <ReleaseNotesSummary preview={preview} />
           )
         ) : (
           <NotesStatus
@@ -168,10 +168,8 @@ export function ReleaseNotesPanel({
 /** Collapsed view: the first few bullets, one line each where possible. */
 function ReleaseNotesSummary({
   preview,
-  version,
 }: {
   preview: ReturnType<typeof releaseNotesPreview> | null;
-  version: string;
 }): ReactElement | null {
   if (preview === null || preview.items.length === 0) {
     return null;
@@ -184,7 +182,8 @@ function ReleaseNotesSummary({
       // taller than its slot, and unscrolled it paints over the buttons.
       // biome-ignore lint/a11y/noNoninteractiveTabindex: keyboard-scrollable region
       tabIndex={0}
-      aria-label={`Release notes summary for version ${version}`}
+      // Unversioned: the notes are the release's, not the offered version's.
+      aria-label="Release notes summary"
       className="hover-scrollbar min-h-0 flex-1 space-y-1 overflow-y-auto overscroll-contain py-2 pr-1"
       data-testid="update-release-notes-summary"
     >

--- a/studio/frontend/src/components/update/release-notes-panel.tsx
+++ b/studio/frontend/src/components/update/release-notes-panel.tsx
@@ -180,9 +180,8 @@ function ReleaseNotesSummary({
 
   return (
     <ul
-      // Scrolls for the same reason the expanded notes do: in a short window
-      // the card's slot for this list is smaller than the list, and without a
-      // scroller here the bullets are painted straight over the buttons.
+      // Scrolls like the expanded notes: in a short window this list is
+      // taller than its slot, and unscrolled it paints over the buttons.
       // biome-ignore lint/a11y/noNoninteractiveTabindex: keyboard-scrollable region
       tabIndex={0}
       aria-label={`Release notes summary for version ${version}`}

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -88,12 +88,14 @@ export function WebUpdateBanner({
               : // The floor is this card with its notes closed, measured in a
                 // browser: 8rem wide enough for one row of actions, 12rem once
                 // the card is narrow enough to wrap them onto a second row
-                // (184px at a 390px viewport). A capped rail takes the card's
+                // (184px at a 390px viewport). 480px is where the card reaches
+                // its 448px max width; the row wraps at a 404px card, so that
+                // leaves margin for wider text. A capped rail takes the card's
                 // height out of the notes, which clip, and stops at the
                 // buttons. min-height:auto would be the whole card, so the card
                 // would give up nothing and the banner below it would be the
                 // one clipped.
-                "pointer-events-auto flex min-h-48 w-[calc(100vw-2rem)] max-w-[448px] flex-col sm:min-h-32",
+                "pointer-events-auto flex min-h-48 w-[calc(100vw-2rem)] max-w-[448px] flex-col min-[480px]:min-h-32",
           )}
           data-testid="web-update-banner"
         >

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -85,16 +85,14 @@ export function WebUpdateBanner({
             // Wider than the other overlays: notes preview plus three buttons.
             positioned
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
-              : // The floor is this card with its notes closed, measured in a
-                // browser: 8rem wide enough for one row of actions, 12rem once
-                // the card is narrow enough to wrap them onto a second row
-                // (184px at a 390px viewport). 480px is where the card reaches
-                // its 448px max width; the row wraps at a 404px card, so that
-                // leaves margin for wider text. A capped rail takes the card's
-                // height out of the notes, which clip, and stops at the
-                // buttons. min-height:auto would be the whole card, so the card
-                // would give up nothing and the banner below it would be the
-                // one clipped.
+              : // Floor = this card with its notes closed, measured in a
+                // browser: 8rem for one row of actions, 12rem once the card is
+                // narrow enough to wrap them onto a second (184px at a 390px
+                // viewport). The row wraps below a 404px card, which is a 436px
+                // viewport, so 480px leaves margin for wider text. Under the
+                // floor a capped rail takes the height out of the notes, which
+                // clip; min-height:auto would instead be the whole card, so
+                // this one would yield nothing and clip the banner below it.
                 "pointer-events-auto flex min-h-48 w-[calc(100vw-2rem)] max-w-[448px] flex-col min-[480px]:min-h-32",
           )}
           data-testid="web-update-banner"

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -95,6 +95,10 @@ export function WebUpdateBanner({
                 // would yield nothing and clip the banner below it.
                 "pointer-events-auto flex min-h-[calc(12rem*var(--ui-font-scale,1)/0.9375)] w-[calc(100vw-2rem)] max-w-[448px] flex-col",
           )}
+          // Dismissible, so the stack may cover the composer to show it
+          // whole. See useStackGeometry: a card that cannot be got rid of
+          // does not get that licence.
+          data-overlay-dismissible="true"
           data-testid="web-update-banner"
         >
           <div className="relative flex max-h-[calc(100dvh_-_2rem)] min-h-0 flex-col overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -85,12 +85,15 @@ export function WebUpdateBanner({
             // Wider than the other overlays: notes preview plus three buttons.
             positioned
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
-              : // min-h-32 is this card with its notes closed. A capped rail
-                // takes its height out of the notes, which clip, and stops at
-                // the buttons. min-height:auto would be the whole card, so the
-                // card would give up nothing and the banner below it would be
-                // the one clipped.
-                "pointer-events-auto flex min-h-32 w-[calc(100vw-2rem)] max-w-[448px] flex-col",
+              : // The floor is this card with its notes closed, measured in a
+                // browser: 8rem wide enough for one row of actions, 12rem once
+                // the card is narrow enough to wrap them onto a second row
+                // (184px at a 390px viewport). A capped rail takes the card's
+                // height out of the notes, which clip, and stops at the
+                // buttons. min-height:auto would be the whole card, so the card
+                // would give up nothing and the banner below it would be the
+                // one clipped.
+                "pointer-events-auto flex min-h-48 w-[calc(100vw-2rem)] max-w-[448px] flex-col sm:min-h-32",
           )}
           data-testid="web-update-banner"
         >

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -85,15 +85,15 @@ export function WebUpdateBanner({
             // Wider than the other overlays: notes preview plus three buttons.
             positioned
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
-              : // Floor = this card with its notes closed, measured in a
-                // browser: 8rem for one row of actions, 12rem once the card is
-                // narrow enough to wrap them onto a second (184px at a 390px
-                // viewport). The row wraps below a 404px card, which is a 436px
-                // viewport, so 480px leaves margin for wider text. Under the
-                // floor a capped rail takes the height out of the notes, which
-                // clip; min-height:auto would instead be the whole card, so
-                // this one would yield nothing and clip the banner below it.
-                "pointer-events-auto flex min-h-48 w-[calc(100vw-2rem)] max-w-[448px] flex-col min-[480px]:min-h-32",
+              : // Floor = this card with its notes closed. Written against
+                // --ui-font-scale so it tracks Settings > Appearance: at the
+                // 20px maximum the action row wraps at every card width and
+                // the notes-closed card is 209px, well over the 128px a
+                // default-font measurement would have pinned. Under the floor
+                // a capped rail takes the height out of the notes, which clip;
+                // min-height:auto would instead be the whole card, so this one
+                // would yield nothing and clip the banner below it.
+                "pointer-events-auto flex min-h-[calc(12rem*var(--ui-font-scale,1)/0.9375)] w-[calc(100vw-2rem)] max-w-[448px] flex-col",
           )}
           data-testid="web-update-banner"
         >

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -93,14 +93,20 @@ export function WebUpdateBanner({
                 //
                 // A fixed part plus a font-scaled part, the shape index.css
                 // already uses for --picker-control-h, because only some of the
-                // card moves with Settings > Appearance. Measured, not guessed:
-                // the action row wraps between 17px and 18px, and above that
-                // wrap the need is exactly linear (199px at scale 1.125, 204 at
-                // 1.1875, 209 at 1.25), which this reproduces. Below the wrap it
-                // over-reserves by about 40px, the safe direction. Scaling the
-                // whole 12rem box instead asked 256px where 209 was needed, and
-                // a floor nothing can meet covers the composer for no gain.
-                "pointer-events-auto flex min-h-[calc(109px+80px*var(--ui-font-scale,1))] w-[calc(100vw-2rem)] max-w-[448px] flex-col",
+                // card moves with Settings > Appearance. Measured at every step
+                // from 15px to 20px rather than guessed, and exact across that
+                // range: 184, 189, 194, 199, 204, 209. Scaling the whole 12rem
+                // box instead asked 256px where 209 was needed, and a floor
+                // nothing can meet covers the composer for no gain.
+                //
+                // Below 384px the action pair wraps onto a row of its own on
+                // top of the notes toggle's, and the card needs a whole extra
+                // row: 259px at 20px where the wide card needs 209. A floor
+                // that misses it lets a dodging placement clip a row of
+                // buttons inside the card's own overflow-hidden surface. The
+                // narrow constants bound that regime (229, 235, 241, 247, 253,
+                // 259) and are exact from 17px up, where the extra wrap starts.
+                "pointer-events-auto flex min-h-[calc(109px+80px*var(--ui-font-scale,1))] w-[calc(100vw-2rem)] max-w-[448px] flex-col max-[383px]:min-h-[calc(139px+96px*var(--ui-font-scale,1))]",
           )}
           // Dismissible, so the stack may cover the composer to show it
           // whole. See useStackGeometry: a card that cannot be got rid of

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -85,14 +85,11 @@ export function WebUpdateBanner({
             // Wider than the other overlays: notes preview plus three buttons.
             positioned
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
-              : // min-h-32 is the card with its notes closed: 8rem covers the
-                // header, the buttons and the card's own padding. A capped
-                // stack therefore takes the card's height out of the notes,
-                // which clip, and stops at the row of buttons instead of
-                // squeezing until the notes print over them. min-height:auto
-                // would be the whole card including the notes, so the card
-                // would not give up anything and the banner under it would be
-                // the one clipped instead.
+              : // min-h-32 is this card with its notes closed. A capped rail
+                // takes its height out of the notes, which clip, and stops at
+                // the buttons. min-height:auto would be the whole card, so the
+                // card would give up nothing and the banner below it would be
+                // the one clipped.
                 "pointer-events-auto flex min-h-32 w-[calc(100vw-2rem)] max-w-[448px] flex-col",
           )}
           data-testid="web-update-banner"

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -85,11 +85,19 @@ export function WebUpdateBanner({
             // Wider than the other overlays: notes preview plus three buttons.
             positioned
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
-              : "pointer-events-auto flex min-h-0 w-[calc(100vw-2rem)] max-w-[448px] flex-col",
+              : // min-h-32 is the card with its notes closed: 8rem covers the
+                // header, the buttons and the card's own padding. A capped
+                // stack therefore takes the card's height out of the notes,
+                // which clip, and stops at the row of buttons instead of
+                // squeezing until the notes print over them. min-height:auto
+                // would be the whole card including the notes, so the card
+                // would not give up anything and the banner under it would be
+                // the one clipped instead.
+                "pointer-events-auto flex min-h-32 w-[calc(100vw-2rem)] max-w-[448px] flex-col",
           )}
           data-testid="web-update-banner"
         >
-          <div className="relative flex max-h-[calc(100dvh_-_2rem)] flex-col overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
+          <div className="relative flex max-h-[calc(100dvh_-_2rem)] min-h-0 flex-col overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
             <button
               type="button"
               onClick={dismiss}
@@ -113,7 +121,7 @@ export function WebUpdateBanner({
               </svg>
             </button>
 
-            <div className="flex min-w-0 items-start gap-4 pr-6">
+            <div className="flex min-w-0 shrink-0 items-start gap-4 pr-6">
               <Download
                 aria-hidden="true"
                 className="mt-1 size-5 shrink-0 text-foreground"
@@ -139,8 +147,9 @@ export function WebUpdateBanner({
               className="min-h-0 flex-1"
             />
 
-            {/* one row at one type size; wraps only on narrow viewports */}
-            <div className="mt-4 flex flex-wrap items-center justify-between gap-y-2">
+            {/* one row at one type size; wraps only on narrow viewports, and
+                never compresses on a short one */}
+            <div className="mt-4 flex shrink-0 flex-wrap items-center justify-between gap-y-2">
               <Button
                 size="sm"
                 variant="ghost"

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -85,15 +85,22 @@ export function WebUpdateBanner({
             // Wider than the other overlays: notes preview plus three buttons.
             positioned
               ? "fixed bottom-4 right-4 z-[9999] w-[calc(100vw-2rem)] max-w-[448px]"
-              : // Floor = this card with its notes closed. Written against
-                // --ui-font-scale so it tracks Settings > Appearance: at the
-                // 20px maximum the action row wraps at every card width and
-                // the notes-closed card is 209px, well over the 128px a
-                // default-font measurement would have pinned. Under the floor
-                // a capped rail takes the height out of the notes, which clip;
-                // min-height:auto would instead be the whole card, so this one
-                // would yield nothing and clip the banner below it.
-                "pointer-events-auto flex min-h-[calc(12rem*var(--ui-font-scale,1)/0.9375)] w-[calc(100vw-2rem)] max-w-[448px] flex-col",
+              : // Floor = the header and the action row, the parts of this card
+                // that cannot give up height. Under it a capped rail takes the
+                // height out of the notes, which clip; min-height:auto would
+                // instead be the whole card, so this one would yield nothing
+                // and clip the banner below it.
+                //
+                // A fixed part plus a font-scaled part, the shape index.css
+                // already uses for --picker-control-h, because only some of the
+                // card moves with Settings > Appearance. Measured, not guessed:
+                // the action row wraps between 17px and 18px, and above that
+                // wrap the need is exactly linear (199px at scale 1.125, 204 at
+                // 1.1875, 209 at 1.25), which this reproduces. Below the wrap it
+                // over-reserves by about 40px, the safe direction. Scaling the
+                // whole 12rem box instead asked 256px where 209 was needed, and
+                // a floor nothing can meet covers the composer for no gain.
+                "pointer-events-auto flex min-h-[calc(109px+80px*var(--ui-font-scale,1))] w-[calc(100vw-2rem)] max-w-[448px] flex-col",
           )}
           // Dismissible, so the stack may cover the composer to show it
           // whole. See useStackGeometry: a card that cannot be got rid of

--- a/studio/frontend/src/features/settings/hooks/use-published-frame.ts
+++ b/studio/frontend/src/features/settings/hooks/use-published-frame.ts
@@ -19,8 +19,16 @@ import { useMonitorFrameStore } from "../stores/monitor-frame-store";
  *
  * Re-measured on resize and through a ResizeObserver, because the composer
  * grows with its input and moves from centred to docked with no resize event.
+ *
+ * `coverable` says the stack may paint over this box rather than clip itself,
+ * for the windows too short to do both. Off by default: the Live monitor's
+ * controls have to stay clickable, and anything else that publishes here should
+ * decide deliberately rather than inherit the composer's answer.
  */
-export function usePublishedFrame(element: HTMLElement | null): void {
+export function usePublishedFrame(
+  element: HTMLElement | null,
+  { coverable = false }: { coverable?: boolean } = {},
+): void {
   // This caller's claim on the store, stable for the life of the component.
   const publisher = useMemo(() => ({}), []);
   const setFrame = useMonitorFrameStore((state) => state.setFrame);
@@ -44,6 +52,7 @@ export function usePublishedFrame(element: HTMLElement | null): void {
         top: box.top,
         right: box.right,
         bottom: box.bottom,
+        coverable,
       });
     };
     measure();
@@ -56,5 +65,5 @@ export function usePublishedFrame(element: HTMLElement | null): void {
       observer?.disconnect();
       clearFrame(publisher);
     };
-  }, [element, publisher, setFrame, clearFrame]);
+  }, [element, publisher, coverable, setFrame, clearFrame]);
 }

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -365,7 +365,6 @@ export function useStackGeometry(): StackPlacement {
   }));
   const [neededRoom, setNeededRoom] = useState(ASSUMED_STACK_HEIGHT);
   const [floorRoom, setFloorRoom] = useState(ASSUMED_STACK_HEIGHT);
-  const [overflowing, setOverflowing] = useState(false);
   useEffect(() => {
     const onResize = () =>
       setViewport({ width: window.innerWidth, height: window.innerHeight });
@@ -380,7 +379,6 @@ export function useStackGeometry(): StackPlacement {
       if (node.childElementCount === 0) {
         setNeededRoom((current) => (current === 0 ? current : 0));
         setFloorRoom((current) => (current === 0 ? current : 0));
-        setOverflowing((current) => (current ? false : current));
         return;
       }
       // Drop the cap and put it back in one synchronous block, so scrollHeight
@@ -406,12 +404,6 @@ export function useStackGeometry(): StackPlacement {
       }
       setNeededRoom((current) => (current === natural ? current : natural));
       setFloorRoom((current) => (current === floor ? current : floor));
-      // Whether the stack scrolls is read back from the capped box, not from
-      // `natural` against the cap: under the cap the cards give up height of
-      // their own, so a stack that asks for more than the cap can still fit
-      // inside it. Only the box that scrolls knows that it does.
-      const scrolls = node.scrollHeight > node.clientHeight;
-      setOverflowing((current) => (current === scrolls ? current : scrolls));
     };
     measure();
     // Every box inside the stack, not just the stack itself. At its cap the container's
@@ -465,15 +457,24 @@ export function useStackGeometry(): StackPlacement {
       mutations.disconnect();
     };
   }, []);
+  const geometry = stackGeometry(
+    published,
+    viewport.width,
+    viewport.height,
+    neededRoom,
+    floorRoom,
+  );
   return {
-    ...stackGeometry(
-      published,
-      viewport.width,
-      viewport.height,
-      neededRoom,
-      floorRoom,
-    ),
+    ...geometry,
     ref,
-    overflowing,
+    // Derived from the placement, not read back off the node. A DOM reading
+    // latches: the stack is capped and scrolling for a frame, the placement
+    // then changes to one that fits, and nothing resizes afterwards to correct
+    // the flag, so a rail with nothing to scroll to keeps the pointer input it
+    // took. The cards absorb everything between their floor and their natural
+    // height, so a cap below the floor is exactly when the rail has to scroll.
+    // A pixel of slack, since the floor is a rounded scrollHeight and the cap
+    // is not.
+    overflowing: floorRoom > geometry.maxHeight + 1,
   };
 }

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -333,11 +333,9 @@ export function useStackGeometry(): StackPlacement {
       // Drop the cap and put it back in one synchronous block, so scrollHeight
       // sees the unconstrained layout but nothing else ever sees the uncapped
       // box. Through style, not state: React rewrites the same value next render.
-      //
-      // The stack scrolls when its cards do not fit, and an uncapped box does
-      // not overflow, so lifting the cap clamps scrollTop to 0 and putting it
-      // back does not undo that: any descendant resize would throw a reader
-      // back to the first banner. Restore it alongside the cap.
+      // An uncapped box does not overflow, so lifting the cap clamps scrollTop
+      // to 0 and putting it back does not undo that: every descendant resize
+      // would throw a reader back to the first card. Restore it with the cap.
       const capped = node.style.maxHeight;
       const scrolled = node.scrollTop;
       node.style.maxHeight = "none";

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -293,6 +293,12 @@ export function stackGeometry(
 export type StackPlacement = StackGeometry & {
   /** Attach to the stack container so its height feeds back into the placement. */
   ref: (node: HTMLElement | null) => void;
+  /**
+   * The cards need more room than the cap allows, so the stack is scrolling.
+   * It is click-through the rest of the time, which also costs it its
+   * scrollbar, and a scroller nobody can drag hides the cards below the fold.
+   */
+  overflowing: boolean;
 };
 
 /**
@@ -315,6 +321,7 @@ export function useStackGeometry(): StackPlacement {
     height: typeof window === "undefined" ? 0 : window.innerHeight,
   }));
   const [neededRoom, setNeededRoom] = useState(ASSUMED_STACK_HEIGHT);
+  const [overflowing, setOverflowing] = useState(false);
   useEffect(() => {
     const onResize = () =>
       setViewport({ width: window.innerWidth, height: window.innerHeight });
@@ -328,6 +335,7 @@ export function useStackGeometry(): StackPlacement {
       // An empty stack asks for nothing, so nothing is dodged for it.
       if (node.childElementCount === 0) {
         setNeededRoom((current) => (current === 0 ? current : 0));
+        setOverflowing((current) => (current ? false : current));
         return;
       }
       // Drop the cap and put it back in one synchronous block, so scrollHeight
@@ -345,6 +353,12 @@ export function useStackGeometry(): StackPlacement {
         node.scrollTop = scrolled;
       }
       setNeededRoom((current) => (current === natural ? current : natural));
+      // Whether the stack scrolls is read back from the capped box, not from
+      // `natural` against the cap: under the cap the cards give up height of
+      // their own, so a stack that asks for more than the cap can still fit
+      // inside it. Only the box that scrolls knows that it does.
+      const scrolls = node.scrollHeight > node.clientHeight;
+      setOverflowing((current) => (current === scrolls ? current : scrolls));
     };
     measure();
     // Every box inside the stack, not just the stack itself. At its cap the container's
@@ -401,5 +415,6 @@ export function useStackGeometry(): StackPlacement {
   return {
     ...stackGeometry(published, viewport.width, viewport.height, neededRoom),
     ref,
+    overflowing,
   };
 }

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -14,6 +14,17 @@ export type MonitorFrame = {
   top: number;
   right: number;
   bottom: number;
+  /**
+   * Whether the stack may paint over this box when there is nowhere left to
+   * put itself. Off by default, because the box that started this store is the
+   * Live monitor and its Close button and resize grip have to stay clickable.
+   *
+   * The chat composer opts in. In a short window there is no arrangement that
+   * both dodges it and shows the cards whole, and the two ways to lose are not
+   * equal: a clipped card reads as broken, a card over the composer reads as a
+   * card over the composer and has a dismiss button on it.
+   */
+  coverable?: boolean;
 };
 
 /**
@@ -42,7 +53,8 @@ function sameFrame(a: MonitorFrame | null, b: MonitorFrame | null): boolean {
     a.left === b.left &&
     a.top === b.top &&
     a.right === b.right &&
-    a.bottom === b.bottom
+    a.bottom === b.bottom &&
+    Boolean(a.coverable) === Boolean(b.coverable)
   );
 }
 
@@ -247,6 +259,27 @@ export function stackGeometry(
   neededRoom: number = ASSUMED_STACK_HEIGHT,
 ): StackGeometry {
   const list = frames === null ? [] : Array.isArray(frames) ? frames : [frames];
+  const placed = place(list, viewportWidth, viewportHeight, neededRoom);
+  if (placed.maxHeight >= neededRoom || !list.some((f) => f.coverable)) {
+    return placed;
+  }
+  // Nowhere to put the stack whole while dodging everything. Drop the boxes
+  // that said they may be covered and try again: the stack takes the corner and
+  // paints over the composer, which is what the cards being on top means.
+  // Clipping them instead is what the report was about, and a card sliced off
+  // at the rail's edge looks like it has slid behind the page.
+  const uncoverable = list.filter((f) => !f.coverable);
+  const covering = place(uncoverable, viewportWidth, viewportHeight, neededRoom);
+  return covering.maxHeight > placed.maxHeight ? covering : placed;
+}
+
+/** `stackGeometry` for one set of boxes, all of which must be dodged. */
+function place(
+  list: readonly MonitorFrame[],
+  viewportWidth: number,
+  viewportHeight: number,
+  neededRoom: number,
+): StackGeometry {
   if (list.length === 0) {
     const bottom = stackBottomInset(
       null,

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -138,7 +138,9 @@ function reachesStack(
 ): boolean {
   // At least a pixel: a needed room of 0 lets the capped branch hand back a
   // max-height of 0, which browsers honour, leaving the stack invisible.
-  return roomBelow(frame, viewportHeight, bottomInset) < Math.max(1, neededRoom);
+  return (
+    roomBelow(frame, viewportHeight, bottomInset) < Math.max(1, neededRoom)
+  );
 }
 
 /** The inset that clears this box's top edge, whether or not it fits there. */
@@ -261,10 +263,22 @@ export function stackGeometry(
   // to `neededRoom` so a caller that knows only one number keeps the stricter
   // reading of it.
   floorRoom: number = neededRoom,
+  // Height of the run of cards at the bottom of the stack that the reader
+  // cannot dismiss. Covering is refused when that run would land on a box.
+  persistentTail = 0,
 ): StackGeometry {
   const list = frames === null ? [] : Array.isArray(frames) ? frames : [frames];
   const placed = place(list, viewportWidth, viewportHeight, neededRoom);
-  if (placed.maxHeight >= floorRoom || !list.some((f) => f.coverable)) {
+  // What the persistent run would occupy if the stack took the corner.
+  const tailTop = viewportHeight - STACK_INSET - persistentTail;
+  const safeToCover = list.every(
+    (frame) => !frame.coverable || frame.bottom <= tailTop,
+  );
+  if (
+    placed.maxHeight >= floorRoom ||
+    !safeToCover ||
+    !list.some((f) => f.coverable)
+  ) {
     return placed;
   }
   // Nowhere to put the stack even at its floor while dodging everything. Drop
@@ -279,7 +293,12 @@ export function stackGeometry(
   // the composer to win those 3px is a worse answer than a slightly shorter
   // notes preview.
   const uncoverable = list.filter((f) => !f.coverable);
-  const covering = place(uncoverable, viewportWidth, viewportHeight, neededRoom);
+  const covering = place(
+    uncoverable,
+    viewportWidth,
+    viewportHeight,
+    neededRoom,
+  );
   return covering.maxHeight > placed.maxHeight ? covering : placed;
 }
 
@@ -365,6 +384,7 @@ export function useStackGeometry(): StackPlacement {
   }));
   const [neededRoom, setNeededRoom] = useState(ASSUMED_STACK_HEIGHT);
   const [floorRoom, setFloorRoom] = useState(ASSUMED_STACK_HEIGHT);
+  const [persistentTail, setPersistentTail] = useState(0);
   useEffect(() => {
     const onResize = () =>
       setViewport({ width: window.innerWidth, height: window.innerHeight });
@@ -387,6 +407,16 @@ export function useStackGeometry(): StackPlacement {
       // An uncapped box does not overflow, so lifting the cap clamps scrollTop
       // to 0 and putting it back does not undo that: every descendant resize
       // would throw a reader back to the first card. Restore it with the cap.
+      // `transition-property: all` reaches this box, so each write below starts
+      // a transition on max-height, and a transition's computed value is its
+      // *start* value until the timeline advances. Reading scrollHeight flushes
+      // style within the same frame, so the probe would read the cap it just
+      // replaced, and the restore would leave the box computing 0px while its
+      // inline style says otherwise: a rail with three whole cards laid out
+      // below a zero-height box, which is what the loaded models indicator
+      // turned up. Suppressed for the probe and restored with it.
+      const eased = node.style.transition;
+      node.style.transition = "none";
       const capped = node.style.maxHeight;
       const scrolled = node.scrollTop;
       node.style.maxHeight = "none";
@@ -402,8 +432,34 @@ export function useStackGeometry(): StackPlacement {
       if (node.scrollTop !== scrolled) {
         node.scrollTop = scrolled;
       }
+      // Flush the restore under the suppression, or putting `transition` back
+      // hands the pending max-height change to a transition after all.
+      void node.scrollHeight;
+      node.style.transition = eased;
       setNeededRoom((current) => (current === natural ? current : natural));
       setFloorRoom((current) => (current === floor ? current : floor));
+      // How much of the stack, measured up from the corner, the reader cannot
+      // dismiss. The loaded models indicator and the download panel are last,
+      // so a covering placement puts them nearest the bottom edge: over Send
+      // that is #8210 again and permanently, rather than until a dismiss. The
+      // indicator ships off by default (#8346), which makes this whoever turned
+      // it on rather than nobody.
+      //
+      // A height rather than a flag, because whether it is a problem depends on
+      // where the composer is. Docked under a thread it sits on the bottom edge
+      // and the tail lands on it; on an empty chat it is centred and the corner
+      // below it is free, so the cards that reach it are the dismissible ones
+      // and there is nothing to protect.
+      let tail = 0;
+      for (let i = node.children.length - 1; i >= 0; i -= 1) {
+        const child = node.children[i];
+        if (child.hasAttribute("data-overlay-dismissible")) break;
+        tail += child.getBoundingClientRect().height + STACK_GAP;
+      }
+      const persistent = Math.round(tail);
+      setPersistentTail((current) =>
+        current === persistent ? current : persistent,
+      );
     };
     measure();
     // Every box inside the stack, not just the stack itself. At its cap the container's
@@ -463,6 +519,7 @@ export function useStackGeometry(): StackPlacement {
     viewport.height,
     neededRoom,
     floorRoom,
+    persistentTail,
   );
   return {
     ...geometry,

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -257,17 +257,27 @@ export function stackGeometry(
   viewportWidth: number,
   viewportHeight: number,
   neededRoom: number = ASSUMED_STACK_HEIGHT,
+  // What the stack cannot give up, as opposed to what it would like. Defaults
+  // to `neededRoom` so a caller that knows only one number keeps the stricter
+  // reading of it.
+  floorRoom: number = neededRoom,
 ): StackGeometry {
   const list = frames === null ? [] : Array.isArray(frames) ? frames : [frames];
   const placed = place(list, viewportWidth, viewportHeight, neededRoom);
-  if (placed.maxHeight >= neededRoom || !list.some((f) => f.coverable)) {
+  if (placed.maxHeight >= floorRoom || !list.some((f) => f.coverable)) {
     return placed;
   }
-  // Nowhere to put the stack whole while dodging everything. Drop the boxes
-  // that said they may be covered and try again: the stack takes the corner and
-  // paints over the composer, which is what the cards being on top means.
-  // Clipping them instead is what the report was about, and a card sliced off
-  // at the rail's edge looks like it has slid behind the page.
+  // Nowhere to put the stack even at its floor while dodging everything. Drop
+  // the boxes that said they may be covered and try again: the stack takes the
+  // corner and paints over the composer, which is what the cards being on top
+  // means. Clipping them instead is what the report was about, and a card
+  // sliced off at the rail's edge looks like it has slid behind the page.
+  //
+  // Tested against the floor and not the natural height on purpose. The cards
+  // are allowed to give up their notes, so a placement 3px short of the height
+  // they would prefer is still a placement that shows all of them, and covering
+  // the composer to win those 3px is a worse answer than a slightly shorter
+  // notes preview.
   const uncoverable = list.filter((f) => !f.coverable);
   const covering = place(uncoverable, viewportWidth, viewportHeight, neededRoom);
   return covering.maxHeight > placed.maxHeight ? covering : placed;
@@ -354,6 +364,7 @@ export function useStackGeometry(): StackPlacement {
     height: typeof window === "undefined" ? 0 : window.innerHeight,
   }));
   const [neededRoom, setNeededRoom] = useState(ASSUMED_STACK_HEIGHT);
+  const [floorRoom, setFloorRoom] = useState(ASSUMED_STACK_HEIGHT);
   const [overflowing, setOverflowing] = useState(false);
   useEffect(() => {
     const onResize = () =>
@@ -368,6 +379,7 @@ export function useStackGeometry(): StackPlacement {
       // An empty stack asks for nothing, so nothing is dodged for it.
       if (node.childElementCount === 0) {
         setNeededRoom((current) => (current === 0 ? current : 0));
+        setFloorRoom((current) => (current === 0 ? current : 0));
         setOverflowing((current) => (current ? false : current));
         return;
       }
@@ -381,11 +393,19 @@ export function useStackGeometry(): StackPlacement {
       const scrolled = node.scrollTop;
       node.style.maxHeight = "none";
       const natural = node.scrollHeight;
+      // And the other end of the same measurement: squeezed to nothing, what is
+      // left is what the cards refuse to give up. The difference between the two
+      // is the height the stack can donate to a dodge, and asking a placement to
+      // hold `natural` when it only has to hold `floor` is what made a 3px
+      // shortfall at 1280x830 give up on dodging the composer entirely.
+      node.style.maxHeight = "0px";
+      const floor = node.scrollHeight;
       node.style.maxHeight = capped;
       if (node.scrollTop !== scrolled) {
         node.scrollTop = scrolled;
       }
       setNeededRoom((current) => (current === natural ? current : natural));
+      setFloorRoom((current) => (current === floor ? current : floor));
       // Whether the stack scrolls is read back from the capped box, not from
       // `natural` against the cap: under the cap the cards give up height of
       // their own, so a stack that asks for more than the cap can still fit
@@ -446,7 +466,13 @@ export function useStackGeometry(): StackPlacement {
     };
   }, []);
   return {
-    ...stackGeometry(published, viewport.width, viewport.height, neededRoom),
+    ...stackGeometry(
+      published,
+      viewport.width,
+      viewport.height,
+      neededRoom,
+      floorRoom,
+    ),
     ref,
     overflowing,
   };

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -441,6 +441,21 @@ export function useStackGeometry(): StackPlacement {
       const scrolled = node.scrollTop;
       node.style.maxHeight = "none";
       const natural = node.scrollHeight;
+      // Taken here, uncapped, and not after the cap goes back on. The tail
+      // panels are min-h-0 with their own scrollers, so under a tight cap they
+      // measure as almost nothing, the placement reads that as a tail it can
+      // safely put in the corner, the corner's larger cap lets them grow, and
+      // the next measurement says the opposite: the two placements would swap
+      // back and forth for as long as a download and an update card share the
+      // rail. One size that does not depend on the answer, as with the two
+      // heights above.
+      let tail = 0;
+      for (let i = node.children.length - 1; i >= 0; i -= 1) {
+        const child = node.children[i];
+        if (child.hasAttribute("data-overlay-dismissible")) break;
+        tail += child.getBoundingClientRect().height + STACK_GAP;
+      }
+      const persistent = Math.round(tail);
       // And the other end of the same measurement: squeezed to nothing, what is
       // left is what the cards refuse to give up. The difference between the two
       // is the height the stack can donate to a dodge, and asking a placement to
@@ -475,13 +490,6 @@ export function useStackGeometry(): StackPlacement {
       // and the tail lands on it; on an empty chat it is centred and the corner
       // below it is free, so the cards that reach it are the dismissible ones
       // and there is nothing to protect.
-      let tail = 0;
-      for (let i = node.children.length - 1; i >= 0; i -= 1) {
-        const child = node.children[i];
-        if (child.hasAttribute("data-overlay-dismissible")) break;
-        tail += child.getBoundingClientRect().height + STACK_GAP;
-      }
-      const persistent = Math.round(tail);
       setPersistentTail((current) =>
         current === persistent ? current : persistent,
       );

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -333,10 +333,19 @@ export function useStackGeometry(): StackPlacement {
       // Drop the cap and put it back in one synchronous block, so scrollHeight
       // sees the unconstrained layout but nothing else ever sees the uncapped
       // box. Through style, not state: React rewrites the same value next render.
+      //
+      // The stack scrolls when its cards do not fit, and an uncapped box does
+      // not overflow, so lifting the cap clamps scrollTop to 0 and putting it
+      // back does not undo that: any descendant resize would throw a reader
+      // back to the first banner. Restore it alongside the cap.
       const capped = node.style.maxHeight;
+      const scrolled = node.scrollTop;
       node.style.maxHeight = "none";
       const natural = node.scrollHeight;
       node.style.maxHeight = capped;
+      if (node.scrollTop !== scrolled) {
+        node.scrollTop = scrolled;
+      }
       setNeededRoom((current) => (current === natural ? current : natural));
     };
     measure();

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -269,16 +269,7 @@ export function stackGeometry(
 ): StackGeometry {
   const list = frames === null ? [] : Array.isArray(frames) ? frames : [frames];
   const placed = place(list, viewportWidth, viewportHeight, neededRoom);
-  // What the persistent run would occupy if the stack took the corner.
-  const tailTop = viewportHeight - STACK_INSET - persistentTail;
-  const safeToCover = list.every(
-    (frame) => !frame.coverable || frame.bottom <= tailTop,
-  );
-  if (
-    placed.maxHeight >= floorRoom ||
-    !safeToCover ||
-    !list.some((f) => f.coverable)
-  ) {
+  if (placed.maxHeight >= floorRoom || !list.some((f) => f.coverable)) {
     return placed;
   }
   // Nowhere to put the stack even at its floor while dodging everything. Drop
@@ -299,6 +290,22 @@ export function stackGeometry(
     viewportHeight,
     neededRoom,
   );
+  // Where the run the reader cannot dismiss would actually land, measured from
+  // the placement being considered rather than from the corner. Dropping the
+  // composer does not always leave the stack at the bottom: an uncoverable
+  // monitor can still lift it, which carries the tail up onto the very box the
+  // corner-based reading had just cleared.
+  const tailTop = viewportHeight - covering.bottom - persistentTail;
+  const safeToCover = list.every(
+    (frame) => !frame.coverable || frame.bottom <= tailTop,
+  );
+  // Covering has to buy the thing it is for. A placement that takes the
+  // composer and STILL cannot show the cards at their floor has paid the whole
+  // price for nothing: the rail scrolls either way, so the one that leaves Send
+  // reachable is the better of two bad answers.
+  if (!safeToCover || covering.maxHeight < floorRoom) {
+    return placed;
+  }
   return covering.maxHeight > placed.maxHeight ? covering : placed;
 }
 
@@ -418,6 +425,19 @@ export function useStackGeometry(): StackPlacement {
       const eased = node.style.transition;
       node.style.transition = "none";
       const capped = node.style.maxHeight;
+      // The rail's own scroll position is not the only one at stake. Uncapping
+      // it grows every scroller inside it, which shortens their scrollable
+      // range and clamps any that were scrolled past the new end: read the
+      // release notes to the bottom, let a download tick, and the list the
+      // reader was in jumps. The rail's cap comes back, but a clamped
+      // descendant does not come back with it, so each one is noted here and
+      // put back below.
+      const scrollers: Array<[Element, number]> = [];
+      for (const child of node.querySelectorAll("*")) {
+        if (child.scrollTop > 0) {
+          scrollers.push([child, child.scrollTop]);
+        }
+      }
       const scrolled = node.scrollTop;
       node.style.maxHeight = "none";
       const natural = node.scrollHeight;
@@ -431,6 +451,11 @@ export function useStackGeometry(): StackPlacement {
       node.style.maxHeight = capped;
       if (node.scrollTop !== scrolled) {
         node.scrollTop = scrolled;
+      }
+      for (const [child, top] of scrollers) {
+        if (child.scrollTop !== top) {
+          child.scrollTop = top;
+        }
       }
       // Flush the restore under the suppression, or putting `transition` back
       // hands the pending max-height change to a transition after all.

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -333,6 +333,33 @@ test("the height is measured with the hook's own cap lifted", async () => {
 });
 
 // The sweep above, re-run at the heights the stack actually takes.
+// The stack scrolls now, and an uncapped box does not overflow, so the
+// measurement has to put scrollTop back with the cap or a descendant resize
+// throws a reader of the download list back to the first banner.
+test("the measurement restores the stack's scroll position", async () => {
+  const source = await readFile(
+    new URL(
+      "../src/features/settings/stores/monitor-frame-store.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const measure = source.slice(
+    source.indexOf("const measure = () => {"),
+    source.indexOf("const observer = new ResizeObserver"),
+  );
+  assert.match(
+    measure,
+    /const scrolled = node\.scrollTop;[\s\S]*node\.style\.maxHeight = "none";/,
+    "scrollTop is read after the cap comes off, when it has already clamped",
+  );
+  assert.match(
+    measure,
+    /node\.style\.maxHeight = capped;[\s\S]*node\.scrollTop = scrolled;/,
+    "the scroll position is never put back",
+  );
+});
+
 test("no measured height leaves the stack overlapping a box", () => {
   const composer = { left: 412, top: 664, right: 1148, bottom: 814 };
   for (const needed of [0, 40, 80, 120, 200, 320]) {

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -333,9 +333,9 @@ test("the height is measured with the hook's own cap lifted", async () => {
 });
 
 // The sweep above, re-run at the heights the stack actually takes.
-// The stack scrolls now, and an uncapped box does not overflow, so the
-// measurement has to put scrollTop back with the cap or a descendant resize
-// throws a reader of the download list back to the first banner.
+// The stack scrolls now, and an uncapped box does not, so the measurement has
+// to put scrollTop back with the cap or a resize below throws a reader of the
+// download list back to the first card.
 test("the measurement restores the stack's scroll position", async () => {
   const source = await readFile(
     new URL(

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -461,6 +461,40 @@ test("a placement that fits the cards at their floor is not given up on", () => 
   assert.ok(geometry.maxHeight >= floor, "and it still holds the cards");
 });
 
+// The loaded models indicator is the LAST child of the rail, so it is the one
+// that lands on the corner, and it is persistent: over Send it is #8210 again,
+// permanently rather than until a dismiss. #8346 ships it off by default, which
+// makes this whoever turned it on rather than nobody.
+test("a persistent card that would land on the composer stops the cover", () => {
+  const H = 534;
+  // Docked under a thread: it sits on the bottom edge, so the corner is where
+  // the persistent tail would go and the tail would land on Send.
+  const docked = { left: 236, top: 380, right: 684, bottom: 518, coverable: true };
+  const dodging = stackGeometry(docked, 921, H, 460, 420, 60);
+  assert.ok(
+    H - dodging.bottom <= docked.top,
+    "the persistent tail took the docked composer's corner",
+  );
+});
+
+test("a persistent card clear of the composer does not stop the cover", () => {
+  const H = 534;
+  // The welcome composer, centred. The corner underneath it is free, so the
+  // cards that reach it are the dismissible ones and there is nothing to
+  // protect: covering is still the right answer.
+  const welcome = { left: 236, top: 275, right: 684, bottom: 387, coverable: true };
+  const covering = stackGeometry(welcome, 921, H, 460, 420, 60);
+  assert.equal(covering.bottom, 16, "it gave up a cover that was safe");
+  assert.ok(covering.maxHeight >= 460, "and the cards are whole");
+});
+
+test("no persistent tail means the old answer", () => {
+  const composer = { left: 236, top: 300, right: 684, bottom: 420, coverable: true };
+  const withZero = stackGeometry(composer, 921, 534, 420, 420, 0);
+  const withoutArg = stackGeometry(composer, 921, 534, 420, 420);
+  assert.deepEqual(withoutArg, withZero);
+});
+
 // One number means the strict reading of it, so nothing that knows only the
 // natural height silently starts covering things.
 test("a caller that passes one height gets the stricter answer", () => {

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -364,7 +364,12 @@ test("no measured height leaves the stack overlapping a box", () => {
   const composer = { left: 412, top: 664, right: 1148, bottom: 814 };
   for (const needed of [0, 40, 80, 120, 200, 320]) {
     for (let bottom = 60; bottom <= CHAT_H - 16; bottom += 4) {
-      const box = { left: 996, top: Math.max(0, bottom - 180), right: 1264, bottom };
+      const box = {
+        left: 996,
+        top: Math.max(0, bottom - 180),
+        right: 1264,
+        bottom,
+      };
       for (const boxes of [[box], [box, composer]]) {
         const geometry = stackGeometry(boxes, CHAT_W, CHAT_H, needed);
         const label = `needed=${needed} bottom=${bottom} n=${boxes.length}`;
@@ -388,7 +393,13 @@ test("no measured height leaves the stack overlapping a box", () => {
 test("a stack that cannot fit above the composer covers it rather than clipping", () => {
   // 534px tall, the size from the report, with the welcome composer centred.
   const H = 534;
-  const composer = { left: 236, top: 300, right: 684, bottom: 420, coverable: true };
+  const composer = {
+    left: 236,
+    top: 300,
+    right: 684,
+    bottom: 420,
+    coverable: true,
+  };
   const needed = 339;
   const covered = stackGeometry(composer, 921, H, needed);
   assert.equal(covered.bottom, 16, "the stack left the corner");
@@ -399,7 +410,8 @@ test("a stack that cannot fit above the composer covers it rather than clipping"
   // The same box that has to be dodged when dodging it costs nothing.
   const roomy = stackGeometry(composer, 921, 1200, needed);
   assert.ok(
-    1200 - roomy.bottom <= composer.top || roomy.maxHeight <= 1200 - 16 - composer.bottom,
+    1200 - roomy.bottom <= composer.top ||
+      roomy.maxHeight <= 1200 - 16 - composer.bottom,
     "a composer that could have been dodged was covered anyway",
   );
 });
@@ -413,7 +425,10 @@ test("a box that never said it may be covered is still never covered", () => {
   const stackTop = H - geometry.bottom - geometry.maxHeight;
   const clearsAbove = H - geometry.bottom <= monitor.top;
   const clearsBelow = stackTop >= monitor.bottom;
-  assert.ok(clearsAbove || clearsBelow, "the stack was allowed over the monitor");
+  assert.ok(
+    clearsAbove || clearsBelow,
+    "the stack was allowed over the monitor",
+  );
 });
 
 // The fallback drops the coverable boxes and places against what is left, so
@@ -422,12 +437,23 @@ test("a box that never said it may be covered is still never covered", () => {
 // clear a monitor either, and the claim here is that the composer's permission
 // is not inherited, not that the monitor is always dodged.
 test("a coverable composer does not licence covering the monitor beside it", () => {
-  const composer = { left: 236, top: 300, right: 684, bottom: 420, coverable: true };
+  const composer = {
+    left: 236,
+    top: 300,
+    right: 684,
+    bottom: 420,
+    coverable: true,
+  };
   const monitor = { left: 640, top: 60, right: 905, bottom: 250 };
   for (const height of [534, 700, 900, 1200]) {
     for (const needed of [56, 200, 339, 600]) {
       const alone = stackGeometry(monitor, 921, height, needed);
-      const withComposer = stackGeometry([composer, monitor], 921, height, needed);
+      const withComposer = stackGeometry(
+        [composer, monitor],
+        921,
+        height,
+        needed,
+      );
       const clearance = (g: { bottom: number; maxHeight: number }) => ({
         edge: height - g.bottom,
         top: height - g.bottom - g.maxHeight,
@@ -450,7 +476,13 @@ test("a coverable composer does not licence covering the monitor beside it", () 
 // the stack off a dodge that fitted and put it over the composer.
 test("a placement that fits the cards at their floor is not given up on", () => {
   const H = 830;
-  const composer = { left: 416, top: 415, right: 864, bottom: 530, coverable: true };
+  const composer = {
+    left: 416,
+    top: 415,
+    right: 864,
+    bottom: 530,
+    coverable: true,
+  };
   const natural = 394;
   const floor = 339;
   const geometry = stackGeometry(composer, 1280, H, natural, floor);
@@ -469,7 +501,13 @@ test("a persistent card that would land on the composer stops the cover", () => 
   const H = 534;
   // Docked under a thread: it sits on the bottom edge, so the corner is where
   // the persistent tail would go and the tail would land on Send.
-  const docked = { left: 236, top: 380, right: 684, bottom: 518, coverable: true };
+  const docked = {
+    left: 236,
+    top: 380,
+    right: 684,
+    bottom: 518,
+    coverable: true,
+  };
   const dodging = stackGeometry(docked, 921, H, 460, 420, 60);
   assert.ok(
     H - dodging.bottom <= docked.top,
@@ -482,14 +520,87 @@ test("a persistent card clear of the composer does not stop the cover", () => {
   // The welcome composer, centred. The corner underneath it is free, so the
   // cards that reach it are the dismissible ones and there is nothing to
   // protect: covering is still the right answer.
-  const welcome = { left: 236, top: 275, right: 684, bottom: 387, coverable: true };
+  const welcome = {
+    left: 236,
+    top: 275,
+    right: 684,
+    bottom: 387,
+    coverable: true,
+  };
   const covering = stackGeometry(welcome, 921, H, 460, 420, 60);
   assert.equal(covering.bottom, 16, "it gave up a cover that was safe");
   assert.ok(covering.maxHeight >= 460, "and the cards are whole");
 });
 
+test("covering is refused when it still cannot show the cards", () => {
+  // A short window with a monitor across the top: dropping the composer buys a
+  // few pixels and still leaves the rail under its floor. The rail scrolls
+  // either way, so paying the composer for those pixels buys nothing.
+  const H = 400;
+  const monitor = { left: 473, top: 0, right: 921, bottom: 200 };
+  const composer = {
+    left: 236,
+    top: 250,
+    right: 684,
+    bottom: 384,
+    coverable: true,
+  };
+  const both = stackGeometry([monitor, composer], 921, H, 460, 192, 0);
+  const dodging = stackGeometry([monitor, composer], 921, H, 460, 10_000, 0);
+  assert.deepEqual(
+    both,
+    dodging,
+    "it covered the composer for a placement that is still under the floor",
+  );
+});
+
+test("covering is taken when it does reach the floor", () => {
+  // The same shape with room above the composer once it is dropped: now the
+  // cover earns its price and the cards come out whole.
+  const H = 534;
+  const composer = {
+    left: 236,
+    top: 275,
+    right: 684,
+    bottom: 500,
+    coverable: true,
+  };
+  const covering = stackGeometry(composer, 921, H, 460, 300, 0);
+  // 16, the corner inset: the stack took the corner and the composer with it.
+  assert.equal(covering.bottom, 16, "it refused a cover that fits");
+  assert.ok(covering.maxHeight >= 300, "and the cards are whole");
+});
+
+test("the persistent tail is judged where the fallback actually lands", () => {
+  // Dropping the composer does not always leave the stack at the corner: an
+  // uncoverable monitor at the bottom still lifts it, and the lift carries the
+  // tail up onto the composer that the corner-based reading had just cleared.
+  const H = 800;
+  const monitor = { left: 473, top: 600, right: 921, bottom: 800 };
+  // Well above the corner, so a corner-based check calls covering safe.
+  const composer = {
+    left: 236,
+    top: 380,
+    right: 684,
+    bottom: 560,
+    coverable: true,
+  };
+  const placement = stackGeometry([monitor, composer], 921, H, 700, 240, 80);
+  const railBottom = H - placement.bottom;
+  assert.ok(
+    railBottom - 80 >= composer.bottom || railBottom <= composer.top,
+    `the persistent tail landed on the composer (rail bottom ${railBottom})`,
+  );
+});
+
 test("no persistent tail means the old answer", () => {
-  const composer = { left: 236, top: 300, right: 684, bottom: 420, coverable: true };
+  const composer = {
+    left: 236,
+    top: 300,
+    right: 684,
+    bottom: 420,
+    coverable: true,
+  };
   const withZero = stackGeometry(composer, 921, 534, 420, 420, 0);
   const withoutArg = stackGeometry(composer, 921, 534, 420, 420);
   assert.deepEqual(withoutArg, withZero);
@@ -498,7 +609,13 @@ test("no persistent tail means the old answer", () => {
 // One number means the strict reading of it, so nothing that knows only the
 // natural height silently starts covering things.
 test("a caller that passes one height gets the stricter answer", () => {
-  const composer = { left: 416, top: 415, right: 864, bottom: 530, coverable: true };
+  const composer = {
+    left: 416,
+    top: 415,
+    right: 864,
+    bottom: 530,
+    coverable: true,
+  };
   const one = stackGeometry(composer, 1280, 830, 394);
   const two = stackGeometry(composer, 1280, 830, 394, 394);
   assert.deepEqual(one, two);
@@ -597,7 +714,9 @@ test("every box inside the stack is observed, not just the stack", async () => {
     ),
     "utf8",
   );
-  const wiring = source.slice(source.indexOf("const observer = new ResizeObserver"));
+  const wiring = source.slice(
+    source.indexOf("const observer = new ResizeObserver"),
+  );
   assert.ok(
     !/observer\.observe\(node\)/.test(wiring),
     "the root alone is observed, so an intrinsic descendant resize is missed",
@@ -609,7 +728,11 @@ test("every box inside the stack is observed, not just the stack", async () => {
   );
   // A changed subtree has to be re-observed, or a banner arriving after mount is missed.
   const onMutation = wiring.slice(wiring.indexOf("new MutationObserver"));
-  assert.match(onMutation, /syncObserved\(\)/, "the observed set is not resynced");
+  assert.match(
+    onMutation,
+    /syncObserved\(\)/,
+    "the observed set is not resynced",
+  );
   // And unobserved on the way out, or a detached node keeps the observer alive.
   assert.match(wiring, /observer\.unobserve\(/, "nothing is ever unobserved");
 });

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -380,6 +380,69 @@ test("no measured height leaves the stack overlapping a box", () => {
   }
 });
 
+// A window too short to hold the cards above the composer has no arrangement
+// that both dodges it and shows them whole. Clipping them is what the overlap
+// report was about, and a card sliced off at the rail's edge reads as one that
+// has slid behind the page, so the stack takes the corner and paints over the
+// composer instead. Only for a box that said it may be covered.
+test("a stack that cannot fit above the composer covers it rather than clipping", () => {
+  // 534px tall, the size from the report, with the welcome composer centred.
+  const H = 534;
+  const composer = { left: 236, top: 300, right: 684, bottom: 420, coverable: true };
+  const needed = 339;
+  const covered = stackGeometry(composer, 921, H, needed);
+  assert.equal(covered.bottom, 16, "the stack left the corner");
+  assert.ok(
+    covered.maxHeight >= needed,
+    `the cards are still clipped: ${covered.maxHeight} < ${needed}`,
+  );
+  // The same box that has to be dodged when dodging it costs nothing.
+  const roomy = stackGeometry(composer, 921, 1200, needed);
+  assert.ok(
+    1200 - roomy.bottom <= composer.top || roomy.maxHeight <= 1200 - 16 - composer.bottom,
+    "a composer that could have been dodged was covered anyway",
+  );
+});
+
+test("a box that never said it may be covered is still never covered", () => {
+  // The Live monitor. Its Close button and resize grip are why this store
+  // exists, so it keeps the old answer even when the stack does not fit.
+  const H = 534;
+  const monitor = { left: 236, top: 300, right: 684, bottom: 420 };
+  const geometry = stackGeometry(monitor, 921, H, 339);
+  const stackTop = H - geometry.bottom - geometry.maxHeight;
+  const clearsAbove = H - geometry.bottom <= monitor.top;
+  const clearsBelow = stackTop >= monitor.bottom;
+  assert.ok(clearsAbove || clearsBelow, "the stack was allowed over the monitor");
+});
+
+// The fallback drops the coverable boxes and places against what is left, so
+// the monitor has to come out of it exactly as it would have on its own. Stated
+// as a comparison rather than an absolute: a window this short cannot always
+// clear a monitor either, and the claim here is that the composer's permission
+// is not inherited, not that the monitor is always dodged.
+test("a coverable composer does not licence covering the monitor beside it", () => {
+  const composer = { left: 236, top: 300, right: 684, bottom: 420, coverable: true };
+  const monitor = { left: 640, top: 60, right: 905, bottom: 250 };
+  for (const height of [534, 700, 900, 1200]) {
+    for (const needed of [56, 200, 339, 600]) {
+      const alone = stackGeometry(monitor, 921, height, needed);
+      const withComposer = stackGeometry([composer, monitor], 921, height, needed);
+      const clearance = (g: { bottom: number; maxHeight: number }) => ({
+        edge: height - g.bottom,
+        top: height - g.bottom - g.maxHeight,
+      });
+      const a = clearance(alone);
+      const b = clearance(withComposer);
+      const label = `height=${height} needed=${needed}`;
+      assert.ok(
+        b.top >= a.top || b.edge <= monitor.top,
+        `the composer pushed the stack further over the monitor: ${label}`,
+      );
+    }
+  }
+});
+
 // Same rule, applied to the other publisher: a monitor dragged up the screen
 // leaves the corner free, so the stack belongs in it.
 test("a monitor away from the corner no longer lifts the stack", () => {

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -443,6 +443,33 @@ test("a coverable composer does not licence covering the monitor beside it", () 
   }
 });
 
+// The cards may give up their notes, so a placement short of the height they
+// would PREFER still shows all of them. Covering the composer to win those few
+// pixels is the worse answer, and testing the fallback against the natural
+// height rather than the floor is what did it: at 1280x830 a 3px shortfall took
+// the stack off a dodge that fitted and put it over the composer.
+test("a placement that fits the cards at their floor is not given up on", () => {
+  const H = 830;
+  const composer = { left: 416, top: 415, right: 864, bottom: 530, coverable: true };
+  const natural = 394;
+  const floor = 339;
+  const geometry = stackGeometry(composer, 1280, H, natural, floor);
+  assert.ok(
+    H - geometry.bottom <= composer.top,
+    "the stack covered a composer it could have dodged",
+  );
+  assert.ok(geometry.maxHeight >= floor, "and it still holds the cards");
+});
+
+// One number means the strict reading of it, so nothing that knows only the
+// natural height silently starts covering things.
+test("a caller that passes one height gets the stricter answer", () => {
+  const composer = { left: 416, top: 415, right: 864, bottom: 530, coverable: true };
+  const one = stackGeometry(composer, 1280, 830, 394);
+  const two = stackGeometry(composer, 1280, 830, 394, 394);
+  assert.deepEqual(one, two);
+});
+
 // Same rule, applied to the other publisher: a monitor dragged up the screen
 // leaves the corner free, so the stack belongs in it.
 test("a monitor away from the corner no longer lifts the stack", () => {

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The overlay rail is height-capped by stackGeometry, and on the chat routes
+// the composer publishes a box that makes the cap small. Everything in the rail
+// was shrinkable, so the cap came out of the update card: its release notes
+// were painted over its own "Show release notes / Remind me later / Update"
+// row, and the card was clipped mid-sentence.
+//
+// The rule this pins: inside a card the notes are the only part allowed to give
+// up height, and they clip or scroll while doing it. Inside the rail the update
+// cards give up nothing, and the rail scrolls if that leaves it short.
+//
+// Read from the source: the node suite has no DOM to compute styles in.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function read(path: string): string {
+  return readFileSync(new URL(`../src/${path}`, import.meta.url), "utf8");
+}
+
+const TAURI = read("components/tauri/update-banner.tsx");
+const WEB = read("components/web/update-banner.tsx");
+const LLAMA = read("components/llama-update-banner.tsx");
+const NOTES = read("components/update/release-notes-panel.tsx");
+const PROVIDER = read("app/provider.tsx");
+
+/** The class string opened by `anchor`, up to its closing quote. */
+function classes(source: string, anchor: string): string {
+  const at = source.indexOf(anchor);
+  if (at === -1) {
+    throw new Error(`${anchor} not found`);
+  }
+  return source.slice(at, source.indexOf('"', at + anchor.length));
+}
+
+const CARDS: ReadonlyArray<readonly [string, string]> = [
+  ["tauri", TAURI],
+  ["web", WEB],
+];
+
+for (const [name, source] of CARDS) {
+  test(`the ${name} card's header cannot be compressed`, () => {
+    assert.match(
+      classes(source, "flex min-w-0 "),
+      /\bshrink-0\b/,
+      "the header shrinks, so the version line collides with the notes",
+    );
+  });
+
+  test(`the ${name} card's action row cannot be compressed`, () => {
+    const footer = classes(source, "mt-4 flex ");
+    assert.match(
+      footer,
+      /\bshrink-0\b/,
+      "the buttons shrink, so the notes are painted over them",
+    );
+    // Wrapping is how a narrow card copes; it is not compression.
+    assert.match(footer, /\bflex-wrap\b/, "the buttons must still wrap");
+  });
+
+  test(`the ${name} card stops shrinking at its buttons`, () => {
+    const stacked = classes(source, "pointer-events-auto flex ");
+    // 8rem is the card with its notes closed, measured in a browser. Under it
+    // the buttons are the next thing to go.
+    assert.match(
+      stacked,
+      /\bmin-h-32\b/,
+      "a capped rail squeezes the card past its own buttons",
+    );
+    // min-h-0 was the old floor and it is no floor at all.
+    assert.ok(
+      !/\bmin-h-0\b/.test(stacked),
+      "min-h-0 lets the rail squeeze the card to nothing",
+    );
+  });
+}
+
+test("the two update cards do not drift apart", () => {
+  // One is the desktop card and one the browser card, but they are the same
+  // card, so a fix applied to one and not the other is the bug coming back.
+  // The header and the rail-facing root are the same string on both.
+  for (const anchor of ["flex min-w-0 ", "pointer-events-auto flex "]) {
+    assert.equal(
+      classes(TAURI, anchor),
+      classes(WEB, anchor),
+      `${anchor} differs between the desktop and browser cards`,
+    );
+  }
+  // The action rows justify differently, so compare only what this fix pins.
+  for (const rule of ["shrink-0", "flex-wrap"]) {
+    assert.ok(
+      classes(TAURI, "mt-4 flex ").includes(rule) &&
+        classes(WEB, "mt-4 flex ").includes(rule),
+      `one action row is missing ${rule}`,
+    );
+  }
+});
+
+test("the llama.cpp card keeps its full height in the rail", () => {
+  // Nothing inside it can give up height, so squeezing it only mangles it.
+  assert.match(
+    classes(LLAMA, "pointer-events-auto w-[calc(100vw-2rem)]"),
+    /\bshrink-0\b/,
+  );
+});
+
+test("the notes panel clips whatever height it gives up", () => {
+  assert.match(
+    classes(NOTES, "mt-3 flex min-h-0 flex-col"),
+    /\boverflow-hidden\b/,
+    "the panel shrinks but its content still paints past the panel",
+  );
+  // The panel root is the clipper. The surface inside it keeps its intrinsic
+  // height: a scroll container there collapses the expanded notes to nothing,
+  // because their scroller is a flex-basis-0 child of it.
+  assert.ok(
+    !/overflow-hidden[^"]*rounded-\[14px\]/.test(NOTES),
+    "the inner surface clips, which empties the expanded notes",
+  );
+});
+
+test("the collapsed notes summary scrolls, like the expanded notes", () => {
+  // The expanded notes already scrolled; the collapsed bullet list did not,
+  // and the collapsed list is what the reported screenshot was showing.
+  const summary = classes(NOTES, "hover-scrollbar min-h-0 flex-1 space-y-1");
+  assert.match(summary, /\boverflow-y-auto\b/);
+  assert.match(summary, /\boverscroll-contain\b/);
+  const expanded = classes(NOTES, "hover-scrollbar max-h-64");
+  assert.match(expanded, /\boverflow-y-auto\b/);
+  assert.match(expanded, /\boverscroll-contain\b/);
+});
+
+test("the rail scrolls rather than spilling its cards", () => {
+  const rails = PROVIDER.split("pointer-events-none fixed right-4 z-[9998]");
+  // The desktop rail and the browser rail.
+  assert.equal(rails.length - 1, 2, "the rail count changed");
+  for (const rail of rails.slice(1)) {
+    const rules = rail.slice(0, rail.indexOf('"'));
+    assert.match(rules, /\boverflow-y-auto\b/, "a capped rail clips its cards");
+    // The scroller clips at the padding box, so without room reserved there the
+    // cards lose their shadows; the negative margin puts the rail back where it
+    // was.
+    assert.match(rules, /\bp-3\b/);
+    assert.match(rules, /-m-3/);
+  }
+});

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -62,17 +62,17 @@ for (const [name, source] of CARDS) {
 
   test(`the ${name} card stops shrinking at its buttons`, () => {
     const stacked = classes(source, "pointer-events-auto flex ");
-    // 8rem is the card with its notes closed, measured in a browser. Under it
-    // the buttons are the next thing to go. min-h-0 was the old floor and it
-    // is no floor at all.
+    // The floor is the card with its notes closed, measured in a browser: 8rem
+    // for one row of actions, 12rem once the card is narrow enough to wrap them
+    // onto two. min-h-0 was the old floor and it is no floor at all.
     assert.ok(
       !/\bmin-h-0\b/.test(stacked),
       "min-h-0 lets the rail squeeze the card to nothing",
     );
     assert.match(
       source,
-      /\bmin-h-32\b/,
-      "a capped rail squeezes the card past its own buttons",
+      /\bmin-h-48 sm:min-h-32\b|\bmin-h-48\b[^"]*\bsm:min-h-32\b/,
+      "one floor for both widths clips the wrapped action row",
     );
   });
 }
@@ -82,7 +82,7 @@ test("the desktop failure card does not shrink at all", () => {
   // only clips the diagnostics and the retry button.
   assert.match(
     TAURI,
-    /showFailure \? "shrink-0" : "min-h-32"/,
+    /showFailure \? "shrink-0" : "min-h-48 sm:min-h-32"/,
     "the failure card shares the notes-bearing card's floor, which is too low",
   );
 });
@@ -100,7 +100,7 @@ test("the two update cards do not drift apart", () => {
   const root = (source: string) =>
     classes(source, "pointer-events-auto flex ")
       .split(" ")
-      .filter((rule) => rule !== "min-h-32")
+      .filter((rule) => !rule.endsWith("min-h-32") && rule !== "min-h-48")
       .join(" ");
   assert.equal(
     root(TAURI),

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -25,6 +25,7 @@ const WEB = read("components/web/update-banner.tsx");
 const LLAMA = read("components/llama-update-banner.tsx");
 const NOTES = read("components/update/release-notes-panel.tsx");
 const PROVIDER = read("app/provider.tsx");
+const STORE = read("features/settings/stores/monitor-frame-store.ts");
 
 /** The class string opened by `anchor`, up to its closing quote. */
 function classes(source: string, anchor: string): string {
@@ -152,7 +153,7 @@ test("the collapsed notes summary scrolls, like the expanded notes", () => {
 });
 
 test("the rail scrolls rather than spilling its cards", () => {
-  const rails = PROVIDER.split("pointer-events-none fixed right-4 z-[9998]");
+  const rails = PROVIDER.split("fixed right-4 z-[9998]");
   // The desktop rail and the browser rail.
   assert.equal(rails.length - 1, 2, "the rail count changed");
   for (const rail of rails.slice(1)) {
@@ -174,4 +175,28 @@ test("the rail scrolls rather than spilling its cards", () => {
       "vertical padding on the measured node inflates the measured height",
     );
   }
+});
+
+// pointer-events-none takes the rail's scrollbar with it, and only the cards
+// opt back in, so a scrolling rail nobody can drag hides the cards under the
+// fold. It is click-through only while there is nothing to scroll to.
+test("a scrolling rail takes pointer input, a fitting one stays click-through", () => {
+  const rails = PROVIDER.split("fixed right-4 z-[9998]");
+  assert.equal(rails.length - 1, 2, "the rail count changed");
+  for (const rail of rails.slice(1)) {
+    const branch = rail.slice(0, rail.indexOf("style={{"));
+    assert.match(
+      branch,
+      /stack\.overflowing\s*\?\s*"pointer-events-auto"\s*:\s*"pointer-events-none"/,
+      "the rail is click-through unconditionally",
+    );
+  }
+  // Read from the capped box. Comparing the natural height against the cap
+  // instead reports every stack whose cards are giving up height, which is
+  // most of them, and hands the rail pointer input it does not need.
+  assert.match(
+    STORE,
+    /const scrolls = node\.scrollHeight > node\.clientHeight;/,
+    "the overflow flag is not measured on the capped box",
+  );
 });

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -209,12 +209,19 @@ test("a scrolling rail takes pointer input, a fitting one stays click-through", 
       "the rail is click-through unconditionally",
     );
   }
-  // Read from the capped box. Comparing the natural height against the cap
-  // instead reports every stack whose cards are giving up height, which is
-  // most of them, and hands the rail pointer input it does not need.
+  // Derived from the placement, never read back off the node. A DOM reading
+  // latches: the stack scrolls for a frame, the placement then changes to one
+  // that fits, and nothing resizes afterwards to correct the flag, so a rail
+  // with nothing to scroll to keeps the pointer input it took. Compared
+  // against the floor rather than the natural height, since the cards absorb
+  // everything in between.
   assert.match(
     STORE,
-    /const scrolls = node\.scrollHeight > node\.clientHeight;/,
-    "the overflow flag is not measured on the capped box",
+    /overflowing: floorRoom > geometry\.maxHeight/,
+    "the overflow flag is not derived from the placement",
+  );
+  assert.ok(
+    !/setOverflowing/.test(STORE),
+    "a latched DOM reading is back",
   );
 });

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -63,18 +63,24 @@ for (const [name, source] of CARDS) {
 
   test(`the ${name} card stops shrinking at its buttons`, () => {
     const stacked = classes(source, "pointer-events-auto flex ");
-    // The floor is the card with its notes closed. It has to be written
-    // against --ui-font-scale, not measured once at the default type size:
+    // The floor is the header and the action row. It has to follow
+    // --ui-font-scale, not be measured once at the default type size:
     // Settings > Appearance goes to 20px, where the action row wraps at every
-    // card width and a 128px floor cuts the buttons in half.
+    // card width and a 128px floor cuts the buttons in half. A fixed part plus
+    // a scaled one, since only some of the card moves with the setting, and
+    // scaling the whole box asked 256px where 209 was needed.
     assert.ok(
       !/\bmin-h-0\b/.test(stacked),
       "min-h-0 lets the rail squeeze the card to nothing",
     );
     assert.match(
       source,
-      /min-h-\[calc\(12rem\*var\(--ui-font-scale,1\)\/0\.9375\)\]/,
-      "the floor is a fixed height, so it is wrong at every other type size",
+      /min-h-\[calc\(\d+px\+\d+px\*var\(--ui-font-scale,1\)\)\]/,
+      "the floor does not track the type size in the shape index.css uses",
+    );
+    assert.ok(
+      !/12rem\*var\(--ui-font-scale/.test(source),
+      "the whole box is being scaled again, which over-reserves the floor",
     );
     assert.ok(
       !/min-h-48|min-h-32/.test(source),
@@ -88,7 +94,7 @@ test("the desktop failure card does not shrink at all", () => {
   // only clips the diagnostics and the retry button.
   assert.match(
     TAURI,
-    /showFailure \? "shrink-0" : "min-h-\[calc\(12rem/,
+    /showFailure\s*\n?\s*\? "shrink-0"/,
     "the failure card shares the notes-bearing card's floor, which is too low",
   );
 });
@@ -142,13 +148,26 @@ test("the two update cards do not drift apart", () => {
 // and the download panel deliberately do not carry it: they are the last
 // children, so they are what would land on Send.
 test("only the dismissible cards licence covering the composer", () => {
-  for (const [name, source] of [...CARDS, ["llama", LLAMA] as const]) {
+  for (const [name, source] of CARDS) {
     assert.match(
       source,
       /data-overlay-dismissible="true"/,
       `the ${name} card lost its dismissible marker, so the stack will never cover`,
     );
   }
+  // The llama.cpp card carries the licence CONDITIONALLY: its dismiss button
+  // goes away for the length of an update, and a card that cannot be got rid
+  // of must not be one the stack parks on Send.
+  assert.match(
+    LLAMA,
+    /data-overlay-dismissible=\{applying \? undefined : "true"\}/,
+    "the llama card licences covering the composer while it is mid-update",
+  );
+  assert.match(
+    LLAMA,
+    /\{applying \? null : \(\s*\n\s*<button/,
+    "the dismiss button is no longer the thing the licence is tied to",
+  );
   const indicator = read("features/loaded-models/loaded-models-indicator.tsx");
   const downloads = read(
     "features/hub/download-manager/download-manager-panel.tsx",

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -71,7 +71,7 @@ for (const [name, source] of CARDS) {
     );
     assert.match(
       source,
-      /\bmin-h-48 sm:min-h-32\b|\bmin-h-48\b[^"]*\bsm:min-h-32\b/,
+      /min-h-48[^"]*min-\[480px\]:min-h-32/,
       "one floor for both widths clips the wrapped action row",
     );
   });
@@ -82,7 +82,7 @@ test("the desktop failure card does not shrink at all", () => {
   // only clips the diagnostics and the retry button.
   assert.match(
     TAURI,
-    /showFailure \? "shrink-0" : "min-h-48 sm:min-h-32"/,
+    /showFailure \? "shrink-0" : "min-h-48 min-\[480px\]:min-h-32"/,
     "the failure card shares the notes-bearing card's floor, which is too low",
   );
 });
@@ -100,7 +100,7 @@ test("the two update cards do not drift apart", () => {
   const root = (source: string) =>
     classes(source, "pointer-events-auto flex ")
       .split(" ")
-      .filter((rule) => !rule.endsWith("min-h-32") && rule !== "min-h-48")
+      .filter((rule) => !rule.includes("min-h-32") && rule !== "min-h-48")
       .join(" ");
   assert.equal(
     root(TAURI),

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -2,14 +2,13 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 // The overlay rail is height-capped by stackGeometry, and on the chat routes
-// the composer publishes a box that makes the cap small. Everything in the rail
-// was shrinkable, so the cap came out of the update card: its release notes
-// were painted over its own "Show release notes / Remind me later / Update"
-// row, and the card was clipped mid-sentence.
+// the composer publishes a box that makes the cap small. Nothing in the rail
+// was shrink-0, so the cap came out of the update card and its release notes
+// were painted over its own row of buttons.
 //
-// The rule this pins: inside a card the notes are the only part allowed to give
-// up height, and they clip or scroll while doing it. Inside the rail the update
-// cards give up nothing, and the rail scrolls if that leaves it short.
+// The rule pinned here: the notes are the only part of a card allowed to give
+// up height, and they clip while doing it; the card floors at its buttons; the
+// rail scrolls if that still does not fit.
 //
 // Read from the source: the node suite has no DOM to compute styles in.
 

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -136,6 +136,46 @@ test("the two update cards do not drift apart", () => {
   }
 });
 
+// Covering the composer is licensed per card, and the licence is carried on
+// the card rather than inferred in the store, so a new overlay added to the
+// rail is persistent until someone says otherwise. The loaded models indicator
+// and the download panel deliberately do not carry it: they are the last
+// children, so they are what would land on Send.
+test("only the dismissible cards licence covering the composer", () => {
+  for (const [name, source] of [...CARDS, ["llama", LLAMA] as const]) {
+    assert.match(
+      source,
+      /data-overlay-dismissible="true"/,
+      `the ${name} card lost its dismissible marker, so the stack will never cover`,
+    );
+  }
+  const indicator = read("features/loaded-models/loaded-models-indicator.tsx");
+  const downloads = read(
+    "features/hub/download-manager/download-manager-panel.tsx",
+  );
+  for (const [name, source] of [
+    ["loaded models indicator", indicator],
+    ["download panel", downloads],
+  ] as const) {
+    assert.ok(
+      !/data-overlay-dismissible/.test(source),
+      `the ${name} is persistent and must not licence covering the composer`,
+    );
+  }
+  assert.match(
+    STORE,
+    /child\.hasAttribute\("data-overlay-dismissible"\)/,
+    "the store no longer asks the cards whether it may cover",
+  );
+  // Measured up from the corner, so the run that stops a cover is the one that
+  // would land on the composer, not any persistent card anywhere in the stack.
+  assert.match(
+    STORE,
+    /for \(let i = node\.children\.length - 1; i >= 0; i -= 1\)/,
+    "the persistent run is no longer counted from the bottom of the stack",
+  );
+});
+
 test("the llama.cpp card keeps its full height in the rail", () => {
   // Nothing inside it can give up height, so squeezing it only mangles it.
   assert.match(
@@ -220,8 +260,24 @@ test("a scrolling rail takes pointer input, a fitting one stays click-through", 
     /overflowing: floorRoom > geometry\.maxHeight/,
     "the overflow flag is not derived from the placement",
   );
+  assert.ok(!/setOverflowing/.test(STORE), "a latched DOM reading is back");
+  // The probe writes max-height twice and reads scrollHeight between the
+  // writes. transition-property: all reaches the rail, so unsuppressed each
+  // write starts a transition, and a transition computes its start value
+  // until the timeline advances: the box computes 0px while its inline style
+  // reads back as the cap, and three whole cards lay out below it.
+  const suppressed = STORE.indexOf('node.style.transition = "none"');
+  const probe = STORE.slice(
+    suppressed,
+    STORE.indexOf("setNeededRoom", suppressed),
+  );
   assert.ok(
-    !/setOverflowing/.test(STORE),
-    "a latched DOM reading is back",
+    probe.length > 0 && /node\.style\.maxHeight = "none"/.test(probe),
+    "the height probe is not run with transitions suppressed",
+  );
+  assert.match(
+    STORE,
+    /void node\.scrollHeight;\s*\n\s*node\.style\.transition = eased;/,
+    "the restored cap is handed back to a transition",
   );
 });

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -122,10 +122,12 @@ test("the two update cards do not drift apart", () => {
     classes(WEB, "flex min-w-0 "),
     "the headers differ between the desktop and browser cards",
   );
+  // Both floors are dropped before comparing, the plain one and the narrow
+  // variant: the two cards measure differently and are meant to differ here.
   const root = (source: string) =>
     classes(source, "pointer-events-auto flex ")
       .split(" ")
-      .filter((rule) => !rule.startsWith("min-h-"))
+      .filter((rule) => !/^(max-\[\d+px\]:)?min-h-/.test(rule))
       .join(" ");
   assert.equal(
     root(TAURI),

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -63,31 +63,50 @@ for (const [name, source] of CARDS) {
   test(`the ${name} card stops shrinking at its buttons`, () => {
     const stacked = classes(source, "pointer-events-auto flex ");
     // 8rem is the card with its notes closed, measured in a browser. Under it
-    // the buttons are the next thing to go.
-    assert.match(
-      stacked,
-      /\bmin-h-32\b/,
-      "a capped rail squeezes the card past its own buttons",
-    );
-    // min-h-0 was the old floor and it is no floor at all.
+    // the buttons are the next thing to go. min-h-0 was the old floor and it
+    // is no floor at all.
     assert.ok(
       !/\bmin-h-0\b/.test(stacked),
       "min-h-0 lets the rail squeeze the card to nothing",
     );
+    assert.match(
+      source,
+      /\bmin-h-32\b/,
+      "a capped rail squeezes the card past its own buttons",
+    );
   });
 }
+
+test("the desktop failure card does not shrink at all", () => {
+  // It has no notes panel, so there is nothing in it to give up: shrinking it
+  // only clips the diagnostics and the retry button.
+  assert.match(
+    TAURI,
+    /showFailure \? "shrink-0" : "min-h-32"/,
+    "the failure card shares the notes-bearing card's floor, which is too low",
+  );
+});
 
 test("the two update cards do not drift apart", () => {
   // One is the desktop card and one the browser card, but they are the same
   // card, so a fix applied to one and not the other is the bug coming back.
-  // The header and the rail-facing root are the same string on both.
-  for (const anchor of ["flex min-w-0 ", "pointer-events-auto flex "]) {
-    assert.equal(
-      classes(TAURI, anchor),
-      classes(WEB, anchor),
-      `${anchor} differs between the desktop and browser cards`,
-    );
-  }
+  // The headers are the same string; the roots share everything except the
+  // floor, which the desktop card varies for its failure state.
+  assert.equal(
+    classes(TAURI, "flex min-w-0 "),
+    classes(WEB, "flex min-w-0 "),
+    "the headers differ between the desktop and browser cards",
+  );
+  const root = (source: string) =>
+    classes(source, "pointer-events-auto flex ")
+      .split(" ")
+      .filter((rule) => rule !== "min-h-32")
+      .join(" ");
+  assert.equal(
+    root(TAURI),
+    root(WEB),
+    "the rail-facing roots differ between the desktop and browser cards",
+  );
   // The action rows justify differently, so compare only what this fix pins.
   for (const rule of ["shrink-0", "flex-wrap"]) {
     assert.ok(
@@ -142,7 +161,17 @@ test("the rail scrolls rather than spilling its cards", () => {
     // The scroller clips at the padding box, so without room reserved there the
     // cards lose their shadows; the negative margin puts the rail back where it
     // was.
-    assert.match(rules, /\bp-3\b/);
-    assert.match(rules, /-m-3/);
+    assert.match(rules, /\bpx-3\b/);
+    assert.match(rules, /-mx-3/);
+    // Sideways only. This node is the one useStackGeometry measures, so
+    // vertical padding is counted into scrollHeight and the stack asks for room
+    // it does not occupy: a card that fits under the composer then measures as
+    // one that does not, and the rail lifts over it. The cap has to stay on
+    // this same node too, since measure() lifts it here to read the natural
+    // height; on a parent, the read would be the placement's own output.
+    assert.ok(
+      !/\bp-3\b/.test(rules) && !/\bpy-3\b/.test(rules),
+      "vertical padding on the measured node inflates the measured height",
+    );
   }
 });

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -63,17 +63,22 @@ for (const [name, source] of CARDS) {
 
   test(`the ${name} card stops shrinking at its buttons`, () => {
     const stacked = classes(source, "pointer-events-auto flex ");
-    // The floor is the card with its notes closed, measured in a browser: 8rem
-    // for one row of actions, 12rem once the card is narrow enough to wrap them
-    // onto two. min-h-0 was the old floor and it is no floor at all.
+    // The floor is the card with its notes closed. It has to be written
+    // against --ui-font-scale, not measured once at the default type size:
+    // Settings > Appearance goes to 20px, where the action row wraps at every
+    // card width and a 128px floor cuts the buttons in half.
     assert.ok(
       !/\bmin-h-0\b/.test(stacked),
       "min-h-0 lets the rail squeeze the card to nothing",
     );
     assert.match(
       source,
-      /min-h-48[^"]*min-\[480px\]:min-h-32/,
-      "one floor for both widths clips the wrapped action row",
+      /min-h-\[calc\(12rem\*var\(--ui-font-scale,1\)\/0\.9375\)\]/,
+      "the floor is a fixed height, so it is wrong at every other type size",
+    );
+    assert.ok(
+      !/min-h-48|min-h-32/.test(source),
+      "a leftover fixed floor still binds and still clips",
     );
   });
 }
@@ -83,8 +88,21 @@ test("the desktop failure card does not shrink at all", () => {
   // only clips the diagnostics and the retry button.
   assert.match(
     TAURI,
-    /showFailure \? "shrink-0" : "min-h-48 min-\[480px\]:min-h-32"/,
+    /showFailure \? "shrink-0" : "min-h-\[calc\(12rem/,
     "the failure card shares the notes-bearing card's floor, which is too low",
+  );
+});
+
+test("the desktop failure card can scroll to its own diagnostics", () => {
+  // The card is capped at the viewport and clips, and the rail cannot scroll
+  // to what that cap hides, so the clipboard fallback needs its own scroller
+  // or the report the reader is told to copy is the part that disappears.
+  const region = classes(TAURI, "hover-scrollbar min-h-0 flex-1 ");
+  assert.match(region, /\boverflow-y-auto\b/, "the report cannot be scrolled");
+  assert.match(region, /\boverscroll-contain\b/);
+  assert.ok(
+    !/shrink-0[^"]*resize-none/.test(TAURI),
+    "a shrink-0 textarea pushes itself past the card's cap again",
   );
 });
 
@@ -101,7 +119,7 @@ test("the two update cards do not drift apart", () => {
   const root = (source: string) =>
     classes(source, "pointer-events-auto flex ")
       .split(" ")
-      .filter((rule) => !rule.includes("min-h-32") && rule !== "min-h-48")
+      .filter((rule) => !rule.startsWith("min-h-"))
       .join(" ");
   assert.equal(
     root(TAURI),

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -291,7 +291,14 @@ SPOT = SCOPE == "spot"
 # The two that squeeze the rail hardest, re-run at the largest UI font size.
 # The whole matrix again would not fit the job's budget and would say the same
 # thing three times over.
-FONT_SCALE_VIEWPORTS = [(921, 534), (390, 500)]
+# 320x480 is not a spare small size, it is the one that bites. Below 384px the
+# card's action pair wraps onto a row of its own on top of the notes toggle's,
+# and at the 20px setting that is a whole extra row: 259px where the wide card
+# needs 209. The height matters as much as the width, because the harm needs a
+# rail cap BETWEEN the two. At 320x480 the cap is 293px, so a 209px floor let
+# the card shrink to 209 and its own overflow-hidden surface cut 34px off Copy
+# command; at 320x568 the cap is 528px and nothing is squeezed at all.
+FONT_SCALE_VIEWPORTS = [(921, 534), (390, 500), (320, 480)]
 # appearance-custom-store.ts: UI_FONT_SIZE_RANGE, UI_FONT_SIZE_CSS_BASE and the
 # persist version. Kept in step by test_update_release_notes.py.
 UI_FONT_SIZE_MAX = 20
@@ -401,6 +408,11 @@ MEASURE = """
     // Clipped by the card, not by the rail. What the rail hides is under a
     // fold the reader can scroll to; what the card hides is gone for good.
     card: rect(card), llama: rect(llama),
+    // The same two, as much of them as the rail is SHOWING. Containment is
+    // asked of these: a card the rail has folded away is not on screen at all,
+    // and judging its unclipped rect against the viewport fails it for being
+    // scrolled out of sight, which is what the reach check below is for.
+    cardShown: clip(card, rail), llamaShown: clip(llama, rail),
     notesBody: clip(body, notes),
     toggle: clip(toggle, surface),
     snooze: clip(snooze, surface),
@@ -509,10 +521,16 @@ def measure(page, label: str) -> dict:
         f"card={facts['card']} llama={facts['llama']}",
     )
     for name in ("card", "llama", "footer", "toggle"):
+        # As shown, where the rail can hide it; as measured otherwise. A card
+        # entirely under the fold is None here and is the reach check's to make.
+        shown = facts.get(f"{name}Shown", facts[name]) if name in ("card", "llama") \
+            else facts[name]
+        if name in ("card", "llama") and shown is None:
+            continue
         check(
             f"{label}: the {name} stays inside the viewport",
-            inside(facts[name], view),
-            f"{name}={facts[name]} viewport={view}",
+            inside(shown, view),
+            f"{name}={shown} viewport={view}",
         )
     # Anything the rail is holding under its fold has to come back when the
     # rail is scrolled to it, and land on screen when it does.

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -268,17 +268,27 @@ def boot(page, path: str) -> None:
 
 def main() -> int:
     wait_for_health(BASE, timeout = 60.0, info = info)
-    token = api("/api/auth/login", {"username": "unsloth", "password": OLD})["access_token"]
+    # OLD is already NEW on a rerun, or when an earlier suite in the same job
+    # rotated it, and that login fails before the rotation below can be skipped.
     try:
-        api(
-            "/api/auth/change-password",
-            {"current_password": OLD, "new_password": NEW},
-            token,
-        )
+        token = api("/api/auth/login", {"username": "unsloth", "password": OLD})[
+            "access_token"
+        ]
     except urllib.error.HTTPError as exc:
-        # Already rotated by a previous run on the same install.
         if exc.code not in (400, 401, 403):
             raise
+        token = None
+    if token is not None:
+        try:
+            api(
+                "/api/auth/change-password",
+                {"current_password": OLD, "new_password": NEW},
+                token,
+            )
+        except urllib.error.HTTPError as exc:
+            # Already rotated by a previous run on the same install.
+            if exc.code not in (400, 401, 403):
+                raise
     session = api("/api/auth/login", {"username": "unsloth", "password": NEW})
 
     # add_init_script takes raw source, not a function to call.

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -145,6 +145,17 @@ VIEWPORTS = [
 ]
 ROUTES = [("new chat", "/"), ("train", "/train"), ("model hub", "/model-hub")]
 
+# The two that squeeze the rail hardest, re-run at the largest UI font size.
+# The whole matrix again would not fit the job's budget and would say the same
+# thing three times over.
+FONT_SCALE_VIEWPORTS = [(921, 534), (390, 500)]
+# appearance-custom-store.ts: UI_FONT_SIZE_RANGE, UI_FONT_SIZE_CSS_BASE and the
+# persist version. Kept in step by test_update_release_notes.py.
+UI_FONT_SIZE_MAX = 20
+UI_FONT_SIZE_DEFAULT = 15
+UI_FONT_SIZE_CSS_BASE = 16
+APPEARANCE_STORE_VERSION = 5
+
 failures: list[str] = []
 checks = [0]
 
@@ -222,11 +233,13 @@ MEASURE = """
   const surface = card ? card.firstElementChild : null;
   return {
     viewport: {width: innerWidth, height: innerHeight},
-    card: clip(card, rail), llama: clip(llama, rail),
+    // Clipped by the card, not by the rail. What the rail hides is under a
+    // fold the reader can scroll to; what the card hides is gone for good.
+    card: rect(card), llama: rect(llama),
     notesBody: clip(body, notes),
-    toggle: clip(clip(toggle, surface), rail),
-    snooze: clip(clip(snooze, surface), rail),
-    copy: clip(clip(copy, surface), rail),
+    toggle: clip(toggle, surface),
+    snooze: clip(snooze, surface),
+    copy: clip(copy, surface),
     footer: rect(footer),
     llamaText: llama ? (llama.innerText || '') : '',
     // pointer-events-none costs the rail its scrollbar, so it may only be
@@ -242,6 +255,48 @@ MEASURE = """
   };
 }
 """
+
+
+# Scroll each box into the rail's view and report what is still hidden. The
+# rail is the last resort the cards fall back on, so "below the fold" is a pass
+# and "cannot be brought into view" is the failure.
+REACH = """
+(selectors) => {
+  const q = (sel) => document.querySelector(sel);
+  const card = q('[data-testid="web-update-banner"]');
+  const llama = q('[data-testid="llama-update-banner"]');
+  const rail = card ? card.parentElement : (llama ? llama.parentElement : null);
+  if (!rail) return null;
+  const was = rail.scrollTop;
+  const out = {};
+  for (const [name, sel] of Object.entries(selectors)) {
+    const el = q(sel);
+    if (!el) { out[name] = null; continue; }
+    el.scrollIntoView({block: 'nearest', inline: 'nearest'});
+    const r = el.getBoundingClientRect();
+    const b = rail.getBoundingClientRect();
+    out[name] = {
+      hidden: Math.round(Math.max(0,
+        Math.max(b.top - r.top, 0) + Math.max(r.bottom - b.bottom, 0)) * 10) / 10,
+      offscreen: r.top < -0.5 || r.bottom > innerHeight + 0.5,
+      // Taller than the fold itself: no scroll position shows all of it, and
+      // none has to, since every part of it can be scrolled to.
+      taller: r.height > b.height + 1,
+      scrollable: rail.scrollHeight > rail.clientHeight,
+    };
+  }
+  rail.scrollTop = was;
+  return out;
+}
+"""
+
+REACHABLE = {
+    "card": '[data-testid="web-update-banner"]',
+    "llama": '[data-testid="llama-update-banner"]',
+    "toggle": '[data-testid="web-update-release-notes-toggle"]',
+    "snooze": '[data-testid="web-update-snooze-button"]',
+    "copy": '[data-testid="web-update-copy-button"]',
+}
 
 
 def overlap(a: dict | None, b: dict | None) -> float:
@@ -288,6 +343,20 @@ def measure(page, label: str) -> dict:
             inside(facts[name], view),
             f"{name}={facts[name]} viewport={view}",
         )
+    # Anything the rail is holding under its fold has to come back when the
+    # rail is scrolled to it, and land on screen when it does.
+    reach = page.evaluate(REACH, REACHABLE)
+    for name, seen in (reach or {}).items():
+        if seen is None:
+            continue
+        reached = (
+            seen["scrollable"] if seen["taller"] else seen["hidden"] <= 1.0
+        )
+        check(
+            f"{label}: the {name} can be scrolled into the rail's view",
+            reached and not seen["offscreen"],
+            f"{name}={seen}",
+        )
     if facts["railScrolls"] is not None:
         scrolls = facts["railScrolls"]
         check(
@@ -307,11 +376,24 @@ def measure(page, label: str) -> dict:
     for name in ("card", "llama", "toggle", "snooze", "copy"):
         box = facts[name]
         check(
-            f"{label}: the {name} is not clipped away",
+            f"{label}: the card does not clip its own {name} away",
             box is not None and box["height"] > 1.0 and box["width"] > 1.0,
             f"{name}={box}",
         )
     return facts
+
+
+def stub(payload: dict):
+    """A route handler that answers with `payload`."""
+
+    def handler(route) -> None:
+        route.fulfill(
+            status = 200,
+            content_type = "application/json",
+            body = json.dumps(payload),
+        )
+
+    return handler
 
 
 def boot(page, path: str) -> None:
@@ -444,6 +526,51 @@ def main() -> int:
                 f"text={facts['llamaText']!r}",
             )
             llama_payload[0] = LLAMA_STATUS
+            context.close()
+
+        # Settings > Appearance scales the type, and the card's floor is
+        # written against that scale rather than measured once at the default.
+        # At the 20px maximum the action row wraps at every card width, so a
+        # default-font floor left the buttons clipped inside the card.
+        for width, height in FONT_SCALE_VIEWPORTS:
+            context = browser.new_context(
+                viewport = {"width": width, "height": height},
+                reduced_motion = "reduce",
+            )
+            context.add_init_script(seed_js)
+            context.add_init_script(
+                "localStorage.setItem('unsloth_appearance_customization', "
+                + json.dumps(
+                    json.dumps(
+                        {
+                            "state": {"customization": {"uiFontSize": UI_FONT_SIZE_MAX}},
+                            "version": APPEARANCE_STORE_VERSION,
+                        }
+                    )
+                )
+                + ");"
+            )
+            for pattern, payload in (
+                ("**/api/studio/update-status*", UPDATE_STATUS),
+                ("**/api/studio/release-notes*", RELEASE_NOTES),
+                ("**/api/llama/update-status*", LLAMA_STATUS),
+            ):
+                # A two-argument handler is called with (route, request), so the
+                # payload has to be closed over rather than defaulted in.
+                context.route(pattern, stub(payload))
+            page = context.new_page()
+            boot(page, "/")
+            scale = page.evaluate(
+                "() => getComputedStyle(document.documentElement)"
+                ".getPropertyValue('--ui-font-scale').trim()"
+            )
+            check(
+                f"{width}x{height} at {UI_FONT_SIZE_MAX}px: the type is actually scaled",
+                scale not in ("", str(UI_FONT_SIZE_DEFAULT / UI_FONT_SIZE_CSS_BASE)),
+                f"--ui-font-scale={scale!r}, so the rest of this pass proves nothing",
+            )
+            measure(page, f"{width}x{height} at {UI_FONT_SIZE_MAX}px")
+            page.screenshot(path = str(ART / f"{width}x{height}-font{UI_FONT_SIZE_MAX}.png"))
             context.close()
         browser.close()
 

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -29,6 +29,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import sync_playwright
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -46,8 +47,11 @@ ART.mkdir(parents = True, exist_ok = True)
 PLAYWRIGHT_BROWSER = os.environ.get("STUDIO_PLAYWRIGHT_BROWSER", "chromium").lower()
 PLAYWRIGHT_CHANNEL = os.environ.get("STUDIO_PLAYWRIGHT_CHANNEL") or None
 
-# The web check fires 5s after mount and the llama.cpp one after 1s.
+# The web check fires 5s after mount and the llama.cpp one after 1s; this is
+# the ceiling on waiting for them, not the wait itself.
 SETTLE_MS = int(os.environ.get("STUDIO_UI_BANNER_SETTLE_MS", "9000"))
+# What the cards need after they mount, to animate in and lay out.
+SETTLED_MS = int(os.environ.get("STUDIO_UI_BANNER_SETTLED_MS", "900"))
 
 LATEST = "2099.1.0"
 
@@ -312,7 +316,20 @@ def measure(page, label: str) -> dict:
 
 def boot(page, path: str) -> None:
     page.goto(f"{BASE}{path}", wait_until = "domcontentloaded")
-    page.wait_for_timeout(SETTLE_MS)
+    # Both cards are on a timer, the app one at 5s and llama.cpp at 1s, so wait
+    # for them rather than for the worst case: this step runs 24 times and the
+    # job it shares has minutes, not tens of minutes, to spare.
+    for testid in ("web-update-banner", "llama-update-banner"):
+        try:
+            page.wait_for_selector(
+                f'[data-testid="{testid}"]', state = "attached", timeout = SETTLE_MS
+            )
+        except PlaywrightTimeoutError:
+            # Let the caller's own checks report the missing card; a bare
+            # timeout here would say nothing about which one or where.
+            pass
+    # The banners animate in, and a box measured mid-transition is not the box.
+    page.wait_for_timeout(SETTLED_MS)
     landed = page.evaluate("location.pathname")
     if landed.startswith(("/login", "/onboarding", "/change-password")):
         raise AssertionError(f"not authenticated: landed on {landed}")

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The overlay rail's update banners must never print over each other.
+
+The reported failure: on New chat, in a window short enough that the composer
+crowds the rail, the app-update card's release notes were painted over its own
+"Show release notes / Remind me later / Update" row. Train and Model hub were
+fine, because only the chat routes publish a composer box into the frame store
+and only that box caps the rail.
+
+Nothing in the node suite can catch this. It is a flex shrink distributed across
+a capped column, so it needs a real layout, a real ResizeObserver and the real
+route, and it only appears at particular viewport heights. The boxes are read
+back from getBoundingClientRect and intersected with whatever clips them, so a
+rect hidden by an overflow-hidden ancestor is not counted as visible.
+
+Both update endpoints are stubbed with page.route, so this runs on any host: no
+GPU, no pypi release, no llama.cpp build.
+
+Run: BASE_URL, STUDIO_OLD_PW and STUDIO_NEW_PW as the other suites take them.
+STUDIO_PLAYWRIGHT_BROWSER selects chromium (default), firefox or webkit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _playwright_robust import (  # noqa: E402
+    chromium_launch_args,
+    wait_for_health,
+)
+
+BASE = os.environ["BASE_URL"]
+OLD = os.environ["STUDIO_OLD_PW"]
+NEW = os.environ["STUDIO_NEW_PW"]
+ART = Path(os.environ.get("PW_ART_DIR", "logs/playwright-update-banner"))
+ART.mkdir(parents = True, exist_ok = True)
+
+PLAYWRIGHT_BROWSER = os.environ.get("STUDIO_PLAYWRIGHT_BROWSER", "chromium").lower()
+PLAYWRIGHT_CHANNEL = os.environ.get("STUDIO_PLAYWRIGHT_CHANNEL") or None
+
+# The web check fires 5s after mount and the llama.cpp one after 1s.
+SETTLE_MS = int(os.environ.get("STUDIO_UI_BANNER_SETTLE_MS", "9000"))
+
+LATEST = "2099.1.0"
+
+# Long enough that the collapsed preview alone overflows a capped card.
+NOTES_MARKDOWN = "\n".join(
+    [
+        f"## {LATEST}",
+        "",
+        "### What's Changed",
+        "",
+        "- DeepSeek-V4 0731 DSpark 2x faster inference support, with a lead "
+        "sentence long enough to wrap onto a second line in a 448px card.",
+        "- Many bug fixes across training, inference and the model hub.",
+        "- Training page full rework.",
+        "- Studio desktop update flow reworked.",
+    ]
+)
+
+UPDATE_STATUS = {
+    "current_version": "2026.8.7",
+    "latest_version": LATEST,
+    "update_available": True,
+    "install_source": "pypi",
+    "can_show_web_notification": True,
+    "release_notes_url": "https://unsloth.ai/docs/new/changelog",
+    "checked_at": "2099-01-01T00:00:00Z",
+    "reason": None,
+    "error": None,
+}
+RELEASE_NOTES = {
+    "version": LATEST,
+    "markdown": NOTES_MARKDOWN,
+    "matched": True,
+    "truncated": False,
+    "source": "test",
+    "release_notes_url": "https://unsloth.ai/docs/new/changelog",
+    "error": None,
+}
+LLAMA_STATUS = {
+    "supported": True,
+    "update_available": True,
+    "llama_update_available": True,
+    "update_component": "llama",
+    "installed_tag": "b10333",
+    "latest_tag": "b10333-mix-e34b418",
+    "update_size_bytes": 28 * 1024 * 1024,
+    "component": "llama.cpp",
+    "whisper": {
+        "update_available": False,
+        "installed_tag": "v1.9.1",
+        "latest_tag": "v1.9.1",
+        "update_size_bytes": None,
+        "skip_reason": "up_to_date",
+    },
+    "job": {
+        "state": "idle",
+        "message": "",
+        "from_tag": None,
+        "to_tag": None,
+        "reload_required": None,
+        "error": None,
+        "progress": None,
+        "finished_at": None,
+    },
+}
+# The same card, renamed: whisper.cpp is not a second banner.
+WHISPER_STATUS = dict(
+    LLAMA_STATUS,
+    llama_update_available = False,
+    update_component = "whisper",
+    component = "whisper.cpp",
+    whisper = {
+        "update_available": True,
+        "installed_tag": "v1.9.1",
+        "latest_tag": "v1.9.2",
+        "update_size_bytes": 11 * 1024 * 1024,
+        "skip_reason": None,
+    },
+)
+
+# 921x534 and 768x500 are where the report reproduces; the taller ones prove the
+# fix costs nothing when there is room.
+VIEWPORTS = [(1440, 900), (1280, 830), (921, 534), (768, 500), (390, 844)]
+ROUTES = [("new chat", "/"), ("train", "/train"), ("model hub", "/model-hub")]
+
+failures: list[str] = []
+checks = [0]
+
+
+def info(s: str) -> None:
+    print(f"[banner] {s}", flush = True)
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    checks[0] += 1
+    if ok:
+        info(f"PASS {name}")
+        return
+    failures.append(f"{name} ({detail})" if detail else name)
+    info(f"FAIL {name} {detail}")
+
+
+def api(path: str, payload: dict | None = None, token: str | None = None) -> dict:
+    data = None if payload is None else json.dumps(payload).encode()
+    request = urllib.request.Request(
+        f"{BASE}{path}",
+        data = data,
+        method = "POST" if data else "GET",
+        headers = {"Content-Type": "application/json"}
+        | ({"Authorization": f"Bearer {token}"} if token else {}),
+    )
+    with urllib.request.urlopen(request, timeout = 30) as response:
+        return json.loads(response.read().decode())
+
+
+# Every box the fix is about, already intersected with whatever clips it.
+MEASURE = """
+() => {
+  const rect = (el) => {
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return {top: r.top, bottom: r.bottom, left: r.left, right: r.right,
+            width: r.width, height: r.height};
+  };
+  const clip = (el, clipper) => {
+    const a = rect(el), b = rect(clipper);
+    if (!a || !b) return a;
+    // Only a scroll or hidden ancestor hides anything; clipping to a visible
+    // one would erase the very overflow this is looking for.
+    if (getComputedStyle(clipper).overflow === 'visible') return a;
+    const top = Math.max(a.top, b.top), bottom = Math.min(a.bottom, b.bottom);
+    const left = Math.max(a.left, b.left), right = Math.min(a.right, b.right);
+    if (bottom <= top || right <= left) return null;
+    return {top, bottom, left, right, width: right - left, height: bottom - top};
+  };
+  const q = (sel) => document.querySelector(sel);
+  const card = q('[data-testid="web-update-banner"]');
+  const llama = q('[data-testid="llama-update-banner"]');
+  const notes = q('[data-testid="update-release-notes-panel"]');
+  const body = q('[data-testid="update-release-notes-summary"]')
+            || q('[data-testid="update-release-notes-scroll"]');
+  const toggle = q('[data-testid="web-update-release-notes-toggle"]');
+  const snooze = q('[data-testid="web-update-snooze-button"]');
+  const copy = q('[data-testid="web-update-copy-button"]');
+  const footer = snooze ? snooze.closest('div').parentElement : null;
+  const rail = card ? card.parentElement : (llama ? llama.parentElement : null);
+  return {
+    viewport: {width: innerWidth, height: innerHeight},
+    card: clip(card, rail), llama: clip(llama, rail),
+    notesBody: clip(body, notes),
+    toggle: rect(toggle), snooze: rect(snooze), copy: rect(copy),
+    footer: rect(footer),
+    llamaText: llama ? (llama.innerText || '') : '',
+  };
+}
+"""
+
+
+def overlap(a: dict | None, b: dict | None) -> float:
+    """Pixels of the smaller intersecting side, 0 if they do not intersect."""
+    if not a or not b:
+        return 0.0
+    dy = min(a["bottom"], b["bottom"]) - max(a["top"], b["top"])
+    dx = min(a["right"], b["right"]) - max(a["left"], b["left"])
+    # Half a pixel of touching is a rounded edge, not an overlap.
+    return round(min(dy, dx), 1) if dy > 0.5 and dx > 0.5 else 0.0
+
+
+def inside(box: dict | None, viewport: dict) -> bool:
+    if not box:
+        return True
+    return (
+        box["top"] >= -0.5
+        and box["left"] >= -0.5
+        and box["bottom"] <= viewport["height"] + 0.5
+        and box["right"] <= viewport["width"] + 0.5
+    )
+
+
+def measure(page, label: str) -> dict:
+    facts = page.evaluate(MEASURE)
+    view = facts["viewport"]
+    check(
+        f"{label}: the notes do not print over the buttons",
+        overlap(facts["notesBody"], facts["footer"]) == 0.0
+        and overlap(facts["notesBody"], facts["toggle"]) == 0.0,
+        f"notes={facts['notesBody']} footer={facts['footer']}",
+    )
+    check(
+        f"{label}: the two banners do not print over each other",
+        overlap(facts["card"], facts["llama"]) == 0.0,
+        f"card={facts['card']} llama={facts['llama']}",
+    )
+    for name in ("card", "llama", "footer", "toggle"):
+        check(
+            f"{label}: the {name} stays inside the viewport",
+            inside(facts[name], view),
+            f"{name}={facts[name]} viewport={view}",
+        )
+    return facts
+
+
+def boot(page, path: str) -> None:
+    page.goto(f"{BASE}{path}", wait_until = "domcontentloaded")
+    page.wait_for_timeout(SETTLE_MS)
+    landed = page.evaluate("location.pathname")
+    if landed.startswith(("/login", "/onboarding", "/change-password")):
+        raise AssertionError(f"not authenticated: landed on {landed}")
+
+
+def main() -> int:
+    wait_for_health(BASE, timeout = 60.0, info = info)
+    token = api("/api/auth/login", {"username": "unsloth", "password": OLD})[
+        "access_token"
+    ]
+    try:
+        api(
+            "/api/auth/change-password",
+            {"current_password": OLD, "new_password": NEW},
+            token,
+        )
+    except urllib.error.HTTPError as exc:
+        # Already rotated by a previous run on the same install.
+        if exc.code not in (400, 401, 403):
+            raise
+    session = api("/api/auth/login", {"username": "unsloth", "password": NEW})
+
+    # add_init_script takes raw source, not a function to call.
+    seed_js = (
+        "(() => {"
+        f"  localStorage.setItem('unsloth_auth_token', {json.dumps(session['access_token'])});"
+        f"  localStorage.setItem('unsloth_refresh_token', {json.dumps(session.get('refresh_token', ''))});"
+        "  localStorage.setItem('unsloth_show_llama_update_banner', 'true');"
+        # A dismissal from an earlier run would hide the very card under test.
+        "  for (const k of Object.keys(localStorage))"
+        "    if (k.startsWith('unsloth_web_update_dismissed')) localStorage.removeItem(k);"
+        "})();"
+    )
+
+    if PLAYWRIGHT_BROWSER not in ("chromium", "firefox", "webkit"):
+        info(f"FAIL unsupported STUDIO_PLAYWRIGHT_BROWSER={PLAYWRIGHT_BROWSER!r}")
+        return 1
+
+    with sync_playwright() as p:
+        launch_kwargs: dict = {"headless": True}
+        if PLAYWRIGHT_BROWSER == "chromium":
+            launch_kwargs["args"] = chromium_launch_args()
+            if PLAYWRIGHT_CHANNEL:
+                launch_kwargs["channel"] = PLAYWRIGHT_CHANNEL
+        elif PLAYWRIGHT_CHANNEL:
+            info("FAIL STUDIO_PLAYWRIGHT_CHANNEL requires chromium")
+            return 1
+        browser = getattr(p, PLAYWRIGHT_BROWSER).launch(**launch_kwargs)
+
+        llama_payload = [LLAMA_STATUS]
+        for width, height in VIEWPORTS:
+            context = browser.new_context(
+                viewport = {"width": width, "height": height},
+                reduced_motion = "reduce",
+            )
+            context.add_init_script(seed_js)
+            context.route(
+                "**/api/studio/update-status*",
+                lambda route: route.fulfill(
+                    status = 200,
+                    content_type = "application/json",
+                    body = json.dumps(UPDATE_STATUS),
+                ),
+            )
+            context.route(
+                "**/api/studio/release-notes*",
+                lambda route: route.fulfill(
+                    status = 200,
+                    content_type = "application/json",
+                    body = json.dumps(RELEASE_NOTES),
+                ),
+            )
+            context.route(
+                "**/api/llama/update-status*",
+                lambda route: route.fulfill(
+                    status = 200,
+                    content_type = "application/json",
+                    body = json.dumps(llama_payload[0]),
+                ),
+            )
+            page = context.new_page()
+            for name, path in ROUTES:
+                size = f"{width}x{height}"
+                boot(page, path)
+                if path == "/":
+                    check(
+                        f"{size} {name}: the app update card is on screen",
+                        page.locator('[data-testid="web-update-banner"]').count() == 1,
+                        "nothing to measure, so every other check is vacuous",
+                    )
+                measure(page, f"{size} {name} collapsed")
+                page.screenshot(path = str(ART / f"{size}-{path.strip('/') or 'new-chat'}.png"))
+
+                toggle = page.locator(
+                    '[data-testid="web-update-release-notes-toggle"]'
+                )
+                if toggle.count() == 1:
+                    toggle.click()
+                    page.wait_for_timeout(1500)
+                    measure(page, f"{size} {name} expanded")
+
+            # whisper.cpp renames the same card rather than adding a second one.
+            llama_payload[0] = WHISPER_STATUS
+            boot(page, "/")
+            facts = measure(page, f"{width}x{height} new chat whisper")
+            check(
+                f"{width}x{height}: whisper.cpp reuses the one runtime card",
+                page.locator('[data-testid="llama-update-banner"]').count() <= 1
+                and "whisper.cpp" in facts["llamaText"],
+                f"text={facts['llamaText']!r}",
+            )
+            llama_payload[0] = LLAMA_STATUS
+            context.close()
+        browser.close()
+
+    info(f"{checks[0]} checks, {len(failures)} failed")
+    for failure in failures:
+        info(f"  {failure}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -225,6 +225,16 @@ MEASURE = """
     copy: clip(clip(copy, surface), rail),
     footer: rect(footer),
     llamaText: llama ? (llama.innerText || '') : '',
+    // pointer-events-none costs the rail its scrollbar, so it may only be
+    // click-through while there is nothing under the fold to scroll to.
+    railScrolls: rail ? rail.scrollHeight > rail.clientHeight : null,
+    railPointerEvents: rail ? getComputedStyle(rail).pointerEvents : null,
+    // What a click on the rail's own gutter lands on when it is click-through.
+    gutterIsRail: rail ? (() => {
+      const r = rail.getBoundingClientRect();
+      return document.elementFromPoint(
+        Math.round(r.right - 2), Math.round(r.top + r.height / 2)) === rail;
+    })() : null,
   };
 }
 """
@@ -273,6 +283,20 @@ def measure(page, label: str) -> dict:
             f"{label}: the {name} stays inside the viewport",
             inside(facts[name], view),
             f"{name}={facts[name]} viewport={view}",
+        )
+    if facts["railScrolls"] is not None:
+        scrolls = facts["railScrolls"]
+        check(
+            f"{label}: the rail takes pointer input exactly when it scrolls",
+            facts["railPointerEvents"] == ("auto" if scrolls else "none"),
+            f"scrolls={scrolls} pointerEvents={facts['railPointerEvents']}",
+        )
+        # Click-through is what pointer-events-none is for, and the gutter is
+        # the widest part of the rail that no card covers.
+        check(
+            f"{label}: a rail with nothing to scroll to stays click-through",
+            scrolls or facts["gutterIsRail"] is False,
+            f"scrolls={scrolls} gutterIsRail={facts['gutterIsRail']}",
         )
     # The notes are allowed to yield all of their height, and do; the controls
     # are not, and a card clipped to nothing is the failure being tested for.

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -143,7 +143,11 @@ def info(s: str) -> None:
     print(f"[banner] {s}", flush = True)
 
 
-def check(name: str, ok: bool, detail: str = "") -> None:
+def check(
+    name: str,
+    ok: bool,
+    detail: str = "",
+) -> None:
     checks[0] += 1
     if ok:
         info(f"PASS {name}")
@@ -152,7 +156,11 @@ def check(name: str, ok: bool, detail: str = "") -> None:
     info(f"FAIL {name} {detail}")
 
 
-def api(path: str, payload: dict | None = None, token: str | None = None) -> dict:
+def api(
+    path: str,
+    payload: dict | None = None,
+    token: str | None = None,
+) -> dict:
     data = None if payload is None else json.dumps(payload).encode()
     request = urllib.request.Request(
         f"{BASE}{path}",
@@ -262,9 +270,7 @@ def boot(page, path: str) -> None:
 
 def main() -> int:
     wait_for_health(BASE, timeout = 60.0, info = info)
-    token = api("/api/auth/login", {"username": "unsloth", "password": OLD})[
-        "access_token"
-    ]
+    token = api("/api/auth/login", {"username": "unsloth", "password": OLD})["access_token"]
     try:
         api(
             "/api/auth/change-password",
@@ -348,9 +354,7 @@ def main() -> int:
                 measure(page, f"{size} {name} collapsed")
                 page.screenshot(path = str(ART / f"{size}-{path.strip('/') or 'new-chat'}.png"))
 
-                toggle = page.locator(
-                    '[data-testid="web-update-release-notes-toggle"]'
-                )
+                toggle = page.locator('[data-testid="web-update-release-notes-toggle"]')
                 if toggle.count() == 1:
                     toggle.click()
                     page.wait_for_timeout(1500)

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -186,6 +186,83 @@ RESIZE_SWEEP = [
 # it feeds, and the reflow after that. Nothing is fetched, so this is short.
 RESIZE_SETTLE_MS = int(os.environ.get("STUDIO_UI_BANNER_RESIZE_MS", "700"))
 
+# The four runtime status endpoints the loaded models card reads, shaped as
+# tests/studio/playwright_loaded_models_indicator.py has them. Only chat holds
+# anything: one loaded model is all it takes to put the card in the rail.
+CHAT_LOADED = {
+    "active_model": "unsloth/Qwen3-4B", "loaded": ["unsloth/Qwen3-4B"],
+    "is_gguf": False, "is_mlx": False, "is_vision": False, "is_audio": False,
+    "audio_type": None, "gguf_variant": None,
+}
+NOTHING_DIFFUSION = {
+    "loaded": False, "repo_id": None, "family": None, "device": None,
+    "dtype": None, "model_kind": None,
+}
+NOTHING_VIDEO = dict(NOTHING_DIFFUSION, transformer_quant = None)
+NOTHING_STT = {
+    "available": True, "loaded_model": None, "device": None,
+    "transformers": {"loaded_model": None, "device": None},
+    "mtmd": {"loaded_model": None, "device": None},
+    "gguf": {"loaded_model": None, "device": None},
+}
+
+# Where the stack is tight enough that it would cover the composer if it were
+# allowed to. Two is enough: the rule is per card, not per size.
+INDICATOR_VIEWPORTS = [(921, 534), (768, 500)]
+
+# Does anything in the rail overlap the composer? Read off the same page, since
+# the composer is not one of the boxes the cards know about.
+COMPOSER_CLEARANCE = """
+() => {
+  const card = document.querySelector('[data-testid="web-update-banner"]');
+  const composer = document.querySelector('form');
+  if (!card || !composer) return {composer: null, overlap: 0};
+  const rail = card.parentElement;
+  const a = rail.getBoundingClientRect();
+  const b = composer.getBoundingClientRect();
+  const dy = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
+  const dx = Math.min(a.right, b.right) - Math.max(a.left, b.left);
+  return {
+    composer: {top: Math.round(b.top), bottom: Math.round(b.bottom)},
+    rail: {top: Math.round(a.top), bottom: Math.round(a.bottom)},
+    // In the RAIL, not merely on the page: the card is draggable, and one
+    // parked elsewhere would satisfy a page-wide search while telling us
+    // nothing about the stack whose placement is under test.
+    // The inline cap next to what the box actually computes: a rail whose
+    // measurement leaves a transition behind reports a healthy cap and lays
+    // its cards out below a zero-height box.
+    railStyle: {bottom: rail.style.bottom, maxHeight: rail.style.maxHeight,
+                kids: rail.childElementCount,
+                height: getComputedStyle(rail).height,
+                cappedTo: getComputedStyle(rail).maxHeight},
+    indicator: (() => {
+      const label = Array.from(document.querySelectorAll('*')).find(
+        (el) => el.childElementCount === 0
+          && el.textContent.trim() === 'Loaded models',
+      );
+      return Boolean(label && rail.contains(label));
+    })(),
+    overlap: (dy > 0.5 && dx > 0.5) ? Math.round(Math.min(dy, dx) * 10) / 10 : 0,
+    // The same question asked of the part of the stack the reader cannot get
+    // rid of. A dismissible card over Send is the trade the placement makes to
+    // show that card whole; the tail below it would be over Send for good.
+    tailOverlap: (() => {
+      let worst = 0;
+      for (let i = rail.children.length - 1; i >= 0; i -= 1) {
+        const kid = rail.children[i];
+        if (kid.hasAttribute('data-overlay-dismissible')) break;
+        const k = kid.getBoundingClientRect();
+        if (k.width < 1 || k.height < 1) continue;
+        const ky = Math.min(k.bottom, b.bottom) - Math.max(k.top, b.top);
+        const kx = Math.min(k.right, b.right) - Math.max(k.left, b.left);
+        if (ky > 0.5 && kx > 0.5) worst = Math.max(worst, Math.min(ky, kx));
+      }
+      return Math.round(worst * 10) / 10;
+    })(),
+  };
+}
+"""
+
 # A minimised window has no layout to photograph, so what is actually testable
 # is the RESTORE: the geometry is measured by a ResizeObserver and cached in
 # React state, and a window that goes away and comes back is exactly how a stale
@@ -480,6 +557,39 @@ def stub(payload: dict):
     return handler
 
 
+RAIL_BOX = """
+() => {
+  const card = document.querySelector('[data-testid="web-update-banner"]')
+            || document.querySelector('[data-testid="llama-update-banner"]');
+  if (!card) return null;
+  const r = card.parentElement.getBoundingClientRect();
+  return [Math.round(r.top), Math.round(r.bottom), Math.round(r.height)].join(',');
+}
+"""
+
+
+def settle_stack(page, tries: int = 24, gap_ms: int = 250) -> None:
+    """Wait until the rail's box stops moving.
+
+    Waits for STABILITY, not for the answer the checks want: a card mounting
+    late changes the stack's height, which re-measures the placement, which
+    moves the rail on the frame after that. Measuring in the middle of that is
+    how the models indicator pass reported the cards below the viewport when a
+    probe watching the same page settled correctly a second later. Waiting for
+    `card.bottom <= innerHeight` instead would be waiting for the assertion,
+    and would pass on a layout that never settled at all.
+    """
+    seen = None
+    stable = 0
+    for _ in range(tries):
+        now = page.evaluate(RAIL_BOX)
+        stable = stable + 1 if now is not None and now == seen else 0
+        seen = now
+        if stable >= 2:
+            return
+        page.wait_for_timeout(gap_ms)
+
+
 def boot(page, path: str) -> None:
     page.goto(f"{BASE}{path}", wait_until = "domcontentloaded")
     # Both cards are on a timer, the app one at 5s and llama.cpp at 1s, so wait
@@ -494,6 +604,7 @@ def boot(page, path: str) -> None:
             pass
     # The banners animate in, and a box measured mid-transition is not the box.
     page.wait_for_timeout(SETTLED_MS)
+    settle_stack(page)
     landed = page.evaluate("location.pathname")
     if landed.startswith(("/login", "/onboarding", "/change-password")):
         raise AssertionError(f"not authenticated: landed on {landed}")
@@ -612,6 +723,62 @@ def main() -> int:
             llama_payload[0] = LLAMA_STATUS
             context.close()
 
+        # The loaded models indicator, switched on. It is the last child of the
+        # rail, so it is the card that lands on the corner, and it is a
+        # persistent status card rather than a dismissible banner: over Send it
+        # is the bug the rail dodges the composer for in the first place. With
+        # it up the stack must go back to dodging, however tight the window.
+        # #8346 ships it off by default, so nothing above this point sees it.
+        for width, height in INDICATOR_VIEWPORTS:
+            context = browser.new_context(
+                viewport = {"width": width, "height": height},
+                reduced_motion = "reduce",
+            )
+            context.add_init_script(seed_js)
+            context.add_init_script(
+                "localStorage.setItem('unsloth_show_loaded_models_indicator', 'true');"
+            )
+            # The card only exists when something is loaded, so the preference
+            # alone would leave the rail exactly as it was and this whole pass
+            # would agree with itself about nothing.
+            for pattern, payload in (
+                ("**/api/studio/update-status*", UPDATE_STATUS),
+                ("**/api/studio/release-notes*", RELEASE_NOTES),
+                ("**/api/llama/update-status*", LLAMA_STATUS),
+                ("**/api/inference/status", CHAT_LOADED),
+                ("**/api/inference/images/status", NOTHING_DIFFUSION),
+                ("**/api/inference/video/status", NOTHING_VIDEO),
+                ("**/api/inference/audio/stt/status", NOTHING_STT),
+            ):
+                context.route(pattern, stub(payload))
+            page = context.new_page()
+            boot(page, "/")
+            page.wait_for_selector("text=Loaded models", timeout = 30_000)
+            # A third card in the stack re-measures the placement, and the rail
+            # moves on the frame after that.
+            settle_stack(page)
+            measure(page, f"{width}x{height} with the models indicator")
+            seen = page.evaluate(COMPOSER_CLEARANCE)
+            check(
+                f"{width}x{height}: the rail computes the cap it was given",
+                not seen["railStyle"]["maxHeight"]
+                or seen["railStyle"]["cappedTo"] == seen["railStyle"]["maxHeight"],
+                f"{seen['railStyle']}, so the cards are laid out below a box"
+                " that is not the size the placement asked for",
+            )
+            check(
+                f"{width}x{height}: the models indicator is actually up",
+                seen["indicator"],
+                f"{seen}, so the clearance check below proves nothing",
+            )
+            check(
+                f"{width}x{height}: a persistent card in the rail keeps off the composer",
+                seen["composer"] is None or seen["tailOverlap"] == 0,
+                f"{seen}, so the models indicator is sitting on Send",
+            )
+            page.screenshot(path = str(ART / f"{width}x{height}-indicator.png"))
+            context.close()
+
         if SPOT:
             info(f"{checks[0]} checks, {len(failures)} failed")
             for failure in failures:
@@ -642,6 +809,7 @@ def main() -> int:
             # Long enough for the ResizeObserver, the placement it feeds and the
             # reflow that follows. Short because nothing is being fetched.
             page.wait_for_timeout(RESIZE_SETTLE_MS)
+            settle_stack(page)
             measure(page, f"{width}x{height} resized")
         page.set_viewport_size({"width": 1280, "height": 830})
         page.wait_for_timeout(RESIZE_SETTLE_MS)

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -338,6 +338,12 @@ def api(
         return json.loads(response.read().decode())
 
 
+def read_ui_font_size(token: str) -> int | None:
+    """The Appearance type size this install is on before the suite touches it."""
+    current = api("/api/settings/personalization", token = token)
+    return current["appearance"]["customization"].get("uiFontSize")
+
+
 def set_ui_font_size(token: str, size: int | None) -> None:
     """Set, or clear, the Appearance type size on the SERVER.
 
@@ -875,6 +881,10 @@ def main() -> int:
         # Set on the server and put back in a finally, because the appearance
         # store syncs up: leaving it at 20px hands every later suite in this job
         # a Studio whose type is not the default, and they will not notice.
+        # Put BACK what was there, which is not always the default: run this
+        # against your own Studio and an unconditional reset would take your
+        # Appearance setting with it.
+        was = read_ui_font_size(session["access_token"])
         set_ui_font_size(session["access_token"], UI_FONT_SIZE_MAX)
         try:
             for width, height in FONT_SCALE_VIEWPORTS:
@@ -904,7 +914,7 @@ def main() -> int:
                 page.screenshot(path = str(ART / f"{width}x{height}-font{UI_FONT_SIZE_MAX}.png"))
                 context.close()
         finally:
-            set_ui_font_size(session["access_token"], None)
+            set_ui_font_size(session["access_token"], was)
         browser.close()
 
     info(f"{checks[0]} checks, {len(failures)} failed")

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -321,9 +321,7 @@ def boot(page, path: str) -> None:
     # job it shares has minutes, not tens of minutes, to spare.
     for testid in ("web-update-banner", "llama-update-banner"):
         try:
-            page.wait_for_selector(
-                f'[data-testid="{testid}"]', state = "attached", timeout = SETTLE_MS
-            )
+            page.wait_for_selector(f'[data-testid="{testid}"]', state = "attached", timeout = SETTLE_MS)
         except PlaywrightTimeoutError:
             # Let the caller's own checks report the missing card; a bare
             # timeout here would say nothing about which one or where.

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -157,11 +157,29 @@ ROUTES = [("new chat", "/"), ("train", "/train"), ("model hub", "/model-hub")]
 # Windows laptop; 900x600 is the desktop app's own minimum window; the rest are
 # ordinary small windows down to a phone in portrait.
 RESIZE_SWEEP = [
-    (3840, 2160), (2560, 1440), (1920, 1080), (1680, 1050), (1600, 900),
-    (1512, 982), (1440, 900), (1366, 768), (1280, 800), (1280, 720),
-    (1152, 720), (1024, 768), (1024, 600), (960, 640), (900, 600),
-    (800, 600), (768, 500), (720, 480), (640, 480), (430, 932),
-    (390, 844), (360, 640), (320, 568),
+    (3840, 2160),
+    (2560, 1440),
+    (1920, 1080),
+    (1680, 1050),
+    (1600, 900),
+    (1512, 982),
+    (1440, 900),
+    (1366, 768),
+    (1280, 800),
+    (1280, 720),
+    (1152, 720),
+    (1024, 768),
+    (1024, 600),
+    (960, 640),
+    (900, 600),
+    (800, 600),
+    (768, 500),
+    (720, 480),
+    (640, 480),
+    (430, 932),
+    (390, 844),
+    (360, 640),
+    (320, 568),
 ]
 
 # What a resize needs before it has settled: the ResizeObserver, the placement
@@ -532,7 +550,7 @@ def main() -> int:
         browser = getattr(p, PLAYWRIGHT_BROWSER).launch(**launch_kwargs)
 
         llama_payload = [LLAMA_STATUS]
-        for width, height in (VIEWPORTS[2:5] if SPOT else VIEWPORTS):
+        for width, height in VIEWPORTS[2:5] if SPOT else VIEWPORTS:
             context = browser.new_context(
                 viewport = {"width": width, "height": height},
                 reduced_motion = "reduce",
@@ -563,7 +581,7 @@ def main() -> int:
                 ),
             )
             page = context.new_page()
-            for name, path in (ROUTES[:1] if SPOT else ROUTES):
+            for name, path in ROUTES[:1] if SPOT else ROUTES:
                 size = f"{width}x{height}"
                 boot(page, path)
                 if path == "/":
@@ -657,7 +675,8 @@ def main() -> int:
                 a, b = restored[name], fresh[name]
                 check(
                     f"{back_w}x{back_h}: the {name} restores to where a fresh load puts it",
-                    a is not None and b is not None
+                    a is not None
+                    and b is not None
                     and abs(a["top"] - b["top"]) <= 1.0
                     and abs(a["height"] - b["height"]) <= 1.0,
                     f"restored={a} fresh={b}",
@@ -699,9 +718,7 @@ def main() -> int:
                     f"--ui-font-scale={scale!r}, so the rest of this pass proves nothing",
                 )
                 measure(page, f"{width}x{height} at {UI_FONT_SIZE_MAX}px")
-                page.screenshot(
-                    path = str(ART / f"{width}x{height}-font{UI_FONT_SIZE_MAX}.png")
-                )
+                page.screenshot(path = str(ART / f"{width}x{height}-font{UI_FONT_SIZE_MAX}.png"))
                 context.close()
         finally:
             set_ui_font_size(session["access_token"], None)

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -523,8 +523,7 @@ def measure(page, label: str) -> dict:
     for name in ("card", "llama", "footer", "toggle"):
         # As shown, where the rail can hide it; as measured otherwise. A card
         # entirely under the fold is None here and is the reach check's to make.
-        shown = facts.get(f"{name}Shown", facts[name]) if name in ("card", "llama") \
-            else facts[name]
+        shown = facts.get(f"{name}Shown", facts[name]) if name in ("card", "llama") else facts[name]
         if name in ("card", "llama") and shown is None:
             continue
         check(

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -145,6 +145,43 @@ VIEWPORTS = [
 ]
 ROUTES = [("new chat", "/"), ("train", "/train"), ("model hub", "/model-hub")]
 
+# Real display and window sizes, walked by RESIZING one already-loaded page
+# rather than booting one each: a resize is what a maximise, an unmaximise, a
+# restore from the dock and a drag of the window edge all are, so this is the
+# cheap sweep and the realistic one at the same time. Ordered largest first so
+# the run starts from the roomiest layout and squeezes.
+#
+# 3840x2160 and 2560x1440 are maximised on a 4K and a QHD display; 1920x1080 is
+# the commonest desktop there is; 1512x982 and 1440x900 are the default scaled
+# resolutions of a 14in MacBook Pro and a MacBook Air; 1366x768 is the commonest
+# Windows laptop; 900x600 is the desktop app's own minimum window; the rest are
+# ordinary small windows down to a phone in portrait.
+RESIZE_SWEEP = [
+    (3840, 2160), (2560, 1440), (1920, 1080), (1680, 1050), (1600, 900),
+    (1512, 982), (1440, 900), (1366, 768), (1280, 800), (1280, 720),
+    (1152, 720), (1024, 768), (1024, 600), (960, 640), (900, 600),
+    (800, 600), (768, 500), (720, 480), (640, 480), (430, 932),
+    (390, 844), (360, 640), (320, 568),
+]
+
+# What a resize needs before it has settled: the ResizeObserver, the placement
+# it feeds, and the reflow after that. Nothing is fetched, so this is short.
+RESIZE_SETTLE_MS = int(os.environ.get("STUDIO_UI_BANNER_RESIZE_MS", "700"))
+
+# A minimised window has no layout to photograph, so what is actually testable
+# is the RESTORE: the geometry is measured by a ResizeObserver and cached in
+# React state, and a window that goes away and comes back is exactly how a stale
+# measurement would survive. Each pair is (parked, restored).
+RESTORE_CYCLES = [((320, 400), (1920, 1080)), ((320, 400), (900, 600))]
+
+# `spot` is the same suite cut down to what a SECOND browser engine is worth
+# running: the viewports that reproduce, one route, no resize sweep and no type
+# pass. Chromium runs `full`; Firefox and WebKit run this, because the job they
+# share has minutes rather than tens of minutes to spare and a third full pass
+# would mostly re-answer questions the first one already answered.
+SCOPE = os.environ.get("STUDIO_UI_BANNER_SCOPE", "full").lower()
+SPOT = SCOPE == "spot"
+
 # The two that squeeze the rail hardest, re-run at the largest UI font size.
 # The whole matrix again would not fit the job's budget and would say the same
 # thing three times over.
@@ -181,17 +218,33 @@ def api(
     path: str,
     payload: dict | None = None,
     token: str | None = None,
+    method: str | None = None,
 ) -> dict:
     data = None if payload is None else json.dumps(payload).encode()
     request = urllib.request.Request(
         f"{BASE}{path}",
         data = data,
-        method = "POST" if data else "GET",
+        method = method or ("POST" if data else "GET"),
         headers = {"Content-Type": "application/json"}
         | ({"Authorization": f"Bearer {token}"} if token else {}),
     )
     with urllib.request.urlopen(request, timeout = 30) as response:
         return json.loads(response.read().decode())
+
+
+def set_ui_font_size(token: str, size: int | None) -> None:
+    """Set, or clear, the Appearance type size on the SERVER.
+
+    Seeding it into localStorage is not enough and is actively harmful: the
+    appearance store syncs up to `/api/settings/personalization`, so a browser
+    that starts at 20px leaves the install at 20px for everything that runs
+    after it. That is not hypothetical, it is how a whole afternoon of local
+    runs came to be measured at 20px while reporting themselves as default,
+    and how a later suite in the same CI job would inherit it.
+    """
+    current = api("/api/settings/personalization", token = token)
+    current["appearance"]["customization"]["uiFontSize"] = size
+    api("/api/settings/personalization", current, token = token, method = "PUT")
 
 
 # Every box the fix is about, already intersected with whatever clips it.
@@ -245,6 +298,12 @@ MEASURE = """
     // pointer-events-none costs the rail its scrollbar, so it may only be
     // click-through while there is nothing under the fold to scroll to.
     railScrolls: rail ? rail.scrollHeight > rail.clientHeight : null,
+    // A classic scrollbar (Windows, Linux) takes width out of the box it is
+    // on; an overlay one (macOS, and WebKit generally) does not. The rail
+    // reserves a gutter for exactly this, so the card's width must not depend
+    // on which platform it is or on whether the rail happens to be scrolling.
+    railGutterPx: rail ? Math.round(rail.offsetWidth - rail.clientWidth) : null,
+    cardWidth: card ? Math.round(card.getBoundingClientRect().width) : null,
     railPointerEvents: rail ? getComputedStyle(rail).pointerEvents : null,
     // What a click on the rail's own gutter lands on when it is click-through.
     gutterIsRail: rail ? (() => {
@@ -355,6 +414,15 @@ def measure(page, label: str) -> dict:
             reached and not seen["offscreen"],
             f"{name}={seen}",
         )
+    if facts["cardWidth"] is not None:
+        # 448px is the card's max width and 2rem the viewport inset it keeps.
+        want = min(448, view["width"] - 32)
+        check(
+            f"{label}: the card keeps its full width whatever the scrollbar does",
+            abs(facts["cardWidth"] - want) <= 1,
+            f"cardWidth={facts['cardWidth']} want={want} "
+            f"railGutter={facts['railGutterPx']} scrolls={facts['railScrolls']}",
+        )
     if facts["railScrolls"] is not None:
         scrolls = facts["railScrolls"]
         check(
@@ -464,7 +532,7 @@ def main() -> int:
         browser = getattr(p, PLAYWRIGHT_BROWSER).launch(**launch_kwargs)
 
         llama_payload = [LLAMA_STATUS]
-        for width, height in VIEWPORTS:
+        for width, height in (VIEWPORTS[2:5] if SPOT else VIEWPORTS):
             context = browser.new_context(
                 viewport = {"width": width, "height": height},
                 reduced_motion = "reduce",
@@ -495,7 +563,7 @@ def main() -> int:
                 ),
             )
             page = context.new_page()
-            for name, path in ROUTES:
+            for name, path in (ROUTES[:1] if SPOT else ROUTES):
                 size = f"{width}x{height}"
                 boot(page, path)
                 if path == "/":
@@ -526,50 +594,117 @@ def main() -> int:
             llama_payload[0] = LLAMA_STATUS
             context.close()
 
-        # Settings > Appearance scales the type, and the card's floor is
-        # written against that scale rather than measured once at the default.
-        # At the 20px maximum the action row wraps at every card width, so a
-        # default-font floor left the buttons clipped inside the card.
-        for width, height in FONT_SCALE_VIEWPORTS:
-            context = browser.new_context(
-                viewport = {"width": width, "height": height},
+        if SPOT:
+            info(f"{checks[0]} checks, {len(failures)} failed")
+            for failure in failures:
+                info(f"  {failure}")
+            browser.close()
+            return 1 if failures else 0
+
+        # One page, many window sizes. Every check the core matrix runs, at
+        # every resolution in RESIZE_SWEEP, for the price of one boot: the
+        # cards are already mounted and a resize is all a maximise or a restore
+        # ever is. It also exercises the path a fresh load never does, where
+        # the placement has to re-measure rather than measure once.
+        context = browser.new_context(
+            viewport = {"width": RESIZE_SWEEP[0][0], "height": RESIZE_SWEEP[0][1]},
+            reduced_motion = "reduce",
+        )
+        context.add_init_script(seed_js)
+        for pattern, payload in (
+            ("**/api/studio/update-status*", UPDATE_STATUS),
+            ("**/api/studio/release-notes*", RELEASE_NOTES),
+            ("**/api/llama/update-status*", LLAMA_STATUS),
+        ):
+            context.route(pattern, stub(payload))
+        page = context.new_page()
+        boot(page, "/")
+        for width, height in RESIZE_SWEEP:
+            page.set_viewport_size({"width": width, "height": height})
+            # Long enough for the ResizeObserver, the placement it feeds and the
+            # reflow that follows. Short because nothing is being fetched.
+            page.wait_for_timeout(RESIZE_SETTLE_MS)
+            measure(page, f"{width}x{height} resized")
+        page.set_viewport_size({"width": 1280, "height": 830})
+        page.wait_for_timeout(RESIZE_SETTLE_MS)
+        page.screenshot(path = str(ART / "resize-sweep-end.png"))
+
+        # Parked small and brought back. A minimised window cannot be
+        # photographed, but the restore is where a cached measurement would
+        # show, and the claim is that it lands where a fresh load of the same
+        # size does rather than merely looking tidy.
+        for (small_w, small_h), (back_w, back_h) in RESTORE_CYCLES:
+            page.set_viewport_size({"width": small_w, "height": small_h})
+            page.wait_for_timeout(RESIZE_SETTLE_MS)
+            page.set_viewport_size({"width": back_w, "height": back_h})
+            page.wait_for_timeout(RESIZE_SETTLE_MS)
+            restored = measure(page, f"{back_w}x{back_h} restored from {small_w}x{small_h}")
+            fresh_context = browser.new_context(
+                viewport = {"width": back_w, "height": back_h},
                 reduced_motion = "reduce",
             )
-            context.add_init_script(seed_js)
-            context.add_init_script(
-                "localStorage.setItem('unsloth_appearance_customization', "
-                + json.dumps(
-                    json.dumps(
-                        {
-                            "state": {"customization": {"uiFontSize": UI_FONT_SIZE_MAX}},
-                            "version": APPEARANCE_STORE_VERSION,
-                        }
-                    )
-                )
-                + ");"
-            )
+            fresh_context.add_init_script(seed_js)
             for pattern, payload in (
                 ("**/api/studio/update-status*", UPDATE_STATUS),
                 ("**/api/studio/release-notes*", RELEASE_NOTES),
                 ("**/api/llama/update-status*", LLAMA_STATUS),
             ):
-                # A two-argument handler is called with (route, request), so the
-                # payload has to be closed over rather than defaulted in.
-                context.route(pattern, stub(payload))
-            page = context.new_page()
-            boot(page, "/")
-            scale = page.evaluate(
-                "() => getComputedStyle(document.documentElement)"
-                ".getPropertyValue('--ui-font-scale').trim()"
-            )
-            check(
-                f"{width}x{height} at {UI_FONT_SIZE_MAX}px: the type is actually scaled",
-                scale not in ("", str(UI_FONT_SIZE_DEFAULT / UI_FONT_SIZE_CSS_BASE)),
-                f"--ui-font-scale={scale!r}, so the rest of this pass proves nothing",
-            )
-            measure(page, f"{width}x{height} at {UI_FONT_SIZE_MAX}px")
-            page.screenshot(path = str(ART / f"{width}x{height}-font{UI_FONT_SIZE_MAX}.png"))
-            context.close()
+                fresh_context.route(pattern, stub(payload))
+            fresh_page = fresh_context.new_page()
+            boot(fresh_page, "/")
+            fresh = measure(fresh_page, f"{back_w}x{back_h} fresh")
+            for name in ("card", "llama", "footer"):
+                a, b = restored[name], fresh[name]
+                check(
+                    f"{back_w}x{back_h}: the {name} restores to where a fresh load puts it",
+                    a is not None and b is not None
+                    and abs(a["top"] - b["top"]) <= 1.0
+                    and abs(a["height"] - b["height"]) <= 1.0,
+                    f"restored={a} fresh={b}",
+                )
+            fresh_context.close()
+        context.close()
+
+        # Settings > Appearance scales the type, and the card's floor is
+        # written against that scale rather than measured once at the default.
+        # At the 20px maximum the action row wraps at every card width, so a
+        # default-font floor left the buttons clipped inside the card.
+        #
+        # Set on the server and put back in a finally, because the appearance
+        # store syncs up: leaving it at 20px hands every later suite in this job
+        # a Studio whose type is not the default, and they will not notice.
+        set_ui_font_size(session["access_token"], UI_FONT_SIZE_MAX)
+        try:
+            for width, height in FONT_SCALE_VIEWPORTS:
+                context = browser.new_context(
+                    viewport = {"width": width, "height": height},
+                    reduced_motion = "reduce",
+                )
+                context.add_init_script(seed_js)
+                for pattern, payload in (
+                    ("**/api/studio/update-status*", UPDATE_STATUS),
+                    ("**/api/studio/release-notes*", RELEASE_NOTES),
+                    ("**/api/llama/update-status*", LLAMA_STATUS),
+                ):
+                    context.route(pattern, stub(payload))
+                page = context.new_page()
+                boot(page, "/")
+                scale = page.evaluate(
+                    "() => getComputedStyle(document.documentElement)"
+                    ".getPropertyValue('--ui-font-scale').trim()"
+                )
+                check(
+                    f"{width}x{height} at {UI_FONT_SIZE_MAX}px: the type is actually scaled",
+                    scale not in ("", str(UI_FONT_SIZE_DEFAULT / UI_FONT_SIZE_CSS_BASE)),
+                    f"--ui-font-scale={scale!r}, so the rest of this pass proves nothing",
+                )
+                measure(page, f"{width}x{height} at {UI_FONT_SIZE_MAX}px")
+                page.screenshot(
+                    path = str(ART / f"{width}x{height}-font{UI_FONT_SIZE_MAX}.png")
+                )
+                context.close()
+        finally:
+            set_ui_font_size(session["access_token"], None)
         browser.close()
 
     info(f"{checks[0]} checks, {len(failures)} failed")

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -349,9 +349,7 @@ def measure(page, label: str) -> dict:
     for name, seen in (reach or {}).items():
         if seen is None:
             continue
-        reached = (
-            seen["scrollable"] if seen["taller"] else seen["hidden"] <= 1.0
-        )
+        reached = seen["scrollable"] if seen["taller"] else seen["hidden"] <= 1.0
         check(
             f"{label}: the {name} can be scrolled into the rail's view",
             reached and not seen["offscreen"],

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -130,7 +130,15 @@ WHISPER_STATUS = dict(
 
 # 921x534 and 768x500 are where the report reproduces; the taller ones prove the
 # fix costs nothing when there is room.
-VIEWPORTS = [(1440, 900), (1280, 830), (921, 534), (768, 500), (390, 844)]
+VIEWPORTS = [
+    (1440, 900),
+    (1280, 830),
+    (921, 534),
+    (768, 500),
+    (390, 844),
+    # Narrow enough to wrap the action row, short enough to hit the card's floor.
+    (390, 500),
+]
 ROUTES = [("new chat", "/"), ("train", "/train"), ("model hub", "/model-hub")]
 
 failures: list[str] = []
@@ -180,8 +188,11 @@ MEASURE = """
     return {top: r.top, bottom: r.bottom, left: r.left, right: r.right,
             width: r.width, height: r.height};
   };
+  // Takes an element or an already-clipped box, so clips can be chained.
   const clip = (el, clipper) => {
-    const a = rect(el), b = rect(clipper);
+    if (el === null) return null;
+    const a = el.top !== undefined ? el : rect(el);
+    const b = rect(clipper);
     if (!a || !b) return a;
     // Only a scroll or hidden ancestor hides anything; clipping to a visible
     // one would erase the very overflow this is looking for.
@@ -202,11 +213,16 @@ MEASURE = """
   const copy = q('[data-testid="web-update-copy-button"]');
   const footer = snooze ? snooze.closest('div').parentElement : null;
   const rail = card ? card.parentElement : (llama ? llama.parentElement : null);
+  // The clipper is the card's inner surface, the one with overflow-hidden; the
+  // rail-facing root above it is overflow-visible and clips nothing.
+  const surface = card ? card.firstElementChild : null;
   return {
     viewport: {width: innerWidth, height: innerHeight},
     card: clip(card, rail), llama: clip(llama, rail),
     notesBody: clip(body, notes),
-    toggle: rect(toggle), snooze: rect(snooze), copy: rect(copy),
+    toggle: clip(clip(toggle, surface), rail),
+    snooze: clip(clip(snooze, surface), rail),
+    copy: clip(clip(copy, surface), rail),
     footer: rect(footer),
     llamaText: llama ? (llama.innerText || '') : '',
   };
@@ -225,8 +241,11 @@ def overlap(a: dict | None, b: dict | None) -> float:
 
 
 def inside(box: dict | None, viewport: dict) -> bool:
+    # A missing box is not "inside": clip() returns None for an element that is
+    # entirely hidden, and reading that as a pass would make this whole suite
+    # green on the one failure it exists to catch.
     if not box:
-        return True
+        return False
     return (
         box["top"] >= -0.5
         and box["left"] >= -0.5
@@ -254,6 +273,15 @@ def measure(page, label: str) -> dict:
             f"{label}: the {name} stays inside the viewport",
             inside(facts[name], view),
             f"{name}={facts[name]} viewport={view}",
+        )
+    # The notes are allowed to yield all of their height, and do; the controls
+    # are not, and a card clipped to nothing is the failure being tested for.
+    for name in ("card", "llama", "toggle", "snooze", "copy"):
+        box = facts[name]
+        check(
+            f"{label}: the {name} is not clipped away",
+            box is not None and box["height"] > 1.0 and box["width"] > 1.0,
+            f"{name}={box}",
         )
     return facts
 

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -271,9 +271,7 @@ def main() -> int:
     # OLD is already NEW on a rerun, or when an earlier suite in the same job
     # rotated it, and that login fails before the rotation below can be skipped.
     try:
-        token = api("/api/auth/login", {"username": "unsloth", "password": OLD})[
-            "access_token"
-        ]
+        token = api("/api/auth/login", {"username": "unsloth", "password": OLD})["access_token"]
     except urllib.error.HTTPError as exc:
         if exc.code not in (400, 401, 403):
             raise

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -190,17 +190,28 @@ RESIZE_SETTLE_MS = int(os.environ.get("STUDIO_UI_BANNER_RESIZE_MS", "700"))
 # tests/studio/playwright_loaded_models_indicator.py has them. Only chat holds
 # anything: one loaded model is all it takes to put the card in the rail.
 CHAT_LOADED = {
-    "active_model": "unsloth/Qwen3-4B", "loaded": ["unsloth/Qwen3-4B"],
-    "is_gguf": False, "is_mlx": False, "is_vision": False, "is_audio": False,
-    "audio_type": None, "gguf_variant": None,
+    "active_model": "unsloth/Qwen3-4B",
+    "loaded": ["unsloth/Qwen3-4B"],
+    "is_gguf": False,
+    "is_mlx": False,
+    "is_vision": False,
+    "is_audio": False,
+    "audio_type": None,
+    "gguf_variant": None,
 }
 NOTHING_DIFFUSION = {
-    "loaded": False, "repo_id": None, "family": None, "device": None,
-    "dtype": None, "model_kind": None,
+    "loaded": False,
+    "repo_id": None,
+    "family": None,
+    "device": None,
+    "dtype": None,
+    "model_kind": None,
 }
 NOTHING_VIDEO = dict(NOTHING_DIFFUSION, transformer_quant = None)
 NOTHING_STT = {
-    "available": True, "loaded_model": None, "device": None,
+    "available": True,
+    "loaded_model": None,
+    "device": None,
     "transformers": {"loaded_model": None, "device": None},
     "mtmd": {"loaded_model": None, "device": None},
     "gguf": {"loaded_model": None, "device": None},
@@ -568,7 +579,11 @@ RAIL_BOX = """
 """
 
 
-def settle_stack(page, tries: int = 24, gap_ms: int = 250) -> None:
+def settle_stack(
+    page,
+    tries: int = 24,
+    gap_ms: int = 250,
+) -> None:
     """Wait until the rail's box stops moving.
 
     Waits for STABILITY, not for the answer the checks want: a card mounting

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -5,15 +5,13 @@
 
 The reported failure: on New chat, in a window short enough that the composer
 crowds the rail, the app-update card's release notes were painted over its own
-"Show release notes / Remind me later / Update" row. Train and Model hub were
-fine, because only the chat routes publish a composer box into the frame store
-and only that box caps the rail.
+row of buttons. Train and Model hub were fine, because only the chat routes
+publish a composer box into the frame store and only that box caps the rail.
 
-Nothing in the node suite can catch this. It is a flex shrink distributed across
-a capped column, so it needs a real layout, a real ResizeObserver and the real
-route, and it only appears at particular viewport heights. The boxes are read
-back from getBoundingClientRect and intersected with whatever clips them, so a
-rect hidden by an overflow-hidden ancestor is not counted as visible.
+The node suite cannot catch this: it is a flex shrink across a capped column, so
+it needs a real layout, a real ResizeObserver and the real route, and it shows
+only at some viewport heights. Rects are intersected with whatever clips them,
+so anything an overflow-hidden ancestor hides does not count as visible.
 
 Both update endpoints are stubbed with page.route, so this runs on any host: no
 GPU, no pypi release, no llama.cpp build.

--- a/tests/studio/test_overlay_layering.py
+++ b/tests/studio/test_overlay_layering.py
@@ -49,7 +49,9 @@ def _monitor_root_z() -> int:
 def _stack_z() -> int:
     """The bottom-right overlay stack. Both copies, browser and desktop."""
     src = PROVIDER.read_text(encoding = "utf-8")
-    stacks = re.findall(r'className="pointer-events-none fixed right-4 z-\[(\d+)\]', src)
+    # The click-through class is applied conditionally, so it is not part of
+    # the literal the stack's own classes are authored in.
+    stacks = re.findall(r'"fixed right-4 z-\[(\d+)\]', src)
     assert stacks, "the bottom-right overlay stack was not found"
     assert len(set(stacks)) == 1, f"the two stacks disagree on z-index: {stacks}"
     return int(stacks[0])

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -1115,6 +1115,12 @@ def test_code_span_closers_ignore_backslashes():
     assert body.count("escaped(text") == 1, "only an opener can be escaped"
 
 
+# The card's notes-closed height, written against Settings > Appearance rather
+# than measured once at the default 15px: at the 20px maximum the action row
+# wraps at every card width and a fixed 128px floor cuts the buttons in half.
+_SCALED_FLOOR = "min-h-[calc(12rem*var(--ui-font-scale,1)/0.9375)]"
+
+
 def _overlay_stacks(provider: str) -> int:
     """How many bottom-right overlay stacks the provider renders."""
     return len(re.findall(r"z-\[9998\][^\"]*flex flex-col items-end gap-2", provider))
@@ -1139,7 +1145,7 @@ def test_the_overlay_stack_fits_the_viewport():
     # The update card cannot: its header and buttons are fixed and only its
     # notes yield, so it floors instead and the stack scrolls past it.
     web = WEB_BANNER.read_text(encoding = "utf-8")
-    assert "min-h-48" in web and "min-[480px]:min-h-32" in web
+    assert _SCALED_FLOOR in web, "the floor is fixed, so it is wrong at other type sizes"
     assert provider.count("overflow-y-auto") >= stacks, "a capped stack clips its cards"
 
 
@@ -1150,7 +1156,7 @@ def test_the_desktop_stack_is_capped_like_the_browser_one():
     assert provider.count("useStackGeometry()") == 2, "both stacks measure themselves"
     assert provider.count("maxHeight: stack.maxHeight") == 2, "both stacks are capped"
     tauri = TAURI_BANNER.read_text(encoding = "utf-8")
-    assert "min-h-48" in tauri and "min-[480px]:min-h-32" in tauri
+    assert _SCALED_FLOOR in tauri, "the floor is fixed, so it is wrong at other type sizes"
 
 
 def test_the_stack_geometry_is_checked_numerically():

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -1122,7 +1122,11 @@ def test_code_span_closers_ignore_backslashes():
 # scaling one whole box for both asked 256px where 209 was needed, and a floor
 # nothing can meet makes the stack cover the composer for no gain.
 _SCALED_FLOOR_WEB = "min-h-[calc(109px+80px*var(--ui-font-scale,1))]"
-_SCALED_FLOOR_TAURI = "min-h-[calc(113px+96px*var(--ui-font-scale,1))]"
+# Below 384px the action pair wraps onto its own row and the card needs a
+# whole extra one: 259px at the 20px setting where the wide card needs 209.
+_NARROW_FLOOR_WEB = "max-[383px]:min-h-[calc(139px+96px*var(--ui-font-scale,1))]"
+_SCALED_FLOOR_TAURI = "min-h-[calc(117px+93px*var(--ui-font-scale,1))]"
+_NARROW_FLOOR_TAURI = "max-[383px]:min-h-[calc(24px+224px*var(--ui-font-scale,1))]"
 
 
 def _overlay_stacks(provider: str) -> int:
@@ -1150,6 +1154,7 @@ def test_the_overlay_stack_fits_the_viewport():
     # notes yield, so it floors instead and the stack scrolls past it.
     web = WEB_BANNER.read_text(encoding = "utf-8")
     assert _SCALED_FLOOR_WEB in web, "the floor is fixed, so it is wrong at other type sizes"
+    assert _NARROW_FLOOR_WEB in web, "the floor misses the narrow card's extra button row"
     assert provider.count("overflow-y-auto") >= stacks, "a capped stack clips its cards"
 
 
@@ -1161,6 +1166,7 @@ def test_the_desktop_stack_is_capped_like_the_browser_one():
     assert provider.count("maxHeight: stack.maxHeight") == 2, "both stacks are capped"
     tauri = TAURI_BANNER.read_text(encoding = "utf-8")
     assert _SCALED_FLOOR_TAURI in tauri, "the floor is fixed, so it is wrong at other type sizes"
+    assert _NARROW_FLOOR_TAURI in tauri, "the floor misses the narrow card's extra button row"
 
 
 def test_the_stack_geometry_is_checked_numerically():

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -915,10 +915,13 @@ def test_only_the_notes_region_scrolls(banner):
     """The dismiss control sits inside the card, so scrolling the card itself
     carried it off screen on a short viewport."""
     src = banner.read_text(encoding = "utf-8")
-    assert "flex max-h-[calc(100dvh_-_2rem)] flex-col overflow-hidden" in src
+    assert "flex max-h-[calc(100dvh_-_2rem)] min-h-0 flex-col overflow-hidden" in src
     assert 'className="min-h-0 flex-1"' in src
     panel = PANEL.read_text(encoding = "utf-8")
     assert "max-h-64 min-h-0 flex-1 overflow-y-auto" in panel
+    # The collapsed summary scrolls too: without it the bullets were painted
+    # over the row of buttons once the card's slot for them got small.
+    assert "min-h-0 flex-1 space-y-1 overflow-y-auto" in panel
 
 
 def test_a_comment_marker_in_prose_cannot_swallow_later_releases(changelog_module):
@@ -1112,6 +1115,11 @@ def test_code_span_closers_ignore_backslashes():
     assert body.count("escaped(text") == 1, "only an opener can be escaped"
 
 
+def _overlay_stacks(provider: str) -> int:
+    """How many bottom-right overlay stacks the provider renders."""
+    return len(re.findall(r"z-\[9998\][^\"]*flex flex-col items-end gap-2", provider))
+
+
 def test_the_overlay_stack_fits_the_viewport():
     """The update card's own cap does not account for a long download list stacked
     beneath it. The cap is no longer the literal class `max-h-[calc(100dvh_-_2rem)]`
@@ -1119,16 +1127,20 @@ def test_the_overlay_stack_fits_the_viewport():
     studio/frontend/tests/monitor-stack-inset.test.ts; what has to hold here is that
     the stack reads it rather than growing unbounded."""
     provider = (FRONTEND / "app/provider.tsx").read_text(encoding = "utf-8")
-    stacks = provider.count("z-[9998] flex flex-col items-end gap-2")
+    stacks = _overlay_stacks(provider)
     assert stacks, "the bottom-right overlay stack is gone"
     # Counted, not merely present: capping only one of the stacks is the bug here.
     assert provider.count("maxHeight: stack.maxHeight") == stacks, "every stack is capped"
     panel = (FRONTEND / "features/hub/download-manager/download-manager-panel.tsx").read_text(
         encoding = "utf-8"
     )
-    # Both overlays scroll internally, so they can give up height.
+    # The download list scrolls internally, so it can give up height.
     assert "flex min-h-0" in panel
-    assert "flex min-h-0" in WEB_BANNER.read_text(encoding = "utf-8")
+    # The update card cannot: its header and buttons are fixed and only its
+    # notes yield, so it floors instead and the stack scrolls past it.
+    web = WEB_BANNER.read_text(encoding = "utf-8")
+    assert "min-h-48" in web and "sm:min-h-32" in web
+    assert provider.count("overflow-y-auto") >= stacks, "a capped stack clips its cards"
 
 
 def test_the_desktop_stack_is_capped_like_the_browser_one():
@@ -1137,7 +1149,8 @@ def test_the_desktop_stack_is_capped_like_the_browser_one():
     provider = (FRONTEND / "app/provider.tsx").read_text(encoding = "utf-8")
     assert provider.count("useStackGeometry()") == 2, "both stacks measure themselves"
     assert provider.count("maxHeight: stack.maxHeight") == 2, "both stacks are capped"
-    assert "flex min-h-0" in TAURI_BANNER.read_text(encoding = "utf-8")
+    tauri = TAURI_BANNER.read_text(encoding = "utf-8")
+    assert "min-h-48" in tauri and "sm:min-h-32" in tauri
 
 
 def test_the_stack_geometry_is_checked_numerically():
@@ -1377,7 +1390,7 @@ def test_the_download_panel_can_shrink_inside_the_capped_stack():
     )
     assert 'positioned ? "fixed bottom-4 right-4 z-50" : "flex min-h-0 justify-end"' in panel
     provider = (FRONTEND / "app/provider.tsx").read_text(encoding="utf-8")
-    stacks = provider.count("z-[9998] flex flex-col items-end gap-2")
+    stacks = _overlay_stacks(provider)
     assert provider.count("maxHeight: stack.maxHeight") == stacks, "the cap this has to absorb"
 
 

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -1139,7 +1139,7 @@ def test_the_overlay_stack_fits_the_viewport():
     # The update card cannot: its header and buttons are fixed and only its
     # notes yield, so it floors instead and the stack scrolls past it.
     web = WEB_BANNER.read_text(encoding = "utf-8")
-    assert "min-h-48" in web and "sm:min-h-32" in web
+    assert "min-h-48" in web and "min-[480px]:min-h-32" in web
     assert provider.count("overflow-y-auto") >= stacks, "a capped stack clips its cards"
 
 
@@ -1150,7 +1150,7 @@ def test_the_desktop_stack_is_capped_like_the_browser_one():
     assert provider.count("useStackGeometry()") == 2, "both stacks measure themselves"
     assert provider.count("maxHeight: stack.maxHeight") == 2, "both stacks are capped"
     tauri = TAURI_BANNER.read_text(encoding = "utf-8")
-    assert "min-h-48" in tauri and "sm:min-h-32" in tauri
+    assert "min-h-48" in tauri and "min-[480px]:min-h-32" in tauri
 
 
 def test_the_stack_geometry_is_checked_numerically():

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -1160,9 +1160,7 @@ def test_the_desktop_stack_is_capped_like_the_browser_one():
     assert provider.count("useStackGeometry()") == 2, "both stacks measure themselves"
     assert provider.count("maxHeight: stack.maxHeight") == 2, "both stacks are capped"
     tauri = TAURI_BANNER.read_text(encoding = "utf-8")
-    assert _SCALED_FLOOR_TAURI in tauri, (
-        "the floor is fixed, so it is wrong at other type sizes"
-    )
+    assert _SCALED_FLOOR_TAURI in tauri, "the floor is fixed, so it is wrong at other type sizes"
 
 
 def test_the_stack_geometry_is_checked_numerically():

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -1115,10 +1115,14 @@ def test_code_span_closers_ignore_backslashes():
     assert body.count("escaped(text") == 1, "only an opener can be escaped"
 
 
-# The card's notes-closed height, written against Settings > Appearance rather
-# than measured once at the default 15px: at the 20px maximum the action row
-# wraps at every card width and a fixed 128px floor cuts the buttons in half.
-_SCALED_FLOOR = "min-h-[calc(12rem*var(--ui-font-scale,1)/0.9375)]"
+# The card's incompressible height, a fixed part plus a part that follows
+# Settings > Appearance rather than one number measured at the default 15px: at
+# the 20px maximum the action row wraps at every card width. The two cards have
+# their own constants because the desktop one carries an extra status line;
+# scaling one whole box for both asked 256px where 209 was needed, and a floor
+# nothing can meet makes the stack cover the composer for no gain.
+_SCALED_FLOOR_WEB = "min-h-[calc(109px+80px*var(--ui-font-scale,1))]"
+_SCALED_FLOOR_TAURI = "min-h-[calc(113px+96px*var(--ui-font-scale,1))]"
 
 
 def _overlay_stacks(provider: str) -> int:
@@ -1145,7 +1149,7 @@ def test_the_overlay_stack_fits_the_viewport():
     # The update card cannot: its header and buttons are fixed and only its
     # notes yield, so it floors instead and the stack scrolls past it.
     web = WEB_BANNER.read_text(encoding = "utf-8")
-    assert _SCALED_FLOOR in web, "the floor is fixed, so it is wrong at other type sizes"
+    assert _SCALED_FLOOR_WEB in web, "the floor is fixed, so it is wrong at other type sizes"
     assert provider.count("overflow-y-auto") >= stacks, "a capped stack clips its cards"
 
 
@@ -1156,7 +1160,9 @@ def test_the_desktop_stack_is_capped_like_the_browser_one():
     assert provider.count("useStackGeometry()") == 2, "both stacks measure themselves"
     assert provider.count("maxHeight: stack.maxHeight") == 2, "both stacks are capped"
     tauri = TAURI_BANNER.read_text(encoding = "utf-8")
-    assert _SCALED_FLOOR in tauri, "the floor is fixed, so it is wrong at other type sizes"
+    assert _SCALED_FLOOR_TAURI in tauri, (
+        "the floor is fixed, so it is wrong at other type sizes"
+    )
 
 
 def test_the_stack_geometry_is_checked_numerically():


### PR DESCRIPTION
Reported with a screenshot of the v0.1.60-beta to v0.1.61-beta offer: on New chat the "New Unsloth version" card had its release notes printed straight over its own "Show release notes / Remind me later / Update" row, and the card was clipped mid-sentence. The same card on Train and on Model hub was fine, and smaller windows were worse.

## Why one route and not the others

The chat composer publishes its box to the monitor frame store (`usePublishedFrame` in `thread.tsx`), so `stackGeometry` caps the bottom-right overlay rail. Train and Model hub publish nothing, so the rail gets the whole viewport and never has to take height from anyone.

Under that cap the rail's flex children shrink, and nothing in the rail was `shrink-0`. The app-update card's rail-facing root was `flex min-h-0 ... flex-col` and its card `overflow-hidden`, so it had no floor at all, and neither its header nor its action row said they could not be compressed. `ReleaseNotesPanel` had a scroller in the expanded state only. The collapsed bullet summary was a plain `ul` with no overflow containment, so once its box was squeezed the bullets painted through everything under them. That is the screenshot.

So this is a constrained-height flex failure inside one shared stack, not a z-index one. The banners were already stacked correctly.

## The rule now

Inside a card: the notes are the only part allowed to give up height, and they clip or scroll while doing it. Header and action row are `shrink-0`.

Between cards: the app-update card floors at `min-h-32`, which is that same card measured in a browser with its notes closed, so a tight rail takes the height out of the notes and stops at the row of buttons. `min-height: auto` would have been the whole card including the notes, so the card would give up nothing and the banner underneath would be the one clipped instead.

If even that does not fit, the rail scrolls rather than spilling cards over the composer. The padding there is for the card shadows, which a scroller would otherwise clip at its own edge, and the negative margin cancels it so nothing moves.

`monitor-frame-store.ts` is untouched. Putting a `MIN_STACK_ROOM` floor on the branch that caps the rail would park it back over the composer, which is what #8210 and #8301 fixed.

## Measured, in a browser

Two Studios from the same backend, one built from this branch's merge base and one from its head, the app update forced with `UNSLOTH_STUDIO_FAKE_UPDATE` and the llama.cpp banner stubbed, driven with Playwright. The number is the visible overlap in pixels between the release notes and the action row, after intersecting every rect with whatever actually clips it, so a rect hidden behind an `overflow-hidden` ancestor does not count.

| viewport | route | before | after |
| --- | --- | --- | --- |
| 1440x900 | new chat | 0 | 0 |
| 1280x830 | new chat | 9.3 | 0 |
| 921x534 | new chat | 36.3 | 0 |
| 900x600 | new chat | 36.3 | 0 |
| 768x500 | new chat | 36.3 | 0 |
| 390x844 | new chat | 49.7 | 0 |
| all six | train, model hub | 0 | 0 |

Notes expanded as well as collapsed, on both sides. 36 pairs in total, no overlap anywhere on the head, no change on the two routes that were already correct.

## Tests

`studio/frontend/tests/update-banner-flex-priority.test.ts`, in the source-reading style the stack already uses, pinning the flex priorities, the notes clip, the collapsed summary's scroller and both rails. Mutation checked against the merge base: 10 of its 11 cases fail there. The eleventh is the one asserting the desktop and browser cards carry the same rules, which is true on both sides and is there so a future fix to one of them cannot skip the other.

`tests/studio/playwright_update_banner_layout.py`, alongside the other Playwright suites, stubbing `/api/studio/update-status`, `/api/studio/release-notes` and `/api/llama/update-status` with `page.route` so it needs no GPU, no release and no llama.cpp build. 220 checks over 5 viewports and 3 routes, collapsed and expanded, plus the whisper.cpp variant to pin that it renames the one runtime card instead of adding a second. 13 fail on the merge base, 0 on this branch.

`npm test` is 1613 of 1613, and `tsc -b` is clean. `biome check` and `eslint` report exactly what they report on the merge base for these five files, nothing added.

## Also worth recording

whisper.cpp is not a second banner. `_merge_whisper_status` folds it into the same `LlamaUpdateBanner` through `update_component`, so it gets this fix for free, and the Playwright suite now says so. stable-diffusion.cpp has a prebuilt installer but no update status route, hook or banner at all, so there is nothing there to fix yet.
