### PR TITLE
Drop socket reads that arrive after an h11 connection is closed

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2138,12 +2138,19 @@ def run_server(
                 ready_event.set()
 
     # server_header=False suppresses uvicorn's "Server: uvicorn"; SecurityHeadersMiddleware sets its own.
+    # http=... is uvicorn's own h11 protocol unless we are on the plain-h11 path, where it
+    # becomes a subclass that ignores socket reads delivered after the connection was already
+    # closed. Without it every clean shutdown on Windows ends in an h11 LocalProtocolError
+    # traceback that reads as a crash; see utils/uvicorn_h11_shutdown.py for the full sequence.
+    from utils.uvicorn_h11_shutdown import uvicorn_http_protocol
+
     config_kwargs = dict(
         host = host,
         port = port,
         log_level = "info",
         access_log = False,
         server_header = False,
+        http = uvicorn_http_protocol(),
     )
     # Colab only: trust X-Forwarded-* from Colab's reverse proxy so the app sees
     # the real https origin. forwarded_allow_ips="*" is safe in Colab's

--- a/studio/backend/tests/test_uvicorn_h11_shutdown_quiet.py
+++ b/studio/backend/tests/test_uvicorn_h11_shutdown_quiet.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Issue #8404: no h11 traceback when a poll lands after we close the connection.
+
+On Windows, every clean shutdown printed an unhandled asyncio traceback ending in
+``h11._util.LocalProtocolError: can't handle event type Response when role=SERVER
+and state=CLOSED``. The frontend keeps polling ``/api/inference/status`` while
+uvicorn is closing connections, so a request is already in the socket when
+``H11Protocol.shutdown()`` sends ``h11.ConnectionClosed()`` and closes the
+transport. The proactor transport hands that read to the protocol anyway (the
+selector transport used on Linux and macOS removes the reader inside
+``close()``, which is why this only shows up on Windows), h11 then rejects the
+bytes and uvicorn's unguarded ``send_400_response()`` blows up.
+
+Two things in these fixtures are shaped by the platform, not by convenience:
+
+* the post-close ``data_received()`` call is made directly, exactly as
+  ``_ProactorReadPipeTransport._loop_reading()``'s ``finally:`` clause does it,
+  because Linux's selector transport will never make that call;
+* ``uvicorn.protocols.http.auto.AutoHTTPProtocol`` is forced to ``H11Protocol``,
+  because a dev box with httptools installed resolves to httptools while the
+  Studio requirements pin plain uvicorn, which is the h11 path the report hit.
+
+Everything downstream of the injected read -- the h11 state machine, the
+``RemoteProtocolError``, uvicorn's 400 path -- is the real code.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+from pathlib import Path
+
+import h11
+import pytest
+from uvicorn.config import Config
+from uvicorn.protocols.http.h11_impl import H11Protocol
+from uvicorn.server import ServerState
+
+from utils.uvicorn_h11_shutdown import uvicorn_http_protocol
+
+
+REQUEST = b"GET /api/inference/status HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"
+
+
+@pytest.fixture
+def patched_protocol_class(monkeypatch):
+    """The protocol Studio installs when uvicorn would otherwise use plain h11."""
+    import uvicorn.protocols.http.auto as auto
+
+    monkeypatch.setattr(auto, "AutoHTTPProtocol", H11Protocol)
+    protocol_class = uvicorn_http_protocol()
+    assert protocol_class is not "auto"  # noqa: F632 - a class is expected here
+    assert issubclass(protocol_class, H11Protocol)
+    return protocol_class
+
+
+class _FakeTransport(asyncio.Transport):
+    """Enough of a transport for H11Protocol; records writes, owns no socket."""
+
+    def __init__(self):
+        super().__init__()
+        self.chunks = []
+        self.closing = False
+
+    def write(self, data):
+        self.chunks.append(bytes(data))
+
+    def close(self):
+        self.closing = True
+
+    def is_closing(self):
+        return self.closing
+
+    def get_extra_info(self, name, default = None):
+        if name == "sockname":
+            return ("127.0.0.1", 8000)
+        if name == "peername":
+            return ("127.0.0.1", 54321)
+        return default
+
+    def pause_reading(self):
+        pass
+
+    def resume_reading(self):
+        pass
+
+
+async def _app(scope, receive, send):
+    assert scope["type"] == "http"
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"content-type", b"text/plain")],
+    })
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+def _build_protocol(protocol_class):
+    config = Config(app = _app, access_log = False)
+    config.load()
+    return protocol_class(
+        config = config,
+        server_state = ServerState(),
+        app_state = {},
+    )
+
+
+async def _serve_one_request(protocol_class):
+    protocol = _build_protocol(protocol_class)
+    transport = _FakeTransport()
+    protocol.connection_made(transport)
+
+    protocol.data_received(REQUEST)
+    for _ in range(100):
+        await asyncio.sleep(0)
+        if protocol.cycle is not None and protocol.cycle.response_complete:
+            break
+    assert protocol.cycle is not None and protocol.cycle.response_complete
+    return protocol, transport
+
+
+async def _serve_then_shutdown_then_poll(protocol_class):
+    """One keep-alive request, then a graceful shutdown, then a late poll."""
+    protocol, transport = await _serve_one_request(protocol_class)
+
+    # uvicorn.Server.shutdown() calls this on every live connection.
+    protocol.shutdown()
+    assert protocol.conn.our_state is h11.CLOSED
+
+    # The poll that was already in the socket when we closed.
+    protocol.data_received(REQUEST)
+    return protocol, transport
+
+
+def test_late_poll_after_shutdown_is_dropped(patched_protocol_class, caplog):
+    """The patched protocol must ignore the post-close read instead of answering it."""
+    with caplog.at_level(logging.WARNING, logger = "uvicorn.error"):
+        protocol, transport = asyncio.run(
+            _serve_then_shutdown_then_poll(patched_protocol_class)
+        )
+
+    assert protocol.conn.our_state is h11.CLOSED
+    assert b"400" not in b"".join(transport.chunks)
+    assert "Invalid HTTP request received." not in caplog.text
+
+
+def test_unpatched_h11_protocol_still_raises():
+    """Pin the upstream behaviour the fix works around, so the test cannot go vacuous."""
+    with pytest.raises(h11.LocalProtocolError) as excinfo:
+        asyncio.run(_serve_then_shutdown_then_poll(H11Protocol))
+    assert "state=CLOSED" in str(excinfo.value)
+
+
+def test_live_connection_still_parses_normally(patched_protocol_class):
+    """The guard must only fire on a closed connection, never on a live one."""
+    _protocol, transport = asyncio.run(_serve_one_request(patched_protocol_class))
+    assert b"200 OK" in b"".join(transport.chunks)
+
+
+def test_httptools_choice_is_left_alone(monkeypatch):
+    """uvicorn picks httptools when it is installed; that path needs no patching."""
+    import uvicorn.protocols.http.auto as auto
+
+    class _NotH11:
+        pass
+
+    monkeypatch.setattr(auto, "AutoHTTPProtocol", _NotH11)
+    assert uvicorn_http_protocol() == "auto"
+
+
+def test_run_server_passes_the_protocol_to_uvicorn_config():
+    """AST-only check, because importing run.py drags in torch and the whole app."""
+    source = (Path(__file__).resolve().parents[1] / "run.py").read_text(encoding = "utf-8")
+    tree = ast.parse(source)
+
+    wired = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if name != "dict":
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "http":
+                continue
+            value = keyword.value
+            if (
+                isinstance(value, ast.Call)
+                and getattr(value.func, "id", "") == "uvicorn_http_protocol"
+            ):
+                wired = True
+    assert wired, "run_server must build uvicorn.Config with http = uvicorn_http_protocol()"

