### PR TITLE
fix(studio): return 404 for mistyped GGUF model ids on /v1 API

### DIFF
--- a/studio/backend/core/inference/openai_auto_download.py
+++ b/studio/backend/core/inference/openai_auto_download.py
@@ -134,11 +134,12 @@ def is_downloadable_ref(requested: str) -> bool:
 
 
 def looks_like_gguf_hub_repo_id(repo_id: str) -> bool:
-    """Whether *repo_id* names a GGUF catalog entry, not a LiteLLM/OpenRouter label.
+    """Whether *repo_id* names a Studio catalog entry, not a LiteLLM/OpenRouter label.
 
     Namespaced ids without a GGUF suffix are foreign routing labels (``openai/gpt-4o``).
     ``-GGUF`` and the ``unsloth/`` namespace mark ids clients pick from this server's
-    model list; a mistyped one must 404 instead of being answered by another model.
+    model list (GGUF and Transformers-backed entries alike); a mistyped one must 404
+    instead of being answered by another loaded model.
     """
     text = (repo_id or "").strip()
     if "/" not in text:

--- a/studio/backend/core/inference/openai_auto_download.py
+++ b/studio/backend/core/inference/openai_auto_download.py
@@ -133,6 +133,26 @@ def is_downloadable_ref(requested: str) -> bool:
     return True
 
 
+def looks_like_gguf_hub_repo_id(repo_id: str) -> bool:
+    """Whether *repo_id* names a GGUF catalog entry, not a LiteLLM/OpenRouter label.
+
+    Namespaced ids without a GGUF suffix are foreign routing labels (``openai/gpt-4o``).
+    ``-GGUF`` and the ``unsloth/`` namespace mark ids clients pick from this server's
+    model list; a mistyped one must 404 instead of being answered by another model.
+    """
+    text = (repo_id or "").strip()
+    if "/" not in text:
+        return False
+    from hub.utils.paths import is_valid_repo_id
+
+    if not is_valid_repo_id(text):
+        return False
+    name = text.rsplit("/", 1)[-1]
+    if name.lower().endswith("-gguf"):
+        return True
+    return text.lower().startswith("unsloth/")
+
+
 def looks_like_quant(variant: Optional[str]) -> bool:
     """Whether a ``:suffix`` names a GGUF quant rather than a foreign tag.
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4715,6 +4715,25 @@ def _record_refused_request(
     api_monitor.fail(entry_id, refusal.message)
 
 
+def _resident_id_is_namespaced() -> bool:
+    """Whether what is serving has an ``org/name`` id to compare a request against.
+
+    A model loaded from a plain directory is advertised under a bare name, so a
+    namespaced request cannot be told apart from it. Refusing one there would 404
+    the weights that are in fact serving, so treat it as undecidable instead.
+    """
+    llama_backend = get_llama_cpp_backend()
+    if getattr(llama_backend, "is_loaded", False):
+        candidates = (
+            getattr(llama_backend, "model_identifier", None),
+            getattr(llama_backend, "_openai_advertised_id", None),
+            _llama_public_model_id(llama_backend),
+        )
+    else:
+        candidates = (getattr(get_inference_backend(), "active_model_name", None),)
+    return any("/" in (public_model_id(c) or "") for c in candidates if c)
+
+
 def _loaded_satisfies(requested: str) -> bool:
     """Whether what is serving right now actually answers to *requested*.
 
@@ -4970,6 +4989,12 @@ async def _reject_unservable_model(
         downloaded = here = switchable = False
     if still_indexing:
         _raise_still_indexing(requested_model, fastapi_request)
+    if gguf_hub_repo and not (quantified or here):
+        # Decisive only against a resident carrying a hub-style id of its own; a
+        # directory-loaded model advertises a bare name that no namespaced request
+        # can be told apart from. Checked here, not with the other shape tests, so
+        # a foreign label never pays for it.
+        gguf_hub_repo = await asyncio.to_thread(_resident_id_is_namespaced)
     if not (quantified or here or gguf_hub_repo):
         return
     if switchable:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4874,7 +4874,11 @@ async def _reject_unservable_model(
     locally is still a concrete reference. Only runs while something is serving:
     with nothing loaded, :func:`_no_model_loaded_error` already says the right thing.
     """
-    from core.inference.openai_auto_download import looks_like_quant, split_model_ref
+    from core.inference.openai_auto_download import (
+        looks_like_gguf_hub_repo_id,
+        looks_like_quant,
+        split_model_ref,
+    )
 
     if (
         not isinstance(requested_model, str)
@@ -4884,6 +4888,7 @@ async def _reject_unservable_model(
         return
     base, variant = split_model_ref(requested_model)
     quantified = looks_like_quant(variant)
+    gguf_hub_repo = looks_like_gguf_hub_repo_id(base)
     from core.inference.local_model_resolver import (
         index_is_built,
         recently_downloaded,
@@ -4958,12 +4963,12 @@ async def _reject_unservable_model(
     except Exception as exc:
         # Can't verify: an explicit quant still proves intent, so refuse; let anything else by.
         logger.debug("unservable-model check failed for %r: %s", requested_model, exc)
-        if not quantified:
+        if not quantified and not gguf_hub_repo:
             return
         downloaded = here = switchable = False
     if still_indexing:
         _raise_still_indexing(requested_model, fastapi_request)
-    if not (quantified or here):
+    if not (quantified or here or gguf_hub_repo):
         return
     if switchable:
         # On disk and switching allowed, so the swap failed: the resident model is wrong weights.

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4962,8 +4962,10 @@ async def _reject_unservable_model(
         raise
     except Exception as exc:
         # Can't verify: an explicit quant still proves intent, so refuse; let anything else by.
+        # A catalog-shaped id is not enough here. This path cannot tell "not downloaded" from
+        # "the scan broke", so refusing one would 404 models that are downloaded and servable.
         logger.debug("unservable-model check failed for %r: %s", requested_model, exc)
-        if not quantified and not gguf_hub_repo:
+        if not quantified:
             return
         downloaded = here = switchable = False
     if still_indexing:

--- a/studio/backend/tests/test_openai_auto_download.py
+++ b/studio/backend/tests/test_openai_auto_download.py
@@ -243,6 +243,32 @@ def test_downloadable(raw):
     assert auto_dl.is_downloadable_ref(raw) is True
 
 
+@pytest.mark.parametrize(
+    "repo_id,expected",
+    [
+        ("unsloth/gemma-4-E2B-it-GGUF", True),
+        ("org/nope-GGUF", True),
+        ("unsloth/typo-vision", True),
+        ("openai/gpt-4o", False),
+        ("anthropic/claude-3.5-sonnet", False),
+        ("meta-llama/llama-3-70b-instruct", False),
+        ("org/Unlisted", False),
+        ("gpt-4", False),
+    ],
+)
+def test_looks_like_gguf_hub_repo_id(repo_id, expected):
+    assert auto_dl.looks_like_gguf_hub_repo_id(repo_id) is expected
+
+
+def test_a_mistyped_gguf_repo_is_refused_while_another_model_is_loaded(monkeypatch):
+    # #8376: a mistyped GGUF catalog id must 404, not be answered by the resident model.
+    loaded = _Loaded("unsloth/A-GGUF", "UD-Q4_K_XL")
+    with pytest.raises(HTTPException) as excinfo:
+        _reject("unsloth/typo-vision-GGUF", loaded, monkeypatch)
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.detail["error"]["code"] == "model_not_found"
+
+
 def test_gguf_variants_skips_companions():
     variants = auto_dl._gguf_variants(_gguf_repo_info().siblings)
     # Companions are not quants of their own...

--- a/studio/backend/tests/test_openai_auto_download.py
+++ b/studio/backend/tests/test_openai_auto_download.py
@@ -1055,6 +1055,40 @@ def test_diagnosis_failure_never_breaks_a_servable_request(monkeypatch):
     assert asyncio.run(inference_route._reject_unservable_model("unsloth/B-GGUF", _Req())) is None
 
 
+def _reject_with_active(model, active, monkeypatch):
+    """Refusal check with a non-GGUF backend resident under *active*."""
+    idle = type("B", (), {"is_loaded": False, "model_identifier": None, "hf_variant": None})()
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: idle)
+    monkeypatch.setattr(
+        inference_route,
+        "get_inference_backend",
+        lambda: type("B", (), {"active_model_name": active})(),
+    )
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_local_gguf", lambda _n, **_kw: None
+    )
+    monkeypatch.setattr(inference_route, "_unavailable_model_message", _fake_unavailable_message)
+    return asyncio.run(inference_route._reject_unservable_model(model, _Req()))
+
+
+def test_a_directory_loaded_model_is_not_refused_under_its_own_hub_id(monkeypatch):
+    # ModelConfig.identifier is the path for a local load, so the model is advertised
+    # under a bare name that no org/name request can be told apart from. Refusing one
+    # 404s the weights serving right now.
+    local = "/srv/models/gemma-3-4b-it"
+    assert _reject_with_active("unsloth/gemma-3-4b-it", local, monkeypatch) is None
+    assert _reject_with_active("unsloth/gemma-3-4b-it:latest", local, monkeypatch) is None
+
+
+def test_an_hf_cache_load_keeps_its_namespace_and_still_refuses_a_typo(monkeypatch):
+    # A cache path maps back to org/name, so the resident id stays comparable there.
+    cache = "/h/.cache/huggingface/hub/models--unsloth--gemma-3-4b-it/snapshots/abc"
+    assert _reject_with_active("unsloth/gemma-3-4b-it", cache, monkeypatch) is None
+    with pytest.raises(HTTPException) as excinfo:
+        _reject_with_active("unsloth/typo-vision-GGUF", cache, monkeypatch)
+    assert excinfo.value.status_code == 404
+
+
 def test_anthropic_surface_gets_its_own_envelope(monkeypatch):
     loaded = _Loaded("unsloth/A-GGUF", "UD-Q4_K_XL")
     monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: loaded)

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -4595,6 +4595,35 @@ def _chat_error(payload):
     return exc.value.status_code, exc.value.detail
 
 
+def test_chat_mistyped_gguf_repo_404s_before_vision_guard(monkeypatch):
+    # #8376: image request with a mistyped GGUF id must 404, not 400 on the loaded model.
+    from fastapi import HTTPException
+
+    backend = _FakeBackend("unsloth/text-only-GGUF", "UD-Q4_K_XL")
+    rec = _LoadRecorder(backend)
+    _wire(monkeypatch, enabled = True, resolves_to = None, backend = backend, recorder = rec)
+    monkeypatch.setattr(
+        "utils.openai_auto_switch_settings.get_openai_auto_download_enabled", lambda: False
+    )
+    monkeypatch.setattr(
+        resolver,
+        "describe_local_miss",
+        lambda _m: (resolver.MISS_MODEL_NOT_FOUND, ()),
+    )
+    payload = _chat_request(
+        model = "unsloth/typo-vision-GGUF",
+        image_base64 = "aGVsbG8=",
+    )
+    request = type("_R", (), {"url": type("_U", (), {"path": "/v1/chat/completions"})()})()
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            inference_route.openai_chat_completions(payload, request, "tester")
+        )
+    assert exc.value.status_code == 404
+    assert exc.value.detail["error"]["code"] == "model_not_found"
+    assert rec.calls == []
+
+
 def test_chat_names_undownloaded_model_404s_with_available_ids(monkeypatch):
     # The reported bug: the model is not here, so the switch did nothing and /inference/load
     # cannot fix it. Name it and list what can serve.

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -4616,9 +4616,7 @@ def test_chat_mistyped_gguf_repo_404s_before_vision_guard(monkeypatch):
     )
     request = type("_R", (), {"url": type("_U", (), {"path": "/v1/chat/completions"})()})()
     with pytest.raises(HTTPException) as exc:
-        asyncio.run(
-            inference_route.openai_chat_completions(payload, request, "tester")
-        )
+        asyncio.run(inference_route.openai_chat_completions(payload, request, "tester"))
     assert exc.value.status_code == 404
     assert exc.value.detail["error"]["code"] == "model_not_found"
     assert rec.calls == []


### PR DESCRIPTION
Fixes #8376

## Summary

When a client called `/v1/chat/completions` (or other OpenAI-compatible endpoints) with a **model name that was not loaded** — for example a mistyped vision model id — the server silently routed the request to whatever model was already in memory. The client then got misleading errors (e.g. *"Image provided but current GGUF model does not support vision"*) instead of a clear `model_not_found` response.

This change refuses mistyped or missing **GGUF catalog** model ids instead of answering with the wrong weights.

## Root cause

`_reject_unservable_model()` only refused a named model when it looked like an explicit quant (`:Q4_K_M`) or was already known locally (`here`). A bare hub-style id like `unsloth/typo-vision-GGUF` that was **not** downloaded and **not** in the catalog fell through to drop-in OpenAI compatibility — so the loaded text model answered the request.

## Fix

- Added `looks_like_gguf_hub_repo_id()` in `openai_auto_download.py` to detect ids that clearly target this server's GGUF catalog:
  - repo names ending in `-GGUF`
  - anything under the `unsloth/` namespace
- Updated `_reject_unservable_model()` to treat those ids as **concrete references** and return **404 `model_not_found`** when they do not match the loaded model.

LiteLLM / OpenRouter-style labels (`openai/gpt-4o`, `anthropic/claude-3.5-sonnet`, etc.) still fall through to the loaded model for drop-in compatibility.

## Files changed

| File | Change |
|------|--------|
| `studio/backend/core/inference/openai_auto_download.py` | `looks_like_gguf_hub_repo_id()` helper |
| `studio/backend/routes/inference.py` | Use helper in `_reject_unservable_model()` |
| `studio/backend/tests/test_openai_auto_download.py` | Helper + reject-path unit tests |
| `studio/backend/tests/test_openai_auto_switch.py` | Chat completions integration test (image + mistyped id → 404) |

## Test plan

- [x] `pytest tests/test_openai_auto_download.py::test_looks_like_gguf_hub_repo_id`
- [x] `pytest tests/test_openai_auto_download.py::test_a_mistyped_gguf_repo_is_refused_while_another_model_is_loaded`
- [x] `pytest tests/test_openai_auto_switch.py::test_chat_mistyped_gguf_repo_404s_before_vision_guard`
- [x] Regression: foreign provider labels (`openai/gpt-4o`, etc.) still fall through
- [x] Regression: `org/Unlisted` ids not in catalog still fall through