### PR TITLE
Studio: verify the flash-attn import after installing it

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1277,7 +1277,9 @@ def _install_package_wheel_first(
     # rc=0 is not proof again here: pip/uv exit 0 on "Requirement already satisfied" without
     # installing anything, so a rejected wheel would otherwise be reported as a success.
     if not _is_importable_isolated(import_name):
-        _reject_install(event_queue, pypi_name, display_name, "installed from PyPI but will not import")
+        _reject_install(
+            event_queue, pypi_name, display_name, "installed from PyPI but will not import"
+        )
         return False
 
     if is_hip:

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -988,8 +988,12 @@ def _is_importable_isolated(import_name: str) -> bool:
     """
     try:
         result = _sp.run(
-            [sys.executable, "-c", "import importlib, sys; importlib.import_module(sys.argv[1])",
-             import_name],
+            [
+                sys.executable,
+                "-c",
+                "import importlib, sys; importlib.import_module(sys.argv[1])",
+                import_name,
+            ],
             stdout = _sp.DEVNULL,
             stderr = _sp.DEVNULL,
             timeout = 300,

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -979,6 +979,49 @@ def _is_importable(import_name: str) -> bool:
         return False
 
 
+def _is_importable_isolated(import_name: str) -> bool:
+    """Probe the import in a child process.
+
+    A wheel built for the wrong arch can abort or segfault inside the extension's own
+    initialiser instead of raising, and that would kill this worker outright rather than
+    fall back. A child turns it into a return code (negative = fatal signal).
+    """
+    try:
+        result = _sp.run(
+            [sys.executable, "-c", "import importlib, sys; importlib.import_module(sys.argv[1])",
+             import_name],
+            stdout = _sp.DEVNULL,
+            stderr = _sp.DEVNULL,
+            timeout = 300,
+            # No env override: the probe should see exactly what the real in-process import
+            # will see a moment later, and nothing here decodes child output.
+        )
+    except (OSError, _sp.TimeoutExpired) as exc:
+        logger.debug("%s import probe did not complete (%s)", import_name, exc)
+        return False
+    if result.returncode != 0:
+        logger.debug("%s import probe exited %s", import_name, result.returncode)
+    return result.returncode == 0
+
+
+def _uninstall_package(pypi_name: str, display_name: str) -> None:
+    if shutil.which("uv"):
+        cmd = ["uv", "pip", "uninstall", "--python", sys.executable, pypi_name]
+    else:
+        cmd = [sys.executable, "-m", "pip", "uninstall", "-y", pypi_name]
+    result = _sp.run(
+        cmd,
+        stdout = _sp.PIPE,
+        stderr = _sp.STDOUT,
+        text = True,
+        encoding = "utf-8",
+        errors = "replace",
+        env = utf8_child_env(),
+    )
+    if result.returncode != 0:
+        logger.warning("Could not remove the rejected %s install:\n%s", display_name, result.stdout)
+
+
 def _install_package_wheel_first(
     *,
     event_queue: Any,
@@ -1029,8 +1072,9 @@ def _install_package_wheel_first(
         ):
             if result.returncode == 0:
                 # A wheel can install yet fail to import (CUDA/ABI or arch mismatch), so
-                # verify rather than trust the exit code.
-                if _is_importable(import_name):
+                # verify rather than trust the exit code. Out of process: this wheel is
+                # unvalidated native code and a bad one can take the worker down with it.
+                if _is_importable_isolated(import_name):
                     logger.info("Installed prebuilt %s wheel successfully", display_name)
                     return True
                 logger.warning(
@@ -1072,6 +1116,14 @@ def _install_package_wheel_first(
         else:
             pypi_status_message = f"Installing {display_name} from PyPI for faster training..."
 
+    if wheel_rejected:
+        # Remove it rather than installing over it. pip/uv would report the broken
+        # distribution as satisfying the spec and do nothing, and --force-reinstall is not
+        # the answer: both scope it to the whole resolved transaction ("Reinstall all
+        # packages"), which for flash-attn pulls in torch and could swap the running CUDA
+        # stack underneath this worker.
+        _uninstall_package(pypi_name, display_name)
+
     _send_status(event_queue, pypi_status_message)
 
     plain_pypi_install = pypi_version is None
@@ -1083,15 +1135,10 @@ def _install_package_wheel_first(
                 "install",
                 "--python",
                 sys.executable,
+                pypi_spec,
             ]
-            if wheel_rejected:
-                pypi_cmd.append("--reinstall")
-            pypi_cmd.append(pypi_spec)
         else:
-            pypi_cmd = [sys.executable, "-m", "pip", "install"]
-            if wheel_rejected:
-                pypi_cmd.append("--force-reinstall")
-            pypi_cmd.append(pypi_spec)
+            pypi_cmd = [sys.executable, "-m", "pip", "install", pypi_spec]
     else:
         if shutil.which("uv"):
             pypi_cmd = [
@@ -1106,8 +1153,6 @@ def _install_package_wheel_first(
             # Avoid stale cache artifacts from partial HIP source builds
             if is_hip:
                 pypi_cmd.append("--no-cache")
-            if wheel_rejected:
-                pypi_cmd.append("--reinstall")
             pypi_cmd.append(pypi_spec)
         else:
             pypi_cmd = [
@@ -1118,10 +1163,8 @@ def _install_package_wheel_first(
                 "--no-build-isolation",
                 "--no-deps",
                 "--no-cache-dir",
+                pypi_spec,
             ]
-            if wheel_rejected:
-                pypi_cmd.append("--force-reinstall")
-            pypi_cmd.append(pypi_spec)
 
     # ROCm source compilation can take 10-30 min; use a generous timeout. Non-HIP installs
     # keep the pre-existing "no timeout" behaviour so unrelated slow builds (causal-conv1d
@@ -1203,7 +1246,7 @@ def _install_package_wheel_first(
 
     # rc=0 is not proof again here: pip/uv exit 0 on "Requirement already satisfied" without
     # installing anything, so a rejected wheel would otherwise be reported as a success.
-    if not _is_importable(import_name):
+    if not _is_importable_isolated(import_name):
         logger.warning("%s installed from PyPI but is not importable", display_name)
         _send_status(event_queue, f"{display_name} is installed but not usable on this GPU")
         return False

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -973,9 +973,8 @@ def _is_importable(import_name: str) -> bool:
         __import__(import_name)
         return True
     except Exception as exc:
-        # A wheel built for another arch/ABI raises OSError/RuntimeError ("undefined symbol",
-        # "no kernel image is available"), not ImportError, so catch everything: the caller
-        # treats any failure as "not installed" and falls back rather than hard-failing.
+        # A wrong-arch/ABI wheel raises OSError/RuntimeError ("undefined symbol"), not
+        # ImportError, so catch everything and let the caller fall back.
         logger.debug("%s is not importable (%s: %s)", import_name, type(exc).__name__, exc)
         return False
 
@@ -1025,8 +1024,8 @@ def _install_package_wheel_first(
             run = _sp.run,
         ):
             if result.returncode == 0:
-                # A wheel can install yet fail to import (CUDA/ABI or arch mismatch); verify
-                # before trusting it, else fall through to the PyPI/source path below.
+                # A wheel can install yet fail to import (CUDA/ABI or arch mismatch), so
+                # verify rather than trust the exit code.
                 if _is_importable(import_name):
                     logger.info("Installed prebuilt %s wheel successfully", display_name)
                     return True

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -986,9 +986,9 @@ _IMPORT_PROBE_TIMEOUT = 300
 def _is_importable_isolated(import_name: str) -> bool:
     """Probe the import in a child process.
 
-    A wheel built for the wrong arch can abort or segfault inside the extension's own
-    initialiser instead of raising, and that would kill this worker outright rather than
-    fall back. A child turns it into a return code (negative = fatal signal).
+    A wrong-arch wheel can abort or segfault in its initialiser instead of raising, which
+    would kill this worker rather than fall back. A child turns that into a return code
+    (negative = fatal signal).
     """
     try:
         result = _sp.run(
@@ -1001,8 +1001,7 @@ def _is_importable_isolated(import_name: str) -> bool:
             stdout = _sp.DEVNULL,
             stderr = _sp.DEVNULL,
             timeout = _IMPORT_PROBE_TIMEOUT,
-            # No env override: the probe should see exactly what the real in-process import
-            # will see a moment later, and nothing here decodes child output.
+            # No env override: the probe must see what the real in-process import will.
         )
     except (OSError, _sp.TimeoutExpired) as exc:
         logger.debug("%s import probe did not complete (%s)", import_name, exc)
@@ -1052,8 +1051,7 @@ def _install_package_wheel_first(
         logger.info("Skipping %s installation while offline", display_name)
         return False
 
-    # Set when a wheel installed but would not import: pip/uv treat the broken distribution
-    # as satisfying the fallback spec, so it has to be replaced rather than installed over.
+    # Set when a wheel installed but would not import; see the uninstall before the fallback.
     wheel_rejected = False
 
     env = probe_torch_wheel_env(timeout = 30)
@@ -1080,8 +1078,8 @@ def _install_package_wheel_first(
         ):
             if result.returncode == 0:
                 # A wheel can install yet fail to import (CUDA/ABI or arch mismatch), so
-                # verify rather than trust the exit code. Out of process: this wheel is
-                # unvalidated native code and a bad one can take the worker down with it.
+                # verify rather than trust the exit code, and do it out of process: a bad
+                # one can take the worker down with it.
                 if _is_importable_isolated(import_name):
                     logger.info("Installed prebuilt %s wheel successfully", display_name)
                     return True
@@ -1125,11 +1123,10 @@ def _install_package_wheel_first(
             pypi_status_message = f"Installing {display_name} from PyPI for faster training..."
 
     if wheel_rejected:
-        # Remove it rather than installing over it. pip/uv would report the broken
-        # distribution as satisfying the spec and do nothing, and --force-reinstall is not
-        # the answer: both scope it to the whole resolved transaction ("Reinstall all
-        # packages"), which for flash-attn pulls in torch and could swap the running CUDA
-        # stack underneath this worker.
+        # Remove it rather than install over it: pip/uv would report the broken
+        # distribution as already satisfying the spec and do nothing. --force-reinstall is
+        # not the answer either, since both scope it to the whole resolved transaction,
+        # which for flash-attn means torch and the running CUDA stack.
         _uninstall_package(pypi_name, display_name)
 
     _send_status(event_queue, pypi_status_message)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1001,6 +1001,10 @@ def _install_package_wheel_first(
         logger.info("Skipping %s installation while offline", display_name)
         return False
 
+    # Set when a wheel installed but would not import: pip/uv treat the broken distribution
+    # as satisfying the fallback spec, so it has to be replaced rather than installed over.
+    wheel_rejected = False
+
     env = probe_torch_wheel_env(timeout = 30)
     if wheel_url_builder is not None:
         wheel_url = wheel_url_builder(env)
@@ -1033,6 +1037,7 @@ def _install_package_wheel_first(
                     "%s wheel installed but is not importable; falling back to PyPI",
                     display_name,
                 )
+                wheel_rejected = True
                 break
             logger.warning(
                 "%s failed to install %s wheel:\n%s",
@@ -1078,10 +1083,15 @@ def _install_package_wheel_first(
                 "install",
                 "--python",
                 sys.executable,
-                pypi_spec,
             ]
+            if wheel_rejected:
+                pypi_cmd.append("--reinstall")
+            pypi_cmd.append(pypi_spec)
         else:
-            pypi_cmd = [sys.executable, "-m", "pip", "install", pypi_spec]
+            pypi_cmd = [sys.executable, "-m", "pip", "install"]
+            if wheel_rejected:
+                pypi_cmd.append("--force-reinstall")
+            pypi_cmd.append(pypi_spec)
     else:
         if shutil.which("uv"):
             pypi_cmd = [
@@ -1096,6 +1106,8 @@ def _install_package_wheel_first(
             # Avoid stale cache artifacts from partial HIP source builds
             if is_hip:
                 pypi_cmd.append("--no-cache")
+            if wheel_rejected:
+                pypi_cmd.append("--reinstall")
             pypi_cmd.append(pypi_spec)
         else:
             pypi_cmd = [
@@ -1106,8 +1118,10 @@ def _install_package_wheel_first(
                 "--no-build-isolation",
                 "--no-deps",
                 "--no-cache-dir",
-                pypi_spec,
             ]
+            if wheel_rejected:
+                pypi_cmd.append("--force-reinstall")
+            pypi_cmd.append(pypi_spec)
 
     # ROCm source compilation can take 10-30 min; use a generous timeout. Non-HIP installs
     # keep the pre-existing "no timeout" behaviour so unrelated slow builds (causal-conv1d
@@ -1185,6 +1199,13 @@ def _install_package_wheel_first(
                     display_name,
                     result.stdout,
                 )
+        return False
+
+    # rc=0 is not proof again here: pip/uv exit 0 on "Requirement already satisfied" without
+    # installing anything, so a rejected wheel would otherwise be reported as a success.
+    if not _is_importable(import_name):
+        logger.warning("%s installed from PyPI but is not importable", display_name)
+        _send_status(event_queue, f"{display_name} is installed but not usable on this GPU")
         return False
 
     if is_hip:

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1036,10 +1036,10 @@ def _uninstall_package(pypi_name: str, display_name: str) -> bool:
 def _distribution_present(pypi_name: str) -> bool:
     """Whether the distribution's METADATA is installed, without importing it.
 
-    Metadata is the thing that matters: unsloth/models/_utils.py gates on
-    ``_package_available`` (metadata) and only then imports the native module, so metadata
-    left behind is what turns a rejected wheel into an in-process crash. Reading it never
-    loads the extension, so this is safe to call even for a wheel that would abort.
+    Metadata is what matters: unsloth/models/_utils.py gates on ``_package_available`` and
+    only then imports the native module, so metadata left behind is what turns a rejected
+    wheel into an in-process crash. Reading it never loads the extension, so this is safe
+    even for a wheel that would abort.
     """
     importlib.invalidate_caches()
     try:
@@ -1052,10 +1052,9 @@ def _distribution_present(pypi_name: str) -> bool:
 def _reject_install(event_queue: Any, pypi_name: str, display_name: str, reason: str) -> None:
     """Discard an install that will not import, and say which state we ended in.
 
-    Idempotent and state-based, so it is safe to call on EVERY exit from the install path
-    rather than only the ones somebody remembered: it no-ops when the distribution is
-    already gone. Leaving it in place is not the same as never having installed it, since
-    the metadata gate above would import the extension anyway.
+    Idempotent, so it is safe on EVERY exit rather than only the ones somebody remembered:
+    it no-ops when the distribution is already gone. Leaving it in place is not the same as
+    never having installed it, since the metadata gate above imports it anyway.
     """
     if not _distribution_present(pypi_name):
         return
@@ -1076,12 +1075,11 @@ def _install_package_wheel_first(
     """Install a fast-path package, wheel first, and never leave an unusable one behind.
 
     The two "touch nothing" guards run here, outside the cleanup: an already-working
-    package returns before any subprocess, and offline returns without changing anything.
-    Everything after them is an install attempt, so the invariant applies to it -- ANY
-    unsuccessful exit, including a timeout or a failed install, discards whatever is left
-    rather than leaving metadata the in-process import would pick up. Enforcing that here
-    rather than at each return is deliberate: this is the fourth defect of exactly that
-    shape, each one a path somebody did not think to clean up.
+    package returns before any subprocess, and offline changes nothing. Everything after
+    them is an install attempt, so ANY unsuccessful exit -- timeout, failed install, bad
+    import -- discards what is left rather than leaving metadata the in-process import
+    would pick up. Enforced here rather than at each return because four separate exits
+    have now been found that forgot to clean up.
     """
     if _is_importable(import_name):
         logger.info("%s already installed", display_name)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -979,6 +979,10 @@ def _is_importable(import_name: str) -> bool:
         return False
 
 
+# Kept in step with install_python_stack._FLASH_ATTN_IMPORT_PROBE_TIMEOUT.
+_IMPORT_PROBE_TIMEOUT = 300
+
+
 def _is_importable_isolated(import_name: str) -> bool:
     """Probe the import in a child process.
 
@@ -996,7 +1000,7 @@ def _is_importable_isolated(import_name: str) -> bool:
             ],
             stdout = _sp.DEVNULL,
             stderr = _sp.DEVNULL,
