### PR TITLE
Studio: name the checkpoint on MiniMax H3 quant chips

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -1428,10 +1428,8 @@ function GgufVariantExpander({
     }
     return recommended;
   }, [variantGroups, preferredByGroup, totalBudgetGb, budgetKnown, getGgufFit]);
-  // Every workflow's recommendation, flattened. Only for readers with no row to
-  // ask about, like the footprint representative below; a ROW asks its own
-  // group, since two groups recommending different quants would otherwise light
-  // both rows in both groups.
+  // Flattened, for readers with no row to ask about (the footprint representative
+  // below). A ROW asks its own group, or it lights the other group's pick too.
   const effectiveRecommended = useMemo(
     () => new Set(effectiveRecommendedByGroup.values()),
     [effectiveRecommendedByGroup],
@@ -1684,10 +1682,8 @@ function GgufVariantExpander({
         );
         const showGroupHeading =
           group?.title != null && group.variants[0]?.filename === v.filename;
-        // This row's OWN workflow recommendation. Matching on the quant alone
-        // would also light the other workflow's pick, and only holds today
-        // because the backend keys an H3 quant by its file; a row knows its
-        // group, so it should not depend on that.
+        // Its own group's pick. Matching on the quant alone happens to work only
+        // because an H3 key is unique per file, which is the backend's rule.
         const isRecommended =
           group != null &&
           effectiveRecommendedByGroup.get(group.key) === v.quant;
@@ -2167,8 +2163,8 @@ function localModelIsGguf(m: LocalModelInfo): boolean {
 function localPathTooltip(
   name: string,
   path: string,
-  // A row standing for ONE checkpoint says which, since the path does not: an
-  // H3 repo holds a keyframe and a reference partition in the same directory.
+  // Which checkpoint, since the path cannot say: an H3 repo holds its keyframe
+  // and reference partitions in one directory.
   detail?: string,
 ): ReactNode {
   return (

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -189,6 +189,8 @@ import type {
 } from "./types";
 import { describeVariantListingError } from "./variant-listing-error";
 import {
+  ggufQuantChipLabel,
+  ggufQuantDetailLabel,
   ggufVariantPickerLabel,
   groupGgufVariantsForPicker,
   h3PickerHasOnlyPrunedBuilds,
@@ -1426,6 +1428,10 @@ function GgufVariantExpander({
     }
     return recommended;
   }, [variantGroups, preferredByGroup, totalBudgetGb, budgetKnown, getGgufFit]);
+  // Every workflow's recommendation, flattened. Only for readers with no row to
+  // ask about, like the footprint representative below; a ROW asks its own
+  // group, since two groups recommending different quants would otherwise light
+  // both rows in both groups.
   const effectiveRecommended = useMemo(
     () => new Set(effectiveRecommendedByGroup.values()),
     [effectiveRecommendedByGroup],
@@ -1678,6 +1684,13 @@ function GgufVariantExpander({
         );
         const showGroupHeading =
           group?.title != null && group.variants[0]?.filename === v.filename;
+        // This row's OWN workflow recommendation. Matching on the quant alone
+        // would also light the other workflow's pick, and only holds today
+        // because the backend keys an H3 quant by its file; a row knows its
+        // group, so it should not depend on that.
+        const isRecommended =
+          group != null &&
+          effectiveRecommendedByGroup.get(group.key) === v.quant;
         const fit = getGgufFit(v.size_bytes);
         const oom = fit === "oom";
         const tight = fit === "tight";
@@ -1731,7 +1744,7 @@ function GgufVariantExpander({
                     </span>
                   ) : null}
                 </>
-              ) : effectiveRecommended.has(v.quant) ? (
+              ) : isRecommended ? (
                 <span className="ml-1.5 text-ui-9 font-sans font-medium text-primary/70">
                   recommended
                 </span>
@@ -2151,10 +2164,17 @@ function localModelIsGguf(m: LocalModelInfo): boolean {
   );
 }
 
-function localPathTooltip(name: string, path: string): ReactNode {
+function localPathTooltip(
+  name: string,
+  path: string,
+  // A row standing for ONE checkpoint says which, since the path does not: an
+  // H3 repo holds a keyframe and a reference partition in the same directory.
+  detail?: string,
+): ReactNode {
   return (
     <>
       <span className="block break-words">{name}</span>
+      {detail ? <span className="mt-0.5 block break-words">{detail}</span> : null}
       <span className="block mt-1 text-ui-10 text-muted-foreground break-all">
         {path}
       </span>
@@ -4424,9 +4444,11 @@ export function HubModelPicker({
         <div className="min-w-0 flex-1">
           <ModelRow
             label={entry.repoId}
-            tooltipText={`${entry.repoId} (${entry.quant})`}
+            tooltipText={`${entry.repoId} (${ggufQuantDetailLabel(
+              entry.quant,
+            )})`}
             meta="GGUF"
-            quantChip={entry.quant}
+            quantChip={ggufQuantChipLabel(entry.quant)}
             alignMeta="device"
             selected={isSelected}
             loaded={isLoaded}
@@ -4544,9 +4566,13 @@ export function HubModelPicker({
         <div className="min-w-0 flex-1">
           <ModelRow
             label={c.repo_id}
-            tooltipText={localPathTooltip(c.repo_id, c.cache_path)}
+            tooltipText={localPathTooltip(
+              c.repo_id,
+              c.cache_path,
+              ggufQuantDetailLabel(variant.quant),
+            )}
             meta={`GGUF · ${formatBytes(variant.size_bytes)}`}
-            quantChip={variant.quant}
+            quantChip={ggufQuantChipLabel(variant.quant)}
             showVision={c.has_vision || sole.hasVision}
             selected={isSelected}
             loaded={rowState.loaded}

--- a/studio/frontend/src/features/model-picker/components/model-selector/variant-presentation.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/variant-presentation.ts
@@ -15,9 +15,22 @@ export type GgufVariantPresentationGroup<T extends PresentableGgufVariant> = {
   variants: T[];
 };
 
-const H3_FILENAME = /^minimax_h3_(fl2va|ref2va)(?:_pruned)?-(.+)\.gguf$/i;
+// The `.gguf` is optional because a variant KEY is read with the same parser as
+// a filename: the backend keys an H3 checkpoint by its own path
+// (`_unknown_gguf_variant_key`), so a quant reads `minimax_h3_fl2va_pruned-Q4_K_M`
+// with no suffix. The quant group is lazy so the optional suffix wins when it is
+// there.
+const H3_FILENAME = /^minimax_h3_(fl2va|ref2va)(?:_pruned)?-(.+?)(?:\.gguf)?$/i;
 const GGUF_SHARD_SUFFIX = /-\d{5}-of-\d{5}$/i;
 const PATH_SEPARATOR = /[\\/]/;
+
+// What each workflow is called where no section heading names it. Deliberately
+// the backend's own wording in `_apply_gguf_display_labels`, so one checkpoint
+// does not read two ways across the Hub card and a row's tooltip.
+const H3_WORKFLOW_LABEL = {
+  "text-frames": "Text & frames",
+  "reference-media": "References",
+} as const;
 
 type H3Presentation = {
   group: "text-frames" | "reference-media";
@@ -25,12 +38,9 @@ type H3Presentation = {
   build: "Full" | "Pruned";
 };
 
-function h3Presentation(
-  variant: PresentableGgufVariant,
-): H3Presentation | null {
-  const filename =
-    variant.filename.split(PATH_SEPARATOR).at(-1) ?? variant.filename;
-  const match = H3_FILENAME.exec(filename);
+function h3PresentationFor(name: string): H3Presentation | null {
+  const leaf = name.split(PATH_SEPARATOR).at(-1) ?? name;
+  const match = H3_FILENAME.exec(leaf);
   if (!match) {
     return null;
   }
@@ -38,8 +48,36 @@ function h3Presentation(
     group:
       match[1].toLowerCase() === "ref2va" ? "reference-media" : "text-frames",
     quantLabel: match[2].replace(GGUF_SHARD_SUFFIX, ""),
-    build: filename.toLowerCase().includes("_pruned-") ? "Pruned" : "Full",
+    build: leaf.toLowerCase().includes("_pruned-") ? "Pruned" : "Full",
   };
+}
+
+function h3Presentation(
+  variant: PresentableGgufVariant,
+): H3Presentation | null {
+  return h3PresentationFor(variant.filename);
+}
+
+/** A GGUF quant KEY as the row's mono chip.
+ *
+ *  The quant alone, because the chip's column is capped at 7.2em -- wide enough
+ *  for `UD-Q4_K_XL` and no wider, by design, so the meta columns line up down the
+ *  list. An H3 key is a whole file stem, so left alone the chip reads
+ *  `minimax_h3_fl2va_pruned-Q4_K_M` and clips to nonsense; the workflow and build
+ *  it also carries go to `ggufQuantDetailLabel` and the row's tooltip, which has
+ *  the room. Anything that is already just a quant is returned untouched. */
+export function ggufQuantChipLabel(quant: string): string {
+  return h3PresentationFor(quant)?.quantLabel ?? quant;
+}
+
+/** The same key in full, for a tooltip: which workflow the checkpoint drives and
+ *  which build it is. The backend's wording, so the Hub card and this row agree. */
+export function ggufQuantDetailLabel(quant: string): string {
+  const h3 = h3PresentationFor(quant);
+  if (!h3) {
+    return quant;
+  }
+  return `${H3_WORKFLOW_LABEL[h3.group]} · ${h3.quantLabel} · ${h3.build}`;
 }
 
 export function ggufVariantPickerLabel(

--- a/studio/frontend/src/features/model-picker/components/model-selector/variant-presentation.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/variant-presentation.ts
@@ -15,18 +15,15 @@ export type GgufVariantPresentationGroup<T extends PresentableGgufVariant> = {
   variants: T[];
 };
 
-// The `.gguf` is optional because a variant KEY is read with the same parser as
-// a filename: the backend keys an H3 checkpoint by its own path
-// (`_unknown_gguf_variant_key`), so a quant reads `minimax_h3_fl2va_pruned-Q4_K_M`
-// with no suffix. The quant group is lazy so the optional suffix wins when it is
-// there.
+// `.gguf` optional: an H3 quant KEY is the file stem the backend keyed it by
+// (`_unknown_gguf_variant_key`), so the same parser reads both. Lazy quant group
+// so the suffix wins when present.
 const H3_FILENAME = /^minimax_h3_(fl2va|ref2va)(?:_pruned)?-(.+?)(?:\.gguf)?$/i;
 const GGUF_SHARD_SUFFIX = /-\d{5}-of-\d{5}$/i;
 const PATH_SEPARATOR = /[\\/]/;
 
-// What each workflow is called where no section heading names it. Deliberately
-// the backend's own wording in `_apply_gguf_display_labels`, so one checkpoint
-// does not read two ways across the Hub card and a row's tooltip.
+// The backend's own wording (`_apply_gguf_display_labels`), so the Hub card and a
+// row's tooltip name one checkpoint the same way.
 const H3_WORKFLOW_LABEL = {
   "text-frames": "Text & frames",
   "reference-media": "References",
@@ -58,20 +55,14 @@ function h3Presentation(
   return h3PresentationFor(variant.filename);
 }
 
-/** A GGUF quant KEY as the row's mono chip.
- *
- *  The quant alone, because the chip's column is capped at 7.2em -- wide enough
- *  for `UD-Q4_K_XL` and no wider, by design, so the meta columns line up down the
- *  list. An H3 key is a whole file stem, so left alone the chip reads
- *  `minimax_h3_fl2va_pruned-Q4_K_M` and clips to nonsense; the workflow and build
- *  it also carries go to `ggufQuantDetailLabel` and the row's tooltip, which has
- *  the room. Anything that is already just a quant is returned untouched. */
+/** A GGUF quant KEY as the row's mono chip: the quant alone, since that column is
+ *  capped at 7.2em and an H3 key is a whole file stem that clips to nonsense. The
+ *  workflow and build go to `ggufQuantDetailLabel`. Other quants pass through. */
 export function ggufQuantChipLabel(quant: string): string {
   return h3PresentationFor(quant)?.quantLabel ?? quant;
 }
 
-/** The same key in full, for a tooltip: which workflow the checkpoint drives and
- *  which build it is. The backend's wording, so the Hub card and this row agree. */
+/** The same key in full, for a tooltip with room for it: workflow and build. */
 export function ggufQuantDetailLabel(quant: string): string {
   const h3 = h3PresentationFor(quant);
   if (!h3) {

--- a/studio/frontend/tests/model-picker-variant-presentation.test.ts
+++ b/studio/frontend/tests/model-picker-variant-presentation.test.ts
@@ -173,13 +173,13 @@ test("each workflow uses the nearest-size fallback for different quant names", (
 });
 
 test("an H3 quant chip is the quant alone, because the column is capped", () => {
-  // 7.2em fits UD-Q4_K_XL and no more, so the whole file stem clips to nonsense.
+  // The column fits UD-Q4_K_XL and no more.
   assert.equal(ggufQuantChipLabel("minimax_h3_fl2va_pruned-Q4_K_M"), "Q4_K_M");
   assert.equal(
     ggufQuantChipLabel("minimax_h3_ref2va-UD-Q3_K_XL"),
     "UD-Q3_K_XL",
   );
-  // The same key with its suffix still on, and a shard counter, read alike.
+  // A suffix still on, and a shard counter, read alike.
   assert.equal(
     ggufQuantChipLabel("minimax_h3_ref2va_pruned-Q4_K_M.gguf"),
     "Q4_K_M",
@@ -214,8 +214,7 @@ test("an ordinary quant key is left exactly as it is", () => {
 });
 
 test("the picker label is unchanged by the key-shaped parse", () => {
-  // The filename path still wins: adding the optional suffix to the pattern must
-  // not change what a ROW reads, which is the quant alone under its heading.
+  // The optional suffix must not change what a ROW reads under its heading.
   const pruned = variant("minimax_h3_fl2va_pruned-UD-Q3_K_XL.gguf", 9);
   assert.equal(
     ggufVariantPickerLabel(pruned, {

--- a/studio/frontend/tests/model-picker-variant-presentation.test.ts
+++ b/studio/frontend/tests/model-picker-variant-presentation.test.ts
@@ -5,6 +5,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  ggufQuantChipLabel,
+  ggufQuantDetailLabel,
   ggufVariantPickerLabel,
   groupGgufVariantsForPicker,
   h3PickerHasOnlyPrunedBuilds,
@@ -168,4 +170,59 @@ test("each workflow uses the nearest-size fallback for different quant names", (
 
   assert.equal(preferred.get("text-frames"), textRecommended);
   assert.equal(preferred.get("reference-media"), referenceQ3);
+});
+
+test("an H3 quant chip is the quant alone, because the column is capped", () => {
+  // 7.2em fits UD-Q4_K_XL and no more, so the whole file stem clips to nonsense.
+  assert.equal(ggufQuantChipLabel("minimax_h3_fl2va_pruned-Q4_K_M"), "Q4_K_M");
+  assert.equal(
+    ggufQuantChipLabel("minimax_h3_ref2va-UD-Q3_K_XL"),
+    "UD-Q3_K_XL",
+  );
+  // The same key with its suffix still on, and a shard counter, read alike.
+  assert.equal(
+    ggufQuantChipLabel("minimax_h3_ref2va_pruned-Q4_K_M.gguf"),
+    "Q4_K_M",
+  );
+  assert.equal(
+    ggufQuantChipLabel("minimax_h3_fl2va_pruned-Q4_K_M-00001-of-00002"),
+    "Q4_K_M",
+  );
+});
+
+test("the tooltip keeps the workflow the chip has no room for", () => {
+  assert.equal(
+    ggufQuantDetailLabel("minimax_h3_fl2va_pruned-Q4_K_M"),
+    "Text & frames · Q4_K_M · Pruned",
+  );
+  assert.equal(
+    ggufQuantDetailLabel("minimax_h3_ref2va-UD-Q3_K_XL"),
+    "References · UD-Q3_K_XL · Full",
+  );
+});
+
+test("an ordinary quant key is left exactly as it is", () => {
+  for (const label of [ggufQuantChipLabel, ggufQuantDetailLabel]) {
+    assert.equal(label("Q4_K_M"), "Q4_K_M");
+    assert.equal(label("UD-Q2_K_XL"), "UD-Q2_K_XL");
+    assert.equal(label("distilled-1.1/Q4_K_M"), "distilled-1.1/Q4_K_M");
+    assert.equal(
+      label("qwen3vl_32b_minimax_h3-Q4_K_M"),
+      "qwen3vl_32b_minimax_h3-Q4_K_M",
+    );
+  }
+});
+
+test("the picker label is unchanged by the key-shaped parse", () => {
+  // The filename path still wins: adding the optional suffix to the pattern must
+  // not change what a ROW reads, which is the quant alone under its heading.
+  const pruned = variant("minimax_h3_fl2va_pruned-UD-Q3_K_XL.gguf", 9);
+  assert.equal(
+    ggufVariantPickerLabel(pruned, {
+      h3Grouped: true,
+      hideH3PrunedBuild: true,
+    }),
+    "UD-Q3_K_XL",
+  );
+  assert.equal(groupGgufVariantsForPicker([pruned])[0]?.key, "text-frames");
 });


### PR DESCRIPTION
## Problem

#8450 grouped the MiniMax H3 GGUF quants in the model selector's expander, where a section heading names the workflow, so a row can read as a bare `Q4_K`.

Two On Device rows sit outside that expander and print the quant key verbatim: the pinned-quant row and the sole-quant row. For H3 the backend keys a checkpoint by its own file (`_unknown_gguf_variant_key`), so the key is a whole file stem and the chip reads `minimax_h3_fl2va_pruned-Q4_K`. `META_COLUMN.quant` is `w-[7.2em]` ("Fits `UD-Q4_K_XL`; a hard cap, so longer quants clip"), so it does not read as a long label, it wraps and clips to two unreadable lines.

## Fix

- The chip carries the quant alone, which is what that column is sized for and what every other repo already shows.
- The workflow and build move to the row's tooltip, in the backend's own wording (`Text & frames` / `References`), so the Hub card and the picker agree on what the checkpoint is. `localPathTooltip` takes an optional third line for it.
- An ordinary quant is returned unchanged, so every non-H3 repo is untouched.
- Key the expander's `recommended` badge on the row's own group. Matching on the quant alone would light the other workflow's pick as well; it only holds today because an H3 quant key happens to be unique per file, which is a backend rule two layers away.

## Screenshots

Both rows, from two isolated installs at the merge base and this head, against a cache seeded to hold exactly one H3 quant.

<img width="945" alt="pr8466-quant-chip-before-after" src="https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/pr-evidence-8466/evidence/pr8466_before_after.png" />

BEFORE the chip holds `minimax_h3_fl2va_pruned-Q4_K`, wrapped and clipped by the column. AFTER it reads `Q4_K`.

## Testing

- Frontend test suite (1,957 passed, 4 new)
- `npm run typecheck`, `npm run build`, `catalog:check`
- Biome error and warning counts on all three files identical to the merge base
- Two isolated Studio installs at the merge base and this head, driven by the same Playwright scene against a cache seeded to hold exactly one H3 quant
