### PR TITLE
Desktop: show the newest line of the desktop setup log

### DIFF
--- a/studio/frontend/src/components/tauri/setup-log.tsx
+++ b/studio/frontend/src/components/tauri/setup-log.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { ChevronDown as ChevronDownIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useState } from "react";
+
+// A wrapped line lands a few pixels off the bottom, which is not scrolling away.
+const TAIL_SLACK_PX = 24;
+
+function isAtTail(pane: HTMLPreElement): boolean {
+  return (
+    pane.scrollHeight - pane.scrollTop - pane.clientHeight <= TAIL_SLACK_PX
+  );
+}
+
+/** The install, repair and update log, following its newest line unless the reader scrolls up. */
+export function SetupLogDetails({
+  label,
+  lines,
+}: {
+  label: string;
+  lines: string[];
+}) {
+  if (lines.length === 0) {
+    return null;
+  }
+  return <SetupLog label={label} lines={lines} />;
+}
+
+// Separate component so a retry, which empties the log and fills it again, discards this
+// state with the <details> it mirrors instead of leaving the new one a stale `open`.
+function SetupLog({ label, lines }: { label: string; lines: string[] }) {
+  // State, not a ref, so the effect below re-runs once the pane is mounted.
+  const [pane, setPane] = useState<HTMLPreElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [following, setFollowing] = useState(true);
+  const text = lines.join("\n");
+
+  // `open` is a dependency because a collapsed <details> has no layout to scroll, so a
+  // log opened after its last line arrived has to be scrolled on the open itself.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: new output is what the pane has to follow, and it reaches the effect as rendered text
+  useEffect(() => {
+    if (!(pane && open && following)) {
+      return;
+    }
+    pane.scrollTop = pane.scrollHeight;
+  }, [pane, open, following, text]);
+
+  return (
+    <details
+      className="group mt-2 w-full max-w-sm text-left"
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+        <span className="group-open:hidden">Show {label} details</span>
+        <span className="hidden group-open:inline">Hide {label} details</span>
+        <HugeiconsIcon
+          icon={ChevronDownIcon}
+          aria-hidden="true"
+          strokeWidth={1.5}
+          className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
+        />
+      </summary>
+      <pre
+        ref={setPane}
+        onScroll={(event) => setFollowing(isAtTail(event.currentTarget))}
+        className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground"
+      >
+        {text}
+      </pre>
+    </details>
+  );
+}

