### PR TITLE
Document why resumed Hermes one-shots re-add --yolo and --accept-hooks

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -485,6 +485,14 @@ def _hermes_resume_oneshot_args(args: list[str]) -> list[str]:
             raise typer.BadParameter(
                 "Hermes cannot resume a one-shot session with --usage-file; remove that option."
             )
+        # `chat -Q -q` is the only mode that can resume a session, but it does not
+        # inherit hermes' one-shot approval semantics: `-z` itself sets
+        # HERMES_YOLO_MODE=1 and HERMES_ACCEPT_HOOKS=1 for the call (hermes_cli/
+        # oneshot.py in _HERMES_INSTALL_COMMIT), because a one-shot has no user at
+        # the terminal to answer a prompt. Re-add the equivalent flags so a resumed `-z` keeps behaving like a
+        # plain `-z` instead of stalling on an approval nobody can answer. This is
+        # parity with the flag the user already typed, not the --yolo option: a
+        # resumed *interactive* session still prompts as usual.
         prefix = ["chat", "-Q"]
         if "--yolo" not in rewritten:
             prefix.append("--yolo")


### PR DESCRIPTION
Comment only, no behaviour change.

`_hermes_resume_oneshot_args` rewrites a resumed one-shot (`unsloth start hermes --resume <id> -z '<prompt>'`) into `hermes chat -Q -q ...`, since `chat` is the only mode that can resume a session, and then re-adds `--yolo` and `--accept-hooks` if they are not already there. Read from the Unsloth side alone that looks like it is quietly bypassing our own `--yolo` opt-in, and it has now been flagged as such more than once.

It is not. Hermes' `-z/--oneshot` is not an approval-gated mode in the first place. Against the commit we pin in `_HERMES_INSTALL_COMMIT` (`NousResearch/hermes-agent@f1af945`):

- `hermes_cli/oneshot.py` sets `HERMES_YOLO_MODE=1` and `HERMES_ACCEPT_HOOKS=1` unconditionally before running the agent, with the comment "Auto-approve any shell / tool approvals. Non-interactive by definition, a prompt would hang forever". The module docstring says "Approvals = auto-bypassed".
- The `-z` help text in `hermes_cli/_parser.py` says the same thing: "approvals are auto-bypassed. Intended for scripts / pipes."
- `--yolo` and `--accept-hooks` are exactly the flag forms of those two env vars.
- `chat -q` runs through `cli.py`, which sets `HERMES_INTERACTIVE=1`, so it prompts.

So the two flags restore what the user's own `-z` already implied, and dropping them would leave a scripted resume sitting on an approval prompt that the one-shot contract says nobody is there to answer. Hermes' own kanban dispatcher spawns workers the same way, `--accept-hooks ... chat -q ... -Q` in `hermes_cli/kanban_db.py`.

Nothing here changes a resumed interactive session, which still prompts as usual, and a plain `unsloth start hermes -z '<prompt>'` without `--resume` still gets no `--yolo` from us. Added the comment so the reasoning lives next to the code instead of being re-derived from upstream each time.

`unsloth_cli/tests/test_start.py`: 497 passed, 3 skipped.
