### PR TITLE
Diffusion: the local prequant scheme probe no longer runs the checkpoint's pickle

### DIFF
--- a/studio/backend/core/inference/diffusion_prequant.py
+++ b/studio/backend/core/inference/diffusion_prequant.py
@@ -198,6 +198,84 @@ def resolve_prequant_source(
 _LOCAL_PREQUANT_SCHEME: dict[tuple[str, int, int], Optional[str]] = {}
 
 
+class _OpaqueGlobal:
+    """Stand-in for every class/function a probed checkpoint's pickle names.
+
+    A pickle can invoke ANY global it names (``__reduce__`` is a call), so resolving them for real
+    is what makes ``weights_only = False`` code execution. The metadata probe needs none of them:
+    ``format`` and ``metadata`` are plain str/dict/number opcodes, and the ``state_dict`` next to
+    them is the only part that needs real classes. Handing back an inert object for every global
+    leaves the metadata intact and turns the rest of the file into scenery. Accepts the shapes
+    pickle drives an object through -- construction (``REDUCE``/``NEWOBJ``), ``BUILD``, and the
+    list/dict item appends -- so a legitimate checkpoint still parses to the end."""
+
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(cls)
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return _OpaqueGlobal()
+
+    def __setstate__(self, state):
+        pass
+
+    def __setitem__(self, key, value):
+        pass
+
+    def append(self, value):
+        pass
+
+    def extend(self, values):
+        pass
+
+
+_METADATA_PICKLE: Any = None
+
+
+def _metadata_only_pickle():
+    """A ``pickle_module`` for ``torch.load`` that resolves no globals (see ``_OpaqueGlobal``).
+
+    torch's own ``UnpicklerWrapper`` subclasses whatever ``Unpickler`` this hands it and calls
+    ``super().find_class`` last, so storages, ``mmap`` and ``map_location`` keep working exactly as
+    they do on the trusted load path; only the global lookup is neutered.
+
+    Built once and reused: it carries no per-probe state, and a fresh ``Unpickler`` subclass per
+    call would leave a new type behind on every candidate scheme the auto ladder asks about. Also
+    nothing global -- ``pickle`` itself and the trusted ``torch.load`` path are untouched, so the
+    real load still resolves the torchao classes it needs."""
+    global _METADATA_PICKLE
+    if _METADATA_PICKLE is not None:
+        return _METADATA_PICKLE
+
+    import pickle
+    import types
+
+    class _Unpickler(pickle.Unpickler):
+        def find_class(self, module, name):
+            # The ONE exception: torch's persistent_load reads ``.dtype`` off the storage class in
+            # the record id, so a tensor whose storage type torch's own wrapper does not special
+            # case (``UntypedStorage``, i.e. every fp8 tensor) would abort the parse. These are
+            # plain types, looked up on an already-imported torch, never called by us.
+            if name.endswith("Storage") and module in ("torch", "torch.storage"):
+                import sys
+                resolved = getattr(sys.modules.get(module), name, None)
+                if isinstance(resolved, type):
+                    return resolved
+            return _OpaqueGlobal
+
+    shim = types.SimpleNamespace(
+        Unpickler = _Unpickler,
+        # The legacy (non-zip) reader reads its magic number through this.
+        load = lambda f, **kwargs: _Unpickler(f, **kwargs).load(),
+        UnpicklingError = pickle.UnpicklingError,
+    )
+    shim.__name__ = "unsloth_prequant_metadata_pickle"  # torch's dill-version check reads this
+    _METADATA_PICKLE = shim
+    return shim
+
+
 def local_prequant_scheme(path: str) -> Optional[str]:
     """The scheme a local pre-quant checkpoint records, or None when it cannot be read.
 
@@ -210,9 +288,18 @@ def local_prequant_scheme(path: str) -> Optional[str]:
 
     Cheap despite the file size: ``mmap`` plus ``map_location = "meta"`` maps the storages instead
     of reading them, so only the pickle structure is parsed (~1s on a 34 GB checkpoint). Cached on
-    (path, mtime, size) because the auto ladder asks once per candidate scheme. ``weights_only``
-    has to be False for the torchao subclasses, which is what the loader already does, and the
-    path is allowlisted before we get here, so this opens nothing new."""
+    (path, mtime, size) because the auto ladder asks once per candidate scheme.
+
+    Executes NOTHING out of the file. The load path unpickles for real because it has to build the
+    torchao subclasses, and by then the operator has committed to the checkpoint. This is only a
+    probe: it runs during PLANNING (``/images/download-plan`` reaches it through
+    ``usable_prequant_source``) on a request-supplied path, for candidate schemes the ladder is
+    still guessing at, and on files it is about to reject -- so a checkpoint that never loads must
+    not get to run code either. ``_metadata_only_pickle`` resolves no globals, which leaves the
+    ``format``/``metadata`` header (plain str/dict opcodes) readable while the weights parse to
+    inert placeholders we never look at. ``weights_only = True`` would not do: it refuses the
+    torchao subclasses outright, so every real fp8/int8 override would read as unknown and planning
+    would budget dense for a checkpoint that loads fine."""
     import os
 
     try:
@@ -229,7 +316,13 @@ def local_prequant_scheme(path: str) -> Optional[str]:
     scheme: Optional[str] = None
     try:
         import torch
-        obj = torch.load(real, map_location = "meta", weights_only = False, mmap = True)
+        obj = torch.load(
+            real,
+            map_location = "meta",
+            weights_only = False,
+            mmap = True,
+            pickle_module = _metadata_only_pickle(),
+        )
         if isinstance(obj, dict) and obj.get("format") in PREQUANT_FORMATS:
             recorded = (obj.get("metadata") or {}).get("scheme")
             scheme = str(recorded) if recorded else None

--- a/studio/backend/tests/test_diffusion_prequant.py
+++ b/studio/backend/tests/test_diffusion_prequant.py
@@ -219,6 +219,71 @@ def test_an_unreadable_override_is_not_usable(tmp_path, monkeypatch):
     assert pq.usable_prequant_source(fam, "fp8", path_override = str(ckpt)) is None
 
 
+def test_the_scheme_probe_runs_no_code_out_of_the_checkpoint(tmp_path, monkeypatch):
+    """The probe reads metadata; it must not execute the file's pickle.
+
+    Unlike the load, this runs during PLANNING (``/images/download-plan`` reaches it through
+    ``usable_prequant_source``) on a request-supplied path, for schemes the auto ladder is only
+    guessing at, and on checkpoints it is about to refuse. A plain
+    ``torch.load(weights_only = False)`` here would run whatever the file names before the scheme
+    is ever compared.
+    """
+    import os
+
+    import torch
+
+    class _Boom:
+        def __reduce__(self):
+            # A side effect on disk, not an exception: the probe swallows exceptions, so a raise
+            # would pass whether or not the payload ran.
+            return (os.mkdir, (str(tmp_path / "executed"),))
+
+    ckpt = tmp_path / "model.pt"
+    torch.save(
+        {
+            "format": PREQUANT_FORMAT,
+            "metadata": {"scheme": "fp8"},
+            "state_dict": {"weight": _Boom()},
+        },
+        str(ckpt),
+    )
+    monkeypatch.setattr(pq, "_allowed_prequant_roots", lambda: [os.path.realpath(str(tmp_path))])
+
+    # The metadata still reads (the header is plain pickle data), so planning keeps working...
+    # ...and every probe answers the same, with nothing in the file ever running: the memo is what
+    # collapses the auto ladder's repeat asks, not what keeps the payload from firing a second time.
+    for _ in range(3):
+        pq._LOCAL_PREQUANT_SCHEME.clear()
+        assert pq.local_prequant_scheme(str(ckpt)) == "fp8"
+        assert not (tmp_path / "executed").exists()
+
+
+def test_the_scheme_probe_reads_a_quantized_checkpoint(tmp_path):
+    """Resolving no globals must not cost us the real artifacts.
+
+    ``weights_only = True`` would be the one-line fix, but it refuses the torchao tensor
+    subclasses a pre-quant checkpoint is made of, so every genuine fp8/int8 override would read as
+    unknown and planning would budget dense for a file that loads fine. fp8 storages are the case
+    that bites: torch's own unpickler leaves ``UntypedStorage`` to us.
+    """
+    import torch
+
+    ckpt = tmp_path / "model.pt"
+    torch.save(
+        {
+            "format": PREQUANT_FORMAT,
+            "metadata": {"scheme": "fp8", "min_features": 128, "fp8_granularity": "per_row"},
+            "state_dict": {
+                "a.weight": torch.randn(8, 8).to(torch.float8_e4m3fn),
+                "a.scale": torch.randn(8),
+                "b.weight": torch.randint(-8, 8, (8, 8), dtype = torch.int8),
+            },
+        },
+        str(ckpt),
+    )
+    assert pq.local_prequant_scheme(str(ckpt)) == "fp8"
+
+
 def test_the_local_scheme_cache_survives_a_same_second_swap(tmp_path):
     """Two checkpoints of one model differ only in scheme, so an atomic swap is same-size.
 


### PR DESCRIPTION
`local_prequant_scheme()` reads the scheme out of a local pre-quant checkpoint with `torch.load(..., weights_only = False)`, which executes whatever the file names before the metadata is ever inspected.

The load path unpickles for real because it has to build the torchao subclasses, and by then the operator has committed to that checkpoint. This probe is different:

- it runs during **planning**, not loading: `/images/download-plan` forwards `transformer_prequant_path` into `download_plan()` -> `_dense_quant_prefetch_needed()` -> `_uncached_prequant_repo()` -> `usable_prequant_source()` -> here,
- on a request-supplied path, gated only by allowlist membership and existence,
- for candidate schemes the `auto` ladder is still guessing at,
- and on files it is about to **reject** for being baked for the wrong scheme.

A checkpoint that never loads should not get to run code either.

## The fix

The probe now hands `torch.load` a `pickle_module` whose unpickler resolves no globals: every class and function the file names becomes an inert placeholder. The `format`/`metadata` header is plain str/dict pickle opcodes, so it still reads; the weights parse into placeholders nothing looks at.

torch's own `UnpicklerWrapper` subclasses whatever `Unpickler` it is given and calls `super().find_class` last, so `mmap`, `map_location = "meta"` and storage loading behave exactly as they do on the trusted path. Only the global lookup is neutered. One narrow exception: `torch` / `torch.storage` `*Storage` **types** resolve for real, because torch's `persistent_load` reads `.dtype` off them (`UntypedStorage`, which is every fp8 tensor, is not special-cased by torch's own wrapper). They are plain types and we never call them.

Nothing global is touched. `pickle` itself and the trusted `load_prequantized_transformer` path are unchanged, so the real load still resolves the torchao classes it needs.

## Why not `weights_only = True`

That is the one-line version and it is wrong here. It refuses the torchao tensor subclasses a pre-quant checkpoint is made of, so every genuine fp8/int8 override would read as unknown, `usable_prequant_source()` would answer `None`, and planning would budget dense for a file that loads fine. That is exactly the bug the scheme check was added to stop, only inverted. The added `test_the_scheme_probe_reads_a_quantized_checkpoint` pins that half so the shortcut cannot be taken later.

## Tests

`studio/backend/tests/test_diffusion_prequant.py`: 70 passed.

Two new tests:

- `test_the_scheme_probe_runs_no_code_out_of_the_checkpoint` saves a checkpoint whose state dict carries a `__reduce__` payload with an on-disk side effect (not an exception, since the probe swallows those). The scheme still reads as `fp8` and the payload never runs, across repeated probes with the memo cleared. Fails on `main`.
- `test_the_scheme_probe_reads_a_quantized_checkpoint` saves an fp8 + int8 + scale state dict and asserts the scheme still reads, which is what `weights_only = True` would break.

Verified against torch 2.9.1 outside the suite as well: repeated and interleaved probes are stable, 8 concurrent threads agree, `pickle.Unpickler` is untouched, `_serialization_tls.map_location` is back to `None` afterwards, a real `torch.load(weights_only = False)` in the same process still rebuilds real tensors before and after a probe, and 100 uncached probes leak no file descriptors. A `_make_wrapper_subclass` tensor (the torchao shape) reads fine.

Wider run over the prequant, auto-policy, backend, convrot, diffusion/video routes, sd.cpp and gguf-variant files: same 85 pre-existing failures as `main` on this host (77 of them missing PyAV, the rest a bundled-diffusers revision check and a local torchao/torch mismatch), with the only delta being the 2 new tests passing.

## Scope

Not family specific. `resolve_prequant_source()` returns the path source before any family lookup, so an override reaches the probe for any image diffusion family loadable through the diffusers path on a CUDA bf16 host. Video is unaffected: `VideoLoadRequest` has no `transformer_prequant_path`, so video only ever reaches `usable_prequant_source()` with no override.
