### PR TITLE
Studio: keep prose that documents call:NAME{...} in the answer

### DIFF
--- a/studio/backend/core/inference/tool_call_parser.py
+++ b/studio/backend/core/inference/tool_call_parser.py
@@ -495,22 +495,18 @@ def _strip_mistral_closed_calls(text: str) -> str:
     return "".join(out)
 
 
-# Reasoning closers a real call may follow directly: the display strips run per segment
-# after ``strip_outside_think``, so ``</think>call:NAME{..}`` starts its segment.
+# A real call may follow a reasoning close directly: the strips run per segment after
+# ``strip_outside_think``, so ``</think>call:NAME{..}`` starts its segment.
 _GEMMA_ANCHOR_CLOSERS = ("</think>", "[/THINK]", "</thinking>")
 
 
 def _gemma_call_is_anchored(text: str, start: int, floor: int) -> bool:
-    """Whether a markerless ``call:NAME{...}`` at ``start`` OWNS its position.
-
-    A call owns its position when only horizontal whitespace separates it from
-    ``floor`` (the scan origin: content start, past a leading JSON answer, or past
-    the previously stripped call), from the start of its line, or from a reasoning
-    close. Anywhere else the shape is a sentence documenting the syntax -- the model
-    said it mid-prose -- so the DISPLAY strip keeps it rather than deleting the
-    user's answer around it. The parser is deliberately not gated this way: it still
-    promotes an unanchored call, so a call the loop executes stays visible instead of
-    being silently erased from the response."""
+    """Whether a markerless ``call:NAME{...}`` at ``start`` OWNS its position: only
+    horizontal whitespace between it and ``floor`` (the scan origin), the start of its
+    line, or a reasoning close. Anywhere else it reads as a sentence documenting the
+    syntax, so the DISPLAY strip keeps it. The parser is deliberately NOT gated this
+    way, so a call it promotes mid-prose stays visible instead of the answer being
+    deleted around it."""
     i = start - 1
     while i >= floor and text[i] in " \t\r":
         i -= 1
