### PR TITLE
Stop inference polling during Studio shutdown

### DIFF
--- a/studio/frontend/src/components/shutdown-dialog.tsx
+++ b/studio/frontend/src/components/shutdown-dialog.tsx
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
+import { markServerShuttingDown } from "@/lib/server-shutdown";
 import { toastError } from "@/shared/toast";
 import { useState } from "react";
 import {
@@ -33,6 +34,7 @@ export function ShutdownDialog({
 
   const handleStop = async () => {
     setStopping(true);
+    markServerShuttingDown();
     let accepted = false;
     try {
       const res = await authFetch("/api/shutdown", { method: "POST" });

--- a/studio/frontend/src/features/api-monitor/api-monitor-overlay.tsx
+++ b/studio/frontend/src/features/api-monitor/api-monitor-overlay.tsx
@@ -10,6 +10,7 @@ import {
   useFloatingPanelOrderStore,
   useFloatingPanelZIndex,
 } from "@/lib/floating-panel-order";
+import { isServerShuttingDown } from "@/lib/server-shutdown";
 import { cn } from "@/lib/utils";
 import {
   ArrowExpand01Icon,
@@ -157,6 +158,9 @@ export function ApiMonitorOverlay(): ReactElement | null {
     }
 
     function poll(): void {
+      if (isServerShuttingDown()) {
+        return;
+      }
       // A hidden tab has nobody to show the panel to.
       if (document.hidden) {
         schedule();
@@ -168,10 +172,10 @@ export function ApiMonitorOverlay(): ReactElement | null {
         })
         .catch(() => {
           // An unreachable server is the full page's story to tell.
-          if (!cancelled) setData(null);
+          if (!cancelled && !isServerShuttingDown()) setData(null);
         })
         .finally(() => {
-          if (!cancelled) schedule();
+          if (!cancelled && !isServerShuttingDown()) schedule();
         });
     }
 

--- a/studio/frontend/src/features/api-monitor/use-api-monitor.ts
+++ b/studio/frontend/src/features/api-monitor/use-api-monitor.ts
@@ -10,6 +10,7 @@ import type {
   ApiMonitorEntry,
   ApiMonitorResponse,
 } from "@/features/chat/types/api";
+import { isServerShuttingDown } from "@/lib/server-shutdown";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { clearMonitor } from "./clear-monitor";
 import { type MonitorStats, computeStats } from "./stats";
@@ -117,6 +118,9 @@ export function useApiMonitor({
     let timer: number | undefined;
 
     function poll(): void {
+      if (isServerShuttingDown()) {
+        return;
+      }
       getApiMonitor()
         .then((next) => {
           if (cancelled) return;
@@ -124,11 +128,11 @@ export function useApiMonitor({
           setError(null);
         })
         .catch((err: unknown) => {
-          if (cancelled) return;
+          if (cancelled || isServerShuttingDown()) return;
           setError(err instanceof Error ? err.message : "Monitor unavailable");
         })
         .finally(() => {
-          if (cancelled) return;
+          if (cancelled || isServerShuttingDown()) return;
           setLoading(false);
           timer = window.setTimeout(poll, intervalMs);
         });

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -13,6 +13,7 @@ import { isHuggingFaceOffline } from "@/features/hub/lib/network";
 // eslint-disable-next-line no-restricted-imports
 import { consumeNativePathToken } from "@/features/native-intents/api";
 import { formatApiErrorBody } from "@/lib/format-fastapi-error";
+import { throwIfServerShuttingDown } from "@/lib/server-shutdown";
 import { withModelLoadNotice } from "@/lib/model-lifecycle-events";
 import type {
   MessageRecord,
@@ -169,16 +170,19 @@ export async function listLoras(
 export async function getInferenceStatus(
   signal?: AbortSignal,
 ): Promise<InferenceStatusResponse> {
+  throwIfServerShuttingDown();
   const response = await authFetch("/api/inference/status", { signal });
   return parseJsonOrThrow<InferenceStatusResponse>(response);
 }
 
 export async function getApiMonitor(): Promise<ApiMonitorResponse> {
+  throwIfServerShuttingDown();
   const response = await authFetch("/api/inference/monitor");
   return parseJsonOrThrow<ApiMonitorResponse>(response);
 }
 
 export async function getApiMonitorEntry(id: string): Promise<ApiMonitorEntry> {
+  throwIfServerShuttingDown();
   const response = await authFetch(
     `/api/inference/monitor/${encodeURIComponent(id)}`,
   );

--- a/studio/frontend/src/features/loaded-models/use-loaded-models.ts
+++ b/studio/frontend/src/features/loaded-models/use-loaded-models.ts
@@ -4,6 +4,7 @@
 import { toast } from "@/lib/toast";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { subscribeModelLifecycle } from "@/lib/model-lifecycle-events";
+import { isServerShuttingDown } from "@/lib/server-shutdown";
 import { ejectLoadedModel, readLoadedModels } from "./loaded-models-api";
 import {
   type LoadedModelEntry,
@@ -108,7 +109,7 @@ export function useLoadedModels(
     // Keyed on recording, not showing: a closed card keeps polling so a load
     // started outside this tab, which raises no lifecycle event at all, still
     // brings it back.
-    if (!track) return;
+    if (!track || isServerShuttingDown()) return;
     if (inFlightRef.current) {
       // Remember the ask instead of dropping it: the refresh an eject queues
       // collides with the poll it has to correct more often than not.
@@ -190,7 +191,7 @@ export function useLoadedModels(
     if (!track) return;
     refresh();
     const timer = window.setInterval(() => {
-      if (document.hidden) return;
+      if (document.hidden || isServerShuttingDown()) return;
       refresh();
     }, POLL_INTERVAL_MS);
     // Pick up a load or unload done in another tab.

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { fetchDeviceType, usePlatformStore } from "@/config/env";
+import { isServerShuttingDown } from "@/lib/server-shutdown";
 import {
   type BackendModelDetails,
   type GgufVariantDetail,
@@ -1036,6 +1037,7 @@ export function AgentsTab() {
   useEffect(() => {
     let cancelled = false;
     const sync = () => {
+      if (isServerShuttingDown()) return;
       const seq = ++statusSeq.current;
       getInferenceStatus()
         .then((status) => {

--- a/studio/frontend/src/lib/server-shutdown.ts
+++ b/studio/frontend/src/lib/server-shutdown.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { isAppClosing } from "../components/tauri/closing-signal.ts";
+
+let serverShuttingDown = false;
+
+/** Stop background inference polls once the user has asked the server to exit. */
+export function markServerShuttingDown(): void {
+  serverShuttingDown = true;
+}
+
+/** True while the Studio server is winding down and poll traffic would race uvicorn. */
+export function isServerShuttingDown(): boolean {
+  return serverShuttingDown || isAppClosing();
+}
+
+/** Shared guard for inference status/monitor fetches and their poll loops. */
+export function throwIfServerShuttingDown(): void {
+  if (isServerShuttingDown()) {
+    throw new DOMException("Server is shutting down", "AbortError");
+  }
+}

--- a/studio/frontend/tests/server-shutdown-polling.test.ts
+++ b/studio/frontend/tests/server-shutdown-polling.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clearAppClosing,
+  markAppClosing,
+} from "../src/components/tauri/closing-signal.ts";
+import {
+  isServerShuttingDown,
+  markServerShuttingDown,
+  throwIfServerShuttingDown,
+} from "../src/lib/server-shutdown.ts";
+
+test("throwIfServerShuttingDown is a no-op while the server is running", () => {
+  assert.equal(isServerShuttingDown(), false);
+  assert.doesNotThrow(() => throwIfServerShuttingDown());
+});
+
+test("desktop app closing also pauses inference polling", () => {
+  markAppClosing();
+  try {
+    assert.equal(isServerShuttingDown(), true);
+    assert.throws(() => throwIfServerShuttingDown(), (error: unknown) => {
+      return error instanceof DOMException && error.name === "AbortError";
+    });
+  } finally {
+    clearAppClosing();
+  }
+});
+
+test("markServerShuttingDown stops inference polling", () => {
+  markServerShuttingDown();
+  assert.equal(isServerShuttingDown(), true);
+  assert.throws(() => throwIfServerShuttingDown(), (error: unknown) => {
+    return error instanceof DOMException && error.name === "AbortError";
+  });
+});
+
+test("the shutdown dialog marks the server as shutting down before POSTing", async () => {
+  const dialog = await readFile(
+    new URL("../src/components/shutdown-dialog.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    dialog,
+    /markServerShuttingDown\(\)/,
+    "shutdown must stop inference polls before uvicorn begins closing connections",
+  );
+});

--- a/studio/frontend/tests/server-shutdown-polling.test.ts
+++ b/studio/frontend/tests/server-shutdown-polling.test.ts
@@ -2,7 +2,9 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   clearAppClosing,
@@ -13,6 +15,10 @@ import {
   markServerShuttingDown,
   throwIfServerShuttingDown,
 } from "../src/lib/server-shutdown.ts";
+
+function read(path: string): string {
+  return readFileSync(fileURLToPath(new URL(path, import.meta.url)), "utf8");
+}
 
 test("throwIfServerShuttingDown is a no-op while the server is running", () => {
   assert.equal(isServerShuttingDown(), false);
@@ -39,14 +45,73 @@ test("markServerShuttingDown stops inference polling", () => {
   });
 });
 
-test("the shutdown dialog marks the server as shutting down before POSTing", async () => {
-  const dialog = await readFile(
-    new URL("../src/components/shutdown-dialog.tsx", import.meta.url),
-    "utf8",
-  );
+test("the shutdown dialog marks the server as shutting down before POSTing", () => {
+  const dialog = read("../src/components/shutdown-dialog.tsx");
   assert.match(
     dialog,
     /markServerShuttingDown\(\)/,
     "shutdown must stop inference polls before uvicorn begins closing connections",
   );
+  const stopIndex = dialog.indexOf("markServerShuttingDown()");
+  const postIndex = dialog.indexOf('authFetch("/api/shutdown"');
+  assert.ok(
+    stopIndex >= 0 && postIndex > stopIndex,
+    "markServerShuttingDown must run before POST /api/shutdown",
+  );
+});
+
+test("inference status and monitor fetches refuse to run during shutdown", () => {
+  const api = read("../src/features/chat/api/chat-api.ts");
+  for (const fn of [
+    "getInferenceStatus",
+    "getApiMonitor",
+    "getApiMonitorEntry",
+  ]) {
+    const start = api.indexOf(`export async function ${fn}`);
+    assert.ok(start >= 0, `${fn} must exist`);
+    const body = api.slice(start, api.indexOf("\nexport ", start + 1));
+    assert.match(
+      body,
+      /throwIfServerShuttingDown\(\)/,
+      `${fn} must guard shutdown polls`,
+    );
+  }
+});
+
+test("loaded-models polling stands down during shutdown", () => {
+  const hook = read("../src/features/loaded-models/use-loaded-models.ts");
+  assert.match(hook, /isServerShuttingDown\(\)/);
+  assert.match(
+    hook,
+    /if \(!track \|\| isServerShuttingDown\(\)\) return;/,
+    "refresh must not start a read while the server is shutting down",
+  );
+  assert.match(
+    hook,
+    /if \(document\.hidden \|\| isServerShuttingDown\(\)\) return;/,
+    "the interval poll must stand down during shutdown",
+  );
+});
+
+test("api monitor polling stands down during shutdown", () => {
+  const hook = read("../src/features/api-monitor/use-api-monitor.ts");
+  const poll = hook.slice(hook.indexOf("function poll(): void"), hook.indexOf("poll();"));
+  assert.match(poll, /if \(isServerShuttingDown\(\)\) \{\s*return;\s*\}/);
+  assert.match(poll, /if \(cancelled \|\| isServerShuttingDown\(\)\) return;/);
+});
+
+test("api monitor overlay polling stands down during shutdown", () => {
+  const overlay = read("../src/features/api-monitor/api-monitor-overlay.tsx");
+  const poll = overlay.slice(
+    overlay.indexOf("function poll(): void"),
+    overlay.indexOf("poll();", overlay.indexOf("function poll(): void")),
+  );
+  assert.match(poll, /if \(isServerShuttingDown\(\)\) \{\s*return;\s*\}/);
+  assert.match(poll, /if \(!cancelled && !isServerShuttingDown\(\)\) schedule\(\)/);
+});
+
+test("agents tab inference status sync stands down during shutdown", () => {
+  const tab = read("../src/features/settings/tabs/agents-tab.tsx");
+  const sync = tab.slice(tab.indexOf("const sync = () => {"), tab.indexOf("sync();"));
+  assert.match(sync, /if \(isServerShuttingDown\(\)\) return;/);
 });


### PR DESCRIPTION
## Summary

Fixes #8404

Clean Studio shutdown printed an asyncio/h11 traceback on Windows because the frontend kept polling `/api/inference/status` and `/api/inference/monitor` while uvicorn was closing connections.

## Changes

- Add `server-shutdown.ts` with a shared shutting-down flag (also respects the existing desktop `app-closing` signal)
- Call `markServerShuttingDown()` from the shutdown dialog before POSTing `/api/shutdown`
- Pause inference poll loops in loaded-models, API monitor overlay/hook, and agents tab
- Guard `getInferenceStatus` / `getApiMonitor` fetch helpers so in-flight polls stop issuing new requests

## Test plan

- [x] `node --experimental-strip-types --test tests/server-shutdown-polling.test.ts`