-            timeout = 300,
+            timeout = _IMPORT_PROBE_TIMEOUT,
             # No env override: the probe should see exactly what the real in-process import
             # will see a moment later, and nothing here decodes child output.
         )

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1071,12 +1071,7 @@ def _reject_install(event_queue: Any, pypi_name: str, display_name: str, reason:
 
 
 def _install_package_wheel_first(
-    *,
-    event_queue: Any,
-    import_name: str,
-    display_name: str,
-    pypi_name: str,
-    **kwargs: Any,
+    *, event_queue: Any, import_name: str, display_name: str, pypi_name: str, **kwargs: Any
 ) -> bool:
     """Install a fast-path package, wheel first, and never leave an unusable one behind.
 

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1011,7 +1011,8 @@ def _is_importable_isolated(import_name: str) -> bool:
     return result.returncode == 0
 
 
-def _uninstall_package(pypi_name: str, display_name: str) -> None:
+def _uninstall_package(pypi_name: str, display_name: str) -> bool:
+    """Remove a distribution. True iff it is gone afterwards."""
     if shutil.which("uv"):
         cmd = ["uv", "pip", "uninstall", "--python", sys.executable, pypi_name]
     else:
@@ -1027,6 +1028,27 @@ def _uninstall_package(pypi_name: str, display_name: str) -> None:
     )
     if result.returncode != 0:
         logger.warning("Could not remove the rejected %s install:\n%s", display_name, result.stdout)
+        return False
+    return True
+
+
+def _reject_install(event_queue: Any, pypi_name: str, display_name: str, reason: str) -> None:
+    """Discard an install that will not import, and say which state we ended in.
+
+    Every rejection goes through here. Leaving the distribution in place is not the same as
+    never having installed it: unsloth/models/_utils.py gates on package METADATA and then
+    imports the native module in process, so a wheel the isolated probe could not survive
+    would be loaded anyway and take the training process with it.
+    """
+    logger.warning("%s %s", display_name, reason)
+    if _uninstall_package(pypi_name, display_name):
+        _send_status(event_queue, f"{display_name} is not usable on this GPU; removed it")
+    else:
+        _send_status(
+            event_queue,
+            f"{display_name} is not usable on this GPU and could not be removed; "
+            f"uninstall {pypi_name} manually before training",
+        )
 
 
 def _install_package_wheel_first(
@@ -1127,6 +1149,9 @@ def _install_package_wheel_first(
         # distribution as already satisfying the spec and do nothing. --force-reinstall is
         # not the answer either, since both scope it to the whole resolved transaction,
         # which for flash-attn means torch and the running CUDA stack.
+        #
+        # Not fatal if it fails: the fallback then no-ops on "already satisfied", the probe
+        # below rejects it, and _reject_install reports the state we actually ended in.
         _uninstall_package(pypi_name, display_name)
 
     _send_status(event_queue, pypi_status_message)
@@ -1252,8 +1277,7 @@ def _install_package_wheel_first(
     # rc=0 is not proof again here: pip/uv exit 0 on "Requirement already satisfied" without
     # installing anything, so a rejected wheel would otherwise be reported as a success.
     if not _is_importable_isolated(import_name):
-        logger.warning("%s installed from PyPI but is not importable", display_name)
-        _send_status(event_queue, f"{display_name} is installed but not usable on this GPU")
+        _reject_install(event_queue, pypi_name, display_name, "installed from PyPI but will not import")
         return False
 
     if is_hip:

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -12,6 +12,7 @@ version-switching. Pattern follows core/data_recipe/jobs/worker.py.
 from __future__ import annotations
 
 from loggers import get_logger
+import importlib
 import math
 import os
 import shutil
@@ -56,7 +57,6 @@ from utils.training_runs import build_default_output_dir_name
 from utils.wheel_utils import (
     direct_wheel_url,
     flash_attn_wheel_url,
-    has_blackwell_gpu,
     install_wheel,
     probe_torch_wheel_env,
     url_exists,
@@ -966,6 +966,20 @@ def _hipcc_gcc_install_dir() -> str | None:
     return None
 
 
+def _is_importable(import_name: str) -> bool:
+    # Invalidate finder caches so a package installed earlier in this process is seen.
+    importlib.invalidate_caches()
+    try:
+        __import__(import_name)
+        return True
+    except Exception as exc:
+        # A wheel built for another arch/ABI raises OSError/RuntimeError ("undefined symbol",
+        # "no kernel image is available"), not ImportError, so catch everything: the caller
+        # treats any failure as "not installed" and falls back rather than hard-failing.
+        logger.debug("%s is not importable (%s: %s)", import_name, type(exc).__name__, exc)
+        return False
+
+
 def _install_package_wheel_first(
     *,
     event_queue: Any,
@@ -980,12 +994,9 @@ def _install_package_wheel_first(
     pypi_spec: str | None = None,
     pypi_status_message: str | None = None,
 ) -> bool:
-    try:
-        __import__(import_name)
+    if _is_importable(import_name):
         logger.info("%s already installed", display_name)
         return True
-    except ImportError:
-        pass
 
     if _model_offline_mode_enabled():
         logger.info("Skipping %s installation while offline", display_name)
@@ -1014,8 +1025,16 @@ def _install_package_wheel_first(
             run = _sp.run,
         ):
             if result.returncode == 0:
-                logger.info("Installed prebuilt %s wheel successfully", display_name)
-                return True
+                # A wheel can install yet fail to import (CUDA/ABI or arch mismatch); verify
+                # before trusting it, else fall through to the PyPI/source path below.
+                if _is_importable(import_name):
+                    logger.info("Installed prebuilt %s wheel successfully", display_name)
+                    return True
+                logger.warning(
+                    "%s wheel installed but is not importable; falling back to PyPI",
+                    display_name,
+                )
+                break
             logger.warning(
                 "%s failed to install %s wheel:\n%s",
                 installer,
@@ -1963,12 +1982,6 @@ def _should_try_runtime_flash_attn_install(max_seq_length: int) -> bool:
 
 def _ensure_flash_attn_for_long_context(event_queue: Any, max_seq_length: int) -> None:
     if not _should_try_runtime_flash_attn_install(max_seq_length):
-        return
-    if has_blackwell_gpu():
-        _send_status(
-            event_queue,
-            "Skipping flash-attn install: Blackwell GPU detected (sm_100+); no compatible prebuilt wheel",
-        )
         return
 
     installed = _install_package_wheel_first(

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from loggers import get_logger
 import importlib
+import importlib.metadata
 import math
 import os
 import shutil
@@ -1032,14 +1033,32 @@ def _uninstall_package(pypi_name: str, display_name: str) -> bool:
     return True
 
 
+def _distribution_present(pypi_name: str) -> bool:
+    """Whether the distribution's METADATA is installed, without importing it.
+
+    Metadata is the thing that matters: unsloth/models/_utils.py gates on
+    ``_package_available`` (metadata) and only then imports the native module, so metadata
+    left behind is what turns a rejected wheel into an in-process crash. Reading it never
+    loads the extension, so this is safe to call even for a wheel that would abort.
+    """
+    importlib.invalidate_caches()
+    try:
+        importlib.metadata.distribution(pypi_name)
+        return True
+    except Exception:
+        return False
+
+
 def _reject_install(event_queue: Any, pypi_name: str, display_name: str, reason: str) -> None:
     """Discard an install that will not import, and say which state we ended in.
 
-    Every rejection goes through here. Leaving the distribution in place is not the same as
-    never having installed it: unsloth/models/_utils.py gates on package METADATA and then
-    imports the native module in process, so a wheel the isolated probe could not survive
-    would be loaded anyway and take the training process with it.
+    Idempotent and state-based, so it is safe to call on EVERY exit from the install path
+    rather than only the ones somebody remembered: it no-ops when the distribution is
+    already gone. Leaving it in place is not the same as never having installed it, since
+    the metadata gate above would import the extension anyway.
     """
+    if not _distribution_present(pypi_name):
+        return
     logger.warning("%s %s", display_name, reason)
     if _uninstall_package(pypi_name, display_name):
         _send_status(event_queue, f"{display_name} is not usable on this GPU; removed it")
@@ -1057,14 +1076,18 @@ def _install_package_wheel_first(
     import_name: str,
     display_name: str,
     pypi_name: str,
-    pypi_version: str | None = None,
-    filename_prefix: str | None = None,
-    release_tag: str | None = None,
-    release_base_url: str | None = None,
-    wheel_url_builder: Callable[[dict[str, str] | None], str | None] | None = None,
-    pypi_spec: str | None = None,
-    pypi_status_message: str | None = None,
+    **kwargs: Any,
 ) -> bool:
+    """Install a fast-path package, wheel first, and never leave an unusable one behind.
+
+    The two "touch nothing" guards run here, outside the cleanup: an already-working
+    package returns before any subprocess, and offline returns without changing anything.
+    Everything after them is an install attempt, so the invariant applies to it -- ANY
+    unsuccessful exit, including a timeout or a failed install, discards whatever is left
+    rather than leaving metadata the in-process import would pick up. Enforcing that here
+    rather than at each return is deliberate: this is the fourth defect of exactly that
+    shape, each one a path somebody did not think to clean up.
+    """
     if _is_importable(import_name):
         logger.info("%s already installed", display_name)
         return True
@@ -1073,6 +1096,36 @@ def _install_package_wheel_first(
         logger.info("Skipping %s installation while offline", display_name)
         return False
 
+    installed = False
+    try:
+        installed = _attempt_package_install(
+            event_queue = event_queue,
+            import_name = import_name,
+            display_name = display_name,
+            pypi_name = pypi_name,
+            **kwargs,
+        )
+        return installed
+    finally:
+        if not installed:
+            _reject_install(event_queue, pypi_name, display_name, "will not import")
+
+
+def _attempt_package_install(
+    *,
+    event_queue: Any,
+    import_name: str,
+    display_name: str,
+    pypi_name: str,
+    pypi_version: str | None = None,
+    filename_prefix: str | None = None,
+    release_tag: str | None = None,
+    release_base_url: str | None = None,
+    wheel_url_builder: Callable[[dict[str, str] | None], str | None] | None = None,
+    pypi_spec: str | None = None,
+    pypi_status_message: str | None = None,
+) -> bool:
+    """The install itself. Call it through _install_package_wheel_first, never directly."""
     # Set when a wheel installed but would not import; see the uninstall before the fallback.
     wheel_rejected = False
 
@@ -1150,8 +1203,8 @@ def _install_package_wheel_first(
         # not the answer either, since both scope it to the whole resolved transaction,
         # which for flash-attn means torch and the running CUDA stack.
         #
-        # Not fatal if it fails: the fallback then no-ops on "already satisfied", the probe
-        # below rejects it, and _reject_install reports the state we actually ended in.
+        # A failure here is caught by the _reject_install in the finally below, which is
+        # reached from every exit rather than only the ones that remember to clean up.
         _uninstall_package(pypi_name, display_name)
 
     _send_status(event_queue, pypi_status_message)
@@ -1275,11 +1328,9 @@ def _install_package_wheel_first(
         return False
 
     # rc=0 is not proof again here: pip/uv exit 0 on "Requirement already satisfied" without
-    # installing anything, so a rejected wheel would otherwise be reported as a success.
+    # installing anything. Returning False is enough; the caller's finally discards it.
     if not _is_importable_isolated(import_name):
-        _reject_install(
-            event_queue, pypi_name, display_name, "installed from PyPI but will not import"
-        )
+        logger.warning("%s installed from PyPI but will not import", display_name)
         return False
 
     if is_hip:

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -55,7 +55,6 @@ def _load_worker_module():
         for name in (
             "direct_wheel_url",
             "flash_attn_wheel_url",
-            "has_blackwell_gpu",
             "install_wheel",
             "probe_torch_wheel_env",
             "url_exists",

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -19,6 +19,7 @@ def _load_worker_module():
         "utils.child_stdio",
         "utils.hardware",
         "utils.hf_dataset_options",
+        "utils.native_tls",
         "utils.training_runs",
         "utils.wheel_utils",
     )
@@ -46,6 +47,13 @@ def _load_worker_module():
         hf_dataset_options = types.ModuleType("utils.hf_dataset_options")
         hf_dataset_options.hf_dataset_split_instruction_names = lambda *_args, **_kwargs: ()
         sys.modules["utils.hf_dataset_options"] = hf_dataset_options
+
+        # worker.py calls this at import time. Without the stub the module only loads when
+        # some other test happened to import the real utils.native_tls first, so this file
+        # passed in a full run and failed on its own.
+        native_tls = types.ModuleType("utils.native_tls")
+        native_tls.activate_native_tls = lambda *_args, **_kwargs: None
+        sys.modules["utils.native_tls"] = native_tls
 
         training_runs = types.ModuleType("utils.training_runs")
         training_runs.build_default_output_dir_name = lambda *_args, **_kwargs: "training-run"

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import builtins
 import subprocess
 import sys
+import types
 from typing import Any
 from unittest import mock
 
@@ -55,6 +56,33 @@ def _missing_flash_attn_import():
     return fake_import
 
 
+def _flash_attn_import_until_installed(state: dict[str, bool]):
+    """Import stub for a flash_attn that appears only once ``state['installed']`` is set.
+
+    The installers verify the import after a zero exit code, so a mock that keeps failing
+    models a broken wheel, not a working one. Tests that mean "the wheel worked" have to
+    flip the flag when install_wheel runs.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(
+        name,
+        globals = None,
+        locals = None,
+        fromlist = (),
+        level = 0,
+    ):
+        if name == "flash_attn":
+            if not state.get("installed"):
+                raise ImportError
+            # A stub, not a real import: flash_attn is not installed in the test env, and
+            # whether it happens to be is not what these tests are about.
+            return types.ModuleType("flash_attn")
+        return real_import(name, globals, locals, fromlist, level)
+
+    return fake_import
+
+
 def _missing_module_import(missing: str):
     real_import = builtins.__import__
 
@@ -84,8 +112,45 @@ def test_should_try_runtime_flash_attn_install_threshold_and_skip(monkeypatch):
 @linux_only
 def test_runtime_flash_attn_prefers_prebuilt_wheel(monkeypatch):
     statuses: list[str] = []
+    state: dict[str, bool] = {"installed": False}
+
+    def _install(*_args, **_kwargs):
+        state["installed"] = True
+        return [("pip", subprocess.CompletedProcess(["pip"], 0, ""))]
 
     monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
+    monkeypatch.setattr(builtins, "__import__", _flash_attn_import_until_installed(state))
+    monkeypatch.setattr(
+        worker,
+        "flash_attn_wheel_url",
+        lambda env: "https://example.com/fa.whl",
+    )
+    monkeypatch.setattr(worker, "url_exists", lambda url: True)
+    monkeypatch.setattr(
+        worker,
+        "_send_status",
+        lambda queue, message: statuses.append(message),
+    )
+    monkeypatch.setattr(worker, "install_wheel", _install)
+
+    worker._ensure_flash_attn_for_long_context(event_queue = [], max_seq_length = 32768)
+
+    assert statuses == ["Installing flash-attn for faster training..."]
+
+
+@linux_only
+def test_runtime_flash_attn_wheel_that_does_not_import_falls_back(monkeypatch):
+    """A wheel for the wrong arch/ABI installs with rc=0 and then will not load.
+
+    This is the shape of the Blackwell breakage in #6961 and #5420: trusting the exit code
+    left a flash_attn in site-packages that raised on import mid-training. Verify the import
+    instead, so a wheel that cannot load is treated as not installed.
+    """
+    statuses: list[str] = []
+    pypi_calls: list[list[str]] = []
+
+    monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
+    # Never becomes importable, however the install exits.
     monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
     monkeypatch.setattr(
         worker,
@@ -103,10 +168,19 @@ def test_runtime_flash_attn_prefers_prebuilt_wheel(monkeypatch):
         "install_wheel",
         lambda *args, **kwargs: [("pip", subprocess.CompletedProcess(["pip"], 0, ""))],
     )
+    monkeypatch.setattr(worker.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        worker._sp,
+        "run",
+        lambda cmd, **kwargs: pypi_calls.append(cmd)
+        or subprocess.CompletedProcess(cmd, 1, ""),
+    )
 
     worker._ensure_flash_attn_for_long_context(event_queue = [], max_seq_length = 32768)
 
-    assert statuses == ["Installing flash-attn for faster training..."]
+    # The wheel is not silently trusted: it falls through to the PyPI path.
+    assert "Installing flash-attn from PyPI for long-context training..." in statuses
+    assert pypi_calls, "expected a PyPI install attempt after the wheel failed to import"
 
 
 @linux_only

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -275,7 +275,46 @@ def test_runtime_flash_attn_rejected_wheel_is_not_reported_installed(monkeypatch
     )
 
     assert installed is False
-    assert "flash-attn is installed but not usable on this GPU" in statuses
+    # and it is removed, not left where _package_available would advertise it.
+    assert "flash-attn is not usable on this GPU; removed it" in statuses
+
+
+@linux_only
+def test_runtime_flash_attn_says_so_when_the_rejected_install_cannot_be_removed(monkeypatch):
+    """A distribution still on disk is not the same state as never having installed one."""
+    statuses: list[str] = []
+
+    monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
+    monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
+    monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: False)
+    monkeypatch.setattr(worker, "flash_attn_wheel_url", lambda env: None)
+    monkeypatch.setattr(worker, "url_exists", lambda url: False)
+    monkeypatch.setattr(worker.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        worker,
+        "_send_status",
+        lambda queue, message: statuses.append(message),
+    )
+    # Install exits 0; every uninstall attempt fails (read-only or locked site-packages).
+    monkeypatch.setattr(
+        worker._sp,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(
+            cmd, 1 if "uninstall" in cmd else 0, ""
+        ),
+    )
+
+    installed = worker._install_package_wheel_first(
+        event_queue = [],
+        import_name = "flash_attn",
+        display_name = "flash-attn",
+        pypi_name = "flash-attn",
+        pypi_spec = "flash-attn",
+    )
+
+    assert installed is False
+    assert any("could not be removed" in s for s in statuses), statuses
+    assert not any("removed it" in s for s in statuses), statuses
 
 
 @linux_only

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -299,9 +299,7 @@ def test_runtime_flash_attn_says_so_when_the_rejected_install_cannot_be_removed(
     monkeypatch.setattr(
         worker._sp,
         "run",
-        lambda cmd, **kw: subprocess.CompletedProcess(
-            cmd, 1 if "uninstall" in cmd else 0, ""
-        ),
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1 if "uninstall" in cmd else 0, ""),
     )
 
     installed = worker._install_package_wheel_first(

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -372,6 +372,9 @@ def test_runtime_flash_attn_rejected_wheel_is_not_reported_installed(monkeypatch
     monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
     monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
     monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: False)
+    # The discard is state-based, so the installed-but-broken state has to be stated here.
+    # Without this the test only passes on a machine that happens to have flash-attn.
+    monkeypatch.setattr(worker, "_distribution_present", lambda name: True)
     monkeypatch.setattr(
         worker,
         "flash_attn_wheel_url",
@@ -419,6 +422,8 @@ def test_runtime_flash_attn_says_so_when_the_rejected_install_cannot_be_removed(
     monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
     monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
     monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: False)
+    # State the installed-but-broken state explicitly; see the note above.
+    monkeypatch.setattr(worker, "_distribution_present", lambda name: True)
     monkeypatch.setattr(worker, "flash_attn_wheel_url", lambda env: None)
     monkeypatch.setattr(worker, "url_exists", lambda url: False)
     monkeypatch.setattr(worker.shutil, "which", lambda name: None)

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -139,6 +139,138 @@ class TestIsImportableIsolated:
         assert "import flash_attn" not in " ".join(captured[0])
 
 
+class TestNoExitLeavesAnUnusableInstall:
+    """Every unsuccessful exit discards the distribution, not just the ones with a call.
+
+    The metadata gate in unsloth/models/_utils.py imports the extension in process, so
+    anything left behind is loaded anyway. Four rounds of review found four separate exits
+    that forgot to clean up, which is why this is enforced in one place.
+    """
+
+    def _run(self, monkeypatch, *, run_side_effect):
+        removals: list[list[str]] = []
+
+        def _spy(cmd, **kwargs):
+            if "uninstall" in cmd:
+                removals.append(list(cmd))
+                return subprocess.CompletedProcess(cmd, 0, "")
+            return run_side_effect(cmd, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
+        monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: False)
+        # Metadata says it is installed, which is exactly the state that must not survive.
+        monkeypatch.setattr(worker, "_distribution_present", lambda name: True)
+        monkeypatch.setattr(worker, "flash_attn_wheel_url", lambda env: None)
+        monkeypatch.setattr(worker, "url_exists", lambda url: False)
+        monkeypatch.setattr(worker.shutil, "which", lambda name: None)
+        monkeypatch.setattr(worker, "_send_status", lambda q, m: None)
+        monkeypatch.setattr(worker._sp, "run", _spy)
+
+        installed = worker._install_package_wheel_first(
+            event_queue = [],
+            import_name = "flash_attn",
+            display_name = "flash-attn",
+            pypi_name = "flash-attn",
+            pypi_spec = "flash-attn",
+        )
+        return installed, removals
+
+    def test_a_failed_fallback_install_still_cleans_up(self, monkeypatch):
+        installed, removals = self._run(
+            monkeypatch,
+            run_side_effect = lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1, "boom"),
+        )
+        assert installed is False
+        assert removals, "a non-zero fallback exit must not leave the distribution installed"
+
+    def test_a_timed_out_fallback_still_cleans_up(self, monkeypatch):
+        """Only the ROCm source build sets a timeout, so this is the path that can raise."""
+        removals: list[list[str]] = []
+
+        def _spy(cmd, **kwargs):
+            if "uninstall" in cmd:
+                removals.append(list(cmd))
+                return subprocess.CompletedProcess(cmd, 0, "")
+            raise subprocess.TimeoutExpired(cmd = cmd, timeout = 1800)
+
+        monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
+        monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: False)
+        monkeypatch.setattr(worker, "_distribution_present", lambda name: True)
+        monkeypatch.setattr(
+            worker,
+            "probe_torch_wheel_env",
+            lambda timeout = 30: {
+                "python_tag": "cp313",
+                "torch_mm": "2.10",
+                "cuda_major": "",
+                "hip_version": "6.2",
+                "cxx11abi": "TRUE",
+                "platform_tag": "linux_x86_64",
+            },
+        )
+        monkeypatch.setattr(worker, "flash_attn_wheel_url", lambda env: None)
+        monkeypatch.setattr(worker, "url_exists", lambda url: False)
+        # hipcc present, so the ROCm build is attempted rather than skipped.
+        monkeypatch.setattr(worker.shutil, "which", lambda name: "/opt/rocm/bin/hipcc")
+        monkeypatch.setattr(worker, "_send_status", lambda q, m: None)
+        monkeypatch.setattr(worker._sp, "run", _spy)
+
+        installed = worker._install_package_wheel_first(
+            event_queue = [],
+            import_name = "flash_attn",
+            display_name = "flash-attn",
+            pypi_name = "flash-attn",
+            pypi_spec = "flash-attn",
+        )
+
+        assert installed is False
+        assert removals, "a timed-out build must not leave the distribution installed"
+
+    def test_nothing_installed_means_nothing_to_remove(self, monkeypatch):
+        """The discard is state-based, so a clean failure does not run a pointless uninstall."""
+        removals: list[list[str]] = []
+
+        def _spy(cmd, **_kwargs):
+            if "uninstall" in cmd:
+                removals.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 1, "")
+
+        monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
+        monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: False)
+        monkeypatch.setattr(worker, "_distribution_present", lambda name: False)
+        monkeypatch.setattr(worker, "flash_attn_wheel_url", lambda env: None)
+        monkeypatch.setattr(worker, "url_exists", lambda url: False)
+        monkeypatch.setattr(worker.shutil, "which", lambda name: None)
+        monkeypatch.setattr(worker, "_send_status", lambda q, m: None)
+        monkeypatch.setattr(worker._sp, "run", _spy)
+
+        worker._install_package_wheel_first(
+            event_queue = [],
+            import_name = "flash_attn",
+            display_name = "flash-attn",
+            pypi_name = "flash-attn",
+            pypi_spec = "flash-attn",
+        )
+
+        assert removals == []
+
+    def test_a_working_package_is_never_touched(self, monkeypatch):
+        """The guard runs before the cleanup, so an install that works is left alone."""
+        calls: list[list[str]] = []
+        monkeypatch.setattr(worker, "_is_importable", lambda name: True)
+        monkeypatch.setattr(worker._sp, "run", lambda cmd, **kw: calls.append(list(cmd)))
+
+        installed = worker._install_package_wheel_first(
+            event_queue = [],
+            import_name = "flash_attn",
+            display_name = "flash-attn",
+            pypi_name = "flash-attn",
+        )
+
+        assert installed is True
+        assert calls == [], "a working package must not be probed, installed or removed"
+
+
 def test_should_try_runtime_flash_attn_install_threshold_and_skip(monkeypatch):
     monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
     assert worker._should_try_runtime_flash_attn_install(32767) is False

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -177,16 +177,70 @@ def test_runtime_flash_attn_wheel_that_does_not_import_falls_back(monkeypatch):
 
     # The wheel is not silently trusted: it falls through to the PyPI path.
     assert "Installing flash-attn from PyPI for long-context training..." in statuses
