### PR TITLE
Windows installer: fix single-AMD-GPU detection and the unrecoverable "needs repair" loop

### DIFF
--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -221,6 +221,14 @@ jobs:
       - name: AMD venv repair loop tests
         shell: pwsh
         run: pwsh -NoProfile -File tests/studio/test_amd_venv_repair_loop.ps1
+      # The same file again under Windows PowerShell 5.1, which is the shell the CLI actually
+      # launches setup.ps1 with. Every other step here is `shell: pwsh` (PowerShell 7), and 7
+      # returns `.Count = 1` for the single CimInstance that 5.1 returns `$null` for, so the
+      # pwsh run above passes against the unfixed #8335 code. Only this leg fails on it.
+      - name: AMD venv repair loop tests (Windows PowerShell 5.1)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: powershell -NoProfile -File tests\studio\test_amd_venv_repair_loop.ps1
       - name: POSIX rollback lifecycle tests
         if: runner.os == 'Linux'
         run: sh tests/sh/test_install_rollback_lifecycle.sh

--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -214,17 +214,15 @@ jobs:
       - name: XPU arm64 torchaudio tests
         shell: pwsh
         run: pwsh -NoProfile -File tests/studio/test_xpu_arm64_torchaudio.ps1
-      # Same again: the filesystem reads are mocked and the only real child process is a
-      # `python -c` one-liner, so no venv, no AMD GPU and no Windows are needed. Read the file
-      # header before adding cases -- pwsh 7 cannot reproduce the 5.1 half of #8335, and the
-      # checks that cover it are deliberately source shapes.
+      # Same again: mocked filesystem reads and one `python -c` child, so no venv, no AMD GPU and
+      # no Windows needed. Read the file header before adding cases -- pwsh 7 cannot reproduce the
+      # 5.1 half of #8335, so the checks covering it are deliberately source shapes.
       - name: AMD venv repair loop tests
         shell: pwsh
         run: pwsh -NoProfile -File tests/studio/test_amd_venv_repair_loop.ps1
-      # The same file again under Windows PowerShell 5.1, which is the shell the CLI actually
-      # launches setup.ps1 with. Every other step here is `shell: pwsh` (PowerShell 7), and 7
-      # returns `.Count = 1` for the single CimInstance that 5.1 returns `$null` for, so the
-      # pwsh run above passes against the unfixed #8335 code. Only this leg fails on it.
+      # The same file under Windows PowerShell 5.1, the shell the CLI actually launches setup.ps1
+      # with. Every other step here is `shell: pwsh` (PowerShell 7), and 7 answers `.Count = 1`
+      # for the single CimInstance 5.1 answers `$null` for, so only this leg fails on unfixed #8335.
       - name: AMD venv repair loop tests (Windows PowerShell 5.1)
         if: runner.os == 'Windows'
         shell: powershell

--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -70,6 +70,7 @@ on:
       - 'studio/setup.ps1'
       - 'tests/studio/test_setup_xpu_runtime_prereport.ps1'
       - 'tests/studio/test_xpu_arm64_torchaudio.ps1'
+      - 'tests/studio/test_amd_venv_repair_loop.ps1'
       - 'tests/sh/test_install_sh_xpu_flavor_probe.sh'
       - 'tests/sh/test_setup_xpu_fastpath_escape.sh'
       - 'tests/sh/test_setup_xpu_posix_summary.sh'
@@ -118,6 +119,7 @@ on:
       - 'studio/setup.ps1'
       - 'tests/studio/test_setup_xpu_runtime_prereport.ps1'
       - 'tests/studio/test_xpu_arm64_torchaudio.ps1'
+      - 'tests/studio/test_amd_venv_repair_loop.ps1'
       - 'tests/sh/test_install_sh_xpu_flavor_probe.sh'
       - 'tests/sh/test_setup_xpu_fastpath_escape.sh'
       - 'tests/sh/test_setup_xpu_posix_summary.sh'
@@ -212,6 +214,13 @@ jobs:
       - name: XPU arm64 torchaudio tests
         shell: pwsh
         run: pwsh -NoProfile -File tests/studio/test_xpu_arm64_torchaudio.ps1
+      # Same again: the filesystem reads are mocked and the only real child process is a
+      # `python -c` one-liner, so no venv, no AMD GPU and no Windows are needed. Read the file
+      # header before adding cases -- pwsh 7 cannot reproduce the 5.1 half of #8335, and the
+      # checks that cover it are deliberately source shapes.
+      - name: AMD venv repair loop tests
+        shell: pwsh
+        run: pwsh -NoProfile -File tests/studio/test_amd_venv_repair_loop.ps1
       - name: POSIX rollback lifecycle tests
         if: runner.os == 'Linux'
         run: sh tests/sh/test_install_rollback_lifecycle.sh

--- a/install.ps1
+++ b/install.ps1
@@ -3438,11 +3438,13 @@ exit 0
     # detect -- would block a bare `& python -c ...` forever. ProcessStartInfo, not &, so stderr
     # cannot trip $ErrorActionPreference; BOTH streams drain async so a noisy import cannot
     # deadlock on a full pipe; WaitForExit bounds the wait and kills the child. Every failure
-    # (timeout, crash, exception) reads as .Ok = $false. Defined above the Intel scan, since
-    # PowerShell binds a function only when its definition runs.
+    # (timeout, crash, exception) reads as .Ok = $false, and .Error carries WHICH failure it
+    # was: stderr used to be drained and thrown away, so a driver-level DLL load error and a
+    # missing torch were indistinguishable at every call site. Defined above the Intel scan,
+    # since PowerShell binds a function only when its definition runs.
     function Invoke-BoundedPythonProbe {
         param([string]$PythonExe, [string]$Code, [int]$TimeoutSec = 30)
-        $result = [pscustomobject]@{ Ok = $false; Output = "" }
+        $result = [pscustomobject]@{ Ok = $false; Output = ""; Error = "" }
         if (-not $PythonExe -or -not $Code) { return $result }
         try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
@@ -3457,13 +3459,22 @@ exit 0
             $errTask = $proc.StandardError.ReadToEndAsync()
             if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
                 try { $proc.Kill() } catch {}
+                # Synthesised, not read back: the reader tasks are the thing that may never
+                # complete on a wedged child, so waiting on them here would reintroduce the
+                # hang this helper exists to bound.
+                $result.Error = "python did not answer within $TimeoutSec seconds"
                 return $result
             }
             $result.Output = $outTask.GetAwaiter().GetResult()
-            [void]$errTask.GetAwaiter().GetResult()
+            # Kept, not discarded: on a failed probe this is the only place the real OSError /
+            # WinError text exists.
+            $result.Error = $errTask.GetAwaiter().GetResult()
             $result.Ok = ($proc.ExitCode -eq 0)
             return $result
-        } catch { return $result }
+        } catch {
+            $result.Error = $_.Exception.Message
+            return $result
+        }
     }
 
     # Bounded Win32_VideoController scan: the query can block forever on a degraded WMI

--- a/install.ps1
+++ b/install.ps1
@@ -4609,6 +4609,19 @@ exit 0
     $env:SKIP_STUDIO_BASE = "1"
     $env:STUDIO_PACKAGE_NAME = $PackageName
     $env:UNSLOTH_NO_TORCH = if ($SkipTorch) { "true" } else { "false" }
+    # The torch family THIS run settled on for this host. setup.ps1 rescans the hardware from
+    # scratch and keeps a GPU wheel rather than forcing another family over it -- but "a GPU
+    # wheel is in the venv" is not on its own evidence that this installer put it there. The
+    # migrated-venv arm above installs unsloth only and never touches torch, and the flavor
+    # repair no-ops whenever the expected tag is 'cpu' or unrecognised, so an upgrade from an
+    # older layout can hand setup a wheel from a previous install on different hardware.
+    # Empty means "no answer": --no-torch, or a custom index whose leaf names no flavor. Always
+    # assigned so a previous run in the same session cannot leak a value -- on 7.5+ that leaves
+    # it present and blank, and on 5.1 / 7.0-7.4 an empty assignment removes it; setup.ps1
+    # treats both as unknown.
+    $env:UNSLOTH_INSTALLER_TORCH_TAG = if ($SkipTorch) { "" } else {
+        [string](Get-ExpectedTorchFlavorTag -TorchIndexUrl $TorchIndexUrl -ROCmIndexUrl $ROCmIndexUrl)
+    }
     # Tauri desktop app bundles its own frontend — skip Node/npm/frontend build
     $env:SKIP_STUDIO_FRONTEND = if ($TauriMode) { "1" } else { "0" }
     # Always set STUDIO_LOCAL_INSTALL explicitly to avoid stale values from

--- a/install.ps1
+++ b/install.ps1
@@ -3438,10 +3438,9 @@ exit 0
     # detect -- would block a bare `& python -c ...` forever. ProcessStartInfo, not &, so stderr
     # cannot trip $ErrorActionPreference; BOTH streams drain async so a noisy import cannot
     # deadlock on a full pipe; WaitForExit bounds the wait and kills the child. Every failure
-    # (timeout, crash, exception) reads as .Ok = $false, and .Error carries WHICH failure it
-    # was: stderr used to be drained and thrown away, so a driver-level DLL load error and a
-    # missing torch were indistinguishable at every call site. Defined above the Intel scan,
-    # since PowerShell binds a function only when its definition runs.
+    # (timeout, crash, exception) reads as .Ok = $false; .Error carries WHICH one, since stderr
+    # used to be drained and discarded, leaving a driver-level DLL load error and a missing torch
+    # indistinguishable. Defined above the Intel scan: PowerShell binds a function when it runs.
     function Invoke-BoundedPythonProbe {
         param([string]$PythonExe, [string]$Code, [int]$TimeoutSec = 30)
         $result = [pscustomobject]@{ Ok = $false; Output = ""; Error = "" }
@@ -3459,15 +3458,13 @@ exit 0
             $errTask = $proc.StandardError.ReadToEndAsync()
             if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
                 try { $proc.Kill() } catch {}
-                # Synthesised, not read back: the reader tasks are the thing that may never
-                # complete on a wedged child, so waiting on them here would reintroduce the
-                # hang this helper exists to bound.
+                # Synthesised, not read back: waiting on the reader tasks of a wedged child
+                # would reintroduce the hang this helper exists to bound.
                 $result.Error = "python did not answer within $TimeoutSec seconds"
                 return $result
             }
             $result.Output = $outTask.GetAwaiter().GetResult()
-            # Kept, not discarded: on a failed probe this is the only place the real OSError /
-            # WinError text exists.
+            # Kept, not discarded: the only place a failed probe's OSError / WinError text exists.
             $result.Error = $errTask.GetAwaiter().GetResult()
             $result.Ok = ($proc.ExitCode -eq 0)
             return $result
@@ -4609,16 +4606,12 @@ exit 0
     $env:SKIP_STUDIO_BASE = "1"
     $env:STUDIO_PACKAGE_NAME = $PackageName
     $env:UNSLOTH_NO_TORCH = if ($SkipTorch) { "true" } else { "false" }
-    # The torch family THIS run settled on for this host. setup.ps1 rescans the hardware from
-    # scratch and keeps a GPU wheel rather than forcing another family over it -- but "a GPU
-    # wheel is in the venv" is not on its own evidence that this installer put it there. The
-    # migrated-venv arm above installs unsloth only and never touches torch, and the flavor
-    # repair no-ops whenever the expected tag is 'cpu' or unrecognised, so an upgrade from an
-    # older layout can hand setup a wheel from a previous install on different hardware.
-    # Empty means "no answer": --no-torch, or a custom index whose leaf names no flavor. Always
-    # assigned so a previous run in the same session cannot leak a value -- on 7.5+ that leaves
-    # it present and blank, and on 5.1 / 7.0-7.4 an empty assignment removes it; setup.ps1
-    # treats both as unknown.
+    # The torch family THIS run settled on, for setup.ps1's preserve guard (full rationale there,
+    # at $InstallerTorchTag): "a GPU wheel is in the venv" is not on its own evidence that this
+    # installer put it there -- the migrated-venv arm above installs unsloth only and never
+    # touches torch. Empty means "no answer": --no-torch, or a custom index whose leaf names no
+    # flavor. Always assigned so a previous run in the same session cannot leak a value; 7.5+
+    # keeps it present and blank, 5.1 / 7.0-7.4 remove it, and setup.ps1 treats both as unknown.
     $env:UNSLOTH_INSTALLER_TORCH_TAG = if ($SkipTorch) { "" } else {
         [string](Get-ExpectedTorchFlavorTag -TorchIndexUrl $TorchIndexUrl -ROCmIndexUrl $ROCmIndexUrl)
     }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1013,10 +1013,13 @@ function Get-RocmPinStaleTags {
 # or a hanging Intel driver init would block a bare `& python -c ...` forever. ProcessStartInfo,
 # not &, so stderr cannot trip $ErrorActionPreference; BOTH streams drain async so a noisy import
 # cannot deadlock on a full pipe; WaitForExit bounds the wait and kills the child. Every failure
-# reads as .Ok = $false. Mirrors install.ps1's copy.
+# reads as .Ok = $false, and .Error carries WHICH failure it was: stderr used to be drained and
+# thrown away, so "the HIP DLLs will not load", "torch is not installed" and "the import never
+# came back" all arrived at the caller as the same silent False -- and one of those callers
+# deletes the environment over that answer. Mirrors install.ps1's copy.
 function Invoke-BoundedPythonProbe {
     param([string]$PythonExe, [string]$Code, [int]$TimeoutSec = 30)
-    $result = [pscustomobject]@{ Ok = $false; Output = "" }
+    $result = [pscustomobject]@{ Ok = $false; Output = ""; Error = "" }
     if (-not $PythonExe -or -not $Code) { return $result }
     try {
         $psi = New-Object System.Diagnostics.ProcessStartInfo
@@ -1031,13 +1034,22 @@ function Invoke-BoundedPythonProbe {
         $errTask = $proc.StandardError.ReadToEndAsync()
         if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
             try { $proc.Kill() } catch {}
+            # Synthesised, not read back: the reader tasks are the thing that may never
+            # complete on a wedged child, so waiting on them here would reintroduce the hang
+            # this helper exists to bound.
+            $result.Error = "python did not answer within $TimeoutSec seconds"
             return $result
         }
         $result.Output = $outTask.GetAwaiter().GetResult()
-        [void]$errTask.GetAwaiter().GetResult()
+        # Kept, not discarded: on a failed probe this is the only place the real OSError /
+        # WinError text exists, and the caller decides what to do with the venv based on it.
+        $result.Error = $errTask.GetAwaiter().GetResult()
         $result.Ok = ($proc.ExitCode -eq 0)
         return $result
-    } catch { return $result }
+    } catch {
+        $result.Error = $_.Exception.Message
+        return $result
+    }
 }
 
 # True when $PythonExe's torch can actually drive an Intel GPU. Quiet on purpose: the three
@@ -1163,6 +1175,24 @@ function Test-VenvTorchIsXpu {
         $verPy = Join-Path $VenvPath "Lib\site-packages\torch\version.py"
         if (-not (Test-Path -LiteralPath $verPy)) { return $false }
         return [bool]((Get-Content -LiteralPath $verPy -TotalCount 40 -ErrorAction Stop) -match "__version__\s*=\s*'[^']*\+xpu")
+    } catch { return $false }
+}
+
+# Is this venv's torch a ROCm wheel? The AMD counterpart of the check above, and it exists for
+# the same reason: the host most likely to fail inside `import torch` is an AMD box whose HIP
+# runtime faulted, where the DLL load raises OSError (or hangs) while version.py on disk still
+# names a perfectly good wheel. Answering that question by launching the interpreter that just
+# died is how a working environment got deleted. Both spellings are accepted because the wheel
+# label depends on the index: download.pytorch.org publishes "2.8.0+rocm6.4" while the AMD
+# Windows wheels publish "2.9.0+gfx1151". The dist-info name is NOT usable -- pip normalises the
+# local label out of it.
+function Test-VenvTorchIsRocm {
+    param([string]$VenvPath)
+    if (-not $VenvPath) { return $false }
+    try {
+        $verPy = Join-Path $VenvPath "Lib\site-packages\torch\version.py"
+        if (-not (Test-Path -LiteralPath $verPy)) { return $false }
+        return [bool]((Get-Content -LiteralPath $verPy -TotalCount 40 -ErrorAction Stop) -match "__version__\s*=\s*'[^']*\+(rocm|gfx)")
     } catch { return $false }
 }
 
@@ -2338,7 +2368,13 @@ if (-not $HasNvidiaSmi) {
             # inference forwards nothing: code 45 ("not connected") is routine on a muxless
             # laptop with a parked dGPU, and with no healthy peer there is nothing to
             # depose. Mirrors the same fallback in install_python_stack.py's WMI path.
-            $wmiGpus = if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus }
+            # @() wraps the WHOLE if, not each branch: a one-element array unrolls on its way
+            # out of an if-expression, and a scalar's .Count is $null under Windows PowerShell
+            # 5.1, so the single Radeon in the machine read as no AMD GPU at all -- no
+            # $script:ROCmGpuLabels, no inferred gfx arch, "gpu none" in the report, and an
+            # installed +rocm venv judged stale against a required "cpu" (#8335). Same idiom as
+            # the Intel scan below and in install.ps1.
+            $wmiGpus = @(if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus })
             if ($wmiGpus.Count -gt 0) {
                 $script:ROCmGpuLabels = @($wmiGpus | ForEach-Object { $_.Name })
                 $ROCmGpuLabel = $script:ROCmGpuLabels[0]
@@ -3805,6 +3841,9 @@ $installedTorchTag = $null
 if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode) {
     $VenvPyExe = Join-Path $VenvDir "Scripts\python.exe"
     $installedTorchTag = $null
+    # Declared before the branch that assigns it: the failure message below reads its .Error to
+    # say WHY torch did not answer, and a venv with no python.exe never runs the probe at all.
+    $_verProbe = $null
     $shouldRebuild = $false
     # Set when a stale venv under a pin is repaired in place (force-reinstall) not wiped.
     $script:PinChangedForceReinstall = $false
@@ -3840,6 +3879,16 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
             $installedTorchTag = "xpu"
             substep "PyTorch did not respond in time but this venv holds an XPU build -- keeping it." "Yellow"
             substep "If training fails, update the Intel GPU compute driver." "Yellow"
+        } elseif (Test-VenvTorchIsRocm -VenvPath $VenvDir) {
+            # Same rescue on the AMD side, and it is the one that has cost users whole installs.
+            # A faulted Adrenalin or HIP runtime makes `import torch` raise at the DLL load or
+            # never return, and the venv then reads as "torch could not be imported" -- so the
+            # ROCm environment that is actually fine gets thrown away and reinstalled, which
+            # does not fix a driver. version.py on disk still names the wheel, so trust it and
+            # point at the driver instead (#8335, #7275).
+            $installedTorchTag = "rocm"
+            substep "PyTorch did not respond but this venv holds a ROCm build -- keeping it." "Yellow"
+            substep "If training fails, reboot and update the AMD Adrenalin / HIP SDK driver." "Yellow"
         } else {
             $shouldRebuild = $true
         }
@@ -3937,7 +3986,8 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
     # A +xpu venv is never wiped by a DIRECT update: on a hybrid NVIDIA+Arc box the promotion
     # above is gated on -not $HasNvidiaSmi, so a later pinless update expects a cu* tag, calls the
     # working Arc venv stale and deletes it -- then exits, because only install.ps1 creates venvs.
-    # Under install.ps1 ($InstallerManagedSetup) the rollback copy exists, so leave that alone.
+    # Under install.ps1 ($InstallerManagedSetup) this escape stays out of the way: that run is
+    # handled by the in-place repair below, which covers every flavour rather than just xpu.
     if ($shouldRebuild -and -not $InstallerManagedSetup -and $installedTorchTag -eq "xpu") {
         substep "Keeping the installed Intel XPU environment (this host expects $expectedTorchTag)." "Yellow"
         substep "Re-run install.ps1 to replace it -- that path rebuilds with a rollback copy." "Yellow"
@@ -3949,14 +3999,41 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
         $script:PreservedXpuVenv = $true
     }
 
+    $reason = $null
     if ($shouldRebuild) {
         $reason = if ($installedTorchTag) { "torch $installedTorchTag != required $expectedTorchTag" } else { "torch could not be imported" }
-        if ($InstallerManagedSetup) {
-            substep "Stale venv detected ($reason)." "Yellow"
-            Write-StudioLine "   [ERROR] The existing Unsloth environment needs repair." -ForegroundColor Red
-            Write-StudioLine "           Re-run install.ps1 so it can replace the environment safely with rollback." -ForegroundColor Yellow
-            Exit-SetupFailure "The existing Unsloth environment needs repair"
+        # "torch could not be imported" covers a dead GPU driver, a half-written wheel and no
+        # torch at all, and the user is about to be handed a decision about their environment
+        # based on it. Print what python actually said -- the last stderr line is the exception
+        # -- so a WinError 126 reads as a driver problem instead of a broken install.
+        if ($_verProbe -and -not $_verProbe.Ok -and $_verProbe.Error) {
+            $_probeErrLine = @($_verProbe.Error -split "`r?`n" |
+                Where-Object { $_.Trim() } | Select-Object -Last 1)[0]
+            if ($_probeErrLine) { substep "PyTorch reported: $($_probeErrLine.Trim())" "DarkGray" }
         }
+    }
+
+    # The abort that used to live here was an unrecoverable fixed point, and it has now been
+    # reported from four separate triggers (#5942, #7275, #8335, plus a driver crash). It told
+    # the user to "re-run install.ps1 so it can replace the environment safely with rollback"
+    # -- but install.ps1 IS the caller under $InstallerManagedSetup, it had already done
+    # exactly that earlier in the same run, and its failure path then moves the previous
+    # environment straight back. So every attempt ended on the byte-identical state it started
+    # from, the next attempt reached the same verdict, and the install could never converge.
+    #
+    # Repair in place instead of wiping: the dependency pass force-reinstalls the torch trio
+    # from the resolved index over this venv, which is the route an index-pin change and a cu*
+    # family change already take a few lines above. Deleting is not an option on this path
+    # anyway -- install.ps1 invokes setup through the venv's own unsloth.exe, so python.exe is
+    # locked by the process running this script.
+    if ($shouldRebuild -and $InstallerManagedSetup) {
+        substep "Environment does not match this host ($reason) -- reinstalling PyTorch in place." "Yellow"
+        substep "install.ps1 keeps a rollback copy of the previous environment until this run succeeds." "DarkGray"
+        $script:PinChangedForceReinstall = $true
+        $shouldRebuild = $false
+    }
+
+    if ($shouldRebuild) {
         substep "Stale venv detected ($reason) -- rebuilding..." "Yellow"
         # why: mirror install.ps1 env-mode guard so an update against a custom
         # UNSLOTH_STUDIO_HOME never wipes an unrelated unsloth_studio venv;

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1182,10 +1182,16 @@ function Test-VenvTorchIsXpu {
 # the same reason: the host most likely to fail inside `import torch` is an AMD box whose HIP
 # runtime faulted, where the DLL load raises OSError (or hangs) while version.py on disk still
 # names a perfectly good wheel. Answering that question by launching the interpreter that just
-# died is how a working environment got deleted. Both spellings are accepted because the wheel
-# label depends on the index: download.pytorch.org publishes "2.8.0+rocm6.4" while the AMD
-# Windows wheels publish "2.9.0+gfx1151". The dist-info name is NOT usable -- pip normalises the
-# local label out of it.
+# died is how a working environment got deleted.
+#
+# The label is always "+rocm", never "+gfx", on every index that actually publishes wheels:
+# repo.amd.com/rocm/whl/<arch>/torch/ (the Windows wheels, arch in the URL only) ships
+# torch-2.11.0+rocm7.13.0-cp312-cp312-win_amd64.whl, and download.pytorch.org/whl/rocm6.4 ships
+# the two-component 2.8.0+rocm6.4 (Linux only). The arch is NOT in the version -- the same
+# 2.9.1+rocm7.13.0 filename is a different binary under gfx1151, gfx110X-all and gfx120X-all.
+# "gfx" is accepted anyway, cheaply, so a future per-arch local label cannot make this read a
+# ROCm venv as unknown and delete it. The dist-info name is NOT usable either -- pip normalises
+# the local label out of it.
 function Test-VenvTorchIsRocm {
     param([string]$VenvPath)
     if (-not $VenvPath) { return $false }
@@ -3838,6 +3844,10 @@ $InstallerManagedSetup = $env:UNSLOTH_INSTALL_ROLLBACK_MANAGED -match '^(?i:true
 # force-reinstall and a fresh install never enters that block. Declaring it keeps a caller's
 # Set-StrictMode from making the read fatal.
 $installedTorchTag = $null
+# Hoisted for the same reason, and it now carries more weight than it used to: four install arms
+# read it to decide --force-reinstall, and it is the flag the installer-managed repair below
+# raises. Assigned only inside the block, which a fresh install never enters.
+$script:PinChangedForceReinstall = $false
 if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode) {
     $VenvPyExe = Join-Path $VenvDir "Scripts\python.exe"
     $installedTorchTag = $null
@@ -4007,8 +4017,12 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
         # based on it. Print what python actually said -- the last stderr line is the exception
         # -- so a WinError 126 reads as a driver problem instead of a broken install.
         if ($_verProbe -and -not $_verProbe.Ok -and $_verProbe.Error) {
-            $_probeErrLine = @($_verProbe.Error -split "`r?`n" |
-                Where-Object { $_.Trim() } | Select-Object -Last 1)[0]
+            # No @(...)[0] around this: the guard above passes on a whitespace-only stderr,
+            # Where-Object then drops every line, and indexing [0] into the empty array that
+            # leaves is fatal under a caller's Set-StrictMode. -Last 1 already yields either
+            # one string or nothing, which is exactly what the test below wants.
+            $_probeErrLine = $_verProbe.Error -split "`r?`n" |
+                Where-Object { $_.Trim() } | Select-Object -Last 1
             if ($_probeErrLine) { substep "PyTorch reported: $($_probeErrLine.Trim())" "DarkGray" }
         }
     }
@@ -4071,6 +4085,24 @@ if (-not (Test-Path -LiteralPath $VenvDir)) {
             $_venvPyVer = (& $_venvPyExe --version 2>&1 | Out-String).Trim()
             if ($_venvPyVer) { substep $_venvPyVer }
         } catch {}
+    } else {
+        # Stop here, because nothing downstream would. The activation below is a dot-source,
+        # and a MISSING script is a NON-terminating error at the "Continue" the pip section
+        # runs at -- so setup would print one red line and carry straight on, resolving every
+        # `python` and `uv pip` that follows against whatever interpreter is on PATH and
+        # installing the whole stack outside the environment it was asked to build. It can
+        # then exit 0 over a venv that never gained a single package.
+        #
+        # An interpreter-less venv is incomplete, not out of date, so none of the decisions
+        # above apply to it: the in-place torch repair has no interpreter to repair through,
+        # and the rebuild path deletes the directory only to hit "Virtual environment not
+        # found" a few lines up. Say what is actually wrong and fail. Unlike the abort this
+        # replaced upstream, re-creating the environment genuinely changes this state --
+        # install.ps1 still holds the rollback copy of the previous one.
+        Write-StudioLine "[ERROR] $VenvDir has no interpreter at Scripts\python.exe." -ForegroundColor Red
+        Write-StudioLine "        The environment is incomplete rather than out of date. Re-run the installer" -ForegroundColor Yellow
+        Write-StudioLine "        to rebuild it: irm https://unsloth.ai/install.ps1 | iex" -ForegroundColor Yellow
+        Exit-SetupFailure "No interpreter at $_venvPyExe"
     }
 }
 

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3845,6 +3845,16 @@ Set-PersistedNoTorch -VenvPath $VenvDir -NoTorch $NoTorchMode
 # every accepted spelling to one value both sides parse identically.
 $env:UNSLOTH_NO_TORCH = if ($NoTorchMode) { "true" } else { "false" }
 $InstallerManagedSetup = $env:UNSLOTH_INSTALL_ROLLBACK_MANAGED -match '^(?i:true|1|yes)$'
+# The torch family install.ps1 settled on for this host, in the same vocabulary the probe below
+# produces (cu<digits> / rocm / xpu / cpu). $null means it did not say: an installer old enough
+# to predate the variable (setup.ps1 ships in the pip package, install.ps1 is fetched from
+# unsloth.ai, so the two can be different ages), --no-torch, or a custom index whose leaf names
+# no flavor. Absent is treated as unknown rather than as a mismatch, which is what keeps an
+# older cached installer on exactly the behaviour it had before this variable existed.
+# IsNullOrWhiteSpace covers both spellings of "no answer": PowerShell 7.5+ keeps an empty
+# assignment as a present blank value, 5.1 and 7.0-7.4 remove the variable instead.
+$InstallerTorchTag = if ([string]::IsNullOrWhiteSpace($env:UNSLOTH_INSTALLER_TORCH_TAG)) { $null }
+                     else { $env:UNSLOTH_INSTALLER_TORCH_TAG.Trim().ToLowerInvariant() }
 # Only the stale-venv block below assigns this, but the XPU install reads it to decide whether to
 # force-reinstall and a fresh install never enters that block. Declaring it keeps a caller's
 # Set-StrictMode from making the read fatal.
@@ -4014,11 +4024,20 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
         $script:PreservedXpuVenv = $true
     }
 
-    # A GPU wheel is never force-reinstalled onto a DIFFERENT family on the strength of a rescan.
-    # Under $InstallerManagedSetup install.ps1 resolved the index and installed this trio minutes
-    # ago in this same run, off its own probe, and its flavor repair re-lands the trio whenever the
-    # venv disagrees with the index it chose -- so by the time setup runs, a GPU wheel here IS
-    # install.ps1's answer for this host. When setup's second, independent probe then lands
+    # A GPU wheel install.ps1 SELECTED is never force-reinstalled onto a different family on the
+    # strength of a rescan. install.ps1 reports the family it settled on in
+    # $env:UNSLOTH_INSTALLER_TORCH_TAG, and only a wheel matching it is treated as its answer,
+    # because "there is a GPU wheel in the venv" does not by itself mean this run put it there:
+    # the migrated-venv arm (install.ps1's `if ($_Migrated)`) installs unsloth alone and never
+    # touches torch, and install.ps1's flavor repair no-ops whenever its expected tag is 'cpu' or
+    # unrecognised. So an ordinary upgrade from the legacy ~/.unsloth/studio/.venv layout can hand
+    # setup a +cu118 wheel from a previous install on different hardware, and preserving THAT
+    # would leave the environment permanently wrong -- including on a mapped AMD host, where the
+    # kept cu* tag also blocks the ROCm reroute below (it needs $CuTag -eq "cpu"). Those repair,
+    # in place, as they did before this guard existed.
+    # $InstallerTorchTag $null means the installer did not say -- an older cached install.ps1,
+    # or --no-torch -- and unknown falls back to preserving, which is the behaviour that shipped
+    # before the variable existed. When setup's second, independent probe then lands
     # somewhere else, the disagreement is between the two probes, not with the hardware: a
     # Get-CimInstance that threw, an nvidia-smi that did not answer, the single-Radeon unroll of
     # #8335, a ROCm scan that failed on a box that also holds an NVIDIA card. Setup has no better
