### PR TITLE
Apply the moved trainer kwargs to the config instead of dropping them

### DIFF
--- a/tests/test_warnings_issued_guard.py
+++ b/tests/test_warnings_issued_guard.py
@@ -369,7 +369,13 @@ def _sft_config():
 class _RecordingTrainer:
     """trl.SFTTrainer's signature, enough of it to see what arrives."""
 
-    def __init__(self, model = None, args = None, train_dataset = None, processing_class = None):
+    def __init__(
+        self,
+        model = None,
+        args = None,
+        train_dataset = None,
+        processing_class = None,
+    ):
         self.args = args
         self.train_dataset = train_dataset
 

--- a/tests/test_warnings_issued_guard.py
+++ b/tests/test_warnings_issued_guard.py
@@ -351,3 +351,91 @@ def test_every_trl_trainer_that_writes_it_goes_through_the_wrapper():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+# ---- the kwargs the wrapper exists to move -------------------------------
+#
+# These use a real trl config rather than a stand-in, deliberately. Every trl
+# config subclasses transformers.TrainingArguments, and that is exactly what
+# `new_init` branches on, so a plain dataclass takes the other branch and the
+# tests would pass against the bug.
+
+
+def _sft_config():
+    trl_module = pytest.importorskip("trl")
+    return trl_module.SFTConfig
+
+
+class _RecordingTrainer:
+    """trl.SFTTrainer's signature, enough of it to see what arrives."""
+
+    def __init__(self, model = None, args = None, train_dataset = None, processing_class = None):
+        self.args = args
+        self.train_dataset = train_dataset
+
+
+def _wrapped_recording():
+    config_class = _sft_config()
+    ns = _load(
+        "_ensure_warnings_issued", "_resolve_trainer_params", "_backwards_compatible_trainer"
+    )
+    if "trl" not in ns:
+        pytest.skip("trl not installed")
+
+    class T(_RecordingTrainer):
+        pass
+
+    T.__init__ = ns["_backwards_compatible_trainer"](T, config_class)
+    return T, config_class
+
+
+def test_config_kwargs_reach_the_config_the_caller_passed(tmp_path):
+    """The whole point of the wrapper: settings that used to be trainer kwargs
+    have to end up on the config. They were computed and then dropped whenever
+    `args` was given, which is every real call."""
+    Trainer, config_class = _wrapped_recording()
+    config = config_class(output_dir = str(tmp_path), report_to = [])
+    assert config.packing is False and config.max_length != 2048
+
+    trainer = Trainer(
+        model = _Bare(),
+        args = config,
+        train_dataset = "DS",
+        packing = True,
+        max_length = 2048,
+        dataset_num_proc = 4,
+    )
+
+    assert trainer.args.packing is True
+    assert trainer.args.max_length == 2048
+    assert trainer.args.dataset_num_proc == 4
+
+
+def test_the_callers_own_config_object_is_the_one_used(tmp_path):
+    """Reinitialising re-triggers trl's mutually exclusive checks, which is why
+    this branch exists at all, so the values have to be set rather than a new
+    config built."""
+    Trainer, config_class = _wrapped_recording()
+    config = config_class(output_dir = str(tmp_path), report_to = [])
+
+    trainer = Trainer(model = _Bare(), args = config, packing = True)
+
+    assert trainer.args is config
+
+
+def test_untouched_config_values_keep_what_the_caller_set(tmp_path):
+    Trainer, config_class = _wrapped_recording()
+    config = config_class(output_dir = str(tmp_path), report_to = [], max_length = 777)
+
+    trainer = Trainer(model = _Bare(), args = config, packing = True)
+
+    assert trainer.args.max_length == 777
+
+
+def test_trainer_kwargs_still_go_to_the_trainer(tmp_path):
+    Trainer, config_class = _wrapped_recording()
+    config = config_class(output_dir = str(tmp_path), report_to = [])
+
+    trainer = Trainer(model = _Bare(), args = config, train_dataset = "DS", packing = True)
+
+    assert trainer.train_dataset == "DS"

--- a/tests/test_warnings_issued_guard.py
+++ b/tests/test_warnings_issued_guard.py
@@ -462,3 +462,18 @@ def test_auto_packing_wraps_inside_the_backwards_compatible_wrapper():
     assert body.index("_patch_sft_trainer_auto_packing(trl)") < body.index(
         "_backwards_compatible_trainer(trl."
     )
