### PR TITLE
Fix TokenizersBackend in exported tokenizer_config.json

### DIFF
--- a/tests/saving/test_sanitize_tokenizer_class_in_config.py
+++ b/tests/saving/test_sanitize_tokenizer_class_in_config.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from unsloth_zoo.saving_utils import sanitize_tokenizer_class_in_config
+
+
+def test_sanitize_tokenizer_class_rewrites_tokenizers_backend(tmp_path):
+    (tmp_path / "tokenizer.json").write_text("{}", encoding = "utf-8")
+    tokenizer_config = tmp_path / "tokenizer_config.json"
+    tokenizer_config.write_text(
+        json.dumps({"tokenizer_class": "TokenizersBackend", "model_max_length": 8192}),
+        encoding = "utf-8",
+    )
+
+    sanitize_tokenizer_class_in_config(None, tmp_path)
+
+    saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
+    assert saved_config["tokenizer_class"] == "PreTrainedTokenizerFast"
+    assert saved_config["model_max_length"] == 8192
+
+
+def test_sanitize_tokenizer_class_leaves_loadable_classes_alone(tmp_path):
+    (tmp_path / "tokenizer.json").write_text("{}", encoding = "utf-8")
+    tokenizer_config = tmp_path / "tokenizer_config.json"
+    tokenizer_config.write_text(
+        json.dumps({"tokenizer_class": "LlamaTokenizerFast"}),
+        encoding = "utf-8",
+    )
+
+    sanitize_tokenizer_class_in_config(None, tmp_path)
+
+    saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
+    assert saved_config["tokenizer_class"] == "LlamaTokenizerFast"
+
+
+def test_sanitize_tokenizer_class_uses_source_tokenizer_class_when_available(tmp_path):
+    tokenizer_config = tmp_path / "tokenizer_config.json"
+    tokenizer_config.write_text(
+        json.dumps({"tokenizer_class": "TokenizersBackend"}),
+        encoding = "utf-8",
+    )
+
+    class Qwen2TokenizerFast:
+        pass
+
+    sanitize_tokenizer_class_in_config(Qwen2TokenizerFast(), tmp_path)
+
+    saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
+    assert saved_config["tokenizer_class"] == "Qwen2TokenizerFast"
+
+
+def test_sanitize_tokenizer_class_supports_filename_prefix(tmp_path):
+    (tmp_path / "tokenizer.json").write_text("{}", encoding = "utf-8")
+    prefixed_config = tmp_path / "adapter-tokenizer_config.json"
+    prefixed_config.write_text(
+        json.dumps({"tokenizer_class": "TokenizersBackend"}),
+        encoding = "utf-8",
+    )
+
+    sanitize_tokenizer_class_in_config(None, tmp_path, filename_prefix = "adapter")
+
+    saved_config = json.loads(prefixed_config.read_text(encoding = "utf-8"))
+    assert saved_config["tokenizer_class"] == "PreTrainedTokenizerFast"
+    assert not (tmp_path / "tokenizer_config.json").exists()
+
+
+def test_sanitize_tokenizer_class_skips_without_tokenizer_json_or_source_class(tmp_path):
+    tokenizer_config = tmp_path / "tokenizer_config.json"
+    tokenizer_config.write_text(
+        json.dumps({"tokenizer_class": "TokenizersBackend"}),
+        encoding = "utf-8",
+    )
+
+    sanitize_tokenizer_class_in_config(None, tmp_path)
+
+    saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
+    assert saved_config["tokenizer_class"] == "TokenizersBackend"
+
+
+@pytest.mark.parametrize(
+    "tokenizer_class",
+    ("PreTrainedTokenizerFast", "GemmaTokenizer", "Qwen2Tokenizer"),
+)
+def test_sanitize_tokenizer_class_is_noop_for_exportable_values(tmp_path, tokenizer_class):
+    tokenizer_config = tmp_path / "tokenizer_config.json"
+    tokenizer_config.write_text(
+        json.dumps({"tokenizer_class": tokenizer_class}),
+        encoding = "utf-8",
+    )
+
+    sanitize_tokenizer_class_in_config(None, tmp_path)
+
+    saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
+    assert saved_config["tokenizer_class"] == tokenizer_class

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -89,6 +89,49 @@ except:
 from pathlib import Path
 from peft import PeftModelForCausalLM, PeftModel
 