--- a/studio/backend/tests/test_uvicorn_h11_shutdown_quiet.py
+++ b/studio/backend/tests/test_uvicorn_h11_shutdown_quiet.py
@@ -74,7 +74,11 @@ class _FakeTransport(asyncio.Transport):
     def is_closing(self):
         return self.closing
 
-    def get_extra_info(self, name, default = None):
+    def get_extra_info(
+        self,
+        name,
+        default = None,
+    ):
         if name == "sockname":
             return ("127.0.0.1", 8000)
         if name == "peername":
@@ -90,11 +94,13 @@ class _FakeTransport(asyncio.Transport):
 
 async def _app(scope, receive, send):
     assert scope["type"] == "http"
-    await send({
-        "type": "http.response.start",
-        "status": 200,
-        "headers": [(b"content-type", b"text/plain")],
-    })
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/plain")],
+        }
+    )
     await send({"type": "http.response.body", "body": b"ok"})
 
 
@@ -138,9 +144,7 @@ async def _serve_then_shutdown_then_poll(protocol_class):
 def test_late_poll_after_shutdown_is_dropped(patched_protocol_class, caplog):
     """The patched protocol must ignore the post-close read instead of answering it."""
     with caplog.at_level(logging.WARNING, logger = "uvicorn.error"):
