### PR TITLE
Studio: keep a Windows path from splitting on its drive letter

### DIFF
--- a/studio/backend/core/inference/openai_auto_download.py
+++ b/studio/backend/core/inference/openai_auto_download.py
@@ -99,16 +99,20 @@ def _public_label(repo_id: str, variant: Optional[str]) -> str:
 def split_model_ref(requested: str) -> tuple[str, Optional[str]]:
     """``org/repo:QUANT`` -> ``("org/repo", "QUANT")``; no suffix -> variant None.
 
-    Splits on the last colon. A slash-bearing suffix is only a variant when a real
-    Hub repo precedes it: "build/llama-13b" is a subdirectory GGUF key the catalog
-    advertises, while "C:/models/x.gguf" leaves a drive letter that is no repo id.
+    Splits on the last colon. A separator-bearing suffix is only a variant when a
+    real Hub repo precedes it: "build/llama-13b" is a subdirectory GGUF key the
+    catalog advertises, while "C:/models/x.gguf" leaves a drive letter that is no
+    repo id. Backslashes count too, or a Windows path named as the model id
+    ("N:\\AI Models\\repo\\model-UD-Q8_K_XL") splits on its drive letter and leaves
+    base = "N", which matches no resident quant, no advertised path and no index
+    key, so a model that loaded fine is then reported as an unservable one.
     """
     text = (requested or "").strip()
     base, sep, suffix = text.rpartition(":")
     if not sep or not base or not suffix:
         return text, None
     stripped = base.strip()
-    if "/" in suffix:
+    if "/" in suffix or "\\" in suffix:
         from hub.utils.paths import is_valid_repo_id
         if "/" not in stripped or not is_valid_repo_id(stripped):
             return text, None

--- a/studio/backend/tests/test_openai_auto_download.py
+++ b/studio/backend/tests/test_openai_auto_download.py
@@ -263,6 +263,60 @@ def test_looks_like_quant_separates_quants_from_foreign_tags():
     assert not auto_dl.looks_like_quant(None)
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # The reported shape: a scan folder on another drive, quant in the file name.
+        r"N:\AI Models\LiquidAI\LFM2.5-8B-A1B-UD-Q8_K_XL",
+        r"C:\models\x.gguf",
+        r"C:\Users\me\.lmstudio\models\org\repo\model-Q4_K_M.gguf",
+        # A UNC share has no drive letter but still must not split on a colon it lacks.
+        r"D:\models\repo:build\llama-13b",
+        r"E:\models\repo:distilled\model-Q6_K",
+    ],
+)
+def test_a_windows_path_is_never_split_on_its_drive_letter(raw):
+    """A Windows absolute path named as the model id must stay whole.
+
+    Reported on Windows 10 with an external scan folder: rpartition(":") leaves
+    base = "N" and hands the rest of the path back as the variant, so nothing
+    downstream can place the model. base is what _resident_quant_is compares
+    against, what _advertised_local_path and recently_downloaded look up, and what
+    describe_local_miss reports on, so a drive letter poisons all four at once and
+    the model that just loaded is then refused as unservable.
+    """
+    assert auto_dl.split_model_ref(raw) == (raw, None)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Unchanged: a real Hub repo before the colon still pins a path-qualified key.
+        ("unsloth/repo-GGUF:distilled/model-Q6_K", ("unsloth/repo-GGUF", "distilled/model-Q6_K")),
+        ("unsloth/repo-GGUF:Q4_K_M", ("unsloth/repo-GGUF", "Q4_K_M")),
+        ("llama3:latest", ("llama3", "latest")),
+        ("/srv/models/repo:Q4_K_M", ("/srv/models/repo", "Q4_K_M")),
+        ("build/llama-13b", ("build/llama-13b", None)),
+        ("C:/models/x.gguf", ("C:/models/x.gguf", None)),
+        ("/home/me/models/x:build/llama-13b", ("/home/me/models/x:build/llama-13b", None)),
+    ],
+)
+def test_the_windows_guard_leaves_every_other_ref_alone(raw, expected):
+    # The backslash arm only widens what counts as a path suffix, so POSIX paths,
+    # Ollama tags, plain quants and subdirectory keys all parse exactly as before.
+    assert auto_dl.split_model_ref(raw) == expected
+
+
+def test_a_windows_path_never_reaches_looks_like_quant_as_a_variant():
+    # looks_like_quant reads any separator-bearing label as one of our advertised
+    # subdirectory keys, which is what made a drive-letter split look like a real
+    # quant request. Splitting correctly is what keeps that from ever being asked.
+    assert auto_dl.looks_like_quant(r"distilled\model-Q6_K")
+    _, variant = auto_dl.split_model_ref(r"N:\AI Models\LiquidAI\LFM2.5-8B-A1B-UD-Q8_K_XL")
+    assert variant is None
+    assert not auto_dl.looks_like_quant(variant)
+
+
 def test_match_variant_is_case_insensitive_and_exact():
     variants = {"UD-Q4_K_XL": 1, "Q8_0": 2}
     assert auto_dl._match_variant("ud-q4_k_xl", variants) == "UD-Q4_K_XL"
