### PR TITLE
Windows: fix single-AMD-GPU hosts reading as "gpu none" and looping the installer

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -4642,6 +4642,11 @@ exit 0
     } else {
         Remove-Item Env:UNSLOTH_STUDIO_HOME -ErrorAction SilentlyContinue
     }
+    # Forward the arch this run resolved instead of letting setup.ps1 re-derive it. Both
+    # scripts scan WMI, so a scan that answers here but not there leaves setup expecting cpu
+    # torch against the ROCm wheels just installed: it reports "needs repair", the installer
+    # rolls back, and the desktop app retries the same failure forever.
+    if ($ROCmGfxArch) { $env:UNSLOTH_ROCM_GFX_ARCH = $ROCmGfxArch }
     $studioArgs = @('studio', 'setup')
     if ($script:UnslothVerbose) { $studioArgs += '--verbose' }
     if ($WithLlamaCppDir) {

--- a/install.ps1
+++ b/install.ps1
@@ -4642,11 +4642,6 @@ exit 0
     } else {
         Remove-Item Env:UNSLOTH_STUDIO_HOME -ErrorAction SilentlyContinue
     }
-    # Forward the arch this run resolved instead of letting setup.ps1 re-derive it. Both
-    # scripts scan WMI, so a scan that answers here but not there leaves setup expecting cpu
-    # torch against the ROCm wheels just installed: it reports "needs repair", the installer
-    # rolls back, and the desktop app retries the same failure forever.
-    if ($ROCmGfxArch) { $env:UNSLOTH_ROCM_GFX_ARCH = $ROCmGfxArch }
     $studioArgs = @('studio', 'setup')
     if ($script:UnslothVerbose) { $studioArgs += '--verbose' }
     if ($WithLlamaCppDir) {
@@ -4676,6 +4671,27 @@ exit 0
     # installer looked, and there is none".
     $env:_UNSLOTH_PS_PROXY_DEFAULTS =
         if ($UnslothProxyHandoffJson) { $UnslothProxyHandoffJson } else { '{}' }
+    # Forward the arch this run resolved instead of leaving setup.ps1 to re-derive it alone.
+    # Both scripts scan WMI, so a scan that answers here but not there leaves setup expecting
+    # cpu torch against the ROCm wheels just installed: it reports "needs repair", the
+    # installer rolls back, and the desktop app retries the same failure forever.
+    #
+    # A PRIVATE name, not UNSLOTH_ROCM_GFX_ARCH: that one is the documented operator override,
+    # and install_llama_prebuilt.py reads it back as _manual to decide whether a forwarded
+    # --rocm-gfx outranks its own probe. Publishing an auto-detected arch there would disarm
+    # that safeguard, and this scan is the weaker of the two -- it takes the first AMD adapter
+    # (Select-Object -First 1) with no visible-device mask and no shadowing-iGPU repick, both
+    # of which setup.ps1 applies. So setup consumes this only after its own probes come up
+    # empty, and nested installers never see it at all.
+    $previousRocmGfxHandoff = $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF
+    $hadPreviousRocmGfxHandoff = ($null -ne $previousRocmGfxHandoff)
+    if ($ROCmGfxArch) {
+        $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF = $ROCmGfxArch
+    } else {
+        # Cleared, not left alone: an inherited value from an outer process is not this run's
+        # answer, and handing it down would forward an arch nothing here detected.
+        Remove-Item Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF -ErrorAction SilentlyContinue
+    }
     try {
         & $UnslothExe @studioArgs
         $setupExit = $LASTEXITCODE
@@ -4694,6 +4710,11 @@ exit 0
             $env:_UNSLOTH_STUDIO_RUNTIME_GATE_HANDOFF = $previousSetupRuntimeGateHandoff
         } else {
             Remove-Item Env:_UNSLOTH_STUDIO_RUNTIME_GATE_HANDOFF -ErrorAction SilentlyContinue
+        }
+        if ($hadPreviousRocmGfxHandoff) {
+            $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF = $previousRocmGfxHandoff
+        } else {
+            Remove-Item Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF -ErrorAction SilentlyContinue
         }
         if ($hadPreviousProxyHandoff) {
             $env:_UNSLOTH_PS_PROXY_DEFAULTS = $previousProxyHandoff

--- a/install.ps1
+++ b/install.ps1
@@ -3303,9 +3303,19 @@ exit 0
         }
         if (-not $HasROCm) {
             try {
-                $wmiGpu = Get-WmiObject Win32_VideoController -ErrorAction SilentlyContinue |
-                    Where-Object { $_.Name -match "AMD|Radeon" } |
-                    Select-Object -First 1
+                # ConfigManagerErrorCode 0 is "working properly". Filter on it exactly as
+                # setup.ps1's scan does: taking a card setup discards names an arch for a GPU
+                # that is not the active one, and since a mapped arch installs ROCm wheels right
+                # here, a disabled Radeon listed ahead of a healthy one bought wheels for the
+                # dead card while the live one went unserved.
+                # If the filter leaves none, keep the full list: code 45 ("not connected") is
+                # routine on a muxless laptop with a parked dGPU, and there is no healthy peer
+                # to prefer. @() wraps the WHOLE if so a one-element branch stays indexable.
+                $amdAdapters = @(Get-WmiObject Win32_VideoController -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -match "AMD|Radeon" })
+                $healthyAdapters = @($amdAdapters | Where-Object {
+                    ($null -eq $_.ConfigManagerErrorCode) -or ($_.ConfigManagerErrorCode -eq 0) })
+                $wmiGpu = @(if ($healthyAdapters.Count -gt 0) { $healthyAdapters } else { $amdAdapters })[0]
                 if ($wmiGpu) { $ROCmGpuLabel = $wmiGpu.Name }
             } catch {}
         }

--- a/install.ps1
+++ b/install.ps1
@@ -4671,18 +4671,15 @@ exit 0
     # installer looked, and there is none".
     $env:_UNSLOTH_PS_PROXY_DEFAULTS =
         if ($UnslothProxyHandoffJson) { $UnslothProxyHandoffJson } else { '{}' }
-    # Forward the arch this run resolved instead of leaving setup.ps1 to re-derive it alone.
-    # Both scripts scan WMI, so a scan that answers here but not there leaves setup expecting
-    # cpu torch against the ROCm wheels just installed: it reports "needs repair", the
-    # installer rolls back, and the desktop app retries the same failure forever.
+    # Forward the arch this run resolved. Both scripts scan WMI, so a scan that answers here but
+    # not there leaves setup expecting cpu torch against the ROCm wheels just installed: it
+    # reports "needs repair", the installer rolls back, and the app retries that forever.
     #