-        protocol, transport = asyncio.run(
-            _serve_then_shutdown_then_poll(patched_protocol_class)
-        )
+        protocol, transport = asyncio.run(_serve_then_shutdown_then_poll(patched_protocol_class))
 
     assert protocol.conn.our_state is h11.CLOSED
     assert b"400" not in b"".join(transport.chunks)

--- a/studio/backend/tests/test_uvicorn_h11_shutdown_quiet.py
+++ b/studio/backend/tests/test_uvicorn_h11_shutdown_quiet.py
@@ -212,10 +212,40 @@ def test_malformed_request_still_gets_400(patched_protocol_class, name, raw):
     protocol, transport = asyncio.run(_drive())
 
     assert seen_states and all(
-        state not in (h11.CLOSED, h11.ERROR) for state in seen_states
+        state not in (h11.MUST_CLOSE, h11.CLOSED, h11.ERROR) for state in seen_states
     ), f"{name}: guard would have fired on a live connection, states = {seen_states}"
     assert protocol.conn.their_state is h11.ERROR
     assert b"400 Bad Request" in b"".join(transport.chunks), name
+
+
+async def _reject_then_poll(protocol_class):
+    """One malformed request, answered with a real 400, then a second late read."""
+    protocol = _build_protocol(protocol_class)
+    transport = _FakeTransport()
+    protocol.connection_made(transport)
+
+    protocol.data_received(b"GET\r\n\r\n")
+    await asyncio.sleep(0)
+    assert b"400 Bad Request" in b"".join(transport.chunks)
+    # send_400_response() closes the transport without sending ConnectionClosed,
+    # so h11 parks the server at MUST_CLOSE rather than CLOSED.
+    assert protocol.conn.our_state is h11.MUST_CLOSE
+
+    protocol.data_received(REQUEST)
+    return protocol, transport
+
+
+def test_late_read_after_a_400_is_dropped(patched_protocol_class):
+    """The window after a rejected request is terminal too, and must not retry the 400."""
+    protocol, _transport = asyncio.run(_reject_then_poll(patched_protocol_class))
+    assert protocol.conn.our_state is h11.MUST_CLOSE
+
+
+def test_unpatched_h11_protocol_raises_after_a_400_too():
+    """Pin the upstream behaviour on this path, so the test above cannot go vacuous."""
+    with pytest.raises(h11.LocalProtocolError) as excinfo:
+        asyncio.run(_reject_then_poll(H11Protocol))
+    assert "state=MUST_CLOSE" in str(excinfo.value)
 
 
 def test_httptools_choice_is_left_alone(monkeypatch):

--- a/studio/backend/tests/test_uvicorn_h11_shutdown_quiet.py
+++ b/studio/backend/tests/test_uvicorn_h11_shutdown_quiet.py
@@ -52,7 +52,7 @@ def patched_protocol_class(monkeypatch):
 
     monkeypatch.setattr(auto, "AutoHTTPProtocol", H11Protocol)
     protocol_class = uvicorn_http_protocol()
