### PR TITLE
Desktop: let a launch step over a backend it cannot attribute

### DIFF
--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -84,12 +84,9 @@ function externalConflictMessage(preflight: DesktopPreflightResult) {
     return "The desktop-owned Unsloth backend is still starting. Wait a moment, then try again.";
   }
 
-  // Do not describe a backend from an unknown install as terminal-started.
-  if (preflight.reason === "ambiguous_root_external_backend_active") {
-    return preflight.port
-      ? `An Unsloth server is already running on port ${preflight.port}, and this app cannot confirm which install it belongs to. Stop that server, then reopen Unsloth.`
-      : "An Unsloth server is already running, and this app cannot confirm which install it belongs to. Stop that server, then reopen Unsloth.";
-  }
+  // A backend we cannot attribute to this install no longer reaches here: the
+  // launch steps over its port. Only a mutation still refuses, and that message
+  // comes from external_conflict_message in commands.rs.
 
   if (preflight.reason?.startsWith("desktop_owned_backend_unmanageable:")) {
     return preflight.port

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -165,7 +165,11 @@ fn choose_ownerless_spawned_preflight(
 
 fn mutation_blocker_from_probe(probe: BackendProbe) -> Option<ExternalBackendConflict> {
     match probe {
-        BackendProbe::ExternalConflict { port, reason } => {
+        // A launch may step over an unadoptable backend; rewriting the venv may
+        // not. We cannot prove an id-less backend is not running out of our own
+        // install, so a mutation still refuses, exactly as it did before.
+        BackendProbe::ExternalConflict { port, reason }
+        | BackendProbe::Unrelated { port, reason } => {
             Some(ExternalBackendConflict { port, reason })
         }
         BackendProbe::Ready { port } => Some(ExternalBackendConflict {
@@ -179,7 +183,10 @@ fn mutation_blocker_from_probe(probe: BackendProbe) -> Option<ExternalBackendCon
 pub async fn mutation_blocking_backend_ignoring(
     ignored_ports: &[u16],
 ) -> Option<ExternalBackendConflict> {
-    mutation_blocker_from_probe(probe_existing_backends(ignored_ports).await)
+    backend::probe_backend_ports(ignored_ports)
+        .await
+        .into_iter()
+        .find_map(mutation_blocker_from_probe)
 }
 
 pub async fn desktop_preflight_result() -> DesktopPreflightResult {
@@ -913,7 +920,7 @@ exit 1
     }
 
     #[tokio::test]
-    async fn backend_missing_root_id_is_external_conflict_before_auth_probe() {
+    async fn backend_missing_root_id_is_unrelated_before_auth_probe() {
         let probe = probe_test_backend(
             r#"{"status":"healthy","service":"Unsloth UI Backend","desktop_protocol_version":1,"supports_desktop_auth":true}"#,
             "401 Unauthorized",
@@ -922,7 +929,7 @@ exit 1
 
         assert!(matches!(
             probe,
-            BackendProbe::ExternalConflict {
+            BackendProbe::Unrelated {
                 reason,
                 ..
             } if reason == "ambiguous_root_external_backend_active"
@@ -930,7 +937,7 @@ exit 1
     }
 
     #[tokio::test]
-    async fn backend_expected_root_id_missing_is_external_conflict_before_auth_probe() {
+    async fn backend_expected_root_id_missing_is_unrelated_before_auth_probe() {
         install_test_owner();
         let port = backend_server(desktop_ready_health(EXPECTED_ROOT_ID), "401 Unauthorized").await;
         let client = crate::loopback_http::client(std::time::Duration::from_secs(2)).unwrap();
@@ -938,11 +945,48 @@ exit 1
 
         assert!(matches!(
             backend_desktop_auth_status(&client, port, &health, None).await,
-            BackendProbe::ExternalConflict {
+            BackendProbe::Unrelated {
                 reason,
                 ..
             } if reason == "ambiguous_root_external_backend_active"
         ));
+    }
+
+    /// The report this came from: an id-less Studio answered on a candidate
+    /// port, and a perfectly healthy install refused to launch at all.
+    #[test]
+    fn an_unrelated_backend_does_not_block_a_launch() {
+        let result = choose_preflight(
+            ManagedProbe::Ready {
+                bin: PathBuf::from("/bin/unsloth"),
+            },
+            BackendProbe::Unrelated {
+                port: 8888,
+                reason: "ambiguous_root_external_backend_active".to_string(),
+            },
+        );
+
+        assert_eq!(
+            result.disposition,
+            DesktopPreflightDisposition::ManagedReady
+        );
+        assert_eq!(result.port, None);
+    }
+
+    /// ...but a venv rewrite underneath it is still refused, because we cannot
+    /// rule out that it is our own install serving from a terminal.
+    #[test]
+    fn an_unrelated_backend_still_blocks_mutations() {
+        assert_eq!(
+            mutation_blocker_from_probe(BackendProbe::Unrelated {
+                port: 8899,
+                reason: "ambiguous_root_external_backend_active".to_string(),
+            }),
+            Some(ExternalBackendConflict {
+                port: 8899,
+                reason: "ambiguous_root_external_backend_active".to_string(),
+            })
+        );
     }
 
     #[tokio::test]

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -213,7 +213,10 @@ pub(super) async fn backend_desktop_auth_status(
 
     match root_status {
         BackendRootStatus::AmbiguousRoot | BackendRootStatus::ExpectedUnavailable => {
-            return BackendProbe::ExternalConflict {
+            // Not adoptable, and not proof that our own install is serving: an
+            // id-less backend is just as likely a remote Studio reached through
+            // a port forward. Starting is fine, the port simply is not free.
+            return BackendProbe::Unrelated {
                 port,
                 reason: "ambiguous_root_external_backend_active".to_string(),
             };
@@ -289,10 +292,13 @@ pub(super) async fn backend_desktop_auth_status(
     }
 }
 
-pub(super) async fn probe_existing_backends(ignored_ports: &[u16]) -> BackendProbe {
+/// Classify every candidate port. Callers pick from the result, because launch
+/// and mutation weigh the outcomes differently: launch may step over a backend
+/// it cannot adopt, a venv rewrite may not.
+pub(super) async fn probe_backend_ports(ignored_ports: &[u16]) -> Vec<BackendProbe> {
     let client = match crate::loopback_http::client(Duration::from_secs(2)) {
         Ok(client) => client,
-        Err(_) => return BackendProbe::Missing,
+        Err(_) => return Vec::new(),
     };
 
     // Fan out health probes concurrently. The desktop-auth probe is still
@@ -314,21 +320,27 @@ pub(super) async fn probe_existing_backends(ignored_ports: &[u16]) -> BackendPro
     }
 
     let expected_studio_root_id = crate::desktop_backend_owner::read_expected_studio_root_id();
-    let mut first_conflict = None;
-    let mut first_ready = None;
-    let mut first_old = None;
+    let mut probes = Vec::new();
     for (port, health) in candidates {
         if ignored_ports.contains(&port) {
             continue;
         }
-        match backend_desktop_auth_status(
-            &client,
-            port,
-            &health,
-            expected_studio_root_id.as_deref(),
-        )
-        .await
-        {
+        probes.push(
+            backend_desktop_auth_status(&client, port, &health, expected_studio_root_id.as_deref())
+                .await,
+        );
+    }
+    probes
+}
+
+/// Pick the outcome that decides a launch. An `Unrelated` backend is not a
+/// verdict at all: the port is taken, the backend picks the next one.
+fn select_launch_probe(probes: Vec<BackendProbe>) -> BackendProbe {
+    let mut first_conflict = None;
+    let mut first_ready = None;
+    let mut first_old = None;
+    for probe in probes {
+        match probe {
             conflict @ BackendProbe::ExternalConflict { .. } if first_conflict.is_none() => {
                 first_conflict = Some(conflict)
             }
@@ -336,6 +348,9 @@ pub(super) async fn probe_existing_backends(ignored_ports: &[u16]) -> BackendPro
                 first_ready = Some(ready)
             }
             old @ BackendProbe::Old { .. } if first_old.is_none() => first_old = Some(old),
+            BackendProbe::Unrelated { port, reason } => {
+                info!("Desktop preflight: skipping port {port} ({reason})");
+            }
             _ => {}
         }
     }
@@ -344,6 +359,10 @@ pub(super) async fn probe_existing_backends(ignored_ports: &[u16]) -> BackendPro
         .or(first_ready)
         .or(first_old)
         .unwrap_or(BackendProbe::Missing)
+}
+
+pub(super) async fn probe_existing_backends(ignored_ports: &[u16]) -> BackendProbe {
+    select_launch_probe(probe_backend_ports(ignored_ports).await)
 }
 
 #[cfg(test)]
@@ -366,8 +385,45 @@ mod tests {
         }
     }
 
+    fn unrelated(port: u16) -> BackendProbe {
+        BackendProbe::Unrelated {
+            port,
+            reason: "ambiguous_root_external_backend_active".to_string(),
+        }
+    }
+
+    /// A tunnelled or id-less Studio anywhere in 8888..=8908 used to poison the
+    /// whole launch, even with every other port free.
+    #[test]
+    fn unrelated_backends_never_decide_a_launch() {
+        assert_eq!(
+            select_launch_probe(vec![unrelated(8888), unrelated(8899)]),
+            BackendProbe::Missing
+        );
+        assert_eq!(
+            select_launch_probe(vec![unrelated(8888), BackendProbe::Ready { port: 8890 }]),
+            BackendProbe::Ready { port: 8890 }
+        );
+    }
+
+    #[test]
+    fn a_genuine_conflict_still_decides_a_launch() {
+        let conflict = BackendProbe::ExternalConflict {
+            port: 8890,
+            reason: "desktop_owned_backend_active".to_string(),
+        };
+        assert_eq!(
+            select_launch_probe(vec![
+                unrelated(8888),
+                BackendProbe::Ready { port: 8889 },
+                conflict.clone(),
+            ]),
+            conflict
+        );
+    }
+
     /// Minting an id at startup must not reclassify a backend that predates
-    /// ownership: it reports no id, or an empty one, and stays a conflict.
+    /// ownership: it reports no id, or an empty one, and stays unadoptable.
     #[test]
     fn ownerless_backends_stay_ambiguous_once_a_local_id_exists() {
         for reported in [None, Some(""), Some("not-hex"), Some("AAAA")] {

--- a/studio/src-tauri/src/preflight/types.rs
+++ b/studio/src-tauri/src/preflight/types.rs
@@ -41,4 +41,9 @@ pub(super) enum BackendProbe {
     Ready { port: u16 },
     Old { port: u16, reason: String },
     ExternalConflict { port: u16, reason: String },
+    /// A backend answered here, but it is not adoptable and not provably ours:
+    /// it reports no install id, so it may be a remote Studio behind a tunnel or
+    /// an install that predates the id. Launching skips the port; mutating flows
+    /// still refuse, since they cannot rule out our own venv underneath it.
+    Unrelated { port: u16, reason: String },
 }


### PR DESCRIPTION
## The problem

Two support reports, Windows 0.1.62-beta and macOS 0.1.61-beta, end the same way on a healthy install:

```
disposition=external_conflict
reason=ambiguous_root_external_backend_active
can_auto_repair=false
managed_bin_exists=true
error=An Unsloth server is already running on port 8888, and this app cannot
      confirm which install it belongs to. Stop that server, then reopen Unsloth.
```

`backend_root_status` classifies a server that reports no `studio_root_id`, an empty one, or a non-hex one as `AmbiguousRoot`, and `preflight/backend.rs` turned that straight into a terminal `ExternalConflict`. Two ways to land there, one per report:

- an `ssh -L 127.0.0.1:8888` forward to a machine that also runs Studio. The health probe gets a real Unsloth answer, but the id belongs to the other box.
- any install without `share/studio_install_id`. `_studio_root_id()` reports `""`, and its own docstring says that means "the launcher accepts any healthy backend", which is the opposite of what preflight did with it.

`probe_existing_backends` folds with `first_conflict.or(first_ready).or(first_old)` across the whole 8888..=8908 candidate range, so a single such server anywhere in the range failed the launch. The macOS report is exactly that: the conflict is on **8899**, 8888 is free, the install probes `Ready`, and the app still refuses.

The irony is that the fallback the user wanted already exists one layer down. `backend_args` just passes `-p`, `_resolve_port` slides 8888 to 8889 for `--api-only`, and `validate_candidate_port` validates whatever `TAURI_PORT` announced without ever comparing it to what was requested. Preflight simply never let the spawn happen.

Reproduced against a live server that answers `studio_root_id: ""`:

```
$ curl -s http://127.0.0.1:8888/api/health | jq '{service, studio_root_id, desktop_owner}'
{ "service": "Unsloth UI Backend", "studio_root_id": "", "desktop_owner": null }
```

## The change

A backend we cannot attribute is not evidence that this install is serving. It now probes as `BackendProbe::Unrelated`, and the two callers weigh it differently:

**Launch** skips the port and logs it. `choose_preflight` falls through to the managed state, the backend starts, and it picks the next free port itself and reports it through `TAURI_PORT` as before. Nothing in the spawn path needed to change.

**Mutation keeps today's behaviour exactly.** A repair or update rewrites the shared venv, and an id-less backend could still be this install started from a terminal, so `mutation_blocker_from_probe` treats `Unrelated` as a blocker. It also gets its own selector over the full probe list now, so an `Unrelated` on a later port is no longer swallowed by an `Old` on an earlier one. That split is the point of the change: a false skip on launch costs nothing, a false pass on a venv rewrite corrupts an install.

`ForeignRoot` stays `Old`. A valid but different id is positive proof the server is not ours, and `Old` is already non-fatal on both paths.

Deliberately not included:

- **A Rust-side port scan before spawn.** It would be advisory only, since the child re-resolves and `TAURI_PORT` is authoritative, and the two fallbacks would routinely disagree and make the "Starting backend: ... -p 8890" log line lie.
- **Reading the Python `studio-{port}-{pid}.pid` files to prove local ownership.** Our own child writes one too, so a repair right after a normal start would see itself as a conflict, and Rust has no cross-platform process create-time to detect a recycled PID the way `_pid_is_studio_backend` does. Keeping the mutation path conservative gets the same safety property with no new failure mode.

## Tests

`cargo test --no-fail-fast`: 234 passed.

Updated, since they encoded the old classification:

- `backend_missing_root_id_is_external_conflict_before_auth_probe` -> `..._is_unrelated_...`
- `backend_expected_root_id_missing_is_external_conflict_before_auth_probe` -> `..._is_unrelated_...`

Added:

- `unrelated_backends_never_decide_a_launch` and `a_genuine_conflict_still_decides_a_launch`, pure folds over `select_launch_probe`, including the macOS shape of an unrelated server sitting on a port while another is free.
- `an_unrelated_backend_does_not_block_a_launch`, the end of the reported failure: `ManagedReady` with `port: None`.
- `an_unrelated_backend_still_blocks_mutations`, the regression guard for the safety property.

Unaffected and verified still passing: `external_conflict_blocks_managed_flow`, `stale_same_root_without_desktop_owner_is_external_conflict`, `backend_root_id_mismatch_is_old_before_auth_probe`, `mutation_guard_blocks_second_external_backend_when_owned_child_is_ignored`.
