### PR TITLE
Windows: verify the publisher of the installers we download and run

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2223,6 +2223,20 @@ exit 0
             return $null
         }
 
+        # $full comes from the python.org listing, so the bytes differ per patch release and
+        # cannot be pinned to a committed SHA-256 the way install_node_prebuilt.py pins Node.
+        # Verify the publisher instead: this executable is about to run with this process's
+        # privileges, and HTTPS only vouches for the transfer, not for what arrived. Status
+        # alone would accept any trusted CA's code-signing cert, including an attacker's.
+        $sig = Get-AuthenticodeSignature -LiteralPath $dest
+        if ($sig.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
+            $null -eq $sig.SignerCertificate -or
+            $sig.SignerCertificate.Subject -notmatch '(^|,\s*)O=Python Software Foundation(,|$)') {
+            substep "python.org installer is not validly signed by the Python Software Foundation (signature status: $($sig.Status)); not running it." "Yellow"
+            Remove-Item -LiteralPath $dest -Force -ErrorAction SilentlyContinue
+            return $null
+        }
+
         # Per-user install => no UAC. PrependPath puts python + py on PATH;
         # Include_launcher installs py.exe (preferred by Find-CompatiblePython).
         substep "installing Python $full (silent, per-user)..."

--- a/install.ps1
+++ b/install.ps1
@@ -2228,11 +2228,19 @@ exit 0
         # Verify the publisher instead: this executable is about to run with this process's
         # privileges, and HTTPS only vouches for the transfer, not for what arrived. Status
         # alone would accept any trusted CA's code-signing cert, including an attacker's.
-        $sig = Get-AuthenticodeSignature -LiteralPath $dest
-        if ($sig.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
+        # Inspecting the file can itself fail (antivirus quarantines the download before we
+        # look at it, the path becomes unreadable), and the script-wide 'Stop' at the top
+        # would turn that into a terminating error that escapes the function, skipping the
+        # $null fallback and leaving the executable behind. Unreadable is unverified, so it
+        # takes the same route as a bad signature.
+        $sig = $null
+        try { $sig = Get-AuthenticodeSignature -LiteralPath $dest } catch { $sig = $null }
+        if ($null -eq $sig -or
+            $sig.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
             $null -eq $sig.SignerCertificate -or
-            $sig.SignerCertificate.Subject -notmatch '(^|,\s*)O=Python Software Foundation(,|$)') {
-            substep "python.org installer is not validly signed by the Python Software Foundation (signature status: $($sig.Status)); not running it." "Yellow"
+            $sig.SignerCertificate.Subject -notmatch '(^|,\s*)O="?Python Software Foundation"?(,|$)') {
+            $sigStatus = if ($null -eq $sig) { "could not be read" } else { $sig.Status }
+            substep "python.org installer is not validly signed by the Python Software Foundation (signature status: $sigStatus); not running it." "Yellow"
             Remove-Item -LiteralPath $dest -Force -ErrorAction SilentlyContinue
             return $null
         }

--- a/install.ps1
+++ b/install.ps1
@@ -2223,16 +2223,12 @@ exit 0
             return $null
         }
 
