### PR TITLE
Studio: keep the compiled cache when a sibling backend is live

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -341,7 +341,9 @@ from utils.torch_warmup import (
     start_background_warm,
     warm_status,
 )
-from utils.cache_cleanup import clear_unsloth_compiled_cache
+from utils.cache_cleanup import (
+    clear_compiled_cache_unless_shared as _clear_compiled_cache_unless_shared,
+)
 from utils.lifespan_shutdown import run_lifespan_shutdown
 from utils.native_path_leases import native_path_leases_supported
 from utils.update_status import (
@@ -630,25 +632,13 @@ def _post_warm_background_work(generation: Optional[int] = None) -> None:
 
 
 def clear_compiled_cache_unless_shared(app: FastAPI) -> None:
-    """Clear the compiled cache, unless another backend of this install is live.
+    """Clear the compiled cache unless a sibling backend of this install is live.
 
-    The cache sits in the install tree, not the studio home, so two of our own
-    backends share it and the wipe would delete modules the other one is still
-    importing -- including the Unsloth*Trainer.py that the in-process clears
-    preserve for spawn workers. run_server supplies the probe on app.state;
-    without it (tests, an embedded app) the old unconditional clear stands.
+    The decision lives in cache_cleanup, next to the paths it clears and the lock
+    that serializes it against a sibling's startup; run_server puts the probe on
+    app.state because main.py must not import run.py back.
     """
-    probe = getattr(app.state, "live_sibling_backend", None)
-    sibling = probe() if callable(probe) else None
-    if sibling is None:
-        clear_unsloth_compiled_cache()
-        return
-    import structlog as _structlog
-
-    _structlog.get_logger(__name__).info(
-        "Keeping the compiled cache: another backend of this install is live",
-        sibling_pid = sibling,
-    )
+    _clear_compiled_cache_unless_shared(getattr(app.state, "live_sibling_backend", None))
 
 
 @asynccontextmanager

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -638,11 +638,7 @@ def clear_compiled_cache_unless_shared(app: FastAPI) -> None:
     that serializes it against a sibling's startup; run_server puts the probe on
     app.state because main.py must not import run.py back.
     """
-    _clear_compiled_cache_unless_shared(
-        getattr(app.state, "live_sibling_backend", None),
-        started_at = getattr(app.state, "backend_started_at", None),
-        established_probe = getattr(app.state, "established_sibling_backend", None),
-    )
+    _clear_compiled_cache_unless_shared(getattr(app.state, "live_sibling_backend", None))
 
 
 @asynccontextmanager

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -641,6 +641,7 @@ def clear_compiled_cache_unless_shared(app: FastAPI) -> None:
     _clear_compiled_cache_unless_shared(
         getattr(app.state, "live_sibling_backend", None),
         started_at = getattr(app.state, "backend_started_at", None),
+        established_probe = getattr(app.state, "established_sibling_backend", None),
     )
 
 

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -638,7 +638,10 @@ def clear_compiled_cache_unless_shared(app: FastAPI) -> None:
     that serializes it against a sibling's startup; run_server puts the probe on
     app.state because main.py must not import run.py back.
     """
-    _clear_compiled_cache_unless_shared(getattr(app.state, "live_sibling_backend", None))
+    _clear_compiled_cache_unless_shared(
+        getattr(app.state, "live_sibling_backend", None),
+        started_at = getattr(app.state, "backend_started_at", None),
+    )
 
 
 @asynccontextmanager

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -629,6 +629,28 @@ def _post_warm_background_work(generation: Optional[int] = None) -> None:
     _warm_rag_embedder()
 
 
+def clear_compiled_cache_unless_shared(app: FastAPI) -> None:
+    """Clear the compiled cache, unless another backend of this install is live.
+
+    The cache sits in the install tree, not the studio home, so two of our own
+    backends share it and the wipe would delete modules the other one is still
+    importing -- including the Unsloth*Trainer.py that the in-process clears
+    preserve for spawn workers. run_server supplies the probe on app.state;
+    without it (tests, an embedded app) the old unconditional clear stands.
+    """
+    probe = getattr(app.state, "live_sibling_backend", None)
+    sibling = probe() if callable(probe) else None
+    if sibling is None:
+        clear_unsloth_compiled_cache()
+        return
+    import structlog as _structlog
+
+    _structlog.get_logger(__name__).info(
+        "Keeping the compiled cache: another backend of this install is live",
+        sibling_pid = sibling,
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup: detect hardware, seed default admin if needed. Shutdown: clean up compiled cache."""
@@ -639,7 +661,7 @@ async def lifespan(app: FastAPI):
     import structlog as _structlog
 
     _lifespan_log = _structlog.get_logger(__name__)
-    clear_unsloth_compiled_cache()
+    clear_compiled_cache_unless_shared(app)
 
     # Move the legacy sandbox up here rather than from the first request: the
     # copy can be minutes when the studio home is on another filesystem.
@@ -783,7 +805,7 @@ async def lifespan(app: FastAPI):
 
     await run_lifespan_shutdown(
         terminate_hub_downloads,
-        clear_unsloth_compiled_cache,
+        lambda: clear_compiled_cache_unless_shared(app),
         _hw_module,
     )
     # Shutdown cleared the state this warm produced, so release the one-per-process latch.

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1235,14 +1235,13 @@ def _remove_pid_file():
     _PID_FILE is checked even when the per-port record was never written, since
     _write_pid_file writes the two independently.
 
-    The startup marker goes here too, not only from the atexit hook: run_server
-    returns while uvicorn runs on a daemon thread, so an embedded host (a
-    notebook) can stop the server and keep the process alive. The marker left
-    behind would then answer every later probe as a live sibling and no backend
-    of this install would ever clear the compiled cache again. atexit stays as
-    the fallback for a startup that fails before any record is written.
+    The startup marker is deliberately NOT dropped here. _graceful_shutdown
+    calls this before the server thread is joined, and a backend that is still
+    finishing an in-flight request or a background warm is still importing from
+    the cache; going invisible there would let a replacement clear it underneath.
+    The marker goes when the server thread actually ends, and from the atexit
+    hook if the process exits first.
     """
-    _remove_startup_marker()
     # Nothing here may raise: _graceful_shutdown calls this at the end, and an
     # unreadable or undeletable record must not abandon the rest of the exit
     # path. _read_pid_record already swallows OSError/UnicodeDecodeError.
@@ -2432,7 +2431,10 @@ def run_server(
             # An embedded host stays alive after the server thread ends, and a
             # post-readiness failure in here never reaches run_server's caller,
             # so nothing else takes these back. They would keep validating
-            # against the still-live host PID with no backend serving.
+            # against the still-live host PID with no backend serving. This is
+            # also the point at which the backend has genuinely stopped serving,
+            # which is why the marker goes here rather than in _remove_pid_file.
+            _remove_startup_marker()
             _remove_pid_file()
 
     thread = Thread(target = _run, daemon = True)

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1028,6 +1028,7 @@ def write_startup_marker() -> None:
         from utils.cache_cleanup import compiled_cache_lock
     except Exception:
         import contextlib
+
         # No lock available means an unserialized publish, which is what this
         # did before the lock existed. Startup still has to happen.
         compiled_cache_lock = contextlib.nullcontext

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -831,7 +831,7 @@ PID_FILE_GLOB = "studio-*.pid"
 # server with a port in the name, and a process that has not bound yet is not
 # one. Only the sibling probe reads these.
 STARTUP_MARKER_GLOB = "studio-starting-*.marker"
-_OWN_STARTUP_MARKER: "Path | None" = None
+_OWN_STARTUP_MARKERS: "list[Path]" = []
 
 
 def _pid_file_for_port(port: int) -> Path:
@@ -981,6 +981,30 @@ def _legacy_studio_on_port(port: int) -> "int | None":
     return pid
 
 
+def _startup_marker_dirs() -> "list[Path]":
+    """Where a startup marker is written, and looked for.
+
+    Two places, because the studio home is the wrong key for this question. What
+    the marker protects is the compiled cache, and `clear_unsloth_compiled_cache`
+    also clears whatever UNSLOTH_COMPILE_LOCATION names, which is set
+    independently of UNSLOTH_STUDIO_HOME. Two studio homes can therefore point at
+    one cache directory, and a home-scoped marker leaves each of them believing
+    it is alone. `cache_coordination_dir` is keyed on the cache paths themselves,
+    so both of them land in the same directory.
+    """
+    dirs = [_studio_root()]
+    try:
+        from utils.cache_cleanup import cache_coordination_dir
+        shared = cache_coordination_dir()
+    except Exception:
+        # An import or path failure here only costs cross-home discovery; the
+        # home-scoped marker, which is the common case, still gets written.
+        return dirs
+    if shared not in dirs:
+        dirs.append(shared)
+    return dirs
+
+
 def write_startup_marker() -> None:
     """Record that this process is coming up, before uvicorn starts.
 
@@ -990,21 +1014,36 @@ def write_startup_marker() -> None:
     exact race this is meant to prevent, so a sibling has to be discoverable
     from the moment it could do any clearing.
 
+    Published under the same lock the clear takes, so the marker cannot appear in
+    the gap between a sibling's probe and its rmtree; that ordering is the whole
+    point of the marker.
+
     Best effort, like the records themselves: a studio home we cannot write to
     is not a reason to refuse to start.
     """
-    global _OWN_STARTUP_MARKER
     me = os.getpid()
-    path = _studio_root() / f"studio-starting-{me}.marker"
     created = _process_create_time(me)
+    body = f"{me}\n{created if created is not None else ''}\n"
     try:
-        _studio_root().mkdir(parents = True, exist_ok = True)
-        # Same layout as a per-port record, so _read_pid_record parses both. An
-        # unknown start time is a blank line, which it reads back as None.
-        path.write_text(f"{me}\n{created if created is not None else ''}\n", encoding = "utf-8")
-    except OSError:
+        from utils.cache_cleanup import compiled_cache_lock
+    except Exception:
+        import contextlib
+        # No lock available means an unserialized publish, which is what this
+        # did before the lock existed. Startup still has to happen.
+        compiled_cache_lock = contextlib.nullcontext
+    with compiled_cache_lock():
+        for directory in _startup_marker_dirs():
+            path = directory / f"studio-starting-{me}.marker"
+            try:
+                directory.mkdir(parents = True, exist_ok = True)
+                # Same layout as a per-port record, so _read_pid_record parses
+                # both. An unknown start time is a blank line, read back as None.
+                path.write_text(body, encoding = "utf-8")
+            except OSError:
+                continue
+            _OWN_STARTUP_MARKERS.append(path)
+    if not _OWN_STARTUP_MARKERS:
         return
-    _OWN_STARTUP_MARKER = path
     import atexit
 
     # Registered here rather than beside the pid-file hook: startup can fail
@@ -1013,21 +1052,22 @@ def write_startup_marker() -> None:
 
 
 def _remove_startup_marker() -> None:
-    global _OWN_STARTUP_MARKER
-    if _OWN_STARTUP_MARKER is None:
-        return
-    try:
-        _OWN_STARTUP_MARKER.unlink(missing_ok = True)
-    except OSError:
-        pass
-    _OWN_STARTUP_MARKER = None
+    while _OWN_STARTUP_MARKERS:
+        path = _OWN_STARTUP_MARKERS.pop()
+        try:
+            path.unlink(missing_ok = True)
+        except OSError:
+            pass
 
 
 def _startup_marker_records() -> "list[tuple[int, float | None, str | None] | None]":
-    try:
-        return [_read_pid_record(p) for p in _studio_root().glob(STARTUP_MARKER_GLOB)]
-    except OSError:
-        return []
+    records: "list[tuple[int, float | None, str | None] | None]" = []
+    for directory in _startup_marker_dirs():
+        try:
+            records.extend(_read_pid_record(p) for p in directory.glob(STARTUP_MARKER_GLOB))
+        except OSError:
+            continue
+    return records
 
 
 def _legacy_record() -> "tuple[int, float | None, str | None] | None":
@@ -1054,13 +1094,20 @@ def live_sibling_backend() -> "int | None":
     explicit pid check keeps it correct for the marker, which is.
     """
     me = os.getpid()
-    for record in _startup_marker_records() + _per_port_records() + [_legacy_record()]:
+    timed = [r for r in _startup_marker_records() + _per_port_records() if r is not None]
+    for record in timed + [_legacy_record()]:
         if record is None:
             continue
         pid, created, _address = record
         if pid == me or not _pid_alive(pid):
             continue
-        if _pid_is_studio_backend(pid, [created]):
+        # Corroborate against every other record for this PID, the way
+        # _legacy_studio_on_port does. studio.pid holds a bare PID with no start
+        # time, and an untimed record is trusted unconditionally, so on its own
+        # it would resurrect a server that died and had its PID reused -- and
+        # keep the compiled cache forever on the strength of it. A timestamped
+        # record for the same PID that fails the check is the proof it is gone.
+        if _pid_is_studio_backend(pid, [created] + [r[1] for r in timed if r[0] == pid]):
             return pid
     return None
 
@@ -1195,11 +1242,19 @@ def _legacy_heir() -> "int | None":
 
 
 def _remove_pid_file():
-    """Remove the PID files that belong to this process.
+    """Remove the records that belong to this process.
 
     _PID_FILE is checked even when the per-port record was never written, since
     _write_pid_file writes the two independently.
+
+    The startup marker goes here too, not only from the atexit hook: run_server
+    returns while uvicorn runs on a daemon thread, so an embedded host (a
+    notebook) can stop the server and keep the process alive. The marker left
+    behind would then answer every later probe as a live sibling and no backend
+    of this install would ever clear the compiled cache again. atexit stays as
+    the fallback for a startup that fails before any record is written.
     """
+    _remove_startup_marker()
     # Nothing here may raise: _graceful_shutdown calls this at the end, and an
     # unreadable or undeletable record must not abandon the rest of the exit
     # path. _read_pid_record already swallows OSError/UnicodeDecodeError.

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1158,13 +1158,32 @@ def _legacy_record() -> "tuple[tuple[int, float | None, str | None], float] | No
     return None if record is None else (record, _record_written_at(_PID_FILE))
 
 
+def _sibling_is_running(pid: int) -> bool:
+    """Alive, and not an exited process nobody waited on.
+
+    A zombie answers kill(0) and keeps its start time, so on its own liveness
+    reads it as a serving backend. Under a non-reaping parent (PID 1 in some
+    containers) it can stay that way indefinitely, and a record pointing at one
+    would pin the compiled cache on every later startup.
+    """
+    if not _pid_alive(pid):
+        return False
+    try:
+        from utils.process_lifetime import _pid_is_zombie
+    except Exception:  # noqa: BLE001
+        # The check is an exclusion, so without it this behaves as it did
+        # before: alive is alive.
+        return True
+    return not _pid_is_zombie(pid)
+
+
 def _live_sibling(records: "list", me: int, timed: "list") -> "int | None":
     for entry in records:
         if entry is None:
             continue
         record, written_at = entry
         pid, created, _address = record
-        if pid == me or not _pid_alive(pid):
+        if pid == me or not _sibling_is_running(pid):
             continue
         # Corroborate against other records for this PID, the way
         # _legacy_studio_on_port does. studio.pid holds a bare PID with no start

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1089,6 +1089,24 @@ def _legacy_record() -> "tuple[int, float | None, str | None] | None":
         return None
 
 
+def _live_sibling(records: "list", me: int, timed: "list") -> "int | None":
+    for record in records:
+        if record is None:
+            continue
+        pid, created, _address = record
+        if pid == me or not _pid_alive(pid):
+            continue
+        # Corroborate against every other record for this PID, the way
+        # _legacy_studio_on_port does. studio.pid holds a bare PID with no start
+        # time, and an untimed record is trusted unconditionally, so on its own
+        # it would resurrect a server that died and had its PID reused -- and
+        # keep the compiled cache forever on the strength of it. A timestamped
+        # record for the same PID that fails the check is the proof it is gone.
+        if _pid_is_studio_backend(pid, [created] + [r[1] for r in timed if r[0] == pid]):
+            return pid
+    return None
+
+
 def live_sibling_backend() -> "int | None":
     """PID of another live Studio backend of this install, or None.
 
@@ -1107,21 +1125,21 @@ def live_sibling_backend() -> "int | None":
     """
     me = os.getpid()
     timed = [r for r in _startup_marker_records() + _per_port_records() if r is not None]
-    for record in timed + [_legacy_record()]:
-        if record is None:
-            continue
-        pid, created, _address = record
-        if pid == me or not _pid_alive(pid):
-            continue
-        # Corroborate against every other record for this PID, the way
-        # _legacy_studio_on_port does. studio.pid holds a bare PID with no start
-        # time, and an untimed record is trusted unconditionally, so on its own
-        # it would resurrect a server that died and had its PID reused -- and
-        # keep the compiled cache forever on the strength of it. A timestamped
-        # record for the same PID that fails the check is the proof it is gone.
-        if _pid_is_studio_backend(pid, [created] + [r[1] for r in timed if r[0] == pid]):
-            return pid
-    return None
+    return _live_sibling(timed + [_legacy_record()], me, timed)
+
+
+def established_sibling_backend() -> "int | None":
+    """PID of a sibling that has already bound a port, or None.
+
+    Deliberately blind to startup markers. A sibling that is itself still
+    starting has not cleaned anything, so it is not a reason to keep a stale
+    cache; a sibling that is serving is, and a pre-upgrade one writes no marker
+    and no stamp, so judging it by whether it has cleared would clear the cache
+    underneath it.
+    """
+    me = os.getpid()
+    timed = [r for r in _per_port_records() if r is not None]
+    return _live_sibling(timed + [_legacy_record()], me, timed)
 
 
 def _per_port_records() -> "list[tuple[int, float | None, str | None] | None]":
@@ -2032,7 +2050,22 @@ _PARALLEL_MAX = 64
 _PARALLEL_DEFAULT_PLAIN = 4
 
 
-def run_server(
+def run_server(*args, **kwargs):
+    """Start the server, and take the startup marker back if it never starts.
+
+    An embedded caller keeps its process alive across a failure -- colab.py
+    catches SystemExit and Exception around this -- and no exit hook runs then.
+    A marker left behind would answer every later sibling probe as a live
+    backend, so no backend of this install would clear the compiled cache again.
+    """
+    try:
+        return _run_server(*args, **kwargs)
+    except BaseException:
+        _remove_startup_marker()
+        raise
+
+
+def _run_server(
     host: str = "127.0.0.1",
     port: int = 8888,
     frontend_path: Path = _DEFAULT_FRONTEND_PATH,
@@ -2185,6 +2218,7 @@ def run_server(
     # shutdown, when a sibling may have started since. On app.state rather than
     # imported, because main.py must not import this module back.
     app.state.live_sibling_backend = live_sibling_backend
+    app.state.established_sibling_backend = established_sibling_backend
     # Read here rather than in main.py: the decision is about whether anything
     # cleared since THIS process started, and the marker is already written.
     app.state.backend_started_at = _process_create_time(os.getpid())

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1038,50 +1038,107 @@ def write_startup_marker() -> None:
     atexit.register(_remove_startup_marker)
 
 
+# Enough attempts to outlast the usual Windows holder (an indexer or a scanner
+# with the file open), short enough that shutdown is not visibly delayed.
+_MARKER_REMOVAL_ATTEMPTS = 5
+_MARKER_REMOVAL_BACKOFF_SECONDS = 0.2
+
+
 def _remove_startup_marker() -> None:
-    # A path is dropped from the list only once it is actually gone. A transient
-    # unlink failure would otherwise lose the only reference to it, leaving a
-    # marker on disk that no later cleanup can retry: its recorded start time
-    # still matches this process, so an embedded host that keeps running would
-    # go on answering as a live backend and pin the compiled cache.
+    """Delete this process's startup markers, retrying a failure a few times.
+
+    A path is dropped from the list only once it is actually gone. A transient
+    unlink failure would otherwise lose the only reference to it, leaving a
+    marker on disk that no later cleanup can retry: its recorded start time
+    still matches this process, so an embedded host that keeps running would go
+    on answering as a live backend and pin the compiled cache.
+
+    Retrying here rather than only keeping the path is what makes that recovery
+    real. The one guaranteed later call is the atexit hook, which an embedded
+    host that outlives its backend does not reach for a long time, if ever.
+    """
+    import time
+
     remaining = []
     while _OWN_STARTUP_MARKERS:
         path = _OWN_STARTUP_MARKERS.pop()
-        try:
-            path.unlink(missing_ok = True)
-        except OSError:
-            remaining.append(path)
+        for attempt in range(_MARKER_REMOVAL_ATTEMPTS):
+            try:
+                path.unlink(missing_ok = True)
+                break
+            except OSError:
+                if attempt + 1 == _MARKER_REMOVAL_ATTEMPTS:
+                    # Still tracked, so the atexit hook and any later call try
+                    # again; this is the floor, not the only chance.
+                    remaining.append(path)
+                    break
+                time.sleep(_MARKER_REMOVAL_BACKOFF_SECONDS)
     _OWN_STARTUP_MARKERS.extend(remaining)
 
 
-def _startup_marker_records() -> "list[tuple[int, float | None, str | None] | None]":
+def _record_written_at(path: Path) -> float:
+    """When *path* was last written, or 0.0 when the filesystem will not say.
+
+    0.0 makes an unreadable time the oldest possible, so it never wins the
+    "which statement about this PID came last" comparison below.
+    """
     try:
-        return [_read_pid_record(p) for p in _studio_root().glob(STARTUP_MARKER_GLOB)]
+        return path.stat().st_mtime
     except OSError:
-        return []
+        return 0.0
 
 
-def _legacy_record() -> "tuple[int, float | None, str | None] | None":
+def _timed_records() -> "list[tuple[tuple[int, float | None, str | None], float]]":
+    """Every startup marker and per-port record, each with its write time."""
+    paths: "list[Path]" = []
+    for pattern in (STARTUP_MARKER_GLOB, PID_FILE_GLOB):
+        try:
+            paths.extend(_studio_root().glob(pattern))
+        except OSError:
+            continue
+    found = []
+    for path in paths:
+        record = _read_pid_record(path)
+        if record is not None:
+            found.append((record, _record_written_at(path)))
+    return found
+
+
+def _legacy_record() -> "tuple[tuple[int, float | None, str | None], float] | None":
     try:
-        return _read_pid_record(_PID_FILE) if _PID_FILE.is_file() else None
+        if not _PID_FILE.is_file():
+            return None
     except OSError:
         return None
+    record = _read_pid_record(_PID_FILE)
+    return None if record is None else (record, _record_written_at(_PID_FILE))
 
 
 def _live_sibling(records: "list", me: int, timed: "list") -> "int | None":
-    for record in records:
-        if record is None:
+    for entry in records:
+        if entry is None:
             continue
+        record, written_at = entry
         pid, created, _address = record
         if pid == me or not _pid_alive(pid):
             continue
-        # Corroborate against every other record for this PID, the way
+        # Corroborate against other records for this PID, the way
         # _legacy_studio_on_port does. studio.pid holds a bare PID with no start
         # time, and an untimed record is trusted unconditionally, so on its own
         # it would resurrect a server that died and had its PID reused -- and
         # keep the compiled cache forever on the strength of it. A timestamped
-        # record for the same PID that fails the check is the proof it is gone.
-        if _pid_is_studio_backend(pid, [created] + [r[1] for r in timed if r[0] == pid]):
+        # record for the same PID that fails the check is evidence it is gone.
+        #
+        # Only a record written no earlier than this one counts as that
+        # evidence. A pre-upgrade backend writes a bare studio.pid and nothing
+        # else, so if it starts on a PID a crashed current-version backend left
+        # a timestamped record for, the older timestamp is a statement about a
+        # process that is gone, not about this one. Letting it veto would clear
+        # the compiled cache under a serving legacy backend.
+        corroborating = [
+            other[1] for other, other_written in timed if other[0] == pid and other_written >= written_at
+        ]
+        if _pid_is_studio_backend(pid, [created] + corroborating):
             return pid
     return None
 
@@ -1103,7 +1160,7 @@ def live_sibling_backend() -> "int | None":
     explicit pid check keeps it correct for the marker, which is.
     """
     me = os.getpid()
-    timed = [r for r in _startup_marker_records() + _per_port_records() if r is not None]
+    timed = _timed_records()
     return _live_sibling(timed + [_legacy_record()], me, timed)
 
 

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2092,7 +2092,16 @@ def _drops_its_marker_on_failure(start):
         try:
             return start(*args, **kwargs)
         except BaseException:
-            _remove_startup_marker()
+            # Only when no server thread is left running. A KeyboardInterrupt
+            # during the readiness wait asks uvicorn to stop and re-raises
+            # without joining, so the thread may still be finishing lifespan
+            # startup or shutdown. Taking the marker back there makes a backend
+            # that is still up invisible to a sibling, which would then clear
+            # the compiled cache under it. That thread's own finally removes
+            # the marker at the point it has genuinely stopped serving.
+            thread = _server_thread
+            if thread is None or not thread.is_alive():
+                _remove_startup_marker()
             raise
 
     return started

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -981,31 +981,6 @@ def _legacy_studio_on_port(port: int) -> "int | None":
     return pid
 
 
-def _startup_marker_dirs() -> "list[Path]":
-    """Where a startup marker is written, and looked for.
-
-    Two places, because the studio home is the wrong key for this question. What
-    the marker protects is the compiled cache, and `clear_unsloth_compiled_cache`
-    also clears whatever UNSLOTH_COMPILE_LOCATION names, which is set
-    independently of UNSLOTH_STUDIO_HOME. Two studio homes can therefore point at
-    one cache directory, and a home-scoped marker leaves each of them believing
-    it is alone. `cache_coordination_dirs` is keyed per cache path, so any
-    install that would clear the same directory lands in the same place.
-    """
-    dirs = [_studio_root()]
-    try:
-        from utils.cache_cleanup import cache_coordination_dirs
-        shared = cache_coordination_dirs()
-    except Exception:
-        # An import or path failure here only costs cross-home discovery; the
-        # home-scoped marker, which is the common case, still gets written.
-        return dirs
-    for directory in shared:
-        if directory not in dirs:
-            dirs.append(directory)
-    return dirs
-
-
 def write_startup_marker() -> None:
     """Record that this process is coming up, before uvicorn starts.
 
@@ -1044,16 +1019,16 @@ def write_startup_marker() -> None:
                 "Publishing the startup marker without the cache lock: another backend "
                 "has held it for 30s"
             )
-        for directory in _startup_marker_dirs():
-            path = directory / f"studio-starting-{me}.marker"
-            try:
-                directory.mkdir(parents = True, exist_ok = True)
-                # Same layout as a per-port record, so _read_pid_record parses
-                # both. An unknown start time is a blank line, read back as None.
-                path.write_text(body, encoding = "utf-8")
-            except OSError:
-                continue
+        directory = _studio_root()
+        path = directory / f"studio-starting-{me}.marker"
+        try:
+            directory.mkdir(parents = True, exist_ok = True)
+            # Same layout as a per-port record, so _read_pid_record parses both.
+            # An unknown start time is a blank line, read back as None.
+            path.write_text(body, encoding = "utf-8")
             _OWN_STARTUP_MARKERS.append(path)
+        except OSError:
+            pass
     if not _OWN_STARTUP_MARKERS:
         return
     import atexit
@@ -1073,13 +1048,10 @@ def _remove_startup_marker() -> None:
 
 
 def _startup_marker_records() -> "list[tuple[int, float | None, str | None] | None]":
-    records: "list[tuple[int, float | None, str | None] | None]" = []
-    for directory in _startup_marker_dirs():
-        try:
-            records.extend(_read_pid_record(p) for p in directory.glob(STARTUP_MARKER_GLOB))
-        except OSError:
-            continue
-    return records
+    try:
+        return [_read_pid_record(p) for p in _studio_root().glob(STARTUP_MARKER_GLOB)]
+    except OSError:
+        return []
 
 
 def _legacy_record() -> "tuple[int, float | None, str | None] | None":
@@ -1125,20 +1097,6 @@ def live_sibling_backend() -> "int | None":
     """
     me = os.getpid()
     timed = [r for r in _startup_marker_records() + _per_port_records() if r is not None]
-    return _live_sibling(timed + [_legacy_record()], me, timed)
-
-
-def established_sibling_backend() -> "int | None":
-    """PID of a sibling that has already bound a port, or None.
-
-    Deliberately blind to startup markers. A sibling that is itself still
-    starting has not cleaned anything, so it is not a reason to keep a stale
-    cache; a sibling that is serving is, and a pre-upgrade one writes no marker
-    and no stamp, so judging it by whether it has cleared would clear the cache
-    underneath it.
-    """
-    me = os.getpid()
-    timed = [r for r in _per_port_records() if r is not None]
     return _live_sibling(timed + [_legacy_record()], me, timed)
 
 
@@ -2050,22 +2008,33 @@ _PARALLEL_MAX = 64
 _PARALLEL_DEFAULT_PLAIN = 4
 
 
-def run_server(*args, **kwargs):
-    """Start the server, and take the startup marker back if it never starts.
+def _drops_its_marker_on_failure(start):
+    """Take the startup marker back if the server never starts.
 
     An embedded caller keeps its process alive across a failure -- colab.py
-    catches SystemExit and Exception around this -- and no exit hook runs then.
-    A marker left behind would answer every later sibling probe as a live
+    catches SystemExit and Exception around run_server -- and no exit hook runs
+    then. A marker left behind would answer every later sibling probe as a live
     backend, so no backend of this install would clear the compiled cache again.
+
+    A decorator rather than a renamed inner function: run_server's signature is
+    a contract here, read both by inspect.signature and by tests that parse the
+    def out of this file, and functools.wraps keeps both intact.
     """
-    try:
-        return _run_server(*args, **kwargs)
-    except BaseException:
-        _remove_startup_marker()
-        raise
+    import functools
+
+    @functools.wraps(start)
+    def started(*args, **kwargs):
+        try:
+            return start(*args, **kwargs)
+        except BaseException:
+            _remove_startup_marker()
+            raise
+
+    return started
 
 
-def _run_server(
+@_drops_its_marker_on_failure
+def run_server(
     host: str = "127.0.0.1",
     port: int = 8888,
     frontend_path: Path = _DEFAULT_FRONTEND_PATH,
@@ -2218,10 +2187,6 @@ def _run_server(
     # shutdown, when a sibling may have started since. On app.state rather than
     # imported, because main.py must not import this module back.
     app.state.live_sibling_backend = live_sibling_backend
-    app.state.established_sibling_backend = established_sibling_backend
-    # Read here rather than in main.py: the decision is about whether anything
-    # cleared since THIS process started, and the marker is already written.
-    app.state.backend_started_at = _process_create_time(os.getpid())
 
     logger.info(
         "Imported FastAPI app in %.1fms",
@@ -2464,6 +2429,11 @@ def _run_server(
             loop.close()
             if not ready_event.is_set():
                 startup_failed.set()
+            # An embedded host stays alive after the server thread ends, and a
+            # post-readiness failure in here never reaches run_server's caller,
+            # so nothing else takes these back. They would keep validating
+            # against the still-live host PID with no backend serving.
+            _remove_pid_file()
 
     thread = Thread(target = _run, daemon = True)
     _server_thread = thread

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2173,7 +2173,6 @@ def run_server(
     # lock differently from the clear that follows, and serialize nothing.
     try:
         from utils.paths.storage_roots import setup_cache_env
-
         setup_cache_env()
     except Exception:  # noqa: BLE001
         # main.py seeds it too, and does not depend on this having worked.

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -976,6 +976,29 @@ def _legacy_studio_on_port(port: int) -> "int | None":
     return pid
 
 
+def live_sibling_backend() -> "int | None":
+    """PID of another live Studio backend of this install, or None.
+
+    Two of ours at once is a supported configuration: `_resolve_port` refuses
+    only the port one of ours already holds, and `_abort_already_running` tells
+    the user to pick another. They share an install-tree compiled cache, so the
+    second one must not wipe it out from under the first.
+
+    Called before `_write_pid_file`, so our own record is not there yet; the
+    explicit pid check keeps it correct if that ever changes.
+    """
+    me = os.getpid()
+    for record in _per_port_records():
+        if record is None:
+            continue
+        pid, created, _address = record
+        if pid == me or not _pid_alive(pid):
+            continue
+        if _pid_is_studio_backend(pid, [created]):
+            return pid
+    return None
+
+
 def _per_port_records() -> "list[tuple[int, float | None, str | None] | None]":
     try:
         return [_read_pid_record(p) for p in _studio_root().glob(PID_FILE_GLOB)]
@@ -2008,6 +2031,11 @@ def run_server(
     import_started = time.perf_counter()
 
     from main import app, setup_frontend, _desktop_owner, _IS_COLAB
+
+    # Handed to lifespan as a callable, not a value: it is asked again at
+    # shutdown, when a sibling may have started since. On app.state rather than
+    # imported, because main.py must not import this module back.
+    app.state.live_sibling_backend = live_sibling_backend
 
     logger.info(
         "Imported FastAPI app in %.1fms",

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -989,19 +989,20 @@ def _startup_marker_dirs() -> "list[Path]":
     also clears whatever UNSLOTH_COMPILE_LOCATION names, which is set
     independently of UNSLOTH_STUDIO_HOME. Two studio homes can therefore point at
     one cache directory, and a home-scoped marker leaves each of them believing
-    it is alone. `cache_coordination_dir` is keyed on the cache paths themselves,
-    so both of them land in the same directory.
+    it is alone. `cache_coordination_dirs` is keyed per cache path, so any
+    install that would clear the same directory lands in the same place.
     """
     dirs = [_studio_root()]
     try:
-        from utils.cache_cleanup import cache_coordination_dir
-        shared = cache_coordination_dir()
+        from utils.cache_cleanup import cache_coordination_dirs
+        shared = cache_coordination_dirs()
     except Exception:
         # An import or path failure here only costs cross-home discovery; the
         # home-scoped marker, which is the common case, still gets written.
         return dirs
-    if shared not in dirs:
-        dirs.append(shared)
+    for directory in shared:
+        if directory not in dirs:
+            dirs.append(directory)
     return dirs
 
 
@@ -1025,14 +1026,24 @@ def write_startup_marker() -> None:
     created = _process_create_time(me)
     body = f"{me}\n{created if created is not None else ''}\n"
     try:
-        from utils.cache_cleanup import compiled_cache_lock
+        from utils.cache_cleanup import compiled_cache_lock, LOCK_BUSY
     except Exception:
         import contextlib
 
         # No lock available means an unserialized publish, which is what this
         # did before the lock existed. Startup still has to happen.
         compiled_cache_lock = contextlib.nullcontext
-    with compiled_cache_lock():
+        LOCK_BUSY = None
+    # A longer budget than a clear takes: publishing behind a holder that is
+    # mid-rmtree is the case worth waiting out. Publishing anyway if the wait
+    # runs out is still right, because a marker that never appears makes this
+    # backend invisible, which is the failure the marker exists to prevent.
+    with compiled_cache_lock(timeout = 30.0) as lock_state:
+        if lock_state == LOCK_BUSY:
+            logger.warning(
+                "Publishing the startup marker without the cache lock: another backend "
+                "has held it for 30s"
+            )
         for directory in _startup_marker_dirs():
             path = directory / f"studio-starting-{me}.marker"
             try:
@@ -2155,6 +2166,18 @@ def run_server(
     # Before the import, not just before uvicorn: this is what makes us visible
     # to a sibling's own probe, and the earlier it lands the smaller the window
     # in which two launches can each believe they are alone.
+    #
+    # The cache env has to be seeded first. main.py pins UNSLOTH_COMPILE_LOCATION
+    # at import time, which is after this point, and that variable is part of the
+    # coordination key: publishing before it is set would key the marker and the
+    # lock differently from the clear that follows, and serialize nothing.
+    try:
+        from utils.paths.storage_roots import setup_cache_env
+
+        setup_cache_env()
+    except Exception:  # noqa: BLE001
+        # main.py seeds it too, and does not depend on this having worked.
+        pass
     write_startup_marker()
 
     from main import app, setup_frontend, _desktop_owner, _IS_COLAB
@@ -2163,6 +2186,9 @@ def run_server(
     # shutdown, when a sibling may have started since. On app.state rather than
     # imported, because main.py must not import this module back.
     app.state.live_sibling_backend = live_sibling_backend
+    # Read here rather than in main.py: the decision is about whether anything
+    # cleared since THIS process started, and the marker is already written.
+    app.state.backend_started_at = _process_create_time(os.getpid())
 
     logger.info(
         "Imported FastAPI app in %.1fms",

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -827,6 +827,11 @@ from utils.paths.storage_roots import studio_root as _studio_root
 # Legacy single-instance file; still read so `stop` finds an older build's server.
 _PID_FILE = _studio_root() / "studio.pid"
 PID_FILE_GLOB = "studio-*.pid"
+# Deliberately not a .pid: everything that globs PID_FILE_GLOB expects a bound
+# server with a port in the name, and a process that has not bound yet is not
+# one. Only the sibling probe reads these.
+STARTUP_MARKER_GLOB = "studio-starting-*.marker"
+_OWN_STARTUP_MARKER: "Path | None" = None
 
 
 def _pid_file_for_port(port: int) -> Path:
@@ -976,6 +981,62 @@ def _legacy_studio_on_port(port: int) -> "int | None":
     return pid
 
 
+def write_startup_marker() -> None:
+    """Record that this process is coming up, before uvicorn starts.
+
+    The per-port record cannot be written until uvicorn reports the bound port,
+    and lifespan startup runs well before that. Two overlapping launches would
+    otherwise each find no sibling and each clear the shared compiled cache, the
+    exact race this is meant to prevent, so a sibling has to be discoverable
+    from the moment it could do any clearing.
+
+    Best effort, like the records themselves: a studio home we cannot write to
+    is not a reason to refuse to start.
+    """
+    global _OWN_STARTUP_MARKER
+    me = os.getpid()
+    path = _studio_root() / f"studio-starting-{me}.marker"
+    created = _process_create_time(me)
+    try:
+        _studio_root().mkdir(parents = True, exist_ok = True)
+        # Same layout as a per-port record, so _read_pid_record parses both. An
+        # unknown start time is a blank line, which it reads back as None.
+        path.write_text(f"{me}\n{created if created is not None else ''}\n", encoding = "utf-8")
+    except OSError:
+        return
+    _OWN_STARTUP_MARKER = path
+    import atexit
+
+    # Registered here rather than beside the pid-file hook: startup can fail
+    # between these two points, and the marker has to go either way.
+    atexit.register(_remove_startup_marker)
+
+
+def _remove_startup_marker() -> None:
+    global _OWN_STARTUP_MARKER
+    if _OWN_STARTUP_MARKER is None:
+        return
+    try:
+        _OWN_STARTUP_MARKER.unlink(missing_ok = True)
+    except OSError:
+        pass
+    _OWN_STARTUP_MARKER = None
+
+
+def _startup_marker_records() -> "list[tuple[int, float | None, str | None] | None]":
+    try:
+        return [_read_pid_record(p) for p in _studio_root().glob(STARTUP_MARKER_GLOB)]
+    except OSError:
+        return []
+
+
+def _legacy_record() -> "tuple[int, float | None, str | None] | None":
+    try:
+        return _read_pid_record(_PID_FILE) if _PID_FILE.is_file() else None
+    except OSError:
+        return None
+
+
 def live_sibling_backend() -> "int | None":
     """PID of another live Studio backend of this install, or None.
 
@@ -984,11 +1045,16 @@ def live_sibling_backend() -> "int | None":
     the user to pick another. They share an install-tree compiled cache, so the
     second one must not wipe it out from under the first.
 
+    All three records are read, because a sibling can be in a state where only
+    one of them exists: a startup marker while it is still binding, a per-port
+    record once it has bound, and `studio.pid` alone for a pre-upgrade server or
+    one whose best-effort per-port write failed.
+
     Called before `_write_pid_file`, so our own record is not there yet; the
-    explicit pid check keeps it correct if that ever changes.
+    explicit pid check keeps it correct for the marker, which is.
     """
     me = os.getpid()
-    for record in _per_port_records():
+    for record in _startup_marker_records() + _per_port_records() + [_legacy_record()]:
         if record is None:
             continue
         pid, created, _address = record
@@ -2029,6 +2095,11 @@ def run_server(
         print("  - loading PyTorch, Unsloth and Transformers...", flush = True)
 
     import_started = time.perf_counter()
+
+    # Before the import, not just before uvicorn: this is what makes us visible
+    # to a sibling's own probe, and the earlier it lands the smaller the window
+    # in which two launches can each believe they are alone.
+    write_startup_marker()
 
     from main import app, setup_frontend, _desktop_owner, _IS_COLAB
 

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1039,12 +1039,19 @@ def write_startup_marker() -> None:
 
 
 def _remove_startup_marker() -> None:
+    # A path is dropped from the list only once it is actually gone. A transient
+    # unlink failure would otherwise lose the only reference to it, leaving a
+    # marker on disk that no later cleanup can retry: its recorded start time
+    # still matches this process, so an embedded host that keeps running would
+    # go on answering as a live backend and pin the compiled cache.
+    remaining = []
     while _OWN_STARTUP_MARKERS:
         path = _OWN_STARTUP_MARKERS.pop()
         try:
             path.unlink(missing_ok = True)
         except OSError:
-            pass
+            remaining.append(path)
+    _OWN_STARTUP_MARKERS.extend(remaining)
 
 
 def _startup_marker_records() -> "list[tuple[int, float | None, str | None] | None]":

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1136,7 +1136,9 @@ def _live_sibling(records: "list", me: int, timed: "list") -> "int | None":
         # process that is gone, not about this one. Letting it veto would clear
         # the compiled cache under a serving legacy backend.
         corroborating = [
-            other[1] for other, other_written in timed if other[0] == pid and other_written >= written_at
+            other[1]
+            for other, other_written in timed
+            if other[0] == pid and other_written >= written_at
         ]
         if _pid_is_studio_backend(pid, [created] + corroborating):
             return pid

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -832,6 +832,7 @@ PID_FILE_GLOB = "studio-*.pid"
 # one. Only the sibling probe reads these.
 STARTUP_MARKER_GLOB = "studio-starting-*.marker"
 _OWN_STARTUP_MARKERS: "list[Path]" = []
+_STARTUP_MARKER_HOOK_REGISTERED = False
 
 
 def _pid_file_for_port(port: int) -> Path:
@@ -1027,7 +1028,12 @@ def write_startup_marker() -> None:
             # Same layout as a per-port record, so _read_pid_record parses both.
             # An unknown start time is a blank line, read back as None.
             path.write_text(body, encoding = "utf-8")
-            _OWN_STARTUP_MARKERS.append(path)
+            # Not appended twice. The path is the same file every time (this
+            # PID names it), so a second publish rewrites identical bytes, but
+            # a duplicate entry would be popped and retried twice on the way
+            # out for no reason.
+            if path not in _OWN_STARTUP_MARKERS:
+                _OWN_STARTUP_MARKERS.append(path)
         except OSError:
             pass
     if not _OWN_STARTUP_MARKERS:
@@ -1036,8 +1042,13 @@ def write_startup_marker() -> None:
 
     # Registered here rather than beside the pid-file hook: startup can fail
     # between these two points, and the marker has to go either way. Before the
-    # wait below, so an interrupt during it still takes the marker back.
-    atexit.register(_remove_startup_marker)
+    # wait below, so an interrupt during it still takes the marker back. Once
+    # per process: the hook drains the whole list, so a second registration
+    # only runs it again on an empty one.
+    global _STARTUP_MARKER_HOOK_REGISTERED
+    if not _STARTUP_MARKER_HOOK_REGISTERED:
+        atexit.register(_remove_startup_marker)
+        _STARTUP_MARKER_HOOK_REGISTERED = True
     if published_unlocked:
         _wait_out_a_running_cache_clear(compiled_cache_lock, LOCK_BUSY)
 

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1014,7 +1014,8 @@ def write_startup_marker() -> None:
     # runs out is still right, because a marker that never appears makes this
     # backend invisible, which is the failure the marker exists to prevent.
     with compiled_cache_lock(timeout = 30.0) as lock_state:
-        if lock_state == LOCK_BUSY:
+        published_unlocked = lock_state == LOCK_BUSY
+        if published_unlocked:
             logger.warning(
                 "Publishing the startup marker without the cache lock: another backend "
                 "has held it for 30s"
@@ -1034,8 +1035,40 @@ def write_startup_marker() -> None:
     import atexit
 
     # Registered here rather than beside the pid-file hook: startup can fail
-    # between these two points, and the marker has to go either way.
+    # between these two points, and the marker has to go either way. Before the
+    # wait below, so an interrupt during it still takes the marker back.
     atexit.register(_remove_startup_marker)
+    if published_unlocked:
+        _wait_out_a_running_cache_clear(compiled_cache_lock, LOCK_BUSY)
+
+
+# A clear is an rmtree of one directory. Five minutes is not how long that takes
+# even on network storage; it is how long to keep waiting before deciding that
+# refusing to start is worse for the user than starting on a cache that may lose
+# files underneath it.
+_CACHE_CLEAR_WAIT_SECONDS = 300.0
+
+
+def _wait_out_a_running_cache_clear(compiled_cache_lock, lock_busy) -> None:
+    """Block until whoever is clearing the compiled cache has finished.
+
+    The marker is already published, so this backend is visible to every sibling
+    probe from here on, which is what publishing unlocked bought. What it must
+    not do is return to a caller that immediately imports and compiles into a
+    cache another backend is still deleting: that is the cross-backend race the
+    lock exists to close. Taking the lock and dropping it again is the wait.
+
+    The lock is an OS file lock, released when its holder exits, so a crashed
+    backend cannot hold this here.
+    """
+    with compiled_cache_lock(timeout = _CACHE_CLEAR_WAIT_SECONDS) as state:
+        if state == lock_busy:
+            logger.warning(
+                "Starting while another backend is still clearing the compiled cache: "
+                "it has held the lock for %ss. Compiled modules may be removed underneath "
+                "this one and recompiled.",
+                int(30.0 + _CACHE_CLEAR_WAIT_SECONDS),
+            )
 
 
 # Enough attempts to outlast the usual Windows holder (an indexer or a scanner

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -878,14 +878,80 @@ def test_one_of_two_cold_starts_clears_the_stale_modules(tmp_path, monkeypatch):
     )
     started = time.time()
 
-    cache_cleanup.clear_compiled_cache_unless_shared(lambda: 8550, started_at = started)
+    cache_cleanup.clear_compiled_cache_unless_shared(
+        lambda: 8550, started_at = started, established_probe = lambda: None
+    )
 
     assert events == ["clear"], "the first cold start clears"
 
     # A second one, started at the same time, now finds a clear newer than itself.
-    cache_cleanup.clear_compiled_cache_unless_shared(lambda: 8551, started_at = started)
+    cache_cleanup.clear_compiled_cache_unless_shared(
+        lambda: 8551, started_at = started, established_probe = lambda: None
+    )
 
     assert events == ["clear"], "the second one keeps what the first just cleaned"
+
+
+def test_an_established_sibling_keeps_the_cache_even_with_no_stamp(tmp_path, monkeypatch):
+    # A pre-upgrade sibling writes no stamp at all, so judging it by stamps
+    # would read an established backend as a concurrent cold start and clear the
+    # cache underneath it.
+    events = []
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+
+    cache_cleanup.clear_compiled_cache_unless_shared(
+        lambda: 8550, started_at = time.time(), established_probe = lambda: 8550
+    )
+
+    assert events == []
+
+
+def test_one_install_stamp_does_not_speak_for_another_installs_caches(tmp_path, monkeypatch):
+    # Two installs sharing only UNSLOTH_COMPILE_LOCATION: a stamp for the shared
+    # directory must not stand in for this install's own cache dirs, whose stale
+    # modules register_compiled_cache_on_path would put back on sys.path.
+    shared = tmp_path / "shared"
+    private = tmp_path / "private"
+    monkeypatch.setattr(cache_cleanup, "cache_coordination_dirs", lambda: [shared, private])
+    shared.mkdir()
+    (shared / "cleared").write_text(str(time.time() + 60), encoding = "utf-8")
+    events = []
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+
+    cache_cleanup.clear_compiled_cache_unless_shared(
+        lambda: 8550, started_at = time.time(), established_probe = lambda: None
+    )
+
+    assert events == ["clear"], "the unstamped private cache still needs clearing"
+
+
+def test_a_partial_lock_set_is_not_reported_as_held(tmp_path, monkeypatch):
+    # The directory that fails may be the shared one two installs coordinate
+    # through, so holding only the private locks is not protection.
+    blocked = tmp_path / "not-a-directory"
+    blocked.write_text("", encoding = "utf-8")
+    monkeypatch.setattr(
+        cache_cleanup, "cache_coordination_dirs", lambda: [tmp_path / "ok", blocked / "lock"]
+    )
+
+    with cache_cleanup.compiled_cache_lock() as state:
+        assert state == cache_cleanup.LOCK_UNAVAILABLE
+
+
+def test_coordination_paths_that_cannot_be_resolved_degrade(tmp_path, monkeypatch):
+    # No temp dir, or a configured path that will not expand: taking the lock has
+    # to degrade rather than abort a startup that only wanted to know about siblings.
+    def boom():
+        raise RuntimeError("no temp dir")
+
+    monkeypatch.setattr(cache_cleanup, "cache_coordination_dirs", boom)
+
+    with cache_cleanup.compiled_cache_lock() as state:
+        assert state == cache_cleanup.LOCK_UNAVAILABLE
 
 
 def test_a_sibling_that_started_before_us_keeps_the_cache(tmp_path, monkeypatch):
@@ -933,3 +999,37 @@ def test_contention_is_still_retried_to_the_timeout(tmp_path, monkeypatch):
     with cache_cleanup.compiled_cache_lock(timeout = 0.2) as state:
         assert state == cache_cleanup.LOCK_BUSY
     assert time.monotonic() - started >= 0.2, "contention waits out the budget"
+
+
+def test_a_startup_that_raises_takes_its_marker_back(tmp_path, monkeypatch):
+    # colab.py catches SystemExit and Exception around run_server and keeps the
+    # process alive, so no exit hook runs. A marker left behind would answer
+    # every later probe as a live backend of this install.
+    run.write_startup_marker()
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) != []
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("startup failed")
+
+    monkeypatch.setattr(run, "_run_server", explode)
+
+    with pytest.raises(RuntimeError):
+        run.run_server()
+
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []
+    assert run._OWN_STARTUP_MARKERS == []
+
+
+def test_a_startup_that_exits_takes_its_marker_back(tmp_path, monkeypatch):
+    # SystemExit is a BaseException, and it is the one colab.py catches.
+    run.write_startup_marker()
+
+    def bail(*args, **kwargs):
+        raise SystemExit(1)
+
+    monkeypatch.setattr(run, "_run_server", bail)
+
+    with pytest.raises(SystemExit):
+        run.run_server()
+
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
+import threading
 import time
 import sys
 from pathlib import Path
@@ -904,6 +905,41 @@ def test_a_startup_that_exits_takes_its_marker_back(tmp_path, monkeypatch):
     monkeypatch.setattr(run, "run_server", run._drops_its_marker_on_failure(bail))
 
     with pytest.raises(SystemExit):
+        run.run_server()
+
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []
+
+
+def test_an_interrupt_leaves_the_marker_to_a_live_server_thread(tmp_path, monkeypatch):
+    # The KeyboardInterrupt path asks uvicorn to stop and re-raises without
+    # joining, so the thread may still be finishing lifespan startup or
+    # shutdown. Taking the marker back there makes a backend that is still up
+    # invisible to a sibling, which would clear the compiled cache under it.
+    run.write_startup_marker()
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) != []
+
+    stop = threading.Event()
+    serving = threading.Thread(target = stop.wait, daemon = True)
+    serving.start()
+    monkeypatch.setattr(run, "_server_thread", serving)
+
+    def interrupt(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(run, "run_server", run._drops_its_marker_on_failure(interrupt))
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            run.run_server()
+
+        assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) != [], "the sibling can no longer see it"
+        assert run._OWN_STARTUP_MARKERS != []
+    finally:
+        stop.set()
+        serving.join(timeout = 5)
+
+    # Once that thread is gone, the same failure does take the marker back:
+    # nothing else is going to.
+    with pytest.raises(KeyboardInterrupt):
         run.run_server()
 
     assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -28,7 +28,6 @@ from utils import cache_cleanup  # noqa: E402
 # Captured before the autouse fixture stubs them, for the tests that exercise them.
 _REAL_IS_STUDIO_BACKEND = run._pid_is_studio_backend
 _REAL_PID_ALIVE = run._pid_alive
-_REAL_COORDINATION_DIRS = cache_cleanup.cache_coordination_dirs
 
 
 @pytest.fixture(autouse = True)
@@ -38,10 +37,7 @@ def isolated_root(tmp_path, monkeypatch):
     monkeypatch.setattr(run, "_OWN_PID_FILE", None)
     monkeypatch.setattr(run, "_pid_alive", lambda pid: True)
     monkeypatch.setattr(run, "_pid_is_studio_backend", lambda pid, created_times = (): True)
-    # The cross-home coordination directory is a real path under the system temp
-    # dir, so without this the marker tests would see (and leave) markers from
-    # every other Studio on this machine.
-    monkeypatch.setattr(cache_cleanup, "cache_coordination_dirs", lambda: [tmp_path / "shared"])
+    # The lock lives in the studio home, which is already redirected above.
     monkeypatch.setattr(run, "_OWN_STARTUP_MARKERS", [])
     yield
 
@@ -702,56 +698,6 @@ def test_a_timed_record_for_another_pid_leaves_the_legacy_one_alone(tmp_path, mo
     assert run.live_sibling_backend() == 8550
 
 
-def test_the_startup_marker_is_written_where_cache_siblings_can_see_it(tmp_path):
-    # UNSLOTH_COMPILE_LOCATION is set independently of UNSLOTH_STUDIO_HOME, so a
-    # marker in the studio home alone cannot be seen by a backend of another home
-    # that clears the same cache.
-    run.write_startup_marker()
-
-    name = f"studio-starting-{os.getpid()}.marker"
-    assert (tmp_path / name).is_file()
-    assert (tmp_path / "shared" / name).is_file()
-
-
-def test_a_sibling_in_another_studio_home_is_found_through_the_shared_cache_dir(tmp_path):
-    shared = tmp_path / "shared"
-    shared.mkdir()
-    (shared / "studio-starting-8550.marker").write_text("8550\n", encoding = "utf-8")
-
-    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []
-    assert run.live_sibling_backend() == 8550
-
-
-def test_the_coordination_directory_follows_the_cache_path_not_the_studio_home(
-    tmp_path, monkeypatch
-):
-    monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path / "cache"))
-    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "home_a"))
-    first = _REAL_COORDINATION_DIRS()
-
-    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "home_b"))
-    assert _REAL_COORDINATION_DIRS() == first
-
-    # A different cache is a different set of backends to coordinate with.
-    monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path / "other_cache"))
-    assert _REAL_COORDINATION_DIRS() != first
-
-
-def test_two_installs_sharing_one_cache_overlap_even_with_different_trees(tmp_path, monkeypatch):
-    # Keying the whole path set would give two installs different directories
-    # whenever their install-tree candidates differ, even though both delete out
-    # of the configured one. Coordination is per path, so the shared one matches.
-    monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path / "shared_cache"))
-    monkeypatch.setattr(cache_cleanup, "_CACHE_DIRS", [tmp_path / "install_a"])
-    install_a = set(_REAL_COORDINATION_DIRS())
-
-    monkeypatch.setattr(cache_cleanup, "_CACHE_DIRS", [tmp_path / "install_b"])
-    install_b = set(_REAL_COORDINATION_DIRS())
-
-    assert install_a != install_b
-    assert install_a & install_b, "the shared cache must give them a common directory"
-
-
 def test_the_cache_lock_is_exclusive(tmp_path):
     # Two backends racing is the whole point, so the second one must be told the
     # section is taken rather than be let into it.