-    assert protocol_class is not "auto"  # noqa: F632 - a class is expected here
+    assert protocol_class != "auto"
     assert issubclass(protocol_class, H11Protocol)
     return protocol_class
 
@@ -162,6 +162,60 @@ def test_live_connection_still_parses_normally(patched_protocol_class):
     """The guard must only fire on a closed connection, never on a live one."""
     _protocol, transport = asyncio.run(_serve_one_request(patched_protocol_class))
     assert b"200 OK" in b"".join(transport.chunks)
+
+
+@pytest.mark.parametrize(
+    "name, raw",
+    [
+        ("bad_request_line", b"GET\r\n\r\n"),
+        ("bad_header_no_colon", b"GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nNoColonHere\r\n\r\n"),
+        (
+            "invalid_content_length",
+            b"POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: notanumber\r\n\r\n",
+        ),
+        (
+            "duplicate_content_length",
+            b"POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\nContent-Length: 4\r\n\r\nabc",
+        ),
+        (
+            "invalid_chunked",
+            b"POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nTransfer-Encoding: chunked\r\n\r\nZZ\r\n",
+        ),
+    ],
+)
+def test_malformed_request_still_gets_400(patched_protocol_class, name, raw):
+    """The guard must never swallow uvicorn's real 400 for a genuinely bad request.
+
+    A remote protocol violation moves ``their_state`` to ERROR and leaves
+    ``our_state`` alone (h11 ``Connection.next_event()`` calls
+    ``_process_error(self.their_role)``), so the guard cannot see a terminal
+    ``our_state`` here and uvicorn's ``send_400_response()`` runs as usual. This
+    pins that split, because a guard that also tripped on ``their_state`` would
+    turn a cosmetic shutdown fix into a functional regression.
+    """
+    seen_states = []
+
+    class _Recording(patched_protocol_class):
+        def data_received(self, data):
+            seen_states.append(self.conn.our_state)
+            super().data_received(data)
+
+    async def _drive():
+        protocol = _build_protocol(_Recording)
+        transport = _FakeTransport()
+        protocol.connection_made(transport)
+        protocol.data_received(raw)
+        for _ in range(100):
+            await asyncio.sleep(0)
+        return protocol, transport
+
+    protocol, transport = asyncio.run(_drive())
+
+    assert seen_states and all(
+        state not in (h11.CLOSED, h11.ERROR) for state in seen_states
+    ), f"{name}: guard would have fired on a live connection, states = {seen_states}"
+    assert protocol.conn.their_state is h11.ERROR
+    assert b"400 Bad Request" in b"".join(transport.chunks), name
 
 
 def test_httptools_choice_is_left_alone(monkeypatch):

--- a/studio/backend/utils/uvicorn_h11_shutdown.py
+++ b/studio/backend/utils/uvicorn_h11_shutdown.py
@@ -66,9 +66,18 @@ def _shutdown_quiet_h11_protocol() -> Union[type, None]:
         return None
 
     # our_state CLOSED means we already sent h11.ConnectionClosed(); ERROR means
-    # a previous send violated the state machine. In both cases uvicorn can no
-    # longer write a response on this connection, so feeding it more inbound
-    # bytes can only produce the spurious 400 attempt described above.
+    # a previous send violated the state machine; MUST_CLOSE means h11 will let
+    # us send nothing but ConnectionClosed. In all three uvicorn can no longer
+    # write a response on this connection, so feeding it more inbound bytes can
+    # only produce the spurious 400 attempt described above.
+    #
+    # MUST_CLOSE matters because send_400_response() never sends
+    # ConnectionClosed: it writes the 400 and closes the transport, and h11's
+    # (ERROR, DONE) state-triggered rule then leaves the server at MUST_CLOSE
+    # until connection_lost(). A second proactor read in that window reaches the
+    # same unguarded send_400_response() and raises the same LocalProtocolError,
+    # only with state=MUST_CLOSE. Any non-HTTP bytes spanning more than one read
+    # get there, a browser sent to https://127.0.0.1:<port> included.
     #
     # This deliberately reads our_state and never their_state. A malformed
     # request from a live client is a *remote* violation: h11's next_event()