-    assert pypi_calls, "expected a PyPI install attempt after the wheel failed to import"
+    installs = [cmd for cmd in pypi_calls if "install" in cmd]
+    assert installs, "expected a PyPI install attempt after the wheel failed to import"
+    # and that fallback must replace the rejected wheel, not install over it: pip reports
+    # the broken distribution as already satisfied and exits 0 without doing anything.
+    assert all("--force-reinstall" in cmd for cmd in installs), installs
+
+
+@linux_only
+def test_runtime_flash_attn_rejected_wheel_is_not_reported_installed(monkeypatch):
+    """A no-op fallback must not be read as success.
+
+    pip exits 0 on "Requirement already satisfied" and uv on "Would make no changes", so
+    the exit code alone would report the rejected wheel as a working install.
+    """
+    statuses: list[str] = []
+
+    monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
+    monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
+    monkeypatch.setattr(
+        worker,
+        "flash_attn_wheel_url",
+        lambda env: "https://example.com/fa.whl",
+    )
+    monkeypatch.setattr(worker, "url_exists", lambda url: True)
+    monkeypatch.setattr(
+        worker,
+        "_send_status",
+        lambda queue, message: statuses.append(message),
+    )
+    monkeypatch.setattr(
+        worker,
+        "install_wheel",
+        lambda *args, **kwargs: [("pip", subprocess.CompletedProcess(["pip"], 0, ""))],
+    )
+    monkeypatch.setattr(worker.shutil, "which", lambda name: None)
+    # The fallback "succeeds" the way an already-satisfied install does: rc=0, nothing done.
+    monkeypatch.setattr(
+        worker._sp,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, "Requirement already satisfied"),
+    )
+
+    installed = worker._install_package_wheel_first(
+        event_queue = [],
+        import_name = "flash_attn",
+        display_name = "flash-attn",
+        pypi_name = "flash-attn",
+        wheel_url_builder = worker.flash_attn_wheel_url,
+        pypi_spec = "flash-attn",
+        pypi_status_message = "Installing flash-attn from PyPI for long-context training...",
+    )
+
+    assert installed is False
+    assert "flash-attn is installed but not usable on this GPU" in statuses
 
 
 @linux_only
 def test_runtime_flash_attn_falls_back_to_pypi(monkeypatch):
     calls: list[list[str]] = []
     statuses: list[str] = []
