### PR TITLE
Point the Images rail contract at the in-flow footer padding

### DIFF
--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -784,7 +784,12 @@ def test_image_page_structural_panes_share_the_container_breakpoint():
     assert "@[50rem]:flex-row @[50rem]:overflow-hidden" in section
     assert "@[50rem]:w-[408px]" in section
     assert "md:flex-row" not in section
-    assert "gap-4 px-10 pt-9 pb-20 @[50rem]:overflow-y-auto" in section
+    # pb-6, not the old pb-20: the action is an in-flow footer now, so the rail no longer
+    # reserves 80px for an overlay to sit in. The crossfade into that footer is the
+    # -action mask, which is why the two are asserted together -- the small padding is
+    # only correct while the fade is there to dissolve the last control into the footer.
+    assert "panel-scroll-fade-action" in section
+    assert "gap-4 px-10 pt-9 pb-6 @[50rem]:overflow-y-auto" in section
     assert "p-6 px-10 @[50rem]:pt-[60px]" in section
     assert "border-t border-foreground/10 px-10 py-3" in section
 


### PR DESCRIPTION
`tests/studio/test_desktop_reliability_frontend_contract.py` is red on main right now.

#8411 moved the Images Create action into an in-flow footer and dropped the rail from `pb-20` to `pb-6`, but the contract that pins those utilities still names the old string:

```
assert "gap-4 px-10 pt-9 pb-20 @[50rem]:overflow-y-auto" in section
AssertionError
```

Reproduced on a clean worktree of main, no other changes: `1 failed, 34 passed`.

## The change

The assertion now names `pb-6`, and asserts `panel-scroll-fade-action` next to it. The two belong together: the small padding is only correct while the 48px mask is there to dissolve the last control into the footer, so a later change that drops the fade but keeps `pb-6` should fail here rather than pass quietly.

## Checks

- With the fix: 35 passed.
- The assertion is not vacuous: reverting the page back to `pb-20` with the new contract in place turns the test red again.
- `tests/studio/` as a whole is unchanged by this beyond the one test going green.

## Not fixed here

Three other contracts are also red on main and are unrelated to this area, so they are left for whoever owns them rather than bundled in:

- `test_model_picker_contracts.py::test_a_lost_generate_post_must_prove_it_reached_the_backend` (expects `knownIds`)
- `test_remote_connection_models_contract.py::test_frontend_sync_backfills_local_models_to_backend` (expects `Promise.allSettled(backfillTasks)`)
- `test_remote_connection_models_contract.py::test_chat_page_hydrates_connections_on_startup` (expects `syncExternalProvidersFromBackend`)

Each fails identically on a clean main worktree.