### PR TITLE
Fix 404 on Linux .deb download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Download the native Unsloth desktop app for your operating system:
   </tr>
   <tr>
     <td><b>Linux (deb)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.61-beta/Unsloth-Desktop-0_1_61_beta-Linux.deb'>Download</a></td>
+    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.61-beta/Unsloth-Desktop-0_1_61_beta-Ubuntu.deb'>Download</a></td>
   </tr>
   <tr>
     <td><b>Linux (AppImage)</b></td>


### PR DESCRIPTION
The Linux (deb) download link in the README points to `Unsloth-Desktop-0_1_61_beta-Linux.deb`, but the asset published on the `v0.1.61-beta` release is named `Unsloth-Desktop-0_1_61_beta-Ubuntu.deb`. The link returns a 404.

Verified status codes for all five README download links before the fix:

| Asset | Status |
| --- | --- |
| Windows.exe | 200 |
| MacOS.dmg | 200 |
| Linux.deb | 404 |
| Linux.AppImage | 200 |
| ARM64.app.tar.gz | 200 |

This changes the link to the actual asset name, which returns 200.