+try:
+    from unsloth_zoo.saving_utils import sanitize_tokenizer_class_in_config
+except ImportError:
+
+    def sanitize_tokenizer_class_in_config(tokenizer, saved_folder, filename_prefix = None):
+        _UNLOADABLE_TOKENIZER_CLASSES = frozenset({"TokenizersBackend"})
+        if saved_folder is None:
+            return
+
+        tokenizer_config_name = (
+            f"{filename_prefix}-tokenizer_config.json"
+            if filename_prefix
+            else "tokenizer_config.json"
+        )
+        tokenizer_config_path = os.path.join(str(saved_folder), tokenizer_config_name)
+        if not os.path.isfile(tokenizer_config_path):
+            return
+
+        source = tokenizer.tokenizer if tokenizer is not None and hasattr(tokenizer, "tokenizer") else tokenizer
+        replacement = None
+        if source is not None and type(source).__name__ not in _UNLOADABLE_TOKENIZER_CLASSES:
+            replacement = type(source).__name__
+        elif os.path.isfile(os.path.join(str(saved_folder), "tokenizer.json")):
+            replacement = "PreTrainedTokenizerFast"
+        if replacement is None:
+            return
+
+        try:
+            with open(tokenizer_config_path, "r", encoding = "utf-8") as file:
+                config = json.load(file)
+            if config.get("tokenizer_class") not in _UNLOADABLE_TOKENIZER_CLASSES:
+                return
+            if config.get("tokenizer_class") == replacement:
+                return
+            config["tokenizer_class"] = replacement
+            with open(tokenizer_config_path, "w", encoding = "utf-8") as file:
+                json.dump(config, file, indent = 2, ensure_ascii = False)
+                file.write("\n")
+        except Exception as error:
+            logger.warning_once(
+                f"Unsloth: Could not sanitize tokenizer_class in {tokenizer_config_path}: {error}"
+            )
+
 __all__ = [
     "print_quantization_methods",
     "unsloth_save_model",
@@ -1367,6 +1410,11 @@ def unsloth_save_model(
 
         tokenizer.save_pretrained(**tokenizer_save_settings)
         _preserve_tokenizer_eos_token(
+            tokenizer,
+            tokenizer_save_settings["save_directory"],
+            filename_prefix = tokenizer_save_settings.get("filename_prefix"),
+        )
+        sanitize_tokenizer_class_in_config(
             tokenizer,
             tokenizer_save_settings["save_directory"],
             filename_prefix = tokenizer_save_settings.get("filename_prefix"),
@@ -7875,6 +7923,11 @@ def patch_saving_functions(model, vision = False):
             token = kwargs.get("token", None),
         )
         _preserve_tokenizer_eos_token(
+            self,
+            save_directory,
+            filename_prefix = filename_prefix,
+        )
+        sanitize_tokenizer_class_in_config(
             self,
             save_directory,
             filename_prefix = filename_prefix,

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -93,7 +93,11 @@ try:
     from unsloth_zoo.saving_utils import sanitize_tokenizer_class_in_config
 except ImportError:
 
-    def sanitize_tokenizer_class_in_config(tokenizer, saved_folder, filename_prefix = None):
+    def sanitize_tokenizer_class_in_config(
+        tokenizer,
+        saved_folder,
+        filename_prefix = None,
+    ):
         _UNLOADABLE_TOKENIZER_CLASSES = frozenset({"TokenizersBackend"})
         if saved_folder is None:
             return
@@ -107,7 +111,11 @@ except ImportError:
         if not os.path.isfile(tokenizer_config_path):
             return
 
-        source = tokenizer.tokenizer if tokenizer is not None and hasattr(tokenizer, "tokenizer") else tokenizer
+        source = (
+            tokenizer.tokenizer
+            if tokenizer is not None and hasattr(tokenizer, "tokenizer")
+            else tokenizer
+        )
         replacement = None
         if source is not None and type(source).__name__ not in _UNLOADABLE_TOKENIZER_CLASSES:
             replacement = type(source).__name__
@@ -131,6 +139,7 @@ except ImportError:
             logger.warning_once(
                 f"Unsloth: Could not sanitize tokenizer_class in {tokenizer_config_path}: {error}"
             )
+
 
 __all__ = [
     "print_quantization_methods",


### PR DESCRIPTION
## Summary

Fixes #8444

Transformers 5.x can write `"tokenizer_class": "TokenizersBackend"` when saving fast tokenizers. That value is an internal wrapper class, so `AutoTokenizer.from_pretrained`, llama.cpp's `convert_hf_to_gguf.py`, and mlx_lm fail to reload exported checkpoints.

This PR sanitizes `tokenizer_config.json` after export:
- If the saved class is `TokenizersBackend`, rewrite it to a loadable value
- Prefer the source tokenizer's concrete class when available
- Otherwise fall back to `PreTrainedTokenizerFast` when `tokenizer.json` is present

## Changes

- `unsloth/save.py`: call `sanitize_tokenizer_class_in_config` from the patched tokenizer save path and merged export path
- `tests/saving/test_sanitize_tokenizer_class_in_config.py`: unit tests for the sanitizer

## Companion change

MLX and other zoo save paths also need the sanitizer in `unsloth-zoo` (see companion PR).

## Test plan

- [x] `pytest tests/saving/test_sanitize_tokenizer_class_in_config.py`
- [x] `pytest tests/saving/test_preserve_tokenizer_eos_token.py`