### PR TITLE
Move the Video, Train and Audio actions into the same in-flow footer

### DIFF
--- a/studio/frontend/src/features/audio/audio-page.tsx
+++ b/studio/frontend/src/features/audio/audio-page.tsx
@@ -1901,12 +1901,12 @@ export function AudioPage({ active = true }: { active?: boolean }) {
       {/* Below 50rem the panes stack and the page scrolls as one column, matching Images and
           Video: side by side, the 408px rail plus a usable preview needs more width than that. */}
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden pl-2 pr-5 pt-9 sm:pr-8 @[50rem]:flex-row @[50rem]:overflow-hidden">
-        <div className="relative flex w-full shrink-0 flex-col border-b border-border/60 pl-8 @[50rem]:w-[408px] @[50rem]:overflow-hidden @[50rem]:border-r @[50rem]:border-b-0">
+        <div className="flex w-full shrink-0 flex-col border-b border-border/60 pl-8 @[50rem]:w-[408px] @[50rem]:overflow-hidden @[50rem]:border-r @[50rem]:border-b-0">
           <div
             ref={attachSettingsScroll}
             onScroll={onSettingsScroll}
             className={cn(
-              "hover-scrollbar panel-scroll-fade flex min-h-0 flex-1 flex-col gap-4 pb-20 pl-0.5 pr-8 @[50rem]:overflow-y-auto",
+              "hover-scrollbar panel-scroll-fade-action flex min-h-0 flex-1 flex-col gap-4 pb-6 pl-0.5 pr-8 @[50rem]:overflow-y-auto",
               settingsFadeClass,
             )}
           >
@@ -2034,9 +2034,10 @@ export function AudioPage({ active = true }: { active?: boolean }) {
             )}
           </div>
           {mode === "speak" ? (
-            <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-7 pl-8 pr-8">
+            /* The scroll mask provides the fade; leave the footer unpainted to avoid dark-mode banding. */
+            <div className="relative z-10 flex shrink-0 justify-center pt-0.5 pb-4 pl-8 pr-8">
               <Button
-                className="btn-float-action pointer-events-auto h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
+                className="relative z-10 h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
                 onClick={
                   busy === "generating" ? handleStopGeneration : handleGenerate
                 }

--- a/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
+++ b/studio/frontend/src/features/images/train/diffusion-train-panel.tsx
@@ -1483,16 +1483,13 @@ export function DiffusionTrainPanel({
   return (
     <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden pr-5 sm:pr-8 @[50rem]:flex-row @[50rem]:overflow-hidden">
       {/* Left: configure. The 408px rail and container breakpoint match Create and the shared header. */}
-      <div className="relative flex w-full min-w-0 shrink-0 flex-col border-b border-border/60 pl-10 @[50rem]:w-[408px] @[50rem]:overflow-hidden @[50rem]:border-r @[50rem]:border-b-0">
+      <div className="flex w-full min-w-0 shrink-0 flex-col border-b border-border/60 pl-10 @[50rem]:w-[408px] @[50rem]:overflow-hidden @[50rem]:border-r @[50rem]:border-b-0">
         {/* Keep the former row-level top inset inside the pane so the divider reaches the header. */}
         <div
           ref={attachSettingsScroll}
           onScroll={onSettingsScroll}
           className={cn(
-            // pb-20 at every width: the floating Start training button below is absolutely
-            // positioned over this rail and stands 72px tall (h-11 + pb-7), so a smaller
-            // phone padding puts it on top of the Adapter name field.
-            "hover-scrollbar panel-scroll-fade flex min-h-0 flex-1 flex-col gap-5 overflow-x-hidden pb-20 pl-0.5 pr-8 pt-[42px] @[50rem]:overflow-y-auto",
+            "hover-scrollbar panel-scroll-fade-action flex min-h-0 flex-1 flex-col gap-5 overflow-x-hidden pb-6 pl-0.5 pr-8 pt-[42px] @[50rem]:overflow-y-auto",
             settingsFadeClass,
           )}
         >
@@ -1826,12 +1823,13 @@ export function DiffusionTrainPanel({
           </div>
 
         </div>
-        {/* Floats over the settings, as Create's Generate does.
+        {/* In its own footer, as Create's Generate is. The scroll mask provides the fade,
+            so the footer stays unpainted to avoid dark-mode banding.
             Stop lives in the run card next to the live stats. */}
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-7 pl-8 pr-8">
+        <div className="relative z-10 flex shrink-0 justify-center pt-0.5 pb-4 pl-8 pr-8">
           <Button
             type="button"
-            className="btn-float-action pointer-events-auto h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
+            className="relative z-10 h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
             onClick={onStart}
             disabled={starting || uploading || running || familyUntrainable}
           >

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -2967,16 +2967,13 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           letting a wide row pan the page sideways on a phone. */}
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden pl-2 pr-5 pt-9 sm:pr-8 md:flex-row md:overflow-hidden">
         {/* Widened by the pl-8 so the controls keep their old width. */}
-        <div className="relative flex w-full shrink-0 flex-col border-b border-border/60 pl-8 md:w-[400px] md:overflow-hidden md:border-r md:border-b-0">
+        <div className="flex w-full shrink-0 flex-col border-b border-border/60 pl-8 md:w-[400px] md:overflow-hidden md:border-r md:border-b-0">
           {/* pl-0.5 keeps focus rings off the scroll container's edge. */}
           <div
             ref={attachSettingsScroll}
             onScroll={onSettingsScroll}
             className={cn(
-              // pb-20 at every width: the floating Generate button below is absolutely
-              // positioned over this rail and stands 72px tall (h-11 + pb-7), so a smaller
-              // phone padding puts it on top of the last control.
-              "hover-scrollbar panel-scroll-fade flex min-h-0 flex-1 flex-col gap-4 pb-20 pl-0.5 pr-7 md:overflow-y-auto",
+              "hover-scrollbar panel-scroll-fade-action flex min-h-0 flex-1 flex-col gap-4 pb-6 pl-0.5 pr-7 md:overflow-y-auto",
               settingsFadeClass,
             )}
           >
@@ -3328,12 +3325,12 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           </AdvancedDisclosure>
 
           </div>
-          {/* Floats over the settings so it needs no bar of its own. */}
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-7 pl-8 pr-7">
+          {/* The scroll mask provides the fade; leave the footer unpainted to avoid dark-mode banding. */}
+          <div className="relative z-10 flex shrink-0 justify-center pt-0.5 pb-4 pl-8 pr-7">
             {busy === "generating" ? (
               <Button
-                // Opaque hover: this one floats over the settings too.
-                className="pointer-events-auto h-11 px-8 hover:bg-muted dark:hover:bg-muted"
+                // Kept in step with the Images Stop control, which uses the same fill.
+                className="relative z-10 h-11 px-8 hover:bg-muted dark:hover:bg-muted"
                 variant="outline"
                 onClick={handleCancelGenerate}
               >
@@ -3342,7 +3339,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
               </Button>
             ) : (
               <Button
-                className="btn-float-action pointer-events-auto h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
+                className="relative z-10 h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
                 onClick={handleGenerate}
                 disabled={busy !== null || !status?.loaded}
               >

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1376,17 +1376,6 @@ html[data-chat-font] .aui-root {
 		pointer-events: auto;
 	}
 
-	/* The Create / Train action floats over its settings, so hover must lighten the fill
-	   rather than thin it: a translucent green would show the controls behind it. Mixes to
-	   what bg-primary/80 looks like on the page, but stays opaque. */
-	.btn-float-action:hover:not(:disabled) {
-		background-color: color-mix(
-			in srgb,
-			var(--primary) 80%,
-			var(--background)
-		) !important;
-	}
-
 	/* Inline numeric input — used for slider values and Context Length.
 	   Designed to read as *editable text* rather than a pill button so
 	   it doesn't mirror the Select/dropdown components on the panel.


### PR DESCRIPTION
Follow-on to #8411, which moved the Images Create action out of an absolute overlay into an in-flow footer. Video's Generate, Train's Start training and the Audio page's Generate were left floating over their rails, so the four panels currently disagree and three of them keep the behaviour #8411 fixed.

## Why

The 80px bottom padding on each rail was sized so the floating button clears the *last* control at full scroll. That is the one scroll position where the old layout looks correct; anything passing under the button mid-scroll is covered. Sweeping scroll positions and counting interactive controls whose visible box intersects the action button, on the pre-8411 tree:

| surface | 1440x900 | 1440x620 |
| --- | --- | --- |
| Images Create (fixed by #8411) | 1 | 3 (Width, Width presets, Height, at 30% scroll) |
| Images Train | 1 | 1 |
| Video | 1 (Seed) | 1 (a resolution preset) |
| Audio | 0 | 0 |

![The Generate action covering the Resolution row](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/pr-assets-8411/pr-assets/8411/generate-overlap-1440x620.png)

Left is the old layout on Images Create: `1024` and the truncated `24` sit either side of the button covering the row between them. Video and Train do the same thing today.

## What changes

Per panel, the same shape #8411 used on Create: the action leaves the absolute overlay for a `shrink-0` footer, the rail drops to `pb-6` and takes `panel-scroll-fade-action` so its content dissolves into the footer, and the column stops being a positioning context (the action wrapper was its only absolutely positioned descendant in each case).

Two notes:

- **Audio measured zero occluded controls here**, so it is included for consistency rather than a reproduced fault. It has to be in this commit regardless: it was the last user of `btn-float-action`, and dropping that rule while Audio still floated would have broken its hover.
- **`btn-float-action` is removed.** It existed to keep the hover fill opaque over the controls behind it. Nothing floats over controls now, and the first painted ancestor behind each footer measures `rgb(24, 24, 24)`, which is `--background`, so the default translucent `hover:bg-primary/80` composites to exactly the colour `color-mix(in srgb, primary 80%, background)` produced.

## Validation

Two isolated installs driven over [Chromium, Firefox, WebKit] x [1440x900, 1440x620] x [Images Create, Images Train, Video, Audio], 48 cells, no errors:

| check | before | after |
| --- | --- | --- |
| controls under the action | 1-3 per panel | 0 everywhere |
| action `position` | `absolute` | `relative` |
| rail `padding-bottom` | 80px | 24px |
| blocked hit tests at the bottom of the rail | 0 | 0 |

The hit test is `elementFromPoint` at the centre of every fully visible control at full scroll, so this does not trade an occluded control for an unclickable one.

`npm run typecheck` clean, 1946/1946 frontend tests pass, and per-file eslint counts are unchanged (audio 14, video 29, train 7).

## Left alone

`.panel-scroll-fade` now has no consumers, since all four rails use `.panel-scroll-fade-action`. Its doc comment in `use-scroll-fades.ts` is still accurate, so pruning a shared utility belongs in its own change rather than here.