+    state: dict[str, bool] = {"installed": False}
 
     monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
-    monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
+    monkeypatch.setattr(builtins, "__import__", _flash_attn_import_until_installed(state))
     monkeypatch.setattr(
         worker,
         "probe_torch_wheel_env",
@@ -214,6 +268,8 @@ def test_runtime_flash_attn_falls_back_to_pypi(monkeypatch):
 
     def fake_run(cmd, **kwargs):
         calls.append(list(cmd))
+        # A real install makes the module importable; the post-install check requires it.
+        state["installed"] = True
         return subprocess.CompletedProcess(cmd, 0, "")
 
     monkeypatch.setattr(worker._sp, "run", fake_run)
@@ -221,6 +277,7 @@ def test_runtime_flash_attn_falls_back_to_pypi(monkeypatch):
     worker._ensure_flash_attn_for_long_context(event_queue = [], max_seq_length = 32768)
 
     assert statuses == ["Installing flash-attn from PyPI for long-context training..."]
+    # No wheel was installed here (url_exists is False), so nothing needs replacing.
     assert calls == [[sys.executable, "-m", "pip", "install", "flash-attn"]]
 
 

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -172,8 +172,7 @@ def test_runtime_flash_attn_wheel_that_does_not_import_falls_back(monkeypatch):
     monkeypatch.setattr(
         worker._sp,
         "run",
-        lambda cmd, **kwargs: pypi_calls.append(cmd)
-        or subprocess.CompletedProcess(cmd, 1, ""),
+        lambda cmd, **kwargs: pypi_calls.append(cmd) or subprocess.CompletedProcess(cmd, 1, ""),
     )
 
     worker._ensure_flash_attn_for_long_context(event_queue = [], max_seq_length = 32768)

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -99,6 +99,50 @@ def _missing_module_import(missing: str):
     return fake_import
 
 
+class TestIsImportableIsolated:
+    """The probe runs in a child so a bad native extension cannot take the worker with it."""
+
+    def test_clean_exit_is_importable(self, monkeypatch):
+        monkeypatch.setattr(
+            worker._sp, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0)
+        )
+        assert worker._is_importable_isolated("flash_attn") is True
+
+    def test_import_error_exit_is_not_importable(self, monkeypatch):
+        monkeypatch.setattr(
+            worker._sp, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1)
+        )
+        assert worker._is_importable_isolated("flash_attn") is False
+
+    def test_fatal_signal_is_not_importable(self, monkeypatch):
+        # SIGSEGV in the extension's initialiser: rc -11, and no Python exception to catch.
+        monkeypatch.setattr(
+            worker._sp, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], -11)
+        )
+        assert worker._is_importable_isolated("flash_attn") is False
+
+    def test_timeout_is_not_importable(self, monkeypatch):
+        def _hang(*_args, **_kwargs):
+            raise subprocess.TimeoutExpired(cmd = "python", timeout = 300)
+
+        monkeypatch.setattr(worker._sp, "run", _hang)
+        assert worker._is_importable_isolated("flash_attn") is False
+
+    def test_the_module_name_is_passed_as_an_argument(self, monkeypatch):
+        captured: list[list[str]] = []
+
+        def _record(cmd, **_kwargs):
+            captured.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(worker._sp, "run", _record)
+        worker._is_importable_isolated("flash_attn")
+
+        # argv, not string-formatted into the -c body.
+        assert captured[0][-1] == "flash_attn"
+        assert "import flash_attn" not in " ".join(captured[0])
+
+
 def test_should_try_runtime_flash_attn_install_threshold_and_skip(monkeypatch):
     monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
     assert worker._should_try_runtime_flash_attn_install(32767) is False
