### PR TITLE
Studio: pair slim whisper with ROCm targets hipBLASLt has no kernels for (#8364)

### DIFF
--- a/studio/backend/core/inference/stt_ggml_sidecar.py
+++ b/studio/backend/core/inference/stt_ggml_sidecar.py
@@ -244,15 +244,13 @@ def slim_runtime_intact(binary: str) -> bool:
         )
     if intact and marker.get("backend") == "rocm":
         # Membership plus required, not equality: hipBLASLt builds no Tensile
-        # kernels for several targets (gfx1030 and the rest of RDNA2 among
-        # them), so llama's linux ROCm bundle for those ships libhipblaslt with
-        # no hipblaslt/ catalog beside it. The installer wires whichever
-        # catalogs the bundle actually has, so demanding both here read a
-        # correctly wired install as broken and left dictation unavailable on a
-        # runtime whisper.cpp runs fine on. rocblas stays mandatory, the backend
-        # module links librocblas directly, and a name outside the pair still
-        # means stale or hand-edited wiring. See #8364. Windows overlays wire no
-        # catalogs at all, so both sets are empty there and nothing changes.
+        # kernels for gfx1030 and the rest of RDNA2, so llama's ROCm bundle for
+        # those ships libhipblaslt with no hipblaslt/ catalog, and the installer
+        # wires only the catalogs the bundle has; demanding both read a correct
+        # install as broken (#8364). rocblas stays mandatory (the backend module
+        # links librocblas directly) and a name outside the pair still means
+        # stale wiring. Windows overlays wire no catalogs, so both sets are
+        # empty there and this reduces to the old equality.
         known_runtime_dirs = set() if sys.platform == "win32" else {"hipblaslt", "rocblas"}
         required_runtime_dirs = set() if sys.platform == "win32" else {"rocblas"}
         # Any wiring from version 2 on records linked_runtime_directories, so

--- a/studio/backend/core/inference/stt_ggml_sidecar.py
+++ b/studio/backend/core/inference/stt_ggml_sidecar.py
@@ -243,7 +243,18 @@ def slim_runtime_intact(binary: str) -> bool:
             for name in runtime_dirs
         )
     if intact and marker.get("backend") == "rocm":
-        expected_runtime_dirs = set() if sys.platform == "win32" else {"hipblaslt", "rocblas"}
+        # Membership plus required, not equality: hipBLASLt builds no Tensile
+        # kernels for several targets (gfx1030 and the rest of RDNA2 among
+        # them), so llama's linux ROCm bundle for those ships libhipblaslt with
+        # no hipblaslt/ catalog beside it. The installer wires whichever
+        # catalogs the bundle actually has, so demanding both here read a
+        # correctly wired install as broken and left dictation unavailable on a
+        # runtime whisper.cpp runs fine on. rocblas stays mandatory, the backend
+        # module links librocblas directly, and a name outside the pair still
+        # means stale or hand-edited wiring. See #8364. Windows overlays wire no
+        # catalogs at all, so both sets are empty there and nothing changes.
+        known_runtime_dirs = set() if sys.platform == "win32" else {"hipblaslt", "rocblas"}
+        required_runtime_dirs = set() if sys.platform == "win32" else {"rocblas"}
         # Any wiring from version 2 on records linked_runtime_directories, so
         # pin the floor, not one version, or an installer bump strands installs.
         wiring_version = marker.get("runtime_wiring_version")
@@ -251,7 +262,8 @@ def slim_runtime_intact(binary: str) -> bool:
             isinstance(wiring_version, int)
             and wiring_version >= 2
             and isinstance(runtime_dirs, list)
