### PR TITLE
Studio: keep Deep Research internal calls out of the tool loop

### DIFF
--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1143,12 +1143,10 @@ class ResearchSupervisor:
             "messages": messages,
             "stream": True,
             "stream_options": {"include_usage": True},
-            # Research drives its own web/RAG gathering and never reads tool calls back,
-            # so its internal hop must not enter Studio's tool loop. Both opt-outs are
-            # needed: `unsloth run --enable-tools` sets a process-wide policy that
-            # overrides a per-request `enable_tools`, and an omitted `enabled_tools`
-            # resolves to every built-in (python/terminal included), which would let
-            # gathered untrusted page text steer the run into executing tools.
+            # Gathered page text lands in these prompts and research never reads tool calls
+            # back, so this hop must stay out of the tool loop. Both opt-outs are needed:
+            # --enable-tools overrides a per-request enable_tools, and an omitted
+            # enabled_tools resolves to every built-in, python and terminal included.
             "tool_choice": "none",
             "enabled_tools": [],
             "temperature": inference.get("temperature", 0.2),

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1143,6 +1143,14 @@ class ResearchSupervisor:
             "messages": messages,
             "stream": True,
             "stream_options": {"include_usage": True},
+            # Research drives its own web/RAG gathering and never reads tool calls back,
+            # so its internal hop must not enter Studio's tool loop. Both opt-outs are
+            # needed: `unsloth run --enable-tools` sets a process-wide policy that
+            # overrides a per-request `enable_tools`, and an omitted `enabled_tools`
+            # resolves to every built-in (python/terminal included), which would let
+            # gathered untrusted page text steer the run into executing tools.
+            "tool_choice": "none",
+            "enabled_tools": [],
             "temperature": inference.get("temperature", 0.2),
         }
         if inference.get("topP") is not None:

--- a/studio/backend/tests/test_research_internal_call_tool_gate.py
+++ b/studio/backend/tests/test_research_internal_call_tool_gate.py
@@ -3,12 +3,10 @@
 
 """Deep Research's internal hop must never enter the local tool loop.
 
-Research puts gathered web/document text into its prompts and posts them back through
-/v1/chat/completions with an internal key. `unsloth run --enable-tools` sets a process-wide
-policy that overrides a per-request `enable_tools`, and an omitted `enabled_tools` resolves
-to every built-in (python/terminal included), so without a hard opt-out an injected page
-could steer that hop into executing tools. These tests pin the opt-out at the route, where
-the decision is actually made, and pin that the opt-out costs an ordinary run nothing.
+Its prompts carry gathered web and document text and go back through /v1/chat/completions,
+where --enable-tools overrides a per-request enable_tools and an omitted enabled_tools
+resolves to every built-in, python and terminal included. These tests pin the opt-out at the
+route, where the decision is made, and pin that it costs an ordinary run nothing.
 """
 
 import json
@@ -89,8 +87,8 @@ def _entry_point(monkeypatch, *, policy, opt_out):
 
 
 def test_forced_tool_policy_would_reach_the_tool_loop_without_the_opt_out(monkeypatch):
-    # Guards the test itself: it must fail if the route ever stops forcing tools on here,
-    # otherwise the assertion below would pass for the wrong reason.
+    # Guards the test below: without this, it would pass if the route ever stopped forcing
+    # tools on here, for entirely the wrong reason.
     entry, kwargs = _entry_point(monkeypatch, policy = True, opt_out = False)
     assert entry == "tool_loop"
     assert {t["function"]["name"] for t in kwargs["tools"]} >= {"python", "terminal"}
@@ -120,9 +118,9 @@ def test_the_opt_out_changes_nothing_a_default_install_does(monkeypatch, policy)
 
 
 def test_json_mode_research_calls_send_llama_server_an_unchanged_body():
-    # The JSON-mode phases take the llama-server passthrough instead of the loop above, so
-    # pin the wire body there too: no tools means no tool_choice is forwarded at all, and
-    # Unsloth-only extensions never leak upstream.
+    # The JSON-mode phases take the llama-server passthrough, not the loop above, so pin
+    # that wire body too: no tools means no tool_choice is forwarded, and Unsloth-only
+    # extensions never leave Studio.
     from models.inference import ChatCompletionRequest
 
     class _PassthroughBackend:

--- a/studio/backend/tests/test_research_internal_call_tool_gate.py
+++ b/studio/backend/tests/test_research_internal_call_tool_gate.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Deep Research's internal hop must never enter the local tool loop.
+
+Research puts gathered web/document text into its prompts and posts them back through
+/v1/chat/completions with an internal key. `unsloth run --enable-tools` sets a process-wide
+policy that overrides a per-request `enable_tools`, and an omitted `enabled_tools` resolves
+to every built-in (python/terminal included), so without a hard opt-out an injected page
+could steer that hop into executing tools. These tests pin the opt-out at the route, where
+the decision is actually made, and pin that the opt-out costs an ordinary run nothing.
+"""
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth.authentication import get_current_subject
+import routes.inference as inference_route
+from state.tool_policy import reset_tool_policy, set_tool_policy
+
+
+@pytest.fixture(autouse = True)
+def _clean_policy():
+    reset_tool_policy()
+    yield
+    reset_tool_policy()
+
+
+class _Backend:
+    """Records which generation entry point the route picked."""
+
+    is_loaded = True
+    model_identifier = "test/model.gguf"
+    _is_audio = False
+    is_vision = False
+    supports_tools = True
+
+    def __init__(self):
+        self.calls = []
+
+    def generate_chat_completion(self, **kwargs):
+        self.calls.append(("plain", kwargs))
+        yield "the answer"
+
+    def generate_chat_completion_with_tools(self, **kwargs):
+        self.calls.append(("tool_loop", kwargs))
+        yield {"type": "content", "text": "the answer"}
+
+
+def _client(monkeypatch, backend):
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: backend)
+    app = FastAPI()
+    app.include_router(inference_route.router)
+    app.dependency_overrides[get_current_subject] = lambda: "test-user"
+    return TestClient(app)
+
+
+def _research_payload(opt_out: bool):
+    """The payload ResearchSupervisor._stream_completion builds, with the opt-out on or off."""
+    body = {
+        "model": "test/model.gguf",
+        "messages": [{"role": "user", "content": "<untrusted_web_evidence>...</untrusted_web_evidence>"}],
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": 0.2,
+        "max_tokens": 512,
+    }
+    if opt_out:
+        body["tool_choice"] = "none"
+        body["enabled_tools"] = []
+    return body
+
+
+def _entry_point(monkeypatch, *, policy, opt_out):
+    backend = _Backend()
+    if policy is not None:
+        set_tool_policy(policy)
+    response = _client(monkeypatch, backend).post(
+        "/chat/completions", json = _research_payload(opt_out)
+    )
+    assert response.status_code == 200
+    assert "the answer" in response.text
+    return backend.calls[0][0], backend.calls[0][1]
+
+
+def test_forced_tool_policy_would_reach_the_tool_loop_without_the_opt_out(monkeypatch):
+    # Guards the test itself: it must fail if the route ever stops forcing tools on here,
+    # otherwise the assertion below would pass for the wrong reason.
+    entry, kwargs = _entry_point(monkeypatch, policy = True, opt_out = False)
+    assert entry == "tool_loop"
+    assert {t["function"]["name"] for t in kwargs["tools"]} >= {"python", "terminal"}
+
+
+@pytest.mark.parametrize("policy", [None, True, False])
+def test_the_research_payload_never_enters_the_tool_loop(monkeypatch, policy):
+    entry, kwargs = _entry_point(monkeypatch, policy = policy, opt_out = True)
+    assert entry == "plain"
+    assert not kwargs.get("tools")
+
+
+@pytest.mark.parametrize("policy", [None, False])
+def test_the_opt_out_changes_nothing_a_default_install_does(monkeypatch, policy):
+    # Without --enable-tools the hop was already tool-free, so the two fields must not
+    # perturb what the model is handed: same entry point, same generation kwargs.
+    before_entry, before_kwargs = _entry_point(monkeypatch, policy = policy, opt_out = False)
+    reset_tool_policy()
+    after_entry, after_kwargs = _entry_point(monkeypatch, policy = policy, opt_out = True)
+
+    assert (before_entry, after_entry) == ("plain", "plain")
+    # cancel_event is a fresh object per request, so identity differences say nothing.
+    drop = {"cancel_event"}
+    assert {k: v for k, v in before_kwargs.items() if k not in drop} == {
+        k: v for k, v in after_kwargs.items() if k not in drop
+    }
+
+
+def test_json_mode_research_calls_send_llama_server_an_unchanged_body():
+    # The JSON-mode phases take the llama-server passthrough instead of the loop above, so
+    # pin the wire body there too: no tools means no tool_choice is forwarded at all, and
+    # Unsloth-only extensions never leak upstream.
+    from models.inference import ChatCompletionRequest
+
+    class _PassthroughBackend:
+        supports_tools = True
+        supports_tool_passthrough = True
+        markup_profile = None
+
+        def _request_reasoning_kwargs(self, enable_thinking, reasoning_effort, preserve):
+            return None
+
+    backend = _PassthroughBackend()
+    bodies = []
+    for opt_out in (False, True):
+        payload = ChatCompletionRequest(
+            **_research_payload(opt_out), response_format = {"type": "json_object"}
+        )
+        assert inference_route._takes_tool_passthrough(payload, backend) is True
+        bodies.append(inference_route._build_openai_passthrough_body(payload, llama_backend = backend))
+
+    assert bodies[0] == bodies[1]
+    assert "tool_choice" not in bodies[1] and "tools" not in bodies[1]
+    assert "enabled_tools" not in bodies[1] and "enable_tools" not in bodies[1]
+    assert json.loads(json.dumps(bodies[1]))["response_format"] == {"type": "json_object"}

--- a/studio/backend/tests/test_research_internal_call_tool_gate.py
+++ b/studio/backend/tests/test_research_internal_call_tool_gate.py
@@ -62,7 +62,9 @@ def _research_payload(opt_out: bool):
     """The payload ResearchSupervisor._stream_completion builds, with the opt-out on or off."""
     body = {
         "model": "test/model.gguf",
-        "messages": [{"role": "user", "content": "<untrusted_web_evidence>...</untrusted_web_evidence>"}],
+        "messages": [
+            {"role": "user", "content": "<untrusted_web_evidence>...</untrusted_web_evidence>"}
+        ],
         "stream": True,
         "stream_options": {"include_usage": True},
         "temperature": 0.2,
@@ -138,7 +140,9 @@ def test_json_mode_research_calls_send_llama_server_an_unchanged_body():
             **_research_payload(opt_out), response_format = {"type": "json_object"}
         )
         assert inference_route._takes_tool_passthrough(payload, backend) is True
-        bodies.append(inference_route._build_openai_passthrough_body(payload, llama_backend = backend))
+        bodies.append(
+            inference_route._build_openai_passthrough_body(payload, llama_backend = backend)
+        )
 
     assert bodies[0] == bodies[1]
     assert "tool_choice" not in bodies[1] and "tools" not in bodies[1]

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -798,10 +798,8 @@ def _run_stream(supervisor, timeout_seconds: float = 30.0) -> tuple:
 
 
 def test_stream_completion_opts_out_of_the_tool_loop(monkeypatch):
-    # Research gathers untrusted page text into its prompts, so the internal hop must not
-    # enter Studio's tool loop. `unsloth run --enable-tools` overrides a per-request
-    # `enable_tools`, and an omitted `enabled_tools` means every built-in, so the payload
-    # carries both hard opt-outs.
+    # Gathered page text lands in these prompts, and --enable-tools would otherwise
+    # override the request and expand an omitted enabled_tools to every built-in.
     sent = _install_fake_client(monkeypatch, [_response(200, body = _stream_body())])
     supervisor = _make_supervisor(_noop_check_active)
     assert _run_stream(supervisor) == ("report", "", "stop", None)

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -728,7 +728,7 @@ def _install_fake_client(monkeypatch, responses: list) -> list:
             return False
 
         def build_request(self, method, url, **kwargs):
-            return (method, url)
+            return {"method": method, "url": url, **kwargs}
 
         async def post(self, url, **kwargs):
             sent.append(url)
@@ -795,6 +795,19 @@ def _run_stream(supervisor, timeout_seconds: float = 30.0) -> tuple:
             report_progress = False,
         )
     )
+
+
+def test_stream_completion_opts_out_of_the_tool_loop(monkeypatch):
+    # Research gathers untrusted page text into its prompts, so the internal hop must not
+    # enter Studio's tool loop. `unsloth run --enable-tools` overrides a per-request
+    # `enable_tools`, and an omitted `enabled_tools` means every built-in, so the payload
+    # carries both hard opt-outs.
+    sent = _install_fake_client(monkeypatch, [_response(200, body = _stream_body())])
+    supervisor = _make_supervisor(_noop_check_active)
+    assert _run_stream(supervisor) == ("report", "", "stop", None)
+    assert len(sent) == 1
+    assert sent[0]["json"]["tool_choice"] == "none"
+    assert sent[0]["json"]["enabled_tools"] == []
 
 
 def _capture_backoff(monkeypatch) -> list:


### PR DESCRIPTION
Deep Research sends its planning, decision and synthesis prompts back through `/v1/chat/completions` with an internal API key, and those prompts carry text gathered from web pages and uploaded documents. The payload only set model, messages and sampling fields, so it never opted out of the tool loop.

On the receiving side, `_effective_enable_tools` (`routes/inference.py:2549`) lets a process-wide policy override the per-request value, and an omitted `enabled_tools` expands to every built-in (`routes/inference.py:2997`), which includes `python` and `terminal`. Under `unsloth run --enable-tools`, a prompt-injected page in the evidence set could therefore steer the research hop into executing Studio tools.

### Fix

Send both hard opt-outs on that hop:

```python
"tool_choice": "none",
"enabled_tools": [],
```

Both are needed, for different backends:

- GGUF short-circuits on `tool_choice: "none"` via `_client_disabled_tool_calls` (`routes/inference.py:11100`).
- The safetensors path resolves `_sf_tools_on` from `_effective_enable_tools` alone (`routes/inference.py:12759`) and never consults `tool_choice`, so only an empty `enabled_tools` closes it there.

All six model calls in `research_runs.py` funnel through the single `_stream_completion` payload builder, and the module has one HTTP client, so this covers every Deep Research hop.

### Why this cannot break a research run

Deep Research drives its own web and RAG gathering and never reads tool calls back (no `tool_calls` handling anywhere in `research_runs.py`), so this only removes a path it could not use.

It also fixes a stall under `--enable-tools`. The hop previously entered the loop with the confirm gate engaged: the payload sets no `permission_mode` and no `confirm_tool_calls`, so `_permission_mode_confirm` falls back to `bool(stream)` and returns `True` (`routes/inference.py:2621`). Nothing on the research side answers a confirmation, which is the case `routes/inference.py:2664-2667` already warns about.

On a default install there is no behaviour change at all. Driving the real route with the exact research payload across tool policy unset / `True` / `False`, and across the plain, thinking-on, thinking-off and `top_p` variants, the generation kwargs handed to the backend are identical with and without the two fields. The JSON-mode phases do not use that path: they take the llama-server passthrough, where the emitted body is also identical, because `_build_passthrough_payload` only writes `tool_choice` alongside a surviving tool catalog (`routes/inference.py:18264-18273`) and `enabled_tools` is an Unsloth-only extension that never leaves Studio. Passthrough routing (`_takes_tool_passthrough`) is unchanged either way.

No frontend change. The research UI never sends tool flags, and `routes/research_runs.py:177-181` already rejects `tools` and `enabledTools` in a run config.

### Tests

- `tests/test_research_runs_hardening.py`: the internal payload carries both opt-outs. Reverting the source change makes it fail.
- `tests/test_research_internal_call_tool_gate.py` (new): pins the decision at the route, where it is actually made. It asserts the research payload never enters the tool loop under any policy, that the JSON-mode passthrough body is unchanged, and that the generation kwargs on a default install are unaffected. It also carries a guard test that fails if the route ever stops forcing tools on, so the main assertion cannot pass for the wrong reason.

578 tests pass across the four research suites plus `test_gguf_tool_non_streaming`, `test_openai_tool_passthrough` and `test_sf_client_tools_passthrough`.