-        # $full comes from the python.org listing, so the bytes differ per patch release and
-        # cannot be pinned to a committed SHA-256 the way install_node_prebuilt.py pins Node.
-        # Verify the publisher instead: this executable is about to run with this process's
-        # privileges, and HTTPS only vouches for the transfer, not for what arrived. Status
-        # alone would accept any trusted CA's code-signing cert, including an attacker's.
-        # Inspecting the file can itself fail (antivirus quarantines the download before we
-        # look at it, the path becomes unreadable), and the script-wide 'Stop' at the top
-        # would turn that into a terminating error that escapes the function, skipping the
-        # $null fallback and leaving the executable behind. Unreadable is unverified, so it
-        # takes the same route as a bad signature.
+        # Same trust boundary as the VC++ runtime in studio/setup.ps1: $full moves per patch
+        # release, so there is no SHA-256 to pin and the publisher is what we can check.
+        # Inspection itself can fail (antivirus quarantining the download first), and the
+        # script-wide 'Stop' would let that escape the function, skipping the $null fallback
+        # and leaving the executable behind. Unreadable is unverified, so it takes the same
+        # route as a bad signature.
         $sig = $null
         try { $sig = Get-AuthenticodeSignature -LiteralPath $dest } catch { $sig = $null }
         if ($null -eq $sig -or

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1514,12 +1514,10 @@ function Ensure-VCRedist {
         } catch { $_prevProtocol = $null }
         try {
             Invoke-WebRequest -Uri $url -OutFile $dst -UseBasicParsing -TimeoutSec 300
-            # HTTPS secures the transfer, not the payload: what lands on disk is about to run
-            # with this process's privileges. The evergreen URL rules out a SHA-256 pin (the
-            # bytes change with every VS servicing update, unlike the pinned Node archives in
-            # install_node_prebuilt.py), so verify the publisher instead. Status alone is not
-            # enough -- any code-signing cert from any trusted CA passes it -- so the chain
-            # must also lead back to Microsoft, which no attacker-obtained cert will.
+            # HTTPS secures the transfer, not the payload, and this runs with the setup
+            # process's privileges. The evergreen URL rules out a SHA-256 pin (the bytes
+            # change with every VS servicing update), so check the publisher. Status alone
+            # is not enough: any trusted CA's code-signing cert passes it.
             $sig = Get-AuthenticodeSignature -LiteralPath $dst
             if ($sig.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
                 $null -eq $sig.SignerCertificate -or

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1523,7 +1523,7 @@ function Ensure-VCRedist {
             $sig = Get-AuthenticodeSignature -LiteralPath $dst
             if ($sig.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
                 $null -eq $sig.SignerCertificate -or
-                $sig.SignerCertificate.Subject -notmatch '(^|,\s*)O=Microsoft Corporation(,|$)') {
+                $sig.SignerCertificate.Subject -notmatch '(^|,\s*)O="?Microsoft Corporation"?(,|$)') {
                 throw "the downloaded VC++ runtime is not validly signed by Microsoft (signature status: $($sig.Status))"
             }
             $p = Start-Process -FilePath $dst -ArgumentList '/quiet', '/norestart' -Wait -PassThru

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1514,6 +1514,18 @@ function Ensure-VCRedist {
         } catch { $_prevProtocol = $null }
         try {
             Invoke-WebRequest -Uri $url -OutFile $dst -UseBasicParsing -TimeoutSec 300
+            # HTTPS secures the transfer, not the payload: what lands on disk is about to run
+            # with this process's privileges. The evergreen URL rules out a SHA-256 pin (the
+            # bytes change with every VS servicing update, unlike the pinned Node archives in
+            # install_node_prebuilt.py), so verify the publisher instead. Status alone is not
+            # enough -- any code-signing cert from any trusted CA passes it -- so the chain
+            # must also lead back to Microsoft, which no attacker-obtained cert will.
+            $sig = Get-AuthenticodeSignature -LiteralPath $dst
+            if ($sig.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
+                $null -eq $sig.SignerCertificate -or
+                $sig.SignerCertificate.Subject -notmatch '(^|,\s*)O=Microsoft Corporation(,|$)') {
+                throw "the downloaded VC++ runtime is not validly signed by Microsoft (signature status: $($sig.Status))"
+            }
             $p = Start-Process -FilePath $dst -ArgumentList '/quiet', '/norestart' -Wait -PassThru
             # 3010 = success, reboot required; usable either way.
             if ($p.ExitCode -notin @(0, 3010)) {

--- a/tests/python/test_windows_vcredist_download_tls.py
+++ b/tests/python/test_windows_vcredist_download_tls.py
@@ -37,7 +37,8 @@ def test_the_download_is_verified_as_microsoft_signed_before_it_runs():
     execute = block.index("Start-Process", verify)
     assert download < verify < execute
     assert "SignatureStatus]::Valid" in block
-    assert "O=Microsoft Corporation" in block
+    # Loose on the quoting, since an RDN value may arrive quoted, strict on the publisher.
+    assert "Microsoft Corporation" in block
 
 
 def _script(starting_protocol: str) -> str:

--- a/tests/python/test_windows_vcredist_download_tls.py
+++ b/tests/python/test_windows_vcredist_download_tls.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-"""The direct VC++ runtime download must negotiate TLS 1.2 on legacy protocol defaults."""
+"""The direct VC++ runtime download must negotiate TLS 1.2 and run only Microsoft's binary."""
 
 from __future__ import annotations
 
@@ -25,6 +25,19 @@ def _download_block() -> str:
     start = source.index(_START)
     end = source.index(_END, start) + len(_END)
     return source[start:end]
+
+
+def test_the_download_is_verified_as_microsoft_signed_before_it_runs():
+    # No pwsh needed: Get-AuthenticodeSignature is Windows-only, so the ordering of the three
+    # steps in the real block is the thing to hold still. A verification placed after
+    # Start-Process, or one that only checks Status, would still "pass" on a swapped binary.
+    block = _download_block()
+    download = block.index("Invoke-WebRequest")
+    verify = block.index("Get-AuthenticodeSignature", download)
+    execute = block.index("Start-Process", verify)
+    assert download < verify < execute
+    assert "SignatureStatus]::Valid" in block
+    assert "O=Microsoft Corporation" in block
 
 
 def _script(starting_protocol: str) -> str:


### PR DESCRIPTION
Two Windows fallbacks download an executable to the temp directory and run it straight away. `studio/setup.ps1` fetches the VC++ runtime when winget is absent or fails, and `install.ps1` fetches the python.org installer when it cannot find a usable interpreter. Both call `Start-Process` on the freshly downloaded file with nothing in between, and setup may be running elevated.

HTTPS vouches for the transfer, not for what arrived. Anything that can substitute the payload on a trusted delivery path gets arbitrary code execution during install.

## Why not a hash pin

`install_node_prebuilt.py` pins Node archives to committed SHA-256 values and refuses unpinned installs, which is the right pattern when a URL names an exact artifact. Neither of these URLs does:

- `aka.ms/vs/17/release/vc_redist.x64.exe` is evergreen. It currently redirects to a 25,635,768 byte file last modified 16 Jul 2026, and the bytes change with every VS servicing update. A committed pin would break the installer on Microsoft's schedule.
- the python.org patch version is resolved at runtime from the directory listing, so there is no fixed artifact to pin.

Worth noting since it looks like a free win: the `aka.ms` redirect target embeds the file's SHA-256 in its path, and it does check out (`CC0FF0EB...96B713B` matches the download). It is not a control though. The redirect and the file travel the same path, so anything able to swap the binary also serves the redirect naming its hash. It would only prove the CDN agrees with itself.

## What this does instead

Verify the publisher before executing. `Get-AuthenticodeSignature` has to come back `Valid`, and the signer subject has to carry `O=Microsoft Corporation` or `O=Python Software Foundation` respectively. The status on its own is not enough, since any code-signing certificate from any trusted CA satisfies it, including one an attacker holds. The organisation in the subject is the part they cannot get.

Both failure paths are the ones already present, so nothing new dead-ends:

- the VC++ `throw` lands in the existing `catch`, which prints the same yellow line and falls through to the manual install instructions that were already there
- the python.org check returns `$null` exactly like the download failure two lines above it, so the caller still falls back to uv and astral.sh

`Ensure-VCRedist` was already non-fatal. The only new behaviour on either path is refusing to execute a binary the expected publisher did not sign.

## The runtime is still required

Checked rather than assumed, since this sits next to a change that could look like it is removing the need for it. From the torch 2.9.1 `win_amd64` wheel:

```
does the wheel bundle the MSVC runtime?   none bundled
torch/lib/c10.dll:        msvcp140.dll, vcruntime140.dll, vcruntime140_1.dll
torch/lib/torch_cpu.dll:  msvcp140.dll, vcruntime140.dll, vcruntime140_1.dll
```

Hard imports, nothing vendored, and none of the three ship in-box on Windows. The Universal CRT does, the VC++ runtime does not. `virgin-windows-probe.ps1` already asserts their absence on a bare container for exactly this reason.

## Verification

- `install.ps1` and `studio/setup.ps1` both parse clean under the PowerShell AST parser
- Pester `tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1`: 31 passed, 0 failed, 7 skipped
- `tests/python/test_windows_vcredist_download_tls.py`: 3 passed, including a new test that holds the download, verify, execute ordering in place. It is a static check on the real block sliced out of `setup.ps1`, so it runs everywhere. `Get-AuthenticodeSignature` is Windows only, and a verification placed after `Start-Process` would still pass a runtime check that never reaches it.
- both subject patterns checked against the real certificate subjects and against near misses. `O=Evil Inc`, `O=Microsoft Corporation Ltd`, `O=Python Software Foundation Inc` and an `OU=` prefixed decoy are all rejected.