@@ -523,8 +519,7 @@ def _strip_gemma_wrapperless_calls(text: str, enabled_tool_names: Optional[set] 
     """Strip closed wrapper-less Gemma ``call:NAME{...}`` calls with balanced brace
     scanning (nested arguments are removed whole). ``enabled_tool_names`` gates the
     strip like the parser gate: a disabled/example name stays visible; ``None``
-    strips every closed call. An UNANCHORED call (mid-sentence, see
-    ``_gemma_call_is_anchored``) is prose too and is kept whole."""
+    strips every closed call. An unanchored (mid-sentence) call is prose too."""
     if _whole_content_is_json_value(text):
         return text
     n = len(text)
@@ -533,8 +528,8 @@ def _strip_gemma_wrapperless_calls(text: str, enabled_tool_names: Optional[set] 
     cursor = _leading_json_value_end(text) or 0
     if cursor:
         out.append(text[:cursor])
-    # Anchor floor: the scan origin, then the end of each call this strip removed, so
-    # ``call:a{} call:b{}`` stays one span pair while prose after a call does not.
+    # Anchor origin, advanced only past calls this strip removed, so ``call:a{} call:b{}``
+    # stays a pair while prose after a call does not inherit its anchor.
     floor = cursor
     while cursor < n:
         m = _GEMMA_BARE_TC_RE.search(text, cursor)
@@ -550,12 +545,11 @@ def _strip_gemma_wrapperless_calls(text: str, enabled_tool_names: Optional[set] 
         closed = end is not None
         next_index = (end + 1) if closed else len(text)
         if not closed:
-            # Unclosed call: drop an anchored enabled call to EOS; keep prose (a
-            # disabled/example name, or a mid-sentence shape) as written.
+            # Unclosed: drop an anchored enabled call to EOS, keep prose as written.
             out.append(text[cursor:] if keep else text[cursor : m.start()])
             break
         if keep:
-            # Prose, not a call: keep it whole.
+            # Prose, not a call.
             out.append(text[cursor:next_index])
         else:
             out.append(text[cursor : m.start()])

--- a/studio/backend/core/inference/tool_call_parser.py
+++ b/studio/backend/core/inference/tool_call_parser.py
@@ -495,11 +495,36 @@ def _strip_mistral_closed_calls(text: str) -> str:
     return "".join(out)
 
 
+# Reasoning closers a real call may follow directly: the display strips run per segment
+# after ``strip_outside_think``, so ``</think>call:NAME{..}`` starts its segment.
+_GEMMA_ANCHOR_CLOSERS = ("</think>", "[/THINK]", "</thinking>")
+
+
+def _gemma_call_is_anchored(text: str, start: int, floor: int) -> bool:
+    """Whether a markerless ``call:NAME{...}`` at ``start`` OWNS its position.
+
+    A call owns its position when only horizontal whitespace separates it from
+    ``floor`` (the scan origin: content start, past a leading JSON answer, or past
+    the previously stripped call), from the start of its line, or from a reasoning
+    close. Anywhere else the shape is a sentence documenting the syntax -- the model
+    said it mid-prose -- so the DISPLAY strip keeps it rather than deleting the
+    user's answer around it. The parser is deliberately not gated this way: it still
+    promotes an unanchored call, so a call the loop executes stays visible instead of
+    being silently erased from the response."""
+    i = start - 1
+    while i >= floor and text[i] in " \t\r":
+        i -= 1
+    if i < floor or text[i] == "\n":
+        return True
+    return any(text.endswith(closer, floor, i + 1) for closer in _GEMMA_ANCHOR_CLOSERS)
+
+
 def _strip_gemma_wrapperless_calls(text: str, enabled_tool_names: Optional[set] = None) -> str:
     """Strip closed wrapper-less Gemma ``call:NAME{...}`` calls with balanced brace
     scanning (nested arguments are removed whole). ``enabled_tool_names`` gates the
     strip like the parser gate: a disabled/example name stays visible; ``None``
-    strips every closed call."""
+    strips every closed call. An UNANCHORED call (mid-sentence, see
+    ``_gemma_call_is_anchored``) is prose too and is kept whole."""
     if _whole_content_is_json_value(text):
         return text
     n = len(text)
@@ -508,26 +533,33 @@ def _strip_gemma_wrapperless_calls(text: str, enabled_tool_names: Optional[set] 
     cursor = _leading_json_value_end(text) or 0
     if cursor:
         out.append(text[:cursor])
+    # Anchor floor: the scan origin, then the end of each call this strip removed, so
+    # ``call:a{} call:b{}`` stays one span pair while prose after a call does not.
+    floor = cursor
     while cursor < n:
         m = _GEMMA_BARE_TC_RE.search(text, cursor)
         if not m:
             out.append(text[cursor:])
             break
-        disabled = enabled_tool_names is not None and m.group(1) not in enabled_tool_names
+        keep = (enabled_tool_names is not None and m.group(1) not in enabled_tool_names) or (
+            not _gemma_call_is_anchored(text, m.start(), floor)
+        )
         brace = m.end() - 1  # _GEMMA_BARE_TC_RE consumes through the opening ``{``
         # Same boundary scanner as the parser: strip exactly what it consumed.
         end = _gemma_body_brace_end(text, brace)
         closed = end is not None
         next_index = (end + 1) if closed else len(text)
         if not closed:
-            # Unclosed call: drop an enabled call to EOS; keep a disabled/example name as prose.
-            out.append(text[cursor:] if disabled else text[cursor : m.start()])
+            # Unclosed call: drop an anchored enabled call to EOS; keep prose (a
+            # disabled/example name, or a mid-sentence shape) as written.
+            out.append(text[cursor:] if keep else text[cursor : m.start()])
             break
-        if disabled:
-            # Disabled/example name is prose: keep it whole.
+        if keep:
+            # Prose, not a call: keep it whole.
             out.append(text[cursor:next_index])
         else:
             out.append(text[cursor : m.start()])
+            floor = next_index
         cursor = next_index  # already past the matching ``}``
     return "".join(out)
 

--- a/studio/backend/tests/test_gemma_tool_parse_edge_cases.py
+++ b/studio/backend/tests/test_gemma_tool_parse_edge_cases.py
@@ -411,9 +411,8 @@ def test_malformed_gemma_mapping_value_does_not_hang():
     assert not t.is_alive(), "parse_tool_calls_from_text hung on malformed mapping input"
 
 
-# ── Wrapper-less ``call:NAME{...}``: the display strip only removes a call that
-# OWNS its position. The parser is deliberately unchanged, so an executed call is
-# never erased from the answer while a sentence about the syntax survives intact.
+# ── Wrapper-less ``call:NAME{...}``: the display strip removes only a call that OWNS
+# its position. The parser is unchanged, so a promoted call is never erased silently.
 
 
 def _strip(text: str, enabled = None) -> str:

--- a/studio/backend/tests/test_gemma_tool_parse_edge_cases.py
+++ b/studio/backend/tests/test_gemma_tool_parse_edge_cases.py
@@ -418,7 +418,6 @@ def test_malformed_gemma_mapping_value_does_not_hang():
 
 def _strip(text: str, enabled = None) -> str:
     from core.inference.tool_call_parser import strip_tool_markup
-
     return strip_tool_markup(text, final = True, enabled_tool_names = enabled)
 
 

--- a/studio/backend/tests/test_gemma_tool_parse_edge_cases.py
+++ b/studio/backend/tests/test_gemma_tool_parse_edge_cases.py
@@ -409,3 +409,58 @@ def test_malformed_gemma_mapping_value_does_not_hang():
     t.start()
     t.join(timeout = 10.0)
     assert not t.is_alive(), "parse_tool_calls_from_text hung on malformed mapping input"
+
+
+# ── Wrapper-less ``call:NAME{...}``: the display strip only removes a call that
+# OWNS its position. The parser is deliberately unchanged, so an executed call is
+# never erased from the answer while a sentence about the syntax survives intact.
+
+
+def _strip(text: str, enabled = None) -> str:
+    from core.inference.tool_call_parser import strip_tool_markup
+
+    return strip_tool_markup(text, final = True, enabled_tool_names = enabled)
+
+
+def test_wrapperless_call_in_mid_sentence_prose_is_kept_by_every_display_strip():
+    from core.inference.safetensors_agentic import strip_tool_markup_streaming
+    from routes.inference import _strip_tool_xml as _routes_strip
+
+    prose = 'Here is the syntax: call:terminal{command: "rm -rf /tmp/x"}. Do not run it.'
+    en = {"terminal", "python", "web_search"}
+    assert _strip(prose, en) == prose
+    assert strip_tool_markup_streaming(prose, enabled_tool_names = en) == prose
+    assert _routes_strip(prose, en) == prose
+
+
+def test_anchored_wrapperless_calls_are_still_stripped():
+    en = {"web_search"}
+    # Content start, line start, after a reasoning close, and back-to-back calls.
+    assert _strip("call:web_search{query:cats}", en) == ""
+    assert _strip("Sure!\ncall:web_search{query:cats}", en) == "Sure!"
+    assert "call:web_search" not in _strip("<think>plan</think>call:web_search{query:cats}", en)
+    assert _strip("call:web_search{query:hi} call:web_search{query:yo}", en) == ""
+    # A leading JSON answer is data; the call after it still owns its line.
+    assert "call:web_search" not in _strip('{"summary":"done"}\ncall:web_search{query:cats}', en)
+
+
+def test_unclosed_wrapperless_call_strip_follows_the_same_anchor_rule():
+    en = {"web_search"}
+    # Anchored + enabled: a truncated call is still dropped to EOS (streaming heal).
+    assert _strip("Sure!\ncall:web_search{query:weath", en) == "Sure!"
+    # Mid-sentence: prose, kept as written.
+    inline = "You can run call:web_search{query:weath"
+    assert _strip(inline, en) == inline
+
+
+def test_streaming_display_of_prose_call_never_shrinks():
+    from core.inference.safetensors_agentic import strip_tool_markup_streaming
+
+    prose = "You can run call:web_search{query:cats} to search."
+    en = {"web_search"}
+    seen = ""
+    for i in range(1, len(prose) + 1):
+        out = strip_tool_markup_streaming(prose[:i], enabled_tool_names = en)
+        assert len(out) >= len(seen), (i, out, seen)
+        seen = out
+    assert seen == prose

--- a/studio/backend/tests/test_pr5624_regressions.py
+++ b/studio/backend/tests/test_pr5624_regressions.py
@@ -560,9 +560,7 @@ def test_wrapperless_gemma_call_gated_by_enabled_tools():
     inline = "Answer. call:web_search{query:hi}"
     inline_calls = parse_tool_calls_from_text(inline, enabled_tool_names = {"web_search"})
     assert [c["function"]["name"] for c in inline_calls] == ["web_search"], inline_calls
-    assert (
-        strip_tool_markup(inline, final = True, enabled_tool_names = {"web_search"}) == inline
-    )
+    assert strip_tool_markup(inline, final = True, enabled_tool_names = {"web_search"}) == inline
 
 
 def test_kimi_section_end_inside_arg_string_is_not_a_truncation():

--- a/studio/backend/tests/test_pr5624_regressions.py
+++ b/studio/backend/tests/test_pr5624_regressions.py
@@ -458,8 +458,7 @@ def test_strip_tool_markup_removes_nested_wrapperless_gemma_call():
     assert "}" not in stripped
     assert "answer:" in stripped and "done" in stripped
 
-    # Mid-sentence, the same shape is a sentence about the syntax: kept whole (the
-    # markerless form owns its position only at a content/line/reasoning boundary).
+    # Mid-sentence the same shape is a sentence about the syntax: kept whole.
     prose = "answer: call:f{loc:{city:NYC},n:3} done"
     assert strip_tool_markup(prose, final = True) == prose
 
@@ -554,9 +553,8 @@ def test_wrapperless_gemma_call_gated_by_enabled_tools():
         real, final = True, enabled_tool_names = {"web_search"}
     )
 
-    # Mid-sentence the shape is ambiguous, so the strip is deliberately NOT a mirror of
-    # the parser: the parser still promotes it, and the text stays visible rather than
-    # the answer being deleted around a call the user never sees.
+    # Mid-sentence the strip is deliberately NOT the parser's mirror: the call is still
+    # promoted, and its text stays visible instead of the answer being deleted around it.
     inline = "Answer. call:web_search{query:hi}"
     inline_calls = parse_tool_calls_from_text(inline, enabled_tool_names = {"web_search"})
     assert [c["function"]["name"] for c in inline_calls] == ["web_search"], inline_calls

--- a/studio/backend/tests/test_pr5624_regressions.py
+++ b/studio/backend/tests/test_pr5624_regressions.py
@@ -452,11 +452,16 @@ def test_deepseek_v3_with_call_terminator_parses_in_strict_mode():
 
 def test_strip_tool_markup_removes_nested_wrapperless_gemma_call():
     # Wrapper-less Gemma call with a NESTED object arg: the balanced helper must strip the whole call, not leave a trailing ``}``.
-    text = "answer: call:f{loc:{city:NYC},n:3} done"
+    text = "answer:\ncall:f{loc:{city:NYC},n:3} done"
     stripped = strip_tool_markup(text, final = True)
     assert "call:f" not in stripped
     assert "}" not in stripped
     assert "answer:" in stripped and "done" in stripped
+
+    # Mid-sentence, the same shape is a sentence about the syntax: kept whole (the
+    # markerless form owns its position only at a content/line/reasoning boundary).
+    prose = "answer: call:f{loc:{city:NYC},n:3} done"
+    assert strip_tool_markup(prose, final = True) == prose
 
 
 # Pass-3 review findings: bare-Kimi streaming (non-final) strip symmetry
@@ -482,10 +487,14 @@ def test_routes_layer_strip_removes_wrapperless_gemma_call():
     # Gemma 4 (skip_special_tokens) emits a wrapper-less ``call:NAME{..}`` with no XML markers.
     from routes.inference import _strip_tool_xml as _routes_strip
 
-    text = 'before call:web_search{query:"weather in Sydney"} after'
+    text = 'before\ncall:web_search{query:"weather in Sydney"} after'
     stripped = _routes_strip(text)
     assert "call:web_search" not in stripped
     assert "before" in stripped and "after" in stripped
+
+    # The same call mid-sentence reads as prose, so the route keeps the answer intact.
+    prose = 'before call:web_search{query:"weather in Sydney"} after'
+    assert _routes_strip(prose) == prose
 
 
 def test_deepseek_envelope_end_inside_arg_string_is_not_a_truncation():
@@ -536,12 +545,23 @@ def test_wrapperless_gemma_call_gated_by_enabled_tools():
     assert "call:foo{x:1}" in strip_tool_markup(
         prose, final = True, enabled_tool_names = {"web_search"}
     )
-    # An enabled name is still a real call (parsed, and stripped from display).
-    real = "Answer. call:web_search{query:hi}"
+    # An enabled name is still a real call, and a call at a line boundary (the shape
+    # Gemma emits) is stripped from display.
+    real = "Answer.\ncall:web_search{query:hi}"
     calls = parse_tool_calls_from_text(real, enabled_tool_names = {"web_search"})
     assert [c["function"]["name"] for c in calls] == ["web_search"], calls
     assert "call:web_search" not in strip_tool_markup(
         real, final = True, enabled_tool_names = {"web_search"}
+    )
+
+    # Mid-sentence the shape is ambiguous, so the strip is deliberately NOT a mirror of
+    # the parser: the parser still promotes it, and the text stays visible rather than
+    # the answer being deleted around a call the user never sees.
+    inline = "Answer. call:web_search{query:hi}"
+    inline_calls = parse_tool_calls_from_text(inline, enabled_tool_names = {"web_search"})
+    assert [c["function"]["name"] for c in inline_calls] == ["web_search"], inline_calls
+    assert (
+        strip_tool_markup(inline, final = True, enabled_tool_names = {"web_search"}) == inline
     )
 
 

--- a/studio/backend/tests/test_safetensors_tool_loop.py
+++ b/studio/backend/tests/test_safetensors_tool_loop.py
@@ -666,8 +666,7 @@ class TestParser:
         assert "call:f" not in out
         assert "}" not in out
         assert "ok" in out and "tail" in out
-        # Mid-sentence the same shape is prose: streaming display keeps it, so the
-        # answer never loses a sentence around a call the user cannot see.
+        # Mid-sentence the same shape is prose: streaming display keeps it.
         inline = "ok call:f{loc:{city:NYC},n:3} tail"
         assert strip_tool_markup_streaming(inline) == inline
 

--- a/studio/backend/tests/test_safetensors_tool_loop.py
+++ b/studio/backend/tests/test_safetensors_tool_loop.py
@@ -661,11 +661,15 @@ class TestParser:
     def test_streaming_strip_handles_nested_wrapperless_gemma(self):
         # Same class of bug for the wrapper-less Gemma call:NAME{...} form with a
         # nested object argument.
-        raw = "ok call:f{loc:{city:NYC},n:3} tail"
+        raw = "ok\ncall:f{loc:{city:NYC},n:3} tail"
         out = strip_tool_markup_streaming(raw)
         assert "call:f" not in out
         assert "}" not in out
-        assert "ok " in out and "tail" in out
+        assert "ok" in out and "tail" in out
+        # Mid-sentence the same shape is prose: streaming display keeps it, so the
+        # answer never loses a sentence around a call the user cannot see.
+        inline = "ok call:f{loc:{city:NYC},n:3} tail"
+        assert strip_tool_markup_streaming(inline) == inline
 
     def test_streaming_strip_keeps_prose_after_function_xml_with_literal_marker(self):
         # A literal ``<function=...>`` in a value is data: the strip must close at the REAL
@@ -1099,8 +1103,11 @@ class TestParserMultiFormat:
         assert result == []
 
     def test_gemma4_bare_strip_markup_final(self):
-        text = "Here you go: call:web_search{query:weather today}"
+        text = "Here you go:\ncall:web_search{query:weather today}"
         assert "call:web_search" not in strip_tool_markup(text, final = True)
+        # Mid-sentence: prose, kept whole.
+        inline = "Here you go: call:web_search{query:weather today}"
+        assert strip_tool_markup(inline, final = True) == inline
 
     # ── Cross-format sentinels ────────────────────────────────────
 

--- a/studio/backend/tests/test_tool_xml_strip.py
+++ b/studio/backend/tests/test_tool_xml_strip.py
@@ -836,11 +836,11 @@ def test_route_strip_gates_wrapperless_gemma_by_enabled_tools():
         "Answer.\ncall:web_search{query:x}", {"web_search"}
     )
     # Mid-sentence the shape is prose whatever the name, so the answer is kept whole.
