### PR TITLE
Add Cua Driver MCP preset to Unsloth Desktop

### DIFF
--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -21,6 +21,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { isTauri } from "@/lib/api-base";
 
 import {
   type McpServerConfig,
@@ -29,6 +30,7 @@ import {
   updateMcpServer,
 } from "./api/mcp-servers-api";
 import { ChatMcpServersDialog } from "./chat-mcp-servers-dialog";
+import { getMcpPresets } from "./mcp-presets";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 
 // Matches the Thinking pill chevron so the affordance reads the same.
@@ -48,43 +50,9 @@ const ArrowDownStandardIcon: FC<{ className?: string }> = ({ className }) => (
   </svg>
 );
 
-type McpPreset = {
-  id: string;
-  displayName: string; // stored row name
-  url: string;
-  label?: string; // dropdown text, if different from displayName
-  hint?: string; // shown when the row is highlighted
-  disablesWebSearch?: boolean; // turn the built-in Search pill off when enabled
-};
-
-// Keyless remote MCP presets (rate-limited free tiers, no API key).
-// Hugging Face runs anonymously; add a token via "Manage MCP servers".
-const MCP_PRESETS: readonly McpPreset[] = [
-  {
-    id: "unsloth-docs",
-    displayName: "Unsloth Docs",
-    url: "https://unsloth.ai/docs/~gitbook/mcp",
-  },
-  {
-    id: "context7",
-    displayName: "Context7",
-    url: "https://mcp.context7.com/mcp",
-    label: "Context7 (Realtime Docs)",
-  },
-  {
-    id: "exa",
-    displayName: "Exa",
-    url: "https://mcp.exa.ai/mcp",
-    label: "Exa (Semantic Search)",
-    hint: "Enabling Exa will disable default search",
-    disablesWebSearch: true,
-  },
-  {
-    id: "huggingface",
-    displayName: "Hugging Face",
-    url: "https://huggingface.co/mcp",
-  },
-] as const;
+// Desktop adds local stdio integrations. Browser clients keep the keyless
+// remote presets, which also work against hosted Unsloth backends.
+const MCP_PRESETS = getMcpPresets(isTauri);
 
 // mcp_servers has no UNIQUE(url); dedupe by normalized URL so a preset toggle
 // reuses its row instead of duplicating.

--- a/studio/frontend/src/features/chat/mcp-presets.ts
+++ b/studio/frontend/src/features/chat/mcp-presets.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export type McpPreset = {
+  id: string;
+  displayName: string;
+  url: string;
+  label?: string;
+  hint?: string;
+  disablesWebSearch?: boolean;
+};
+
+const REMOTE_MCP_PRESETS: readonly McpPreset[] = [
+  {
+    id: "unsloth-docs",
+    displayName: "Unsloth Docs",
+    url: "https://unsloth.ai/docs/~gitbook/mcp",
+  },
+  {
+    id: "context7",
+    displayName: "Context7",
+    url: "https://mcp.context7.com/mcp",
+    label: "Context7 (Realtime Docs)",
+  },
+  {
+    id: "exa",
+    displayName: "Exa",
+    url: "https://mcp.exa.ai/mcp",
+    label: "Exa (Semantic Search)",
+    hint: "Enabling Exa will disable default search",
+    disablesWebSearch: true,
+  },
+  {
+    id: "huggingface",
+    displayName: "Hugging Face",
+    url: "https://huggingface.co/mcp",
+  },
+] as const;
+
+const CUA_DRIVER_PRESET: McpPreset = {
+  id: "cua-driver",
+  displayName: "Cua Driver",
+  url: "cua-driver mcp",
+  label: "Cua Driver (Computer Use)",
+  hint: "Requires Cua Driver on PATH. Install from cua.ai/docs/cua-driver",
+};
+
+export function getMcpPresets(isDesktop: boolean): readonly McpPreset[] {
+  return isDesktop
+    ? [CUA_DRIVER_PRESET, ...REMOTE_MCP_PRESETS]
+    : REMOTE_MCP_PRESETS;
+}

--- a/studio/frontend/tests/mcp-presets.test.ts
+++ b/studio/frontend/tests/mcp-presets.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getMcpPresets } from "../src/features/chat/mcp-presets.ts";
+
+test("desktop offers Cua Driver as a local stdio MCP preset", () => {
+  const preset = getMcpPresets(true).find(({ id }) => id === "cua-driver");
+
+  assert.deepEqual(preset, {
+    id: "cua-driver",
+    displayName: "Cua Driver",
+    url: "cua-driver mcp",
+    label: "Cua Driver (Computer Use)",
+    hint: "Requires Cua Driver on PATH. Install from cua.ai/docs/cua-driver",
+  });
+});
+
+test("browser clients do not advertise a local desktop command", () => {
+  assert.equal(
+    getMcpPresets(false).some(({ id }) => id === "cua-driver"),
+    false,
+  );
+});
+
+test("desktop keeps the existing remote MCP presets", () => {
+  const ids = getMcpPresets(true).map(({ id }) => id);
+
+  for (const id of ["unsloth-docs", "context7", "exa", "huggingface"]) {
+    assert.ok(ids.includes(id), `missing ${id}`);
+  }
+});


### PR DESCRIPTION
## What changed

- Add a desktop-only Cua Driver preset to Chat's MCP menu.
- Register the existing stdio MCP client with `cua-driver mcp`.
- Keep the local command out of browser-hosted Unsloth clients.
- Add regression coverage for the desktop and browser preset lists.

## Why

Unsloth Desktop already supports local stdio MCP servers. This preset makes Cua Driver a one-click option, so tool-capable local models can use its computer-use tools without manually entering the command.

## Validation

- `npm run typecheck`
- `npm test` (1,949 passed)
- `npm run build`
- Focused ESLint on the new preset module and test
- Tauri development build and first-run desktop launch
- Live `cua-driver mcp` initialize and `tools/list` smoke (54 tools)

The desktop UI smoke reached Unsloth's first-run installer because the local backend is not installed on the test host, so the MCP menu itself was not clicked in the running desktop app.