@@ -944,6 +998,55 @@ def test_a_failed_switch_is_reported_not_answered_by_the_resident_model(monkeypa
     assert excinfo.value.status_code == 503
     assert excinfo.value.detail["error"]["code"] == "model_switch_failed"
     assert excinfo.value.headers["Retry-After"] == "5"
+
+
+def test_a_windows_scan_folder_model_is_not_reported_as_a_failed_switch(monkeypatch):
+    """The model loads, then the guard 503s it: success toast and failure banner together.
+
+    Reported on Windows 10 with models kept on a second drive. _reject_unservable_model
+    runs after the switch, and split_model_ref used to hand it base = "N", which matches
+    no resident id, so the guard concluded the swap had failed and raised 503
+    model_switch_failed for a model that was serving. The stand-in is loaded from the
+    exact path the request names, which is what a scan-folder load looks like.
+    """
+    path = r"N:\AI Models\LiquidAI\LFM2.5-8B-A1B-UD-Q8_K_XL"
+    loaded = _Loaded(path, "UD-Q8_K_XL")
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: loaded)
+    monkeypatch.setattr(
+        inference_route,
+        "get_inference_backend",
+        lambda: type("B", (), {"active_model_name": None})(),
+    )
+    # On disk and switching on: exactly the combination that produced the 503.
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_local_gguf",
+        lambda name, **_kw: (path, "UD-Q8_K_XL", name),
+    )
+    monkeypatch.setattr(
+        "utils.openai_auto_switch_settings.get_openai_auto_switch_enabled", lambda: True
+    )
+    monkeypatch.setattr(inference_route, "_unavailable_model_message", _fake_unavailable_message)
+    assert asyncio.run(inference_route._reject_unservable_model(path, _Req())) is None
+    # Forward slashes from a client that normalised them must land the same way.
+    assert (
+        asyncio.run(inference_route._reject_unservable_model(path.replace("\\", "/"), _Req()))
+        is None
+    )
+
+
+def test_a_windows_path_for_another_model_is_still_refused(monkeypatch):
+    # The other half: parsing the path whole must not turn the guard off. A different
+    # drive path while this one is resident is still the wrong weights.
+    loaded = _Loaded(r"N:\AI Models\LiquidAI\LFM2.5-8B-A1B-UD-Q8_K_XL", "UD-Q8_K_XL")
+    with pytest.raises(HTTPException) as excinfo:
+        _reject(
+            r"N:\AI Models\Qwen\Qwen3-8B-UD-Q4_K_XL",
+            loaded,
+            monkeypatch,
+            downloaded = True,
+            auto_switch = True,
+        )
+    assert excinfo.value.status_code == 503
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## The bug

Sending a Windows absolute path as the model id over `/v1` returned HTTP 503 `model_switch_failed` for a model that had loaded and was serving, so the UI showed a success toast and a failure banner at the same time.

`split_model_ref` (`studio/backend/core/inference/openai_auto_download.py`) split on the last colon and only treated a forward slash in the suffix as evidence of a path:

```
'N:\AI Models\LiquidAI\LFM2.5-8B-A1B-UD-Q8_K_XL'
  -> base    = 'N'
     variant = '\AI Models\LiquidAI\LFM2.5-8B-A1B-UD-Q8_K_XL'
```

`base` is load bearing in several places, and a drive letter poisons all of them at once:

- `_resident_quant_is` (`routes/inference.py:4806`) compares the resident quant `UD-Q8_K_XL` against that whole string, so it can never match
- `_advertised_local_path(base)` (`:4938`)
- `recently_downloaded(base)` (`:4950`)
- `describe_local_miss` (`core/inference/local_model_resolver.py:483`)
- the bare-ref flag at `:5103`

With no match anywhere, `switchable` stays true and `_reject_unservable_model` concludes the swap failed, raising 503 from `routes/inference.py:4968-4974`. It runs after `_resolve_and_switch` (`:5272-5274`), which is why the model really is loaded when the banner appears.

This was latent until `looks_like_quant` began reading any separator-bearing label as one of our advertised subdirectory keys (`if "/" in label.replace("\\", "/")`). That made every Windows absolute path read as an explicit quant request, which is the signal the guard treats as proof the caller meant this server.

## The fix

Guard on both separators:

```python
if "/" in suffix or "\\" in suffix:
```

Fixing the split beats narrowing `looks_like_quant`, because the corrupted `base` breaks the lookups above regardless of how the variant is classified.

Behaviour is unchanged for `unsloth/repo-GGUF:Q4_K_M`, `unsloth/repo-GGUF:distilled/model-Q6_K`, `llama3:latest`, `/srv/models/repo:Q4_K_M`, `build/llama-13b`, `C:/models/x.gguf` and POSIX absolute paths. All are pinned in a case table.

## Tests

`studio/backend/tests/test_openai_auto_download.py`:

- a Windows-path case table for `split_model_ref`, plus the neutrality table above
- a check that a Windows path can no longer reach `looks_like_quant` as a variant, while the subdirectory-key behaviour it was added for stays asserted
- a guard-level test driving `_reject_unservable_model` with the backend loaded from the scan-folder path, the resolver returning it and auto-switch on: exactly the combination that produced the 503. Reverting only the source change reproduces `503 model_switch_failed` on it
- the inverse case, so a different drive path while this one is resident is still refused

From `studio/backend/`:

```
python -m pytest tests/test_openai_auto_download.py tests/test_gguf_variants_local_resolution.py tests/test_gguf_variant_rows.py tests/test_model_picker_regression.py -q
```

285 passed before, 300 passed after.

## Note

This is one mechanism in the wider theme of models Studio did not download itself. It is drive-letter specific and does not address the Linux, Ollama and custom-folder reports in that theme, which have separate causes.