@@ -119,6 +163,8 @@ def test_runtime_flash_attn_prefers_prebuilt_wheel(monkeypatch):
 
     monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
     monkeypatch.setattr(builtins, "__import__", _flash_attn_import_until_installed(state))
+    # The post-install probe runs in a child; model it off the same flag.
+    monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: state["installed"])
     monkeypatch.setattr(
         worker,
         "flash_attn_wheel_url",
@@ -150,6 +196,7 @@ def test_runtime_flash_attn_wheel_that_does_not_import_falls_back(monkeypatch):
     monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
     # Never becomes importable, however the install exits.
     monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
+    monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: False)
     monkeypatch.setattr(
         worker,
         "flash_attn_wheel_url",
@@ -179,9 +226,10 @@ def test_runtime_flash_attn_wheel_that_does_not_import_falls_back(monkeypatch):
     assert "Installing flash-attn from PyPI for long-context training..." in statuses
     installs = [cmd for cmd in pypi_calls if "install" in cmd]
     assert installs, "expected a PyPI install attempt after the wheel failed to import"
-    # and that fallback must replace the rejected wheel, not install over it: pip reports
-    # the broken distribution as already satisfied and exits 0 without doing anything.
-    assert all("--force-reinstall" in cmd for cmd in installs), installs
+    # The rejected wheel is removed first. Installing over it is a no-op (pip reports it as
+    # already satisfied), and --force-reinstall would widen the transaction to torch.
+    assert any("uninstall" in cmd for cmd in pypi_calls), pypi_calls
+    assert not any("--force-reinstall" in cmd for cmd in installs), installs
 
 
 @linux_only
@@ -195,6 +243,7 @@ def test_runtime_flash_attn_rejected_wheel_is_not_reported_installed(monkeypatch
 
     monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
     monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
+    monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: False)
     monkeypatch.setattr(
         worker,
         "flash_attn_wheel_url",
@@ -259,6 +308,7 @@ def test_runtime_flash_attn_falls_back_to_pypi(monkeypatch):
     )
     monkeypatch.setattr(worker, "url_exists", lambda url: False)
     monkeypatch.setattr(worker.shutil, "which", lambda name: None)
+    monkeypatch.setattr(worker, "_is_importable_isolated", lambda name: state["installed"])
     monkeypatch.setattr(
         worker,
         "_send_status",

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -103,15 +103,11 @@ class TestIsImportableIsolated:
     """The probe runs in a child so a bad native extension cannot take the worker with it."""
 
     def test_clean_exit_is_importable(self, monkeypatch):
-        monkeypatch.setattr(
-            worker._sp, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0)
-        )
+        monkeypatch.setattr(worker._sp, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0))
         assert worker._is_importable_isolated("flash_attn") is True
 
     def test_import_error_exit_is_not_importable(self, monkeypatch):
-        monkeypatch.setattr(
-            worker._sp, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1)
-        )
+        monkeypatch.setattr(worker._sp, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1))
         assert worker._is_importable_isolated("flash_attn") is False
 
     def test_fatal_signal_is_not_importable(self, monkeypatch):

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -59,9 +59,8 @@ def _missing_flash_attn_import():
 def _flash_attn_import_until_installed(state: dict[str, bool]):
     """Import stub for a flash_attn that appears only once ``state['installed']`` is set.
 
-    The installers verify the import after a zero exit code, so a mock that keeps failing
-    models a broken wheel, not a working one. Tests that mean "the wheel worked" have to
-    flip the flag when install_wheel runs.
+    The installers verify the import, so a mock that keeps failing models a broken wheel,
+    not a working one: "the wheel worked" means flipping the flag when install_wheel runs.
     """
     real_import = builtins.__import__
 
@@ -140,11 +139,10 @@ def test_runtime_flash_attn_prefers_prebuilt_wheel(monkeypatch):
 
 @linux_only
 def test_runtime_flash_attn_wheel_that_does_not_import_falls_back(monkeypatch):
-    """A wheel for the wrong arch/ABI installs with rc=0 and then will not load.
+    """A wrong-arch/ABI wheel installs with rc=0 and then will not load.
 
