### PR TITLE
Report unsloth's own version on the MLX path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 unsloth = "unsloth_cli:app"
 
 [tool.setuptools.dynamic]
-version = {attr = "unsloth.models._utils.__version__"}
+version = {attr = "unsloth._version.__version__"}
 
 [tool.setuptools]
 include-package-data = true

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -359,7 +359,10 @@ def get_unsloth_version() -> str:
     except PackageNotFoundError:
         pass
 
-    version_file = _Path(__file__).resolve().parents[2] / "unsloth" / "models" / "_utils.py"
+    # _version.py, not models/_utils.py: the literal lives in a leaf module so that
+    # pyproject's `attr:` and the torch-free MLX path can both read it. _utils.py now
+    # re-exports it, and an import line does not match the scan below.
+    version_file = _Path(__file__).resolve().parents[2] / "unsloth" / "_version.py"
     try:
         for line in version_file.read_text(encoding = "utf-8").splitlines():
             if line.startswith("__version__ = "):

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -359,12 +359,9 @@ def get_unsloth_version() -> str:
     except PackageNotFoundError:
         pass
 
-    # _version.py first: the literal lives in a leaf module so that pyproject's `attr:`
-    # and the torch-free MLX path can both read it. models/_utils.py is still tried after
-    # it, because it held the literal before and now holds only a re-export, which this
-    # prefix scan does not match -- so a tree where only one of the two files is current
-    # (a partial `unsloth studio update`, a stale checkout) still reports a real version
-    # instead of silently falling through to "dev".
+    # Both files: the literal moved to _version.py, and models/_utils.py now holds only a
+    # re-export, which this prefix scan does not match. Trying both keeps a half-updated
+    # tree reporting a real version instead of falling through to "dev".
     root = _Path(__file__).resolve().parents[2] / "unsloth"
     for version_file in (root / "_version.py", root / "models" / "_utils.py"):
         try:

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -359,16 +359,20 @@ def get_unsloth_version() -> str:
     except PackageNotFoundError:
         pass
 
-    # _version.py, not models/_utils.py: the literal lives in a leaf module so that
-    # pyproject's `attr:` and the torch-free MLX path can both read it. _utils.py now
-    # re-exports it, and an import line does not match the scan below.
-    version_file = _Path(__file__).resolve().parents[2] / "unsloth" / "_version.py"
-    try:
-        for line in version_file.read_text(encoding = "utf-8").splitlines():
-            if line.startswith("__version__ = "):
-                return line.split("=", 1)[1].strip().strip('"').strip("'")
-    except (OSError, UnicodeDecodeError):
-        pass
+    # _version.py first: the literal lives in a leaf module so that pyproject's `attr:`
+    # and the torch-free MLX path can both read it. models/_utils.py is still tried after
+    # it, because it held the literal before and now holds only a re-export, which this
+    # prefix scan does not match -- so a tree where only one of the two files is current
+    # (a partial `unsloth studio update`, a stale checkout) still reports a real version
+    # instead of silently falling through to "dev".
+    root = _Path(__file__).resolve().parents[2] / "unsloth"
+    for version_file in (root / "_version.py", root / "models" / "_utils.py"):
+        try:
+            for line in version_file.read_text(encoding = "utf-8").splitlines():
+                if line.startswith("__version__ = "):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+        except (OSError, UnicodeDecodeError):
+            continue
     return "dev"
 
 

--- a/tests/test_version_single_source.py
+++ b/tests/test_version_single_source.py
@@ -79,7 +79,6 @@ def test_models_utils_still_re_exports_the_same_version():
     # Every banner, every saved config's unsloth_version, and unsloth.__version__ on the
     # GPU path come through here.
     from unsloth.models._utils import __version__ as via_utils
-
     assert via_utils == _load_version_module_standalone().__version__
 
 

