### PR TITLE
Linux: resolve the ROCm version from every source, not the first that answers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2936,7 +2936,21 @@ _rocm_tag_from_hipconfig() {
 
 _rocm_tag_from_dpkg() {
     command -v dpkg-query >/dev/null 2>&1 || return 0
-    _rt_ver=$(dpkg-query -W -f='${Version}\n' rocm-core 2>/dev/null) || return 0
+    # ${Status}, not ${Version} alone. dpkg-query -W lists every package in the
+    # status database except purged ones (man dpkg-query, --list: "regardless of
+    # their status ... excluding the ones marked as not-installed"), so a
+    # rocm-core taken out with `apt remove` and not purged stays queryable in
+    # state "deinstall ok config-files" and still reports the version it had.
+    # Under highest-wins that dead entry would outrank every live source: a host
+    # that ran ROCm 7.0, downgraded to 6.1 and never purged would resolve rocm7.0
+    # off a package that is not there. Every other source at least describes a
+    # tree that exists, so this one has to require the status word "installed".
+    # ${Status} is a documented showformat field with no dpkg
+    # version floor, and dpkg-query renders an unrecognised field as empty rather
+    # than failing, so on any dpkg that somehow lacks it this source goes silent
+    # instead of over-reporting.
+    _rt_ver=$(dpkg-query -W -f='${Status} ${Version}\n' rocm-core 2>/dev/null \
+        | awk '$3 == "installed" && $4 != "" { print $4; exit }') || return 0
     [ -n "$_rt_ver" ] || return 0
     printf '%s\n' "$_rt_ver" | sed 's/^[0-9]*://' \
         | awk -F'[.-]' '{print "rocm"$1"."$2; exit}' || return 0
@@ -2972,14 +2986,39 @@ _highest_rocm_tag() {
 # and the 6.0+ gate below sent it to CPU-only wheels (issue #8402). A source
 # reporting lower than another on the same host is stale packaging, not a
 # downgrade, so the highest reading is the one that describes the runtime.
+#
+# The symmetric risk of highest-wins is overshoot: a source reading HIGHER than
+# the host now picks the wheel family instead of being shadowed by its position.
+# Two things bound it. PyTorch's ROCm wheels vendor their own ROCm userspace
+# into torch/lib, so what they need from the host is the amdgpu/KFD driver, and
+# AMD documents that as compatible +/- 2 releases (a year's span from 6.4), not
+# pinned to the userspace these sources report. And the normalisation below can
+# only emit a leaf PyTorch publishes. What is NOT bounded is a reading taken off
+# something that is not installed at all, so the one source that can produce one
+# -- a removed-but-not-purged dpkg rocm-core -- is filtered above. Past that,
+# disagreement is named on stderr: when overshoot does bite it surfaces as an
+# HSA error at the first HIP call, or a GPU that is simply absent from torch,
+# and neither points back here without the readings in the log.
 _detect_rocm_version_tag() {
-    {
+    _rt_readings=$({
         _rocm_tag_from_amd_smi
         _rocm_tag_from_version_file
         _rocm_tag_from_hipconfig
         _rocm_tag_from_dpkg
         _rocm_tag_from_rpm
-    } 2>/dev/null | _highest_rocm_tag
+    } 2>/dev/null) || _rt_readings=""
+    _rt_best=$(printf '%s\n' "$_rt_readings" | _highest_rocm_tag) || _rt_best=""
+    if [ -n "$_rt_best" ]; then
+        # Same shape gate as _highest_rocm_tag, so a garbage or major-0 reading
+        # is not named as a dissenting opinion when it never was a candidate.
+        _rt_seen=$(printf '%s\n' "$_rt_readings" \
+            | grep '^rocm[1-9][0-9]*\.[0-9][0-9]*$' | sort -u | tr '\n' ' ') || _rt_seen=""
+        case "$_rt_seen" in
+            ""|"$_rt_best ") : ;;  # one reading, or every source agreeing
+            *) echo "[WARN] ROCm version sources disagree (${_rt_seen% }) -- using the highest, $_rt_best." >&2 ;;
+        esac
+    fi
+    printf '%s\n' "$_rt_best"
 }
 
 # ── Detect GPU and choose PyTorch index URL ──
@@ -3060,13 +3099,16 @@ get_torch_index_url() {
         fi
         # AMD GPU confirmed -- detect ROCm version
         _rocm_tag=""
-        _rocm_tag=$(_detect_rocm_version_tag 2>/dev/null) || _rocm_tag=""
+        _rocm_tag=$(_detect_rocm_version_tag) || _rocm_tag=""
         # ^ || guard: when EVERY version source is missing (e.g. rocminfo present
         # but rocm-core not installed, so dpkg-query/rpm exit 1), detection must
         # still return empty-and-successful rather than let set -e kill the
         # installer BEFORE the actionable no-version WARN below -- exactly the
         # fresh-install case it exists for. _detect_rocm_version_tag holds that
-        # contract internally; the guard here is belt and braces.
+        # contract internally; the guard here is belt and braces. stderr is NOT
+        # redirected: every source's own noise is already suppressed inside the
+        # resolver, so the only thing left on stderr is its deliberate
+        # sources-disagree breadcrumb, which belongs in the install log.
         # Validate _rocm_tag: must match "rocmX.Y" with major >= 1.
         # _highest_rocm_tag already enforces this shape; kept as a second gate so
         # a future source added to _detect_rocm_version_tag cannot leak garbage

--- a/install.sh
+++ b/install.sh
@@ -2963,7 +2963,20 @@ _rocm_tag_from_dpkg() {
 
 _rocm_tag_from_rpm() {
     command -v rpm >/dev/null 2>&1 || return 0
-    _rt_ver=$(rpm -q --qf '%{VERSION}\n' rocm-core 2>/dev/null) || return 0
+    # Bounded: this is the one source highest-wins newly made unconditional that
+    # can block forever. It used to be LAST in a first-answer-wins `||` chain, so
+    # on any RHEL/SLES host with a normal ROCm install /opt/rocm/.info/version
+    # answered at position two and rpm was never invoked; now every source runs.
+    # `rpm -q` is not a lock-free read: on the BerkeleyDB backend (rpm < 4.16,
+    # i.e. RHEL 8 / SLES 15 -- both supported ROCm platforms) a leftover
+    # /var/lib/rpm/__db.00* from any killed rpm/yum leaves plain queries wedged
+    # in futex until the files are deleted (rhbz#485780, rhbz#73097), and rpm
+    # 6.0.x reintroduced a read lock that deadlocks `rpm --query` against a
+    # running dnf transaction (rhbz#2463435). A version probe must not be able to
+    # hang the installer, and a timed-out probe is just a source that declined to
+    # answer. _run_bounded no-ops where `timeout` is absent, so this adds no
+    # dependency the file did not already have.
+    _rt_ver=$(_run_bounded rpm -q --qf '%{VERSION}\n' rocm-core 2>/dev/null) || return 0
     [ -n "$_rt_ver" ] || return 0
     printf '%s\n' "$_rt_ver" | awk -F'[.-]' '{print "rocm"$1"."$2; exit}' || return 0
 }

--- a/install.sh
+++ b/install.sh
@@ -2919,8 +2919,13 @@ _cap_cuda_family_for_pre_turing() {
 # kill the installer, so every helper returns 0 no matter what its source does.
 _rocm_tag_from_amd_smi() {
     command -v amd-smi >/dev/null 2>&1 || return 0
+    # Stop at the field separator and require digits. amd-smi prints one pipe-delimited line
+    # ("... | ROCm version: N/A | amdgpu version: 6.10.10 | ..."), so stripping every non-digit
+    # glued the amdgpu driver version onto the ROCm one and reported the driver as ROCm. That
+    # was harmless while this source was shadowed by position; under highest-wins a fabricated
+    # reading can outvote a correct one, so an unparseable field must yield nothing instead.
     amd-smi version 2>/dev/null | awk -F'ROCm version: ' \
-        'NF>1{gsub(/[^0-9.]/, "", $2); split($2,a,"."); print "rocm"a[1]"."a[2]; exit}' || return 0
+        'NF>1{v=$2; sub(/[ \t|].*$/, "", v); if (v ~ /^[0-9]+\.[0-9]+/) {split(v,a,"."); print "rocm"a[1]"."a[2]} exit}' || return 0
 }
 
 _rocm_tag_from_version_file() {

--- a/install.sh
+++ b/install.sh
@@ -2909,6 +2909,79 @@ _cap_cuda_family_for_pre_turing() {
     printf '%s\n' "$1"
 }
 
+# ── ROCm version sources ──
+# One helper per source. Each prints at most one "rocmX.Y" line and nothing when
+# its source is absent or unparseable.
+#
+# CONTRACT: none of these may fail its caller. install.sh runs under set -e, and
+# the case where EVERY source is missing (a real AMD GPU with no ROCm userspace)
+# has to reach the actionable warning at the end of the ROCm branch rather than
+# kill the installer, so every helper returns 0 no matter what its source does.
+_rocm_tag_from_amd_smi() {
+    command -v amd-smi >/dev/null 2>&1 || return 0
+    amd-smi version 2>/dev/null | awk -F'ROCm version: ' \
+        'NF>1{gsub(/[^0-9.]/, "", $2); split($2,a,"."); print "rocm"a[1]"."a[2]; exit}' || return 0
+}
+
+_rocm_tag_from_version_file() {
+    [ -r /opt/rocm/.info/version ] || return 0
+    awk -F. '{print "rocm"$1"."$2; exit}' /opt/rocm/.info/version || return 0
+}
+
+_rocm_tag_from_hipconfig() {
+    command -v hipconfig >/dev/null 2>&1 || return 0
+    hipconfig --version 2>/dev/null \
+        | awk 'NR==1 && /^[0-9]/{split($1,a,"."); if(a[1]+0>0){print "rocm"a[1]"."a[2]}}' || return 0
+}
+
+_rocm_tag_from_dpkg() {
+    command -v dpkg-query >/dev/null 2>&1 || return 0
+    _rt_ver=$(dpkg-query -W -f='${Version}\n' rocm-core 2>/dev/null) || return 0
+    [ -n "$_rt_ver" ] || return 0
+    printf '%s\n' "$_rt_ver" | sed 's/^[0-9]*://' \
+        | awk -F'[.-]' '{print "rocm"$1"."$2; exit}' || return 0
+}
+
+_rocm_tag_from_rpm() {
+    command -v rpm >/dev/null 2>&1 || return 0
+    _rt_ver=$(rpm -q --qf '%{VERSION}\n' rocm-core 2>/dev/null) || return 0
+    [ -n "$_rt_ver" ] || return 0
+    printf '%s\n' "$_rt_ver" | awk -F'[.-]' '{print "rocm"$1"."$2; exit}' || return 0
+}
+
+# Highest "rocmX.Y" line on stdin (major >= 1), or nothing when no line is usable.
+_highest_rocm_tag() {
+    awk '
+        /^rocm[0-9]+\.[0-9]+$/ {
+            split(substr($0, 5), a, ".")
+            maj = a[1] + 0; min = a[2] + 0
+            if (maj < 1) next
+            if (!seen || maj > best_maj || (maj == best_maj && min > best_min)) {
+                best_maj = maj; best_min = min; seen = 1
+            }
+        }
+        END { if (seen) printf "rocm%d.%d\n", best_maj, best_min }
+    '
+}
+
+# Resolve the host ROCm version by consulting EVERY source and taking the
+# highest, rather than the first that answers. Distros with split ROCm packaging
+# ship one component well behind the runtime the GPU actually uses: Debian 13
+# (and Linux Mint on top of it) packages hipconfig at 5.7.x next to a 6.1.x
+# rocminfo/HSA, so first-answer resolution reported rocm5.7 on a working gfx1100
+# and the 6.0+ gate below sent it to CPU-only wheels (issue #8402). A source
+# reporting lower than another on the same host is stale packaging, not a
+# downgrade, so the highest reading is the one that describes the runtime.
+_detect_rocm_version_tag() {
+    {
+        _rocm_tag_from_amd_smi
+        _rocm_tag_from_version_file
+        _rocm_tag_from_hipconfig
+        _rocm_tag_from_dpkg
+        _rocm_tag_from_rpm
+    } 2>/dev/null | _highest_rocm_tag
+}
+
 # ── Detect GPU and choose PyTorch index URL ──
 # Mirrors Get-TorchIndexUrl in install.ps1.
 # On CPU-only machines this returns the cpu index, avoiding the solver
@@ -2987,26 +3060,17 @@ get_torch_index_url() {
         fi
         # AMD GPU confirmed -- detect ROCm version
         _rocm_tag=""
-        _rocm_tag=$({ command -v amd-smi >/dev/null 2>&1 && \
-            amd-smi version 2>/dev/null | awk -F'ROCm version: ' \
-                'NF>1{gsub(/[^0-9.]/, "", $2); split($2,a,"."); print "rocm"a[1]"."a[2]; ok=1; exit} END{exit !ok}'; } || \
-            { [ -r /opt/rocm/.info/version ] && \
-                awk -F. '{print "rocm"$1"."$2; exit}' /opt/rocm/.info/version; } || \
-            { command -v hipconfig >/dev/null 2>&1 && \
-                hipconfig --version 2>/dev/null | awk 'NR==1 && /^[0-9]/{split($1,a,"."); if(a[1]+0>0){print "rocm"a[1]"."a[2]; found=1}} END{exit !found}'; } || \
-            { command -v dpkg-query >/dev/null 2>&1 && \
-                ver="$(dpkg-query -W -f='${Version}\n' rocm-core 2>/dev/null)" && \
-                [ -n "$ver" ] && \
-                printf '%s\n' "$ver" | sed 's/^[0-9]*://' | awk -F'[.-]' '{print "rocm"$1"."$2; exit}'; } || \
-            { command -v rpm >/dev/null 2>&1 && \
-                ver="$(rpm -q --qf '%{VERSION}\n' rocm-core 2>/dev/null)" && \
-                [ -n "$ver" ] && \
-                printf '%s\n' "$ver" | awk -F'[.-]' '{print "rocm"$1"."$2; exit}'; }) 2>/dev/null || _rocm_tag=""
+        _rocm_tag=$(_detect_rocm_version_tag 2>/dev/null) || _rocm_tag=""
         # ^ || guard: when EVERY version source is missing (e.g. rocminfo present
-        # but rocm-core not installed, so dpkg-query/rpm exit 1), the whole ||
-        # chain fails and set -e would kill the installer BEFORE the actionable
-        # no-version WARN below -- exactly the fresh-install case it exists for.
-        # Validate _rocm_tag: must match "rocmX.Y" with major >= 1
+        # but rocm-core not installed, so dpkg-query/rpm exit 1), detection must
+        # still return empty-and-successful rather than let set -e kill the
+        # installer BEFORE the actionable no-version WARN below -- exactly the
+        # fresh-install case it exists for. _detect_rocm_version_tag holds that
+        # contract internally; the guard here is belt and braces.
+        # Validate _rocm_tag: must match "rocmX.Y" with major >= 1.
+        # _highest_rocm_tag already enforces this shape; kept as a second gate so
+        # a future source added to _detect_rocm_version_tag cannot leak garbage
+        # into the wheel-index cases below.
         case "$_rocm_tag" in
             rocm[1-9]*.[0-9]*) : ;;  # valid (major >= 1)
             *) _rocm_tag="" ;;        # reject malformed (empty, garbled, or major=0)
@@ -3016,7 +3080,11 @@ get_torch_index_url() {
             case "$_rocm_tag" in
                 rocm[1-5].*)
                     echo "[WARN] ROCm $_rocm_tag detected but PyTorch ROCm wheels require ROCm 6.0+ -- falling back to CPU-only PyTorch" >&2
+                    echo "[WARN] $_rocm_tag is the HIGHEST version any of amd-smi, /opt/rocm/.info/version, hipconfig or rocm-core reported." >&2
                     echo "[WARN] Upgrade ROCm: https://rocm.docs.amd.com/en/latest/deploy/linux/index.html" >&2
+                    echo "[WARN] If this host really runs ROCm 6.0+ and only its packaging says otherwise, pin the wheels and re-run:" >&2
+                    echo "[WARN]   UNSLOTH_TORCH_INDEX_FAMILY=rocm6.4   (a PyTorch wheel leaf: rocm6.0-6.4, rocm7.0-7.2)" >&2
+                    echo "[WARN]   UNSLOTH_TORCH_INDEX_URL=<full index URL>   (takes precedence, used verbatim)" >&2
                     echo "$_base/cpu"; return ;;
             esac
             # Supported tags; 6.5+ clips to rocm6.4, 7.3+ caps to rocm7.2.

--- a/install.sh
+++ b/install.sh
@@ -2910,20 +2910,16 @@ _cap_cuda_family_for_pre_turing() {
 }
 
 # ── ROCm version sources ──
-# One helper per source. Each prints at most one "rocmX.Y" line and nothing when
-# its source is absent or unparseable.
-#
-# CONTRACT: none of these may fail its caller. install.sh runs under set -e, and
-# the case where EVERY source is missing (a real AMD GPU with no ROCm userspace)
-# has to reach the actionable warning at the end of the ROCm branch rather than
-# kill the installer, so every helper returns 0 no matter what its source does.
+# One helper per source, each printing at most one "rocmX.Y" line, and each
+# returning 0 unconditionally: install.sh runs under set -e, so a real AMD GPU
+# with no ROCm userspace at all has to reach the actionable warning at the end of
+# the ROCm branch rather than have a failing source kill the installer.
 _rocm_tag_from_amd_smi() {
     command -v amd-smi >/dev/null 2>&1 || return 0
-    # Stop at the field separator and require digits. amd-smi prints one pipe-delimited line
-    # ("... | ROCm version: N/A | amdgpu version: 6.10.10 | ..."), so stripping every non-digit
-    # glued the amdgpu driver version onto the ROCm one and reported the driver as ROCm. That
-    # was harmless while this source was shadowed by position; under highest-wins a fabricated
-    # reading can outvote a correct one, so an unparseable field must yield nothing instead.
+    # Cut at the field separator and require digits: the line is pipe-delimited
+    # ("... | ROCm version: N/A | amdgpu version: 6.10.10 | ..."), so stripping every
+    # non-digit fabricated rocm6.10 out of the amdgpu driver version. Position used to
+    # hide that; under highest-wins a fabricated reading outvotes a real 6.1.
     amd-smi version 2>/dev/null | awk -F'ROCm version: ' \
         'NF>1{v=$2; sub(/[ \t|].*$/, "", v); if (v ~ /^[0-9]+\.[0-9]+/) {split(v,a,"."); print "rocm"a[1]"."a[2]} exit}' || return 0
 }
@@ -2941,19 +2937,14 @@ _rocm_tag_from_hipconfig() {
 
 _rocm_tag_from_dpkg() {
     command -v dpkg-query >/dev/null 2>&1 || return 0
-    # ${Status}, not ${Version} alone. dpkg-query -W lists every package in the
-    # status database except purged ones (man dpkg-query, --list: "regardless of
-    # their status ... excluding the ones marked as not-installed"), so a
-    # rocm-core taken out with `apt remove` and not purged stays queryable in
-    # state "deinstall ok config-files" and still reports the version it had.
-    # Under highest-wins that dead entry would outrank every live source: a host
-    # that ran ROCm 7.0, downgraded to 6.1 and never purged would resolve rocm7.0
-    # off a package that is not there. Every other source at least describes a
-    # tree that exists, so this one has to require the status word "installed".
-    # ${Status} is a documented showformat field with no dpkg
-    # version floor, and dpkg-query renders an unrecognised field as empty rather
-    # than failing, so on any dpkg that somehow lacks it this source goes silent
-    # instead of over-reporting.
+    # Require the status word "installed". dpkg-query -W lists every package in the
+    # status database except purged ones, so a rocm-core taken out with `apt remove`
+    # stays queryable in state "deinstall ok config-files" still reporting the version
+    # it had, and under highest-wins that dead entry outranks every live source (ran
+    # 7.0, downgraded to 6.1, never purged -> rocm7.0 off a tree that is gone).
+    # ${Status} over ${db:Status-Status}: documented showformat field with no dpkg
+    # version floor, and dpkg renders an unrecognised field as empty rather than
+    # failing, so a dpkg lacking it goes silent instead of over-reporting.
     _rt_ver=$(dpkg-query -W -f='${Status} ${Version}\n' rocm-core 2>/dev/null \
         | awk '$3 == "installed" && $4 != "" { print $4; exit }') || return 0
     [ -n "$_rt_ver" ] || return 0
@@ -2963,19 +2954,16 @@ _rocm_tag_from_dpkg() {
 
 _rocm_tag_from_rpm() {
     command -v rpm >/dev/null 2>&1 || return 0
-    # Bounded: this is the one source highest-wins newly made unconditional that
-    # can block forever. It used to be LAST in a first-answer-wins `||` chain, so
-    # on any RHEL/SLES host with a normal ROCm install /opt/rocm/.info/version
-    # answered at position two and rpm was never invoked; now every source runs.
-    # `rpm -q` is not a lock-free read: on the BerkeleyDB backend (rpm < 4.16,
-    # i.e. RHEL 8 / SLES 15 -- both supported ROCm platforms) a leftover
-    # /var/lib/rpm/__db.00* from any killed rpm/yum leaves plain queries wedged
-    # in futex until the files are deleted (rhbz#485780, rhbz#73097), and rpm
-    # 6.0.x reintroduced a read lock that deadlocks `rpm --query` against a
-    # running dnf transaction (rhbz#2463435). A version probe must not be able to
-    # hang the installer, and a timed-out probe is just a source that declined to
-    # answer. _run_bounded no-ops where `timeout` is absent, so this adds no
-    # dependency the file did not already have.
+    # Bounded, alone among the five, because this is the one source highest-wins
+    # newly made unconditional that can block forever: it used to be LAST in a
+    # first-answer-wins `||` chain, so /opt/rocm/.info/version answered at position
+    # two and rpm was never invoked on a normal RHEL/SLES install. `rpm -q` is not a
+    # lock-free read -- a leftover /var/lib/rpm/__db.00* from a killed rpm/yum wedges
+    # plain queries in futex on the BerkeleyDB backend (rpm < 4.16, i.e. RHEL 8 /
+    # SLES 15; rhbz#485780, rhbz#73097), and rpm 6.0.x deadlocks `rpm --query`
+    # against a running dnf (rhbz#2463435). A version probe must not hang the
+    # installer, and a timed-out probe is just a source that declined to answer.
+    # _run_bounded no-ops where `timeout` is absent, so this adds no dependency.
     _rt_ver=$(_run_bounded rpm -q --qf '%{VERSION}\n' rocm-core 2>/dev/null) || return 0
     [ -n "$_rt_ver" ] || return 0
     printf '%s\n' "$_rt_ver" | awk -F'[.-]' '{print "rocm"$1"."$2; exit}' || return 0
@@ -2996,27 +2984,17 @@ _highest_rocm_tag() {
     '
 }
 
-# Resolve the host ROCm version by consulting EVERY source and taking the
-# highest, rather than the first that answers. Distros with split ROCm packaging
-# ship one component well behind the runtime the GPU actually uses: Debian 13
-# (and Linux Mint on top of it) packages hipconfig at 5.7.x next to a 6.1.x
-# rocminfo/HSA, so first-answer resolution reported rocm5.7 on a working gfx1100
-# and the 6.0+ gate below sent it to CPU-only wheels (issue #8402). A source
-# reporting lower than another on the same host is stale packaging, not a
-# downgrade, so the highest reading is the one that describes the runtime.
-#
-# The symmetric risk of highest-wins is overshoot: a source reading HIGHER than
-# the host now picks the wheel family instead of being shadowed by its position.
-# Two things bound it. PyTorch's ROCm wheels vendor their own ROCm userspace
-# into torch/lib, so what they need from the host is the amdgpu/KFD driver, and
-# AMD documents that as compatible +/- 2 releases (a year's span from 6.4), not
-# pinned to the userspace these sources report. And the normalisation below can
-# only emit a leaf PyTorch publishes. What is NOT bounded is a reading taken off
-# something that is not installed at all, so the one source that can produce one
-# -- a removed-but-not-purged dpkg rocm-core -- is filtered above. Past that,
-# disagreement is named on stderr: when overshoot does bite it surfaces as an
-# HSA error at the first HIP call, or a GPU that is simply absent from torch,
-# and neither points back here without the readings in the log.
+# Consult EVERY source and take the highest, not the first that answers. Distros
+# with split ROCm packaging ship one component well behind the runtime the GPU
+# actually uses: Debian 13 (and Linux Mint on top of it) packages hipconfig at
+# 5.7.x next to a 6.1.x rocminfo/HSA, so first-answer resolution reported rocm5.7
+# on a working gfx1100 and the 6.0+ gate below sent it to CPU-only wheels (issue
+# #8402). A source reading lower than another on the same host is stale packaging,
+# not a downgrade. The symmetric risk, overshoot, is bounded: PyTorch's ROCm wheels
+# vendor their own userspace and need only an amdgpu/KFD driver AMD documents as
+# compatible +/- 2 releases, the normalisation below can only emit a leaf PyTorch
+# publishes, the one source that can report a tree that is not installed is
+# filtered above, and any disagreement is named on stderr for the install log.
 _detect_rocm_version_tag() {
     _rt_readings=$({
         _rocm_tag_from_amd_smi
@@ -3027,8 +3005,8 @@ _detect_rocm_version_tag() {
     } 2>/dev/null) || _rt_readings=""
     _rt_best=$(printf '%s\n' "$_rt_readings" | _highest_rocm_tag) || _rt_best=""
     if [ -n "$_rt_best" ]; then
-        # Same shape gate as _highest_rocm_tag, so a garbage or major-0 reading
-        # is not named as a dissenting opinion when it never was a candidate.
+        # Same shape gate as _highest_rocm_tag: a reading that was never a candidate
+        # must not be named as a dissenting opinion.
         _rt_seen=$(printf '%s\n' "$_rt_readings" \
             | grep '^rocm[1-9][0-9]*\.[0-9][0-9]*$' | sort -u | tr '\n' ' ') || _rt_seen=""
         case "$_rt_seen" in
@@ -3118,19 +3096,13 @@ get_torch_index_url() {
         # AMD GPU confirmed -- detect ROCm version
         _rocm_tag=""
         _rocm_tag=$(_detect_rocm_version_tag) || _rocm_tag=""
-        # ^ || guard: when EVERY version source is missing (e.g. rocminfo present
-        # but rocm-core not installed, so dpkg-query/rpm exit 1), detection must
-        # still return empty-and-successful rather than let set -e kill the
-        # installer BEFORE the actionable no-version WARN below -- exactly the
-        # fresh-install case it exists for. _detect_rocm_version_tag holds that
-        # contract internally; the guard here is belt and braces. stderr is NOT
-        # redirected: every source's own noise is already suppressed inside the
-        # resolver, so the only thing left on stderr is its deliberate
-        # sources-disagree breadcrumb, which belongs in the install log.
-        # Validate _rocm_tag: must match "rocmX.Y" with major >= 1.
-        # _highest_rocm_tag already enforces this shape; kept as a second gate so
-        # a future source added to _detect_rocm_version_tag cannot leak garbage
-        # into the wheel-index cases below.
+        # ^ || guard: belt and braces on the set -e contract the helpers hold, so a
+        # fresh AMD host with no version source at all still reaches the actionable
+        # no-version WARN below. stderr is deliberately not redirected: each source
+        # already silences its own noise, leaving only the sources-disagree
+        # breadcrumb, which belongs in the install log.
+        # Shape gate on "rocmX.Y" with major >= 1: _highest_rocm_tag enforces it too,
+        # kept so a future source cannot leak garbage into the cases below.
         case "$_rocm_tag" in
             rocm[1-9]*.[0-9]*) : ;;  # valid (major >= 1)
             *) _rocm_tag="" ;;        # reject malformed (empty, garbled, or major=0)

--- a/tests/sh/test_get_torch_index_url.sh
+++ b/tests/sh/test_get_torch_index_url.sh
@@ -53,6 +53,23 @@ _FAKE_ROCM_DIR=$(mktemp -d)
     echo ""
     sed -n '/^_cap_cuda_family_for_pre_turing()/,/^}/p' "$INSTALL_SH"
     echo ""
+    # ROCm version sources + the highest-wins resolver they feed. Same sync rule
+    # as the gfx helpers above: miss one and the ROCm branch silently returns the
+    # CPU index instead of a rocm one.
+    sed -n '/^_rocm_tag_from_amd_smi()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_rocm_tag_from_version_file()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_rocm_tag_from_hipconfig()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_rocm_tag_from_dpkg()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_rocm_tag_from_rpm()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_highest_rocm_tag()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_detect_rocm_version_tag()/,/^}/p' "$INSTALL_SH"
+    echo ""
     sed -n '/^get_torch_index_url()/,/^}/p' "$INSTALL_SH"
 } | sed -e "s|/usr/bin/nvidia-smi|$_FAKE_SMI_DIR/nvidia-smi-absent|g" \
       -e "s|/opt/rocm|$_FAKE_ROCM_DIR|g" \

--- a/tests/sh/test_get_torch_index_url.sh
+++ b/tests/sh/test_get_torch_index_url.sh
@@ -53,9 +53,8 @@ _FAKE_ROCM_DIR=$(mktemp -d)
     echo ""
     sed -n '/^_cap_cuda_family_for_pre_turing()/,/^}/p' "$INSTALL_SH"
     echo ""
-    # ROCm version sources + the highest-wins resolver they feed. Same sync rule
-    # as the gfx helpers above: miss one and the ROCm branch silently returns the
-    # CPU index instead of a rocm one.
+    # Same sync rule as the gfx helpers above: miss one of the version sources or
+    # the resolver they feed and the ROCm branch silently returns the CPU index.
     sed -n '/^_rocm_tag_from_amd_smi()/,/^}/p' "$INSTALL_SH"
     echo ""
     sed -n '/^_rocm_tag_from_version_file()/,/^}/p' "$INSTALL_SH"

--- a/tests/sh/test_rocm_version_source_disagreement.sh
+++ b/tests/sh/test_rocm_version_source_disagreement.sh
@@ -5,16 +5,12 @@
 #
 # Debian 13 (and Linux Mint on top of it) packages hipconfig at 5.7.x next to a
 # 6.1.x rocminfo/HSA runtime. install.sh used to take the FIRST version source
-# that answered, so on that packaging it resolved rocm5.7, the "PyTorch ROCm
-# wheels require ROCm 6.0+" gate fired, and a working RX 7900 XTX (gfx1100) got
-# CPU-only torch. Detection now reads EVERY source and takes the highest.
-#
-# The properties pinned here:
-#   1. a stale low source never shadows a higher one, from any source position
-#   2. a genuine ROCm 5.x host with nothing higher still falls back to CPU
-#   3. the sub-6.0 warning names the documented override
-#   4. every source missing still warns and does NOT kill the installer (set -e)
-#   5. supported-tag normalisation (patch levels, 6.5+ clip, 7.3+ cap) unchanged
+# that answered, so it resolved rocm5.7, the "requires ROCm 6.0+" gate fired, and
+# a working RX 7900 XTX (gfx1100) got CPU-only torch. Detection now reads EVERY
+# source and takes the highest. Pinned here: a stale low source never shadows a
+# higher one from any position; a genuine 5.x host still falls back to CPU; the
+# sub-6.0 warning names the documented override; every source missing still warns
+# without killing the installer (set -e); tag normalisation is unchanged.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -24,12 +20,10 @@ FAIL=0
 
 _FUNC_FILE=$(mktemp)
 _FAKE_SMI_DIR=$(mktemp -d)
-# The version sources read absolute host paths: /opt/rocm/.info/version for the
-# version file, and _ensure_rocm_probe_env appends /opt/rocm/bin to PATH. On a
-# real ROCm host that would leak the host's ROCm into every assertion. The
-# NVIDIA fallback reads /proc/driver/nvidia/gpus by absolute path too, and this
-# suite must behave the same on an NVIDIA box as on a bare one. Redirect all
-# three prefixes into empty temp dirs so the harness is hermetic.
+# The version sources, _ensure_rocm_probe_env's PATH append and the NVIDIA
+# fallback all read absolute host paths, which would leak the test host's own
+# ROCm or NVIDIA into every assertion. Redirect all three prefixes into empty
+# temp dirs so the suite is hermetic on a ROCm, NVIDIA or bare box alike.
 _FAKE_ROCM_DIR=$(mktemp -d)
 _FAKE_PROC_NV_DIR=$(mktemp -d)
 {
@@ -79,8 +73,8 @@ _FAKE_PROC_NV_DIR=$(mktemp -d)
       -e "s|/opt/rocm|$_FAKE_ROCM_DIR|g" \
   > "$_FUNC_FILE"
 
-# Guard the extraction itself: a renamed helper would otherwise make every ROCm
-# assertion below fail as a plain "cpu" with no hint why.
+# Guard the extraction: a renamed helper would otherwise make every ROCm assertion
+# below fail as a plain "cpu" with no hint why.
 for _fn in _rocm_tag_from_amd_smi _rocm_tag_from_version_file _rocm_tag_from_hipconfig \
            _rocm_tag_from_dpkg _rocm_tag_from_rpm _highest_rocm_tag \
            _detect_rocm_version_tag get_torch_index_url; do
@@ -92,10 +86,10 @@ done
 
 # Minimal tool set: no amd-smi, hipconfig, dpkg-query, rpm or rocminfo unless a
 # scenario supplies one, so an unrelated host package cannot answer a probe.
+# `timeout` and `sleep` must stay in it for case 14: _run_bounded looks up
+# `timeout` on PATH, so dropping it silently turns the bounded probe back into an
+# unbounded one and that case passes for the wrong reason.
 _TOOLS_DIR=$(mktemp -d)
-# `timeout` and `sleep` are here for case 14: _run_bounded looks up `timeout` on
-# PATH, so leaving it out of this minimal set would silently turn the bounded
-# probe back into an unbounded one and make that case pass for the wrong reason.
 for _cmd in uname grep sed head sh bash cat awk printf tr ls sort timeout sleep; do
     _real=$(command -v "$_cmd" 2>/dev/null || true)
     [ -n "$_real" ] && ln -sf "$_real" "$_TOOLS_DIR/$_cmd"
@@ -132,15 +126,13 @@ assert_contains() {
 }
 
 # ── Scenario builders ───────────────────────────────────────────────────────
-# Every scenario starts from a clean mock dir and an empty fake /opt/rocm, then
-# adds only the sources it wants to exist.
+# Every scenario starts from a clean mock dir and an empty fake /opt/rocm.
 _MOCK_DIR=$(mktemp -d)
 
 reset_sources() {
     rm -rf "$_MOCK_DIR" "$_FAKE_ROCM_DIR/.info"
     _MOCK_DIR=$(mktemp -d)
-    # rocminfo is what makes this an AMD host at all: _has_amd_rocm_gpu needs a
-    # gfx name and _probe_amd_gfx_arch needs a readable arch, otherwise the ROCm
+    # rocminfo is what makes this an AMD host at all: without a gfx name the ROCm
     # branch bails before any version source is consulted. gfx1100 = RX 7900 XTX,
     # the card in the report.
     cat > "$_MOCK_DIR/rocminfo" <<'MOCK'
@@ -184,10 +176,9 @@ MOCK
     chmod +x "$_MOCK_DIR/amd-smi"
 }
 
-# $1 = the raw value of the "ROCm version:" field, e.g. "6.4.0" or "N/A".
-# Unlike add_amd_smi this reproduces the WHOLE line amd-smi really prints, with
-# the amdgpu driver version following the ROCm one, so a parser that runs past
-# the field separator is caught.
+# $1 = the raw value of the "ROCm version:" field, e.g. "6.4.0" or "N/A". Unlike
+# add_amd_smi this reproduces the WHOLE line, amdgpu driver version and all, so a
+# parser that runs past the field separator is caught.
 add_amd_smi_line() {
     cat > "$_MOCK_DIR/amd-smi" <<MOCK
 #!/bin/sh
@@ -200,15 +191,11 @@ MOCK
 }
 
 # $1 = rocm-core version as dpkg reports it (epoch prefixes allowed, e.g. 1:6.2.4-1)
-# $2 = dpkg status word, default "installed". "config-files" is the state a
-#      package left behind by `apt remove` without `apt purge` sits in: still in
-#      /var/lib/dpkg/status, still carrying its old version, and still reported
-#      by `dpkg-query -W`, which per man dpkg-query lists packages "regardless of
-#      their status" and skips only purged ones.
-#
-# The mock renders the showformat string it is given rather than printing a bare
-# version, so these assertions test how install.sh ASKS dpkg for the version,
-# not just how it parses the answer.
+# $2 = dpkg status word, default "installed". "config-files" is where `apt remove`
+#      without `apt purge` leaves a package: still in /var/lib/dpkg/status, still
+#      carrying its old version, and still reported by `dpkg-query -W`.
+# The mock renders the showformat string it is given rather than a bare version, so
+# these assertions test how install.sh ASKS dpkg, not just how it parses the answer.
 add_dpkg_rocm_core() {
     printf '%s\n' "$1" > "$_MOCK_DIR/.dpkg-version"
     printf '%s\n' "${2:-installed}" > "$_MOCK_DIR/.dpkg-status"
@@ -217,8 +204,7 @@ add_dpkg_rocm_core() {
 _d=${0%/*}
 _ver=$(cat "$_d/.dpkg-version")
 _status=$(cat "$_d/.dpkg-status")
-# dpkg's Status field is "<want> <error-flag> <status>"; a package removed but
-# not purged reads "deinstall ok config-files".
+# Status is "<want> <error-flag> <status>": removed but not purged reads "deinstall ok config-files".
 case "$_status" in installed) _want=install ;; *) _want=deinstall ;; esac
 _fmt=''
 _found=''
@@ -232,7 +218,6 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
-# Anything other than rocm-core is genuinely unknown to this box.
 [ -n "$_found" ] || exit 1
 [ -n "$_fmt" ] || _fmt='${Package}\t${Version}\n'
 # Unknown fields render empty, which is what real dpkg-query does.
@@ -261,13 +246,10 @@ MOCK
     chmod +x "$_MOCK_DIR/rpm"
 }
 
-# Run get_torch_index_url against the current scenario. stdout only.
 add_wedged_rpm() {
-    # Stands in for `rpm -q` wedged on the rpmdb: a leftover /var/lib/rpm/__db.00*
-    # from a killed rpm/yum leaves plain queries stuck in futex on the BerkeleyDB
-    # backend (rpm < 4.16, i.e. RHEL 8 / SLES 15), and rpm 6.0.x deadlocks
-    # `rpm --query` against a running dnf transaction. Sleeps rather than really
-    # wedging so the suite stays hermetic and killable.
+    # Stands in for `rpm -q` wedged on the rpmdb (stale BerkeleyDB __db locks on
+    # rpm < 4.16, i.e. RHEL 8 / SLES 15; the rpm 6.0.x deadlock against dnf).
+    # Sleeps rather than really wedging so the suite stays hermetic and killable.
     cat > "$_MOCK_DIR/rpm" <<MOCK
 #!/bin/sh
 sleep 30
@@ -275,8 +257,8 @@ MOCK
     chmod +x "$_MOCK_DIR/rpm"
 }
 
-# run_index under an OUTER bound, so if the probe is ever unbounded again this
-# case fails in $1 seconds instead of hanging the whole suite.
+# run_index under an OUTER bound: an unbounded probe fails this in $1 seconds
+# instead of hanging the suite.
 run_index_outer_bounded() {
     PATH="$_MOCK_DIR:$_TOOLS_DIR" timeout "$1" bash -c \
         "unset CUDA_VISIBLE_DEVICES UNSLOTH_ROCM_GFX_ARCH UNSLOTH_TORCH_INDEX_URL UNSLOTH_TORCH_INDEX_FAMILY
@@ -296,10 +278,9 @@ run_warnings() {
          _ARCH=x86_64; . '$_FUNC_FILE'; get_torch_index_url" 2>&1 >/dev/null | tr '\n' ' '
 }
 
-# Same, under `set -e` like the real installer, reporting only the exit status.
-# This is the property the || guard in install.sh exists for: with every version
-# source missing the detection must return empty AND succeed, or the installer
-# dies before it can print the actionable warning.
+# Same, under `set -e` like the real installer, reporting only the exit status:
+# with every source missing, detection must return empty AND succeed or the
+# installer dies before the actionable warning.
 run_status_under_set_e() {
     PATH="$_MOCK_DIR:$_TOOLS_DIR" bash -c \
         "set -e
@@ -313,10 +294,8 @@ _BASE="https://download.pytorch.org/whl"
 echo "=== test_rocm_version_source_disagreement ==="
 
 # ── 1. The reported host ────────────────────────────────────────────────────
-# ROCm present under /opt/rocm but with no .info/version file (the reporter's
-# log fell through to hipconfig), hipconfig from the distro's 5.7 packaging, and
-# rocm-core at 6.1 in dpkg. Before the fix this resolved rocm5.7 and returned the
-# cpu index; hipconfig answers third, ahead of dpkg.
+# No /opt/rocm/.info/version, hipconfig from the distro's 5.7 packaging, rocm-core
+# at 6.1 in dpkg. Before the fix hipconfig answered first and this returned cpu.
 reset_sources
 add_hipconfig "5.7.31921-0"
 add_dpkg_rocm_core "1:6.1.2-1"
@@ -326,14 +305,12 @@ case "$_warn" in
     *"require ROCm 6.0+"*) assert_eq "the same host emits no 6.0+ gate warning" "" "$_warn" ;;
     *) assert_eq "the same host emits no 6.0+ gate warning" "ok" "ok" ;;
 esac
-# The readings disagreed, so the log has to say which ones and which won. This is
-# the breadcrumb that makes a wrong-HIGH reading diagnosable from an install log.
+# The breadcrumb that makes a wrong-HIGH reading diagnosable from an install log.
 assert_contains "disagreeing sources are named" "sources disagree (rocm5.7 rocm6.1)" "$_warn"
 assert_contains "the winning reading is named" "using the highest, rocm6.1" "$_warn"
 
-# 2. Same shape when the 6.x reading comes from /opt/rocm/.info/version. This one
-#    already worked (the version file outranks hipconfig by position), so it is
-#    here to pin that the reordering did not lose it.
+# 2. Same shape from /opt/rocm/.info/version. This one already worked by position,
+#    so it is here to pin that the rewrite did not lose it.
 reset_sources
 add_hipconfig "5.7.31921-0"
 add_version_file "6.1.2-98"
@@ -345,8 +322,8 @@ add_hipconfig "5.7.31921-0"
 add_rpm_rocm_core "6.3.0"
 assert_eq "hipconfig 5.7 + rocm-core 6.3 (rpm) -> rocm6.3" "$_BASE/rocm6.3" "$(run_index)"
 
-# 4. First-answer resolution was not only a floor problem: amd-smi answering
-#    first with a lower version must not shadow a newer runtime either.
+# 4. Not only a floor problem: amd-smi answering first with a lower version must
+#    not shadow a newer runtime either.
 reset_sources
 add_amd_smi "6.1.0"
 add_dpkg_rocm_core "6.4.1-1"
@@ -361,17 +338,11 @@ assert_eq "all sources agree on 6.4 -> rocm6.4" "$_BASE/rocm6.4" "$(run_index)"
 assert_eq "agreeing sources emit no disagreement breadcrumb" "" "$(run_warnings)"
 
 # ── 5b. Overshoot: highest-wins must not let a DEAD source pick the wheels ──
-# Highest-wins fixes the undershoot in issue #8402, and creates the symmetric
-# risk that a source reading HIGHER than the runtime now wins outright. The two
-# directions are not equally bad: undershoot lands on CPU wheels, which are slow
-# but work, while overshoot installs wheels the runtime cannot load and the
-# install fails later, at torch import or first kernel launch. So the one host
-# state that can manufacture a wrong-HIGH reading has to be excluded.
-#
-# That state is dpkg's. `dpkg-query -W` reports packages in "deinstall ok
-# config-files" -- removed with `apt remove`, never purged -- and they still
-# carry the version they had. A box that ran ROCm 7.0, went back to 6.1 and
-# never purged therefore offers dpkg a 7.0 that outranks every honest source.
+# Undershoot lands on CPU wheels, which work; overshoot installs wheels the runtime
+# cannot load. The one host state that can manufacture a wrong-HIGH reading is
+# dpkg's: `dpkg-query -W` reports packages left in "deinstall ok config-files" by
+# `apt remove` without a purge, still carrying the version they had, so a box that
+# ran ROCm 7.0 and went back to 6.1 offers a 7.0 that outranks every honest source.
 # Detection must require the status word "installed".
 reset_sources
 add_hipconfig "6.1.40093-0"
@@ -380,18 +351,16 @@ assert_eq "config-files rocm-core 7.0 on a 6.1 host -> rocm6.1, not rocm7.0" \
     "$_BASE/rocm6.1" "$(run_index)"
 assert_eq "the dead dpkg entry is not even named as a disagreement" "" "$(run_warnings)"
 
-# 5c. And the live entry still has to win, or the fix for the reported bug is
-#     gone. This is the pair that makes 5b non-vacuous: same versions, same
-#     sources, only the dpkg status word differs.
+# 5c. The live entry still has to win, or the fix for the reported bug is gone.
+#     This is what makes 5b non-vacuous: only the dpkg status word differs.
 reset_sources
 add_hipconfig "5.7.31921-0"
 add_dpkg_rocm_core "1:6.1.2-1" installed
 assert_eq "installed rocm-core 6.1 still beats hipconfig 5.7 -> rocm6.1" \
     "$_BASE/rocm6.1" "$(run_index)"
 
-# 5d. The other dpkg states a half-finished or interrupted operation leaves
-#     behind are not "installed" either, and none of them describes a runtime
-#     the GPU can use.
+# 5d. The states an interrupted dpkg operation leaves behind are not "installed"
+#     either, and none of them describes a runtime the GPU can use.
 for _dead in config-files half-installed unpacked half-configured; do
     reset_sources
     add_hipconfig "6.1.40093-0"
@@ -401,14 +370,11 @@ for _dead in config-files half-installed unpacked half-configured; do
 done
 
 # ── 5e. A stale-HIGH reading in each source position, one at a time ─────────
-# The audit behind 5b found exactly one source with a documented over-reporting
-# state (dpkg's, fixed above). The other four have no equivalent: rpm drops a
-# package's version on erase, /opt/rocm's .info/version belongs to whichever
-# tree /opt/rocm resolves to, and amd-smi and hipconfig report the userspace
-# they were run from. So for those four, a HIGH reading is treated as the truth
-# on purpose, and what bounds it is the tag normalisation: the resolver can
-# never emit an index leaf PyTorch does not publish, and the install log names
-# every reading so the choice is auditable. These cases pin both halves.
+# dpkg's was the only source with a documented over-reporting state: rpm drops a
+# version on erase, .info/version belongs to whichever tree /opt/rocm resolves to,
+# and amd-smi and hipconfig report the userspace they were run from. For those four
+# a HIGH reading is deliberately taken as truth, bounded by the tag normalisation
+# (never an index leaf PyTorch does not publish) and auditable from the log.
 for _pos in amd-smi version-file hipconfig rpm; do
     reset_sources
     add_hipconfig "6.1.40093-0"
@@ -427,9 +393,8 @@ for _pos in amd-smi version-file hipconfig rpm; do
     fi
 done
 
-# 5f. dpkg in that same position: an INSTALLED high reading behaves like the
-#     other four (it is the runtime, and the host is simply newer than the
-#     wheels), so the cap applies rather than a rejection.
+# 5f. dpkg in that same position: an INSTALLED high reading is the runtime, so the
+#     cap applies rather than a rejection.
 reset_sources
 add_hipconfig "6.1.40093-0"
 add_dpkg_rocm_core "1:9.9.0-1" installed
@@ -445,8 +410,8 @@ assert_contains "5.x host warns about the 6.0+ requirement" "require ROCm 6.0+" 
 assert_contains "5.x warning names the resolved tag" "ROCm rocm5.7 detected" "$_warn"
 assert_contains "5.x warning says it took the highest reading" "HIGHEST version" "$_warn"
 
-# 7. The warning must name a documented way forward. Both overrides return early
-#    from get_torch_index_url, before any GPU probing, so naming them is honest.
+# 7. Both overrides return early from get_torch_index_url, before any GPU probing,
+#    so naming them in the warning is honest.
 assert_contains "5.x warning names UNSLOTH_TORCH_INDEX_FAMILY" \
     "UNSLOTH_TORCH_INDEX_FAMILY=rocm6.4" "$_warn"
 assert_contains "5.x warning names UNSLOTH_TORCH_INDEX_URL" \
@@ -463,8 +428,8 @@ _result=$(PATH="$_MOCK_DIR:$_TOOLS_DIR" bash -c \
 assert_eq "the named override reaches this path -> rocm6.4" "$_BASE/rocm6.4" "$_result"
 
 # ── 9. Every source missing: warn, do not die ───────────────────────────────
-# rocminfo alone (fresh AMD host with no ROCm userspace): no version source
-# answers at all. Under set -e the whole detection must still succeed.
+# rocminfo alone, a fresh AMD host with no ROCm userspace. Under set -e the whole
+# detection must still succeed.
 reset_sources
 assert_eq "no version source at all -> cpu" "$_BASE/cpu" "$(run_index)"
 assert_eq "no version source at all -> exit 0 under set -e" "0" "$(run_status_under_set_e)"
@@ -504,12 +469,10 @@ for _case in "6.0.2:rocm6.0" "6.1.3:rocm6.1" "6.2.4:rocm6.2" "6.3.1:rocm6.3" \
 done
 
 # ── 13. amd-smi reports one pipe-delimited line, and the ROCm field can be N/A ──
-# Real output carries the amdgpu driver version AFTER the ROCm one on the same
-# line, and prints "ROCm version: N/A" when no ROCm userspace is detectable.
-# Reading the field without stopping at the separator glued the two together and
-# reported the driver version as ROCm (N/A + amdgpu 6.10.10 -> "rocm6.10").
-# Position used to hide that; under highest-wins a fabricated reading can outvote
-# a correct source, so an unparseable field has to yield nothing at all.
+# The amdgpu driver version follows the ROCm one on the same line, so reading the
+# field without stopping at the separator glued them together (N/A + amdgpu 6.10.10
+# -> "rocm6.10"). Position used to hide that; under highest-wins a fabricated
+# reading outvotes a correct source, so an unparseable field must yield nothing.
 for _case in "N/A:" "6.4.0:rocm6.4" "7.0.2:rocm7.0" ":"; do
     _field="${_case%%:*}"
     _want="${_case##*:}"
@@ -519,8 +482,7 @@ for _case in "N/A:" "6.4.0:rocm6.4" "7.0.2:rocm7.0" ":"; do
         assert_eq "amd-smi full line, ROCm field '$_field' -> $_want" \
             "$_BASE/$_want" "$(run_index)"
     else
-        # Nothing else answers, so an unusable field must reach the CPU fallback
-        # rather than contribute a number.
+        # Nothing else answers, so an unusable field must reach the CPU fallback.
         assert_eq "amd-smi full line, ROCm field '$_field' -> no reading" \
             "$_BASE/cpu" "$(run_index)"
     fi
@@ -534,26 +496,22 @@ assert_eq "amd-smi N/A beside amdgpu 6.10 does not outvote a real 6.1" \
     "$_BASE/rocm6.1" "$(run_index)"
 
 # ── 14. A wedged rpmdb must not hang the installer ─────────────────────────
-# Highest-wins needs every source's answer, so no source can be short-circuited
-# any more and reordering them cannot help. That makes blast radius the thing to
-# check: `rpm -q` used to be LAST in a first-answer-wins chain, so on any RHEL /
-# SLES host with a normal ROCm install /opt/rocm/.info/version answered at
-# position two and rpm was never invoked at all. Now it always runs, and unlike
-# the other sources it can block indefinitely on the rpmdb (stale BerkeleyDB
-# __db locks on rpm < 4.16; the rpm 6.0.x read-lock deadlock against dnf). An
-# installer that hangs forever is worse than one that mis-detects, so the probe
-# is bounded and a timed-out source simply declines to answer.
+# Highest-wins short-circuits nothing, so `rpm -q` now always runs where it used to
+# be LAST in a first-answer chain and /opt/rocm/.info/version answered ahead of it
+# on any normal RHEL/SLES install. Alone among the sources it can block forever on
+# the rpmdb (stale BerkeleyDB __db locks on rpm < 4.16; the rpm 6.0.x read-lock
+# deadlock against dnf), and an installer that hangs is worse than one that
+# mis-detects, so this probe is bounded and a timed-out source declines to answer.
 reset_sources
 add_version_file "6.4.0-1"
 add_wedged_rpm
 _t0=$(date +%s)
-# `|| _res=""` so the outer bound firing is reported as a FAIL below rather than
-# taking the suite down through set -e with no verdict printed.
+# `|| _res=""` so the outer bound firing is a FAIL below rather than taking the
+# suite down through set -e with no verdict printed.
 _res=$(run_index_outer_bounded 20) || _res=""
 _t1=$(date +%s)
-# The wedged source must not take the answer down with it: the version file
-# still resolves the host. Empty here means the outer bound fired, i.e. the
-# rpm probe ran unbounded.
+# The wedged source must not take the answer down with it. Empty here means the
+# outer bound fired, i.e. the rpm probe ran unbounded.
 assert_eq "a wedged rpm does not stop the version file resolving the host" \
     "$_BASE/rocm6.4" "$_res"
 if [ "$((_t1 - _t0))" -lt 20 ]; then

--- a/tests/sh/test_rocm_version_source_disagreement.sh
+++ b/tests/sh/test_rocm_version_source_disagreement.sh
@@ -93,7 +93,10 @@ done
 # Minimal tool set: no amd-smi, hipconfig, dpkg-query, rpm or rocminfo unless a
 # scenario supplies one, so an unrelated host package cannot answer a probe.
 _TOOLS_DIR=$(mktemp -d)
-for _cmd in uname grep sed head sh bash cat awk printf tr ls sort; do
+# `timeout` and `sleep` are here for case 14: _run_bounded looks up `timeout` on
+# PATH, so leaving it out of this minimal set would silently turn the bounded
+# probe back into an unbounded one and make that case pass for the wrong reason.
+for _cmd in uname grep sed head sh bash cat awk printf tr ls sort timeout sleep; do
     _real=$(command -v "$_cmd" 2>/dev/null || true)
     [ -n "$_real" ] && ln -sf "$_real" "$_TOOLS_DIR/$_cmd"
 done
@@ -259,6 +262,27 @@ MOCK
 }
 
 # Run get_torch_index_url against the current scenario. stdout only.
+add_wedged_rpm() {
+    # Stands in for `rpm -q` wedged on the rpmdb: a leftover /var/lib/rpm/__db.00*
+    # from a killed rpm/yum leaves plain queries stuck in futex on the BerkeleyDB
+    # backend (rpm < 4.16, i.e. RHEL 8 / SLES 15), and rpm 6.0.x deadlocks
+    # `rpm --query` against a running dnf transaction. Sleeps rather than really
+    # wedging so the suite stays hermetic and killable.
+    cat > "$_MOCK_DIR/rpm" <<MOCK
+#!/bin/sh
+sleep 30
+MOCK
+    chmod +x "$_MOCK_DIR/rpm"
+}
+
+# run_index under an OUTER bound, so if the probe is ever unbounded again this
+# case fails in $1 seconds instead of hanging the whole suite.
+run_index_outer_bounded() {
+    PATH="$_MOCK_DIR:$_TOOLS_DIR" timeout "$1" bash -c \
+        "unset CUDA_VISIBLE_DEVICES UNSLOTH_ROCM_GFX_ARCH UNSLOTH_TORCH_INDEX_URL UNSLOTH_TORCH_INDEX_FAMILY
+         _ARCH=x86_64; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
+}
+
 run_index() {
     PATH="$_MOCK_DIR:$_TOOLS_DIR" bash -c \
         "unset CUDA_VISIBLE_DEVICES UNSLOTH_ROCM_GFX_ARCH UNSLOTH_TORCH_INDEX_URL UNSLOTH_TORCH_INDEX_FAMILY
@@ -508,6 +532,36 @@ add_amd_smi_line "N/A"
 add_version_file "6.1.3-42"
 assert_eq "amd-smi N/A beside amdgpu 6.10 does not outvote a real 6.1" \
     "$_BASE/rocm6.1" "$(run_index)"
+
+# ── 14. A wedged rpmdb must not hang the installer ─────────────────────────
+# Highest-wins needs every source's answer, so no source can be short-circuited
+# any more and reordering them cannot help. That makes blast radius the thing to
+# check: `rpm -q` used to be LAST in a first-answer-wins chain, so on any RHEL /
+# SLES host with a normal ROCm install /opt/rocm/.info/version answered at
+# position two and rpm was never invoked at all. Now it always runs, and unlike
+# the other sources it can block indefinitely on the rpmdb (stale BerkeleyDB
+# __db locks on rpm < 4.16; the rpm 6.0.x read-lock deadlock against dnf). An
+# installer that hangs forever is worse than one that mis-detects, so the probe
+# is bounded and a timed-out source simply declines to answer.
+reset_sources
+add_version_file "6.4.0-1"
+add_wedged_rpm
+_t0=$(date +%s)
+# `|| _res=""` so the outer bound firing is reported as a FAIL below rather than
+# taking the suite down through set -e with no verdict printed.
+_res=$(run_index_outer_bounded 20) || _res=""
+_t1=$(date +%s)
+# The wedged source must not take the answer down with it: the version file
+# still resolves the host. Empty here means the outer bound fired, i.e. the
+# rpm probe ran unbounded.
+assert_eq "a wedged rpm does not stop the version file resolving the host" \
+    "$_BASE/rocm6.4" "$_res"
+if [ "$((_t1 - _t0))" -lt 20 ]; then
+    assert_eq "the rpm probe is bounded, not left to block the installer" "ok" "ok"
+else
+    assert_eq "the rpm probe is bounded, not left to block the installer" \
+        "under 20s" "$((_t1 - _t0))s (outer bound fired)"
+fi
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/sh/test_rocm_version_source_disagreement.sh
+++ b/tests/sh/test_rocm_version_source_disagreement.sh
@@ -1,0 +1,348 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# Regression tests for ROCm version resolution in install.sh (issue #8402).
+#
+# Debian 13 (and Linux Mint on top of it) packages hipconfig at 5.7.x next to a
+# 6.1.x rocminfo/HSA runtime. install.sh used to take the FIRST version source
+# that answered, so on that packaging it resolved rocm5.7, the "PyTorch ROCm
+# wheels require ROCm 6.0+" gate fired, and a working RX 7900 XTX (gfx1100) got
+# CPU-only torch. Detection now reads EVERY source and takes the highest.
+#
+# The properties pinned here:
+#   1. a stale low source never shadows a higher one, from any source position
+#   2. a genuine ROCm 5.x host with nothing higher still falls back to CPU
+#   3. the sub-6.0 warning names the documented override
+#   4. every source missing still warns and does NOT kill the installer (set -e)
+#   5. supported-tag normalisation (patch levels, 6.5+ clip, 7.3+ cap) unchanged
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../../install.sh"
+PASS=0
+FAIL=0
+
+_FUNC_FILE=$(mktemp)
+_FAKE_SMI_DIR=$(mktemp -d)
+# The version sources read absolute host paths: /opt/rocm/.info/version for the
+# version file, and _ensure_rocm_probe_env appends /opt/rocm/bin to PATH. On a
+# real ROCm host that would leak the host's ROCm into every assertion. The
+# NVIDIA fallback reads /proc/driver/nvidia/gpus by absolute path too, and this
+# suite must behave the same on an NVIDIA box as on a bare one. Redirect all
+# three prefixes into empty temp dirs so the harness is hermetic.
+_FAKE_ROCM_DIR=$(mktemp -d)
+_FAKE_PROC_NV_DIR=$(mktemp -d)
+{
+    sed -n '/^_run_bounded()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_cvd_hides_nvidia()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_has_amd_rocm_gpu()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_has_usable_nvidia_gpu()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_ensure_rocm_probe_env()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_probe_amd_gfx_arch()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_amd_gpu_present_via_pci()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_infer_amd_gfx_arch_from_gpu_name()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_infer_linux_amd_gfx_arch()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_amd_arch_index_family_for_gfx()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_trim_index_path_slashes()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_nvidia_cu126_verdict()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_cap_cuda_family_for_pre_turing()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_rocm_tag_from_amd_smi()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_rocm_tag_from_version_file()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_rocm_tag_from_hipconfig()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_rocm_tag_from_dpkg()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_rocm_tag_from_rpm()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_highest_rocm_tag()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_detect_rocm_version_tag()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^get_torch_index_url()/,/^}/p' "$INSTALL_SH"
+} | sed -e "s|/usr/bin/nvidia-smi|$_FAKE_SMI_DIR/nvidia-smi-absent|g" \
+      -e "s|/proc/driver/nvidia|$_FAKE_PROC_NV_DIR|g" \
+      -e "s|/opt/rocm|$_FAKE_ROCM_DIR|g" \
+  > "$_FUNC_FILE"
+
+# Guard the extraction itself: a renamed helper would otherwise make every ROCm
+# assertion below fail as a plain "cpu" with no hint why.
+for _fn in _rocm_tag_from_amd_smi _rocm_tag_from_version_file _rocm_tag_from_hipconfig \
+           _rocm_tag_from_dpkg _rocm_tag_from_rpm _highest_rocm_tag \
+           _detect_rocm_version_tag get_torch_index_url; do
+    if ! grep -q "^$_fn()" "$_FUNC_FILE"; then
+        echo "  FAIL: install.sh no longer defines $_fn() at column 0"
+        exit 1
+    fi
+done
+
+# Minimal tool set: no amd-smi, hipconfig, dpkg-query, rpm or rocminfo unless a
+# scenario supplies one, so an unrelated host package cannot answer a probe.
+_TOOLS_DIR=$(mktemp -d)
+for _cmd in uname grep sed head sh bash cat awk printf tr ls; do
+    _real=$(command -v "$_cmd" 2>/dev/null || true)
+    [ -n "$_real" ] && ln -sf "$_real" "$_TOOLS_DIR/$_cmd"
+done
+
+cleanup() {
+    rm -rf "$_FUNC_FILE" "$_FAKE_SMI_DIR" "$_FAKE_ROCM_DIR" "$_FAKE_PROC_NV_DIR" "$_TOOLS_DIR" "$_MOCK_DIR"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    _label="$1"; _expected="$2"; _actual="$3"
+    if [ "$_actual" = "$_expected" ]; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected '$_expected', got '$_actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    _label="$1"; _needle="$2"; _haystack="$3"
+    case "$_haystack" in
+        *"$_needle"*)
+            echo "  PASS: $_label"
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            echo "  FAIL: $_label (no '$_needle' in: $_haystack)"
+            FAIL=$((FAIL + 1))
+            ;;
+    esac
+}
+
+# ── Scenario builders ───────────────────────────────────────────────────────
+# Every scenario starts from a clean mock dir and an empty fake /opt/rocm, then
+# adds only the sources it wants to exist.
+_MOCK_DIR=$(mktemp -d)
+
+reset_sources() {
+    rm -rf "$_MOCK_DIR" "$_FAKE_ROCM_DIR/.info"
+    _MOCK_DIR=$(mktemp -d)
+    # rocminfo is what makes this an AMD host at all: _has_amd_rocm_gpu needs a
+    # gfx name and _probe_amd_gfx_arch needs a readable arch, otherwise the ROCm
+    # branch bails before any version source is consulted. gfx1100 = RX 7900 XTX,
+    # the card in the report.
+    cat > "$_MOCK_DIR/rocminfo" <<'MOCK'
+#!/bin/sh
+cat <<'ROCMINFO'
+*******
+Agent 2
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Device Type:             GPU
+ROCMINFO
+MOCK
+    chmod +x "$_MOCK_DIR/rocminfo"
+}
+
+# $1 = version string printed by "hipconfig --version" (e.g. 5.7.31921-0)
+add_hipconfig() {
+    cat > "$_MOCK_DIR/hipconfig" <<MOCK
+#!/bin/sh
+echo "$1"
+MOCK
+    chmod +x "$_MOCK_DIR/hipconfig"
+}
+
+# $1 = contents of /opt/rocm/.info/version (e.g. 6.1.2-98)
+add_version_file() {
+    mkdir -p "$_FAKE_ROCM_DIR/.info"
+    printf '%s\n' "$1" > "$_FAKE_ROCM_DIR/.info/version"
+}
+
+# $1 = ROCm version reported by "amd-smi version"
+add_amd_smi() {
+    cat > "$_MOCK_DIR/amd-smi" <<MOCK
+#!/bin/sh
+case "\$1" in
+    list) printf 'GPU: 0\\n  BDF: 0000:03:00.0\\n  NAME: gfx1100\\n' ;;
+    *) echo "AMDSMI Tool: 25.0.1 | AMDSMI Library version: 25.0.1.0 | ROCm version: $1" ;;
+esac
+MOCK
+    chmod +x "$_MOCK_DIR/amd-smi"
+}
+
+# $1 = rocm-core version as dpkg reports it (epoch prefixes allowed, e.g. 1:6.2.4-1)
+add_dpkg_rocm_core() {
+    cat > "$_MOCK_DIR/dpkg-query" <<MOCK
+#!/bin/sh
+# Only rocm-core is known here; anything else is "not installed".
+for _a in "\$@"; do
+    case "\$_a" in rocm-core) echo "$1"; exit 0 ;; esac
+done
+exit 1
+MOCK
+    chmod +x "$_MOCK_DIR/dpkg-query"
+}
+
+# $1 = rocm-core version as rpm reports it
+add_rpm_rocm_core() {
+    cat > "$_MOCK_DIR/rpm" <<MOCK
+#!/bin/sh
+for _a in "\$@"; do
+    case "\$_a" in rocm-core) echo "$1"; exit 0 ;; esac
+done
+exit 1
+MOCK
+    chmod +x "$_MOCK_DIR/rpm"
+}
+
+# Run get_torch_index_url against the current scenario. stdout only.
+run_index() {
+    PATH="$_MOCK_DIR:$_TOOLS_DIR" bash -c \
+        "unset CUDA_VISIBLE_DEVICES UNSLOTH_ROCM_GFX_ARCH UNSLOTH_TORCH_INDEX_URL UNSLOTH_TORCH_INDEX_FAMILY
+         _ARCH=x86_64; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
+}
+
+# Same, but returns the warnings instead of the index, on one line.
+run_warnings() {
+    PATH="$_MOCK_DIR:$_TOOLS_DIR" bash -c \
+        "unset CUDA_VISIBLE_DEVICES UNSLOTH_ROCM_GFX_ARCH UNSLOTH_TORCH_INDEX_URL UNSLOTH_TORCH_INDEX_FAMILY
+         _ARCH=x86_64; . '$_FUNC_FILE'; get_torch_index_url" 2>&1 >/dev/null | tr '\n' ' '
+}
+
+# Same, under `set -e` like the real installer, reporting only the exit status.
+# This is the property the || guard in install.sh exists for: with every version
+# source missing the detection must return empty AND succeed, or the installer
+# dies before it can print the actionable warning.
+run_status_under_set_e() {
+    PATH="$_MOCK_DIR:$_TOOLS_DIR" bash -c \
+        "set -e
+         unset CUDA_VISIBLE_DEVICES UNSLOTH_ROCM_GFX_ARCH UNSLOTH_TORCH_INDEX_URL UNSLOTH_TORCH_INDEX_FAMILY
+         _ARCH=x86_64; . '$_FUNC_FILE'; get_torch_index_url >/dev/null 2>&1; echo \$?" \
+        2>/dev/null
+}
+
+_BASE="https://download.pytorch.org/whl"
+
+echo "=== test_rocm_version_source_disagreement ==="
+
+# ── 1. The reported host ────────────────────────────────────────────────────
+# ROCm present under /opt/rocm but with no .info/version file (the reporter's
+# log fell through to hipconfig), hipconfig from the distro's 5.7 packaging, and
+# rocm-core at 6.1 in dpkg. Before the fix this resolved rocm5.7 and returned the
+# cpu index; hipconfig answers third, ahead of dpkg.
+reset_sources
+add_hipconfig "5.7.31921-0"
+add_dpkg_rocm_core "1:6.1.2-1"
+assert_eq "Debian 13 hipconfig 5.7 + rocm-core 6.1 -> rocm6.1" "$_BASE/rocm6.1" "$(run_index)"
+assert_eq "the same host emits no 6.0+ gate warning" "" "$(run_warnings)"
+
+# 2. Same shape when the 6.x reading comes from /opt/rocm/.info/version. This one
+#    already worked (the version file outranks hipconfig by position), so it is
+#    here to pin that the reordering did not lose it.
+reset_sources
+add_hipconfig "5.7.31921-0"
+add_version_file "6.1.2-98"
+assert_eq "hipconfig 5.7 + version file 6.1 -> rocm6.1" "$_BASE/rocm6.1" "$(run_index)"
+
+# 3. And from rpm, the last source in the order.
+reset_sources
+add_hipconfig "5.7.31921-0"
+add_rpm_rocm_core "6.3.0"
+assert_eq "hipconfig 5.7 + rocm-core 6.3 (rpm) -> rocm6.3" "$_BASE/rocm6.3" "$(run_index)"
+
+# 4. First-answer resolution was not only a floor problem: amd-smi answering
+#    first with a lower version must not shadow a newer runtime either.
+reset_sources
+add_amd_smi "6.1.0"
+add_dpkg_rocm_core "6.4.1-1"
+assert_eq "amd-smi 6.1 + rocm-core 6.4 -> rocm6.4 (highest, not first)" "$_BASE/rocm6.4" "$(run_index)"
+
+# 5. Agreement is unchanged: all sources on 6.4 still resolve 6.4.
+reset_sources
+add_amd_smi "6.4.0"
+add_version_file "6.4.0-1"
+add_hipconfig "6.4.43482-0"
+assert_eq "all sources agree on 6.4 -> rocm6.4" "$_BASE/rocm6.4" "$(run_index)"
+
+# ── 6. A genuine ROCm 5.x host still falls back to CPU ──────────────────────
+reset_sources
+add_hipconfig "5.7.31921-0"
+add_version_file "5.7.1-90"
+assert_eq "genuine ROCm 5.7 everywhere -> cpu" "$_BASE/cpu" "$(run_index)"
+_warn=$(run_warnings)
+assert_contains "5.x host warns about the 6.0+ requirement" "require ROCm 6.0+" "$_warn"
+assert_contains "5.x warning names the resolved tag" "ROCm rocm5.7 detected" "$_warn"
+assert_contains "5.x warning says it took the highest reading" "HIGHEST version" "$_warn"
+
+# 7. The warning must name a documented way forward. Both overrides return early
+#    from get_torch_index_url, before any GPU probing, so naming them is honest.
+assert_contains "5.x warning names UNSLOTH_TORCH_INDEX_FAMILY" \
+    "UNSLOTH_TORCH_INDEX_FAMILY=rocm6.4" "$_warn"
+assert_contains "5.x warning names UNSLOTH_TORCH_INDEX_URL" \
+    "UNSLOTH_TORCH_INDEX_URL=" "$_warn"
+
+# 8. And the override it names has to actually work on this same host.
+reset_sources
+add_hipconfig "5.7.31921-0"
+add_version_file "5.7.1-90"
+_result=$(PATH="$_MOCK_DIR:$_TOOLS_DIR" bash -c \
+    "unset CUDA_VISIBLE_DEVICES UNSLOTH_ROCM_GFX_ARCH UNSLOTH_TORCH_INDEX_URL
+     export UNSLOTH_TORCH_INDEX_FAMILY=rocm6.4
+     _ARCH=x86_64; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null)
+assert_eq "the named override reaches this path -> rocm6.4" "$_BASE/rocm6.4" "$_result"
+
+# ── 9. Every source missing: warn, do not die ───────────────────────────────
+# rocminfo alone (fresh AMD host with no ROCm userspace): no version source
+# answers at all. Under set -e the whole detection must still succeed.
+reset_sources
+assert_eq "no version source at all -> cpu" "$_BASE/cpu" "$(run_index)"
+assert_eq "no version source at all -> exit 0 under set -e" "0" "$(run_status_under_set_e)"
+_warn=$(run_warnings)
+assert_contains "no-version host still reaches its actionable warning" \
+    "no ROCm/HIP install was found" "$_warn"
+assert_contains "no-version warning still lists the detection sources" \
+    "Minimum required for version detection" "$_warn"
+
+# 10. Sources present but every one of them unparseable: same contract.
+reset_sources
+add_amd_smi "N/A"
+add_hipconfig "unknown"
+add_version_file "not-a-version"
+assert_eq "unparseable sources -> cpu" "$_BASE/cpu" "$(run_index)"
+assert_eq "unparseable sources -> exit 0 under set -e" "0" "$(run_status_under_set_e)"
+assert_contains "unparseable sources reach the no-version warning" \
+    "no ROCm/HIP install was found" "$(run_warnings)"
+
+# 11. A source reporting major 0 is garbage, not a version below every other.
+reset_sources
+add_hipconfig "0.0.0"
+add_version_file "6.2.0-1"
+assert_eq "major-0 source ignored, 6.2 wins -> rocm6.2" "$_BASE/rocm6.2" "$(run_index)"
+
+# ── 12. Supported-tag normalisation is unchanged ────────────────────────────
+# PyTorch publishes major.minor index leaves only, so patch levels normalise;
+# 6.5+ clips to the last 6.x wheel set and 7.3+ caps to the latest known.
+for _case in "6.0.2:rocm6.0" "6.1.3:rocm6.1" "6.2.4:rocm6.2" "6.3.1:rocm6.3" \
+             "6.4.1:rocm6.4" "7.0.1:rocm7.0" "7.1.0:rocm7.1" "7.2.1:rocm7.2" \
+             "6.5.0:rocm6.4" "6.9.0:rocm6.4" "7.3.0:rocm7.2" "8.0.0:rocm7.2"; do
+    _ver="${_case%%:*}"
+    _want="${_case##*:}"
+    reset_sources
+    add_amd_smi "$_ver"
+    assert_eq "amd-smi $_ver -> $_want" "$_BASE/$_want" "$(run_index)"
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/sh/test_rocm_version_source_disagreement.sh
+++ b/tests/sh/test_rocm_version_source_disagreement.sh
@@ -181,6 +181,21 @@ MOCK
     chmod +x "$_MOCK_DIR/amd-smi"
 }
 
+# $1 = the raw value of the "ROCm version:" field, e.g. "6.4.0" or "N/A".
+# Unlike add_amd_smi this reproduces the WHOLE line amd-smi really prints, with
+# the amdgpu driver version following the ROCm one, so a parser that runs past
+# the field separator is caught.
+add_amd_smi_line() {
+    cat > "$_MOCK_DIR/amd-smi" <<MOCK
+#!/bin/sh
+case "\$1" in
+    list) printf 'GPU: 0\\n  BDF: 0000:03:00.0\\n  NAME: gfx1100\\n' ;;
+    *) echo "AMDSMI Tool: 24.7.1+b446d6c-dirty | AMDSMI Library version: 24.7.2.0 | ROCm version: $1 | amdgpu version: 6.10.10 | hsmp version: 2.2" ;;
+esac
+MOCK
+    chmod +x "$_MOCK_DIR/amd-smi"
+}
+
 # $1 = rocm-core version as dpkg reports it (epoch prefixes allowed, e.g. 1:6.2.4-1)
 # $2 = dpkg status word, default "installed". "config-files" is the state a
 #      package left behind by `apt remove` without `apt purge` sits in: still in
@@ -463,6 +478,36 @@ for _case in "6.0.2:rocm6.0" "6.1.3:rocm6.1" "6.2.4:rocm6.2" "6.3.1:rocm6.3" \
     add_amd_smi "$_ver"
     assert_eq "amd-smi $_ver -> $_want" "$_BASE/$_want" "$(run_index)"
 done
+
+# ── 13. amd-smi reports one pipe-delimited line, and the ROCm field can be N/A ──
+# Real output carries the amdgpu driver version AFTER the ROCm one on the same
+# line, and prints "ROCm version: N/A" when no ROCm userspace is detectable.
+# Reading the field without stopping at the separator glued the two together and
+# reported the driver version as ROCm (N/A + amdgpu 6.10.10 -> "rocm6.10").
+# Position used to hide that; under highest-wins a fabricated reading can outvote
+# a correct source, so an unparseable field has to yield nothing at all.
+for _case in "N/A:" "6.4.0:rocm6.4" "7.0.2:rocm7.0" ":"; do
+    _field="${_case%%:*}"
+    _want="${_case##*:}"
+    reset_sources
+    add_amd_smi_line "$_field"
+    if [ -n "$_want" ]; then
+        assert_eq "amd-smi full line, ROCm field '$_field' -> $_want" \
+            "$_BASE/$_want" "$(run_index)"
+    else
+        # Nothing else answers, so an unusable field must reach the CPU fallback
+        # rather than contribute a number.
+        assert_eq "amd-smi full line, ROCm field '$_field' -> no reading" \
+            "$_BASE/cpu" "$(run_index)"
+    fi
+done
+
+# The driver version must never win the vote over a real, lower ROCm reading.
+reset_sources
+add_amd_smi_line "N/A"
+add_version_file "6.1.3-42"
+assert_eq "amd-smi N/A beside amdgpu 6.10 does not outvote a real 6.1" \
+    "$_BASE/rocm6.1" "$(run_index)"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/sh/test_rocm_version_source_disagreement.sh
+++ b/tests/sh/test_rocm_version_source_disagreement.sh
@@ -93,7 +93,7 @@ done
 # Minimal tool set: no amd-smi, hipconfig, dpkg-query, rpm or rocminfo unless a
 # scenario supplies one, so an unrelated host package cannot answer a probe.
 _TOOLS_DIR=$(mktemp -d)
-for _cmd in uname grep sed head sh bash cat awk printf tr ls; do
+for _cmd in uname grep sed head sh bash cat awk printf tr ls sort; do
     _real=$(command -v "$_cmd" 2>/dev/null || true)
     [ -n "$_real" ] && ln -sf "$_real" "$_TOOLS_DIR/$_cmd"
 done
@@ -182,14 +182,51 @@ MOCK
 }
 
 # $1 = rocm-core version as dpkg reports it (epoch prefixes allowed, e.g. 1:6.2.4-1)
+# $2 = dpkg status word, default "installed". "config-files" is the state a
+#      package left behind by `apt remove` without `apt purge` sits in: still in
+#      /var/lib/dpkg/status, still carrying its old version, and still reported
+#      by `dpkg-query -W`, which per man dpkg-query lists packages "regardless of
+#      their status" and skips only purged ones.
+#
+# The mock renders the showformat string it is given rather than printing a bare
+# version, so these assertions test how install.sh ASKS dpkg for the version,
+# not just how it parses the answer.
 add_dpkg_rocm_core() {
-    cat > "$_MOCK_DIR/dpkg-query" <<MOCK
+    printf '%s\n' "$1" > "$_MOCK_DIR/.dpkg-version"
+    printf '%s\n' "${2:-installed}" > "$_MOCK_DIR/.dpkg-status"
+    cat > "$_MOCK_DIR/dpkg-query" <<'MOCK'
 #!/bin/sh
-# Only rocm-core is known here; anything else is "not installed".
-for _a in "\$@"; do
-    case "\$_a" in rocm-core) echo "$1"; exit 0 ;; esac
+_d=${0%/*}
+_ver=$(cat "$_d/.dpkg-version")
+_status=$(cat "$_d/.dpkg-status")
+# dpkg's Status field is "<want> <error-flag> <status>"; a package removed but
+# not purged reads "deinstall ok config-files".
+case "$_status" in installed) _want=install ;; *) _want=deinstall ;; esac
+_fmt=''
+_found=''
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -f=*)           _fmt=${1#-f=} ;;
+        --showformat=*) _fmt=${1#--showformat=} ;;
+        -f|--showformat) shift; _fmt=$1 ;;
+        -*)             : ;;
+        rocm-core)      _found=1 ;;
+    esac
+    shift
 done
-exit 1
+# Anything other than rocm-core is genuinely unknown to this box.
+[ -n "$_found" ] || exit 1
+[ -n "$_fmt" ] || _fmt='${Package}\t${Version}\n'
+# Unknown fields render empty, which is what real dpkg-query does.
+_out=$(printf '%s' "$_fmt" | sed \
+    -e "s|\${Package}|rocm-core|g" \
+    -e "s|\${Status}|$_want ok $_status|g" \
+    -e "s|\${db:Status-Status}|$_status|g" \
+    -e "s|\${db:Status-Want}|$_want|g" \
+    -e "s|\${db:Status-Eflag}|ok|g" \
+    -e "s|\${Version}|$_ver|g" \
+    -e "s|\${[^}]*}||g")
+printf "$_out"
 MOCK
     chmod +x "$_MOCK_DIR/dpkg-query"
 }
@@ -245,7 +282,15 @@ reset_sources
 add_hipconfig "5.7.31921-0"
 add_dpkg_rocm_core "1:6.1.2-1"
 assert_eq "Debian 13 hipconfig 5.7 + rocm-core 6.1 -> rocm6.1" "$_BASE/rocm6.1" "$(run_index)"
-assert_eq "the same host emits no 6.0+ gate warning" "" "$(run_warnings)"
+_warn=$(run_warnings)
+case "$_warn" in
+    *"require ROCm 6.0+"*) assert_eq "the same host emits no 6.0+ gate warning" "" "$_warn" ;;
+    *) assert_eq "the same host emits no 6.0+ gate warning" "ok" "ok" ;;
+esac
+# The readings disagreed, so the log has to say which ones and which won. This is
+# the breadcrumb that makes a wrong-HIGH reading diagnosable from an install log.
+assert_contains "disagreeing sources are named" "sources disagree (rocm5.7 rocm6.1)" "$_warn"
+assert_contains "the winning reading is named" "using the highest, rocm6.1" "$_warn"
 
 # 2. Same shape when the 6.x reading comes from /opt/rocm/.info/version. This one
 #    already worked (the version file outranks hipconfig by position), so it is
@@ -274,6 +319,82 @@ add_amd_smi "6.4.0"
 add_version_file "6.4.0-1"
 add_hipconfig "6.4.43482-0"
 assert_eq "all sources agree on 6.4 -> rocm6.4" "$_BASE/rocm6.4" "$(run_index)"
+assert_eq "agreeing sources emit no disagreement breadcrumb" "" "$(run_warnings)"
+
+# ── 5b. Overshoot: highest-wins must not let a DEAD source pick the wheels ──
+# Highest-wins fixes the undershoot in issue #8402, and creates the symmetric
+# risk that a source reading HIGHER than the runtime now wins outright. The two
+# directions are not equally bad: undershoot lands on CPU wheels, which are slow
+# but work, while overshoot installs wheels the runtime cannot load and the
+# install fails later, at torch import or first kernel launch. So the one host
+# state that can manufacture a wrong-HIGH reading has to be excluded.
+#
+# That state is dpkg's. `dpkg-query -W` reports packages in "deinstall ok
+# config-files" -- removed with `apt remove`, never purged -- and they still
+# carry the version they had. A box that ran ROCm 7.0, went back to 6.1 and
+# never purged therefore offers dpkg a 7.0 that outranks every honest source.
+# Detection must require the status word "installed".
+reset_sources
+add_hipconfig "6.1.40093-0"
+add_dpkg_rocm_core "1:7.0.0-1" config-files
+assert_eq "config-files rocm-core 7.0 on a 6.1 host -> rocm6.1, not rocm7.0" \
+    "$_BASE/rocm6.1" "$(run_index)"
+assert_eq "the dead dpkg entry is not even named as a disagreement" "" "$(run_warnings)"
+
+# 5c. And the live entry still has to win, or the fix for the reported bug is
+#     gone. This is the pair that makes 5b non-vacuous: same versions, same
+#     sources, only the dpkg status word differs.
+reset_sources
+add_hipconfig "5.7.31921-0"
+add_dpkg_rocm_core "1:6.1.2-1" installed
+assert_eq "installed rocm-core 6.1 still beats hipconfig 5.7 -> rocm6.1" \
+    "$_BASE/rocm6.1" "$(run_index)"
+
+# 5d. The other dpkg states a half-finished or interrupted operation leaves
+#     behind are not "installed" either, and none of them describes a runtime
+#     the GPU can use.
+for _dead in config-files half-installed unpacked half-configured; do
+    reset_sources
+    add_hipconfig "6.1.40093-0"
+    add_dpkg_rocm_core "1:7.2.0-1" "$_dead"
+    assert_eq "dpkg state '$_dead' at 7.2 does not select wheels -> rocm6.1" \
+        "$_BASE/rocm6.1" "$(run_index)"
+done
+
+# ── 5e. A stale-HIGH reading in each source position, one at a time ─────────
+# The audit behind 5b found exactly one source with a documented over-reporting
+# state (dpkg's, fixed above). The other four have no equivalent: rpm drops a
+# package's version on erase, /opt/rocm's .info/version belongs to whichever
+# tree /opt/rocm resolves to, and amd-smi and hipconfig report the userspace
+# they were run from. So for those four, a HIGH reading is treated as the truth
+# on purpose, and what bounds it is the tag normalisation: the resolver can
+# never emit an index leaf PyTorch does not publish, and the install log names
+# every reading so the choice is auditable. These cases pin both halves.
+for _pos in amd-smi version-file hipconfig rpm; do
+    reset_sources
+    add_hipconfig "6.1.40093-0"
+    case "$_pos" in
+        amd-smi)      add_amd_smi "9.9.0" ;;
+        version-file) add_version_file "9.9.0-1" ;;
+        hipconfig)    add_hipconfig "9.9.31921-0" ;;
+        rpm)          add_rpm_rocm_core "9.9.0" ;;
+    esac
+    # Clipped to the newest leaf PyTorch actually publishes, never rocm9.9.
+    assert_eq "a 9.9 reading from $_pos is capped to the newest published leaf" \
+        "$_BASE/rocm7.2" "$(run_index)"
+    if [ "$_pos" != "hipconfig" ]; then
+        assert_contains "a 9.9 reading from $_pos is recorded in the log" \
+            "sources disagree (rocm6.1 rocm9.9) -- using the highest, rocm9.9" "$(run_warnings)"
+    fi
+done
+
+# 5f. dpkg in that same position: an INSTALLED high reading behaves like the
+#     other four (it is the runtime, and the host is simply newer than the
+#     wheels), so the cap applies rather than a rejection.
+reset_sources
+add_hipconfig "6.1.40093-0"
+add_dpkg_rocm_core "1:9.9.0-1" installed
+assert_eq "an installed 9.9 rocm-core is capped, not rejected" "$_BASE/rocm7.2" "$(run_index)"
 
 # ── 6. A genuine ROCm 5.x host still falls back to CPU ──────────────────────
 reset_sources

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -2636,13 +2636,37 @@ class TestInstallShStructure:
         fn = _extract_sh_function_body(source, "get_torch_index_url")
         probe_fn = _extract_sh_function_body(source, "_probe_amd_gfx_arch")
         family_fn = _extract_sh_function_body(source, "_amd_arch_index_family_for_gfx")
+        # The version chain lives in its own helpers, so they have to be extracted
+        # too. Without them get_torch_index_url calls a command that does not
+        # exist, the guarded assignment swallows the 127, and the no-version
+        # endpoint is reached for the wrong reason -- the test would then pass no
+        # matter what the resolver did. Verified by mutation: making
+        # _detect_rocm_version_tag return a real tag left this test green.
+        version_fns = [
+            _extract_sh_function_body(source, name)
+            for name in (
+                "_rocm_tag_from_amd_smi",
+                "_rocm_tag_from_version_file",
+                "_rocm_tag_from_hipconfig",
+                "_rocm_tag_from_dpkg",
+                "_rocm_tag_from_rpm",
+                "_highest_rocm_tag",
+                "_detect_rocm_version_tag",
+            )
+        ]
         assert fn and probe_fn and family_fn
+        assert all(version_fns), "ROCm version helpers not found in install.sh"
         with tempfile.TemporaryDirectory() as d:
             # Neutralise the host's real ROCm: the version chain reads
             # /opt/rocm/.info/version directly (no tool to shim), which resolves
             # a tag on a real ROCm box and skips the no-version endpoint under
             # test. Same path-substitution technique as the KFD topology tests.
-            fn = fn.replace("/opt/rocm/.info/version", Path(d, "no-rocm-version").as_posix())
+            # The read lives in _rocm_tag_from_version_file, so the rewrite has to
+            # land on the helper text; applying it to fn alone became a no-op.
+            version_fns = [
+                body.replace("/opt/rocm/.info/version", Path(d, "no-rocm-version").as_posix())
+                for body in version_fns
+            ]
             with open(os.path.join(d, "uname"), "w", encoding = "utf-8", newline = "\n") as f:
                 f.write('#!/bin/sh\ncase "${1:-}" in -m) echo x86_64 ;; *) echo Linux ;; esac\n')
             # Silence every ROCm version source, not just amd-smi: a dev box with
@@ -2665,6 +2689,8 @@ class TestInstallShStructure:
                 + probe_fn
                 + "\n"
                 + family_fn
+                + "\n"
+                + "\n".join(version_fns)
                 + "\n"
                 + fn
                 + "\n"

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -78,6 +78,50 @@ def _extract_sh_function_body(source: str, name: str) -> str:
     return source[start:]
 
 
+# A dpkg-query -W stand-in faithful enough to test how install.sh ASKS for the
+# version, not only how it parses the answer: it renders whichever showformat
+# string it is handed, and it answers for a package in ANY state, because the
+# real tool does too (man dpkg-query, --list: packages are listed "regardless of
+# their status", and only purged ones are left out). A rocm-core removed with
+# `apt remove` and never purged therefore keeps reporting the version it had.
+_DPKG_QUERY_STUB = r"""#!/bin/sh
+_status='__STATUS__'
+_ver='__VERSION__'
+# dpkg's Status field is "<want> <error-flag> <status>".
+case "$_status" in installed) _want=install ;; *) _want=deinstall ;; esac
+_fmt=''
+_found=''
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -f=*)            _fmt=${1#-f=} ;;
+        --showformat=*)  _fmt=${1#--showformat=} ;;
+        -f|--showformat) shift; _fmt=$1 ;;
+        -*)              : ;;
+        rocm-core)       _found=1 ;;
+    esac
+    shift
+done
+[ -n "$_found" ] || exit 1
+[ -n "$_fmt" ] || _fmt='${Package}\t${Version}\n'
+# Unrecognised fields render empty, like the real dpkg-query.
+_out=$(printf '%s' "$_fmt" | sed \
+    -e "s|\${Package}|rocm-core|g" \
+    -e "s|\${Status}|$_want ok $_status|g" \
+    -e "s|\${db:Status-Status}|$_status|g" \
+    -e "s|\${db:Status-Want}|$_want|g" \
+    -e "s|\${db:Status-Eflag}|ok|g" \
+    -e "s|\${Version}|$_ver|g" \
+    -e "s|\${[^}]*}||g")
+printf "$_out"
+"""
+
+
+def _write_dpkg_query_stub(path: str, version: str, status: str = "installed") -> None:
+    with open(path, "w", encoding = "utf-8") as f:
+        f.write(_DPKG_QUERY_STUB.replace("__STATUS__", status).replace("__VERSION__", version))
+    os.chmod(path, 0o755)
+
+
 # ── Helper: build HostInfo for different scenarios ──────────────────────────
 
 
@@ -2113,6 +2157,9 @@ class TestInstallShStructure:
                         ) as f:
                             f.write(line + "\n")
                         continue
+                    if name == "dpkg-query":
+                        _write_dpkg_query_stub(os.path.join(d, name), line, "installed")
+                        continue
                     p = os.path.join(d, name)
                     with open(p, "w", encoding = "utf-8") as f:
                         f.write(f"#!/bin/sh\necho '{line}'\n")
@@ -2124,6 +2171,49 @@ class TestInstallShStructure:
                 assert r.stdout.strip() == "TAG:rocm6.4", (
                     f"{winner} reported 6.4 while every other source reported 5.7, "
                     f"but detection resolved {r.stdout.strip()}"
+                )
+
+    def test_removed_dpkg_rocm_core_cannot_pick_the_wheels(self):
+        """Highest-wins fixed the undershoot in #8402 and opened the symmetric
+        hole: a source reading HIGHER than the runtime now wins outright.
+        Undershoot lands on CPU wheels, which work; overshoot installs wheels the
+        runtime cannot load. `dpkg-query -W` reports packages left in "deinstall
+        ok config-files" by `apt remove` without `apt purge`, still carrying the
+        version they had, so a host that ran ROCm 7.0 and went back to 6.1 hands
+        dpkg a 7.0 that beats every live source. Only "installed" counts.
+        Executed, not text, and paired with the installed case so the assertion
+        cannot pass on the version alone."""
+        shell = shutil.which("bash")
+        if not shell:
+            pytest.skip("bash needed to execute the version chain")
+        source = (PACKAGE_ROOT / "install.sh").read_text(encoding = "utf-8")
+        for status, expected in (("config-files", "TAG:rocm6.1"), ("installed", "TAG:rocm7.0")):
+            with tempfile.TemporaryDirectory() as d:
+                rocm_prefix = os.path.join(d, "rocm")
+                script_body = self._rocm_version_detection_script(source, rocm_prefix)
+                # The live runtime, via the version file: ROCm 6.1.
+                os.makedirs(os.path.join(rocm_prefix, ".info"), exist_ok = True)
+                with open(
+                    os.path.join(rocm_prefix, ".info", "version"), "w", encoding = "utf-8"
+                ) as f:
+                    f.write("6.1.2-98\n")
+                _write_dpkg_query_stub(os.path.join(d, "dpkg-query"), "1:7.0.0-1", status)
+                # Silence the other sources so a real ROCm on the test host
+                # cannot answer and make this machine-dependent.
+                for name in ("amd-smi", "hipconfig", "rpm"):
+                    p = os.path.join(d, name)
+                    with open(p, "w", encoding = "utf-8") as f:
+                        f.write("#!/bin/sh\nexit 1\n")
+                    os.chmod(p, 0o755)
+                script = "set -euo pipefail\n" + script_body + '\nprintf "TAG:%s\\n" "$_rocm_tag"\n'
+                env = dict(os.environ, PATH = d + os.pathsep + os.environ.get("PATH", ""))
+                r = subprocess.run(
+                    [shell, "-c", script], env = env, capture_output = True, text = True
+                )
+                assert r.returncode == 0, r.stderr
+                assert r.stdout.strip() == expected, (
+                    f"dpkg rocm-core 7.0 in state {status!r} next to a 6.1 version file "
+                    f"resolved {r.stdout.strip()}, expected {expected}"
                 )
 
     def test_cuda_precedence(self):

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -2020,23 +2020,50 @@ class TestInstallShStructure:
             '[ "$_torch_index_pinned" = true ]' in source[summary - 700 : summary]
         ), "the gpu summary must not claim no usable ROCm for a pinned index"
 
+    # The helpers _detect_rocm_version_tag consults, in source order.
+    _ROCM_VERSION_SOURCES = (
+        "_rocm_tag_from_amd_smi",
+        "_rocm_tag_from_version_file",
+        "_rocm_tag_from_hipconfig",
+        "_rocm_tag_from_dpkg",
+        "_rocm_tag_from_rpm",
+    )
+
+    def _rocm_version_detection_script(self, source: str, rocm_prefix: str) -> str:
+        """The version-source helpers plus the resolver and the guarded
+        assignment that get_torch_index_url makes, as a runnable script.
+
+        /opt/rocm is redirected to `rocm_prefix` so the version file is a source
+        the test controls: a real ROCm host would otherwise answer one of the
+        probes and make the assertions machine-dependent."""
+        parts = []
+        for name in (*self._ROCM_VERSION_SOURCES, "_highest_rocm_tag", "_detect_rocm_version_tag"):
+            body = _extract_sh_function_body(source, name)
+            assert body, f"install.sh no longer defines {name}()"
+            parts.append(body)
+        assignment = re.search(
+            r'^        _rocm_tag=\$\(_detect_rocm_version_tag.*?\|\| _rocm_tag=""\n',
+            source,
+            re.S | re.M,
+        )
+        assert assignment, "could not extract the guarded _rocm_tag assignment"
+        parts.append(assignment.group(0))
+        return "\n".join(parts).replace("/opt/rocm", rocm_prefix)
+
     def test_rocm_version_chain_survives_no_source_under_set_e(self):
         """When every ROCm version source is missing (e.g. rocminfo present but
-        rocm-core not installed, so dpkg-query/rpm exit 1), the _rocm_tag ||
-        chain fails as a whole; without the || guard set -e kills the installer
-        BEFORE the actionable no-version WARN it feeds. Executed, not text."""
+        rocm-core not installed, so dpkg-query/rpm exit 1), detection must still
+        return empty AND succeed; otherwise set -e kills the installer BEFORE the
+        actionable no-version WARN it feeds. Executed, not text."""
         shell = shutil.which("bash")
         if not shell:
             pytest.skip("bash needed to execute the version chain")
         sh_path = PACKAGE_ROOT / "install.sh"
         source = sh_path.read_text(encoding = "utf-8")
-        chain = re.search(
-            r'^        _rocm_tag=\$\(\{ command -v amd-smi.*?\|\| _rocm_tag=""\n',
-            source,
-            re.S | re.M,
-        )
-        assert chain, "could not extract the guarded _rocm_tag chain"
         with tempfile.TemporaryDirectory() as d:
+            # Nothing is created under this prefix, so the version file is
+            # missing too: every source comes up empty.
+            script_body = self._rocm_version_detection_script(source, os.path.join(d, "rocm"))
             # Tools exist on PATH but yield nothing usable, like a box with the
             # probe tools installed and no rocm-core package.
             for name in ("amd-smi", "hipconfig", "dpkg-query", "rpm"):
@@ -2045,13 +2072,59 @@ class TestInstallShStructure:
                     f.write("#!/bin/sh\nexit 1\n")
                 os.chmod(p, 0o755)
             script = (
-                "set -euo pipefail\n" + chain.group(0) + '\nprintf "SURVIVED:%s\\n" "$_rocm_tag"\n'
+                "set -euo pipefail\n" + script_body + '\nprintf "SURVIVED:%s\\n" "$_rocm_tag"\n'
             )
             env = dict(os.environ, PATH = d + os.pathsep + os.environ.get("PATH", ""))
             r = subprocess.run([shell, "-c", script], env = env, capture_output = True, text = True)
-            assert r.returncode == 0, f"version chain aborted under set -e: {r.stderr}"
-            assert r.stdout.startswith("SURVIVED:"), r.stdout
+            assert r.returncode == 0, f"version detection aborted under set -e: {r.stderr}"
+            assert r.stdout.strip() == "SURVIVED:", r.stdout
         assert "rocm" in source.lower()
+
+    def test_rocm_version_detection_takes_the_highest_source(self):
+        """Issue #8402: Debian 13 ships hipconfig 5.7 next to a 6.1 runtime, so
+        stopping at the first source that answered gated a working gfx1100 out to
+        CPU wheels. Every source is read and the highest wins. Executed, not
+        text, and asserted per source position so no single ordering passes by
+        accident."""
+        shell = shutil.which("bash")
+        if not shell:
+            pytest.skip("bash needed to execute the version chain")
+        source = (PACKAGE_ROOT / "install.sh").read_text(encoding = "utf-8")
+        # Each source answers, one of them higher than the rest. Whichever
+        # position holds the 6.4 reading, that is the one that must win.
+        # "version-file" is /opt/rocm/.info/version rather than a PATH tool.
+        outputs = {
+            "amd-smi": "AMDSMI Tool: 25.0.1 | ROCm version: {v}",
+            "version-file": "{v}.1-98",
+            "hipconfig": "{v}.31921-0",
+            "dpkg-query": "1:{v}.4-1",
+            "rpm": "{v}.4-1",
+        }
+        for winner in outputs:
+            with tempfile.TemporaryDirectory() as d:
+                rocm_prefix = os.path.join(d, "rocm")
+                script_body = self._rocm_version_detection_script(source, rocm_prefix)
+                for name, template in outputs.items():
+                    line = template.format(v = "6.4" if name == winner else "5.7")
+                    if name == "version-file":
+                        os.makedirs(os.path.join(rocm_prefix, ".info"), exist_ok = True)
+                        with open(
+                            os.path.join(rocm_prefix, ".info", "version"), "w", encoding = "utf-8"
+                        ) as f:
+                            f.write(line + "\n")
+                        continue
+                    p = os.path.join(d, name)
+                    with open(p, "w", encoding = "utf-8") as f:
+                        f.write(f"#!/bin/sh\necho '{line}'\n")
+                    os.chmod(p, 0o755)
+                script = "set -euo pipefail\n" + script_body + '\nprintf "TAG:%s\\n" "$_rocm_tag"\n'
+                env = dict(os.environ, PATH = d + os.pathsep + os.environ.get("PATH", ""))
+                r = subprocess.run([shell, "-c", script], env = env, capture_output = True, text = True)
+                assert r.returncode == 0, r.stderr
+                assert r.stdout.strip() == "TAG:rocm6.4", (
+                    f"{winner} reported 6.4 while every other source reported 5.7, "
+                    f"but detection resolved {r.stdout.strip()}"
+                )
 
     def test_cuda_precedence(self):
         """ROCm detection runs only when NVIDIA is absent (check runtime ordering in get_torch_index_url)."""

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -2085,7 +2085,15 @@ class TestInstallShStructure:
         the test controls: a real ROCm host would otherwise answer one of the
         probes and make the assertions machine-dependent."""
         parts = []
-        for name in (*self._ROCM_VERSION_SOURCES, "_highest_rocm_tag", "_detect_rocm_version_tag"):
+        # _run_bounded first: _rocm_tag_from_rpm routes its query through it, so
+        # leaving it out would make the rpm source silently answer nothing and
+        # the per-position assertions below pass for the wrong reason.
+        for name in (
+            "_run_bounded",
+            *self._ROCM_VERSION_SOURCES,
+            "_highest_rocm_tag",
+            "_detect_rocm_version_tag",
+        ):
             body = _extract_sh_function_body(source, name)
             assert body, f"install.sh no longer defines {name}()"
             parts.append(body)

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -78,12 +78,11 @@ def _extract_sh_function_body(source: str, name: str) -> str:
     return source[start:]
 
 
-# A dpkg-query -W stand-in faithful enough to test how install.sh ASKS for the
-# version, not only how it parses the answer: it renders whichever showformat
-# string it is handed, and it answers for a package in ANY state, because the
-# real tool does too (man dpkg-query, --list: packages are listed "regardless of
-# their status", and only purged ones are left out). A rocm-core removed with
-# `apt remove` and never purged therefore keeps reporting the version it had.
+# A dpkg-query -W stand-in that renders whichever showformat string it is handed,
+# so this tests how install.sh ASKS for the version, not only how it parses the
+# answer. It answers for a package in ANY state because the real tool does: only
+# purged ones are left out, so a rocm-core removed with `apt remove` and never
+# purged keeps reporting the version it had.
 _DPKG_QUERY_STUB = r"""#!/bin/sh
 _status='__STATUS__'
 _ver='__VERSION__'
@@ -2068,7 +2067,6 @@ class TestInstallShStructure:
             '[ "$_torch_index_pinned" = true ]' in source[summary - 700 : summary]
         ), "the gpu summary must not claim no usable ROCm for a pinned index"
 
-    # The helpers _detect_rocm_version_tag consults, in source order.
     _ROCM_VERSION_SOURCES = (
         "_rocm_tag_from_amd_smi",
         "_rocm_tag_from_version_file",
@@ -2086,8 +2084,8 @@ class TestInstallShStructure:
         probes and make the assertions machine-dependent."""
         parts = []
         # _run_bounded first: _rocm_tag_from_rpm routes its query through it, so
-        # leaving it out would make the rpm source silently answer nothing and
-        # the per-position assertions below pass for the wrong reason.
+        # omitting it makes that source answer nothing and the per-position
+        # assertions below pass for the wrong reason.
         for name in (
             "_run_bounded",
             *self._ROCM_VERSION_SOURCES,
@@ -2117,8 +2115,7 @@ class TestInstallShStructure:
         sh_path = PACKAGE_ROOT / "install.sh"
         source = sh_path.read_text(encoding = "utf-8")
         with tempfile.TemporaryDirectory() as d:
-            # Nothing is created under this prefix, so the version file is
-            # missing too: every source comes up empty.
+            # Nothing is created under this prefix, so every source comes up empty.
             script_body = self._rocm_version_detection_script(source, os.path.join(d, "rocm"))
             # Tools exist on PATH but yield nothing usable, like a box with the
             # probe tools installed and no rocm-core package.
@@ -2146,8 +2143,7 @@ class TestInstallShStructure:
         if not shell:
             pytest.skip("bash needed to execute the version chain")
         source = (PACKAGE_ROOT / "install.sh").read_text(encoding = "utf-8")
-        # Each source answers, one of them higher than the rest. Whichever
-        # position holds the 6.4 reading, that is the one that must win.
+        # Each source answers; whichever position holds the 6.4 reading must win.
         # "version-file" is /opt/rocm/.info/version rather than a PATH tool.
         outputs = {
             "amd-smi": "AMDSMI Tool: 25.0.1 | ROCm version: {v}",
@@ -2210,8 +2206,7 @@ class TestInstallShStructure:
                 ) as f:
                     f.write("6.1.2-98\n")
                 _write_dpkg_query_stub(os.path.join(d, "dpkg-query"), "1:7.0.0-1", status)
-                # Silence the other sources so a real ROCm on the test host
-                # cannot answer and make this machine-dependent.
+                # Silence the rest so a real ROCm on the test host cannot answer.
                 for name in ("amd-smi", "hipconfig", "rpm"):
                     p = os.path.join(d, name)
                     with open(p, "w", encoding = "utf-8") as f:
@@ -2644,12 +2639,10 @@ class TestInstallShStructure:
         fn = _extract_sh_function_body(source, "get_torch_index_url")
         probe_fn = _extract_sh_function_body(source, "_probe_amd_gfx_arch")
         family_fn = _extract_sh_function_body(source, "_amd_arch_index_family_for_gfx")
-        # The version chain lives in its own helpers, so they have to be extracted
-        # too. Without them get_torch_index_url calls a command that does not
-        # exist, the guarded assignment swallows the 127, and the no-version
-        # endpoint is reached for the wrong reason -- the test would then pass no
-        # matter what the resolver did. Verified by mutation: making
-        # _detect_rocm_version_tag return a real tag left this test green.
+        # The version helpers must be extracted too: without them get_torch_index_url
+        # calls a missing command, the guarded assignment swallows the 127, and the
+        # no-version endpoint is reached for the wrong reason. Verified by mutation
+        # (making _detect_rocm_version_tag return a real tag left this test green).
         version_fns = [
             _extract_sh_function_body(source, name)
             for name in (
@@ -2669,8 +2662,8 @@ class TestInstallShStructure:
             # /opt/rocm/.info/version directly (no tool to shim), which resolves
             # a tag on a real ROCm box and skips the no-version endpoint under
             # test. Same path-substitution technique as the KFD topology tests.
-            # The read lives in _rocm_tag_from_version_file, so the rewrite has to
-            # land on the helper text; applying it to fn alone became a no-op.
+            # The read moved into _rocm_tag_from_version_file, so the rewrite has to
+            # land on the helper text; applying it to fn alone is a no-op.
             version_fns = [
                 body.replace("/opt/rocm/.info/version", Path(d, "no-rocm-version").as_posix())
                 for body in version_fns

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -116,7 +116,11 @@ printf "$_out"
 """
 
 
-def _write_dpkg_query_stub(path: str, version: str, status: str = "installed") -> None:
+def _write_dpkg_query_stub(
+    path: str,
+    version: str,
+    status: str = "installed",
+) -> None:
     with open(path, "w", encoding = "utf-8") as f:
         f.write(_DPKG_QUERY_STUB.replace("__STATUS__", status).replace("__VERSION__", version))
     os.chmod(path, 0o755)
@@ -2207,9 +2211,7 @@ class TestInstallShStructure:
                     os.chmod(p, 0o755)
                 script = "set -euo pipefail\n" + script_body + '\nprintf "TAG:%s\\n" "$_rocm_tag"\n'
                 env = dict(os.environ, PATH = d + os.pathsep + os.environ.get("PATH", ""))
-                r = subprocess.run(
-                    [shell, "-c", script], env = env, capture_output = True, text = True
-                )
+                r = subprocess.run([shell, "-c", script], env = env, capture_output = True, text = True)
                 assert r.returncode == 0, r.stderr
                 assert r.stdout.strip() == expected, (
                     f"dpkg rocm-core 7.0 in state {status!r} next to a 6.1 version file "


### PR DESCRIPTION
Fixes #8402

## The report

A Linux Mint 22.2 host with an RX 7900 XTX (gfx1100) and a working ROCm install got `torch 2.10.0+cpu`. The install log carried the evidence against its own conclusion:

```
[WARN] ROCm 5.7 detected but PyTorch ROCm wheels require ROCm 6.0+ -- falling back to CPU-only PyTorch
...
GPU: AMD ROCm (gfx1100)  ROCm: /opt/rocm
```

`install.sh` took the ROCm version from the first source that answered, in the order `amd-smi`, `/opt/rocm/.info/version`, `hipconfig`, `dpkg rocm-core`, `rpm rocm-core`. Debian 13, and Linux Mint on top of it, packages `hipconfig` at `5.7.31921-0` next to a 6.1.x `rocminfo`/HSA runtime. `hipconfig` answers third, `dpkg` fourth, so detection settled on `rocm5.7`, the 6.0+ gate fired, and a card that ROCm supports fine trained on CPU.

## The change

Detection reads every source and takes the **highest**, rather than the first that answers. On a single host a source reading lower than another is stale packaging, not a downgrade, so the highest reading is the one that describes the runtime the GPU uses.

The inline `||` chain becomes one helper per source plus a highest-wins resolver. Each helper returns 0 unconditionally, so the case it has to survive - a real AMD GPU with no ROCm userspace at all, where `dpkg-query`/`rpm` exit 1 - still reaches the actionable "no ROCm/HIP install was found" warning instead of dying under `set -e`.

The sub-6.0 warning also names a way forward: it says the version reported was the highest any source gave, and names `UNSLOTH_TORCH_INDEX_FAMILY` and `UNSLOTH_TORCH_INDEX_URL`. Both return from `get_torch_index_url` before any GPU probing and are forwarded through the WSL reroute, so they are a real override for a host with split packaging.

## The obvious objection: does highest-wins overshoot?

Swapping first-answer-wins for highest-wins fixes the undershoot and raises the symmetric risk: a source reading *higher* than the host now picks the wheel family instead of being shadowed by its position. Three things bound it.

**1. A dead package can no longer vote.** This is the one real hole and the second commit closes it. `dpkg-query -W` lists every package in the status database except purged ones ([man dpkg-query](https://manpages.debian.org/bookworm/dpkg/dpkg-query.1.en.html), `--list`: packages are listed "regardless of their status", excluding only `not-installed`). A `rocm-core` taken out with `apt remove` and never purged sits in state `deinstall ok config-files` and still reports the version it had. A host that ran ROCm 7.0, went back to 6.1 and never purged therefore offered a 7.0 reading off a package that is gone. Fourth in the old chain it was usually shadowed; under highest-wins it beat every live source.

Detection now asks for `${Status}` alongside `${Version}` and uses the version only when the status word is `installed`. `${Status}` is a documented showformat field with no dpkg version floor, and `dpkg-query` renders an unrecognised field as empty rather than failing, so on a dpkg that somehow lacked it this source would go silent rather than over-report.

**2. The other four sources have no equivalent state.** Each was checked for the same class of problem:

| Source | Can it report higher than the host? |
| --- | --- |
| `rpm -q rocm-core` | No config-files analogue. `rpm -e` drops the header record, and `rpm -q` then exits 1, which the helper already treats as no answer. |
| `/opt/rocm/.info/version` | Describes whatever tree `/opt/rocm` resolves to. |
| `amd-smi version` | Resolves `librocm-core.so`, so it reports a ROCm that is installed, not the driver. |
| `hipconfig --version` | Reads the version file of the tree it lives in, so it reports a ROCm that is installed. The reported bug is the opposite direction. |

What the last three cannot do, on a host carrying several ROCm trees, is say which runtime a process will actually load. None of them knows, and neither does this installer.

**3. Even a genuinely high reading is mostly harmless.** PyTorch's ROCm wheels vendor their own ROCm userspace into `torch/lib`, so what they need from the host is the amdgpu/KFD driver, and AMD documents [driver/userspace compatibility](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html) as +/- 2 releases, widening to about a year's span from 6.4 on. On top of that the existing normalisation can only emit an index leaf PyTorch publishes (6.5+ clips to `rocm6.4`, 7.3+ caps to `rocm7.2`), so no reading can produce a 404 index.

The residue is a multi-version host where the pick is too new for the driver. That does not fail loudly: it surfaces as an HSA error at the first HIP call, or as a GPU silently missing from torch, neither of which points back at wheel selection. So when the sources disagree, resolution now names every reading and which one won:

```
[WARN] ROCm version sources disagree (rocm5.7 rocm6.1) -- using the highest, rocm6.1.
```

Agreeing sources stay silent. The call site stops discarding stderr, which only ever carried this line; each source's own noise is suppressed inside the resolver.

## Tests

`tests/sh/test_rocm_version_source_disagreement.sh` (51 assertions):

- the reported Debian 13 shape, and a stale **low** reading in each of the five source positions
- the `config-files` `rocm-core` at 7.0 on a 6.1 host, plus its `installed` twin at the same versions, so the assertion cannot pass on the version alone
- the other non-installed dpkg states (`half-installed`, `unpacked`, `half-configured`)
- a stale **high** reading in each of the five positions, capped to a published leaf and recorded in the log
- a genuine ROCm 5.x host still falling back to CPU, and the override the warning names actually reaching that path
- every source missing not killing the installer under `set -e`
- the unchanged tag normalisation (patch levels, 6.5+ clip, 7.3+ cap)

The dpkg-query mock renders the showformat string it is handed rather than printing a bare version, so the tests cover how `install.sh` *asks* for the version and not only how it parses the answer. `tests/studio/install/test_rocm_support.py` gains the same mock and the config-files/installed pair.

Both new dpkg cases were confirmed to fail against the first commit and pass after the second, so they are not vacuous.

Full run on this branch: `tests/sh` 45/45 scripts pass, `test_get_torch_index_url.sh` 64 assertions, `test_rocm_support.py` 486 passed 1 skipped, `test_ci_shell_suite_coverage.py` + `test_cross_platform_parity.py` 105 passed. `bash -n`, `dash -n` and `shellcheck -e SC1090,SC2034` all clean, with the shellcheck finding multiset unchanged from `main`.

## Not in this change

- `get_radeon_wheel_url` and the Radeon repo path are untouched.
- The Python-side ROCm probes in `studio/` are untouched; this is `install.sh`'s detection only.
- No attempt to determine which ROCm runtime a process will actually load. For wheel selection that would mean reading `/sys/module/amdgpu/version` and the driver compatibility matrix rather than any of these five userspace sources, which is a larger change than this bug needs.
