### PR TITLE
Studio: keep the download rail in the corner under the welcome composer

### DIFF
--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -135,18 +135,24 @@ function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
  * Asked against the inset in force, never a fixed one: lifting over one box
  * moves the stack up into the next, and a box that had room at the corner may
  * have none there.
+ *
+ * A box that may be covered is asked against the floor, not the natural height.
+ * It has already said the stack outranks it, so a band holding every card is
+ * enough and the room they would prefer is not worth leaving the corner for.
+ * Two downloads make the rail taller than the welcome composer's band, and
+ * lifting for that put the panel mid-window with the corner under it empty.
  */
 function reachesStack(
   frame: MonitorFrame,
   viewportHeight: number,
   bottomInset: number,
   neededRoom: number,
+  floorRoom: number = neededRoom,
 ): boolean {
+  const wanted = frame.coverable ? floorRoom : neededRoom;
   // At least a pixel: a needed room of 0 lets the capped branch hand back a
   // max-height of 0, which browsers honour, leaving the stack invisible.
-  return (
-    roomBelow(frame, viewportHeight, bottomInset) < Math.max(1, neededRoom)
-  );
+  return roomBelow(frame, viewportHeight, bottomInset) < Math.max(1, wanted);
 }
 
 /** The inset that clears this box's top edge, whether or not it fits there. */
