### PR TITLE
Model hub: fall back to base_model for the provider logo

### DIFF
--- a/studio/backend/hub/schemas/inventory.py
+++ b/studio/backend/hub/schemas/inventory.py
@@ -219,6 +219,9 @@ class CachedRepoBase(BaseModel):
     # Inferred pipeline task ("text-to-image" / "text-to-video" / a chat task / None). The task-scoped pickers filter On
     # Device rows on it and the chat picker routes a diffusion pick by it, so a row without one is dropped from those lists.
     task: Optional[str] = None
+    # `base_model` off the cached card. Names the upstream provider for a re-upload
+    # whose own repo name matches no known family, so the row keeps its logo offline.
+    base_model: Optional[str] = None
 
 
 class CachedGgufRepo(CachedRepoBase):

--- a/studio/backend/hub/services/models/cache_inventory.py
+++ b/studio/backend/hub/services/models/cache_inventory.py
@@ -570,6 +570,11 @@ def _scan_cached_gguf(
                 last_modified = max(last_modified, (existing or {}).get("last_modified", 0.0))
                 if last_modified > 0:
                     row["last_modified"] = last_modified
+                # GGUF repos skip the checkpoint metadata pass, so read the card
+                # directly for the provider logo's base-model fallback.
+                gguf_base_model = _cached_repo_base_model(gguf_snapshot or snapshot_path)
+                if gguf_base_model is not None:
+                    row["base_model"] = gguf_base_model
                 row.update(
                     _cache_inventory_fields(
                         repo_id,
@@ -907,6 +912,25 @@ def _read_model_card_frontmatter(path: Path) -> dict:
         return {}
 
 
+def _card_base_model(card: dict) -> Optional[str]:
+    # The Hub API synthesizes `base_model:<id>` tags, but the card on disk carries
+    # only the raw `base_model` key, as a string or a list.
+    value = card.get("base_model")
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, list):
+        for entry in value:
+            if isinstance(entry, str) and entry.strip():
+                return entry.strip()
+    return None
+
+
+def _cached_repo_base_model(snapshot: Optional[Path]) -> Optional[str]:
+    if snapshot is None:
+        return None
+    return _card_base_model(_read_model_card_frontmatter(snapshot / "README.md"))
+
+
 def _cached_model_local_metadata(repo_path: Path, snapshot: Optional[Path] = None) -> dict:
     # Describe the directory the row hands out, not merely the newest.
     if snapshot is None:
@@ -938,6 +962,9 @@ def _cached_model_local_metadata(repo_path: Path, snapshot: Optional[Path] = Non
         clean_tags = [tag.strip() for tag in tags if isinstance(tag, str) and tag.strip()]
         if clean_tags:
             result["tags"] = clean_tags
+    base_model = _card_base_model(card)
+    if base_model is not None:
+        result["base_model"] = base_model
     return result
 
 

--- a/studio/backend/hub/workers/hf_download.py
+++ b/studio/backend/hub/workers/hf_download.py
@@ -243,6 +243,13 @@ def _format_path_list(paths: tuple[str, ...], cap: int = _VERIFY_PATH_LIST_CAP) 
     return f"{head}, ... and {len(paths) - cap} more"
 
 
+def _gguf_allow_patterns(targets: list[str]) -> list[str]:
+    """Shards plus the card. The card is the only on-disk source of `base_model`, which
+    names the provider for a repo whose own name matches no known family. Verification is
+    manifest-driven and reclaim only touches .gguf, so the extra file is inert."""
+    return [*targets, "README.md"]
+
+
 def _verify_completed_download(
     repo_type: RepoType,
     repo_id: str,
@@ -720,7 +727,7 @@ def _download_gguf_variant(repo_id: str, variant: str, hf_token: str | None, mod
     snapshot_path = snapshot_download(
         repo_id = repo_id,
         token = _hf_token_arg(hf_token),
-        allow_patterns = targets,
+        allow_patterns = _gguf_allow_patterns(targets),
         max_workers = 1,
     )
     _verify_completed_download(

--- a/studio/backend/tests/test_cached_card_base_model.py
+++ b/studio/backend/tests/test_cached_card_base_model.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Keep this test runnable without optional logging deps.
+if "structlog" not in sys.modules:
+
+    class _DummyLogger:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: None
+
+    sys.modules["structlog"] = types.SimpleNamespace(
+        BoundLogger = _DummyLogger,
+        get_logger = lambda *args, **kwargs: _DummyLogger(),
+    )
+
+from hub.services.models import cache_inventory as CI
+
+
+# Verbatim frontmatter shape of unsloth/Muse-Glimmer-30B-GGUF: the base model is a
+# list under `base_model`, and `tags` never carries the Hub's synthesized entries.
+MUSE_GLIMMER_CARD = """---
+license: apache-2.0
+library_name: transformers
+pipeline_tag: image-text-to-text
+tags:
+- unsloth
+- meta
+base_model:
+- meta-models/Muse-Glimmer-30B
+---
+
+# Muse Glimmer
+"""
+
+
+def _snapshot(tmp_path: Path, card: str) -> Path:
+    snapshot = tmp_path / "snapshots" / "abc123"
+    snapshot.mkdir(parents = True)
+    (snapshot / "README.md").write_text(card, encoding = "utf-8")
+    return snapshot
+
+
+def test_card_base_model_reads_a_list(tmp_path):
+    snapshot = _snapshot(tmp_path, MUSE_GLIMMER_CARD)
+    assert CI._cached_repo_base_model(snapshot) == "meta-models/Muse-Glimmer-30B"
+
+
+def test_card_base_model_reads_a_bare_string():
+    assert CI._card_base_model({"base_model": " meta-llama/Llama-3.1-8B "}) == (
+        "meta-llama/Llama-3.1-8B"
+    )
+
+
+@pytest.mark.parametrize(
+    "card",
+    [{}, {"base_model": ""}, {"base_model": []}, {"base_model": [None, "  "]}, {"base_model": 7}],
+)
+def test_card_base_model_ignores_junk(card):
+    assert CI._card_base_model(card) is None
+
+
+def test_cached_repo_base_model_tolerates_a_missing_card(tmp_path):
+    assert CI._cached_repo_base_model(None) is None
+    assert CI._cached_repo_base_model(tmp_path) is None
+
+
+def test_local_metadata_carries_the_base_model(tmp_path):
+    repo_path = tmp_path / "models--unsloth--Muse-Glimmer-30B-GGUF"
+    repo_path.mkdir()
+    snapshot = _snapshot(repo_path, MUSE_GLIMMER_CARD)
+
+    metadata = CI._cached_model_local_metadata(repo_path, snapshot)
+
+    assert metadata["base_model"] == "meta-models/Muse-Glimmer-30B"
+    # The card's own tag list stays untouched, and carries no base_model entry.
+    assert metadata["tags"] == ["unsloth", "meta"]
+
+
+def test_gguf_scan_emits_the_card_base_model(tmp_path, monkeypatch):
+    """The GGUF scan skips the checkpoint metadata pass, so it must read the card itself."""
+    from types import SimpleNamespace
+
+    from hub.utils import inventory_scan
+
+    snapshot_id = "a" * 40
+    repo_dir = tmp_path / "models--unsloth--Muse-Glimmer-30B-GGUF"
+    snapshot = repo_dir / "snapshots" / snapshot_id
+    snapshot.mkdir(parents = True)
+    (repo_dir / "refs").mkdir(parents = True)
+    (repo_dir / "refs" / "main").write_text(snapshot_id, encoding = "utf-8")
+    (snapshot / "Muse-Glimmer-30B-UD-Q4_K_XL.gguf").write_bytes(b"\0" * 32)
+    (snapshot / "README.md").write_text(MUSE_GLIMMER_CARD, encoding = "utf-8")
+
+    monkeypatch.setattr(inventory_scan, "hf_cache_roots", lambda **kw: [tmp_path])
+    monkeypatch.setattr(
+        "utils.hf_cache_settings.get_hf_cache_paths",
+        lambda: SimpleNamespace(hub_cache = tmp_path),
+    )
+    inventory_scan.invalidate_hf_cache_scans()
+    try:
+        rows = CI._scan_cached_gguf()
+    finally:
+        inventory_scan.invalidate_hf_cache_scans()
+
+    assert [row["repo_id"] for row in rows] == ["unsloth/Muse-Glimmer-30B-GGUF"]
+    assert rows[0]["base_model"] == "meta-models/Muse-Glimmer-30B"

--- a/studio/backend/tests/test_cached_card_base_model.py
+++ b/studio/backend/tests/test_cached_card_base_model.py
@@ -110,3 +110,24 @@ def test_gguf_scan_emits_the_card_base_model(tmp_path, monkeypatch):
 
     assert [row["repo_id"] for row in rows] == ["unsloth/Muse-Glimmer-30B-GGUF"]
     assert rows[0]["base_model"] == "meta-models/Muse-Glimmer-30B"
+
+
+def test_response_schemas_keep_the_base_model():
+    """The routes serialize through these models, so an undeclared field is dropped."""
+    from hub.schemas.inventory import CachedGgufResponse, CachedModelsResponse
+
+    row = {"repo_id": "unsloth/Muse-Glimmer-30B-GGUF", "base_model": "meta-models/Muse-Glimmer-30B"}
+    for response_model in (CachedGgufResponse, CachedModelsResponse):
+        payload = response_model.model_validate({"cached": [row]}).model_dump()
+        assert payload["cached"][0]["base_model"] == "meta-models/Muse-Glimmer-30B", response_model
+
+
+def test_managed_gguf_download_keeps_the_card():
+    """The card is the only on-disk source of base_model, so the GGUF fetch must allow it."""
+    from hub.workers.hf_download import _gguf_allow_patterns
+
+    targets = ["Muse-Glimmer-30B-UD-Q4_K_XL.gguf", "mmproj-F16.gguf"]
+    patterns = _gguf_allow_patterns(targets)
+
+    assert patterns[: len(targets)] == targets, "shards must still be fetched"
+    assert "README.md" in patterns

--- a/studio/frontend/src/features/hub/catalog/model-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-card.tsx
@@ -261,7 +261,7 @@ export const ModelCard = memo(function ModelCard({
     unsupportedReason: support?.reason ?? null,
     resourceLabel: isDataset ? "dataset" : "model",
   });
-  const iconUrl = useAvatarImageUrl(row.owner, row.repo);
+  const iconUrl = useAvatarImageUrl(row.owner, row.repo, row.result.baseModel);
   const dominant = useDominantColor(iconUrl);
   const cardAccentStyle = useMemo(
     () => ({
@@ -283,6 +283,7 @@ export const ModelCard = memo(function ModelCard({
         <OwnerAvatar
           owner={row.owner}
           repoName={row.repo}
+          baseModel={row.result.baseModel}
           className="size-11 shrink-0 rounded-[14px] text-ui-17 ring-1 ring-white/10"
           remote={false}
         />

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -595,6 +595,7 @@ export const ModelInspector = memo(function ModelInspector({
           <OwnerAvatar
             owner={model.owner}
             repoName={model.title}
+            baseModel={model.baseModelHubId ?? model.baseModel}
             className="size-[60px] rounded-[18px] text-ui-19"
           />
           <div className="min-w-0 flex-1">

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -43,6 +43,7 @@ import { memo, useDeferredValue, useMemo } from "react";
 import { selectActiveJob, useDownloadManagerStore } from "../download-manager";
 import { useCopyFeedback } from "../hooks/use-copy-feedback";
 import { useDatasetSize } from "../hooks/use-dataset-size";
+import { detectBaseModel } from "../lib/model-capabilities";
 import {
   formatLibrary,
   formatLocalUpdated,
@@ -595,7 +596,11 @@ export const ModelInspector = memo(function ModelInspector({
           <OwnerAvatar
             owner={model.owner}
             repoName={model.title}
-            baseModel={model.baseModelHubId ?? model.baseModel}
+            baseModel={
+              model.baseModelHubId ??
+              model.baseModel ??
+              detectBaseModel(model.tags)
+            }
             className="size-[60px] rounded-[18px] text-ui-19"
           />
           <div className="min-w-0 flex-1">

--- a/studio/frontend/src/features/hub/catalog/models-catalog-rows.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-catalog-rows.tsx
@@ -21,6 +21,7 @@ import {
   ggufVariantDisplayLabel,
   useHfTokenStore,
 } from "@/features/hub";
+import { detectBaseModel } from "../lib/model-capabilities";
 import { modelIdsMatch } from "../lib/model-identity";
 import {
   ModelRowMenu,
@@ -476,6 +477,7 @@ export const DiscoverModelRow = memo(function DiscoverModelRow({
         <OwnerAvatar
           owner={row.owner}
           repoName={row.repo}
+          baseModel={row.result.baseModel}
           className="size-8 rounded-[11px]"
           remote={false}
         />
@@ -537,6 +539,16 @@ export const DiscoverModelRow = memo(function DiscoverModelRow({
     </CatalogRow>
   );
 });
+
+/** `base_model:` id for a row: local rows prefer the adapter config, cached rows the tags. */
+function inventoryRowBaseModel(
+  row: CachedInventoryRow | LocalInventoryRow,
+): string | null {
+  if (row.kind === "local") {
+    return row.baseModelHubId ?? row.baseModel ?? detectBaseModel(row.tags);
+  }
+  return detectBaseModel(row.tags);
+}
 
 function cachedRowActive(
   row: CachedInventoryRow,
@@ -621,6 +633,7 @@ export const InventoryRow = memo(function InventoryRow({
       ? cachedRowActive(row, activeCheckpoint, activeGgufVariant)
       : localRowActive(row, activeCheckpoint, activeGgufVariant);
   const title = row.kind === "cache" ? row.repo : row.title;
+  const rowBaseModel = inventoryRowBaseModel(row);
 
   const subLabel = row.owner;
   const trailing =
@@ -839,6 +852,7 @@ export const InventoryRow = memo(function InventoryRow({
           <OwnerAvatar
             owner={row.owner}
             repoName={title}
+            baseModel={rowBaseModel}
             className="size-8 shrink-0 rounded-[9px] text-ui-12"
             remote={false}
           />
@@ -911,6 +925,7 @@ export const InventoryRow = memo(function InventoryRow({
           <OwnerAvatar
             owner={row.owner}
             repoName={title}
+            baseModel={rowBaseModel}
             className="size-9 rounded-[12px]"
             remote={false}
           />

--- a/studio/frontend/src/features/hub/catalog/models-catalog-rows.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-catalog-rows.tsx
@@ -547,7 +547,7 @@ function inventoryRowBaseModel(
   if (row.kind === "local") {
     return row.baseModelHubId ?? row.baseModel ?? detectBaseModel(row.tags);
   }
-  return detectBaseModel(row.tags);
+  return row.baseModel ?? detectBaseModel(row.tags);
 }
 
 function cachedRowActive(

--- a/studio/frontend/src/features/hub/catalog/models-table.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-table.tsx
@@ -642,6 +642,7 @@ export const ResultCard = memo(function ResultCard({
       <OwnerAvatar
         owner={row.owner}
         repoName={row.repo}
+        baseModel={row.result.baseModel}
         className="size-[52px] shrink-0 rounded-[16px] text-ui-16 ring-1 ring-black/5 dark:ring-white/10"
         remote={false}
       />
@@ -761,6 +762,7 @@ export const ResultGridRow = memo(function ResultGridRow({
           <OwnerAvatar
             owner={row.owner}
             repoName={row.repo}
+            baseModel={row.result.baseModel}
             className="size-9 shrink-0 rounded-[12px] text-ui-13 ring-1 ring-black/5 dark:ring-white/10"
             remote={false}
           />
@@ -883,6 +885,7 @@ export const ResultSplitRow = memo(function ResultSplitRow({
       <OwnerAvatar
         owner={row.owner}
         repoName={row.repo}
+        baseModel={row.result.baseModel}
         className="size-8 shrink-0 rounded-[9px] text-ui-12"
         remote={false}
       />

--- a/studio/frontend/src/features/hub/catalog/owner-avatar.tsx
+++ b/studio/frontend/src/features/hub/catalog/owner-avatar.tsx
@@ -52,6 +52,7 @@ function avatarImageRetryDelay(failures: number): number {
 export function OwnerAvatar({
   owner,
   repoName,
+  baseModel,
   size = "md",
   className,
   remote = true,
@@ -63,6 +64,8 @@ export function OwnerAvatar({
    * (e.g. an Unsloth Qwen2.5 re-upload shows the Qwen logo).
    */
   repoName?: string;
+  /** `base_model:` id, when known. Names the provider when `repoName` matches nothing. */
+  baseModel?: string | null;
   size?: AvatarSize;
   className?: string;
   /**
@@ -72,7 +75,7 @@ export function OwnerAvatar({
    */
   remote?: boolean;
 }) {
-  const providerLogo = resolveOwnerProviderLogo(owner, repoName);
+  const providerLogo = resolveOwnerProviderLogo(owner, repoName, baseModel);
   if (providerLogo) {
     return (
       <ProviderLogoTile
@@ -105,8 +108,9 @@ export function OwnerAvatar({
 export function useAvatarImageUrl(
   owner: string,
   repoName?: string,
+  baseModel?: string | null,
 ): string | null {
-  const provider = resolveOwnerProviderLogo(owner, repoName);
+  const provider = resolveOwnerProviderLogo(owner, repoName, baseModel);
   const isUnsloth = isUnslothOwner(owner);
   const remoteUrl = useHfOwnerAvatar(
     owner.trim() || "?",

--- a/studio/frontend/src/features/hub/hooks/use-selected-model-view.ts
+++ b/studio/frontend/src/features/hub/hooks/use-selected-model-view.ts
@@ -2,7 +2,11 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { useMemo } from "react";
-import { detectCapabilities, detectLicense } from "../lib/model-capabilities";
+import {
+  detectBaseModel,
+  detectCapabilities,
+  detectLicense,
+} from "../lib/model-capabilities";
 import {
   buildSummary,
   localSourceLabel,
@@ -253,7 +257,13 @@ export function useSelectedModelView({
         selectedHfResult?.quantMethod ??
         selectedCachedRow.quantMethod ??
         undefined;
-      const mergedBaseModel = selectedHfResult?.baseModel ?? null;
+      // Offline the Hub result is gone, so fall back to what the cache itself knows:
+      // the card's `base_model`, then the synthesized tags a full snapshot carries.
+      const mergedBaseModel =
+        selectedHfResult?.baseModel ??
+        selectedCachedRow.baseModel ??
+        detectBaseModel(mergedTags) ??
+        null;
       return {
         id: selectedCachedRow.repoId,
         kind: "cache",
@@ -272,7 +282,11 @@ export function useSelectedModelView({
         requiresVariant: selectedCachedRow.capabilities.requiresVariant,
         modelFormat: selectedCachedRow.modelFormat,
         baseModel: mergedBaseModel,
-        baseModelSource: mergedBaseModel ? "huggingface" : null,
+        baseModelSource: mergedBaseModel
+          ? selectedHfResult?.baseModel
+            ? "huggingface"
+            : "local"
+          : null,
         baseModelHubId: mergedBaseModel,
         isDownloaded: !selectedCachedRow.partial,
         isPartial: selectedCachedRow.partial ?? false,

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -848,7 +848,8 @@ export function ModelsPage() {
         !isConfiguredHiddenModelId(hiddenEmbeddingModelIds, row.id) &&
         // Feed shows logo'd models, plus iconless ones above the likes threshold.
         (!isFeedMode ||
-          resolveOwnerProviderLogo(row.owner, row.repo) !== null ||
+          resolveOwnerProviderLogo(row.owner, row.repo, row.result.baseModel) !==
+            null ||
           (row.result.likes ?? 0) >= MIN_ICONLESS_MODEL_LIKES) &&
         matchesFormat(
           detectResultFormat(row.result),

--- a/studio/frontend/src/features/hub/inventory/api.ts
+++ b/studio/frontend/src/features/hub/inventory/api.ts
@@ -54,6 +54,8 @@ export interface CachedGgufRepo {
   pipeline_tag?: string | null;
   task?: string | null;
   tags?: string[];
+  /** `base_model` off the cached card; the Hub's synthesized tags are not on disk. */
+  base_model?: string | null;
   library_name?: string | null;
 }
 
@@ -73,6 +75,8 @@ export interface CachedModelRepo {
   pipeline_tag?: string | null;
   task?: string | null;
   tags?: string[];
+  /** `base_model` off the cached card; the Hub's synthesized tags are not on disk. */
+  base_model?: string | null;
   library_name?: string | null;
   quant_method?: string | null;
 }

--- a/studio/frontend/src/features/hub/inventory/types.ts
+++ b/studio/frontend/src/features/hub/inventory/types.ts
@@ -62,6 +62,8 @@ export interface CachedInventoryRow {
   // run to tens of GB and the row is how they are seen and deleted, but never a pick.
   companion?: boolean;
   tags?: string[];
+  /** `base_model` from the cached card; the Hub's synthesized tags are not on disk. */
+  baseModel?: string | null;
   libraryName?: string | null;
   quantMethod?: string | null;
   liveDownload?: boolean;

--- a/studio/frontend/src/features/hub/inventory/view-models.ts
+++ b/studio/frontend/src/features/hub/inventory/view-models.ts
@@ -173,6 +173,7 @@ export function buildCachedInventoryRow(
     single_file?: boolean;
     companion?: boolean;
     tags?: string[];
+    base_model?: string | null;
     library_name?: string | null;
     quant_method?: string | null;
     inventory_id?: string | null;
@@ -236,6 +237,7 @@ export function buildCachedInventoryRow(
     singleFile: row.single_file ?? false,
     companion: row.companion ?? false,
     tags: row.tags,
+    baseModel: row.base_model ?? null,
     libraryName: row.library_name ?? null,
     quantMethod: row.quant_method ?? null,
     optimistic: row.optimistic,

--- a/studio/frontend/src/features/hub/lib/provider-logos.ts
+++ b/studio/frontend/src/features/hub/lib/provider-logos.ts
@@ -329,12 +329,27 @@ const BASE_MODEL_RELATIONS: readonly string[] = [
 ];
 
 /**
+ * True when the upload is the base model re-uploaded rather than a model built on
+ * it: unsloth/Muse-Glimmer-30B-GGUF over meta-models/Muse-Glimmer-30B, but not
+ * FLUX.2-klein-9B-ComfyUI over Qwen/Qwen3-8B, whose base names only a component.
+ */
+function isReuploadOf(uploadRepoName: string, baseRepoName: string): boolean {
+	if (!baseRepoName) return false;
+	return uploadRepoName.toLowerCase().startsWith(baseRepoName.toLowerCase());
+}
+
+/**
  * Provider behind a `base_model:` id, or null. Owner wins: it is the publisher of
  * record, and resolves even when the base repo name matches nothing. A bare id
  * with no owner is read as a repo name.
+ *
+ * `uploadRepoName` gates the lookup on the upload being that base re-uploaded, so a
+ * text encoder cannot lend its logo to the pack shipping it, and a community
+ * finetune is not relabeled as its upstream.
  */
 export function providerLogoFromBaseModel(
 	baseModelId: string | null | undefined,
+	uploadRepoName?: string,
 ): ProviderLogo | null {
 	let id = baseModelId?.trim();
 	if (!id) return null;
@@ -346,10 +361,13 @@ export function providerLogoFromBaseModel(
 	}
 	if (!id) return null;
 	const slash = id.indexOf("/");
+	const baseRepoName = slash === -1 ? id : id.slice(slash + 1);
+	if (uploadRepoName !== undefined && !isReuploadOf(uploadRepoName, baseRepoName)) {
+		return null;
+	}
 	if (slash === -1) return matchProviderLogo(id);
 	return (
-		matchProviderLogoByOwner(id.slice(0, slash)) ??
-		matchProviderLogo(id.slice(slash + 1))
+		matchProviderLogoByOwner(id.slice(0, slash)) ?? matchProviderLogo(baseRepoName)
 	);
 }
 
@@ -377,7 +395,9 @@ export function resolveOwnerProviderLogo(
 	repoName: string | null | undefined,
 	baseModelId?: string | null,
 ): ProviderLogo | null {
-	if (!isProviderRelabeledOwner(owner)) return null;
-	const named = repoName ? matchProviderLogo(repoName) : null;
-	return named ?? providerLogoFromBaseModel(baseModelId);
+	if (!isProviderRelabeledOwner(owner) || !repoName) return null;
+	return (
+		matchProviderLogo(repoName) ??
+		providerLogoFromBaseModel(baseModelId, repoName)
+	);
 }

--- a/studio/frontend/src/features/hub/lib/provider-logos.ts
+++ b/studio/frontend/src/features/hub/lib/provider-logos.ts
@@ -318,6 +318,16 @@ export function matchProviderLogoByOwner(owner: string): ProviderLogo | null {
 	return null;
 }
 
+// Hub relation qualifiers, which prefix the id in a `base_model:` tag. detectBaseModel
+// unwraps `quantized:` only, so strip the rest here before reading the owner.
+const BASE_MODEL_RELATIONS: readonly string[] = [
+	"quantized:",
+	"finetune:",
+	"adapter:",
+	"merge:",
+	"preference:",
+];
+
 /**
  * Provider behind a `base_model:` id, or null. Owner wins: it is the publisher of
  * record, and resolves even when the base repo name matches nothing. A bare id
@@ -326,7 +336,14 @@ export function matchProviderLogoByOwner(owner: string): ProviderLogo | null {
 export function providerLogoFromBaseModel(
 	baseModelId: string | null | undefined,
 ): ProviderLogo | null {
-	const id = baseModelId?.trim();
+	let id = baseModelId?.trim();
+	if (!id) return null;
+	for (const relation of BASE_MODEL_RELATIONS) {
+		if (id.toLowerCase().startsWith(relation)) {
+			id = id.slice(relation.length).trim();
+			break;
+		}
+	}
 	if (!id) return null;
 	const slash = id.indexOf("/");
 	if (slash === -1) return matchProviderLogo(id);

--- a/studio/frontend/src/features/hub/lib/provider-logos.ts
+++ b/studio/frontend/src/features/hub/lib/provider-logos.ts
@@ -12,6 +12,9 @@
  * NVIDIA's Nemotron/Minitron/Mistral-NeMo before meta-llama/mistralai, and
  * DeepSeek-R1-Distill- before Qwen/meta-llama. Repo names are case-sensitive -
  * match the publisher's exact casing (e.g. `phi-` for v1/v2 vs `Phi-` for v3+).
+ *
+ * When the repo name matches nothing (unsloth/Muse-Glimmer-30B-GGUF), the
+ * `base_model:` owner decides: meta-models/Muse-Glimmer-30B -> Meta.
  */
 
 /**
@@ -51,6 +54,11 @@ export interface ProviderLogo {
 	 * (`gemma` -> `diffusiongemma-`, `gemma-3n`, not `gemmafy`). Use stems unique to one provider.
 	 */
 	stems?: readonly string[];
+	/**
+	 * Hub orgs publishing this provider, matched in full and case-insensitively
+	 * (never a prefix - `metavoice` is not Meta). Only used on a `base_model:` owner.
+	 */
+	owners?: readonly string[];
 }
 
 export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
@@ -75,6 +83,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 			"OpenCodeReasoning",
 			"Cosmos-"
 		],
+		owners: ["nvidia"],
 	},
 
 	// `DeepSeek-R1-Distill-*` must beat Qwen/meta-llama on the suffix family.
@@ -91,6 +100,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 			"deepseek-llm-",
 			"deepseek-coder-",
 		],
+		owners: ["deepseek-ai"],
 	},
 
 	{
@@ -109,6 +119,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 			"phi-2",
 			"phi-",
 		],
+		owners: ["microsoft"],
 	},
 
 	// The broad `Qwen` prefix catches Qwen1.5/2/2.5/3/future versions without explicit entries.
@@ -119,6 +130,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		treatment: "original",
 		background: "white",
 		prefixes: ["Qwen", "QwQ-", "QVQ-"],
+		owners: ["Qwen"],
 	},
 
 	{
@@ -129,6 +141,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		background: "transparent",
 		fit: "cover",
 		prefixes: ["Kimi-", "Moonlight-"],
+		owners: ["moonshotai"],
 	},
 
 	// Z.ai (THUDM successor).
@@ -140,6 +153,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		background: "transparent",
 		fit: "cover",
 		prefixes: ["GLM-", "glm-", "chatglm", "codegeex"],
+		owners: ["zai-org", "THUDM"],
 	},
 
 	{
@@ -149,6 +163,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		treatment: "mono-black",
 		background: "white",
 		prefixes: ["grok-"],
+		owners: ["xai-org"],
 	},
 
 	{
@@ -158,6 +173,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		treatment: "original",
 		background: "white",
 		prefixes: ["MiniMax-"],
+		owners: ["MiniMaxAI", "MiniMax-AI"],
 	},
 
 	// SmolLM family lives under HuggingFaceTB.
@@ -168,6 +184,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		treatment: "original",
 		background: "white",
 		prefixes: ["SmolLM"],
+		owners: ["HuggingFaceTB"],
 	},
 
 	{
@@ -178,6 +195,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		background: "transparent",
 		fit: "cover",
 		prefixes: ["granite-", "granitelib-"],
+		owners: ["ibm-granite", "ibm"],
 	},
 
 	{
@@ -187,6 +205,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		treatment: "original",
 		background: "white",
 		prefixes: ["c4ai-command", "aya-"],
+		owners: ["CohereLabs", "CohereForAI"],
 	},
 
 	{
@@ -196,6 +215,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		treatment: "mono-theme",
 		background: "transparent",
 		prefixes: ["gpt-oss-"],
+		owners: ["openai"],
 	},
 
 	{
@@ -223,6 +243,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 			"bert-",
 		],
 		stems: ["gemma"],
+		owners: ["google", "google-bert", "google-t5", "google-deepmind"],
 	},
 
 	// After NVIDIA so `Mistral-NeMo-` wins; generic Mistral-/Mixtral- fall through here.
@@ -233,6 +254,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 		treatment: "original",
 		background: "white",
 		prefixes: ["Mistral-", "Mixtral-", "Codestral-", "Pixtral-", "Devstral-", "Ministral-", "Voxtral-", "Magistral-"],
+		owners: ["mistralai", "mistral-community"],
 	},
 
 	// Last among Llama-prefix providers so NVIDIA's Llama-3.x-Nemotron/Minitron match first.
@@ -251,6 +273,7 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 			"llama-",
 			"meta-"
 		],
+		owners: ["meta-llama", "meta", "meta-models", "facebook", "facebookresearch"],
 	},
 ];
 
@@ -283,6 +306,36 @@ export function matchProviderLogo(repoName: string): ProviderLogo | null {
 	return null;
 }
 
+/** Hub org -> its provider, or null. Full-string, case-insensitive. */
+export function matchProviderLogoByOwner(owner: string): ProviderLogo | null {
+	const needle = owner.trim().toLowerCase();
+	if (!needle) return null;
+	for (const provider of PROVIDER_LOGOS) {
+		if (provider.owners?.some((org) => org.toLowerCase() === needle)) {
+			return provider;
+		}
+	}
+	return null;
+}
+
+/**
+ * Provider behind a `base_model:` id, or null. Owner wins: it is the publisher of
+ * record, and resolves even when the base repo name matches nothing. A bare id
+ * with no owner is read as a repo name.
+ */
+export function providerLogoFromBaseModel(
+	baseModelId: string | null | undefined,
+): ProviderLogo | null {
+	const id = baseModelId?.trim();
+	if (!id) return null;
+	const slash = id.indexOf("/");
+	if (slash === -1) return matchProviderLogo(id);
+	return (
+		matchProviderLogoByOwner(id.slice(0, slash)) ??
+		matchProviderLogo(id.slice(slash + 1))
+	);
+}
+
 // Owners whose avatars get swapped for the matched provider's logo.
 const RELABELED_OWNERS: ReadonlySet<string> = new Set(["unsloth"]);
 
@@ -297,11 +350,17 @@ export function isProviderRelabeledOwner(
 /**
  * Provider logo to render in place of the owner's profile picture, or null.
  * Only owners in RELABELED_OWNERS are eligible.
+ *
+ * The repo name wins, so a re-upload keeps the mark it is named after
+ * (DeepSeek-R1-Distill-Llama-8B is DeepSeek's, not Meta's). `baseModelId` is the
+ * fallback for names that match nothing.
  */
 export function resolveOwnerProviderLogo(
 	owner: string | null | undefined,
 	repoName: string | null | undefined,
+	baseModelId?: string | null,
 ): ProviderLogo | null {
-	if (!isProviderRelabeledOwner(owner) || !repoName) return null;
-	return matchProviderLogo(repoName);
+	if (!isProviderRelabeledOwner(owner)) return null;
+	const named = repoName ? matchProviderLogo(repoName) : null;
+	return named ?? providerLogoFromBaseModel(baseModelId);
 }

--- a/studio/frontend/tests/hub-provider-logo-base-model.test.ts
+++ b/studio/frontend/tests/hub-provider-logo-base-model.test.ts
@@ -56,6 +56,18 @@ test("an unknown base owner falls through to the base repo name", () => {
   assert.equal(providerLogoFromBaseModel(null), null);
 });
 
+test("relation qualifiers are stripped before the owner is read", () => {
+  for (const relation of ["quantized", "finetune", "adapter", "merge"]) {
+    assert.equal(
+      providerLogoFromBaseModel(`${relation}:meta-models/Muse-Glimmer-30B`)?.id,
+      "meta-llama",
+      relation,
+    );
+  }
+  // A repo whose own name starts with a relation word is not a qualifier.
+  assert.equal(providerLogoFromBaseModel("mergekit-community/x"), null);
+});
+
 test("only relabeled owners inherit a provider mark", () => {
   assert.equal(
     resolveOwnerProviderLogo(
@@ -80,4 +92,27 @@ test("every declared base-model owner is unique to one provider", () => {
       seen.set(key, provider.id);
     }
   }
+});
+
+test("a cached row carries the backend's card base model into the logo", async () => {
+  const { register } = await import("node:module");
+  register("./bundler-resolver.mjs", import.meta.url);
+  const { buildCachedInventoryRow } = await import(
+    "../src/features/hub/inventory/view-models.ts"
+  );
+
+  const row = buildCachedInventoryRow(
+    {
+      repo_id: "unsloth/Muse-Glimmer-30B-GGUF",
+      size_bytes: 20_000_000_000,
+      base_model: "meta-models/Muse-Glimmer-30B",
+    },
+    "gguf",
+  );
+
+  assert.equal(row.baseModel, "meta-models/Muse-Glimmer-30B");
+  assert.equal(
+    resolveOwnerProviderLogo(row.owner, row.repo, row.baseModel)?.id,
+    "meta-llama",
+  );
 });

--- a/studio/frontend/tests/hub-provider-logo-base-model.test.ts
+++ b/studio/frontend/tests/hub-provider-logo-base-model.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PROVIDER_LOGOS,
+  matchProviderLogoByOwner,
+  providerLogoFromBaseModel,
+  resolveOwnerProviderLogo,
+} from "../src/features/hub/lib/provider-logos.ts";
+
+test("an Unsloth re-upload named after no family takes the base model's mark", () => {
+  // unsloth/Muse-Glimmer-30B-GGUF matches no prefix; base_model names Meta.
+  assert.equal(
+    resolveOwnerProviderLogo(
+      "unsloth",
+      "Muse-Glimmer-30B-GGUF",
+      "meta-models/Muse-Glimmer-30B",
+    )?.id,
+    "meta-llama",
+  );
+  assert.equal(
+    resolveOwnerProviderLogo("unsloth", "Muse-Glimmer-30B-GGUF", null),
+    null,
+  );
+});
+
+test("the repo name still wins over base-model provenance", () => {
+  // DeepSeek's Llama distill is DeepSeek's, not Meta's, whichever base is tagged.
+  assert.equal(
+    resolveOwnerProviderLogo(
+      "unsloth",
+      "DeepSeek-R1-Distill-Llama-8B-GGUF",
+      "meta-llama/Llama-3.1-8B",
+    )?.id,
+    "deepseek-ai",
+  );
+});
+
+test("base-model owners resolve in full, never as a prefix", () => {
+  assert.equal(matchProviderLogoByOwner("meta-models")?.id, "meta-llama");
+  assert.equal(matchProviderLogoByOwner("META-LLAMA")?.id, "meta-llama");
+  assert.equal(matchProviderLogoByOwner("metavoice"), null);
+  assert.equal(matchProviderLogoByOwner(""), null);
+});
+
+test("an unknown base owner falls through to the base repo name", () => {
+  assert.equal(
+    providerLogoFromBaseModel("some-lab/Qwen3-30B-A3B")?.id,
+    "qwen",
+  );
+  assert.equal(providerLogoFromBaseModel("Llama-3.2-1B")?.id, "meta-llama");
+  assert.equal(providerLogoFromBaseModel("some-lab/Untitled-7B"), null);
+  assert.equal(providerLogoFromBaseModel(null), null);
+});
+
+test("only relabeled owners inherit a provider mark", () => {
+  assert.equal(
+    resolveOwnerProviderLogo(
+      "some-org",
+      "Muse-Glimmer-30B-GGUF",
+      "meta-models/Muse-Glimmer-30B",
+    ),
+    null,
+  );
+});
+
+test("every declared base-model owner is unique to one provider", () => {
+  const seen = new Map<string, string>();
+  for (const provider of PROVIDER_LOGOS) {
+    for (const owner of provider.owners ?? []) {
+      const key = owner.toLowerCase();
+      assert.equal(
+        seen.get(key),
+        undefined,
+        `${owner} is claimed by both ${seen.get(key)} and ${provider.id}`,
+      );
+      seen.set(key, provider.id);
+    }
+  }
+});

--- a/studio/frontend/tests/hub-provider-logo-base-model.test.ts
+++ b/studio/frontend/tests/hub-provider-logo-base-model.test.ts
@@ -68,6 +68,38 @@ test("relation qualifiers are stripped before the owner is read", () => {
   assert.equal(providerLogoFromBaseModel("mergekit-community/x"), null);
 });
 
+test("a model built on a base does not borrow its mark", () => {
+  // Qwen3-8B is FLUX.2's text encoder, not its publisher.
+  assert.equal(
+    resolveOwnerProviderLogo("unsloth", "FLUX.2-klein-9B-ComfyUI", "Qwen/Qwen3-8B"),
+    null,
+  );
+  assert.equal(
+    resolveOwnerProviderLogo("unsloth", "flux-text-encoders", "google/t5-v1_1-xxl"),
+    null,
+  );
+  // A community finetune stays unbranded rather than being relabeled upstream.
+  assert.equal(
+    resolveOwnerProviderLogo(
+      "unsloth",
+      "Hermes-3-Llama-3.1-70B-bnb-4bit",
+      "meta-llama/Llama-3.1-70B",
+    ),
+    null,
+  );
+});
+
+test("a re-upload of the base keeps the mark, suffixes and all", () => {
+  for (const [repo, base, id] of [
+    ["Muse-Glimmer-30B-unsloth-bnb-4bit", "meta-models/Muse-Glimmer-30B", "meta-llama"],
+    ["whisper-large-v3-turbo", "openai/whisper-large-v3", "openai"],
+    ["mistral-7b-v0.3-bnb-4bit", "mistralai/Mistral-7B-v0.3", "mistralai"],
+    ["KernelLLM-GGUF", "facebook/KernelLLM", "meta-llama"],
+  ]) {
+    assert.equal(resolveOwnerProviderLogo("unsloth", repo, base)?.id, id, repo);
+  }
+});
+
 test("only relabeled owners inherit a provider mark", () => {
   assert.equal(
     resolveOwnerProviderLogo(


### PR DESCRIPTION
## The problem

Model hub picks the provider logo off the repo name alone. That works for anything named after a known family: `unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF` hits the `Llama-` prefix and gets Meta's mark.

It falls over for re-uploads whose name carries no family stem. `unsloth/Muse-Glimmer-30B-GGUF` matches nothing, so it shows the sloth even though the Hub tags say exactly who published it:

```
unsloth/Muse-Glimmer-30B-GGUF -> base_model:meta-models/Muse-Glimmer-30B
```

We already parse that tag and render it as the "Base" chip in the inspector. It just never reached logo resolution.

## The fix

Each provider now lists the Hub orgs it publishes under (`owners`), and `base_model` provenance becomes the fallback when the repo name matches nothing.

Resolution order is repo name, then base-model owner, then base repo name. Name-first matters: it keeps `DeepSeek-R1-Distill-Llama-8B` on DeepSeek's mark rather than flipping it to Meta.

Owners match in full and case-insensitively, never as a prefix, so `metavoice` does not become Meta.

`base_model` is threaded through all the avatar call sites (card, grid, split, table, inspector) plus the feed icon filter. Cached rows read it from the Hub tags, local rows prefer the adapter config.

## Verification

End to end through the real resolution path against live Hub metadata:

| Model | Base | Logo |
| --- | --- | --- |
| Muse-Glimmer-30B-GGUF | meta-models/Muse-Glimmer-30B | Meta |
| MiniMax-H3-GGUF | MiniMaxAI/MiniMax-H3 | MiniMax AI |
| Kimi-K3-GGUF | moonshotai/Kimi-K3 | Moonshot AI |
| DeepSeek-V4-Flash-0731-GGUF | deepseek-ai/DeepSeek-V4-Flash-0731 | DeepSeek |
| gpt-oss-20b-GGUF | openai/gpt-oss-20b | OpenAI |
| DeepSeek-R1-Distill-Llama-8B-GGUF | deepseek-ai/DeepSeek-R1-Distill-Llama-8B | DeepSeek, not Meta |

Adds 6 tests in `hub-provider-logo-base-model.test.ts` covering the fallback, repo-name precedence, full-string owner matching, the relabeled-owner gate, and a guard that no org is claimed by two providers.

Full frontend suite passes at 1959, typecheck is clean, and no new lint errors.

## Note

`Inkling-Small-GGUF` still shows the sloth. Its base is `thinkingmachines/Inkling-Small` and we have no Thinking Machines logo in the registry. Happy to add one in a follow up if we want it.
