### PR TITLE
Stop conversation_extension crashing when the caller keeps their columns

### DIFF
--- a/tests/python/test_to_sharegpt_optional_none.py
+++ b/tests/python/test_to_sharegpt_optional_none.py
@@ -95,3 +95,69 @@ def test_optional_block_falsy_but_present_gating_value_still_renders():
     merged_prompt = "Count: [[{n}]]!"
     out = _render(merged_prompt, ["n"], {"n": [0]})
     assert out[0] == "Count: 0!"
+
+
+def _load_to_sharegpt():
+    # Same trick as above: pull to_sharegpt and the two helpers it calls out of
+    # the source without importing unsloth.
+    source = Path(__file__).parents[2] / "unsloth" / "chat_templates.py"
+    tree = ast.parse(source.read_text(encoding = "utf-8"))
+    wanted = {"_parse_combined_prompt", "_create_formatter", "to_sharegpt"}
+    funcs = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name in wanted
+    ]
+    namespace = {"re": re}
+    module = ast.Module(body = funcs, type_ignores = [])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(source), "exec"), namespace)
+    return namespace["to_sharegpt"]
+
+
+def _alpaca():
+    from datasets import Dataset
+
+    return Dataset.from_dict(
+        {"instruction" : ["a", "b", "c", "d"], "output" : ["1", "2", "3", "4"]}
+    )
+
+
+def test_conversation_extension_with_columns_kept():
+    # Both flags are documented. Extending shuffled copies used to concatenate
+    # the caller's columns once per extension, which datasets rejects.
+    to_sharegpt = _load_to_sharegpt()
+    converted = to_sharegpt(
+        _alpaca(),
+        merged_prompt = "{instruction}",
+        remove_unused_columns = False,
+        conversation_extension = 3,
+    )
+
+    assert converted.column_names == ["instruction", "output", "conversations"]
+    assert len(converted[0]["conversations"]) == 6
+
+
+def test_conversation_extension_drops_its_scaffolding_columns():
+    to_sharegpt = _load_to_sharegpt()
+    for extension in (2, 3, 4):
+        converted = to_sharegpt(
+            _alpaca(),
+            merged_prompt = "{instruction}",
+            remove_unused_columns = False,
+            conversation_extension = extension,
+        )
+        numbered = [name for name in converted.column_names if name.startswith("conversations")]
+        assert numbered == ["conversations"], converted.column_names
+        assert len(converted[0]["conversations"]) == 2 * extension
+
+
+def test_conversation_extension_unchanged_when_columns_removed():
+    to_sharegpt = _load_to_sharegpt()
+    converted = to_sharegpt(
+        _alpaca(),
+        merged_prompt = "{instruction}",
+        conversation_extension = 3,
+    )
+
+    assert converted.column_names == ["conversations"]
+    assert len(converted[0]["conversations"]) == 6
+    assert all(turn["value"] for row in converted for turn in row["conversations"])

--- a/tests/python/test_to_sharegpt_optional_none.py
+++ b/tests/python/test_to_sharegpt_optional_none.py
@@ -115,10 +115,7 @@ def _load_to_sharegpt():
 
 def _alpaca():
     from datasets import Dataset
-
-    return Dataset.from_dict(
-        {"instruction" : ["a", "b", "c", "d"], "output" : ["1", "2", "3", "4"]}
-    )
+    return Dataset.from_dict({"instruction": ["a", "b", "c", "d"], "output": ["1", "2", "3", "4"]})
 
 
 def test_conversation_extension_with_columns_kept():

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2350,7 +2350,10 @@ def to_sharegpt(
     all_shuffled = [dataset]
     for j in range(1, n_extensions+1):
         shuffled = dataset.shuffle(seed = random_state+j).rename_columns({"conversations0" : f"conversations{j}"})
-        all_shuffled.append(shuffled)
+        # Only the conversations come from the shuffled copies. Any other column
+        # the caller kept is still on the first one, and concatenating it once
+        # per extension is what datasets rejects as a duplicated column.
+        all_shuffled.append(shuffled.select_columns([f"conversations{j}"]))
     dataset = concatenate_datasets(all_shuffled, axis = 1)
 
     # Combine them into 1
@@ -2370,8 +2373,9 @@ def to_sharegpt(
         __combine_conversations__,
         batched = True,
         desc = "Extending conversations",
-        # Remove unused columns!
-        remove_columns = dataset.column_names if remove_unused_columns else None,
+        # Remove unused columns! The numbered conversation columns are scaffolding
+        # rather than the caller's data, so they go either way.
+        remove_columns = dataset.column_names if remove_unused_columns else conversation_columns,
     )
     return dataset
 


### PR DESCRIPTION
## Problem

`to_sharegpt` extends conversations by shuffling copies of the dataset and concatenating them along `axis=1`:

```python
dataset = dataset.rename_columns({"conversations" : "conversations0"})
all_shuffled = [dataset]
for j in range(1, n_extensions+1):
    shuffled = dataset.shuffle(seed = random_state+j).rename_columns({"conversations0" : f"conversations{j}"})
    all_shuffled.append(shuffled)
dataset = concatenate_datasets(all_shuffled, axis = 1)
```

With `remove_unused_columns=False` the caller's own columns are still on every copy, so the concatenation gets `instruction` and `output` once per extension:

```
remove_unused_columns=True   conversation_extension=3  ->  OK
remove_unused_columns=False  conversation_extension=1  ->  OK
remove_unused_columns=False  conversation_extension=2  ->  ValueError: The table can't have duplicated columns but columns ['instruction', 'output'] are duplicated.
remove_unused_columns=False  conversation_extension=3  ->  ValueError: ...
```

Both flags are documented in the function's own docstring, and every `conversation_extension` above 1 hits it. The error comes from `datasets` and names the user's own column, which gives no hint that the two options are the trigger.

## Fix

Take only the conversations column from each shuffled copy. The first copy is untouched, so the caller's columns survive exactly as before.

The numbered `conversations0..N` columns are this function's scaffolding rather than the caller's data, so they are dropped in the final map either way. `remove_unused_columns=False` should mean keeping the caller's columns, not the intermediates:

```
before:  ['instruction', 'output', 'conversations0', 'conversations1', 'conversations2', 'conversations']
after:   ['instruction', 'output', 'conversations']
```

## Test

Three tests added to `tests/python/test_to_sharegpt_optional_none.py`, which is the mapped file for this function and already loads the helpers with `ast` so unsloth does not have to be imported.

```
                                                      before   after
test_conversation_extension_with_columns_kept          FAIL     pass
test_conversation_extension_drops_its_scaffolding_columns  FAIL  pass
test_conversation_extension_unchanged_when_columns_removed  pass  pass
```

`python -m pytest tests/python/test_to_sharegpt_optional_none.py` gives 2 failed / 7 passed against `main` and 9 passed with this change. Both runs use files fetched fresh from `main` at fbf18cb, so the before column is a real upstream control.

The tests pass an explicit `merged_prompt` so they exercise only the extension path and stay independent of #8277, which is open against the merging map in the same function. The two changes are in different hunks and do not conflict.

This is the follow-up I flagged at the end of #8277. Opening it separately as offered there, but happy to fold it in instead if you would rather review one change to this function.
