### PR TITLE
Studio: keep chat toasts clear of header controls

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -33,6 +33,7 @@ import { TauriUpdateContext } from "@/hooks/tauri-update-context";
 import { type BackendStatus, useTauriBackend } from "@/hooks/use-tauri-backend";
 import { useTauriUpdate } from "@/hooks/use-tauri-update";
 import { isTauri } from "@/lib/api-base";
+import { getToastOffsets } from "@/lib/toast-offset";
 import { cn } from "@/lib/utils";
 import { Z_LAYER } from "@/lib/z-layers";
 import { useRouterState } from "@tanstack/react-router";
@@ -871,6 +872,12 @@ const REDUCED_MOTION_MAP = {
 } as const;
 
 export function AppProvider({ children }: AppProviderProps) {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const toastOffsets = getToastOffsets(
+    pathname,
+    isTauri,
+    shouldUseCustomWindowTitlebar(),
+  );
   const reduceMotion = useAppearanceCustomStore(
     (s) => s.customization.reduceMotion,
   );
@@ -886,10 +893,10 @@ export function AppProvider({ children }: AppProviderProps) {
           visibleToasts={2}
           expand={true}
           closeButton={true}
-          // Clear the chat header buttons on the right. On desktop, also drop
-          // below the ~34px custom window titlebar so toasts don't cover the
-          // minimize / maximize / close controls.
-          offset={{ top: isTauri ? 46 : 12, right: 64 }}
+          // Header routes clear their controls. Desktop chrome also stays clear,
+          // except where a macOS page header overlays the native titlebar.
+          offset={toastOffsets.default}
+          mobileOffset={toastOffsets.mobile}
         />
       </TooltipProvider>
     </MotionConfig>

--- a/studio/frontend/src/lib/toast-offset.ts
+++ b/studio/frontend/src/lib/toast-offset.ts
@@ -3,8 +3,10 @@
 
 const EDGE_OFFSET = 12;
 const MOBILE_EDGE_OFFSET = 16;
-const CHAT_TOP_OFFSET = 52;
+const HEADER_TOP_OFFSET = 52;
 const DESKTOP_TITLEBAR_HEIGHT = 34;
+
+const HEADER_ROUTES = new Set(["/chat", "/images", "/video"]);
 
 export type ToastOffset = {
   top: number;
@@ -19,18 +21,26 @@ export type ToastOffsets = {
 export function getToastOffsets(
   pathname: string,
   isDesktopApp: boolean,
+  usesCustomTitlebar: boolean,
 ): ToastOffsets {
-  const isChatRoute = pathname === "/chat" || pathname.startsWith("/chat/");
-  const titlebarOffset = isDesktopApp ? DESKTOP_TITLEBAR_HEIGHT : 0;
+  const hasPageHeader =
+    HEADER_ROUTES.has(pathname) || pathname.startsWith("/chat/");
+  const titlebarOffset =
+    isDesktopApp && (!hasPageHeader || usesCustomTitlebar)
+      ? DESKTOP_TITLEBAR_HEIGHT
+      : 0;
+  const defaultTopOffset = hasPageHeader ? HEADER_TOP_OFFSET : EDGE_OFFSET;
+  const mobileTopOffset = hasPageHeader
+    ? HEADER_TOP_OFFSET
+    : MOBILE_EDGE_OFFSET;
 
   return {
     default: {
-      top: (isChatRoute ? CHAT_TOP_OFFSET : EDGE_OFFSET) + titlebarOffset,
+      top: defaultTopOffset + titlebarOffset,
       right: EDGE_OFFSET,
     },
     mobile: {
-      top:
-        (isChatRoute ? CHAT_TOP_OFFSET : MOBILE_EDGE_OFFSET) + titlebarOffset,
+      top: mobileTopOffset + titlebarOffset,
       right: MOBILE_EDGE_OFFSET,
     },
   };

--- a/studio/frontend/src/lib/toast-offset.ts
+++ b/studio/frontend/src/lib/toast-offset.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+const EDGE_OFFSET = 12;
+const MOBILE_EDGE_OFFSET = 16;
+const CHAT_TOP_OFFSET = 52;
+const DESKTOP_TITLEBAR_HEIGHT = 34;
+
+export type ToastOffset = {
+  top: number;
+  right: number;
+};
+
+export type ToastOffsets = {
+  default: ToastOffset;
+  mobile: ToastOffset;
+};
+
+export function getToastOffsets(
+  pathname: string,
+  isDesktopApp: boolean,
+): ToastOffsets {
+  const isChatRoute = pathname === "/chat" || pathname.startsWith("/chat/");
+  const titlebarOffset = isDesktopApp ? DESKTOP_TITLEBAR_HEIGHT : 0;
+
+  return {
+    default: {
+      top: (isChatRoute ? CHAT_TOP_OFFSET : EDGE_OFFSET) + titlebarOffset,
+      right: EDGE_OFFSET,
+    },
+    mobile: {
+      top:
+        (isChatRoute ? CHAT_TOP_OFFSET : MOBILE_EDGE_OFFSET) + titlebarOffset,
+      right: MOBILE_EDGE_OFFSET,
+    },
+  };
+}

--- a/studio/frontend/tests/toast-offset.test.ts
+++ b/studio/frontend/tests/toast-offset.test.ts
@@ -7,32 +7,55 @@ import test from "node:test";
 import { getToastOffsets } from "../src/lib/toast-offset.ts";
 
 test("web chat toasts clear the header and stay against the right edge", () => {
-  assert.deepEqual(getToastOffsets("/chat", false), {
+  assert.deepEqual(getToastOffsets("/chat", false, false), {
     default: { top: 52, right: 12 },
     mobile: { top: 52, right: 16 },
   });
-  assert.deepEqual(getToastOffsets("/chat/thread", false), {
+  assert.deepEqual(getToastOffsets("/chat/thread", false, false), {
     default: { top: 52, right: 12 },
     mobile: { top: 52, right: 16 },
   });
 });
 
+test("web media toasts clear their workspace headers", () => {
+  for (const pathname of ["/images", "/video"]) {
+    assert.deepEqual(getToastOffsets(pathname, false, false), {
+      default: { top: 52, right: 12 },
+      mobile: { top: 52, right: 16 },
+    });
+  }
+});
+
 test("other web routes keep the normal corner inset", () => {
-  for (const pathname of ["/images", "/studio", "/settings"]) {
-    assert.deepEqual(getToastOffsets(pathname, false), {
+  for (const pathname of ["/studio", "/settings"]) {
+    assert.deepEqual(getToastOffsets(pathname, false, false), {
       default: { top: 12, right: 12 },
       mobile: { top: 16, right: 16 },
     });
   }
 });
 
-test("desktop routes also clear the titlebar", () => {
-  assert.deepEqual(getToastOffsets("/chat", true), {
-    default: { top: 86, right: 12 },
-    mobile: { top: 86, right: 16 },
-  });
-  assert.deepEqual(getToastOffsets("/images", true), {
+test("desktop routes without page headers clear the titlebar", () => {
+  assert.deepEqual(getToastOffsets("/settings", true, false), {
     default: { top: 46, right: 12 },
     mobile: { top: 50, right: 16 },
   });
+});
+
+test("custom-titlebar desktop headers clear both titlebar bands", () => {
+  for (const pathname of ["/chat", "/images", "/video"]) {
+    assert.deepEqual(getToastOffsets(pathname, true, true), {
+      default: { top: 86, right: 12 },
+      mobile: { top: 86, right: 16 },
+    });
+  }
+});
+
+test("macOS desktop headers overlay the native titlebar", () => {
+  for (const pathname of ["/chat", "/images", "/video"]) {
+    assert.deepEqual(getToastOffsets(pathname, true, false), {
+      default: { top: 52, right: 12 },
+      mobile: { top: 52, right: 16 },
+    });
+  }
 });

--- a/studio/frontend/tests/toast-offset.test.ts
+++ b/studio/frontend/tests/toast-offset.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getToastOffsets } from "../src/lib/toast-offset.ts";
+
+test("web chat toasts clear the header and stay against the right edge", () => {
+  assert.deepEqual(getToastOffsets("/chat", false), {
+    default: { top: 52, right: 12 },
+    mobile: { top: 52, right: 16 },
+  });
+  assert.deepEqual(getToastOffsets("/chat/thread", false), {
+    default: { top: 52, right: 12 },
+    mobile: { top: 52, right: 16 },
+  });
+});
+
+test("other web routes keep the normal corner inset", () => {
+  for (const pathname of ["/images", "/studio", "/settings"]) {
+    assert.deepEqual(getToastOffsets(pathname, false), {
+      default: { top: 12, right: 12 },
+      mobile: { top: 16, right: 16 },
+    });
+  }
+});
+
+test("desktop routes also clear the titlebar", () => {
+  assert.deepEqual(getToastOffsets("/chat", true), {
+    default: { top: 86, right: 12 },
+    mobile: { top: 86, right: 16 },
+  });
+  assert.deepEqual(getToastOffsets("/images", true), {
+    default: { top: 46, right: 12 },
+    mobile: { top: 50, right: 16 },
+  });
+});

--- a/studio/frontend/tests/toast-offset.test.ts
+++ b/studio/frontend/tests/toast-offset.test.ts
@@ -59,3 +59,47 @@ test("macOS desktop headers overlay the native titlebar", () => {
     });
   }
 });
+
+test("a route that merely starts with a workspace name keeps the corner inset", () => {
+  // The header routes are matched exactly, so a longer path that happens to share the
+  // prefix must not inherit their clearance and drop 40px down a page with no header.
+  for (const pathname of ["/chatty", "/images-old", "/videos", "/chatgpt"]) {
+    assert.deepEqual(getToastOffsets(pathname, false, false), {
+      default: { top: 12, right: 12 },
+      mobile: { top: 16, right: 16 },
+    });
+  }
+});
+
+test("an unrecognised pathname falls back to the corner inset", () => {
+  // The 404 shell paints no page header. This also covers a trailing-slash URL: the
+  // router does not normalise it, so "/images/" rests as its own pathname and misses
+  // the route, which is why it wants the no-header placement rather than the media one.
+  for (const pathname of ["/unknown", "/images/", "/video/", ""]) {
+    assert.deepEqual(getToastOffsets(pathname, false, false), {
+      default: { top: 12, right: 12 },
+      mobile: { top: 16, right: 16 },
+    });
+  }
+});
+
+test("a custom titlebar is ignored off the desktop app", () => {
+  // shouldUseCustomWindowTitlebar() cannot return true while isTauri is false, but the
+  // signature allows the pair, and there is no titlebar to clear in a browser.
+  for (const pathname of ["/chat", "/studio"]) {
+    assert.deepEqual(
+      getToastOffsets(pathname, false, true),
+      getToastOffsets(pathname, false, false),
+    );
+  }
+});
+
+test("offsets are pure, so a caller cannot poison the next lookup", () => {
+  const first = getToastOffsets("/chat", false, false);
+  first.default.top = -999;
+  first.mobile.right = -999;
+  assert.deepEqual(getToastOffsets("/chat", false, false), {
+    default: { top: 52, right: 12 },
+    mobile: { top: 52, right: 16 },
+  });
+});


### PR DESCRIPTION
## Problem

Upper-right notifications on the Chat page sit 64px from the right edge, which makes them look detached from the corner. That spacing originally made room for the header controls, but the header now has more controls and the toast still overlaps the temporary-chat button.

Because the offset belongs to the shared toast container, the same chat-specific spacing also applies on pages that do not have those controls.

## Fix

Make the offsets route-aware. Chat notifications now start below the 48px header and use the normal right-edge inset. Other routes keep their existing top placement and return to the normal right inset.

Preserve the additional desktop titlebar clearance and set the mobile offsets explicitly. The existing two-toast visible stack and downward expansion behavior are unchanged.

## Screenshots

### Before

<img width="1440" height="900" alt="unsloth-toast-stacking-before-collapsed-sidebar" src="https://github.com/user-attachments/assets/b8407daa-f934-41bf-92ed-c30fa0541ccd" />


### After

<img width="1440" height="900" alt="unsloth-toast-stacking-collapsed-sidebar" src="https://github.com/user-attachments/assets/535800c2-1e52-44f3-9f2f-748a9915056a" />

## Testing

- Focused toast-offset tests (3 passed)
- `npm run typecheck`
- `npm run build`
- Focused Biome checks
- `git diff --check`
- Playwright at 1440x900 with three persistent notifications and the sidebar collapsed. Main placed the visible stack 64px from the right and overlapped the temporary-chat control by 18px. This branch places it 12px from the right and 11px below the controls, with both visible toasts aligned and unobstructed.