-    This is the shape of the Blackwell breakage in #6961 and #5420: trusting the exit code
-    left a flash_attn in site-packages that raised on import mid-training. Verify the import
-    instead, so a wheel that cannot load is treated as not installed.
+    The Blackwell shape (#5420, #6961): trusting the exit code left a flash_attn that
+    raised on import mid-training. It must be treated as not installed.
     """
     statuses: list[str] = []
     pypi_calls: list[list[str]] = []

--- a/studio/backend/utils/wheel_utils.py
+++ b/studio/backend/utils/wheel_utils.py
@@ -24,16 +24,11 @@ _logger = logging.getLogger(__name__)
 FLASH_ATTN_RELEASE_BASE_URL = "https://github.com/Dao-AILab/flash-attention/releases/download"
 
 
-# No arch gate on the flash-attn install path, deliberately. One lived here: Dao-AILab
-# published no sm_100+ wheels, the older-arch ones failed to load on Blackwell, so
-# has_blackwell_gpu() skipped the install (#5420). Upstream then shipped Blackwell
-# kernels -- the wheels this resolver builds now carry sm_100/sm_120 cubins -- and the
-# gate became the bug instead, denying B200 hosts a wheel that works (#6961).
-#
-# It is not coming back. An arch gate encodes a snapshot of what upstream published and
-# goes stale silently in both directions. What both failures actually needed is the
-# post-install import check the callers now do: it catches a wheel that installs and
-# will not load, whatever the reason, and needs no table of who ships what.
+# No arch gate here, deliberately. has_blackwell_gpu() skipped flash-attn when upstream
+# published no sm_100+ wheels (#5420), then became the bug once it did, denying B200 hosts
+# a working wheel (#6961). An arch gate encodes a snapshot of what upstream ships and goes
+# stale silently both ways; the callers' post-install import check catches a wheel that
+# will not load whatever the cause.
 
 
 def wheel_platform_tag() -> str | None:

--- a/studio/backend/utils/wheel_utils.py
+++ b/studio/backend/utils/wheel_utils.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import functools
 import json
 import logging
 import os
@@ -25,48 +24,16 @@ _logger = logging.getLogger(__name__)
 FLASH_ATTN_RELEASE_BASE_URL = "https://github.com/Dao-AILab/flash-attention/releases/download"
 
 
-@functools.lru_cache(maxsize = 1)
-def has_blackwell_gpu() -> bool:
-    """Return True if any visible NVIDIA GPU has compute capability >= 10.0 (Blackwell).
-
-    Cached for the process lifetime; tests mocking nvidia-smi must call
-    ``has_blackwell_gpu.cache_clear()`` first.
-    """
-    # Detection disabled for now: Dao-AILab ships Blackwell (sm_100+) flash-attn
-    # wheels and url_exists() already gates resolution, so we no longer skip
-    # flash-attn on Blackwell. The nvidia-smi probe below is kept for possible
-    # future arch-based gating; drop this early return to re-enable it.
-    return False
-    exe = shutil.which("nvidia-smi")
-    if not exe:
-        return False
-    try:
-        result = subprocess.run(
-            [exe, "--query-gpu=compute_cap", "--format=csv,noheader"],
-            stdout = subprocess.PIPE,
-            stderr = subprocess.DEVNULL,
-            text = True,
-            encoding = "utf-8",
-            errors = "replace",
-            timeout = 10,
-            env = child_env_without_native_path_secret(),
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    if result.returncode != 0:
-        return False
-    for line in result.stdout.splitlines():
-        cap = line.strip()
-        if not cap:
-            continue
-        major_part = cap.split(".", 1)[0]
-        try:
-            major = int(major_part)
-        except ValueError:
-            continue
-        if major >= 10:
-            return True
-    return False
+# No arch gate on the flash-attn install path, deliberately. One lived here: Dao-AILab
+# published no sm_100+ wheels, the older-arch ones failed to load on Blackwell, so
+# has_blackwell_gpu() skipped the install (#5420). Upstream then shipped Blackwell
+# kernels -- the wheels this resolver builds now carry sm_100/sm_120 cubins -- and the
+# gate became the bug instead, denying B200 hosts a wheel that works (#6961).
+#
+# It is not coming back. An arch gate encodes a snapshot of what upstream published and
+# goes stale silently in both directions. What both failures actually needed is the
+# post-install import check the callers now do: it catches a wheel that installs and
+# will not load, whatever the reason, and needs no table of who ships what.
 
 
 def wheel_platform_tag() -> str | None:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -36,7 +36,6 @@ import install_manifest  # noqa: E402
 from backend.utils.wheel_utils import (
     flash_attn_package_version,
     flash_attn_wheel_url,
-    has_blackwell_gpu,
     install_wheel,
     probe_torch_wheel_env,
     url_exists,
@@ -3649,28 +3648,32 @@ def _flash_attn_install_disabled() -> bool:
     return os.getenv("UNSLOTH_STUDIO_SKIP_FLASHATTN_INSTALL") == "1"
 
 
-def _ensure_flash_attn() -> None:
-    if _flash_attn_install_disabled():
-        return
-    if NO_TORCH:
-        return
-    if has_blackwell_gpu():
-        _step(
-            "warning",
-            "Skipping flash-attn: Blackwell GPU detected (sm_100+); no compatible prebuilt wheel",
-            _cyan,
-        )
-        return
-    if IS_WINDOWS or IS_MACOS:
-        return
-    if (
+def _flash_attn_importable() -> bool:
+    """Whether flash_attn imports in this interpreter, checked out of process.
+
+    A wheel built for another arch/ABI installs fine and then raises OSError/RuntimeError
+    ("undefined symbol", "no kernel image is available") on import, so a zero pip exit code
+    is not proof the install is usable. Run it in a child so a half-loaded native extension
+    cannot poison the installer process.
+    """
+    return (
         subprocess.run(
             [sys.executable, "-c", "import flash_attn"],
             stdout = subprocess.DEVNULL,
             stderr = subprocess.DEVNULL,
         ).returncode
         == 0
-    ):
+    )
+
+
+def _ensure_flash_attn() -> None:
+    if _flash_attn_install_disabled():
+        return
+    if NO_TORCH:
+        return
+    if IS_WINDOWS or IS_MACOS:
+        return
+    if _flash_attn_importable():
         return
 
     env = probe_torch_wheel_env()
@@ -3683,7 +3686,16 @@ def _ensure_flash_attn() -> None:
             uv_needs_system = UV_NEEDS_SYSTEM,
         ):
             if wheel_result.returncode == 0:
-                return
+                # A wheel can install yet fail to import (CUDA/ABI or arch mismatch); verify
+                # rather than trusting the exit code, so setup reports what actually happened.
+                if _flash_attn_importable():
+                    return
+                _step(
+                    "warning",
+                    "flash-attn wheel installed but is not importable on this GPU",
+                    _cyan,
+                )
+                break
             _print_optional_install_failure(
                 f"Installing flash-attn prebuilt wheel with {installer}",
                 wheel_result,

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3671,15 +3671,24 @@ def _flash_attn_importable() -> bool:
     return result.returncode == 0
 
 
-def _remove_rejected_flash_attn() -> None:
-    """Uninstall a flash-attn that installed but will not import."""
+def _remove_rejected_flash_attn() -> bool:
+    """Uninstall a flash-attn that installed but will not import. True iff it is gone.
+
+    Mirrors the mode the wheel was installed with: UV_NEEDS_SYSTEM is set exactly when the
+    --python probe failed, so uninstalling with --python there would use the one mode
+    already known not to work in this environment.
+    """
     if USE_UV and shutil.which("uv"):
-        cmd = ["uv", "pip", "uninstall", "--python", sys.executable, "flash-attn"]
+        cmd = ["uv", "pip", "uninstall"]
+        if UV_NEEDS_SYSTEM:
+            cmd.append("--system")
+        else:
+            cmd.extend(["--python", sys.executable])
+        cmd.append("flash-attn")
     else:
         cmd = [sys.executable, "-m", "pip", "uninstall", "-y", "flash-attn"]
     removed = subprocess.run(cmd, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
-    if removed.returncode != 0:
-        _step("warning", "Could not remove the unusable flash-attn install", _cyan)
+    return removed.returncode == 0
 
 
 def _ensure_flash_attn() -> None:
@@ -3708,12 +3717,21 @@ def _ensure_flash_attn() -> None:
                 # Remove it before giving up. Left installed, unsloth/models/_utils.py finds
                 # it by metadata (_package_available) and then imports the native module
                 # in process, so a wheel that killed the probe would kill training too.
-                _remove_rejected_flash_attn()
-                _step(
-                    "warning",
-                    "flash-attn wheel installed but is not importable on this GPU; removed it",
-                    _cyan,
-                )
+                if _remove_rejected_flash_attn():
+                    _step(
+                        "warning",
+                        "flash-attn wheel installed but is not importable on this GPU; removed it",
+                        _cyan,
+                    )
+                else:
+                    # Say so plainly: it is still importable in process, so this is not the
+                    # same state as never having installed it.
+                    _step(
+                        "warning",
+                        "flash-attn wheel is not importable on this GPU and could not be "
+                        "removed; uninstall flash-attn manually before training",
+                        _cyan,
+                    )
                 break
             _print_optional_install_failure(
                 f"Installing flash-attn prebuilt wheel with {installer}",

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3649,12 +3649,11 @@ def _flash_attn_install_disabled() -> bool:
 
 
 def _flash_attn_importable() -> bool:
-    """Whether flash_attn imports in this interpreter, checked out of process.
+    """Whether flash_attn imports, checked out of process.
 
-    A wheel built for another arch/ABI installs fine and then raises OSError/RuntimeError
-    ("undefined symbol", "no kernel image is available") on import, so a zero pip exit code
-    is not proof the install is usable. Run it in a child so a half-loaded native extension
-    cannot poison the installer process.
+    A wrong-arch/ABI wheel installs fine and raises on import, so a zero pip exit code is
+    not proof the install is usable. Run it in a child so a half-loaded native extension
+    cannot poison the installer.
     """
     return (
         subprocess.run(
@@ -3686,8 +3685,7 @@ def _ensure_flash_attn() -> None:
             uv_needs_system = UV_NEEDS_SYSTEM,
         ):
             if wheel_result.returncode == 0:
-                # A wheel can install yet fail to import (CUDA/ABI or arch mismatch); verify
-                # rather than trusting the exit code, so setup reports what actually happened.
+                # Verify rather than trust the exit code, so setup reports what happened.
                 if _flash_attn_importable():
                     return
                 _step(

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3674,11 +3674,10 @@ def _flash_attn_importable() -> bool:
 def _remove_rejected_flash_attn() -> bool:
     """Uninstall a flash-attn that installed but will not import. True iff it is gone.
 
-    Targets the same interpreter install_wheel installed into, which is always
-    ``sys.executable``: its uv command passes --python as well as --system, and its pip
-    fallback runs that interpreter directly. Uninstalling with --system ALONE would remove
-    from the system Python instead, leaving the rejected wheel in the venv while setup
-    reported it gone.
+    Targets the interpreter install_wheel installed into, always ``sys.executable``: its uv
+    command passes --python as well as --system, and its pip fallback runs that interpreter.
+    --system ALONE would remove from the system Python, leaving the rejected wheel in the
+    venv while setup reported it gone.
     """
     if USE_UV and shutil.which("uv"):
         cmd = ["uv", "pip", "uninstall"]

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3656,9 +3656,8 @@ def _flash_attn_importable() -> bool:
     """Whether flash_attn imports, checked out of process.
 
     A wrong-arch/ABI wheel installs fine and raises on import, so a zero pip exit code is
-    not proof the install is usable. Run it in a child so a half-loaded native extension
-    cannot poison the installer, and bound it: initialisation can hang rather than fail,
-    and an unbounded probe would leave setup waiting forever instead of warning.
+    not proof the install is usable. In a child, so a half-loaded native extension cannot
+    poison the installer, and bounded, since initialisation can hang rather than fail.
     """
     try:
         result = subprocess.run(

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3671,6 +3671,17 @@ def _flash_attn_importable() -> bool:
     return result.returncode == 0
 
 
+def _remove_rejected_flash_attn() -> None:
+    """Uninstall a flash-attn that installed but will not import."""
+    if USE_UV and shutil.which("uv"):
+        cmd = ["uv", "pip", "uninstall", "--python", sys.executable, "flash-attn"]
+    else:
+        cmd = [sys.executable, "-m", "pip", "uninstall", "-y", "flash-attn"]
+    removed = subprocess.run(cmd, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
+    if removed.returncode != 0:
+        _step("warning", "Could not remove the unusable flash-attn install", _cyan)
+
+
 def _ensure_flash_attn() -> None:
     if _flash_attn_install_disabled():
         return
@@ -3694,9 +3705,13 @@ def _ensure_flash_attn() -> None:
                 # Verify rather than trust the exit code, so setup reports what happened.
                 if _flash_attn_importable():
                     return
+                # Remove it before giving up. Left installed, unsloth/models/_utils.py finds
+                # it by metadata (_package_available) and then imports the native module
+                # in process, so a wheel that killed the probe would kill training too.
+                _remove_rejected_flash_attn()
                 _step(
                     "warning",
-                    "flash-attn wheel installed but is not importable on this GPU",
+                    "flash-attn wheel installed but is not importable on this GPU; removed it",
                     _cyan,
                 )
                 break

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3648,21 +3648,28 @@ def _flash_attn_install_disabled() -> bool:
     return os.getenv("UNSLOTH_STUDIO_SKIP_FLASHATTN_INSTALL") == "1"
 
 
+# Matches worker._is_importable_isolated: the same untrusted import, bounded the same way.
+_FLASH_ATTN_IMPORT_PROBE_TIMEOUT = 300
+
+
 def _flash_attn_importable() -> bool:
     """Whether flash_attn imports, checked out of process.
 
     A wrong-arch/ABI wheel installs fine and raises on import, so a zero pip exit code is
     not proof the install is usable. Run it in a child so a half-loaded native extension
-    cannot poison the installer.
+    cannot poison the installer, and bound it: initialisation can hang rather than fail,
+    and an unbounded probe would leave setup waiting forever instead of warning.
     """
-    return (
-        subprocess.run(
+    try:
+        result = subprocess.run(
             [sys.executable, "-c", "import flash_attn"],
             stdout = subprocess.DEVNULL,
             stderr = subprocess.DEVNULL,
-        ).returncode
-        == 0
-    )
+            timeout = _FLASH_ATTN_IMPORT_PROBE_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
 
 
 def _ensure_flash_attn() -> None:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3674,17 +3674,17 @@ def _flash_attn_importable() -> bool:
 def _remove_rejected_flash_attn() -> bool:
     """Uninstall a flash-attn that installed but will not import. True iff it is gone.
 
-    Mirrors the mode the wheel was installed with: UV_NEEDS_SYSTEM is set exactly when the
-    --python probe failed, so uninstalling with --python there would use the one mode
-    already known not to work in this environment.
+    Targets the same interpreter install_wheel installed into, which is always
+    ``sys.executable``: its uv command passes --python as well as --system, and its pip
+    fallback runs that interpreter directly. Uninstalling with --system ALONE would remove
+    from the system Python instead, leaving the rejected wheel in the venv while setup
+    reported it gone.
     """
     if USE_UV and shutil.which("uv"):
         cmd = ["uv", "pip", "uninstall"]
         if UV_NEEDS_SYSTEM:
             cmd.append("--system")
-        else:
-            cmd.extend(["--python", sys.executable])
-        cmd.append("flash-attn")
+        cmd.extend(["--python", sys.executable, "flash-attn"])
     else:
         cmd = [sys.executable, "-m", "pip", "uninstall", "-y", "flash-attn"]
     removed = subprocess.run(cmd, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)

--- a/tests/python/test_flash_attn_install_python_stack.py
+++ b/tests/python/test_flash_attn_install_python_stack.py
@@ -364,8 +364,9 @@ class TestEnsureFlashAttn:
         assert any("flash-attn" in cmd for cmd in removals), removals
         assert ("warning", "Continuing without flash-attn") in step_messages
 
-    def test_uninstall_mirrors_the_uv_system_mode(self):
-        """UV_NEEDS_SYSTEM is set exactly when --python failed, so --python cannot be used."""
+    def test_uninstall_targets_the_interpreter_install_wheel_used(self):
+        """install_wheel passes --python as well as --system, and its pip fallback runs
+        sys.executable directly, so --system alone would uninstall from the wrong Python."""
         commands: list[list[str]] = []
 
         def fake_run(cmd, **kwargs):
@@ -380,7 +381,9 @@ class TestEnsureFlashAttn:
         ):
             assert ips._remove_rejected_flash_attn() is True
 
-        assert commands == [["uv", "pip", "uninstall", "--system", "flash-attn"]]
+        assert commands == [
+            ["uv", "pip", "uninstall", "--system", "--python", sys.executable, "flash-attn"]
+        ]
 
     def test_uninstall_targets_the_interpreter_without_system_mode(self):
         commands: list[list[str]] = []

--- a/tests/python/test_flash_attn_install_python_stack.py
+++ b/tests/python/test_flash_attn_install_python_stack.py
@@ -227,10 +227,10 @@ class TestEnsureFlashAttn:
         assert kwargs["uv_needs_system"] is True
 
     def test_wheel_that_does_not_import_is_not_trusted(self):
-        """pip exits 0 on a wheel built for another arch/ABI; the import is what decides.
+        """pip exits 0 on a wrong-arch/ABI wheel; the import is what decides.
 
-        This is the #5420 / #6961 Blackwell shape: the wheel installs, then raises on import.
-        Setup has to report that rather than claiming flash-attn is ready.
+        The #5420 / #6961 Blackwell shape: setup must report that rather than claim
+        flash-attn is ready.
         """
         step_messages: list[tuple[str, str]] = []
 

--- a/tests/python/test_flash_attn_install_python_stack.py
+++ b/tests/python/test_flash_attn_install_python_stack.py
@@ -187,6 +187,12 @@ class TestEnsureFlashAttn:
     def _import_check(self, code: int = 1):
         return subprocess.CompletedProcess(["python", "-c", "import flash_attn"], code)
 
+    def _import_fails_removal_works(self, cmd, **_kwargs):
+        """flash_attn never imports, but uninstalling it succeeds."""
+        if "uninstall" in cmd:
+            return subprocess.CompletedProcess(cmd, 0)
+        return self._import_check()
+
     def test_prefers_exact_match_wheel(self):
         install_calls = []
 
@@ -296,8 +302,8 @@ class TestEnsureFlashAttn:
                     (label, value)
                 ),
             ),
-            # Import never succeeds, before or after the install.
-            mock.patch("subprocess.run", return_value = self._import_check()),
+            # Import never succeeds, before or after the install; the removal does.
+            mock.patch("subprocess.run", side_effect = self._import_fails_removal_works),
         ):
             ips._ensure_flash_attn()
 
@@ -357,6 +363,88 @@ class TestEnsureFlashAttn:
         assert removals, "the rejected wheel must be uninstalled, not left in site-packages"
         assert any("flash-attn" in cmd for cmd in removals), removals
         assert ("warning", "Continuing without flash-attn") in step_messages
+
+    def test_uninstall_mirrors_the_uv_system_mode(self):
+        """UV_NEEDS_SYSTEM is set exactly when --python failed, so --python cannot be used."""
+        commands: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with (
+            mock.patch.object(ips, "USE_UV", True),
+            mock.patch.object(ips, "UV_NEEDS_SYSTEM", True),
+            mock.patch.object(ips.shutil, "which", return_value = "/usr/bin/uv"),
+            mock.patch("subprocess.run", side_effect = fake_run),
+        ):
+            assert ips._remove_rejected_flash_attn() is True
+
+        assert commands == [["uv", "pip", "uninstall", "--system", "flash-attn"]]
+
+    def test_uninstall_targets_the_interpreter_without_system_mode(self):
+        commands: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with (
+            mock.patch.object(ips, "USE_UV", True),
+            mock.patch.object(ips, "UV_NEEDS_SYSTEM", False),
+            mock.patch.object(ips.shutil, "which", return_value = "/usr/bin/uv"),
+            mock.patch("subprocess.run", side_effect = fake_run),
+        ):
+            assert ips._remove_rejected_flash_attn() is True
+
+        assert commands == [
+            ["uv", "pip", "uninstall", "--python", sys.executable, "flash-attn"]
+        ]
+
+    def test_a_failed_removal_is_not_reported_as_removed(self):
+        """Still importable in process, so it must not read like a clean skip."""
+        step_messages: list[tuple[str, str]] = []
+
+        def fake_run(cmd, **kwargs):
+            if "uninstall" in cmd:
+                return subprocess.CompletedProcess(cmd, 1)
+            return self._import_check()
+
+        with (
+            mock.patch.object(ips, "NO_TORCH", False),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", False),
+            mock.patch.object(
+                ips,
+                "probe_torch_wheel_env",
+                return_value = {
+                    "python_tag": "cp313",
+                    "torch_mm": "2.10",
+                    "cuda_major": "13",
+                    "cxx11abi": "TRUE",
+                    "platform_tag": "linux_x86_64",
+                },
+            ),
+            mock.patch.object(ips, "url_exists", return_value = True),
+            mock.patch.object(
+                ips,
+                "install_wheel",
+                return_value = [("uv", subprocess.CompletedProcess(["uv"], 0, ""))],
+            ),
+            mock.patch.object(
+                ips,
+                "_step",
+                side_effect = lambda label, value, color_fn = None: step_messages.append(
+                    (label, value)
+                ),
+            ),
+            mock.patch("subprocess.run", side_effect = fake_run),
+        ):
+            ips._ensure_flash_attn()
+
+        warnings = [value for _, value in step_messages]
+        assert any("could not be removed" in value for value in warnings), warnings
+        assert not any("removed it" in value for value in warnings), warnings
 
     def test_working_wheel_reports_no_warning(self):
         """The happy path stays silent: install exits 0 and the module imports."""

--- a/tests/python/test_flash_attn_install_python_stack.py
+++ b/tests/python/test_flash_attn_install_python_stack.py
@@ -303,8 +303,59 @@ class TestEnsureFlashAttn:
 
         assert (
             "warning",
-            "flash-attn wheel installed but is not importable on this GPU",
+            "flash-attn wheel installed but is not importable on this GPU; removed it",
         ) in step_messages
+        assert ("warning", "Continuing without flash-attn") in step_messages
+
+    def test_rejected_wheel_is_uninstalled(self):
+        """Leaving it installed is not "continuing without flash-attn".
+
+        unsloth/models/_utils.py finds it by metadata (_package_available) and then imports
+        the native module in process, so a wheel that killed the probe kills training too.
+        """
+        step_messages: list[tuple[str, str]] = []
+        removals: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            if "uninstall" in cmd:
+                removals.append(list(cmd))
+                return subprocess.CompletedProcess(cmd, 0)
+            return self._import_check()
+
+        with (
+            mock.patch.object(ips, "NO_TORCH", False),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", False),
+            mock.patch.object(
+                ips,
+                "probe_torch_wheel_env",
+                return_value = {
+                    "python_tag": "cp313",
+                    "torch_mm": "2.10",
+                    "cuda_major": "13",
+                    "cxx11abi": "TRUE",
+                    "platform_tag": "linux_x86_64",
+                },
+            ),
+            mock.patch.object(ips, "url_exists", return_value = True),
+            mock.patch.object(
+                ips,
+                "install_wheel",
+                return_value = [("uv", subprocess.CompletedProcess(["uv"], 0, ""))],
+            ),
+            mock.patch.object(
+                ips,
+                "_step",
+                side_effect = lambda label, value, color_fn = None: step_messages.append(
+                    (label, value)
+                ),
+            ),
+            mock.patch("subprocess.run", side_effect = fake_run),
+        ):
+            ips._ensure_flash_attn()
+
+        assert removals, "the rejected wheel must be uninstalled, not left in site-packages"
+        assert any("flash-attn" in cmd for cmd in removals), removals
         assert ("warning", "Continuing without flash-attn") in step_messages
 
     def test_working_wheel_reports_no_warning(self):

--- a/tests/python/test_flash_attn_install_python_stack.py
+++ b/tests/python/test_flash_attn_install_python_stack.py
@@ -397,9 +397,7 @@ class TestEnsureFlashAttn:
         ):
             assert ips._remove_rejected_flash_attn() is True
 
-        assert commands == [
-            ["uv", "pip", "uninstall", "--python", sys.executable, "flash-attn"]
-        ]
+        assert commands == [["uv", "pip", "uninstall", "--python", sys.executable, "flash-attn"]]
 
     def test_a_failed_removal_is_not_reported_as_removed(self):
         """Still importable in process, so it must not read like a clean skip."""

--- a/tests/python/test_flash_attn_install_python_stack.py
+++ b/tests/python/test_flash_attn_install_python_stack.py
@@ -149,6 +149,40 @@ class TestFlashAttnWheelSelection:
         )
 
 
+class TestFlashAttnImportProbe:
+    """The probe is bounded: a native extension can hang in its initialiser, not just fail."""
+
+    def test_clean_exit_is_importable(self):
+        with mock.patch(
+            "subprocess.run",
+            return_value = subprocess.CompletedProcess(["python"], 0),
+        ):
+            assert ips._flash_attn_importable() is True
+
+    def test_non_zero_exit_is_not_importable(self):
+        with mock.patch(
+            "subprocess.run",
+            return_value = subprocess.CompletedProcess(["python"], 1),
+        ):
+            assert ips._flash_attn_importable() is False
+
+    def test_a_hung_import_is_not_importable(self):
+        with mock.patch(
+            "subprocess.run",
+            side_effect = subprocess.TimeoutExpired(cmd = "python", timeout = 300),
+        ):
+            assert ips._flash_attn_importable() is False
+
+    def test_the_probe_is_bounded(self):
+        with mock.patch(
+            "subprocess.run",
+            return_value = subprocess.CompletedProcess(["python"], 0),
+        ) as run:
+            ips._flash_attn_importable()
+
+        assert run.call_args.kwargs["timeout"] == ips._FLASH_ATTN_IMPORT_PROBE_TIMEOUT
+
+
 class TestEnsureFlashAttn:
     def _import_check(self, code: int = 1):
         return subprocess.CompletedProcess(["python", "-c", "import flash_attn"], code)

--- a/tests/python/test_flash_attn_install_python_stack.py
+++ b/tests/python/test_flash_attn_install_python_stack.py
@@ -226,6 +226,98 @@ class TestEnsureFlashAttn:
         _, kwargs = install_calls[0]
         assert kwargs["uv_needs_system"] is True
 
+    def test_wheel_that_does_not_import_is_not_trusted(self):
+        """pip exits 0 on a wheel built for another arch/ABI; the import is what decides.
+
+        This is the #5420 / #6961 Blackwell shape: the wheel installs, then raises on import.
+        Setup has to report that rather than claiming flash-attn is ready.
+        """
+        step_messages: list[tuple[str, str]] = []
+
+        with (
+            mock.patch.object(ips, "NO_TORCH", False),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", False),
+            mock.patch.object(
+                ips,
+                "probe_torch_wheel_env",
+                return_value = {
+                    "python_tag": "cp313",
+                    "torch_mm": "2.10",
+                    "cuda_major": "13",
+                    "cxx11abi": "TRUE",
+                    "platform_tag": "linux_x86_64",
+                },
+            ),
+            mock.patch.object(ips, "url_exists", return_value = True),
+            mock.patch.object(
+                ips,
+                "install_wheel",
+                return_value = [("uv", subprocess.CompletedProcess(["uv"], 0, ""))],
+            ),
+            mock.patch.object(
+                ips,
+                "_step",
+                side_effect = lambda label, value, color_fn = None: step_messages.append(
+                    (label, value)
+                ),
+            ),
+            # Import never succeeds, before or after the install.
+            mock.patch("subprocess.run", return_value = self._import_check()),
+        ):
+            ips._ensure_flash_attn()
+
+        assert (
+            "warning",
+            "flash-attn wheel installed but is not importable on this GPU",
+        ) in step_messages
+        assert ("warning", "Continuing without flash-attn") in step_messages
+
+    def test_working_wheel_reports_no_warning(self):
+        """The happy path stays silent: install exits 0 and the module imports."""
+        step_messages: list[tuple[str, str]] = []
+        import_calls: list[int] = []
+
+        def fake_run(cmd, **kwargs):
+            # First call is the pre-install check (missing), the second verifies the install.
+            import_calls.append(1)
+            return self._import_check(1 if len(import_calls) == 1 else 0)
+
+        with (
+            mock.patch.object(ips, "NO_TORCH", False),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", False),
+            mock.patch.object(
+                ips,
+                "probe_torch_wheel_env",
+                return_value = {
+                    "python_tag": "cp313",
+                    "torch_mm": "2.10",
+                    "cuda_major": "13",
+                    "cxx11abi": "TRUE",
+                    "platform_tag": "linux_x86_64",
+                },
+            ),
+            mock.patch.object(ips, "url_exists", return_value = True),
+            mock.patch.object(
+                ips,
+                "install_wheel",
+                return_value = [("uv", subprocess.CompletedProcess(["uv"], 0, ""))],
+            ),
+            mock.patch.object(
+                ips,
+                "_step",
+                side_effect = lambda label, value, color_fn = None: step_messages.append(
+                    (label, value)
+                ),
+            ),
+            mock.patch("subprocess.run", side_effect = fake_run),
+        ):
+            ips._ensure_flash_attn()
+
+        assert step_messages == []
+        assert len(import_calls) == 2, "expected a verification import after the install"
+
     def test_wheel_failure_warns_and_continues(self):
         step_messages: list[tuple[str, str]] = []
         printed_failures: list[str] = []


### PR DESCRIPTION
A prebuilt wheel can install with exit code 0 and then fail to load, so the exit code on its own is not proof the install is usable. We have now hit that twice on Blackwell, from both directions:

- #5420: Dao-AILab published no sm_100+ wheels, the older-arch ones installed fine and raised on import, so `has_blackwell_gpu()` was added to skip the install.
- #6961: upstream then shipped Blackwell kernels, and that same gate became the bug, denying B200 hosts a wheel that works. 03cbe21 disabled it with an unconditional `return False`.

Neither fix addressed what both failures actually had in common, which is that nothing checked whether the installed wheel could be imported.

## What this changes

**Verify the import after a zero exit code**, in the two paths that did not, and treat a failure as not installed. `ssm_runtime._install_kernel` already did exactly this, for the same reason:

> A wheel can install yet fail to import (CUDA/ABI mismatch); verify before trusting it

So this is that existing check applied to `install_python_stack._ensure_flash_attn` and `worker._install_package_wheel_first`, rather than a new pattern.

`worker._is_importable()` catches any exception rather than only `ImportError`. An arch or ABI mismatch surfaces as `OSError` / `RuntimeError` ("undefined symbol", "no kernel image is available"), which the old `except ImportError` pre-check would have let escape mid-training.

**Drop `has_blackwell_gpu()` and its two call sites.** It has returned `False` unconditionally since 03cbe21, so both blocks were already unreachable and removing them changes no behaviour at all. I left a comment in `wheel_utils.py` recording why there is no arch gate, since the dead code reads like an oversight otherwise. An arch gate encodes a snapshot of what upstream publishes and goes stale silently in both directions; the import check catches a wheel that will not load whatever the cause, and needs no table of who ships what.

The xFormers path in `diffusion_attention.py` is deliberately left alone: it already handles ABI mismatch by resolving the URL against the running torch.

## Verification

Checked on an 8x B200 host (`compute_cap 10.0`).

The wheel this resolver builds for cu13 / torch2.10 / cp313 carries Blackwell kernels. `cuobjdump --list-elf`:

```
sm_100  sm_120  sm_80  sm_90
```

It installs through `wheel_utils.install_wheel()` itself and runs:

```
device: NVIDIA B200   compute cap: (10, 0)   flash_attn: 2.8.1
output shape: (2, 4096, 16, 128)   finite: True
max |fa - sdpa|: 0.0078125
```

The new check discriminates correctly against that install: `True` in the venv holding the working wheel, `False` where it is absent.

Live probe of the URL matrix the resolver builds (torch 2.8 to 2.12, cu12/cu13, cp311/312/313): 30 URLs built, 17 live, 13 return 404. `url_exists()` is what decides whether anything installs, which is also why the arch gate was redundant by the time it was removed.

Unrelated but worth recording, since I checked it while probing: torch 2.9 + cp313 returns 404 because upstream only ever built cp312 for torch 2.9, across v2.8.1, v2.8.2, v2.8.3 and v2.8.3.post1. The resolver is correct there and the PyPI fallback is the right outcome, so nothing to change.

## Tests

Targeted suites: 176 passed, 5 skipped. Three tests are new, one per behaviour:

- a working wheel installs and is trusted
- a wheel that never imports falls through to PyPI instead of being reported as installed
- the setup installer warns rather than claiming success

`test_runtime_flash_attn_prefers_prebuilt_wheel` needed updating: it mocked `install_wheel` to return rc=0 while stubbing `__import__` to always fail, which under the new semantics is a broken wheel, not a working one. It now flips the import stub when the install runs, which is what "the wheel worked" actually means.

Full sweep of `tests/python` and `studio/backend/tests`, same command before and after:

| | failed | passed | errors |
| --- | --- | --- | --- |
| main | 668 | 17393 | 360 |
| this branch | 668 | 17396 | 360 |

`+3 passed` is exactly the new tests. The 668 failures and 360 errors are pre-existing missing-dependency failures in that venv, identical on main.

One caveat rather than a clean claim: the two failure lists differ by 2 entries, both in `test_stt_broken_runtime_falls_back.py`. All 5 tests in that file fail in isolation on `ModuleNotFoundError: No module named 'jwt'`, and which subset the full run reports shuffles with ordering; two consecutive runs on main also differed by one. That file has no reference to anything touched here.