--- a/tests/test_version_single_source.py
+++ b/tests/test_version_single_source.py
@@ -1,0 +1,137 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure-CPU, no-network tests pinning unsloth/_version.py as the one source of the version.
+
+Three consumers read that literal by different means and each breaks differently when it
+moves: pyproject resolves it with a static AST parse (a non-literal makes setuptools import
+torch inside the build env), Studio's version fallback scans the file line by line for
+``__version__ = `` (a re-export line silently reports "dev"), and the MLX branch of
+unsloth/__init__.py imports the module directly (anything with imports defeats its
+torch-free boot, which is what drove it to borrow unsloth_zoo's number instead -- unsloth#8171).
+
+None of that is visible from `unsloth.__version__` on a GPU host, so it is pinned here.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_VERSION_FILE = _REPO_ROOT / "unsloth" / "_version.py"
+
+_HEAVY = ("torch", "transformers", "trl", "peft", "triton", "unsloth_zoo")
+
+
+def _load_version_module_standalone():
+    """Load _version.py off disk, bypassing the unsloth package __init__."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_unsloth_version_probe", _VERSION_FILE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_version_file_is_a_literal_in_a_module_with_no_imports():
+    tree = ast.parse(_VERSION_FILE.read_text(encoding = "utf-8"))
+
+    imports = [n for n in ast.walk(tree) if isinstance(n, (ast.Import, ast.ImportFrom))]
+    assert imports == [], (
+        "unsloth/_version.py must import nothing: pyproject reads it with a static AST "
+        "parse, and the torch-free MLX path imports it directly."
+    )
+
+    assigns = [n for n in tree.body if isinstance(n, ast.Assign)]
+    assert len(assigns) == 1, "the module should hold the version and nothing else"
+    target, value = assigns[0].targets[0], assigns[0].value
+    assert target.id == "__version__"
+    assert isinstance(value, ast.Constant) and isinstance(value.value, str), (
+        "__version__ must stay a plain string literal, else setuptools falls back to "
+        "importing unsloth.models._utils (and torch) at build time."
+    )
+
+
+def test_importing_the_version_alone_pulls_in_no_heavy_dependency():
+    before = {name for name in _HEAVY if name in sys.modules}
+    module = _load_version_module_standalone()
+    after = {name for name in _HEAVY if name in sys.modules}
+
+    assert isinstance(module.__version__, str) and module.__version__
+    assert after - before == set(), "reading the version must not import the world"
+
+
+def test_models_utils_still_re_exports_the_same_version():
+    # Every banner, every saved config's unsloth_version, and unsloth.__version__ on the
+    # GPU path come through here.
+    from unsloth.models._utils import __version__ as via_utils
+
+    assert via_utils == _load_version_module_standalone().__version__
+
+
+def test_pyproject_reads_the_version_from_the_leaf_module():
+    pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding = "utf-8")
+    match = re.search(r"^version\s*=\s*\{attr\s*=\s*\"([^\"]+)\"\}", pyproject, re.MULTILINE)
+    assert match, "pyproject must keep deriving the distribution version from an attr"
+    assert match.group(1) == "unsloth._version.__version__"
+
+
+def test_setuptools_resolves_the_version_without_importing_torch():
+    read_attr = pytest.importorskip("setuptools.config.expand").read_attr
+
+    before = {name for name in _HEAVY if name in sys.modules}
+    resolved = read_attr("unsloth._version.__version__", root_dir = str(_REPO_ROOT))
+    after = {name for name in _HEAVY if name in sys.modules}
+
+    assert resolved == _load_version_module_standalone().__version__
+    assert after - before == set(), (
+        "the build must resolve the version statically; importing unsloth.models._utils "
+        "here would drag torch into the build environment."
+    )
+
+
+def test_studio_version_fallback_scans_a_file_that_holds_the_literal():
+    # studio/backend/main.py::get_unsloth_version falls back to scanning this file when
+    # the distribution metadata is missing (source checkouts). It matches the line
+    # prefix, so pointing it at a module that only re-exports the name reports "dev".
+    main_py = (_REPO_ROOT / "studio" / "backend" / "main.py").read_text(encoding = "utf-8")
+    match = re.search(
+        r"version_file\s*=\s*_Path\(__file__\)\.resolve\(\)\.parents\[2\]\s*/(.+)", main_py
+    )
+    assert match, "get_unsloth_version's fallback path moved; re-pin it here"
+
+    parts = re.findall(r"\"([^\"]+)\"", match.group(1))
+    scanned = _REPO_ROOT.joinpath(*parts)
+    assert scanned.exists(), f"the fallback scans {scanned}, which does not exist"
+
+    scraped = None
+    for line in scanned.read_text(encoding = "utf-8").splitlines():
+        if line.startswith("__version__ = "):
+            scraped = line.split("=", 1)[1].strip().strip('"').strip("'")
+            break
+    assert scraped == _load_version_module_standalone().__version__, (
+        f"{scanned.name} has no `__version__ = ` literal for the fallback to find, so "
+        "Studio would report its version as 'dev' on a source checkout."
+    )
+
+
+def test_the_mlx_branch_no_longer_borrows_the_zoo_version():
+    # unsloth#8171: the MLX path reported unsloth_zoo's number, which is a different
+    # package pinned with >=, so it was neither the installed core nor the latest zoo.
+    init_py = (_REPO_ROOT / "unsloth" / "__init__.py").read_text(encoding = "utf-8")
+    assert "__version__ = unsloth_zoo.__version__" not in init_py
+    assert "from ._version import __version__" in init_py

--- a/tests/test_version_single_source.py
+++ b/tests/test_version_single_source.py
@@ -27,9 +27,14 @@ None of that is visible from `unsloth.__version__` on a GPU host, so it is pinne
 import ast
 import re
 import sys
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
 from pathlib import Path
 
 import pytest
+
+
+def _raise_not_found(name):
+    raise _PackageNotFoundError(name)
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _VERSION_FILE = _REPO_ROOT / "unsloth" / "_version.py"
@@ -103,29 +108,82 @@ def test_setuptools_resolves_the_version_without_importing_torch():
     )
 
 
-def test_studio_version_fallback_scans_a_file_that_holds_the_literal():
-    # studio/backend/main.py::get_unsloth_version falls back to scanning this file when
-    # the distribution metadata is missing (source checkouts). It matches the line
-    # prefix, so pointing it at a module that only re-exports the name reports "dev".
+def _get_unsloth_version_with_metadata_missing(main_py_path):
+    """Run studio/backend/main.py::get_unsloth_version with the distribution metadata
+    forced absent, which is the source-checkout case its file scan exists for.
+
+    The function body is exec'd rather than imported because importing main.py starts the
+    whole FastAPI backend.
+    """
+    src = _Path_read(main_py_path)
+    start = src.index("def get_unsloth_version()")
+    body = src[start : src.index("\n\n\n", start)]
+    namespace = {
+        "_Path": Path,
+        "PackageNotFoundError": _PackageNotFoundError,
+        "package_version": _raise_not_found,
+        "__file__": str(main_py_path),
+    }
+    exec(compile(body, "main.py", "exec"), namespace)
+    return namespace["get_unsloth_version"]()
+
+
+def _Path_read(p):
+    return Path(p).read_text(encoding = "utf-8")
+
+
+def test_studio_version_fallback_reports_the_real_version_on_a_source_checkout():
+    # get_unsloth_version falls back to scanning the source when distribution metadata is
+    # missing. The scan matches a `__version__ = ` line prefix, so a file that only
+    # re-exports the name yields nothing and Studio silently reports "dev". Driving the
+    # real function against the real tree catches that whatever the scan is pointed at.
+    reported = _get_unsloth_version_with_metadata_missing(
+        _REPO_ROOT / "studio" / "backend" / "main.py"
+    )
+    assert reported == _load_version_module_standalone().__version__, (
+        f"the fallback reported {reported!r}; Studio would show that instead of the "
+        "real version on a source checkout."
+    )
+
+
+def test_the_studio_fallback_survives_a_half_updated_tree(tmp_path):
+    # The fallback is what a source checkout relies on, and a checkout can be half
+    # updated: `unsloth studio update` pulls a repo, and a stale tree can carry a new
+    # main.py beside an old models/_utils.py or the reverse. Either file alone must still
+    # yield a real version rather than "dev".
+    import re as _re
+
     main_py = (_REPO_ROOT / "studio" / "backend" / "main.py").read_text(encoding = "utf-8")
-    match = re.search(
-        r"version_file\s*=\s*_Path\(__file__\)\.resolve\(\)\.parents\[2\]\s*/(.+)", main_py
-    )
-    assert match, "get_unsloth_version's fallback path moved; re-pin it here"
+    start = main_py.index("def get_unsloth_version()")
+    body = main_py[start : main_py.index("\n\n\n", start)]
 
-    parts = re.findall(r"\"([^\"]+)\"", match.group(1))
-    scanned = _REPO_ROOT.joinpath(*parts)
-    assert scanned.exists(), f"the fallback scans {scanned}, which does not exist"
+    def _version_for(layout):
+        root = tmp_path / layout
+        (root / "unsloth" / "models").mkdir(parents = True)
+        (root / "studio" / "backend").mkdir(parents = True)
+        if layout in ("current", "only_version"):
+            (root / "unsloth" / "_version.py").write_text('__version__ = "9.9.9"\n')
+        if layout == "only_utils":
+            (root / "unsloth" / "models" / "_utils.py").write_text('__version__ = "9.9.9"\n')
+        else:
+            (root / "unsloth" / "models" / "_utils.py").write_text(
+                "from .._version import __version__\n"
+            )
+        namespace = {
+            "_Path": Path,
+            "PackageNotFoundError": _PackageNotFoundError,
+            # Force the metadata lookup to miss, which is the source-checkout case.
+            "package_version": _raise_not_found,
+            "__file__": str(root / "studio" / "backend" / "main.py"),
+        }
+        exec(compile(body, "main.py", "exec"), namespace)
+        return namespace["get_unsloth_version"]()
 
-    scraped = None
-    for line in scanned.read_text(encoding = "utf-8").splitlines():
-        if line.startswith("__version__ = "):
-            scraped = line.split("=", 1)[1].strip().strip('"').strip("'")
-            break
-    assert scraped == _load_version_module_standalone().__version__, (
-        f"{scanned.name} has no `__version__ = ` literal for the fallback to find, so "
-        "Studio would report its version as 'dev' on a source checkout."
-    )
+    assert _version_for("current") == "9.9.9"
+    assert _version_for("only_version") == "9.9.9"
+    assert _version_for("only_utils") == "9.9.9"
+    # Neither file carries a literal: reporting "dev" is correct, not a silent wrong number.
+    assert _version_for("neither") == "dev"
 
 
 def test_the_mlx_branch_no_longer_borrows_the_zoo_version():

--- a/tests/test_version_single_source.py
+++ b/tests/test_version_single_source.py
@@ -36,6 +36,7 @@ import pytest
 def _raise_not_found(name):
     raise _PackageNotFoundError(name)
 
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _VERSION_FILE = _REPO_ROOT / "unsloth" / "_version.py"
 

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -202,7 +202,12 @@ if _IS_MLX:
     import types as _types
     import warnings as _warnings
 
-    __version__ = unsloth_zoo.__version__
+    # unsloth_zoo's number is a different package's, and the two are pinned with `>=`
+    # rather than `==`, so borrowing it reported a version that was neither the
+    # installed core nor the latest zoo. `_version` is a leaf module with no imports,
+    # so reading it here keeps this branch torch-free while agreeing with the GPU path,
+    # with `pip show unsloth`, and with what `unsloth --version` prints.
+    from ._version import __version__
     DEVICE_TYPE = "mlx"
     _MLX_TRAINER_ACCEPTS_VAR_KWARGS = False
     _MLX_TRAINER_SUPPORTED_KWARGS = frozenset()

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -202,11 +202,9 @@ if _IS_MLX:
     import types as _types
     import warnings as _warnings
 
-    # unsloth_zoo's number is a different package's, and the two are pinned with `>=`
-    # rather than `==`, so borrowing it reported a version that was neither the
-    # installed core nor the latest zoo. `_version` is a leaf module with no imports,
-    # so reading it here keeps this branch torch-free while agreeing with the GPU path,
-    # with `pip show unsloth`, and with what `unsloth --version` prints.
+    # unsloth_zoo is a different distribution, pinned `>=`, so borrowing its number
+    # reported neither the installed core nor the latest zoo. `_version` imports nothing,
+    # so this stays torch-free while agreeing with the GPU path and `pip show unsloth`.
     from ._version import __version__
 
     DEVICE_TYPE = "mlx"

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -208,6 +208,7 @@ if _IS_MLX:
     # so reading it here keeps this branch torch-free while agreeing with the GPU path,
     # with `pip show unsloth`, and with what `unsloth --version` prints.
     from ._version import __version__
+
     DEVICE_TYPE = "mlx"
     _MLX_TRAINER_ACCEPTS_VAR_KWARGS = False
     _MLX_TRAINER_SUPPORTED_KWARGS = frozenset()

--- a/unsloth/_version.py
+++ b/unsloth/_version.py
@@ -1,0 +1,26 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The single source of truth for the version of THIS package.
+#
+# It lives alone in a module with no imports for two reasons. First, pyproject.toml
+# reads it through `version = {attr = "unsloth._version.__version__"}`, and setuptools
+# resolves that with a static AST parse as long as the value stays a plain string
+# literal -- so building a wheel never has to import torch. Keep it a literal.
+# Second, the MLX path in `unsloth/__init__.py` is deliberately torch-free and cannot
+# reach `unsloth.models._utils`, where this used to live; importing that module pulls
+# in torch, transformers, trl, peft and the Triton kernels. A leaf module both paths
+# can import is what stops the MLX branch from having to borrow unsloth_zoo's version
+# instead, which reported a different package's number entirely.
+__version__ = "2026.8.12"

--- a/unsloth/_version.py
+++ b/unsloth/_version.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The single source of truth for the version of THIS package.
+# The single source of truth for this package's version.
 #
-# It lives alone in a module with no imports for two reasons. First, pyproject.toml
-# reads it through `version = {attr = "unsloth._version.__version__"}`, and setuptools
-# resolves that with a static AST parse as long as the value stays a plain string
-# literal -- so building a wheel never has to import torch. Keep it a literal.
-# Second, the MLX path in `unsloth/__init__.py` is deliberately torch-free and cannot
-# reach `unsloth.models._utils`, where this used to live; importing that module pulls
-# in torch, transformers, trl, peft and the Triton kernels. A leaf module both paths
-# can import is what stops the MLX branch from having to borrow unsloth_zoo's version
-# instead, which reported a different package's number entirely.
+# Keep it a plain literal in a module with no imports. pyproject reads it through
+# `attr:`, which setuptools resolves by static AST parse, so a build never imports torch;
+# and the torch-free MLX path in __init__.py imports it directly, which it cannot do for
+# models/_utils.py (torch, transformers, trl, peft, Triton). That is why the MLX branch
+# used to borrow unsloth_zoo's version, reporting a different package's number.
 __version__ = "2026.8.12"

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2026.8.12"
+from .._version import __version__
 
 __all__ = [
     "SUPPORTS_BFLOAT16",


### PR DESCRIPTION
## The bug

`unsloth.__version__` reports a different package's version on Apple Silicon.

`unsloth/__init__.py` has two branches. The GPU path resolves the version through `_gpu_init` to `unsloth/models/_utils.py`, which held the literal that `pyproject.toml` also builds the distribution version from, so it is correct and cannot drift from the wheel. The MLX path does not reach any of that and set the name directly:

```python
__version__ = unsloth_zoo.__version__
```

`unsloth_zoo` is a separate distribution, pinned `unsloth_zoo>=2026.8.9` rather than `==`, so on an MLX install the reported string is neither the installed core nor necessarily the latest zoo. It also disagrees with `pip show unsloth`, with `unsloth --version` (`unsloth_cli/__init__.py`, which reads distribution metadata), and with Studio's `get_unsloth_version()` on the same machine.

Not theoretical: the environment block in #8317 shows `Unsloth CLI: 2026.8.10` alongside `Unsloth Python package in Studio: 2026.8.7` on one macOS host.

## Why the obvious fixes do not work

The issue suggests `importlib.metadata.version("unsloth")`. That is wrong as the primary source: it fails for source checkouts and vendored copies with no `dist-info`.

Moving the literal itself to `importlib.metadata` would break packaging outright. Setuptools resolves `version = {attr = ...}` with a static AST parse, which works only while the value is a plain string literal. A non-literal forces setuptools to import `unsloth.models._utils` inside the build environment, which imports torch, transformers, trl and peft, and then look up a distribution that is not yet installed.

`from .models._utils import __version__` is equally unavailable on the MLX path. Importing it runs `unsloth/models/__init__.py`, which pulls in the loaders and the Triton kernels and defeats the torch-free boot that branch deliberately protects. The same branch already side-loads `dataprep/raw_text.py` by file path for exactly this reason.

## The fix

Put the literal in `unsloth/_version.py`, a leaf module that imports nothing, and have every consumer read it from there.

- `unsloth/__init__.py` MLX branch reads it instead of the zoo's.
- `unsloth/models/_utils.py` re-exports it, so every existing consumer (the patching banners, the `unsloth_version` written into saved configs, `unsloth.models.__version__`) is unchanged.
- `pyproject.toml` points its `attr:` at it. Still a plain literal in a module with no imports, so the static parse keeps working and the build never imports torch.
- `studio/backend/main.py::get_unsloth_version()` follows. Its fallback for source checkouts scans a file line by line for a `__version__ = ` prefix, and `_utils.py` now holds a re-export line rather than the literal, so leaving it pointed there would have made Studio report its version as `dev`.

The GPU path's reported value does not change.

## Validation

```
tests/test_version_single_source.py                              7 passed
tests/test_version_single_source.py + collection hygiene
  + broken-tf import guard                                      51 passed
studio/backend  pytest tests/ -k version                       399 passed, 2 skipped
```

(The two collection errors in the studio run are pre-existing and unrelated: `test_mcp_server.py` and `test_rag_ocr_fallback.py` need `fastmcp`, which is not installed here.)

Values after the change:

```
build-time attr resolution : 2026.8.12   heavy modules imported: none
unsloth.__version__        : 2026.8.12
unsloth.models._utils      : 2026.8.12
```

The new tests pin the three properties that each break differently and none of which are visible from `unsloth.__version__` on a GPU host: the file stays a literal with no imports, setuptools resolves it without importing torch, and Studio's fallback scans a file that still contains a matching line. Each was mutation-checked by reverting the corresponding change and confirming the matching test fails.

The MLX branch itself cannot be executed on this machine, so that one line is verified by reading rather than running. The import it now uses is a plain sibling module with no imports and no platform-dependent behavior.