@@ -810,7 +756,7 @@ def test_a_lock_that_cannot_be_taken_at_all_still_clears(tmp_path, monkeypatch):
     # cache is never cleared again on that machine; fall back to the plain probe.
     blocked = tmp_path / "not-a-directory"
     blocked.write_text("", encoding = "utf-8")
-    monkeypatch.setattr(cache_cleanup, "cache_coordination_dirs", lambda: [blocked / "lock"])
+    monkeypatch.setattr(cache_cleanup, "cache_coordination_dir", lambda: blocked / "lock")
     events = []
     monkeypatch.setattr(
         cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
@@ -868,106 +814,6 @@ def test_the_startup_marker_is_published_under_the_cache_lock(tmp_path, monkeypa
     assert events == [("lock", False), ("unlock", True)]
 
 
-def test_one_of_two_cold_starts_clears_the_stale_modules(tmp_path, monkeypatch):
-    # Both published a marker before either reached its clear, so each sees the
-    # other. Keeping the cache on both counts would leave modules that are stale
-    # for both of them, which is what the startup clear exists to remove.
-    events = []
-    monkeypatch.setattr(
-        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
-    )
-    started = time.time()
-
-    cache_cleanup.clear_compiled_cache_unless_shared(
-        lambda: 8550, started_at = started, established_probe = lambda: None
-    )
-
-    assert events == ["clear"], "the first cold start clears"
-
-    # A second one, started at the same time, now finds a clear newer than itself.
-    cache_cleanup.clear_compiled_cache_unless_shared(
-        lambda: 8551, started_at = started, established_probe = lambda: None
-    )
-
-    assert events == ["clear"], "the second one keeps what the first just cleaned"
-
-
-def test_an_established_sibling_keeps_the_cache_even_with_no_stamp(tmp_path, monkeypatch):
-    # A pre-upgrade sibling writes no stamp at all, so judging it by stamps
-    # would read an established backend as a concurrent cold start and clear the
-    # cache underneath it.
-    events = []
-    monkeypatch.setattr(
-        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
-    )
-
-    cache_cleanup.clear_compiled_cache_unless_shared(
-        lambda: 8550, started_at = time.time(), established_probe = lambda: 8550
-    )
-
-    assert events == []
-
-
-def test_one_install_stamp_does_not_speak_for_another_installs_caches(tmp_path, monkeypatch):
-    # Two installs sharing only UNSLOTH_COMPILE_LOCATION: a stamp for the shared
-    # directory must not stand in for this install's own cache dirs, whose stale
-    # modules register_compiled_cache_on_path would put back on sys.path.
-    shared = tmp_path / "shared"
-    private = tmp_path / "private"
-    monkeypatch.setattr(cache_cleanup, "cache_coordination_dirs", lambda: [shared, private])
-    shared.mkdir()
-    (shared / "cleared").write_text(str(time.time() + 60), encoding = "utf-8")
-    events = []
-    monkeypatch.setattr(
-        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
-    )
-
-    cache_cleanup.clear_compiled_cache_unless_shared(
-        lambda: 8550, started_at = time.time(), established_probe = lambda: None
-    )
-
-    assert events == ["clear"], "the unstamped private cache still needs clearing"
-
-
-def test_a_partial_lock_set_is_not_reported_as_held(tmp_path, monkeypatch):
-    # The directory that fails may be the shared one two installs coordinate
-    # through, so holding only the private locks is not protection.
-    blocked = tmp_path / "not-a-directory"
-    blocked.write_text("", encoding = "utf-8")
-    monkeypatch.setattr(
-        cache_cleanup, "cache_coordination_dirs", lambda: [tmp_path / "ok", blocked / "lock"]
-    )
-
-    with cache_cleanup.compiled_cache_lock() as state:
-        assert state == cache_cleanup.LOCK_UNAVAILABLE
-
-
-def test_coordination_paths_that_cannot_be_resolved_degrade(tmp_path, monkeypatch):
-    # No temp dir, or a configured path that will not expand: taking the lock has
-    # to degrade rather than abort a startup that only wanted to know about siblings.
-    def boom():
-        raise RuntimeError("no temp dir")
-
-    monkeypatch.setattr(cache_cleanup, "cache_coordination_dirs", boom)
-
-    with cache_cleanup.compiled_cache_lock() as state:
-        assert state == cache_cleanup.LOCK_UNAVAILABLE
-
-
-def test_a_sibling_that_started_before_us_keeps_the_cache(tmp_path, monkeypatch):
-    # An established backend cleared long before this process started, so there
-    # is nothing stale and its modules must survive.
-    events = []
-    monkeypatch.setattr(
-        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
-    )
-    cache_cleanup._record_clear()
-
-    cache_cleanup.clear_compiled_cache_unless_shared(lambda: 8550, started_at = time.time() - 60)
-
-    assert events == []
-
-
 def test_a_filesystem_that_cannot_lock_is_not_read_as_contention(tmp_path, monkeypatch):
     # ENOSYS is the lock being unsupported, not a sibling holding it. Retrying it
     # to a timeout and answering busy would keep the cache forever, since busy is
@@ -1011,7 +857,7 @@ def test_a_startup_that_raises_takes_its_marker_back(tmp_path, monkeypatch):
     def explode(*args, **kwargs):
         raise RuntimeError("startup failed")
 
-    monkeypatch.setattr(run, "_run_server", explode)
+    monkeypatch.setattr(run, "run_server", run._drops_its_marker_on_failure(explode))
 
     with pytest.raises(RuntimeError):
         run.run_server()
@@ -1027,9 +873,45 @@ def test_a_startup_that_exits_takes_its_marker_back(tmp_path, monkeypatch):
     def bail(*args, **kwargs):
         raise SystemExit(1)
 
-    monkeypatch.setattr(run, "_run_server", bail)
+    monkeypatch.setattr(run, "run_server", run._drops_its_marker_on_failure(bail))
 
     with pytest.raises(SystemExit):
         run.run_server()
 
     assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []
+
+
+def test_a_server_thread_that_dies_after_readiness_drops_its_records(tmp_path, monkeypatch):
+    # An embedded host stays alive after the uvicorn thread ends, and a failure
+    # in there never reaches run_server's caller. Records left behind would keep
+    # validating against the still-live host PID with no backend serving.
+    run.write_startup_marker()
+    run._write_pid_file(8905, "127.0.0.1")
+
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) != []
+    assert _files(tmp_path) != []
+
+    run._remove_pid_file()
+
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []
+    assert _files(tmp_path) == []
+
+
+def test_two_cold_starts_keep_rather_than_delete_each_others_modules(tmp_path, monkeypatch):
+    # The documented limitation of scoping this back: both keep a cache neither
+    # cleaned, which is the safe direction. The failure being replaced is the two
+    # of them deleting each other's modules mid-run.
+    events = []
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: 8550)
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: 8551)
+
+    assert events == []
+
+    # ...and a launch that really is alone still clears.
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: None)
+
+    assert events == ["clear"]

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -931,7 +931,9 @@ def test_an_interrupt_leaves_the_marker_to_a_live_server_thread(tmp_path, monkey
         with pytest.raises(KeyboardInterrupt):
             run.run_server()
 
-        assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) != [], "the sibling can no longer see it"
+        assert (
+            list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) != []
+        ), "the sibling can no longer see it"
         assert run._OWN_STARTUP_MARKERS != []
     finally:
         stop.set()

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -843,6 +843,61 @@ def test_the_startup_marker_is_published_under_the_cache_lock(tmp_path, monkeypa
     assert events == [("lock", False), ("unlock", True)]
 
 
+def test_a_busy_lock_publishes_then_waits_for_the_clear_to_finish(tmp_path, monkeypatch):
+    # Publishing unlocked keeps this backend visible to sibling probes, but
+    # returning straight away would let the caller import and compile into a
+    # cache the holder is still deleting. The marker goes out first, then the
+    # wait, so both halves hold.
+    marker = tmp_path / f"studio-starting-{os.getpid()}.marker"
+    timeouts = []
+
+    @contextlib.contextmanager
+    def _lock(timeout = None):
+        timeouts.append((timeout, marker.exists()))
+        # Busy the first time (the publish), free the second (the wait).
+        yield cache_cleanup.LOCK_BUSY if len(timeouts) == 1 else cache_cleanup.LOCK_HELD
+
+    monkeypatch.setattr(cache_cleanup, "compiled_cache_lock", _lock)
+
+    run.write_startup_marker()
+
+    assert timeouts == [
+        (30.0, False),
+        (run._CACHE_CLEAR_WAIT_SECONDS, True),
+    ], "the wait must come after the marker is on disk"
+
+
+def test_a_lock_taken_at_once_does_not_wait(tmp_path, monkeypatch):
+    # Nobody is clearing, so there is nothing to wait for.
+    calls = []
+
+    @contextlib.contextmanager
+    def _lock(timeout = None):
+        calls.append(timeout)
+        yield cache_cleanup.LOCK_HELD
+
+    monkeypatch.setattr(cache_cleanup, "compiled_cache_lock", _lock)
+
+    run.write_startup_marker()
+
+    assert calls == [30.0]
+
+
+def test_a_clear_that_never_finishes_still_lets_the_backend_start(tmp_path, monkeypatch):
+    # Refusing to start is worse for the user than starting on a cache that may
+    # lose files, so the wait is bounded and startup continues past it.
+    @contextlib.contextmanager
+    def _lock(timeout = None):
+        yield cache_cleanup.LOCK_BUSY
+
+    monkeypatch.setattr(cache_cleanup, "compiled_cache_lock", _lock)
+    monkeypatch.setattr(run, "_CACHE_CLEAR_WAIT_SECONDS", 0.0)
+
+    run.write_startup_marker()
+
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) != []
+
+
 def test_a_filesystem_that_cannot_lock_is_not_read_as_contention(tmp_path, monkeypatch):
     # ENOSYS is the lock being unsupported, not a sibling holding it. Retrying it
     # to a timeout and answering busy would keep the cache forever, since busy is

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -8,6 +8,7 @@ Imports run.py directly, so run under the Unsloth venv.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 from pathlib import Path
@@ -20,10 +21,12 @@ if str(_BACKEND) not in sys.path:
     sys.path.insert(0, str(_BACKEND))
 
 import run  # noqa: E402
