### PR TITLE
Point the remote-connection contract test at the current call sites

### DIFF
--- a/tests/studio/test_remote_connection_models_contract.py
+++ b/tests/studio/test_remote_connection_models_contract.py
@@ -10,7 +10,8 @@ REPO = Path(__file__).resolve().parents[2]
 FRONTEND = REPO / "studio/frontend/src"
 PROVIDERS_API = FRONTEND / "features/chat/api/providers-api.ts"
 SYNC_PROVIDERS = FRONTEND / "features/chat/sync-external-providers.ts"
-CHAT_PAGE = FRONTEND / "features/chat/chat-page.tsx"
+CREDENTIAL_BOOTSTRAP = FRONTEND / "features/credentials/bootstrap.ts"
+APP_ROOT = FRONTEND / "app/routes/__root.tsx"
 PROVIDERS_DB = REPO / "studio/backend/storage/providers_db.py"
 PROVIDERS_MODELS = REPO / "studio/backend/models/providers.py"
 
@@ -39,7 +40,9 @@ def test_frontend_sync_backfills_local_models_to_backend():
     source = SYNC_PROVIDERS.read_text(encoding = "utf-8")
     assert "updateProviderConfig" in source
     assert "needsModelBackfill" in source
-    assert "Promise.allSettled(backfillTasks)" in source
+    # settleTasksIfCurrent is the Promise.allSettled this used to inline (#8299); it
+    # additionally drops the writes when the auth session has moved on.
+    assert "settleTasksIfCurrent(backfillTasks" in source
 
 
 def test_frontend_sync_preserves_local_provider_options():
@@ -49,10 +52,13 @@ def test_frontend_sync_preserves_local_provider_options():
     assert "openaiContainerTtlMinutes" in source
 
 
-def test_chat_page_hydrates_connections_on_startup():
-    source = CHAT_PAGE.read_text(encoding = "utf-8")
+def test_app_hydrates_connections_on_startup():
+    # #8299 moved startup hydration off the chat page into the credential bootstrap,
+    # which the app root runs before releasing content.
+    source = CREDENTIAL_BOOTSTRAP.read_text(encoding = "utf-8")
     assert "syncExternalProvidersFromBackend" in source
-    assert "await hydratePersistedSettings()" in source
+    assert "runCredentialBootstrap" in source
+    assert "bootstrapPersistedCredentials" in APP_ROOT.read_text(encoding = "utf-8")
 
 
 def test_providers_api_sends_models_to_backend():


### PR DESCRIPTION
`tests/studio/test_remote_connection_models_contract.py` has two static assertions that grep the frontend for literals #8299 refactored away, so `Repo tests (CPU)` has been red on `main` for every PR since:

```
FAILED test_frontend_sync_backfills_local_models_to_backend
  assert 'Promise.allSettled(backfillTasks)' in ...
FAILED test_chat_page_hydrates_connections_on_startup
  assert 'syncExternalProvidersFromBackend' in ...
```

Both behaviours are intact, only their call sites moved:

- `sync-external-providers.ts` now calls `settleTasksIfCurrent(backfillTasks, isCurrent)`, which is the same `Promise.allSettled` plus a check that the auth session has not moved on.
- startup hydration left `chat-page.tsx` for `features/credentials/bootstrap.ts`, which `app/routes/__root.tsx` runs before releasing content.

This retargets the assertions without weakening them: the backfill still has to be settled, the bootstrap still has to sync providers from the backend, and the root still has to invoke it. Deleting the `settleTasksIfCurrent(backfillTasks, isCurrent)` line still turns the first test red, so it keeps its teeth.

Test only, no product code touched. `python -m pytest tests/studio/test_remote_connection_models_contract.py -q` gives 7 passed.