-    assert "call:web_search" in _strip_tool_xml(
-        "Answer. call:web_search{query:x}", {"web_search"}
-    )
+    assert "call:web_search" in _strip_tool_xml("Answer. call:web_search{query:x}", {"web_search"})
     # No gate (legacy) strips every closed call that owns its position.
-    assert "call:foo" not in _strip_tool_xml("To document syntax you write\ncall:foo{query:example}")
+    assert "call:foo" not in _strip_tool_xml(
+        "To document syntax you write\ncall:foo{query:example}"
+    )
 
 
 def test_gemma_strip_gate_empty_tools_preserves_prose():

--- a/studio/backend/tests/test_tool_xml_strip.py
+++ b/studio/backend/tests/test_tool_xml_strip.py
@@ -831,12 +831,16 @@ def test_route_strip_gates_wrapperless_gemma_by_enabled_tools():
     # like the parser/loop, so a disabled/example name in prose is preserved in ...
     prose = "To document syntax you write call:foo{query:example}. That shows the format."
     assert "call:foo{query:example}" in _strip_tool_xml(prose, {"web_search"})
-    # An enabled name is still a real call and stripped.
+    # An enabled name at a line boundary is still a real call and stripped.
     assert "call:web_search" not in _strip_tool_xml(
+        "Answer.\ncall:web_search{query:x}", {"web_search"}
+    )
+    # Mid-sentence the shape is prose whatever the name, so the answer is kept whole.
+    assert "call:web_search" in _strip_tool_xml(
         "Answer. call:web_search{query:x}", {"web_search"}
     )