-            and set(runtime_dirs) == expected_runtime_dirs
+            and set(runtime_dirs) <= known_runtime_dirs
+            and required_runtime_dirs <= set(runtime_dirs)
         )
     if not intact:
         logger.warning(

--- a/studio/backend/tests/test_stt_ggml_sidecar.py
+++ b/studio/backend/tests/test_stt_ggml_sidecar.py
@@ -255,6 +255,60 @@ def test_slim_guard_rejects_missing_rocm_catalog(tmp_path):
     assert ggml_module.slim_runtime_intact(binary) is False
 
 
+def test_slim_guard_accepts_rocm_wiring_without_a_hipblaslt_catalog(tmp_path):
+    # #8364: reporter on Linux x64 with an RX 6800 (gfx1030). hipBLASLt builds
+    # no Tensile kernels for that target, so llama's linux-x64-rocm-gfx103X
+    # bundle ships libhipblaslt.so.1 with no hipblaslt/ catalog, the installer
+    # wires rocblas alone, and this install is complete. The old equality check
+    # read it as broken, which is what took dictation away while inference on
+    # the very same runtime kept working.
+    names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
+    binary = _slim_install(
+        tmp_path,
+        linked_libraries = names,
+        backend = "rocm",
+        linked_runtime_directories = ["rocblas"],
+        runtime_wiring_version = 3,
+    )
+    (Path(binary).parent / "libggml-hip.so").write_bytes(b"ggml")
+    assert ggml_module.slim_runtime_intact(binary) is True
+
+
+def test_slim_guard_rejects_rocm_wiring_without_rocblas(tmp_path):
+    # rocblas is the load-bearing catalog: libggml-hip.so links librocblas
+    # directly, so a marker that never wired it is stale wiring, not a target
+    # quirk, and must still send the user through `unsloth studio update`.
+    names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
+    for case in ([], ["hipblaslt"]):
+        root = tmp_path / f"case_{len(case)}"
+        root.mkdir()
+        binary = _slim_install(
+            root,
+            linked_libraries = names,
+            backend = "rocm",
+            linked_runtime_directories = case,
+            runtime_wiring_version = 3,
+        )
+        (Path(binary).parent / "libggml-hip.so").write_bytes(b"ggml")
+        assert ggml_module.slim_runtime_intact(binary) is False
+
+
+def test_slim_guard_rejects_rocm_wiring_with_an_unknown_catalog(tmp_path):
+    # Membership is bounded by the catalogs this installer wires, so a name
+    # outside the pair means a hand-edited or foreign marker and fails closed
+    # even though rocblas is present.
+    names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
+    binary = _slim_install(
+        tmp_path,
+        linked_libraries = names,
+        backend = "rocm",
+        linked_runtime_directories = ["rocblas", "unexpected"],
+        runtime_wiring_version = 3,
+    )
+    (Path(binary).parent / "libggml-hip.so").write_bytes(b"ggml")
+    assert ggml_module.slim_runtime_intact(binary) is False
+
+
 def test_slim_guard_accepts_newer_rocm_wiring_version(tmp_path):
     # The guard pins a floor, not one version: an installer bump must not strand
     # ROCm installs as unavailable when every wired library is present.
@@ -297,6 +351,24 @@ def test_slim_guard_accepts_windows_rocm_dll_overlay(monkeypatch, tmp_path):
     for name in names:
         (Path(binary).parent / name).write_bytes(b"dll")
     assert ggml_module.slim_runtime_intact(binary) is True
+
+
+def test_slim_guard_windows_rocm_still_expects_no_catalogs(monkeypatch, tmp_path):
+    # Windows behaviour is unchanged by #8364: the overlay wires DLLs and no
+    # kernel catalogs at all, so any recorded catalog there is still a marker
+    # this installer did not write.
+    monkeypatch.setattr(ggml_module.sys, "platform", "win32")
+    names = ["ggml.dll", "ggml-base.dll", "ggml-hip.dll", "amdhip64.dll"]
+    binary = _slim_install(
+        tmp_path,
+        linked_libraries = names,
+        backend = "rocm",
+        linked_runtime_directories = ["rocblas"],
+        runtime_wiring_version = 2,
+    )
+    for name in names:
+        (Path(binary).parent / name).write_bytes(b"dll")
+    assert ggml_module.slim_runtime_intact(binary) is False
 
 
 def test_slim_guard_ignores_fat_and_markerless_installs(tmp_path):

--- a/studio/backend/tests/test_stt_ggml_sidecar.py
+++ b/studio/backend/tests/test_stt_ggml_sidecar.py
@@ -256,12 +256,10 @@ def test_slim_guard_rejects_missing_rocm_catalog(tmp_path):
 
 
 def test_slim_guard_accepts_rocm_wiring_without_a_hipblaslt_catalog(tmp_path):
-    # #8364: reporter on Linux x64 with an RX 6800 (gfx1030). hipBLASLt builds
-    # no Tensile kernels for that target, so llama's linux-x64-rocm-gfx103X
-    # bundle ships libhipblaslt.so.1 with no hipblaslt/ catalog, the installer
-    # wires rocblas alone, and this install is complete. The old equality check
-    # read it as broken, which is what took dictation away while inference on
-    # the very same runtime kept working.
+    # #8364: RX 6800 (gfx1030) on linux x64. hipBLASLt builds no kernels for
+    # that target, so the bundle ships no hipblaslt/ catalog and rocblas alone
+    # is a complete install; the old equality check read it as broken and took
+    # dictation away while inference on the same runtime kept working.
     names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
     binary = _slim_install(
         tmp_path,
@@ -275,9 +273,8 @@ def test_slim_guard_accepts_rocm_wiring_without_a_hipblaslt_catalog(tmp_path):
 
 
 def test_slim_guard_rejects_rocm_wiring_without_rocblas(tmp_path):
-    # rocblas is the load-bearing catalog: libggml-hip.so links librocblas
-    # directly, so a marker that never wired it is stale wiring, not a target
-    # quirk, and must still send the user through `unsloth studio update`.
+    # rocblas is load-bearing (libggml-hip.so links librocblas directly), so a
+    # marker that never wired it is stale wiring, not a target quirk.
     names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
     for case in ([], ["hipblaslt"]):
         root = tmp_path / f"case_{len(case)}"
@@ -294,10 +291,9 @@ def test_slim_guard_rejects_rocm_wiring_without_rocblas(tmp_path):
 
 
 def test_slim_guard_rejects_an_empty_catalog_the_marker_names(tmp_path):
-    # Membership replaced the equality check on the marker, not the per-directory
-    # "exists and holds a file" check on disk. A wired catalog that went empty is
-    # still a broken install and must send the user through `unsloth studio
-    # update`, never read as intact and fail at server launch instead.
+    # Membership replaced the equality check on the marker, not the on-disk
+    # "exists and holds a file" check: a wired catalog gone empty is still a
+    # broken install, not intact-then-failing at server launch.
     names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
     for empty in ("hipblaslt", "rocblas"):
         root = tmp_path / f"empty_{empty}"
@@ -333,8 +329,7 @@ def test_slim_guard_rejects_rocm_wiring_with_no_version(tmp_path):
 
 def test_slim_guard_rejects_rocm_wiring_with_an_unknown_catalog(tmp_path):
     # Membership is bounded by the catalogs this installer wires, so a name
-    # outside the pair means a hand-edited or foreign marker and fails closed
-    # even though rocblas is present.
+    # outside the pair fails closed even though rocblas is present.
     names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
     binary = _slim_install(
         tmp_path,
@@ -392,9 +387,8 @@ def test_slim_guard_accepts_windows_rocm_dll_overlay(monkeypatch, tmp_path):
 
 
 def test_slim_guard_windows_rocm_still_expects_no_catalogs(monkeypatch, tmp_path):
-    # Windows behaviour is unchanged by #8364: the overlay wires DLLs and no
-    # kernel catalogs at all, so any recorded catalog there is still a marker
-    # this installer did not write.
+    # Windows is unchanged by #8364: the overlay wires DLLs and no catalogs, so
+    # any recorded catalog is a marker this installer did not write.
     monkeypatch.setattr(ggml_module.sys, "platform", "win32")
     names = ["ggml.dll", "ggml-base.dll", "ggml-hip.dll", "amdhip64.dll"]
     binary = _slim_install(

--- a/studio/backend/tests/test_stt_ggml_sidecar.py
+++ b/studio/backend/tests/test_stt_ggml_sidecar.py
@@ -293,6 +293,44 @@ def test_slim_guard_rejects_rocm_wiring_without_rocblas(tmp_path):
         assert ggml_module.slim_runtime_intact(binary) is False
 
 
+def test_slim_guard_rejects_an_empty_catalog_the_marker_names(tmp_path):
+    # Membership replaced the equality check on the marker, not the per-directory
+    # "exists and holds a file" check on disk. A wired catalog that went empty is
+    # still a broken install and must send the user through `unsloth studio
+    # update`, never read as intact and fail at server launch instead.
+    names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
+    for empty in ("hipblaslt", "rocblas"):
+        root = tmp_path / f"empty_{empty}"
+        root.mkdir()
+        binary = _slim_install(
+            root,
+            linked_libraries = names,
+            backend = "rocm",
+            linked_runtime_directories = ["hipblaslt", "rocblas"],
+            runtime_wiring_version = 3,
+        )
+        bin_dir = Path(binary).parent
+        (bin_dir / "libggml-hip.so").write_bytes(b"ggml")
+        assert ggml_module.slim_runtime_intact(binary) is True
+        (bin_dir / empty / "kernel.dat").unlink()
+        assert ggml_module.slim_runtime_intact(binary) is False
+
+
+def test_slim_guard_rejects_rocm_wiring_with_no_version(tmp_path):
+    # The version floor is a positive test, not a default: a marker with no
+    # runtime_wiring_version at all predates catalog wiring and must reinstall.
+    names = ["libggml.so.0", "libggml-base.so.0", "libggml-hip.so"]
+    binary = _slim_install(
+        tmp_path,
+        linked_libraries = names,
+        backend = "rocm",
+        linked_runtime_directories = ["rocblas"],
+        runtime_wiring_version = None,
+    )
+    (Path(binary).parent / "libggml-hip.so").write_bytes(b"ggml")
+    assert ggml_module.slim_runtime_intact(binary) is False
+
+
 def test_slim_guard_rejects_rocm_wiring_with_an_unknown_catalog(tmp_path):
     # Membership is bounded by the catalogs this installer wires, so a name
     # outside the pair means a hand-edited or foreign marker and fails closed

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -186,7 +186,20 @@ SLIM_ROCM_LIBRARY_GLOBS = (
     "libhsa*.so*",
     "libroc*.so*",
 )
+# Kernel catalog directories a Linux ROCm llama bundle can ship beside its
+# libraries, mirrored into the whisper bin dir so the packaged libraries find
+# their Tensile kernels next to themselves.
 SLIM_ROCM_RUNTIME_DIRS = ("hipblaslt", "rocblas")
+# Of those, the ones a paired runtime must actually carry. hipBLASLt builds no
+# Tensile kernels for several targets (gfx1030 / RDNA2 among them), so llama's
+# linux-x64-rocm-gfx103X bundle ships libhipblaslt.so.1 with no hipblaslt/
+# catalog at all, while every other published target carries one. rocblas is the
+# load-bearing catalog: libggml-hip links librocblas directly and every
+# published linux ROCm bundle ships rocblas/library. install_llama_prebuilt
+# already copies whichever catalogs the archive has (runtime_subdirs_for_choice
+# is guarded by is_dir()), so demanding both here rejected a runtime llama.cpp
+# itself runs fine on. See #8364.
+SLIM_ROCM_REQUIRED_RUNTIME_DIRS = ("rocblas",)
 # 3: libomp*.so*/dylib joined the wiring, so version 2 installs are missing
 # libomp.so.5 on linux arm64 and must re-wire.
 SLIM_RUNTIME_WIRING_VERSION = 3
@@ -854,11 +867,20 @@ def link_runtime_directories(
     linked: list[str] = []
     for name in SLIM_ROCM_RUNTIME_DIRS:
         source_root = llama_bin_dir / name
-        if not source_root.is_dir():
-            raise PrebuiltFallback(f"paired ROCm runtime is missing its {name} kernel catalog")
-        files = [path for path in source_root.rglob("*") if path.is_file()]
+        required = name in SLIM_ROCM_REQUIRED_RUNTIME_DIRS
+        files = (
+            [path for path in source_root.rglob("*") if path.is_file()]
+            if source_root.is_dir()
+            else []
+        )
         if not files:
-            raise PrebuiltFallback(f"paired ROCm runtime has an empty {name} kernel catalog")
+            if not required:
+                # A target hipBLASLt has no kernels for: llama ships the library
+                # without a catalog and runs, so whisper must pair the same way.
+                log(f"slim install: paired ROCm runtime ships no {name} kernel catalog; skipping")
+                continue
+            missing = "is missing its" if not source_root.is_dir() else "has an empty"
+            raise PrebuiltFallback(f"paired ROCm runtime {missing} {name} kernel catalog")
         for source in files:
             _link_or_copy(source, whisper_bin_dir / name / source.relative_to(source_root))
         linked.append(name)
@@ -987,12 +1009,16 @@ def existing_install_matches(
             )
             return False
         runtime_dirs = marker.get("linked_runtime_directories")
+        # Subset, not equality: a target without hipBLASLt kernels wires rocblas
+        # alone and is complete (#8364). Anything outside the known catalog names,
+        # or a missing rocblas, still means stale or hand-edited wiring.
         if (
             marker.get("backend") == "rocm"
             and not host.is_windows
             and (
                 not isinstance(runtime_dirs, list)
-                or set(runtime_dirs) != set(SLIM_ROCM_RUNTIME_DIRS)
+                or not set(runtime_dirs) <= set(SLIM_ROCM_RUNTIME_DIRS)
+                or not set(SLIM_ROCM_REQUIRED_RUNTIME_DIRS) <= set(runtime_dirs)
             )
         ):
             log(f"existing ROCm install at {install_dir} lacks kernel catalogs; reinstalling")

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -186,19 +186,16 @@ SLIM_ROCM_LIBRARY_GLOBS = (
     "libhsa*.so*",
     "libroc*.so*",
 )
-# Kernel catalog directories a Linux ROCm llama bundle can ship beside its
-# libraries, mirrored into the whisper bin dir so the packaged libraries find
-# their Tensile kernels next to themselves.
+# Kernel catalogs a linux ROCm llama bundle can ship, mirrored into the whisper
+# bin dir so the packaged libraries find their Tensile kernels beside them.
 SLIM_ROCM_RUNTIME_DIRS = ("hipblaslt", "rocblas")
 # Of those, the ones a paired runtime must actually carry. hipBLASLt builds no
-# Tensile kernels for several targets (gfx1030 / RDNA2 among them), so llama's
-# linux-x64-rocm-gfx103X bundle ships libhipblaslt.so.1 with no hipblaslt/
-# catalog at all, while every other published target carries one. rocblas is the
-# load-bearing catalog: libggml-hip links librocblas directly and every
-# published linux ROCm bundle ships rocblas/library. install_llama_prebuilt
-# already copies whichever catalogs the archive has (runtime_subdirs_for_choice
-# is guarded by is_dir()), so demanding both here rejected a runtime llama.cpp
-# itself runs fine on. See #8364.
+# Tensile kernels for gfx1030 / RDNA2, so llama's linux-x64-rocm-gfx103X bundle
+# ships libhipblaslt.so.1 with no hipblaslt/ catalog while every other published
+# target carries one. rocblas is load-bearing: libggml-hip links librocblas
+# directly and every published linux ROCm bundle ships rocblas/library. The
+# llama installer copies only the catalogs the archive has, so demanding both
+# here rejected a runtime llama.cpp itself runs fine on (#8364).
 SLIM_ROCM_REQUIRED_RUNTIME_DIRS = ("rocblas",)
 # 3: libomp*.so*/dylib joined the wiring, so version 2 installs are missing
 # libomp.so.5 on linux arm64 and must re-wire.
@@ -875,8 +872,8 @@ def link_runtime_directories(
         )
         if not files:
             if not required:
-                # A target hipBLASLt has no kernels for: llama ships the library
-                # without a catalog and runs, so whisper must pair the same way.
+                # hipBLASLt has no kernels for this target; llama pairs without
+                # the catalog and runs, so whisper must pair the same way.
                 log(f"slim install: paired ROCm runtime ships no {name} kernel catalog; skipping")
                 continue
             missing = "is missing its" if not source_root.is_dir() else "has an empty"
@@ -1009,9 +1006,9 @@ def existing_install_matches(
             )
             return False
         runtime_dirs = marker.get("linked_runtime_directories")
-        # Subset, not equality: a target without hipBLASLt kernels wires rocblas
-        # alone and is complete (#8364). Anything outside the known catalog names,
-        # or a missing rocblas, still means stale or hand-edited wiring.
+        # Subset plus required, not equality: a target without hipBLASLt kernels
+        # wires rocblas alone and is complete (#8364), while an unknown name or
+        # a missing rocblas still means stale or hand-edited wiring.
         if (
             marker.get("backend") == "rocm"
             and not host.is_windows

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -1233,8 +1233,7 @@ def test_rocm_runtime_wires_packaged_dependency_closure_and_catalogs(tmp_path, m
 
 def test_rocm_runtime_requires_the_rocblas_kernel_catalog(tmp_path):
     # rocblas stays mandatory: libggml-hip.so lists librocblas.so.5 in its ELF
-    # NEEDED (checked on the published b10342 linux-x64-rocm-gfx103X bundle) and
-    # every published linux ROCm bundle carries rocblas/library.
+    # NEEDED (checked on the published b10342 linux-x64-rocm-gfx103X bundle).
     llama_bin = _fake_llama_bin(tmp_path, backend_module = "libggml-hip.so")
     (llama_bin / "hipblaslt").mkdir()
     (llama_bin / "hipblaslt" / "kernel.dat").write_bytes(b"kernel")
@@ -1274,9 +1273,8 @@ def _gfx103x_llama_bin(tmp_path: Path) -> Path:
 
 
 def test_rocm_runtime_wires_rocblas_when_hipblaslt_ships_no_kernels(tmp_path):
-    # #8364: reporter on Linux x64, AMD RX 6800 (gfx1030), ROCm 7.13.99004. The
-    # whisper update failed every startup with "paired ROCm runtime is missing
-    # its hipblaslt kernel catalog" while inference kept working.
+    # #8364: RX 6800 (gfx1030) on linux x64. The whisper update failed every
+    # startup on "missing its hipblaslt kernel catalog" while inference ran.
     llama_bin = _gfx103x_llama_bin(tmp_path)
     whisper_bin = tmp_path / "whisper-bin"
 
@@ -1325,7 +1323,7 @@ def test_rocm_runtime_treats_an_empty_hipblaslt_catalog_as_absent(tmp_path):
 )
 def test_runtime_directories_are_a_linux_rocm_concern_only(tmp_path, whisper_os, backend):
     # Non-regression for the backends #8364 must not touch: no catalog is looked
-    # for, so a bundle without one can never be rejected over it either.
+    # for, so a bundle without one is never rejected over it.
     llama_bin = _fake_llama_bin(tmp_path, backend_module = None)
     assert (
         M.link_runtime_directories(
@@ -1452,10 +1450,8 @@ def test_existing_rocm_install_reinstalls_over_an_empty_catalog_on_disk(
     tmp_path, monkeypatch, empty
 ):
     # Relaxing the marker check to membership must not relax the on-disk check:
-    # a marker that names a catalog still has to find files in it. An install
-    # whose hipblaslt/ went empty (a partial wipe, a half-finished copy) has to
-    # read as broken and reinstall, not as intact-but-broken, or dictation fails
-    # at launch with the marker insisting the install is current.
+    # a marker that names a catalog still has to find files in it, or dictation
+    # fails at launch with the marker insisting the install is current.
     host = _host("linux", "x64", has_rocm = True, rocm_gfx = "gfx1030")
     monkeypatch.setattr(M.core, "existing_install_matches", lambda *a: True)
     bin_dir = tmp_path / "build" / "bin"

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -1447,6 +1447,43 @@ def test_existing_rocm_install_accepts_the_catalogs_the_target_has(
     assert M.existing_install_matches(tmp_path, host, object()) is current
 
 
+@pytest.mark.parametrize("empty", ["hipblaslt", "rocblas"])
+def test_existing_rocm_install_reinstalls_over_an_empty_catalog_on_disk(
+    tmp_path, monkeypatch, empty
+):
+    # Relaxing the marker check to membership must not relax the on-disk check:
+    # a marker that names a catalog still has to find files in it. An install
+    # whose hipblaslt/ went empty (a partial wipe, a half-finished copy) has to
+    # read as broken and reinstall, not as intact-but-broken, or dictation fails
+    # at launch with the marker insisting the install is current.
+    host = _host("linux", "x64", has_rocm = True, rocm_gfx = "gfx1030")
+    monkeypatch.setattr(M.core, "existing_install_matches", lambda *a: True)
+    bin_dir = tmp_path / "build" / "bin"
+    bin_dir.mkdir(parents = True)
+    server = bin_dir / "whisper-server"
+    server.write_text("bin")
+    server.chmod(0o755)
+    (bin_dir / "libggml.so.0").write_text("lib")
+    for name in ("hipblaslt", "rocblas"):
+        (bin_dir / name / "library").mkdir(parents = True)
+        if name != empty:
+            (bin_dir / name / "library" / "kernel.dat").write_text("kernel")
+    monkeypatch.setattr(M, "installed_server_path", lambda d, h: server)
+    monkeypatch.setattr(
+        M,
+        "load_prebuilt_metadata",
+        lambda d: {
+            "install_kind": "slim",
+            "backend": "rocm",
+            "runtime_wiring_version": M.SLIM_RUNTIME_WIRING_VERSION,
+            "linked_libraries": ["libggml.so.0"],
+            "linked_runtime_directories": ["hipblaslt", "rocblas"],
+        },
+    )
+
+    assert M.existing_install_matches(tmp_path, host, object()) is False
+
+
 def test_link_ggml_runtime_libomp_alone_is_not_a_pairing(tmp_path):
     # A libomp without any ggml library is not a usable llama runtime.
     bin_dir = tmp_path / "llama_bin"

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -1231,7 +1231,10 @@ def test_rocm_runtime_wires_packaged_dependency_closure_and_catalogs(tmp_path, m
         assert linked_catalog.stat().st_ino == source_catalog.stat().st_ino
 
 
-def test_rocm_runtime_requires_both_kernel_catalogs(tmp_path):
+def test_rocm_runtime_requires_the_rocblas_kernel_catalog(tmp_path):
+    # rocblas stays mandatory: libggml-hip.so lists librocblas.so.5 in its ELF
+    # NEEDED (checked on the published b10342 linux-x64-rocm-gfx103X bundle) and
+    # every published linux ROCm bundle carries rocblas/library.
     llama_bin = _fake_llama_bin(tmp_path, backend_module = "libggml-hip.so")
     (llama_bin / "hipblaslt").mkdir()
     (llama_bin / "hipblaslt" / "kernel.dat").write_bytes(b"kernel")
@@ -1242,6 +1245,97 @@ def test_rocm_runtime_requires_both_kernel_catalogs(tmp_path):
             backend = "rocm",
             host = _host("linux", "x64"),
         )
+
+
+def test_rocm_runtime_rejects_an_empty_rocblas_kernel_catalog(tmp_path):
+    llama_bin = _fake_llama_bin(tmp_path, backend_module = "libggml-hip.so")
+    (llama_bin / "rocblas" / "library").mkdir(parents = True)
+    with pytest.raises(PrebuiltFallback, match = "empty rocblas"):
+        M.link_runtime_directories(
+            llama_bin,
+            tmp_path / "whisper-bin",
+            backend = "rocm",
+            host = _host("linux", "x64"),
+        )
+
+
+def _gfx103x_llama_bin(tmp_path: Path) -> Path:
+    """The published linux-x64-rocm-gfx103X layout from #8364: librocblas plus
+    its Tensile catalog, and libhipblaslt.so.1 with no hipblaslt/ catalog at all.
+    hipBLASLt builds no kernels for gfx1030 (RDNA2), so nothing is missing here;
+    llama.cpp installs and runs inference on exactly this tree."""
+    llama_bin = _fake_llama_bin(tmp_path, backend_module = "libggml-hip.so")
+    for name in ("libamdhip64.so.7", "libhipblas.so.3", "librocblas.so.5", "libhipblaslt.so.1"):
+        (llama_bin / name).write_bytes(name.encode())
+    catalog = llama_bin / "rocblas" / "library"
+    catalog.mkdir(parents = True)
+    (catalog / "TensileLibrary_Type_HH_Contraction_gfx1030.dat").write_bytes(b"kernel")
+    return llama_bin
+
+
+def test_rocm_runtime_wires_rocblas_when_hipblaslt_ships_no_kernels(tmp_path):
+    # #8364: reporter on Linux x64, AMD RX 6800 (gfx1030), ROCm 7.13.99004. The
+    # whisper update failed every startup with "paired ROCm runtime is missing
+    # its hipblaslt kernel catalog" while inference kept working.
+    llama_bin = _gfx103x_llama_bin(tmp_path)
+    whisper_bin = tmp_path / "whisper-bin"
+
+    linked_dirs = M.link_runtime_directories(
+        llama_bin,
+        whisper_bin,
+        backend = "rocm",
+        host = _host("linux", "x64", has_rocm = True, rocm_gfx = "gfx1030"),
+    )
+
+    assert linked_dirs == ["rocblas"]
+    catalog = whisper_bin / "rocblas" / "library" / "TensileLibrary_Type_HH_Contraction_gfx1030.dat"
+    assert catalog.is_file()
+    assert catalog.stat().st_ino == (llama_bin / "rocblas" / "library" / catalog.name).stat().st_ino
+    # No empty stand-in directory: the sidecar treats an empty catalog as broken.
+    assert not (whisper_bin / "hipblaslt").exists()
+
+
+def test_rocm_runtime_treats_an_empty_hipblaslt_catalog_as_absent(tmp_path):
+    llama_bin = _gfx103x_llama_bin(tmp_path)
+    (llama_bin / "hipblaslt" / "library").mkdir(parents = True)
+    whisper_bin = tmp_path / "whisper-bin"
+
+    assert M.link_runtime_directories(
+        llama_bin,
+        whisper_bin,
+        backend = "rocm",
+        host = _host("linux", "x64", has_rocm = True, rocm_gfx = "gfx1030"),
+    ) == ["rocblas"]
+    assert not (whisper_bin / "hipblaslt").exists()
+
+
+@pytest.mark.parametrize(
+    "whisper_os, backend",
+    [
+        ("linux", "cpu"),
+        ("linux", "cuda"),
+        ("linux", "vulkan"),
+        ("macos", "cpu"),
+        ("macos", "metal"),
+        ("windows", "cpu"),
+        ("windows", "cuda"),
+        ("windows", "vulkan"),
+        ("windows", "rocm"),
+    ],
+)
+def test_runtime_directories_are_a_linux_rocm_concern_only(tmp_path, whisper_os, backend):
+    # Non-regression for the backends #8364 must not touch: no catalog is looked
+    # for, so a bundle without one can never be rejected over it either.
+    llama_bin = _fake_llama_bin(tmp_path, backend_module = None)
+    assert (
+        M.link_runtime_directories(
+            llama_bin,
+            tmp_path / f"whisper-bin-{whisper_os}-{backend}",
+            backend = backend,
+            host = _host(whisper_os, "x64"),
+        )
+        == []
+    )
 
 
 def test_rocm_runtime_catalog_copy_fallback(tmp_path, monkeypatch):
@@ -1308,6 +1402,49 @@ def test_existing_slim_install_requires_wired_libraries(tmp_path, monkeypatch):
     assert M.existing_install_matches(tmp_path, host, object()) is True
     marker.update(backend = "rocm", linked_runtime_directories = [])
     assert M.existing_install_matches(tmp_path, _host("windows", "x64"), object()) is True
+
+
+@pytest.mark.parametrize(
+    "runtime_dirs, current",
+    [
+        (["hipblaslt", "rocblas"], True),  # every target hipBLASLt has kernels for
+        (["rocblas"], True),  # gfx1030 and friends: #8364
+        ([], False),  # rocblas is load-bearing, never optional
+        (["hipblaslt"], False),
+        (["rocblas", "unexpected"], False),  # not a catalog this installer wires
+        ("rocblas", False),  # not a list: hand-edited or truncated marker
+    ],
+)
+def test_existing_rocm_install_accepts_the_catalogs_the_target_has(
+    tmp_path, monkeypatch, runtime_dirs, current
+):
+    # #8364: a gfx1030 install wires rocblas alone and is complete, so "already
+    # matches" must hold for it, while a marker with no rocblas still reinstalls.
+    host = _host("linux", "x64", has_rocm = True, rocm_gfx = "gfx1030")
+    monkeypatch.setattr(M.core, "existing_install_matches", lambda *a: True)
+    bin_dir = tmp_path / "build" / "bin"
+    bin_dir.mkdir(parents = True)
+    server = bin_dir / "whisper-server"
+    server.write_text("bin")
+    server.chmod(0o755)
+    (bin_dir / "libggml.so.0").write_text("lib")
+    for name in ("hipblaslt", "rocblas", "unexpected"):
+        (bin_dir / name).mkdir()
+        (bin_dir / name / "kernel.dat").write_text("kernel")
+    monkeypatch.setattr(M, "installed_server_path", lambda d, h: server)
+    monkeypatch.setattr(
+        M,
+        "load_prebuilt_metadata",
+        lambda d: {
+            "install_kind": "slim",
+            "backend": "rocm",
+            "runtime_wiring_version": M.SLIM_RUNTIME_WIRING_VERSION,
+            "linked_libraries": ["libggml.so.0"],
+            "linked_runtime_directories": runtime_dirs,
+        },
+    )
+
+    assert M.existing_install_matches(tmp_path, host, object()) is current
 
 
 def test_link_ggml_runtime_libomp_alone_is_not_a_pairing(tmp_path):
@@ -1397,6 +1534,54 @@ def test_slim_install_wires_links_and_marker(tmp_path, monkeypatch):
     ]
     assert marker["runtime_wiring_version"] == M.SLIM_RUNTIME_WIRING_VERSION
     assert marker["linked_runtime_directories"] == []
+
+
+def test_slim_rocm_install_pairs_a_runtime_without_a_hipblaslt_catalog(tmp_path, monkeypatch):
+    # End to end over the #8364 tree: the install must complete and the marker
+    # must record the one catalog the gfx1030 bundle actually ships.
+    host = _host("linux", "x64", has_rocm = True, rocm_gfx = "gfx1030")
+    archive, sha256 = _build_slim_bundle(tmp_path, host)
+    llama_bin = _gfx103x_llama_bin(tmp_path)
+
+    def fake_download(url, destination):
+        destination.parent.mkdir(parents = True, exist_ok = True)
+        destination.write_bytes(archive.read_bytes())
+
+    monkeypatch.setattr(M, "detect_host", lambda: host)
+    monkeypatch.setattr(M, "download_file", fake_download)
+    monkeypatch.setattr(M, "_elf_needed", lambda path: set())
+    monkeypatch.setattr(
+        M,
+        "installed_llama_runtime",
+        lambda install_dir = None: (llama_bin, SLIM_LLAMA_TAG, "rocm-gfx103X"),
+    )
+    manifest = M.parse_manifest(_manifest([_slim_artifact(sha256 = sha256)]))
+    bundle = M.ReleaseBundle(
+        repo = "unslothai/whisper.cpp",
+        release_tag = RELEASE_TAG,
+        manifest = manifest,
+        asset_urls = {SLIM_ASSET: f"https://example.invalid/{SLIM_ASSET}"},
+    )
+    monkeypatch.setattr(
+        M,
+        "fetch_release_for_install",
+        lambda repo, *, published_release_tag = None: (bundle, {SLIM_ASSET: sha256}),
+    )
+
+    install_dir = tmp_path / "whisper.cpp"
+    assert M.install_prebuilt(install_dir, backend = "rocm") == M.EXIT_SUCCESS
+
+    whisper_bin = install_dir / "build" / "bin"
+    assert (whisper_bin / "libggml-hip.so").is_file()
+    assert (whisper_bin / "rocblas" / "library").is_dir()
+    assert not (whisper_bin / "hipblaslt").exists()
+    marker = json.loads((install_dir / M.METADATA_FILENAME).read_text())
+    assert marker["backend"] == "rocm"
+    assert marker["install_kind"] == "slim"
+    assert marker["linked_runtime_directories"] == ["rocblas"]
+    assert marker["runtime_wiring_version"] == M.SLIM_RUNTIME_WIRING_VERSION
+    # A second run is a no-op: the wiring the target can have is the wiring it has.
+    assert M.install_prebuilt(install_dir, backend = "rocm") == M.EXIT_SUCCESS
 
 
 def test_slim_links_survive_a_llama_dir_swap(tmp_path, monkeypatch):


### PR DESCRIPTION
### What breaks

Reported in #8364: Linux x64, Radeon RX 6800 (gfx1030), ROCm 7.13.99004, paired llama
`b10333-mix-e34b418`. Every Studio startup ends with

```
[whisper-prebuilt] prebuilt install failed: paired ROCm runtime is missing its hipblaslt kernel catalog
```

while inference on that very same llama runtime works. Two places assume that every Linux ROCm
llama bundle carries both kernel catalogs:

- `studio/install_whisper_prebuilt.py`, `link_runtime_directories`: a missing or empty entry of
  `SLIM_ROCM_RUNTIME_DIRS = ("hipblaslt", "rocblas")` raises `PrebuiltFallback`, so the slim
  whisper install never completes and the update fails on every launch.
- `studio/backend/core/inference/stt_ggml_sidecar.py`, `slim_runtime_intact`: the launch guard
  demands `set(linked_runtime_directories) == {"hipblaslt", "rocblas"}`. Fixing only the
  installer would leave this half in place, and an install correctly wired with `rocblas` alone
  would still read as a broken runtime, so dictation would stay unavailable.

Both are relaxed the same way: membership plus required, rather than set equality. Any subset of
the catalogs this installer wires is accepted, `rocblas` stays mandatory, and a name outside the
pair still fails closed as stale or hand edited wiring. Windows is untouched on both sides, since
the Windows ROCm overlay wires DLLs and no catalogs at all, which is the empty set either way.

The install error disappearing is the visible half. What actually comes back for the reporter is
dictation, which the launch guard was holding shut on a runtime whisper.cpp runs fine on.

### The asset evidence

Counted by extracting the published `unslothai/llama.cpp` Linux ROCm tarballs, not from the issue
body:

| llama bundle | files under `hipblaslt/` | files under `rocblas/` | ships `libhipblaslt*.so` |
| --- | --- | --- | --- |
| linux-x64-rocm-gfx103X | 0 | 996 | yes |
| linux-x64-rocm-gfx110X | 414 | 602 | yes |
| linux-x64-rocm-gfx1150 | 103 | 153 | yes |
| linux-x64-rocm-gfx1151 | 103 | 153 | yes |
| linux-x64-rocm-gfx120X | 578 | 222 | yes |
| linux-x64-rocm-gfx908 | 111 | 229 | yes |
| linux-x64-rocm-gfx90a | 205 | 490 | yes |

gfx103X counted on `b10342-mix-e34b418`, the rest on `b10333-mix-e34b418`, the build the
reporter is paired with.

hipBLASLt builds no Tensile kernels for RDNA2, so the gfx103X bundle ships `libhipblaslt.so.1`
with no `hipblaslt/` directory at all. Nothing is missing from it, and llama.cpp installs and
serves inference on exactly that tree.

`rocblas` is the load bearing one and stays required: `readelf -d` on the published
`libggml-hip.so.0.19.0` from the gfx103X bundle lists `librocblas.so.5` in `NEEDED` alongside
`libhipblas.so.3` and `libamdhip64.so.7`, and no `libhipblaslt`. Every published Linux ROCm
bundle carries `rocblas/library`.

### Release side remedy

A client fix only reaches people who re-run setup. When a GPU bundle is genuinely missing a
runtime file, shipping it in the bundle needs no client change at all and self heals existing
installs through the `runtime_wiring_version` fingerprint, so it is the cheaper lever and worth
preferring for the next case of this shape. It does not apply to gfx103X, where there are no
hipBLASLt kernels to ship in the first place, which is why this one has to be handled client
side.

### Relationship to #8379

#8379 fixes the Windows `libomp140.x86_64.dll` pairing and is gated on `host.is_windows`, so the
two changes are disjoint. Verified that this branch merges cleanly with `pull/8379/head`, and the
merged tree passes both suites (116 and 46).

### Tests

- `tests/studio/install/test_install_whisper_prebuilt_logic.py`: 106 passed. New cases cover the
  real gfx103X layout end to end, an empty `hipblaslt/` treated as absent, `rocblas` still
  required and still rejected when empty, and every non Linux-ROCm backend asserted to look for
  no catalog at all.
- From `studio/backend/`, `tests/test_stt_ggml_sidecar.py`: 46 passed, up from 42. New cases
  cover a marker recording `["rocblas"]` alone reading as intact, a marker without `rocblas`
  and a marker with an unknown catalog name both reading as broken, and Windows ROCm still
  expecting no catalogs.

Closes #8364.
