### PR TITLE
Desktop: stop the loopback client following redirects

### DIFF
--- a/studio/src-tauri/src/loopback_http.rs
+++ b/studio/src-tauri/src/loopback_http.rs
@@ -1,9 +1,15 @@
 use std::time::Duration;
 
+/// Redirects are refused for the same reason `streaming_client` refuses them, and it matters
+/// more here: this is the client that posts `.desktop_secret` to `/api/auth/desktop-login`.
+/// reqwest follows up to 10 redirects by default, and its cross-host protection strips headers,
+/// not bodies, so a responder answering 307 would carry the secret off-host after the loopback
+/// URL had already been checked.
 pub(crate) fn client(timeout: Duration) -> Result<reqwest::Client, reqwest::Error> {
     reqwest::Client::builder()
         .no_proxy()
         .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none())
         .build()
 }
 
@@ -75,6 +81,41 @@ mod tests {
                 .unwrap()
         });
         assert!(response.status().is_success());
+        server.join().unwrap();
+    }
+
+    /// The desktop secret rides this client to /api/auth/desktop-login. A 307
+    /// preserves the method and body, so a followed redirect would hand the
+    /// secret to whatever the Location header names. Refuse instead: the caller
+    /// sees the 307 itself and treats it as a failed login.
+    #[test]
+    fn a_redirect_is_returned_not_followed() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut discard = [0_u8; 2048];
+            let _ = stream.read(&mut discard);
+            let _ = stream.write_all(
+                b"HTTP/1.1 307 Temporary Redirect\r\nLocation: http://evil.test/collect\r\n\
+                  Content-Length: 0\r\nConnection: close\r\n\r\n",
+            );
+        });
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let response = runtime.block_on(async {
+            super::client(Duration::from_secs(2))
+                .unwrap()
+                .post(format!("http://127.0.0.1:{port}/api/auth/desktop-login"))
+                .json(&serde_json::json!({ "secret": "desktop-not-a-real-secret" }))
+                .send()
+                .await
+                .unwrap()
+        });
+
+        assert_eq!(response.status().as_u16(), 307);
+        // Still the port we dialled: nothing was re-sent anywhere else.
+        assert_eq!(response.url().port(), Some(port));
         server.join().unwrap();
     }
 }


### PR DESCRIPTION
## Motivation

`loopback_http::client` is the client the desktop app uses to post `.desktop_secret` to `/api/auth/desktop-login`. It was built with `no_proxy()` and a timeout, but no redirect policy.

reqwest follows up to 10 redirects by default. Its cross-host protection strips **headers**, not bodies, and a `307 Temporary Redirect` preserves both the method and the body. So a responder on the loopback port could answer `307` and have the desktop secret re-sent to whatever `Location` names, after the loopback URL had already been checked.

The sibling constructor in the same file already refuses redirects, with the reason written out:

> Redirects are refused so a loopback URL cannot be bounced off-host after the check.

`client` never got the same treatment, and it is the one carrying the credential.

## Fix

One line: `.redirect(reqwest::redirect::Policy::none())` on `client`, matching `streaming_client`.

No behaviour change for any real backend. Studio never redirects these routes, so nothing that works today starts failing; a redirect now surfaces to the caller as the redirect status rather than being followed.

## Tests

`a_redirect_is_returned_not_followed`: posts a desktop-login shaped body to a stub that answers `307` with an off-host `Location`, and asserts the caller gets the `307` back and the response URL is still the port we dialled, so nothing was re-sent elsewhere.

`cargo test --no-fail-fast` in `studio/src-tauri`: 230 passed. (`mutation_guard_blocks_second_external_backend_when_owned_child_is_ignored` fails on my machine because unrelated processes hold ports in the 8888-8908 scan range; it fails the same way on a clean checkout.)

## Note

This PR started as a full fix for the desktop-secret phishing finding that #8328 also targets, and has been cut back to just this redirect bug.

The rest is not worth the change. That finding needs an attacker who is a **different OS user** on the same machine: anyone running code as you can simply read `~/.unsloth/studio/auth/.desktop_secret`, which is `0600` in a `0700` directory, and no handshake helps. Studio desktop is a GUI that runs on single-user laptops and workstations, so the shared-machine case it protects is rare, and the guard needed to close it is large enough to carry its own risk.

The redirect gap is worth fixing on its own merits regardless of that argument, so that is all this PR is now.