+from utils import cache_cleanup  # noqa: E402
 
 # Captured before the autouse fixture stubs them, for the tests that exercise them.
 _REAL_IS_STUDIO_BACKEND = run._pid_is_studio_backend
 _REAL_PID_ALIVE = run._pid_alive
+_REAL_COORDINATION_DIR = cache_cleanup.cache_coordination_dir
 
 
 @pytest.fixture(autouse = True)
@@ -33,6 +36,11 @@ def isolated_root(tmp_path, monkeypatch):
     monkeypatch.setattr(run, "_OWN_PID_FILE", None)
     monkeypatch.setattr(run, "_pid_alive", lambda pid: True)
     monkeypatch.setattr(run, "_pid_is_studio_backend", lambda pid, created_times = (): True)
+    # The cross-home coordination directory is a real path under the system temp
+    # dir, so without this the marker tests would see (and leave) markers from
+    # every other Studio on this machine.
+    monkeypatch.setattr(cache_cleanup, "cache_coordination_dir", lambda: tmp_path / "shared")
+    monkeypatch.setattr(run, "_OWN_STARTUP_MARKERS", [])
     yield
 
 
@@ -635,7 +643,7 @@ def test_the_startup_marker_is_written_and_removed(tmp_path):
     run._remove_startup_marker()
 
     assert not marker.exists()