--- a/studio/frontend/src/components/tauri/startup-screen.tsx
+++ b/studio/frontend/src/components/tauri/startup-screen.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { SetupLogDetails } from "@/components/tauri/setup-log";
 import {
   installProgressMessage,
   startupWaitingMessage,
@@ -11,8 +12,6 @@ import { Spinner } from "@/components/ui/spinner";
 import type { BackendStatus } from "@/hooks/use-tauri-backend";
 import type { CopySupportDiagnosticsResult } from "@/lib/tauri-diagnostics";
 
-import { ChevronDown as ChevronDownIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
 import { type ReactNode, useEffect, useState } from "react";
 
@@ -218,23 +217,7 @@ function InstallingContent({
           {message.title}
         </p>
         <p className="text-sm text-muted-foreground">{message.subtitle}</p>
-        {detailLines.length > 0 && (
-          <details className="group mt-2 w-full max-w-sm text-left">
-            <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-              <span className="group-open:hidden">Show installation details</span>
-              <span className="hidden group-open:inline">Hide installation details</span>
-              <HugeiconsIcon
-                icon={ChevronDownIcon}
-                aria-hidden="true"
-                strokeWidth={1.5}
-                className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
-              />
-            </summary>
-            <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
-              {detailLines.join("\n")}
-            </pre>
-          </details>
-        )}
+        <SetupLogDetails label="installation" lines={detailLines} />
       </div>
     </div>
   );
@@ -260,23 +243,7 @@ function RepairingContent({
         <Spinner className="size-6 text-primary" />
         <p className="text-sm font-bold text-foreground">Getting things ready...</p>
         <p className="text-sm text-muted-foreground">This won’t take long.</p>
-        {detailLines.length > 0 && (
-          <details className="group mt-2 w-full max-w-sm text-left">
-            <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-              <span className="group-open:hidden">Show setup details</span>
-              <span className="hidden group-open:inline">Hide setup details</span>
-              <HugeiconsIcon
-                icon={ChevronDownIcon}
-                aria-hidden="true"
-                strokeWidth={1.5}
-                className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
-              />
-            </summary>
-            <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
-              {detailLines.join("\n")}
-            </pre>
-          </details>
-        )}
+        <SetupLogDetails label="setup" lines={detailLines} />
       </div>
     </div>
   );

--- a/studio/frontend/src/components/tauri/update-screen.tsx
+++ b/studio/frontend/src/components/tauri/update-screen.tsx
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { SetupLogDetails } from "@/components/tauri/setup-log";
 import { Spinner } from "@/components/ui/spinner";
 import type { UpdateStatus } from "@/hooks/use-tauri-update";
 import type { CopySupportDiagnosticsResult } from "@/lib/tauri-diagnostics";
 
-import { ChevronDown as ChevronDownIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 
@@ -69,30 +68,6 @@ function statusSubtext(status: UpdateStatus, progress: number): string {
     default:
       return "";
   }
-}
-
-function UpdateDetails({ logs }: { logs: string[] }) {
-  if (logs.length === 0) {
-    return null;
-  }
-
-  return (
-    <details className="group mt-2 w-full max-w-sm text-left">
-      <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-        <span className="group-open:hidden">Show update details</span>
-        <span className="hidden group-open:inline">Hide update details</span>
-        <HugeiconsIcon
-          icon={ChevronDownIcon}
-          aria-hidden="true"
-          strokeWidth={1.5}
-          className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
-        />
-      </summary>
-      <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
-        {logs.join("\n")}
-      </pre>
-    </details>
-  );
 }
 
 export function UpdateScreen({
@@ -223,7 +198,7 @@ export function UpdateScreen({
               />
             )}
 
-            <UpdateDetails logs={logs} />
+            <SetupLogDetails label="update" lines={logs} />
           </div>
         </motion.div>
       </div>

--- a/studio/frontend/tests/tauri-details-toggle.test.ts
+++ b/studio/frontend/tests/tauri-details-toggle.test.ts
@@ -23,22 +23,30 @@ function summaryForLabel(sourceText: string, label: string): string {
 }
 
 test("Tauri detail toggles put a custom down chevron after their labels", async () => {
+  const label = "Show {label} details";
+  const summary = summaryForLabel(await source("setup-log.tsx"), label);
+
+  assert.match(summary, /\blist-none\b/);
+  assert.match(summary, /\[&::\-webkit-details-marker\]:hidden/);
+  assert.match(summary, /\bflex\b/);
+  assert.ok(
+    summary.indexOf("<HugeiconsIcon") > summary.indexOf(label) &&
+      summary.includes("icon={ChevronDownIcon}"),
+    "chevron must be on the right",
+  );
+
+  // The three screens reach that summary through the one shared toggle.
   const startup = await source("startup-screen.tsx");
   const update = await source("update-screen.tsx");
-
-  for (const [sourceText, label] of [
-    [startup, "Show installation details"],
-    [startup, "Show setup details"],
-    [update, "Show update details"],
+  for (const [sourceText, name] of [
+    [startup, "installation"],
+    [startup, "setup"],
+    [update, "update"],
   ] as const) {
-    const summary = summaryForLabel(sourceText, label);
-    assert.match(summary, /\blist-none\b/);
-    assert.match(summary, /\[&::\-webkit-details-marker\]:hidden/);
-    assert.match(summary, /\bflex\b/);
-    assert.ok(
-      summary.indexOf("<HugeiconsIcon") > summary.indexOf(label) &&
-        summary.includes("icon={ChevronDownIcon}"),
-      `${label} chevron must be on the right`,
+    assert.match(
+      sourceText,
+      new RegExp(`<SetupLogDetails\\b[^>]*\\blabel="${name}"`),
+      `${name} toggle is missing`,
     );
   }
 });


### PR DESCRIPTION
## Problem

The desktop setup screens render their log in a fixed-height, scrollable pane that nothing ever scrolls. While an install, repair or backend update is running, the pane therefore sits at the top of the log: the user reads the first few lines of a setup that started minutes ago, while the line describing what is happening right now is below the fold. Opening the disclosure after output has already stopped has the same result — the log starts at line one.

## What changed

The install, repair and update screens each carried a byte-identical copy of that pane, so this replaces all three with one `SetupLogDetails` component that follows the newest line:

- as output arrives, and
- on opening the disclosure, since a log opened after its last line arrived has no later render to scroll it.

A reader who scrolls up keeps their place; scrolling back to within a line's height of the bottom (24px, so a wrapped line does not count as leaving) resumes following.

<img width="415" height="161" alt="43d769ef-0f9f-4cfa-acdc-2e81cda8627b" src="https://github.com/user-attachments/assets/a657e53c-3e4f-4d01-acff-f7ba32631cf3" />


The follow state lives in an inner component that mounts and unmounts with the `<details>` element it mirrors, rather than in the exported wrapper. This matters because the update path empties the log and refills it on retry (`replaceLogs([])` in `use-tauri-update.ts`): state that survived that gap would leave the fresh pane holding an `open` flag its brand-new closed element does not have, and a "reader scrolled away" flag for a log the reader has never seen. Verified before the fix that this reproduces the original bug — after a retry, opening the log landed 2347px from the bottom.

`tests/tauri-details-toggle.test.ts` follows the markup it guards: the chevron summary now exists once in the shared component, so the test asserts the chevron invariants there and separately asserts that all three screens still render the toggle with their own label. Both halves were checked against mutations (removing the chevron, and a screen dropping the pane) to confirm they still fail on the regressions they describe.

## Risks

Presentation-only, confined to the three desktop setup screens; no backend or install logic is touched. The scroll write is guarded so it cannot run against a collapsed pane, and the pane renders nothing at all when there are no lines, as before.

One deliberate behaviour change beyond the fix: after a failed update, a retry starts with the disclosure closed and following re-armed, discarding any scroll position from the previous attempt. That position referred to a log that no longer exists.

## Validation

Frontend suite, type check and formatter:

```bash
npm test        # 1623 passed
npm run typecheck
npx biome check src/components/tauri/setup-log.tsx
```

The pane itself was driven in a browser against output streaming at one line per 250ms, in each state it can reach:

| Case | Result |
| --- | --- |
| Disclosure open while output streams | stays pinned to the last line |
| Reader scrolls up mid-stream | stays put as further lines arrive |
| Reader scrolls back to the bottom | resumes following |
| Log emptied | pane removed |
| Retry log opened afterwards | opens on its newest line |

Also built as a desktop bundle and launched against an empty home directory to confirm the install path still reaches the Get Started screen and streams into the shared pane.
