### PR TITLE
Studio: read a native Windows model path as one reference

### DIFF
--- a/studio/backend/core/inference/openai_auto_download.py
+++ b/studio/backend/core/inference/openai_auto_download.py
@@ -99,16 +99,17 @@ def _public_label(repo_id: str, variant: Optional[str]) -> str:
 def split_model_ref(requested: str) -> tuple[str, Optional[str]]:
     """``org/repo:QUANT`` -> ``("org/repo", "QUANT")``; no suffix -> variant None.
 
-    Splits on the last colon. A slash-bearing suffix is only a variant when a real
-    Hub repo precedes it: "build/llama-13b" is a subdirectory GGUF key the catalog
-    advertises, while "C:/models/x.gguf" leaves a drive letter that is no repo id.
+    Splits on the last colon. A suffix bearing either separator is only a variant
+    when a real Hub repo precedes it: "build/llama-13b" is a subdirectory GGUF key
+    the catalog advertises, while "C:/models/x.gguf" -- and the native Windows
+    "C:\\models\\x.gguf" -- leaves a drive letter that is no repo id.
     """
     text = (requested or "").strip()
     base, sep, suffix = text.rpartition(":")
     if not sep or not base or not suffix:
         return text, None
     stripped = base.strip()
-    if "/" in suffix:
+    if "/" in suffix.replace("\\", "/"):
         from hub.utils.paths import is_valid_repo_id
         if "/" not in stripped or not is_valid_repo_id(stripped):
             return text, None

--- a/studio/backend/tests/test_openai_auto_download.py
+++ b/studio/backend/tests/test_openai_auto_download.py
@@ -212,6 +212,18 @@ def _run(model, hf_token = None):
         # Still a path, not a variant: no Hub repo precedes the colon.
         ("/home/me/models/x:build/llama-13b", ("/home/me/models/x:build/llama-13b", None)),
         ("D:/models/repo:build/llama-13b", ("D:/models/repo:build/llama-13b", None)),
+        # A native Windows path is one reference: the drive letter is no repo id, so
+        # reading the rest of the path as its variant refused a model already loaded.
+        ("C:\\models\\qwen.gguf", ("C:\\models\\qwen.gguf", None)),
+        ("c:\\qwen.gguf", ("c:\\qwen.gguf", None)),
+        ("\\\\server\\share\\qwen.gguf", ("\\\\server\\share\\qwen.gguf", None)),
+        # A quant still pins one, on either spelling of the path.
+        ("C:\\models\\qwen.gguf:Q4_K_M", ("C:\\models\\qwen.gguf", "Q4_K_M")),
+        ("C:/models/qwen.gguf:Q4_K_M", ("C:/models/qwen.gguf", "Q4_K_M")),
+        ("\\\\server\\share\\qwen.gguf:Q4_K_M", ("\\\\server\\share\\qwen.gguf", "Q4_K_M")),
+        # A backslash-qualified variant key still parses behind a real Hub repo.
+        ("org/repo:build\\model.gguf", ("org/repo", "build\\model.gguf")),
+        ("D:\\models\\repo:build\\llama-13b", ("D:\\models\\repo:build\\llama-13b", None)),
     ],
 )
 def test_split_model_ref(raw, expected):
@@ -1173,6 +1185,18 @@ def test_an_ollama_tag_still_matches_the_resident_gguf(monkeypatch):
     assert inference_route._loaded_satisfies("unsloth/A-GGUF:8b") is True
     assert inference_route._loaded_satisfies("unsloth/A-GGUF:UD-Q4_K_XL") is True
     assert inference_route._loaded_satisfies("unsloth/A-GGUF:Q8_0") is False
+
+
+def test_a_windows_path_matches_the_gguf_loaded_from_it(monkeypatch):
+    # The drive letter read as the repo and the rest of the path as an explicit quant, so a
+    # model loaded from that path never matched its own name and the call was refused instead.
+    loaded = _Loaded("C:\\models\\qwen.gguf", "Q4_K_M")
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: loaded)
+    assert inference_route._loaded_satisfies("C:\\models\\qwen.gguf") is True
+    # Either spelling of the same path names the same weights.
+    assert inference_route._loaded_satisfies("C:/models/qwen.gguf") is True
+    assert inference_route._loaded_satisfies("C:\\models\\qwen.gguf:Q4_K_M") is True
+    assert inference_route._loaded_satisfies("C:\\models\\qwen.gguf:Q8_0") is False
 
 
 def test_a_probing_adoption_never_releases_the_slot(hub, monkeypatch):

--- a/studio/backend/tests/test_openai_auto_download.py
+++ b/studio/backend/tests/test_openai_auto_download.py
@@ -224,21 +224,17 @@ def _run(model, hf_token = None):
         # A backslash-qualified variant key still parses behind a real Hub repo.
         ("org/repo:build\\model.gguf", ("org/repo", "build\\model.gguf")),
         ("D:\\models\\repo:build\\llama-13b", ("D:\\models\\repo:build\\llama-13b", None)),
