### PR TITLE
Read the IME re-arm flush off the live composer

### DIFF
--- a/tests/studio/playwright_chat_ime_i18n.py
+++ b/tests/studio/playwright_chat_ime_i18n.py
@@ -10,6 +10,7 @@ playwright_chat_ui.py: BASE_URL, STUDIO_NEW_PW, PW_ART_DIR, STUDIO_UI_STRICT.
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -119,11 +120,35 @@ with sync_playwright() as p:
     console_errors: list[str] = []
     expected_probe_cancel_500s = [0]
 
+    # A send answers "does this thread / message row exist yet" with a GET that
+    # 404s until the row lands (#8136 replaced a full listing with that read),
+    # and the browser logs every 404 as a console.error with no URL in its text.
+    # Those two reads are expected traffic on a healthy send, so they are matched
+    # on the failing resource's URL -- taken from the console message's location,
+    # not its text -- and nothing else is exempted.
+    EXPECTED_404_URL_RES = (
+        re.compile(r"/api/chat/threads/[^/?#]+$"),
+        re.compile(r"/api/chat/threads/[^/?#]+/messages/[^/?#]+$"),
+    )
+
+    def _is_expected_send_404(text: str, url: str) -> bool:
+        if "status of 404" not in text:
+            return False
+        return any(pattern.search(url) for pattern in EXPECTED_404_URL_RES)
+
     def _on_console(m):
         if m.type != "error":
             return
         try:
-            console_errors.append(m.text)
+            text = m.text
+            url = ""
+            try:
+                url = (m.location or {}).get("url", "") or ""
+            except Exception:
+                url = ""
+            if _is_expected_send_404(text, url):
+                return
+            console_errors.append(text)
         except Exception:
             return
 
@@ -572,6 +597,17 @@ with sync_playwright() as p:
     )
     # Second watchdog cycle: requestSubmit() after the re-armed window must be
     # allowed; the buggy build stays gated forever.
+    #
+    # The flush has to be read off the composer that is on screen when the
+    # submit settles, not off the node captured before it. A send in a new chat
+    # swaps the empty-thread view for the thread view, so React unmounts the
+    # textarea this step composed into and mounts a fresh one. Since #8136
+    # rendered the send without waiting on persistence, that swap lands inside
+    # the 250ms settle window, and the detached node keeps '你好' forever --
+    # which reads as "Send never unlocked" on a build that sent the message
+    # correctly. `sent` is the corroboration that the flush came from a real
+    # send and not from the composer being replaced: a blocked submit leaves
+    # the text in the live composer and adds no user message.
     rearm_probe = page.evaluate(
         """async (selector) => {
             const ta = document.querySelector(selector);
@@ -580,25 +616,46 @@ with sync_playwright() as p:
             const before = ta.value;
             // Wait past the 2500ms watchdog + slack so the re-armed timer
             // fires. If the fix is missing this still resolves but the
-            // submit will not flush the textarea.
+            // submit will not flush the composer.
             await new Promise(r => setTimeout(r, 3500));
             try { form.requestSubmit(); } catch (e) {}
-            // Give the submit handler a tick to flush state.
-            await new Promise(r => setTimeout(r, 250));
-            return {ok: true, before, after: ta.value};
+            // Give the submit handler a tick to flush state, then re-read the
+            // live composer (see above; `ta` may be detached by now).
+            let live = null;
+            let sent = false;
+            for (let i = 0; i < 12; i++) {
+                await new Promise(r => setTimeout(r, 250));
+                live = document.querySelector(selector);
+                sent = Array.from(
+                    document.querySelectorAll('.aui-user-message-root')
+                ).some((n) => (n.innerText || '').includes(before));
+                if (sent && live && live.value !== before) break;
+            }
+            return {
+                ok: true,
+                before,
+                after: live ? live.value : null,
+                sent,
+                detached: !ta.isConnected,
+            };
         }""",
         'textarea[aria-label="Message input"]',
     )
-    if rearm_probe.get("ok") and rearm_probe.get("after") == rearm_probe.get("before"):
+    if rearm_probe.get("ok") and (
+        rearm_probe.get("after") == rearm_probe.get("before") or not rearm_probe.get("sent")
+    ):
         shoot("06d-keydown-rearm-FAIL")
         fail(
             "After the keydown re-pin the watchdog never re-armed; Send "
             "stayed permanently locked on the WSL+Chrome stuck-end path "
-            "(#5546 follow-up regression)."
+            "(#5546 follow-up regression). Live composer still "
+            f"{rearm_probe.get('after')!r}, message delivered="
+            f"{rearm_probe.get('sent')}."
         )
     info(
-        "watchdog re-armed after keydown re-pin: textarea flushed from "
-        f"{rearm_probe.get('before')!r} to {rearm_probe.get('after')!r}"
+        "watchdog re-armed after keydown re-pin: composer flushed from "
+        f"{rearm_probe.get('before')!r} to {rearm_probe.get('after')!r} "
+        f"(message delivered; composer node swapped={rearm_probe.get('detached')})"
     )
     shoot("06d-keydown-rearm")
     info("keydown re-pin re-arm PASS")

--- a/tests/studio/playwright_chat_ime_i18n.py
+++ b/tests/studio/playwright_chat_ime_i18n.py
@@ -123,18 +123,35 @@ with sync_playwright() as p:
     # A send answers "does this thread / message row exist yet" with a GET that
     # 404s until the row lands (#8136 replaced a full listing with that read),
     # and the browser logs every 404 as a console.error with no URL in its text.