-    # No gate (legacy) strips every closed call.
-    assert "call:foo" not in _strip_tool_xml(prose)
+    # No gate (legacy) strips every closed call that owns its position.
+    assert "call:foo" not in _strip_tool_xml("To document syntax you write\ncall:foo{query:example}")
 
 
 def test_gemma_strip_gate_empty_tools_preserves_prose():
@@ -850,7 +854,7 @@ def test_gemma_strip_gate_empty_tools_preserves_prose():
     assert "call:foo{query:example}" in _strip_tool_xml(prose, _gemma_strip_gate(None))
     # An enabled tool's real call is still stripped.
     assert "call:web_search" not in _strip_tool_xml(
-        "Answer. call:web_search{query:x}",
+        "Answer.\ncall:web_search{query:x}",
         _gemma_strip_gate([{"function": {"name": "web_search"}}]),
     )
 


### PR DESCRIPTION
Gemma 4 emits tool calls as `<|tool_call>call:NAME{...}<tool_call|>`, but `skip_special_tokens` removes the wrapper, so the call reaches us markerless as `call:NAME{...}`. The display strip handled that by scanning the whole response and deleting every closed match whose name is an enabled tool. An answer that documents the syntax therefore lost its middle:

```
in:  Here is the syntax: call:terminal{command: "rm -rf /tmp/x"}. Do not run it.
out: Here is the syntax: . Do not run it.
```