-        # The rest of the shapes a Windows model path really arrives in. Each one leaves a
-        # drive letter that is no repo id, so each has to survive the colon split whole.
-        # Extended-length and device-namespace prefixes: the "\\?\" that Windows uses past
-        # MAX_PATH, which Studio hits on deep .lmstudio trees.
+        # Extended-length and device-namespace prefixes, used past MAX_PATH.
         ("\\\\?\\C:\\models\\qwen.gguf", ("\\\\?\\C:\\models\\qwen.gguf", None)),
         ("\\\\.\\C:\\models\\qwen.gguf", ("\\\\.\\C:\\models\\qwen.gguf", None)),
         ("\\\\?\\C:\\models\\qwen.gguf:UD-Q4_K_XL", ("\\\\?\\C:\\models\\qwen.gguf", "UD-Q4_K_XL")),
-        # Drive-relative: legal on Windows and has no separator after the colon at all.
+        # Drive-relative: no separator after the colon at all.
         ("C:models\\x.gguf", ("C:models\\x.gguf", None)),
-        # Mixed separators, which Windows accepts and users paste.
+        # Mixed separators, and the bare drive root.
         ("C:/models\\x.gguf", ("C:/models\\x.gguf", None)),
         ("C:\\models/x.gguf", ("C:\\models/x.gguf", None)),
-        # Bare drive root.
         ("C:\\", ("C:\\", None)),
-        # A UNC share whose name ends in the admin "$".
+        # An admin UNC share.
         ("\\\\server\\share$\\qwen.gguf", ("\\\\server\\share$\\qwen.gguf", None)),
         # An Ollama tag must still split, or a foreign id starts being served locally.
         ("name:latest", ("name", "latest")),

--- a/studio/backend/tests/test_openai_auto_download.py
+++ b/studio/backend/tests/test_openai_auto_download.py
@@ -224,6 +224,25 @@ def _run(model, hf_token = None):
         # A backslash-qualified variant key still parses behind a real Hub repo.
         ("org/repo:build\\model.gguf", ("org/repo", "build\\model.gguf")),
         ("D:\\models\\repo:build\\llama-13b", ("D:\\models\\repo:build\\llama-13b", None)),
+        # The rest of the shapes a Windows model path really arrives in. Each one leaves a
+        # drive letter that is no repo id, so each has to survive the colon split whole.
+        # Extended-length and device-namespace prefixes: the "\\?\" that Windows uses past
+        # MAX_PATH, which Studio hits on deep .lmstudio trees.
+        ("\\\\?\\C:\\models\\qwen.gguf", ("\\\\?\\C:\\models\\qwen.gguf", None)),
+        ("\\\\.\\C:\\models\\qwen.gguf", ("\\\\.\\C:\\models\\qwen.gguf", None)),
+        ("\\\\?\\C:\\models\\qwen.gguf:UD-Q4_K_XL", ("\\\\?\\C:\\models\\qwen.gguf", "UD-Q4_K_XL")),
+        # Drive-relative: legal on Windows and has no separator after the colon at all.
+        ("C:models\\x.gguf", ("C:models\\x.gguf", None)),
+        # Mixed separators, which Windows accepts and users paste.
+        ("C:/models\\x.gguf", ("C:/models\\x.gguf", None)),
+        ("C:\\models/x.gguf", ("C:\\models/x.gguf", None)),
+        # Bare drive root.
+        ("C:\\", ("C:\\", None)),
+        # A UNC share whose name ends in the admin "$".
+        ("\\\\server\\share$\\qwen.gguf", ("\\\\server\\share$\\qwen.gguf", None)),
+        # An Ollama tag must still split, or a foreign id starts being served locally.
+        ("name:latest", ("name", "latest")),
+        ("llama3:8b", ("llama3", "8b")),
     ],
 )
 def test_split_model_ref(raw, expected):


### PR DESCRIPTION
## The bug

On Windows, naming a local GGUF by its native absolute path — `C:\models\qwen.gguf` — makes every `/v1` request fail with `503 model_switch_failed`, even when that exact model is already loaded and serving. The same file named `C:/models/qwen.gguf` works, which is what makes it look arbitrary from the outside.

It also hits Studio's own chat, which reaches the same `/v1` path: a model Studio loaded itself, addressed by its directory path, is refused with "The model 'E:\Models\unsloth\Ornith-1.0-35B-GGUF' is downloaded, but this server could not switch to it" while that model sits in the Loaded models card. Any drive-letter reference is affected, file or directory.

## Root cause

`split_model_ref` splits a model reference on its last colon, then decides whether the suffix is a quant (`org/repo:Q4_K_M`) or part of a path (`C:/models/qwen.gguf`) by testing the suffix for a forward slash. A native Windows path's suffix, `\models\qwen.gguf`, contains no forward slash, so the drive-letter guard never fired and the reference parsed as repo `C` plus variant `\models\qwen.gguf`.

Both consumers of that parse then misbehave. `_loaded_satisfies` matches `C` against the loaded model's identifier and path, never matches, and concludes the resident model does not answer the request. The auto-switch path compounds it: `looks_like_quant` reads a separator-bearing suffix as a path-qualified variant key, so `\models\qwen.gguf` counts as an *explicit quant request*, and the request is held to a quant equality no loaded model can satisfy. Refusal, not service.