-    assert run._OWN_STARTUP_MARKER is None
+    assert run._OWN_STARTUP_MARKERS == []
 
 
 def test_our_own_startup_marker_is_not_a_sibling(tmp_path):
@@ -652,3 +660,192 @@ def test_a_startup_marker_is_invisible_to_the_pid_file_glob(tmp_path):
     (tmp_path / "studio-starting-8550.marker").write_text("8550\n", encoding = "utf-8")
 
     assert list(tmp_path.glob(run.PID_FILE_GLOB)) == []
+
+
+def test_stopping_an_embedded_server_removes_the_startup_marker(tmp_path):
+    # run_server returns while uvicorn runs on a daemon thread, so a notebook can
+    # stop the server without the process exiting and atexit never firing. A
+    # marker left behind answers every later probe as a live sibling, and no
+    # backend of this install would clear the compiled cache again.
+    run.write_startup_marker()
+    marker = tmp_path / f"studio-starting-{os.getpid()}.marker"
+    assert marker.is_file()
+
+    run._remove_pid_file()
+
+    assert not marker.exists()
+    assert not (tmp_path / "shared" / marker.name).exists()
+
+
+def test_a_bare_legacy_record_cannot_resurrect_a_reused_pid(tmp_path, monkeypatch):
+    # studio.pid holds a PID and no start time, and an untimed record is trusted
+    # unconditionally. A timestamped record for that same PID that fails the
+    # check is proof the server is gone, so the bare one must not override it.
+    monkeypatch.setattr(run, "_pid_is_studio_backend", _REAL_IS_STUDIO_BACKEND)
+    monkeypatch.setattr(run, "_process_create_time", lambda pid: 999.0)
+    (tmp_path / "studio-8888-8550.pid").write_text("8550\n111.5\n127.0.0.1", encoding = "utf-8")
+    (tmp_path / "studio.pid").write_text("8550", encoding = "utf-8")
+
+    assert run.live_sibling_backend() is None
+
+
+def test_a_timed_record_for_another_pid_leaves_the_legacy_one_alone(tmp_path, monkeypatch):
+    # Corroboration is per PID: a dead record for a different server says nothing
+    # about the pre-upgrade one, which is recorded in studio.pid and nowhere else.
+    monkeypatch.setattr(run, "_pid_is_studio_backend", _REAL_IS_STUDIO_BACKEND)
+    monkeypatch.setattr(run, "_process_create_time", lambda pid: 999.0)
+    (tmp_path / "studio-8888-8551.pid").write_text("8551\n111.5\n127.0.0.1", encoding = "utf-8")
+    (tmp_path / "studio.pid").write_text("8550", encoding = "utf-8")
+
+    assert run.live_sibling_backend() == 8550
+
+
+def test_the_startup_marker_is_written_where_cache_siblings_can_see_it(tmp_path):
+    # UNSLOTH_COMPILE_LOCATION is set independently of UNSLOTH_STUDIO_HOME, so a
+    # marker in the studio home alone cannot be seen by a backend of another home
+    # that clears the same cache.
+    run.write_startup_marker()
+
+    name = f"studio-starting-{os.getpid()}.marker"
+    assert (tmp_path / name).is_file()
+    assert (tmp_path / "shared" / name).is_file()
+
+
+def test_a_sibling_in_another_studio_home_is_found_through_the_shared_cache_dir(tmp_path):
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    (shared / "studio-starting-8550.marker").write_text("8550\n", encoding = "utf-8")
+
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []
+    assert run.live_sibling_backend() == 8550
+
+
+def test_the_coordination_directory_follows_the_cache_path_not_the_studio_home(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path / "cache"))
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "home_a"))
+    first = _REAL_COORDINATION_DIR()
+
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "home_b"))
+    assert _REAL_COORDINATION_DIR() == first
+
+    # A different cache is a different set of backends to coordinate with.
+    monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path / "other_cache"))
+    assert _REAL_COORDINATION_DIR() != first
+
+
+def test_the_cache_lock_is_exclusive(tmp_path):
+    # Two backends racing is the whole point, so the second one must be told the
+    # section is taken rather than be let into it.
+    with cache_cleanup.compiled_cache_lock() as first:
+        assert first == cache_cleanup.LOCK_HELD
+        with cache_cleanup.compiled_cache_lock(timeout = 0.05) as second:
+            assert second == cache_cleanup.LOCK_BUSY
+
+    with cache_cleanup.compiled_cache_lock() as again:
+        assert again == cache_cleanup.LOCK_HELD
+
+
+def test_the_probe_and_the_clear_happen_inside_one_lock(tmp_path, monkeypatch):
+    # The race Codex flagged: our probe finds nobody, a sibling publishes and
+    # starts compiling, and then our rmtree deletes what it just wrote.
+    events = []
+
+    @contextlib.contextmanager
+    def _lock(timeout = None):
+        events.append("lock")
+        try:
+            yield cache_cleanup.LOCK_HELD
+        finally:
+            events.append("unlock")
+
+    monkeypatch.setattr(cache_cleanup, "compiled_cache_lock", _lock)
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: events.append("probe"))
+
+    assert events == ["lock", "probe", "clear", "unlock"]
+
+
+def test_a_busy_cache_lock_keeps_the_cache_without_probing(tmp_path, monkeypatch):
+    # Whoever holds it is a sibling by definition, so the answer is already known.
+    events = []
+
+    @contextlib.contextmanager
+    def _lock(timeout = None):
+        yield cache_cleanup.LOCK_BUSY
+
+    monkeypatch.setattr(cache_cleanup, "compiled_cache_lock", _lock)
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: events.append("probe"))
+
+    assert events == []
+
+
+def test_a_lock_that_cannot_be_taken_at_all_still_clears(tmp_path, monkeypatch):
+    # An unwritable temp dir or a filesystem without flock must not mean the
+    # cache is never cleared again on that machine; fall back to the plain probe.
+    blocked = tmp_path / "not-a-directory"
+    blocked.write_text("", encoding = "utf-8")
+    monkeypatch.setattr(cache_cleanup, "cache_coordination_dir", lambda: blocked / "lock")
+    events = []
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+
+    with cache_cleanup.compiled_cache_lock() as state:
+        assert state == cache_cleanup.LOCK_UNAVAILABLE
+
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: None)
+
+    assert events == ["clear"]
+
+
+def test_a_live_sibling_keeps_the_compiled_cache(tmp_path, monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: 8550)
+
+    assert events == []
+
+
+def test_no_sibling_probe_clears_unconditionally(tmp_path, monkeypatch):
+    # An embedded app or a test never sets the probe, and the old behaviour stands.
+    events = []
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+
+    cache_cleanup.clear_compiled_cache_unless_shared(None)
+
+    assert events == ["clear"]
+
+
+def test_the_startup_marker_is_published_under_the_cache_lock(tmp_path, monkeypatch):
+    # Publication has to be inside the same section as a sibling's probe and
+    # clear, or the marker lands in the gap between them and is clear-and-lost.
+    marker = tmp_path / f"studio-starting-{os.getpid()}.marker"
+    events = []
+
+    @contextlib.contextmanager
+    def _lock(timeout = None):
+        events.append(("lock", marker.exists()))
+        try:
+            yield cache_cleanup.LOCK_HELD
+        finally:
+            events.append(("unlock", marker.exists()))
+
+    monkeypatch.setattr(cache_cleanup, "compiled_cache_lock", _lock)
+
+    run.write_startup_marker()
+
+    assert events == [("lock", False), ("unlock", True)]

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -566,3 +566,35 @@ def test_the_legacy_file_is_taken_over_from_a_dead_server(tmp_path, monkeypatch)
     run._write_pid_file(8902, "127.0.0.1")
 
     assert (tmp_path / "studio.pid").read_text(encoding = "utf-8") == str(os.getpid())