@@ -198,6 +204,7 @@ export function stackBottomInset(
   viewportWidth: number,
   viewportHeight: number,
   neededRoom: number = ASSUMED_STACK_HEIGHT,
+  floorRoom: number = neededRoom,
 ): number {
   if (!frame) return STACK_INSET;
   // Only dodge a box that is in the stack's column and crowds its corner; one
@@ -205,7 +212,7 @@ export function stackBottomInset(
   // corner free.
   const inTheWay =
     inStackColumn(frame, viewportWidth) &&
-    reachesStack(frame, viewportHeight, STACK_INSET, neededRoom);
+    reachesStack(frame, viewportHeight, STACK_INSET, neededRoom, floorRoom);
   return inTheWay ? dodgeInset(frame, viewportHeight) : STACK_INSET;
 }
 
@@ -230,10 +237,11 @@ export function stackMaxHeight(
   viewportHeight: number,
   bottomInset: number,
   neededRoom: number = ASSUMED_STACK_HEIGHT,
+  floorRoom: number = neededRoom,
 ): number {
   const ownMargin = viewportHeight - bottomInset - STACK_INSET;
   if (!frame || !inStackColumn(frame, viewportWidth)) return ownMargin;
-  if (reachesStack(frame, viewportHeight, bottomInset, neededRoom)) {
+  if (reachesStack(frame, viewportHeight, bottomInset, neededRoom, floorRoom)) {
     // Lifted over: bottomInset already cleared it.
     if (liftFits(frame, viewportHeight)) return ownMargin;
     // Seated inside it instead. Stop below its header, or the Close button goes
@@ -274,7 +282,13 @@ export function stackGeometry(
   persistentTail = 0,
 ): StackGeometry {
   const list = frames === null ? [] : Array.isArray(frames) ? frames : [frames];
-  const placed = place(list, viewportWidth, viewportHeight, neededRoom);
+  const placed = place(
+    list,
+    viewportWidth,
+    viewportHeight,
+    neededRoom,
+    floorRoom,
+  );
   if (placed.maxHeight >= floorRoom || !list.some((f) => f.coverable)) {
     return placed;
   }
@@ -295,6 +309,7 @@ export function stackGeometry(
     viewportWidth,
     viewportHeight,
     neededRoom,
+    floorRoom,
   );
   // Where the run the reader cannot dismiss would actually land, measured from
   // the placement being considered rather than from the corner. Dropping the
@@ -321,6 +336,7 @@ function place(
   viewportWidth: number,
   viewportHeight: number,
   neededRoom: number,
+  floorRoom: number = neededRoom,
 ): StackGeometry {
   if (list.length === 0) {
     const bottom = stackBottomInset(
@@ -348,7 +364,7 @@ function place(
   for (let pass = 0; pass <= column.length; pass += 1) {
     let next = bottom;
     for (const frame of column) {
-      if (reachesStack(frame, viewportHeight, bottom, neededRoom)) {
+      if (reachesStack(frame, viewportHeight, bottom, neededRoom, floorRoom)) {
         next = Math.max(next, dodgeInset(frame, viewportHeight));
       }
     }
@@ -359,7 +375,14 @@ function place(
     bottom,
     maxHeight: Math.min(
       ...list.map((f) =>
-        stackMaxHeight(f, viewportWidth, viewportHeight, bottom, neededRoom),
+        stackMaxHeight(
+          f,
+          viewportWidth,
+          viewportHeight,
+          bottom,
+          neededRoom,
+          floorRoom,
+        ),
       ),
     ),
   };

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -122,25 +122,22 @@ function inStackColumn(frame: MonitorFrame, viewportWidth: number): boolean {
  *
  * This is the whole difference between the two composer layouts. Docked under a
  * thread it crowds the corner and has to be dodged, or the card covers Send. On
- * an empty chat the welcome layout pads it well clear of the bottom, and
- * lifting over it there is what put the banners in the middle of the page with
- * the corner underneath them empty.
+ * an empty chat it sits well clear of the bottom, and lifting over it there
+ * strands the stack mid-page with the corner underneath it empty.
  *
- * Measured against what the stack actually is, not a fixed guess. In a short
- * window the welcome composer left 83px under it and the 80px card fits, but the
- * old constant said 120, so the stack lifted over the composer and left the very
- * corner it was dodging empty. `neededRoom` comes from the stack's own
- * ResizeObserver (see useStackGeometry), so a taller stack still gets dodged.
+ * So the room is measured, never guessed: `neededRoom` is the stack's own
+ * ResizeObserver height (see useStackGeometry). A fixed 120 once lifted an 80px
+ * card out of an 83px gap it fit in.
  *
  * Asked against the inset in force, never a fixed one: lifting over one box
  * moves the stack up into the next, and a box that had room at the corner may
  * have none there.
  *
- * A box that may be covered is asked against the floor, not the natural height.
- * It has already said the stack outranks it, so a band holding every card is
- * enough and the room they would prefer is not worth leaving the corner for.
- * Two downloads make the rail taller than the welcome composer's band, and
- * lifting for that put the panel mid-window with the corner under it empty.
+ * A box that may be covered is asked against the floor instead. It has already
+ * said the stack outranks it, so a band holding every card whole is enough, and
+ * the height the cards would prefer is not worth leaving the corner for: a rail
+ * taller than the welcome composer's band was being parked mid-window for room
+ * it scrolls anyway.
  */
 function reachesStack(
   frame: MonitorFrame,

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -293,6 +293,53 @@ test("a stack too tall for that gap is still lifted over", () => {
   assert.ok(SHORT_H - inset <= SHORT_WELCOME.top, "and clears it fully");
 });
 
+// Two active downloads on the welcome screen of a 1600x891 window. The rail is
+// taller than the 163px band under the composer but its cards scroll, so the
+// height it would PREFER is not worth the corner: dodging for it left the panel
+// mid-window with the corner under it empty.
+const WIDE_W = 1600;
+const WIDE_H = 891;
+const WIDE_WELCOME = {
+  left: 532,
+  top: 524,
+  right: 1520,
+  bottom: 704,
+  coverable: true,
+};
+
+test("a rail that scrolls into the welcome composer's band keeps the corner", () => {
+  const geometry = stackGeometry(WIDE_WELCOME, WIDE_W, WIDE_H, 328, 140);
+  assert.equal(geometry.bottom, 16, "the panel belongs in the corner");
+  assert.ok(geometry.maxHeight >= 140, "and holds the cards at their floor");
+  const stackTop = WIDE_H - geometry.bottom - geometry.maxHeight;
+  assert.ok(stackTop >= WIDE_WELCOME.bottom, "without reaching the composer");
+});
+
+test("a rail whose floor will not fit that band is still lifted over", () => {
+  const geometry = stackGeometry(WIDE_WELCOME, WIDE_W, WIDE_H, 328, 300);
+  assert.ok(geometry.bottom > 16, "300px cannot fit in 163px, so it moves");
+  assert.ok(
+    WIDE_H - geometry.bottom <= WIDE_WELCOME.top,
+    "and clears the composer fully",
+  );
+});
+
+test("the docked composer is dodged however little the rail insists on", () => {
+  const docked = {
+    left: 412,
+    top: 664,
+    right: 1148,
+    bottom: 814,
+    coverable: true,
+  };
+  for (const floor of [1, 40, 120]) {
+    assert.ok(
+      stackBottomInset(docked, CHAT_W, CHAT_H, 260, floor) > 16,
+      `a rail with a ${floor}px floor must still clear Send`,
+    );
+  }
+});
+
 test("a docked composer is dodged whatever the stack measures", () => {
   const docked = { left: 412, top: 664, right: 1148, bottom: 814 };
   for (const height of [40, 80, 120, 260]) {


### PR DESCRIPTION
## The bug

With two active downloads the panel sits in the middle of the window, with the bottom-right corner underneath it empty.

The chat composer publishes its box to the overlay-frame store as `coverable`, and the rail dodges anything that crowds its corner. On the welcome screen the composer is centred rather than docked, so it leaves a usable band beneath it, but `reachesStack` measures that band against the rail's **natural** height. One download fits, two do not, so the rail is lifted clear of the composer's top edge and ends up adrift with the corner it was dodging left empty.

That is also why the same build differs per machine: a narrower window, a shorter card or a single download fits the band and lands in the corner as expected.

## The fix

Ask a `coverable` box against the stack's **floor** instead of its natural height.

```ts
const wanted = frame.coverable ? floorRoom : neededRoom;
```

The composer is the only box that opts into `coverable`, and having said the stack outranks it, a band that holds every card whole is enough. The height the cards would prefer is not worth leaving the corner for, and the rail scrolls for the rest, which is what its cap and its scroller are already for.

`floorRoom` is measured by `useStackGeometry` and already handed to `stackGeometry`; this threads it down through `place` to `reachesStack`, defaulting to `neededRoom` so a caller that knows only one number keeps the stricter reading.

What does not change:

- The docked composer leaves no band at all, so it still gets its dodge whatever the rail measures, and the card cannot land on Send.
- A rail whose floor genuinely will not fit the band is still lifted over, so no card is clipped to win the corner.
- The Live monitor is not `coverable`, so its placement is untouched.
- The covering fallback for windows too short to do either is untouched.

## Tests

`studio/frontend/tests/monitor-stack-inset.test.ts` gains three cases, taken from the reported window (1600x891, welcome composer leaving a 163px band):

- a rail that scrolls into the band keeps the corner and still clears the composer
- a rail whose floor will not fit that band is still lifted fully clear
- the docked composer is dodged for floors of 1, 40 and 120px

The existing suite passes unchanged, including the two cases this logic was written for: `a card that fits under the welcome composer keeps the corner`, `a stack too tall for that gap is still lifted over` (83px band, so it still lifts), and `a placement that fits the cards at their floor is not given up on`.

44/44 in that file, and the wider frontend suite has the same 10 pre-existing failures with and without this branch (clipboard and background-load-notice, unrelated). `biome check` reports the same 30 warnings on both files before and after, and `tsc` flags nothing in either.

