### PR TITLE
Studio: clarify MiniMax H3 GGUF modes

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -40,7 +40,6 @@ import {
   TrainIcon,
   TransportConflictDialog,
   deleteCachedModel,
-  ggufVariantDisplayLabel,
   invalidateGgufVariantsCache,
   listGgufVariants as listGgufVariantsCached,
   useGgufVariantsCacheVersions,
@@ -189,6 +188,12 @@ import type {
   ModelSelectorChangeMeta,
 } from "./types";
 import { describeVariantListingError } from "./variant-listing-error";
+import {
+  ggufVariantPickerLabel,
+  groupGgufVariantsForPicker,
+  h3PickerHasOnlyPrunedBuilds,
+  preferredGgufVariantByGroup,
+} from "./variant-presentation";
 import {
   shouldMountVariantExpander,
   toggleAutoExpandedRow,
@@ -1384,29 +1389,47 @@ function GgufVariantExpander({
     [budgetKnown, gpuBudgetGb, totalBudgetGb],
   );
 
-  // If the recommended variant is OOM, pick the largest fitting one;
-  // if all are OOM, recommend the smallest.
-  const effectiveRecommended = useMemo(() => {
-    if (
-      !variants ||
-      variants.length === 0 ||
-      (totalBudgetGb <= 0 && !budgetKnown)
-    ) {
-      return defaultVariant;
+  const variantGroups = useMemo(
+    () => groupGgufVariantsForPicker(variants ?? []),
+    [variants],
+  );
+  const preferredByGroup = useMemo(
+    () => preferredGgufVariantByGroup(variantGroups, defaultVariant),
+    [variantGroups, defaultVariant],
+  );
+
+  // Each workflow gets its own recommendation. If its preferred variant is
+  // OOM, use the largest one that can run; if all are OOM, use the smallest.
+  const effectiveRecommendedByGroup = useMemo(() => {
+    const recommended = new Map<string, string>();
+    for (const group of variantGroups) {
+      const preferred = preferredByGroup.get(group.key) ?? null;
+      if (totalBudgetGb <= 0 && !budgetKnown) {
+        if (preferred) recommended.set(group.key, preferred.quant);
+        continue;
+      }
+      if (preferred && getGgufFit(preferred.size_bytes) !== "oom") {
+        recommended.set(group.key, preferred.quant);
+        continue;
+      }
+      const fitting = group.variants
+        .filter((variant) => getGgufFit(variant.size_bytes) !== "oom")
+        .sort((left, right) => right.size_bytes - left.size_bytes);
+      if (fitting[0]) {
+        recommended.set(group.key, fitting[0].quant);
+        continue;
+      }
+      const smallest = [...group.variants].sort(
+        (left, right) => left.size_bytes - right.size_bytes,
+      )[0];
+      if (smallest) recommended.set(group.key, smallest.quant);
     }
-    const defaultV = variants.find((v) => v.quant === defaultVariant);
-    if (defaultV && getGgufFit(defaultV.size_bytes) !== "oom")
-      return defaultVariant;
-    // Largest non-OOM variant (best quality that fits)
-    const fitting = variants.filter((v) => getGgufFit(v.size_bytes) !== "oom");
-    if (fitting.length > 0) {
-      fitting.sort((a, b) => b.size_bytes - a.size_bytes);
-      return fitting[0].quant;
-    }
-    // All OOM -- recommend smallest (most likely to partially run)
-    const sorted = [...variants].sort((a, b) => a.size_bytes - b.size_bytes);
-    return sorted[0]?.quant ?? defaultVariant;
-  }, [variants, defaultVariant, totalBudgetGb, budgetKnown, getGgufFit]);
+    return recommended;
+  }, [variantGroups, preferredByGroup, totalBudgetGb, budgetKnown, getGgufFit]);
+  const effectiveRecommended = useMemo(
+    () => new Set(effectiveRecommendedByGroup.values()),
+    [effectiveRecommendedByGroup],
+  );
 
   const sortedVariants = useMemo(() => {
     if (!variants) return variants;
@@ -1417,24 +1440,27 @@ function GgufVariantExpander({
       const base = f === "fits" ? 0 : 1;
       return v.downloaded ? base : base + 2;
     };
-    return [...variants].sort((a, b) => {
-      const aTier = tierOf(a);
-      const bTier = tierOf(b);
-      if (aTier !== bTier) return aTier - bTier;
+    return variantGroups.flatMap((group) => {
+      const recommended = effectiveRecommendedByGroup.get(group.key);
+      return [...group.variants].sort((a, b) => {
+        const aTier = tierOf(a);
+        const bTier = tierOf(b);
+        if (aTier !== bTier) return aTier - bTier;
 
-      // Within the same tier, recommended goes first
-      const aIsRec = a.quant === effectiveRecommended;
-      const bIsRec = b.quant === effectiveRecommended;
-      if (aIsRec !== bIsRec) return aIsRec ? -1 : 1;
+        // Within the same tier, the workflow's recommendation goes first.
+        const aIsRec = a.quant === recommended;
+        const bIsRec = b.quant === recommended;
+        if (aIsRec !== bIsRec) return aIsRec ? -1 : 1;
 
-      // fits: largest first (best quality that fits in GPU)
-      // tight/OOM: smallest first (closest to fitting, fastest to run)
-      const fitsInGpu = aTier === 0 || aTier === 2;
-      return fitsInGpu
-        ? b.size_bytes - a.size_bytes
-        : a.size_bytes - b.size_bytes;
+        // fits: largest first (best quality that fits in GPU)
+        // tight/OOM: smallest first (closest to fitting, fastest to run)
+        const fitsInGpu = aTier === 0 || aTier === 2;
+        return fitsInGpu
+          ? b.size_bytes - a.size_bytes
+          : a.size_bytes - b.size_bytes;
+      });
     });
-  }, [variants, effectiveRecommended, getGgufFit]);
+  }, [variants, variantGroups, effectiveRecommendedByGroup, getGgufFit]);
 
   // On Device only: when Show all quantizations is off, list quants already on
   // disk, torn ones included. Browse lists always show every quant.
@@ -1448,6 +1474,14 @@ function GgufVariantExpander({
       showAll: showAllQuantizations,
     });
   }, [sortedVariants, showAllQuantizations, onDevice]);
+  const displayVariantGroups = useMemo(
+    () => groupGgufVariantsForPicker(displayVariants ?? []),
+    [displayVariants],
+  );
+  const hideH3PrunedBuild = useMemo(
+    () => h3PickerHasOnlyPrunedBuilds(displayVariants ?? []),
+    [displayVariants],
+  );
 
   // A diffusion GGUF is not self-contained: the loader also needs a text
   // encoder, VAE, tokenizer and configs. That companion set is NOT
@@ -1473,8 +1507,8 @@ function GgufVariantExpander({
       // The recommended quant is the representative of its own group when it
       // has one; otherwise the group's first row stands.
       if (
-        current.quant !== effectiveRecommended &&
-        variant.quant === effectiveRecommended
+        !effectiveRecommended.has(current.quant) &&
+        effectiveRecommended.has(variant.quant)
       ) {
         byKey.set(key, variant);
       }
@@ -1607,7 +1641,7 @@ function GgufVariantExpander({
     >
       {/* On Device shows the model name above, so the Quantizations heading is
           redundant; its Vision badge is relayed to the name instead. */}
-      {!onDevice && (
+      {!onDevice && !displayVariantGroups.some((group) => group.title) && (
         <div className="px-2 py-1 flex items-center gap-1.5">
           <span className="text-ui-10 font-semibold uppercase tracking-wider text-muted-foreground">
             Quantizations
@@ -1624,7 +1658,26 @@ function GgufVariantExpander({
           )}
         </div>
       )}
+      {!onDevice &&
+        hasVision &&
+        displayVariantGroups.some((group) => group.title) && (
+          <div className="px-2 pt-1">
+            <span className="flex items-center gap-0.5 text-ui-9 font-medium text-indigo-700 dark:text-indigo-300">
+              <HugeiconsIcon
+                icon={ViewIcon}
+                className="size-3"
+                strokeWidth={1.8}
+              />
+              Vision
+            </span>
+          </div>
+        )}
       {displayVariants.map((v) => {
+        const group = displayVariantGroups.find((candidate) =>
+          candidate.variants.some((variant) => variant.filename === v.filename),
+        );
+        const showGroupHeading =
+          group?.title != null && group.variants[0]?.filename === v.filename;
         const fit = getGgufFit(v.size_bytes);
         const oom = fit === "oom";
         const tight = fit === "tight";
@@ -1657,10 +1710,11 @@ function GgufVariantExpander({
             )}
           >
             <span className="min-w-0 flex-1 truncate font-mono text-xs">
-              <span
-                className={cn(oom && "!text-gray-500 dark:!text-gray-400")}
-              >
-                {ggufVariantDisplayLabel(v)}
+              <span className={cn(oom && "!text-gray-500 dark:!text-gray-400")}>
+                {ggufVariantPickerLabel(v, {
+                  h3Grouped: group?.title != null,
+                  hideH3PrunedBuild,
+                })}
               </span>
               {unusableLocal ? (
                 <span className="ml-1.5 text-ui-9 font-sans font-medium text-amber-700 dark:text-amber-300">
@@ -1677,7 +1731,7 @@ function GgufVariantExpander({
                     </span>
                   ) : null}
                 </>
-              ) : v.quant === effectiveRecommended ? (
+              ) : effectiveRecommended.has(v.quant) ? (
                 <span className="ml-1.5 text-ui-9 font-sans font-medium text-primary/70">
                   recommended
                 </span>
@@ -1707,7 +1761,19 @@ function GgufVariantExpander({
             </span>
           </button>
         );
-        return (
+        return [
+          showGroupHeading && group?.title ? (
+            <div key={`${v.filename}:group`} className="px-2 pb-1 pt-2">
+              <div className="text-xs font-semibold text-foreground">
+                {group.title}
+              </div>
+              {group.description && (
+                <div className="mt-0.5 text-ui-10 leading-snug text-muted-foreground">
+                  {group.description}
+                </div>
+              )}
+            </div>
+          ) : null,
           <div key={v.filename} className="flex items-center">
             {/* The explanation rides the row button; nested button triggers are not accessible. */}
             {companionBytes === null ? (
@@ -1823,8 +1889,8 @@ function GgufVariantExpander({
                   }
                 />
               )}
-          </div>
-        );
+          </div>,
+        ];
       })}
     </div>
   );

--- a/studio/frontend/src/features/model-picker/components/model-selector/variant-presentation.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/variant-presentation.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+type PresentableGgufVariant = {
+  filename: string;
+  quant: string;
+  display_label?: string | null;
+  size_bytes: number;
+};
+
+export type GgufVariantPresentationGroup<T extends PresentableGgufVariant> = {
+  key: string;
+  title: string | null;
+  description: string | null;
+  variants: T[];
+};
+
+const H3_FILENAME = /^minimax_h3_(fl2va|ref2va)(?:_pruned)?-(.+)\.gguf$/i;
+const GGUF_SHARD_SUFFIX = /-\d{5}-of-\d{5}$/i;
+const PATH_SEPARATOR = /[\\/]/;
+
+type H3Presentation = {
+  group: "text-frames" | "reference-media";
+  quantLabel: string;
+  build: "Full" | "Pruned";
+};
+
+function h3Presentation(
+  variant: PresentableGgufVariant,
+): H3Presentation | null {
+  const filename =
+    variant.filename.split(PATH_SEPARATOR).at(-1) ?? variant.filename;
+  const match = H3_FILENAME.exec(filename);
+  if (!match) {
+    return null;
+  }
+  return {
+    group:
+      match[1].toLowerCase() === "ref2va" ? "reference-media" : "text-frames",
+    quantLabel: match[2].replace(GGUF_SHARD_SUFFIX, ""),
+    build: filename.toLowerCase().includes("_pruned-") ? "Pruned" : "Full",
+  };
+}
+
+export function ggufVariantPickerLabel(
+  variant: PresentableGgufVariant,
+  options?: { h3Grouped?: boolean; hideH3PrunedBuild?: boolean },
+): string {
+  const h3 = options?.h3Grouped ? h3Presentation(variant) : null;
+  if (h3) {
+    return options?.hideH3PrunedBuild && h3.build === "Pruned"
+      ? h3.quantLabel
+      : `${h3.quantLabel} · ${h3.build}`;
+  }
+  return variant.display_label?.trim() || variant.quant;
+}
+
+export function h3PickerHasOnlyPrunedBuilds(
+  variants: readonly PresentableGgufVariant[],
+): boolean {
+  return (
+    variants.length > 0 &&
+    variants.every((variant) => h3Presentation(variant)?.build === "Pruned")
+  );
+}
+
+export function groupGgufVariantsForPicker<T extends PresentableGgufVariant>(
+  variants: readonly T[],
+): GgufVariantPresentationGroup<T>[] {
+  const classified = variants.map((variant) => ({
+    variant,
+    presentation: h3Presentation(variant),
+  }));
+  if (
+    classified.length === 0 ||
+    classified.some(({ presentation }) => presentation === null)
+  ) {
+    return [
+      {
+        key: "quantizations",
+        title: null,
+        description: null,
+        variants: [...variants],
+      },
+    ];
+  }
+
+  const textFrames = classified
+    .filter(({ presentation }) => presentation?.group === "text-frames")
+    .map(({ variant }) => variant);
+  const referenceMedia = classified
+    .filter(({ presentation }) => presentation?.group === "reference-media")
+    .map(({ variant }) => variant);
+
+  return [
+    {
+      key: "text-frames",
+      title: "Text / first and last frames",
+      description:
+        "Generate from a prompt, optionally using first and last frame images.",
+      variants: textFrames,
+    },
+    {
+      key: "reference-media",
+      title: "Reference media",
+      description: "Generate using reference images, video, or audio.",
+      variants: referenceMedia,
+    },
+  ].filter((group) => group.variants.length > 0);
+}
+
+export function preferredGgufVariantByGroup<T extends PresentableGgufVariant>(
+  groups: readonly GgufVariantPresentationGroup<T>[],
+  defaultVariant: string | null,
+): Map<string, T | null> {
+  const allVariants = groups.flatMap((group) => group.variants);
+  const defaultDetail = allVariants.find(
+    (variant) => variant.quant === defaultVariant,
+  );
+  const defaultPresentation = defaultDetail
+    ? h3Presentation(defaultDetail)
+    : null;
+
+  return new Map(
+    groups.map((group) => {
+      const exactDefault = group.variants.find(
+        (variant) => variant.quant === defaultVariant,
+      );
+      if (exactDefault || !defaultDetail) {
+        return [group.key, exactDefault ?? null];
+      }
+      const semanticCounterpart = defaultPresentation
+        ? group.variants.find((variant) => {
+            const presentation = h3Presentation(variant);
+            return (
+              presentation?.quantLabel.toLowerCase() ===
+                defaultPresentation.quantLabel.toLowerCase() &&
+              presentation.build === defaultPresentation.build
+            );
+          })
+        : undefined;
+      if (semanticCounterpart) {
+        return [group.key, semanticCounterpart];
+      }
+      const nearestSize = [...group.variants].sort(
+        (left, right) =>
+          Math.abs(left.size_bytes - defaultDetail.size_bytes) -
+          Math.abs(right.size_bytes - defaultDetail.size_bytes),
+      )[0];
+      return [group.key, nearestSize ?? null];
+    }),
+  );
+}

--- a/studio/frontend/tests/model-picker-variant-presentation.test.ts
+++ b/studio/frontend/tests/model-picker-variant-presentation.test.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ggufVariantPickerLabel,
+  groupGgufVariantsForPicker,
+  h3PickerHasOnlyPrunedBuilds,
+  preferredGgufVariantByGroup,
+} from "../src/features/model-picker/components/model-selector/variant-presentation.ts";
+
+const GGUF_SUFFIX = /\.gguf$/i;
+
+const variant = (filename: string, size: number) => ({
+  filename,
+  quant: filename.replace(GGUF_SUFFIX, ""),
+  display_label: filename.includes("ref2va")
+    ? "References · Q4_K · Pruned"
+    : "Text & frames · Q4_K · Pruned",
+  size_bytes: size,
+});
+
+test("MiniMax H3 variants are grouped by generation workflow", () => {
+  const textQ8 = variant("minimax_h3_fl2va_pruned-Q8_0.gguf", 20);
+  const referenceQ8 = variant("minimax_h3_ref2va_pruned-Q8_0.gguf", 19);
+  const textQ4 = variant("minimax_h3_fl2va_pruned-Q4_K.gguf", 11);
+  const referenceQ4 = variant("minimax_h3_ref2va_pruned-Q4_K.gguf", 10);
+
+  const groups = groupGgufVariantsForPicker([
+    textQ8,
+    referenceQ8,
+    textQ4,
+    referenceQ4,
+  ]);
+
+  assert.deepEqual(
+    groups.map(({ key, title, description, variants }) => ({
+      key,
+      title,
+      description,
+      files: variants.map((entry) => entry.filename),
+    })),
+    [
+      {
+        key: "text-frames",
+        title: "Text / first and last frames",
+        description:
+          "Generate from a prompt, optionally using first and last frame images.",
+        files: [textQ8.filename, textQ4.filename],
+      },
+      {
+        key: "reference-media",
+        title: "Reference media",
+        description: "Generate using reference images, video, or audio.",
+        files: [referenceQ8.filename, referenceQ4.filename],
+      },
+    ],
+  );
+});
+
+test("MiniMax H3 rows show only their quantization", () => {
+  const pruned = variant("minimax_h3_fl2va_pruned-UD-Q3_K_XL.gguf", 9);
+  const full = variant("minimax_h3_ref2va-Q4_K_M.gguf", 11);
+
+  assert.equal(
+    ggufVariantPickerLabel(pruned, {
+      h3Grouped: true,
+      hideH3PrunedBuild: true,
+    }),
+    "UD-Q3_K_XL",
+  );
+  assert.equal(
+    ggufVariantPickerLabel(full, {
+      h3Grouped: true,
+      hideH3PrunedBuild: true,
+    }),
+    "Q4_K_M · Full",
+  );
+});
+
+test("MiniMax H3 rows omit shard suffixes from quantization labels", () => {
+  const sharded = variant(
+    "minimax_h3_ref2va_pruned-Q4_K_M-00001-of-00002.gguf",
+    11,
+  );
+
+  assert.equal(
+    ggufVariantPickerLabel(sharded, {
+      h3Grouped: true,
+      hideH3PrunedBuild: true,
+    }),
+    "Q4_K_M",
+  );
+  assert.equal(
+    groupGgufVariantsForPicker([sharded])[0]?.key,
+    "reference-media",
+  );
+});
+
+test("Pruned is hidden only when every visible H3 build is pruned", () => {
+  const textPruned = variant("minimax_h3_fl2va_pruned-Q4_K_M.gguf", 11);
+  const referencePruned = variant("minimax_h3_ref2va_pruned-Q4_K_M.gguf", 10);
+  const full = variant("minimax_h3_ref2va-Q4_K_M.gguf", 18);
+
+  assert.equal(
+    h3PickerHasOnlyPrunedBuilds([textPruned, referencePruned]),
+    true,
+  );
+  assert.equal(h3PickerHasOnlyPrunedBuilds([textPruned, full]), false);
+  assert.equal(
+    ggufVariantPickerLabel(textPruned, { h3Grouped: true }),
+    "Q4_K_M · Pruned",
+  );
+});
+
+test("generic and mixed repositories retain their existing presentation", () => {
+  const generic = {
+    filename: "model-Q4_K_M.gguf",
+    quant: "Q4_K_M",
+    display_label: "Q4_K_M · distilled",
+    size_bytes: 4,
+  };
+  const h3 = variant("minimax_h3_fl2va_pruned-Q4_K.gguf", 11);
+
+  assert.equal(ggufVariantPickerLabel(generic), "Q4_K_M · distilled");
+  assert.deepEqual(groupGgufVariantsForPicker([h3, generic]), [
+    {
+      key: "quantizations",
+      title: null,
+      description: null,
+      variants: [h3, generic],
+    },
+  ]);
+});
+
+test("each workflow prefers the same quantization and build as the default", () => {
+  const textRecommended = variant("minimax_h3_fl2va-Q4_K_M.gguf", 20_000);
+  const referenceMatching = variant("minimax_h3_ref2va-Q4_K_M.gguf", 30_000);
+  const referenceCloser = variant("minimax_h3_ref2va_pruned-Q6_K.gguf", 20_001);
+  const groups = groupGgufVariantsForPicker([
+    referenceCloser,
+    textRecommended,
+    referenceMatching,
+  ]);
+
+  const preferred = preferredGgufVariantByGroup(groups, textRecommended.quant);
+
+  assert.equal(preferred.get("text-frames"), textRecommended);
+  assert.equal(preferred.get("reference-media"), referenceMatching);
+});
+
+test("each workflow uses the nearest-size fallback for different quant names", () => {
+  const textRecommended = variant(
+    "minimax_h3_fl2va_pruned-UD-Q3_K_XL.gguf",
+    9_559,
+  );
+  const referenceQ3 = variant("minimax_h3_ref2va_pruned-Q3_K.gguf", 8_716);
+  const referenceQ4 = variant("minimax_h3_ref2va_pruned-Q4_K.gguf", 11_381);
+  const groups = groupGgufVariantsForPicker([
+    referenceQ4,
+    textRecommended,
+    referenceQ3,
+  ]);
+
+  const preferred = preferredGgufVariantByGroup(groups, textRecommended.quant);
+
+  assert.equal(preferred.get("text-frames"), textRecommended);
+  assert.equal(preferred.get("reference-media"), referenceQ3);
+});


### PR DESCRIPTION
## Problem

MiniMax H3 GGUF exposes separate checkpoints for text and first or last frame generation and for reference media generation. The picker interleaved both workflows by file size, repeated the workflow and `Pruned` labels on every quant, and provided only one recommendation across the combined list.

This made the mode choice difficult to scan and left `References` ambiguous for users who do not know the checkpoint names.

## Fix

- Group MiniMax H3 GGUF variants into **Text / first and last frames** and **Reference media** sections with short descriptions.
- Show only the quant name when every visible H3 build is pruned.
- Preserve `Full` and `Pruned` when a repository contains both, so equal quants remain distinguishable.
- Pair workflow recommendations by quantization and build before falling back to checkpoint size.
- Keep shard counters out of quantization labels for split GGUF checkpoints.
- Keep download, fit, and exact-file selection behavior unchanged.
- Choose and sort a recommended quant independently within each workflow.
- Leave generic and mixed GGUF repositories on their existing presentation path.

## Screenshots

### Before
<img width="486" height="442" alt="minimax-h3-picker-before" src="https://github.com/user-attachments/assets/29d50b14-f4c0-4f1a-a167-d0a114ff313c" />


### After
<img width="486" height="441" alt="minimax-h3-picker-after" src="https://github.com/user-attachments/assets/1eb062bb-e702-4db5-ac25-bbcb5c36b0bb" />


## Testing

- Frontend test suite (1,953 passed)
- Focused MiniMax H3 picker presentation tests (7 passed)
- `npm run typecheck`
- `npm run build`
- Catalog checks and `git diff --check`
- Playwright at 1600x1000 against Studio instances built from the base commit and this branch
- Playwright confirmed the BF16 picker row opens the two-mode MiniMax H3 dialog before loading