+
+
+def test_a_live_sibling_is_found_so_the_shared_cache_survives(tmp_path):
+    # The compiled cache is install-tree relative, so a second backend of this
+    # install must not wipe it out from under the first.
+    (tmp_path / "studio-8888-8550.pid").write_text("8550\n\n127.0.0.1", encoding = "utf-8")
+
+    assert run.live_sibling_backend() == 8550
+
+
+def test_our_own_record_is_not_a_sibling(tmp_path):
+    # _write_pid_file has already run by shutdown, so our own record is there.
+    me = os.getpid()
+    (tmp_path / f"studio-8888-{me}.pid").write_text(f"{me}\n\n127.0.0.1", encoding = "utf-8")
+
+    assert run.live_sibling_backend() is None
+
+
+def test_a_dead_record_is_not_a_sibling(tmp_path, monkeypatch):
+    # A crashed server leaves its record behind; clearing the cache is right then.
+    monkeypatch.setattr(run, "_pid_alive", lambda pid: False)
+    (tmp_path / "studio-8888-8550.pid").write_text("8550\n\n127.0.0.1", encoding = "utf-8")
+
+    assert run.live_sibling_backend() is None
+
+
+def test_a_reused_pid_is_not_a_sibling(tmp_path, monkeypatch):
+    # Alive, but not our server: the create_time no longer matches the record.
+    monkeypatch.setattr(run, "_pid_is_studio_backend", lambda pid, created_times = (): False)
+    (tmp_path / "studio-8888-8550.pid").write_text("8550\n1.0\n127.0.0.1", encoding = "utf-8")
+
+    assert run.live_sibling_backend() is None

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -37,7 +37,10 @@ def isolated_root(tmp_path, monkeypatch):
     monkeypatch.setattr(run, "_OWN_PID_FILE", None)
     monkeypatch.setattr(run, "_pid_alive", lambda pid: True)
     monkeypatch.setattr(run, "_pid_is_studio_backend", lambda pid, created_times = (): True)
-    # The lock lives in the studio home, which is already redirected above.
+    # The lock lives in the studio home. A session-scoped conftest fixture
+    # already keeps that out of the developer's real one, but this file
+    # redirects everything else it touches to tmp_path, so redirect this too.
+    monkeypatch.setattr(cache_cleanup, "cache_coordination_dir", lambda: tmp_path)
     monkeypatch.setattr(run, "_OWN_STARTUP_MARKERS", [])
     yield
 
@@ -660,19 +663,23 @@ def test_a_startup_marker_is_invisible_to_the_pid_file_glob(tmp_path):
     assert list(tmp_path.glob(run.PID_FILE_GLOB)) == []
 
 
-def test_stopping_an_embedded_server_removes_the_startup_marker(tmp_path):
-    # run_server returns while uvicorn runs on a daemon thread, so a notebook can
-    # stop the server without the process exiting and atexit never firing. A
-    # marker left behind answers every later probe as a live sibling, and no
-    # backend of this install would clear the compiled cache again.
+def test_the_marker_outlives_the_early_record_drop(tmp_path):
+    # _graceful_shutdown drops the records before the server thread is joined,
+    # while an in-flight request or a background warm may still be importing
+    # from the cache. Going invisible there would let a replacement clear it
+    # underneath, so the marker waits for the thread to actually end.
     run.write_startup_marker()
     marker = tmp_path / f"studio-starting-{os.getpid()}.marker"
-    assert marker.is_file()
+    run._write_pid_file(8906, "127.0.0.1")
 
     run._remove_pid_file()
 
+    assert marker.is_file(), "the backend is still serving until the thread ends"
+    assert _files(tmp_path) == []
+
+    run._remove_startup_marker()
+
     assert not marker.exists()
-    assert not (tmp_path / "shared" / marker.name).exists()
 
 
 def test_a_bare_legacy_record_cannot_resurrect_a_reused_pid(tmp_path, monkeypatch):
@@ -884,13 +891,15 @@ def test_a_startup_that_exits_takes_its_marker_back(tmp_path, monkeypatch):
 def test_a_server_thread_that_dies_after_readiness_drops_its_records(tmp_path, monkeypatch):
     # An embedded host stays alive after the uvicorn thread ends, and a failure
     # in there never reaches run_server's caller. Records left behind would keep
-    # validating against the still-live host PID with no backend serving.
+    # validating against the still-live host PID with no backend serving. Both
+    # calls are what the thread's finally block makes.
     run.write_startup_marker()
     run._write_pid_file(8905, "127.0.0.1")
 
     assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) != []
     assert _files(tmp_path) != []
 
+    run._remove_startup_marker()
     run._remove_pid_file()
 
     assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -598,3 +598,57 @@ def test_a_reused_pid_is_not_a_sibling(tmp_path, monkeypatch):
     (tmp_path / "studio-8888-8550.pid").write_text("8550\n1.0\n127.0.0.1", encoding = "utf-8")
 
     assert run.live_sibling_backend() is None
+
+
+def test_a_sibling_that_is_still_binding_is_found(tmp_path):
+    # The window Codex flagged: lifespan startup runs, and would clear the
+    # cache, long before uvicorn reports a port for _write_pid_file to record.
+    (tmp_path / "studio-starting-8550.marker").write_text("8550\n", encoding = "utf-8")
+
+    assert run.live_sibling_backend() == 8550
+
+
+def test_a_legacy_only_sibling_is_found(tmp_path):
+    # A pre-upgrade server is recorded here and nowhere else, and so is one
+    # whose best-effort per-port write failed.
+    (tmp_path / "studio.pid").write_text("8550", encoding = "utf-8")
+
+    assert run.live_sibling_backend() == 8550
+
+
+def test_a_dead_legacy_record_is_not_a_sibling(tmp_path, monkeypatch):
+    monkeypatch.setattr(run, "_pid_alive", lambda pid: False)
+    (tmp_path / "studio.pid").write_text("8550", encoding = "utf-8")
+
+    assert run.live_sibling_backend() is None
+
+
+def test_the_startup_marker_is_written_and_removed(tmp_path):
+    run.write_startup_marker()
+    marker = tmp_path / f"studio-starting-{os.getpid()}.marker"
+
+    assert marker.is_file()
+    # Parsed by the same reader as a per-port record, with a real start time.
+    record = run._read_pid_record(marker)
+    assert record is not None and record[0] == os.getpid()
+
+    run._remove_startup_marker()
+
+    assert not marker.exists()
+    assert run._OWN_STARTUP_MARKER is None
+
+
+def test_our_own_startup_marker_is_not_a_sibling(tmp_path):
+    run.write_startup_marker()
+
+    assert run.live_sibling_backend() is None
+
+    run._remove_startup_marker()
+
+
+def test_a_startup_marker_is_invisible_to_the_pid_file_glob(tmp_path):
+    # Everything reading PID_FILE_GLOB expects a port in the name; a process
+    # that has not bound yet has none, so `stop` and _legacy_heir must skip it.
+    (tmp_path / "studio-starting-8550.marker").write_text("8550\n", encoding = "utf-8")
+
+    assert list(tmp_path.glob(run.PID_FILE_GLOB)) == []

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -9,7 +9,9 @@ Imports run.py directly, so run under the Unsloth venv.
 from __future__ import annotations
 
 import contextlib
+import errno
 import os
+import time
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -26,7 +28,7 @@ from utils import cache_cleanup  # noqa: E402
 # Captured before the autouse fixture stubs them, for the tests that exercise them.
 _REAL_IS_STUDIO_BACKEND = run._pid_is_studio_backend
 _REAL_PID_ALIVE = run._pid_alive
-_REAL_COORDINATION_DIR = cache_cleanup.cache_coordination_dir
+_REAL_COORDINATION_DIRS = cache_cleanup.cache_coordination_dirs
 
 
 @pytest.fixture(autouse = True)
@@ -39,7 +41,7 @@ def isolated_root(tmp_path, monkeypatch):
     # The cross-home coordination directory is a real path under the system temp
     # dir, so without this the marker tests would see (and leave) markers from
     # every other Studio on this machine.
-    monkeypatch.setattr(cache_cleanup, "cache_coordination_dir", lambda: tmp_path / "shared")
+    monkeypatch.setattr(cache_cleanup, "cache_coordination_dirs", lambda: [tmp_path / "shared"])
     monkeypatch.setattr(run, "_OWN_STARTUP_MARKERS", [])
     yield
 
@@ -725,14 +727,31 @@ def test_the_coordination_directory_follows_the_cache_path_not_the_studio_home(
 ):
     monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path / "cache"))
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "home_a"))
-    first = _REAL_COORDINATION_DIR()
+    first = _REAL_COORDINATION_DIRS()
 
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "home_b"))
-    assert _REAL_COORDINATION_DIR() == first
+    assert _REAL_COORDINATION_DIRS() == first
 
     # A different cache is a different set of backends to coordinate with.
     monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path / "other_cache"))
-    assert _REAL_COORDINATION_DIR() != first
+    assert _REAL_COORDINATION_DIRS() != first
+
+
+def test_two_installs_sharing_one_cache_overlap_even_with_different_trees(
+    tmp_path, monkeypatch
+):
+    # Keying the whole path set would give two installs different directories
+    # whenever their install-tree candidates differ, even though both delete out
+    # of the configured one. Coordination is per path, so the shared one matches.
+    monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path / "shared_cache"))
+    monkeypatch.setattr(cache_cleanup, "_CACHE_DIRS", [tmp_path / "install_a"])
+    install_a = set(_REAL_COORDINATION_DIRS())
+
+    monkeypatch.setattr(cache_cleanup, "_CACHE_DIRS", [tmp_path / "install_b"])
+    install_b = set(_REAL_COORDINATION_DIRS())
+
+    assert install_a != install_b
+    assert install_a & install_b, "the shared cache must give them a common directory"
 
 
 def test_the_cache_lock_is_exclusive(tmp_path):
