### PR TITLE
macOS: stop the Xcode CLT dialog during venv creation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2507,26 +2507,32 @@ if [ "$SKIP_TORCH" = true ] && [ "$MAC_INTEL" = true ] && [ -z "$_USER_PYTHON" ]
     fi
 fi
 
+# Apple Silicon venv: request an arch-explicit arm64 CPython so uv cannot reuse a
+# cached x86_64 (Rosetta) build. torch ships no macOS x86_64 wheels since 2.2.2, so
+# an x86_64 venv makes the torch install unresolvable. The arm64 guard below is kept
+# as a backstop for migrated / pre-existing venvs.
+#
+# only-managed: uv otherwise walks PATH and *executes* every interpreter it finds to
+# read its version. On a Mac with no Command Line Tools /usr/bin/python3 is Apple's
+# xcode_select shim, so that probe pops the "command line developer tools" dialog
+# naming python3, for tools this install never needs.
+#
+# The flag also drops uv's system-interpreter fallback, and an offline host with no
+# cached managed build then has nothing left to resolve. Retry unflagged so that host
+# keeps the install it had before: the dialog is worth removing, a failed install is not.
+_uv_venv_arm64() {  # label
+    run_install_cmd "$1" uv venv "$VENV_DIR" \
+        --python-preference only-managed \
+        --python "cpython-${PYTHON_VERSION}-macos-aarch64-none" \
+    || run_install_cmd "$1 (system Python)" uv venv "$VENV_DIR" \
+        --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
+}
+
 if [ ! -x "$VENV_DIR/bin/python" ]; then
     step "venv" "creating Python ${PYTHON_VERSION} virtual environment"
     substep "$VENV_DIR"
     if [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ] && [ -z "$_USER_PYTHON" ]; then
-        # Apple Silicon: request an arch-explicit arm64 CPython so uv cannot
-        # reuse a cached x86_64 (Rosetta) build. torch ships no macOS x86_64
-        # wheels since 2.2.2, so an x86_64 venv makes the torch install
-        # unresolvable. The arm64 guard below is kept as a backstop for
-        # migrated / pre-existing venvs.
-        #
-        # only-managed: uv otherwise walks PATH and *executes* each interpreter it
-        # finds to read its version, before downloading the build asked for here.
-        # On a Mac with no Command Line Tools, /usr/bin/python3 is Apple's
-        # xcode_select tool shim (byte-identical to /usr/bin/git and /usr/bin/clang),
-        # so that probe pops the "command line developer tools" dialog naming
-        # python3 -- for tools this install never needs. The request is already a
-        # managed build, so this only stops the search, it changes nothing chosen.
-        run_install_cmd "create venv" uv venv "$VENV_DIR" \
-            --python-preference only-managed \
-            --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
+        _uv_venv_arm64 "create venv"
     else
         run_install_cmd "create venv" uv venv "$VENV_DIR" \
             --python "$(_python_request "$PYTHON_VERSION")"
