### PR TITLE
Scope the Studio DNS-pinning opt-out to proxied fetches

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -9832,11 +9832,9 @@ class _SNIHTTPSHandler(urllib.request.HTTPSHandler):
 def _explicit_proxy_applies(url: str) -> bool:
     """Whether urllib sends *url* through an explicitly configured proxy.
 
-    Only then does the hostname have to stay in the request URL: the proxy does
-    the DNS itself and applies hostname policy / TLS interception, and this host
-    never resolves the name at connect time. Without a proxy urllib resolves it
-    again, which is exactly what DNS rebinding attacks, so the fetch stays pinned
-    to the validated IP.
+    Only then may the hostname stay in the request URL: the proxy resolves it, so
+    this host never looks it up again. Without one urllib would, which is the
+    DNS-rebinding window, so those fetches stay pinned to the validated IP.
     """
     from urllib.parse import urlparse
     from urllib.request import getproxies, proxy_bypass
@@ -9847,8 +9845,7 @@ def _explicit_proxy_applies(url: str) -> bool:
     try:
         return not proxy_bypass(parsed.hostname or "")
     except (OSError, ValueError):
-        # proxy_bypass reads system config on macOS/Windows; treat a failure as
-        # "no proxy" so the safe pinned path is what we fall back to.
+        # proxy_bypass reads system config on macOS/Windows; failure falls back to pinning.
         return False
 
 
@@ -10209,8 +10206,7 @@ def _fetch_url_raw(
                 current_url
             ):
                 # Enterprise proxies need the hostname in CONNECT for policy and TLS
-                # interception. The proxy resolves it, so this host never repeats the
-                # lookup and there is no rebinding window to close here.
+                # interception, and they resolve it, so nothing rebinds behind us.
                 request_url = urlunparse(cp._replace(netloc = validated_netloc))
             else:
                 # Pin to the validated IP to prevent DNS rebinding.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -9829,6 +9829,29 @@ class _SNIHTTPSHandler(urllib.request.HTTPSHandler):
         return _PinnedHTTPSConnection(host, sni_hostname = self._sni_hostname, **kwargs)
 
 
+def _explicit_proxy_applies(url: str) -> bool:
+    """Whether urllib sends *url* through an explicitly configured proxy.
+
+    Only then does the hostname have to stay in the request URL: the proxy does
+    the DNS itself and applies hostname policy / TLS interception, and this host
+    never resolves the name at connect time. Without a proxy urllib resolves it
+    again, which is exactly what DNS rebinding attacks, so the fetch stays pinned
+    to the validated IP.
+    """
+    from urllib.parse import urlparse
+    from urllib.request import getproxies, proxy_bypass
+
+    parsed = urlparse(url)
+    if parsed.scheme not in getproxies():
+        return False
+    try:
+        return not proxy_bypass(parsed.hostname or "")
+    except (OSError, ValueError):
+        # proxy_bypass reads system config on macOS/Windows; treat a failure as
+        # "no proxy" so the safe pinned path is what we fall back to.
+        return False
+
+
 def _validate_and_resolve_host(hostname: str, port: int) -> tuple[bool, str, str]:
     """Resolve *hostname*, reject non-public IPs, return a pinned IP string.
 
@@ -10182,8 +10205,12 @@ def _fetch_url_raw(
             validated_netloc = f"[{current_host}]" if ":" in current_host else current_host
             if cp.port:
                 validated_netloc = f"{validated_netloc}:{cp.port}"
-            if os.environ.get(_DISABLE_DNS_PINNING_ENV) == "1":
-                # Enterprise proxies need the hostname in CONNECT for policy and TLS interception.
+            if os.environ.get(_DISABLE_DNS_PINNING_ENV) == "1" and _explicit_proxy_applies(
+                current_url
+            ):
+                # Enterprise proxies need the hostname in CONNECT for policy and TLS
+                # interception. The proxy resolves it, so this host never repeats the
+                # lookup and there is no rebinding window to close here.
                 request_url = urlunparse(cp._replace(netloc = validated_netloc))
             else:
                 # Pin to the validated IP to prevent DNS rebinding.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -9829,21 +9829,23 @@ class _SNIHTTPSHandler(urllib.request.HTTPSHandler):
         return _PinnedHTTPSConnection(host, sni_hostname = self._sni_hostname, **kwargs)
 
 
-def _explicit_proxy_applies(url: str) -> bool:
-    """Whether urllib sends *url* through an explicitly configured proxy.
+def _explicit_proxy_applies(scheme: str, host: str) -> bool:
+    """Whether urllib routes a *scheme* request for *host* through a proxy.
 
-    Only then may the hostname stay in the request URL: the proxy resolves it, so
-    this host never looks it up again. Without one urllib would, which is the
-    DNS-rebinding window, so those fetches stay pinned to the validated IP.
+    Only a proxied fetch may keep the hostname in the request URL: the proxy
+    resolves it, so this host never looks it up again. A direct one would, which
+    is the DNS-rebinding window, so it stays pinned to the validated IP.
+
+    *host* must be the ``host[:port]`` form ``Request.host`` carries, since that
+    is what ``ProxyHandler`` passes to ``proxy_bypass``; probing the bare hostname
+    instead would disagree with it on a port-qualified NO_PROXY entry.
     """
