### PR TITLE
Studio: name a connected model the provider dropped instead of its raw id

### DIFF
--- a/studio/frontend/src/features/chat/audio-attachment-adapter.ts
+++ b/studio/frontend/src/features/chat/audio-attachment-adapter.ts
@@ -13,6 +13,7 @@ import type {
   PendingAttachment,
 } from "@assistant-ui/react";
 import { toast } from "sonner";
+import { externalModelLabel } from "./lib/external-model-label";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 
 // crypto.randomUUID is undefined in non-secure contexts (HTTP over a LAN IP).
@@ -44,7 +45,13 @@ export class AudioAttachmentAdapter implements AttachmentAdapter {
         ? "The last model failed to load. Check the server logs, then load a model before adding audio files."
         : "Load a model before adding audio files.";
     } else if (!activeModel?.hasAudioInput) {
-      const label = activeModel?.name || checkpoint || "Current model";
+      // A connected provider's model has no row in `models`, so without the parse this
+      // named it by its raw `external::…` id (#8405).
+      const label =
+        activeModel?.name ||
+        externalModelLabel(checkpoint) ||
+        checkpoint ||
+        "Current model";
       unavailableReason = `${label} cannot accept audio. Load an audio-input model before attaching audio files.`;
     }
     if (unavailableReason) {

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -5,6 +5,7 @@ import {
   applyModelLoadConfigToRuntime,
   currentRuntimePerModelConfig,
   type DeletedModelRef,
+  type ExternalConnectionRef,
   type ExternalModelOption,
   type LoraModelOption,
   type ModelOption,
@@ -539,6 +540,7 @@ const CompareContent = memo(function CompareContent({
   models,
   loraModels,
   externalModels,
+  externalConnections,
   onFoldersChange,
   onModelsChange,
   deleteDisabled,
@@ -549,6 +551,7 @@ const CompareContent = memo(function CompareContent({
   models: ModelOption[];
   loraModels: LoraModelOption[];
   externalModels: ExternalModelOption[];
+  externalConnections: ExternalConnectionRef[];
   onFoldersChange?: () => void;
   onModelsChange?: (deletedModel?: DeletedModelRef) => void;
   deleteDisabled?: boolean;
@@ -569,6 +572,7 @@ const CompareContent = memo(function CompareContent({
       models={models}
       loraModels={loraModels}
       externalModels={externalModels}
+      externalConnections={externalConnections}
       onFoldersChange={onFoldersChange}
       onModelsChange={onModelsChange}
       deleteDisabled={deleteDisabled}
@@ -767,6 +771,7 @@ function GeneralCompareHeader({
   models,
   loraModels,
   externalModels,
+  externalConnections,
   value,
   selectedConfig,
   selectedGgufVariant,
@@ -779,6 +784,7 @@ function GeneralCompareHeader({
   models: ModelOption[];
   loraModels: LoraModelOption[];
   externalModels: ExternalModelOption[];
+  externalConnections: ExternalConnectionRef[];
   value: string;
   selectedConfig?: PerModelConfig | null;
   selectedGgufVariant?: string | null;
@@ -811,6 +817,7 @@ function GeneralCompareHeader({
         models={models}
         loraModels={loraModels}
         externalModels={externalModels}
+        externalConnections={externalConnections}
         value={value}
         selectedConfig={selectedConfig}
         selectedGgufVariant={selectedGgufVariant}
@@ -834,6 +841,7 @@ const GeneralCompareContent = memo(function GeneralCompareContent({
   models,
   loraModels,
   externalModels,
+  externalConnections,
   onFoldersChange,
   onModelsChange,
   deleteDisabled,
@@ -844,6 +852,7 @@ const GeneralCompareContent = memo(function GeneralCompareContent({
   models: ModelOption[];
   loraModels: LoraModelOption[];
   externalModels: ExternalModelOption[];
+  externalConnections: ExternalConnectionRef[];
   onFoldersChange?: () => void;
   onModelsChange?: (deletedModel?: DeletedModelRef) => void;
   deleteDisabled?: boolean;
@@ -942,6 +951,7 @@ const GeneralCompareContent = memo(function GeneralCompareContent({
               models={models}
               loraModels={loraModels}
               externalModels={externalModels}
+              externalConnections={externalConnections}
               value={model1.id}
               selectedConfig={model1.config}
               selectedGgufVariant={model1.ggufVariant}
@@ -973,6 +983,7 @@ const GeneralCompareContent = memo(function GeneralCompareContent({
               models={models}
               loraModels={loraModels}
               externalModels={externalModels}
+              externalConnections={externalConnections}
               value={model2.id}
               selectedConfig={model2.config}
               selectedGgufVariant={model2.ggufVariant}
@@ -3059,6 +3070,25 @@ export function ChatPage({
         ),
     [externalProvidersForChat, lastOpenRouterChosenModel],
   );
+  // `externalModels` above is flat-mapped from `provider.models`, the ids the user ticked,
+  // so a model unticked in the connection dialog leaves it exactly like one the provider
+  // withdrew. The connection also caches the whole fetched catalogue, which tells the two
+  // apart, and the picker needs that to avoid blaming the provider for the user's own edit.
+  // Depends on the store value and the gate rather than on `externalProvidersForChat`,
+  // which is a plain conditional and so hands every hook that reads it a fresh array each
+  // render.
+  const externalConnections = useMemo<ExternalConnectionRef[]>(
+    () =>
+      connectionsEnabled
+        ? externalProviders.map((provider) => ({
+            id: provider.id,
+            name: provider.name,
+            providerType: provider.providerType,
+            availableModels: provider.availableModels,
+          }))
+        : [],
+    [connectionsEnabled, externalProviders],
+  );
 
   const localModelInventory = useDeviceInventorySources(["localModels"], {
     enabled: active,
@@ -3310,6 +3340,7 @@ export function ChatPage({
                 models={models}
                 loraModels={loraModels}
                 externalModels={externalModels}
+                externalConnections={externalConnections}
                 value={inferenceParams.checkpoint}
                 // Resident, not merely picked: an image or video load evicts
                 // the chat model and leaves this selection behind, so the tick
@@ -3547,6 +3578,7 @@ export function ChatPage({
             models={models}
             loraModels={loraModels}
             externalModels={externalModels}
+            externalConnections={externalConnections}
             onFoldersChange={refreshLocalModels}
             onModelsChange={refreshModelLists}
             deleteDisabled={modelOperationInProgress}

--- a/studio/frontend/src/features/chat/lib/external-model-label.ts
+++ b/studio/frontend/src/features/chat/lib/external-model-label.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { parseExternalModelId } from "../external-providers";
+
+/**
+ * The model id a connection was asked for, e.g. `kimi-k2.5`, or null when *id* is not an
+ * `external::<connectionId>::<modelId>` selection.
+ *
+ * A connected model has no row in `store.models`, so every label chain that looks a
+ * checkpoint up there falls through to the checkpoint itself. `buildExternalModelId`
+ * percent-encodes the model id, so the raw string carries no separator any generic shortener
+ * can use and the user is shown `external::6235be0905af4221::kimi-k2.5` (#8405). Put this
+ * ahead of the raw id in those chains.
+ */
+export function externalModelLabel(
+  id: string | null | undefined,
+): string | null {
+  return parseExternalModelId(id)?.modelId ?? null;
+}
+
+/**
+ * The short label for a compare pane's model id: the trailing segment, as the compare
+ * toasts have always shown for a local model.
+ *
+ * A compare pane takes its id straight from the picker, and the compare header offers
+ * connected models, so `external::abc::openai%2Fgpt-5` reached the plain
+ * `id.split("/").pop()` this replaced and came back whole. Parsing first yields `gpt-5`.
+ */
+export function compareModelDisplayName(id: string): string {
+  const value = externalModelLabel(id) ?? id;
+  const parts = value.split("/");
+  return parts[parts.length - 1] || value;
+}

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -111,6 +111,7 @@ import {
   parseExternalModelId,
   providerTypeSupportsVision,
 } from "./external-providers";
+import { compareModelDisplayName } from "./lib/external-model-label";
 import { useExternalProvidersStore } from "./stores/external-providers-store";
 import { useComposerPillFit } from "@/hooks/use-composer-pill-fit";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -1163,11 +1164,6 @@ export function SharedComposer({
       });
       let loadedFromConfig = false;
 
-      function modelDisplayName(id: string): string {
-        const parts = id.split("/");
-        return parts[parts.length - 1] || id;
-      }
-
       // Warm the device cache before the snapshot below reconciles the GPU
       // pick: on a cold cache the reconcile passes a stale pick through.
       try {
@@ -1400,7 +1396,7 @@ export function SharedComposer({
           }
           if (!upgraded) {
             throw new Error(
-              `${modelDisplayName(sel.id)} needs a newer transformers release to load.`,
+              `${compareModelDisplayName(sel.id)} needs a newer transformers release to load.`,
             );
           }
         }
@@ -1419,7 +1415,7 @@ export function SharedComposer({
           });
           if (!approved) {
             throw new Error(
-              `${modelDisplayName(sel.id)} needs custom code approval to load.`,
+              `${compareModelDisplayName(sel.id)} needs custom code approval to load.`,
             );
           }
         }
@@ -1599,8 +1595,8 @@ export function SharedComposer({
       if (handle1) handle1.appendMessage(content);
       if (handle2) handle2.appendMessage(content);
 
-      const name1 = model1?.id ? modelDisplayName(model1.id) : "";
-      const name2 = model2?.id ? modelDisplayName(model2.id) : "";
+      const name1 = model1?.id ? compareModelDisplayName(model1.id) : "";
+      const name2 = model2?.id ? compareModelDisplayName(model2.id) : "";
       const toastId = toast("Comparing models…", { duration: Infinity });
 
       setComparing(true);

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -43,6 +43,8 @@ import {
   resolveInitialConfig,
 } from "../model-config/per-model-config";
 import { ModelConfigPage } from "./model-config-page";
+import { HubModelPicker, hasDownloadedModels } from "./model-selector/pickers";
+import { missingExternalModel } from "./model-selector/missing-external-model";
 import type { CommunityModelPolicy } from "./model-selector/audio-picker-policy";
 import type { CatalogGroup } from "./model-selector/model-catalog";
 import { HubModelPicker, hasDownloadedModels } from "./model-selector/pickers";
@@ -676,6 +678,7 @@ export function ModelSelector({
   const open = controlledOpen ?? uncontrolledOpen;
   const setOpen = onOpenChange ?? setUncontrolledOpen;
   const navigate = useNavigate();
+  const t = useT();
   const [uncontrolled, setUncontrolled] = useState(defaultValue ?? "");
 
   const selected = value ?? uncontrolled;
@@ -735,18 +738,37 @@ export function ModelSelector({
   const currentModel = useMemo(() => {
     if (!selected) return undefined;
     const found = optionById.get(selected);
+    // A connection that dropped the picked model takes its option away and leaves the
+    // id in the checkpoint, and the generic fallback below cannot shorten an
+    // `external::` id. Name the model the user picked, and say it is gone: it cannot be
+    // loaded, so a tidy name on its own would hide the failure until the next send
+    // (#8405).
+    const missingExternal = found
+      ? null
+      : missingExternalModel(selected, externalModels);
     // No catalog entry (yet, or ever); a cached GGUF's checkpoint is a snapshot path.
     // The leaf, not the namespaced public id (#7966), matches the catalog row that
     // later replaces this one.
-    const fallbackName = modelDisplayName(selected);
+    const fallbackName = missingExternal?.modelName ?? modelDisplayName(selected);
     if (activeGgufVariant) {
       const desc = `GGUF · ${activeGgufVariant}`;
       return found
         ? { ...found, description: desc }
         : { id: selected, name: fallbackName, description: desc };
     }
+    if (missingExternal) {
+      return {
+        id: selected,
+        name: fallbackName,
+        description: missingExternal.providerName
+          ? t("picker.modelDroppedByProvider", {
+              provider: missingExternal.providerName,
+            })
+          : t("picker.modelDropped"),
+      };
+    }
     return found ?? { id: selected, name: fallbackName };
-  }, [selected, optionById, activeGgufVariant]);
+  }, [selected, optionById, activeGgufVariant, externalModels, t]);
 
   function handleSelect(id: string, meta: ModelSelectorChangeMeta) {
     if (onValueChange) {

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -44,7 +44,10 @@ import {
 } from "../model-config/per-model-config";
 import { ModelConfigPage } from "./model-config-page";
 import { HubModelPicker, hasDownloadedModels } from "./model-selector/pickers";
-import { missingExternalModel } from "./model-selector/missing-external-model";
+import {
+  type ExternalConnectionRef,
+  missingExternalModel,
+} from "./model-selector/missing-external-model";
 import type { CommunityModelPolicy } from "./model-selector/audio-picker-policy";
 import type { CatalogGroup } from "./model-selector/model-catalog";
 import { HubModelPicker, hasDownloadedModels } from "./model-selector/pickers";
@@ -126,6 +129,7 @@ export type {
   ModelOption,
   ModelSelectorChangeMeta,
 } from "./model-selector/types";
+export type { ExternalConnectionRef } from "./model-selector/missing-external-model";
 
 interface ModelSelectorProps {
   models: ModelOption[];
@@ -136,6 +140,12 @@ interface ModelSelectorProps {
   loadedModelIdOverride?: string;
   loraModels?: LoraModelOption[];
   externalModels?: ExternalModelOption[];
+  /**
+   * The connections behind `externalModels`, carrying each one's cached catalogue.
+   * `externalModels` lists only the models the user ticked, so it cannot tell a model the
+   * user turned off from one the provider withdrew; the catalogue can.
+   */
+  externalConnections?: ExternalConnectionRef[];
   value?: string;
   defaultValue?: string;
   /**
@@ -645,6 +655,7 @@ export function ModelSelector({
   loadedModelIdOverride,
   loraModels = [],
   externalModels = [],
+  externalConnections = [],
   value,
   defaultValue,
   activeGgufVariant,
@@ -738,14 +749,15 @@ export function ModelSelector({
   const currentModel = useMemo(() => {
     if (!selected) return undefined;
     const found = optionById.get(selected);
-    // A connection that dropped the picked model takes its option away and leaves the
+    // A pick whose connection no longer offers it takes its option away and leaves the
     // id in the checkpoint, and the generic fallback below cannot shorten an
-    // `external::` id. Name the model the user picked, and say it is gone: it cannot be
-    // loaded, so a tidy name on its own would hide the failure until the next send
-    // (#8405).
+    // `external::` id. Name the model the user picked, and say why it is unusable: it
+    // cannot be loaded, so a tidy name on its own would hide the failure until the next
+    // send (#8405). The connections carry the cached catalogue, which is what separates a
+    // model the user unticked from one the provider withdrew.
     const missingExternal = found
       ? null
-      : missingExternalModel(selected, externalModels);
+      : missingExternalModel(selected, externalModels, externalConnections);
     // No catalog entry (yet, or ever); a cached GGUF's checkpoint is a snapshot path.
     // The leaf, not the namespaced public id (#7966), matches the catalog row that
     // later replaces this one.
@@ -757,18 +769,29 @@ export function ModelSelector({
         : { id: selected, name: fallbackName, description: desc };
     }
     if (missingExternal) {
+      const disabled = missingExternal.state === "disabled";
       return {
         id: selected,
         name: fallbackName,
         description: missingExternal.providerName
-          ? t("picker.modelDroppedByProvider", {
-              provider: missingExternal.providerName,
-            })
-          : t("picker.modelDropped"),
+          ? t(
+              disabled
+                ? "picker.modelDisabledByProvider"
+                : "picker.modelDroppedByProvider",
+              { provider: missingExternal.providerName },
+            )
+          : t(disabled ? "picker.modelDisabled" : "picker.modelDropped"),
       };
     }
     return found ?? { id: selected, name: fallbackName };
-  }, [selected, optionById, activeGgufVariant, externalModels, t]);
+  }, [
+    selected,
+    optionById,
+    activeGgufVariant,
+    externalModels,
+    externalConnections,
+    t,
+  ]);
 
   function handleSelect(id: string, meta: ModelSelectorChangeMeta) {
     if (onValueChange) {

--- a/studio/frontend/src/features/model-picker/components/model-selector/missing-external-model.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/missing-external-model.ts
@@ -2,7 +2,10 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 // eslint-disable-next-line no-restricted-imports -- Avoid the chat barrel's React exports.
-import { parseExternalModelId } from "@/features/chat/external-providers";
+import {
+  allowsManualModelIdsWithCatalog,
+  parseExternalModelId,
+} from "@/features/chat/external-providers";
 
 /** The connection fields the picker carries for every model a connection offers. */
 export interface ExternalModelRef {
@@ -66,11 +69,14 @@ export interface MissingExternalModel {
  * `availableModels`. Since `externalModels` is flat-mapped from `models`, the enabled list
  * alone cannot tell the two apart and naming the provider there accuses it of a withdrawal
  * the user performed. `dropped` is therefore claimed only on positive evidence: a catalogue
- * that was cached, is non-empty, and does not list the model. Anything less, including a
- * connection saved before `availableModels` existed, is reported as `disabled`, whose
- * wording is true whenever the id is absent from `models` and which claims nothing about the
- * provider. A connection that is not in *connections* at all is not a claim we can soften,
- * so it keeps the `dropped` reading it has always had.
+ * that was cached, is non-empty, does not list the model, and could have listed it in the
+ * first place. That last clause rules out the connections whose dialog offers a manual
+ * model-ID box beside the fetched list, since a typed-in ID is saved to `models` only and a
+ * catalogue that never carried it says nothing when the user later deletes it. Anything
+ * less, including a connection saved before `availableModels` existed, is reported as
+ * `disabled`, whose wording is true whenever the id is absent from `models` and which claims
+ * nothing about the provider. A connection that is not in *connections* at all is not a
+ * claim we can soften, so it keeps the `dropped` reading it has always had.
  */
 export function missingExternalModel(
   selected: string | null | undefined,
@@ -92,12 +98,19 @@ export function missingExternalModel(
     (entry) => entry.id === parsed.providerId,
   );
   const catalog = connection?.availableModels;
+  // Ollama, vLLM, llama.cpp and OpenRouter take typed-in model IDs beside the fetched list,
+  // and the dialog saves those to `models` alone, so their catalogue never carried them and
+  // its silence about one is not evidence of anything.
+  const catalogCoversEveryId = !allowsManualModelIdsWithCatalog(
+    connection?.providerType,
+  );
   // `modelId` is decoded and `availableModels` holds raw provider ids, so these compare
   // directly; an empty catalogue is unknown rather than empty, since a connection with no
   // enabled models never gets one written.
   const dropped =
     connection == null ||
-    (catalog != null &&
+    (catalogCoversEveryId &&
+      catalog != null &&
       catalog.length > 0 &&
       !catalog.includes(parsed.modelId));
   if (dropped) {

--- a/studio/frontend/src/features/model-picker/components/model-selector/missing-external-model.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/missing-external-model.ts
@@ -12,18 +12,41 @@ export interface ExternalModelRef {
   providerType: string;
 }
 
-export interface MissingExternalModel {
-  /** The model as the user picked it, e.g. `kimi-k2.5`. */
-  modelName: string;
-  /** The connection's display name, when it still offers at least one other model. */
-  providerName: string | null;
-  /** Registry key (e.g. openai, ollama), from the same sibling entry. */
-  providerType: string | null;
+/**
+ * The connection-level fields this helper needs beyond the enabled options: a connection
+ * caches the provider's whole catalogue in `availableModels`, while `models` holds only the
+ * subset the user ticked, and `externalModels` is built from `models` alone.
+ */
+export interface ExternalConnectionRef {
+  id: string;
+  name: string;
+  providerType?: string;
+  /** Cached catalogue from the provider's /models response, when one was ever stored. */
+  availableModels?: readonly string[];
 }
 
 /**
- * Describes an `external::<connectionId>::<modelId>` selection that its connection no
- * longer offers, or null for any other selection.
+ * Why the selection has no option behind it.
+ *
+ * `disabled` is the user's own doing and reversible from the connection dialog; `dropped` is
+ * the provider's, and no amount of re-ticking brings the model back.
+ */
+export type MissingExternalModelState = "disabled" | "dropped";
+
+export interface MissingExternalModel {
+  /** The model as the user picked it, e.g. `kimi-k2.5`. */
+  modelName: string;
+  /** The connection's display name, when one can be read. */
+  providerName: string | null;
+  /** Registry key (e.g. openai, ollama), from the same source as the name. */
+  providerType: string | null;
+  /** Which of the two ways the option went away. */
+  state: MissingExternalModelState;
+}
+
+/**
+ * Describes an `external::<connectionId>::<modelId>` selection with no option behind it, or
+ * null for any other selection.
  *
  * Fetch Models replaces a connection's model list wholesale, and nothing reconciles the
  * active pick against it, so a model the provider dropped leaves the picker's option list
@@ -32,14 +55,27 @@ export interface MissingExternalModel {
  * path-shaped nor a `org/name` repo id, so the trigger printed the raw `external::…` string
  * for a model that can no longer be loaded (#8405).
  *
- * Parsing recovers the name the user actually picked, and the connection's display name
- * comes from any sibling model still listed under the same connection id. A connection that
- * dropped every model has no sibling to read, so `providerName` is null and the caller says
- * only that the model is gone.
+ * Parsing recovers the name the user actually picked. The connection's display name comes
+ * from any sibling model still listed under the same connection id, and for a disabled pick
+ * from the connection itself, which is still there even when every one of its models is
+ * unticked.
+ *
+ * An option can go away two ways, and only one of them is the provider's doing. The
+ * connection dialog saves the ticked ids as `models` and the fetched catalogue as
+ * `availableModels`, so unticking the active model drops it from `models` while it stays in
+ * `availableModels`. Since `externalModels` is flat-mapped from `models`, the enabled list
+ * alone cannot tell the two apart and naming the provider there accuses it of a withdrawal
+ * the user performed. `dropped` is therefore claimed only on positive evidence: a catalogue
+ * that was cached, is non-empty, and does not list the model. Anything less, including a
+ * connection saved before `availableModels` existed, is reported as `disabled`, whose
+ * wording is true whenever the id is absent from `models` and which claims nothing about the
+ * provider. A connection that is not in *connections* at all is not a claim we can soften,
+ * so it keeps the `dropped` reading it has always had.
  */
 export function missingExternalModel(
   selected: string | null | undefined,
   externalModels: readonly ExternalModelRef[],
+  connections: readonly ExternalConnectionRef[] = [],
 ): MissingExternalModel | null {
   const parsed = parseExternalModelId(selected);
   if (!parsed) {
@@ -52,9 +88,30 @@ export function missingExternalModel(
   const sibling = externalModels.find(
     (option) => option.providerId === parsed.providerId,
   );
+  const connection = connections.find(
+    (entry) => entry.id === parsed.providerId,
+  );
+  const catalog = connection?.availableModels;
+  // `modelId` is decoded and `availableModels` holds raw provider ids, so these compare
+  // directly; an empty catalogue is unknown rather than empty, since a connection with no
+  // enabled models never gets one written.
+  const dropped =
+    connection == null ||
+    (catalog != null &&
+      catalog.length > 0 &&
+      !catalog.includes(parsed.modelId));
+  if (dropped) {
+    return {
+      modelName: parsed.modelId,
+      providerName: sibling?.providerName ?? null,
+      providerType: sibling?.providerType ?? null,
+      state: "dropped",
+    };
+  }
   return {
     modelName: parsed.modelId,
-    providerName: sibling?.providerName ?? null,
-    providerType: sibling?.providerType ?? null,
+    providerName: sibling?.providerName ?? connection.name,
+    providerType: sibling?.providerType ?? connection.providerType ?? null,
+    state: "disabled",
   };
 }

--- a/studio/frontend/src/features/model-picker/components/model-selector/missing-external-model.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/missing-external-model.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// eslint-disable-next-line no-restricted-imports -- Avoid the chat barrel's React exports.
+import { parseExternalModelId } from "@/features/chat/external-providers";
+
+/** The connection fields the picker carries for every model a connection offers. */
+export interface ExternalModelRef {
+  id: string;
+  providerId: string;
+  providerName: string;
+  providerType: string;
+}
+
+export interface MissingExternalModel {
+  /** The model as the user picked it, e.g. `kimi-k2.5`. */
+  modelName: string;
+  /** The connection's display name, when it still offers at least one other model. */
+  providerName: string | null;
+  /** Registry key (e.g. openai, ollama), from the same sibling entry. */
+  providerType: string | null;
+}
+
+/**
+ * Describes an `external::<connectionId>::<modelId>` selection that its connection no
+ * longer offers, or null for any other selection.
+ *
+ * Fetch Models replaces a connection's model list wholesale, and nothing reconciles the
+ * active pick against it, so a model the provider dropped leaves the picker's option list
+ * while its id stays in `params.checkpoint`. The picker's generic fallback cannot shorten
+ * that id: `modelDisplayName` is an exact identity function for it, since the id is neither
+ * path-shaped nor a `org/name` repo id, so the trigger printed the raw `external::…` string
+ * for a model that can no longer be loaded (#8405).
+ *
+ * Parsing recovers the name the user actually picked, and the connection's display name
+ * comes from any sibling model still listed under the same connection id. A connection that
+ * dropped every model has no sibling to read, so `providerName` is null and the caller says
+ * only that the model is gone.
+ */
+export function missingExternalModel(
+  selected: string | null | undefined,
+  externalModels: readonly ExternalModelRef[],
+): MissingExternalModel | null {
+  const parsed = parseExternalModelId(selected);
+  if (!parsed) {
+    return null;
+  }
+  // Still offered: the option carries a real name and never reaches the fallback.
+  if (externalModels.some((option) => option.id === selected)) {
+    return null;
+  }
+  const sibling = externalModels.find(
+    (option) => option.providerId === parsed.providerId,
+  );
+  return {
+    modelName: parsed.modelId,
+    providerName: sibling?.providerName ?? null,
+    providerType: sibling?.providerType ?? null,
+  };
+}

--- a/studio/frontend/src/features/model-picker/index.ts
+++ b/studio/frontend/src/features/model-picker/index.ts
@@ -29,6 +29,7 @@ export {
 export { useActiveModelConfig } from "./hooks/use-active-model-config";
 export type {
   DeletedModelRef,
+  ExternalConnectionRef,
   ExternalModelOption,
   LoraModelOption,
   ModelOption,

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -20,6 +20,8 @@ export const ar = {
     pickModelFile: "اختيار ملف نموذج من القرص",
     modelDropped: "لم يعد متاحًا",
     modelDroppedByProvider: "{provider} · لم يعد متاحًا",
+    modelDisabled: "غير مُفعَّل",
+    modelDisabledByProvider: "{provider} · غير مُفعَّل",
     multipleMatches:
       "توجد عدة نتائج مطابقة ضمن {noun}. اختر نتيجة من القائمة.",
     rateLimitedTitle: "تم بلوغ حد طلبات Hugging Face",

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -18,6 +18,8 @@ export const ar = {
     modelSourceAriaLabel: "مصدر النموذج",
     hubSectionAriaLabel: "قسم Hub",
     pickModelFile: "اختيار ملف نموذج من القرص",
+    modelDropped: "لم يعد متاحًا",
+    modelDroppedByProvider: "{provider} · لم يعد متاحًا",
     multipleMatches:
       "توجد عدة نتائج مطابقة ضمن {noun}. اختر نتيجة من القائمة.",
     rateLimitedTitle: "تم بلوغ حد طلبات Hugging Face",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -18,7 +18,7 @@ export const de = {
     modelSourceAriaLabel: "Modellquelle",
     hubSectionAriaLabel: "Hub-Bereich",
     pickModelFile: "Modelldatei vom Datenträger auswählen",
-    modelDropped: "Nicht mehr verfügbar",
+    modelDropped: "Nicht mehr angeboten",
     modelDroppedByProvider: "{provider} · nicht mehr angeboten",
     multipleMatches:
       "Mehrere passende {noun} gefunden. Wählen Sie einen Eintrag aus der Liste aus.",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -20,6 +20,8 @@ export const de = {
     pickModelFile: "Modelldatei vom Datenträger auswählen",
     modelDropped: "Nicht mehr angeboten",
     modelDroppedByProvider: "{provider} · nicht mehr angeboten",
+    modelDisabled: "Nicht aktiviert",
+    modelDisabledByProvider: "{provider} · nicht aktiviert",
     multipleMatches:
       "Mehrere passende {noun} gefunden. Wählen Sie einen Eintrag aus der Liste aus.",
     rateLimitedTitle: "Hugging Face-Ratenlimit erreicht",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -18,6 +18,8 @@ export const de = {
     modelSourceAriaLabel: "Modellquelle",
     hubSectionAriaLabel: "Hub-Bereich",
     pickModelFile: "Modelldatei vom Datenträger auswählen",
+    modelDropped: "Nicht mehr verfügbar",
+    modelDroppedByProvider: "{provider} · nicht mehr angeboten",
     multipleMatches:
       "Mehrere passende {noun} gefunden. Wählen Sie einen Eintrag aus der Liste aus.",
     rateLimitedTitle: "Hugging Face-Ratenlimit erreicht",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -14,6 +14,8 @@ export const en = {
     modelSourceAriaLabel: "Model source",
     hubSectionAriaLabel: "Hub section",
     pickModelFile: "Pick a model file from disk",
+    modelDropped: "No longer offered",
+    modelDroppedByProvider: "{provider} · no longer offered",
     multipleMatches: "Multiple matching {noun}. Choose one from the list.",
     rateLimitedTitle: "Hugging Face rate limit reached",
     rateLimitedBody: "Wait a moment, then retry searching {noun}.",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -16,6 +16,8 @@ export const en = {
     pickModelFile: "Pick a model file from disk",
     modelDropped: "No longer offered",
     modelDroppedByProvider: "{provider} · no longer offered",
+    modelDisabled: "Not enabled",
+    modelDisabledByProvider: "{provider} · not enabled",
     multipleMatches: "Multiple matching {noun}. Choose one from the list.",
     rateLimitedTitle: "Hugging Face rate limit reached",
     rateLimitedBody: "Wait a moment, then retry searching {noun}.",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -18,6 +18,8 @@ export const es = {
     modelSourceAriaLabel: "Origen del modelo",
     hubSectionAriaLabel: "Sección del Hub",
     pickModelFile: "Elegir un archivo de modelo del disco",
+    modelDropped: "Ya no está disponible",
+    modelDroppedByProvider: "{provider} · ya no se ofrece",
     multipleMatches:
       "Hay varios {noun} coincidentes. Elige uno de la lista.",
     rateLimitedTitle: "Se alcanzó el límite de solicitudes de Hugging Face",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -20,6 +20,8 @@ export const es = {
     pickModelFile: "Elegir un archivo de modelo del disco",
     modelDropped: "Ya no se ofrece",
     modelDroppedByProvider: "{provider} · ya no se ofrece",
+    modelDisabled: "No activado",
+    modelDisabledByProvider: "{provider} · no activado",
     multipleMatches:
       "Hay varios {noun} coincidentes. Elige uno de la lista.",
     rateLimitedTitle: "Se alcanzó el límite de solicitudes de Hugging Face",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -18,7 +18,7 @@ export const es = {
     modelSourceAriaLabel: "Origen del modelo",
     hubSectionAriaLabel: "Sección del Hub",
     pickModelFile: "Elegir un archivo de modelo del disco",
-    modelDropped: "Ya no está disponible",
+    modelDropped: "Ya no se ofrece",
     modelDroppedByProvider: "{provider} · ya no se ofrece",
     multipleMatches:
       "Hay varios {noun} coincidentes. Elige uno de la lista.",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -18,6 +18,8 @@ export const fr = {
     modelSourceAriaLabel: "Source du modèle",
     hubSectionAriaLabel: "Section du Hub",
     pickModelFile: "Choisir un fichier de modèle sur le disque",
+    modelDropped: "Plus proposé",
+    modelDroppedByProvider: "{provider} · plus proposé",
     multipleMatches:
       "Plusieurs {noun} correspondent. Choisissez-en un dans la liste.",
     rateLimitedTitle: "Limite de requêtes Hugging Face atteinte",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -20,6 +20,8 @@ export const fr = {
     pickModelFile: "Choisir un fichier de modèle sur le disque",
     modelDropped: "N'est plus proposé",
     modelDroppedByProvider: "{provider} · n'est plus proposé",
+    modelDisabled: "Non activé",
+    modelDisabledByProvider: "{provider} · non activé",
     multipleMatches:
       "Plusieurs {noun} correspondent. Choisissez-en un dans la liste.",
     rateLimitedTitle: "Limite de requêtes Hugging Face atteinte",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -18,8 +18,8 @@ export const fr = {
     modelSourceAriaLabel: "Source du modèle",
     hubSectionAriaLabel: "Section du Hub",
     pickModelFile: "Choisir un fichier de modèle sur le disque",
-    modelDropped: "Plus proposé",
-    modelDroppedByProvider: "{provider} · plus proposé",
+    modelDropped: "N'est plus proposé",
+    modelDroppedByProvider: "{provider} · n'est plus proposé",
     multipleMatches:
       "Plusieurs {noun} correspondent. Choisissez-en un dans la liste.",
     rateLimitedTitle: "Limite de requêtes Hugging Face atteinte",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -18,6 +18,8 @@ export const hi = {
     modelSourceAriaLabel: "मॉडल स्रोत",
     hubSectionAriaLabel: "Hub सेक्शन",
     pickModelFile: "डिस्क से मॉडल फ़ाइल चुनें",
+    modelDropped: "अब उपलब्ध नहीं",
+    modelDroppedByProvider: "{provider} · अब उपलब्ध नहीं",
     multipleMatches:
       "एक से अधिक मेल खाते {noun} मिले। सूची में से एक चुनें।",
     rateLimitedTitle: "Hugging Face की अनुरोध सीमा पूरी हो गई",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -20,6 +20,8 @@ export const hi = {
     pickModelFile: "डिस्क से मॉडल फ़ाइल चुनें",
     modelDropped: "अब उपलब्ध नहीं",
     modelDroppedByProvider: "{provider} · अब उपलब्ध नहीं",
+    modelDisabled: "सक्षम नहीं",
+    modelDisabledByProvider: "{provider} · सक्षम नहीं",
     multipleMatches:
       "एक से अधिक मेल खाते {noun} मिले। सूची में से एक चुनें।",
     rateLimitedTitle: "Hugging Face की अनुरोध सीमा पूरी हो गई",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -1200,7 +1200,7 @@ export const it = {
     modelSourceAriaLabel: "Origine del modello",
     hubSectionAriaLabel: "Sezione Hub",
     pickModelFile: "Scegli un file del modello dal disco",
-    modelDropped: "Non più disponibile",
+    modelDropped: "Non più offerto",
     modelDroppedByProvider: "{provider} · non più offerto",
     multipleMatches:
       "Sono stati trovati più {noun} corrispondenti. Scegline uno dall'elenco.",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -1202,6 +1202,8 @@ export const it = {
     pickModelFile: "Scegli un file del modello dal disco",
     modelDropped: "Non più offerto",
     modelDroppedByProvider: "{provider} · non più offerto",
+    modelDisabled: "Non attivato",
+    modelDisabledByProvider: "{provider} · non attivato",
     multipleMatches:
       "Sono stati trovati più {noun} corrispondenti. Scegline uno dall'elenco.",
     rateLimitedTitle: "Limite di richieste di Hugging Face raggiunto",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -1200,6 +1200,8 @@ export const it = {
     modelSourceAriaLabel: "Origine del modello",
     hubSectionAriaLabel: "Sezione Hub",
     pickModelFile: "Scegli un file del modello dal disco",
+    modelDropped: "Non più disponibile",
+    modelDroppedByProvider: "{provider} · non più offerto",
     multipleMatches:
       "Sono stati trovati più {noun} corrispondenti. Scegline uno dall'elenco.",
     rateLimitedTitle: "Limite di richieste di Hugging Face raggiunto",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -21,6 +21,8 @@ export const ja = {
     pickModelFile: "ディスクからモデルファイルを選択",
     modelDropped: "提供終了",
     modelDroppedByProvider: "{provider} · 提供終了",
+    modelDisabled: "無効",
+    modelDisabledByProvider: "{provider} · 無効",
     multipleMatches:
       "一致する{noun}が複数あります。リストから1つ選択してください。",
     rateLimitedTitle: "Hugging Face のレート制限に達しました",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -19,6 +19,8 @@ export const ja = {
     modelSourceAriaLabel: "モデルのソース",
     hubSectionAriaLabel: "Hub セクション",
     pickModelFile: "ディスクからモデルファイルを選択",
+    modelDropped: "提供終了",
+    modelDroppedByProvider: "{provider} · 提供終了",
     multipleMatches:
       "一致する{noun}が複数あります。リストから1つ選択してください。",
     rateLimitedTitle: "Hugging Face のレート制限に達しました",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -17,6 +17,8 @@ export const ko = {
     modelSourceAriaLabel: "모델 소스",
     hubSectionAriaLabel: "Hub 섹션",
     pickModelFile: "디스크에서 모델 파일 선택",
+    modelDropped: "더 이상 제공되지 않음",
+    modelDroppedByProvider: "{provider} · 더 이상 제공되지 않음",
     multipleMatches:
       "일치하는 {noun} 항목이 여러 개 있습니다. 목록에서 하나를 선택하세요.",
     rateLimitedTitle: "Hugging Face 요청 한도에 도달했습니다",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -19,6 +19,8 @@ export const ko = {
     pickModelFile: "디스크에서 모델 파일 선택",
     modelDropped: "더 이상 제공되지 않음",
     modelDroppedByProvider: "{provider} · 더 이상 제공되지 않음",
+    modelDisabled: "사용 안 함",
+    modelDisabledByProvider: "{provider} · 사용 안 함",
     multipleMatches:
       "일치하는 {noun} 항목이 여러 개 있습니다. 목록에서 하나를 선택하세요.",
     rateLimitedTitle: "Hugging Face 요청 한도에 도달했습니다",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -18,6 +18,8 @@ export const ptBR = {
     modelSourceAriaLabel: "Origem do modelo",
     hubSectionAriaLabel: "Seção do Hub",
     pickModelFile: "Escolher um arquivo de modelo no disco",
+    modelDropped: "Não é mais oferecido",
+    modelDroppedByProvider: "{provider} · não é mais oferecido",
     multipleMatches:
       "Há vários {noun} correspondentes. Escolha uma opção na lista.",
     rateLimitedTitle: "Limite de requisições do Hugging Face atingido",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -20,6 +20,8 @@ export const ptBR = {
     pickModelFile: "Escolher um arquivo de modelo no disco",
     modelDropped: "Não é mais oferecido",
     modelDroppedByProvider: "{provider} · não é mais oferecido",
+    modelDisabled: "Não ativado",
+    modelDisabledByProvider: "{provider} · não ativado",
     multipleMatches:
       "Há vários {noun} correspondentes. Escolha uma opção na lista.",
     rateLimitedTitle: "Limite de requisições do Hugging Face atingido",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -18,6 +18,8 @@ export const ru = {
     modelSourceAriaLabel: "Источник модели",
     hubSectionAriaLabel: "Раздел Hub",
     pickModelFile: "Выбрать файл модели на диске",
+    modelDropped: "Больше не предлагается",
+    modelDroppedByProvider: "{provider} · больше не предлагается",
     multipleMatches:
       "В категории «{noun}» найдено несколько совпадений. Выберите одно из списка.",
     rateLimitedTitle: "Достигнут лимит запросов Hugging Face",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -20,6 +20,8 @@ export const ru = {
     pickModelFile: "Выбрать файл модели на диске",
     modelDropped: "Больше не предлагается",
     modelDroppedByProvider: "{provider} · больше не предлагается",
+    modelDisabled: "Не включена",
+    modelDisabledByProvider: "{provider} · не включена",
     multipleMatches:
       "В категории «{noun}» найдено несколько совпадений. Выберите одно из списка.",
     rateLimitedTitle: "Достигнут лимит запросов Hugging Face",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -19,6 +19,8 @@ export const zhCN = {
     pickModelFile: "从磁盘选择模型文件",
     modelDropped: "已不再提供",
     modelDroppedByProvider: "{provider} · 已不再提供",
+    modelDisabled: "未启用",
+    modelDisabledByProvider: "{provider} · 未启用",
     multipleMatches: "找到多个匹配的{noun}。请从列表中选择一个。",
     rateLimitedTitle: "已达到 Hugging Face 速率限制",
     rateLimitedBody: "请稍候，然后重试搜索{noun}。",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -17,6 +17,8 @@ export const zhCN = {
     modelSourceAriaLabel: "模型来源",
     hubSectionAriaLabel: "Hub 分区",
     pickModelFile: "从磁盘选择模型文件",
+    modelDropped: "已不再提供",
+    modelDroppedByProvider: "{provider} · 已不再提供",
     multipleMatches: "找到多个匹配的{noun}。请从列表中选择一个。",
     rateLimitedTitle: "已达到 Hugging Face 速率限制",
     rateLimitedBody: "请稍候，然后重试搜索{noun}。",

--- a/studio/frontend/tests/external-model-selection-label.test.ts
+++ b/studio/frontend/tests/external-model-selection-label.test.ts
@@ -15,7 +15,10 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
 import { modelDisplayName } from "../src/features/hub/lib/model-identity.ts";
-import type { ExternalModelRef } from "../src/features/model-picker/components/model-selector/missing-external-model.ts";
+import type {
+  ExternalConnectionRef,
+  ExternalModelRef,
+} from "../src/features/model-picker/components/model-selector/missing-external-model.ts";
 import { registerBundlerResolver } from "./helpers/kit.ts";
 
 // Both helpers reach across the tree the way vite resolves it: the "@/" alias and an
@@ -43,6 +46,16 @@ const option = (
   ...overrides,
 });
 
+const connection = (
+  overrides: Partial<ExternalConnectionRef> = {},
+): ExternalConnectionRef => ({
+  id: CONNECTION_ID,
+  name: "Ollama",
+  providerType: "ollama",
+  availableModels: ["llama3.2", "kimi-k2.5"],
+  ...overrides,
+});
+
 // The premise: the shared helper cannot shorten this id, which is why the picker's
 // fallback printed it verbatim.
 test("the generic display helper leaves an external id untouched", () => {
@@ -50,12 +63,18 @@ test("the generic display helper leaves an external id untouched", () => {
 });
 
 test("a dropped connected model is named, never shown as its raw id", () => {
-  // Fetch Models replaced the connection's list and kimi-k2.5 is no longer in it.
-  const missing = missingExternalModel(DROPPED_ID, [option("llama3.2")]);
+  // Fetch Models replaced both lists and kimi-k2.5 is in neither, so the catalogue is
+  // positive evidence that the provider withdrew it.
+  const missing = missingExternalModel(
+    DROPPED_ID,
+    [option("llama3.2")],
+    [connection({ availableModels: ["llama3.2"] })],
+  );
   assert.deepEqual(missing, {
     modelName: "kimi-k2.5",
     providerName: "Ollama",
     providerType: "ollama",
+    state: "dropped",
   });
   assert.doesNotMatch(missing?.modelName ?? "", /external::/);
 });
@@ -65,6 +84,7 @@ test("a connection that dropped every model still names the model", () => {
     modelName: "kimi-k2.5",
     providerName: null,
     providerType: null,
+    state: "dropped",
   });
 });
 
@@ -79,7 +99,89 @@ test("a sibling under a different connection does not lend its name", () => {
     modelName: "kimi-k2.5",
     providerName: null,
     providerType: null,
+    state: "dropped",
   });
+});
+
+// The connection dialog writes the ticked ids to `models` and the fetched catalogue to
+// `availableModels`, and the picker's option list is built from `models` alone. Unticking
+// the active model therefore looks exactly like a withdrawal unless the catalogue is
+// consulted, and blaming the provider for the user's own edit is what these cover.
+test("a model the user unticked is reported as disabled, not dropped", () => {
+  assert.deepEqual(
+    missingExternalModel(DROPPED_ID, [option("llama3.2")], [connection()]),
+    {
+      modelName: "kimi-k2.5",
+      providerName: "Ollama",
+      providerType: "ollama",
+      state: "disabled",
+    },
+  );
+});
+
+test("unticking every model still names the connection", () => {
+  // No sibling option survives, so the connection itself is the only source for the name.
+  assert.deepEqual(missingExternalModel(DROPPED_ID, [], [connection()]), {
+    modelName: "kimi-k2.5",
+    providerName: "Ollama",
+    providerType: "ollama",
+    state: "disabled",
+  });
+});
+
+test("a connection saved before availableModels existed is not called dropped", () => {
+  // Legacy persisted connections carry no catalogue at all. Absent evidence, the claim the
+  // provider withdrew the model is exactly the guess that produced the wrong label, so the
+  // neutral reading wins: the id is out of `models`, which is all "not enabled" asserts.
+  assert.deepEqual(
+    missingExternalModel(
+      DROPPED_ID,
+      [option("llama3.2")],
+      [connection({ availableModels: undefined })],
+    ),
+    {
+      modelName: "kimi-k2.5",
+      providerName: "Ollama",
+      providerType: "ollama",
+      state: "disabled",
+    },
+  );
+});
+
+test("an empty cached catalogue is unknown, not proof of a withdrawal", () => {
+  assert.equal(
+    missingExternalModel(
+      DROPPED_ID,
+      [option("llama3.2")],
+      [connection({ availableModels: [] })],
+    )?.state,
+    "disabled",
+  );
+});
+
+test("another connection's catalogue does not vouch for this one", () => {
+  const missing = missingExternalModel(
+    DROPPED_ID,
+    [option("llama3.2")],
+    [
+      connection({ availableModels: ["llama3.2"] }),
+      connection({
+        id: "other",
+        name: "OpenRouter",
+        providerType: "openrouter",
+        availableModels: ["kimi-k2.5"],
+      }),
+    ],
+  );
+  assert.equal(missing?.state, "dropped");
+});
+
+test("re-ticking the model clears the label entirely", () => {
+  const restored = option("kimi-k2.5");
+  assert.equal(
+    missingExternalModel(restored.id, [restored], [connection()]),
+    null,
+  );
 });
 
 test("a percent-encoded model id is decoded for display", () => {
@@ -167,14 +269,35 @@ test("the picker trigger resolves a dropped connected model before naming it", (
   assert.ok(memo, "currentModel not found in model-selector.tsx");
   assert.match(
     memo,
-    /missingExternalModel\(\s*selected,\s*externalModels,?\s*\)/,
-    "the fallback must consult the connected-model list before modelDisplayName",
+    /missingExternalModel\(\s*selected,\s*externalModels,\s*externalConnections,?\s*\)/,
+    "the fallback must consult the connections as well as the enabled options",
   );
   // A name alone would hide that the model cannot be loaded, so the trigger says so.
   assert.match(memo, /picker\.modelDroppedByProvider/);
   assert.match(memo, /picker\.modelDropped\b/);
-  // A memo that reads externalModels must list it, or the label survives a refresh.
+  // The enabled list alone cannot tell a disabled model from a withdrawn one, so both
+  // readings must be reachable from here.
+  assert.match(memo, /picker\.modelDisabledByProvider/);
+  assert.match(memo, /picker\.modelDisabled\b/);
+  // A memo that reads these must list them, or the label survives a refresh.
   assert.match(memo, /\[[^\]]*\bexternalModels\b[^\]]*\]\s*\)?\s*$/);
+  assert.match(memo, /\[[^\]]*\bexternalConnections\b[^\]]*\]\s*\)?\s*$/);
+});
+
+// The catalogue only reaches the picker if chat-page builds it from the connections and
+// passes it down both the single-chat and compare paths.
+test("the chat page feeds the picker the connections behind the options", () => {
+  const page = readFileSync(
+    fileURLToPath(new URL("../src/features/chat/chat-page.tsx", import.meta.url)),
+    "utf8",
+  );
+  assert.match(page, /availableModels: provider\.availableModels/);
+  // Once for the memo's own type, then every hop from chat-page to the picker.
+  assert.ok(
+    (page.match(/externalConnections=\{externalConnections\}/g) ?? []).length >=
+      5,
+    "externalConnections must reach the picker on both the chat and compare paths",
+  );
 });
 
 test("the compare and audio toasts use the external-aware labels", () => {
@@ -237,5 +360,16 @@ test("the dropped-model strings are translated everywhere", async () => {
     assert.equal(typeof picker.modelDropped, "string", locale);
     assert.equal(typeof picker.modelDroppedByProvider, "string", locale);
     assert.match(picker.modelDroppedByProvider, /\{provider\}/, locale);
+    assert.equal(typeof picker.modelDisabled, "string", locale);
+    assert.equal(typeof picker.modelDisabledByProvider, "string", locale);
+    assert.match(picker.modelDisabledByProvider, /\{provider\}/, locale);
+    // The two readings make different claims, so a locale that reuses one string for both
+    // puts the withdrawal wording back on the user's own edit.
+    assert.notEqual(picker.modelDisabled, picker.modelDropped, locale);
+    assert.notEqual(
+      picker.modelDisabledByProvider,
+      picker.modelDroppedByProvider,
+      locale,
+    );
   }
 });

--- a/studio/frontend/tests/external-model-selection-label.test.ts
+++ b/studio/frontend/tests/external-model-selection-label.test.ts
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// #8405: a connected provider that drops the picked model leaves its
+// `external::<connectionId>::<modelId>` id in the checkpoint with no option behind it, and
+// every generic shortener in the app is an identity function for that id. These cover the
+// three surfaces a raw id was verified to reach: the picker trigger, the compare toasts and
+// the audio-attachment toast.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+import { modelDisplayName } from "../src/features/hub/lib/model-identity.ts";
+import type { ExternalModelRef } from "../src/features/model-picker/components/model-selector/missing-external-model.ts";
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+// Both helpers reach across the tree the way vite resolves it: the "@/" alias and an
+// extensionless relative import.
+registerBundlerResolver();
+const { compareModelDisplayName, externalModelLabel } = await import(
+  "../src/features/chat/lib/external-model-label.ts"
+);
+const { missingExternalModel } = await import(
+  "../src/features/model-picker/components/model-selector/missing-external-model.ts"
+);
+
+// The id from the report, built by buildExternalModelId(providerId, "kimi-k2.5").
+const CONNECTION_ID = "6235be0905af4221";
+const DROPPED_ID = `external::${CONNECTION_ID}::kimi-k2.5`;
+
+const option = (
+  modelId: string,
+  overrides: Partial<ExternalModelRef> = {},
+): ExternalModelRef => ({
+  id: `external::${CONNECTION_ID}::${encodeURIComponent(modelId)}`,
+  providerId: CONNECTION_ID,
+  providerName: "Ollama",
+  providerType: "ollama",
+  ...overrides,
+});
+
+// The premise: the shared helper cannot shorten this id, which is why the picker's
+// fallback printed it verbatim.
+test("the generic display helper leaves an external id untouched", () => {
+  assert.equal(modelDisplayName(DROPPED_ID), DROPPED_ID);
+});
+
+test("a dropped connected model is named, never shown as its raw id", () => {
+  // Fetch Models replaced the connection's list and kimi-k2.5 is no longer in it.
+  const missing = missingExternalModel(DROPPED_ID, [option("llama3.2")]);
+  assert.deepEqual(missing, {
+    modelName: "kimi-k2.5",
+    providerName: "Ollama",
+    providerType: "ollama",
+  });
+  assert.doesNotMatch(missing?.modelName ?? "", /external::/);
+});
+
+test("a connection that dropped every model still names the model", () => {
+  assert.deepEqual(missingExternalModel(DROPPED_ID, []), {
+    modelName: "kimi-k2.5",
+    providerName: null,
+    providerType: null,
+  });
+});
+
+test("a sibling under a different connection does not lend its name", () => {
+  const other = option("gpt-5", {
+    id: "external::other::gpt-5",
+    providerId: "other",
+    providerName: "OpenAI",
+    providerType: "openai",
+  });
+  assert.deepEqual(missingExternalModel(DROPPED_ID, [other]), {
+    modelName: "kimi-k2.5",
+    providerName: null,
+    providerType: null,
+  });
+});
+
+test("a percent-encoded model id is decoded for display", () => {
+  const id = "external::conn::openai%2Fgpt-5";
+  assert.equal(missingExternalModel(id, [])?.modelName, "openai/gpt-5");
+});
+
+test("a model the connection still offers is not treated as missing", () => {
+  const listed = option("kimi-k2.5");
+  assert.equal(missingExternalModel(listed.id, [listed]), null);
+});
+
+test("local and hub selections are left to the generic helper", () => {
+  for (const id of [
+    "unsloth/gemma-3-4b-it-GGUF",
+    "/models/gemma-3-4b-it.gguf",
+    "C:\\models\\gemma.gguf",
+    "",
+    null,
+    undefined,
+  ]) {
+    assert.equal(missingExternalModel(id, []), null);
+  }
+});
+
+// Compare toasts: reachable because the compare pane headers accept connected models and
+// the send path has no external guard.
+test("compare toasts name the connected model, not its id", () => {
+  assert.equal(compareModelDisplayName(DROPPED_ID), "kimi-k2.5");
+  assert.equal(
+    compareModelDisplayName("external::conn::openai%2Fgpt-5"),
+    "gpt-5",
+  );
+  // Unchanged for everything else.
+  assert.equal(
+    compareModelDisplayName("unsloth/gemma-3-4b-it"),
+    "gemma-3-4b-it",
+  );
+  assert.equal(compareModelDisplayName("gemma-3-4b-it"), "gemma-3-4b-it");
+});
+
+test("externalModelLabel yields null for a non-external id", () => {
+  assert.equal(externalModelLabel("unsloth/gemma-3-4b-it"), null);
+  assert.equal(externalModelLabel(null), null);
+  assert.equal(externalModelLabel(DROPPED_ID), "kimi-k2.5");
+});
+
+// No DOM renderer here, so assert the wiring in the source the way
+// artifact-frame-network-access.test.ts does: the fix only reaches the user if these three
+// call sites route the checkpoint through the helpers above.
+const sourceOf = (relative: string, kind: ts.ScriptKind): ts.SourceFile => {
+  const path = fileURLToPath(new URL(relative, import.meta.url));
+  return ts.createSourceFile(
+    path,
+    readFileSync(path, "utf8"),
+    ts.ScriptTarget.ESNext,
+    true,
+    kind,
+  );
+};
+
+/** The body of the `currentModel` useMemo in the picker, or null if it moved. */
+function currentModelMemo(): string | null {
+  const source = sourceOf(
+    "../src/features/model-picker/components/model-selector.tsx",
+    ts.ScriptKind.TSX,
+  );
+  let body: string | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.name.getText() === "currentModel" &&
+      node.initializer
+    ) {
+      body = node.initializer.getText();
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  return body;
+}
+
+test("the picker trigger resolves a dropped connected model before naming it", () => {
+  const memo = currentModelMemo();
+  assert.ok(memo, "currentModel not found in model-selector.tsx");
+  assert.match(
+    memo,
+    /missingExternalModel\(\s*selected,\s*externalModels,?\s*\)/,
+    "the fallback must consult the connected-model list before modelDisplayName",
+  );
+  // A name alone would hide that the model cannot be loaded, so the trigger says so.
+  assert.match(memo, /picker\.modelDroppedByProvider/);
+  assert.match(memo, /picker\.modelDropped\b/);
+  // A memo that reads externalModels must list it, or the label survives a refresh.
+  assert.match(memo, /\[[^\]]*\bexternalModels\b[^\]]*\]\s*\)?\s*$/);
+});
+
+test("the compare and audio toasts use the external-aware labels", () => {
+  const composer = readFileSync(
+    fileURLToPath(
+      new URL("../src/features/chat/shared-composer.tsx", import.meta.url),
+    ),
+    "utf8",
+  );
+  assert.match(
+    composer,
+    /const name1 = model1\?\.id \? compareModelDisplayName\(/,
+  );
+  assert.match(
+    composer,
+    /const name2 = model2\?\.id \? compareModelDisplayName\(/,
+  );
+  // The local split("/") helper that leaked the id must be gone.
+  assert.doesNotMatch(composer, /function modelDisplayName\(/);
+
+  const audio = readFileSync(
+    fileURLToPath(
+      new URL(
+        "../src/features/chat/audio-attachment-adapter.ts",
+        import.meta.url,
+      ),
+    ),
+    "utf8",
+  );
+  assert.match(
+    audio,
+    /activeModel\?\.name \|\|\s*externalModelLabel\(checkpoint\) \|\|/,
+  );
+});
+
+// The strings the trigger shows must exist in every locale: check-parity treats "picker."
+// as a required overlay prefix, so a missing one fails CI rather than falling back.
+test("the dropped-model strings are translated everywhere", async () => {
+  const locales = [
+    "ar",
+    "de",
+    "en",
+    "es",
+    "fr",
+    "hi",
+    "it",
+    "ja",
+    "ko",
+    "pt-br",
+    "ru",
+    "zh-CN",
+  ];
+  for (const locale of locales) {
+    const module = (await import(`../src/i18n/locales/${locale}.ts`)) as Record<
+      string,
+      { picker?: Record<string, string> }
+    >;
+    const picker = Object.values(module).find((value) => value?.picker)?.picker;
+    assert.ok(picker, `${locale} has no picker section`);
+    assert.equal(typeof picker.modelDropped, "string", locale);
+    assert.equal(typeof picker.modelDroppedByProvider, "string", locale);
+    assert.match(picker.modelDroppedByProvider, /\{provider\}/, locale);
+  }
+});

--- a/studio/frontend/tests/external-model-selection-label.test.ts
+++ b/studio/frontend/tests/external-model-selection-label.test.ts
@@ -56,6 +56,28 @@ const connection = (
   ...overrides,
 });
 
+// A connection whose dialog has no manual model-ID box beside the fetched list: every id it
+// can hold came from the catalogue, so the catalogue is a complete record of what it offers.
+const CATALOG_ONLY_ID = "9f1c33d0a7b24e18";
+const CATALOG_ONLY_PICK = `external::${CATALOG_ONLY_ID}::gpt-5.4-mini`;
+
+const catalogOnlyOption = (modelId: string): ExternalModelRef => ({
+  id: `external::${CATALOG_ONLY_ID}::${encodeURIComponent(modelId)}`,
+  providerId: CATALOG_ONLY_ID,
+  providerName: "OpenAI",
+  providerType: "openai",
+});
+
+const catalogOnlyConnection = (
+  overrides: Partial<ExternalConnectionRef> = {},
+): ExternalConnectionRef => ({
+  id: CATALOG_ONLY_ID,
+  name: "OpenAI",
+  providerType: "openai",
+  availableModels: ["gpt-5.4", "gpt-5.4-mini"],
+  ...overrides,
+});
+
 // The premise: the shared helper cannot shorten this id, which is why the picker's
 // fallback printed it verbatim.
 test("the generic display helper leaves an external id untouched", () => {
@@ -63,19 +85,32 @@ test("the generic display helper leaves an external id untouched", () => {
 });
 
 test("a dropped connected model is named, never shown as its raw id", () => {
-  // Fetch Models replaced both lists and kimi-k2.5 is in neither, so the catalogue is
-  // positive evidence that the provider withdrew it.
+  // Fetch Models replaced both lists and gpt-5.4-mini is in neither. Nothing but the
+  // catalogue can put an id in this connection's `models`, so the catalogue is positive
+  // evidence that the provider withdrew it.
+  const missing = missingExternalModel(
+    CATALOG_ONLY_PICK,
+    [catalogOnlyOption("gpt-5.4")],
+    [catalogOnlyConnection({ availableModels: ["gpt-5.4"] })],
+  );
+  assert.deepEqual(missing, {
+    modelName: "gpt-5.4-mini",
+    providerName: "OpenAI",
+    providerType: "openai",
+    state: "dropped",
+  });
+  assert.doesNotMatch(missing?.modelName ?? "", /external::/);
+});
+
+test("the pick from the report is named, never shown as its raw id", () => {
   const missing = missingExternalModel(
     DROPPED_ID,
     [option("llama3.2")],
     [connection({ availableModels: ["llama3.2"] })],
   );
-  assert.deepEqual(missing, {
-    modelName: "kimi-k2.5",
-    providerName: "Ollama",
-    providerType: "ollama",
-    state: "dropped",
-  });
+  assert.equal(missing?.modelName, "kimi-k2.5");
+  assert.equal(missing?.providerName, "Ollama");
+  assert.equal(missing?.providerType, "ollama");
   assert.doesNotMatch(missing?.modelName ?? "", /external::/);
 });
 
@@ -161,19 +196,113 @@ test("an empty cached catalogue is unknown, not proof of a withdrawal", () => {
 
 test("another connection's catalogue does not vouch for this one", () => {
   const missing = missingExternalModel(
-    DROPPED_ID,
-    [option("llama3.2")],
+    CATALOG_ONLY_PICK,
+    [catalogOnlyOption("gpt-5.4")],
     [
-      connection({ availableModels: ["llama3.2"] }),
-      connection({
+      catalogOnlyConnection({ availableModels: ["gpt-5.4"] }),
+      catalogOnlyConnection({
         id: "other",
-        name: "OpenRouter",
-        providerType: "openrouter",
-        availableModels: ["kimi-k2.5"],
+        name: "Azure OpenAI",
+        availableModels: ["gpt-5.4-mini"],
       }),
     ],
   );
   assert.equal(missing?.state, "dropped");
+});
+
+// Ollama, vLLM, llama.cpp and OpenRouter take typed-in model IDs beside the fetched list,
+// and chat-providers-dialog.tsx saves those to `models` only: `modelsToSave` unions the
+// ticked ids with the manual ones, while `availableModels` is written as the fetched
+// catalogue alone. A catalogue that never carried an id cannot report its withdrawal, so
+// deleting the id from the manual box has to read as the user's own edit.
+test("a manual model ID the user deleted is not blamed on the provider", () => {
+  // The state a save leaves behind: llama3.2 stays ticked, the typed-in kimi-k2.5 is gone
+  // from `models`, and the catalogue is untouched because it never held it.
+  assert.deepEqual(
+    missingExternalModel(
+      DROPPED_ID,
+      [option("llama3.2")],
+      [connection({ availableModels: ["llama3.2"] })],
+    ),
+    {
+      modelName: "kimi-k2.5",
+      providerName: "Ollama",
+      providerType: "ollama",
+      state: "disabled",
+    },
+  );
+});
+
+test("no connection that takes manual model IDs reports a withdrawal", () => {
+  for (const providerType of ["ollama", "vllm", "llama_cpp", "custom"]) {
+    assert.equal(
+      missingExternalModel(
+        DROPPED_ID,
+        [option("llama3.2", { providerType })],
+        [connection({ providerType, availableModels: ["llama3.2"] })],
+      )?.state,
+      "disabled",
+      providerType,
+    );
+  }
+});
+
+test("an OpenRouter model list is a shortlist, never proof of a withdrawal", () => {
+  // OpenRouter is curated: the dialog saves `availableModels: []` and the sync fills the
+  // gap from the registry's `default_models`, so the list the picker sees is a handful of
+  // suggestions rather than the 300-odd models the gateway actually serves.
+  assert.equal(
+    missingExternalModel(
+      DROPPED_ID,
+      [option("llama3.2", { providerType: "openrouter" })],
+      [
+        connection({
+          name: "OpenRouter",
+          providerType: "openrouter",
+          availableModels: ["openai/gpt-5.4", "anthropic/claude-sonnet-5"],
+        }),
+      ],
+    )?.state,
+    "disabled",
+  );
+});
+
+test("a catalogue-only connection still reports a real withdrawal", () => {
+  // The other half of the rule: OpenAI has no manual model-ID box, so every id in `models`
+  // came from a fetch and the catalogue's silence is the provider's own answer.
+  assert.equal(
+    missingExternalModel(
+      CATALOG_ONLY_PICK,
+      [catalogOnlyOption("gpt-5.4")],
+      [catalogOnlyConnection({ availableModels: ["gpt-5.4"] })],
+    )?.state,
+    "dropped",
+  );
+  // An id the catalogue still carries is the user's own untick either way.
+  assert.equal(
+    missingExternalModel(
+      CATALOG_ONLY_PICK,
+      [catalogOnlyOption("gpt-5.4")],
+      [catalogOnlyConnection()],
+    )?.state,
+    "disabled",
+  );
+});
+
+test("a connection with no readable type keeps trusting its catalogue", () => {
+  assert.equal(
+    missingExternalModel(
+      CATALOG_ONLY_PICK,
+      [catalogOnlyOption("gpt-5.4")],
+      [
+        catalogOnlyConnection({
+          providerType: undefined,
+          availableModels: ["gpt-5.4"],
+        }),
+      ],
+    )?.state,
+    "dropped",
+  );
 });
 
 test("re-ticking the model clears the label entirely", () => {


### PR DESCRIPTION
Fixes #8405.

## The bug

Select a model from a connection, then go to Connections and Fetch Models on that provider at a point where it no longer offers the selected model. The chat header shows:

```
external::6235be0905af4221::kimi-k2.5
```

## Why

Fetch Models replaces a connection's model list wholesale and nothing reconciles the active pick against it. `chat-page.tsx` clears an external checkpoint only when Connections are turned off, so the id survives in `params.checkpoint` with no catalog entry behind it, and the picker trigger falls through to its generic fallback in `model-selector.tsx`.

That fallback is `modelDisplayName`, which is an exact identity function for this input. `buildExternalModelId` percent-encodes the model id, so the string holds no literal `/`: `isHubRepoId` is false, `looksLikeModelPath` is false, and `clean.slice(clean.lastIndexOf("/") + 1)` returns the whole thing.

## The fix

The trigger parses the id before naming it, so the pill reads the model the user actually picked, and it says the model is gone. A tidy name on its own would be worse than the raw id: the model cannot be loaded, so the failure would stay hidden until the next send. The connection's display name comes from any sibling model still listed under the same connection id; a connection that dropped every model falls back to "No longer offered".

Deliberately not changed: the loaded tick stays, because it is also the eject control, and clearing a dead selection in one click is the useful action here. Nor does this prune the stale checkpoint on refresh: a provider fetch that errors or returns partial results would then silently destroy the user's pick.

Two other surfaces reach a raw `external::` id and get the same treatment:

- Compare toasts (`shared-composer.tsx`). The compare pane headers accept connected models and the send path has no external guard, so the local `id.split("/")` helper returned the id whole. Replaced with a shared helper that parses first.
- The audio-attachment toast. A connected model has no row in `store.models`, so "&lt;model&gt; cannot accept audio" named the raw checkpoint.

The transformers-upgrade and remote-code toasts use the same helper but are not reachable with an external id: they need a successful `/api/inference/validate`, which 400s on an `external::` identifier.

## Before and after

Captured on two isolated installs, the merge base and this branch, with an Ollama connection registered through `/api/providers/` whose model list does not contain the selected model.

BEFORE: the pill prints `external::dafd9a8e229f474b::kimi-k2.5`.
AFTER: the pill reads `kimi-k2.5` with `Ollama · no longer offered`.

## Tests

`studio/frontend/tests/external-model-selection-label.test.ts`, 12 new cases: the frontend suite goes 1953 to 1965, all passing. They cover the parse, the sibling lookup for the connection name, the connection that dropped every model, percent-encoded ids, the still-offered case, non-external selections left to the generic helper, and the wiring at each of the three call sites. Reverting any single source file in this PR turns one of them red.

`npm run typecheck` and `npm run i18n:check:strict` are clean; the two new `picker.*` strings are translated in all 12 locales, as check-parity requires.