-    # Those two reads are expected traffic on a healthy send, so they are matched
-    # on the failing resource's URL -- taken from the console message's location,
-    # not its text -- and nothing else is exempted.
+    # Those two reads are expected traffic on a healthy send. The URL alone does
+    # not identify them: a persistence PUT or PATCH to the very same path 404s on
+    # exactly these patterns, and silently exempting that would hide a real
+    # failure to save. So the exemption is resolved against the response ledger
+    # below -- a console 404 is forgiven only if an actual GET 404 was observed
+    # at that URL, and each observed GET is spent by at most one console error.
     EXPECTED_404_URL_RES = (
         re.compile(r"/api/chat/threads/[^/?#]+$"),
         re.compile(r"/api/chat/threads/[^/?#]+/messages/[^/?#]+$"),
     )
 
-    def _is_expected_send_404(text: str, url: str) -> bool:
-        if "status of 404" not in text:
-            return False
+    # url -> count of GET responses that returned 404 and are not yet spent.
+    unspent_get_404s: dict[str, int] = {}
+    # (text, url) for console 404s whose URL matched; resolved after the run.
+    deferred_404_console: list[tuple[str, str]] = []
+
+    def _url_is_exemptible(url: str) -> bool:
         return any(pattern.search(url) for pattern in EXPECTED_404_URL_RES)
+
+    def _on_response(response):
+        try:
+            if response.status != 404:
+                return
+            url = response.url
+            if response.request.method != "GET" or not _url_is_exemptible(url):
+                return
+            unspent_get_404s[url] = unspent_get_404s.get(url, 0) + 1
+        except Exception:
+            return
 
     def _on_console(m):
         if m.type != "error":
@@ -146,15 +163,30 @@ with sync_playwright() as p:
                 url = (m.location or {}).get("url", "") or ""
             except Exception:
                 url = ""
-            if _is_expected_send_404(text, url):
+            if "status of 404" in text and _url_is_exemptible(url):
+                deferred_404_console.append((text, url))
                 return
             console_errors.append(text)
         except Exception:
             return
 
+    def _resolve_deferred_404s() -> None:
+        """Promote every console 404 with no matching unspent GET into a failure.
+
+        Ordering between the response event and the console error is not
+        guaranteed, so resolution happens once at the end rather than inline.
+        """
+        for text, url in deferred_404_console:
+            remaining = unspent_get_404s.get(url, 0)
+            if remaining > 0:
+                unspent_get_404s[url] = remaining - 1
+                continue
+            console_errors.append(text)
+
     def _attach_listeners(target):
         target.on("pageerror", lambda e: page_errors.append(str(e)))
         target.on("console", _on_console)
+        target.on("response", _on_response)
 
     _attach_listeners(page)
 
@@ -817,6 +849,7 @@ with sync_playwright() as p:
 
     # 7. Final state: filter benign 401 noise via is_benign_*; fail on real errors.
     shoot("07-final")
+    _resolve_deferred_404s()
     real_page_errors = [e for e in page_errors if not is_benign_page_error(e)]
     probe_cancel_500_allowance = expected_probe_cancel_500s[0]
     real_console_errors = []


### PR DESCRIPTION
`Chat UI Tests` fails on main at the IME probe's step 6d:

    [ime] FAIL: After the keydown re-pin the watchdog never re-armed; Send stayed
    permanently locked on the WSL+Chrome stuck-end path (#5546 follow-up regression).

The premise is false. Instrumenting the composer hook shows the keydown re-pin does re-arm the watchdog, the watchdog fires, the gate opens and the message is sent:

    [IMEDBG] onKeyDown key= Enter kc= 229 nativeComposing= true
    [IMEDBG] refreshStuckTimer composing= true        <- re-pin DOES re-arm
    [IMEDBG] watchdog fired (refresh)
    [IMEDBG] shouldBlockSend sendable= true composing= false

What step 6d read was a textarea React had already unmounted: same_node false, stale_connected false, live_value "", Stop button up. A send in a new chat swaps the empty-thread view for the thread view, so the node the step composed into is discarded still holding the text.

Bisected to 5c332c323 ("render a chat send without waiting on persistence", #8136). At 5c332c323^ the step passes with after ""; at 5c332c323 it fails with after "你好" and live_value "". The composer node was always swapped on the first send; #8136 moved the swap earlier, into the step's 250 ms settle window.

Two changes, both in the probe:

1. Step 6d re-reads the composer that is on screen when the submit settles, and additionally requires a user message bubble to contain the composed text. That makes the assertion stronger, not weaker: a genuinely non-re-arming watchdog leaves the text in the live composer and sends nothing, so it still fails, and the message now prints the live value and whether the message was delivered.
2. #8136 also made the send path do two existence reads that 404 until the row lands, and Chromium logs each as a console.error. This probe is the only one that fails on console errors. Those two reads are skipped by matching the failing resource's URL from the console message's location; every other console error still fails the probe.

Negative control: deleting refreshStuckTimer() from the keydown re-pin branch and rebuilding makes the fixed step fail again with "Live composer still '你好', message delivered=False". So it still catches the lock-up it is named for.

No app code changed, so the browser and OS matrix is untouched. Also run: tests/studio/test_composer_rtl_bidi_attribute.py (the static guard for this same area), test_stt_model_search_locator_contract.py and test_first_turn_thread_identity.py, 38 passed; ruff clean.

Worth a separate look, not fixed here: #8136 makes the frontend GET a thread id it just minted locally before the POST that creates it, so every new chat costs a guaranteed 404 round trip and dirties the browser console.