### PR TITLE
Studio: optimize model picker scans with shared inventory caching

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -60,6 +60,10 @@ import {
   useRepoDownload,
 } from "@/features/hub/download-manager";
 import {
+  INVENTORY_FRESHNESS_WINDOW_MS,
+  useDeviceInventorySources,
+} from "@/features/hub/inventory";
+import {
   type NativeIntent,
   NativeAttachmentTargetContext,
   NativeModelChip,
@@ -112,7 +116,7 @@ import {
   useState,
 } from "react";
 import type { PanelImperativeHandle } from "react-resizable-panels";
-import { listLocalModels, notifyChatHistoryUpdated } from "./api/chat-api";
+import { notifyChatHistoryUpdated } from "./api/chat-api";
 import { ArtifactSurface } from "./artifacts/artifact-surface";
 import {
   clearAutoOpenedArtifacts,
@@ -3066,38 +3070,39 @@ export function ChatPage({
     [externalProvidersForChat, lastOpenRouterChosenModel],
   );
 
-  const [localModels, setLocalModels] = useState<LoraModelOption[]>([]);
+  const localModelInventory = useDeviceInventorySources(["localModels"], {
+    enabled: active,
+  });
+  const localModels = useMemo<LoraModelOption[]>(
+    () =>
+      localModelInventory.localModels.rows
+        .filter(
+          (model) =>
+            model.source === "lmstudio" ||
+            model.source === "models_dir" ||
+            model.source === "custom",
+        )
+        .map((model) => ({
+          id: model.id,
+          name:
+            model.source === "lmstudio" && model.model_id
+              ? model.model_id
+              : model.display_name,
+          baseModel:
+            model.source === "lmstudio"
+              ? "LM Studio"
+              : model.source === "custom"
+                ? "Custom Folders"
+                : "Local models",
+          updatedAt: model.updated_at ?? undefined,
+          source: "local" as const,
+        })),
+    [localModelInventory.localModels.rows],
+  );
 
   const refreshLocalModels = useCallback(() => {
-    void listLocalModels()
-      .then((res) => {
-        setLocalModels(
-          res.models
-            .filter(
-              (m) =>
-                m.source === "lmstudio" ||
-                m.source === "models_dir" ||
-                m.source === "custom",
-            )
-            .map((m) => ({
-              id: m.id,
-              name:
-                m.source === "lmstudio" && m.model_id
-                  ? m.model_id
-                  : m.display_name,
-              baseModel:
-                m.source === "lmstudio"
-                  ? "LM Studio"
-                  : m.source === "custom"
-                    ? "Custom Folders"
-                    : "Local models",
-              updatedAt: m.updated_at ?? undefined,
-              source: "local" as const,
-            })),
-        );
-      })
-      .catch(() => {});
-  }, [navigate]);
+    void localModelInventory.refresh();
+  }, [localModelInventory.refresh]);
 
   const refreshModelLists = useCallback(
     (deletedModel?: DeletedModelRef) => {
@@ -3134,8 +3139,8 @@ export function ChatPage({
   const refreshDeferredModelInventories = useCallback(() => {
     inventoryRefreshStartedRef.current = true;
     void refresh({ includeLoras: true });
-    refreshLocalModels();
-  }, [refresh, refreshLocalModels]);
+    void localModelInventory.refreshIfOlderThan(INVENTORY_FRESHNESS_WINDOW_MS);
+  }, [refresh, localModelInventory.refreshIfOlderThan]);
 
   useEffect(() => {
     if (getTrainingCompareHandoff()) return;

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -63,6 +63,7 @@ import {
   INVENTORY_FRESHNESS_WINDOW_MS,
   useDeviceInventorySources,
 } from "@/features/hub/inventory";
+import { chatLocalModelOptions } from "./local-model-options";
 import {
   type NativeIntent,
   NativeAttachmentTargetContext,
@@ -3074,29 +3075,7 @@ export function ChatPage({
     enabled: active,
   });
   const localModels = useMemo<LoraModelOption[]>(
-    () =>
-      localModelInventory.localModels.rows
-        .filter(
-          (model) =>
-            model.source === "lmstudio" ||
-            model.source === "models_dir" ||
-            model.source === "custom",
-        )
-        .map((model) => ({
-          id: model.id,
-          name:
-            model.source === "lmstudio" && model.model_id
-              ? model.model_id
-              : model.display_name,
-          baseModel:
-            model.source === "lmstudio"
-              ? "LM Studio"
-              : model.source === "custom"
-                ? "Custom Folders"
-                : "Local models",
-          updatedAt: model.updated_at ?? undefined,
-          source: "local" as const,
-        })),
+    () => chatLocalModelOptions(localModelInventory.localModels.rows),
     [localModelInventory.localModels.rows],
   );
 

--- a/studio/frontend/src/features/chat/local-model-options.ts
+++ b/studio/frontend/src/features/chat/local-model-options.ts
@@ -6,23 +6,23 @@ import type { LoraModelOption } from "@/features/model-picker/components/model-s
 
 /** The device-inventory sources Chat lists as local models.
  *
- * `ollama` matters: the compat endpoint Chat used to call reported Ollama pulls as
- * `custom`, while the shared inventory reports their own source, so leaving it out drops
- * every Ollama model from the selector.
+ * Deliberately the same set as the picker's `PICKER_LOCAL_SOURCES`, and `ollama` is
+ * deliberately absent from both. The compat endpoint Chat used to call materialized a
+ * `.gguf` link eagerly and handed back a loadable path, while `/api/hub/local` scans
+ * read-only and returns an opaque `ollama-manifest:` reference that only
+ * `materialize_ollama_model_ref` can resolve. Nothing calls that yet, so offering these
+ * rows would produce entries that fail on selection rather than load.
  */
 const CHAT_LOCAL_SOURCES: ReadonlySet<LocalModelInfo["source"]> = new Set([
   "lmstudio",
   "models_dir",
   "custom",
-  "ollama",
 ]);
 
 function baseModelLabel(source: LocalModelInfo["source"]): string {
   switch (source) {
     case "lmstudio":
       return "LM Studio";
-    case "ollama":
-      return "Ollama";
     case "custom":
       return "Custom Folders";
     default:

--- a/studio/frontend/src/features/chat/local-model-options.ts
+++ b/studio/frontend/src/features/chat/local-model-options.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import type { LocalModelInfo } from "@/features/hub/inventory/api";
+import type { LoraModelOption } from "@/features/model-picker/components/model-selector/types";
+
+/** The device-inventory sources Chat lists as local models.
+ *
+ * `ollama` matters: the compat endpoint Chat used to call reported Ollama pulls as
+ * `custom`, while the shared inventory reports their own source, so leaving it out drops
+ * every Ollama model from the selector.
+ */
+const CHAT_LOCAL_SOURCES: ReadonlySet<LocalModelInfo["source"]> = new Set([
+  "lmstudio",
+  "models_dir",
+  "custom",
+  "ollama",
+]);
+
+function baseModelLabel(source: LocalModelInfo["source"]): string {
+  switch (source) {
+    case "lmstudio":
+      return "LM Studio";
+    case "ollama":
+      return "Ollama";
+    case "custom":
+      return "Custom Folders";
+    default:
+      return "Local models";
+  }
+}
+
+/** Chat's local model options, one per load id.
+ *
+ * The shared inventory keys a row on (format, path), so a directory holding both GGUF and
+ * safetensors weights arrives as two rows with distinct `inventory_id` but the SAME `id`.
+ * The selector keys on `id` (`key={adapter.id}`, `selected={value === adapter.id}`), so
+ * both rows would collide on a React key and render as selected together. The compat
+ * endpoint returned one row per directory, so collapsing on `id` keeps that behaviour.
+ */
+export function chatLocalModelOptions(
+  rows: readonly LocalModelInfo[],
+): LoraModelOption[] {
+  const options: LoraModelOption[] = [];
+  const seen = new Set<string>();
+  for (const model of rows) {
+    if (!CHAT_LOCAL_SOURCES.has(model.source) || seen.has(model.id)) {
+      continue;
+    }
+    seen.add(model.id);
+    options.push({
+      id: model.id,
+      name:
+        model.source === "lmstudio" && model.model_id
+          ? model.model_id
+          : model.display_name,
+      baseModel: baseModelLabel(model.source),
+      updatedAt: model.updated_at ?? undefined,
+      source: "local" as const,
+    });
+  }
+  return options;
+}

--- a/studio/frontend/src/features/hub/inventory/index.ts
+++ b/studio/frontend/src/features/hub/inventory/index.ts
@@ -71,6 +71,7 @@ export {
   type DeviceInventorySource,
   type DeviceInventorySourceState,
 } from "./use-device-inventory";
+export { INVENTORY_FRESHNESS_WINDOW_MS } from "./inventory-freshness";
 export {
   useHubInventory,
   type HubInventoryKind,

--- a/studio/frontend/src/features/hub/inventory/inventory-freshness.ts
+++ b/studio/frontend/src/features/hub/inventory/inventory-freshness.ts
@@ -26,6 +26,32 @@ export function isInventoryStampFresh(
   return age >= 0 && age < Math.max(0, maxAgeMs);
 }
 
+/** Whether a completed forced scan CONFIRMS a previously observed empty inventory.
+ *
+ * Only such a scan may stamp `revalidatedAt`. Stamping every force instead means a manual
+ * refresh of a populated inventory that happens to come back empty records itself as its
+ * own confirmation, so `useHubInventory` settles the picker on "no models" after ONE scan
+ * and the intended second look never happens.
+ */
+export function isEmptyRevalidation(
+  force: boolean,
+  previous: {
+    key: string | null;
+    ready: boolean;
+    error: string | null;
+    rowCount: number;
+  },
+  requestKey: string,
+): boolean {
+  return (
+    force &&
+    previous.key === requestKey &&
+    previous.ready &&
+    previous.error === null &&
+    previous.rowCount === 0
+  );
+}
+
 export function inventoryRefreshDecision(
   source: {
     ready: boolean;

--- a/studio/frontend/src/features/hub/inventory/inventory-freshness.ts
+++ b/studio/frontend/src/features/hub/inventory/inventory-freshness.ts
@@ -26,30 +26,46 @@ export function isInventoryStampFresh(
   return age >= 0 && age < Math.max(0, maxAgeMs);
 }
 
-/** Whether a completed forced scan CONFIRMS a previously observed empty inventory.
+/** The `revalidatedAt` a completed scan should leave behind.
  *
- * Only such a scan may stamp `revalidatedAt`. Stamping every force instead means a manual
- * refresh of a populated inventory that happens to come back empty records itself as its
- * own confirmation, so `useHubInventory` settles the picker on "no models" after ONE scan
- * and the intended second look never happens.
+ * The stamp means one thing only: "an empty inventory has been seen TWICE, so the emptiness
+ * is confirmed". `useHubInventory` skips its second look while the stamp is fresh, so it has
+ * to track both ends of that claim.
+ *
+ * - rows came back, so the inventory is not empty: clear it. Keeping it would let a later
+ *   FIRST empty scan land inside the window and read as already confirmed.
+ * - a forced scan over an inventory already observed empty: this is the second look, stamp
+ *   it. Stamping every force instead lets a manual refresh that happens to return empty
+ *   record itself as its own confirmation.
+ * - anything else: carry the stamp for the same key, and drop it when the key changes.
  */
-export function isEmptyRevalidation(
-  force: boolean,
+export function nextRevalidationStamp({
+  force,
+  requestKey,
+  previous,
+  rowCount,
+  now,
+}: {
+  force: boolean;
+  requestKey: string;
   previous: {
     key: string | null;
     ready: boolean;
     error: string | null;
     rowCount: number;
-  },
-  requestKey: string,
-): boolean {
-  return (
-    force &&
-    previous.key === requestKey &&
-    previous.ready &&
-    previous.error === null &&
-    previous.rowCount === 0
-  );
+    revalidatedAt: number | null;
+  };
+  rowCount: number;
+  now: number;
+}): number | null {
+  if (rowCount > 0) {
+    return null;
+  }
+  const sameKey = previous.key === requestKey;
+  if (force && sameKey && previous.ready && previous.error === null && previous.rowCount === 0) {
+    return now;
+  }
+  return sameKey ? previous.revalidatedAt : null;
 }
 
 export function inventoryRefreshDecision(

--- a/studio/frontend/src/features/hub/inventory/inventory-freshness.ts
+++ b/studio/frontend/src/features/hub/inventory/inventory-freshness.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export type InventoryRefreshDecision = "reuse" | "join" | "refresh";
+export const INVENTORY_FRESHNESS_WINDOW_MS = 30_000;
+
+export function inventoryRefreshDecision(
+  source: {
+    ready: boolean;
+    loading: boolean;
+    error: string | null;
+    key: string | null;
+    refreshedAt: number | null;
+  },
+  requestKey: string,
+  now: number,
+  maxAgeMs: number,
+): InventoryRefreshDecision {
+  if (!source.ready || source.key !== requestKey || source.loading) {
+    return "join";
+  }
+  if (source.error !== null) {
+    return "refresh";
+  }
+  if (
+    source.refreshedAt === null ||
+    now - source.refreshedAt >= Math.max(0, maxAgeMs)
+  ) {
+    return "refresh";
+  }
+  return "reuse";
+}

--- a/studio/frontend/src/features/hub/inventory/inventory-freshness.ts
+++ b/studio/frontend/src/features/hub/inventory/inventory-freshness.ts
@@ -4,6 +4,28 @@
 export type InventoryRefreshDecision = "reuse" | "join" | "refresh";
 export const INVENTORY_FRESHNESS_WINDOW_MS = 30_000;
 
+/** Whether a `Date.now()` stamp is still inside `maxAgeMs`.
+ *
+ * A NEGATIVE age counts as stale, not fresh. These stamps come from `Date.now()`, which
+ * tracks the system clock and can step backwards (an NTP correction of more than ~125ms
+ * jumps rather than slews, and a VM resume or a user editing the clock does the same); only
+ * `performance.now()` is monotonic. Without the guard a stamp from the future reads as
+ * "younger than the window", so every caller reuses and the inventory stays frozen for the
+ * length of the skew -- including `refreshIfOlderThan(0)`, which callers use to mean
+ * "refresh unconditionally".
+ */
+export function isInventoryStampFresh(
+  stamp: number | null,
+  now: number,
+  maxAgeMs: number,
+): boolean {
+  if (stamp === null) {
+    return false;
+  }
+  const age = now - stamp;
+  return age >= 0 && age < Math.max(0, maxAgeMs);
+}
+
 export function inventoryRefreshDecision(
   source: {
     ready: boolean;
@@ -22,11 +44,7 @@ export function inventoryRefreshDecision(
   if (source.error !== null) {
     return "refresh";
   }
-  if (
-    source.refreshedAt === null ||
-    now - source.refreshedAt >= Math.max(0, maxAgeMs)
-  ) {
-    return "refresh";
-  }
-  return "reuse";
+  return isInventoryStampFresh(source.refreshedAt, now, maxAgeMs)
+    ? "reuse"
+    : "refresh";
 }

--- a/studio/frontend/src/features/hub/inventory/inventory-settlement.ts
+++ b/studio/frontend/src/features/hub/inventory/inventory-settlement.ts
@@ -3,20 +3,18 @@
 
 export function resolveInventorySettlement({
   downloadedReady,
-  emptyRevalidationSignature,
+  emptyRevalidationFresh,
   hasActiveEmptyRefresh,
   hasInventoryRows,
   hasUnreadyInventoryFailure,
   inventoryFailed,
-  lastEmptyRevalidationSignature,
 }: {
   downloadedReady: boolean;
-  emptyRevalidationSignature: string;
+  emptyRevalidationFresh: boolean;
   hasActiveEmptyRefresh: boolean;
   hasInventoryRows: boolean;
   hasUnreadyInventoryFailure: boolean;
   inventoryFailed: boolean;
-  lastEmptyRevalidationSignature: string | null;
 }): {
   emptyRevalidationRequired: boolean;
   inventorySettled: boolean;
@@ -26,7 +24,7 @@ export function resolveInventorySettlement({
     !inventoryFailed &&
     !hasInventoryRows &&
     !hasActiveEmptyRefresh &&
-    lastEmptyRevalidationSignature !== emptyRevalidationSignature;
+    !emptyRevalidationFresh;
   return {
     emptyRevalidationRequired,
     inventorySettled:

--- a/studio/frontend/src/features/hub/inventory/use-device-inventory.ts
+++ b/studio/frontend/src/features/hub/inventory/use-device-inventory.ts
@@ -20,6 +20,7 @@ import { useInventoryVersion } from "../stores/inventory-events";
 import { useCallback, useEffect, useMemo } from "react";
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
+import { inventoryRefreshDecision } from "./inventory-freshness";
 
 export type DeviceInventorySource =
   | "cachedGguf"
@@ -42,6 +43,8 @@ export type DeviceInventorySourceState<Rows extends readonly unknown[]> = {
   ready: boolean;
   error: string | null;
   key: string | null;
+  refreshedAt: number | null;
+  revalidatedAt: number | null;
 };
 
 type DeviceInventoryState = {
@@ -66,6 +69,7 @@ type UseDeviceInventoryResult<
   Sources extends readonly DeviceInventorySource[],
 > = Pick<DeviceInventoryState, Sources[number]> & {
   refresh: () => Promise<void>;
+  refreshIfOlderThan: (maxAgeMs: number) => Promise<void>;
 };
 
 const TOKEN_SCOPED_SOURCES = new Set<DeviceInventorySource>([
@@ -86,6 +90,8 @@ function emptySource<
     ready: false,
     error: null,
     key: null,
+    refreshedAt: null,
+    revalidatedAt: null,
   };
 }
 
@@ -214,7 +220,12 @@ export function fetchInventorySource<K extends DeviceInventorySource>(
     forceQueue.set(key, refetch);
     return refetch;
   }
-  if (!options.force && current.ready && current.key === key) {
+  if (
+    !options.force &&
+    current.ready &&
+    current.error === null &&
+    current.key === key
+  ) {
     return Promise.resolve(current.rows);
   }
 
@@ -225,17 +236,26 @@ export function fetchInventorySource<K extends DeviceInventorySource>(
     ready: current.ready,
     error: null,
     key,
+    refreshedAt: current.key === key ? current.refreshedAt : null,
+    revalidatedAt: current.key === key ? current.revalidatedAt : null,
   });
 
   const request = runSourceFetch(source, options.hfToken)
     .then((rows) => {
       if (useDeviceInventoryStore.getState()[source].key === key) {
+        const refreshedAt = Date.now();
         updateSourceState(source, {
           rows,
           loading: false,
           ready: true,
           error: null,
           key,
+          refreshedAt,
+          revalidatedAt: options.force
+            ? refreshedAt
+            : current.key === key
+              ? current.revalidatedAt
+              : null,
         });
       }
       return rows;
@@ -261,23 +281,6 @@ export function fetchInventorySource<K extends DeviceInventorySource>(
 
   inFlight.set(key, request);
   return request;
-}
-
-export function inventoryEmptyRevalidationSignature(
-  sources: readonly Pick<
-    DeviceInventorySourceState<readonly unknown[]>,
-    "error" | "key" | "ready"
-  >[],
-): string {
-  return sources
-    .map((source) =>
-      [
-        source.key ?? "pending",
-        source.ready ? "ready" : "pending",
-        source.error ?? "",
-      ].join("\u0001"),
-    )
-    .join("\u0002");
 }
 
 export function useTokenScopedInventoryRequestOptions(
@@ -368,6 +371,43 @@ export function useDeviceInventorySources<
     }
   }, [sourceList, hfToken, tokenFingerprint, inventoryVersion]);
 
+  const refreshIfOlderThan = useCallback(
+    async (maxAgeMs: number) => {
+      const now = Date.now();
+      const requests = sourceList.flatMap((source) => {
+        const key = sourceRequestKey(
+          source,
+          inventoryVersion,
+          tokenFingerprint,
+        );
+        const current = useDeviceInventoryStore.getState()[source];
+        const decision = inventoryRefreshDecision(current, key, now, maxAgeMs);
+        if (decision === "reuse") return [];
+        return [
+          {
+            source,
+            request: fetchInventorySource(source, {
+              hfToken,
+              tokenFingerprint,
+              inventoryVersion,
+              force: decision === "refresh",
+            }),
+          },
+        ];
+      });
+      const results = await Promise.allSettled(
+        requests.map(({ request }) => request),
+      );
+      for (const [index, result] of results.entries()) {
+        if (result.status === "rejected") {
+          const source = requests[index]?.source;
+          if (source) logInventorySourceFailure(source, result.reason);
+        }
+      }
+    },
+    [sourceList, hfToken, tokenFingerprint, inventoryVersion],
+  );
+
   useEffect(() => {
     if (!enabled) {
       return;
@@ -384,5 +424,6 @@ export function useDeviceInventorySources<
   return {
     ...state,
     refresh,
+    refreshIfOlderThan,
   } as UseDeviceInventoryResult<Sources>;
 }

--- a/studio/frontend/src/features/hub/inventory/use-device-inventory.ts
+++ b/studio/frontend/src/features/hub/inventory/use-device-inventory.ts
@@ -20,7 +20,10 @@ import { useInventoryVersion } from "../stores/inventory-events";
 import { useCallback, useEffect, useMemo } from "react";
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
-import { inventoryRefreshDecision } from "./inventory-freshness";
+import {
+  inventoryRefreshDecision,
+  isEmptyRevalidation,
+} from "./inventory-freshness";
 
 export type DeviceInventorySource =
   | "cachedGguf"
@@ -251,7 +254,16 @@ export function fetchInventorySource<K extends DeviceInventorySource>(
           error: null,
           key,
           refreshedAt,
-          revalidatedAt: options.force
+          revalidatedAt: isEmptyRevalidation(
+            Boolean(options.force),
+            {
+              key: current.key,
+              ready: current.ready,
+              error: current.error,
+              rowCount: current.rows.length,
+            },
+            key,
+          )
             ? refreshedAt
             : current.key === key
               ? current.revalidatedAt

--- a/studio/frontend/src/features/hub/inventory/use-device-inventory.ts
+++ b/studio/frontend/src/features/hub/inventory/use-device-inventory.ts
@@ -22,7 +22,7 @@ import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 import {
   inventoryRefreshDecision,
-  isEmptyRevalidation,
+  nextRevalidationStamp,
 } from "./inventory-freshness";
 
 export type DeviceInventorySource =
@@ -254,20 +254,19 @@ export function fetchInventorySource<K extends DeviceInventorySource>(
           error: null,
           key,
           refreshedAt,
-          revalidatedAt: isEmptyRevalidation(
-            Boolean(options.force),
-            {
+          revalidatedAt: nextRevalidationStamp({
+            force: Boolean(options.force),
+            requestKey: key,
+            previous: {
               key: current.key,
               ready: current.ready,
               error: current.error,
               rowCount: current.rows.length,
+              revalidatedAt: current.revalidatedAt,
             },
-            key,
-          )
-            ? refreshedAt
-            : current.key === key
-              ? current.revalidatedAt
-              : null,
+            rowCount: rows.length,
+            now: refreshedAt,
+          }),
         });
       }
       return rows;

--- a/studio/frontend/src/features/hub/inventory/use-hub-inventory.ts
+++ b/studio/frontend/src/features/hub/inventory/use-hub-inventory.ts
@@ -37,7 +37,10 @@ import {
   defaultCapabilities,
   normalizeTimestamp,
 } from "./view-models";
-import { INVENTORY_FRESHNESS_WINDOW_MS } from "./inventory-freshness";
+import {
+  INVENTORY_FRESHNESS_WINDOW_MS,
+  isInventoryStampFresh,
+} from "./inventory-freshness";
 
 export interface HubInventory {
   cachedRows: CachedInventoryRow[];
@@ -610,8 +613,11 @@ export function useHubInventory(
   const emptyRevalidationFresh = relevantInventorySources.every(
     (source) =>
       source.error === null &&
-      source.revalidatedAt !== null &&
-      now - source.revalidatedAt < INVENTORY_FRESHNESS_WINDOW_MS,
+      isInventoryStampFresh(
+        source.revalidatedAt,
+        now,
+        INVENTORY_FRESHNESS_WINDOW_MS,
+      ),
   );
   const { emptyRevalidationRequired, inventorySettled } =
     resolveInventorySettlement({

--- a/studio/frontend/src/features/hub/inventory/use-hub-inventory.ts
+++ b/studio/frontend/src/features/hub/inventory/use-hub-inventory.ts
@@ -7,7 +7,7 @@ import {
   useDownloadManagerStore,
 } from "@/features/hub/download-manager";
 import { useHfTokenStore } from "@/features/hub/stores/hf-token-store";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { LocalDatasetInfo } from "./api";
 import {
   dedupeSameSourceHubCacheRows,
@@ -29,7 +29,6 @@ import { resolveInventorySettlement } from "./inventory-settlement";
 import type { CachedInventoryRow, LocalInventoryRow } from "./types";
 import {
   type DeviceInventorySource,
-  inventoryEmptyRevalidationSignature,
   useDeviceInventorySources,
 } from "./use-device-inventory";
 import {
@@ -38,6 +37,7 @@ import {
   defaultCapabilities,
   normalizeTimestamp,
 } from "./view-models";
+import { INVENTORY_FRESHNESS_WINDOW_MS } from "./inventory-freshness";
 
 export interface HubInventory {
   cachedRows: CachedInventoryRow[];
@@ -49,6 +49,7 @@ export interface HubInventory {
   inventoryError: boolean;
   inventoryWarning: boolean;
   refreshInventory: () => Promise<void>;
+  refreshInventoryIfOlderThan: (maxAgeMs: number) => Promise<void>;
 }
 
 export type HubInventoryKind = "models" | "datasets";
@@ -263,6 +264,13 @@ export function useHubInventory(
   const refreshDatasetInventory = datasetInventory.refresh;
   const refreshLocalModelInventory = localModelInventory.refresh;
   const refreshLocalDatasetInventory = localDatasetInventory.refresh;
+  const refreshModelInventoryIfOlderThan = modelInventory.refreshIfOlderThan;
+  const refreshDatasetInventoryIfOlderThan =
+    datasetInventory.refreshIfOlderThan;
+  const refreshLocalModelInventoryIfOlderThan =
+    localModelInventory.refreshIfOlderThan;
+  const refreshLocalDatasetInventoryIfOlderThan =
+    localDatasetInventory.refreshIfOlderThan;
   const pendingHints = useInventoryHintStore((state) => state.pending);
   const observedInventoryKeys = useInventoryHintStore(
     (state) => state.observedKeys,
@@ -281,8 +289,6 @@ export function useHubInventory(
     [isDatasetMode],
   );
   const liveInventoryJobs = useDownloadManagerStore(selectLiveInventoryJobs);
-  const [lastEmptyRevalidationSignature, setLastEmptyRevalidationSignature] =
-    useState<string | null>(null);
   const pendingForRenderRef = useRef<PendingInventoryHints | null>(null);
 
   const pendingForRenderNext = useMemo(
@@ -557,6 +563,33 @@ export function useHubInventory(
   const refreshInventory = useCallback(async () => {
     await refreshDeviceInventory();
   }, [refreshDeviceInventory]);
+  const refreshInventoryIfOlderThan = useCallback(
+    async (maxAgeMs: number) => {
+      if (isDatasetMode) {
+        await Promise.all([
+          refreshDatasetInventoryIfOlderThan(maxAgeMs),
+          ...(includeLocal
+            ? [refreshLocalDatasetInventoryIfOlderThan(maxAgeMs)]
+            : []),
+        ]);
+        return;
+      }
+      await Promise.all([
+        refreshModelInventoryIfOlderThan(maxAgeMs),
+        ...(includeLocal
+          ? [refreshLocalModelInventoryIfOlderThan(maxAgeMs)]
+          : []),
+      ]);
+    },
+    [
+      includeLocal,
+      isDatasetMode,
+      refreshDatasetInventoryIfOlderThan,
+      refreshLocalDatasetInventoryIfOlderThan,
+      refreshLocalModelInventoryIfOlderThan,
+      refreshModelInventoryIfOlderThan,
+    ],
+  );
   const downloadedReady = isDatasetMode ? datasetReady : modelReady;
   const hasInventoryRows =
     cachedRows.length > 0 || effectiveLocalRows.length > 0;
@@ -566,37 +599,28 @@ export function useHubInventory(
     : cachedGgufSource.loading ||
       cachedModelsSource.loading ||
       (includeLocal && localModelsSource.loading);
-  const emptyRevalidationSignature = useMemo(
-    () =>
-      isDatasetMode
-        ? inventoryEmptyRevalidationSignature([
-            cachedDatasetsSource,
-            ...(includeLocal ? [localDatasetsSource] : []),
-          ])
-        : inventoryEmptyRevalidationSignature([
-            cachedGgufSource,
-            cachedModelsSource,
-            ...(includeLocal ? [localModelsSource] : []),
-          ]),
-    [
-      cachedDatasetsSource,
-      cachedGgufSource,
-      cachedModelsSource,
-      includeLocal,
-      isDatasetMode,
-      localDatasetsSource,
-      localModelsSource,
-    ],
+  const relevantInventorySources = isDatasetMode
+    ? [cachedDatasetsSource, ...(includeLocal ? [localDatasetsSource] : [])]
+    : [
+        cachedGgufSource,
+        cachedModelsSource,
+        ...(includeLocal ? [localModelsSource] : []),
+      ];
+  const now = Date.now();
+  const emptyRevalidationFresh = relevantInventorySources.every(
+    (source) =>
+      source.error === null &&
+      source.revalidatedAt !== null &&
+      now - source.revalidatedAt < INVENTORY_FRESHNESS_WINDOW_MS,
   );
   const { emptyRevalidationRequired, inventorySettled } =
     resolveInventorySettlement({
       downloadedReady,
-      emptyRevalidationSignature,
+      emptyRevalidationFresh,
       hasActiveEmptyRefresh,
       hasInventoryRows,
       hasUnreadyInventoryFailure,
       inventoryFailed,
-      lastEmptyRevalidationSignature,
     });
 
   useEffect(() => {
@@ -604,13 +628,11 @@ export function useHubInventory(
       return;
     }
     const timer = window.setTimeout(() => {
-      setLastEmptyRevalidationSignature(emptyRevalidationSignature);
       void refreshDeviceInventory();
     }, 500);
     return () => window.clearTimeout(timer);
   }, [
     emptyRevalidationRequired,
-    emptyRevalidationSignature,
     enabled,
     refreshDeviceInventory,
   ]);
@@ -625,5 +647,6 @@ export function useHubInventory(
     inventoryError: inventoryFailed,
     inventoryWarning,
     refreshInventory,
+    refreshInventoryIfOlderThan,
   };
 }

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -12,6 +12,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { usePlatformStore } from "@/config/env";
+import { INVENTORY_FRESHNESS_WINDOW_MS } from "@/features/hub/inventory";
 import { ApiProviderLogo } from "@/features/chat";
 import {
   type ScanFolderInfo,
@@ -2369,8 +2370,13 @@ export function HubModelPicker({
   }, []);
 
   const pickerInventory = useChatPickerInventory({ enabled: true });
-  const { cachedGguf, cachedModels, cachedReady, refreshInventory } =
-    pickerInventory;
+  const {
+    cachedGguf,
+    cachedModels,
+    cachedReady,
+    refreshInventory,
+    refreshInventoryIfOlderThan,
+  } = pickerInventory;
   const cachedReadyAtMount = useRef(cachedReady);
   const lmStudioModels = useMemo(
     () =>
@@ -2562,8 +2568,8 @@ export function HubModelPicker({
     if (!shouldRefreshPickerInventoryOnMount(cachedReadyAtMount.current)) {
       return;
     }
-    void refreshInventory();
-  }, [refreshInventory]);
+    void refreshInventoryIfOlderThan(INVENTORY_FRESHNESS_WINDOW_MS);
+  }, [refreshInventoryIfOlderThan]);
 
   // Hide downloaded models from the recommended list. Case-insensitive
   // since the HF cache lowercases repo IDs.

--- a/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
+++ b/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
@@ -73,6 +73,7 @@ export interface ChatPickerInventory {
   cachedReady: boolean;
   localModels: LocalModelInfo[];
   refreshInventory: () => Promise<void>;
+  refreshInventoryIfOlderThan: (maxAgeMs: number) => Promise<void>;
 }
 
 export function useChatPickerInventory(
@@ -134,5 +135,6 @@ export function useChatPickerInventory(
     cachedReady: inventory.downloadedReady,
     localModels,
     refreshInventory: inventory.refreshInventory,
+    refreshInventoryIfOlderThan: inventory.refreshInventoryIfOlderThan,
   };
 }

--- a/studio/frontend/tests/chat-local-model-options.test.ts
+++ b/studio/frontend/tests/chat-local-model-options.test.ts
@@ -29,15 +29,21 @@ function row(over: Record<string, unknown> = {}) {
   } as never;
 }
 
-test("Ollama pulls stay in the local model list", () => {
-  // /api/models/local reported these as "custom"; /api/hub/local reports "ollama". Filtering
-  // on the old set removed every Ollama model from Chat.
-  const options = chatLocalModelOptions([
-    row({ id: "/ollama/llama3", display_name: "llama3", source: "ollama" }),
-  ]);
-  assert.equal(options.length, 1);
-  assert.equal(options[0]?.id, "/ollama/llama3");
-  assert.equal(options[0]?.baseModel, "Ollama");
+test("Ollama rows are withheld until their refs are loadable", () => {
+  // /api/hub/local scans read-only and returns an opaque `ollama-manifest:` id that only
+  // materialize_ollama_model_ref can turn into a .gguf path, and nothing calls that yet.
+  // The picker withholds these rows for the same reason (PICKER_LOCAL_SOURCES), so Chat
+  // matches it: an entry that fails on click is worse than one that is not offered.
+  assert.deepEqual(
+    chatLocalModelOptions([
+      row({
+        id: "ollama-manifest:%2Fhome%2Fu%2F.ollama%2Fmanifests%2Fllama3",
+        display_name: "llama3",
+        source: "ollama",
+      }),
+    ]),
+    [],
+  );
 });
 
 test("a directory with two weight formats yields one option per load id", () => {

--- a/studio/frontend/tests/chat-local-model-options.test.ts
+++ b/studio/frontend/tests/chat-local-model-options.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Chat reads local models from the shared device inventory rather than the compat
+// /api/models/local endpoint. The two disagree in ways that silently drop models, so the
+// mapping is pinned here against what each endpoint actually returns.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { chatLocalModelOptions } = await import(
+  "../src/features/chat/local-model-options.ts"
+);
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    id: "/models/demo",
+    // biome-ignore lint/style/useNamingConvention: API schema
+    display_name: "demo",
+    path: "/models/demo",
+    source: "models_dir",
+    // biome-ignore lint/style/useNamingConvention: API schema
+    updated_at: 1,
+    ...over,
+  } as never;
+}
+
+test("Ollama pulls stay in the local model list", () => {
+  // /api/models/local reported these as "custom"; /api/hub/local reports "ollama". Filtering
+  // on the old set removed every Ollama model from Chat.
+  const options = chatLocalModelOptions([
+    row({ id: "/ollama/llama3", display_name: "llama3", source: "ollama" }),
+  ]);
+  assert.equal(options.length, 1);
+  assert.equal(options[0]?.id, "/ollama/llama3");
+  assert.equal(options[0]?.baseModel, "Ollama");
+});
+
+test("a directory with two weight formats yields one option per load id", () => {
+  // The shared inventory keys a row on (format, path), so this arrives as two rows with the
+  // same `id`. The selector keys on `id`, so both would share a React key and read as
+  // selected together.
+  const options = chatLocalModelOptions([
+    row({ model_format: "gguf", inventory_id: "models_dir:gguf:/models/demo" }),
+    row({
+      model_format: "safetensors",
+      inventory_id: "models_dir:safetensors:/models/demo",
+    }),
+  ]);
+  assert.equal(options.length, 1);
+  assert.equal(options[0]?.id, "/models/demo");
+});
+
+test("hf_cache rows stay out of the local list", () => {
+  assert.deepEqual(chatLocalModelOptions([row({ source: "hf_cache" })]), []);
+});
+
+test("LM Studio rows prefer the model id and keep their label", () => {
+  const options = chatLocalModelOptions([
+    row({
+      id: "/lm/x",
+      source: "lmstudio",
+      model_id: "publisher/model",
+      display_name: "x",
+    }),
+  ]);
+  assert.equal(options[0]?.name, "publisher/model");
+  assert.equal(options[0]?.baseModel, "LM Studio");
+});
+
+test("custom and models_dir rows keep the labels the picker groups on", () => {
+  const options = chatLocalModelOptions([
+    row({ id: "/a", source: "custom" }),
+    row({ id: "/b", source: "models_dir" }),
+  ]);
+  assert.deepEqual(
+    options.map((o) => o.baseModel),
+    ["Custom Folders", "Local models"],
+  );
+});

--- a/studio/frontend/tests/inventory-freshness.test.ts
+++ b/studio/frontend/tests/inventory-freshness.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   inventoryRefreshDecision,
+  isEmptyRevalidation,
   isInventoryStampFresh,
 } from "../src/features/hub/inventory/inventory-freshness.ts";
 
@@ -145,4 +146,25 @@ test("isInventoryStampFresh rejects a null, an expired and a future stamp", () =
   assert.equal(isInventoryStampFresh(NOW + 1, NOW, 30_000), false);
   assert.equal(isInventoryStampFresh(NOW - 29_999, NOW, 30_000), true);
   assert.equal(isInventoryStampFresh(NOW, NOW, 30_000), true);
+});
+
+test("only a forced scan confirming an empty inventory stamps revalidation", () => {
+  const empty = { key: KEY, ready: true, error: null, rowCount: 0 };
+  assert.equal(isEmptyRevalidation(true, empty, KEY), true);
+
+  // A manual refresh of a POPULATED inventory that happens to come back empty is the first
+  // scan to see the empty state, not its confirmation. Stamping it settles the picker on
+  // "no models" after one scan.
+  assert.equal(
+    isEmptyRevalidation(true, { ...empty, rowCount: 4 }, KEY),
+    false,
+  );
+  // Not forced, a different key, unready, or previously failed: none of those confirm.
+  assert.equal(isEmptyRevalidation(false, empty, KEY), false);
+  assert.equal(isEmptyRevalidation(true, { ...empty, key: "other" }, KEY), false);
+  assert.equal(isEmptyRevalidation(true, { ...empty, ready: false }, KEY), false);
+  assert.equal(
+    isEmptyRevalidation(true, { ...empty, error: "scan failed" }, KEY),
+    false,
+  );
 });

--- a/studio/frontend/tests/inventory-freshness.test.ts
+++ b/studio/frontend/tests/inventory-freshness.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { inventoryRefreshDecision } from "../src/features/hub/inventory/inventory-freshness.ts";
+
+const NOW = 100_000;
+const KEY = "localModels:7:local";
+
+test("fresh inventory is reused across rapid picker opens", () => {
+  assert.equal(
+    inventoryRefreshDecision(
+      {
+        ready: true,
+        loading: false,
+        error: null,
+        key: KEY,
+        refreshedAt: NOW - 1_000,
+      },
+      KEY,
+      NOW,
+      30_000,
+    ),
+    "reuse",
+  );
+});
+
+test("an in-flight inventory request is joined without queuing another scan", () => {
+  assert.equal(
+    inventoryRefreshDecision(
+      {
+        ready: false,
+        loading: true,
+        error: null,
+        key: KEY,
+        refreshedAt: null,
+      },
+      KEY,
+      NOW,
+      30_000,
+    ),
+    "join",
+  );
+});
+
+test("expired inventory is refreshed", () => {
+  assert.equal(
+    inventoryRefreshDecision(
+      {
+        ready: true,
+        loading: false,
+        error: null,
+        key: KEY,
+        refreshedAt: NOW - 30_000,
+      },
+      KEY,
+      NOW,
+      30_000,
+    ),
+    "refresh",
+  );
+});
+
+test("an invalidated inventory key is fetched without a forced follow-up", () => {
+  assert.equal(
+    inventoryRefreshDecision(
+      {
+        ready: true,
+        loading: false,
+        error: null,
+        key: "localModels:6:local",
+        refreshedAt: NOW,
+      },
+      KEY,
+      NOW,
+      30_000,
+    ),
+    "join",
+  );
+});
+
+test("a failed current key is refreshed even while its prior rows are fresh", () => {
+  assert.equal(
+    inventoryRefreshDecision(
+      {
+        ready: true,
+        loading: false,
+        error: "scan failed",
+        key: KEY,
+        refreshedAt: NOW - 1_000,
+      },
+      KEY,
+      NOW,
+      30_000,
+    ),
+    "refresh",
+  );
+});

--- a/studio/frontend/tests/inventory-freshness.test.ts
+++ b/studio/frontend/tests/inventory-freshness.test.ts
@@ -4,7 +4,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { inventoryRefreshDecision } from "../src/features/hub/inventory/inventory-freshness.ts";
+import {
+  inventoryRefreshDecision,
+  isInventoryStampFresh,
+} from "../src/features/hub/inventory/inventory-freshness.ts";
 
 const NOW = 100_000;
 const KEY = "localModels:7:local";
@@ -97,4 +100,49 @@ test("a failed current key is refreshed even while its prior rows are fresh", ()
     ),
     "refresh",
   );
+});
+
+test("a stamp from the future is refreshed, not reused", () => {
+  // `Date.now()` follows the system clock, so a stamp can end up in the future after an
+  // NTP correction, a VM resume or a user editing the clock. A negative age must not read
+  // as "younger than the window", or the picker stops scanning for the length of the skew.
+  assert.equal(
+    inventoryRefreshDecision(
+      {
+        ready: true,
+        loading: false,
+        error: null,
+        key: KEY,
+        refreshedAt: NOW + 3_600_000,
+      },
+      KEY,
+      NOW,
+      30_000,
+    ),
+    "refresh",
+  );
+});
+
+test("a zero max age always refreshes, even after the clock steps backwards", () => {
+  // refreshIfOlderThan(0) means "refresh unconditionally"; a future stamp must not turn it
+  // into a no-op.
+  for (const refreshedAt of [NOW - 1, NOW, NOW + 60_000]) {
+    assert.equal(
+      inventoryRefreshDecision(
+        { ready: true, loading: false, error: null, key: KEY, refreshedAt },
+        KEY,
+        NOW,
+        0,
+      ),
+      "refresh",
+    );
+  }
+});
+
+test("isInventoryStampFresh rejects a null, an expired and a future stamp", () => {
+  assert.equal(isInventoryStampFresh(null, NOW, 30_000), false);
+  assert.equal(isInventoryStampFresh(NOW - 30_000, NOW, 30_000), false);
+  assert.equal(isInventoryStampFresh(NOW + 1, NOW, 30_000), false);
+  assert.equal(isInventoryStampFresh(NOW - 29_999, NOW, 30_000), true);
+  assert.equal(isInventoryStampFresh(NOW, NOW, 30_000), true);
 });

--- a/studio/frontend/tests/inventory-freshness.test.ts
+++ b/studio/frontend/tests/inventory-freshness.test.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import {
   inventoryRefreshDecision,
-  isEmptyRevalidation,
+  nextRevalidationStamp,
   isInventoryStampFresh,
 } from "../src/features/hub/inventory/inventory-freshness.ts";
 
@@ -148,23 +148,53 @@ test("isInventoryStampFresh rejects a null, an expired and a future stamp", () =
   assert.equal(isInventoryStampFresh(NOW, NOW, 30_000), true);
 });
 
-test("only a forced scan confirming an empty inventory stamps revalidation", () => {
-  const empty = { key: KEY, ready: true, error: null, rowCount: 0 };
-  assert.equal(isEmptyRevalidation(true, empty, KEY), true);
+test("the revalidation stamp tracks both ends of a confirmed empty inventory", () => {
+  const emptyPrev = {
+    key: KEY,
+    ready: true,
+    error: null,
+    rowCount: 0,
+    revalidatedAt: null as number | null,
+  };
+  const call = (over: Record<string, unknown>) =>
+    nextRevalidationStamp({
+      force: true,
+      requestKey: KEY,
+      previous: emptyPrev,
+      rowCount: 0,
+      now: NOW,
+      ...over,
+    });
 
-  // A manual refresh of a POPULATED inventory that happens to come back empty is the first
-  // scan to see the empty state, not its confirmation. Stamping it settles the picker on
-  // "no models" after one scan.
+  // A forced second look at an inventory already seen empty is the confirmation.
+  assert.equal(call({}), NOW);
+
+  // Rows came back, so the inventory is not empty: the stamp must be cleared, or a later
+  // FIRST empty scan inside the window reads as already confirmed and the picker settles
+  // on "no models" after one look.
+  assert.equal(call({ rowCount: 3 }), null);
   assert.equal(
-    isEmptyRevalidation(true, { ...empty, rowCount: 4 }, KEY),
-    false,
+    call({ rowCount: 3, previous: { ...emptyPrev, revalidatedAt: NOW - 1_000 } }),
+    null,
   );
-  // Not forced, a different key, unready, or previously failed: none of those confirm.
-  assert.equal(isEmptyRevalidation(false, empty, KEY), false);
-  assert.equal(isEmptyRevalidation(true, { ...empty, key: "other" }, KEY), false);
-  assert.equal(isEmptyRevalidation(true, { ...empty, ready: false }, KEY), false);
+
+  // First empty scan after a populated one is an observation, not a confirmation.
   assert.equal(
-    isEmptyRevalidation(true, { ...empty, error: "scan failed" }, KEY),
-    false,
+    call({ previous: { ...emptyPrev, rowCount: 4, revalidatedAt: null } }),
+    null,
+  );
+  // Not forced, unready or previously failed: carry, never stamp.
+  assert.equal(call({ force: false }), null);
+  assert.equal(call({ previous: { ...emptyPrev, ready: false } }), null);
+  assert.equal(call({ previous: { ...emptyPrev, error: "scan failed" } }), null);
+  // A key change drops the previous confirmation.
+  assert.equal(
+    call({ previous: { ...emptyPrev, key: "other", revalidatedAt: NOW - 10 } }),
+    null,
+  );
+  // Same key, nothing decisive: carry what was there.
+  assert.equal(
+    call({ force: false, previous: { ...emptyPrev, revalidatedAt: NOW - 500 } }),
+    NOW - 500,
   );
 });

--- a/studio/frontend/tests/inventory-settlement.test.ts
+++ b/studio/frontend/tests/inventory-settlement.test.ts
@@ -7,7 +7,7 @@ import { resolveInventorySettlement } from "../src/features/hub/inventory/invent
 
 const emptyReadyInventory = {
   downloadedReady: true,
-  emptyRevalidationSignature: "empty-ready",
+  emptyRevalidationFresh: false,
   hasActiveEmptyRefresh: false,
   hasInventoryRows: false,
   hasUnreadyInventoryFailure: false,
@@ -18,7 +18,6 @@ test("keeps an empty ready inventory unsettled until revalidation", () => {
   assert.deepEqual(
     resolveInventorySettlement({
       ...emptyReadyInventory,
-      lastEmptyRevalidationSignature: null,
     }),
     {
       emptyRevalidationRequired: true,
@@ -28,7 +27,7 @@ test("keeps an empty ready inventory unsettled until revalidation", () => {
   assert.deepEqual(
     resolveInventorySettlement({
       ...emptyReadyInventory,
-      lastEmptyRevalidationSignature: "empty-ready",
+      emptyRevalidationFresh: true,
     }),
     {
       emptyRevalidationRequired: false,
@@ -46,7 +45,6 @@ test("settles usable rows and failures with prior ready state", () => {
       resolveInventorySettlement({
         ...emptyReadyInventory,
         ...state,
-        lastEmptyRevalidationSignature: null,
       }),
       {
         emptyRevalidationRequired: false,
@@ -62,7 +60,6 @@ test("keeps an unready failure unsettled for the next enable retry", () => {
       ...emptyReadyInventory,
       hasUnreadyInventoryFailure: true,
       inventoryFailed: true,
-      lastEmptyRevalidationSignature: null,
     }),
     {
       emptyRevalidationRequired: false,
@@ -78,7 +75,6 @@ test("settles a partial failure when another source returned rows", () => {
       hasInventoryRows: true,
       hasUnreadyInventoryFailure: true,
       inventoryFailed: true,
-      lastEmptyRevalidationSignature: null,
     }),
     {
       emptyRevalidationRequired: false,


### PR DESCRIPTION
Opening Studio's model picker repeatedly scans the same model folders, even when Chat completed the same scan only seconds earlier. Each unnecessary scan took 0.6 to 2.8 seconds on the test machine and repeated the same disk and CPU work.

This change makes Chat and the model picker use the same inventory result. A completed scan can be reused for 30 seconds, and a picker opened while a scan is running joins that scan instead of scheduling another one.

### What changed

- Deleting a model or changing the configured scan folders still forces a new scan immediately.
- An empty result is confirmed with one real second scan before Studio treats it as settled. That confirmed empty result can then be reused across picker opens for 30 seconds.
- A failed scan is retried, and changing the inventory key clears the previous result's freshness.

### Results

Scenario: load `/chat`, wait 8 seconds, then open and close the model picker three times.

| Observed in the browser | Main | This change |
|---|---:|---:|
| Local inventory requests | 5 | 1 |
| Request durations | 0.584s, 2.795s, 2.534s, 2.300s, 1.732s | 0.843s |

### Testing

- `node --experimental-strip-types --test tests/inventory-freshness.test.ts tests/inventory-settlement.test.ts` (9 passed)
- `npm run typecheck`
- `npm run build`
- Repeated the picker-open scenario in a live browser against main and this branch.