-    from urllib.parse import urlparse
     from urllib.request import getproxies, proxy_bypass
 
-    parsed = urlparse(url)
-    if parsed.scheme not in getproxies():
+    if scheme not in getproxies():
         return False
     try:
-        return not proxy_bypass(parsed.hostname or "")
+        return not proxy_bypass(host)
     except (OSError, ValueError):
         # proxy_bypass reads system config on macOS/Windows; failure falls back to pinning.
         return False
@@ -10202,9 +10204,11 @@ def _fetch_url_raw(
             validated_netloc = f"[{current_host}]" if ":" in current_host else current_host
             if cp.port:
                 validated_netloc = f"{validated_netloc}:{cp.port}"
-            if os.environ.get(_DISABLE_DNS_PINNING_ENV) == "1" and _explicit_proxy_applies(
-                current_url
-            ):
+            # Decide the routing once, on the netloc urllib itself tests, then hold
+            # the opener to it: a pinned request carries an IP, which no NO_PROXY
+            # entry matches, so ProxyHandler would proxy a bypassed host.
+            proxied = _explicit_proxy_applies(cp.scheme, validated_netloc)
+            if os.environ.get(_DISABLE_DNS_PINNING_ENV) == "1" and proxied:
                 # Enterprise proxies need the hostname in CONNECT for policy and TLS
                 # interception, and they resolve it, so nothing rebinds behind us.
                 request_url = urlunparse(cp._replace(netloc = validated_netloc))
@@ -10214,10 +10218,11 @@ def _fetch_url_raw(
                 ip_netloc = f"{ip_str}:{cp.port}" if cp.port else ip_str
                 request_url = urlunparse(cp._replace(netloc = ip_netloc))
 
-            opener = urllib.request.build_opener(
-                _NoRedirect,
-                _SNIHTTPSHandler(current_host),
-            )
+            handlers = [_NoRedirect, _SNIHTTPSHandler(current_host)]
+            if not proxied:
+                # An empty ProxyHandler is the documented way to opt a request out.
+                handlers.append(urllib.request.ProxyHandler({}))
+            opener = urllib.request.build_opener(*handlers)
 
             headers = {
                 "User-Agent": ua,

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -10206,9 +10206,9 @@ def _fetch_url_raw(
             validated_netloc = f"[{current_host}]" if ":" in current_host else current_host
             if cp.port:
                 validated_netloc = f"{validated_netloc}:{cp.port}"
-            # Decide the routing once, on the netloc urllib itself tests, then hold
-            # the opener to it: a pinned request carries an IP, which no NO_PROXY
-            # entry matches, so ProxyHandler would proxy a bypassed host.
+            # Decide routing once, on the netloc urllib tests: a pinned request
+            # carries an IP, which no NO_PROXY entry matches, so the opener below
+            # has to carry the decision rather than re-derive it.
             proxied = _explicit_proxy_applies(cp.scheme, validated_netloc)
             if os.environ.get(_DISABLE_DNS_PINNING_ENV) == "1" and proxied:
                 # Enterprise proxies need the hostname in CONNECT for policy and TLS

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -9842,7 +9842,9 @@ def _explicit_proxy_applies(scheme: str, host: str) -> bool:
     """
     from urllib.request import getproxies, proxy_bypass
 
-    if scheme not in getproxies():
+    # ProxyHandler lowercases every mapping key, and the Windows registry can hand
+    # back "HTTPS=...", so normalize before testing or a proxy-only host goes direct.
+    if scheme not in {key.lower() for key in getproxies()}:
         return False
     try:
         return not proxy_bypass(host)

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2479,8 +2479,9 @@ def _build_arg_parser():
     parser.add_argument(
         "--disable-dns-pinning",
         action = "store_true",
-        help = "Allow hostname-based web fetches for enterprise proxies. WARNING: weakens "
-        "DNS-rebinding protection; hostname and redirect validation remain enabled.",
+        help = "Send the hostname (not the validated IP) in web fetches that go through an "
+        "explicitly configured HTTP(S)_PROXY, so the proxy can apply hostname policy and "
+        "TLS interception. Direct fetches stay pinned to the validated IP.",
     )
     parser.add_argument(
         "--parallel",

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -783,6 +783,81 @@ def test_fetch_url_raw_dns_pinning_proxy_opt_out(
     assert requested[0].get_header("Host") == "example.com:8443"
 
 
+@pytest.mark.parametrize(
+    "no_proxy,disable_dns_pinning,expected_url",
+    [
+        # urllib tests NO_PROXY against Request.host, so a port-qualified entry only
+        # matches with the port: probing the bare hostname would call this proxied,
+        # keep the hostname, and let the direct connect re-resolve it.
+        ("example.com:8443", True, "https://203.0.113.7:8443/page?q=1"),
+        ("example.com", True, "https://203.0.113.7:8443/page?q=1"),
+        ("other.example", True, "https://example.com:8443/page?q=1"),
+        ("example.com", False, "https://203.0.113.7:8443/page?q=1"),
+    ],
+)
+def test_fetch_url_raw_no_proxy_routing(monkeypatch, no_proxy, disable_dns_pinning, expected_url):
+    # Real getproxies/proxy_bypass here, not stubs: both read the environment first
+    # on every platform, and the point is to agree with what urllib actually does.
+    import email
+    import urllib.request
+
+    import core.inference.tools as tools_mod
+
+    class _FakeResp:
+        headers = email.message_from_string("Content-Type: text/plain\n")
+
+        def __init__(self):
+            self._body = b"ok"
+
+        def read(self, n = -1):
+            body, self._body = self._body, b""
+            return body
+
+    requested = []
+    built = []
+
+    class _FakeOpener:
+        def open(
+            self,
+            req,
+            timeout = None,
+        ):
+            requested.append(req)
+            return _FakeResp()
+
+    def fake_build_opener(*handlers):
+        built.append(handlers)
+        return _FakeOpener()
+
+    for var in ("http_proxy", "https_proxy", "no_proxy", "all_proxy", "REQUEST_METHOD"):
+        monkeypatch.delenv(var, raising = False)
+        monkeypatch.delenv(var.upper(), raising = False)
+    monkeypatch.setenv("https_proxy", "http://proxy.corp:3128")
+    monkeypatch.setenv("no_proxy", no_proxy)
+    monkeypatch.setenv("UNSLOTH_STUDIO_DISABLE_DNS_PINNING", "1" if disable_dns_pinning else "0")
+    monkeypatch.setattr(
+        tools_mod,
+        "_validate_and_resolve_host",
+        lambda host, port: (True, "", "203.0.113.7"),
+    )
+    monkeypatch.setattr(urllib.request, "build_opener", fake_build_opener)
+
+    err, body, _content_type = tools_mod._fetch_url_raw("https://example.com:8443/page?q=1")
+
+    assert err is None
+    assert body == "ok"
+    assert [req.full_url for req in requested] == [expected_url]
+    # A bypassed host keeps its direct route: the pinned IP would never match the
+    # NO_PROXY entry, so the opener has to carry the decision instead.
+    bypassed = expected_url.startswith("https://203.0.113.7")
+    empty_proxy_handlers = [
+        h
+        for h in built[0]
+        if isinstance(h, urllib.request.ProxyHandler) and not h.proxies
+    ]
+    assert bool(empty_proxy_handlers) is bypassed
+
+
 def test_fetch_url_raw_rejects_embedded_credentials(monkeypatch):
     # Credentials in the URL are blocked rather than stripped, so they can never
     # leak to a redirect target or into logs.

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -783,6 +783,61 @@ def test_fetch_url_raw_dns_pinning_proxy_opt_out(
     assert requested[0].get_header("Host") == "example.com:8443"
 
 
+def test_fetch_url_raw_proxy_scheme_key_case_insensitive(monkeypatch):
+    # A Windows registry ProxyServer value keeps the case it was written in, so
+    # getproxies can return "HTTPS". ProxyHandler lowercases its keys, so an
+    # exact-case test here would disable a proxy that urllib would have used.
+    import email
+    import urllib.request
+
+    import core.inference.tools as tools_mod
+
+    class _FakeResp:
+        headers = email.message_from_string("Content-Type: text/plain\n")
+
+        def __init__(self):
+            self._body = b"ok"
+
+        def read(self, n = -1):
+            body, self._body = self._body, b""
+            return body
+
+    requested = []
+    built = []
+
+    class _FakeOpener:
+        def open(
+            self,
+            req,
+            timeout = None,
+        ):
+            requested.append(req)
+            return _FakeResp()
+
+    monkeypatch.setenv("UNSLOTH_STUDIO_DISABLE_DNS_PINNING", "1")
+    monkeypatch.setattr(
+        tools_mod,
+        "_validate_and_resolve_host",
+        lambda host, port: (True, "", "203.0.113.7"),
+    )
+    monkeypatch.setattr(urllib.request, "getproxies", lambda: {"HTTPS": "http://proxy.corp:3128"})
+    monkeypatch.setattr(urllib.request, "proxy_bypass", lambda host: False)
+    monkeypatch.setattr(
+        urllib.request,
+        "build_opener",
+        lambda *handlers: built.append(handlers) or _FakeOpener(),
+    )
+
+    err, body, _content_type = tools_mod._fetch_url_raw("https://example.com:8443/page?q=1")
+
+    assert err is None
+    assert body == "ok"
+    assert [req.full_url for req in requested] == ["https://example.com:8443/page?q=1"]
+    assert not [
+        h for h in built[0] if isinstance(h, urllib.request.ProxyHandler) and not h.proxies
+    ]
+
+
 @pytest.mark.parametrize(
     "no_proxy,disable_dns_pinning,expected_url",
     [

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -715,13 +715,22 @@ def test_fetch_url_raw_missing_content_type_reported_empty(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "disable_dns_pinning,expected_url",
+    "disable_dns_pinning,proxied,expected_url",
     [
-        (False, "https://203.0.113.7:8443/page?q=1"),
-        (True, "https://example.com:8443/page?q=1"),
+        (False, False, "https://203.0.113.7:8443/page?q=1"),
+        (False, True, "https://203.0.113.7:8443/page?q=1"),
+        # The opt-out only applies to a proxied fetch: a direct one would resolve
+        # the hostname again, which is the DNS-rebinding hole it must not reopen.
+        (True, False, "https://203.0.113.7:8443/page?q=1"),
+        (True, True, "https://example.com:8443/page?q=1"),
     ],
 )
-def test_fetch_url_raw_dns_pinning_proxy_opt_out(monkeypatch, disable_dns_pinning, expected_url):
+def test_fetch_url_raw_dns_pinning_proxy_opt_out(
+    monkeypatch,
+    disable_dns_pinning,
+    proxied,
+    expected_url,
+):
     import email
     import urllib.request
 
@@ -757,6 +766,14 @@ def test_fetch_url_raw_dns_pinning_proxy_opt_out(monkeypatch, disable_dns_pinnin
     monkeypatch.setenv("UNSLOTH_STUDIO_DISABLE_DNS_PINNING", "1" if disable_dns_pinning else "0")
     monkeypatch.setattr(tools_mod, "_validate_and_resolve_host", resolve)
     monkeypatch.setattr(urllib.request, "build_opener", lambda *handlers: _FakeOpener())
+    # Patch the lookups rather than the env: getproxies/proxy_bypass read system
+    # settings on macOS and Windows.
+    monkeypatch.setattr(
+        urllib.request,
+        "getproxies",
+        lambda: {"https": "http://proxy.corp:3128"} if proxied else {},
+    )
+    monkeypatch.setattr(urllib.request, "proxy_bypass", lambda host: False)
 
     # No embedded credentials: the web access policy rejects those outright
     # (see test_fetch_url_raw_rejects_embedded_credentials).

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -833,9 +833,7 @@ def test_fetch_url_raw_proxy_scheme_key_case_insensitive(monkeypatch):
     assert err is None
     assert body == "ok"
     assert [req.full_url for req in requested] == ["https://example.com:8443/page?q=1"]
-    assert not [
-        h for h in built[0] if isinstance(h, urllib.request.ProxyHandler) and not h.proxies
-    ]
+    assert not [h for h in built[0] if isinstance(h, urllib.request.ProxyHandler) and not h.proxies]
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -851,9 +851,7 @@ def test_fetch_url_raw_no_proxy_routing(monkeypatch, no_proxy, disable_dns_pinni
     # NO_PROXY entry, so the opener has to carry the decision instead.
     bypassed = expected_url.startswith("https://203.0.113.7")
     empty_proxy_handlers = [
-        h
-        for h in built[0]
-        if isinstance(h, urllib.request.ProxyHandler) and not h.proxies
+        h for h in built[0] if isinstance(h, urllib.request.ProxyHandler) and not h.proxies
     ]
     assert bool(empty_proxy_handlers) is bypassed
 

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -726,10 +726,7 @@ def test_fetch_url_raw_missing_content_type_reported_empty(monkeypatch):
     ],
 )
 def test_fetch_url_raw_dns_pinning_proxy_opt_out(
-    monkeypatch,
-    disable_dns_pinning,
-    proxied,
-    expected_url,
+    monkeypatch, disable_dns_pinning, proxied, expected_url
 ):
     import email
     import urllib.request

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1407,8 +1407,9 @@ def studio_default(
     disable_dns_pinning: bool = typer.Option(
         False,
         "--disable-dns-pinning",
-        help = "Allow hostname-based web fetches for enterprise proxies. WARNING: weakens "
-        "DNS-rebinding protection; hostname and redirect validation remain enabled.",
+        help = "Send the hostname (not the validated IP) in web fetches that go through an "
+        "explicitly configured HTTP(S)_PROXY, so the proxy can apply hostname policy and "
+        "TLS interception. Direct fetches stay pinned to the validated IP.",
     ),
     password: str = typer.Option(
         "",
@@ -1926,8 +1927,9 @@ def run(
         False,
         "--disable-dns-pinning",
         rich_help_panel = _RUN_PANEL_TOOLS,
-        help = "Allow hostname-based web fetches for enterprise proxies. WARNING: weakens "
-        "DNS-rebinding protection; hostname and redirect validation remain enabled.",
+        help = "Send the hostname (not the validated IP) in web fetches that go through an "
+        "explicitly configured HTTP(S)_PROXY, so the proxy can apply hostname policy and "
+        "TLS interception. Direct fetches stay pinned to the validated IP.",
     ),
     tool_call_healing: Optional[bool] = typer.Option(
         None,


### PR DESCRIPTION
`--disable-dns-pinning` (added in #7416 for enterprise proxies) currently drops the pinned IP for every fetch, not just proxied ones. When the flag is on and there is no proxy configured, urllib resolves the hostname a second time at connect time, so a hostname that passed validation as a public address can come back as loopback, link-local or an internal address on the second lookup.

Reproduced against the current fetch path with a local DNS-rebinding harness (`getaddrinfo` returns a public IP for validation, then `127.0.0.1` for the connect), fetching a loopback-only HTTP server:

```
before  opt-out set, no proxy   dns=[93.184.216.34, 127.0.0.1]  body="REBIND_SECRET_FROM_127001"  loopback hits=1
after   opt-out set, no proxy   dns=[93.184.216.34]             body=""                           loopback hits=0
```

## Fix

Keep the flag, but apply it only where it is actually needed and where pinning is impossible anyway, which is a fetch that goes through an explicitly configured proxy:

```python
if os.environ.get(_DISABLE_DNS_PINNING_ENV) == "1" and _explicit_proxy_applies(current_url):
    request_url = urlunparse(cp._replace(netloc = validated_netloc))   # proxy resolves it
else:
    ...                                                                # pin to the validated IP
```

`_explicit_proxy_applies()` reads `urllib.request.getproxies()` / `proxy_bypass()`, the same source `ProxyHandler` builds from, and fails closed to the pinned path on any error. On a proxied fetch the name is resolved by the proxy and never by the Studio host, so there is no local rebinding window to close there.

## Behaviour

- Default (flag unset): unchanged, always pinned.
- Flag set, proxy configured: unchanged, hostname still reaches the proxy for policy and TLS interception.
- Flag set, no proxy: now pinned. This is the hole above.
- Transparent and intercepting proxies: unaffected either way, SNI and the `Host` header are still the real hostname via `_SNIHTTPSHandler`.
- Explicit HTTPS proxies keep working on the pinned path too: `_PinnedHTTPSConnection.connect()` delegates to `http.client.HTTPConnection.connect()`, which still issues the CONNECT tunnel.
- `all_proxy`-only setups are not a regression: urllib dispatches on `https_open`/`http_open` and never calls `all_open`, so those fetches were already going direct.

No frontend, API or route changes. The flag keeps its name, default and misuse errors on `unsloth studio`, `unsloth studio run` and `studio/backend/run.py`, so Desktop and scripted launches that pass it are unaffected. Only the help text changed, to describe the proxy-scoped behaviour. The check short-circuits on the env var, so there is no added cost for anyone who has not opted in (`getproxies` hits SystemConfiguration on macOS and the registry on Windows).

## Tests

`test_fetch_url_raw_dns_pinning_proxy_opt_out` now covers the full opt-out by proxied matrix, including the regression case (opt-out set, no proxy, expect the validated IP). `getproxies`/`proxy_bypass` are patched rather than the env, since both read system settings on macOS and Windows.

```
studio/backend/tests/test_web_fetch_extraction.py   1100 passed
studio/backend/tests/test_secure_tunnel_gate.py       44 passed
tests/studio/test_cli_studio_defaults.py               3 passed
```

The existing flag-registration tests in `test_secure_tunnel_gate.py` and `test_cli_studio_defaults.py` pass unmodified.

One thing worth stating: when an operator configures an explicit proxy, that proxy's DNS is trusted by definition, so split-horizon proxy DNS cannot be pinned from Studio's side in any design. That stays the operator's trust boundary.
