### PR TITLE
Verify the VC++ runtime installer is Microsoft-signed before running it

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1514,6 +1514,17 @@ function Ensure-VCRedist {
         } catch { $_prevProtocol = $null }
         try {
             Invoke-WebRequest -Uri $url -OutFile $dst -UseBasicParsing -TimeoutSec 300
+            # HTTPS only protects the transfer; the executable is a separate trust boundary,
+            # and the evergreen URL cannot be hash-pinned the way the uv archive is. Make
+            # Windows validate the Authenticode chain and confirm Microsoft signed it before
+            # running it with this process's privileges. A failure here throws into the catch
+            # below, which is the same non-fatal path a failed download already takes.
+            $_sig = Get-AuthenticodeSignature -LiteralPath $dst
+            if ($_sig.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
+                $null -eq $_sig.SignerCertificate -or
+                $_sig.SignerCertificate.Subject -notmatch '(^|,\s*)O="?Microsoft Corporation"?(,|$)') {
+                throw "the downloaded VC++ runtime is not validly signed by Microsoft (status: $($_sig.Status))"
+            }
             $p = Start-Process -FilePath $dst -ArgumentList '/quiet', '/norestart' -Wait -PassThru
             # 3010 = success, reboot required; usable either way.
             if ($p.ExitCode -notin @(0, 3010)) {

--- a/tests/python/test_windows_vcredist_download_tls.py
+++ b/tests/python/test_windows_vcredist_download_tls.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-"""The direct VC++ runtime download must negotiate TLS 1.2 on legacy protocol defaults."""
+"""Security checks on the direct VC++ runtime download in studio/setup.ps1."""
 
 from __future__ import annotations
 
@@ -25,6 +25,18 @@ def _download_block() -> str:
     start = source.index(_START)
     end = source.index(_END, start) + len(_END)
     return source[start:end]
+
+
+def test_the_download_is_verified_as_microsoft_signed_before_it_runs():
+    # The evergreen aka.ms URL cannot be hash-pinned, so Authenticode is the only integrity
+    # check available, and it is worthless unless it happens before Start-Process.
+    block = _download_block()
+    download = block.index("Invoke-WebRequest")
+    verify = block.index("Get-AuthenticodeSignature", download)
+    execute = block.index("Start-Process", verify)
+    assert download < verify < execute
+    assert "SignatureStatus]::Valid" in block
+    assert "Microsoft Corporation" in block
 
 
 def _script(starting_protocol: str) -> str:


### PR DESCRIPTION
`Ensure-VCRedist` in `studio/setup.ps1` downloads `vc_redist.x64.exe` from `aka.ms` and hands it straight to `Start-Process` when winget is unavailable or fails. HTTPS protects the transfer, but the downloaded executable is a separate trust boundary, and nothing checked it before it ran with the privileges of the setup process.

This is the fallback that exists for LTSC and Server images, so it is a normal part of the Windows Studio install and not a rare branch.

### The fix

The evergreen URL cannot be hash-pinned the way `install.ps1` pins the uv archive: Microsoft reserves that link and reissues the payload on every servicing update, so a committed SHA-256 would break the installer on the next runtime update. Authenticode is the check that fits. Between the download and the execution, the runtime now has to present a `Valid` signature and an `O=Microsoft Corporation` signer, or it is not run.

A rejection throws into the `catch` that already wraps the download, so it stays non-fatal, deletes the temp file in the existing `finally`, and falls through to the manual-install instructions that were already there.

### Behaviour

I sliced the live block out of `setup.ps1` and ran it under `pwsh` with `Invoke-WebRequest`, `Get-AuthenticodeSignature` and `Start-Process` stubbed, so this is the shipped path rather than a paraphrase:

| Signature | Result |
| --- | --- |
| Valid, `O=Microsoft Corporation` | downloaded, verified, executed `/quiet /norestart`, `Refresh-Environment` |
| `NotSigned` | yellow substep, run continues, exit 0 |
| Valid but `O=Evil Corp` | yellow substep, run continues, exit 0 |
| `NotTrusted` | yellow substep, run continues, exit 0 |

The successful path is unchanged in ordering and side effects, and produces no new output. Nothing becomes fatal and no new prompt appears.

The publisher match was checked against the real Microsoft subject, a bare `O=Microsoft Corporation`, and the quoted `O="Microsoft Corporation"` form, and it rejects both `O=Microsoft Corporation Ltd` and a `CN=Not Microsoft Corporation, O=Attacker` lookalike.

### Notes on the two things that could have bitten

`Get-AuthenticodeSignature` lives in `Microsoft.PowerShell.Security`, which is exactly the class of cmdlet `install.ps1:31` warns stops resolving under a profile that sets `$PSModuleAutoLoadingPreference = 'None'`. `setup.ps1` runs `-NoProfile` and `install.ps1` forces `'All'`, so autoloading is live. `-LiteralPath` on that cmdlet goes back to PowerShell 3.0, so Windows PowerShell 5.1 on an old image is fine.

One behaviour does change: a host whose certificate store cannot validate Microsoft's code-signing chain now skips the automatic runtime install and shows the manual link instead. That needs automatic root update disabled by policy together with a missing Microsoft root, on a machine that just completed an HTTPS fetch from `aka.ms`. Offline CRL or OCSP alone does not trigger it, since the default WinVerifyTrust policy does not hard-fail on revocation-unavailable. Skipping is the right side to fail on here, and the path already ends on working manual instructions.

### Tests

`tests/python/test_windows_vcredist_download_tls.py` gains a test that slices the real block out of `setup.ps1` and asserts the ordering `Invoke-WebRequest` before `Get-AuthenticodeSignature` before `Start-Process`, so verification cannot drift after the execution or be dropped.

240 tests pass across the suites that touch `setup.ps1`: `test_studio_install_workspace_guard.py`, `test_installer_interactive_prompts.py`, `test_profile_startup_gate.py`, `test_installer_profile_hardening.py`, `test_windows_arm64_python_choice.py` and the vcredist file itself.