@@ -76,9 +85,9 @@ def _shutdown_quiet_h11_protocol() -> Union[type, None]:
     # leaves our_state at IDLE or SEND_RESPONSE, exactly so that a server can
     # still answer 400 (h11 docs, "error handling"). So the guard cannot fire
     # on a request uvicorn is still able to reject properly, and h11 only ever
-    # reaches CLOSED from IDLE, DONE or MUST_CLOSE, meaning a response is
+    # reaches CLOSED or MUST_CLOSE from IDLE or DONE, meaning a response is
     # either finished or was never started.
-    terminal_states = (h11.CLOSED, h11.ERROR)
+    terminal_states = (h11.MUST_CLOSE, h11.CLOSED, h11.ERROR)
 
     class _ShutdownQuietH11Protocol(H11Protocol):  # type: ignore[misc, valid-type]
         """H11Protocol that drops reads delivered after the connection closed."""

--- a/studio/backend/utils/uvicorn_h11_shutdown.py
+++ b/studio/backend/utils/uvicorn_h11_shutdown.py
@@ -18,13 +18,20 @@ The sequence, all of it in third-party code:
    ``/api/inference/monitor`` on that keep-alive connection, so a request can
    already be sitting in the socket. On Windows the proactor transport still
    hands it to the protocol after ``close()``:
-   ``_ProactorReadPipeTransport._loop_reading()`` returns early on
-   ``self._closing``, but its ``finally:`` clause calls ``_data_received()``
-   anyway (CPython ``Lib/asyncio/proactor_events.py``). The overlapped
-   ``WSARecv()`` is deliberately not cancelled -- see bpo-33694, cancelling it
-   loses data. The selector transport used on Linux and macOS removes the
-   reader inside ``close()``, so its read callback cannot fire again, which is
-   why this is Windows-only in practice.
+   ``_ProactorReadPipeTransport._loop_reading()`` assigns ``length`` from
+   ``fut.result()`` before it returns early on ``self._closing``, and its
+   ``finally:`` clause then calls ``_data_received()`` anyway (CPython
+   ``Lib/asyncio/proactor_events.py``). ``close()`` does cancel ``_read_fut``,
+   but that cannot help here: a read whose overlapped ``WSARecv()`` already
+   completed had ``_ov`` cleared by ``_OverlappedFuture.set_result()``, so
+   ``cancel()`` is a no-op and the done callback queued before ``close()`` still
+   runs. CPython 3.9 also set ``data = None`` in that branch and so never
+   delivered; 3.10 dropped that line when the reader moved to ``recv_into()``,
+   which is why the report needs 3.10 or newer. The selector transport used on
+   Linux and macOS removes the reader inside ``close()``, and uvloop calls
+   ``_stop_reading()`` inside its own ``close()`` (and does not build on
+   Windows at all), so on every other platform the read callback cannot fire
+   again, which is why this is Windows-only in practice.
 3. h11 sees bytes after it expected EOF, so ``next_event()`` raises
    ``RemoteProtocolError``. uvicorn logs "Invalid HTTP request received." and
    calls ``send_400_response()``, whose very first ``self.conn.send(...)``
@@ -62,6 +69,15 @@ def _shutdown_quiet_h11_protocol() -> Union[type, None]:
     # a previous send violated the state machine. In both cases uvicorn can no
     # longer write a response on this connection, so feeding it more inbound
     # bytes can only produce the spurious 400 attempt described above.
+    #
+    # This deliberately reads our_state and never their_state. A malformed
+    # request from a live client is a *remote* violation: h11's next_event()
+    # calls _process_error(their_role), which moves their_state to ERROR and
+    # leaves our_state at IDLE or SEND_RESPONSE, exactly so that a server can
+    # still answer 400 (h11 docs, "error handling"). So the guard cannot fire
+    # on a request uvicorn is still able to reject properly, and h11 only ever
+    # reaches CLOSED from IDLE, DONE or MUST_CLOSE, meaning a response is
+    # either finished or was never started.
     terminal_states = (h11.CLOSED, h11.ERROR)
 
     class _ShutdownQuietH11Protocol(H11Protocol):  # type: ignore[misc, valid-type]

