### PR TITLE
Hide loaded models card on chat

### DIFF
--- a/studio/frontend/src/features/loaded-models/loaded-models-indicator.tsx
+++ b/studio/frontend/src/features/loaded-models/loaded-models-indicator.tsx
@@ -61,9 +61,12 @@ const KIND_ICONS: Record<LoadedModelKind, typeof SparkleIcon> = {
   stt: Mic01Icon,
 };
 
-// Nothing to report on the auth and onboarding screens. Desktop auto-authenticates,
-// so only the browser needs the token check: polling before one exists is all 401s.
+// Chat already exposes the selected model and its eject action, so repeating the
+// global card there adds noise. Nothing is shown on auth/onboarding screens either.
+// Desktop auto-authenticates, so only the browser needs the token check: polling
+// before one exists is all 401s.
 const HIDDEN_ROUTES = new Set([
+  "/chat",
   "/login",
   "/signup",
   "/change-password",

--- a/studio/frontend/tests/loaded-models-dismiss.test.ts
+++ b/studio/frontend/tests/loaded-models-dismiss.test.ts
@@ -209,3 +209,18 @@ test("recording follows the route and auth gate, but not the dismissal", () => {
   // And dismissal stays out of it, or a closed card could never reopen itself.
   assert.doesNotMatch(call, /dismissed/);
 });
+
+test("chat hides the redundant global card", () => {
+  const indicator = readFileSync(
+    new URL(
+      "../src/features/loaded-models/loaded-models-indicator.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(
+    indicator,
+    /const HIDDEN_ROUTES = new Set\(\[[\s\S]*?"\/chat"/,
+    "chat already has model selection and eject controls",
+  );
+});

--- a/tests/studio/playwright_loaded_models_indicator.py
+++ b/tests/studio/playwright_loaded_models_indicator.py
@@ -381,9 +381,7 @@ def run(page, state: Runtime) -> None:
         "new chat hides the redundant loaded-models card",
         page.locator(CARD).count() == 0,
     )
-    page.screenshot(
-        path = str(ART / f"chat-active-1920x411-{PLAYWRIGHT_BROWSER}.png")
-    )
+    page.screenshot(path = str(ART / f"chat-active-1920x411-{PLAYWRIGHT_BROWSER}.png"))
     page.goto(
         BASE + "/chat?thread=loaded-models-regression",
         wait_until = "domcontentloaded",

--- a/tests/studio/playwright_loaded_models_indicator.py
+++ b/tests/studio/playwright_loaded_models_indicator.py
@@ -236,7 +236,7 @@ def boot(
     show: bool = True,
 ) -> None:
     """Reload with a known localStorage, then wait for the card to settle."""
-    page.goto(BASE, wait_until = "domcontentloaded")
+    page.goto(BASE + "/hub", wait_until = "domcontentloaded")
     # The indicator ships off, so every check that wants the card has to switch
     # it on. Pass show = False to exercise the default.
     seeded = dict(seed or {})
@@ -356,6 +356,46 @@ def run(page, state: Runtime) -> None:
     text = card_text(page)
     check("chat row names its quant", "Q4_K_M" in text)
     check("dictation row is distinguished", "Dictation" in text)
+
+    # Keep the visual regression focused on the reported chat-model card. The
+    # dictation runtime above is deliberately synthetic coverage for the
+    # multi-runtime list and should not imply that STT is always resident.
+    state.stt = json.loads(json.dumps(NOTHING_STT))
+    boot(page, state)
+    page.wait_for_selector(CARD, timeout = 30_000)
+    check(
+        "visual fixture contains only the chat runtime",
+        len(rows(page)) == 1,
+        str(rows(page)),
+    )
+
+    # Chat already owns model selection and eject controls. The persistent
+    # global card only repeats those controls and adds noise to the conversation
+    # surface, so it is hidden for both a new chat and a selected thread. Keep a
+    # stable screenshot for before/after visual review.
+    layout_viewport = {"width": 1920, "height": 411}
+    page.set_viewport_size(layout_viewport)
+    page.goto(BASE + "/chat", wait_until = "domcontentloaded")
+    page.wait_for_timeout(1500)
+    check(
+        "new chat hides the redundant loaded-models card",
+        page.locator(CARD).count() == 0,
+    )
+    page.screenshot(
+        path = str(ART / f"chat-active-1920x411-{PLAYWRIGHT_BROWSER}.png")
+    )
+    page.goto(
+        BASE + "/chat?thread=loaded-models-regression",
+        wait_until = "domcontentloaded",
+    )
+    page.wait_for_timeout(500)
+    check(
+        "selected chat hides the redundant loaded-models card",
+        page.locator(CARD).count() == 0,
+    )
+    page.set_viewport_size({"width": 1440, "height": 900})
+    page.goto(BASE + "/hub", wait_until = "domcontentloaded")
+    page.wait_for_selector(CARD, timeout = 30_000)
 
     # The card mounts from the root, so it must survive a route change.
     for route in ("/hub", "/train", "/images"):


### PR DESCRIPTION
## Summary

- hide the global Loaded models card on new and selected chat routes
- retain the card on Hub, Train, Images, and other non-chat surfaces
- add static and Playwright regression coverage, including a stable chat screenshot

## Why

Chat already exposes the selected model and eject controls, so the global card duplicates controls and adds unnecessary visual noise.

## Validation

- `npm test` — 1,600/1,600 passed
- `npm run typecheck`
- `npm run build`
- loaded-models unit regression — 15/15 passed after rebase
- Chromium loaded-models Playwright suite — 41/41 passed after rebase

The Playwright suite covers new chat, selected threads, non-chat route visibility, runtime variants, partial failures, positioning, drag/collapse behavior, eject behavior, and polling preferences.