@@ -793,7 +812,7 @@ def test_a_lock_that_cannot_be_taken_at_all_still_clears(tmp_path, monkeypatch):
     # cache is never cleared again on that machine; fall back to the plain probe.
     blocked = tmp_path / "not-a-directory"
     blocked.write_text("", encoding = "utf-8")
-    monkeypatch.setattr(cache_cleanup, "cache_coordination_dir", lambda: blocked / "lock")
+    monkeypatch.setattr(cache_cleanup, "cache_coordination_dirs", lambda: [blocked / "lock"])
     events = []
     monkeypatch.setattr(
         cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
@@ -849,3 +868,70 @@ def test_the_startup_marker_is_published_under_the_cache_lock(tmp_path, monkeypa
     run.write_startup_marker()
 
     assert events == [("lock", False), ("unlock", True)]
+
+
+def test_one_of_two_cold_starts_clears_the_stale_modules(tmp_path, monkeypatch):
+    # Both published a marker before either reached its clear, so each sees the
+    # other. Keeping the cache on both counts would leave modules that are stale
+    # for both of them, which is what the startup clear exists to remove.
+    events = []
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+    started = time.time()
+
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: 8550, started_at = started)
+
+    assert events == ["clear"], "the first cold start clears"
+
+    # A second one, started at the same time, now finds a clear newer than itself.
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: 8551, started_at = started)
+
+    assert events == ["clear"], "the second one keeps what the first just cleaned"
+
+
+def test_a_sibling_that_started_before_us_keeps_the_cache(tmp_path, monkeypatch):
+    # An established backend cleared long before this process started, so there
+    # is nothing stale and its modules must survive.
+    events = []
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+    cache_cleanup._record_clear()
+
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: 8550, started_at = time.time() - 60)
+
+    assert events == []
+
+
+def test_a_filesystem_that_cannot_lock_is_not_read_as_contention(tmp_path, monkeypatch):
+    # ENOSYS is the lock being unsupported, not a sibling holding it. Retrying it
+    # to a timeout and answering busy would keep the cache forever, since busy is
+    # read as proof of a sibling.
+    def unsupported(fd):
+        raise OSError(errno.ENOSYS, "flock not supported")
+
+    monkeypatch.setattr(cache_cleanup, "_try_lock", unsupported)
+    events = []
+    monkeypatch.setattr(
+        cache_cleanup, "clear_unsloth_compiled_cache", lambda *a, **k: events.append("clear")
+    )
+
+    with cache_cleanup.compiled_cache_lock(timeout = 30.0) as state:
+        assert state == cache_cleanup.LOCK_UNAVAILABLE
+
+    cache_cleanup.clear_compiled_cache_unless_shared(lambda: None)
+
+    assert events == ["clear"]
+
+
+def test_contention_is_still_retried_to_the_timeout(tmp_path, monkeypatch):
+    def busy(fd):
+        raise OSError(errno.EWOULDBLOCK, "held")
+
+    monkeypatch.setattr(cache_cleanup, "_try_lock", busy)
+
+    started = time.monotonic()
+    with cache_cleanup.compiled_cache_lock(timeout = 0.2) as state:
+        assert state == cache_cleanup.LOCK_BUSY
+    assert time.monotonic() - started >= 0.2, "contention waits out the budget"

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -684,14 +684,35 @@ def test_the_marker_outlives_the_early_record_drop(tmp_path):
 
 def test_a_bare_legacy_record_cannot_resurrect_a_reused_pid(tmp_path, monkeypatch):
     # studio.pid holds a PID and no start time, and an untimed record is trusted
-    # unconditionally. A timestamped record for that same PID that fails the
-    # check is proof the server is gone, so the bare one must not override it.
+    # unconditionally. A timestamped record for that same PID, written after it,
+    # is proof the server is gone, so the bare one must not override it.
     monkeypatch.setattr(run, "_pid_is_studio_backend", _REAL_IS_STUDIO_BACKEND)
     monkeypatch.setattr(run, "_process_create_time", lambda pid: 999.0)
-    (tmp_path / "studio-8888-8550.pid").write_text("8550\n111.5\n127.0.0.1", encoding = "utf-8")
-    (tmp_path / "studio.pid").write_text("8550", encoding = "utf-8")
+    legacy = tmp_path / "studio.pid"
+    timed = tmp_path / "studio-8888-8550.pid"
+    legacy.write_text("8550", encoding = "utf-8")
+    timed.write_text("8550\n111.5\n127.0.0.1", encoding = "utf-8")
+    os.utime(legacy, (100.0, 100.0))
+    os.utime(timed, (200.0, 200.0))
 
     assert run.live_sibling_backend() is None
+
+
+def test_an_older_timed_record_does_not_veto_a_newer_legacy_one(tmp_path, monkeypatch):
+    # The other order is a pre-upgrade backend starting on a PID a crashed
+    # current-version backend left a record for: it writes studio.pid and
+    # nothing else. The older timestamp describes the process that is gone, so
+    # letting it veto would clear the compiled cache under a serving backend.
+    monkeypatch.setattr(run, "_pid_is_studio_backend", _REAL_IS_STUDIO_BACKEND)
+    monkeypatch.setattr(run, "_process_create_time", lambda pid: 999.0)
+    legacy = tmp_path / "studio.pid"
+    timed = tmp_path / "studio-8888-8550.pid"
+    timed.write_text("8550\n111.5\n127.0.0.1", encoding = "utf-8")
+    legacy.write_text("8550", encoding = "utf-8")
+    os.utime(timed, (100.0, 100.0))
+    os.utime(legacy, (200.0, 200.0))
+
+    assert run.live_sibling_backend() == 8550
 
 
 def test_a_timed_record_for_another_pid_leaves_the_legacy_one_alone(tmp_path, monkeypatch):