The name gate does not help here, because the sentence names a real tool.

## Change

`_strip_gemma_wrapperless_calls` now gates on position as well as name. A markerless call owns its position when only horizontal whitespace separates it from the scan origin, the start of its line, or a reasoning close (`</think>`, `[/THINK]`, `</thinking>`). That covers what Gemma actually emits:

| response | display |
| --- | --- |
| `call:web_search{query:cats}` | stripped |
| `Sure!` newline `call:web_search{query:cats}` | stripped, `Sure!` kept |
| `<think>plan</think>call:web_search{query:cats}` | stripped |
| `call:a{} call:b{}` | both stripped |
| `{"summary":"done"}` newline `call:web_search{query:cats}` | stripped, JSON answer kept |
| `You can run call:web_search{query:cats} to search.` | kept whole |

Anywhere else the shape reads as a sentence about the syntax and is kept whole, exactly like the existing disabled-name case. The `floor` the anchor measures from advances only past calls the strip actually removed, so back to back calls stay a pair while prose after a call does not inherit the anchor.

The parser is deliberately unchanged. The strip is no longer its mirror: a call promoted mid sentence still runs, and now stays visible in the answer rather than the surrounding text being deleted around a call the user cannot see. The one shape that regresses is a genuine mid sentence call, which executes and also shows its raw text next to the tool card. That is the right side to fail on, since the two cases are indistinguishable at that position.