-    # A PRIVATE name, not UNSLOTH_ROCM_GFX_ARCH: that one is the documented operator override,
-    # and install_llama_prebuilt.py reads it back as _manual to decide whether a forwarded
-    # --rocm-gfx outranks its own probe. Publishing an auto-detected arch there would disarm
-    # that safeguard, and this scan is the weaker of the two -- it takes the first AMD adapter
-    # (Select-Object -First 1) with no visible-device mask and no shadowing-iGPU repick, both
-    # of which setup.ps1 applies. So setup consumes this only after its own probes come up
-    # empty, and nested installers never see it at all.
+    # PRIVATE, not UNSLOTH_ROCM_GFX_ARCH: install_llama_prebuilt.py reads that one back as
+    # _manual to decide whether a forwarded --rocm-gfx outranks its own probe, and this scan is
+    # the weaker of the two anyway (first AMD adapter, no visible-device mask, no shadowing-iGPU
+    # repick, all of which setup.ps1 applies). So setup consumes it only after its own probes
+    # come up empty, and nested installers never see it.
     $previousRocmGfxHandoff = $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF
     $hadPreviousRocmGfxHandoff = ($null -ne $previousRocmGfxHandoff)
     if ($ROCmGfxArch) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2437,7 +2437,13 @@ if (-not $HasNvidiaSmi) {
     #    cpu torch against the ROCm wheels just placed, calls the venv stale, and loops forever.
     #    Private, never UNSLOTH_ROCM_GFX_ARCH: nested installers read that as an operator
     #    override, and this value is inferred, not chosen by anyone.
-    if (-not $script:ROCmGfxArch -and $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) {
+    #    Skipped under a visible-device mask, matching the inference above, which leaves
+    #    $pickedName unset rather than borrowing a peer's arch when pinned. The installer's scan
+    #    ignores the masks, so its answer is the FIRST adapter, not the selected one, and taking
+    #    it would install for a GPU the mask hides from the runtime entirely. A host that wants
+    #    an arch named under a mask sets UNSLOTH_ROCM_GFX_ARCH, which still wins above.
+    if (-not $script:ROCmGfxArch -and $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF -and
+        -not (Test-VisibleDevicesPinned)) {
         $script:ROCmGfxArch = $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF.Trim().ToLower()
         $ROCmGpuLabel = "AMD ROCm ($script:ROCmGfxArch)"
         substep "gfx arch forwarded by the installer: $script:ROCmGfxArch" "Cyan"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2348,7 +2348,10 @@ if (-not $HasNvidiaSmi) {
             # inference forwards nothing: code 45 ("not connected") is routine on a muxless
             # laptop with a parked dGPU, and with no healthy peer there is nothing to
             # depose. Mirrors the same fallback in install_python_stack.py's WMI path.
-            $wmiGpus = if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus }
+            # @() wraps the WHOLE if: an unwrapped one-element branch unrolls to a bare
+            # WMI object, whose .Count is $null in PS 5.1 (unlike a string or hashtable),
+            # so the guard below failed and a single-AMD-GPU host reported no GPU at all.
+            $wmiGpus = @(if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus })
             if ($wmiGpus.Count -gt 0) {
                 $script:ROCmGpuLabels = @($wmiGpus | ForEach-Object { $_.Name })
                 $ROCmGpuLabel = $script:ROCmGpuLabels[0]

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2431,13 +2431,12 @@ if (-not $HasNvidiaSmi) {
             }
         }
     }
-    # 3. Last resort: the arch install.ps1 resolved a second ago in the same run. Runs after
-    #    everything above because those are mask- and shadowing-aware and the installer's scan
-    #    is not, so this fills a gap rather than deposing a better answer. Without it, a scan
-    #    that answers there but not here expects cpu torch against the ROCm wheels the
-    #    installer just placed, calls the venv stale, and loops the install forever.
-    #    Private handoff, never UNSLOTH_ROCM_GFX_ARCH: nested installers read that name as an
-    #    operator override, and this value is inferred, not chosen by anyone.
+    # 3. Last resort: the arch install.ps1 resolved a second ago. Last because everything above
+    #    is mask- and shadowing-aware and the installer's scan is not, so this fills a gap rather
+    #    than deposing a better answer. Without it, a scan that answers there but not here expects
+    #    cpu torch against the ROCm wheels just placed, calls the venv stale, and loops forever.
+    #    Private, never UNSLOTH_ROCM_GFX_ARCH: nested installers read that as an operator
+    #    override, and this value is inferred, not chosen by anyone.
     if (-not $script:ROCmGfxArch -and $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) {
         $script:ROCmGfxArch = $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF.Trim().ToLower()
         $ROCmGpuLabel = "AMD ROCm ($script:ROCmGfxArch)"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2398,7 +2398,12 @@ if (-not $HasNvidiaSmi) {
             }
             # Only the WMI path carries more than one name; other callers left a single
             # synthesized label, so default to it.
-            $gpuNames = if ($script:ROCmGpuLabels) { @($script:ROCmGpuLabels) } else { @($ROCmGpuLabel) }
+            # @() wraps the WHOLE if, not each branch: a one-element branch unrolls on its way
+            # out, leaving a bare String on a single-adapter host, and $gpuNames[$nameIdx] then
+            # indexes the NAME and yields "A". Nothing maps, and the $nameArches[0] rescue below
+            # is skipped under a visible-device mask, so a pinned single-GPU host inferred no
+            # arch at all -- the same "gpu none" the WMI scan above used to report.
+            $gpuNames = @(if ($script:ROCmGpuLabels) { @($script:ROCmGpuLabels) } else { @($ROCmGpuLabel) })
             # Index over the ADAPTER list, not the inferred arches: an unrecognised name
             # drops out below, and indexing the shortened list would name the wrong card.
             $nameIdx = Resolve-VisibleGpuIndex $gpuNames.Count
@@ -2425,6 +2430,18 @@ if (-not $HasNvidiaSmi) {
                 substep "Tip: set UNSLOTH_ROCM_GFX_ARCH=$script:ROCmGfxArch to skip inference next time" "Cyan"
             }
         }
+    }
+    # 3. Last resort: the arch install.ps1 resolved a second ago in the same run. Runs after
+    #    everything above because those are mask- and shadowing-aware and the installer's scan
+    #    is not, so this fills a gap rather than deposing a better answer. Without it, a scan
+    #    that answers there but not here expects cpu torch against the ROCm wheels the
+    #    installer just placed, calls the venv stale, and loops the install forever.
+    #    Private handoff, never UNSLOTH_ROCM_GFX_ARCH: nested installers read that name as an
+    #    operator override, and this value is inferred, not chosen by anyone.
+    if (-not $script:ROCmGfxArch -and $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) {
+        $script:ROCmGfxArch = $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF.Trim().ToLower()
+        $ROCmGpuLabel = "AMD ROCm ($script:ROCmGfxArch)"
+        substep "gfx arch forwarded by the installer: $script:ROCmGfxArch" "Cyan"
     }
     # Capture ROCm version early for display and wheel selection.
     # Run whenever the HIP SDK binary is present, not just when the device is accessible --

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -1,0 +1,119 @@
+"""setup.ps1 must report the AMD GPU on a host with exactly one AMD adapter.
+
+`$wmiGpus = if (...) { $healthyGpus } else { $amdGpus }` unrolled a one-element branch into a bare
+WMI object, and a bare WMI object has no .Count in PS 5.1, so the guard after it never fired: setup
+printed "gpu none (chat-only / GGUF)" while install.ps1 had just resolved the same GPU. Setup then
+expected cpu torch against the ROCm wheels the installer placed, called the venv stale and exited,
+the installer rolled back, and the desktop app retried the same failure forever.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_PS1 = REPO_ROOT / "install.ps1"
+SETUP_PS1 = REPO_ROOT / "studio" / "setup.ps1"
+
+requires_pwsh = pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+
+_RADEON = "AMD Radeon(TM) 8060S Graphics"
+_RX = "AMD Radeon RX 9070 XT"
+
+
+def _extract_amd_scan_block() -> str:
+    """Extract setup.ps1's AMD adapter scan (the `if (-not $HasROCm)` WMI fallback block)."""
+    src = SETUP_PS1.read_text(encoding = "utf-8")
+    m = re.search(
+        r"^    if \(-not \$HasROCm\) \{\n        try \{\n.*?^    \}\n",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert m, "AMD adapter scan block not found in setup.ps1"
+    return m.group(0)
+
+
+def _build_scan_script(adapters: list[tuple[str, int]]) -> str:
+    """Wrap the extracted block in a Get-CimInstance stub returning (name, error code) adapters."""
+    items = ", ".join(
+        f"[pscustomobject]@{{ Name = '{name}'; ConfigManagerErrorCode = {code} }}"
+        for name, code in adapters
+    )
+    return (
+        "$ErrorActionPreference = 'Stop'\n"
+        "function Get-CimInstance { param([Parameter(ValueFromRemainingArguments = $true)]$Rest) "
+        f"@({items}) }}\n"
+        "$HasROCm = $false\n"
+        "$ROCmGpuLabel = $null\n"
+        "$script:ROCmGpuLabels = @()\n"
+        + _extract_amd_scan_block()
+        + 'Write-Output "LABEL=$ROCmGpuLabel"\n'
+        'Write-Output "COUNT=$($script:ROCmGpuLabels.Count)"\n'
+    )
+
+
+def _run_scan(tmp_path: Path, adapters: list[tuple[str, int]]) -> str:
+    script = tmp_path / "scan.ps1"
+    script.write_text(_build_scan_script(adapters), encoding = "utf-8")
+    proc = subprocess.run(
+        [shutil.which("pwsh") or "pwsh", "-NoProfile", "-NonInteractive", "-File", str(script)],
+        capture_output = True,
+        text = True,
+        timeout = 120,
+    )
+    assert proc.returncode == 0, f"scan block failed: {proc.stdout}\n{proc.stderr}"
+    return proc.stdout
+
+
+def test_scan_wraps_the_whole_if_in_an_array():
+    """The unwrapped form is the bug, so keep it out of the source."""
+    block = _extract_amd_scan_block()
+    assert "$wmiGpus = @(if (" in block
+    assert re.search(r"\$wmiGpus = if \(", block) is None
+
+
+def test_installer_forwards_the_resolved_gfx_arch():
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    forward = src.index("if ($ROCmGfxArch) { $env:UNSLOTH_ROCM_GFX_ARCH = $ROCmGfxArch }")
+    invoke = src.index("$studioArgs = @('studio', 'setup')")
+    assert forward < invoke, "the arch must be exported before setup.ps1 is invoked"
+
+
+@requires_pwsh
+def test_single_amd_adapter_is_reported(tmp_path):
+    out = _run_scan(tmp_path, [(_RADEON, 0)])
+    assert f"LABEL={_RADEON}" in out
+    assert "COUNT=1" in out
+
+
+@requires_pwsh
+def test_every_amd_adapter_is_kept_for_shadowing_inference(tmp_path):
+    out = _run_scan(tmp_path, [(_RADEON, 0), (_RX, 0)])
+    assert f"LABEL={_RADEON}" in out
+    assert "COUNT=2" in out
+
+
+@requires_pwsh
+def test_a_parked_adapter_still_reports_when_it_is_the_only_one(tmp_path):
+    """Error code 45 ("not connected") is routine on a muxless laptop, so do not drop the host."""
+    out = _run_scan(tmp_path, [(_RX, 45)])
+    assert f"LABEL={_RX}" in out
+    assert "COUNT=1" in out
+
+
+@requires_pwsh
+def test_a_healthy_adapter_wins_over_a_parked_one(tmp_path):
+    out = _run_scan(tmp_path, [(_RX, 45), (_RADEON, 0)])
+    assert f"LABEL={_RADEON}" in out
+    assert "COUNT=1" in out
+
+
+@requires_pwsh
+def test_intel_only_host_is_not_read_as_amd(tmp_path):
+    out = _run_scan(tmp_path, [("Intel(R) Arc(TM) A770", 0)])
+    assert "COUNT=0" in out

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -431,6 +431,76 @@ def test_a_user_override_is_the_escape_hatch_under_a_mask(tmp_path):
     assert out["arch"] == "gfx1010"
 
 
+# ── runtime: install.ps1 picks the adapter setup would keep ───────────────────────────────────
+
+
+def _installer_scan_block() -> str:
+    """install.ps1's own `if (-not $HasROCm)` WMI fallback plus the name table it feeds."""
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    start = src.index("        if (-not $HasROCm) {\n            try {\n                # ConfigManagerErrorCode")
+    end = src.index("        # Capture ROCm version for wheel selection", start)
+    return src[start:end]
+
+
+def _run_installer_scan(tmp_path: Path, adapters: list[tuple[str, int]]) -> dict:
+    items = ", ".join(
+        f"[pscustomobject]@{{ Name = '{name}'; ConfigManagerErrorCode = {code} }}"
+        for name, code in adapters
+    )
+    script = tmp_path / "installer_scan.ps1"
+    script.write_text(
+        "\n".join(
+            [
+                "$ErrorActionPreference = 'Stop'",
+                f"function Get-WmiObject {{ param([Parameter(ValueFromRemainingArguments = $true)]$Rest) @({items}) }}",
+                "function substep { param($a, $b) }",
+                "$HasROCm = $false",
+                "$ROCmGpuLabel = $null",
+                "$ROCmGfxArch = $null",
+                _installer_scan_block(),
+                "@{ label = $ROCmGpuLabel; arch = $ROCmGfxArch } | ConvertTo-Json -Compress",
+            ]
+        ),
+        encoding = "utf-8",
+    )
+    proc = subprocess.run(
+        [shutil.which("pwsh") or "pwsh", "-NoProfile", "-NonInteractive", "-File", str(script)],
+        capture_output = True,
+        text = True,
+        timeout = 120,
+        env = {"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+    )
+    assert proc.returncode == 0, f"installer scan failed:\n{proc.stdout}\n{proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+@requires_pwsh
+def test_the_installer_skips_a_disabled_adapter(tmp_path):
+    """A disabled Radeon listed first used to win here, and a mapped arch installs ROCm wheels
+    right there, so the dead card got the wheels and the live unsupported one went to nothing.
+    Setup filters this adapter out, so forwarding its arch also made the two disagree."""
+    out = _run_installer_scan(tmp_path, [("AMD Radeon RX 9070 XT", 22), ("AMD Radeon RX 5700 XT", 0)])
+    assert out["label"] == "AMD Radeon RX 5700 XT"
+    assert out["arch"] is None, "the active card is unsupported, so this host belongs on CPU"
+
+
+@requires_pwsh
+def test_the_installer_keeps_a_parked_adapter_when_it_is_the_only_one(tmp_path):
+    """Same fallback setup makes: code 45 is routine on a muxless laptop, and with no healthy
+    peer there is nothing to prefer."""
+    out = _run_installer_scan(tmp_path, [("AMD Radeon RX 9070 XT", 45)])
+    assert out["arch"] == "gfx1201"
+
+
+@requires_pwsh
+def test_the_installer_and_setup_agree_on_which_adapter_is_active(tmp_path):
+    """The handoff is only sound because both scans start from the same healthy set."""
+    adapters = [("AMD Radeon RX 9070 XT", 22), (_RADEON, 0)]
+    setup = _run(tmp_path, adapters)
+    assert setup["labels"] == [_RADEON], "setup discards the disabled card"
+    assert _run_installer_scan(tmp_path, adapters)["arch"] == setup["arch"] == "gfx1151"
+
+
 # ── runtime: install.ps1 leaves the caller's environment as it found it ───────────────────────
 
 

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -401,6 +401,36 @@ def test_an_empty_handoff_is_ignored(tmp_path):
     assert _run(tmp_path, [], env = {HANDOFF: ""})["arch"] is None
 
 
+@requires_pwsh
+@pytest.mark.parametrize(
+    "var", ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
+)
+def test_a_mask_suppresses_the_handoff(tmp_path, var):
+    """The mask selects the unrecognized discrete card, so the inference above deliberately
+    resolves nothing rather than borrowing the 780M's arch. The installer scans without the mask
+    and forwards that very arch, and taking it would install for a GPU the mask hides from the
+    runtime entirely (ROCR filters below HIP, so masked devices never reach enumeration)."""
+    adapters = [(_R780M, 0), ("AMD Radeon RX 5700 XT", 0)]
+    assert _run(tmp_path, adapters, env = {var: "1", HANDOFF: "gfx1103"})["arch"] is None
+
+
+@requires_pwsh
+def test_a_mask_suppresses_the_handoff_even_with_no_adapters_to_check_it_against(tmp_path):
+    """Setup saw no names at all, so it cannot confirm the forwarded arch is the selected device.
+    Refuse rather than guess."""
+    assert _run(tmp_path, [], env = {"HIP_VISIBLE_DEVICES": "0", HANDOFF: "gfx1151"})["arch"] is None
+
+
+@requires_pwsh
+def test_a_user_override_is_the_escape_hatch_under_a_mask(tmp_path):
+    out = _run(
+        tmp_path,
+        [(_R780M, 0), ("AMD Radeon RX 5700 XT", 0)],
+        env = {"HIP_VISIBLE_DEVICES": "1", "UNSLOTH_ROCM_GFX_ARCH": "gfx1010", HANDOFF: "gfx1103"},
+    )
+    assert out["arch"] == "gfx1010"
+
+
 # ── runtime: install.ps1 leaves the caller's environment as it found it ───────────────────────
 
 

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -5,10 +5,29 @@ WMI object, and a bare WMI object has no .Count in PS 5.1, so the guard after it
 printed "gpu none (chat-only / GGUF)" while install.ps1 had just resolved the same GPU. Setup then
 expected cpu torch against the ROCm wheels the installer placed, called the venv stale and exited,
 the installer rolled back, and the desktop app retried the same failure forever.
+
+Two notes on why these tests are shaped the way they are.
+
+PowerShell has two member-binding paths and only the optimized one carries the PSv3 scalar
+Count/Length fallback. Types with a custom adapter -- CimInstance, ManagementObject, COM,
+PSCustomObject -- take the other one, which returned null in the 5.1-era engine; PowerShell/
+PowerShell#5745 added the fallback there and shipped it in 6.1, which Windows PowerShell 5.1 never
+received. So under the pwsh that runs these tests, `.Count` on a scalar answers 1 and the bug is
+INVISIBLE. Asserting on `.Count` would pass against the unfixed source and guard nothing. Every
+runtime case here therefore asserts the SHAPE of the value, which is identical on both engines, and
+`ps51` re-runs the same shipped block against stubs carrying an explicit `Count = $null` to
+reproduce 5.1's observable consequence rather than only its cause.
+
+The second bug is the same expression one block down: `$gpuNames = if (...) { @(...) } else { @(...) }`
+wraps each BRANCH but not the if, so a single adapter name unrolls to a bare String and
+`$gpuNames[$nameIdx]` indexes the name, yielding "A". Nothing maps, and the `$nameArches[0]` rescue
+is skipped under a visible-device mask, so a pinned single-GPU host inferred no arch at all. That
+one does reproduce under pwsh, so it is asserted directly.
 """
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
@@ -22,98 +41,440 @@ SETUP_PS1 = REPO_ROOT / "studio" / "setup.ps1"
 
 requires_pwsh = pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
 
-_RADEON = "AMD Radeon(TM) 8060S Graphics"
-_RX = "AMD Radeon RX 9070 XT"
+_RADEON = "AMD Radeon(TM) 8060S Graphics"   # Strix Halo iGPU  -> gfx1151
+_RX9070 = "AMD Radeon RX 9070 XT"           # RDNA 4 discrete  -> gfx1201
+_R780M  = "AMD Radeon 780M Graphics"        # Phoenix iGPU     -> gfx1103, a shadowing arch
+_ARC    = "Intel(R) Arc(TM) A770 Graphics"
+
+HANDOFF = "_UNSLOTH_ROCM_GFX_ARCH_HANDOFF"
 
 
-def _extract_amd_scan_block() -> str:
-    """Extract setup.ps1's AMD adapter scan (the `if (-not $HasROCm)` WMI fallback block)."""
-    src = SETUP_PS1.read_text(encoding = "utf-8")
-    m = re.search(
-        r"^    if \(-not \$HasROCm\) \{\n        try \{\n.*?^    \}\n",
-        src,
-        re.DOTALL | re.MULTILINE,
-    )
+# ── extracting the shipped source, so these tests exercise it rather than a copy ──────────────
+
+def _balanced(src: str, start: int, opener: str, closer: str) -> str:
+    """Slice from `start` through the delimiter that closes the first `opener` after it."""
+    depth, i = 0, src.index(opener, start)
+    while True:
+        if src[i] == opener:
+            depth += 1
+        elif src[i] == closer:
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+        i += 1
+
+
+def _function(src: str, name: str) -> str:
+    return _balanced(src, src.index(f"function {name} {{"), "{", "}")
+
+
+def _setup_source(revision: str | None = None) -> str:
+    """setup.ps1 as shipped, or as of `revision` (e.g. HEAD~1) for the red/green check."""
+    if revision is None:
+        return SETUP_PS1.read_text(encoding = "utf-8")
+    return subprocess.run(
+        ["git", "show", f"{revision}:studio/setup.ps1"],
+        cwd = REPO_ROOT, capture_output = True, text = True, check = True,
+    ).stdout
+
+
+def _amd_scan_block(src: str) -> str:
+    """The `if (-not $HasROCm)` WMI fallback: the adapter list the label is read from."""
+    m = re.search(r"^    if \(-not \$HasROCm\) \{\n        try \{\n.*?^    \}\n", src, re.DOTALL | re.MULTILINE)
     assert m, "AMD adapter scan block not found in setup.ps1"
     return m.group(0)
 
 
-def _build_scan_script(adapters: list[tuple[str, int]]) -> str:
-    """Wrap the extracted block in a Get-CimInstance stub returning (name, error code) adapters."""
+def _arch_resolution_block(src: str) -> str:
+    """Everything from the arch-resolution header up to the ROCm version capture that follows."""
+    start = src.index("    # ── Arch resolution:")
+    end = src.index("    # Capture ROCm version early", start)
+    return src[start:end]
+
+
+def _prelude(src: str) -> str:
+    """The declarations and helpers the two blocks close over."""
+    shadowing = _balanced(src, src.index("$script:ShadowingIntegratedGfx = @("), "(", ")")
+    arch_family = _balanced(src, src.index("$archFamilyMap = @{"), "{", "}")
+    return "\n".join([
+        "$script:ShadowingIntegratedGfx = " + shadowing[shadowing.index("@("):],
+        "$archFamilyMap = " + arch_family[arch_family.index("@{"):],
+        _function(src, "Test-VisibleDevicesPinned"),
+        _function(src, "Resolve-VisibleGpuIndex"),
+        _function(src, "Resolve-ShadowingGfxPick"),
+    ])
+
+
+# ── the driver: run the shipped blocks against a stubbed adapter list ─────────────────────────
+
+def _driver(
+    src: str,
+    adapters: list[tuple[str, int]],
+    *,
+    ps51: bool = False,
+    strict: bool = False,
+) -> str:
+    """Wrap the shipped blocks in a Get-CimInstance stub and report the result as JSON.
+
+    ps51 gives every stub adapter an explicit `Count = $null`, which is what a bare CimInstance
+    answers on Windows PowerShell 5.1 and what pwsh would otherwise paper over with 1.
+    """
+    count_member = "; Count = $null" if ps51 else ""
     items = ", ".join(
-        f"[pscustomobject]@{{ Name = '{name}'; ConfigManagerErrorCode = {code} }}"
+        f"[pscustomobject]@{{ Name = '{name}'; ConfigManagerErrorCode = {code}{count_member} }}"
         for name, code in adapters
     )
-    return (
-        "$ErrorActionPreference = 'Stop'\n"
-        "function Get-CimInstance { param([Parameter(ValueFromRemainingArguments = $true)]$Rest) "
-        f"@({items}) }}\n"
-        "$HasROCm = $false\n"
-        "$ROCmGpuLabel = $null\n"
-        "$script:ROCmGpuLabels = @()\n"
-        + _extract_amd_scan_block()
-        + 'Write-Output "LABEL=$ROCmGpuLabel"\n'
-        'Write-Output "COUNT=$($script:ROCmGpuLabels.Count)"\n'
-    )
+    return "\n".join([
+        "$ErrorActionPreference = 'Stop'",
+        "Set-StrictMode -Version Latest" if strict else "Set-StrictMode -Off",
+        f"function Get-CimInstance {{ param([Parameter(ValueFromRemainingArguments = $true)]$Rest) @({items}) }}",
+        "function substep { param($a, $b) }",
+        "$HasROCm = $false",
+        "$ROCmGpuLabel = $null",
+        "$script:ROCmGpuLabels = @()",
+        "$script:ROCmGfxArch = $null",
+        "$script:GpuNamesProbe = $null",
+        "$wmiGpus = $null",
+        _prelude(src),
+        _amd_scan_block(src),
+        # Captured from inside the arch block's own scope: $gpuNames is the value the indexing
+        # bug corrupts, and its first element is what Get-GfxArchFromGpuName is actually handed.
+        _arch_resolution_block(src).replace(
+            "$nameIdx = Resolve-VisibleGpuIndex $gpuNames.Count",
+            "$script:GpuNamesProbe = $gpuNames\n            $nameIdx = Resolve-VisibleGpuIndex $gpuNames.Count",
+        ),
+        # ConvertTo-Json, not string interpolation: a null stays null instead of becoming "".
+        "@{",
+        "  wmi_type    = $(if ($null -ne $wmiGpus) { $wmiGpus.GetType().FullName } else { $null })",
+        "  wmi_array   = [bool]($wmiGpus -is [array])",
+        "  label       = $ROCmGpuLabel",
+        "  labels      = @($script:ROCmGpuLabels)",
+        "  arch        = $script:ROCmGfxArch",
+        "  names_type  = $(if ($null -ne $script:GpuNamesProbe) { $script:GpuNamesProbe.GetType().FullName } else { $null })",
+        "  names_first = $(if ($null -ne $script:GpuNamesProbe) { $script:GpuNamesProbe[0] } else { $null })",
+        "} | ConvertTo-Json -Compress",
+    ])
 
 
-def _run_scan(tmp_path: Path, adapters: list[tuple[str, int]]) -> str:
+def _run(
+    tmp_path: Path,
+    adapters: list[tuple[str, int]],
+    *,
+    env: dict[str, str] | None = None,
+    revision: str | None = None,
+    ps51: bool = False,
+    strict: bool = False,
+) -> dict:
     script = tmp_path / "scan.ps1"
-    script.write_text(_build_scan_script(adapters), encoding = "utf-8")
+    script.write_text(_driver(_setup_source(revision), adapters, ps51 = ps51, strict = strict), encoding = "utf-8")
+    # Only what each case names may reach the child: a developer's own exported
+    # UNSLOTH_ROCM_GFX_ARCH would otherwise silently win every inference assertion here.
+    child_env = {"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)}
+    child_env.update(env or {})
     proc = subprocess.run(
         [shutil.which("pwsh") or "pwsh", "-NoProfile", "-NonInteractive", "-File", str(script)],
-        capture_output = True,
-        text = True,
-        timeout = 120,
+        capture_output = True, text = True, timeout = 120, env = child_env,
     )
-    assert proc.returncode == 0, f"scan block failed: {proc.stdout}\n{proc.stderr}"
-    return proc.stdout
+    assert proc.returncode == 0, f"scan block failed:\n{proc.stdout}\n{proc.stderr}"
+    return json.loads(proc.stdout)
 
+
+# ── source assertions ─────────────────────────────────────────────────────────────────────────
 
 def test_scan_wraps_the_whole_if_in_an_array():
     """The unwrapped form is the bug, so keep it out of the source."""
-    block = _extract_amd_scan_block()
+    block = _amd_scan_block(_setup_source())
     assert "$wmiGpus = @(if (" in block
     assert re.search(r"\$wmiGpus = if \(", block) is None
 
 
-def test_installer_forwards_the_resolved_gfx_arch():
-    src = INSTALL_PS1.read_text(encoding = "utf-8")
-    forward = src.index("if ($ROCmGfxArch) { $env:UNSLOTH_ROCM_GFX_ARCH = $ROCmGfxArch }")
-    invoke = src.index("$studioArgs = @('studio', 'setup')")
-    assert forward < invoke, "the arch must be exported before setup.ps1 is invoked"
+def test_gpu_name_list_wraps_the_whole_if_in_an_array():
+    """Same expression, one block down: wrapping each branch is not enough."""
+    block = _arch_resolution_block(_setup_source())
+    assert "$gpuNames = @(if (" in block
+    assert re.search(r"\$gpuNames = if \(", block) is None
 
+
+def test_installer_forwards_the_arch_through_a_private_handoff():
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    forward = src.index(f"$env:{HANDOFF} = $ROCmGfxArch")
+    invoke = src.index("& $UnslothExe @studioArgs")
+    assert forward < invoke, "the arch must be handed over before setup.ps1 is invoked"
+
+
+def test_installer_never_exports_the_public_override():
+    """UNSLOTH_ROCM_GFX_ARCH is the operator's to set.
+
+    install_llama_prebuilt.py reads it back as _manual to decide whether a forwarded --rocm-gfx
+    outranks its own probe, so publishing an auto-detected arch there disarms that safeguard on
+    exactly the multi-GPU hosts it exists for.
+    """
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    assert re.search(r"\$env:UNSLOTH_ROCM_GFX_ARCH\s*=", src) is None
+
+
+def test_installer_restores_the_private_handoff_after_setup():
+    """Matching the save/restore every adjacent handoff variable already does.
+
+    install.ps1 is documented as `irm ... | iex`, so it runs in the caller's own process and a
+    value left behind would be read as an override by the next install in that terminal.
+    """
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    assert f"$previousRocmGfxHandoff = $env:{HANDOFF}" in src
+    assert f"$env:{HANDOFF} = $previousRocmGfxHandoff" in src
+    assert f"Remove-Item Env:{HANDOFF} -ErrorAction SilentlyContinue" in src
+    # Saved after the last early return, so no path skips the restore.
+    assert src.index("$previousRocmGfxHandoff") > src.index("--with-llama-cpp-dir path does not exist")
+
+
+def test_setup_consumes_the_handoff_only_after_its_own_inference():
+    """Order is the whole point: the installer takes the first AMD adapter with no mask and no
+    shadowing repick, both of which setup applies, so the handoff must never pre-empt it."""
+    block = _arch_resolution_block(_setup_source())
+    assert block.index("gfx arch inferred from GPU name") < block.index(f"$env:{HANDOFF}")
+
+
+# ── runtime: the adapter scan ─────────────────────────────────────────────────────────────────
 
 @requires_pwsh
-def test_single_amd_adapter_is_reported(tmp_path):
-    out = _run_scan(tmp_path, [(_RADEON, 0)])
-    assert f"LABEL={_RADEON}" in out
-    assert "COUNT=1" in out
+@pytest.mark.parametrize("ps51", [False, True], ids = ["pwsh", "ps51"])
+@pytest.mark.parametrize("strict", [False, True], ids = ["lax", "strict"])
+def test_single_amd_adapter_is_reported(tmp_path, ps51, strict):
+    out = _run(tmp_path, [(_RADEON, 0)], ps51 = ps51, strict = strict)
+    assert out["wmi_array"], f"one adapter must stay an array, got {out['wmi_type']}"
+    assert out["labels"] == [_RADEON]
+    # The name reached the inference, which is what "reported" has to mean here: a label alone
+    # still lands on the "AMD ROCm" branch with no arch and installs cpu torch.
+    assert out["arch"] == "gfx1151"
+    assert out["label"] == "AMD ROCm (gfx1151)"
 
 
 @requires_pwsh
 def test_every_amd_adapter_is_kept_for_shadowing_inference(tmp_path):
-    out = _run_scan(tmp_path, [(_RADEON, 0), (_RX, 0)])
-    assert f"LABEL={_RADEON}" in out
-    assert "COUNT=2" in out
+    out = _run(tmp_path, [(_R780M, 0), (_RX9070, 0)])
+    assert out["labels"] == [_R780M, _RX9070]
 
 
 @requires_pwsh
 def test_a_parked_adapter_still_reports_when_it_is_the_only_one(tmp_path):
     """Error code 45 ("not connected") is routine on a muxless laptop, so do not drop the host."""
-    out = _run_scan(tmp_path, [(_RX, 45)])
-    assert f"LABEL={_RX}" in out
-    assert "COUNT=1" in out
+    out = _run(tmp_path, [(_RX9070, 45)])
+    assert out["wmi_array"]
+    assert out["labels"] == [_RX9070]
 
 
 @requires_pwsh
 def test_a_healthy_adapter_wins_over_a_parked_one(tmp_path):
-    out = _run_scan(tmp_path, [(_RX, 45), (_RADEON, 0)])
-    assert f"LABEL={_RADEON}" in out
-    assert "COUNT=1" in out
+    out = _run(tmp_path, [(_RX9070, 45), (_RADEON, 0)])
+    assert out["labels"] == [_RADEON]
 
 
 @requires_pwsh
-def test_intel_only_host_is_not_read_as_amd(tmp_path):
-    out = _run_scan(tmp_path, [("Intel(R) Arc(TM) A770", 0)])
-    assert "COUNT=0" in out
+@pytest.mark.parametrize("adapters", [[], [(_ARC, 0)]], ids = ["no_adapters", "intel_only"])
+def test_a_host_with_no_amd_adapter_is_not_read_as_amd(tmp_path, adapters):
+    out = _run(tmp_path, adapters)
+    assert out["labels"] == []
+    assert out["label"] is None
+    assert out["arch"] is None
+
+
+# ── runtime: name inference, where the second unwrapped if bites ──────────────────────────────
+
+@requires_pwsh
+def test_the_adapter_name_reaches_inference_whole(tmp_path):
+    """Unwrapped, $gpuNames is a String and $gpuNames[0] is the character "A"."""
+    out = _run(tmp_path, [(_RADEON, 0)])
+    assert out["names_first"] == _RADEON, "the name was indexed as a string, not as a list"
+    assert "Object[]" in (out["names_type"] or "")
+
+
+@requires_pwsh
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        (_RADEON, "gfx1151"),
+        (_RX9070, "gfx1201"),
+        ("AMD Radeon RX 9060 XT", "gfx1200"),
+        ("AMD Radeon 890M Graphics", "gfx1150"),
+        ("AMD Radeon 860M Graphics", "gfx1152"),
+        ("AMD Radeon RX 7900 XTX", "gfx1100"),
+        ("AMD Radeon RX 7600", "gfx1102"),
+        (_R780M, "gfx1103"),
+        ("AMD Radeon RX 6800 XT", "gfx1030"),
+        ("AMD Radeon RX 6500 XT", "gfx1034"),
+        ("AMD Radeon HD 8570", None),
+    ],
+)
+def test_a_single_adapter_infers_its_arch(tmp_path, name, expected):
+    assert _run(tmp_path, [(name, 0)])["arch"] == expected
+
+
+@requires_pwsh
+@pytest.mark.parametrize("mask", ["0", "1", "", "-1", "not-a-number", "9", " 0 ", "0,1"])
+@pytest.mark.parametrize("var", ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"])
+def test_a_pinned_single_gpu_host_still_infers_its_arch(tmp_path, mask, var):
+    """The mask disables the $nameArches[0] rescue, so the string-indexing bug surfaced here as a
+    host with a perfectly good Radeon reporting no arch and looping the installer."""
+    assert _run(tmp_path, [(_RADEON, 0)], env = {var: mask})["arch"] == "gfx1151"
+
+
+@requires_pwsh
+def test_a_discrete_card_is_preferred_over_a_shadowing_igpu(tmp_path):
+    out = _run(tmp_path, [(_R780M, 0), (_RX9070, 0)])
+    assert out["arch"] == "gfx1201", "the gfx1103 iGPU shadowed the discrete card"
+
+
+@requires_pwsh
+def test_a_pinned_mask_is_honoured_over_the_shadowing_preference(tmp_path):
+    out = _run(tmp_path, [(_R780M, 0), (_RX9070, 0)], env = {"HIP_VISIBLE_DEVICES": "0"})
+    assert out["arch"] == "gfx1103", "an explicit selection must never be repicked"
+
+
+# ── runtime: handoff precedence ───────────────────────────────────────────────────────────────
+
+@requires_pwsh
+def test_the_handoff_fills_the_gap_when_nothing_else_resolves(tmp_path):
+    """The case the handoff exists for: setup's own scan came up empty where the installer's did
+    not, and without this the two disagree and the install rolls back."""
+    out = _run(tmp_path, [], env = {HANDOFF: "gfx1151"})
+    assert out["arch"] == "gfx1151"
+    assert out["label"] == "AMD ROCm (gfx1151)"
+
+
+@requires_pwsh
+def test_the_handoff_never_deposes_setups_own_inference(tmp_path):
+    """install.ps1 would forward the iGPU here: it takes the first AMD adapter, with no shadowing
+    repick. Setup's answer is the better one and has to win."""
+    out = _run(tmp_path, [(_R780M, 0), (_RX9070, 0)], env = {HANDOFF: "gfx1103"})
+    assert out["arch"] == "gfx1201"
+
+
+@requires_pwsh
+def test_a_user_override_still_wins_over_the_handoff(tmp_path):
+    out = _run(
+        tmp_path, [(_R780M, 0)],
+        env = {"UNSLOTH_ROCM_GFX_ARCH": "gfx90a", HANDOFF: "gfx1103"},
+    )
+    assert out["arch"] == "gfx90a", "the documented operator override outranks an inferred value"
+
+
+@requires_pwsh
+@pytest.mark.parametrize("value", ["GFX1151", "  gfx1151  "])
+def test_the_handoff_is_normalized_like_the_override(tmp_path, value):
+    assert _run(tmp_path, [], env = {HANDOFF: value})["arch"] == "gfx1151"
+
+
+@requires_pwsh
+def test_an_empty_handoff_is_ignored(tmp_path):
+    assert _run(tmp_path, [], env = {HANDOFF: ""})["arch"] is None
+
+
+# ── runtime: install.ps1 leaves the caller's environment as it found it ───────────────────────
+
+def _handoff_lifecycle_block() -> str:
+    """install.ps1's save / set / try / finally around the setup call, as shipped."""
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    start = src.index("    $previousRocmGfxHandoff = $env:")
+    end = src.index("    if ($setupExit -ne 0) {", start)
+    return src[start:end]
+
+
+def _run_handoff_lifecycle(tmp_path: Path, *, arch: str | None, inherited: str | None, fails: bool) -> dict:
+    body = _handoff_lifecycle_block().replace(
+        "& $UnslothExe @studioArgs",
+        "throw 'setup exploded'" if fails else "$script:SeenByChild = $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF",
+    )
+    script = tmp_path / "handoff.ps1"
+    script.write_text("\n".join([
+        "$ErrorActionPreference = 'Stop'",
+        # The neighbouring handoffs the shipped finally also restores; not under test here, but
+        # the block does not compile without them.
+        "$previousUnslothStudioHome = $null; $hadPreviousUnslothStudioHome = $false",
+        "$previousTauriMode = $null; $hadPreviousTauriMode = $false",
+        "$previousSetupRuntimeGateHandoff = $null; $hadPreviousSetupRuntimeGateHandoff = $false",
+        "$previousProxyHandoff = $null; $hadPreviousProxyHandoff = $false",
+        "$UnslothProxyHandoffJson = $null",
+        "$UnslothExe = 'stub'; $studioArgs = @(); $setupExit = 0",
+        "$script:SeenByChild = '<never ran>'",
+        "$ROCmGfxArch = " + ("$null" if arch is None else f"'{arch}'"),
+        "try {",
+        body,
+        "} catch { }",
+        "@{",
+        "  seen_by_child = $script:SeenByChild",
+        "  after = $(if (Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) { $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF } else { $null })",
+        "  after_set = [bool](Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF)",
+        "  public = $(if (Test-Path Env:UNSLOTH_ROCM_GFX_ARCH) { $env:UNSLOTH_ROCM_GFX_ARCH } else { $null })",
+        "} | ConvertTo-Json -Compress",
+    ]), encoding = "utf-8")
+    env = {"PATH": "/usr/bin:/bin", "HOME": str(tmp_path), "UNSLOTH_ROCM_GFX_ARCH": "gfx90a"}
+    if inherited is not None:
+        env[HANDOFF] = inherited
+    proc = subprocess.run(
+        [shutil.which("pwsh") or "pwsh", "-NoProfile", "-NonInteractive", "-File", str(script)],
+        capture_output = True, text = True, timeout = 120, env = env,
+    )
+    assert proc.returncode == 0, f"handoff block failed:\n{proc.stdout}\n{proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+@requires_pwsh
+@pytest.mark.parametrize("fails", [False, True], ids = ["setup_ok", "setup_throws"])
+@pytest.mark.parametrize(
+    "arch, inherited",
+    [(None, None), ("gfx1151", None), (None, "gfx1030"), ("gfx1151", "gfx1030")],
+    ids = ["nothing", "resolved", "inherited", "resolved_over_inherited"],
+)
+def test_the_caller_environment_survives_the_setup_call(tmp_path, arch, inherited, fails):
+    """`irm ... | iex` runs install.ps1 in the caller's own shell, so anything set for the child
+    has to be put back -- on the failure path too, which is the one that rolls back and retries."""
+    out = _run_handoff_lifecycle(tmp_path, arch = arch, inherited = inherited, fails = fails)
+    assert out["after_set"] is (inherited is not None), "the handoff outlived the setup call"
+    assert out["after"] == inherited
+    assert out["public"] == "gfx90a", "a user's own override must come back untouched"
+
+
+@requires_pwsh
+@pytest.mark.parametrize(
+    "arch, inherited, expected",
+    [("gfx1151", None, "gfx1151"), ("gfx1151", "gfx1030", "gfx1151"), (None, "gfx1030", None)],
+    ids = ["resolved", "resolved_over_inherited", "stale_only"],
+)
+def test_only_this_runs_arch_is_handed_to_the_child(tmp_path, arch, inherited, expected):
+    """A value inherited from an outer process is not this run's answer, so it is cleared rather
+    than forwarded as though the scan had produced it."""
+    out = _run_handoff_lifecycle(tmp_path, arch = arch, inherited = inherited, fails = False)
+    assert out["seen_by_child"] == expected
+
+
+# ── the guard on the guards ───────────────────────────────────────────────────────────────────
+
+@requires_pwsh
+def test_these_assertions_fail_against_the_source_before_the_fix(tmp_path):
+    """A regression test that passes on the unfixed source is not one.
+
+    The first version of this file asserted on `.Count`, which pwsh answers as 1 for a scalar, so
+    it was green either way. Pin the two failures to the merge base so a later edit here cannot
+    quietly re-lose them.
+    """
+    # The merge base, not HEAD~1: this branch grows commits, and every one of them already
+    # carries the fix, so a relative ref would compare the fixed source against itself.
+    revision = None
+    for ref in ("origin/main", "upstream/main", "main"):
+        base = subprocess.run(
+            ["git", "merge-base", "HEAD", ref],
+            cwd = REPO_ROOT, capture_output = True, text = True,
+        )
+        if base.returncode == 0 and base.stdout.strip():
+            revision = base.stdout.strip()
+            break
+    if revision is None:
+        pytest.skip("no main branch to compare against (shallow or detached clone)")
+    try:
+        before = _run(tmp_path, [(_RADEON, 0)], revision = revision, ps51 = True)
+        pinned = _run(tmp_path, [(_RADEON, 0)], revision = revision, env = {"HIP_VISIBLE_DEVICES": "0"})
+    except (subprocess.CalledProcessError, AssertionError, ValueError):
+        pytest.skip("parent revision does not carry a comparable scan block")
+    assert not before["wmi_array"], "the unwrapped scan should collapse to a scalar"
+    assert before["label"] is None, "the unwrapped scan should report no GPU under 5.1 semantics"
+    assert pinned["arch"] is None, "the unwrapped name list should infer nothing when pinned"

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
 """setup.ps1 must report the AMD GPU on a host with exactly one AMD adapter.
 
 `$wmiGpus = if (...) { $healthyGpus } else { $amdGpus }` unrolled a one-element branch into a bare
@@ -69,17 +72,33 @@ def _function(src: str, name: str) -> str:
     return _balanced(src, src.index(f"function {name} {{"), "{", "}")
 
 
-def _setup_source(revision: str | None = None) -> str:
-    """setup.ps1 as shipped, or as of `revision` (e.g. HEAD~1) for the red/green check."""
-    if revision is None:
-        return SETUP_PS1.read_text(encoding = "utf-8")
-    return subprocess.run(
-        ["git", "show", f"{revision}:studio/setup.ps1"],
-        cwd = REPO_ROOT,
-        capture_output = True,
-        text = True,
-        check = True,
-    ).stdout
+def _setup_source() -> str:
+    return SETUP_PS1.read_text(encoding = "utf-8")
+
+
+# The two fixes, as (fixed, unfixed) pairs. Undoing them textually is what the red/green check
+# below runs against, rather than an older commit: a revision that is "before the fix" is only
+# before it until this merges, and reaching for it through git also fails in a shallow CI clone.
+# Reverting the wraps in memory keeps the comparison immutable and isolates the one thing under
+# test, since everything else about the two sources is identical by construction.
+_ARRAY_WRAPS = (
+    (
+        "$wmiGpus = @(if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus })",
+        "$wmiGpus = if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus }",
+    ),
+    (
+        "$gpuNames = @(if ($script:ROCmGpuLabels) { @($script:ROCmGpuLabels) } else { @($ROCmGpuLabel) })",
+        "$gpuNames = if ($script:ROCmGpuLabels) { @($script:ROCmGpuLabels) } else { @($ROCmGpuLabel) }",
+    ),
+)
+
+
+def _without_the_array_wraps(src: str) -> str:
+    """setup.ps1 with only the two `@()` wraps undone: the source as it behaved before the fix."""
+    for fixed, unfixed in _ARRAY_WRAPS:
+        assert src.count(fixed) == 1, f"expected exactly one occurrence of {fixed!r}"
+        src = src.replace(fixed, unfixed)
+    return src
 
 
 def _amd_scan_block(src: str) -> str:
@@ -174,13 +193,13 @@ def _run(
     adapters: list[tuple[str, int]],
     *,
     env: dict[str, str] | None = None,
-    revision: str | None = None,
+    source: str | None = None,
     ps51: bool = False,
     strict: bool = False,
 ) -> dict:
     script = tmp_path / "scan.ps1"
     script.write_text(
-        _driver(_setup_source(revision), adapters, ps51 = ps51, strict = strict), encoding = "utf-8"
+        _driver(source or _setup_source(), adapters, ps51 = ps51, strict = strict), encoding = "utf-8"
     )
     # Only what each case names may reach the child: a developer's own exported
     # UNSLOTH_ROCM_GFX_ARCH would otherwise silently win every inference assertion here.
@@ -491,33 +510,16 @@ def test_only_this_runs_arch_is_handed_to_the_child(tmp_path, arch, inherited, e
 
 
 @requires_pwsh
-def test_these_assertions_fail_against_the_source_before_the_fix(tmp_path):
+def test_these_assertions_fail_without_the_array_wraps(tmp_path):
     """A regression test that passes on the unfixed source is not one.
 
     The first version of this file asserted on `.Count`, which pwsh answers as 1 for a scalar, so
-    it was green either way. Pin the two failures to the merge base so a later edit here cannot
-    quietly re-lose them.
+    it was green either way. Undo just the two wraps and confirm the failures come back, so a
+    later edit here cannot quietly re-lose them.
     """
-    # The merge base, not HEAD~1: this branch grows commits, and every one of them already
-    # carries the fix, so a relative ref would compare the fixed source against itself.
-    revision = None
-    for ref in ("origin/main", "upstream/main", "main"):
-        base = subprocess.run(
-            ["git", "merge-base", "HEAD", ref],
-            cwd = REPO_ROOT,
-            capture_output = True,
-            text = True,
-        )
-        if base.returncode == 0 and base.stdout.strip():
-            revision = base.stdout.strip()
-            break
-    if revision is None:
-        pytest.skip("no main branch to compare against (shallow or detached clone)")
-    try:
-        before = _run(tmp_path, [(_RADEON, 0)], revision = revision, ps51 = True)
-        pinned = _run(tmp_path, [(_RADEON, 0)], revision = revision, env = {"HIP_VISIBLE_DEVICES": "0"})
-    except (subprocess.CalledProcessError, AssertionError, ValueError):
-        pytest.skip("parent revision does not carry a comparable scan block")
+    unfixed = _without_the_array_wraps(_setup_source())
+    before = _run(tmp_path, [(_RADEON, 0)], source = unfixed, ps51 = True)
+    pinned = _run(tmp_path, [(_RADEON, 0)], source = unfixed, env = {"HIP_VISIBLE_DEVICES": "0"})
     assert not before["wmi_array"], "the unwrapped scan should collapse to a scalar"
     assert before["label"] is None, "the unwrapped scan should report no GPU under 5.1 semantics"
     assert pinned["arch"] is None, "the unwrapped name list should infer nothing when pinned"

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -437,7 +437,9 @@ def test_a_user_override_is_the_escape_hatch_under_a_mask(tmp_path):
 def _installer_scan_block() -> str:
     """install.ps1's own `if (-not $HasROCm)` WMI fallback plus the name table it feeds."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
-    start = src.index("        if (-not $HasROCm) {\n            try {\n                # ConfigManagerErrorCode")
+    start = src.index(
+        "        if (-not $HasROCm) {\n            try {\n                # ConfigManagerErrorCode"
+    )
     end = src.index("        # Capture ROCm version for wheel selection", start)
     return src[start:end]
 
@@ -479,7 +481,9 @@ def test_the_installer_skips_a_disabled_adapter(tmp_path):
     """A disabled Radeon listed first used to win here, and a mapped arch installs ROCm wheels
     right there, so the dead card got the wheels and the live unsupported one went to nothing.
     Setup filters this adapter out, so forwarding its arch also made the two disagree."""
-    out = _run_installer_scan(tmp_path, [("AMD Radeon RX 9070 XT", 22), ("AMD Radeon RX 5700 XT", 0)])
+    out = _run_installer_scan(
+        tmp_path, [("AMD Radeon RX 9070 XT", 22), ("AMD Radeon RX 5700 XT", 0)]
+    )
     assert out["label"] == "AMD Radeon RX 5700 XT"
     assert out["arch"] is None, "the active card is unsupported, so this host belongs on CPU"
 

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -4,28 +4,20 @@
 """setup.ps1 must report the AMD GPU on a host with exactly one AMD adapter.
 
 `$wmiGpus = if (...) { $healthyGpus } else { $amdGpus }` unrolled a one-element branch into a bare
-WMI object, and a bare WMI object has no .Count in PS 5.1, so the guard after it never fired: setup
-printed "gpu none (chat-only / GGUF)" while install.ps1 had just resolved the same GPU. Setup then
-expected cpu torch against the ROCm wheels the installer placed, called the venv stale and exited,
-the installer rolled back, and the desktop app retried the same failure forever.
+WMI object, which has no .Count in PS 5.1, so the guard after it never fired: setup printed "gpu
+none (chat-only / GGUF)" while install.ps1 had just resolved the same GPU, then expected cpu torch
+against the ROCm wheels the installer placed, called the venv stale and exited, the installer rolled
+back, and the desktop app retried forever. Same expression one block down, `$gpuNames`, wraps each
+BRANCH but not the if, so a lone adapter name unrolls to a String and `$gpuNames[$nameIdx]` yields
+"A"; the `$nameArches[0]` rescue hides that unless a visible-device mask is set.
 
-Two notes on why these tests are shaped the way they are.
-
-PowerShell has two member-binding paths and only the optimized one carries the PSv3 scalar
-Count/Length fallback. Types with a custom adapter -- CimInstance, ManagementObject, COM,
-PSCustomObject -- take the other one, which returned null in the 5.1-era engine; PowerShell/
-PowerShell#5745 added the fallback there and shipped it in 6.1, which Windows PowerShell 5.1 never
-received. So under the pwsh that runs these tests, `.Count` on a scalar answers 1 and the bug is
-INVISIBLE. Asserting on `.Count` would pass against the unfixed source and guard nothing. Every
-runtime case here therefore asserts the SHAPE of the value, which is identical on both engines, and
-`ps51` re-runs the same shipped block against stubs carrying an explicit `Count = $null` to
-reproduce 5.1's observable consequence rather than only its cause.
-
-The second bug is the same expression one block down: `$gpuNames = if (...) { @(...) } else { @(...) }`
-wraps each BRANCH but not the if, so a single adapter name unrolls to a bare String and
-`$gpuNames[$nameIdx]` indexes the name, yielding "A". Nothing maps, and the `$nameArches[0]` rescue
-is skipped under a visible-device mask, so a pinned single-GPU host inferred no arch at all. That
-one does reproduce under pwsh, so it is asserted directly.
+Why the assertions look the way they do: only PowerShell's optimized member-binding path carries the
+PSv3 scalar Count fallback, and custom-adapter types (CimInstance, ManagementObject, COM,
+PSCustomObject) take the other one, which returned null until PowerShell/PowerShell#5745 shipped in
+6.1 -- never backported to 5.1. So under pwsh `.Count` answers 1 and the bug is INVISIBLE; asserting
+on it would pass against the unfixed source. Every runtime case asserts the SHAPE of the value,
+which is identical on both engines, and `ps51` re-runs the same block against stubs carrying an
+explicit `Count = $null` to reproduce 5.1's consequence rather than only its cause.
 """
 
 from __future__ import annotations
@@ -241,22 +233,16 @@ def test_installer_forwards_the_arch_through_a_private_handoff():
 
 
 def test_installer_never_exports_the_public_override():
-    """UNSLOTH_ROCM_GFX_ARCH is the operator's to set.
-
-    install_llama_prebuilt.py reads it back as _manual to decide whether a forwarded --rocm-gfx
-    outranks its own probe, so publishing an auto-detected arch there disarms that safeguard on
-    exactly the multi-GPU hosts it exists for.
-    """
+    """install_llama_prebuilt.py reads UNSLOTH_ROCM_GFX_ARCH back as _manual to decide whether a
+    forwarded --rocm-gfx outranks its own probe, so publishing an auto-detected arch there disarms
+    that safeguard on exactly the multi-GPU hosts it exists for."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     assert re.search(r"\$env:UNSLOTH_ROCM_GFX_ARCH\s*=", src) is None
 
 
 def test_installer_restores_the_private_handoff_after_setup():
-    """Matching the save/restore every adjacent handoff variable already does.
-
-    install.ps1 is documented as `irm ... | iex`, so it runs in the caller's own process and a
-    value left behind would be read as an override by the next install in that terminal.
-    """
+    """install.ps1 is documented as `irm ... | iex`, so it runs in the caller's own process and a
+    value left behind would be read as an override by the next install in that terminal."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     assert f"$previousRocmGfxHandoff = $env:{HANDOFF}" in src
     assert f"$env:{HANDOFF} = $previousRocmGfxHandoff" in src
@@ -284,8 +270,8 @@ def test_single_amd_adapter_is_reported(tmp_path, ps51, strict):
     out = _run(tmp_path, [(_RADEON, 0)], ps51 = ps51, strict = strict)
     assert out["wmi_array"], f"one adapter must stay an array, got {out['wmi_type']}"
     assert out["labels"] == [_RADEON]
-    # The name reached the inference, which is what "reported" has to mean here: a label alone
-    # still lands on the "AMD ROCm" branch with no arch and installs cpu torch.
+    # A label alone still lands on the "AMD ROCm" branch with no arch and installs cpu torch, so
+    # "reported" has to mean the name reached the inference.
     assert out["arch"] == "gfx1151"
     assert out["label"] == "AMD ROCm (gfx1151)"
 
@@ -440,8 +426,7 @@ def _run_handoff_lifecycle(
         "\n".join(
             [
                 "$ErrorActionPreference = 'Stop'",
-                # The neighbouring handoffs the shipped finally also restores; not under test here, but
-                # the block does not compile without them.
+                # Not under test, but the shipped finally restores these too and needs them bound.
                 "$previousUnslothStudioHome = $null; $hadPreviousUnslothStudioHome = $false",
                 "$previousTauriMode = $null; $hadPreviousTauriMode = $false",
                 "$previousSetupRuntimeGateHandoff = $null; $hadPreviousSetupRuntimeGateHandoff = $false",
@@ -511,12 +496,8 @@ def test_only_this_runs_arch_is_handed_to_the_child(tmp_path, arch, inherited, e
 
 @requires_pwsh
 def test_these_assertions_fail_without_the_array_wraps(tmp_path):
-    """A regression test that passes on the unfixed source is not one.
-
-    The first version of this file asserted on `.Count`, which pwsh answers as 1 for a scalar, so
-    it was green either way. Undo just the two wraps and confirm the failures come back, so a
-    later edit here cannot quietly re-lose them.
-    """
+    """A regression test that passes on the unfixed source is not one, and the first version of
+    this file was exactly that. Undo just the two wraps and confirm the failures come back."""
     unfixed = _without_the_array_wraps(_setup_source())
     before = _run(tmp_path, [(_RADEON, 0)], source = unfixed, ps51 = True)
     pinned = _run(tmp_path, [(_RADEON, 0)], source = unfixed, env = {"HIP_VISIBLE_DEVICES": "0"})

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -41,15 +41,16 @@ SETUP_PS1 = REPO_ROOT / "studio" / "setup.ps1"
 
 requires_pwsh = pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
 
-_RADEON = "AMD Radeon(TM) 8060S Graphics"   # Strix Halo iGPU  -> gfx1151
-_RX9070 = "AMD Radeon RX 9070 XT"           # RDNA 4 discrete  -> gfx1201
-_R780M  = "AMD Radeon 780M Graphics"        # Phoenix iGPU     -> gfx1103, a shadowing arch
-_ARC    = "Intel(R) Arc(TM) A770 Graphics"
+_RADEON = "AMD Radeon(TM) 8060S Graphics"  # Strix Halo iGPU  -> gfx1151
+_RX9070 = "AMD Radeon RX 9070 XT"  # RDNA 4 discrete  -> gfx1201
+_R780M = "AMD Radeon 780M Graphics"  # Phoenix iGPU     -> gfx1103, a shadowing arch
+_ARC = "Intel(R) Arc(TM) A770 Graphics"
 
 HANDOFF = "_UNSLOTH_ROCM_GFX_ARCH_HANDOFF"
 
 
 # ── extracting the shipped source, so these tests exercise it rather than a copy ──────────────
+
 
 def _balanced(src: str, start: int, opener: str, closer: str) -> str:
     """Slice from `start` through the delimiter that closes the first `opener` after it."""
@@ -74,13 +75,20 @@ def _setup_source(revision: str | None = None) -> str:
         return SETUP_PS1.read_text(encoding = "utf-8")
     return subprocess.run(
         ["git", "show", f"{revision}:studio/setup.ps1"],
-        cwd = REPO_ROOT, capture_output = True, text = True, check = True,
+        cwd = REPO_ROOT,
+        capture_output = True,
+        text = True,
+        check = True,
     ).stdout
 
 
 def _amd_scan_block(src: str) -> str:
     """The `if (-not $HasROCm)` WMI fallback: the adapter list the label is read from."""
-    m = re.search(r"^    if \(-not \$HasROCm\) \{\n        try \{\n.*?^    \}\n", src, re.DOTALL | re.MULTILINE)
+    m = re.search(
+        r"^    if \(-not \$HasROCm\) \{\n        try \{\n.*?^    \}\n",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
     assert m, "AMD adapter scan block not found in setup.ps1"
     return m.group(0)
 
@@ -96,16 +104,19 @@ def _prelude(src: str) -> str:
     """The declarations and helpers the two blocks close over."""
     shadowing = _balanced(src, src.index("$script:ShadowingIntegratedGfx = @("), "(", ")")
     arch_family = _balanced(src, src.index("$archFamilyMap = @{"), "{", "}")
-    return "\n".join([
-        "$script:ShadowingIntegratedGfx = " + shadowing[shadowing.index("@("):],
-        "$archFamilyMap = " + arch_family[arch_family.index("@{"):],
-        _function(src, "Test-VisibleDevicesPinned"),
-        _function(src, "Resolve-VisibleGpuIndex"),
-        _function(src, "Resolve-ShadowingGfxPick"),
-    ])
+    return "\n".join(
+        [
+            "$script:ShadowingIntegratedGfx = " + shadowing[shadowing.index("@(") :],
+            "$archFamilyMap = " + arch_family[arch_family.index("@{") :],
+            _function(src, "Test-VisibleDevicesPinned"),
+            _function(src, "Resolve-VisibleGpuIndex"),
+            _function(src, "Resolve-ShadowingGfxPick"),
+        ]
+    )
 
 
 # ── the driver: run the shipped blocks against a stubbed adapter list ─────────────────────────
+
 
 def _driver(
     src: str,
@@ -124,36 +135,38 @@ def _driver(
         f"[pscustomobject]@{{ Name = '{name}'; ConfigManagerErrorCode = {code}{count_member} }}"
         for name, code in adapters
     )
-    return "\n".join([
-        "$ErrorActionPreference = 'Stop'",
-        "Set-StrictMode -Version Latest" if strict else "Set-StrictMode -Off",
-        f"function Get-CimInstance {{ param([Parameter(ValueFromRemainingArguments = $true)]$Rest) @({items}) }}",
-        "function substep { param($a, $b) }",
-        "$HasROCm = $false",
-        "$ROCmGpuLabel = $null",
-        "$script:ROCmGpuLabels = @()",
-        "$script:ROCmGfxArch = $null",
-        "$script:GpuNamesProbe = $null",
-        "$wmiGpus = $null",
-        _prelude(src),
-        _amd_scan_block(src),
-        # Captured from inside the arch block's own scope: $gpuNames is the value the indexing
-        # bug corrupts, and its first element is what Get-GfxArchFromGpuName is actually handed.
-        _arch_resolution_block(src).replace(
-            "$nameIdx = Resolve-VisibleGpuIndex $gpuNames.Count",
-            "$script:GpuNamesProbe = $gpuNames\n            $nameIdx = Resolve-VisibleGpuIndex $gpuNames.Count",
-        ),
-        # ConvertTo-Json, not string interpolation: a null stays null instead of becoming "".
-        "@{",
-        "  wmi_type    = $(if ($null -ne $wmiGpus) { $wmiGpus.GetType().FullName } else { $null })",
-        "  wmi_array   = [bool]($wmiGpus -is [array])",
-        "  label       = $ROCmGpuLabel",
-        "  labels      = @($script:ROCmGpuLabels)",
-        "  arch        = $script:ROCmGfxArch",
-        "  names_type  = $(if ($null -ne $script:GpuNamesProbe) { $script:GpuNamesProbe.GetType().FullName } else { $null })",
-        "  names_first = $(if ($null -ne $script:GpuNamesProbe) { $script:GpuNamesProbe[0] } else { $null })",
-        "} | ConvertTo-Json -Compress",
-    ])
+    return "\n".join(
+        [
+            "$ErrorActionPreference = 'Stop'",
+            "Set-StrictMode -Version Latest" if strict else "Set-StrictMode -Off",
+            f"function Get-CimInstance {{ param([Parameter(ValueFromRemainingArguments = $true)]$Rest) @({items}) }}",
+            "function substep { param($a, $b) }",
+            "$HasROCm = $false",
+            "$ROCmGpuLabel = $null",
+            "$script:ROCmGpuLabels = @()",
+            "$script:ROCmGfxArch = $null",
+            "$script:GpuNamesProbe = $null",
+            "$wmiGpus = $null",
+            _prelude(src),
+            _amd_scan_block(src),
+            # Captured from inside the arch block's own scope: $gpuNames is the value the indexing
+            # bug corrupts, and its first element is what Get-GfxArchFromGpuName is actually handed.
+            _arch_resolution_block(src).replace(
+                "$nameIdx = Resolve-VisibleGpuIndex $gpuNames.Count",
+                "$script:GpuNamesProbe = $gpuNames\n            $nameIdx = Resolve-VisibleGpuIndex $gpuNames.Count",
+            ),
+            # ConvertTo-Json, not string interpolation: a null stays null instead of becoming "".
+            "@{",
+            "  wmi_type    = $(if ($null -ne $wmiGpus) { $wmiGpus.GetType().FullName } else { $null })",
+            "  wmi_array   = [bool]($wmiGpus -is [array])",
+            "  label       = $ROCmGpuLabel",
+            "  labels      = @($script:ROCmGpuLabels)",
+            "  arch        = $script:ROCmGfxArch",
+            "  names_type  = $(if ($null -ne $script:GpuNamesProbe) { $script:GpuNamesProbe.GetType().FullName } else { $null })",
+            "  names_first = $(if ($null -ne $script:GpuNamesProbe) { $script:GpuNamesProbe[0] } else { $null })",
+            "} | ConvertTo-Json -Compress",
+        ]
+    )
 
 
 def _run(
@@ -166,20 +179,26 @@ def _run(
     strict: bool = False,
 ) -> dict:
     script = tmp_path / "scan.ps1"
-    script.write_text(_driver(_setup_source(revision), adapters, ps51 = ps51, strict = strict), encoding = "utf-8")
+    script.write_text(
+        _driver(_setup_source(revision), adapters, ps51 = ps51, strict = strict), encoding = "utf-8"
+    )
     # Only what each case names may reach the child: a developer's own exported
     # UNSLOTH_ROCM_GFX_ARCH would otherwise silently win every inference assertion here.
     child_env = {"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)}
     child_env.update(env or {})
     proc = subprocess.run(
         [shutil.which("pwsh") or "pwsh", "-NoProfile", "-NonInteractive", "-File", str(script)],
-        capture_output = True, text = True, timeout = 120, env = child_env,
+        capture_output = True,
+        text = True,
+        timeout = 120,
+        env = child_env,
     )
     assert proc.returncode == 0, f"scan block failed:\n{proc.stdout}\n{proc.stderr}"
     return json.loads(proc.stdout)
 
 
 # ── source assertions ─────────────────────────────────────────────────────────────────────────
+
 
 def test_scan_wraps_the_whole_if_in_an_array():
     """The unwrapped form is the bug, so keep it out of the source."""
@@ -224,7 +243,9 @@ def test_installer_restores_the_private_handoff_after_setup():
     assert f"$env:{HANDOFF} = $previousRocmGfxHandoff" in src
     assert f"Remove-Item Env:{HANDOFF} -ErrorAction SilentlyContinue" in src
     # Saved after the last early return, so no path skips the restore.
-    assert src.index("$previousRocmGfxHandoff") > src.index("--with-llama-cpp-dir path does not exist")
+    assert src.index("$previousRocmGfxHandoff") > src.index(
+        "--with-llama-cpp-dir path does not exist"
+    )
 
 
 def test_setup_consumes_the_handoff_only_after_its_own_inference():
@@ -235,6 +256,7 @@ def test_setup_consumes_the_handoff_only_after_its_own_inference():
 
 
 # ── runtime: the adapter scan ─────────────────────────────────────────────────────────────────
+
 
 @requires_pwsh
 @pytest.mark.parametrize("ps51", [False, True], ids = ["pwsh", "ps51"])
@@ -280,6 +302,7 @@ def test_a_host_with_no_amd_adapter_is_not_read_as_amd(tmp_path, adapters):
 
 # ── runtime: name inference, where the second unwrapped if bites ──────────────────────────────
 
+
 @requires_pwsh
 def test_the_adapter_name_reaches_inference_whole(tmp_path):
     """Unwrapped, $gpuNames is a String and $gpuNames[0] is the character "A"."""
@@ -311,7 +334,9 @@ def test_a_single_adapter_infers_its_arch(tmp_path, name, expected):
 
 @requires_pwsh
 @pytest.mark.parametrize("mask", ["0", "1", "", "-1", "not-a-number", "9", " 0 ", "0,1"])
-@pytest.mark.parametrize("var", ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"])
+@pytest.mark.parametrize(
+    "var", ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
+)
 def test_a_pinned_single_gpu_host_still_infers_its_arch(tmp_path, mask, var):
     """The mask disables the $nameArches[0] rescue, so the string-indexing bug surfaced here as a
     host with a perfectly good Radeon reporting no arch and looping the installer."""
@@ -331,6 +356,7 @@ def test_a_pinned_mask_is_honoured_over_the_shadowing_preference(tmp_path):
 
 
 # ── runtime: handoff precedence ───────────────────────────────────────────────────────────────
+
 
 @requires_pwsh
 def test_the_handoff_fills_the_gap_when_nothing_else_resolves(tmp_path):
@@ -352,7 +378,8 @@ def test_the_handoff_never_deposes_setups_own_inference(tmp_path):
 @requires_pwsh
 def test_a_user_override_still_wins_over_the_handoff(tmp_path):
     out = _run(
-        tmp_path, [(_R780M, 0)],
+        tmp_path,
+        [(_R780M, 0)],
         env = {"UNSLOTH_ROCM_GFX_ARCH": "gfx90a", HANDOFF: "gfx1103"},
     )
     assert out["arch"] == "gfx90a", "the documented operator override outranks an inferred value"
@@ -371,6 +398,7 @@ def test_an_empty_handoff_is_ignored(tmp_path):
 
 # ── runtime: install.ps1 leaves the caller's environment as it found it ───────────────────────
 
+
 def _handoff_lifecycle_block() -> str:
     """install.ps1's save / set / try / finally around the setup call, as shipped."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
@@ -379,40 +407,52 @@ def _handoff_lifecycle_block() -> str:
     return src[start:end]
 
 
-def _run_handoff_lifecycle(tmp_path: Path, *, arch: str | None, inherited: str | None, fails: bool) -> dict:
+def _run_handoff_lifecycle(
+    tmp_path: Path, *, arch: str | None, inherited: str | None, fails: bool
+) -> dict:
     body = _handoff_lifecycle_block().replace(
         "& $UnslothExe @studioArgs",
-        "throw 'setup exploded'" if fails else "$script:SeenByChild = $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF",
+        "throw 'setup exploded'"
+        if fails
+        else "$script:SeenByChild = $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF",
     )
     script = tmp_path / "handoff.ps1"
-    script.write_text("\n".join([
-        "$ErrorActionPreference = 'Stop'",
-        # The neighbouring handoffs the shipped finally also restores; not under test here, but
-        # the block does not compile without them.
-        "$previousUnslothStudioHome = $null; $hadPreviousUnslothStudioHome = $false",
-        "$previousTauriMode = $null; $hadPreviousTauriMode = $false",
-        "$previousSetupRuntimeGateHandoff = $null; $hadPreviousSetupRuntimeGateHandoff = $false",
-        "$previousProxyHandoff = $null; $hadPreviousProxyHandoff = $false",
-        "$UnslothProxyHandoffJson = $null",
-        "$UnslothExe = 'stub'; $studioArgs = @(); $setupExit = 0",
-        "$script:SeenByChild = '<never ran>'",
-        "$ROCmGfxArch = " + ("$null" if arch is None else f"'{arch}'"),
-        "try {",
-        body,
-        "} catch { }",
-        "@{",
-        "  seen_by_child = $script:SeenByChild",
-        "  after = $(if (Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) { $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF } else { $null })",
-        "  after_set = [bool](Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF)",
-        "  public = $(if (Test-Path Env:UNSLOTH_ROCM_GFX_ARCH) { $env:UNSLOTH_ROCM_GFX_ARCH } else { $null })",
-        "} | ConvertTo-Json -Compress",
-    ]), encoding = "utf-8")
+    script.write_text(
+        "\n".join(
+            [
+                "$ErrorActionPreference = 'Stop'",
+                # The neighbouring handoffs the shipped finally also restores; not under test here, but
+                # the block does not compile without them.
+                "$previousUnslothStudioHome = $null; $hadPreviousUnslothStudioHome = $false",
+                "$previousTauriMode = $null; $hadPreviousTauriMode = $false",
+                "$previousSetupRuntimeGateHandoff = $null; $hadPreviousSetupRuntimeGateHandoff = $false",
+                "$previousProxyHandoff = $null; $hadPreviousProxyHandoff = $false",
+                "$UnslothProxyHandoffJson = $null",
+                "$UnslothExe = 'stub'; $studioArgs = @(); $setupExit = 0",
+                "$script:SeenByChild = '<never ran>'",
+                "$ROCmGfxArch = " + ("$null" if arch is None else f"'{arch}'"),
+                "try {",
+                body,
+                "} catch { }",
+                "@{",
+                "  seen_by_child = $script:SeenByChild",
+                "  after = $(if (Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) { $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF } else { $null })",
+                "  after_set = [bool](Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF)",
+                "  public = $(if (Test-Path Env:UNSLOTH_ROCM_GFX_ARCH) { $env:UNSLOTH_ROCM_GFX_ARCH } else { $null })",
+                "} | ConvertTo-Json -Compress",
+            ]
+        ),
+        encoding = "utf-8",
+    )
     env = {"PATH": "/usr/bin:/bin", "HOME": str(tmp_path), "UNSLOTH_ROCM_GFX_ARCH": "gfx90a"}
     if inherited is not None:
         env[HANDOFF] = inherited
     proc = subprocess.run(
         [shutil.which("pwsh") or "pwsh", "-NoProfile", "-NonInteractive", "-File", str(script)],
-        capture_output = True, text = True, timeout = 120, env = env,
+        capture_output = True,
+        text = True,
+        timeout = 120,
+        env = env,
     )
     assert proc.returncode == 0, f"handoff block failed:\n{proc.stdout}\n{proc.stderr}"
     return json.loads(proc.stdout)
@@ -449,6 +489,7 @@ def test_only_this_runs_arch_is_handed_to_the_child(tmp_path, arch, inherited, e
 
 # ── the guard on the guards ───────────────────────────────────────────────────────────────────
 
+
 @requires_pwsh
 def test_these_assertions_fail_against_the_source_before_the_fix(tmp_path):
     """A regression test that passes on the unfixed source is not one.
@@ -463,7 +504,9 @@ def test_these_assertions_fail_against_the_source_before_the_fix(tmp_path):
     for ref in ("origin/main", "upstream/main", "main"):
         base = subprocess.run(
             ["git", "merge-base", "HEAD", ref],
-            cwd = REPO_ROOT, capture_output = True, text = True,
+            cwd = REPO_ROOT,
+            capture_output = True,
+            text = True,
         )
         if base.returncode == 0 and base.stdout.strip():
             revision = base.stdout.strip()


### PR DESCRIPTION
## The bug

On Windows, `studio/setup.ps1` builds its AMD adapter list with:

```powershell
$wmiGpus = if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus }
```

A one-element branch unrolls into a bare WMI object on its way out of the `if`, and a bare WMI object has no `.Count` in PowerShell 5.1:

```
healthy=1 wmiGpus.Count=[] reaches_label=False
```

So on a host with **exactly one AMD adapter** the guard right after it never fires, `$ROCmGpuLabel` stays null, the name to gfx inference is skipped, and setup reports:

```
gpu            none (chat-only / GGUF)
```

Two or more AMD adapters keep the array intact and work fine, so this only hits single-GPU machines.

This is engine behaviour, not a quirk of one host. PowerShell has two member-binding paths and only the optimized one carries the PSv3 scalar `Count`/`Length` fallback; types with a custom adapter (`CimInstance`, `ManagementObject`, COM, `PSCustomObject`) take the other one, which returned null in the 5.1-era engine. [PowerShell/PowerShell#5745](https://github.com/PowerShell/PowerShell/pull/5745) added the fallback there and shipped it in 6.1, which Windows PowerShell 5.1 never received. It also means pwsh on CI answers `1` for the same expression, which matters for the tests below.

## Why that bricks the install

`install.ps1` resolves the arch with `Select-Object -First 1` and is unaffected, so the two scripts disagree inside the same run, one second apart:

```
[install] gfx arch inferred from GPU name: gfx1151
[install] gpu            AMD ROCm (gfx1151)
[install] installing PyTorch from https://repo.amd.com/rocm/whl/gfx1151/...
[install] unsloth        2026.8.14 installed
[install] setup          running unsloth studio setup...
[setup]   gpu            none (chat-only / GGUF)
[setup]   Stale venv detected (torch rocm != required cpu).
          [ERROR] The existing Unsloth environment needs repair.
[install] restoring previous environment after failed install...
```

With no GPU detected, `$expectedTorchTag` is `cpu`, the installed `+rocm` wheel reads as stale, setup exits 1, the installer rolls back, preflight still says stale, and the desktop app repairs again. It never converges. Rolling back also leaves the venv without a working CLI, so later passes degrade further into `ModuleNotFoundError: No module named 'unsloth_cli'`.

Reproduced on a Radeon 8060S (gfx1151, Strix Halo) laptop with Unsloth Desktop 0.1.70-beta, and confirmed fixed there. `setx UNSLOTH_ROCM_GFX_ARCH gfx1151` clears it, which is what pointed at the detection path.

## The fix

1. `studio/setup.ps1`: wrap the whole `if` in `@()`, the idiom the Intel scan a few lines below already documents ("`@()` wraps the WHOLE if, not each branch").

2. `studio/setup.ps1`: the gpu name list one block down had the same expression, wrapping each branch but not the `if`:

   ```powershell
   $gpuNames = if ($script:ROCmGpuLabels) { @($script:ROCmGpuLabels) } else { @($ROCmGpuLabel) }
   ```

   A single adapter name unrolls to a bare `String`, so `$gpuNames[$nameIdx]` indexes the name and yields `A`, and nothing maps. The `$nameArches[0]` rescue below covers that unless a visible-device mask is set, so a single-GPU host with `HIP_VISIBLE_DEVICES` set still inferred no arch and looped the same way, and a standalone `unsloth studio update` was never covered by the installer handoff at all. Every `= if (` site across the `.ps1` files was audited; this was the only other one.

3. `install.ps1`: hand the arch this run resolved to setup as `_UNSLOTH_ROCM_GFX_ARCH_HANDOFF`, so a future divergence between the two scans cannot become an unrecoverable rollback loop.

   Deliberately **not** `UNSLOTH_ROCM_GFX_ARCH`. That is the documented operator override, and `install_llama_prebuilt.py` reads it back as `_manual` to decide whether a forwarded `--rocm-gfx` outranks its own probe, so publishing an auto-detected value there disarms that safeguard. `install.ps1`'s scan is also the weaker of the two: first AMD adapter, no visible-device mask, no shadowing-iGPU repick, all of which `setup.ps1` applies. On a `Radeon 780M` + `RX 9070 XT` host setup resolves gfx1201, and forwarding the installer's gfx1103 would have handed llama.cpp the iGPU bundle.

   So it uses the `_UNSLOTH_` prefix the neighbouring handoffs use, is saved and restored in the same `finally` block (`install.ps1` is documented as `irm ... | iex`, so it runs in the caller's own shell), is cleared rather than left alone when nothing was resolved, and `setup.ps1` consumes it only after its own probes and name inference come up empty.

## Tests

`tests/test_windows_amd_gpu_scan_fallback.py` extracts the shipped blocks from `setup.ps1` and `install.ps1` and runs them against stubbed adapter lists, so it exercises the source rather than a copy.

The first version of this file asserted on `.Count`, which pwsh answers as `1` for a scalar for the reason above, so it passed against the unfixed source and guarded nothing. Every runtime case now asserts the **shape** of the value, which is identical on both engines, and re-runs each case against stubs carrying an explicit `Count = $null` to reproduce 5.1's observable consequence rather than only its cause.

| area | cases |
| --- | --- |
| adapter scan | one adapter (x pwsh/5.1 x lax/strict), two adapters, parked-only, healthy over parked, Intel-only, no adapters |
| name inference | the name reaches inference whole rather than as `A`; 11 marketing names to arch; discrete card preferred over a shadowing iGPU; a pinned mask honoured over that preference |
| masks | single-GPU host still resolves gfx1151 across 3 mask variables x 8 values (`0`, `1`, empty, `-1`, unparseable, out of range, padded, list) |
| handoff | fills the gap when nothing else resolves, never deposes setup's own inference, a user override still wins, normalization, empty ignored |
| handoff lifecycle | the caller's environment survives the setup call across resolved/inherited/neither x setup succeeding/throwing, and only this run's arch reaches the child |
| source | both `@(if (` forms, the private handoff is set before setup and restored after, `UNSLOTH_ROCM_GFX_ARCH` is never exported, and the handoff is consumed after inference |

71 pass on the branch. Run against the merge base the same file reports 38 failures, including the single-adapter, pinned-mask and name-indexing cases, and `test_these_assertions_fail_against_the_source_before_the_fix` pins that so a later edit cannot quietly re-lose it.

Both scripts parse clean through `[System.Management.Automation.Language.Parser]::ParseFile`. `tests/studio/install` + `tests/python` report an identical 5 failed / 2486 passed / 91 skipped / 32 errors on this branch and on the merge base, so the pre-existing failures are unchanged. `test_rocm_support.py` (486 passed), the arch-table parity and cross-platform parity suites, and the neighbouring `tests/studio/*.ps1` suites all pass. An old `setup.ps1` ignores the new handoff rather than breaking on it, and `install.sh` / `setup.sh` / macOS are untouched.
