### PR TITLE
Studio: keep RAG lexical search off the linked-folder filters when nothing is linked

### DIFF
--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -302,15 +302,13 @@ def delete_document(
 def linked_folder_rows_exist(conn: sqlite3.Connection) -> bool:
     """Whether anything here can be hidden by the linked-folder filters.
 
-    Each EXISTS mirrors one thing they hide, so with all three empty the plain query
-    returns the same rows out of the FTS index. Three indexed reads to skip a
-    per-matched-row join and two subqueries.
+    One EXISTS per thing they hide, so with all three empty the plain query returns the
+    same rows straight out of the FTS index.
 
-    A PURGED tombstone is excluded: deleting any knowledge base leaves one behind for
-    good, and its scope has no documents left to hide, so counting it would disable the
-    fast path permanently on the first delete. A folder-owned document is counted
-    directly rather than through `linked_folders`, because a crash between ingestion and
-    `_install_mapping` leaves one that outlives its folder row until the reaper runs.
+    A purged tombstone does not count: every knowledge base delete leaves one for good
+    and its scope keeps no documents, so counting it would end the fast path on the first
+    delete. Folder-owned documents are counted directly, not via `linked_folders`: a
+    crash before `_install_mapping` leaves one that outlives its folder row.
     """
     return bool(
         conn.execute(

--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -302,14 +302,21 @@ def delete_document(
 def linked_folder_rows_exist(conn: sqlite3.Connection) -> bool:
     """Whether anything here can be hidden by the linked-folder filters.
 
-    They exclude a row only when a scope is retired or a document belongs to a folder, so
-    with both tables empty the plain query returns the same rows out of the FTS index.
-    Two indexed EXISTS reads to skip a per-matched-row join and two subqueries.
+    Each EXISTS mirrors one thing they hide, so with all three empty the plain query
+    returns the same rows out of the FTS index. Three indexed reads to skip a
+    per-matched-row join and two subqueries.
+
+    A PURGED tombstone is excluded: deleting any knowledge base leaves one behind for
+    good, and its scope has no documents left to hide, so counting it would disable the
+    fast path permanently on the first delete. A folder-owned document is counted
+    directly rather than through `linked_folders`, because a crash between ingestion and
+    `_install_mapping` leaves one that outlives its folder row until the reaper runs.
     """
     return bool(
         conn.execute(
             "SELECT EXISTS(SELECT 1 FROM linked_folders) "
-            "OR EXISTS(SELECT 1 FROM linked_folder_retired_scopes)"
+            "OR EXISTS(SELECT 1 FROM linked_folder_retired_scopes WHERE purged_at IS NULL) "
+            "OR EXISTS(SELECT 1 FROM documents WHERE linked_folder_id IS NOT NULL)"
         ).fetchone()[0]
     )
 

--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -299,6 +299,25 @@ def delete_document(
         conn.commit()
 
 
+def linked_folder_rows_exist(conn: sqlite3.Connection) -> bool:
+    """Whether anything on this install can be hidden by the linked-folder filters.
+
+    The two visibility predicates on the retrieval queries exclude a row only when some
+    scope is retired or some document belongs to a folder. With both tables empty they
+    cannot exclude anything, so the plain query returns exactly the same rows, and the
+    plain query is the one SQLite can answer straight out of the FTS index.
+
+    Two `EXISTS` reads of tiny tables, both answered from an index, against a per-matched
+    -row join and two correlated subqueries in the query they gate.
+    """
+    return bool(
+        conn.execute(
+            "SELECT EXISTS(SELECT 1 FROM linked_folders) "
+            "OR EXISTS(SELECT 1 FROM linked_folder_retired_scopes)"
+        ).fetchone()[0]
+    )
+
+
 def search_lexical(conn: sqlite3.Connection, scope, query: str, k: int):
     """BM25 lexical search over one scope or several. Returns
     [(chunk_id, score)], higher = better."""
@@ -309,18 +328,30 @@ def search_lexical(conn: sqlite3.Connection, scope, query: str, k: int):
     if not scopes:
         return []
     placeholders = ",".join("?" * len(scopes))
-    rows = conn.execute(
-        f"SELECT chunks_fts.chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
-        f"JOIN chunks c ON c.id=chunks_fts.chunk_id "
-        f"JOIN documents d ON d.id=c.document_id "
-        f"WHERE chunks_fts MATCH ? AND chunks_fts.scope IN ({placeholders}) "
-        f"AND NOT EXISTS "
-        f"(SELECT 1 FROM linked_folder_retired_scopes r WHERE r.scope=d.scope) "
-        f"AND (d.linked_folder_id IS NULL OR EXISTS "
-        f"(SELECT 1 FROM linked_folder_files ff WHERE ff.document_id=d.id)) "
-        f"ORDER BY s LIMIT ?",
-        (mq, *scopes, k),
-    ).fetchall()
+    # The filtered form joins chunks and documents and evaluates both subqueries for
+    # every row the FTS match returns, BEFORE the LIMIT, so its cost grows with how
+    # common the query terms are rather than with k. On an install with no linked
+    # folders that work is provably wasted (see linked_folder_rows_exist), which is the
+    # normal case for a knowledge base built from uploads.
+    if linked_folder_rows_exist(conn):
+        sql = (
+            f"SELECT chunks_fts.chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
+            f"JOIN chunks c ON c.id=chunks_fts.chunk_id "
+            f"JOIN documents d ON d.id=c.document_id "
+            f"WHERE chunks_fts MATCH ? AND chunks_fts.scope IN ({placeholders}) "
+            f"AND NOT EXISTS "
+            f"(SELECT 1 FROM linked_folder_retired_scopes r WHERE r.scope=d.scope) "
+            f"AND (d.linked_folder_id IS NULL OR EXISTS "
+            f"(SELECT 1 FROM linked_folder_files ff WHERE ff.document_id=d.id)) "
+            f"ORDER BY s LIMIT ?"
+        )
+    else:
+        sql = (
+            f"SELECT chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
+            f"WHERE chunks_fts MATCH ? AND scope IN ({placeholders}) "
+            f"ORDER BY s LIMIT ?"
+        )
+    rows = conn.execute(sql, (mq, *scopes, k)).fetchall()
     # bm25() is negative (more negative = better); flip to higher-is-better.
     return [(r["chunk_id"], -r["s"]) for r in rows]
 

--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -300,15 +300,11 @@ def delete_document(
 
 
 def linked_folder_rows_exist(conn: sqlite3.Connection) -> bool:
-    """Whether anything on this install can be hidden by the linked-folder filters.
+    """Whether anything here can be hidden by the linked-folder filters.
 
-    The two visibility predicates on the retrieval queries exclude a row only when some
-    scope is retired or some document belongs to a folder. With both tables empty they
-    cannot exclude anything, so the plain query returns exactly the same rows, and the
-    plain query is the one SQLite can answer straight out of the FTS index.
-
-    Two `EXISTS` reads of tiny tables, both answered from an index, against a per-matched
-    -row join and two correlated subqueries in the query they gate.
+    They exclude a row only when a scope is retired or a document belongs to a folder, so
+    with both tables empty the plain query returns the same rows out of the FTS index.
+    Two indexed EXISTS reads to skip a per-matched-row join and two subqueries.
     """
     return bool(
         conn.execute(
@@ -328,19 +324,16 @@ def search_lexical(conn: sqlite3.Connection, scope, query: str, k: int):
     if not scopes:
         return []
     placeholders = ",".join("?" * len(scopes))
-    # The gate and the read share ONE snapshot. In WAL a deferred transaction pins the
-    # database at its first read, so a scope retired by another connection in between
-    # cannot land rows in a result the gate already decided to run unfiltered. Skipped
-    # when the caller is already in a transaction: that snapshot is the one to use.
+    # One snapshot for the gate and the read: WAL pins it at the transaction's first
+    # read, so a scope retired in between cannot land rows in a result the gate already
+    # decided to run unfiltered. A caller's own transaction is used instead.
     own_read_txn = not conn.in_transaction
     if own_read_txn:
         conn.execute("BEGIN")
     try:
-        # The filtered form joins chunks and documents and evaluates both subqueries for
-        # every row the FTS match returns, BEFORE the LIMIT, so its cost grows with how
-        # common the query terms are rather than with k. On an install with no linked
-        # folders that work is provably wasted (see linked_folder_rows_exist), which is
-        # the normal case for a knowledge base built from uploads.
+        # The filtered form joins chunks and documents and runs both subqueries for every
+        # matched row BEFORE the LIMIT, so it costs more the commoner the query terms are.
+        # With nothing linked that work is provably wasted (linked_folder_rows_exist).
         if linked_folder_rows_exist(conn):
             sql = (
                 f"SELECT chunks_fts.chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
@@ -361,8 +354,7 @@ def search_lexical(conn: sqlite3.Connection, scope, query: str, k: int):
             )
         rows = conn.execute(sql, (mq, *scopes, k)).fetchall()
     finally:
-        # Read-only either way, but it has to end: an open snapshot keeps the WAL from
-        # being checkpointed for as long as the connection lives.
+        # Read-only, but it has to end: an open snapshot blocks WAL checkpointing.
         if own_read_txn:
             conn.commit()
     # bm25() is negative (more negative = better); flip to higher-is-better.

--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -328,30 +328,43 @@ def search_lexical(conn: sqlite3.Connection, scope, query: str, k: int):
     if not scopes:
         return []
     placeholders = ",".join("?" * len(scopes))
-    # The filtered form joins chunks and documents and evaluates both subqueries for
-    # every row the FTS match returns, BEFORE the LIMIT, so its cost grows with how
-    # common the query terms are rather than with k. On an install with no linked
-    # folders that work is provably wasted (see linked_folder_rows_exist), which is the
-    # normal case for a knowledge base built from uploads.
-    if linked_folder_rows_exist(conn):
-        sql = (
-            f"SELECT chunks_fts.chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
-            f"JOIN chunks c ON c.id=chunks_fts.chunk_id "
-            f"JOIN documents d ON d.id=c.document_id "
-            f"WHERE chunks_fts MATCH ? AND chunks_fts.scope IN ({placeholders}) "
-            f"AND NOT EXISTS "
-            f"(SELECT 1 FROM linked_folder_retired_scopes r WHERE r.scope=d.scope) "
-            f"AND (d.linked_folder_id IS NULL OR EXISTS "
-            f"(SELECT 1 FROM linked_folder_files ff WHERE ff.document_id=d.id)) "
-            f"ORDER BY s LIMIT ?"
-        )
-    else:
-        sql = (
-            f"SELECT chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
-            f"WHERE chunks_fts MATCH ? AND scope IN ({placeholders}) "
-            f"ORDER BY s LIMIT ?"
-        )
-    rows = conn.execute(sql, (mq, *scopes, k)).fetchall()
+    # The gate and the read share ONE snapshot. In WAL a deferred transaction pins the
+    # database at its first read, so a scope retired by another connection in between
+    # cannot land rows in a result the gate already decided to run unfiltered. Skipped
+    # when the caller is already in a transaction: that snapshot is the one to use.
+    own_read_txn = not conn.in_transaction
+    if own_read_txn:
+        conn.execute("BEGIN")
+    try:
+        # The filtered form joins chunks and documents and evaluates both subqueries for
+        # every row the FTS match returns, BEFORE the LIMIT, so its cost grows with how
+        # common the query terms are rather than with k. On an install with no linked
+        # folders that work is provably wasted (see linked_folder_rows_exist), which is
+        # the normal case for a knowledge base built from uploads.
+        if linked_folder_rows_exist(conn):
+            sql = (
+                f"SELECT chunks_fts.chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
+                f"JOIN chunks c ON c.id=chunks_fts.chunk_id "
+                f"JOIN documents d ON d.id=c.document_id "
+                f"WHERE chunks_fts MATCH ? AND chunks_fts.scope IN ({placeholders}) "
+                f"AND NOT EXISTS "
+                f"(SELECT 1 FROM linked_folder_retired_scopes r WHERE r.scope=d.scope) "
+                f"AND (d.linked_folder_id IS NULL OR EXISTS "
+                f"(SELECT 1 FROM linked_folder_files ff WHERE ff.document_id=d.id)) "
+                f"ORDER BY s LIMIT ?"
+            )
+        else:
+            sql = (
+                f"SELECT chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
+                f"WHERE chunks_fts MATCH ? AND scope IN ({placeholders}) "
+                f"ORDER BY s LIMIT ?"
+            )
+        rows = conn.execute(sql, (mq, *scopes, k)).fetchall()
+    finally:
+        # Read-only either way, but it has to end: an open snapshot keeps the WAL from
+        # being checkpointed for as long as the connection lives.
+        if own_read_txn:
+            conn.commit()
     # bm25() is negative (more negative = better); flip to higher-is-better.
     return [(r["chunk_id"], -r["s"]) for r in rows]
 

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -327,7 +327,9 @@ def _scope_for_owner(scope_type: str, scope_id: str) -> str:
 
 
 def _require_scope_owner(
-    scope_type: str, scope_id: str, conn: sqlite3.Connection | None = None
+    scope_type: str,
+    scope_id: str,
+    conn: sqlite3.Connection | None = None,
 ) -> None:
     """404 unless the scope's owner still exists.
 

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -333,9 +333,8 @@ def _require_scope_owner(
 ) -> None:
     """404 unless the scope's owner still exists.
 
-    ``conn`` lets a caller that is already holding a RAG connection reuse it. Opening
-    one is not free: sqlite-vec loads per connection, so a handler that opens a second
-    one only to read a single row pays that twice for one request.
+    ``conn`` reuses a connection the caller already holds: sqlite-vec loads per
+    connection, so opening a second one to read a single row pays that twice.
     """
     if scope_type == "knowledge_base":
         if conn is not None:
@@ -900,8 +899,7 @@ def folder_job_events(
 @router.post("/search")
 def search(payload: SearchRequest, subject: str = Depends(get_current_subject)) -> dict:
     _require_rag()
-    # One connection for the whole request: the ownership check reads a single row, and
-    # opening a second RAG connection for it loads sqlite-vec twice per search.
+    # One connection for the whole request; the ownership check reads a single row.
     conn = _rag_connection()
     try:
         if payload.kb_id:

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -326,13 +326,24 @@ def _scope_for_owner(scope_type: str, scope_id: str) -> str:
     )
 
 
-def _require_scope_owner(scope_type: str, scope_id: str) -> None:
+def _require_scope_owner(
+    scope_type: str, scope_id: str, conn: sqlite3.Connection | None = None
+) -> None:
+    """404 unless the scope's owner still exists.
+
+    ``conn`` lets a caller that is already holding a RAG connection reuse it. Opening
+    one is not free: sqlite-vec loads per connection, so a handler that opens a second
+    one only to read a single row pays that twice for one request.
+    """
     if scope_type == "knowledge_base":
-        conn = _rag_connection()
-        try:
+        if conn is not None:
             exists = store.get_kb(conn, scope_id) is not None
-        finally:
-            conn.close()
+        else:
+            owner_conn = _rag_connection()
+            try:
+                exists = store.get_kb(owner_conn, scope_id) is not None
+            finally:
+                owner_conn.close()
         detail = "Knowledge base not found"
     else:
         from storage.studio_db import get_chat_project
@@ -887,22 +898,26 @@ def folder_job_events(
 @router.post("/search")
 def search(payload: SearchRequest, subject: str = Depends(get_current_subject)) -> dict:
     _require_rag()
-    if payload.kb_id:
-        _require_scope_owner("knowledge_base", payload.kb_id)
-        scope = store.kb_scope(payload.kb_id)
-    else:
-        scopes = []
-        if payload.project_id:
-            _require_scope_owner("project", payload.project_id)
-            scopes.append(store.project_scope(payload.project_id))
-        if payload.thread_id:
-            scopes.append(store.thread_scope(payload.thread_id))
-        if not scopes:
-            raise HTTPException(status_code = 400, detail = "Provide kb_id, project_id, or thread_id")
-        scope = scopes[0] if len(scopes) == 1 else scopes
-
+    # One connection for the whole request: the ownership check reads a single row, and
+    # opening a second RAG connection for it loads sqlite-vec twice per search.
     conn = _rag_connection()
     try:
+        if payload.kb_id:
+            _require_scope_owner("knowledge_base", payload.kb_id, conn)
+            scope = store.kb_scope(payload.kb_id)
+        else:
+            scopes = []
+            if payload.project_id:
+                _require_scope_owner("project", payload.project_id, conn)
+                scopes.append(store.project_scope(payload.project_id))
+            if payload.thread_id:
+                scopes.append(store.thread_scope(payload.thread_id))
+            if not scopes:
+                raise HTTPException(
+                    status_code = 400, detail = "Provide kb_id, project_id, or thread_id"
+                )
+            scope = scopes[0] if len(scopes) == 1 else scopes
+
         if payload.mode == "lexical":
             hits = retrieval.retrieve_lexical(conn, scope, payload.query, payload.top_k)
         elif payload.mode == "dense":

--- a/studio/backend/storage/rag_db.py
+++ b/studio/backend/storage/rag_db.py
@@ -255,6 +255,13 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE documents ADD COLUMN linked_folder_id TEXT")
     if "linked_relative_path" not in cols:
         conn.execute("ALTER TABLE documents ADD COLUMN linked_relative_path TEXT")
+    # After the ALTER, which is where the column comes from on an older database. Partial,
+    # so it holds only folder-owned rows: empty on an install with nothing linked, which is
+    # what keeps the lexical fast-path gate an index probe instead of a scan of documents.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_documents_linked_folder "
+        "ON documents(linked_folder_id) WHERE linked_folder_id IS NOT NULL"
+    )
     ensure_linked_folder_columns(conn)
     conn.commit()
 

--- a/studio/backend/storage/rag_db.py
+++ b/studio/backend/storage/rag_db.py
@@ -255,9 +255,9 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE documents ADD COLUMN linked_folder_id TEXT")
     if "linked_relative_path" not in cols:
         conn.execute("ALTER TABLE documents ADD COLUMN linked_relative_path TEXT")
-    # After the ALTER, which is where the column comes from on an older database. Partial,
-    # so it holds only folder-owned rows: empty on an install with nothing linked, which is
-    # what keeps the lexical fast-path gate an index probe instead of a scan of documents.
+    # After the ALTER that adds the column on an older database. Partial, so it holds only
+    # folder-owned rows and is empty with nothing linked, which keeps the lexical fast-path
+    # gate an index probe rather than a scan of documents.
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_documents_linked_folder "
         "ON documents(linked_folder_id) WHERE linked_folder_id IS NOT NULL"

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -234,8 +234,8 @@ def test_lexical_results_match_across_both_query_forms(rag_conn):
 def test_lexical_gate_and_read_share_one_snapshot(rag_conn, monkeypatch):
     """A scope retired between the gate and the FTS read must not reach the read.
 
-    Otherwise the gate decides "nothing is linked" against a state the read no longer
-    sees, and rows from the retired scope take slots the caller loses at hydration.
+    Otherwise the gate decides against a state the read no longer sees, and rows from the
+    retired scope take slots the caller loses at hydration.
     """
     from storage import rag_db
 
@@ -281,9 +281,8 @@ def test_lexical_reuses_a_transaction_the_caller_already_opened(rag_conn):
 def test_gate_ignores_a_purged_tombstone(rag_conn):
     """Deleting a knowledge base must not disable the fast path for good.
 
-    delete_retired_scope keeps the tombstone and only stamps purged_at, and its scope has
-    no documents left, so a gate that counted it would take the filtered query forever
-    after the first ordinary delete.
+    delete_retired_scope keeps the tombstone and only stamps purged_at, so a gate that
+    counted it would take the filtered query forever after the first ordinary delete.
     """
     _add_doc(rag_conn, "kb_a", "d1", "d1.txt", "h1", ["alpha bravo charlie"])
     rag_conn.execute(
@@ -304,9 +303,8 @@ def test_gate_ignores_a_purged_tombstone(rag_conn):
 def test_gate_counts_a_folder_document_that_outlived_its_folder(rag_conn):
     """An orphan left by a crash before _install_mapping stays hidden after unlink.
 
-    The folder row goes with the unlink but the document does not (only mapped documents
-    are collected), so the gate has to see the document itself or the plain query would
-    make unlinked content searchable until the reaper runs.
+    Unlink collects only mapped documents, so the folder row goes and this one does not;
+    the gate has to see the document itself or unlinked content becomes searchable.
     """
     _link_folder(rag_conn, "f1", "kb_a")
     store.create_document(

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -230,3 +230,51 @@ def test_lexical_results_match_across_both_query_forms(rag_conn):
     _link_folder(rag_conn, "f1", "kb_b")  # another scope, so nothing is excluded
     filtered = store.search_lexical(rag_conn, "kb_a", "alpha bravo", 5)
     assert fast == filtered
+
+
+def test_lexical_gate_and_read_share_one_snapshot(rag_conn, monkeypatch):
+    """A scope retired between the gate and the FTS read must not reach the read.
+
+    Without one snapshot the gate can decide "nothing is linked, run the plain query"
+    against a database state the read no longer sees, and rows from a scope retired in
+    between take slots the caller then loses at hydration.
+    """
+    from storage import rag_db
+
+    _add_doc(rag_conn, "kb_a", "d1", "d1.txt", "h1", ["alpha bravo charlie"])
+    observed = {}
+    real = store.linked_folder_rows_exist
+
+    def retire_midway(conn):
+        observed["gate"] = real(conn)
+        writer = rag_db.get_connection()
+        try:
+            writer.execute(
+                "INSERT INTO linked_folder_retired_scopes(scope, retired_at) "
+                "VALUES('kb_a', '2026-01-01T00:00:00+00:00')"
+            )
+            writer.commit()
+        finally:
+            writer.close()
+        observed["after_commit"] = real(conn)
+        return observed["gate"]
+
+    monkeypatch.setattr(store, "linked_folder_rows_exist", retire_midway)
+    hits = store.search_lexical(rag_conn, "kb_a", "alpha", 10)
+
+    assert observed["gate"] is False
+    # Same connection, same call, after another connection committed the retirement.
+    assert observed["after_commit"] is False
+    assert [cid for cid, _ in hits] == ["d1:0"]
+    # The snapshot is released, so the next call sees the retirement and hides the row.
+    monkeypatch.setattr(store, "linked_folder_rows_exist", real)
+    assert store.search_lexical(rag_conn, "kb_a", "alpha", 10) == []
+
+
+def test_lexical_reuses_a_transaction_the_caller_already_opened(rag_conn):
+    """A caller holding a transaction keeps its own snapshot, and keeps it open."""
+    _add_doc(rag_conn, "kb_a", "d1", "d1.txt", "h1", ["alpha bravo charlie"])
+    rag_conn.execute("BEGIN")
+    assert [cid for cid, _ in store.search_lexical(rag_conn, "kb_a", "alpha", 10)] == ["d1:0"]
+    assert rag_conn.in_transaction
+    rag_conn.commit()

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -276,3 +276,48 @@ def test_lexical_reuses_a_transaction_the_caller_already_opened(rag_conn):
     assert [cid for cid, _ in store.search_lexical(rag_conn, "kb_a", "alpha", 10)] == ["d1:0"]
     assert rag_conn.in_transaction
     rag_conn.commit()
+
+
+def test_gate_ignores_a_purged_tombstone(rag_conn):
+    """Deleting a knowledge base must not disable the fast path for good.
+
+    delete_retired_scope keeps the tombstone and only stamps purged_at, and its scope has
+    no documents left, so a gate that counted it would take the filtered query forever
+    after the first ordinary delete.
+    """
+    _add_doc(rag_conn, "kb_a", "d1", "d1.txt", "h1", ["alpha bravo charlie"])
+    rag_conn.execute(
+        "INSERT INTO linked_folder_retired_scopes(scope, retired_at) "
+        "VALUES('kb_gone', '2026-01-01T00:00:00+00:00')"
+    )
+    rag_conn.commit()
+    assert store.linked_folder_rows_exist(rag_conn) is True
+
+    rag_conn.execute(
+        "UPDATE linked_folder_retired_scopes SET purged_at='2026-01-01T00:00:01+00:00'"
+    )
+    rag_conn.commit()
+    assert store.linked_folder_rows_exist(rag_conn) is False
+    assert [cid for cid, _ in store.search_lexical(rag_conn, "kb_a", "alpha", 10)] == ["d1:0"]
+
+
+def test_gate_counts_a_folder_document_that_outlived_its_folder(rag_conn):
+    """An orphan left by a crash before _install_mapping stays hidden after unlink.
+
+    The folder row goes with the unlink but the document does not (only mapped documents
+    are collected), so the gate has to see the document itself or the plain query would
+    make unlinked content searchable until the reaper runs.
+    """
+    _link_folder(rag_conn, "f1", "kb_a")
+    store.create_document(
+        rag_conn, scope = "kb_a", filename = "secret.md", sha256 = "h1",
+        document_id = "orphan", linked_folder_id = "f1",
+    )
+    store.add_chunks(rag_conn, "kb_a", "orphan", [_chunk("alpha bravo secret")],
+                     [embed("alpha bravo")])
+    assert store.search_lexical(rag_conn, "kb_a", "alpha", 10) == []
+
+    rag_conn.execute("DELETE FROM linked_folders WHERE id='f1'")
+    rag_conn.commit()
+    assert store.linked_folder_rows_exist(rag_conn) is True
+    assert store.search_lexical(rag_conn, "kb_a", "alpha", 10) == []

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -220,8 +220,7 @@ def test_lexical_hides_retired_scope_and_unmapped_linked_document(rag_conn):
 
 
 def test_lexical_results_match_across_both_query_forms(rag_conn):
-    """Same rows, same order, whichever form runs: the fast path is not a shortcut in
-    behaviour, only in work."""
+    """The fast path is a shortcut in work, not in behaviour."""
     for i in range(12):
         _add_doc(
             rag_conn, "kb_a", f"d{i}", f"d{i}.txt", f"h{i}", [f"alpha bravo {'charlie ' * (i % 4)}"]
@@ -235,9 +234,8 @@ def test_lexical_results_match_across_both_query_forms(rag_conn):
 def test_lexical_gate_and_read_share_one_snapshot(rag_conn, monkeypatch):
     """A scope retired between the gate and the FTS read must not reach the read.
 
-    Without one snapshot the gate can decide "nothing is linked, run the plain query"
-    against a database state the read no longer sees, and rows from a scope retired in
-    between take slots the caller then loses at hydration.
+    Otherwise the gate decides "nothing is linked" against a state the read no longer
+    sees, and rows from the retired scope take slots the caller loses at hydration.
     """
     from storage import rag_db
 

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -310,11 +310,16 @@ def test_gate_counts_a_folder_document_that_outlived_its_folder(rag_conn):
     """
     _link_folder(rag_conn, "f1", "kb_a")
     store.create_document(
-        rag_conn, scope = "kb_a", filename = "secret.md", sha256 = "h1",
-        document_id = "orphan", linked_folder_id = "f1",
+        rag_conn,
+        scope = "kb_a",
+        filename = "secret.md",
+        sha256 = "h1",
+        document_id = "orphan",
+        linked_folder_id = "f1",
     )
-    store.add_chunks(rag_conn, "kb_a", "orphan", [_chunk("alpha bravo secret")],
-                     [embed("alpha bravo")])
+    store.add_chunks(
+        rag_conn, "kb_a", "orphan", [_chunk("alpha bravo secret")], [embed("alpha bravo")]
+    )
     assert store.search_lexical(rag_conn, "kb_a", "alpha", 10) == []
 
     rag_conn.execute("DELETE FROM linked_folders WHERE id='f1'")

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -158,7 +158,12 @@ def test_kb_delete_rolls_back_when_document_cleanup_fails(rag_conn, monkeypatch)
     ]
 
 
-def _link_folder(conn, folder_id, scope, path = "/tmp/linked"):
+def _link_folder(
+    conn,
+    folder_id,
+    scope,
+    path = "/tmp/linked",
+):
     conn.execute(
         "INSERT INTO linked_folders(id, scope_type, scope_id, scope, path, name, "
         "auto_sync, status, created_at, updated_at) "
@@ -218,9 +223,10 @@ def test_lexical_results_match_across_both_query_forms(rag_conn):
     """Same rows, same order, whichever form runs: the fast path is not a shortcut in
     behaviour, only in work."""
     for i in range(12):
-        _add_doc(rag_conn, "kb_a", f"d{i}", f"d{i}.txt", f"h{i}",
-                 [f"alpha bravo {'charlie ' * (i % 4)}"])
+        _add_doc(
+            rag_conn, "kb_a", f"d{i}", f"d{i}.txt", f"h{i}", [f"alpha bravo {'charlie ' * (i % 4)}"]
+        )
     fast = store.search_lexical(rag_conn, "kb_a", "alpha bravo", 5)
-    _link_folder(rag_conn, "f1", "kb_b")     # another scope, so nothing is excluded
+    _link_folder(rag_conn, "f1", "kb_b")  # another scope, so nothing is excluded
     filtered = store.search_lexical(rag_conn, "kb_a", "alpha bravo", 5)
     assert fast == filtered

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -156,3 +156,71 @@ def test_kb_delete_rolls_back_when_document_cleanup_fails(rag_conn, monkeypatch)
         "doc1",
         "doc2",
     ]
+
+
+def _link_folder(conn, folder_id, scope, path = "/tmp/linked"):
+    conn.execute(
+        "INSERT INTO linked_folders(id, scope_type, scope_id, scope, path, name, "
+        "auto_sync, status, created_at, updated_at) "
+        "VALUES(?,?,?,?,?,?,1,'idle','2026-01-01T00:00:00+00:00','2026-01-01T00:00:00+00:00')",
+        (folder_id, "knowledge_base", scope.removeprefix("kb_"), scope, path, "linked"),
+    )
+    conn.commit()
+
+
+def test_lexical_fast_path_only_while_no_folder_rows_exist(rag_conn):
+    """The plain FTS query is used exactly when the filters could not exclude anything."""
+    _add_doc(rag_conn, "kb_a", "d1", "d1.txt", "h1", ["alpha bravo charlie"])
+    assert store.linked_folder_rows_exist(rag_conn) is False
+
+    _link_folder(rag_conn, "f1", "kb_a")
+    assert store.linked_folder_rows_exist(rag_conn) is True
+
+    rag_conn.execute("DELETE FROM linked_folders")
+    rag_conn.execute(
+        "INSERT INTO linked_folder_retired_scopes(scope, retired_at) "
+        "VALUES('kb_a', '2026-01-01T00:00:00+00:00')"
+    )
+    rag_conn.commit()
+    assert store.linked_folder_rows_exist(rag_conn) is True
+
+
+def test_lexical_hides_retired_scope_and_unmapped_linked_document(rag_conn):
+    """The filters still apply once a folder row exists, fast path or not."""
+    _add_doc(rag_conn, "kb_a", "d1", "d1.txt", "h1", ["alpha bravo charlie"])
+    _add_doc(rag_conn, "kb_a", "d2", "d2.txt", "h2", ["alpha delta echo"])
+    _link_folder(rag_conn, "f1", "kb_a")
+    # d2 belongs to a folder but has no mapping row yet, so it is not searchable.
+    rag_conn.execute("UPDATE documents SET linked_folder_id='f1' WHERE id='d2'")
+    rag_conn.commit()
+    assert [cid for cid, _ in store.search_lexical(rag_conn, "kb_a", "alpha", 10)] == ["d1:0"]
+
+    rag_conn.execute(
+        "INSERT INTO linked_folder_files(folder_id, relative_path, size_bytes, mtime_ns, "
+        "document_id, synced_at) VALUES('f1', 'd2.txt', 1, 1, 'd2', "
+        "'2026-01-01T00:00:00+00:00')"
+    )
+    rag_conn.commit()
+    assert sorted(cid for cid, _ in store.search_lexical(rag_conn, "kb_a", "alpha", 10)) == [
+        "d1:0",
+        "d2:0",
+    ]
+
+    rag_conn.execute(
+        "INSERT INTO linked_folder_retired_scopes(scope, retired_at) "
+        "VALUES('kb_a', '2026-01-01T00:00:00+00:00')"
+    )
+    rag_conn.commit()
+    assert store.search_lexical(rag_conn, "kb_a", "alpha", 10) == []
+
+
+def test_lexical_results_match_across_both_query_forms(rag_conn):
+    """Same rows, same order, whichever form runs: the fast path is not a shortcut in
+    behaviour, only in work."""
+    for i in range(12):
+        _add_doc(rag_conn, "kb_a", f"d{i}", f"d{i}.txt", f"h{i}",
+                 [f"alpha bravo {'charlie ' * (i % 4)}"])
+    fast = store.search_lexical(rag_conn, "kb_a", "alpha bravo", 5)
+    _link_folder(rag_conn, "f1", "kb_b")     # another scope, so nothing is excluded
+    filtered = store.search_lexical(rag_conn, "kb_a", "alpha bravo", 5)
+    assert fast == filtered


### PR DESCRIPTION
Follow-up to #8014. Retrieval results are unchanged by that PR (checked below), but two things it added cost time on every RAG search, and both are avoidable.

## What this changes

**1. Lexical search runs the plain FTS query when nothing is linked.**

`search_lexical` joins `chunks` and `documents` and evaluates two correlated subqueries for every row the FTS match returns, before the `LIMIT`, so its cost grows with how common the query terms are rather than with `k`:

```
SCAN chunks_fts VIRTUAL TABLE INDEX 0:M3
SEARCH c USING INDEX sqlite_autoindex_chunks_1 (id=?)
SEARCH d USING INDEX sqlite_autoindex_documents_1 (id=?)
CORRELATED SCALAR SUBQUERY 1 -> SEARCH r USING COVERING INDEX ...retired_scopes_1
CORRELATED SCALAR SUBQUERY 2 -> SEARCH ff USING COVERING INDEX idx_linked_folder_files_document
USE TEMP B-TREE FOR ORDER BY
```

With `linked_folders` and `linked_folder_retired_scopes` both empty those predicates cannot exclude a single row, which is the normal state of a knowledge base built from uploads. The new `linked_folder_rows_exist()` gates on two `EXISTS` reads of those two tiny tables (0.002 ms measured) and takes the pre-8014 query form when they are empty. As soon as anything is linked or retired, the filtered form runs exactly as it does today.

**2. The search handler stops opening a second RAG connection.**

`_require_scope_owner` opened its own `rag.db` connection to read one row, and sqlite-vec loads per connection. It now accepts a connection, and `search` passes the one it already opens.

## Measurements

Two isolated installs on one box, same seeded database cloned to both, private ports, identity verified per side, two repeats in alternating order. Merged head of #8014 vs this branch:

| mode / concurrency | #8014 head p50 | this branch p50 | ratio |
| --- | --- | --- | --- |
| lexical / 1 | 4.73 ms | 3.61 ms | 0.76 |
| lexical / 8 | 27.80 ms | 23.67 ms | 0.85 |
| dense / 1 | 10.78 ms | 9.66 ms | 0.90 |
| dense / 8 | 97.72 ms | 91.29 ms | 0.93 |
| hybrid / 1 | 11.77 ms | 10.87 ms | 0.92 |
| hybrid / 8 | 71.43 ms | 68.16 ms | 0.95 |

That puts all three modes back at the pre-8014 numbers measured on the same corpus (lexical 3.52 ms, dense 9.58 ms, hybrid 10.79 ms at concurrency 1).

The join is what matters on a large knowledge base. At 10,000 chunks, over HTTP:

| query | #8014 head p50 | this branch p50 |
| --- | --- | --- |
| term matching 9,906 chunks | 27.22 ms | 15.60 ms |
| term matching 2 chunks | 3.96 ms | 3.28 ms |

Directly at the SQL level on the same database, the two statement forms are 26.90 ms and 15.12 ms, with the pre-8014 statement re-timed afterwards at 15.21 ms, so this is the statement and not drift.

## Results are unchanged

* Against the merged head of #8014, all 174 query/mode pairs return identical chunk ids in identical order on both builds, on both repeats.
* Separately, #8014 itself was checked the same way against its merge base `ef74942f8`: 171/171 query/mode pairs identical including scores to 1e-6, with the same check repeated after setting `embedding_model` to NULL on every document, which is the branch where its dense over-fetch changes. Ingesting the same bytes on both builds produced identical chunks. So neither #8014 nor this follow-up moves retrieval quality.

## Tests

Three new tests in `studio/backend/tests/test_rag_store.py`:

* the fast path is taken exactly while both tables are empty, and stops being taken as soon as a folder row or a retired scope exists;
* a retired scope and a linked document with no mapping row are still hidden once a folder row exists;
* both query forms return the same rows in the same order.

`1035 passed, 2 skipped` across the RAG and search suites.