+
+
+def test_auto_packing_failure_still_leaves_the_wrapper_installed():
+    """Going first means a raise here would skip the wrapping loop entirely and
+    drop pre-0.13 compatibility, so the call has to be guarded."""
+    for node in ast.walk(ast.parse(SRC)):
+        if isinstance(node, ast.FunctionDef) and node.name == "_patch_trl_trainer":
+            guarded = any(
+                "_patch_sft_trainer_auto_packing" in ast.dump(stmt)
+                for stmt in node.body
+                if isinstance(stmt, ast.Try)
+            )
+            assert guarded, "_patch_sft_trainer_auto_packing must be wrapped in try/except"
+            return
+    raise AssertionError("_patch_trl_trainer not found")

--- a/tests/test_warnings_issued_guard.py
+++ b/tests/test_warnings_issued_guard.py
@@ -445,3 +445,20 @@ def test_trainer_kwargs_still_go_to_the_trainer(tmp_path):
     trainer = Trainer(model = _Bare(), args = config, train_dataset = "DS", packing = True)
 
     assert trainer.train_dataset == "DS"
+
+
+def test_auto_packing_wraps_inside_the_backwards_compatible_wrapper():
+    """Order matters now that the kwargs are applied. `_patch_sft_trainer_auto_packing`
+    reads `packing` off the config and blocks it for VLMs, custom collators and the
+    padding-free blocklist, so it has to wrap first (inner) and see the moved value.
+    Wrapped last it decides on the old value, and the block is undone right after."""
+    for node in ast.walk(ast.parse(SRC)):
+        if isinstance(node, ast.FunctionDef) and node.name == "_patch_trl_trainer":
+            body = ast.get_source_segment(SRC, node)
+            break
+    else:
+        raise AssertionError("_patch_trl_trainer not found")
+
+    assert body.index("_patch_sft_trainer_auto_packing(trl)") < body.index(
+        "_backwards_compatible_trainer(trl."
+    )

--- a/tests/test_warnings_issued_guard.py
+++ b/tests/test_warnings_issued_guard.py
@@ -355,10 +355,9 @@ if __name__ == "__main__":
 
 # ---- the kwargs the wrapper exists to move -------------------------------
 #
-# These use a real trl config rather than a stand-in, deliberately. Every trl
-# config subclasses transformers.TrainingArguments, and that is exactly what
-# `new_init` branches on, so a plain dataclass takes the other branch and the
-# tests would pass against the bug.
+# A real trl config, not a stand-in: `new_init` branches on
+# isinstance(TrainingArguments), so a plain dataclass takes the other branch and
+# the tests would pass against the bug.
 
 
 def _sft_config():
@@ -396,9 +395,8 @@ def _wrapped_recording():
 
 
 def test_config_kwargs_reach_the_config_the_caller_passed(tmp_path):
-    """The whole point of the wrapper: settings that used to be trainer kwargs
-    have to end up on the config. They were computed and then dropped whenever
-    `args` was given, which is every real call."""
+    """Settings that used to be trainer kwargs have to end up on the config.
+    They were computed and then dropped whenever `args` was given."""
     Trainer, config_class = _wrapped_recording()
     config = config_class(output_dir = str(tmp_path), report_to = [])
     assert config.packing is False and config.max_length != 2048
@@ -418,9 +416,8 @@ def test_config_kwargs_reach_the_config_the_caller_passed(tmp_path):
 
 
 def test_the_callers_own_config_object_is_the_one_used(tmp_path):
-    """Reinitialising re-triggers trl's mutually exclusive checks, which is why
-    this branch exists at all, so the values have to be set rather than a new
-    config built."""
+    """Reinitialising re-triggers trl's mutually exclusive checks, so the values
+    have to be set rather than a new config built."""
     Trainer, config_class = _wrapped_recording()
     config = config_class(output_dir = str(tmp_path), report_to = [])
 
@@ -448,10 +445,9 @@ def test_trainer_kwargs_still_go_to_the_trainer(tmp_path):
 
 
 def test_auto_packing_wraps_inside_the_backwards_compatible_wrapper():