--- a/studio/backend/utils/uvicorn_h11_shutdown.py
+++ b/studio/backend/utils/uvicorn_h11_shutdown.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Silence uvicorn's h11 shutdown traceback on Windows (issue #8404).
+
+Every clean shutdown on Windows printed an unhandled asyncio traceback ending in
+``h11._util.LocalProtocolError: can't handle event type Response when
+role=SERVER and state=CLOSED``. Nothing breaks, but a full traceback on a normal
+exit reads as a crash and gets reported as one.
+
+The sequence, all of it in third-party code:
+
+1. ``uvicorn.Server.shutdown()`` walks the live connections and calls
+   ``H11Protocol.shutdown()`` (``uvicorn/protocols/http/h11_impl.py``), which
+   sends ``h11.ConnectionClosed()`` -- moving the h11 server state to CLOSED --
+   and then calls ``transport.close()``.
+2. The browser is still polling ``/api/inference/status`` and
+   ``/api/inference/monitor`` on that keep-alive connection, so a request can
+   already be sitting in the socket. On Windows the proactor transport still
+   hands it to the protocol after ``close()``:
+   ``_ProactorReadPipeTransport._loop_reading()`` returns early on
+   ``self._closing``, but its ``finally:`` clause calls ``_data_received()``
+   anyway (CPython ``Lib/asyncio/proactor_events.py``). The overlapped
+   ``WSARecv()`` is deliberately not cancelled -- see bpo-33694, cancelling it
+   loses data. The selector transport used on Linux and macOS removes the
+   reader inside ``close()``, so its read callback cannot fire again, which is
+   why this is Windows-only in practice.
+3. h11 sees bytes after it expected EOF, so ``next_event()`` raises
+   ``RemoteProtocolError``. uvicorn logs "Invalid HTTP request received." and
+   calls ``send_400_response()``, whose very first ``self.conn.send(...)``
+   raises ``LocalProtocolError`` because the server state is CLOSED. Nothing
+   catches it, so it escapes ``data_received()`` back into the proactor read
+   callback and asyncio's default handler prints the traceback.
+
+The fix is to stop step 2 from reaching h11 at all rather than to swallow the
+exception at the end: once we have sent ``ConnectionClosed`` and closed the
+transport, no further byte can legally be written on that connection, so the
+inbound data belongs to a request that will never be answered and dropping it
+is exactly what the selector transport already does. Suppressing the
+``LocalProtocolError`` instead would also hide genuine protocol errors on live
+connections, and it would leave the equally misleading "Invalid HTTP request
+received." warning behind.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Union
+
+
+@lru_cache(maxsize = 1)
+def _shutdown_quiet_h11_protocol() -> Union[type, None]:
+    """Build the ``H11Protocol`` subclass that ignores post-close reads."""
+    try:
+        import h11
+        from uvicorn.protocols.http.h11_impl import H11Protocol
+    except Exception:
+        # Any uvicorn/h11 layout we do not recognise: leave uvicorn untouched.
+        return None
+
+    # our_state CLOSED means we already sent h11.ConnectionClosed(); ERROR means
+    # a previous send violated the state machine. In both cases uvicorn can no
+    # longer write a response on this connection, so feeding it more inbound
+    # bytes can only produce the spurious 400 attempt described above.
+    terminal_states = (h11.CLOSED, h11.ERROR)
+
+    class _ShutdownQuietH11Protocol(H11Protocol):  # type: ignore[misc, valid-type]
+        """H11Protocol that drops reads delivered after the connection closed."""
+
+        def data_received(self, data: bytes) -> None:
+            conn = getattr(self, "conn", None)
+            if conn is not None and conn.our_state in terminal_states:
+                return
+            super().data_received(data)
+
+    return _ShutdownQuietH11Protocol
+
+
+def uvicorn_http_protocol() -> Union[str, type]:
+    """Return the value for ``uvicorn.Config(http = ...)``.
+
+    Yields the patched h11 protocol only when uvicorn would have picked plain
+    h11 anyway, so the httptools fast path is never silently disabled. httptools
+    does not need this: its own 400 path writes straight to the transport with
+    no state machine to violate.
+    """
+    try:
+        from uvicorn.protocols.http.auto import AutoHTTPProtocol
+        from uvicorn.protocols.http.h11_impl import H11Protocol
+    except Exception:
+        return "auto"
+
+    if AutoHTTPProtocol is not H11Protocol:
+        return "auto"
+
+    protocol_class = _shutdown_quiet_h11_protocol()
+    if protocol_class is None:
+        return "auto"
+    return protocol_class