One helper backs all three display paths, so nothing else needed touching:

- `strip_tool_markup` / `strip_tool_markup_streaming` (`core/inference/safetensors_agentic.py`)
- GGUF streaming display (`core/inference/llama_cpp.py`)
- `_strip_tool_xml_for_display` (`routes/inference.py`)

The streaming detectors are also unchanged. They match on a buffer that only exists at message start (`_state_buffering` / `_S_BUFFERING` are entered once and never re-entered), so they already drain anchored text only, and cannot hide text the final strip keeps. Anchoring depends only on text before the match, which never changes as more tokens arrive, so the cumulative streaming display stays non shrinking.

## Tests

Seven existing assertions encoded the old delete anywhere behaviour. Each keeps its original point (balanced nested strip, route level strip, name gate) with the sample anchored, plus a new mid sentence case asserting the text survives.

New coverage in `tests/test_gemma_tool_parse_edge_cases.py`:

- the documented syntax survives all three display strips verbatim
- anchored shapes still strip: content start, line start, after `</think>`, back to back, after a leading JSON answer
- unclosed calls follow the same rule: an anchored enabled one still drops to EOS, a mid sentence one is kept
- streaming display never shrinks across chunk boundaries for a prose call

```
python -m pytest tests/test_gemma_tool_parse_edge_cases.py tests/test_pr5624_regressions.py \
  tests/test_tool_call_parser_strict.py tests/test_tool_xml_strip.py tests/test_tool_strip_guard.py \
  tests/test_safetensors_tool_loop.py tests/test_llama_cpp_tool_loop.py -q
```

753 passed before the change, 798 passed after. A wider sweep over every suite importing the parser is 1611 passed, with 3 failures that reproduce identically on a clean tree (local `torchao` / `transformers` version skew, unrelated).