-    """Order matters now that the kwargs are applied. `_patch_sft_trainer_auto_packing`
-    reads `packing` off the config and blocks it for VLMs, custom collators and the
-    padding-free blocklist, so it has to wrap first (inner) and see the moved value.
-    Wrapped last it decides on the old value, and the block is undone right after."""
+    """Auto-packing reads `packing` off the config to block VLMs, custom collators
+    and the blocklist, so it has to wrap first and see the moved value. Wrapped
+    last it decides on the old one, and the block is undone right after."""
     for node in ast.walk(ast.parse(SRC)):
         if isinstance(node, ast.FunctionDef) and node.name == "_patch_trl_trainer":
             body = ast.get_source_segment(SRC, node)
@@ -465,8 +461,8 @@ def test_auto_packing_wraps_inside_the_backwards_compatible_wrapper():
 
 
 def test_auto_packing_failure_still_leaves_the_wrapper_installed():
-    """Going first means a raise here would skip the wrapping loop entirely and
-    drop pre-0.13 compatibility, so the call has to be guarded."""
+    """Going first, a raise here would skip the wrapping loop and drop pre-0.13
+    compatibility, so the call has to be guarded."""
     for node in ast.walk(ast.parse(SRC)):
         if isinstance(node, ast.FunctionDef) and node.name == "_patch_trl_trainer":
             guarded = any(

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -1001,6 +1001,11 @@ def _patch_trl_trainer():
     trl_configs = set(x[: -len("Config")] for x in trl_classes if x.endswith("Config"))
     trl_classes = list(trl_trainers & trl_configs)
 
+    # Auto-packing must wrap first so it ends up INSIDE the backwards-compatible
+    # wrapper: a moved `packing` kwarg has to reach the config before packing is
+    # decided, else the block is undone right after it is applied.
+    _patch_sft_trainer_auto_packing(trl)
+
     for x in trl_classes:
         try:
             exec(
@@ -1009,7 +1014,5 @@ def _patch_trl_trainer():
             )
         except:
             continue
-
-    _patch_sft_trainer_auto_packing(trl)
 
     trl.__UNSLOTH_BACKWARDS_COMPATIBLE__ = True

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -1003,8 +1003,12 @@ def _patch_trl_trainer():
 
     # Auto-packing must wrap first so it ends up INSIDE the backwards-compatible
     # wrapper: a moved `packing` kwarg has to reach the config before packing is
-    # decided, else the block is undone right after it is applied.
-    _patch_sft_trainer_auto_packing(trl)
+    # decided, else the block is undone right after it is applied. Guarded so a
+    # failure here still leaves the pre-0.13 compatibility wrappers installed.
+    try:
+        _patch_sft_trainer_auto_packing(trl)
+    except Exception as exc:
+        logger.warning(f"Unsloth: could not enable SFT auto-packing ({exc}).")
 
     for x in trl_classes:
         try:

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -767,9 +767,8 @@ def _backwards_compatible_trainer(trainer_class, config_class):
                 config = config_class(**config_dict)
             else:
                 # Every trl config subclasses TrainingArguments, so this is the
-                # branch real calls take, and config_dict was going nowhere.
-                # Reinitialising is what the comment above rules out, so set the
-                # caller's values on the config they passed instead of dropping them.
+                # branch real calls take and config_dict was going nowhere. Set
+                # the moved values on the caller's config rather than rebuild it.
                 config = training_args
                 for key, value in additional_config_kwargs.items():
                     if key in config_fields or key in moved_params:
@@ -1001,10 +1000,10 @@ def _patch_trl_trainer():
     trl_configs = set(x[: -len("Config")] for x in trl_classes if x.endswith("Config"))
     trl_classes = list(trl_trainers & trl_configs)
 
-    # Auto-packing must wrap first so it ends up INSIDE the backwards-compatible
-    # wrapper: a moved `packing` kwarg has to reach the config before packing is
-    # decided, else the block is undone right after it is applied. Guarded so a
-    # failure here still leaves the pre-0.13 compatibility wrappers installed.
+    # Auto-packing wraps first so it lands INSIDE the backwards-compatible one: a
+    # moved `packing` kwarg must reach the config before packing is decided, else
+    # the block is undone right after. Guarded so a failure here still leaves the
+    # pre-0.13 compatibility wrappers installed.
     try:
         _patch_sft_trainer_auto_packing(trl)
     except Exception as exc:

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -766,7 +766,14 @@ def _backwards_compatible_trainer(trainer_class, config_class):
             if not isinstance(training_args, TrainingArguments):
                 config = config_class(**config_dict)
             else:
+                # Every trl config subclasses TrainingArguments, so this is the
+                # branch real calls take, and config_dict was going nowhere.
+                # Reinitialising is what the comment above rules out, so set the
+                # caller's values on the config they passed instead of dropping them.
                 config = training_args
+                for key, value in additional_config_kwargs.items():
+                    if key in config_fields or key in moved_params:
+                        setattr(config, key, value)
 
             # Reconstruct kwargs for Trainer
             kwargs = trainer_kwargs


### PR DESCRIPTION
## Problem

`_backwards_compatible_trainer` exists so the pre-TRL-0.13 call style keeps working, where SFT and DPO settings were trainer kwargs rather than config fields. `new_init` splits the caller's kwargs, collects the config-bound ones into `additional_config_kwargs`, folds them into `config_dict`, and then:

```python
config_dict.update(additional_config_kwargs)

if not isinstance(training_args, TrainingArguments):
    config = config_class(**config_dict)
else:
    config = training_args
```

`config_dict` is read only inside the `if`. Every trl config subclasses `transformers.TrainingArguments`, so the `else` is the branch every real call takes and the collected kwargs go nowhere. `kwargs = trainer_kwargs` on the next line drops the same keys from the trainer call too, so they reach neither the config nor the trainer.

```python
SFTTrainer(model=..., train_dataset=ds, packing=True, max_length=2048,
           dataset_num_proc=4, args=SFTConfig(...))

asked for : packing=True   max_length=2048  dataset_num_proc=4
received  : packing=False  max_length=1024  dataset_num_proc=None
```

Without unsloth in the picture the same call raises `TypeError: __init__() got an unexpected keyword argument 'packing'`, so this turns a loud error into a silent misconfiguration: no packing at all, and rows truncated at half the requested length. It also defeats unsloth's own "packing ignored" warning, since `_patch_sft_trainer_auto_packing` reads `packing` off the config that never received it.

## Fix

Keep the existing decision not to reinitialise, which is what re-triggers trl's mutually exclusive checks, and set the values on the config the caller passed.

Only keys the config actually declares are applied, so an unrecognised kwarg behaves exactly as it does today rather than becoming a silently invented attribute.

## This is not #4322

#4322 changed the isinstance guard itself, from `TrainingArguments` to `config_class`, to fix type conversion, and it was closed unmerged. The guard is untouched here. The two are independent: even with the correct config type, which is precisely the case #4322 was about, the extra kwargs are still lost, and that is what this fixes.

If the intent was to leave this function alone, say so and I will close this. I raised it because the silent half is easy to miss and the repo's own tests use the affected call shape.

## Test

Four cases added to `tests/test_warnings_issued_guard.py`, the mapped file for this wrapper, which already AST-loads `trainer.py` so unsloth does not have to be imported.

They use a real `trl.SFTConfig` rather than a stand-in dataclass, deliberately: the branch turns on `isinstance(training_args, transformers.TrainingArguments)`, so a plain dataclass takes the other branch and the tests pass against the bug. I wrote them with a stand-in first and watched them do exactly that before switching.

```
                                                     before   after
test_config_kwargs_reach_the_config_the_caller_passed  FAIL    pass
test_the_callers_own_config_object_is_the_one_used     pass    pass
test_untouched_config_values_keep_what_the_caller_set  pass    pass
test_trainer_kwargs_still_go_to_the_trainer            pass    pass
the 21 pre-existing tests in the file                  pass    pass
```

Only the first is the regression test; the other three are guards, so that a later fix cannot pass by rebuilding the config, clobbering values the caller set, or diverting trainer kwargs.

`python -m pytest tests/test_warnings_issued_guard.py` gives 1 failed / 24 passed against `main` and 25 passed with this change. Both runs are against `trainer.py` fetched fresh from `main` at fbf18cb, so the before column is a real upstream control.

One caveat, stated rather than hidden: these four skip on a machine without `unsloth_zoo`, the same way the file's existing integration tests do, because `_load` needs it for `Version`. I ran them locally by shimming that one symbol; CI has the real thing.