@@ -2582,9 +2588,7 @@ if [ -z "$_USER_PYTHON" ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
         echo "  WARNING: venv was created with an x86_64 (Rosetta) Python on Apple Silicon."
         echo "  Recreating venv with native arm64 Python ${PYTHON_VERSION}..."
         _discard_venv_for_recreate "$VENV_DIR"
-        run_install_cmd "recreate venv (arm64)" uv venv "$VENV_DIR" \
-            --python-preference only-managed \
-            --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
+        _uv_venv_arm64 "recreate venv (arm64)"
         if [ -x "$VENV_DIR/bin/python" ]; then
             : > "$VENV_DIR/.unsloth-studio-owned" 2>/dev/null || true
         fi
@@ -2599,9 +2603,7 @@ if [ -z "$_USER_PYTHON" ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
         echo "  Recreating venv with Python 3.12..."
         _discard_venv_for_recreate "$VENV_DIR"
         PYTHON_VERSION="3.12"
-        run_install_cmd "recreate venv" uv venv "$VENV_DIR" \
-            --python-preference only-managed \
-            --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
+        _uv_venv_arm64 "recreate venv"
         if [ -x "$VENV_DIR/bin/python" ]; then
             : > "$VENV_DIR/.unsloth-studio-owned" 2>/dev/null || true
         fi

--- a/install.sh
+++ b/install.sh
@@ -2516,7 +2516,16 @@ if [ ! -x "$VENV_DIR/bin/python" ]; then
         # wheels since 2.2.2, so an x86_64 venv makes the torch install
         # unresolvable. The arm64 guard below is kept as a backstop for
         # migrated / pre-existing venvs.
+        #
+        # only-managed: uv otherwise walks PATH and *executes* each interpreter it
+        # finds to read its version, before downloading the build asked for here.
+        # On a Mac with no Command Line Tools, /usr/bin/python3 is Apple's
+        # xcode_select tool shim (byte-identical to /usr/bin/git and /usr/bin/clang),
+        # so that probe pops the "command line developer tools" dialog naming
+        # python3 -- for tools this install never needs. The request is already a
+        # managed build, so this only stops the search, it changes nothing chosen.
         run_install_cmd "create venv" uv venv "$VENV_DIR" \
+            --python-preference only-managed \
             --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
     else
         run_install_cmd "create venv" uv venv "$VENV_DIR" \
@@ -2574,6 +2583,7 @@ if [ -z "$_USER_PYTHON" ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
         echo "  Recreating venv with native arm64 Python ${PYTHON_VERSION}..."
         _discard_venv_for_recreate "$VENV_DIR"
         run_install_cmd "recreate venv (arm64)" uv venv "$VENV_DIR" \
+            --python-preference only-managed \
             --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
         if [ -x "$VENV_DIR/bin/python" ]; then
             : > "$VENV_DIR/.unsloth-studio-owned" 2>/dev/null || true
@@ -2590,6 +2600,7 @@ if [ -z "$_USER_PYTHON" ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
         _discard_venv_for_recreate "$VENV_DIR"
         PYTHON_VERSION="3.12"
         run_install_cmd "recreate venv" uv venv "$VENV_DIR" \
+            --python-preference only-managed \
             --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
         if [ -x "$VENV_DIR/bin/python" ]; then
             : > "$VENV_DIR/.unsloth-studio-owned" 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -2515,11 +2515,14 @@ fi
 # only-managed: uv otherwise walks PATH and *executes* every interpreter it finds to
 # read its version. On a Mac with no Command Line Tools /usr/bin/python3 is Apple's
 # xcode_select shim, so that probe pops the "command line developer tools" dialog
-# naming python3, for tools this install never needs.
+# naming python3, for tools this install never needs. Spelled --python-preference
+# rather than its --managed-python alias: identical effect, accepted since uv 0.4.30
+# instead of 0.8.16.
 #
-# The flag also drops uv's system-interpreter fallback, and an offline host with no
-# cached managed build then has nothing left to resolve. Retry unflagged so that host
-# keeps the install it had before: the dialog is worth removing, a failed install is not.
+# The flag also drops uv's system-interpreter fallback, so an offline host, or one
+# with UV_PYTHON_DOWNLOADS=never, has nothing left to resolve and the install dies
+# where it used to work. Retry unflagged for them: the dialog is worth removing, a
+# failed install is not.
 _uv_venv_arm64() {  # label
     run_install_cmd "$1" uv venv "$VENV_DIR" \
         --python-preference only-managed \

--- a/install.sh
+++ b/install.sh
@@ -2507,22 +2507,19 @@ if [ "$SKIP_TORCH" = true ] && [ "$MAC_INTEL" = true ] && [ -z "$_USER_PYTHON" ]
     fi
 fi
 
-# Apple Silicon venv: request an arch-explicit arm64 CPython so uv cannot reuse a
-# cached x86_64 (Rosetta) build. torch ships no macOS x86_64 wheels since 2.2.2, so
-# an x86_64 venv makes the torch install unresolvable. The arm64 guard below is kept
-# as a backstop for migrated / pre-existing venvs.
+# Apple Silicon venv. The arch-explicit arm64 CPython stops uv reusing a cached
+# x86_64 (Rosetta) build: torch ships no macOS x86_64 wheels since 2.2.2, so an
+# x86_64 venv cannot resolve torch. The arm64 guard below backstops older venvs.
 #
-# only-managed: uv otherwise walks PATH and *executes* every interpreter it finds to
-# read its version. On a Mac with no Command Line Tools /usr/bin/python3 is Apple's
-# xcode_select shim, so that probe pops the "command line developer tools" dialog
-# naming python3, for tools this install never needs. Spelled --python-preference
-# rather than its --managed-python alias: identical effect, accepted since uv 0.4.30
-# instead of 0.8.16.
+# only-managed stops uv walking PATH and *executing* every interpreter it finds to
+# read its version. Without CLT, /usr/bin/python3 is Apple's xcode_select shim, so
+# that probe pops the "command line developer tools" dialog for tools this install
+# never needs. Spelled --python-preference, not the --managed-python alias: same
+# effect, accepted since uv 0.4.30 rather than 0.8.16.
 #
-# The flag also drops uv's system-interpreter fallback, so an offline host, or one
-# with UV_PYTHON_DOWNLOADS=never, has nothing left to resolve and the install dies
-# where it used to work. Retry unflagged for them: the dialog is worth removing, a
-# failed install is not.
+# It also drops uv's system-interpreter fallback, so a host that is offline or has
+# UV_PYTHON_DOWNLOADS=never is left with nothing to resolve. Retry unflagged for
+# them: the dialog is worth removing, a failed install is not.
 _uv_venv_arm64() {  # label
     run_install_cmd "$1" uv venv "$VENV_DIR" \
         --python-preference only-managed \

--- a/tests/sh/test_mac_intel_compat.sh
+++ b/tests/sh/test_mac_intel_compat.sh
@@ -571,9 +571,9 @@ echo "=== Apple Silicon x86_64 (Rosetta) venv rebuild ==="
 # Extract the real guard block from install.sh so we exercise the shipped logic
 # (comment header down to its column-0 closing fi).
 _GUARD_FILE=$(mktemp)
-# The guard calls _python_is_skipped and _discard_venv_for_recreate, so the skip
-# list, its reader, and the replacement helpers have to come along or the version
-# check silently never fires and the recreate loses the venv it was handed.
+# The guard calls _python_is_skipped, _discard_venv_for_recreate and _uv_venv_arm64,
+# so the skip list, its reader, and the replacement helpers have to come along or the
+# version check silently never fires and the recreate loses the venv it was handed.
 {
     printf 'substep() { :; }\n'
     sed -n '/^PYTHON_SKIP=/p' "$INSTALL_SH"
@@ -581,10 +581,11 @@ _GUARD_FILE=$(mktemp)
     sed -n '/^_python_is_skipped()/,/^}/p' "$INSTALL_SH"
     sed -n '/^_start_studio_venv_replacement()/,/^}/p' "$INSTALL_SH"
     sed -n '/^_discard_venv_for_recreate()/,/^}/p' "$INSTALL_SH"
+    sed -n '/^_uv_venv_arm64()/,/^}/p' "$INSTALL_SH"
     awk '/Guard against two independent Apple Silicon venv problems/{f=1} f{print} f&&/^fi$/{exit}' \
         "$INSTALL_SH"
 } > "$_GUARD_FILE"
-for _needed in _python_skip_applies _python_is_skipped _start_studio_venv_replacement _discard_venv_for_recreate; do
+for _needed in _python_skip_applies _python_is_skipped _start_studio_venv_replacement _discard_venv_for_recreate _uv_venv_arm64; do
     grep -q "^$_needed()" "$_GUARD_FILE" || {
         echo "  FAIL: could not extract $_needed from install.sh"
         FAIL=$((FAIL + 1))

--- a/tests/sh/test_macos_venv_python_preference.sh
+++ b/tests/sh/test_macos_venv_python_preference.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
-# _uv_venv_arm64: asks uv for a managed CPython only, so uv does not execute every
-# python on PATH (which is the Xcode CLT dialog on a Mac without the tools), and
-# falls back to the unflagged request so an offline host keeps its system Python.
+# _uv_venv_arm64: managed-only, so uv never executes the PATH pythons (the Xcode CLT
+# dialog on a Mac without the tools), with an unflagged retry so a host that cannot
+# resolve a managed build keeps its system Python.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -37,8 +37,8 @@ _FN=$(mktemp)
 sed -n '/^_uv_venv_arm64()/,/^}/p' "$INSTALL_SH" > "$_FN"
 [ -s "$_FN" ] || { echo "  FAIL: _uv_venv_arm64 not found in install.sh"; exit 1; }
 
-# $1 = shell, $2 = exit code the only-managed attempt returns. The stub logs the
-# flags it was handed so ordering and fallback are both visible in one trace.
+# $1 = shell, $2 = exit code for the only-managed attempt. The stub echoes which
+# form it got, so ordering and fallback both show up in one trace.
 _run() {
     "$1" -c '
         . "'"$_FN"'"
@@ -63,8 +63,8 @@ for _sh in sh bash; do
     _out=$(_run "$_sh" 2)
     assert_eq "managed request fails, falls back unflagged" "managed unflagged rc=0 " "$_out"
 
-    # Both attempts failing must still surface non-zero: the caller runs under
-    # set -e and the rollback trap has to fire.
+    # Both failing must stay non-zero: the caller is under set -e and the
+    # rollback trap depends on it.
     _out=$("$_sh" -c '
         . "'"$_FN"'"
         VENV_DIR=/tmp/venv; PYTHON_VERSION=3.12
@@ -76,8 +76,8 @@ done
 
 echo "=== install.sh call sites ==="
 
-# PYTHON_VERSION is re-assigned to 3.12 before the last call site, so the helper
-# has to read it at call time rather than capture it.
+# The last call site re-assigns PYTHON_VERSION to 3.12 first, so the helper has to
+# read it at call time.
 assert_contains "helper expands PYTHON_VERSION at call time" \
     "$(cat "$_FN")" 'cpython-${PYTHON_VERSION}-macos-aarch64-none'
 
@@ -87,8 +87,8 @@ assert_eq "arm64 sites go through the helper only" "0" "$_direct"
 _calls=$(grep -c '^ *_uv_venv_arm64 ' "$INSTALL_SH" || true)
 assert_eq "all three arm64 venv sites routed" "3" "$_calls"
 
-# The non-arm64 branch takes _python_request, which carries a user --python or an
-# explicit interpreter path. only-managed would ignore an interpreter they asked for.
+# _python_request carries a user --python or an interpreter path, which only-managed
+# would ignore.
 _out=$(grep -A 1 '_python_request "\$PYTHON_VERSION"' "$INSTALL_SH" || true)
 if echo "$_out" | grep -q 'only-managed'; then
     echo "  FAIL: only-managed leaked onto a _python_request call site"
@@ -100,9 +100,9 @@ fi
 
 echo "=== Studio installer stream ==="
 
-# install.rs turns [TAURI:ERROR_OUTPUT] into "Installation failed" and only a later
-# [TAURI:ERROR_CLEAR] takes it back, so a fallback that recovers has to emit one or
-# the desktop app reports a failure it already recovered from.
+# install.rs turns [TAURI:ERROR_OUTPUT] into "Installation failed" until a later
+# [TAURI:ERROR_CLEAR]. A recovered fallback must emit one or Studio reports a
+# failure it already recovered from.
 _STREAM=$(mktemp)
 {
     printf 'C_ERR=""; TAURI_MODE=true; UNSLOTH_VERBOSE=false\n'

--- a/tests/sh/test_macos_venv_python_preference.sh
+++ b/tests/sh/test_macos_venv_python_preference.sh
@@ -98,7 +98,54 @@ else
     PASS=$((PASS + 1))
 fi
 
-rm -f "$_FN"
+echo "=== Studio installer stream ==="
+
+# install.rs turns [TAURI:ERROR_OUTPUT] into "Installation failed" and only a later
+# [TAURI:ERROR_CLEAR] takes it back, so a fallback that recovers has to emit one or
+# the desktop app reports a failure it already recovered from.
+_STREAM=$(mktemp)
+{
+    printf 'C_ERR=""; TAURI_MODE=true; UNSLOTH_VERBOSE=false\n'
+    printf 'step() { :; }\ntauri_log() { :; }\n'
+    for _f in _is_verbose tauri_stream_log tauri_clear_install_error _redact_install_output \
+              run_install_cmd _uv_venv_arm64; do
+        sed -n "/^$_f()/,/^}/p" "$INSTALL_SH"
+    done
+} > "$_STREAM"
+
+_UVDIR=$(mktemp -d)
+cat > "$_UVDIR/uv" << 'UV_EOF'
+#!/bin/sh
+case " $* " in *" only-managed "*) [ "$UV_FAIL_MANAGED" = 1 ] && exit 2 ;; esac
+mkdir -p "$2/bin" && printf '#!/bin/sh\n' > "$2/bin/python" && chmod +x "$2/bin/python"
+UV_EOF
+chmod +x "$_UVDIR/uv"
+
+_emit() {  # UV_FAIL_MANAGED
+    _sd=$(mktemp -d)
+    PATH="$_UVDIR:$PATH" VENV_DIR="$_sd/venv" PYTHON_VERSION=3.12 UV_FAIL_MANAGED="$1" \
+        sh -c ". '$_STREAM'; _uv_venv_arm64 'create venv'; echo RC=\$?" 2>&1
+    rm -rf "$_sd"
+}
+
+_out=$(_emit 0)
+assert_contains "managed attempt succeeds, returns 0" "$_out" "RC=0"
+if echo "$_out" | grep -q ERROR_OUTPUT; then
+    echo "  FAIL: clean run must not report a failure"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS: clean run reports no failure"
+    PASS=$((PASS + 1))
+fi
+
+_out=$(_emit 1)
+assert_contains "fallback run still returns 0" "$_out" "RC=0"
+assert_contains "recovery clears the Studio failure" "$_out" "ERROR_CLEAR"
+assert_eq "ERROR_CLEAR is the last error-state line" "ERROR_CLEAR" \
+    "$(echo "$_out" | grep -o 'ERROR_OUTPUT\|ERROR_CLEAR' | tail -1)"
+
+rm -rf "$_UVDIR"
+rm -f "$_FN" "$_STREAM"
 echo ""
 echo "Passed: $PASS, Failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/sh/test_macos_venv_python_preference.sh
+++ b/tests/sh/test_macos_venv_python_preference.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# _uv_venv_arm64: asks uv for a managed CPython only, so uv does not execute every
+# python on PATH (which is the Xcode CLT dialog on a Mac without the tools), and
+# falls back to the unflagged request so an offline host keeps its system Python.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../../install.sh"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    _label="$1"; _expected="$2"; _actual="$3"
+    if [ "$_actual" = "$_expected" ]; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected '$_expected', got '$_actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    _label="$1"; _haystack="$2"; _needle="$3"
+    if echo "$_haystack" | grep -qF "$_needle"; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected to find '$_needle')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+_FN=$(mktemp)
+sed -n '/^_uv_venv_arm64()/,/^}/p' "$INSTALL_SH" > "$_FN"
+[ -s "$_FN" ] || { echo "  FAIL: _uv_venv_arm64 not found in install.sh"; exit 1; }
+
+# $1 = shell, $2 = exit code the only-managed attempt returns. The stub logs the
+# flags it was handed so ordering and fallback are both visible in one trace.
+_run() {
+    "$1" -c '
+        . "'"$_FN"'"
+        VENV_DIR=/tmp/venv; PYTHON_VERSION=3.12
+        run_install_cmd() {
+            shift
+            case " $* " in
+                *" only-managed "*) echo "managed"; return '"$2"' ;;
+            esac
+            echo "unflagged"; return 0
+        }
+        _uv_venv_arm64 "create venv" && echo "rc=0" || echo "rc=$?"
+    ' 2>&1 | tr '\n' ' '
+}
+
+for _sh in sh bash; do
+    echo "=== _uv_venv_arm64 under $_sh ==="
+
+    _out=$(_run "$_sh" 0)
+    assert_eq "managed request succeeds, no fallback" "managed rc=0 " "$_out"
+
+    _out=$(_run "$_sh" 2)
+    assert_eq "managed request fails, falls back unflagged" "managed unflagged rc=0 " "$_out"
+
+    # Both attempts failing must still surface non-zero: the caller runs under
+    # set -e and the rollback trap has to fire.
+    _out=$("$_sh" -c '
+        . "'"$_FN"'"
+        VENV_DIR=/tmp/venv; PYTHON_VERSION=3.12
+        run_install_cmd() { return 2; }
+        _uv_venv_arm64 "create venv" && echo "rc=0" || echo "rc=$?"
+    ' 2>&1)
+    assert_eq "both attempts fail, non-zero propagates" "rc=2" "$_out"
+done
+
+echo "=== install.sh call sites ==="
+
+# PYTHON_VERSION is re-assigned to 3.12 before the last call site, so the helper
+# has to read it at call time rather than capture it.
+assert_contains "helper expands PYTHON_VERSION at call time" \
+    "$(cat "$_FN")" 'cpython-${PYTHON_VERSION}-macos-aarch64-none'
+
+_direct=$(grep -c 'uv venv .*cpython-\${PYTHON_VERSION}-macos-aarch64-none' "$INSTALL_SH" || true)
+assert_eq "arm64 sites go through the helper only" "0" "$_direct"
+
+_calls=$(grep -c '^ *_uv_venv_arm64 ' "$INSTALL_SH" || true)
+assert_eq "all three arm64 venv sites routed" "3" "$_calls"
+
+# The non-arm64 branch takes _python_request, which carries a user --python or an
+# explicit interpreter path. only-managed would ignore an interpreter they asked for.
+_out=$(grep -A 1 '_python_request "\$PYTHON_VERSION"' "$INSTALL_SH" || true)
+if echo "$_out" | grep -q 'only-managed'; then
+    echo "  FAIL: only-managed leaked onto a _python_request call site"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS: _python_request call sites left unflagged"
+    PASS=$((PASS + 1))
+fi
+
+rm -f "$_FN"
+echo ""
+echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## The problem

Installing on a Mac that has never had the Xcode Command Line Tools pops Apple's "command line developer tools" dialog, with text saying `python3` requires them. Nothing in the install needs a compiler, so the prompt is asking the user for 1 to 2 GB of tooling that goes unused.

It is not Unsloth's code making the call. Before downloading the managed build it was asked for, `uv` walks PATH and executes each interpreter it finds to read its version. Its own debug output names the file:

```
DEBUG Found `cpython-3.9.6-macos-aarch64-none` at `/usr/bin/python3` (first executable in the search path)
```

It can only learn "3.9.6" by running that file. On a Mac without CLT, `/usr/bin/python3` is not Python. It is Apple's `xcode_select` tool shim, and running it is what raises the dialog.

## Why that file is a shim

Hashing everything in `/usr/bin` on macOS 26.5.2: **78 binaries are byte-identical**, one md5, 118928 bytes each. Among them `python3`, `git`, `clang`, `gcc`, `cc`, `make`, `swift`, and also `pip3`, `ld`, `strings`, `m4`, `libtool`. The binary self-identifies:

```
$ strings -a /usr/bin/python3 | grep tool-shim
<string>com.apple.dt.xcode_select.tool-shim-public</string>
```

The real interpreter lives inside CLT, at `/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/bin/python3`. With CLT absent there is no real `python3` anywhere, only the shim.

`xcode-select` is a different hash and carries no shim marker, so the existing `xcode-select -p` probe at 2118 is safe. `command -v` and `[ -x ... ]` never trigger anything, they stat without executing.

## The fix

`--python-preference only-managed` on the three `uv venv` calls that already request an explicit managed build (`cpython-${PYTHON_VERSION}-macos-aarch64-none`). Those sites have already decided to use uv's own CPython, so the flag only stops the PATH search. It changes nothing about which interpreter is selected.

The non-arm64 branch a few lines down is deliberately untouched. It takes `_python_request`, which passes through a user's `--python 3.12` or an explicit interpreter path, and `only-managed` would ignore an interpreter they asked for.

## The tools are genuinely not needed

Resolved the full macOS dependency set with source builds forbidden:

```
uv pip install --dry-run --only-binary :all: --python-platform macos --python-version 3.12 \
    -r studio/backend/requirements/studio.txt            -> exit 0
    -r studio/backend/requirements/no-torch-runtime.txt  -> exit 0
```

Everything has a prebuilt macOS wheel. `base.txt` is `unsloth` and `unsloth-zoo`, both pure Python. `sentencepiece>=0.2.0` ships arm64 wheels. `triton_kernels @ git+...` is the only source install and it is skipped on macOS, which `tests/python/test_no_torch_filtering.py:474` already asserts. CPython is uv-managed, and llama.cpp, whisper.cpp and Node are prebuilt downloads.

install.sh already says as much: `_check_macos_deps` at 2233 prints "no Xcode Command Line Tools (not required)", and then uv prompts for them anyway a few hundred lines later.

## Verification

Fake `python3` placed on PATH that logs each execution and exits 1, isolated and empty `UV_CACHE_DIR` and `UV_PYTHON_INSTALL_DIR`, `env -i`.

Before and after, uv 0.12.3, same session:

```
BEFORE (no flag)      exit=0  probes=2  venv=created
AFTER  (with flag)    exit=0  probes=0  venv=created
AFTER  (rerun)        exit=0  probes=0  venv=created
```

install.sh pins no uv version (line 2401 fetches `astral.sh/uv/install.sh`, i.e. latest), so I checked the versions that actually matter: the enforced floor `UV_MIN_VERSION=0.9.3`, the offline floor `UV_OFFLINE_MIN_VERSION=0.8.16`, and current latest 0.12.3.

```
uv 0.8.16   no-flag probes=2 | only-managed probes=0
uv 0.9.3    no-flag probes=2 | only-managed probes=0
uv 0.12.3   no-flag probes=2 | only-managed probes=0
```

The flag is accepted and behaves identically on all three, and the probe is present on all three. Online on 0.12.3 with the flag it downloads cpython-3.12.13, creates the venv, exits 0, zero probes.

Tests:

```
bash -n install.sh                OK
sh -n install.sh                  OK
tests/sh/test_macos_clt_gate      19 passed, 0 failed
tests/sh/test_install_python_guard        25 passed, 0 failed
tests/sh/test_mac_intel_compat            56 passed, 0 failed
tests/sh/test_install_uv_override_space   ALL PASSED
tests/sh/test_install_host_defaults       ALL PASSED
full tests/sh suite               37 suites passed, 5 failed
```

The 5 failures (`test_get_torch_index_url`, `test_llama_build_jobs`, `test_strixhalo_wsl_reroute`, `test_uninstall_sd_cpp_custom_root`, `test_uninstall_webview_data`) fail with identical exit codes on unmodified main, checked by reverting and re-running.

## Scope

First install only. Once uv has a matching managed CPython cached it does not probe PATH at all, so a second run was already quiet. That matches the report being about installing rather than about running.

Not fatal either way. With the probe failing, uv still exits 0 and creates the venv, so dismissing the dialog left the install working. This removes a confusing prompt, it does not unbreak anything.

`--local` installs are out of scope here and still run `git --version` at 2107, which would raise the same dialog naming git. That one is legitimate: `--local` installs `unsloth-zoo @ git+https://` and genuinely needs real git, and there is already a clear message for it at 2120. There is a smaller ordering wart there, the `git --version` sits inside the `if` condition so the dialog appears before that explanation, but that is a different path and a different fix.

## NOT VERIFIED

I never saw the dialog. CLT is installed on this machine and I did not remove it.

What I did verify: that `/usr/bin/python3` is byte-identical to the other shims and carries the `com.apple.dt.xcode_select.tool-shim-public` marker, and that uv executes `/usr/bin/python3` during venv creation. The last link, that executing that shim without CLT raises the dialog, is Apple's documented behaviour and is what install.sh's own comment at 2104 already asserts, but I did not observe it.

Also unverified: what exit status Apple's shim returns when a user clicks Cancel, and whether it blocks waiting. I simulated dismissal with exit 1. And this is macOS arm64 only; I have made no claims about Windows, Linux, CUDA or AMD.

If anyone has a clean Mac or a fresh VM without the Command Line Tools, could you confirm the dialog appears on main and is gone with this flag? That is the one link I cannot close here.