That second half is what produces the "downloaded, but could not switch to it" report. In `_reject_unservable_model`, a reference parsed as quantified must clear `_resident_quant_is(variant)` before the resident model is allowed to answer, and the bogus variant is a path, so it never clears. Replaying the reported values through the gate — `E:\Models\unsloth\Ornith-1.0-35B-GGUF` against a resident `UD-Q4_K_S`:

| | parsed base | parsed variant | quantified | serves |
| --- | --- | --- | --- | --- |
| before | `E` | `\Models\unsloth\Ornith-1.0-35B-GGUF` | yes | no — 503 |
| after | the full path | none | no | yes |

Because the model is on disk and switching is enabled, the refusal takes the `model_switch_failed` branch and reports a failed switch, which reads as a loader problem rather than a parsing one.

The drive-letter case was considered when this parser was introduced in #7454 — its docstring names `C:/models/x.gguf` explicitly — but only the forward-slash spelling was handled, and native Windows paths were never covered. #7501 later reworded the surrounding comments without changing behavior.

## The fix

Normalize backslashes before the separator test, so both spellings of a path separator are read the same way. This mirrors what `looks_like_quant` in the same module already does (`label.replace("\\", "/")`), so the two helpers now agree on what a path-shaped suffix is.

Parse of the same reference in each spelling, as `(base, variant)`:

| reference | before | after |
| --- | --- | --- |
| `C:\models\qwen.gguf` | `('C', '\models\qwen.gguf')` | `('C:\models\qwen.gguf', None)` |
| `C:/models/qwen.gguf` | `('C:/models/qwen.gguf', None)` | unchanged |
| `alias:tag\value` | `('alias', 'tag\value')` | `('alias:tag\value', None)` |
| `alias:tag/value` | `('alias:tag/value', None)` | unchanged |

## Preserved forms

| reference | base | variant |
| --- | --- | --- |
| `C:\models\qwen.gguf` | `C:\models\qwen.gguf` | none |
| `C:/models/qwen.gguf` | `C:/models/qwen.gguf` | none |
| `C:\models\qwen.gguf:Q4_K_M` | `C:\models\qwen.gguf` | `Q4_K_M` |
| `org/repo:Q4_K_M` | `org/repo` | `Q4_K_M` |
| `org/repo:build\model.gguf` | `org/repo` | `build\model.gguf` |
| `\\server\share\qwen.gguf[:Q4_K_M]` | the UNC path | none / `Q4_K_M` |

## Reviewer-relevant risk

The behavior change is confined to references whose colon-suffix contains a backslash: they now parse the way the same reference spelled with forward slashes already parses on `main`.

The consequence worth naming explicitly is that a reference with no valid Hub repo id before its last colon — `alias:tag\value`, `org/repo:build:v1\model.gguf` — previously produced an explicit-quant refusal and now falls through to the resident model. That is intended rather than incidental: `main` already falls through for `alias:tag/value` and `org/repo:build:v1/model.gguf`, and those shapes are indistinguishable from `C:\models\qwen.gguf` under any general rule, so preserving the refusal would mean preserving the bug. No reference gains a fall-through that `main` does not already produce for its forward-slash spelling. Distinguishing them would require special-casing drive letters in the parser, which is worse than the residual it avoids.

Not addressed here, and worth a follow-up: "is this suffix a path?" is still decided independently in `split_model_ref`, `looks_like_quant`, `is_valid_gguf_variant`, and `local_model_resolver`. That resolver parses colons on its own and is deliberately untouched — it looks the full string up in its index first, so a Windows path already resolves there, and a separator disagreement costs a miss rather than a wrong model.

## Validation

```bash
cd studio/backend
python -m pytest tests/test_openai_auto_download.py -q
# 138 passed

python -m pytest tests/test_openai_auto_download.py tests/test_openai_auto_switch.py \
    tests/test_openai_catalog.py tests/test_openai_models_path_leak.py \
    tests/test_gguf_variants_local_resolution.py tests/test_gguf_routing.py \
    tests/test_inference_model_validation.py -q
# 567 passed
```

Coverage is added to the existing `split_model_ref` parametrization (native path, lowercase drive, UNC, each with and without a quant, plus the backslash-qualified Hub variant), and one caller-level case pins the reported symptom: a resident `C:\models\qwen.gguf` is matched by `_loaded_satisfies` under either spelling, and still rejects a mismatched `:Q8_0`. Both were mutation-checked — reverting the production line fails exactly those cases and nothing else.

Testing ran on POSIX, so the platform-dependent step was verified directly rather than by execution: `_norm_path`'s `normcase` plus separator fold makes `C:/models/qwen.gguf` and `C:\models\qwen.gguf` compare equal under both `posixpath` and `ntpath`. Confirmation from a reporter on Windows would be welcome before this is relied on.

Fixes #8365
Fixes #8368
Fixes #8375