@@ -926,10 +947,10 @@ def test_two_cold_starts_keep_rather_than_delete_each_others_modules(tmp_path, m
     assert events == ["clear"]
 
 
-def test_a_marker_that_will_not_delete_stays_retryable(tmp_path, monkeypatch):
-    # Dropping the path before the unlink succeeds loses the only reference to
-    # it. The marker would stay on disk, keep matching this live process, and
-    # pin the compiled cache with no later cleanup able to retry.
+def test_a_transient_unlink_failure_is_retried_on_the_spot(tmp_path, monkeypatch):
+    # A holder that lets go a moment later (an indexer on Windows) must not cost
+    # the marker its removal: waiting for the atexit hook leaves it on disk, and
+    # an embedded host that outlives the backend may not reach that for hours.
     run.write_startup_marker()
     marker = tmp_path / f"studio-starting-{os.getpid()}.marker"
     assert run._OWN_STARTUP_MARKERS == [marker]
@@ -944,11 +965,41 @@ def test_a_marker_that_will_not_delete_stays_retryable(tmp_path, monkeypatch):
         return real_unlink(self, missing_ok = missing_ok)
 
     monkeypatch.setattr(Path, "unlink", refuse_once)
+    monkeypatch.setattr(run, "_MARKER_REMOVAL_BACKOFF_SECONDS", 0.0)
     run._remove_startup_marker()
 
+    assert refused, "the first attempt did not run"
+    assert run._OWN_STARTUP_MARKERS == []
+    assert not marker.exists()
+
+
+def test_a_marker_that_will_not_delete_stays_retryable(tmp_path, monkeypatch):
+    # Once the retries run out, dropping the path loses the only reference to
+    # it. The marker would stay on disk, keep matching this live process, and
+    # pin the compiled cache with no later cleanup able to retry.
+    run.write_startup_marker()
+    marker = tmp_path / f"studio-starting-{os.getpid()}.marker"
+    assert run._OWN_STARTUP_MARKERS == [marker]
+
+    real_unlink = Path.unlink
+    attempts = []
+
+    def refuse_while_locked(self, missing_ok = False):
+        attempts.append(self)
+        if locked:
+            raise OSError("busy")
+        return real_unlink(self, missing_ok = missing_ok)
+
+    locked = True
+    monkeypatch.setattr(Path, "unlink", refuse_while_locked)
+    monkeypatch.setattr(run, "_MARKER_REMOVAL_BACKOFF_SECONDS", 0.0)
+    run._remove_startup_marker()
+
+    assert len(attempts) == run._MARKER_REMOVAL_ATTEMPTS, "the retries did not run"
     assert run._OWN_STARTUP_MARKERS == [marker], "still tracked for a retry"
     assert marker.exists()
 
+    locked = False
     run._remove_startup_marker()
 
     assert run._OWN_STARTUP_MARKERS == []

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -843,6 +843,50 @@ def test_the_startup_marker_is_published_under_the_cache_lock(tmp_path, monkeypa
     assert events == [("lock", False), ("unlock", True)]
 
 
+def test_every_record_call_can_be_repeated(tmp_path):
+    # Startup and shutdown both run more than once in a long-lived embedded
+    # host, and a crash can leave either half done. Each of these has to be
+    # safe to call again on the state the previous call left.
+    run.write_startup_marker()
+    marker = tmp_path / f"studio-starting-{os.getpid()}.marker"
+    published = sorted(p.name for p in tmp_path.iterdir())
+    body = marker.read_text(encoding = "utf-8")
+
+    run.write_startup_marker()
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == published, "a second publish added a file"
+    assert marker.read_text(encoding = "utf-8") == body
+    assert run._OWN_STARTUP_MARKERS == [marker], "tracked twice would be removed twice"
+
+    run._write_pid_file(8888, "127.0.0.1")
+    recorded = sorted(p.name for p in tmp_path.iterdir())
+    run._write_pid_file(8888, "127.0.0.1")
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == recorded
+
+    run._remove_startup_marker()
+    run._remove_startup_marker()
+    run._remove_pid_file()
+    run._remove_pid_file()
+
+    assert list(tmp_path.glob(run.STARTUP_MARKER_GLOB)) == []
+    assert _files(tmp_path) == []
+    assert run._OWN_STARTUP_MARKERS == []
+
+
+def test_reading_the_siblings_changes_nothing_on_disk(tmp_path):
+    # The probe runs on every startup and is a read. If it pruned or rewrote
+    # anything, one install's startup would edit another's records.
+    (tmp_path / "studio-8888-4242.pid").write_text("4242\n111.5\n127.0.0.1", encoding = "utf-8")
+    (tmp_path / "studio.pid").write_text("4243", encoding = "utf-8")
+    before = {p.name: p.read_text(encoding = "utf-8") for p in tmp_path.iterdir()}
+
+    for _ in range(3):
+        run.live_sibling_backend()
+
+    assert {p.name: p.read_text(encoding = "utf-8") for p in tmp_path.iterdir()} == before
+
+
 def test_a_busy_lock_publishes_then_waits_for_the_clear_to_finish(tmp_path, monkeypatch):
     # Publishing unlocked keeps this backend visible to sibling probes, but
     # returning straight away would let the caller import and compile into a

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -924,3 +924,32 @@ def test_two_cold_starts_keep_rather_than_delete_each_others_modules(tmp_path, m
     cache_cleanup.clear_compiled_cache_unless_shared(lambda: None)
 
     assert events == ["clear"]
+
+
+def test_a_marker_that_will_not_delete_stays_retryable(tmp_path, monkeypatch):
+    # Dropping the path before the unlink succeeds loses the only reference to
+    # it. The marker would stay on disk, keep matching this live process, and
+    # pin the compiled cache with no later cleanup able to retry.
+    run.write_startup_marker()
+    marker = tmp_path / f"studio-starting-{os.getpid()}.marker"
+    assert run._OWN_STARTUP_MARKERS == [marker]
+
+    real_unlink = Path.unlink
+    refused = []
+
+    def refuse_once(self, missing_ok = False):
+        if not refused:
+            refused.append(self)
+            raise OSError("busy")
+        return real_unlink(self, missing_ok = missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", refuse_once)
+    run._remove_startup_marker()
+
+    assert run._OWN_STARTUP_MARKERS == [marker], "still tracked for a retry"
+    assert marker.exists()
+
+    run._remove_startup_marker()
+
+    assert run._OWN_STARTUP_MARKERS == []
+    assert not marker.exists()

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -843,6 +843,43 @@ def test_the_startup_marker_is_published_under_the_cache_lock(tmp_path, monkeypa
     assert events == [("lock", False), ("unlock", True)]
 
 
+def test_a_zombie_backend_is_not_a_live_sibling(tmp_path, monkeypatch):
+    # A backend that exited under a non-reaping parent stays a zombie: it
+    # answers kill(0) and keeps its start time, so liveness alone reads it as
+    # serving and its record would pin the compiled cache forever.
+    (tmp_path / "studio-8888-4242.pid").write_text("4242\n111.5\n127.0.0.1", encoding = "utf-8")
+
+    monkeypatch.setattr(run, "_pid_alive", lambda pid: True)
+    assert run.live_sibling_backend() == 4242, "the check under test must start from live"
+
+    import utils.process_lifetime as process_lifetime
+
+    monkeypatch.setattr(process_lifetime, "_pid_is_zombie", lambda pid: pid == 4242)
+
+    assert run.live_sibling_backend() is None
+
+
+def test_a_real_unreaped_child_is_not_a_live_sibling(tmp_path):
+    # The same thing without a patch: a killed but unwaited child.
+    import subprocess
+    import sys
+
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        child.kill()
+        (tmp_path / f"studio-8889-{child.pid}.pid").write_text(
+            f"{child.pid}\n", encoding = "utf-8"
+        )
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if run.live_sibling_backend() is None:
+                break
+            time.sleep(0.05)
+
+        assert run.live_sibling_backend() is None, "a zombie was taken for a serving backend"
+    finally:
+        child.wait()
+
 def test_every_record_call_can_be_repeated(tmp_path):
     # Startup and shutdown both run more than once in a long-lived embedded
     # host, and a crash can leave either half done. Each of these has to be

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -867,9 +867,7 @@ def test_a_real_unreaped_child_is_not_a_live_sibling(tmp_path):
     child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
     try:
         child.kill()
-        (tmp_path / f"studio-8889-{child.pid}.pid").write_text(
-            f"{child.pid}\n", encoding = "utf-8"
-        )
+        (tmp_path / f"studio-8889-{child.pid}.pid").write_text(f"{child.pid}\n", encoding = "utf-8")
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
             if run.live_sibling_backend() is None:
@@ -879,6 +877,7 @@ def test_a_real_unreaped_child_is_not_a_live_sibling(tmp_path):
         assert run.live_sibling_backend() is None, "a zombie was taken for a serving backend"
     finally:
         child.wait()
+
 
 def test_every_record_call_can_be_repeated(tmp_path):
     # Startup and shutdown both run more than once in a long-lived embedded

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -737,9 +737,7 @@ def test_the_coordination_directory_follows_the_cache_path_not_the_studio_home(
     assert _REAL_COORDINATION_DIRS() != first
 
 
-def test_two_installs_sharing_one_cache_overlap_even_with_different_trees(
-    tmp_path, monkeypatch
-):
+def test_two_installs_sharing_one_cache_overlap_even_with_different_trees(tmp_path, monkeypatch):
     # Keying the whole path set would give two installs different directories
     # whenever their install-tree candidates differ, even though both delete out
     # of the configured one. Coordination is per path, so the shared one matches.

--- a/studio/backend/utils/cache_cleanup.py
+++ b/studio/backend/utils/cache_cleanup.py
@@ -9,6 +9,7 @@ selectively between model loads, preserving model-agnostic components (Trainers)
 that spawned subprocesses need.
 """
 
+import contextlib
 import os
 import shutil
 import structlog
@@ -199,6 +200,159 @@ def register_compiled_cache_on_path() -> None:
             pypath_entries.insert(0, resolved)
 
     os.environ["PYTHONPATH"] = os.pathsep.join(pypath_entries)
+
+
+def _coordination_paths() -> List[str]:
+    """The cache directories that identify this install to another backend.
+
+    Deliberately not `get_existing_cache_dirs()`: two backends have to agree on
+    this before either of them has decided anything, and existence flips under
+    them the moment one starts compiling. The launch-directory candidate is left
+    out for the same reason -- two backends of one install started from
+    different shells would key off different sets and never find each other.
+    """
+    paths = [str(p) for p in _CACHE_DIRS]
+    configured = (os.environ.get("UNSLOTH_COMPILE_LOCATION") or "").strip()
+    if configured:
+        paths.append(str(Path(configured).expanduser()))
+    normalized = set()
+    for path in paths:
+        try:
+            normalized.add(os.path.normcase(os.path.realpath(path)))
+        except OSError:
+            normalized.add(os.path.normcase(path))
+    return sorted(normalized)
+
+
+def cache_coordination_dir() -> Path:
+    """Where backends that clear the same compiled cache find each other.
+
+    Keyed on the cache paths, not on the studio home: UNSLOTH_COMPILE_LOCATION is
+    set independently of UNSLOTH_STUDIO_HOME, so two studio homes can point at one
+    cache directory, and a home-scoped probe would have each of them conclude it
+    is alone and wipe the modules the other is importing.
+
+    Under the temp directory because nothing in here has to survive a reboot --
+    every record is checked against a live PID before it counts -- and because
+    the install tree and the cache directory itself are both things we may not be
+    able to write to (read-only install) or are about to delete (the cache).
+    """
+    import hashlib
+    import tempfile
+
+    key = hashlib.sha256("\n".join(_coordination_paths()).encode("utf-8")).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / f"unsloth-studio-cache-{key}"
+
+
+# Held: we may probe and clear. Busy: someone else is in that critical section.
+# Unavailable: no lock could be taken at all (unwritable temp dir, a filesystem
+# without flock), which must not mean "never clear the cache again", so the
+# caller falls back to the unserialized probe it did before this lock existed.
+LOCK_HELD = "held"
+LOCK_BUSY = "busy"
+LOCK_UNAVAILABLE = "unavailable"
+
+# Long enough to outlast a real clear (an rmtree of a few dozen files), short
+# enough that a wedged holder cannot stall lifespan startup behind it.
+_LOCK_TIMEOUT = 10.0
+
+
+@contextlib.contextmanager
+def compiled_cache_lock(timeout: float = _LOCK_TIMEOUT):
+    """Serialize a sibling probe plus cache clear against a sibling's publication.
+
+    Without it the probe is a check-then-act race with a real window: A probes and
+    finds nobody, B publishes its startup marker and begins compiling, A then
+    clears and deletes the modules B just wrote. Holding this across both halves
+    (the probe plus clear here, the marker write in run.py) closes it.
+
+    Never raises at the caller and never waits indefinitely: startup runs through
+    here, so a lock that cannot be taken has to degrade rather than block.
+    """
+    try:
+        lock_dir = cache_coordination_dir()
+        lock_dir.mkdir(parents = True, exist_ok = True)
+        fd = os.open(str(lock_dir / "cache.lock"), os.O_CREAT | os.O_RDWR, 0o600)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(f"Could not open the compiled-cache lock ({exc})")
+        yield LOCK_UNAVAILABLE
+        return
+
+    import time
+
+    state = LOCK_BUSY
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                state = LOCK_HELD
+                break
+            except OSError:
+                # Held by another backend. Retry until the budget runs out; a
+                # clear is short, so a timeout here means the holder is wedged.
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(0.05)
+            except Exception as exc:  # noqa: BLE001
+                # A filesystem with no locking at all (NotImplementedError on
+                # some network mounts). Uncoordinated is still better than a
+                # cache that can never be cleared on that machine.
+                logger.debug(f"Compiled-cache locking unavailable ({exc})")
+                state = LOCK_UNAVAILABLE
+                break
+        yield state
+    finally:
+        try:
+            if state == LOCK_HELD:
+                if os.name == "nt":
+                    import msvcrt
+                    with contextlib.suppress(Exception):
+                        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+                    with contextlib.suppress(Exception):
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+
+
+def clear_compiled_cache_unless_shared(sibling_probe = None) -> None:
+    """Clear the compiled cache, unless another backend of this install is live.
+
+    The cache sits in the install tree, not the studio home, so two of our own
+    backends share it and the wipe would delete modules the other one is still
+    importing -- including the Unsloth*Trainer.py that the in-process clears
+    preserve for spawn workers. run_server supplies the probe; without it (tests,
+    an embedded app) the old unconditional clear stands.
+
+    The probe and the clear run under `compiled_cache_lock` so a sibling cannot
+    publish itself in between and lose the modules it has already compiled.
+    """
+    if not callable(sibling_probe):
+        clear_unsloth_compiled_cache()
+        return
+    with compiled_cache_lock() as lock_state:
+        if lock_state == LOCK_BUSY:
+            # Somebody is inside the critical section, so there is a sibling by
+            # definition; that is already the answer, no probe needed.
+            logger.info(
+                "Keeping the compiled cache: another backend of this install holds the cache lock"
+            )
+            return
+        sibling = sibling_probe()
+        if sibling is None:
+            clear_unsloth_compiled_cache()
+            return
+    logger.info(
+        f"Keeping the compiled cache: another backend of this install is live (PID {sibling})"
+    )
 
 
 def clear_unsloth_compiled_cache(preserve_patterns: Optional[List[str]] = None) -> None:

--- a/studio/backend/utils/cache_cleanup.py
+++ b/studio/backend/utils/cache_cleanup.py
@@ -10,6 +10,7 @@ that spawned subprocesses need.
 """
 
 import contextlib
+import errno
 import os
 import shutil
 import structlog
@@ -224,24 +225,29 @@ def _coordination_paths() -> List[str]:
     return sorted(normalized)
 
 
-def cache_coordination_dir() -> Path:
-    """Where backends that clear the same compiled cache find each other.
+def cache_coordination_dirs() -> List[Path]:
+    """One directory per cache path this install would clear.
 
-    Keyed on the cache paths, not on the studio home: UNSLOTH_COMPILE_LOCATION is
-    set independently of UNSLOTH_STUDIO_HOME, so two studio homes can point at one
-    cache directory, and a home-scoped probe would have each of them conclude it
-    is alone and wipe the modules the other is importing.
+    Per path, not one directory for the whole set: two installs sharing a
+    configured UNSLOTH_COMPILE_LOCATION still have different install-tree
+    candidates, so a key over the whole set would give them different
+    directories even though they delete out of the same one. Keyed per path,
+    any overlap is enough for them to find each other.
 
     Under the temp directory because nothing in here has to survive a reboot --
     every record is checked against a live PID before it counts -- and because
-    the install tree and the cache directory itself are both things we may not be
-    able to write to (read-only install) or are about to delete (the cache).
+    the install tree and the cache directory itself are both things we may not
+    be able to write to (read-only install) or are about to delete.
     """
     import hashlib
     import tempfile
 
-    key = hashlib.sha256("\n".join(_coordination_paths()).encode("utf-8")).hexdigest()[:16]
-    return Path(tempfile.gettempdir()) / f"unsloth-studio-cache-{key}"
+    temp = Path(tempfile.gettempdir())
+    dirs = []
+    for path in _coordination_paths():
+        key = hashlib.sha256(path.encode("utf-8")).hexdigest()[:16]
+        dirs.append(temp / f"unsloth-studio-cache-{key}")
+    return dirs
 
 
 # Held: we may probe and clear. Busy: someone else is in that critical section.
@@ -257,6 +263,44 @@ LOCK_UNAVAILABLE = "unavailable"
 _LOCK_TIMEOUT = 10.0
 
 
+# flock/msvcrt report contention through these; anything else (ENOSYS,
+# EOPNOTSUPP on a network mount) is the lock being unsupported, and retrying it
+# for ten seconds only to answer "busy" would pin the cache forever, since busy
+# is read as proof of a sibling.
+_CONTENTION_ERRNOS = frozenset(
+    code
+    for code in (
+        getattr(errno, "EACCES", None),
+        getattr(errno, "EAGAIN", None),
+        getattr(errno, "EWOULDBLOCK", None),
+        getattr(errno, "EDEADLOCK", None),
+        getattr(errno, "EDEADLK", None),
+    )
+    if code is not None
+)
+
+
+def _try_lock(fd: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+    else:
+        import fcntl
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock(fd: int) -> None:
+    with contextlib.suppress(Exception):
+        if os.name == "nt":
+            import msvcrt
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    with contextlib.suppress(OSError):
+        os.close(fd)
+
+
 @contextlib.contextmanager
 def compiled_cache_lock(timeout: float = _LOCK_TIMEOUT):
     """Serialize a sibling probe plus cache clear against a sibling's publication.
@@ -266,64 +310,100 @@ def compiled_cache_lock(timeout: float = _LOCK_TIMEOUT):
     clears and deletes the modules B just wrote. Holding this across both halves
     (the probe plus clear here, the marker write in run.py) closes it.
 
+    Every coordination directory is locked, in sorted order so two backends
+    holding overlapping sets cannot deadlock against each other.
+
     Never raises at the caller and never waits indefinitely: startup runs through
     here, so a lock that cannot be taken has to degrade rather than block.
     """
-    try:
-        lock_dir = cache_coordination_dir()
-        lock_dir.mkdir(parents = True, exist_ok = True)
-        fd = os.open(str(lock_dir / "cache.lock"), os.O_CREAT | os.O_RDWR, 0o600)
-    except Exception as exc:  # noqa: BLE001
-        logger.debug(f"Could not open the compiled-cache lock ({exc})")
-        yield LOCK_UNAVAILABLE
-        return
-
     import time
 
-    state = LOCK_BUSY
+    paths = sorted(cache_coordination_dirs())
+    fds: "List[int]" = []
+    unsupported = 0
+    state = LOCK_HELD
     deadline = time.monotonic() + timeout
     try:
-        while True:
+        for lock_dir in paths:
             try:
-                if os.name == "nt":
-                    import msvcrt
-                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
-                else:
-                    import fcntl
-                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                state = LOCK_HELD
-                break
-            except OSError:
-                # Held by another backend. Retry until the budget runs out; a
-                # clear is short, so a timeout here means the holder is wedged.
-                if time.monotonic() >= deadline:
-                    break
-                time.sleep(0.05)
+                lock_dir.mkdir(parents = True, exist_ok = True)
+                fd = os.open(str(lock_dir / "cache.lock"), os.O_CREAT | os.O_RDWR, 0o600)
             except Exception as exc:  # noqa: BLE001
-                # A filesystem with no locking at all (NotImplementedError on
-                # some network mounts). Uncoordinated is still better than a
-                # cache that can never be cleared on that machine.
-                logger.debug(f"Compiled-cache locking unavailable ({exc})")
-                state = LOCK_UNAVAILABLE
+                logger.debug(f"Could not open the compiled-cache lock in {lock_dir} ({exc})")
+                unsupported += 1
+                continue
+            while True:
+                try:
+                    _try_lock(fd)
+                    fds.append(fd)
+                    break
+                except OSError as exc:
+                    if exc.errno not in _CONTENTION_ERRNOS:
+                        # Not contention: the filesystem cannot lock at all.
+                        logger.debug(f"Compiled-cache locking unavailable ({exc})")
+                        with contextlib.suppress(OSError):
+                            os.close(fd)
+                        unsupported += 1
+                        break
+                    if time.monotonic() >= deadline:
+                        with contextlib.suppress(OSError):
+                            os.close(fd)
+                        state = LOCK_BUSY
+                        break
+                    time.sleep(0.05)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(f"Compiled-cache locking unavailable ({exc})")
+                    with contextlib.suppress(OSError):
+                        os.close(fd)
+                    unsupported += 1
+                    break
+            if state == LOCK_BUSY:
                 break
+        if state != LOCK_BUSY and not fds:
+            # Nothing could be locked anywhere, which must not mean "never clear
+            # the cache again" on this machine.
+            state = LOCK_UNAVAILABLE if unsupported else LOCK_HELD
         yield state
     finally:
+        for fd in fds:
+            _unlock(fd)
+
+
+def _clear_stamp_paths() -> List[Path]:
+    return [d / "cleared" for d in cache_coordination_dirs()]
+
+
+def _last_clear_time() -> float:
+    """When a backend of this install last cleared, or 0.0.
+
+    Read under the lock. Two launches that overlap after a crash both publish a
+    startup marker before either reaches its clear, so each would see the other
+    and keep a cache that is stale for both. The stamp lets exactly one of them
+    do the clear: whoever holds the lock first finds no stamp newer than its own
+    start and clears, and the other then sees a stamp newer than its start.
+    """
+    newest = 0.0
+    for path in _clear_stamp_paths():
         try:
-            if state == LOCK_HELD:
-                if os.name == "nt":
-                    import msvcrt
-                    with contextlib.suppress(Exception):
-                        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
-                else:
-                    import fcntl
-                    with contextlib.suppress(Exception):
-                        fcntl.flock(fd, fcntl.LOCK_UN)
-        finally:
-            with contextlib.suppress(OSError):
-                os.close(fd)
+            newest = max(newest, float(path.read_text(encoding = "utf-8").strip()))
+        except (OSError, ValueError):
+            continue
+    return newest
 
 
-def clear_compiled_cache_unless_shared(sibling_probe = None) -> None:
+def _record_clear() -> None:
+    import time
+
+    stamp = f"{time.time()}"
+    for path in _clear_stamp_paths():
+        try:
+            path.parent.mkdir(parents = True, exist_ok = True)
+            path.write_text(stamp, encoding = "utf-8")
+        except OSError:
+            continue
+
+
+def clear_compiled_cache_unless_shared(sibling_probe = None, started_at: "float | None" = None) -> None:
     """Clear the compiled cache, unless another backend of this install is live.
 
     The cache sits in the install tree, not the studio home, so two of our own
@@ -334,6 +414,10 @@ def clear_compiled_cache_unless_shared(sibling_probe = None) -> None:
 
     The probe and the clear run under `compiled_cache_lock` so a sibling cannot
     publish itself in between and lose the modules it has already compiled.
+
+    `started_at` is this process's start time. A sibling that is itself still
+    starting is not a reason to keep a cache nobody has cleaned yet, so a clear
+    recorded before we started does not count and one recorded after does.
     """
     if not callable(sibling_probe):
         clear_unsloth_compiled_cache()
@@ -349,6 +433,17 @@ def clear_compiled_cache_unless_shared(sibling_probe = None) -> None:
         sibling = sibling_probe()
         if sibling is None:
             clear_unsloth_compiled_cache()
+            _record_clear()
+            return
+        # A sibling is up, but if nothing has cleared since we started then it
+        # is another cold start and the modules are stale for both of us.
+        if started_at is not None and _last_clear_time() <= started_at:
+            logger.info(
+                f"Clearing the compiled cache before backend {sibling} uses it: "
+                "no backend of this install has cleared it since this one started"
+            )
+            clear_unsloth_compiled_cache()
+            _record_clear()
             return
     logger.info(
         f"Keeping the compiled cache: another backend of this install is live (PID {sibling})"

--- a/studio/backend/utils/cache_cleanup.py
+++ b/studio/backend/utils/cache_cleanup.py
@@ -212,7 +212,6 @@ def cache_coordination_dir() -> Path:
     are not coordinated, and clearing is best effort there, as it was before.
     """
     from utils.paths.storage_roots import studio_root
-
     return studio_root()
 
 

--- a/studio/backend/utils/cache_cleanup.py
+++ b/studio/backend/utils/cache_cleanup.py
@@ -318,7 +318,15 @@ def compiled_cache_lock(timeout: float = _LOCK_TIMEOUT):
     """
     import time
 
-    paths = sorted(cache_coordination_dirs())
+    try:
+        paths = sorted(cache_coordination_dirs())
+    except Exception as exc:  # noqa: BLE001
+        # No temp dir, or a configured path that will not expand. Discovery is
+        # part of taking the lock, so it degrades the same way rather than
+        # aborting a startup that only wanted to know about siblings.
+        logger.debug(f"Could not resolve the compiled-cache coordination dirs ({exc})")
+        yield LOCK_UNAVAILABLE
+        return
     fds: "List[int]" = []
     unsupported = 0
     state = LOCK_HELD
@@ -359,10 +367,13 @@ def compiled_cache_lock(timeout: float = _LOCK_TIMEOUT):
                     break
             if state == LOCK_BUSY:
                 break
-        if state != LOCK_BUSY and not fds:
-            # Nothing could be locked anywhere, which must not mean "never clear
-            # the cache again" on this machine.
-            state = LOCK_UNAVAILABLE if unsupported else LOCK_HELD
+        if state != LOCK_BUSY and (unsupported or not fds):
+            # A partial set is not protection: the one directory that failed may
+            # be the shared one two installs coordinate through, and reporting
+            # held would let both into the critical section. Unavailable is the
+            # honest answer, and it degrades to the unserialized probe rather
+            # than meaning "never clear the cache again" on this machine.
+            state = LOCK_UNAVAILABLE
         yield state
     finally:
         for fd in fds:
@@ -373,22 +384,30 @@ def _clear_stamp_paths() -> List[Path]:
     return [d / "cleared" for d in cache_coordination_dirs()]
 
 
-def _last_clear_time() -> float:
-    """When a backend of this install last cleared, or 0.0.
+def _every_path_cleared_since(started_at: float) -> bool:
+    """Whether every cache this install would clear has been cleared since then.
 
     Read under the lock. Two launches that overlap after a crash both publish a
     startup marker before either reaches its clear, so each would see the other
     and keep a cache that is stale for both. The stamp lets exactly one of them
     do the clear: whoever holds the lock first finds no stamp newer than its own
-    start and clears, and the other then sees a stamp newer than its start.
+    start and clears, and the other then sees one.
+
+    Every path has to answer, not the newest of them: two installs sharing only
+    UNSLOTH_COMPILE_LOCATION would otherwise let one install's stamp for the
+    shared directory stand in for the other's private install-tree caches, whose
+    stale modules `register_compiled_cache_on_path` would then put on sys.path.
     """
-    newest = 0.0
-    for path in _clear_stamp_paths():
+    paths = _clear_stamp_paths()
+    if not paths:
+        return False
+    for path in paths:
         try:
-            newest = max(newest, float(path.read_text(encoding = "utf-8").strip()))
+            if float(path.read_text(encoding = "utf-8").strip()) <= started_at:
+                return False
         except (OSError, ValueError):
-            continue
-    return newest
+            return False
+    return True
 
 
 def _record_clear() -> None:
@@ -403,22 +422,26 @@ def _record_clear() -> None:
 
 
 def clear_compiled_cache_unless_shared(
-    sibling_probe = None, started_at: "float | None" = None
+    sibling_probe = None,
+    started_at: "float | None" = None,
+    established_probe = None,
 ) -> None:
     """Clear the compiled cache, unless another backend of this install is live.
 
     The cache sits in the install tree, not the studio home, so two of our own
     backends share it and the wipe would delete modules the other one is still
     importing -- including the Unsloth*Trainer.py that the in-process clears
-    preserve for spawn workers. run_server supplies the probe; without it (tests,
-    an embedded app) the old unconditional clear stands.
+    preserve for spawn workers. run_server supplies the probes; without them
+    (tests, an embedded app) the old unconditional clear stands.
 
     The probe and the clear run under `compiled_cache_lock` so a sibling cannot
     publish itself in between and lose the modules it has already compiled.
 
-    `started_at` is this process's start time. A sibling that is itself still
-    starting is not a reason to keep a cache nobody has cleaned yet, so a clear
-    recorded before we started does not count and one recorded after does.
+    A sibling that has already bound a port always keeps the cache. Only a
+    sibling that is itself still starting, and only when nothing has cleared
+    since we started, is treated as a concurrent cold start whose stale modules
+    still need removing; a pre-upgrade sibling writes no stamp at all, so
+    judging it by stamps would clear the cache underneath it.
     """
     if not callable(sibling_probe):
         clear_unsloth_compiled_cache()
@@ -436,12 +459,15 @@ def clear_compiled_cache_unless_shared(
             clear_unsloth_compiled_cache()
             _record_clear()
             return
-        # A sibling is up, but if nothing has cleared since we started then it
-        # is another cold start and the modules are stale for both of us.
-        if started_at is not None and _last_clear_time() <= started_at:
+        established = established_probe() if callable(established_probe) else sibling
+        if (
+            established is None
+            and started_at is not None
+            and not _every_path_cleared_since(started_at)
+        ):
             logger.info(
                 f"Clearing the compiled cache before backend {sibling} uses it: "
-                "no backend of this install has cleared it since this one started"
+                "it is starting too and nothing has cleared since this one did"
             )
             clear_unsloth_compiled_cache()
             _record_clear()

--- a/studio/backend/utils/cache_cleanup.py
+++ b/studio/backend/utils/cache_cleanup.py
@@ -203,57 +203,23 @@ def register_compiled_cache_on_path() -> None:
     os.environ["PYTHONPATH"] = os.pathsep.join(pypath_entries)
 
 
-def _coordination_paths() -> List[str]:
-    """The cache directories that identify this install to another backend.
+def cache_coordination_dir() -> Path:
+    """Where backends of this install find each other.
 
-    Deliberately not `get_existing_cache_dirs()`: two backends have to agree on
-    this before either of them has decided anything, and existence flips under
-    them the moment one starts compiling. The launch-directory candidate is left
-    out for the same reason -- two backends of one install started from
-    different shells would key off different sets and never find each other.
+    The studio home, the same scope the startup markers use. Two backends of one
+    install share an install-tree compiled cache and that is the case this
+    coordinates; two SEPARATE installs pointed at one UNSLOTH_COMPILE_LOCATION
+    are not coordinated, and clearing is best effort there, as it was before.
     """
-    paths = [str(p) for p in _CACHE_DIRS]
-    configured = (os.environ.get("UNSLOTH_COMPILE_LOCATION") or "").strip()
-    if configured:
-        paths.append(str(Path(configured).expanduser()))
-    normalized = set()
-    for path in paths:
-        try:
-            normalized.add(os.path.normcase(os.path.realpath(path)))
-        except OSError:
-            normalized.add(os.path.normcase(path))
-    return sorted(normalized)
+    from utils.paths.storage_roots import studio_root
 
-
-def cache_coordination_dirs() -> List[Path]:
-    """One directory per cache path this install would clear.
-
-    Per path, not one directory for the whole set: two installs sharing a
-    configured UNSLOTH_COMPILE_LOCATION still have different install-tree
-    candidates, so a key over the whole set would give them different
-    directories even though they delete out of the same one. Keyed per path,
-    any overlap is enough for them to find each other.
-
-    Under the temp directory because nothing in here has to survive a reboot --
-    every record is checked against a live PID before it counts -- and because
-    the install tree and the cache directory itself are both things we may not
-    be able to write to (read-only install) or are about to delete.
-    """
-    import hashlib
-    import tempfile
-
-    temp = Path(tempfile.gettempdir())
-    dirs = []
-    for path in _coordination_paths():
-        key = hashlib.sha256(path.encode("utf-8")).hexdigest()[:16]
-        dirs.append(temp / f"unsloth-studio-cache-{key}")
-    return dirs
+    return studio_root()
 
 
 # Held: we may probe and clear. Busy: someone else is in that critical section.
-# Unavailable: no lock could be taken at all (unwritable temp dir, a filesystem
-# without flock), which must not mean "never clear the cache again", so the
-# caller falls back to the unserialized probe it did before this lock existed.
+# Unavailable: no lock could be taken at all (unwritable studio home, a
+# filesystem without flock), which must not mean "never clear the cache again",
+# so the caller falls back to the unserialized probe it did before this lock.
 LOCK_HELD = "held"
 LOCK_BUSY = "busy"
 LOCK_UNAVAILABLE = "unavailable"
@@ -310,138 +276,74 @@ def compiled_cache_lock(timeout: float = _LOCK_TIMEOUT):
     clears and deletes the modules B just wrote. Holding this across both halves
     (the probe plus clear here, the marker write in run.py) closes it.
 
-    Every coordination directory is locked, in sorted order so two backends
-    holding overlapping sets cannot deadlock against each other.
-
     Never raises at the caller and never waits indefinitely: startup runs through
     here, so a lock that cannot be taken has to degrade rather than block.
     """
     import time
 
     try:
-        paths = sorted(cache_coordination_dirs())
+        lock_dir = cache_coordination_dir()
+        lock_dir.mkdir(parents = True, exist_ok = True)
+        fd = os.open(str(lock_dir / "compiled-cache.lock"), os.O_CREAT | os.O_RDWR, 0o600)
     except Exception as exc:  # noqa: BLE001
-        # No temp dir, or a configured path that will not expand. Discovery is
-        # part of taking the lock, so it degrades the same way rather than
-        # aborting a startup that only wanted to know about siblings.
-        logger.debug(f"Could not resolve the compiled-cache coordination dirs ({exc})")
+        # Resolving or opening it is part of taking it, so it degrades the same
+        # way rather than aborting a startup that only wanted to know about
+        # siblings.
+        logger.debug(f"Could not open the compiled-cache lock ({exc})")
         yield LOCK_UNAVAILABLE
         return
+
     fds: "List[int]" = []
-    unsupported = 0
     state = LOCK_HELD
     deadline = time.monotonic() + timeout
     try:
-        for lock_dir in paths:
+        while True:
             try:
-                lock_dir.mkdir(parents = True, exist_ok = True)
-                fd = os.open(str(lock_dir / "cache.lock"), os.O_CREAT | os.O_RDWR, 0o600)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug(f"Could not open the compiled-cache lock in {lock_dir} ({exc})")
-                unsupported += 1
-                continue
-            while True:
-                try:
-                    _try_lock(fd)
-                    fds.append(fd)
-                    break
-                except OSError as exc:
-                    if exc.errno not in _CONTENTION_ERRNOS:
-                        # Not contention: the filesystem cannot lock at all.
-                        logger.debug(f"Compiled-cache locking unavailable ({exc})")
-                        with contextlib.suppress(OSError):
-                            os.close(fd)
-                        unsupported += 1
-                        break
-                    if time.monotonic() >= deadline:
-                        with contextlib.suppress(OSError):
-                            os.close(fd)
-                        state = LOCK_BUSY
-                        break
-                    time.sleep(0.05)
-                except Exception as exc:  # noqa: BLE001
+                _try_lock(fd)
+                fds.append(fd)
+                break
+            except OSError as exc:
+                if exc.errno not in _CONTENTION_ERRNOS:
+                    # Not contention: the filesystem cannot lock at all.
                     logger.debug(f"Compiled-cache locking unavailable ({exc})")
                     with contextlib.suppress(OSError):
                         os.close(fd)
-                    unsupported += 1
+                    state = LOCK_UNAVAILABLE
                     break
-            if state == LOCK_BUSY:
+                if time.monotonic() >= deadline:
+                    with contextlib.suppress(OSError):
+                        os.close(fd)
+                    state = LOCK_BUSY
+                    break
+                time.sleep(0.05)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(f"Compiled-cache locking unavailable ({exc})")
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                state = LOCK_UNAVAILABLE
                 break
-        if state != LOCK_BUSY and (unsupported or not fds):
-            # A partial set is not protection: the one directory that failed may
-            # be the shared one two installs coordinate through, and reporting
-            # held would let both into the critical section. Unavailable is the
-            # honest answer, and it degrades to the unserialized probe rather
-            # than meaning "never clear the cache again" on this machine.
-            state = LOCK_UNAVAILABLE
         yield state
     finally:
         for fd in fds:
             _unlock(fd)
 
 
-def _clear_stamp_paths() -> List[Path]:
-    return [d / "cleared" for d in cache_coordination_dirs()]
-
-
-def _every_path_cleared_since(started_at: float) -> bool:
-    """Whether every cache this install would clear has been cleared since then.
-
-    Read under the lock. Two launches that overlap after a crash both publish a
-    startup marker before either reaches its clear, so each would see the other
-    and keep a cache that is stale for both. The stamp lets exactly one of them
-    do the clear: whoever holds the lock first finds no stamp newer than its own
-    start and clears, and the other then sees one.
-
-    Every path has to answer, not the newest of them: two installs sharing only
-    UNSLOTH_COMPILE_LOCATION would otherwise let one install's stamp for the
-    shared directory stand in for the other's private install-tree caches, whose
-    stale modules `register_compiled_cache_on_path` would then put on sys.path.
-    """
-    paths = _clear_stamp_paths()
-    if not paths:
-        return False
-    for path in paths:
-        try:
-            if float(path.read_text(encoding = "utf-8").strip()) <= started_at:
-                return False
-        except (OSError, ValueError):
-            return False
-    return True
-
-
-def _record_clear() -> None:
-    import time
-    stamp = f"{time.time()}"
-    for path in _clear_stamp_paths():
-        try:
-            path.parent.mkdir(parents = True, exist_ok = True)
-            path.write_text(stamp, encoding = "utf-8")
-        except OSError:
-            continue
-
-
-def clear_compiled_cache_unless_shared(
-    sibling_probe = None,
-    started_at: "float | None" = None,
-    established_probe = None,
-) -> None:
+def clear_compiled_cache_unless_shared(sibling_probe = None) -> None:
     """Clear the compiled cache, unless another backend of this install is live.
 
     The cache sits in the install tree, not the studio home, so two of our own
     backends share it and the wipe would delete modules the other one is still
     importing -- including the Unsloth*Trainer.py that the in-process clears
-    preserve for spawn workers. run_server supplies the probes; without them
-    (tests, an embedded app) the old unconditional clear stands.
+    preserve for spawn workers. run_server supplies the probe; without it (tests,
+    an embedded app) the old unconditional clear stands.
 
     The probe and the clear run under `compiled_cache_lock` so a sibling cannot
     publish itself in between and lose the modules it has already compiled.
 
-    A sibling that has already bound a port always keeps the cache. Only a
-    sibling that is itself still starting, and only when nothing has cleared
-    since we started, is treated as a concurrent cold start whose stale modules
-    still need removing; a pre-upgrade sibling writes no stamp at all, so
-    judging it by stamps would clear the cache underneath it.
+    Two launches that overlap from cold both keep a cache neither has cleaned,
+    so stale modules can survive until the next start that finds itself alone.
+    That is the deliberate direction: the failure this replaces was the two of
+    them deleting each other's modules mid-run.
     """
     if not callable(sibling_probe):
         clear_unsloth_compiled_cache()
@@ -457,20 +359,6 @@ def clear_compiled_cache_unless_shared(
         sibling = sibling_probe()
         if sibling is None:
             clear_unsloth_compiled_cache()
-            _record_clear()
-            return
-        established = established_probe() if callable(established_probe) else sibling
-        if (
-            established is None
-            and started_at is not None
-            and not _every_path_cleared_since(started_at)
-        ):
-            logger.info(
-                f"Clearing the compiled cache before backend {sibling} uses it: "
-                "it is starting too and nothing has cleared since this one did"
-            )
-            clear_unsloth_compiled_cache()
-            _record_clear()
             return
     logger.info(
         f"Keeping the compiled cache: another backend of this install is live (PID {sibling})"

--- a/studio/backend/utils/cache_cleanup.py
+++ b/studio/backend/utils/cache_cleanup.py
@@ -393,7 +393,6 @@ def _last_clear_time() -> float:
 
 def _record_clear() -> None:
     import time
-
     stamp = f"{time.time()}"
     for path in _clear_stamp_paths():
         try:
@@ -403,7 +402,9 @@ def _record_clear() -> None:
             continue
 
 
-def clear_compiled_cache_unless_shared(sibling_probe = None, started_at: "float | None" = None) -> None:
+def clear_compiled_cache_unless_shared(
+    sibling_probe = None, started_at: "float | None" = None
+) -> None:
     """Clear the compiled cache, unless another backend of this install is live.
 
     The cache sits in the install tree, not the studio home, so two of our own


### PR DESCRIPTION
Two backends of one install share an install-tree compiled cache, and the second one wiped it out from under the first, deleting modules the first was still importing. That includes the `Unsloth*Trainer.py` the in-process clears deliberately preserve for spawn workers.

Two of ours at once is a supported configuration: `_resolve_port` refuses only the port one of ours already holds, and `_abort_already_running` tells the user to pick another. This is a pre-existing bug rather than a regression; it is reachable on main today with `unsloth studio -p 8889` alongside a Studio on 8888.

## Before and after

Before: lifespan startup and shutdown both cleared the cache unconditionally.

After: they clear it unless another backend of this install is live. A backend records itself on bind in a per-port `studio-{port}-{pid}.pid` file, and older builds write a bare `studio.pid`; a startup marker covers the window before either exists, since lifespan startup runs long before uvicorn reports a bound port.

The probe and the clear run under an advisory lock in the studio home, which a marker write also takes, so a sibling cannot publish itself in the gap between the probe and the deletion that follows. A lock that is already held is itself the answer, since somebody inside the critical section is a sibling by definition. A lock that cannot be taken degrades to the unserialized probe rather than meaning the cache is never cleared again on that machine, and only contention errnos retry.

Records are hints, not proof. A bare `studio.pid` carries no start time, so it is corroborated against the timestamped records for the same pid before it counts, the way `_legacy_studio_on_port` already does. Markers are removed with the other records on any ordinary stop, from the server thread's own termination path when it dies after readiness with an embedded host still alive, and from a `functools.wraps` wrapper when startup raises before readiness, which is the case `colab.py` catches.

## What this deliberately does not do

Two SEPARATE installs pointed at one `UNSLOTH_COMPILE_LOCATION` are not coordinated. An earlier revision of this PR tried to, through temp-rooted per-cache-path directories, and three review rounds each found a real hole in it: a common root that differing `TMPDIR` values break, the legacy working-directory cache missing from the set, clear granularity that would require splitting `clear_unsloth_compiled_cache` so it can clear some directories and not others, and cross-home established state. That is a distributed protocol for an exotic configuration, and it was larger and less safe than the bug being fixed. It is gone; that case behaves as it did before this PR.

A backend started as `uvicorn main:app`, bypassing run.py, is neither seen by others nor held back itself: it writes no pid record and no marker, so it clears unconditionally. That is unchanged from before this PR, where main.py cleared unconditionally on every path. Closing it means moving the record helpers out of run.py into a module both entry points can import, since main.py must not import run.py back, which is a refactor of the record machinery rather than part of this fix.

Two launches of one install that overlap from cold both keep a cache neither has cleaned, so stale modules can survive until a later start finds itself alone. That is the safe direction: the failure it replaces is the two of them deleting each other's modules mid-run.

## Tests

`studio/backend/tests/test_studio_pid_files.py`, 79 passing. Sibling detection across all three record kinds, our own records excluded, dead and reused pids rejected, a bare legacy pid corroborated against a contradicting timestamped one, the marker invisible to `PID_FILE_GLOB` so `stop` and `_legacy_heir` do not mistake an unbound process for a bound one, marker removal on an ordinary stop and on a startup that raises, lock exclusivity and its busy and unavailable fallbacks, and the two-cold-starts case above.

996 pass across that file and every other suite touching these paths, including the three that read `run_server`'s signature.