### PR DESCRIPTION
Fixes #8404.

## The bug

Every clean shutdown on Windows ends in an unhandled asyncio traceback:

```
h11._util.LocalProtocolError: can't handle event type Response when role=SERVER and state=CLOSED
```

Nothing actually breaks, but a full traceback on a normal exit reads as a crash and gets reported as one.

## Why

The whole sequence is in third-party code:

1. `uvicorn.Server.shutdown()` calls `H11Protocol.shutdown()`, which sends `h11.ConnectionClosed()` (moving the h11 server state to CLOSED) and then calls `transport.close()`.
2. The browser is still polling `/api/inference/status` and `/api/inference/monitor` on that keep-alive connection, so a request can already be sitting in the socket. On Windows the proactor transport still hands it to the protocol after `close()`: `_ProactorReadPipeTransport._loop_reading()` returns early on `self._closing`, but its `finally:` clause calls `_data_received()` anyway, and the code says so itself with the comment "deliver data later in `finally` clause". `close()` does cancel the read future, but by then the cancel is a no-op: a read whose overlapped has already completed had its `_ov` cleared by `_OverlappedFuture.set_result()`, and the done callback queued before `close()` still runs. The selector transport used on Linux and macOS calls `_remove_reader()` inside `close()`, so its read callback cannot fire again, which is why this is Windows-only in practice.

   This also requires CPython 3.10 or newer. On 3.9 the `_closing` branch sets `data = None` before returning, so nothing is delivered; that line went away when the reader moved to `recv_into()`. Since the requirements still support `python_version < "3.10"`, a Windows install on 3.9 never had the traceback and gains only inert code.

3. h11 sees bytes when it expected EOF, so `next_event()` raises `RemoteProtocolError`. uvicorn logs "Invalid HTTP request received." and calls `send_400_response()`, whose first `self.conn.send(...)` raises `LocalProtocolError` because the server state is CLOSED. Nothing catches it, so it escapes `data_received()` back into the proactor read callback and asyncio's default handler prints the traceback.

The state machine confirms it directly: after a completed keep-alive cycle and `ConnectionClosed()`, the connection sits at CLOSED/MUST_CLOSE, any further inbound bytes give `RemoteProtocolError: Got data when expecting EOF`, and the 400 attempt then gives the `LocalProtocolError` above.

## The fix

Stop step 2 from reaching h11 rather than swallowing the exception at the end. Once `ConnectionClosed` has been sent and the transport closed, no further byte can legally be written on that connection, so the inbound data belongs to a request that will never be answered, and dropping it is exactly what the selector transport already does on Linux.

Suppressing the `LocalProtocolError` instead would also hide genuine protocol errors on live connections, and it would leave the equally misleading "Invalid HTTP request received." warning behind.

`uvicorn_http_protocol()` hands back the patched class only when uvicorn would have picked plain h11 anyway, so the httptools fast path is never silently disabled. httptools does not need this: its own 400 path writes straight to the transport with no state machine to violate. Any unrecognised uvicorn or h11 layout falls back to `"auto"`, leaving uvicorn untouched.

## Tests

`studio/backend/tests/test_uvicorn_h11_shutdown_quiet.py`, covering the terminal-state drop, the live connection still being forwarded, the httptools passthrough, and the import-failure fallback. Reverting the wiring in `run.py`, removing the module, or emptying the guard body each turns the suite red.

