### PR TITLE
Fix Windows Whisper slim pairing on GPU llama runtimes (ROCm, CUDA, Vulkan)

### DIFF
--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -390,6 +390,18 @@ def llama_runtime_pairs(
     return commit is not None and commit == _llama_ggml_commit(required_tag)
 
 
+def _ships_windows_gpu_ggml_module(llama_bin_dir: Path) -> bool:
+    """Whether a paired Windows llama runtime carries a GPU ggml backend module.
+    Only the cpu-only bundle links ggml against libomp, and bundle_profile cannot
+    tell them apart: it is absent on both the published rocm artifacts and every
+    upstream-sourced install, so the files on disk decide."""
+    for backend, per_os in SLIM_BACKEND_MODULE_GLOBS.items():
+        glob = per_os.get("windows")
+        if backend != "cpu" and glob and any(llama_bin_dir.glob(glob)):
+            return True
+    return False
+
+
 def slim_pairing_for_artifact(
     artifact: dict[str, Any], host: HostInfo, backend: str
 ) -> tuple[Path, str] | None:
@@ -401,7 +413,7 @@ def slim_pairing_for_artifact(
     if runtime is None:
         log(f"slim_selection: {asset} skipped: no managed llama.cpp prebuilt install")
         return None
-    llama_bin_dir, llama_tag, llama_profile = runtime
+    llama_bin_dir, llama_tag, _profile = runtime
     requires_tag = artifact.get("requires_llama_tag")
     if not llama_runtime_pairs(
         llama_tag,
@@ -419,11 +431,11 @@ def slim_pairing_for_artifact(
         log(f"slim_selection: {asset} skipped: manifest lists no requires_ggml_sonames")
         return None
     required_sonames = [str(name) for name in sonames]
-    if host.is_windows and "cpu" not in llama_profile.lower():
+    if host.is_windows and _ships_windows_gpu_ggml_module(llama_bin_dir):
         # The shared Windows manifest lists libomp because the cpu llama bundle
         # links ggml against it; the rocm/cuda/vulkan bundles neither ship nor
         # import it, so requiring it there only ever mis-rejects a valid pairing.
-        # A cpu bundle keeps the gate, since its ggml really does need the DLL.
+        # A cpu-only bundle keeps the gate, since its ggml really needs the DLL.
         # link_ggml_runtime still wires it whenever the bundle ships it.
         required_sonames = [
             name

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -417,11 +417,10 @@ def slim_pairing_for_artifact(
         return None
     required_sonames = [str(name) for name in sonames]
     if host.is_windows:
-        # The shared Windows manifest lists libomp because the CPU llama bundle
-        # links ggml against it; the GPU bundles (rocm, vulkan, cuda) do not ship
-        # it and their ggml DLLs do not import it. libomp is a transitive dep of
-        # llama's own ggml, so a working llama install already satisfies it and
-        # this gate only ever mis-rejects. Keep the ggml ABI sonames; drop libomp.
+        # The shared Windows manifest lists libomp because only the cpu llama
+        # bundle links ggml against it; rocm/cuda/vulkan neither ship nor import
+        # it. It is a transitive dep of llama's own ggml, so a working llama
+        # install already satisfies it and this gate can only mis-reject.
         # link_ggml_runtime still wires it whenever the bundle ships it.
         required_sonames = [
             name

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -161,8 +161,7 @@ SLIM_BACKEND_MODULE_GLOBS = {
     "cuda": {"linux": "libggml-cuda.so*", "windows": "ggml-cuda.dll"},
     "metal": {"macos": "libggml-metal*.dylib"},
     # Windows rocm must name the ggml module: the bundles also ship amdhip64,
-    # hipblas and libhipblaslt, so a looser *hip*.dll would pass on a runtime
-    # that has no ROCm ggml backend at all.
+    # hipblas and libhipblaslt, which a looser *hip*.dll would accept.
     "rocm": {"linux": "libggml-hip.so*", "windows": "ggml-hip*.dll"},
     "vulkan": {"linux": "libggml-vulkan.so*", "windows": "ggml-vulkan.dll"},
 }
@@ -392,8 +391,8 @@ def llama_runtime_pairs(
 
 def _ships_windows_gpu_ggml_module(llama_bin_dir: Path) -> bool:
     """Whether a paired Windows llama runtime carries a GPU ggml backend module.
-    Only the cpu-only bundle links ggml against libomp, and bundle_profile cannot
-    tell them apart: it is absent on both the published rocm artifacts and every
+    Only the cpu bundle links ggml against libomp, and bundle_profile cannot tell
+    the two apart: it is absent on both the published rocm artifacts and every
     upstream-sourced install, so the files on disk decide."""
     for backend, per_os in SLIM_BACKEND_MODULE_GLOBS.items():
         glob = per_os.get("windows")
@@ -432,11 +431,9 @@ def slim_pairing_for_artifact(
         return None
     required_sonames = [str(name) for name in sonames]
     if host.is_windows and _ships_windows_gpu_ggml_module(llama_bin_dir):
-        # The shared Windows manifest lists libomp because the cpu llama bundle
-        # links ggml against it; the rocm/cuda/vulkan bundles neither ship nor
-        # import it, so requiring it there only ever mis-rejects a valid pairing.
-        # A cpu-only bundle keeps the gate, since its ggml really needs the DLL.
-        # link_ggml_runtime still wires it whenever the bundle ships it.
+        # The shared Windows manifest lists libomp only because the cpu bundle's
+        # ggml links against it; a GPU bundle neither ships nor imports it, so
+        # requiring it there only mis-rejects. link_ggml_runtime still wires it.
         required_sonames = [
             name
             for name in required_sonames

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -434,6 +434,10 @@ def slim_pairing_for_artifact(
         # The shared Windows manifest lists libomp only because the cpu bundle's
         # ggml links against it; a GPU bundle neither ships nor imports it, so
         # requiring it there only mis-rejects. link_ggml_runtime still wires it.
+        # This drops libomp140.aarch64.dll as readily as the x64 name, which is
+        # safe only while llama publishes no Windows arm64 GPU bundle: that slice
+        # is clang-built and its ggml really does need LLVM OpenMP (see
+        # SLIM_GGML_LIBRARY_GLOBS). Re-check this gate before adding one.
         required_sonames = [
             name
             for name in required_sonames

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -415,7 +415,19 @@ def slim_pairing_for_artifact(
     if not isinstance(sonames, list) or not sonames:
         log(f"slim_selection: {asset} skipped: manifest lists no requires_ggml_sonames")
         return None
-    missing = [str(name) for name in sonames if not (llama_bin_dir / str(name)).is_file()]
+    required_sonames = [str(name) for name in sonames]
+    if host.is_windows and backend == "rocm":
+        # Windows ROCm llama bundles are built without GGML OpenMP and do not
+        # ship libomp140, while the shared Windows whisper manifest also serves
+        # CPU builds whose ggml runtime does need it. Keep the manifest's ggml
+        # ABI gate, but do not reject the valid ROCm layout for a CPU-only
+        # toolchain runtime. link_ggml_runtime still wires libomp when present.
+        required_sonames = [
+            name
+            for name in required_sonames
+            if not (name.lower().startswith("libomp") and name.lower().endswith(".dll"))
+        ]
+    missing = [name for name in required_sonames if not (llama_bin_dir / name).is_file()]
     if missing:
         log(f"slim_selection: {asset} skipped: llama runtime missing {', '.join(missing)}")
         return None

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -416,12 +416,13 @@ def slim_pairing_for_artifact(
         log(f"slim_selection: {asset} skipped: manifest lists no requires_ggml_sonames")
         return None
     required_sonames = [str(name) for name in sonames]
-    if host.is_windows and backend == "rocm":
-        # Windows ROCm llama bundles are built without GGML OpenMP and do not
-        # ship libomp140, while the shared Windows whisper manifest also serves
-        # CPU builds whose ggml runtime does need it. Keep the manifest's ggml
-        # ABI gate, but do not reject the valid ROCm layout for a CPU-only
-        # toolchain runtime. link_ggml_runtime still wires libomp when present.
+    if host.is_windows:
+        # The shared Windows manifest lists libomp because the CPU llama bundle
+        # links ggml against it; the GPU bundles (rocm, vulkan, cuda) do not ship
+        # it and their ggml DLLs do not import it. libomp is a transitive dep of
+        # llama's own ggml, so a working llama install already satisfies it and
+        # this gate only ever mis-rejects. Keep the ggml ABI sonames; drop libomp.
+        # link_ggml_runtime still wires it whenever the bundle ships it.
         required_sonames = [
             name
             for name in required_sonames

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -160,7 +160,10 @@ SLIM_BACKEND_MODULE_GLOBS = {
     },
     "cuda": {"linux": "libggml-cuda.so*", "windows": "ggml-cuda.dll"},
     "metal": {"macos": "libggml-metal*.dylib"},
-    "rocm": {"linux": "libggml-hip.so*", "windows": "*hip*.dll"},
+    # Windows rocm must name the ggml module: the bundles also ship amdhip64,
+    # hipblas and libhipblaslt, so a looser *hip*.dll would pass on a runtime
+    # that has no ROCm ggml backend at all.
+    "rocm": {"linux": "libggml-hip.so*", "windows": "ggml-hip*.dll"},
     "vulkan": {"linux": "libggml-vulkan.so*", "windows": "ggml-vulkan.dll"},
 }
 
@@ -398,7 +401,7 @@ def slim_pairing_for_artifact(
     if runtime is None:
         log(f"slim_selection: {asset} skipped: no managed llama.cpp prebuilt install")
         return None
-    llama_bin_dir, llama_tag, _profile = runtime
+    llama_bin_dir, llama_tag, llama_profile = runtime
     requires_tag = artifact.get("requires_llama_tag")
     if not llama_runtime_pairs(
         llama_tag,
@@ -416,11 +419,11 @@ def slim_pairing_for_artifact(
         log(f"slim_selection: {asset} skipped: manifest lists no requires_ggml_sonames")
         return None
     required_sonames = [str(name) for name in sonames]
-    if host.is_windows:
-        # The shared Windows manifest lists libomp because only the cpu llama
-        # bundle links ggml against it; rocm/cuda/vulkan neither ship nor import
-        # it. It is a transitive dep of llama's own ggml, so a working llama
-        # install already satisfies it and this gate can only mis-reject.
+    if host.is_windows and "cpu" not in llama_profile.lower():
+        # The shared Windows manifest lists libomp because the cpu llama bundle
+        # links ggml against it; the rocm/cuda/vulkan bundles neither ship nor
+        # import it, so requiring it there only ever mis-rejects a valid pairing.
+        # A cpu bundle keeps the gate, since its ggml really does need the DLL.
         # link_ggml_runtime still wires it whenever the bundle ships it.
         required_sonames = [
             name

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -304,7 +304,8 @@ def test_install_produces_colocated_layout_and_marker(tmp_path, monkeypatch):
 
     server = install_dir / "build" / "bin" / "whisper-server"
     assert server.is_file()
-    assert server.stat().st_mode & 0o111  # +x set on unix
+    if sys.platform != "win32":
+        assert server.stat().st_mode & 0o111  # +x, POSIX only
     # every shared lib from the archive is co-located next to the server
     assert (install_dir / "build" / "bin" / "libwhisper.so").is_file()
     assert (install_dir / "build" / "bin" / "libggml-base.so").is_file()
@@ -552,6 +553,8 @@ def _cuda_host() -> HostInfo:
 def test_installed_llama_runtime_reads_marker(tmp_path):
     root = tmp_path / "llama.cpp"
     bin_dir = root / "build" / "bin"
+    if sys.platform == "win32":
+        bin_dir = bin_dir / "Release"  # the layout installed_llama_runtime resolves on nt
     bin_dir.mkdir(parents = True)
     (root / "UNSLOTH_PREBUILT_INFO.json").write_text(
         json.dumps({"release_tag": SLIM_LLAMA_TAG, "bundle_profile": "cuda13-newer"})
@@ -1255,6 +1258,10 @@ def test_rocm_runtime_catalog_copy_fallback(tmp_path, monkeypatch):
         assert (whisper_bin / directory / "kernel.dat").read_bytes() == directory.encode()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason = "os.access(X_OK) is always true on Windows, so the guard is POSIX only",
+)
 def test_existing_install_requires_executable_server(tmp_path, monkeypatch):
     # A marker-matching install with a non-executable server must reinstall:
     # the sidecar refuses it via os.access(X_OK), so "already matches" would

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -667,6 +667,21 @@ def test_slim_cpu_requires_a_cpu_module(tmp_path, monkeypatch):
 WIN_SLIM_ASSET = "whisper-v1.9.1-unsloth.1-windows-x64-slim.zip"
 
 
+def _windows_slim_manifest(*, requires_ggml_sonames: list[str]) -> dict:
+    return M.parse_manifest(
+        _manifest(
+            [
+                _slim_artifact(
+                    os = "windows",
+                    arch = "x64",
+                    asset = WIN_SLIM_ASSET,
+                    requires_ggml_sonames = requires_ggml_sonames,
+                )
+            ]
+        )
+    )
+
+
 def test_slim_selected_for_cpu_backend_on_windows(tmp_path, monkeypatch):
     bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
     bin_dir.mkdir(parents = True)
@@ -675,22 +690,100 @@ def test_slim_selected_for_cpu_backend_on_windows(tmp_path, monkeypatch):
     monkeypatch.setattr(
         M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "windows-cpu")
     )
-    manifest = M.parse_manifest(
-        _manifest(
-            [
-                _slim_artifact(
-                    os = "windows",
-                    arch = "x64",
-                    asset = WIN_SLIM_ASSET,
-                    requires_ggml_sonames = ["ggml.dll", "ggml-base.dll"],
-                )
-            ]
-        )
+    manifest = _windows_slim_manifest(
+        requires_ggml_sonames = ["ggml.dll", "ggml-base.dll"]
     )
     artifact, backend, _fb = M.select_artifact_with_fallback(
         manifest, _host("windows", "x64"), "cpu"
     )
     assert artifact["asset"] == WIN_SLIM_ASSET and backend == "cpu"
+
+
+def test_windows_rocm_slim_does_not_require_cpu_only_libomp(tmp_path, monkeypatch):
+    # The published Windows manifest is shared by every backend and lists the
+    # OpenMP runtime shipped by CPU llama bundles. Paired ROCm bundles omit it:
+    # their ggml DLLs do not import OpenMP, so this must remain a valid pairing.
+    bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
+    bin_dir.mkdir(parents = True)
+    for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll", "ggml-hip.dll"):
+        (bin_dir / name).write_bytes(b"ggml")
+    monkeypatch.setattr(
+        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "rocm-gfx1150")
+    )
+    manifest = _windows_slim_manifest(
+        requires_ggml_sonames = [
+            "ggml.dll",
+            "ggml-base.dll",
+            "libomp140.x86_64.dll",
+        ]
+    )
+
+    artifact, backend, used_fallback = M.select_artifact_with_fallback(
+        manifest,
+        _host("windows", "x64", has_rocm = True, rocm_gfx = "gfx1150"),
+        "rocm",
+    )
+
+    assert artifact["asset"] == WIN_SLIM_ASSET
+    assert backend == "rocm" and used_fallback is False
+
+
+@pytest.mark.parametrize("backend", ["cpu", "cuda", "vulkan"])
+def test_windows_non_rocm_slim_still_requires_manifest_libomp(
+    tmp_path, monkeypatch, backend
+):
+    bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
+    bin_dir.mkdir(parents = True)
+    module = {
+        "cpu": "ggml-cpu.dll",
+        "cuda": "ggml-cuda.dll",
+        "vulkan": "ggml-vulkan.dll",
+    }[backend]
+    for name in ("ggml.dll", "ggml-base.dll", module):
+        (bin_dir / name).write_bytes(b"ggml")
+    monkeypatch.setattr(
+        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, f"windows-{backend}")
+    )
+    artifact = _windows_slim_manifest(
+        requires_ggml_sonames = [
+            "ggml.dll",
+            "ggml-base.dll",
+            "libomp140.x86_64.dll",
+        ]
+    )["artifacts"][0]
+
+    assert M.slim_pairing_for_artifact(
+        artifact, _host("windows", "x64"), backend
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "missing_name",
+    ["ggml.dll", "ggml-base.dll", "ggml-hip.dll"],
+)
+def test_windows_rocm_slim_still_requires_ggml_runtime(
+    tmp_path, monkeypatch, missing_name
+):
+    bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
+    bin_dir.mkdir(parents = True)
+    for name in {"ggml.dll", "ggml-base.dll", "ggml-hip.dll"} - {missing_name}:
+        (bin_dir / name).write_bytes(b"ggml")
+    monkeypatch.setattr(
+        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "rocm-gfx1150")
+    )
+    artifact = _windows_slim_manifest(
+        requires_ggml_sonames = [
+            "ggml.dll",
+            "ggml-base.dll",
+            "libomp140.x86_64.dll",
+        ]
+    )["artifacts"][0]
+
+    assert M.slim_pairing_for_artifact(
+        artifact,
+        _host("windows", "x64", has_rocm = True, rocm_gfx = "gfx1150"),
+        "rocm",
+    ) is None
 
 
 MAC_SLIM_ASSET = "whisper-v1.9.1-unsloth.1-macos-arm64-slim.tar.gz"

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -717,9 +717,7 @@ def test_windows_gpu_slim_does_not_require_cpu_only_libomp(
     bin_dir.mkdir(parents = True)
     for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll", module):
         (bin_dir / name).write_bytes(b"ggml")
-    monkeypatch.setattr(
-        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, profile)
-    )
+    monkeypatch.setattr(M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, profile))
     manifest = _windows_slim_manifest(requires_ggml_sonames = WIN_LIBOMP_SONAMES)
 
     artifact, chosen, used_fallback = M.select_artifact_with_fallback(
@@ -738,9 +736,7 @@ def test_windows_cpu_bundle_still_requires_manifest_libomp(tmp_path, monkeypatch
     bin_dir.mkdir(parents = True)
     for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll"):
         (bin_dir / name).write_bytes(b"ggml")
-    monkeypatch.setattr(
-        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, profile)
-    )
+    monkeypatch.setattr(M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, profile))
     artifact = _windows_slim_manifest(requires_ggml_sonames = WIN_LIBOMP_SONAMES)["artifacts"][0]
 
     assert M.slim_pairing_for_artifact(artifact, _host("windows", "x64"), "cpu") is None
@@ -776,9 +772,7 @@ def test_windows_rocm_slim_still_requires_ggml_runtime(tmp_path, monkeypatch, mi
     # ggml backend module, so their presence must not stand in for it.
     for name in ("amdhip64_7.dll", "hipblas.dll", "libhipblaslt.dll"):
         (bin_dir / name).write_bytes(b"runtime")
-    monkeypatch.setattr(
-        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "")
-    )
+    monkeypatch.setattr(M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, ""))
     artifact = _windows_slim_manifest(
         requires_ggml_sonames = [
             "ggml.dll",

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -697,35 +697,30 @@ def test_slim_selected_for_cpu_backend_on_windows(tmp_path, monkeypatch):
     assert artifact["asset"] == WIN_SLIM_ASSET and backend == "cpu"
 
 
-@pytest.mark.parametrize(
-    "backend, module, host_kwargs",
-    [
-        ("rocm", "ggml-hip.dll", {"has_rocm": True, "rocm_gfx": "gfx1150"}),
-        ("cuda", "ggml-cuda.dll", {"has_usable_nvidia": True}),
-        ("vulkan", "ggml-vulkan.dll", {}),
-        ("cpu", "ggml-cpu.dll", {}),
-    ],
-)
-def test_windows_slim_does_not_require_cpu_only_libomp(
-    tmp_path, monkeypatch, backend, module, host_kwargs
+WIN_LIBOMP_SONAMES = ["ggml.dll", "ggml-base.dll", "libomp140.x86_64.dll"]
+
+# bundle_profile as published: the ROCm windows artifacts carry none at all.
+WIN_GPU_BUNDLES = [
+    ("rocm", "ggml-hip.dll", "", {"has_rocm": True, "rocm_gfx": "gfx1150"}),
+    ("cuda", "ggml-cuda.dll", "cuda12-portable", {"has_usable_nvidia": True}),
+    ("vulkan", "ggml-vulkan.dll", "windows-vulkan-x64", {}),
+]
+
+
+@pytest.mark.parametrize("backend, module, profile, host_kwargs", WIN_GPU_BUNDLES)
+def test_windows_gpu_slim_does_not_require_cpu_only_libomp(
+    tmp_path, monkeypatch, backend, module, profile, host_kwargs
 ):
     # The shared Windows manifest lists the OpenMP runtime only the cpu llama
-    # bundle ships; the GPU bundles omit it and never import it, so every
-    # backend must still pair.
+    # bundle ships; the GPU bundles omit it and never import it, so they pair.
     bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
     bin_dir.mkdir(parents = True)
     for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll", module):
         (bin_dir / name).write_bytes(b"ggml")
     monkeypatch.setattr(
-        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, f"windows-{backend}")
+        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, profile)
     )
-    manifest = _windows_slim_manifest(
-        requires_ggml_sonames = [
-            "ggml.dll",
-            "ggml-base.dll",
-            "libomp140.x86_64.dll",
-        ]
-    )
+    manifest = _windows_slim_manifest(requires_ggml_sonames = WIN_LIBOMP_SONAMES)
 
     artifact, chosen, used_fallback = M.select_artifact_with_fallback(
         manifest, _host("windows", "x64", **host_kwargs), backend
@@ -733,6 +728,25 @@ def test_windows_slim_does_not_require_cpu_only_libomp(
 
     assert artifact["asset"] == WIN_SLIM_ASSET
     assert chosen == backend and used_fallback is False
+
+
+@pytest.mark.parametrize("profile", ["windows-cpu-x64", "windows-cpu-arm64"])
+def test_windows_cpu_bundle_still_requires_manifest_libomp(tmp_path, monkeypatch, profile):
+    # A cpu bundle's ggml really does import libomp, so a runtime that lost the
+    # DLL must fail the pairing rather than install a whisper that cannot load.
+    bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
+    bin_dir.mkdir(parents = True)
+    for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll"):
+        (bin_dir / name).write_bytes(b"ggml")
+    monkeypatch.setattr(
+        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, profile)
+    )
+    artifact = _windows_slim_manifest(requires_ggml_sonames = WIN_LIBOMP_SONAMES)["artifacts"][0]
+
+    assert M.slim_pairing_for_artifact(artifact, _host("windows", "x64"), "cpu") is None
+
+    (bin_dir / "libomp140.x86_64.dll").write_bytes(b"omp")
+    assert M.slim_pairing_for_artifact(artifact, _host("windows", "x64"), "cpu") is not None
 
 
 def test_linux_slim_still_requires_manifest_libomp(tmp_path, monkeypatch):
@@ -758,8 +772,12 @@ def test_windows_rocm_slim_still_requires_ggml_runtime(tmp_path, monkeypatch, mi
     bin_dir.mkdir(parents = True)
     for name in {"ggml.dll", "ggml-base.dll", "ggml-hip.dll"} - {missing_name}:
         (bin_dir / name).write_bytes(b"ggml")
+    # The HIP DLLs every published ROCm bundle also ships: none of them is the
+    # ggml backend module, so their presence must not stand in for it.
+    for name in ("amdhip64_7.dll", "hipblas.dll", "libhipblaslt.dll"):
+        (bin_dir / name).write_bytes(b"runtime")
     monkeypatch.setattr(
-        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "rocm-gfx1150")
+        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "")
     )
     artifact = _windows_slim_manifest(
         requires_ggml_sonames = [

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -699,25 +699,25 @@ def test_slim_selected_for_cpu_backend_on_windows(tmp_path, monkeypatch):
 
 WIN_LIBOMP_SONAMES = ["ggml.dll", "ggml-base.dll", "libomp140.x86_64.dll"]
 
-# bundle_profile as published: the ROCm windows artifacts carry none at all.
 WIN_GPU_BUNDLES = [
-    ("rocm", "ggml-hip.dll", "", {"has_rocm": True, "rocm_gfx": "gfx1150"}),
-    ("cuda", "ggml-cuda.dll", "cuda12-portable", {"has_usable_nvidia": True}),
-    ("vulkan", "ggml-vulkan.dll", "windows-vulkan-x64", {}),
+    ("rocm", "ggml-hip.dll", {"has_rocm": True, "rocm_gfx": "gfx1150"}),
+    ("cuda", "ggml-cuda.dll", {"has_usable_nvidia": True}),
+    ("vulkan", "ggml-vulkan.dll", {}),
 ]
 
 
-@pytest.mark.parametrize("backend, module, profile, host_kwargs", WIN_GPU_BUNDLES)
+@pytest.mark.parametrize("backend, module, host_kwargs", WIN_GPU_BUNDLES)
 def test_windows_gpu_slim_does_not_require_cpu_only_libomp(
-    tmp_path, monkeypatch, backend, module, profile, host_kwargs
+    tmp_path, monkeypatch, backend, module, host_kwargs
 ):
     # The shared Windows manifest lists the OpenMP runtime only the cpu llama
     # bundle ships; the GPU bundles omit it and never import it, so they pair.
+    # The empty bundle_profile is what the published rocm artifacts carry.
     bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
     bin_dir.mkdir(parents = True)
     for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll", module):
         (bin_dir / name).write_bytes(b"ggml")
-    monkeypatch.setattr(M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, profile))
+    monkeypatch.setattr(M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, ""))
     manifest = _windows_slim_manifest(requires_ggml_sonames = WIN_LIBOMP_SONAMES)
 
     artifact, chosen, used_fallback = M.select_artifact_with_fallback(
@@ -728,13 +728,15 @@ def test_windows_gpu_slim_does_not_require_cpu_only_libomp(
     assert chosen == backend and used_fallback is False
 
 
-@pytest.mark.parametrize("profile", ["windows-cpu-x64", "windows-cpu-arm64"])
+# "" is the upstream-sourced install: install_llama_prebuilt builds those
+# AssetChoices without a bundle_profile, so a real cpu bundle reports no profile.
+@pytest.mark.parametrize("profile", ["windows-cpu-x64", ""])
 def test_windows_cpu_bundle_still_requires_manifest_libomp(tmp_path, monkeypatch, profile):
     # A cpu bundle's ggml really does import libomp, so a runtime that lost the
     # DLL must fail the pairing rather than install a whisper that cannot load.
     bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
     bin_dir.mkdir(parents = True)
-    for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll"):
+    for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu-haswell.dll"):
         (bin_dir / name).write_bytes(b"ggml")
     monkeypatch.setattr(M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, profile))
     artifact = _windows_slim_manifest(requires_ggml_sonames = WIN_LIBOMP_SONAMES)["artifacts"][0]
@@ -772,7 +774,9 @@ def test_windows_rocm_slim_still_requires_ggml_runtime(tmp_path, monkeypatch, mi
     # ggml backend module, so their presence must not stand in for it.
     for name in ("amdhip64_7.dll", "hipblas.dll", "libhipblaslt.dll"):
         (bin_dir / name).write_bytes(b"runtime")
-    monkeypatch.setattr(M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, ""))
+    monkeypatch.setattr(
+        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "")
+    )
     artifact = _windows_slim_manifest(
         requires_ggml_sonames = [
             "ggml.dll",

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -774,9 +774,7 @@ def test_windows_rocm_slim_still_requires_ggml_runtime(tmp_path, monkeypatch, mi
     # ggml backend module, so their presence must not stand in for it.
     for name in ("amdhip64_7.dll", "hipblas.dll", "libhipblaslt.dll"):
         (bin_dir / name).write_bytes(b"runtime")
-    monkeypatch.setattr(
-        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "")
-    )
+    monkeypatch.setattr(M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, ""))
     artifact = _windows_slim_manifest(
         requires_ggml_sonames = [
             "ggml.dll",

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -706,6 +706,10 @@ WIN_GPU_BUNDLES = [
     ("rocm", "ggml-hip.dll", {"has_rocm": True, "rocm_gfx": "gfx1150"}),
     ("cuda", "ggml-cuda.dll", {"has_usable_nvidia": True}),
     ("vulkan", "ggml-vulkan.dll", {}),
+    # The cpu backend on a GPU bundle: the exemption keys on what the paired bin
+    # dir holds, not on the request, and that bundle's ggml-cpu.dll has no libomp
+    # to find either, so this must pair outright rather than via a cpu retry.
+    ("cpu", "ggml-hip.dll", {}),
 ]
 
 

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -793,6 +793,35 @@ def test_windows_rocm_slim_still_requires_ggml_runtime(tmp_path, monkeypatch, mi
     )
 
 
+def test_windows_rocm_slim_rejects_decoy_hip_dlls_alone(tmp_path, monkeypatch):
+    # Same loss, but with libomp present so the soname gate cannot do the
+    # rejecting: only naming the ggml module rejects this, which is what the
+    # older *hip*.dll glob could not do.
+    bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
+    bin_dir.mkdir(parents = True)
+    for name in (
+        "ggml.dll",
+        "ggml-base.dll",
+        "ggml-cpu.dll",
+        "libomp140.x86_64.dll",
+        "amdhip64_7.dll",
+        "hipblas.dll",
+        "libhipblaslt.dll",
+    ):
+        (bin_dir / name).write_bytes(b"x")
+    monkeypatch.setattr(M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, ""))
+    artifact = _windows_slim_manifest(requires_ggml_sonames = WIN_LIBOMP_SONAMES)["artifacts"][0]
+
+    assert (
+        M.slim_pairing_for_artifact(
+            artifact,
+            _host("windows", "x64", has_rocm = True, rocm_gfx = "gfx1150"),
+            "rocm",
+        )
+        is None
+    )
+
+
 MAC_SLIM_ASSET = "whisper-v1.9.1-unsloth.1-macos-arm64-slim.tar.gz"
 
 

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -690,9 +690,7 @@ def test_slim_selected_for_cpu_backend_on_windows(tmp_path, monkeypatch):
     monkeypatch.setattr(
         M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "windows-cpu")
     )
-    manifest = _windows_slim_manifest(
-        requires_ggml_sonames = ["ggml.dll", "ggml-base.dll"]
-    )
+    manifest = _windows_slim_manifest(requires_ggml_sonames = ["ggml.dll", "ggml-base.dll"])
     artifact, backend, _fb = M.select_artifact_with_fallback(
         manifest, _host("windows", "x64"), "cpu"
     )
@@ -729,9 +727,7 @@ def test_windows_rocm_slim_does_not_require_cpu_only_libomp(tmp_path, monkeypatc
 
 
 @pytest.mark.parametrize("backend", ["cpu", "cuda", "vulkan"])
-def test_windows_non_rocm_slim_still_requires_manifest_libomp(
-    tmp_path, monkeypatch, backend
-):
+def test_windows_non_rocm_slim_still_requires_manifest_libomp(tmp_path, monkeypatch, backend):
     bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
     bin_dir.mkdir(parents = True)
     module = {
@@ -752,18 +748,14 @@ def test_windows_non_rocm_slim_still_requires_manifest_libomp(
         ]
     )["artifacts"][0]
 
-    assert M.slim_pairing_for_artifact(
-        artifact, _host("windows", "x64"), backend
-    ) is None
+    assert M.slim_pairing_for_artifact(artifact, _host("windows", "x64"), backend) is None
 
 
 @pytest.mark.parametrize(
     "missing_name",
     ["ggml.dll", "ggml-base.dll", "ggml-hip.dll"],
 )
-def test_windows_rocm_slim_still_requires_ggml_runtime(
-    tmp_path, monkeypatch, missing_name
-):
+def test_windows_rocm_slim_still_requires_ggml_runtime(tmp_path, monkeypatch, missing_name):
     bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
     bin_dir.mkdir(parents = True)
     for name in {"ggml.dll", "ggml-base.dll", "ggml-hip.dll"} - {missing_name}:
@@ -779,11 +771,14 @@ def test_windows_rocm_slim_still_requires_ggml_runtime(
         ]
     )["artifacts"][0]
 
-    assert M.slim_pairing_for_artifact(
-        artifact,
-        _host("windows", "x64", has_rocm = True, rocm_gfx = "gfx1150"),
-        "rocm",
-    ) is None
+    assert (
+        M.slim_pairing_for_artifact(
+            artifact,
+            _host("windows", "x64", has_rocm = True, rocm_gfx = "gfx1150"),
+            "rocm",
+        )
+        is None
+    )
 
 
 MAC_SLIM_ASSET = "whisper-v1.9.1-unsloth.1-macos-arm64-slim.tar.gz"

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -709,10 +709,9 @@ def test_slim_selected_for_cpu_backend_on_windows(tmp_path, monkeypatch):
 def test_windows_slim_does_not_require_cpu_only_libomp(
     tmp_path, monkeypatch, backend, module, host_kwargs
 ):
-    # The published Windows manifest is shared by every backend and lists the
-    # OpenMP runtime that only the CPU llama bundle ships. The GPU bundles omit
-    # it and their ggml DLLs do not import it, so these must all stay valid
-    # pairings; the CPU bundle ships it either way.
+    # The shared Windows manifest lists the OpenMP runtime only the cpu llama
+    # bundle ships; the GPU bundles omit it and never import it, so every
+    # backend must still pair.
     bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
     bin_dir.mkdir(parents = True)
     for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll", module):

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -697,16 +697,28 @@ def test_slim_selected_for_cpu_backend_on_windows(tmp_path, monkeypatch):
     assert artifact["asset"] == WIN_SLIM_ASSET and backend == "cpu"
 
 
-def test_windows_rocm_slim_does_not_require_cpu_only_libomp(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "backend, module, host_kwargs",
+    [
+        ("rocm", "ggml-hip.dll", {"has_rocm": True, "rocm_gfx": "gfx1150"}),
+        ("cuda", "ggml-cuda.dll", {"has_usable_nvidia": True}),
+        ("vulkan", "ggml-vulkan.dll", {}),
+        ("cpu", "ggml-cpu.dll", {}),
+    ],
+)
+def test_windows_slim_does_not_require_cpu_only_libomp(
+    tmp_path, monkeypatch, backend, module, host_kwargs
+):
     # The published Windows manifest is shared by every backend and lists the
-    # OpenMP runtime shipped by CPU llama bundles. Paired ROCm bundles omit it:
-    # their ggml DLLs do not import OpenMP, so this must remain a valid pairing.
+    # OpenMP runtime that only the CPU llama bundle ships. The GPU bundles omit
+    # it and their ggml DLLs do not import it, so these must all stay valid
+    # pairings; the CPU bundle ships it either way.
     bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
     bin_dir.mkdir(parents = True)
-    for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll", "ggml-hip.dll"):
+    for name in ("ggml.dll", "ggml-base.dll", "ggml-cpu.dll", module):
         (bin_dir / name).write_bytes(b"ggml")
     monkeypatch.setattr(
-        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "rocm-gfx1150")
+        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, f"windows-{backend}")
     )
     manifest = _windows_slim_manifest(
         requires_ggml_sonames = [
@@ -716,39 +728,26 @@ def test_windows_rocm_slim_does_not_require_cpu_only_libomp(tmp_path, monkeypatc
         ]
     )
 
-    artifact, backend, used_fallback = M.select_artifact_with_fallback(
-        manifest,
-        _host("windows", "x64", has_rocm = True, rocm_gfx = "gfx1150"),
-        "rocm",
+    artifact, chosen, used_fallback = M.select_artifact_with_fallback(
+        manifest, _host("windows", "x64", **host_kwargs), backend
     )
 
     assert artifact["asset"] == WIN_SLIM_ASSET
-    assert backend == "rocm" and used_fallback is False
+    assert chosen == backend and used_fallback is False
 
 
-@pytest.mark.parametrize("backend", ["cpu", "cuda", "vulkan"])
-def test_windows_non_rocm_slim_still_requires_manifest_libomp(tmp_path, monkeypatch, backend):
-    bin_dir = tmp_path / "llama.cpp" / "build" / "bin" / "Release"
-    bin_dir.mkdir(parents = True)
-    module = {
-        "cpu": "ggml-cpu.dll",
-        "cuda": "ggml-cuda.dll",
-        "vulkan": "ggml-vulkan.dll",
-    }[backend]
-    for name in ("ggml.dll", "ggml-base.dll", module):
-        (bin_dir / name).write_bytes(b"ggml")
+def test_linux_slim_still_requires_manifest_libomp(tmp_path, monkeypatch):
+    # The exemption is Windows only: llama's clang-built linux slices bundle
+    # libomp beside a libggml-base that really imports it, so it stays mandatory.
+    bin_dir = _fake_llama_bin(tmp_path, backend_module = "libggml-cuda.so")
     monkeypatch.setattr(
-        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, f"windows-{backend}")
+        M, "installed_llama_runtime", lambda: (bin_dir, SLIM_LLAMA_TAG, "linux-cuda")
     )
-    artifact = _windows_slim_manifest(
-        requires_ggml_sonames = [
-            "ggml.dll",
-            "ggml-base.dll",
-            "libomp140.x86_64.dll",
-        ]
-    )["artifacts"][0]
+    artifact = _slim_artifact(
+        requires_ggml_sonames = ["libggml.so.0", "libggml-base.so.0", "libomp.so.5"],
+    )
 
-    assert M.slim_pairing_for_artifact(artifact, _host("windows", "x64"), backend) is None
+    assert M.slim_pairing_for_artifact(artifact, _host("linux", "x64"), "cuda") is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Two independent fixes to the Windows Whisper slim pairing.

**1. Stop requiring a CPU-only `libomp` from GPU llama runtimes.** The Windows x64 Whisper slim artifact is shared across backends and its manifest lists `libomp140.x86_64.dll`, because the Windows CPU llama bundle links ggml against it and ships it. The paired GPU bundles do not: ROCm, CUDA and Vulkan neither ship that DLL nor import it. The installer treated every manifest soname as mandatory for every backend, so it filtered out the valid GPU pairings and reported that no Whisper prebuilt was available. This blocked ROCm, CUDA and Vulkan alike, which is why the gate ends up on `host.is_windows` rather than on ROCm alone.

The exemption is decided from the runtime files, not from the marker: it applies only when the paired bin dir actually ships a GPU ggml backend module. `bundle_profile` cannot make the distinction, because it is absent both on the published Windows ROCm artifacts and on every upstream-sourced install. A CPU-only bundle keeps the mandatory soname, since its ggml genuinely needs the DLL.

**2. Require the real ROCm ggml module on Windows.** `SLIM_BACKEND_MODULE_GLOBS["rocm"]["windows"]` was `*hip*.dll`, which is satisfied by `amdhip64_7.dll`, `hipblas.dll` and `libhipblaslt.dll` that every published ROCm bundle ships alongside `ggml-hip.dll`. That would accept a runtime holding the HIP libraries but no ggml HIP backend module. Tightened to `ggml-hip*.dll`, matching the Linux side's `libggml-hip.so*`. This is the one hunk here that can newly reject a pairing rather than newly accept one; it was unreachable before, because `libomp` blocked Windows ROCm entirely.

Fail-closed behaviour is preserved for CPU, CUDA, Vulkan, Linux and macOS, and the core GGML DLLs plus the Windows HIP module stay mandatory for ROCm.

## Evidence

PE import tables of the published artifacts. The Whisper binaries import only `ggml.dll` and `ggml-base.dll`, no OpenMP at all:

| Windows x64 bundle | ships `libomp140.x86_64.dll` | ggml DLLs importing OpenMP |
| --- | --- | --- |
| cpu | present | `libomp140.x86_64.dll` |
| rocm | absent | none |
| vulkan | absent | none |
| cuda | absent | `VCOMP140.DLL` (MSVC redist, not `libomp140`) |

`ggml-hip.dll` is the module name across the gfx103X, gfx110X, gfx1150, gfx120X, gfx908 and gfx90a bundles and across releases back to b9940; upstream builds the backend as target `ggml-hip`.

## Validation

- `98 passed` in `test_install_whisper_prebuilt_logic.py`, including regression tests for each Windows backend, the CPU backend on a GPU runtime, the CPU bundle keeping the gate with and without a `bundle_profile`, Linux keeping it, and `test_windows_rocm_slim_rejects_decoy_hip_dlls_alone` which pins the glob with `libomp` present so only naming the module can reject.
- A differential simulation over 100 cells covering [Windows, Linux, WSL, macOS] x [NVIDIA, AMD, Intel, CPU only] x every installed bundle shape, diffed against the merge base: 25 cells fixed, 0 regressions, every Linux, WSL and macOS cell unchanged. Runtime wiring, the marker and the sidecar launch guard are byte identical to before, including legacy markers with no `linked_libraries`, `runtime_wiring_version: 2`, and no wiring version.
- Real Windows, Linux and macOS runners, with the accelerator spoofed through the installer's own `--has-rocm` / `--rocm-gfx` / `--backend` hints and a real published llama bundle planted as the managed install. All 10 Windows pairings behaved as expected, and a real slim install completed end to end on Windows: the published artifact downloaded and checksum verified, 24 ggml libraries wired, no `libomp` wired, marker correct, launch guard intact, and a second run leaving the tree untouched.

The last commits also let this test file run on Windows at all. Three pre-existing failures were unconditional POSIX assumptions: a `+x` bit assertion, a fixture built at `build/bin` where `installed_llama_runtime()` resolves `build/bin/Release` on nt, and a check depending on `os.access(X_OK)` returning false. Windows now reports `97 passed, 1 skipped` for this file, the skip being the POSIX-only guard.

## Scope

`#8364` is a separate gate (`SLIM_ROCM_RUNTIME_DIRS`, the Linux ROCm hipBLASLt kernel catalog) and stays open after this lands; `#8400` addresses it.
