### PR TITLE
Select the klein row by the label the image picker actually renders

### DIFF
--- a/tests/studio/playwright_image_download_cancel_retry.py
+++ b/tests/studio/playwright_image_download_cancel_retry.py
@@ -27,6 +27,7 @@ from playwright_image_model_footprint import (
     CHECKPOINT_BYTES,
     COMPANION_BYTES,
     FILENAME,
+    KLEIN_ROW,
     REPO_ID,
     REQUIRED_BYTES,
     _api_payload,
@@ -89,7 +90,7 @@ def _open_quant(page, *, navigate: bool) -> None:
     trigger = page.get_by_role("button", name = "Select image model")
     trigger.wait_for(state = "visible", timeout = 30_000)
     trigger.click()
-    page.get_by_text("FLUX.2-klein-4B-GGUF", exact = True).click()
+    page.get_by_text(KLEIN_ROW).first.click()
     gguf = page.get_by_text("GGUF", exact = True)
     if gguf.count() == 1:
         gguf.click()

--- a/tests/studio/playwright_image_download_cancel_retry.py
+++ b/tests/studio/playwright_image_download_cancel_retry.py
@@ -31,6 +31,7 @@ from playwright_image_model_footprint import (
     REPO_ID,
     REQUIRED_BYTES,
     _api_payload,
+    klein_row,
     _json,
 )
 
@@ -90,7 +91,7 @@ def _open_quant(page, *, navigate: bool) -> None:
     trigger = page.get_by_role("button", name = "Select image model")
     trigger.wait_for(state = "visible", timeout = 30_000)
     trigger.click()
-    page.get_by_text(KLEIN_ROW).first.click()
+    klein_row(page).click()
     gguf = page.get_by_text("GGUF", exact = True)
     if gguf.count() == 1:
         gguf.click()

--- a/tests/studio/playwright_image_download_cancel_retry.py
+++ b/tests/studio/playwright_image_download_cancel_retry.py
@@ -27,12 +27,11 @@ from playwright_image_model_footprint import (
     CHECKPOINT_BYTES,
     COMPANION_BYTES,
     FILENAME,
-    KLEIN_ROW,
     REPO_ID,
     REQUIRED_BYTES,
     _api_payload,
-    klein_row,
     _json,
+    klein_row,
 )
 
 

--- a/tests/studio/playwright_image_model_footprint.py
+++ b/tests/studio/playwright_image_model_footprint.py
@@ -9,6 +9,7 @@ live Hugging Face metadata.
 """
 
 import os
+import re
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -24,6 +25,11 @@ COMPANION_BYTES = 8_200_000_000
 REQUIRED_BYTES = CHECKPOINT_BYTES + COMPANION_BYTES
 REPO_ID = "unsloth/FLUX.2-klein-4B-GGUF"
 FILENAME = "FLUX.2-klein-4B-Q4_K_M.gguf"
+# The row is labelled by the catalogue's displayName ("FLUX.2 klein 4B"), not by the
+# artifact repo id. Matching the id exactly waited 30 s for text the picker never
+# renders. This test is about the footprint the row reports, not about its wording,
+# so accept either spelling and let a genuinely missing row still fail.
+KLEIN_ROW = re.compile(r"FLUX\.2[\s\-]klein[\s\-]4B")
 
 
 def _json(route: Route, payload: object) -> None:
@@ -186,7 +192,7 @@ def _open_klein_quant(page) -> None:
         print(page.locator("body").inner_text()[:4_000])
         raise
     trigger.click()
-    klein = page.get_by_text("FLUX.2-klein-4B-GGUF", exact = True)
+    klein = page.get_by_text(KLEIN_ROW).first
     try:
         klein.wait_for(state = "visible", timeout = 30_000)
     except Exception:

--- a/tests/studio/playwright_image_model_footprint.py
+++ b/tests/studio/playwright_image_model_footprint.py
@@ -182,6 +182,18 @@ def _api_payload(path: str, query: dict[str, list[str]], *, full_footprint: bool
     return {}
 
 
+def klein_row(page):
+    """The klein row inside the open picker, and nothing else on the page.
+
+    An unscoped search is not specific enough once a download has been started:
+    the hub download panel labels itself "black-forest-labs/FLUX.2-klein-4B ·
+    Required assets", so a page-wide match returns it first and clicking it
+    leaves the picker where it was. The old exact repo-id text never matched
+    that panel, so scoping only became necessary with the pattern.
+    """
+    return page.locator(".unsloth-model-selector-menu").get_by_text(KLEIN_ROW).first
+
+
 def _open_klein_quant(page) -> None:
     page.goto(f"{BASE_URL}/images", wait_until = "domcontentloaded")
     trigger = page.get_by_role("button", name = "Select image model")
@@ -192,7 +204,7 @@ def _open_klein_quant(page) -> None:
         print(page.locator("body").inner_text()[:4_000])
         raise
     trigger.click()
-    klein = page.get_by_text(KLEIN_ROW).first
+    klein = klein_row(page)
     try:
         klein.wait_for(state = "visible", timeout = 30_000)
     except Exception:


### PR DESCRIPTION
`Unsloth UI CI` has been red on main for days (every run back through 3a628bb37), on a 30 s Playwright timeout:

```
playwright._impl._errors.TimeoutError: Locator.wait_for: Timeout 30000ms exceeded.
Call log:
  - waiting for get_by_text("FLUX.2-klein-4B-GGUF", exact=True) to be visible
```

## Cause

`FLUX.2-klein-4B-GGUF` is the artifact repo id. The row is labelled by the catalogue's `displayName`:

```ts
{
  canonicalId: "unsloth/FLUX.2-klein-4B",
  displayName: "FLUX.2 klein 4B",
  ...
  artifacts: [gguf("unsloth/FLUX.2-klein-4B-GGUF")],
}
```

That `displayName` has read "FLUX.2 klein 4B" since #6763, so the exact-text wait could never match. The body dump the failing run prints confirms it: the list renders `FLUX.2 klein 4B` with a `4.0B` badge, and no row carries the repo id.

Two probes share the mistake, `playwright_image_model_footprint.py` and `playwright_image_download_cancel_retry.py`.

## Fix

One shared pattern, matching either spelling:

```python
KLEIN_ROW = re.compile(r"FLUX\.2[\s\-]klein[\s\-]4B")
```

| candidate | matches |
|---|---|
| `FLUX.2 klein 4B` (rendered today) | yes |
| `unsloth/FLUX.2-klein-4B-GGUF` | yes |
| `FLUX.2 klein 9B` | no |
| `FLUX.2-klein-base-4B` | no |

These tests are about the disk footprint the row reports and the cancel/retry sequence, not about a row's wording, so being label-agnostic is right. A row that is genuinely missing still fails the same way, with the same body dump.

## Verification

The selector change is grounded in the DOM the failing run itself dumped, which is where the rendered label above comes from - it is not a guess at the markup. Both files compile, the shared pattern imports across the two modules, and the match table above is from running it. The live proof is this PR's own `Unsloth UI CI` run, since standing up the Vite app plus backend locally is what that job already does.