### PR TITLE
Studio: keep the Python 3.9 leg on sentence-transformers

### DIFF
--- a/studio/backend/requirements/extras-no-deps.txt
+++ b/studio/backend/requirements/extras-no-deps.txt
@@ -13,7 +13,10 @@ peft==0.18.1
 trl==0.23.1
 # executorch>=1.0.1              # 41.5 MB - no imports in unsloth/zoo/studio
 torch-c-dlpack-ext==0.1.5
-sentence_transformers==5.2.0
+# 5.2 requires >=3.10. This file is applied after no-torch-runtime.txt, so an
+# unconditional pin here would reject 3.9 outright and undo that file's fallback.
+sentence_transformers==5.2.0; python_version >= "3.10"
+sentence_transformers==5.1.2; python_version < "3.10"
 transformers==5.5.0; python_version >= "3.10"
 transformers==4.57.6; python_version < "3.10"
 # No macOS x86_64 wheel at any version, so uv falls back to an sdist that shells out to

--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -83,8 +83,10 @@ trl>=0.18.2,!=0.19.0,<=0.24.0
 # Matches extras-no-deps.txt rather than the newest release: that file installs
 # --no-deps too and runs after this one, so whatever it names wins. Pinning a
 # higher version here would record a number no install ever ends up with. Bump
-# both together.
-sentence-transformers==5.2.0
+# both together. 5.2 requires >=3.10, so 3.9 keeps the newest release it can take,
+# which is what a bare entry resolved to here before.
+sentence-transformers==5.2.0; python_version >= "3.10"
+sentence-transformers==5.1.2; python_version < "3.10"
 cut_cross_entropy==25.1.1
 pillow==12.3.0; python_version >= "3.10"
 pillow==11.3.0; python_version < "3.10"


### PR DESCRIPTION
Follow up to #8408.

That PR pinned `sentence-transformers` in `no-torch-runtime.txt` to a single `==5.2.0`, matching the version `extras-no-deps.txt` installs later. The match is right, but collapsing it to one line dropped the sub-3.10 fallback, and 5.2 requires Python >=3.10, so a 3.9 host has no candidate at all for that entry.

Before the pin, the bare line resolved to 5.1.2 on 3.9:

```
py3.9   x86_64-unknown-linux-gnu   sentence-transformers==5.1.2
py3.9   aarch64-apple-darwin       sentence-transformers==5.1.2
py3.13  x86_64-unknown-linux-gnu   sentence-transformers==5.7.0
```

So this restores that leg explicitly and leaves >=3.10 on 5.2.0.

### How this was found

An audit that resolves every changed line against its pre-PR spec across 6 Python versions and 9 platforms (glibc and musl on x86_64 and aarch64, Windows x86_64 / ARM64 / i686, both macOS architectures), with `single-env/constraints.txt` applied the way `pip_install` applies it, comparing whether each leg resolves, to which version, and whether `--no-build` fails. This was the only entry whose behaviour narrowed.

### Practical impact

Low. That file is already unresolvable on 3.9 for other reasons that predate the pinning work: `cut_cross_entropy==25.1.1`, `pymupdf==1.27.2.3` and `pymupdf4llm==0.3.4` all require >=3.10, and each aborts the whole `pip -r` step first. This is correctness of the file rather than a fix for a reachable failure, and it keeps the entry honest against `requires-python = ">=3.9"`.

Worth deciding separately whether 3.9 is still supported at all. Several existing pins in these files already rule it out, so either the floor should move to 3.10 or those pins need marker splits.