@@ -4040,7 +4059,8 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
     # reached only once $installedTorchTag has answered, which is only true on the path that
     # assigned it.
     if ($shouldRebuild -and $InstallerManagedSetup -and
-        $installedTorchTag -and $installedTorchTag -ne "cpu") {
+        $installedTorchTag -and $installedTorchTag -ne "cpu" -and
+        ((-not $InstallerTorchTag) -or $installedTorchTag -eq $InstallerTorchTag)) {
         substep "This host rescanned as $expectedTorchTag but the installer just placed a $installedTorchTag build here -- keeping it." "Yellow"
         substep "Set UNSLOTH_TORCH_INDEX_URL to move this environment onto another PyTorch build on purpose." "DarkGray"
         $shouldRebuild = $false

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4175,8 +4175,63 @@ if (-not (Test-Path -LiteralPath $VenvDir)) {
 $prevEAP = $ErrorActionPreference
 $ErrorActionPreference = "Continue"
 
+# Existence is not activation. The two refusals above check that a file is THERE; neither can
+# tell whether dot-sourcing it took effect, and the ways it silently does not are ordinary
+# damage on a half-written venv rather than exotica. Activate.ps1 prepends the venv to PATH in
+# its LAST statement -- $env:VIRTUAL_ENV is set well before it -- so a copy truncated by an
+# interrupted or out-of-disk `python -m venv` parses, runs to its last complete statement and
+# returns without printing anything at all, and an unparseable one is a ParserError, which is
+# non-terminating at the "Continue" set just above. Either way the dot-source "succeeds" with
+# the ambient interpreter still first on PATH, and on a real install that is the system or
+# Microsoft Store python, because install.ps1 keeps the venv's Scripts directory off PATH on
+# purpose. Fast-Install then hands exactly that to `uv pip install --python`, the whole stack
+# lands outside the venv, every Exit-SetupFailure below keys off an exit code produced by that
+# same wrong interpreter, and setup exits 0 -- at which point install.ps1 commits over the
+# rollback copy and the previous working environment is gone for good.
+#
+# So assert the post-condition instead of adding a third pre-condition: the `python` now in
+# effect has to live under $VenvDir. Checking $env:VIRTUAL_ENV would not do, precisely because
+# Activate.ps1 sets it before the line that matters.
+function Assert-VenvActivated {
+    param([Parameter(Mandatory = $true)][string]$VenvDir)
+
+    # Both sides are normalised through Get-Item, which is what Activate.ps1 itself uses to
+    # build the PATH entry ($VenvExecDir = Get-Item -Path $VenvExecPath). Agreeing on the
+    # normaliser is what keeps a short 8.3 path, a substituted drive, a junction or a
+    # differently cased drive letter from reading as "outside": neither side resolves or
+    # expands anything the other leaves alone. A guard that false-positives here would break
+    # every install, so every branch that cannot PROVE the interpreter is wrong returns.
+    $venvRoot = $null
+    try { $venvRoot = (Get-Item -LiteralPath $VenvDir -Force -ErrorAction Stop).FullName.TrimEnd('\', '/') } catch { $venvRoot = $null }
+    if (-not $venvRoot) { return }
+
+    $_pyCmd = Get-Command python -ErrorAction SilentlyContinue | Select-Object -First 1
+    # A function or alias named python carries no Source to judge, and judging it wrong would
+    # refuse an install that works. Only an application resolved off PATH is decidable here,
+    # and that is also the only shape Fast-Install's -- python hand-off can be aimed at.
+    if ($_pyCmd -and $_pyCmd.CommandType -ne 'Application') { return }
+    $_pyPath = $null
+    if ($_pyCmd -and $_pyCmd.Source) {
+        try { $_pyPath = (Get-Item -LiteralPath $_pyCmd.Source -Force -ErrorAction Stop).FullName } catch { $_pyPath = $_pyCmd.Source }
+    }
+
+    if ($_pyPath) {
+        foreach ($_sep in @('\', '/')) {
+            if ($_pyPath.StartsWith($venvRoot + $_sep, [System.StringComparison]::OrdinalIgnoreCase)) { return }
+        }
+    }
+
+    $_where = if ($_pyPath) { $_pyPath } else { "nothing on PATH" }
+    Write-StudioLine "[ERROR] Activating $VenvDir did not take effect: python resolves to $_where." -ForegroundColor Red
+    Write-StudioLine "        The activation script is present but did not put the environment on PATH," -ForegroundColor Yellow
+    Write-StudioLine "        so the environment is incomplete rather than out of date. Re-run the installer" -ForegroundColor Yellow
+    Write-StudioLine "        to rebuild it: irm https://unsloth.ai/install.ps1 | iex" -ForegroundColor Yellow
+    Exit-SetupFailure "Activating $VenvDir did not put its interpreter on PATH (python resolves to $_where)"
+}
+
 $ActivateScript = Join-Path $VenvDir "Scripts\Activate.ps1"
 . $ActivateScript
+Assert-VenvActivated -VenvDir $VenvDir
 
 # Try to use uv (much faster than pip), fall back to pip if unavailable
 $UseUv = $false
@@ -4193,6 +4248,13 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
         if (Get-Command uv -ErrorAction SilentlyContinue) { $UseUv = $true }
     } catch { }
 }
+# Refresh-Environment rebuilt PATH from the registry, and the re-activation that was supposed to
+# put the venv back sits inside a catch that swallows everything -- including a dot-source that
+# died after Activate.ps1's own `deactivate -nondestructive` had already restored the pre-venv
+# PATH. Re-check outside the catch, because this is the last statement before Fast-Install starts
+# resolving `python`. On the ordinary path the assertion above already passed and this re-reads
+# the same PATH.
+Assert-VenvActivated -VenvDir $VenvDir
 
 # Helper: install a package, preferring uv with pip fallback
 function Fast-Install {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4009,6 +4009,27 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
         $script:PreservedXpuVenv = $true
     }
 
+    # A GPU wheel is never force-reinstalled down to CPU on the strength of a rescan. Under
+    # $InstallerManagedSetup install.ps1 resolved the index and installed this trio minutes ago
+    # in this same run, off its own probe -- so when setup's second, independent probe lands on
+    # "cpu" while the venv holds +cu / +rocm / +xpu, the disagreement is setup's, not the host's:
+    # a Get-CimInstance that threw, an nvidia-smi that did not answer, the single-Radeon unroll
+    # of #8335. The in-place repair below would then --force-reinstall CPU torch over a working
+    # GPU environment and exit 0, at which point install.ps1 discards the rollback copy and the
+    # downgrade is permanent -- a loud failure traded for a silently wrong install, which is
+    # worse than the loop this whole block exists to end. Keep the wheel: with no
+    # --force-reinstall the CPU arm below leaves it alone, because a +cu / +rocm / +xpu build
+    # already satisfies the CPU torch>= range.
+    if ($shouldRebuild -and $InstallerManagedSetup -and
+        $installedTorchTag -and $installedTorchTag -ne "cpu" -and $expectedTorchTag -eq "cpu") {
+        substep "This host scanned as CPU-only but the installer just placed a $installedTorchTag build here -- keeping it." "Yellow"
+        substep "Set UNSLOTH_TORCH_INDEX_URL to move this environment onto CPU torch on purpose." "DarkGray"
+        $shouldRebuild = $false
+        # Same reason as the direct-update escape above: the pass has to stay on the xpu index,
+        # or triton-windows lands over torch's XPU triton with nothing to swap it back.
+        if ($installedTorchTag -eq "xpu") { $script:PreservedXpuVenv = $true }
+    }
+
     $reason = $null
     if ($shouldRebuild) {
         $reason = if ($installedTorchTag) { "torch $installedTorchTag != required $expectedTorchTag" } else { "torch could not be imported" }
@@ -4080,7 +4101,22 @@ if (-not (Test-Path -LiteralPath $VenvDir)) {
 } else {
     substep "reusing existing virtual environment at $VenvDir"
     $_venvPyExe = Join-Path $VenvDir "Scripts\python.exe"
+    $_venvActivate = Join-Path $VenvDir "Scripts\Activate.ps1"
     if (Test-Path -LiteralPath $_venvPyExe) {
+        # The interpreter is not the only file the rest of this script needs. Everything below
+        # reaches the venv through the dot-sourced Activate.ps1 and a bare `python` -- Fast-Install
+        # resolves its target with (Get-Command python).Source -- and install.ps1 deliberately
+        # leaves the venv's Scripts directory off PATH. So a venv that kept python.exe but lost
+        # Activate.ps1 fails the dot-source, non-terminating at the "Continue" the pip section
+        # runs at, and installs the whole stack into whatever interpreter is on PATH before
+        # exiting 0. Same silent-success hazard as a missing python.exe, one file over, and it is
+        # newly reachable now that an installer-managed stale verdict repairs instead of aborting.
+        if (-not (Test-Path -LiteralPath $_venvActivate)) {
+            Write-StudioLine "[ERROR] $VenvDir has no activation script at Scripts\Activate.ps1." -ForegroundColor Red
+            Write-StudioLine "        The environment is incomplete rather than out of date. Re-run the installer" -ForegroundColor Yellow
+            Write-StudioLine "        to rebuild it: irm https://unsloth.ai/install.ps1 | iex" -ForegroundColor Yellow
+            Exit-SetupFailure "No activation script at $_venvActivate"
+        }
         try {
             $_venvPyVer = (& $_venvPyExe --version 2>&1 | Out-String).Trim()
             if ($_venvPyVer) { substep $_venvPyVer }
@@ -4269,11 +4305,17 @@ sys.exit(0 if install_manifest.verify_install()['ok'] else 1)
         # date" path would leave the user on CPU torch with Train/Export disabled.
         # Force the dependency pass so the ROCm wheels get installed.
         if ($script:ROCmGfxArch) {
-            $_torchIsCpu = $true
-            try {
-                & python -c "import torch, sys; sys.exit(0 if torch.cuda.is_available() else 1)" 2>$null
-                if ($LASTEXITCODE -eq 0) { $_torchIsCpu = $false }
-            } catch {}
+            # Bounded, like every other torch probe in this file and for the reason the disk-based
+            # ROCm rescue above exists: on a faulted HIP runtime `import torch` can never come
+            # back, and the rescue now KEEPS that venv rather than deleting it -- so this is the
+            # first `import torch` such a host reaches. A bare `& python` here waits forever and
+            # setup never finishes. A probe that does not answer keeps $_torchIsCpu true, which is
+            # the same safe direction as before: one dependency pass, never a silent skip. The
+            # default bound is the one the flavour probe above already ran under, on a warmer
+            # page cache, so a healthy venv that answered there answers here.
+            $_rocmTorchProbe = Invoke-BoundedPythonProbe -PythonExe "python" `
+                -Code "import torch, sys; sys.exit(0 if torch.cuda.is_available() else 1)"
+            $_torchIsCpu = -not $_rocmTorchProbe.Ok
             if ($_torchIsCpu) {
                 substep "AMD GPU ($script:ROCmGfxArch) detected but installed PyTorch is CPU-only -- reinstalling ROCm PyTorch" "Cyan"
                 $SkipPythonDeps = $false

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2519,6 +2519,11 @@ $script:IsIntelXpu = $false
 # $script:IsIntelXpu on purpose: it steers the INSTALL, not the hardware report, which must stay
 # honest about the NVIDIA GPU that is also in the machine.
 $script:PreservedXpuVenv = $false
+# The flavour tag ("rocm" / "cu128" / "xpu") of a GPU wheel the stale check below kept because
+# install.ps1 put it there in this same run and setup's rescan disagreed. Declared here, like the
+# flag above it, because the index selection reads it on every run and a fresh install never
+# reaches the assignment -- so under a caller's Set-StrictMode the read would otherwise be fatal.
+$script:PreservedInstallerTorchTag = $null
 $IntelGpuLabel = $null
 if (-not $HasNvidiaSmi -and -not $AmdHasGpuWheels) {
     try {
@@ -4009,24 +4014,45 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
         $script:PreservedXpuVenv = $true
     }
 
-    # A GPU wheel is never force-reinstalled down to CPU on the strength of a rescan. Under
-    # $InstallerManagedSetup install.ps1 resolved the index and installed this trio minutes ago
-    # in this same run, off its own probe -- so when setup's second, independent probe lands on
-    # "cpu" while the venv holds +cu / +rocm / +xpu, the disagreement is setup's, not the host's:
-    # a Get-CimInstance that threw, an nvidia-smi that did not answer, the single-Radeon unroll
-    # of #8335. The in-place repair below would then --force-reinstall CPU torch over a working
-    # GPU environment and exit 0, at which point install.ps1 discards the rollback copy and the
-    # downgrade is permanent -- a loud failure traded for a silently wrong install, which is
-    # worse than the loop this whole block exists to end. Keep the wheel: with no
-    # --force-reinstall the CPU arm below leaves it alone, because a +cu / +rocm / +xpu build
-    # already satisfies the CPU torch>= range.
+    # A GPU wheel is never force-reinstalled onto a DIFFERENT family on the strength of a rescan.
+    # Under $InstallerManagedSetup install.ps1 resolved the index and installed this trio minutes
+    # ago in this same run, off its own probe, and its flavor repair re-lands the trio whenever the
+    # venv disagrees with the index it chose -- so by the time setup runs, a GPU wheel here IS
+    # install.ps1's answer for this host. When setup's second, independent probe then lands
+    # somewhere else, the disagreement is between the two probes, not with the hardware: a
+    # Get-CimInstance that threw, an nvidia-smi that did not answer, the single-Radeon unroll of
+    # #8335, a ROCm scan that failed on a box that also holds an NVIDIA card. Setup has no better
+    # claim than the installer that just ran, and the in-place repair below would --force-reinstall
+    # the other family over a working GPU environment and exit 0, at which point install.ps1
+    # discards the rollback copy and the damage is permanent -- a loud failure traded for a
+    # silently wrong install, which is worse than the loop this whole block exists to end.
+    #
+    # This covers cpu rescans (+rocm -> cpu, the downgrade) and family-to-family ones alike
+    # (+rocm -> cu128, +cu128 -> rocm, +xpu -> cu128). Nothing legitimate is suppressed: a venv
+    # whose torch does not import at all leaves $installedTorchTag $null and still repairs, a CPU
+    # wheel that has to become a GPU one still repairs, a cu* -> cu* move already repaired in
+    # place a few lines above, and an explicit index pin escaped before that. A genuine GPU swap
+    # is install.ps1's job and it does it before calling here.
+    #
+    # $expectedTorchTag is read in the MESSAGE, never in the condition: it is assigned only inside
+    # the `if (-not $shouldRebuild)` block above, so on a venv whose torch would not import at all
+    # it was never created, and reading it under a caller's Set-StrictMode is fatal. The body is
+    # reached only once $installedTorchTag has answered, which is only true on the path that
+    # assigned it.
     if ($shouldRebuild -and $InstallerManagedSetup -and
-        $installedTorchTag -and $installedTorchTag -ne "cpu" -and $expectedTorchTag -eq "cpu") {
-        substep "This host scanned as CPU-only but the installer just placed a $installedTorchTag build here -- keeping it." "Yellow"
-        substep "Set UNSLOTH_TORCH_INDEX_URL to move this environment onto CPU torch on purpose." "DarkGray"
+        $installedTorchTag -and $installedTorchTag -ne "cpu") {
+        substep "This host rescanned as $expectedTorchTag but the installer just placed a $installedTorchTag build here -- keeping it." "Yellow"
+        substep "Set UNSLOTH_TORCH_INDEX_URL to move this environment onto another PyTorch build on purpose." "DarkGray"
         $shouldRebuild = $false
-        # Same reason as the direct-update escape above: the pass has to stay on the xpu index,
-        # or triton-windows lands over torch's XPU triton with nothing to swap it back.
+        # Keeping the wheel is only half the job. The index selection below re-runs the same
+        # rescan, so without this the pass would install the OTHER family's companions over the
+        # wheel we just kept -- and two of those arms force-reinstall torch itself regardless of
+        # $script:PinChangedForceReinstall (the AMD arm always, the XPU arm whenever the installed
+        # tag is not xpu), which would undo this guard from a thousand lines further down.
+        $script:PreservedInstallerTorchTag = $installedTorchTag
+        # Same reason as the direct-update escape above, and it needs its own flag: the pass has
+        # to stay on the xpu index, or triton-windows lands over torch's XPU triton with nothing
+        # to swap it back.
         if ($installedTorchTag -eq "xpu") { $script:PreservedXpuVenv = $true }
     }
 
@@ -4461,6 +4487,19 @@ if ($PinnedTorchIndexUrl) {
     # NVIDIA + Arc host reaches. Ahead of the NVIDIA arm deliberately: converting halfway leaves
     # +xpu torch under triton-windows and no XPU index to swap it back. install.ps1 converts.
     $CuTag = "xpu"
+} elseif ($script:PreservedInstallerTorchTag) {
+    # The stale check kept the GPU wheel install.ps1 placed here minutes ago rather than letting
+    # the rescan force a different family over it. That decision has to reach the install arms
+    # below or it is undone there: the AMD arm force-reinstalls unconditionally, and the XPU arm
+    # force-reinstalls whenever the installed tag is not xpu, so neither one is held off by
+    # $script:PinChangedForceReinstall staying false. Selecting the family that is already
+    # installed keeps both of them out of the way -- a cu* tag skips the AMD reroute below (it
+    # needs $CuTag -eq "cpu") and the XPU arm (it needs "xpu"), and lands on the CUDA arm, which
+    # forces nothing; a kept +rocm venv reads as "cpu" here and lands on the CPU arm, which also
+    # forces nothing and whose bare torch range a +rocm build already satisfies. The +xpu case is
+    # the branch above. Behind the pin check, like every other arm: an explicit pin never gets
+    # this far anyway (it repairs in place before the guard runs).
+    $CuTag = if (Test-CudaFamilyLeaf $script:PreservedInstallerTorchTag) { $script:PreservedInstallerTorchTag } else { "cpu" }
 } elseif ($HasNvidiaSmi) {
     $CuTag = Get-PytorchCudaTag
 } elseif ($script:IsIntelXpu) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1013,10 +1013,10 @@ function Get-RocmPinStaleTags {
 # or a hanging Intel driver init would block a bare `& python -c ...` forever. ProcessStartInfo,
 # not &, so stderr cannot trip $ErrorActionPreference; BOTH streams drain async so a noisy import
 # cannot deadlock on a full pipe; WaitForExit bounds the wait and kills the child. Every failure
-# reads as .Ok = $false, and .Error carries WHICH failure it was: stderr used to be drained and
-# thrown away, so "the HIP DLLs will not load", "torch is not installed" and "the import never
-# came back" all arrived at the caller as the same silent False -- and one of those callers
-# deletes the environment over that answer. Mirrors install.ps1's copy.
+# reads as .Ok = $false, and .Error carries WHICH failure: stderr used to be drained and thrown
+# away, so "the HIP DLLs will not load", "torch is not installed" and "the import never came back"
+# all reached the caller as one silent False -- and one such caller deletes the environment over
+# that answer. Mirrors install.ps1's copy.
 function Invoke-BoundedPythonProbe {
     param([string]$PythonExe, [string]$Code, [int]$TimeoutSec = 30)
     $result = [pscustomobject]@{ Ok = $false; Output = ""; Error = "" }
@@ -1034,15 +1034,14 @@ function Invoke-BoundedPythonProbe {
         $errTask = $proc.StandardError.ReadToEndAsync()
         if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
             try { $proc.Kill() } catch {}
-            # Synthesised, not read back: the reader tasks are the thing that may never
-            # complete on a wedged child, so waiting on them here would reintroduce the hang
-            # this helper exists to bound.
+            # Synthesised, not read back: waiting on the reader tasks of a wedged child would
+            # reintroduce the hang this helper exists to bound.
             $result.Error = "python did not answer within $TimeoutSec seconds"
             return $result
         }
         $result.Output = $outTask.GetAwaiter().GetResult()
-        # Kept, not discarded: on a failed probe this is the only place the real OSError /
-        # WinError text exists, and the caller decides what to do with the venv based on it.
+        # Kept, not discarded: the only place a failed probe's OSError / WinError text exists, and
+        # the caller decides what to do with the venv based on it.
         $result.Error = $errTask.GetAwaiter().GetResult()
         $result.Ok = ($proc.ExitCode -eq 0)
         return $result
@@ -1178,20 +1177,17 @@ function Test-VenvTorchIsXpu {
     } catch { return $false }
 }
 
-# Is this venv's torch a ROCm wheel? The AMD counterpart of the check above, and it exists for
-# the same reason: the host most likely to fail inside `import torch` is an AMD box whose HIP
-# runtime faulted, where the DLL load raises OSError (or hangs) while version.py on disk still
-# names a perfectly good wheel. Answering that question by launching the interpreter that just
-# died is how a working environment got deleted.
+# Is this venv's torch a ROCm wheel? The AMD counterpart of the check above, for the same reason:
+# on an AMD box whose HIP runtime faulted the DLL load raises OSError (or hangs) while version.py
+# on disk still names a perfectly good wheel, so answering by launching the interpreter that just
+# died is how a working environment got deleted. Read off disk, never imported.
 #
-# The label is always "+rocm", never "+gfx", on every index that actually publishes wheels:
+# The label is always "+rocm", never "+gfx", on every index that publishes wheels:
 # repo.amd.com/rocm/whl/<arch>/torch/ (the Windows wheels, arch in the URL only) ships
 # torch-2.11.0+rocm7.13.0-cp312-cp312-win_amd64.whl, and download.pytorch.org/whl/rocm6.4 ships
-# the two-component 2.8.0+rocm6.4 (Linux only). The arch is NOT in the version -- the same
-# 2.9.1+rocm7.13.0 filename is a different binary under gfx1151, gfx110X-all and gfx120X-all.
-# "gfx" is accepted anyway, cheaply, so a future per-arch local label cannot make this read a
-# ROCm venv as unknown and delete it. The dist-info name is NOT usable either -- pip normalises
-# the local label out of it.
+# the two-component 2.8.0+rocm6.4 (Linux only). "gfx" is accepted anyway, cheaply, so a future
+# per-arch local label cannot make this read a ROCm venv as unknown and delete it. The dist-info
+# name is NOT usable either -- pip normalises the local label out of it.
 function Test-VenvTorchIsRocm {
     param([string]$VenvPath)
     if (-not $VenvPath) { return $false }
@@ -2519,10 +2515,9 @@ $script:IsIntelXpu = $false
 # $script:IsIntelXpu on purpose: it steers the INSTALL, not the hardware report, which must stay
 # honest about the NVIDIA GPU that is also in the machine.
 $script:PreservedXpuVenv = $false
-# The flavour tag ("rocm" / "cu128" / "xpu") of a GPU wheel the stale check below kept because
-# install.ps1 put it there in this same run and setup's rescan disagreed. Declared here, like the
-# flag above it, because the index selection reads it on every run and a fresh install never
-# reaches the assignment -- so under a caller's Set-StrictMode the read would otherwise be fatal.
+# Flavour tag ("rocm" / "cu128" / "xpu") of a GPU wheel the stale check below kept. Declared here,
+# like the flag above it, because the index selection reads it on every run while a fresh install
+# never reaches the assignment -- so under a caller's Set-StrictMode the read would be fatal.
 $script:PreservedInstallerTorchTag = $null
 $IntelGpuLabel = $null
 if (-not $HasNvidiaSmi -and -not $AmdHasGpuWheels) {
@@ -3845,29 +3840,28 @@ Set-PersistedNoTorch -VenvPath $VenvDir -NoTorch $NoTorchMode
 # every accepted spelling to one value both sides parse identically.
 $env:UNSLOTH_NO_TORCH = if ($NoTorchMode) { "true" } else { "false" }
 $InstallerManagedSetup = $env:UNSLOTH_INSTALL_ROLLBACK_MANAGED -match '^(?i:true|1|yes)$'
-# The torch family install.ps1 settled on for this host, in the same vocabulary the probe below
-# produces (cu<digits> / rocm / xpu / cpu). $null means it did not say: an installer old enough
-# to predate the variable (setup.ps1 ships in the pip package, install.ps1 is fetched from
-# unsloth.ai, so the two can be different ages), --no-torch, or a custom index whose leaf names
-# no flavor. Absent is treated as unknown rather than as a mismatch, which is what keeps an
-# older cached installer on exactly the behaviour it had before this variable existed.
-# IsNullOrWhiteSpace covers both spellings of "no answer": PowerShell 7.5+ keeps an empty
-# assignment as a present blank value, 5.1 and 7.0-7.4 remove the variable instead.
+# The torch family install.ps1 settled on, in the vocabulary the probe below produces (cu<digits>
+# / rocm / xpu / cpu). $null means it did not say: an installer predating the variable (setup.ps1
+# ships in the pip package, install.ps1 is fetched from unsloth.ai, so the two can be different
+# ages), --no-torch, or a custom index whose leaf names no flavor. Absent is unknown rather than a
+# mismatch, which keeps an older cached installer on its pre-variable behaviour. IsNullOrWhiteSpace
+# rather than a presence test: 7.5+ keeps an empty assignment as a present blank value, 5.1 and
+# 7.0-7.4 remove the variable.
 $InstallerTorchTag = if ([string]::IsNullOrWhiteSpace($env:UNSLOTH_INSTALLER_TORCH_TAG)) { $null }
                      else { $env:UNSLOTH_INSTALLER_TORCH_TAG.Trim().ToLowerInvariant() }
 # Only the stale-venv block below assigns this, but the XPU install reads it to decide whether to
 # force-reinstall and a fresh install never enters that block. Declaring it keeps a caller's
 # Set-StrictMode from making the read fatal.
 $installedTorchTag = $null
-# Hoisted for the same reason, and it now carries more weight than it used to: four install arms
-# read it to decide --force-reinstall, and it is the flag the installer-managed repair below
-# raises. Assigned only inside the block, which a fresh install never enters.
+# Hoisted for the same reason: four install arms read it to decide --force-reinstall and the
+# installer-managed repair below raises it, yet only the block a fresh install never enters
+# assigns it.
 $script:PinChangedForceReinstall = $false
 if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode) {
     $VenvPyExe = Join-Path $VenvDir "Scripts\python.exe"
     $installedTorchTag = $null
-    # Declared before the branch that assigns it: the failure message below reads its .Error to
-    # say WHY torch did not answer, and a venv with no python.exe never runs the probe at all.
+    # Declared before the branch that assigns it: the failure message below reads its .Error, and
+    # a venv with no python.exe never runs the probe at all.
     $_verProbe = $null
     $shouldRebuild = $false
     # Set when a stale venv under a pin is repaired in place (force-reinstall) not wiped.
@@ -3905,12 +3899,11 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
             substep "PyTorch did not respond in time but this venv holds an XPU build -- keeping it." "Yellow"
             substep "If training fails, update the Intel GPU compute driver." "Yellow"
         } elseif (Test-VenvTorchIsRocm -VenvPath $VenvDir) {
-            # Same rescue on the AMD side, and it is the one that has cost users whole installs.
-            # A faulted Adrenalin or HIP runtime makes `import torch` raise at the DLL load or
-            # never return, and the venv then reads as "torch could not be imported" -- so the
-            # ROCm environment that is actually fine gets thrown away and reinstalled, which
-            # does not fix a driver. version.py on disk still names the wheel, so trust it and
-            # point at the driver instead (#8335, #7275).
+            # Same rescue on the AMD side, and the one that has cost users whole installs: a
+            # faulted Adrenalin or HIP runtime makes `import torch` raise at the DLL load or never
+            # return, so a fine ROCm environment read as "torch could not be imported" and was
+            # thrown away, which does not fix a driver. version.py on disk still names the wheel,
+            # so trust it and point at the driver instead (#8335, #7275).
             $installedTorchTag = "rocm"
             substep "PyTorch did not respond but this venv holds a ROCm build -- keeping it." "Yellow"
             substep "If training fails, reboot and update the AMD Adrenalin / HIP SDK driver." "Yellow"
@@ -4011,8 +4004,7 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
     # A +xpu venv is never wiped by a DIRECT update: on a hybrid NVIDIA+Arc box the promotion
     # above is gated on -not $HasNvidiaSmi, so a later pinless update expects a cu* tag, calls the
     # working Arc venv stale and deletes it -- then exits, because only install.ps1 creates venvs.
-    # Under install.ps1 ($InstallerManagedSetup) this escape stays out of the way: that run is
-    # handled by the in-place repair below, which covers every flavour rather than just xpu.
+    # Under install.ps1 the in-place repair below covers every flavour, so this escape stays out.
     if ($shouldRebuild -and -not $InstallerManagedSetup -and $installedTorchTag -eq "xpu") {
         substep "Keeping the installed Intel XPU environment (this host expects $expectedTorchTag)." "Yellow"
         substep "Re-run install.ps1 to replace it -- that path rebuilds with a rollback copy." "Yellow"
@@ -4025,88 +4017,79 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
     }
 
     # A GPU wheel install.ps1 SELECTED is never force-reinstalled onto a different family on the
-    # strength of a rescan. install.ps1 reports the family it settled on in
-    # $env:UNSLOTH_INSTALLER_TORCH_TAG, and only a wheel matching it is treated as its answer,
-    # because "there is a GPU wheel in the venv" does not by itself mean this run put it there:
-    # the migrated-venv arm (install.ps1's `if ($_Migrated)`) installs unsloth alone and never
-    # touches torch, and install.ps1's flavor repair no-ops whenever its expected tag is 'cpu' or
-    # unrecognised. So an ordinary upgrade from the legacy ~/.unsloth/studio/.venv layout can hand
-    # setup a +cu118 wheel from a previous install on different hardware, and preserving THAT
-    # would leave the environment permanently wrong -- including on a mapped AMD host, where the
-    # kept cu* tag also blocks the ROCm reroute below (it needs $CuTag -eq "cpu"). Those repair,
-    # in place, as they did before this guard existed.
-    # $InstallerTorchTag $null means the installer did not say -- an older cached install.ps1,
-    # or --no-torch -- and unknown falls back to preserving, which is the behaviour that shipped
-    # before the variable existed. When setup's second, independent probe then lands
-    # somewhere else, the disagreement is between the two probes, not with the hardware: a
-    # Get-CimInstance that threw, an nvidia-smi that did not answer, the single-Radeon unroll of
-    # #8335, a ROCm scan that failed on a box that also holds an NVIDIA card. Setup has no better
-    # claim than the installer that just ran, and the in-place repair below would --force-reinstall
-    # the other family over a working GPU environment and exit 0, at which point install.ps1
-    # discards the rollback copy and the damage is permanent -- a loud failure traded for a
-    # silently wrong install, which is worse than the loop this whole block exists to end.
+    # strength of a rescan. Only a wheel matching the family install.ps1 reported in
+    # $env:UNSLOTH_INSTALLER_TORCH_TAG counts as its answer, because "there is a GPU wheel in the
+    # venv" does not by itself mean this run put it there: the migrated-venv arm (install.ps1's
+    # `if ($_Migrated)`) installs unsloth alone and never touches torch, and install.ps1's flavor
+    # repair no-ops whenever its expected tag is 'cpu' or unrecognised. So an ordinary upgrade off
+    # the legacy ~/.unsloth/studio/.venv layout can hand setup a +cu118 wheel from a previous
+    # install on different hardware; preserving THAT would leave the environment permanently wrong
+    # and, on a mapped AMD host, the kept cu* tag also blocks the ROCm reroute below (it needs
+    # $CuTag -eq "cpu"). Those repair in place, as they did before this guard existed.
     #
-    # This covers cpu rescans (+rocm -> cpu, the downgrade) and family-to-family ones alike
-    # (+rocm -> cu128, +cu128 -> rocm, +xpu -> cu128). Nothing legitimate is suppressed: a venv
-    # whose torch does not import at all leaves $installedTorchTag $null and still repairs, a CPU
-    # wheel that has to become a GPU one still repairs, a cu* -> cu* move already repaired in
-    # place a few lines above, and an explicit index pin escaped before that. A genuine GPU swap
-    # is install.ps1's job and it does it before calling here.
+    # $InstallerTorchTag $null means the installer did not say (an older cached install.ps1, or
+    # --no-torch), and unknown falls back to preserving, the behaviour that shipped before the
+    # variable existed. Otherwise the disagreement is between setup's second probe and the first,
+    # not with the hardware -- a Get-CimInstance that threw, an nvidia-smi that did not answer, the
+    # single-Radeon unroll of #8335 -- and setup has no better claim than the installer that just
+    # ran: the in-place repair below would --force-reinstall the other family over a working GPU
+    # environment and exit 0, at which point install.ps1 discards the rollback copy and the damage
+    # is permanent. A loud failure traded for a silently wrong install is worse than the loop this
+    # block exists to end.
+    #
+    # Covers cpu rescans (+rocm -> cpu) and family-to-family ones (+rocm -> cu128, +cu128 -> rocm,
+    # +xpu -> cu128) alike. Nothing legitimate is suppressed: a venv whose torch does not import at
+    # all leaves $installedTorchTag $null and still repairs, a CPU wheel that has to become a GPU
+    # one still repairs, cu* -> cu* already repaired in place above, and an explicit index pin
+    # escaped before that. A genuine GPU swap is install.ps1's job, done before calling here.
     #
     # $expectedTorchTag is read in the MESSAGE, never in the condition: it is assigned only inside
-    # the `if (-not $shouldRebuild)` block above, so on a venv whose torch would not import at all
-    # it was never created, and reading it under a caller's Set-StrictMode is fatal. The body is
-    # reached only once $installedTorchTag has answered, which is only true on the path that
-    # assigned it.
+    # the `if (-not $shouldRebuild)` block above, so on a venv whose torch would not import it was
+    # never created and reading it under a caller's Set-StrictMode is fatal. The body is reached
+    # only once $installedTorchTag has answered, which is only true on the path that assigned it.
     if ($shouldRebuild -and $InstallerManagedSetup -and
         $installedTorchTag -and $installedTorchTag -ne "cpu" -and
         ((-not $InstallerTorchTag) -or $installedTorchTag -eq $InstallerTorchTag)) {
         substep "This host rescanned as $expectedTorchTag but the installer just placed a $installedTorchTag build here -- keeping it." "Yellow"
         substep "Set UNSLOTH_TORCH_INDEX_URL to move this environment onto another PyTorch build on purpose." "DarkGray"
         $shouldRebuild = $false
-        # Keeping the wheel is only half the job. The index selection below re-runs the same
-        # rescan, so without this the pass would install the OTHER family's companions over the
-        # wheel we just kept -- and two of those arms force-reinstall torch itself regardless of
+        # Keeping the wheel is only half the job: the index selection below re-runs the same
+        # rescan, and two of its arms force-reinstall torch regardless of
         # $script:PinChangedForceReinstall (the AMD arm always, the XPU arm whenever the installed
-        # tag is not xpu), which would undo this guard from a thousand lines further down.
+        # tag is not xpu), undoing this guard from a thousand lines further down.
         $script:PreservedInstallerTorchTag = $installedTorchTag
-        # Same reason as the direct-update escape above, and it needs its own flag: the pass has
-        # to stay on the xpu index, or triton-windows lands over torch's XPU triton with nothing
-        # to swap it back.
+        # Same reason as the direct-update escape above, and it needs its own flag: stay on the
+        # xpu index, or triton-windows lands over torch's XPU triton with nothing to swap it back.
         if ($installedTorchTag -eq "xpu") { $script:PreservedXpuVenv = $true }
     }
 
     $reason = $null
     if ($shouldRebuild) {
         $reason = if ($installedTorchTag) { "torch $installedTorchTag != required $expectedTorchTag" } else { "torch could not be imported" }
-        # "torch could not be imported" covers a dead GPU driver, a half-written wheel and no
-        # torch at all, and the user is about to be handed a decision about their environment
-        # based on it. Print what python actually said -- the last stderr line is the exception
-        # -- so a WinError 126 reads as a driver problem instead of a broken install.
+        # "torch could not be imported" covers a dead GPU driver, a half-written wheel and no torch
+        # at all. Print what python actually said (the last stderr line is the exception), so a
+        # WinError 126 reads as a driver problem instead of a broken install.
         if ($_verProbe -and -not $_verProbe.Ok -and $_verProbe.Error) {
             # No @(...)[0] around this: the guard above passes on a whitespace-only stderr,
-            # Where-Object then drops every line, and indexing [0] into the empty array that
-            # leaves is fatal under a caller's Set-StrictMode. -Last 1 already yields either
-            # one string or nothing, which is exactly what the test below wants.
+            # Where-Object then drops every line, and [0] into the empty array that leaves is fatal
+            # under a caller's Set-StrictMode. -Last 1 already yields one string or nothing.
             $_probeErrLine = $_verProbe.Error -split "`r?`n" |
                 Where-Object { $_.Trim() } | Select-Object -Last 1
             if ($_probeErrLine) { substep "PyTorch reported: $($_probeErrLine.Trim())" "DarkGray" }
         }
     }
 
-    # The abort that used to live here was an unrecoverable fixed point, and it has now been
-    # reported from four separate triggers (#5942, #7275, #8335, plus a driver crash). It told
-    # the user to "re-run install.ps1 so it can replace the environment safely with rollback"
-    # -- but install.ps1 IS the caller under $InstallerManagedSetup, it had already done
-    # exactly that earlier in the same run, and its failure path then moves the previous
-    # environment straight back. So every attempt ended on the byte-identical state it started
-    # from, the next attempt reached the same verdict, and the install could never converge.
+    # The abort that used to live here was an unrecoverable fixed point, reported from four
+    # separate triggers (#5942, #7275, #8335, plus a driver crash). It told the user to re-run
+    # install.ps1 for a safe rollback replace -- but install.ps1 IS the caller under
+    # $InstallerManagedSetup, it had already done exactly that earlier in the same run, and its
+    # failure path moves the previous environment straight back, so every attempt ended on the
+    # byte-identical state it started from and the install could never converge.
     #
-    # Repair in place instead of wiping: the dependency pass force-reinstalls the torch trio
-    # from the resolved index over this venv, which is the route an index-pin change and a cu*
-    # family change already take a few lines above. Deleting is not an option on this path
-    # anyway -- install.ps1 invokes setup through the venv's own unsloth.exe, so python.exe is
-    # locked by the process running this script.
+    # Repair in place instead of wiping: the dependency pass force-reinstalls the torch trio from
+    # the resolved index over this venv, the route an index-pin change and a cu* family change
+    # already take above. Deleting is not an option here anyway -- install.ps1 invokes setup
+    # through the venv's own unsloth.exe, so python.exe is locked by the process running this.
     if ($shouldRebuild -and $InstallerManagedSetup) {
         substep "Environment does not match this host ($reason) -- reinstalling PyTorch in place." "Yellow"
         substep "install.ps1 keeps a rollback copy of the previous environment until this run succeeds." "DarkGray"
@@ -4150,13 +4133,12 @@ if (-not (Test-Path -LiteralPath $VenvDir)) {
     $_venvActivate = Join-Path $VenvDir "Scripts\Activate.ps1"
     if (Test-Path -LiteralPath $_venvPyExe) {
         # The interpreter is not the only file the rest of this script needs. Everything below
-        # reaches the venv through the dot-sourced Activate.ps1 and a bare `python` -- Fast-Install
-        # resolves its target with (Get-Command python).Source -- and install.ps1 deliberately
+        # reaches the venv through the dot-sourced Activate.ps1 and a bare `python` (Fast-Install
+        # resolves its target with (Get-Command python).Source), and install.ps1 deliberately
         # leaves the venv's Scripts directory off PATH. So a venv that kept python.exe but lost
-        # Activate.ps1 fails the dot-source, non-terminating at the "Continue" the pip section
-        # runs at, and installs the whole stack into whatever interpreter is on PATH before
-        # exiting 0. Same silent-success hazard as a missing python.exe, one file over, and it is
-        # newly reachable now that an installer-managed stale verdict repairs instead of aborting.
+        # Activate.ps1 fails the dot-source non-terminatingly at the "Continue" the pip section
+        # runs at, installs the whole stack into whatever interpreter is on PATH, and exits 0.
+        # Newly reachable now that an installer-managed stale verdict repairs instead of aborting.
         if (-not (Test-Path -LiteralPath $_venvActivate)) {
             Write-StudioLine "[ERROR] $VenvDir has no activation script at Scripts\Activate.ps1." -ForegroundColor Red
             Write-StudioLine "        The environment is incomplete rather than out of date. Re-run the installer" -ForegroundColor Yellow
@@ -4168,19 +4150,17 @@ if (-not (Test-Path -LiteralPath $VenvDir)) {
             if ($_venvPyVer) { substep $_venvPyVer }
         } catch {}
     } else {
-        # Stop here, because nothing downstream would. The activation below is a dot-source,
-        # and a MISSING script is a NON-terminating error at the "Continue" the pip section
-        # runs at -- so setup would print one red line and carry straight on, resolving every
-        # `python` and `uv pip` that follows against whatever interpreter is on PATH and
-        # installing the whole stack outside the environment it was asked to build. It can
-        # then exit 0 over a venv that never gained a single package.
+        # Stop here, because nothing downstream would: the activation below is a dot-source, and a
+        # MISSING script is a NON-terminating error at the "Continue" the pip section runs at, so
+        # setup would print one red line and carry on, resolving every `python` and `uv pip` that
+        # follows against whatever interpreter is on PATH, installing the whole stack outside the
+        # environment it was asked to build, and exiting 0 over a venv with not one package in it.
         #
-        # An interpreter-less venv is incomplete, not out of date, so none of the decisions
-        # above apply to it: the in-place torch repair has no interpreter to repair through,
-        # and the rebuild path deletes the directory only to hit "Virtual environment not
-        # found" a few lines up. Say what is actually wrong and fail. Unlike the abort this
-        # replaced upstream, re-creating the environment genuinely changes this state --
-        # install.ps1 still holds the rollback copy of the previous one.
+        # An interpreter-less venv is incomplete, not out of date, so none of the decisions above
+        # apply: the in-place torch repair has no interpreter to repair through, and the rebuild
+        # path deletes the directory only to hit "Virtual environment not found" a few lines up.
+        # Unlike the abort this replaced upstream, re-creating the environment genuinely changes
+        # this state -- install.ps1 still holds the rollback copy of the previous one.
         Write-StudioLine "[ERROR] $VenvDir has no interpreter at Scripts\python.exe." -ForegroundColor Red
         Write-StudioLine "        The environment is incomplete rather than out of date. Re-run the installer" -ForegroundColor Yellow
         Write-StudioLine "        to rebuild it: irm https://unsloth.ai/install.ps1 | iex" -ForegroundColor Yellow
@@ -4195,40 +4175,38 @@ if (-not (Test-Path -LiteralPath $VenvDir)) {
 $prevEAP = $ErrorActionPreference
 $ErrorActionPreference = "Continue"
 
-# Existence is not activation. The two refusals above check that a file is THERE; neither can
-# tell whether dot-sourcing it took effect, and the ways it silently does not are ordinary
-# damage on a half-written venv rather than exotica. Activate.ps1 prepends the venv to PATH in
-# its LAST statement -- $env:VIRTUAL_ENV is set well before it -- so a copy truncated by an
-# interrupted or out-of-disk `python -m venv` parses, runs to its last complete statement and
-# returns without printing anything at all, and an unparseable one is a ParserError, which is
-# non-terminating at the "Continue" set just above. Either way the dot-source "succeeds" with
-# the ambient interpreter still first on PATH, and on a real install that is the system or
-# Microsoft Store python, because install.ps1 keeps the venv's Scripts directory off PATH on
-# purpose. Fast-Install then hands exactly that to `uv pip install --python`, the whole stack
-# lands outside the venv, every Exit-SetupFailure below keys off an exit code produced by that
-# same wrong interpreter, and setup exits 0 -- at which point install.ps1 commits over the
-# rollback copy and the previous working environment is gone for good.
+# Existence is not activation. The two refusals above check that a file is THERE; neither can tell
+# whether dot-sourcing it took effect, and the ways it silently does not are ordinary damage on a
+# half-written venv. Activate.ps1 prepends the venv to PATH in its LAST statement, 28 lines after
+# it sets $env:VIRTUAL_ENV, so a copy truncated by an interrupted or out-of-disk `python -m venv`
+# parses, runs to its last complete statement and returns without printing anything at all, and an
+# unparseable one is a ParserError, non-terminating at the "Continue" set just above. Either way
+# the dot-source "succeeds" with the ambient interpreter still first on PATH -- the system or
+# Microsoft Store python, since install.ps1 keeps the venv's Scripts directory off PATH on purpose.
+# Fast-Install hands exactly that to `uv pip install --python`, the whole stack lands outside the
+# venv, every Exit-SetupFailure below keys off that wrong interpreter's exit code, and setup exits
+# 0 -- at which point install.ps1 commits over the rollback copy and the previous working
+# environment is gone for good.
 #
-# So assert the post-condition instead of adding a third pre-condition: the `python` now in
-# effect has to live under $VenvDir. Checking $env:VIRTUAL_ENV would not do, precisely because
-# Activate.ps1 sets it before the line that matters.
+# So assert the post-condition instead of a third pre-condition: the `python` now in effect has to
+# live under $VenvDir. $env:VIRTUAL_ENV would not do, precisely because Activate.ps1 sets it
+# before the line that matters.
 function Assert-VenvActivated {
     param([Parameter(Mandatory = $true)][string]$VenvDir)
 
-    # Both sides are normalised through Get-Item, which is what Activate.ps1 itself uses to
-    # build the PATH entry ($VenvExecDir = Get-Item -Path $VenvExecPath). Agreeing on the
-    # normaliser is what keeps a short 8.3 path, a substituted drive, a junction or a
-    # differently cased drive letter from reading as "outside": neither side resolves or
-    # expands anything the other leaves alone. A guard that false-positives here would break
-    # every install, so every branch that cannot PROVE the interpreter is wrong returns.
+    # Both sides normalised through Get-Item, which is what Activate.ps1 itself uses to build the
+    # PATH entry ($VenvExecDir = Get-Item -Path $VenvExecPath): agreeing on the normaliser keeps a
+    # short 8.3 path, a substituted drive, a junction or a differently cased drive letter from
+    # reading as "outside". A guard that false-positives here would break every install, so every
+    # branch that cannot PROVE the interpreter is wrong returns.
     $venvRoot = $null
     try { $venvRoot = (Get-Item -LiteralPath $VenvDir -Force -ErrorAction Stop).FullName.TrimEnd('\', '/') } catch { $venvRoot = $null }
     if (-not $venvRoot) { return }
 
     $_pyCmd = Get-Command python -ErrorAction SilentlyContinue | Select-Object -First 1
     # A function or alias named python carries no Source to judge, and judging it wrong would
-    # refuse an install that works. Only an application resolved off PATH is decidable here,
-    # and that is also the only shape Fast-Install's -- python hand-off can be aimed at.
+    # refuse an install that works. Only an application resolved off PATH is decidable, and that
+    # is also the only shape Fast-Install's -- python hand-off can be aimed at.
     if ($_pyCmd -and $_pyCmd.CommandType -ne 'Application') { return }
     $_pyPath = $null
     if ($_pyCmd -and $_pyCmd.Source) {
@@ -4268,12 +4246,10 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
         if (Get-Command uv -ErrorAction SilentlyContinue) { $UseUv = $true }
     } catch { }
 }
-# Refresh-Environment rebuilt PATH from the registry, and the re-activation that was supposed to
-# put the venv back sits inside a catch that swallows everything -- including a dot-source that
-# died after Activate.ps1's own `deactivate -nondestructive` had already restored the pre-venv
-# PATH. Re-check outside the catch, because this is the last statement before Fast-Install starts
-# resolving `python`. On the ordinary path the assertion above already passed and this re-reads
-# the same PATH.
+# Refresh-Environment rebuilt PATH from the registry, and the re-activation meant to put the venv
+# back sits inside a catch that swallows everything -- including a dot-source that died after
+# Activate.ps1's own `deactivate -nondestructive` had restored the pre-venv PATH. Re-check outside
+# the catch: this is the last statement before Fast-Install starts resolving `python`.
 Assert-VenvActivated -VenvDir $VenvDir
 
 # Helper: install a package, preferring uv with pip fallback
@@ -4413,14 +4389,12 @@ sys.exit(0 if install_manifest.verify_install()['ok'] else 1)
         # date" path would leave the user on CPU torch with Train/Export disabled.
         # Force the dependency pass so the ROCm wheels get installed.
         if ($script:ROCmGfxArch) {
-            # Bounded, like every other torch probe in this file and for the reason the disk-based
-            # ROCm rescue above exists: on a faulted HIP runtime `import torch` can never come
-            # back, and the rescue now KEEPS that venv rather than deleting it -- so this is the
-            # first `import torch` such a host reaches. A bare `& python` here waits forever and
-            # setup never finishes. A probe that does not answer keeps $_torchIsCpu true, which is
-            # the same safe direction as before: one dependency pass, never a silent skip. The
-            # default bound is the one the flavour probe above already ran under, on a warmer
-            # page cache, so a healthy venv that answered there answers here.
+            # Bounded, like every other torch probe here and for the reason the disk-based ROCm
+            # rescue above exists: on a faulted HIP runtime `import torch` never comes back, and
+            # the rescue now KEEPS that venv rather than deleting it, so this is the first
+            # `import torch` such a host reaches and an unbounded call would hang setup forever.
+            # A probe that does not answer keeps $_torchIsCpu true, the same safe direction as
+            # before: one dependency pass, never a silent skip.
             $_rocmTorchProbe = Invoke-BoundedPythonProbe -PythonExe "python" `
                 -Code "import torch, sys; sys.exit(0 if torch.cuda.is_available() else 1)"
             $_torchIsCpu = -not $_rocmTorchProbe.Ok
@@ -4570,17 +4544,15 @@ if ($PinnedTorchIndexUrl) {
     # +xpu torch under triton-windows and no XPU index to swap it back. install.ps1 converts.
     $CuTag = "xpu"
 } elseif ($script:PreservedInstallerTorchTag) {
-    # The stale check kept the GPU wheel install.ps1 placed here minutes ago rather than letting
-    # the rescan force a different family over it. That decision has to reach the install arms
-    # below or it is undone there: the AMD arm force-reinstalls unconditionally, and the XPU arm
-    # force-reinstalls whenever the installed tag is not xpu, so neither one is held off by
-    # $script:PinChangedForceReinstall staying false. Selecting the family that is already
-    # installed keeps both of them out of the way -- a cu* tag skips the AMD reroute below (it
-    # needs $CuTag -eq "cpu") and the XPU arm (it needs "xpu"), and lands on the CUDA arm, which
-    # forces nothing; a kept +rocm venv reads as "cpu" here and lands on the CPU arm, which also
-    # forces nothing and whose bare torch range a +rocm build already satisfies. The +xpu case is
-    # the branch above. Behind the pin check, like every other arm: an explicit pin never gets
-    # this far anyway (it repairs in place before the guard runs).
+    # The stale check kept the GPU wheel install.ps1 placed here minutes ago. That decision has to
+    # reach the install arms below or it is undone there: the AMD arm force-reinstalls
+    # unconditionally and the XPU arm whenever the installed tag is not xpu, so neither is held off
+    # by $script:PinChangedForceReinstall staying false. Selecting the family already installed
+    # keeps both out of the way -- a cu* tag skips the AMD reroute below (it needs $CuTag -eq
+    # "cpu") and the XPU arm (it needs "xpu") and lands on the CUDA arm, which forces nothing; a
+    # kept +rocm venv reads as "cpu" here and lands on the CPU arm, whose bare torch range a +rocm
+    # build already satisfies. The +xpu case is the branch above. Behind the pin check, like every
+    # other arm: an explicit pin repairs in place before the guard runs anyway.
     $CuTag = if (Test-CudaFamilyLeaf $script:PreservedInstallerTorchTag) { $script:PreservedInstallerTorchTag } else { "cpu" }
 } elseif ($HasNvidiaSmi) {
     $CuTag = Get-PytorchCudaTag

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -3809,7 +3809,10 @@ class TestSetupPs1ShadowingParity:
         assert "ConfigManagerErrorCode" in block
         # ... but when the filter would leave nothing, keep the parked card rather than
         # reporting no AMD GPU (matches the Python WMI path).
-        assert "if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus }" in block
+        # @() around the WHOLE if, not each branch: an if-expression unrolls a one-element
+        # array, and a scalar's .Count is $null under Windows PowerShell 5.1, so a host with
+        # exactly one Radeon reported no AMD GPU at all (#8335).
+        assert "@(if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus })" in block
 
     def test_index_picks_read_the_same_masks_as_the_pin_check(self):
         # Resolve-ShadowingGfxPick honours CUDA_VISIBLE_DEVICES as a pin, so every site

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -3809,9 +3809,9 @@ class TestSetupPs1ShadowingParity:
         assert "ConfigManagerErrorCode" in block
         # ... but when the filter would leave nothing, keep the parked card rather than
         # reporting no AMD GPU (matches the Python WMI path).
-        # @() around the WHOLE if, not each branch: an if-expression unrolls a one-element
-        # array, and a scalar's .Count is $null under Windows PowerShell 5.1, so a host with
-        # exactly one Radeon reported no AMD GPU at all (#8335).
+        # @() around the WHOLE if, not each branch: an if-expression unrolls a one-element array,
+        # and a CimInstance scalar's .Count is $null on 5.1, so a host with exactly one Radeon
+        # reported no AMD GPU at all (#8335).
         assert "@(if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus })" in block
 
     def test_index_picks_read_the_same_masks_as_the_pin_check(self):

--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -1,0 +1,268 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# A single-AMD-GPU host must not install itself into a loop (#8335).
+#
+# Two defects met on that host. WMI found exactly one Radeon, the if-expression holding it
+# unrolled to a scalar, and a scalar's .Count is $null under Windows PowerShell 5.1, so setup
+# reported "gpu none" and judged the installed ROCm venv stale against a required "cpu". The
+# stale branch under install.ps1 then aborted with "re-run install.ps1", install.ps1's failure
+# path restored the previous environment, and the next run reached the same verdict. Nothing
+# about that pair converges, which is why the same abort has been reported from four unrelated
+# triggers (#5942, #7275, #8335, and a driver crash on Discord).
+#
+# Read this before adding a case: PowerShell 7 returns .Count = 1 for a scalar, so the pwsh that
+# runs this file CANNOT reproduce the 5.1 half of #8335. What it can do is prove the unroll
+# itself still happens here, and assert the @() wrap that fixes it as a source shape. The 5.1
+# leg lives in CI. No check below claims otherwise.
+#
+# Run: pwsh -NoProfile -File tests/studio/test_amd_venv_repair_loop.ps1
+
+$ErrorActionPreference = "Stop"
+$root = (Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, "..", ".."))).Path
+$setup = Join-Path $root "studio/setup.ps1"
+
+$failures = 0
+function Check($name, $cond) {
+    if ($cond) { Write-Host "  PASS  $name" }
+    else { Write-Host "  FAIL  $name" -ForegroundColor Red; $script:failures++ }
+}
+
+# Returns the source text of each named function. The caller Invoke-Expression's it at script
+# scope; doing that inside a function would lose the helpers on return. Recursive, so it also
+# reaches install.ps1's copies, which live inside Install-UnslothStudio.
+function Get-HelperSources($path, $names) {
+    $tokens = $null; $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$errors)
+    if ($errors) { $errors | ForEach-Object { $_.ToString() }; throw "$path has parse errors" }
+    $out = @()
+    foreach ($name in $names) {
+        $fn = $ast.FindAll({ param($n)
+            $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $name
+        }, $true)
+        if ($fn.Count -lt 1) { throw "expected $name in $path, found none" }
+        $out += $fn[0].Extent.Text
+    }
+    return $out
+}
+
+# Stubs for the installers' printers, so this file does not depend on the ANSI helpers.
+# Both use Write-Host, so neither can pollute a function's return value.
+function substep { param([string]$Message, [string]$Color = "DarkGray") }
+function Write-StudioStdoutMirror { param([string]$Line) }
+
+# ---------------------------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== the unroll this pwsh CAN see ==="
+# The bug is the unroll, and it happens on every PowerShell. What differs is only the
+# consequence: 5.1 answers $null to a scalar's .Count and 7 answers 1, so the "-gt 0" test that
+# follows is false there and true here. Hence the source assertion further down.
+$oneGpu = @("AMD Radeon PRO W7900")
+$unwrapped = if ($oneGpu.Count -gt 0) { $oneGpu } else { @() }
+$wrapped = @(if ($oneGpu.Count -gt 0) { $oneGpu } else { @() })
+Check "an if-expression unrolls a one-element array here too" (-not ($unwrapped -is [array]))
+Check "the @() wrap keeps it an array"                        ($wrapped -is [array])
+Check "the wrapped value still counts one GPU"                ($wrapped.Count -eq 1)
+# Stated as a check so it cannot quietly stop being true, and so nobody reads the file as a 5.1
+# repro: on 5.1 this same expression answers $null.
+Check "this pwsh answers 1, not `$null, to a scalar .Count"   ($unwrapped.Count -eq 1)
+Check "so the harness is PowerShell 7, not 5.1"               ($PSVersionTable.PSVersion.Major -ge 6)
+
+# ---------------------------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Test-VenvTorchIsRocm reads the wheel off disk ==="
+# The AMD counterpart of Test-VenvTorchIsXpu. It exists so a faulted HIP runtime -- an
+# `import torch` that raises at the DLL load or never returns -- does not get answered by
+# deleting a perfectly good ROCm environment. Free by design: no interpreter is launched, so a
+# CPU-only host pays nothing for it on every update.
+foreach ($srcText in (Get-HelperSources $setup @("Test-VenvTorchIsRocm"))) { Invoke-Expression $srcText }
+# @() around the call, then [0]: a one-name request returns a one-element array, which unrolls
+# to a String on the way out, and [0] on a String is its first character. The same unroll this
+# file is about, one directory over.
+$isRocmFn = @(Get-HelperSources $setup @("Test-VenvTorchIsRocm"))[0]
+# An empty or wrong extraction would make every case below pass vacuously.
+Check "extraction kept the version file" ($isRocmFn -match 'version\.py')
+
+# Runs on Linux CI too, so the filesystem cmdlets are shadowed: the helper builds a Windows path
+# and this asserts the CONTENT it read, not what the OS resolves.
+function Invoke-IsRocm {
+    param([string] $VenvPath, [string] $VersionPyBody, [switch] $Missing, [switch] $Throws)
+    $sb = [scriptblock]::Create(@"
+param(`$Body, `$Missing, `$Throws)
+function Join-Path {
+    [CmdletBinding()] param([Parameter(Position=0)] [string] `$Path, [Parameter(Position=1)] [string] `$ChildPath)
+    # Shadowed: the real cmdlet validates the drive qualifier, so "C:\..." throws on Linux CI.
+    if (-not `$ChildPath) { return `$Path }
+    return (`$Path.TrimEnd('\', '/') + '\' + `$ChildPath.TrimStart('\', '/'))
+}
+function Test-Path {
+    [CmdletBinding()] param([string] `$LiteralPath, [Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+    return (-not `$Missing)
+}
+function Get-Content {
+    [CmdletBinding()] param([string] `$LiteralPath, [Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+    if (`$Throws) { throw "access denied" }
+    return (`$Body -split "``n")
+}
+$isRocmFn
+Test-VenvTorchIsRocm -VenvPath '$VenvPath'
+"@)
+    return (& $sb $VersionPyBody ([bool]$Missing) ([bool]$Throws))
+}
+
+$XPU  = "__version__ = '2.9.1+xpu'`ndebug = False"
+$CU   = "__version__ = '2.9.1+cu128'`ncuda: Optional[str] = '12.8'"
+$BARE = "__version__ = '2.9.1'"
+# download.pytorch.org labels the wheel +rocmX.Y; the AMD Windows wheels label it +gfxNNNN. Both
+# are ROCm builds and the reporter of #8335 was running the second kind.
+Check "rocm6.4 wheel"        (Invoke-IsRocm "C:\v" "__version__ = '2.8.0+rocm6.4'")
+Check "rocm7.0 wheel"        (Invoke-IsRocm "C:\v" "__version__ = '2.9.0+rocm7.0'")
+Check "gfx1151 wheel"        (Invoke-IsRocm "C:\v" "__version__ = '2.9.0+gfx1151'")
+Check "gfx110X-all wheel"    (Invoke-IsRocm "C:\v" "__version__ = '2.7.1+gfx110X.all'")
+Check "cuda wheel"           (-not (Invoke-IsRocm "C:\v" $CU))
+Check "xpu wheel"            (-not (Invoke-IsRocm "C:\v" $XPU))
+Check "untagged wheel"       (-not (Invoke-IsRocm "C:\v" $BARE))
+# version.py on a CUDA build carries `hip: Optional[str] = None`, and the ROCm builds carry a
+# `gfx` line of their own. Only the local label on __version__ decides, or a CUDA venv would be
+# kept as ROCm and never repaired.
+Check "hip attr but cuda wheel"  (-not (Invoke-IsRocm "C:\v" ($CU + "`nhip: Optional[str] = None")))
+Check "gfx attr but cuda wheel"  (-not (Invoke-IsRocm "C:\v" ($CU + "`ngfx = 'gfx1100'")))
+Check "no torch installed"   (-not (Invoke-IsRocm "C:\v" "__version__ = '2.8.0+rocm6.4'" -Missing))
+Check "unreadable file"      (-not (Invoke-IsRocm "C:\v" "__version__ = '2.8.0+rocm6.4'" -Throws))
+Check "no venv path"         (-not (Invoke-IsRocm "" "__version__ = '2.8.0+rocm6.4'"))
+
+# ---------------------------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Invoke-BoundedPythonProbe keeps the reason it failed ==="
+# Both installers carry a copy, so both are driven. The probe drained stderr and threw it away,
+# which made "the HIP DLLs will not load", "torch is not installed" and "the import never came
+# back" arrive at the caller as one silent False -- and the caller deletes the environment over
+# that answer. The bounding and the async drain must survive intact, so a real child process is
+# launched rather than a mock.
+$py = (Get-Command python3 -ErrorAction SilentlyContinue)
+if (-not $py) { $py = (Get-Command python -ErrorAction SilentlyContinue) }
+Check "an interpreter is available to probe" ($null -ne $py)
+
+foreach ($file in @("install.ps1", "studio/setup.ps1")) {
+    $path = Join-Path $root $file
+    Write-Host "--- $file"
+    foreach ($srcText in (Get-HelperSources $path @("Invoke-BoundedPythonProbe"))) {
+        Invoke-Expression $srcText
+    }
+    if ($py) {
+        $ok = Invoke-BoundedPythonProbe -PythonExe $py.Source -Code 'print(1 + 1)'
+        Check "a good probe still answers"        ($ok.Ok -and $ok.Output.Trim() -eq "2")
+        Check "a good probe reports no error"     ([string]::IsNullOrWhiteSpace($ok.Error))
+
+        # The shape of a driver fault: torch imports, the HIP DLLs do not load, python exits
+        # nonzero with the real cause on stderr and nothing on stdout.
+        $bad = Invoke-BoundedPythonProbe -PythonExe $py.Source -Code 'import sys; sys.stderr.write(chr(91) + chr(87) + chr(105) + chr(110) + chr(69) + chr(114) + chr(114) + chr(111) + chr(114) + chr(32) + chr(49) + chr(50) + chr(54) + chr(93)); sys.exit(1)'
+        Check "a failed probe still reads as not Ok" (-not $bad.Ok)
+        Check "the stderr text survives"             ($bad.Error -match 'WinError 126')
+        # Draining stdout is what stops a noisy import from deadlocking on a full pipe; keeping
+        # stderr must not have changed which stream is which.
+        Check "stderr does not leak into Output"     (-not ($bad.Output -match 'WinError'))
+
+        # A wedged import is the case the whole helper exists for. It must still be bounded, and
+        # it must now say that that is what happened.
+        $slow = Invoke-BoundedPythonProbe -PythonExe $py.Source -Code 'import time; time.sleep(45)' -TimeoutSec 1
+        Check "a hung probe is still bounded"        (-not $slow.Ok)
+        Check "a hung probe says it timed out"       ($slow.Error -match 'did not answer within')
+
+        Check "an empty code string is refused"      (-not (Invoke-BoundedPythonProbe -PythonExe $py.Source -Code '').Ok)
+    }
+    # No interpreter at that path at all: Process.Start throws, and the exception text is the
+    # only thing there is to report.
+    $gone = Invoke-BoundedPythonProbe -PythonExe (Join-Path $root "no-such-python-XYZ") -Code 'print(1)'
+    Check "a missing interpreter reads as not Ok"    (-not $gone.Ok)
+    Check "a missing interpreter reports why"        (-not [string]::IsNullOrWhiteSpace($gone.Error))
+}
+
+# ---------------------------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== source shapes ==="
+# Normalised to LF once, rather than per pattern: on a CRLF checkout every \n-anchored pattern
+# below matches nothing, and the -not checks over an empty region pass vacuously. That is a real
+# incident, not a hypothetical (see test_setup_xpu_runtime_prereport.ps1).
+$setupText = (Get-Content -Raw $setup) -replace "`r`n", "`n"
+
+Write-Host "the AMD WMI fallback survives a single-GPU host"
+# The trailing `\]\n` is what makes the CRLF check below bite: on a CRLF checkout the line ends
+# `[0]\r\n`, so the pattern fails rather than matching a region that is silently empty.
+$_wmiPat = '(?s)(\$amdGpus = @\(Get-CimInstance Win32_VideoController.*?\$ROCmGpuLabel = \$script:ROCmGpuLabels\[0\]\n)'
+$_wmi = if ($setupText -match $_wmiPat) { $Matches[1] } else { "" }
+Check "the WMI fallback was found"        ($_wmi -ne "")
+Check "CRLF is normalised, not tolerated" (-not (($setupText -replace "`n", "`r`n") -match $_wmiPat))
+# This is the #8335 assertion. It is a shape, not a behaviour: see the header.
+Check "the healthy/all choice is @() wrapped" (
+    $_wmi -match '\$wmiGpus = @\(if \(\$healthyGpus\.Count -gt 0\) \{ \$healthyGpus \} else \{ \$amdGpus \}\)')
+Check "the unwrapped form is gone"        (-not ($_wmi -match '\$wmiGpus = if \('))
+# The two lists it chooses between are wrapped for the same reason; the Where-Object above them
+# returns a scalar on a single match too.
+Check "the adapter list is @() wrapped"   ($_wmi -match '\$amdGpus = @\(Get-CimInstance')
+Check "the healthy list is @() wrapped"   ($_wmi -match '\$healthyGpus = @\(\$amdGpus \| Where-Object')
+
+Write-Host "a driver fault does not delete a ROCm venv"
+# Ends on `\{\n`, not on the comment text, for the same CRLF reason as above.
+$_rescuePat = '(?s)(\$_verProbe = Invoke-BoundedPythonProbe.*?\} else \{\n        # Missing python\.exe means)'
+$_rescue = if ($setupText -match $_rescuePat) { $Matches[1] } else { "" }
+Check "the probe chain was found"          ($_rescue -ne "")
+Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_rescuePat))
+Check "an unreadable flavour is rescued off disk" ($_rescue -match 'elseif \(Test-VenvTorchIsRocm -VenvPath \$VenvDir\)')
+Check "the rescue classifies it as rocm"   ($_rescue -match '(?s)elseif \(Test-VenvTorchIsRocm.*?\$installedTorchTag = "rocm"')
+# It must NOT set the rebuild flag, or the whole point is lost.
+Check "the rescue never sets shouldRebuild" (-not ($_rescue -match '(?s)elseif \(Test-VenvTorchIsRocm[^}]*\$shouldRebuild = \$true'))
+# The disk read is the point: launching a second interpreter after the first one hung is exactly
+# what the rescue is avoiding.
+Check "the rescue launches no interpreter" (-not ($_rescue -match '(?s)elseif \(Test-VenvTorchIsRocm.*?Invoke-BoundedPythonProbe'))
+# Matched on the substep ARGUMENT, not the region: the comment above the branch names the driver
+# too, so a loose match stays green with the message itself deleted.
+Check "the rescue names the driver fix"    ($_rescue -match 'substep "[^"]*Adrenalin')
+# Non-AMD, non-Intel families must still rebuild on an unreadable flavour, exactly as before.
+Check "other families still rebuild"       ($_rescue -match '(?s)\} else \{\s*\$shouldRebuild = \$true')
+# The XPU rescue this one is modelled on has to still be there, and ahead of it: an Arc box is
+# not an AMD box and its message names a different driver.
+Check "the XPU rescue is untouched"        ($_rescue -match 'elseif \(Test-VenvTorchIsXpu -VenvPath \$VenvDir\)')
+Check "XPU is judged before ROCm"          (
+    $_rescue.IndexOf('Test-VenvTorchIsXpu -VenvPath') -ge 0 -and
+    $_rescue.IndexOf('Test-VenvTorchIsXpu -VenvPath') -lt $_rescue.IndexOf('Test-VenvTorchIsRocm -VenvPath'))
+
+Write-Host "the stale-venv decision has no dead end left in it"
+# Starts on `\$null\n`, so a CRLF checkout fails the match instead of returning an empty region.
+$_repairPat = '(?s)(\$reason = \$null\n.*?Remove-Item -LiteralPath \$VenvDir -Recurse)'
+$_repair = if ($setupText -match $_repairPat) { $Matches[1] } else { "" }
+Check "the stale-venv decision was found"  ($_repair -ne "")
+Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_repairPat))
+# The abort itself. install.ps1 is the caller under $InstallerManagedSetup, it moved the previous
+# environment aside earlier in the same run, and its failure path moves it straight back -- so
+# exiting here landed on the byte-identical starting state and the next run reached the same
+# verdict. Nothing in that cycle can converge. Bounded to the branch: the delete below still
+# has two legitimate Exit-SetupFailure calls of its own.
+$_managedPat = '(?s)(if \(\$shouldRebuild -and \$InstallerManagedSetup\) \{.*?\n    \}\n)'
+$_managed = if ($_repair -match $_managedPat) { $Matches[1] } else { "" }
+Check "the installer-managed branch was found" ($_managed -ne "")
+Check "an installer-managed run does not abort" (-not ($_managed -match 'Exit-SetupFailure'))
+# Matched on the Write-StudioLine ARGUMENT, so the comment above the branch, which quotes the
+# old advice to explain why it went, cannot keep this green on its own.
+Check "the advice that pointed at itself is gone" (
+    -not ($setupText -match 'Write-StudioLine "\s*Re-run install\.ps1'))
+Check "the abort message is gone too"      (-not ($setupText -match 'The existing Unsloth environment needs repair'))
+# What replaces it: the same in-place repair an index-pin change and a cu* family change already
+# take, which every torch install arm below honours with --force-reinstall.
+Check "an installer-managed run repairs in place" ($_managed -match '\$script:PinChangedForceReinstall = \$true')
+Check "and clears the rebuild flag"        ($_managed -match '\$shouldRebuild = \$false')
+# Deleting was never available on this path anyway: install.ps1 runs setup through the venv's own
+# unsloth.exe, so python.exe is locked by the process executing the script.
+Check "it does not try to wipe the venv it runs from" (-not ($_managed -match 'Remove-Item'))
+# A direct `unsloth studio update` keeps its own self-repair, and the custom-home guard that
+# stops it wiping an unrelated environment stays in front of the delete.
+Check "a direct update still rebuilds"     ($_repair -match 'Stale venv detected \(\$reason\) -- rebuilding')
+Check "the custom-home guard still gates the wipe" ($_repair -match '\$StudioHomeIsCustom')
+# Why it failed, not just that it failed: this is the line that separates a faulted GPU driver
+# from a missing wheel, and the user is about to be told what happened to their environment.
+Check "the swallowed probe error is surfaced" ($_repair -match '\$_verProbe\.Error')
+Check "the probe handle is declared up front" ($setupText -match '(?m)^\s*\$_verProbe = \$null')
+
+Write-Host ""
+if ($failures -gt 0) { Write-Host "$failures check(s) FAILED" -ForegroundColor Red; exit 1 }
+Write-Host "All checks passed" -ForegroundColor Green

--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -4,19 +4,34 @@
 # A single-AMD-GPU host must not install itself into a loop (#8335).
 #
 # Two defects met on that host. WMI found exactly one Radeon, the if-expression holding it
-# unrolled to a scalar, and a scalar's .Count is $null under Windows PowerShell 5.1, so setup
+# unrolled to a scalar, that scalar's .Count read $null under Windows PowerShell 5.1, so setup
 # reported "gpu none" and judged the installed ROCm venv stale against a required "cpu". The
 # stale branch under install.ps1 then aborted with "re-run install.ps1", install.ps1's failure
 # path restored the previous environment, and the next run reached the same verdict. Nothing
 # about that pair converges, which is why the same abort has been reported from four unrelated
 # triggers (#5942, #7275, #8335, and a driver crash on Discord).
 #
-# Read this before adding a case: PowerShell 7 returns .Count = 1 for a scalar, so the pwsh that
-# runs this file CANNOT reproduce the 5.1 half of #8335. What it can do is prove the unroll
-# itself still happens here, and assert the @() wrap that fixes it as a source shape. The 5.1
-# leg lives in CI. No check below claims otherwise.
+# Read this before adding a case, because the obvious repro does not work. It is NOT true that
+# "a scalar's .Count is $null on 5.1" -- a String or an Int32 answers 1 there, exactly as on 7,
+# and anyone checking the claim that way concludes there is no bug. $null comes back only for
+# objects whose PSObject carries no Count of its own: [pscustomobject], which Microsoft
+# documents, and Microsoft.Management.Infrastructure.CimInstance, which it does not. The WMI
+# fallback assigns the second kind. Measured on windows-latest, PowerShell 5.1.26100.33158
+# (Desktop) against a real Get-CimInstance result, with pwsh 7.6.4 on the same runner:
+#
+#   value                       5.1 .Count   7 .Count
+#   'a'                         1            1
+#   [pscustomobject]@{...}      $null        1
+#   CimInstance (one instance)  $null        1
+#   @(if (...) { ... })         1            1
+#
+# So this file adapts to the host instead of claiming one answer. Under 5.1 it reproduces #8335
+# for real, on any Windows machine, with no AMD GPU required. Under pwsh 7 -- including the pwsh
+# on Linux that most contributors run -- the unroll still happens but the consequence does not,
+# so those cases assert the source shape and say so. Every check states which it is.
 #
 # Run: pwsh -NoProfile -File tests/studio/test_amd_venv_repair_loop.ps1
+#  or: powershell -NoProfile -File tests\studio\test_amd_venv_repair_loop.ps1   (5.1, Windows)
 
 $ErrorActionPreference = "Stop"
 $root = (Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, "..", ".."))).Path
@@ -53,20 +68,64 @@ function Write-StudioStdoutMirror { param([string]$Line) }
 
 # ---------------------------------------------------------------------------------------------
 Write-Host ""
-Write-Host "=== the unroll this pwsh CAN see ==="
-# The bug is the unroll, and it happens on every PowerShell. What differs is only the
-# consequence: 5.1 answers $null to a scalar's .Count and 7 answers 1, so the "-gt 0" test that
-# follows is false there and true here. Hence the source assertion further down.
+Write-Host "=== the unroll, and what this host does with it ==="
+$psMajor = $PSVersionTable.PSVersion.Major
+$is51 = ($psMajor -lt 6)
+Write-Host "  host: PowerShell $($PSVersionTable.PSVersion) ($($PSVersionTable.PSEdition))"
+
+# The unroll itself is not version-specific and happens everywhere, so it is asserted flat.
 $oneGpu = @("AMD Radeon PRO W7900")
 $unwrapped = if ($oneGpu.Count -gt 0) { $oneGpu } else { @() }
 $wrapped = @(if ($oneGpu.Count -gt 0) { $oneGpu } else { @() })
-Check "an if-expression unrolls a one-element array here too" (-not ($unwrapped -is [array]))
-Check "the @() wrap keeps it an array"                        ($wrapped -is [array])
-Check "the wrapped value still counts one GPU"                ($wrapped.Count -eq 1)
-# Stated as a check so it cannot quietly stop being true, and so nobody reads the file as a 5.1
-# repro: on 5.1 this same expression answers $null.
-Check "this pwsh answers 1, not `$null, to a scalar .Count"   ($unwrapped.Count -eq 1)
-Check "so the harness is PowerShell 7, not 5.1"               ($PSVersionTable.PSVersion.Major -ge 6)
+Check "an if-expression unrolls a one-element array" (-not ($unwrapped -is [array]))
+Check "the @() wrap keeps it an array"               ($wrapped -is [array])
+Check "the wrapped value still counts one GPU"       ($wrapped.Count -eq 1)
+
+# The consequence IS version-specific, and only for some types. Pinning the string case stops
+# the file from being read as "5.1 returns $null for scalars", which is what makes this defect
+# so easy to dismiss: it does not.
+Check "a String scalar answers 1 on every PowerShell" ((("x")).Count -eq 1)
+Check "so does the unrolled string array"             ($unwrapped.Count -eq 1)
+
+# The type that actually bites. [pscustomobject] is the portable stand-in for CimInstance --
+# same split, and available on the Linux pwsh where most of this suite runs.
+$_countless = ([pscustomobject]@{ Name = "AMD Radeon PRO W7900" }).Count
+if ($is51) {
+    Check "5.1: a Count-less scalar answers `$null"   ($null -eq $_countless)
+} else {
+    Check "7: a Count-less scalar answers 1"          ($_countless -eq 1)
+}
+
+# ---------------------------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== #8335 itself, against a real CIM instance ==="
+# Windows only, because Get-CimInstance is. Win32_OperatingSystem always returns exactly one
+# instance, so it reproduces "the machine has exactly one AMD GPU" on any Windows host without
+# an AMD GPU -- which is the whole reason this defect never showed up in CI. On 5.1 this is a
+# real repro of #8335 and a real regression test for the @() wrap. $IsWindows does not exist on
+# 5.1, where the answer is Windows by construction.
+if ($is51 -or $IsWindows) {
+    $_cim = @(Get-CimInstance Win32_OperatingSystem -ErrorAction SilentlyContinue)
+    Check "exactly one CIM instance to work with" ($_cim.Count -eq 1)
+    if ($_cim.Count -eq 1) {
+        # Byte-for-byte the shape of the WMI fallback, old form and new.
+        $_old = if ($_cim.Count -gt 0) { $_cim } else { @() }
+        $_new = @(if ($_cim.Count -gt 0) { $_cim } else { @() })
+        Check "the unwrapped form is a bare CimInstance" (
+            $_old -is [Microsoft.Management.Infrastructure.CimInstance])
+        Check "the @() wrapped form stays an array"      ($_new -is [array])
+        # `if ($wmiGpus.Count -gt 0)` is the line that gates $script:ROCmGpuLabels. This is the
+        # bug and the fix, stated as the guard actually reads.
+        Check "the @() wrap makes the GPU-label branch fire" ($_new.Count -gt 0)
+        if ($is51) {
+            Check "5.1: the OLD form loses the only adapter (#8335)" (-not ($_old.Count -gt 0))
+        } else {
+            Check "7: the OLD form survives, so 7 cannot see #8335"  ($_old.Count -gt 0)
+        }
+    }
+} else {
+    Write-Host "  SKIP  not Windows, Get-CimInstance unavailable (source shapes below still run)"
+}
 
 # ---------------------------------------------------------------------------------------------
 Write-Host ""
@@ -113,15 +172,30 @@ Test-VenvTorchIsRocm -VenvPath '$VenvPath'
 $XPU  = "__version__ = '2.9.1+xpu'`ndebug = False"
 $CU   = "__version__ = '2.9.1+cu128'`ncuda: Optional[str] = '12.8'"
 $BARE = "__version__ = '2.9.1'"
-# download.pytorch.org labels the wheel +rocmX.Y; the AMD Windows wheels label it +gfxNNNN. Both
-# are ROCm builds and the reporter of #8335 was running the second kind.
+# Read off the indexes rather than assumed. repo.amd.com/rocm/whl/<arch>/torch/ -- the only place
+# Windows ROCm wheels exist -- publishes a THREE-component label and puts the arch in the URL, not
+# the version: torch-2.11.0+rocm7.13.0-cp312-cp312-win_amd64.whl, which is what the #8335 reporter
+# ended up on. download.pytorch.org/whl/rocm6.4 publishes the two-component 2.8.0+rocm6.4, Linux
+# only. So "+rocm" is the label that matters; the "+gfx" arm is defensive, and asserted here so
+# that stays deliberate rather than becoming an unexamined claim about what AMD ships.
 Check "rocm6.4 wheel"        (Invoke-IsRocm "C:\v" "__version__ = '2.8.0+rocm6.4'")
 Check "rocm7.0 wheel"        (Invoke-IsRocm "C:\v" "__version__ = '2.9.0+rocm7.0'")
+# The label the #8335 reporter actually ended up with once the WMI fix was applied, quoted from
+# the issue. Three-part, so it is also the case a two-part `+rocm\d+\.\d+$` anchor would miss.
+Check "rocm7.13.0 wheel (#8335)" (Invoke-IsRocm "C:\v" "__version__ = '2.11.0+rocm7.13.0'")
 Check "gfx1151 wheel"        (Invoke-IsRocm "C:\v" "__version__ = '2.9.0+gfx1151'")
 Check "gfx110X-all wheel"    (Invoke-IsRocm "C:\v" "__version__ = '2.7.1+gfx110X.all'")
+# A dev/nightly release segment sits before the local label, so it must not shift the match.
+Check "nightly rocm wheel"   (Invoke-IsRocm "C:\v" "__version__ = '2.12.0.dev20260801+rocm7.2'")
+Check "nightly cuda wheel"   (-not (Invoke-IsRocm "C:\v" "__version__ = '2.12.0.dev20260801+cu130'"))
+# A source build carries a git hash where the flavour would be, and is not a ROCm wheel.
+Check "source build"         (-not (Invoke-IsRocm "C:\v" "__version__ = '2.9.0a0+git1a2b3c'"))
 Check "cuda wheel"           (-not (Invoke-IsRocm "C:\v" $CU))
 Check "xpu wheel"            (-not (Invoke-IsRocm "C:\v" $XPU))
 Check "untagged wheel"       (-not (Invoke-IsRocm "C:\v" $BARE))
+Check "cpu wheel"            (-not (Invoke-IsRocm "C:\v" "__version__ = '2.10.0+cpu'"))
+# git_version is a real line in torch/version.py and can name a branch. Only __version__ decides.
+Check "gfx in git_version"   (-not (Invoke-IsRocm "C:\v" ($CU + "`ngit_version = 'rocm-branch-gfx1100'")))
 # version.py on a CUDA build carries `hip: Optional[str] = None`, and the ROCm builds carry a
 # `gfx` line of their own. Only the local label on __version__ decides, or a CUDA venv would be
 # kept as ROCm and never repaired.
@@ -262,6 +336,88 @@ Check "the custom-home guard still gates the wipe" ($_repair -match '\$StudioHom
 # from a missing wheel, and the user is about to be told what happened to their environment.
 Check "the swallowed probe error is surfaced" ($_repair -match '\$_verProbe\.Error')
 Check "the probe handle is declared up front" ($setupText -match '(?m)^\s*\$_verProbe = \$null')
+# Read by four install arms to decide --force-reinstall, and raised by the repair above, but
+# assigned only inside the venv-exists block -- so on a fresh install every one of those reads is
+# of a variable that was never created. Harmless bare (falsy, which is the wanted answer), fatal
+# under a caller's Set-StrictMode. Same treatment as $installedTorchTag right above it.
+Check "the force-reinstall flag is declared outside the venv block" (
+    $setupText -match '(?m)^\$script:PinChangedForceReinstall = \$false$')
+
+Write-Host "the surfaced probe error survives a stderr that is only whitespace"
+# The guard is `-and $_verProbe.Error`, and a stderr of blank lines passes it. Where-Object then
+# drops every one of them. Indexing [0] into what that leaves is fatal under a caller's
+# Set-StrictMode -- and studio/setup.bat launches setup WITHOUT -NoProfile, so a profile can set
+# one. Driven for real rather than asserted as a shape, with the replaced form as a control.
+$_strictNewOk = $true
+try {
+    & {
+        Set-StrictMode -Version Latest
+        $probe = [pscustomobject]@{ Ok = $false; Output = ""; Error = "   `r`n`r`n  " }
+        if ($probe -and -not $probe.Ok -and $probe.Error) {
+            $line = $probe.Error -split "`r?`n" | Where-Object { $_.Trim() } | Select-Object -Last 1
+            if ($line) { $null = $line.Trim() }
+        }
+    }
+} catch { $script:_strictNewOk = $false; Write-Host "    threw: $($_.Exception.Message)" }
+Check "the shipped form does not throw under strict mode" $_strictNewOk
+
+$_strictOldThrew = $false
+try {
+    & {
+        Set-StrictMode -Version Latest
+        $probe = [pscustomobject]@{ Error = "   `r`n`r`n  " }
+        $null = @($probe.Error -split "`r?`n" | Where-Object { $_.Trim() } | Select-Object -Last 1)[0]
+    }
+} catch { $script:_strictOldThrew = $true }
+# Without this the check above would pass on any rewrite, including one that never had the bug.
+Check "the @(...)[0] form it replaced really did throw" $_strictOldThrew
+Check "setup.ps1 no longer indexes that pipeline" (
+    -not ($setupText -match 'Select-Object -Last 1\)\[0\]'))
+# A real one-line stderr must still be picked up, or the whole point of keeping it is lost.
+$_realErr = "Traceback (most recent call last):`r`nOSError: [WinError 126] The specified module could not be found"
+$_realLine = $_realErr -split "`r?`n" | Where-Object { $_.Trim() } | Select-Object -Last 1
+Check "a real stderr still yields its last line" ($_realLine -match 'WinError 126')
+
+Write-Host ""
+Write-Host "=== an interpreter-less venv is not repaired in place, it is refused ==="
+# The one state the in-place repair made WORSE than the abort it replaced. A venv directory
+# with no Scripts\python.exe is incomplete, not stale: there is no interpreter to force-reinstall
+# torch through. The abort used to catch it by accident, because it caught every stale verdict.
+#
+# Without a guard it now reaches the activation, and that is a dot-source of a path that does
+# not exist -- which is NOT a terminating error at the "Continue" the pip section runs at. So
+# setup prints one red line and keeps going, and every `python` / `uv pip` after it resolves
+# against whatever interpreter is on PATH. The whole stack lands outside the venv and the run
+# can still exit 0. Prove the hazard first, so the guard below is not asserted on faith.
+$_dotSourceKeptGoing = $false
+& {
+    $ErrorActionPreference = "Continue"
+    . (Join-Path $root "no-such-Activate-XYZ.ps1")
+    $script:_dotSourceKeptGoing = $true
+} 2>$null
+Check "dot-sourcing a missing script does not stop the script" $_dotSourceKeptGoing
+
+# Bounded to the reuse branch: the "not found" branch above it has an Exit-SetupFailure of its
+# own, and matching the whole region would pass on that one. Both ends sit immediately after a
+# non-newline token, so a CRLF checkout fails the match instead of yielding an empty region.
+$_reusePat = '(?s)(substep "reusing existing virtual environment at \$VenvDir"\n.*?Exit-SetupFailure "No interpreter at [^\n]*\n)'
+$_reuse = if ($setupText -match $_reusePat) { $Matches[1] } else { "" }
+Check "the reuse branch was found"         ($_reuse -ne "")
+Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_reusePat))
+Check "it refuses a venv with no interpreter" ($_reuse -match '(?s)\} else \{.*?Exit-SetupFailure "No interpreter at')
+# It must fail rather than fall through, and it must do so BEFORE the dot-source, or the
+# hazard proven above is still live.
+Check "the refusal precedes the activation" (
+    $setupText.IndexOf('Exit-SetupFailure "No interpreter at') -lt
+    $setupText.IndexOf('$ActivateScript = Join-Path $VenvDir'))
+# Not a wipe: install.ps1 is holding the rollback copy and this venv may be the only place the
+# previous one's contents still are.
+Check "it does not delete the venv"        (-not ($_reuse -match 'Remove-Item'))
+# The message has to say incomplete, not stale, or it reads as the loop-causing advice again.
+Check "it says incomplete, not out of date" ($_reuse -match 'incomplete rather than out of date')
+# A healthy venv must be untouched by all of this.
+Check "a venv with an interpreter still just prints its version" (
+    $_reuse -match '(?s)if \(Test-Path -LiteralPath \$_venvPyExe\) \{.*?--version')
 
 Write-Host ""
 if ($failures -gt 0) { Write-Host "$failures check(s) FAILED" -ForegroundColor Red; exit 1 }

--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -3,21 +3,20 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 # A single-AMD-GPU host must not install itself into a loop (#8335).
 #
-# Two defects met on that host. WMI found exactly one Radeon, the if-expression holding it
-# unrolled to a scalar, that scalar's .Count read $null under Windows PowerShell 5.1, so setup
-# reported "gpu none" and judged the installed ROCm venv stale against a required "cpu". The
-# stale branch under install.ps1 then aborted with "re-run install.ps1", install.ps1's failure
-# path restored the previous environment, and the next run reached the same verdict. Nothing
-# about that pair converges, which is why the same abort has been reported from four unrelated
-# triggers (#5942, #7275, #8335, and a driver crash on Discord).
+# Two defects met there. WMI found exactly one Radeon, the if-expression holding it unrolled to a
+# scalar, that scalar's .Count read $null under Windows PowerShell 5.1, so setup reported "gpu
+# none" and judged the installed ROCm venv stale against a required "cpu". The stale branch under
+# install.ps1 then aborted, install.ps1's failure path restored the previous environment, and the
+# next run reached the same verdict -- which is why that abort has been reported from four
+# unrelated triggers (#5942, #7275, #8335, and a driver crash on Discord).
 #
-# Read this before adding a case, because the obvious repro does not work. It is NOT true that
-# "a scalar's .Count is $null on 5.1" -- a String or an Int32 answers 1 there, exactly as on 7,
-# and anyone checking the claim that way concludes there is no bug. $null comes back only for
-# objects whose PSObject carries no Count of its own: [pscustomobject], which Microsoft
-# documents, and Microsoft.Management.Infrastructure.CimInstance, which it does not. The WMI
-# fallback assigns the second kind. Measured on windows-latest, PowerShell 5.1.26100.33158
-# (Desktop) against a real Get-CimInstance result, with pwsh 7.6.4 on the same runner:
+# Read this before adding a case, because the obvious repro does not work. It is NOT true that "a
+# scalar's .Count is $null on 5.1": a String or an Int32 answers 1 there exactly as on 7, so
+# anyone checking the claim that way concludes there is no bug. $null comes back only for objects
+# whose PSObject carries no Count of its own -- [pscustomobject], which Microsoft documents, and
+# CimInstance, which it does not, and the WMI fallback assigns the second kind. Measured on
+# windows-latest, PowerShell 5.1.26100.33158 (Desktop) against a real Get-CimInstance result, with
+# pwsh 7.6.4 on the same runner:
 #
 #   value                       5.1 .Count   7 .Count
 #   'a'                         1            1
@@ -25,10 +24,10 @@
 #   CimInstance (one instance)  $null        1
 #   @(if (...) { ... })         1            1
 #
-# So this file adapts to the host instead of claiming one answer. Under 5.1 it reproduces #8335
-# for real, on any Windows machine, with no AMD GPU required. Under pwsh 7 -- including the pwsh
-# on Linux that most contributors run -- the unroll still happens but the consequence does not,
-# so those cases assert the source shape and say so. Every check states which it is.
+# So this file adapts to the host: under 5.1 it reproduces #8335 for real on any Windows machine
+# with no AMD GPU required, and under pwsh 7 (including the Linux pwsh most contributors run) the
+# unroll still happens but the consequence does not, so those cases assert the source shape. Every
+# check states which it is.
 #
 # Run: pwsh -NoProfile -File tests/studio/test_amd_venv_repair_loop.ps1
 #  or: powershell -NoProfile -File tests\studio\test_amd_venv_repair_loop.ps1   (5.1, Windows)
@@ -43,9 +42,8 @@ function Check($name, $cond) {
     else { Write-Host "  FAIL  $name" -ForegroundColor Red; $script:failures++ }
 }
 
-# Returns the source text of each named function. The caller Invoke-Expression's it at script
-# scope; doing that inside a function would lose the helpers on return. Recursive, so it also
-# reaches install.ps1's copies, which live inside Install-UnslothStudio.
+# Source text of each named function, Invoke-Expression'd at script scope by the caller (inside a
+# function the helpers would be lost on return). Recursive, so it reaches install.ps1's copies too.
 function Get-HelperSources($path, $names) {
     $tokens = $null; $errors = $null
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$errors)
@@ -61,8 +59,7 @@ function Get-HelperSources($path, $names) {
     return $out
 }
 
-# Stubs for the installers' printers, so this file does not depend on the ANSI helpers.
-# Both use Write-Host, so neither can pollute a function's return value.
+# Stubs for the installers' printers. Both use Write-Host, so neither pollutes a return value.
 function substep { param([string]$Message, [string]$Color = "DarkGray") }
 function Write-StudioStdoutMirror { param([string]$Line) }
 
@@ -81,14 +78,13 @@ Check "an if-expression unrolls a one-element array" (-not ($unwrapped -is [arra
 Check "the @() wrap keeps it an array"               ($wrapped -is [array])
 Check "the wrapped value still counts one GPU"       ($wrapped.Count -eq 1)
 
-# The consequence IS version-specific, and only for some types. Pinning the string case stops
-# the file from being read as "5.1 returns $null for scalars", which is what makes this defect
-# so easy to dismiss: it does not.
+# The consequence IS version-specific, and only for some types. Pinning the String case stops this
+# being read as "5.1 returns $null for scalars", which is what makes the defect easy to dismiss.
 Check "a String scalar answers 1 on every PowerShell" ((("x")).Count -eq 1)
 Check "so does the unrolled string array"             ($unwrapped.Count -eq 1)
 
-# The type that actually bites. [pscustomobject] is the portable stand-in for CimInstance --
-# same split, and available on the Linux pwsh where most of this suite runs.
+# The type that bites. [pscustomobject] is the portable CimInstance stand-in: same split, and
+# available on the Linux pwsh where most of this suite runs.
 $_countless = ([pscustomobject]@{ Name = "AMD Radeon PRO W7900" }).Count
 if ($is51) {
     Check "5.1: a Count-less scalar answers `$null"   ($null -eq $_countless)
@@ -100,10 +96,9 @@ if ($is51) {
 Write-Host ""
 Write-Host "=== #8335 itself, against a real CIM instance ==="
 # Windows only, because Get-CimInstance is. Win32_OperatingSystem always returns exactly one
-# instance, so it reproduces "the machine has exactly one AMD GPU" on any Windows host without
-# an AMD GPU -- which is the whole reason this defect never showed up in CI. On 5.1 this is a
-# real repro of #8335 and a real regression test for the @() wrap. $IsWindows does not exist on
-# 5.1, where the answer is Windows by construction.
+# instance, so it reproduces "exactly one AMD GPU" on any Windows host without one -- which is why
+# this defect never showed up in CI. On 5.1 it is a real repro of #8335 and a real regression test
+# for the @() wrap. $IsWindows does not exist on 5.1, where the answer is Windows by construction.
 if ($is51 -or $IsWindows) {
     $_cim = @(Get-CimInstance Win32_OperatingSystem -ErrorAction SilentlyContinue)
     Check "exactly one CIM instance to work with" ($_cim.Count -eq 1)
@@ -114,8 +109,8 @@ if ($is51 -or $IsWindows) {
         Check "the unwrapped form is a bare CimInstance" (
             $_old -is [Microsoft.Management.Infrastructure.CimInstance])
         Check "the @() wrapped form stays an array"      ($_new -is [array])
-        # `if ($wmiGpus.Count -gt 0)` is the line that gates $script:ROCmGpuLabels. This is the
-        # bug and the fix, stated as the guard actually reads.
+        # `if ($wmiGpus.Count -gt 0)` is the line that gates $script:ROCmGpuLabels: the bug and
+        # the fix, stated as the guard actually reads.
         Check "the @() wrap makes the GPU-label branch fire" ($_new.Count -gt 0)
         if ($is51) {
             Check "5.1: the OLD form loses the only adapter (#8335)" (-not ($_old.Count -gt 0))
@@ -130,14 +125,12 @@ if ($is51 -or $IsWindows) {
 # ---------------------------------------------------------------------------------------------
 Write-Host ""
 Write-Host "=== Test-VenvTorchIsRocm reads the wheel off disk ==="
-# The AMD counterpart of Test-VenvTorchIsXpu. It exists so a faulted HIP runtime -- an
-# `import torch` that raises at the DLL load or never returns -- does not get answered by
-# deleting a perfectly good ROCm environment. Free by design: no interpreter is launched, so a
-# CPU-only host pays nothing for it on every update.
+# The AMD counterpart of Test-VenvTorchIsXpu, so a faulted HIP runtime -- an `import torch` that
+# raises at the DLL load or never returns -- is not answered by deleting a good ROCm environment.
+# Free by design: no interpreter is launched, so a CPU-only host pays nothing on every update.
 foreach ($srcText in (Get-HelperSources $setup @("Test-VenvTorchIsRocm"))) { Invoke-Expression $srcText }
-# @() around the call, then [0]: a one-name request returns a one-element array, which unrolls
-# to a String on the way out, and [0] on a String is its first character. The same unroll this
-# file is about, one directory over.
+# @() around the call, then [0]: a one-name request returns a one-element array that unrolls to a
+# String on the way out, and [0] on a String is its first character. The same unroll, one file over.
 $isRocmFn = @(Get-HelperSources $setup @("Test-VenvTorchIsRocm"))[0]
 # An empty or wrong extraction would make every case below pass vacuously.
 Check "extraction kept the version file" ($isRocmFn -match 'version\.py')
@@ -172,16 +165,14 @@ Test-VenvTorchIsRocm -VenvPath '$VenvPath'
 $XPU  = "__version__ = '2.9.1+xpu'`ndebug = False"
 $CU   = "__version__ = '2.9.1+cu128'`ncuda: Optional[str] = '12.8'"
 $BARE = "__version__ = '2.9.1'"
-# Read off the indexes rather than assumed. repo.amd.com/rocm/whl/<arch>/torch/ -- the only place
-# Windows ROCm wheels exist -- publishes a THREE-component label and puts the arch in the URL, not
-# the version: torch-2.11.0+rocm7.13.0-cp312-cp312-win_amd64.whl, which is what the #8335 reporter
-# ended up on. download.pytorch.org/whl/rocm6.4 publishes the two-component 2.8.0+rocm6.4, Linux
-# only. So "+rocm" is the label that matters; the "+gfx" arm is defensive, and asserted here so
-# that stays deliberate rather than becoming an unexamined claim about what AMD ships.
+# Read off the indexes, not assumed. repo.amd.com/rocm/whl/<arch>/torch/ -- the only place Windows
+# ROCm wheels exist -- publishes a THREE-component label with the arch in the URL, not the version
+# (torch-2.11.0+rocm7.13.0-cp312-cp312-win_amd64.whl, what the #8335 reporter ended up on);
+# download.pytorch.org/whl/rocm6.4 publishes the two-component 2.8.0+rocm6.4, Linux only. So
+# "+rocm" is the label that matters and the "+gfx" arm is defensive, asserted here to stay so.
 Check "rocm6.4 wheel"        (Invoke-IsRocm "C:\v" "__version__ = '2.8.0+rocm6.4'")
 Check "rocm7.0 wheel"        (Invoke-IsRocm "C:\v" "__version__ = '2.9.0+rocm7.0'")
-# The label the #8335 reporter actually ended up with once the WMI fix was applied, quoted from
-# the issue. Three-part, so it is also the case a two-part `+rocm\d+\.\d+$` anchor would miss.
+# Three-part, so also the case a two-part `+rocm\d+\.\d+$` anchor would miss.
 Check "rocm7.13.0 wheel (#8335)" (Invoke-IsRocm "C:\v" "__version__ = '2.11.0+rocm7.13.0'")
 Check "gfx1151 wheel"        (Invoke-IsRocm "C:\v" "__version__ = '2.9.0+gfx1151'")
 Check "gfx110X-all wheel"    (Invoke-IsRocm "C:\v" "__version__ = '2.7.1+gfx110X.all'")
@@ -196,9 +187,8 @@ Check "untagged wheel"       (-not (Invoke-IsRocm "C:\v" $BARE))
 Check "cpu wheel"            (-not (Invoke-IsRocm "C:\v" "__version__ = '2.10.0+cpu'"))
 # git_version is a real line in torch/version.py and can name a branch. Only __version__ decides.
 Check "gfx in git_version"   (-not (Invoke-IsRocm "C:\v" ($CU + "`ngit_version = 'rocm-branch-gfx1100'")))
-# version.py on a CUDA build carries `hip: Optional[str] = None`, and the ROCm builds carry a
-# `gfx` line of their own. Only the local label on __version__ decides, or a CUDA venv would be
-# kept as ROCm and never repaired.
+# A CUDA build's version.py carries `hip: Optional[str] = None` and ROCm builds carry a `gfx` line,
+# so only the local label on __version__ decides, or a CUDA venv would be kept as ROCm forever.
 Check "hip attr but cuda wheel"  (-not (Invoke-IsRocm "C:\v" ($CU + "`nhip: Optional[str] = None")))
 Check "gfx attr but cuda wheel"  (-not (Invoke-IsRocm "C:\v" ($CU + "`ngfx = 'gfx1100'")))
 Check "no torch installed"   (-not (Invoke-IsRocm "C:\v" "__version__ = '2.8.0+rocm6.4'" -Missing))
@@ -208,11 +198,10 @@ Check "no venv path"         (-not (Invoke-IsRocm "" "__version__ = '2.8.0+rocm6
 # ---------------------------------------------------------------------------------------------
 Write-Host ""
 Write-Host "=== Invoke-BoundedPythonProbe keeps the reason it failed ==="
-# Both installers carry a copy, so both are driven. The probe drained stderr and threw it away,
-# which made "the HIP DLLs will not load", "torch is not installed" and "the import never came
-# back" arrive at the caller as one silent False -- and the caller deletes the environment over
-# that answer. The bounding and the async drain must survive intact, so a real child process is
-# launched rather than a mock.
+# Both installers carry a copy, so both are driven. The probe drained stderr and threw it away, so
+# "the HIP DLLs will not load", "torch is not installed" and "the import never came back" arrived
+# at the caller as one silent False -- and the caller deletes the environment over that answer.
+# The bounding and the async drain must survive intact, so a real child process is launched.
 $py = (Get-Command python3 -ErrorAction SilentlyContinue)
 if (-not $py) { $py = (Get-Command python -ErrorAction SilentlyContinue) }
 Check "an interpreter is available to probe" ($null -ne $py)
@@ -233,20 +222,17 @@ foreach ($file in @("install.ps1", "studio/setup.ps1")) {
         $bad = Invoke-BoundedPythonProbe -PythonExe $py.Source -Code 'import sys; sys.stderr.write(chr(91) + chr(87) + chr(105) + chr(110) + chr(69) + chr(114) + chr(114) + chr(111) + chr(114) + chr(32) + chr(49) + chr(50) + chr(54) + chr(93)); sys.exit(1)'
         Check "a failed probe still reads as not Ok" (-not $bad.Ok)
         Check "the stderr text survives"             ($bad.Error -match 'WinError 126')
-        # Draining stdout is what stops a noisy import from deadlocking on a full pipe; keeping
-        # stderr must not have changed which stream is which.
+        # Keeping stderr must not have changed which stream is which.
         Check "stderr does not leak into Output"     (-not ($bad.Output -match 'WinError'))
 
-        # A wedged import is the case the whole helper exists for. It must still be bounded, and
-        # it must now say that that is what happened.
+        # The case the helper exists for: still bounded, and now says so.
         $slow = Invoke-BoundedPythonProbe -PythonExe $py.Source -Code 'import time; time.sleep(45)' -TimeoutSec 1
         Check "a hung probe is still bounded"        (-not $slow.Ok)
         Check "a hung probe says it timed out"       ($slow.Error -match 'did not answer within')
 
         Check "an empty code string is refused"      (-not (Invoke-BoundedPythonProbe -PythonExe $py.Source -Code '').Ok)
     }
-    # No interpreter at that path at all: Process.Start throws, and the exception text is the
-    # only thing there is to report.
+    # No interpreter at that path: Process.Start throws, and its text is all there is to report.
     $gone = Invoke-BoundedPythonProbe -PythonExe (Join-Path $root "no-such-python-XYZ") -Code 'print(1)'
     Check "a missing interpreter reads as not Ok"    (-not $gone.Ok)
     Check "a missing interpreter reports why"        (-not [string]::IsNullOrWhiteSpace($gone.Error))
@@ -255,14 +241,14 @@ foreach ($file in @("install.ps1", "studio/setup.ps1")) {
 # ---------------------------------------------------------------------------------------------
 Write-Host ""
 Write-Host "=== source shapes ==="
-# Normalised to LF once, rather than per pattern: on a CRLF checkout every \n-anchored pattern
-# below matches nothing, and the -not checks over an empty region pass vacuously. That is a real
-# incident, not a hypothetical (see test_setup_xpu_runtime_prereport.ps1).
+# Normalised to LF once rather than per pattern: on a CRLF checkout every \n-anchored pattern below
+# matches nothing and the -not checks over an empty region pass vacuously. A real incident, not a
+# hypothetical (see test_setup_xpu_runtime_prereport.ps1).
 $setupText = (Get-Content -Raw $setup) -replace "`r`n", "`n"
 
 Write-Host "the AMD WMI fallback survives a single-GPU host"
 # The trailing `\]\n` is what makes the CRLF check below bite: on a CRLF checkout the line ends
-# `[0]\r\n`, so the pattern fails rather than matching a region that is silently empty.
+# `[0]\r\n`, so the pattern fails rather than matching a silently empty region.
 $_wmiPat = '(?s)(\$amdGpus = @\(Get-CimInstance Win32_VideoController.*?\$ROCmGpuLabel = \$script:ROCmGpuLabels\[0\]\n)'
 $_wmi = if ($setupText -match $_wmiPat) { $Matches[1] } else { "" }
 Check "the WMI fallback was found"        ($_wmi -ne "")
@@ -271,8 +257,7 @@ Check "CRLF is normalised, not tolerated" (-not (($setupText -replace "`n", "`r`
 Check "the healthy/all choice is @() wrapped" (
     $_wmi -match '\$wmiGpus = @\(if \(\$healthyGpus\.Count -gt 0\) \{ \$healthyGpus \} else \{ \$amdGpus \}\)')
 Check "the unwrapped form is gone"        (-not ($_wmi -match '\$wmiGpus = if \('))
-# The two lists it chooses between are wrapped for the same reason; the Where-Object above them
-# returns a scalar on a single match too.
+# Same reason for the two lists it chooses between: Where-Object also returns a scalar on one match.
 Check "the adapter list is @() wrapped"   ($_wmi -match '\$amdGpus = @\(Get-CimInstance')
 Check "the healthy list is @() wrapped"   ($_wmi -match '\$healthyGpus = @\(\$amdGpus \| Where-Object')
 
@@ -286,16 +271,15 @@ Check "an unreadable flavour is rescued off disk" ($_rescue -match 'elseif \(Tes
 Check "the rescue classifies it as rocm"   ($_rescue -match '(?s)elseif \(Test-VenvTorchIsRocm.*?\$installedTorchTag = "rocm"')
 # It must NOT set the rebuild flag, or the whole point is lost.
 Check "the rescue never sets shouldRebuild" (-not ($_rescue -match '(?s)elseif \(Test-VenvTorchIsRocm[^}]*\$shouldRebuild = \$true'))
-# The disk read is the point: launching a second interpreter after the first one hung is exactly
-# what the rescue is avoiding.
+# The disk read is the point: a second interpreter after the first hung is what it avoids.
 Check "the rescue launches no interpreter" (-not ($_rescue -match '(?s)elseif \(Test-VenvTorchIsRocm.*?Invoke-BoundedPythonProbe'))
 # Matched on the substep ARGUMENT, not the region: the comment above the branch names the driver
 # too, so a loose match stays green with the message itself deleted.
 Check "the rescue names the driver fix"    ($_rescue -match 'substep "[^"]*Adrenalin')
 # Non-AMD, non-Intel families must still rebuild on an unreadable flavour, exactly as before.
 Check "other families still rebuild"       ($_rescue -match '(?s)\} else \{\s*\$shouldRebuild = \$true')
-# The XPU rescue this one is modelled on has to still be there, and ahead of it: an Arc box is
-# not an AMD box and its message names a different driver.
+# The XPU rescue this one is modelled on has to stay, and ahead of it: an Arc box names a
+# different driver.
 Check "the XPU rescue is untouched"        ($_rescue -match 'elseif \(Test-VenvTorchIsXpu -VenvPath \$VenvDir\)')
 Check "XPU is judged before ROCm"          (
     $_rescue.IndexOf('Test-VenvTorchIsXpu -VenvPath') -ge 0 -and
@@ -308,46 +292,42 @@ $_repair = if ($setupText -match $_repairPat) { $Matches[1] } else { "" }
 Check "the stale-venv decision was found"  ($_repair -ne "")
 Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_repairPat))
 # The abort itself. install.ps1 is the caller under $InstallerManagedSetup, it moved the previous
-# environment aside earlier in the same run, and its failure path moves it straight back -- so
-# exiting here landed on the byte-identical starting state and the next run reached the same
-# verdict. Nothing in that cycle can converge. Bounded to the branch: the delete below still
-# has two legitimate Exit-SetupFailure calls of its own.
+# environment aside earlier in the same run and its failure path moves it straight back, so exiting
+# here landed on the byte-identical starting state and nothing in that cycle can converge. Bounded
+# to the branch: the delete below has two legitimate Exit-SetupFailure calls of its own.
 $_managedPat = '(?s)(if \(\$shouldRebuild -and \$InstallerManagedSetup\) \{.*?\n    \}\n)'
 $_managed = if ($_repair -match $_managedPat) { $Matches[1] } else { "" }
 Check "the installer-managed branch was found" ($_managed -ne "")
 Check "an installer-managed run does not abort" (-not ($_managed -match 'Exit-SetupFailure'))
-# Matched on the Write-StudioLine ARGUMENT, so the comment above the branch, which quotes the
-# old advice to explain why it went, cannot keep this green on its own.
+# Matched on the Write-StudioLine ARGUMENT, so the comment above the branch, which quotes the old
+# advice to explain why it went, cannot keep this green.
 Check "the advice that pointed at itself is gone" (
     -not ($setupText -match 'Write-StudioLine "\s*Re-run install\.ps1'))
 Check "the abort message is gone too"      (-not ($setupText -match 'The existing Unsloth environment needs repair'))
-# What replaces it: the same in-place repair an index-pin change and a cu* family change already
-# take, which every torch install arm below honours with --force-reinstall.
+# What replaces it: the in-place repair an index-pin change already takes, honoured by every arm.
 Check "an installer-managed run repairs in place" ($_managed -match '\$script:PinChangedForceReinstall = \$true')
 Check "and clears the rebuild flag"        ($_managed -match '\$shouldRebuild = \$false')
-# Deleting was never available on this path anyway: install.ps1 runs setup through the venv's own
-# unsloth.exe, so python.exe is locked by the process executing the script.
+# Deleting was never available here: install.ps1 runs setup through the venv's own unsloth.exe.
 Check "it does not try to wipe the venv it runs from" (-not ($_managed -match 'Remove-Item'))
-# A direct `unsloth studio update` keeps its own self-repair, and the custom-home guard that
-# stops it wiping an unrelated environment stays in front of the delete.
+# A direct `unsloth studio update` keeps its own self-repair, and the custom-home guard stays in
+# front of the delete.
 Check "a direct update still rebuilds"     ($_repair -match 'Stale venv detected \(\$reason\) -- rebuilding')
 Check "the custom-home guard still gates the wipe" ($_repair -match '\$StudioHomeIsCustom')
-# Why it failed, not just that it failed: this is the line that separates a faulted GPU driver
-# from a missing wheel, and the user is about to be told what happened to their environment.
+# Why it failed, not just that it failed: this line separates a faulted GPU driver from a missing
+# wheel, and the user is about to be told what happened to their environment.
 Check "the swallowed probe error is surfaced" ($_repair -match '\$_verProbe\.Error')
 Check "the probe handle is declared up front" ($setupText -match '(?m)^\s*\$_verProbe = \$null')
-# Read by four install arms to decide --force-reinstall, and raised by the repair above, but
-# assigned only inside the venv-exists block -- so on a fresh install every one of those reads is
-# of a variable that was never created. Harmless bare (falsy, which is the wanted answer), fatal
-# under a caller's Set-StrictMode. Same treatment as $installedTorchTag right above it.
+# Read by four install arms and raised by the repair above, but assigned only inside the
+# venv-exists block, so on a fresh install every one of those reads is of a variable that was never
+# created: harmless bare (falsy is the wanted answer), fatal under a caller's Set-StrictMode.
 Check "the force-reinstall flag is declared outside the venv block" (
     $setupText -match '(?m)^\$script:PinChangedForceReinstall = \$false$')
 
 Write-Host "the surfaced probe error survives a stderr that is only whitespace"
-# The guard is `-and $_verProbe.Error`, and a stderr of blank lines passes it. Where-Object then
-# drops every one of them. Indexing [0] into what that leaves is fatal under a caller's
-# Set-StrictMode -- and studio/setup.bat launches setup WITHOUT -NoProfile, so a profile can set
-# one. Driven for real rather than asserted as a shape, with the replaced form as a control.
+# The guard is `-and $_verProbe.Error`, and a stderr of blank lines passes it while Where-Object
+# drops every one, so [0] into what is left is fatal under a caller's Set-StrictMode -- and
+# studio/setup.bat launches setup WITHOUT -NoProfile, so a profile can set one. Driven for real
+# rather than asserted as a shape, with the replaced form as a control.
 $_strictNewOk = $true
 try {
     & {
@@ -380,15 +360,13 @@ Check "a real stderr still yields its last line" ($_realLine -match 'WinError 12
 
 Write-Host ""
 Write-Host "=== an interpreter-less venv is not repaired in place, it is refused ==="
-# The one state the in-place repair made WORSE than the abort it replaced. A venv directory
-# with no Scripts\python.exe is incomplete, not stale: there is no interpreter to force-reinstall
-# torch through. The abort used to catch it by accident, because it caught every stale verdict.
-#
-# Without a guard it now reaches the activation, and that is a dot-source of a path that does
-# not exist -- which is NOT a terminating error at the "Continue" the pip section runs at. So
-# setup prints one red line and keeps going, and every `python` / `uv pip` after it resolves
-# against whatever interpreter is on PATH. The whole stack lands outside the venv and the run
-# can still exit 0. Prove the hazard first, so the guard below is not asserted on faith.
+# The one state the in-place repair made WORSE than the abort it replaced. A venv directory with no
+# Scripts\python.exe is incomplete, not stale -- no interpreter to force-reinstall torch through --
+# and the abort used to catch it by accident, because it caught every stale verdict. Without a
+# guard it now reaches the activation, a dot-source of a path that does not exist, which is NOT a
+# terminating error at the "Continue" the pip section runs at: setup prints one red line and keeps
+# going, every `python` / `uv pip` after it resolves against whatever is on PATH, the whole stack
+# lands outside the venv and the run can still exit 0. Prove the hazard before asserting the guard.
 $_dotSourceKeptGoing = $false
 & {
     $ErrorActionPreference = "Continue"
@@ -397,21 +375,19 @@ $_dotSourceKeptGoing = $false
 } 2>$null
 Check "dot-sourcing a missing script does not stop the script" $_dotSourceKeptGoing
 
-# Bounded to the reuse branch: the "not found" branch above it has an Exit-SetupFailure of its
-# own, and matching the whole region would pass on that one. Both ends sit immediately after a
+# Bounded to the reuse branch: the "not found" branch above has an Exit-SetupFailure of its own,
+# and matching the whole region would pass on that one. Both ends sit immediately after a
 # non-newline token, so a CRLF checkout fails the match instead of yielding an empty region.
 $_reusePat = '(?s)(substep "reusing existing virtual environment at \$VenvDir"\n.*?Exit-SetupFailure "No interpreter at [^\n]*\n)'
 $_reuse = if ($setupText -match $_reusePat) { $Matches[1] } else { "" }
 Check "the reuse branch was found"         ($_reuse -ne "")
 Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_reusePat))
 Check "it refuses a venv with no interpreter" ($_reuse -match '(?s)\} else \{.*?Exit-SetupFailure "No interpreter at')
-# It must fail rather than fall through, and it must do so BEFORE the dot-source, or the
-# hazard proven above is still live.
+# It must fail BEFORE the dot-source, or the hazard proven above is still live.
 Check "the refusal precedes the activation" (
     $setupText.IndexOf('Exit-SetupFailure "No interpreter at') -lt
     $setupText.IndexOf('$ActivateScript = Join-Path $VenvDir'))
-# Not a wipe: install.ps1 is holding the rollback copy and this venv may be the only place the
-# previous one's contents still are.
+# Not a wipe: this venv may be the only place the previous one's contents still are.
 Check "it does not delete the venv"        (-not ($_reuse -match 'Remove-Item'))
 # The message has to say incomplete, not stale, or it reads as the loop-causing advice again.
 Check "it says incomplete, not out of date" ($_reuse -match 'incomplete rather than out of date')
@@ -419,38 +395,34 @@ Check "it says incomplete, not out of date" ($_reuse -match 'incomplete rather t
 Check "a venv with an interpreter still just prints its version" (
     $_reuse -match '(?s)if \(Test-Path -LiteralPath \$_venvPyExe\) \{.*?--version')
 
-# The interpreter is not the only file that has to be there. Everything after this point reaches
-# the venv through the dot-sourced Activate.ps1 and a bare `python` -- Fast-Install resolves its
-# target with (Get-Command python).Source -- and install.ps1 leaves the venv's Scripts directory
-# off PATH on purpose. So a venv that kept python.exe but lost Activate.ps1 hits the SAME hazard
-# proven above, one file over: the dot-source fails without stopping anything and the whole stack
-# lands in the ambient interpreter. Newly reachable, because an installer-managed stale verdict
-# now repairs where it used to abort.
+# The interpreter is not the only file that has to be there. Everything after this reaches the venv
+# through the dot-sourced Activate.ps1 and a bare `python` (Fast-Install resolves its target with
+# (Get-Command python).Source), and install.ps1 leaves the venv's Scripts directory off PATH on
+# purpose, so a venv that kept python.exe but lost Activate.ps1 hits the SAME hazard proven above,
+# one file over. Newly reachable, because a stale verdict now repairs where it used to abort.
 Check "it refuses a venv with no activation script" (
     $_reuse -match 'Exit-SetupFailure "No activation script at')
 Check "the activation script path is built next to the interpreter" (
     $_reuse -match '\$_venvActivate = Join-Path \$VenvDir "Scripts\\Activate\.ps1"')
-# The -ge 0 is not decoration: IndexOf answers -1 when the refusal is not there at all, and -1
-# is less than every other offset, so the ordering alone passes on a tree that never grew it.
+# The -ge 0 is not decoration: IndexOf answers -1 when the refusal is not there, and -1 is less
+# than every other offset, so the ordering alone passes on a tree that never grew it.
 Check "that refusal also precedes the activation" (
     $setupText.IndexOf('Exit-SetupFailure "No activation script at') -ge 0 -and
     $setupText.IndexOf('Exit-SetupFailure "No activation script at') -lt
     $setupText.IndexOf('$ActivateScript = Join-Path $VenvDir'))
-# It is checked on the arm where the interpreter EXISTS, or it only ever fires alongside the
-# missing-interpreter refusal and never on its own.
+# Checked on the arm where the interpreter EXISTS, or it never fires on its own.
 Check "the check sits inside the interpreter-present arm" (
     $_reuse -match '(?s)if \(Test-Path -LiteralPath \$_venvPyExe\) \{.*?Exit-SetupFailure "No activation script at.*?\} else \{')
 Check "it does not delete that venv either" (-not ($_reuse -match 'Remove-Item'))
 
 Write-Host ""
 Write-Host "=== a present activation script is not the same as an activated venv ==="
-# Both refusals above check that a FILE is there. Neither can tell whether dot-sourcing it took
-# effect, and Activate.ps1 prepends the venv to PATH in its very last statement -- $env:VIRTUAL_ENV
-# is set well before it. So a copy truncated by an interrupted or out-of-disk `python -m venv`
-# runs to its last complete statement and returns having changed nothing that matters, and an
-# unparseable one is a ParserError, which is non-terminating at the "Continue" the pip section
-# runs at. Prove both hazards live before asserting the guard, exactly as the missing-script case
-# above is proven.
+# Both refusals above check that a FILE is there; neither can tell whether dot-sourcing it took
+# effect. Activate.ps1 prepends the venv to PATH in its very last statement, 28 lines after it sets
+# $env:VIRTUAL_ENV, so a copy truncated by an interrupted `python -m venv` runs to its last
+# complete statement and returns having changed nothing that matters, and an unparseable one is a
+# ParserError, non-terminating at the "Continue" the pip section runs at. Prove both hazards live
+# before asserting the guard, exactly as the missing-script case above is proven.
 $_actRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("unsloth-activate-" + [guid]::NewGuid().ToString("N"))
 try {
     New-Item -ItemType Directory -Path $_actRoot -Force | Out-Null
@@ -474,17 +446,16 @@ try {
     # The worst part of this one: there is no red line to notice, unlike the missing-file case.
     Check "and raises no error at all" ($Error.Count -eq 0)
     Check "and leaves PATH exactly as it found it" ($env:PATH -eq $_pathBefore)
-    # It still got far enough to set the state a VIRTUAL_ENV check would have trusted, which is
-    # why the guard has to look at the resolved interpreter instead.
+    # It still set the state a VIRTUAL_ENV check would have trusted, which is why the guard looks
+    # at the resolved interpreter instead.
     Check "while still setting the state that precedes the PATH line" ($env:UNSLOTH_ACTIVATE_PROBE -eq "reached")
 
     $env:UNSLOTH_ACTIVATE_PROBE = $null
 
     # The unparseable case has to run in a child host, in setup.ps1's actual shape: script-scope
     # "Continue" and no enclosing try. A ParserError is non-terminating there, but inside a try
-    # under this file's script-scope "Stop" it converts and unwinds, which would prove the
-    # opposite of what setup.ps1 does. setup.ps1 is itself launched as a fresh host process
-    # (unsloth_cli/commands/studio.py), so the child is the faithful reproduction, not a dodge.
+    # under this file's "Stop" it converts and unwinds, proving the opposite. setup.ps1 is itself
+    # launched as a fresh host process, so the child is the faithful reproduction, not a dodge.
     $_hostExe = try { [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName } catch { $null }
     Check "the host executable is known" ($_hostExe -and (Test-Path -LiteralPath $_hostExe))
     $_child = Join-Path $_actRoot "child.ps1"
@@ -503,7 +474,6 @@ try {
     Check "and the run still exits 0" ($_childRc -eq 0)
 
     # ── the guard itself, executed ──
-    # @() then [0]: a one-name request returns a one-element array that unrolls to a String.
     # Caught rather than thrown, so a tree without the guard reports every check below as FAIL
     # instead of unwinding at the first one and hiding the rest.
     $_assertFn = try { @(Get-HelperSources $setup @("Assert-VenvActivated"))[0] } catch { "" }
@@ -513,8 +483,8 @@ try {
     # The -ne "" is the anti-vacuity half: -not on an empty region passes against no guard at all.
     Check "the guard does not settle for VIRTUAL_ENV" (($_assertFn -ne "") -and -not ($_assertFn -match 'VIRTUAL_ENV'))
 
-    # Real directories rather than a Get-Item stub: separator handling, trailing separators and
-    # case folding are the whole risk here, and a stub would just re-implement the bug.
+    # Real directories rather than a Get-Item stub: separators, trailing separators and case
+    # folding are the whole risk, and a stub would just re-implement the bug.
     $_venvOk = Join-Path $_actRoot "venv"
     $_venvOkPy = Join-Path (Join-Path $_venvOk "Scripts") "python.exe"
     New-Item -ItemType File -Path $_venvOkPy -Force | Out-Null
@@ -546,8 +516,7 @@ Assert-VenvActivated -VenvDir `$Venv
 
     Check "an activated venv is accepted" (
         $null -eq (Invoke-AssertVenv -VenvDir $_venvOk -PythonSource $_venvOkPy))
-    # The state this whole section exists for: activation no-opped, so `python` is still the
-    # ambient one install.ps1 took care to leave on PATH.
+    # The state this section exists for: activation no-opped, so `python` is still the ambient one.
     Check "an ambient interpreter is refused" (
         (Invoke-AssertVenv -VenvDir $_venvOk -PythonSource $_ambientPy) -match 'did not put its interpreter on PATH')
     Check "and the refusal names where python actually resolved" (
@@ -568,8 +537,8 @@ Assert-VenvActivated -VenvDir `$Venv
     # An alias or function named python carries no Source, so nothing can be proven about it.
     Check "a non-application python is left alone" (
         $null -eq (Invoke-AssertVenv -VenvDir $_venvOk -PythonSource $_ambientPy -CommandType 'Function'))
-    # If the venv root cannot even be resolved the guard has no ground to stand on, and the two
-    # refusals above it already cover a venv that is not there.
+    # An unresolvable venv root leaves the guard nothing to stand on, and the two refusals above
+    # already cover a venv that is not there.
     Check "an unresolvable venv path is left alone" (
         $null -eq (Invoke-AssertVenv -VenvDir (Join-Path $_actRoot "no-such-venv") -PythonSource $_ambientPy))
 } finally {
@@ -578,7 +547,7 @@ Assert-VenvActivated -VenvDir `$Venv
 
 # ── where it is wired in ──
 # Both ends sit immediately after a non-newline token, so a CRLF checkout fails the match rather
-# than yielding an empty region every -not check below would pass against.
+# than yielding an empty region every -not check would pass against.
 $_actPat = '(?s)(\$ActivateScript = Join-Path \$VenvDir "Scripts\\Activate\.ps1"\n\. \$ActivateScript\n.*?Assert-VenvActivated -VenvDir \$VenvDir\n)'
 $_act = if ($setupText -match $_actPat) { $Matches[1] } else { "" }
 Check "the activation block was found"     ($_act -ne "")
@@ -602,80 +571,72 @@ Check "and that one is outside the swallowing catch" (
     $setupText.IndexOf('} catch { }') -ge 0 -and
     $setupText.IndexOf('} catch { }') -lt
     $setupText.LastIndexOf('Assert-VenvActivated -VenvDir $VenvDir'))
-# It refuses; it does not repair, and it does not wipe a venv install.ps1 may still need to
-# restore from.
+# It refuses; it does not repair, and it does not wipe a venv install.ps1 may still restore from.
 Check "the guard does not delete anything" (($_act -ne "") -and -not ($_act -match 'Remove-Item'))
 
 Write-Host ""
 Write-Host "=== an installer-managed repair never moves a GPU wheel to another family ==="
 # install.ps1 resolves the index and installs the torch trio ITSELF, minutes before it invokes
-# setup, and hands over no record of which family it chose -- setup probes the hardware again
-# from scratch. When that second probe fails (a Get-CimInstance that throws, an nvidia-smi that
-# does not answer, the single-Radeon unroll at the top of this file) setup lands somewhere else,
-# reads the +cu / +rocm / +xpu wheel install.ps1 just placed as stale, and the in-place repair
-# --force-reinstalls the other family over it. Then setup exits 0, install.ps1 counts the run a
-# success and drops the rollback copy. The abort this repair replaced at least failed loudly;
-# this commits a wrong install silently, which is a worse trade.
+# setup, which then probes the hardware again from scratch. When that second probe fails (a
+# Get-CimInstance that throws, an nvidia-smi that does not answer, the single-Radeon unroll at the
+# top of this file) setup lands somewhere else, reads the +cu / +rocm / +xpu wheel install.ps1 just
+# placed as stale, and the in-place repair --force-reinstalls the other family over it. Then setup
+# exits 0, install.ps1 counts the run a success and drops the rollback copy: the abort this repair
+# replaced at least failed loudly, and committing a wrong install silently is a worse trade.
 #
-# "cpu" was only the first direction. The same disagreement runs GPU-to-GPU on any box holding
-# two vendors' cards -- a Radeon plus a GeForce, an Arc plus a GeForce -- where one scan answers
-# in install.ps1 and the other in setup: +rocm read as cu128, +cu128 read as rocm, +xpu read as
-# either. install.ps1's own flavor repair has already reconciled the venv against the index it
-# chose before it calls setup, so a GPU wheel sitting here IS its answer, and setup's second
-# opinion is not better evidence than the first.
+# "cpu" was only the first direction. The same disagreement runs GPU-to-GPU on any box holding two
+# vendors' cards, where one scan answers in install.ps1 and the other in setup: +rocm read as
+# cu128, +cu128 read as rocm, +xpu read as either. install.ps1 has already reconciled the venv
+# against the index it chose, so a GPU wheel sitting here IS its answer.
 $_guardPat = '(?s)(if \(\$shouldRebuild -and \$InstallerManagedSetup -and\n.*?\n    \}\n)'
 $_guard = if ($setupText -match $_guardPat) { $Matches[1] } else { "" }
 Check "the downgrade guard was found"       ($_guard -ne "")
 Check "CRLF is normalised, not tolerated"   (-not (($setupText -replace "`n", "`r`n") -match $_guardPat))
-# The exact condition, because each term is load-bearing. $installedTorchTag is tested FIRST so
-# the read of $expectedTorchTag short-circuits away: that variable is assigned only inside the
-# `if (-not $shouldRebuild)` block above, so on a venv whose torch would not import at all it was
-# never created, and reading it under a caller's Set-StrictMode is fatal.
+# The exact condition, because each term is load-bearing.
 Check "it only fires under the installer"   ($_guard -match '\$InstallerManagedSetup')
 Check "it only fires on a GPU wheel"        ($_guard -match '\$installedTorchTag -and \$installedTorchTag -ne "cpu"')
-# The condition must NOT narrow to a cpu rescan: that spelling left every GPU-to-GPU direction
-# running straight into the in-place repair below.
+# NOT narrowed to a cpu rescan: that spelling left every GPU-to-GPU direction running straight
+# into the in-place repair below.
 Check "it is not narrowed to a cpu rescan"  (-not ($_guard -match '\$expectedTorchTag -eq "cpu"'))
 # $expectedTorchTag is assigned only inside the `if (-not $shouldRebuild)` block above, so on a
-# venv whose torch would not import it was never created. Reading it in the CONDITION would be
-# fatal under a caller's Set-StrictMode, and -and short-circuits it away only if it is not there
-# at all -- inside the body it is reached only once $installedTorchTag has already answered.
+# venv whose torch would not import it was never created and reading it in the CONDITION would be
+# fatal under a caller's Set-StrictMode. In the body it is reached only after $installedTorchTag
+# has answered, which is what makes the message safe.
 Check "the condition never reads the expected tag" (
     -not (($_guard -split '\{', 2)[0] -match '\$expectedTorchTag'))
 Check "it clears the rebuild flag"          ($_guard -match '\$shouldRebuild = \$false')
-# The whole point: no --force-reinstall is raised, so the arm below leaves the GPU wheel in
-# place (a +cu / +rocm / +xpu build already satisfies a bare torch>= range).
+# No --force-reinstall is raised, so the arm below leaves the GPU wheel in place (a +cu / +rocm /
+# +xpu build already satisfies a bare torch>= range).
 Check "it does not raise force-reinstall"   (-not ($_guard -match 'PinChangedForceReinstall = \$true'))
 Check "it does not wipe the venv"           (-not ($_guard -match 'Remove-Item'))
-# An xpu venv kept here needs the same index lock the direct-update escape takes, or the pass
-# installs triton-windows over torch's XPU triton with nothing to swap it back.
+# A kept xpu venv needs the same index lock the direct-update escape takes, or triton-windows
+# lands over torch's XPU triton with nothing to swap it back.
 Check "a kept xpu venv still locks the xpu index" (
     $_guard -match 'if \(\$installedTorchTag -eq "xpu"\) \{ \$script:PreservedXpuVenv = \$true \}')
-# Keeping the wheel is not enough on its own: two install arms a thousand lines below force
-# torch back regardless of $script:PinChangedForceReinstall, so the kept family has to reach the
-# index selection. Same treatment as $script:PreservedXpuVenv, including the declaration outside
-# the venv block that a fresh install never enters.
+# Keeping the wheel is not enough on its own: two install arms a thousand lines below force torch
+# back regardless of $script:PinChangedForceReinstall, so the kept family has to reach the index
+# selection. Same treatment as $script:PreservedXpuVenv, declaration outside the venv block
+# included.
 
 # ── the half of the guard that keeps it from preserving a wheel nobody chose ──
-# "There is a GPU wheel in the venv" is not evidence that THIS install run put it there.
+# "There is a GPU wheel in the venv" is not evidence that THIS install run put it there:
 # install.ps1's migrated-venv arm installs unsloth alone and never touches torch, and its flavor
-# repair no-ops whenever its own expected tag is 'cpu' or unrecognised -- so an ordinary upgrade
-# off the legacy ~/.unsloth/studio/.venv layout hands setup whatever wheel the previous install
-# left, on whatever hardware that was. Preserving THAT is not conservatism, it is a permanently
-# wrong environment that setup then refuses to repair, and on a mapped AMD host the kept cu* tag
-# also blocks the ROCm reroute (it needs $CuTag -eq "cpu"). So install.ps1 says which family it
-# settled on and only a wheel matching it counts as its answer.
+# repair no-ops whenever its own expected tag is 'cpu' or unrecognised, so an ordinary upgrade off
+# the legacy ~/.unsloth/studio/.venv layout hands setup whatever wheel the previous install left,
+# on whatever hardware that was. Preserving THAT is a permanently wrong environment setup then
+# refuses to repair, and on a mapped AMD host the kept cu* tag also blocks the ROCm reroute (it
+# needs $CuTag -eq "cpu"). So install.ps1 says which family it settled on, and only a wheel
+# matching it counts as its answer.
 $installText = (Get-Content -Raw (Join-Path $root "install.ps1")) -replace "`r`n", "`n"
 Check "install.ps1 reports the family it settled on" (
     $installText -match '\$env:UNSLOTH_INSTALLER_TORCH_TAG = if \(\$SkipTorch\) \{ "" \} else \{')
 Check "it reports the resolved flavor, not the raw index URL" (
     $installText -match '\[string\]\(Get-ExpectedTorchFlavorTag -TorchIndexUrl \$TorchIndexUrl -ROCmIndexUrl \$ROCmIndexUrl\)')
 # Unconditional, like $env:UNSLOTH_NO_TORCH next to it: a second install in the same PowerShell
-# session must not inherit the first one's answer. Assigning "" clears it on every edition --
-# 7.5+ keeps a present blank value, 5.1 and 7.0-7.4 remove the variable outright -- and setup
-# reads both as unknown.
-# The -match half is the anti-vacuity half: a bare -notmatch passes against a tree that never
-# grew the assignment at all.
+# session must not inherit the first one's answer. Assigning "" clears it on every edition (7.5+
+# keeps a present blank value, 5.1 and 7.0-7.4 remove the variable) and setup reads both as
+# unknown. The -match half is the anti-vacuity half: a bare -notmatch passes against a tree that
+# never grew the assignment at all.
 Check "the report is assigned on every run, not only when known" (
     ($installText -match '(?m)^\s*\$env:UNSLOTH_INSTALLER_TORCH_TAG = ') -and
     ($installText -notmatch 'if \([^\n]*\) \{\s*\$env:UNSLOTH_INSTALLER_TORCH_TAG'))
@@ -683,10 +644,9 @@ Check "it is handed over before setup is invoked" (
     $installText.IndexOf('$env:UNSLOTH_INSTALLER_TORCH_TAG') -ge 0 -and
     $installText.IndexOf('$env:UNSLOTH_INSTALLER_TORCH_TAG') -lt
     $installText.IndexOf('$studioArgs = @(''studio'', ''setup'')'))
-# setup.ps1 ships in the pip package and install.ps1 is fetched from unsloth.ai, so the two can
-# be different ages. An absent variable therefore has to mean "unknown", not "mismatch", or a
-# cached older installer would start force-reinstalling over its own correct choice -- which is
-# the bug the guard was added for. Blank counts as absent for the 7.5+ spelling.
+# setup.ps1 ships in the pip package and install.ps1 is fetched from unsloth.ai, so the two can be
+# different ages. An absent variable therefore means "unknown", not "mismatch", or a cached older
+# installer would force-reinstall over its own correct choice. Blank counts as absent on 7.5+.
 Check "setup.ps1 reads the reported family"  (
     $setupText -match '(?m)^\$InstallerTorchTag = if \(\[string\]::IsNullOrWhiteSpace\(\$env:UNSLOTH_INSTALLER_TORCH_TAG\)\) \{ \$null \}')
 Check "an absent report is unknown, not a mismatch" (
@@ -711,25 +671,23 @@ Check "the guard precedes the in-place repair" (
     $setupText.IndexOf('if ($shouldRebuild -and $InstallerManagedSetup) {'))
 Write-Host ""
 Write-Host "--- driven end to end, over setup.ps1's own source"
-# A hand-copy of the cascade would keep passing after the file it claims to test changed, which
-# is exactly how the cpu-only spelling survived review. So the WHOLE decision -- the pin escape,
-# the cu*-to-cu* escape, the direct-update xpu escape, this guard and the in-place repair -- is
-# lifted out of setup.ps1 verbatim and executed, and so is the index selection that the kept
-# family has to survive. Nothing below is retyped.
+# A hand-copied simulation drifts and keeps passing after the file it claims to test changed,
+# which is exactly how the cpu-only spelling survived review. So the WHOLE decision -- pin escape,
+# cu*-to-cu* escape, direct-update xpu escape, this guard, the in-place repair -- is lifted out of
+# setup.ps1 verbatim and executed, as is the index selection. Nothing below is retyped.
 $_cascadePat = '(?s)(    if \(\$shouldRebuild -and \$_pinnedIdx -and \$installedTorchTag\) \{.*?\n    if \(\$shouldRebuild -and \$InstallerManagedSetup\) \{.*?\n    \}\n)'
 $_cascade = if ($setupText -match $_cascadePat) { $Matches[1] } else { "" }
 Check "the decision cascade was found"     ($_cascade -ne "")
 Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_cascadePat))
-# Ends on the closing brace of the `else { $CuTag = "cpu" }` arm, so a truncated match cannot
-# leave a region that still assigns $CuTag.
+# Ends on the `else { $CuTag = "cpu" }` brace, so a truncated match cannot leave a region that
+# still assigns $CuTag.
 $_cuTagPat = '(?s)(if \(\$PinnedTorchIndexUrl\) \{\n    \$CuTag = Get-TorchIndexLeaf.*?\n\} else \{\n    \$CuTag = "cpu"\n\}\n)'
 $_cuTag = if ($setupText -match $_cuTagPat) { $Matches[1] } else { "" }
 Check "the index selection was found"      ($_cuTag -ne "")
 Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_cuTagPat))
 # The two install arms that force torch back on their own. Their CONDITIONS are extracted and
-# evaluated below, so "the kept wheel survives" is answered by the shipped gates, not by a claim
-# about them. The AMD arm's --force-reinstall is unconditional inside its block; the XPU arm's
-# is keyed off the installed tag. Both are asserted here so a change to either is caught.
+# evaluated below, so "the kept wheel survives" is answered by the shipped gates. The AMD arm's
+# --force-reinstall is unconditional inside its block; the XPU arm's is keyed off the installed tag.
 Check "the AMD arm still force-reinstalls unconditionally" (
     $setupText -match 'Fast-Install @_rocmTrio --force-reinstall --index-url \$ROCmIndexUrl')
 Check "the XPU arm forces on any non-xpu tag" (
@@ -745,11 +703,10 @@ Check "Test-CudaFamilyLeaf came across"    ((Test-CudaFamilyLeaf "cu128") -and -
 function Get-PytorchCudaTag { return "cu128" }
 
 # One case = one host. Installed is what setup found in the venv; InstallerTag is the family
-# install.ps1 reported settling on for this host (an empty string is the installer saying it has
-# no answer, $null is an installer too old to say at all); Expected is what setup's rescan
-# concluded; the Has* values are that same rescan, and they have to agree with Expected or the
-# case is not a real host. Run at script scope (Invoke-Expression inside a function would put
-# the extracted `$script:` writes and the reads in different scopes).
+# install.ps1 reported ("" is the installer with no answer, $null an installer too old to say);
+# Expected is what setup's rescan concluded, and the Has* values are that same rescan, so they have
+# to agree with it. Run at script scope (Invoke-Expression inside a function would put the
+# extracted `$script:` writes and the reads in different scopes).
 $_cases = @(
     # +rocm venv, rescan found the GeForce in the same box and not the Radeon.
     @{ Name = "rocm wheel the installer chose, rescan says cu128"; Installed = "rocm"; InstallerTag = "rocm"; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
@@ -765,30 +722,28 @@ $_cases = @(
        Keep = $true;  CuTag = "cpu";   Amd = $false; XpuArm = $false }
     @{ Name = "cu128 wheel the installer chose, rescan says cpu";   Installed = "cu128"; InstallerTag = "cu128"; Expected = "cpu";   Nvidia = $false; Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $true;  CuTag = "cu128"; Amd = $false; XpuArm = $false }
-    # An installer too old to carry the variable at all. setup.ps1 ships in the pip package and
-    # install.ps1 is fetched from unsloth.ai, so this pairing is normal, not exotic. Unknown has
-    # to keep preserving or a cached older installer starts losing its own correct choice.
+    # An installer too old to carry the variable at all -- a normal pairing, since the two ship
+    # separately. Unknown has to keep preserving or an older installer loses its own choice.
     @{ Name = "rocm wheel, installer did not say, rescan says cu128"; Installed = "rocm"; InstallerTag = $null; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $true;  CuTag = "cpu";   Amd = $false; XpuArm = $false }
     # ── the wheels the installer did NOT choose ──
-    # An upgrade off the legacy layout: install.ps1's migrated arm installs unsloth alone and
-    # never touches torch, and its flavor repair no-ops when its own expected tag is 'cpu'. So a
-    # +cu118 wheel from a previous install on different hardware arrives here untouched. Both
-    # scans agree the box has no NVIDIA GPU; preserving it would pin the whole dependency pass
-    # onto a cu118 index on a machine that has no CUDA device.
+    # An upgrade off the legacy layout: install.ps1's migrated arm installs unsloth alone and never
+    # touches torch, and its flavor repair no-ops when its own expected tag is 'cpu', so a +cu118
+    # wheel from a previous install on different hardware arrives untouched. Both scans agree there
+    # is no NVIDIA GPU; preserving it would pin the dependency pass onto a cu118 index regardless.
     @{ Name = "stale cu118 wheel the installer did not choose, rescan says cpu"; Installed = "cu118"; InstallerTag = "cpu"; Expected = "cpu"; Nvidia = $false; Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $false; CuTag = "cpu";   Amd = $false; XpuArm = $false }
-    # The same stale wheel on a mapped AMD host. This is the one that costs the most: preserving
-    # it would ALSO set $CuTag to cu118, and the ROCm reroute below needs $CuTag -eq "cpu", so
-    # the Radeon would never get a ROCm wheel and setup would still exit 0.
+    # The same stale wheel on a mapped AMD host, the costliest case: preserving it would ALSO set
+    # $CuTag to cu118, and the ROCm reroute below needs $CuTag -eq "cpu", so the Radeon would never
+    # get a ROCm wheel and setup would still exit 0.
     @{ Name = "stale cu118 wheel the installer did not choose, rescan says rocm"; Installed = "cu118"; InstallerTag = "cpu"; Expected = "rocm"; Nvidia = $false; Xpu = $false; Rocm = $true; Gfx = "gfx1151"
        Keep = $false; CuTag = "cpu";   Amd = $true;  XpuArm = $false }
     # Mirror image: a stale +rocm wheel left by an old Radeon install, on a box that is now
     # NVIDIA and that the installer resolved as CPU (its own ROCm scan found nothing to map).
     @{ Name = "stale rocm wheel the installer did not choose, rescan says cu128"; Installed = "rocm"; InstallerTag = "cpu"; Expected = "cu128"; Nvidia = $true; Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $false; CuTag = "cu128"; Amd = $false; XpuArm = $false }
-    # The installer ran but had no answer to give (a custom index whose leaf names no flavor).
-    # Blank is unknown, exactly like absent, so this preserves.
+    # The installer ran but had no answer (a custom index whose leaf names no flavor): blank is
+    # unknown, exactly like absent, so this preserves.
     @{ Name = "rocm wheel, installer reported blank, rescan says cu128"; Installed = "rocm"; InstallerTag = ""; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $true;  CuTag = "cpu";   Amd = $false; XpuArm = $false }
     # ...and the repairs that MUST still happen, or this guard has reintroduced the loop.
@@ -803,9 +758,9 @@ $_cases = @(
     @{ Name = "torch that will not import";     Installed = $null;   InstallerTag = "cu128"; Expected = $null;   Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $false; CuTag = "cu128"; Amd = $false; XpuArm = $false }
 )
-# The installer report is normalised by setup.ps1's own line, lifted out and executed, not by a
-# retyped copy -- so the empty-string case is answered by the shipped code on whichever edition
-# is running (7.5+ keeps a blank value, 5.1 and 7.0-7.4 remove the variable on that assignment).
+# Normalised by setup.ps1's own line, lifted out and executed rather than retyped, so the
+# empty-string case is answered by the shipped code on whichever edition is running (7.5+ keeps a
+# blank value, 5.1 and 7.0-7.4 remove the variable on that assignment).
 $_tagReadPat = '(?m)^(\$InstallerTorchTag = if \(\[string\]::IsNullOrWhiteSpace\(\$env:UNSLOTH_INSTALLER_TORCH_TAG\)\) \{ \$null \}\n\s+else \{[^\n]*\}\n)'
 $_tagRead = if ($setupText -match $_tagReadPat) { $Matches[1] } else { "" }
 Check "the installer-report read was found" ($_tagRead -ne "")
@@ -813,17 +768,16 @@ Check "the installer-report read was found" ($_tagRead -ne "")
 foreach ($case in $_cases) {
     if ($null -eq $case.InstallerTag) { Remove-Item Env:UNSLOTH_INSTALLER_TORCH_TAG -ErrorAction SilentlyContinue }
     else { $env:UNSLOTH_INSTALLER_TORCH_TAG = $case.InstallerTag }
-    # Guarded, not bare: Invoke-Expression on an empty string is a terminating error at this
-    # file's script-scope "Stop", so a tree whose read line is missing would unwind here and
-    # every behavioural case below would go unreported rather than FAIL. Same reasoning as the
-    # caught extraction in the activation section.
+    # Guarded, not bare: Invoke-Expression on an empty string is a terminating error at this file's
+    # script-scope "Stop", so a tree whose read line is missing would unwind here and leave every
+    # behavioural case below unreported rather than FAIL.
     if ($_tagRead) { Invoke-Expression $_tagRead }
     else { Remove-Variable -Name InstallerTorchTag -Scope Script -ErrorAction SilentlyContinue }
     $script:shouldRebuild = $true
     $script:InstallerManagedSetup = $true
     $script:installedTorchTag = $case.Installed
-    # Left UNASSIGNED when the probe failed, exactly as setup.ps1 leaves it, so a condition that
-    # reads it before $installedTorchTag has answered is caught here rather than on a user's box.
+    # Left UNASSIGNED when the probe failed, exactly as setup.ps1 leaves it, so a condition reading
+    # it before $installedTorchTag has answered is caught here rather than on a user's box.
     if ($null -ne $case.Expected) { $script:expectedTorchTag = $case.Expected }
     else { Remove-Variable -Name expectedTorchTag -Scope Script -ErrorAction SilentlyContinue }
     $script:_pinnedIdx = $null
@@ -857,17 +811,17 @@ foreach ($case in $_cases) {
     Check "    XPU arm runs = $($case.XpuArm)"  ($_xpuRuns -eq $case.XpuArm)
     # The claim the whole guard rests on: no arm re-lands torch over the kept wheel.
     Check "    torch is force-reinstalled = $(-not $case.Keep)" ($_forced -eq (-not $case.Keep))
-    # The kept family must reach the index selection only when the wheel was actually kept, or a
-    # repaired case would still drag the old family through the install arms below.
+    # Only when the wheel was actually kept, or a repaired case drags the old family through the
+    # install arms below.
     Check "    kept family recorded = $($case.Keep)" (
         [bool]$script:PreservedInstallerTorchTag -eq $case.Keep)
 }
 Remove-Item Env:UNSLOTH_INSTALLER_TORCH_TAG -ErrorAction SilentlyContinue
 
-# The guard must not read $expectedTorchTag before $installedTorchTag has answered, and the case
-# above proves the cascade survives it. Prove the hazard is real rather than taking it on trust:
-# under a caller's Set-StrictMode -- studio/setup.bat launches setup WITHOUT -NoProfile, so a
-# profile can set one -- reading a variable that was never assigned throws.
+# The guard must not read $expectedTorchTag before $installedTorchTag has answered, and the cases
+# above prove the cascade survives it. The hazard itself, rather than taken on trust: under a
+# caller's Set-StrictMode -- studio/setup.bat launches setup WITHOUT -NoProfile, so a profile can
+# set one -- reading a variable that was never assigned throws.
 $_strictUnassignedThrew = $false
 try {
     & {
@@ -880,13 +834,12 @@ Check "reading the unassigned expected tag really does throw" $_strictUnassigned
 
 Write-Host ""
 Write-Host "=== the AMD fast-path probe is bounded too ==="
-# The disk-based rescue above KEEPS a venv whose `import torch` never came back. On a direct
-# update that venv then reaches the AMD fast-path check, and a bare `& python -c "import torch"`
-# there waits forever: setup would hang instead of finishing, on precisely the host the rescue
-# was added for. Before the rescue this could not happen, because the same venv was deleted.
-# The leading \n and indent matter: `elseif ($script:ROCmGfxArch) {` ENDS in that same text, and
-# there are two of those higher up the file, so a bare anchor starts the region 1700 lines early
-# and every -not check below it goes green on unrelated code.
+# The disk-based rescue above KEEPS a venv whose `import torch` never came back, and on a direct
+# update that venv reaches the AMD fast-path check, where an unbounded call waits forever: setup
+# would hang instead of finishing, on precisely the host the rescue was added for. Before the
+# rescue this could not happen, because the same venv was deleted. The leading \n and indent
+# matter: `elseif ($script:ROCmGfxArch) {` ENDS in that same text and there are two of those
+# higher up, so a bare anchor starts the region 1700 lines early and every -not check goes green.
 $_amdFastPat = '(?s)(\n        if \(\$script:ROCmGfxArch\) \{\n.*?reinstalling ROCm PyTorch[^\n]*\n)'
 $_amdFast = if ($setupText -match $_amdFastPat) { $Matches[1] } else { "" }
 Check "the AMD fast-path escape was found"  ($_amdFast -ne "")
@@ -894,8 +847,8 @@ Check "CRLF is normalised, not tolerated"   (-not (($setupText -replace "`n", "`
 Check "no bare interpreter call is left"    (-not ($_amdFast -match '&\s*python -c'))
 Check "it goes through the bounded probe"   ($_amdFast -match 'Invoke-BoundedPythonProbe -PythonExe "python"')
 Check "it still asks torch.cuda.is_available" ($_amdFast -match 'torch\.cuda\.is_available')
-# A probe that does not answer must keep reading as CPU: forcing one dependency pass is the safe
-# direction, and reading a timeout as "the GPU is fine" would fast-path past the ROCm install.
+# A probe that does not answer must keep reading as CPU: one dependency pass is the safe direction,
+# and reading a timeout as "the GPU is fine" would fast-path past the ROCm install.
 Check "an unanswered probe still reads as CPU" ($_amdFast -match '\$_torchIsCpu = -not \$_rocmTorchProbe\.Ok')
 
 Write-Host ""

--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -443,15 +443,22 @@ Check "the check sits inside the interpreter-present arm" (
 Check "it does not delete that venv either" (-not ($_reuse -match 'Remove-Item'))
 
 Write-Host ""
-Write-Host "=== an installer-managed repair never downgrades a GPU wheel to CPU ==="
+Write-Host "=== an installer-managed repair never moves a GPU wheel to another family ==="
 # install.ps1 resolves the index and installs the torch trio ITSELF, minutes before it invokes
 # setup, and hands over no record of which family it chose -- setup probes the hardware again
 # from scratch. When that second probe fails (a Get-CimInstance that throws, an nvidia-smi that
-# does not answer, the single-Radeon unroll at the top of this file) setup lands on "cpu",
+# does not answer, the single-Radeon unroll at the top of this file) setup lands somewhere else,
 # reads the +cu / +rocm / +xpu wheel install.ps1 just placed as stale, and the in-place repair
-# --force-reinstalls CPU torch over it. Then setup exits 0, install.ps1 counts the run a success
-# and drops the rollback copy. The abort this repair replaced at least failed loudly; this would
-# commit a CPU-only install on a GPU box, silently, which is a worse trade.
+# --force-reinstalls the other family over it. Then setup exits 0, install.ps1 counts the run a
+# success and drops the rollback copy. The abort this repair replaced at least failed loudly;
+# this commits a wrong install silently, which is a worse trade.
+#
+# "cpu" was only the first direction. The same disagreement runs GPU-to-GPU on any box holding
+# two vendors' cards -- a Radeon plus a GeForce, an Arc plus a GeForce -- where one scan answers
+# in install.ps1 and the other in setup: +rocm read as cu128, +cu128 read as rocm, +xpu read as
+# either. install.ps1's own flavor repair has already reconciled the venv against the index it
+# chose before it calls setup, so a GPU wheel sitting here IS its answer, and setup's second
+# opinion is not better evidence than the first.
 $_guardPat = '(?s)(if \(\$shouldRebuild -and \$InstallerManagedSetup -and\n.*?\n    \}\n)'
 $_guard = if ($setupText -match $_guardPat) { $Matches[1] } else { "" }
 Check "the downgrade guard was found"       ($_guard -ne "")
@@ -462,49 +469,161 @@ Check "CRLF is normalised, not tolerated"   (-not (($setupText -replace "`n", "`
 # never created, and reading it under a caller's Set-StrictMode is fatal.
 Check "it only fires under the installer"   ($_guard -match '\$InstallerManagedSetup')
 Check "it only fires on a GPU wheel"        ($_guard -match '\$installedTorchTag -and \$installedTorchTag -ne "cpu"')
-Check "it only fires when the rescan said cpu" ($_guard -match '\$expectedTorchTag -eq "cpu"')
-Check "the installed tag is tested before the expected one" (
-    $_guard.IndexOf('$installedTorchTag -and') -ge 0 -and
-    $_guard.IndexOf('$installedTorchTag -and') -lt $_guard.IndexOf('$expectedTorchTag -eq "cpu"'))
+# The condition must NOT narrow to a cpu rescan: that spelling left every GPU-to-GPU direction
+# running straight into the in-place repair below.
+Check "it is not narrowed to a cpu rescan"  (-not ($_guard -match '\$expectedTorchTag -eq "cpu"'))
+# $expectedTorchTag is assigned only inside the `if (-not $shouldRebuild)` block above, so on a
+# venv whose torch would not import it was never created. Reading it in the CONDITION would be
+# fatal under a caller's Set-StrictMode, and -and short-circuits it away only if it is not there
+# at all -- inside the body it is reached only once $installedTorchTag has already answered.
+Check "the condition never reads the expected tag" (
+    -not (($_guard -split '\{', 2)[0] -match '\$expectedTorchTag'))
 Check "it clears the rebuild flag"          ($_guard -match '\$shouldRebuild = \$false')
-# The whole point: no --force-reinstall is raised, so the CPU arm below leaves the GPU wheel in
-# place (a +cu / +rocm / +xpu build already satisfies its torch>= range).
+# The whole point: no --force-reinstall is raised, so the arm below leaves the GPU wheel in
+# place (a +cu / +rocm / +xpu build already satisfies a bare torch>= range).
 Check "it does not raise force-reinstall"   (-not ($_guard -match 'PinChangedForceReinstall = \$true'))
 Check "it does not wipe the venv"           (-not ($_guard -match 'Remove-Item'))
 # An xpu venv kept here needs the same index lock the direct-update escape takes, or the pass
 # installs triton-windows over torch's XPU triton with nothing to swap it back.
 Check "a kept xpu venv still locks the xpu index" (
     $_guard -match 'if \(\$installedTorchTag -eq "xpu"\) \{ \$script:PreservedXpuVenv = \$true \}')
+# Keeping the wheel is not enough on its own: two install arms a thousand lines below force
+# torch back regardless of $script:PinChangedForceReinstall, so the kept family has to reach the
+# index selection. Same treatment as $script:PreservedXpuVenv, including the declaration outside
+# the venv block that a fresh install never enters.
+Check "the kept family is recorded for the index selection" (
+    $_guard -match '\$script:PreservedInstallerTorchTag = \$installedTorchTag')
+Check "that flag is declared outside the venv block" (
+    $setupText -match '(?m)^\$script:PreservedInstallerTorchTag = \$null$')
+Check "the declaration precedes the stale check" (
+    $setupText.IndexOf('$script:PreservedInstallerTorchTag = $null') -ge 0 -and
+    $setupText.IndexOf('$script:PreservedInstallerTorchTag = $null') -lt
+    $setupText.IndexOf('$script:PreservedInstallerTorchTag = $installedTorchTag'))
 # ...and it has to run BEFORE the repair, or the repair has already fired.
 Check "the guard precedes the in-place repair" (
     $setupText.IndexOf('if ($shouldRebuild -and $InstallerManagedSetup -and') -ge 0 -and
     $setupText.IndexOf('if ($shouldRebuild -and $InstallerManagedSetup -and') -lt
     $setupText.IndexOf('if ($shouldRebuild -and $InstallerManagedSetup) {'))
-# The repair itself must survive: an unimportable torch ($installedTorchTag $null) and a
-# GPU-to-different-GPU family move are exactly what it is for, and the guard must not swallow
-# them. Driven, not asserted as a shape, over the four combinations that reach it.
-function Test-DowngradeGuard {
-    param($Installed, $Expected)
-    $shouldRebuild = $true
-    $InstallerManagedSetup = $true
-    $installedTorchTag = $Installed
-    $expectedTorchTag = $Expected
-    $force = $false
-    if ($shouldRebuild -and $InstallerManagedSetup -and
-        $installedTorchTag -and $installedTorchTag -ne "cpu" -and $expectedTorchTag -eq "cpu") {
-        $shouldRebuild = $false
-    }
-    if ($shouldRebuild -and $InstallerManagedSetup) { $force = $true; $shouldRebuild = $false }
-    return [pscustomobject]@{ Force = $force; Rebuild = $shouldRebuild }
+Write-Host ""
+Write-Host "--- driven end to end, over setup.ps1's own source"
+# A hand-copy of the cascade would keep passing after the file it claims to test changed, which
+# is exactly how the cpu-only spelling survived review. So the WHOLE decision -- the pin escape,
+# the cu*-to-cu* escape, the direct-update xpu escape, this guard and the in-place repair -- is
+# lifted out of setup.ps1 verbatim and executed, and so is the index selection that the kept
+# family has to survive. Nothing below is retyped.
+$_cascadePat = '(?s)(    if \(\$shouldRebuild -and \$_pinnedIdx -and \$installedTorchTag\) \{.*?\n    if \(\$shouldRebuild -and \$InstallerManagedSetup\) \{.*?\n    \}\n)'
+$_cascade = if ($setupText -match $_cascadePat) { $Matches[1] } else { "" }
+Check "the decision cascade was found"     ($_cascade -ne "")
+Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_cascadePat))
+# Ends on the closing brace of the `else { $CuTag = "cpu" }` arm, so a truncated match cannot
+# leave a region that still assigns $CuTag.
+$_cuTagPat = '(?s)(if \(\$PinnedTorchIndexUrl\) \{\n    \$CuTag = Get-TorchIndexLeaf.*?\n\} else \{\n    \$CuTag = "cpu"\n\}\n)'
+$_cuTag = if ($setupText -match $_cuTagPat) { $Matches[1] } else { "" }
+Check "the index selection was found"      ($_cuTag -ne "")
+Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_cuTagPat))
+# The two install arms that force torch back on their own. Their CONDITIONS are extracted and
+# evaluated below, so "the kept wheel survives" is answered by the shipped gates, not by a claim
+# about them. The AMD arm's --force-reinstall is unconditional inside its block; the XPU arm's
+# is keyed off the installed tag. Both are asserted here so a change to either is caught.
+Check "the AMD arm still force-reinstalls unconditionally" (
+    $setupText -match 'Fast-Install @_rocmTrio --force-reinstall --index-url \$ROCmIndexUrl')
+Check "the XPU arm forces on any non-xpu tag" (
+    $setupText -match 'if \(\$installedTorchTag -ne "xpu"\) \{ \$xpuForce = @\("--force-reinstall"\) \}')
+$_amdGate = if ($setupText -match '(?m)^if \((-not \$TorchIndexPinned -and \(\$HasROCm -or \$ROCmGfxArch\) -and \$CuTag -eq "cpu")\) \{$') { $Matches[1] } else { "" }
+$_xpuGate = if ($setupText -match '(?m)^if \((-not \$ROCmIndexUrl -and \$CuTag -eq "xpu")\) \{ \$XpuIndexUrl') { $Matches[1] } else { "" }
+Check "the AMD reroute gate was found"     ($_amdGate -ne "")
+Check "the XPU arm gate was found"         ($_xpuGate -ne "")
+
+# The real Test-CudaFamilyLeaf, because the index selection calls it on the preserved tag.
+foreach ($srcText in (Get-HelperSources $setup @("Test-CudaFamilyLeaf"))) { Invoke-Expression $srcText }
+Check "Test-CudaFamilyLeaf came across"    ((Test-CudaFamilyLeaf "cu128") -and -not (Test-CudaFamilyLeaf "rocm"))
+function Get-PytorchCudaTag { return "cu128" }
+
+# One case = one host. Installed is what install.ps1 left in the venv; Expected is what setup's
+# rescan concluded; the Has* values are that same rescan, and they have to agree with Expected or
+# the case is not a real host. Run at script scope (Invoke-Expression inside a function would put
+# the extracted `$script:` writes and the reads in different scopes).
+$_cases = @(
+    # +rocm venv, rescan found the GeForce in the same box and not the Radeon.
+    @{ Name = "rocm wheel, rescan says cu128"; Installed = "rocm";  Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $true;  CuTag = "cpu";   Amd = $false; XpuArm = $false }
+    # +cu128 venv, nvidia-smi did not answer this time and the Radeon did.
+    @{ Name = "cu128 wheel, rescan says rocm";  Installed = "cu128"; Expected = "rocm";  Nvidia = $false; Xpu = $false; Rocm = $true;  Gfx = "gfx1151"
+       Keep = $true;  CuTag = "cu128"; Amd = $false; XpuArm = $false }
+    # +xpu venv on an Arc + GeForce box: the promotion above is gated on -not $HasNvidiaSmi.
+    @{ Name = "xpu wheel, rescan says cu128";   Installed = "xpu";   Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $true;  CuTag = "xpu";   Amd = $false; XpuArm = $true }
+    # The direction round one closed, kept as a regression: no GPU found at all.
+    @{ Name = "rocm wheel, rescan says cpu";    Installed = "rocm";  Expected = "cpu";   Nvidia = $false; Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $true;  CuTag = "cpu";   Amd = $false; XpuArm = $false }
+    @{ Name = "cu128 wheel, rescan says cpu";   Installed = "cu128"; Expected = "cpu";   Nvidia = $false; Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $true;  CuTag = "cu128"; Amd = $false; XpuArm = $false }
+    # ...and the repairs that MUST still happen, or this guard has reintroduced the loop.
+    @{ Name = "cpu wheel on a ROCm host";       Installed = "cpu";   Expected = "rocm";  Nvidia = $false; Xpu = $false; Rocm = $true;  Gfx = "gfx1151"
+       Keep = $false; CuTag = "cpu";   Amd = $true;  XpuArm = $false }
+    @{ Name = "cpu wheel on a CUDA host";       Installed = "cpu";   Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $false; CuTag = "cu128"; Amd = $false; XpuArm = $false }
+    # A cu* family move is a repair, not a family change, and escapes before the guard.
+    @{ Name = "cu126 wheel on a cu128 host";    Installed = "cu126"; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $false; CuTag = "cu128"; Amd = $false; XpuArm = $false }
+    # Torch does not import at all: the venv is broken, not a family disagreement.
+    @{ Name = "torch that will not import";     Installed = $null;   Expected = $null;   Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $false; CuTag = "cu128"; Amd = $false; XpuArm = $false }
+)
+foreach ($case in $_cases) {
+    $script:shouldRebuild = $true
+    $script:InstallerManagedSetup = $true
+    $script:installedTorchTag = $case.Installed
+    # Left UNASSIGNED when the probe failed, exactly as setup.ps1 leaves it, so a condition that
+    # reads it before $installedTorchTag has answered is caught here rather than on a user's box.
+    if ($null -ne $case.Expected) { $script:expectedTorchTag = $case.Expected }
+    else { Remove-Variable -Name expectedTorchTag -Scope Script -ErrorAction SilentlyContinue }
+    $script:_pinnedIdx = $null
+    $script:_verProbe = $null
+    $script:PinChangedForceReinstall = $false
+    $script:PreservedXpuVenv = $false
+    $script:PreservedInstallerTorchTag = $null
+    $script:reason = $null
+    Invoke-Expression $_cascade
+
+    $script:PinnedTorchIndexUrl = $null
+    $script:TorchIndexPinned = $false
+    $script:HasNvidiaSmi = $case.Nvidia
+    $script:IsIntelXpu = $case.Xpu
+    $script:HasROCm = $case.Rocm
+    $script:ROCmGfxArch = $case.Gfx
+    Invoke-Expression $_cuTag
+    $script:ROCmIndexUrl = $null
+    $_amdRuns = [bool](Invoke-Expression $_amdGate)
+    # The AMD arm sets $ROCmIndexUrl, and the XPU gate reads it.
+    if ($_amdRuns) { $script:ROCmIndexUrl = "https://repo.amd.com/rocm/whl/gfx1151/" }
+    $_xpuRuns = [bool](Invoke-Expression $_xpuGate)
+    # The three arms' force decisions, as the file spells them.
+    $_forced = $script:PinChangedForceReinstall -or $_amdRuns -or ($_xpuRuns -and $installedTorchTag -ne "xpu")
+
+    Write-Host "  case: $($case.Name)"
+    Check "    it is not rebuilt from scratch"  (-not $script:shouldRebuild)
+    Check "    in-place repair = $(-not $case.Keep)" ($script:PinChangedForceReinstall -eq (-not $case.Keep))
+    Check "    index family = $($case.CuTag)"   ($script:CuTag -eq $case.CuTag)
+    Check "    AMD arm runs = $($case.Amd)"     ($_amdRuns -eq $case.Amd)
+    Check "    XPU arm runs = $($case.XpuArm)"  ($_xpuRuns -eq $case.XpuArm)
+    # The claim the whole guard rests on: no arm re-lands torch over the kept wheel.
+    Check "    torch is force-reinstalled = $(-not $case.Keep)" ($_forced -eq (-not $case.Keep))
 }
-Check "rocm wheel + cpu rescan is kept, not reinstalled" (-not (Test-DowngradeGuard "rocm" "cpu").Force)
-Check "cu128 wheel + cpu rescan is kept, not reinstalled" (-not (Test-DowngradeGuard "cu128" "cpu").Force)
-Check "xpu wheel + cpu rescan is kept, not reinstalled"  (-not (Test-DowngradeGuard "xpu" "cpu").Force)
-Check "an unimportable torch still repairs in place"     ((Test-DowngradeGuard $null "cpu").Force)
-Check "a cpu wheel on a CUDA host still repairs in place" ((Test-DowngradeGuard "cpu" "cu128").Force)
-Check "a rocm wheel on a CUDA host still repairs in place" ((Test-DowngradeGuard "rocm" "cu128").Force)
-Check "nothing reaches the wipe under the installer"      (
-    -not (Test-DowngradeGuard "rocm" "cpu").Rebuild -and -not (Test-DowngradeGuard $null "cpu").Rebuild)
+
+# The guard must not read $expectedTorchTag before $installedTorchTag has answered, and the case
+# above proves the cascade survives it. Prove the hazard is real rather than taking it on trust:
+# under a caller's Set-StrictMode -- studio/setup.bat launches setup WITHOUT -NoProfile, so a
+# profile can set one -- reading a variable that was never assigned throws.
+$_strictUnassignedThrew = $false
+try {
+    & {
+        Set-StrictMode -Version Latest
+        $installedTorchTag = $null
+        $null = ($installedTorchTag -eq "cpu" -or $expectedTorchTag -eq "cpu")
+    }
+} catch { $script:_strictUnassignedThrew = $true }
+Check "reading the unassigned expected tag really does throw" $_strictUnassignedThrew
 
 Write-Host ""
 Write-Host "=== the AMD fast-path probe is bounded too ==="

--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -466,7 +466,16 @@ try {
         'if ($env:PATH -eq $before) { Write-Output "PATH-UNTOUCHED" }',
         'Write-Output "SURVIVED"',
         'exit 0')
-    $_childOut = & $_hostExe -NoProfile -File $_child 2>$null | Out-String
+    # The corrupt script writes its parse error to stderr, and Windows PowerShell 5.1 wraps a
+    # native command's stderr in a NativeCommandError and applies $ErrorActionPreference to it,
+    # so the "Stop" set at the top of this file would end the run here. 7.1 stopped applying the
+    # preference to native stderr, which is why this passes under pwsh and only fails on the 5.1
+    # leg. Scope the preference to the call; the exit code is what this actually judges, and it is
+    # read on the next line.
+    $_childOut = & {
+        $ErrorActionPreference = "Continue"
+        & $_hostExe -NoProfile -File $_child 2>$null
+    } | Out-String
     $_childRc = $LASTEXITCODE
     Check "an unparseable activation script does not stop the script either" ($_childOut -match 'SURVIVED')
     Check "and it leaves PATH untouched too" ($_childOut -match 'PATH-UNTOUCHED')

--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -443,6 +443,170 @@ Check "the check sits inside the interpreter-present arm" (
 Check "it does not delete that venv either" (-not ($_reuse -match 'Remove-Item'))
 
 Write-Host ""
+Write-Host "=== a present activation script is not the same as an activated venv ==="
+# Both refusals above check that a FILE is there. Neither can tell whether dot-sourcing it took
+# effect, and Activate.ps1 prepends the venv to PATH in its very last statement -- $env:VIRTUAL_ENV
+# is set well before it. So a copy truncated by an interrupted or out-of-disk `python -m venv`
+# runs to its last complete statement and returns having changed nothing that matters, and an
+# unparseable one is a ParserError, which is non-terminating at the "Continue" the pip section
+# runs at. Prove both hazards live before asserting the guard, exactly as the missing-script case
+# above is proven.
+$_actRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("unsloth-activate-" + [guid]::NewGuid().ToString("N"))
+try {
+    New-Item -ItemType Directory -Path $_actRoot -Force | Out-Null
+
+    $_truncated = Join-Path $_actRoot "truncated.ps1"
+    # Everything Activate.ps1 does BEFORE its final PATH line, and nothing after it.
+    Set-Content -LiteralPath $_truncated -Value '$env:UNSLOTH_ACTIVATE_PROBE = "reached"'
+    $_corrupt = Join-Path $_actRoot "corrupt.ps1"
+    Set-Content -LiteralPath $_corrupt -Value @('$env:UNSLOTH_ACTIVATE_PROBE = "reached"', 'if ( { unclosed')
+
+    $_pathBefore = $env:PATH
+    $env:UNSLOTH_ACTIVATE_PROBE = ""
+    $Error.Clear()
+    $_truncKeptGoing = $false
+    & {
+        $ErrorActionPreference = "Continue"
+        . $_truncated
+        $script:_truncKeptGoing = $true
+    } 2>$null
+    Check "a truncated activation script does not stop the script" $_truncKeptGoing
+    # The worst part of this one: there is no red line to notice, unlike the missing-file case.
+    Check "and raises no error at all" ($Error.Count -eq 0)
+    Check "and leaves PATH exactly as it found it" ($env:PATH -eq $_pathBefore)
+    # It still got far enough to set the state a VIRTUAL_ENV check would have trusted, which is
+    # why the guard has to look at the resolved interpreter instead.
+    Check "while still setting the state that precedes the PATH line" ($env:UNSLOTH_ACTIVATE_PROBE -eq "reached")
+
+    $env:UNSLOTH_ACTIVATE_PROBE = $null
+
+    # The unparseable case has to run in a child host, in setup.ps1's actual shape: script-scope
+    # "Continue" and no enclosing try. A ParserError is non-terminating there, but inside a try
+    # under this file's script-scope "Stop" it converts and unwinds, which would prove the
+    # opposite of what setup.ps1 does. setup.ps1 is itself launched as a fresh host process
+    # (unsloth_cli/commands/studio.py), so the child is the faithful reproduction, not a dodge.
+    $_hostExe = try { [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName } catch { $null }
+    Check "the host executable is known" ($_hostExe -and (Test-Path -LiteralPath $_hostExe))
+    $_child = Join-Path $_actRoot "child.ps1"
+    Set-Content -LiteralPath $_child -Value @(
+        '$ErrorActionPreference = "Continue"',
+        '$before = $env:PATH',
+        ('. ' + "'" + $_corrupt + "'"),
+        'if ($env:PATH -eq $before) { Write-Output "PATH-UNTOUCHED" }',
+        'Write-Output "SURVIVED"',
+        'exit 0')
+    $_childOut = & $_hostExe -NoProfile -File $_child 2>$null | Out-String
+    $_childRc = $LASTEXITCODE
+    Check "an unparseable activation script does not stop the script either" ($_childOut -match 'SURVIVED')
+    Check "and it leaves PATH untouched too" ($_childOut -match 'PATH-UNTOUCHED')
+    # The whole point: the run can still report success over an environment it never entered.
+    Check "and the run still exits 0" ($_childRc -eq 0)
+
+    # ── the guard itself, executed ──
+    # @() then [0]: a one-name request returns a one-element array that unrolls to a String.
+    # Caught rather than thrown, so a tree without the guard reports every check below as FAIL
+    # instead of unwinding at the first one and hiding the rest.
+    $_assertFn = try { @(Get-HelperSources $setup @("Assert-VenvActivated"))[0] } catch { "" }
+    # An empty or wrong extraction would make every case below pass vacuously.
+    Check "extraction kept the interpreter lookup" ($_assertFn -match 'Get-Command python')
+    # A VIRTUAL_ENV check is the tempting wrong answer, and the truncation above is why it fails.
+    # The -ne "" is the anti-vacuity half: -not on an empty region passes against no guard at all.
+    Check "the guard does not settle for VIRTUAL_ENV" (($_assertFn -ne "") -and -not ($_assertFn -match 'VIRTUAL_ENV'))
+
+    # Real directories rather than a Get-Item stub: separator handling, trailing separators and
+    # case folding are the whole risk here, and a stub would just re-implement the bug.
+    $_venvOk = Join-Path $_actRoot "venv"
+    $_venvOkPy = Join-Path (Join-Path $_venvOk "Scripts") "python.exe"
+    New-Item -ItemType File -Path $_venvOkPy -Force | Out-Null
+    $_venvSibling = Join-Path $_actRoot "venv2"
+    $_venvSiblingPy = Join-Path (Join-Path $_venvSibling "Scripts") "python.exe"
+    New-Item -ItemType File -Path $_venvSiblingPy -Force | Out-Null
+    $_ambientPy = Join-Path (Join-Path $_actRoot "WindowsApps") "python.exe"
+    New-Item -ItemType File -Path $_ambientPy -Force | Out-Null
+
+    # Returns the refusal message, or $null when the guard let the run continue.
+    function Invoke-AssertVenv {
+        param([string] $VenvDir, [string] $PythonSource, [string] $CommandType = 'Application', [switch] $NoPython)
+        $sb = [scriptblock]::Create(@"
+param(`$Venv, `$Src, `$Type, `$NoPy)
+function Write-StudioLine { param([string] `$Line, `$ForegroundColor) }
+# Exit-SetupFailure calls `exit`, which is not catchable; a throw is, so the case can be asserted.
+function Exit-SetupFailure { param([string] `$Message, [int] `$Code = 1) throw "REFUSED: `$Message" }
+function Get-Command {
+    [CmdletBinding()] param([Parameter(Position = 0)] `$Name, [Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+    if (`$NoPy) { return `$null }
+    return [pscustomobject]@{ Source = `$Src; CommandType = `$Type }
+}
+$_assertFn
+Assert-VenvActivated -VenvDir `$Venv
+"@)
+        try { & $sb $VenvDir $PythonSource $CommandType ([bool]$NoPython) | Out-Null; return $null }
+        catch { return $_.Exception.Message }
+    }
+
+    Check "an activated venv is accepted" (
+        $null -eq (Invoke-AssertVenv -VenvDir $_venvOk -PythonSource $_venvOkPy))
+    # The state this whole section exists for: activation no-opped, so `python` is still the
+    # ambient one install.ps1 took care to leave on PATH.
+    Check "an ambient interpreter is refused" (
+        (Invoke-AssertVenv -VenvDir $_venvOk -PythonSource $_ambientPy) -match 'did not put its interpreter on PATH')
+    Check "and the refusal names where python actually resolved" (
+        (Invoke-AssertVenv -VenvDir $_venvOk -PythonSource $_ambientPy) -match 'WindowsApps')
+    Check "no python at all is refused" (
+        (Invoke-AssertVenv -VenvDir $_venvOk -NoPython) -match 'did not put its interpreter on PATH')
+    # A prefix compare without a separator would call venv2 a child of venv.
+    Check "a sibling venv is not mistaken for this one" (
+        (Invoke-AssertVenv -VenvDir $_venvOk -PythonSource $_venvSiblingPy) -match 'did not put its interpreter on PATH')
+
+    # ── the false-positive side, which matters more than the true-positive side ──
+    # A guard that refuses a working install is worse than the bug it closes.
+    Check "a trailing separator on the venv path still passes" (
+        $null -eq (Invoke-AssertVenv -VenvDir ($_venvOk + [System.IO.Path]::DirectorySeparatorChar) -PythonSource $_venvOkPy))
+    # Windows paths are case-insensitive, and the two sides can disagree on case.
+    Check "a differently cased venv path still passes" (
+        $null -eq (Invoke-AssertVenv -VenvDir $_venvOk -PythonSource ($_venvOkPy.ToUpperInvariant())))
+    # An alias or function named python carries no Source, so nothing can be proven about it.
+    Check "a non-application python is left alone" (
+        $null -eq (Invoke-AssertVenv -VenvDir $_venvOk -PythonSource $_ambientPy -CommandType 'Function'))
+    # If the venv root cannot even be resolved the guard has no ground to stand on, and the two
+    # refusals above it already cover a venv that is not there.
+    Check "an unresolvable venv path is left alone" (
+        $null -eq (Invoke-AssertVenv -VenvDir (Join-Path $_actRoot "no-such-venv") -PythonSource $_ambientPy))
+} finally {
+    Remove-Item -LiteralPath $_actRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ── where it is wired in ──
+# Both ends sit immediately after a non-newline token, so a CRLF checkout fails the match rather
+# than yielding an empty region every -not check below would pass against.
+$_actPat = '(?s)(\$ActivateScript = Join-Path \$VenvDir "Scripts\\Activate\.ps1"\n\. \$ActivateScript\n.*?Assert-VenvActivated -VenvDir \$VenvDir\n)'
+$_act = if ($setupText -match $_actPat) { $Matches[1] } else { "" }
+Check "the activation block was found"     ($_act -ne "")
+Check "CRLF is normalised, not tolerated"  (-not (($setupText -replace "`n", "`r`n") -match $_actPat))
+# A post-condition, so it has to come AFTER the dot-source, not alongside the two pre-conditions.
+Check "the assertion follows the dot-source" (
+    $setupText.IndexOf('. $ActivateScript') -ge 0 -and
+    $setupText.IndexOf('. $ActivateScript') -lt
+    $setupText.IndexOf('Assert-VenvActivated -VenvDir $VenvDir'))
+# Nothing between here and Fast-Install re-checks, and Fast-Install is where a wrong interpreter
+# starts receiving the stack.
+Check "it lands before Fast-Install resolves python" (
+    $setupText.IndexOf('Assert-VenvActivated -VenvDir $VenvDir') -ge 0 -and
+    $setupText.IndexOf('Assert-VenvActivated -VenvDir $VenvDir') -lt
+    $setupText.IndexOf('function Fast-Install'))
+# The re-activation after Refresh-Environment sits inside a catch that swallows everything, so
+# the second call site is not a duplicate of the first.
+Check "the re-activation is covered as well" (
+    ([regex]::Matches($setupText, [regex]::Escape('Assert-VenvActivated -VenvDir $VenvDir'))).Count -ge 2)
+Check "and that one is outside the swallowing catch" (
+    $setupText.IndexOf('} catch { }') -ge 0 -and
+    $setupText.IndexOf('} catch { }') -lt
+    $setupText.LastIndexOf('Assert-VenvActivated -VenvDir $VenvDir'))
+# It refuses; it does not repair, and it does not wipe a venv install.ps1 may still need to
+# restore from.
+Check "the guard does not delete anything" (($_act -ne "") -and -not ($_act -match 'Remove-Item'))
+
+Write-Host ""
 Write-Host "=== an installer-managed repair never moves a GPU wheel to another family ==="
 # install.ps1 resolves the index and installs the torch trio ITSELF, minutes before it invokes
 # setup, and hands over no record of which family it chose -- setup probes the hardware again

--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -655,6 +655,47 @@ Check "a kept xpu venv still locks the xpu index" (
 # torch back regardless of $script:PinChangedForceReinstall, so the kept family has to reach the
 # index selection. Same treatment as $script:PreservedXpuVenv, including the declaration outside
 # the venv block that a fresh install never enters.
+
+# ── the half of the guard that keeps it from preserving a wheel nobody chose ──
+# "There is a GPU wheel in the venv" is not evidence that THIS install run put it there.
+# install.ps1's migrated-venv arm installs unsloth alone and never touches torch, and its flavor
+# repair no-ops whenever its own expected tag is 'cpu' or unrecognised -- so an ordinary upgrade
+# off the legacy ~/.unsloth/studio/.venv layout hands setup whatever wheel the previous install
+# left, on whatever hardware that was. Preserving THAT is not conservatism, it is a permanently
+# wrong environment that setup then refuses to repair, and on a mapped AMD host the kept cu* tag
+# also blocks the ROCm reroute (it needs $CuTag -eq "cpu"). So install.ps1 says which family it
+# settled on and only a wheel matching it counts as its answer.
+$installText = (Get-Content -Raw (Join-Path $root "install.ps1")) -replace "`r`n", "`n"
+Check "install.ps1 reports the family it settled on" (
+    $installText -match '\$env:UNSLOTH_INSTALLER_TORCH_TAG = if \(\$SkipTorch\) \{ "" \} else \{')
+Check "it reports the resolved flavor, not the raw index URL" (
+    $installText -match '\[string\]\(Get-ExpectedTorchFlavorTag -TorchIndexUrl \$TorchIndexUrl -ROCmIndexUrl \$ROCmIndexUrl\)')
+# Unconditional, like $env:UNSLOTH_NO_TORCH next to it: a second install in the same PowerShell
+# session must not inherit the first one's answer. Assigning "" clears it on every edition --
+# 7.5+ keeps a present blank value, 5.1 and 7.0-7.4 remove the variable outright -- and setup
+# reads both as unknown.
+# The -match half is the anti-vacuity half: a bare -notmatch passes against a tree that never
+# grew the assignment at all.
+Check "the report is assigned on every run, not only when known" (
+    ($installText -match '(?m)^\s*\$env:UNSLOTH_INSTALLER_TORCH_TAG = ') -and
+    ($installText -notmatch 'if \([^\n]*\) \{\s*\$env:UNSLOTH_INSTALLER_TORCH_TAG'))
+Check "it is handed over before setup is invoked" (
+    $installText.IndexOf('$env:UNSLOTH_INSTALLER_TORCH_TAG') -ge 0 -and
+    $installText.IndexOf('$env:UNSLOTH_INSTALLER_TORCH_TAG') -lt
+    $installText.IndexOf('$studioArgs = @(''studio'', ''setup'')'))
+# setup.ps1 ships in the pip package and install.ps1 is fetched from unsloth.ai, so the two can
+# be different ages. An absent variable therefore has to mean "unknown", not "mismatch", or a
+# cached older installer would start force-reinstalling over its own correct choice -- which is
+# the bug the guard was added for. Blank counts as absent for the 7.5+ spelling.
+Check "setup.ps1 reads the reported family"  (
+    $setupText -match '(?m)^\$InstallerTorchTag = if \(\[string\]::IsNullOrWhiteSpace\(\$env:UNSLOTH_INSTALLER_TORCH_TAG\)\) \{ \$null \}')
+Check "an absent report is unknown, not a mismatch" (
+    $_guard -match '\(\(-not \$InstallerTorchTag\) -or \$installedTorchTag -eq \$InstallerTorchTag\)')
+Check "the read precedes the stale check" (
+    $setupText.IndexOf('$InstallerTorchTag = if ([string]::IsNullOrWhiteSpace(') -ge 0 -and
+    $setupText.IndexOf('$InstallerTorchTag = if ([string]::IsNullOrWhiteSpace(') -lt
+    $setupText.IndexOf('(-not $InstallerTorchTag) -or $installedTorchTag -eq $InstallerTorchTag'))
+
 Check "the kept family is recorded for the index selection" (
     $_guard -match '\$script:PreservedInstallerTorchTag = \$installedTorchTag')
 Check "that flag is declared outside the venv block" (
@@ -703,38 +744,81 @@ foreach ($srcText in (Get-HelperSources $setup @("Test-CudaFamilyLeaf"))) { Invo
 Check "Test-CudaFamilyLeaf came across"    ((Test-CudaFamilyLeaf "cu128") -and -not (Test-CudaFamilyLeaf "rocm"))
 function Get-PytorchCudaTag { return "cu128" }
 
-# One case = one host. Installed is what install.ps1 left in the venv; Expected is what setup's
-# rescan concluded; the Has* values are that same rescan, and they have to agree with Expected or
-# the case is not a real host. Run at script scope (Invoke-Expression inside a function would put
+# One case = one host. Installed is what setup found in the venv; InstallerTag is the family
+# install.ps1 reported settling on for this host (an empty string is the installer saying it has
+# no answer, $null is an installer too old to say at all); Expected is what setup's rescan
+# concluded; the Has* values are that same rescan, and they have to agree with Expected or the
+# case is not a real host. Run at script scope (Invoke-Expression inside a function would put
 # the extracted `$script:` writes and the reads in different scopes).
 $_cases = @(
     # +rocm venv, rescan found the GeForce in the same box and not the Radeon.
-    @{ Name = "rocm wheel, rescan says cu128"; Installed = "rocm";  Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+    @{ Name = "rocm wheel the installer chose, rescan says cu128"; Installed = "rocm"; InstallerTag = "rocm"; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $true;  CuTag = "cpu";   Amd = $false; XpuArm = $false }
     # +cu128 venv, nvidia-smi did not answer this time and the Radeon did.
-    @{ Name = "cu128 wheel, rescan says rocm";  Installed = "cu128"; Expected = "rocm";  Nvidia = $false; Xpu = $false; Rocm = $true;  Gfx = "gfx1151"
+    @{ Name = "cu128 wheel the installer chose, rescan says rocm";  Installed = "cu128"; InstallerTag = "cu128"; Expected = "rocm";  Nvidia = $false; Xpu = $false; Rocm = $true;  Gfx = "gfx1151"
        Keep = $true;  CuTag = "cu128"; Amd = $false; XpuArm = $false }
     # +xpu venv on an Arc + GeForce box: the promotion above is gated on -not $HasNvidiaSmi.
-    @{ Name = "xpu wheel, rescan says cu128";   Installed = "xpu";   Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+    @{ Name = "xpu wheel the installer chose, rescan says cu128";   Installed = "xpu";   InstallerTag = "xpu"; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $true;  CuTag = "xpu";   Amd = $false; XpuArm = $true }
     # The direction round one closed, kept as a regression: no GPU found at all.
-    @{ Name = "rocm wheel, rescan says cpu";    Installed = "rocm";  Expected = "cpu";   Nvidia = $false; Xpu = $false; Rocm = $false; Gfx = $null
+    @{ Name = "rocm wheel the installer chose, rescan says cpu";    Installed = "rocm";  InstallerTag = "rocm"; Expected = "cpu";   Nvidia = $false; Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $true;  CuTag = "cpu";   Amd = $false; XpuArm = $false }
-    @{ Name = "cu128 wheel, rescan says cpu";   Installed = "cu128"; Expected = "cpu";   Nvidia = $false; Xpu = $false; Rocm = $false; Gfx = $null
+    @{ Name = "cu128 wheel the installer chose, rescan says cpu";   Installed = "cu128"; InstallerTag = "cu128"; Expected = "cpu";   Nvidia = $false; Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $true;  CuTag = "cu128"; Amd = $false; XpuArm = $false }
-    # ...and the repairs that MUST still happen, or this guard has reintroduced the loop.
-    @{ Name = "cpu wheel on a ROCm host";       Installed = "cpu";   Expected = "rocm";  Nvidia = $false; Xpu = $false; Rocm = $true;  Gfx = "gfx1151"
+    # An installer too old to carry the variable at all. setup.ps1 ships in the pip package and
+    # install.ps1 is fetched from unsloth.ai, so this pairing is normal, not exotic. Unknown has
+    # to keep preserving or a cached older installer starts losing its own correct choice.
+    @{ Name = "rocm wheel, installer did not say, rescan says cu128"; Installed = "rocm"; InstallerTag = $null; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $true;  CuTag = "cpu";   Amd = $false; XpuArm = $false }
+    # ── the wheels the installer did NOT choose ──
+    # An upgrade off the legacy layout: install.ps1's migrated arm installs unsloth alone and
+    # never touches torch, and its flavor repair no-ops when its own expected tag is 'cpu'. So a
+    # +cu118 wheel from a previous install on different hardware arrives here untouched. Both
+    # scans agree the box has no NVIDIA GPU; preserving it would pin the whole dependency pass
+    # onto a cu118 index on a machine that has no CUDA device.
+    @{ Name = "stale cu118 wheel the installer did not choose, rescan says cpu"; Installed = "cu118"; InstallerTag = "cpu"; Expected = "cpu"; Nvidia = $false; Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $false; CuTag = "cpu";   Amd = $false; XpuArm = $false }
+    # The same stale wheel on a mapped AMD host. This is the one that costs the most: preserving
+    # it would ALSO set $CuTag to cu118, and the ROCm reroute below needs $CuTag -eq "cpu", so
+    # the Radeon would never get a ROCm wheel and setup would still exit 0.
+    @{ Name = "stale cu118 wheel the installer did not choose, rescan says rocm"; Installed = "cu118"; InstallerTag = "cpu"; Expected = "rocm"; Nvidia = $false; Xpu = $false; Rocm = $true; Gfx = "gfx1151"
        Keep = $false; CuTag = "cpu";   Amd = $true;  XpuArm = $false }
-    @{ Name = "cpu wheel on a CUDA host";       Installed = "cpu";   Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+    # Mirror image: a stale +rocm wheel left by an old Radeon install, on a box that is now
+    # NVIDIA and that the installer resolved as CPU (its own ROCm scan found nothing to map).
+    @{ Name = "stale rocm wheel the installer did not choose, rescan says cu128"; Installed = "rocm"; InstallerTag = "cpu"; Expected = "cu128"; Nvidia = $true; Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $false; CuTag = "cu128"; Amd = $false; XpuArm = $false }
+    # The installer ran but had no answer to give (a custom index whose leaf names no flavor).
+    # Blank is unknown, exactly like absent, so this preserves.
+    @{ Name = "rocm wheel, installer reported blank, rescan says cu128"; Installed = "rocm"; InstallerTag = ""; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+       Keep = $true;  CuTag = "cpu";   Amd = $false; XpuArm = $false }
+    # ...and the repairs that MUST still happen, or this guard has reintroduced the loop.
+    @{ Name = "cpu wheel on a ROCm host";       Installed = "cpu";   InstallerTag = "rocm"; Expected = "rocm";  Nvidia = $false; Xpu = $false; Rocm = $true;  Gfx = "gfx1151"
+       Keep = $false; CuTag = "cpu";   Amd = $true;  XpuArm = $false }
+    @{ Name = "cpu wheel on a CUDA host";       Installed = "cpu";   InstallerTag = "cu128"; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $false; CuTag = "cu128"; Amd = $false; XpuArm = $false }
     # A cu* family move is a repair, not a family change, and escapes before the guard.
-    @{ Name = "cu126 wheel on a cu128 host";    Installed = "cu126"; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+    @{ Name = "cu126 wheel on a cu128 host";    Installed = "cu126"; InstallerTag = "cu128"; Expected = "cu128"; Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $false; CuTag = "cu128"; Amd = $false; XpuArm = $false }
     # Torch does not import at all: the venv is broken, not a family disagreement.
-    @{ Name = "torch that will not import";     Installed = $null;   Expected = $null;   Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
+    @{ Name = "torch that will not import";     Installed = $null;   InstallerTag = "cu128"; Expected = $null;   Nvidia = $true;  Xpu = $false; Rocm = $false; Gfx = $null
        Keep = $false; CuTag = "cu128"; Amd = $false; XpuArm = $false }
 )
+# The installer report is normalised by setup.ps1's own line, lifted out and executed, not by a
+# retyped copy -- so the empty-string case is answered by the shipped code on whichever edition
+# is running (7.5+ keeps a blank value, 5.1 and 7.0-7.4 remove the variable on that assignment).
+$_tagReadPat = '(?m)^(\$InstallerTorchTag = if \(\[string\]::IsNullOrWhiteSpace\(\$env:UNSLOTH_INSTALLER_TORCH_TAG\)\) \{ \$null \}\n\s+else \{[^\n]*\}\n)'
+$_tagRead = if ($setupText -match $_tagReadPat) { $Matches[1] } else { "" }
+Check "the installer-report read was found" ($_tagRead -ne "")
+
 foreach ($case in $_cases) {
+    if ($null -eq $case.InstallerTag) { Remove-Item Env:UNSLOTH_INSTALLER_TORCH_TAG -ErrorAction SilentlyContinue }
+    else { $env:UNSLOTH_INSTALLER_TORCH_TAG = $case.InstallerTag }
+    # Guarded, not bare: Invoke-Expression on an empty string is a terminating error at this
+    # file's script-scope "Stop", so a tree whose read line is missing would unwind here and
+    # every behavioural case below would go unreported rather than FAIL. Same reasoning as the
+    # caught extraction in the activation section.
+    if ($_tagRead) { Invoke-Expression $_tagRead }
+    else { Remove-Variable -Name InstallerTorchTag -Scope Script -ErrorAction SilentlyContinue }
     $script:shouldRebuild = $true
     $script:InstallerManagedSetup = $true
     $script:installedTorchTag = $case.Installed
@@ -773,7 +857,12 @@ foreach ($case in $_cases) {
     Check "    XPU arm runs = $($case.XpuArm)"  ($_xpuRuns -eq $case.XpuArm)
     # The claim the whole guard rests on: no arm re-lands torch over the kept wheel.
     Check "    torch is force-reinstalled = $(-not $case.Keep)" ($_forced -eq (-not $case.Keep))
+    # The kept family must reach the index selection only when the wheel was actually kept, or a
+    # repaired case would still drag the old family through the install arms below.
+    Check "    kept family recorded = $($case.Keep)" (
+        [bool]$script:PreservedInstallerTorchTag -eq $case.Keep)
 }
+Remove-Item Env:UNSLOTH_INSTALLER_TORCH_TAG -ErrorAction SilentlyContinue
 
 # The guard must not read $expectedTorchTag before $installedTorchTag has answered, and the case
 # above proves the cascade survives it. Prove the hazard is real rather than taking it on trust:

--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -419,6 +419,113 @@ Check "it says incomplete, not out of date" ($_reuse -match 'incomplete rather t
 Check "a venv with an interpreter still just prints its version" (
     $_reuse -match '(?s)if \(Test-Path -LiteralPath \$_venvPyExe\) \{.*?--version')
 
+# The interpreter is not the only file that has to be there. Everything after this point reaches
+# the venv through the dot-sourced Activate.ps1 and a bare `python` -- Fast-Install resolves its
+# target with (Get-Command python).Source -- and install.ps1 leaves the venv's Scripts directory
+# off PATH on purpose. So a venv that kept python.exe but lost Activate.ps1 hits the SAME hazard
+# proven above, one file over: the dot-source fails without stopping anything and the whole stack
+# lands in the ambient interpreter. Newly reachable, because an installer-managed stale verdict
+# now repairs where it used to abort.
+Check "it refuses a venv with no activation script" (
+    $_reuse -match 'Exit-SetupFailure "No activation script at')
+Check "the activation script path is built next to the interpreter" (
+    $_reuse -match '\$_venvActivate = Join-Path \$VenvDir "Scripts\\Activate\.ps1"')
+# The -ge 0 is not decoration: IndexOf answers -1 when the refusal is not there at all, and -1
+# is less than every other offset, so the ordering alone passes on a tree that never grew it.
+Check "that refusal also precedes the activation" (
+    $setupText.IndexOf('Exit-SetupFailure "No activation script at') -ge 0 -and
+    $setupText.IndexOf('Exit-SetupFailure "No activation script at') -lt
+    $setupText.IndexOf('$ActivateScript = Join-Path $VenvDir'))
+# It is checked on the arm where the interpreter EXISTS, or it only ever fires alongside the
+# missing-interpreter refusal and never on its own.
+Check "the check sits inside the interpreter-present arm" (
+    $_reuse -match '(?s)if \(Test-Path -LiteralPath \$_venvPyExe\) \{.*?Exit-SetupFailure "No activation script at.*?\} else \{')
+Check "it does not delete that venv either" (-not ($_reuse -match 'Remove-Item'))
+
+Write-Host ""
+Write-Host "=== an installer-managed repair never downgrades a GPU wheel to CPU ==="
+# install.ps1 resolves the index and installs the torch trio ITSELF, minutes before it invokes
+# setup, and hands over no record of which family it chose -- setup probes the hardware again
+# from scratch. When that second probe fails (a Get-CimInstance that throws, an nvidia-smi that
+# does not answer, the single-Radeon unroll at the top of this file) setup lands on "cpu",
+# reads the +cu / +rocm / +xpu wheel install.ps1 just placed as stale, and the in-place repair
+# --force-reinstalls CPU torch over it. Then setup exits 0, install.ps1 counts the run a success
+# and drops the rollback copy. The abort this repair replaced at least failed loudly; this would
+# commit a CPU-only install on a GPU box, silently, which is a worse trade.
+$_guardPat = '(?s)(if \(\$shouldRebuild -and \$InstallerManagedSetup -and\n.*?\n    \}\n)'
+$_guard = if ($setupText -match $_guardPat) { $Matches[1] } else { "" }
+Check "the downgrade guard was found"       ($_guard -ne "")
+Check "CRLF is normalised, not tolerated"   (-not (($setupText -replace "`n", "`r`n") -match $_guardPat))
+# The exact condition, because each term is load-bearing. $installedTorchTag is tested FIRST so
+# the read of $expectedTorchTag short-circuits away: that variable is assigned only inside the
+# `if (-not $shouldRebuild)` block above, so on a venv whose torch would not import at all it was
+# never created, and reading it under a caller's Set-StrictMode is fatal.
+Check "it only fires under the installer"   ($_guard -match '\$InstallerManagedSetup')
+Check "it only fires on a GPU wheel"        ($_guard -match '\$installedTorchTag -and \$installedTorchTag -ne "cpu"')
+Check "it only fires when the rescan said cpu" ($_guard -match '\$expectedTorchTag -eq "cpu"')
+Check "the installed tag is tested before the expected one" (
+    $_guard.IndexOf('$installedTorchTag -and') -ge 0 -and
+    $_guard.IndexOf('$installedTorchTag -and') -lt $_guard.IndexOf('$expectedTorchTag -eq "cpu"'))
+Check "it clears the rebuild flag"          ($_guard -match '\$shouldRebuild = \$false')
+# The whole point: no --force-reinstall is raised, so the CPU arm below leaves the GPU wheel in
+# place (a +cu / +rocm / +xpu build already satisfies its torch>= range).
+Check "it does not raise force-reinstall"   (-not ($_guard -match 'PinChangedForceReinstall = \$true'))
+Check "it does not wipe the venv"           (-not ($_guard -match 'Remove-Item'))
+# An xpu venv kept here needs the same index lock the direct-update escape takes, or the pass
+# installs triton-windows over torch's XPU triton with nothing to swap it back.
+Check "a kept xpu venv still locks the xpu index" (
+    $_guard -match 'if \(\$installedTorchTag -eq "xpu"\) \{ \$script:PreservedXpuVenv = \$true \}')
+# ...and it has to run BEFORE the repair, or the repair has already fired.
+Check "the guard precedes the in-place repair" (
+    $setupText.IndexOf('if ($shouldRebuild -and $InstallerManagedSetup -and') -ge 0 -and
+    $setupText.IndexOf('if ($shouldRebuild -and $InstallerManagedSetup -and') -lt
+    $setupText.IndexOf('if ($shouldRebuild -and $InstallerManagedSetup) {'))
+# The repair itself must survive: an unimportable torch ($installedTorchTag $null) and a
+# GPU-to-different-GPU family move are exactly what it is for, and the guard must not swallow
+# them. Driven, not asserted as a shape, over the four combinations that reach it.
+function Test-DowngradeGuard {
+    param($Installed, $Expected)
+    $shouldRebuild = $true
+    $InstallerManagedSetup = $true
+    $installedTorchTag = $Installed
+    $expectedTorchTag = $Expected
+    $force = $false
+    if ($shouldRebuild -and $InstallerManagedSetup -and
+        $installedTorchTag -and $installedTorchTag -ne "cpu" -and $expectedTorchTag -eq "cpu") {
+        $shouldRebuild = $false
+    }
+    if ($shouldRebuild -and $InstallerManagedSetup) { $force = $true; $shouldRebuild = $false }
+    return [pscustomobject]@{ Force = $force; Rebuild = $shouldRebuild }
+}
+Check "rocm wheel + cpu rescan is kept, not reinstalled" (-not (Test-DowngradeGuard "rocm" "cpu").Force)
+Check "cu128 wheel + cpu rescan is kept, not reinstalled" (-not (Test-DowngradeGuard "cu128" "cpu").Force)
+Check "xpu wheel + cpu rescan is kept, not reinstalled"  (-not (Test-DowngradeGuard "xpu" "cpu").Force)
+Check "an unimportable torch still repairs in place"     ((Test-DowngradeGuard $null "cpu").Force)
+Check "a cpu wheel on a CUDA host still repairs in place" ((Test-DowngradeGuard "cpu" "cu128").Force)
+Check "a rocm wheel on a CUDA host still repairs in place" ((Test-DowngradeGuard "rocm" "cu128").Force)
+Check "nothing reaches the wipe under the installer"      (
+    -not (Test-DowngradeGuard "rocm" "cpu").Rebuild -and -not (Test-DowngradeGuard $null "cpu").Rebuild)
+
+Write-Host ""
+Write-Host "=== the AMD fast-path probe is bounded too ==="
+# The disk-based rescue above KEEPS a venv whose `import torch` never came back. On a direct
+# update that venv then reaches the AMD fast-path check, and a bare `& python -c "import torch"`
+# there waits forever: setup would hang instead of finishing, on precisely the host the rescue
+# was added for. Before the rescue this could not happen, because the same venv was deleted.
+# The leading \n and indent matter: `elseif ($script:ROCmGfxArch) {` ENDS in that same text, and
+# there are two of those higher up the file, so a bare anchor starts the region 1700 lines early
+# and every -not check below it goes green on unrelated code.
+$_amdFastPat = '(?s)(\n        if \(\$script:ROCmGfxArch\) \{\n.*?reinstalling ROCm PyTorch[^\n]*\n)'
+$_amdFast = if ($setupText -match $_amdFastPat) { $Matches[1] } else { "" }
+Check "the AMD fast-path escape was found"  ($_amdFast -ne "")
+Check "CRLF is normalised, not tolerated"   (-not (($setupText -replace "`n", "`r`n") -match $_amdFastPat))
+Check "no bare interpreter call is left"    (-not ($_amdFast -match '&\s*python -c'))
+Check "it goes through the bounded probe"   ($_amdFast -match 'Invoke-BoundedPythonProbe -PythonExe "python"')
+Check "it still asks torch.cuda.is_available" ($_amdFast -match 'torch\.cuda\.is_available')
+# A probe that does not answer must keep reading as CPU: forcing one dependency pass is the safe
+# direction, and reading a timeout as "the GPU is fine" would fast-path past the ROCm install.
+Check "an unanswered probe still reads as CPU" ($_amdFast -match '\$_torchIsCpu = -not \$_rocmTorchProbe\.Ok')
+
 Write-Host ""
 if ($failures -gt 0) { Write-Host "$failures check(s) FAILED" -ForegroundColor Red; exit 1 }
 Write-Host "All checks passed" -ForegroundColor Green

--- a/tests/studio/test_setup_xpu_runtime_prereport.ps1
+++ b/tests/studio/test_setup_xpu_runtime_prereport.ps1
@@ -245,8 +245,13 @@ $_keep = if ($setupText -match '(?s)(\$script:PinChangedForceReinstall = \$true.
 Check "the rebuild decision was found"  ($_keep -ne "")
 Check "an xpu venv is spared the wipe"  ($_keep -match '\$installedTorchTag -eq "xpu"')
 Check "the escape clears shouldRebuild" ($_keep -match '(?s)\$installedTorchTag -eq "xpu"\) \{.*?\$shouldRebuild = \$false')
-# install.ps1 keeps a rollback copy, so that path must still be free to rebuild.
-Check "installer-managed runs still rebuild" ($_keep -match '-not \$InstallerManagedSetup')
+# An installer-managed run must NOT take this escape. It is not that install.ps1 is free to
+# wipe the venv -- it never was, it invokes setup through that venv's own unsloth.exe -- it is
+# that the in-place repair below already covers every flavour, xpu included, and reaching it is
+# what stops the run from aborting into the reinstall loop (#8335). This check was previously
+# named "installer-managed runs still rebuild", which described neither the old code (it exited)
+# nor the new one.
+Check "installer-managed runs skip the xpu-only escape" ($_keep -match '-not \$InstallerManagedSetup')
 # Silently keeping a venv the host does not want is its own trap; say how to change it.
 Check "the escape says how to replace it" ($_keep -match 'substep "[^"]*install\.ps1')
 # Keeping the venv is only half the job: the CUDA arm leaves the +xpu wheel satisfied while

--- a/tests/studio/test_setup_xpu_runtime_prereport.ps1
+++ b/tests/studio/test_setup_xpu_runtime_prereport.ps1
@@ -245,12 +245,10 @@ $_keep = if ($setupText -match '(?s)(\$script:PinChangedForceReinstall = \$true.
 Check "the rebuild decision was found"  ($_keep -ne "")
 Check "an xpu venv is spared the wipe"  ($_keep -match '\$installedTorchTag -eq "xpu"')
 Check "the escape clears shouldRebuild" ($_keep -match '(?s)\$installedTorchTag -eq "xpu"\) \{.*?\$shouldRebuild = \$false')
-# An installer-managed run must NOT take this escape. It is not that install.ps1 is free to
-# wipe the venv -- it never was, it invokes setup through that venv's own unsloth.exe -- it is
-# that the in-place repair below already covers every flavour, xpu included, and reaching it is
-# what stops the run from aborting into the reinstall loop (#8335). This check was previously
-# named "installer-managed runs still rebuild", which described neither the old code (it exited)
-# nor the new one.
+# An installer-managed run must NOT take this escape: the in-place repair below already covers
+# every flavour, xpu included, and reaching it is what stops the run from aborting into the
+# reinstall loop (#8335). Wiping was never the alternative -- install.ps1 invokes setup through
+# that venv's own unsloth.exe.
 Check "installer-managed runs skip the xpu-only escape" ($_keep -match '-not \$InstallerManagedSetup')
 # Silently keeping a venv the host does not want is its own trap; say how to change it.
 Check "the escape says how to replace it" ($_keep -match 'substep "[^"]*install\.ps1')


### PR DESCRIPTION
Two defects that met on the same host and left the Windows installer unable to converge on a single-Radeon machine, plus the hazards that surfaced while closing them. Reported on a Radeon PRO W7900 + W7500 box running Windows 10 and ROCm 7.13.99004.

## 1. A single AMD GPU read as no AMD GPU

`studio/setup.ps1`, the WMI fallback that runs when there is no HIP SDK, picked between the healthy adapters and the full adapter list like this:

```powershell
$wmiGpus = if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus }
```

A one-element array unrolls to a scalar on its way out of an if-expression, and for the type `Get-CimInstance` returns that scalar's `.Count` is `$null` under Windows PowerShell 5.1. So on a host with exactly one AMD GPU the next line, `if ($wmiGpus.Count -gt 0)`, was false: `$script:ROCmGpuLabels` was never set, no gfx arch was inferred, the hardware report said `gpu none`, and the installed ROCm environment was then judged stale with `torch rocm != required cpu`.

The type matters and is worth stating precisely, because checking this the obvious way suggests the bug is imaginary. Measured on a `windows-latest` runner, 5.1.26100.33158 against pwsh 7.6.4:

| value | 5.1 `.Count` | 7 `.Count` |
| --- | --- | --- |
| `CimInstance`, one instance | `$null` | 1 |
| `PSCustomObject` | `$null` | 1 |
| String | 1 | 1 |
| plain .NET object | 1 | 1 |

Fixed by wrapping the whole if in `@()`, the idiom the Intel scan already uses in the same file and in `install.ps1`. Verified end to end on that runner by running the pre-fix source from `main` and the post-fix source side by side: one healthy AMD GPU reports 0 before and 1 after, and two-GPU and zero-GPU cases are identical either way, since a two-element array does not unroll. That is why this only ever hit single-card hosts.

`studio/install_python_stack.py`'s WMI path was checked for the same shape. It does not have it: `_names = _healthy or _all_names` is correct Python. The comment in `setup.ps1` claiming to mirror it is now true.

## 2. The "needs repair" abort was a fixed point

Independent of what triggered it, the stale-venv abort could not be recovered from. Under `$InstallerManagedSetup` it printed:

```
[ERROR] The existing Unsloth environment needs repair.
        Re-run install.ps1 so it can replace the environment safely with rollback.
```

`install.ps1` is the caller on that path. It sets `UNSLOTH_INSTALL_ROLLBACK_MANAGED=1` and had already replaced the environment with a rollback copy earlier in the same run, so the advice named the thing that had just happened. Worse, `Exit-SetupFailure` makes `install.ps1` run `Restore-StudioVenvRollback`, which deletes the new environment and moves the old one back, while `Complete-StudioVenvRollback` only runs after setup succeeds. Every attempt therefore ended on the byte-identical state it started from, and the next attempt reached the same verdict.

That abort has now been reported from four unrelated triggers (#5942 on CUDA, #7275 on a ROCm clobber, #8335 here, and a driver crash), so this fixes the loop rather than only the trigger. It is replaced by the in-place torch repair that a changed index pin and a changed CUDA family already use: `PinChangedForceReinstall` makes the dependency pass reinstall the torch trio from the resolved index over the existing environment.

Deleting was never actually available on this path: `install.ps1` invokes setup through the environment's own `unsloth.exe`, so `python.exe` is held open by the process running the script.

## 3. What trading the abort for a repair cost, and how each cost is paid

Removing the fixed point opened a second family of failures with one shape: **setup exits 0 having done the wrong thing**. `install.ps1` treats `setupExit == 0` as the sole criterion for `Complete-StudioVenvRollback`, which deletes the backup, so a silent success is permanent, where the abort at least reverted to an identical starting state. Four such paths were found and closed.

**The installer's GPU wheel is not force-reinstalled away on the strength of a rescan.** Under `$InstallerManagedSetup`, `install.ps1` resolves the index off its own probe and installs the trio before invoking setup, and the environment it hands over carries no family and no index, so setup re-probes from scratch. When those two probes disagree the disagreement is setup's, not the host's: a `Get-CimInstance` that threw, an `nvidia-smi` that did not answer, or the single-Radeon unroll above. The repair would then reinstall a different flavour over a working environment and exit 0. The guard keeps the wheel and records the family so it survives index selection, which matters because the AMD arm force-reinstalls unconditionally and the XPU arm force-reinstalls whenever the installed tag is not `xpu`, so clearing the rebuild flag alone is not enough.

**An incomplete environment is refused rather than silently used.** Everything after the dot-source reaches the environment through `Activate.ps1` and a bare `python`, `Fast-Install` resolves its target with `(Get-Command python).Source`, and `install.ps1` deliberately keeps the environment's `Scripts` directory off PATH. A missing `python.exe`, a missing `Activate.ps1`, or an `Activate.ps1` that is present but truncated therefore installed the entire stack into whatever interpreter was on PATH and still exited 0. The truncated case is the quiet one: in CPython's `Activate.ps1` the PATH assignment is the last statement and `$env:VIRTUAL_ENV` is set 28 lines earlier, so a torn write produces a file that parses, runs to completion, sets `VIRTUAL_ENV` and never touches PATH, raising no error at all. `Assert-VenvActivated` checks the interpreter actually in effect, normalising both sides through `Get-Item` (the same call `Activate.ps1` uses to build its PATH entry) so short paths, substituted drives, junctions and drive-letter case cannot disagree, comparing `OrdinalIgnoreCase` with an explicit separator so `venv2` is not read as a child of `venv`, and returning rather than refusing when anything is unresolvable.

**A driver fault no longer deletes a good ROCm environment.** `setup.ps1` already guarded this hazard for Intel, reading `torch/version.py` off disk through `Test-VenvTorchIsXpu` because "the host most likely to time out inside `import torch` is an Arc box with a stalled driver". There was no ROCm counterpart, so on AMD a faulted Adrenalin or HIP runtime read as "torch could not be imported" and the working environment was thrown away, which does not fix a driver. `Test-VenvTorchIsRocm` is the same free disk read and accepts both wheel spellings, `2.8.0+rocm6.4` from download.pytorch.org and the AMD Windows index form. It judges the local label on `__version__` only, so a CUDA build carrying `hip: Optional[str] = None` is not misread as ROCm.

**The last unbounded `import torch` is bounded.** Because the rescue above now keeps a venv whose import can hang forever, the AMD fast-path probe became the first `import torch` such a host reaches, and it had no bound. It goes through `Invoke-BoundedPythonProbe` like every other probe in the file, with a non-answering probe still reading as CPU so the safe direction is unchanged.

**The swallowed error is shown.** `Invoke-BoundedPythonProbe` drained stderr and discarded it, so "the HIP DLLs will not load", "torch is not installed" and "the import never came back" all reached the caller as the same silent `.Ok = $false`, and the caller deletes environments over that answer. It now carries `.Error`, in both installers, and the stale-venv message prints the last stderr line, so a `WinError 126` reads as a driver problem instead of a broken install. The timeout branch synthesises its message rather than awaiting the reader tasks: awaiting them is exactly the hang the bound exists to prevent.

## Tests

`tests/studio/test_amd_venv_repair_loop.ps1` follows `test_pre_turing_cap.ps1`: AST extraction so the top-level installer never runs, a mocked filesystem for the `version.py` reads, a parity loop over `install.ps1` and `studio/setup.ps1`, and CRLF-normalised source matching with a "was found" guard on every region.

Where behaviour can be driven rather than asserted, it is. The probe checks run a real `python -c` child on both installer copies. The rebuild decision, the index-selection chain and both install-arm gate conditions are extracted from `setup.ps1` and executed against a table of host cases, rather than reimplemented in the test: an earlier hand-copied simulation of that cascade had drifted far enough to assert the wrong outcome. The activation checks build real temporary directories instead of stubbing `Get-Item`, since a stub would only re-implement the behaviour under test.

`cross-platform-parity-ci.yml` sets `shell: pwsh` on every step, so the whole job ran under PowerShell 7, which returns `1` for the scalar 5.1 returns `$null` for and therefore passes against the unfixed code. This adds a `shell: powershell` row on the Windows leg, which is the shell the CLI actually launches `setup.ps1` with and the only one that can fail on defect 1.

Fixes #8335. Also removes the loop reported in #5942, #7275 and the Discord driver-crash report, which reached the same abort from different triggers.
