### PR TITLE
Attach long pastes as a text file in Chat

### DIFF
--- a/studio/backend/core/inference/message_content.py
+++ b/studio/backend/core/inference/message_content.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 
 from typing import Any
 
+# The composer sends a long paste as a text attachment wrapped in this tag, so
+# a paste-only turn carries no `content` text at all.
+_PASTED_TEXT_OPEN = "<pasted_text name="
+_PASTED_TEXT_CLOSE = "</pasted_text>"
+
 
 def content_to_text(content: Any) -> str:
     """Plain text of a `content`: str unchanged, list/tuple text parts newline-joined
@@ -36,3 +41,38 @@ def content_to_text(content: Any) -> str:
                     parts.append(text)
         return "\n".join(parts)
     return str(content)
+
+
+def pasted_text_body(text: str) -> str:
+    """Body of a wrapped paste, or "" for anything else."""
+    if not text.startswith(_PASTED_TEXT_OPEN):
+        return ""
+    body_start = text.find("\n")
+    if body_start == -1:
+        return ""
+    body_end = len(text)
+    closing = "\n" + _PASTED_TEXT_CLOSE
+    if text.endswith(closing):
+        body_end = max(len(text) - len(closing), body_start + 1)
+    return text[body_start + 1 : body_end]
+
+
+def message_text_with_pastes(message: Any) -> str:
+    """Text of a message including any pasted attachment bodies.
+
+    A paste above the composer's threshold is sent as an attachment rather than
+    inline, so `content_to_text` alone reads a paste-only turn as empty. Other
+    attachment types are left out: they were never part of a message's text.
+    """
+    if not isinstance(message, dict):
+        return ""
+    parts = [content_to_text(message.get("content"))]
+    attachments = message.get("attachments")
+    if isinstance(attachments, (list, tuple)):
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            body = pasted_text_body(content_to_text(attachment.get("content")))
+            if body:
+                parts.append(body)
+    return "\n\n".join(part for part in parts if part)

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -19,7 +19,7 @@ from typing import Any, AsyncIterator, Callable
 import httpx
 
 from auth import storage as auth_storage
-from core.inference.message_content import content_to_text
+from core.inference.message_content import message_text_with_pastes
 from core.inference.tool_loop_controller import is_tool_error, strip_result_for_model
 from core.inference.tools import EMPTY_SEARCH_RESULTS, RAG_SOURCES_SENTINEL, execute_tool
 from core.inference.web_access_policy import check_url_access, website_policy_prompt
@@ -201,7 +201,7 @@ def _safe_error(exc: BaseException) -> str:
 
 
 def _extract_text(message: dict) -> str:
-    return content_to_text(message.get("content")).strip()
+    return message_text_with_pastes(message).strip()
 
 
 def _research_question_context(thread_id: str, user_message_id: str) -> tuple[str, str]:

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -18,7 +18,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from auth.authentication import get_current_subject
-from core.inference.message_content import content_to_text
+from core.inference.message_content import message_text_with_pastes
 from core.inference.web_access_policy import normalize_website_policy
 from storage import research_runs_db as db
 from storage.studio_db import get_chat_message, get_chat_thread, upsert_chat_message
@@ -309,7 +309,7 @@ def create_research_run(
         raise HTTPException(
             status_code = 400, detail = "userMessageId must identify a user message in the thread"
         )
-    if not content_to_text(user_message.get("content")).strip():
+    if not message_text_with_pastes(user_message).strip():
         raise HTTPException(
             status_code = 400,
             detail = "Deep research requires a user message with non-empty text",

--- a/studio/backend/tests/test_message_content.py
+++ b/studio/backend/tests/test_message_content.py
@@ -98,3 +98,56 @@ def test_result_supports_string_ops():
     out = mc.content_to_text([{"type": "text", "text": "  padded  "}])
     assert out.strip() == "padded"
     assert isinstance(out, str)
+
+
+def _pasted(name, body, size):
+    return f"<pasted_text name={name} bytes={size}>\n{body}\n</pasted_text>"
+
+
+def test_paste_only_turn_is_not_empty_text():
+    mc = _load_message_content()
+    body = "Fix the retry backoff\ndetail"
+    message = {
+        "content": [],
+        "attachments": [
+            {"content": [{"type": "text", "text": _pasted("Fix.txt", body, 28)}]}
+        ],
+    }
+    # Deep research rejects a message whose text is empty, and a long paste
+    # carries all of its text in the attachment.
+    assert mc.message_text_with_pastes(message) == body
+
+
+def test_typed_text_keeps_the_paste_after_it():
+    mc = _load_message_content()
+    message = {
+        "content": [{"type": "text", "text": "summarise this"}],
+        "attachments": [
+            {"content": [{"type": "text", "text": _pasted("Log.txt", "line", 4)}]}
+        ],
+    }
+    assert mc.message_text_with_pastes(message) == "summarise this\n\nline"
+
+
+def test_other_attachments_are_left_out():
+    mc = _load_message_content()
+    message = {
+        "content": [{"type": "text", "text": "read this"}],
+        "attachments": [
+            {"content": [{"type": "text", "text": "[PDF: paper.pdf]\nAbstract"}]},
+            {"content": [{"type": "text", "text": "<attachment name=n.txt>\nx\n</attachment>"}]},
+        ],
+    }
+    assert mc.message_text_with_pastes(message) == "read this"
+    assert mc.message_text_with_pastes({}) == ""
+    assert mc.message_text_with_pastes(None) == ""
+
+
+def test_pasted_body_unwraps_only_the_wrapper():
+    mc = _load_message_content()
+    assert mc.pasted_text_body(_pasted("a.txt", "body", 4)) == "body"
+    # Without the size, and with a body that itself ends in a tag-like line.
+    assert mc.pasted_text_body("<pasted_text name=a.txt>\nbody") == "body"
+    assert mc.pasted_text_body("plain text") == ""
+    assert mc.pasted_text_body("<attachment name=a.txt>\nbody\n</attachment>") == ""
+    assert mc.pasted_text_body("") == ""

--- a/studio/backend/tests/test_message_content.py
+++ b/studio/backend/tests/test_message_content.py
@@ -109,9 +109,7 @@ def test_paste_only_turn_is_not_empty_text():
     body = "Fix the retry backoff\ndetail"
     message = {
         "content": [],
-        "attachments": [
-            {"content": [{"type": "text", "text": _pasted("Fix.txt", body, 28)}]}
-        ],
+        "attachments": [{"content": [{"type": "text", "text": _pasted("Fix.txt", body, 28)}]}],
     }
     # Deep research rejects a message whose text is empty, and a long paste
     # carries all of its text in the attachment.
@@ -122,9 +120,7 @@ def test_typed_text_keeps_the_paste_after_it():
     mc = _load_message_content()
     message = {
         "content": [{"type": "text", "text": "summarise this"}],
-        "attachments": [
-            {"content": [{"type": "text", "text": _pasted("Log.txt", "line", 4)}]}
-        ],
+        "attachments": [{"content": [{"type": "text", "text": _pasted("Log.txt", "line", 4)}]}],
     }
     assert mc.message_text_with_pastes(message) == "summarise this\n\nline"
 

--- a/studio/frontend/src/components/assistant-ui/attachment.tsx
+++ b/studio/frontend/src/components/assistant-ui/attachment.tsx
@@ -39,6 +39,7 @@ import {
   type PropsWithChildren,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { useShallow } from "zustand/shallow";
@@ -250,7 +251,15 @@ const PastedTextAttachmentUI: FC<{
   name: string;
 }> = ({ attachment, isComposer, name }) => {
   const aui = useAui();
+  const attachmentId = useAuiState(({ attachment: state }) => state.id);
   const [inlining, setInlining] = useState(false);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   // Clicking the chip pours the text back into the composer.
   const showInTextField = useCallback(() => {
@@ -258,14 +267,26 @@ const PastedTextAttachmentUI: FC<{
     setInlining(true);
     void readPastedText(attachment)
       .then((text) => {
-        if (text.length === 0) return;
+        // Reading a big file is slow enough to outlive the send that cleared
+        // the composer, which would leave the text behind as a stray draft.
+        if (!mountedRef.current || text.length === 0) return;
         const composer = aui.composer();
+        if (
+          !composer
+            .getState()
+            .attachments.some((item) => item.id === attachmentId)
+        ) {
+          return;
+        }
         const current = composer.getState().text;
         composer.setText(current.length > 0 ? `${current}\n\n${text}` : text);
         aui.attachment().remove();
       })
-      .finally(() => setInlining(false));
-  }, [attachment, aui, inlining]);
+      .catch(() => undefined)
+      .finally(() => {
+        if (mountedRef.current) setInlining(false);
+      });
+  }, [attachment, attachmentId, aui, inlining]);
 
   const chip = (
     <button

--- a/studio/frontend/src/components/assistant-ui/attachment.tsx
+++ b/studio/frontend/src/components/assistant-ui/attachment.tsx
@@ -21,8 +21,9 @@ import {
   PASTED_TEXT_PREVIEW_MAX_CHARS,
   isPastedTextContent,
   isPastedTextFile,
+  pastedTextContentBytes,
+  pastedTextContentPreview,
   pastedTextPreview,
-  unwrapAttachmentText,
 } from "@/features/chat";
 import { formatBytes } from "@/features/hub/lib/format";
 import { cn } from "@/lib/utils";
@@ -45,7 +46,6 @@ import {
   type PropsWithChildren,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -186,6 +186,7 @@ const AttachmentThumb: FC = () => {
 type PastedTextAttachment = {
   readonly file?: File;
   readonly sentText?: string;
+  readonly sentBytes?: number;
 };
 
 // Long pastes arrive as a synthetic .txt and render as a chip, not a tile.
@@ -203,17 +204,22 @@ const usePastedTextAttachment = (): PastedTextAttachment | null => {
         ? isPastedTextFile(file)
         : isPastedTextContent(sentText);
       if (!pasted) return null;
-      return { file, sentText };
+      return { file, sentText, sentBytes: pastedTextContentBytes(sentText) };
     }),
   );
 };
 
-const readPastedText = async ({
-  file,
-  sentText,
-}: PastedTextAttachment): Promise<string> => {
-  if (file) return await file.text();
-  return unwrapAttachmentText(sentText ?? "");
+/** Only the composer inlines, and there the File is always still around. */
+const readPastedText = async ({ file }: PastedTextAttachment): Promise<string> =>
+  file ? await file.text() : "";
+
+const readPastedTextPreview = async (
+  attachment: PastedTextAttachment,
+): Promise<{ text: string; remaining: number }> => {
+  if (attachment.sentText !== undefined) {
+    return pastedTextContentPreview(attachment.sentText);
+  }
+  return pastedTextPreview(await readPastedText(attachment));
 };
 
 const PastedTextPreviewDialog: FC<
@@ -228,11 +234,11 @@ const PastedTextPreviewDialog: FC<
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    readPastedText(attachment)
-      // Laying out megabytes in one text node locks the page, so show an
-      // opening. The attachment itself still holds everything.
+    // Laying out megabytes in one text node locks the page, so show an
+    // opening. The attachment itself still holds everything.
+    readPastedTextPreview(attachment)
       .then((value) => {
-        if (!cancelled) setPreview(pastedTextPreview(value));
+        if (!cancelled) setPreview(value);
       })
       .catch(() => {
         if (!cancelled) setPreview({ text: "", remaining: 0 });
@@ -275,13 +281,9 @@ const PastedTextAttachmentUI: FC<{
       mountedRef.current = false;
     };
   }, []);
-  // Measured once per mount: sizing a sent paste walks the whole string.
-  const bytes = useMemo(
-    () =>
-      attachment.file?.size ??
-      new Blob([unwrapAttachmentText(attachment.sentText ?? "")]).size,
-    [attachment],
-  );
+  // Read off the header, never measured: the paste can be megabytes and this
+  // runs while the thread is trying to paint.
+  const bytes = attachment.file?.size ?? attachment.sentBytes;
 
   // Clicking the chip pours the text back into the composer.
   const showInTextField = useCallback(() => {
@@ -338,7 +340,7 @@ const PastedTextAttachmentUI: FC<{
         <span className="truncate text-[11px] text-muted-foreground">
           {/* Hover swaps the size for the action. */}
           <span className={isComposer ? "group-hover:hidden" : undefined}>
-            {formatBytes(bytes)}
+            {bytes === undefined ? "Pasted text" : formatBytes(bytes)}
           </span>
           {isComposer ? (
             <span className="hidden items-center gap-0.5 underline underline-offset-2 group-hover:inline-flex">

--- a/studio/frontend/src/components/assistant-ui/attachment.tsx
+++ b/studio/frontend/src/components/assistant-ui/attachment.tsx
@@ -17,7 +17,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { isPastedTextFile, unwrapAttachmentText } from "@/features/chat";
+import {
+  isPastedTextAttachment,
+  isPastedTextFile,
+  rememberPastedTextAttachment,
+  unwrapAttachmentText,
+} from "@/features/chat";
 import { formatBytes } from "@/features/hub/lib/format";
 import { cn } from "@/lib/utils";
 import {
@@ -188,7 +193,10 @@ const usePastedTextAttachment = (): PastedTextAttachment | null => {
     useShallow(({ attachment }): PastedTextAttachment | null => {
       if (attachment.type !== "document") return null;
       const file = (attachment as { file?: File }).file;
-      if (!isPastedTextFile(file, attachment.name)) return null;
+      const pasted = file
+        ? isPastedTextFile(file)
+        : isPastedTextAttachment(attachment.id);
+      if (!pasted) return null;
       const inlineText = attachment.content?.flatMap((part) =>
         part.type === "text" ? [part.text] : [],
       )[0];
@@ -260,6 +268,11 @@ const PastedTextAttachmentUI: FC<{
       mountedRef.current = false;
     };
   }, []);
+  // The sent message keeps the id but not the File, so record it while the
+  // composer still holds both.
+  useEffect(() => {
+    if (isComposer) rememberPastedTextAttachment(attachmentId);
+  }, [attachmentId, isComposer]);
 
   // Clicking the chip pours the text back into the composer.
   const showInTextField = useCallback(() => {
@@ -291,9 +304,10 @@ const PastedTextAttachmentUI: FC<{
   const chip = (
     <button
       className={cn(
-        "aui-pasted-text-chip group flex h-14 max-w-[15rem] min-w-0 cursor-pointer items-center gap-2.5 rounded-[14px] border bg-muted px-3 text-left transition-opacity hover:opacity-90",
+        // Borderless, and in dark mode a shade under the composer surface.
+        "aui-pasted-text-chip group flex h-14 max-w-[15rem] min-w-0 cursor-pointer items-center gap-2.5 rounded-[14px] bg-muted px-3 text-left transition-colors hover:bg-muted-foreground/15 dark:bg-background dark:hover:bg-muted",
         // Keep the label clear of the remove button in the corner.
-        isComposer && "aui-pasted-text-chip-composer border-foreground/20 pr-6",
+        isComposer && "aui-pasted-text-chip-composer pr-6",
       )}
       type="button"
       aria-label={

--- a/studio/frontend/src/components/assistant-ui/attachment.tsx
+++ b/studio/frontend/src/components/assistant-ui/attachment.tsx
@@ -25,7 +25,7 @@ import {
   pastedTextContentPreview,
   pastedTextPreview,
 } from "@/features/chat";
-import { formatBytes } from "@/features/hub/lib/format";
+import { formatBytes } from "@/features/hub";
 import { cn } from "@/lib/utils";
 import {
   AttachmentPrimitive,

--- a/studio/frontend/src/components/assistant-ui/attachment.tsx
+++ b/studio/frontend/src/components/assistant-ui/attachment.tsx
@@ -18,9 +18,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
-  isPastedTextAttachment,
+  PASTED_TEXT_PREVIEW_MAX_CHARS,
+  isPastedTextContent,
   isPastedTextFile,
-  rememberPastedTextAttachment,
+  pastedTextPreview,
   unwrapAttachmentText,
 } from "@/features/chat";
 import { formatBytes } from "@/features/hub/lib/format";
@@ -44,6 +45,7 @@ import {
   type PropsWithChildren,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -183,57 +185,57 @@ const AttachmentThumb: FC = () => {
 
 type PastedTextAttachment = {
   readonly file?: File;
-  readonly inlineText?: string;
-  readonly bytes: number;
+  readonly sentText?: string;
 };
 
 // Long pastes arrive as a synthetic .txt and render as a chip, not a tile.
+// The selector only passes references along: the text can be megabytes, so
+// nothing here may copy or scan it.
 const usePastedTextAttachment = (): PastedTextAttachment | null => {
   return useAuiState(
     useShallow(({ attachment }): PastedTextAttachment | null => {
       if (attachment.type !== "document") return null;
       const file = (attachment as { file?: File }).file;
-      const pasted = file
-        ? isPastedTextFile(file)
-        : isPastedTextAttachment(attachment.id);
-      if (!pasted) return null;
-      const inlineText = attachment.content?.flatMap((part) =>
+      const sentText = attachment.content?.flatMap((part) =>
         part.type === "text" ? [part.text] : [],
       )[0];
-      const unwrapped =
-        inlineText === undefined ? undefined : unwrapAttachmentText(inlineText);
-      return {
-        file,
-        inlineText: unwrapped,
-        bytes: file?.size ?? new Blob([unwrapped ?? ""]).size,
-      };
+      const pasted = file
+        ? isPastedTextFile(file)
+        : isPastedTextContent(sentText);
+      if (!pasted) return null;
+      return { file, sentText };
     }),
   );
 };
 
 const readPastedText = async ({
   file,
-  inlineText,
+  sentText,
 }: PastedTextAttachment): Promise<string> => {
   if (file) return await file.text();
-  return inlineText ?? "";
+  return unwrapAttachmentText(sentText ?? "");
 };
 
 const PastedTextPreviewDialog: FC<
   PropsWithChildren<{ name: string; attachment: PastedTextAttachment }>
 > = ({ attachment, children, name }) => {
   const [open, setOpen] = useState(false);
-  const [text, setText] = useState<string | null>(null);
+  const [preview, setPreview] = useState<{
+    text: string;
+    remaining: number;
+  } | null>(null);
 
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     readPastedText(attachment)
+      // Laying out megabytes in one text node locks the page, so show an
+      // opening. The attachment itself still holds everything.
       .then((value) => {
-        if (!cancelled) setText(value);
+        if (!cancelled) setPreview(pastedTextPreview(value));
       })
       .catch(() => {
-        if (!cancelled) setText("");
+        if (!cancelled) setPreview({ text: "", remaining: 0 });
       });
     return () => {
       cancelled = true;
@@ -246,8 +248,13 @@ const PastedTextPreviewDialog: FC<
       <DialogContent className="aui-pasted-text-dialog flex max-h-[80dvh] w-[min(46rem,92vw)] max-w-none flex-col gap-3 overflow-hidden">
         <DialogTitle className="truncate pr-8 text-sm">{name}</DialogTitle>
         <pre className="aui-pasted-text-dialog-body max-h-[64dvh] overflow-auto whitespace-pre-wrap break-words rounded-lg border bg-muted/40 p-3 text-left font-mono text-xs leading-relaxed">
-          {text ?? "Loading…"}
+          {preview?.text ?? "Loading…"}
         </pre>
+        {preview && preview.remaining > 0 ? (
+          <p className="text-muted-foreground text-xs">
+            {`First ${PASTED_TEXT_PREVIEW_MAX_CHARS.toLocaleString()} characters shown. ${preview.remaining.toLocaleString()} more were sent with the message.`}
+          </p>
+        ) : null}
       </DialogContent>
     </Dialog>
   );
@@ -268,11 +275,13 @@ const PastedTextAttachmentUI: FC<{
       mountedRef.current = false;
     };
   }, []);
-  // The sent message keeps the id but not the File, so record it while the
-  // composer still holds both.
-  useEffect(() => {
-    if (isComposer) rememberPastedTextAttachment(attachmentId);
-  }, [attachmentId, isComposer]);
+  // Measured once per mount: sizing a sent paste walks the whole string.
+  const bytes = useMemo(
+    () =>
+      attachment.file?.size ??
+      new Blob([unwrapAttachmentText(attachment.sentText ?? "")]).size,
+    [attachment],
+  );
 
   // Clicking the chip pours the text back into the composer.
   const showInTextField = useCallback(() => {
@@ -329,7 +338,7 @@ const PastedTextAttachmentUI: FC<{
         <span className="truncate text-[11px] text-muted-foreground">
           {/* Hover swaps the size for the action. */}
           <span className={isComposer ? "group-hover:hidden" : undefined}>
-            {formatBytes(attachment.bytes)}
+            {formatBytes(bytes)}
           </span>
           {isComposer ? (
             <span className="hidden items-center gap-0.5 underline underline-offset-2 group-hover:inline-flex">

--- a/studio/frontend/src/components/assistant-ui/attachment.tsx
+++ b/studio/frontend/src/components/assistant-ui/attachment.tsx
@@ -17,6 +17,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { isPastedTextFile, unwrapAttachmentText } from "@/features/chat";
+import { formatBytes } from "@/features/hub/lib/format";
 import { cn } from "@/lib/utils";
 import {
   AttachmentPrimitive,
@@ -25,10 +27,20 @@ import {
   useAui,
   useAuiState,
 } from "@assistant-ui/react";
-import { AudioWave01Icon, File02Icon } from "@hugeicons/core-free-icons";
+import {
+  AudioWave01Icon,
+  File02Icon,
+  TextAlignLeft01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { PlusIcon, XIcon } from "lucide-react";
-import { type FC, type PropsWithChildren, useEffect, useState } from "react";
+import { ChevronRightIcon, PlusIcon, XIcon } from "lucide-react";
+import {
+  type FC,
+  type PropsWithChildren,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { useShallow } from "zustand/shallow";
 
 const useFileSrc = (file: File | undefined): string | undefined => {
@@ -163,9 +175,156 @@ const AttachmentThumb: FC = () => {
   );
 };
 
+type PastedTextAttachment = {
+  readonly file?: File;
+  readonly inlineText?: string;
+  readonly bytes: number;
+};
+
+// Long pastes arrive as a synthetic .txt and render as a chip, not a tile.
+const usePastedTextAttachment = (): PastedTextAttachment | null => {
+  return useAuiState(
+    useShallow(({ attachment }): PastedTextAttachment | null => {
+      if (attachment.type !== "document") return null;
+      const file = (attachment as { file?: File }).file;
+      if (!isPastedTextFile(file, attachment.name)) return null;
+      const inlineText = attachment.content?.flatMap((part) =>
+        part.type === "text" ? [part.text] : [],
+      )[0];
+      const unwrapped =
+        inlineText === undefined ? undefined : unwrapAttachmentText(inlineText);
+      return {
+        file,
+        inlineText: unwrapped,
+        bytes: file?.size ?? new Blob([unwrapped ?? ""]).size,
+      };
+    }),
+  );
+};
+
+const readPastedText = async ({
+  file,
+  inlineText,
+}: PastedTextAttachment): Promise<string> => {
+  if (file) return await file.text();
+  return inlineText ?? "";
+};
+
+const PastedTextPreviewDialog: FC<
+  PropsWithChildren<{ name: string; attachment: PastedTextAttachment }>
+> = ({ attachment, children, name }) => {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    readPastedText(attachment)
+      .then((value) => {
+        if (!cancelled) setText(value);
+      })
+      .catch(() => {
+        if (!cancelled) setText("");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, attachment]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild={true}>{children}</DialogTrigger>
+      <DialogContent className="aui-pasted-text-dialog flex max-h-[80dvh] w-[min(46rem,92vw)] max-w-none flex-col gap-3 overflow-hidden">
+        <DialogTitle className="truncate pr-8 text-sm">{name}</DialogTitle>
+        <pre className="aui-pasted-text-dialog-body max-h-[64dvh] overflow-auto whitespace-pre-wrap break-words rounded-lg border bg-muted/40 p-3 text-left font-mono text-xs leading-relaxed">
+          {text ?? "Loading…"}
+        </pre>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const PastedTextAttachmentUI: FC<{
+  attachment: PastedTextAttachment;
+  isComposer: boolean;
+  name: string;
+}> = ({ attachment, isComposer, name }) => {
+  const aui = useAui();
+  const [inlining, setInlining] = useState(false);
+
+  // Clicking the chip pours the text back into the composer.
+  const showInTextField = useCallback(() => {
+    if (inlining) return;
+    setInlining(true);
+    void readPastedText(attachment)
+      .then((text) => {
+        if (text.length === 0) return;
+        const composer = aui.composer();
+        const current = composer.getState().text;
+        composer.setText(current.length > 0 ? `${current}\n\n${text}` : text);
+        aui.attachment().remove();
+      })
+      .finally(() => setInlining(false));
+  }, [attachment, aui, inlining]);
+
+  const chip = (
+    <button
+      className={cn(
+        "aui-pasted-text-chip group flex h-14 max-w-[15rem] min-w-0 cursor-pointer items-center gap-2.5 rounded-[14px] border bg-muted px-3 text-left transition-opacity hover:opacity-90",
+        // Keep the label clear of the remove button in the corner.
+        isComposer && "aui-pasted-text-chip-composer border-foreground/20 pr-6",
+      )}
+      type="button"
+      aria-label={
+        isComposer
+          ? `Pasted text: ${name}. Show in text field`
+          : `Pasted text: ${name}. Show contents`
+      }
+      onClick={isComposer ? showInTextField : undefined}
+    >
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-foreground/10">
+        <HugeiconsIcon
+          icon={TextAlignLeft01Icon}
+          strokeWidth={2}
+          className="size-4 text-muted-foreground"
+        />
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate font-medium text-xs">{name}</span>
+        <span className="truncate text-[11px] text-muted-foreground">
+          {/* Hover swaps the size for the action. */}
+          <span className={isComposer ? "group-hover:hidden" : undefined}>
+            {formatBytes(attachment.bytes)}
+          </span>
+          {isComposer ? (
+            <span className="hidden items-center gap-0.5 underline underline-offset-2 group-hover:inline-flex">
+              Show in text field
+              <ChevronRightIcon className="size-3" />
+            </span>
+          ) : null}
+        </span>
+      </span>
+    </button>
+  );
+
+  return (
+    <AttachmentPrimitive.Root className="aui-attachment-root relative">
+      {isComposer ? (
+        chip
+      ) : (
+        <PastedTextPreviewDialog attachment={attachment} name={name}>
+          {chip}
+        </PastedTextPreviewDialog>
+      )}
+      {isComposer && <AttachmentRemove />}
+    </AttachmentPrimitive.Root>
+  );
+};
+
 const AttachmentUI: FC = () => {
   const aui = useAui();
   const isComposer = aui.attachment.source === "composer";
+  const pastedText = usePastedTextAttachment();
 
   const isImage = useAuiState(({ attachment }) => attachment.type === "image");
   const name = useAuiState(({ attachment }) => attachment.name);
@@ -192,6 +351,16 @@ const AttachmentUI: FC = () => {
   const accessibleName = name
     ? `${typeLabel} attachment: ${name}`
     : `${typeLabel} attachment`;
+
+  if (pastedText) {
+    return (
+      <PastedTextAttachmentUI
+        attachment={pastedText}
+        isComposer={isComposer}
+        name={name ?? "Pasted text"}
+      />
+    );
+  }
 
   return (
     <Tooltip>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -36,6 +36,7 @@ import { TerminalToolUI } from "@/components/assistant-ui/tool-ui-terminal";
 import { WebSearchToolUI } from "@/components/assistant-ui/tool-ui-web-search";
 import { ChatDictationBar } from "@/components/assistant-ui/chat-dictation-bar";
 import {
+  isPastedTextFile,
   pasteClipboardFiles,
   pasteLongTextAsFile,
   isStudioDictationAvailable,
@@ -2165,6 +2166,13 @@ const Composer: FC<{
       (attachment) => attachment.status.type === "running",
     ),
   );
+  const attachmentsAreAllPastedText = useAuiState(
+    ({ composer }) =>
+      composer.attachments.length > 0 &&
+      composer.attachments.every((attachment) =>
+        isPastedTextFile((attachment as { file?: File }).file),
+      ),
+  );
   const hasPendingAudio = useChatRuntimeStore((s) =>
     Boolean(s.pendingAudioName),
   );
@@ -2510,9 +2518,7 @@ const Composer: FC<{
   );
   const hasSendableContent =
     composerText.trim().length > 0 || hasAttachments || hasPendingAudio;
-  const canQueueCurrentPrompt =
-    composerText.trim().length > 0 &&
-    !hasAttachments &&
+  const composerAcceptsQueueing =
     !hasPendingAudio &&
     !isComposing &&
     !hasPendingAttachments &&
@@ -2520,6 +2526,12 @@ const Composer: FC<{
     !hasMaterializingAudioAttachments &&
     !disabled &&
     !overlay;
+  const canQueueCurrentPrompt =
+    composerText.trim().length > 0 && !hasAttachments && composerAcceptsQueueing;
+  // A long paste is text the composer parked in a chip, so it queues like the
+  // same text did before it attached, rather than being refused as a file.
+  const canQueuePastedTextPrompt =
+    attachmentsAreAllPastedText && composerAcceptsQueueing;
 
   // Per-thread draft autosave: restore on mount, then mirror composer text
   // into localStorage (debounced) so a half-typed message survives a
@@ -2983,6 +2995,57 @@ const Composer: FC<{
     [createPromptQueueTarget, referenceThreadId],
   );
 
+  // The queue carries text, and a long paste is text the composer parked in a
+  // chip, so fold it back in rather than refusing to queue it as a file.
+  const queuePastedTextPrompt = useCallback(
+    (waitForCurrentRun: boolean): boolean => {
+      const composer = aui.composer();
+      const attachments = composer.getState().attachments;
+      const files: File[] = [];
+      for (const attachment of attachments) {
+        const file = (attachment as { file?: File }).file;
+        if (file === undefined || !isPastedTextFile(file)) return false;
+        files.push(file);
+      }
+      if (files.length === 0) return false;
+
+      const attachmentIds = attachments.map((attachment) => attachment.id);
+      const textAtQueue = composer.getState().text.trim();
+      void Promise.all(files.map((file) => file.text()))
+        .then((texts) => {
+          const queuedPrompt = [textAtQueue, ...texts]
+            .filter((part) => part.trim().length > 0)
+            .join("\n\n");
+          if (queuedPrompt.length === 0) return;
+          startHydratedPromptQueue([queuedPrompt], waitForCurrentRun, () => {
+            const state = composer.getState();
+            // Only clear the composer this prompt was queued from.
+            if (
+              state.text.trim() !== textAtQueue ||
+              state.attachments.length !== attachmentIds.length ||
+              !state.attachments.every(
+                (attachment, index) => attachment.id === attachmentIds[index],
+              )
+            ) {
+              return;
+            }
+            void composer.clearAttachments();
+            flushResourcesSync(() => {
+              composer.setText("");
+            });
+            clearStoredDraft();
+          });
+        })
+        .catch(() => {
+          toast.error("Could not queue the pasted text.", {
+            description: "Show it in the text field, then send it again.",
+          });
+        });
+      return true;
+    },
+    [aui, clearStoredDraft, startHydratedPromptQueue],
+  );
+
   const dismissWaitToast = useCallback(() => {
     if (waitToastRef.current !== null) {
       toast.dismiss(waitToastRef.current);
@@ -3326,6 +3389,12 @@ const Composer: FC<{
           return;
         }
         if (!canQueueCurrentPrompt) {
+          if (
+            canQueuePastedTextPrompt &&
+            queuePastedTextPrompt(liveThreadIsRunning || livePreStreamRunActive)
+          ) {
+            return;
+          }
           if (overlay || hasAttachments || hasPendingAudio) {
             toast.error(
               liveThreadIsRunning
@@ -3417,6 +3486,8 @@ const Composer: FC<{
     [
       aui,
       canQueueCurrentPrompt,
+      canQueuePastedTextPrompt,
+      queuePastedTextPrompt,
       clearStoredDraft,
       closeOverlay,
       composerText,

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2106,8 +2106,9 @@ const Composer: FC<{
     useImeComposerInputHandlers({ submitOnEnter: true });
   const handleFilePaste = useCallback(
     (event: ClipboardEvent<HTMLTextAreaElement>) => {
-      // Bulk text pastes attach as a file instead of filling the input.
-      const attachedPastedText = pasteLongTextAsFile(
+      // Bulk text pastes attach as a file instead of filling the input, except
+      // in image-edit mode, whose submit path takes an inline instruction only.
+      const attachedPastedText = !overlay && pasteLongTextAsFile(
         event,
         (file) => aui.composer().addAttachment(file),
         () =>
@@ -2129,7 +2130,7 @@ const Composer: FC<{
           }),
       );
     },
-    [aui],
+    [aui, overlay],
   );
 
   const composerText = useAuiState(({ composer }) => composer.text);

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2568,8 +2568,16 @@ const Composer: FC<{
   useEffect(() => {
     const draft = draftKey ? (readComposerDraft(draftKey) ?? "") : "";
     const composer = aui.composer();
+    if (composer.getState().isEditing) {
+      composer.setText(draft);
+    }
+  }, [draftKey, aui]);
+  // Separate from the text restore above, which must stay keyed on the draft
+  // alone: this one retries on attachment changes, and rewriting the composer
+  // text on those would drop whatever had been typed since the last autosave.
+  useEffect(() => {
+    const composer = aui.composer();
     if (!composer.getState().isEditing) return;
-    composer.setText(draft);
     if (restoredPasteKeyRef.current === pasteDraftKey) return;
     // The composer outlives a thread switch, so wait for the outgoing paste to
     // clear rather than stacking this thread's draft on top of it. Changing
@@ -2595,7 +2603,7 @@ const Composer: FC<{
     ).finally(() => {
       restoredPasteKeyRef.current = pasteDraftKey;
     });
-  }, [draftKey, pasteDraftKey, pastedTextDraftSignature, aui]);
+  }, [pasteDraftKey, pastedTextDraftSignature, aui]);
   // Keyed on the paste identities, never their bodies, so typing beside a
   // megabyte paste does not rewrite it to localStorage every 300ms.
   useEffect(() => {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2109,7 +2109,11 @@ const Composer: FC<{
       // Bulk text pastes attach as a file instead of filling the input, except
       // in image-edit mode, whose submit path takes an inline instruction only.
       const input = event.currentTarget;
-      const attachedPastedText = !overlay && pasteLongTextAsFile(
+      // An attachment is serialised after all inline text, so only a paste that
+      // was already heading to the end can become one. Mid-text pastes stay
+      // inline, where the order the user typed them in survives.
+      const pasteGoesLast = input.selectionEnd === input.value.length;
+      const attachedPastedText = !overlay && pasteGoesLast && pasteLongTextAsFile(
         event,
         (file) => aui.composer().addAttachment(file),
         () =>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -36,6 +36,7 @@ import { TerminalToolUI } from "@/components/assistant-ui/tool-ui-terminal";
 import { WebSearchToolUI } from "@/components/assistant-ui/tool-ui-web-search";
 import { ChatDictationBar } from "@/components/assistant-ui/chat-dictation-bar";
 import {
+  attachmentsPastedText,
   isPastedTextFile,
   pasteClipboardFiles,
   pasteLongTextAsFile,
@@ -3706,9 +3707,20 @@ const Composer: FC<{
               }
               // disableQueue (project new-chat composer) also blocks the queue
               // button, so a running thread shows Stop instead of Queue.
-              queueDisabled={disableQueue || !canQueueCurrentPrompt}
+              queueDisabled={
+                disableQueue ||
+                !(canQueueCurrentPrompt || canQueuePastedTextPrompt)
+              }
               onQueueClick={() => {
                 if (disableQueue) return;
+                // Same pasted-text path the Enter key takes, or the button
+                // would refuse what submitting the form accepts.
+                if (
+                  canQueuePastedTextPrompt &&
+                  queuePastedTextPrompt(true)
+                ) {
+                  return;
+                }
                 const queuedPrompt = composerText.trim();
                 if (queuedPrompt.length === 0) {
                   return;
@@ -6067,7 +6079,11 @@ const CopyButton: FC = () => {
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleCopy = async () => {
-    const text = aui.message().getCopyText();
+    // getCopyText reads content only, and a long paste sits in an attachment.
+    const pasted = attachmentsPastedText(aui.message().getState().attachments);
+    const text = [aui.message().getCopyText(), pasted]
+      .filter((part) => part.length > 0)
+      .join("\n\n");
     if (await copyToClipboard(text)) {
       setCopied(true);
       if (resetTimeoutRef.current) {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2108,6 +2108,7 @@ const Composer: FC<{
     (event: ClipboardEvent<HTMLTextAreaElement>) => {
       // Bulk text pastes attach as a file instead of filling the input, except
       // in image-edit mode, whose submit path takes an inline instruction only.
+      const input = event.currentTarget;
       const attachedPastedText = !overlay && pasteLongTextAsFile(
         event,
         (file) => aui.composer().addAttachment(file),
@@ -2116,7 +2117,17 @@ const Composer: FC<{
             description: "Paste it again, or paste it in smaller pieces.",
           }),
       );
-      if (attachedPastedText) return;
+      if (attachedPastedText) {
+        // Swallowing the paste also swallowed the replacement the browser
+        // would have made, so drop the selection the paste was meant to cover.
+        const { selectionStart, selectionEnd, value } = input;
+        if (selectionStart !== selectionEnd) {
+          aui
+            .composer()
+            .setText(value.slice(0, selectionStart) + value.slice(selectionEnd));
+        }
+        return;
+      }
       pasteClipboardFiles(
         event,
         async (files) => {
@@ -2180,15 +2191,11 @@ const Composer: FC<{
         isPastedTextFile((attachment as { file?: File }).file),
       ),
   );
-  // Identities only: draft autosave keys off this, and the bodies behind it can
-  // be megabytes.
-  const pastedTextDraftSignature = useAuiState(({ composer }) =>
-    composer.attachments
-      .filter((attachment) =>
-        isPastedTextFile((attachment as { file?: File }).file),
-      )
-      .map((attachment) => attachment.id)
-      .join(","),
+  // Identities only: paste autosave keys off this, and the bodies behind it can
+  // be megabytes. Every attachment counts, not just pasted ones, so removing an
+  // ordinary file also releases the paste restore waiting on it.
+  const composerAttachmentSignature = useAuiState(({ composer }) =>
+    composer.attachments.map((attachment) => attachment.id).join(","),
   );
   const hasPendingAudio = useChatRuntimeStore((s) =>
     Boolean(s.pendingAudioName),
@@ -2581,18 +2588,10 @@ const Composer: FC<{
     const composer = aui.composer();
     if (!composer.getState().isEditing) return;
     if (restoredPasteKeyRef.current === pasteDraftKey) return;
-    // The composer outlives a thread switch, so wait for the outgoing paste to
-    // clear rather than stacking this thread's draft on top of it. Changing
-    // attachments re-runs this effect, which is how that retry happens.
-    if (
-      composer
-        .getState()
-        .attachments.some((attachment) =>
-          isPastedTextFile((attachment as { file?: File }).file),
-        )
-    ) {
-      return;
-    }
+    // The composer outlives a thread switch, so restore only into an empty one
+    // rather than mixing this thread's draft with whatever the last one left.
+    // Changing attachments re-runs this effect, which is how the retry happens.
+    if (composer.getState().attachments.length > 0) return;
     const stored = pasteDraftKey ? readPasteDraft(pasteDraftKey) : [];
     if (stored.length === 0) {
       restoredPasteKeyRef.current = pasteDraftKey;
@@ -2605,7 +2604,7 @@ const Composer: FC<{
     ).finally(() => {
       restoredPasteKeyRef.current = pasteDraftKey;
     });
-  }, [pasteDraftKey, pastedTextDraftSignature, aui]);
+  }, [pasteDraftKey, composerAttachmentSignature, aui]);
   // Keyed on the paste identities, never their bodies, so typing beside a
   // megabyte paste does not rewrite it to localStorage every 300ms.
   useEffect(() => {
@@ -2618,7 +2617,7 @@ const Composer: FC<{
         return text === undefined ? [] : [text];
       });
     writePasteDraft(pasteDraftKey, pastes);
-  }, [pastedTextDraftSignature, pasteDraftKey, aui]);
+  }, [composerAttachmentSignature, pasteDraftKey, aui]);
   useEffect(() => {
     // After a thread switch composerText can still hold the previous
     // thread's text; skip that cycle so it isn't saved under the new key.

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -37,6 +37,7 @@ import { WebSearchToolUI } from "@/components/assistant-ui/tool-ui-web-search";
 import { ChatDictationBar } from "@/components/assistant-ui/chat-dictation-bar";
 import {
   pasteClipboardFiles,
+  pasteLongTextAsFile,
   isStudioDictationAvailable,
   notifyStudioDictationUnavailable,
 } from "@/features/chat";
@@ -2098,6 +2099,16 @@ const Composer: FC<{
     useImeComposerInputHandlers({ submitOnEnter: true });
   const handleFilePaste = useCallback(
     (event: ClipboardEvent<HTMLTextAreaElement>) => {
+      // Bulk text pastes attach as a file instead of filling the input.
+      const attachedPastedText = pasteLongTextAsFile(
+        event,
+        (file) => aui.composer().addAttachment(file),
+        () =>
+          toast.error("Could not attach the pasted text.", {
+            description: "Paste it again, or paste it in smaller pieces.",
+          }),
+      );
+      if (attachedPastedText) return;
       pasteClipboardFiles(
         event,
         async (files) => {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2561,15 +2561,19 @@ const Composer: FC<{
     ? composerPasteDraftKey(draftThreadId)
     : null;
   const lastDraftKeyRef = useRef(draftKey);
-  const lastPasteDraftKeyRef = useRef<string | null>(null);
+  // Which key the paste restore has finished for. The save effect writes only
+  // for that key, so a draft is never cleared before it has been put back.
+  const restoredPasteKeyRef = useRef<string | null>(null);
   const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     const draft = draftKey ? (readComposerDraft(draftKey) ?? "") : "";
     const composer = aui.composer();
     if (!composer.getState().isEditing) return;
     composer.setText(draft);
-    // The composer outlives a thread switch, so restore only into one that
-    // holds no paste already; the stored draft keeps until it can come back.
+    if (restoredPasteKeyRef.current === pasteDraftKey) return;
+    // The composer outlives a thread switch, so wait for the outgoing paste to
+    // clear rather than stacking this thread's draft on top of it. Changing
+    // attachments re-runs this effect, which is how that retry happens.
     if (
       composer
         .getState()
@@ -2579,20 +2583,23 @@ const Composer: FC<{
     ) {
       return;
     }
-    for (const text of pasteDraftKey ? readPasteDraft(pasteDraftKey) : []) {
-      void composer.addAttachment(createPastedTextFile(text));
+    const stored = pasteDraftKey ? readPasteDraft(pasteDraftKey) : [];
+    if (stored.length === 0) {
+      restoredPasteKeyRef.current = pasteDraftKey;
+      return;
     }
-  }, [draftKey, pasteDraftKey, aui]);
+    // Claim the key only once the attachments are in, so the save effect
+    // cannot write an empty composer over the draft still being restored.
+    void Promise.all(
+      stored.map((text) => composer.addAttachment(createPastedTextFile(text))),
+    ).finally(() => {
+      restoredPasteKeyRef.current = pasteDraftKey;
+    });
+  }, [draftKey, pasteDraftKey, pastedTextDraftSignature, aui]);
   // Keyed on the paste identities, never their bodies, so typing beside a
   // megabyte paste does not rewrite it to localStorage every 300ms.
   useEffect(() => {
-    if (lastPasteDraftKeyRef.current !== pasteDraftKey) {
-      // The restore above has not landed for this key yet; writing now would
-      // clear the very draft it is about to put back.
-      lastPasteDraftKeyRef.current = pasteDraftKey;
-      return;
-    }
-    if (!pasteDraftKey) return;
+    if (!pasteDraftKey || restoredPasteKeyRef.current !== pasteDraftKey) return;
     const pastes = aui
       .composer()
       .getState()

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2113,25 +2113,28 @@ const Composer: FC<{
       // was already heading to the end can become one. Mid-text pastes stay
       // inline, where the order the user typed them in survives.
       const pasteGoesLast = input.selectionEnd === input.value.length;
+      const { selectionStart, selectionEnd, value } = input;
+      // Swallowing the paste also swallowed the replacement the browser would
+      // have made. Only once the attachment is in, and only if the composer is
+      // still the one that was pasted into, or a failed paste eats the text.
+      const dropReplacedSelection = () => {
+        if (selectionStart === selectionEnd) return;
+        const composer = aui.composer();
+        if (composer.getState().text !== value) return;
+        composer.setText(value.slice(0, selectionStart) + value.slice(selectionEnd));
+      };
       const attachedPastedText = !overlay && pasteGoesLast && pasteLongTextAsFile(
         event,
-        (file) => aui.composer().addAttachment(file),
+        async (file) => {
+          await aui.composer().addAttachment(file);
+          dropReplacedSelection();
+        },
         () =>
           toast.error("Could not attach the pasted text.", {
             description: "Paste it again, or paste it in smaller pieces.",
           }),
       );
-      if (attachedPastedText) {
-        // Swallowing the paste also swallowed the replacement the browser
-        // would have made, so drop the selection the paste was meant to cover.
-        const { selectionStart, selectionEnd, value } = input;
-        if (selectionStart !== selectionEnd) {
-          aui
-            .composer()
-            .setText(value.slice(0, selectionStart) + value.slice(selectionEnd));
-        }
-        return;
-      }
+      if (attachedPastedText) return;
       pasteClipboardFiles(
         event,
         async (files) => {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -141,6 +141,11 @@ import {
   shouldAbortPendingQueueForSettingsChange,
   snapshotQueuedChatRunSettings,
   composerDraftKey,
+  composerPasteDraftKey,
+  createPastedTextFile,
+  pastedTextOf,
+  readPasteDraft,
+  writePasteDraft,
   markThreadIncognito,
   markChatThreadDeleted,
   type PromptQueueRunFailedEventDetail,
@@ -2173,6 +2178,16 @@ const Composer: FC<{
         isPastedTextFile((attachment as { file?: File }).file),
       ),
   );
+  // Identities only: draft autosave keys off this, and the bodies behind it can
+  // be megabytes.
+  const pastedTextDraftSignature = useAuiState(({ composer }) =>
+    composer.attachments
+      .filter((attachment) =>
+        isPastedTextFile((attachment as { file?: File }).file),
+      )
+      .map((attachment) => attachment.id)
+      .join(","),
+  );
   const hasPendingAudio = useChatRuntimeStore((s) =>
     Boolean(s.pendingAudioName),
   );
@@ -2540,15 +2555,53 @@ const Composer: FC<{
   // previous thread's composer contents.
   const draftThreadId = referenceThreadId;
   const draftKey = draftThreadId ? composerDraftKey(draftThreadId) : null;
+  // A pasted attachment is a File held in memory only, so without its own slot
+  // an unsent paste is the one draft a reload throws away.
+  const pasteDraftKey = draftThreadId
+    ? composerPasteDraftKey(draftThreadId)
+    : null;
   const lastDraftKeyRef = useRef(draftKey);
+  const lastPasteDraftKeyRef = useRef<string | null>(null);
   const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     const draft = draftKey ? (readComposerDraft(draftKey) ?? "") : "";
     const composer = aui.composer();
-    if (composer.getState().isEditing) {
-      composer.setText(draft);
+    if (!composer.getState().isEditing) return;
+    composer.setText(draft);
+    // The composer outlives a thread switch, so restore only into one that
+    // holds no paste already; the stored draft keeps until it can come back.
+    if (
+      composer
+        .getState()
+        .attachments.some((attachment) =>
+          isPastedTextFile((attachment as { file?: File }).file),
+        )
+    ) {
+      return;
     }
-  }, [draftKey, aui]);
+    for (const text of pasteDraftKey ? readPasteDraft(pasteDraftKey) : []) {
+      void composer.addAttachment(createPastedTextFile(text));
+    }
+  }, [draftKey, pasteDraftKey, aui]);
+  // Keyed on the paste identities, never their bodies, so typing beside a
+  // megabyte paste does not rewrite it to localStorage every 300ms.
+  useEffect(() => {
+    if (lastPasteDraftKeyRef.current !== pasteDraftKey) {
+      // The restore above has not landed for this key yet; writing now would
+      // clear the very draft it is about to put back.
+      lastPasteDraftKeyRef.current = pasteDraftKey;
+      return;
+    }
+    if (!pasteDraftKey) return;
+    const pastes = aui
+      .composer()
+      .getState()
+      .attachments.flatMap((attachment) => {
+        const text = pastedTextOf((attachment as { file?: File }).file);
+        return text === undefined ? [] : [text];
+      });
+    writePasteDraft(pasteDraftKey, pastes);
+  }, [pastedTextDraftSignature, pasteDraftKey, aui]);
   useEffect(() => {
     // After a thread switch composerText can still hold the previous
     // thread's text; skip that cycle so it isn't saved under the new key.
@@ -2566,9 +2619,11 @@ const Composer: FC<{
   // Without this the restore effect above puts the sent text back when the
   // runtime rebinds on the first message.
   const draftKeyRef = useRef(draftKey);
+  const pasteDraftKeyRef = useRef(pasteDraftKey);
   useEffect(() => {
     draftKeyRef.current = draftKey;
-  }, [draftKey]);
+    pasteDraftKeyRef.current = pasteDraftKey;
+  }, [draftKey, pasteDraftKey]);
   const clearStoredDraft = useCallback(() => {
     if (draftSaveTimerRef.current !== null) {
       clearTimeout(draftSaveTimerRef.current);
@@ -2577,6 +2632,10 @@ const Composer: FC<{
     const key = draftKeyRef.current;
     if (key) {
       writeComposerDraft(key, "");
+    }
+    const pasteKey = pasteDraftKeyRef.current;
+    if (pasteKey) {
+      writePasteDraft(pasteKey, []);
     }
   }, []);
   // react-textarea-autosize re-measures only on value change or window resize,

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -203,6 +203,7 @@ import {
   listStoredChatMessages,
   listStoredChatThreads,
 } from "./utils/chat-history-storage";
+import { attachmentsSample } from "./utils/pasted-text";
 import { requestTemporaryPromptQueueStop } from "./utils/prompt-queue-boundary";
 import { isAssistantLocalThreadId } from "./utils/thread-ids";
 import {
@@ -1336,8 +1337,11 @@ function ProjectLanding({
           return [
             item.id,
             {
+              // A paste-only message carries its text in the attachment, so
+              // the row would otherwise be blank.
               snippet: firstUserMessage
-                ? extractMessageText(firstUserMessage.content)
+                ? extractMessageText(firstUserMessage.content) ||
+                  attachmentsSample(firstUserMessage.attachments)
                 : "",
               date: formatProjectChatDate(item.createdAt),
             },

--- a/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
@@ -8,6 +8,7 @@ import {
   listStoredChatMessages,
   listStoredChatThreads,
 } from "../utils/chat-history-storage";
+import { attachmentsPastedText } from "../utils/pasted-text.ts";
 
 export interface ChatSearchItem {
   type: "single" | "compare";
@@ -83,11 +84,13 @@ function searchableText(value: unknown, depth = 0): string {
 }
 
 // Pull searchable text from a message: plain text, reasoning/thinking, tool
-// calls (name + args + result) and cited sources (title + url).
+// calls (name + args + result), cited sources (title + url) and pasted bodies.
 function extractText(message: MessageRecord): string {
   const content = message.content;
-  if (!Array.isArray(content)) return "";
+  const pasted = attachmentsPastedText(message.attachments);
+  if (!Array.isArray(content)) return pasted;
   const parts: string[] = [];
+  if (pasted) parts.push(pasted);
   for (const part of content) {
     if (!part || typeof part !== "object") continue;
     const p = part as Record<string, unknown>;

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -153,6 +153,7 @@ export {
   pasteLongTextAsFile,
   pastedTextContentBytes,
   pastedTextContentPreview,
+  pastedTextOf,
   pastedTextPreview,
   shouldAttachPastedText,
 } from "./utils/pasted-text";
@@ -192,8 +193,11 @@ export {
 export {
   clearNewChatDraft,
   composerDraftKey,
+  composerPasteDraftKey,
   readComposerDraft,
+  readPasteDraft,
   writeComposerDraft,
+  writePasteDraft,
 } from "./utils/composer-draft";
 export {
   CONVERSATION_MARKDOWN_FORMAT,

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -145,6 +145,13 @@ export { clearAllChats, countAllChats } from "./utils/clear-all-chats";
 export { offerToDeleteKeptSandboxes } from "./utils/offer-kept-sandbox-files";
 export { pasteClipboardFiles } from "./utils/clipboard-files";
 export {
+  createPastedTextFile,
+  isPastedTextFile,
+  pasteLongTextAsFile,
+  shouldAttachPastedText,
+  unwrapAttachmentText,
+} from "./utils/pasted-text";
+export {
   deleteStoredChatThreads,
   ensureStoredChatThread,
   isThreadIncognito,

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -151,9 +151,10 @@ export {
   isPastedTextContent,
   isPastedTextFile,
   pasteLongTextAsFile,
+  pastedTextContentBytes,
+  pastedTextContentPreview,
   pastedTextPreview,
   shouldAttachPastedText,
-  unwrapAttachmentText,
 } from "./utils/pasted-text";
 export {
   deleteStoredChatThreads,

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -146,8 +146,10 @@ export { offerToDeleteKeptSandboxes } from "./utils/offer-kept-sandbox-files";
 export { pasteClipboardFiles } from "./utils/clipboard-files";
 export {
   createPastedTextFile,
+  isPastedTextAttachment,
   isPastedTextFile,
   pasteLongTextAsFile,
+  rememberPastedTextAttachment,
   shouldAttachPastedText,
   unwrapAttachmentText,
 } from "./utils/pasted-text";

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -145,11 +145,13 @@ export { clearAllChats, countAllChats } from "./utils/clear-all-chats";
 export { offerToDeleteKeptSandboxes } from "./utils/offer-kept-sandbox-files";
 export { pasteClipboardFiles } from "./utils/clipboard-files";
 export {
+  PASTED_TEXT_PREVIEW_MAX_CHARS,
+  attachmentContentText,
   createPastedTextFile,
-  isPastedTextAttachment,
+  isPastedTextContent,
   isPastedTextFile,
   pasteLongTextAsFile,
-  rememberPastedTextAttachment,
+  pastedTextPreview,
   shouldAttachPastedText,
   unwrapAttachmentText,
 } from "./utils/pasted-text";

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -147,6 +147,7 @@ export { pasteClipboardFiles } from "./utils/clipboard-files";
 export {
   PASTED_TEXT_PREVIEW_MAX_CHARS,
   attachmentContentText,
+  attachmentsPastedText,
   createPastedTextFile,
   isPastedTextContent,
   isPastedTextFile,

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -317,9 +317,14 @@ function messageToOpenAI(msg: { role: unknown; content: unknown; attachments?: u
     ...blocks.map((b) => b as Record<string, unknown>),
     ...attachments.flatMap((a) => {
       const att = a as { content?: unknown };
-      return Array.isArray(att.content)
-        ? (att.content as Record<string, unknown>[])
-        : [];
+      if (!Array.isArray(att.content)) return [];
+      // Attachment text only: a message body is verbatim, and the paste
+      // wrapper is not something the user wrote.
+      return (att.content as Record<string, unknown>[]).map((part) =>
+        part?.type === "text" && typeof part.text === "string"
+          ? { ...part, text: unwrapPastedTextContent(part.text) }
+          : part,
+      );
     }),
   ];
 

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -60,6 +60,7 @@ import { toolResultModelText } from "../api/chat-adapter";
 import { usePlusMenuPrefsStore } from "../stores/plus-menu-prefs-store";
 import type { ThreadRecord, MessageRecord } from "../types";
 import { createConversationMarkdownExporter } from "../utils/conversation-markdown-export";
+import { unwrapPastedTextContent } from "../utils/pasted-text.ts";
 import {
   contentBlocksToMarkdownBlocks,
   renderConversationBlocks,
@@ -254,7 +255,11 @@ function messageToText(msg: { content: unknown; attachments?: unknown }): string
   if (Array.isArray(msg.attachments)) {
     for (const attachment of msg.attachments as Array<{ content?: unknown }>) {
       if (!attachment?.content) continue;
-      const attText = contentBlocksToText(attachment.content);
+      // A paste carries a wrapper the same text never had when it fitted
+      // inline, so strip it rather than exporting the marker.
+      const attText = unwrapPastedTextContent(
+        contentBlocksToText(attachment.content),
+      );
       if (attText) parts.push(attText);
     }
   }
@@ -273,6 +278,10 @@ function messageToMarkdown(msg: { content: unknown; attachments?: unknown }): st
         ...contentBlocksToMarkdownBlocks(
           attachment.content,
           normalizeToolResult,
+        ).map((block) =>
+          block.kind === "text"
+            ? { ...block, text: unwrapPastedTextContent(block.text) }
+            : block,
         ),
       );
     }
@@ -623,7 +632,8 @@ function messageToPlainText(msg: {
       }
       const block = b as Record<string, unknown>;
       if (block.type === "text" && typeof block.text === "string" && block.text) {
-        parts.push(block.text);
+        // No-op for message content, which never carries the paste wrapper.
+        parts.push(unwrapPastedTextContent(block.text));
       }
     }
   };

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -619,10 +619,15 @@ function messageToPlainText(msg: {
   attachments?: unknown;
 }): string {
   const parts: string[] = [];
-  const collect = (blocks: unknown) => {
+  // Only attachment text is unwrapped: a message body is verbatim, and may
+  // legitimately quote the wrapper syntax in a code sample.
+  const collect = (blocks: unknown, fromAttachment = false) => {
+    const normalize = fromAttachment
+      ? unwrapPastedTextContent
+      : (text: string) => text;
     // Legacy and imported histories can store content as a plain string.
     if (typeof blocks === "string") {
-      if (blocks.trim()) parts.push(blocks);
+      if (blocks.trim()) parts.push(normalize(blocks));
       return;
     }
     if (!Array.isArray(blocks)) return;
@@ -632,15 +637,14 @@ function messageToPlainText(msg: {
       }
       const block = b as Record<string, unknown>;
       if (block.type === "text" && typeof block.text === "string" && block.text) {
-        // No-op for message content, which never carries the paste wrapper.
-        parts.push(unwrapPastedTextContent(block.text));
+        parts.push(normalize(block.text));
       }
     }
   };
   collect(msg.content);
   if (Array.isArray(msg.attachments)) {
     for (const attachment of msg.attachments as Array<{ content?: unknown }>) {
-      collect(attachment?.content);
+      collect(attachment?.content, true);
     }
   }
   return parts.join("\n\n").trim();

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -328,12 +328,13 @@ class TextAttachmentAdapter implements AttachmentAdapter {
       content: [
         {
           type: "text",
-          // A pasted file gets its own tag, the one marker that outlives the
-          // File once the message is stored.
+          // A pasted file gets its own tag and size, the markers that outlive
+          // the File once the message is stored.
           text: attachmentContentText(
             attachment.name,
             text,
             isPastedTextFile(attachment.file),
+            attachment.file.size,
           ),
         },
       ],

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -531,12 +531,15 @@ function extractTextParts(m: ThreadMessage | undefined): string {
     .trim();
 }
 
-// A message that is only a paste has no inline text, so the thread would stay
-// "New Chat". The attachment holds what the user actually sent.
+// A paste leaves the message's text in an attachment, so a title built from
+// inline text alone is "New Chat" for a paste-only turn and the bare
+// instruction for "summarise this" plus a paste. The sample is bounded.
 function titleTextOf(m: ThreadMessage | undefined): string {
   const text = extractTextParts(m);
-  if (text.length > 0) return text;
-  return m?.role === "user" ? attachmentsSample(m.attachments) : "";
+  if (m?.role !== "user") return text;
+  const sample = attachmentsSample(m.attachments);
+  if (sample.length === 0) return text;
+  return text.length > 0 ? `${text}\n\n${sample}` : sample;
 }
 
 async function generateTitleWithModel(payload: {

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -81,6 +81,7 @@ import {
   chatContentPartAttachmentSignature,
   onChatAttachmentDeleted,
 } from "./utils/chat-attachment-events";
+import { attachmentContentText, isPastedTextFile } from "./utils/pasted-text";
 import {
   refreshContextUsage,
   setActiveBranchReader,
@@ -327,7 +328,13 @@ class TextAttachmentAdapter implements AttachmentAdapter {
       content: [
         {
           type: "text",
-          text: `<attachment name=${attachment.name}>\n${text}\n</attachment>`,
+          // A pasted file gets its own tag, the one marker that outlives the
+          // File once the message is stored.
+          text: attachmentContentText(
+            attachment.name,
+            text,
+            isPastedTextFile(attachment.file),
+          ),
         },
       ],
       status: { type: "complete" },

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -81,7 +81,11 @@ import {
   chatContentPartAttachmentSignature,
   onChatAttachmentDeleted,
 } from "./utils/chat-attachment-events";
-import { attachmentContentText, isPastedTextFile } from "./utils/pasted-text";
+import {
+  attachmentContentText,
+  attachmentsSample,
+  isPastedTextFile,
+} from "./utils/pasted-text";
 import {
   refreshContextUsage,
   setActiveBranchReader,
@@ -527,6 +531,14 @@ function extractTextParts(m: ThreadMessage | undefined): string {
     .trim();
 }
 
+// A message that is only a paste has no inline text, so the thread would stay
+// "New Chat". The attachment holds what the user actually sent.
+function titleTextOf(m: ThreadMessage | undefined): string {
+  const text = extractTextParts(m);
+  if (text.length > 0) return text;
+  return m?.role === "user" ? attachmentsSample(m.attachments) : "";
+}
+
 async function generateTitleWithModel(payload: {
   userText: string;
   assistantText?: string;
@@ -874,7 +886,7 @@ function createStudioDbAdapter(
         firstUserIndex === -1
           ? undefined
           : messages.find((m, i) => m.role === "assistant" && i > firstUserIndex);
-      const userText = extractTextParts(firstUser) || defaultTitle;
+      const userText = titleTextOf(firstUser) || defaultTitle;
       const assistantText = extractTextParts(firstAssistant);
 
       if (!autoTitle) {

--- a/studio/frontend/src/features/chat/utils/clipboard-files.ts
+++ b/studio/frontend/src/features/chat/utils/clipboard-files.ts
@@ -3,6 +3,11 @@
 
 import { isTauri } from "@/lib/api-base";
 import { MAX_AUDIO_SIZE } from "@/lib/audio-utils";
+import {
+  browserClipboardFiles,
+  clipboardAdvertisesFiles,
+  clipboardHasPlainText,
+} from "./clipboard-payload.ts";
 
 const MAX_NATIVE_IMAGE_DIMENSION = 8192;
 const MAX_NATIVE_IMAGE_RGBA_BYTES = 64 * 1024 * 1024;
@@ -21,52 +26,6 @@ type NativeClipboardFile = {
   readonly mimeType: string;
   readonly base64: string;
 };
-
-function browserClipboardFiles(clipboardData: DataTransfer): File[] {
-  const files = Array.from(clipboardData.files).filter((file) => file.size > 0);
-  if (files.length > 0) return files;
-
-  return Array.from(clipboardData.items)
-    .filter((item) => item.kind === "file")
-    .map((item) => item.getAsFile())
-    .filter((file): file is File => file !== null && file.size > 0);
-}
-
-function clipboardTypes(clipboardData: DataTransfer): string[] {
-  return Array.from(clipboardData.types, (type) => type.toLowerCase());
-}
-
-function clipboardHasLocalFileUri(
-  clipboardData: DataTransfer,
-  types: readonly string[],
-): boolean {
-  const uriTypes = types.filter(
-    (type) => type.includes("uri-list") || type.includes("urilist"),
-  );
-  for (const type of uriTypes) {
-    try {
-      if (
-        clipboardData
-          .getData(type)
-          .split(/\r?\n/)
-          .some((line) => line.trim().toLowerCase().startsWith("file:"))
-      ) {
-        return true;
-      }
-    } catch {
-      return false;
-    }
-  }
-  return false;
-}
-
-function clipboardHasPlainText(clipboardData: DataTransfer): boolean {
-  try {
-    return clipboardData.getData("text/plain").length > 0;
-  } catch {
-    return true;
-  }
-}
 
 function validDimension(value: number): boolean {
   return (
@@ -244,16 +203,9 @@ export function pasteClipboardFiles(
     return;
   }
 
-  const types = clipboardTypes(clipboardData);
-  const advertisesImage = types.some((type) => type.startsWith("image/"));
-  const advertisesFile =
-    types.includes("files") ||
-    types.some((type) => type.includes("copied-files")) ||
-    clipboardHasLocalFileUri(clipboardData, types);
-  if (!advertisesImage && !advertisesFile && clipboardHasPlainText(clipboardData)) {
-    return;
-  }
+  const advertisesFiles = clipboardAdvertisesFiles(clipboardData);
+  if (!advertisesFiles && clipboardHasPlainText(clipboardData)) return;
 
-  if (advertisesImage || advertisesFile) event.preventDefault();
+  if (advertisesFiles) event.preventDefault();
   addNativeClipboardFiles(addFiles, onError);
 }

--- a/studio/frontend/src/features/chat/utils/clipboard-payload.ts
+++ b/studio/frontend/src/features/chat/utils/clipboard-payload.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Shared clipboard inspection. The file paste path and the long text paste path
+// must agree on what counts as a file, or a paste falls through both or neither.
+
+function clipboardTypes(clipboardData: DataTransfer): string[] {
+  return Array.from(clipboardData.types, (type) => type.toLowerCase());
+}
+
+function clipboardHasLocalFileUri(
+  clipboardData: DataTransfer,
+  types: readonly string[],
+): boolean {
+  return types
+    .filter((type) => type.includes("uri-list") || type.includes("urilist"))
+    .some((type) => {
+      try {
+        return clipboardData
+          .getData(type)
+          .split(/\r?\n/)
+          .some((line) => line.trim().toLowerCase().startsWith("file:"));
+      } catch {
+        return false;
+      }
+    });
+}
+
+/** Files the browser decoded for us, ready to attach. */
+export function browserClipboardFiles(clipboardData: DataTransfer): File[] {
+  const files = Array.from(clipboardData.files).filter((file) => file.size > 0);
+  if (files.length > 0) return files;
+
+  return Array.from(clipboardData.items)
+    .filter((item) => item.kind === "file")
+    .map((item) => item.getAsFile())
+    .filter((file): file is File => file !== null && file.size > 0);
+}
+
+/** A file entry the browser may still refuse to decode, so the text path defers. */
+export function clipboardHasFileEntries(clipboardData: DataTransfer): boolean {
+  if (Array.from(clipboardData.files).some((file) => file.size > 0)) return true;
+  return Array.from(clipboardData.items).some((item) => item.kind === "file");
+}
+
+// Native (Tauri) images and copied files are advertised by type only, with no
+// entry in files or items, and only pasteClipboardFiles can read them.
+export function clipboardAdvertisesFiles(clipboardData: DataTransfer): boolean {
+  const types = clipboardTypes(clipboardData);
+  return (
+    types.some((type) => type.startsWith("image/")) ||
+    types.includes("files") ||
+    types.some((type) => type.includes("copied-files")) ||
+    clipboardHasLocalFileUri(clipboardData, types)
+  );
+}
+
+export function clipboardHasPlainText(clipboardData: DataTransfer): boolean {
+  try {
+    return clipboardData.getData("text/plain").length > 0;
+  } catch {
+    return true;
+  }
+}

--- a/studio/frontend/src/features/chat/utils/composer-draft.ts
+++ b/studio/frontend/src/features/chat/utils/composer-draft.ts
@@ -5,10 +5,52 @@
 // share the NEW_CHAT_DRAFT_ID slot; callers clear it when a fresh chat starts
 // so one new chat's draft never bleeds into the next.
 const DRAFT_PREFIX = "chat-draft:";
+const PASTE_DRAFT_PREFIX = "chat-draft-pastes:";
 const NEW_CHAT_DRAFT_ID = "__new__";
 
 export function composerDraftKey(threadId: string | null | undefined): string {
   return `${DRAFT_PREFIX}${threadId ?? NEW_CHAT_DRAFT_ID}`;
+}
+
+// Pasted attachments live in their own slot rather than inside the text draft,
+// so typing never rewrites a paste that can run to megabytes.
+export function composerPasteDraftKey(
+  threadId: string | null | undefined,
+): string {
+  return `${PASTE_DRAFT_PREFIX}${threadId ?? NEW_CHAT_DRAFT_ID}`;
+}
+
+// The names are not stored: a pasted file is named from its own text, so
+// recreating it reproduces the name it had.
+export function readPasteDraft(key: string): string[] {
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(key);
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is string => typeof entry === "string");
+  } catch {
+    return [];
+  }
+}
+
+// A paste large enough to blow the storage quota throws here, leaving the text
+// draft untouched, which is why the two slots are written separately.
+export function writePasteDraft(key: string, pastes: readonly string[]): void {
+  try {
+    if (pastes.length > 0) {
+      window.localStorage.setItem(key, JSON.stringify(pastes));
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // ignore write failures
+  }
 }
 
 // All storage access is best-effort: localStorage throws when unavailable
@@ -33,6 +75,7 @@ export function writeComposerDraft(key: string, text: string): void {
 export function clearComposerDraft(threadId: string | null | undefined): void {
   try {
     window.localStorage.removeItem(composerDraftKey(threadId));
+    window.localStorage.removeItem(composerPasteDraftKey(threadId));
   } catch {
     // ignore
   }

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -33,6 +33,8 @@ type ClipboardTextPasteEvent = {
 // Identity separates a pasted blob from a .txt the user attached. A sent
 // message keeps no File, so the wrapper below carries it over instead.
 const pastedTextFiles = new WeakSet<File>();
+// The text as pasted, so draft autosave never re-reads the File on a keystroke.
+const pastedTextByFile = new WeakMap<File, string>();
 
 function countLines(text: string): number {
   let lines = 1;
@@ -96,12 +98,18 @@ export function createPastedTextFile(text: string): File {
     lastModified: Date.now(),
   });
   pastedTextFiles.add(file);
+  pastedTextByFile.set(file, text);
   return file;
 }
 
 /** A live File must match by identity: the name no longer marks a paste. */
 export function isPastedTextFile(file: File | undefined): boolean {
   return file !== undefined && pastedTextFiles.has(file);
+}
+
+/** What was pasted, without a `File.text()` round trip. */
+export function pastedTextOf(file: File | undefined): string | undefined {
+  return file === undefined ? undefined : pastedTextByFile.get(file);
 }
 
 /**

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -4,6 +4,11 @@
 // Long pastes become a .txt attachment instead of flooding the composer.
 // TextAttachmentAdapter still sends the full text to the model.
 
+import {
+  clipboardAdvertisesFiles,
+  clipboardHasFileEntries,
+} from "./clipboard-payload.ts";
+
 const PASTED_TEXT_MIME = "text/plain";
 export const PASTED_TEXT_MIN_CHARS = 2000;
 export const PASTED_TEXT_MIN_LINES = 40;
@@ -203,42 +208,6 @@ export function attachmentsSample(
   return "";
 }
 
-function clipboardHasFiles(clipboardData: DataTransfer): boolean {
-  if (Array.from(clipboardData.files).some((file) => file.size > 0))
-    return true;
-  return Array.from(clipboardData.items).some((item) => item.kind === "file");
-}
-
-function clipboardHasLocalFileUri(
-  clipboardData: DataTransfer,
-  types: readonly string[],
-): boolean {
-  return types
-    .filter((type) => type.includes("uri-list") || type.includes("urilist"))
-    .some((type) => {
-      try {
-        return clipboardData
-          .getData(type)
-          .split(/\r?\n/)
-          .some((line) => line.trim().toLowerCase().startsWith("file:"));
-      } catch {
-        return false;
-      }
-    });
-}
-
-// Native (Tauri) images and copied files are advertised by type only, with no
-// entry in files or items, and pasteClipboardFiles reads them itself.
-function clipboardAdvertisesFiles(clipboardData: DataTransfer): boolean {
-  const types = Array.from(clipboardData.types, (type) => type.toLowerCase());
-  return (
-    types.some((type) => type.startsWith("image/")) ||
-    types.includes("files") ||
-    types.some((type) => type.includes("copied-files")) ||
-    clipboardHasLocalFileUri(clipboardData, types)
-  );
-}
-
 function clipboardText(clipboardData: DataTransfer): string {
   try {
     return clipboardData.getData("text/plain");
@@ -257,7 +226,7 @@ export function pasteLongTextAsFile(
   const { clipboardData } = event;
   if (!clipboardData) return false;
   // Images and files keep the existing paste path.
-  if (clipboardHasFiles(clipboardData)) return false;
+  if (clipboardHasFileEntries(clipboardData)) return false;
   if (clipboardAdvertisesFiles(clipboardData)) return false;
 
   const text = clipboardText(clipboardData);

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -98,20 +98,62 @@ export function isPastedTextFile(file: File | undefined): boolean {
 }
 
 /**
- * Wraps an attachment for the model. A paste gets its own tag, which is also
- * the only marker that survives a reload, since the File does not.
+ * Wraps an attachment for the model. A paste gets its own tag and its size,
+ * the only markers that survive a reload, since the File does not.
  */
 export function attachmentContentText(
   name: string,
   text: string,
   pasted: boolean,
+  bytes?: number,
 ): string {
-  const tag = pasted ? PASTED_TEXT_TAG : "attachment";
-  return `<${tag} name=${name}>\n${text}\n</${tag}>`;
+  if (!pasted) return `<attachment name=${name}>\n${text}\n</attachment>`;
+  const size = bytes === undefined ? "" : ` bytes=${bytes}`;
+  return `<${PASTED_TEXT_TAG} name=${name}${size}>\n${text}\n</${PASTED_TEXT_TAG}>`;
 }
 
 export function isPastedTextContent(text: string | undefined): boolean {
   return text?.startsWith(`<${PASTED_TEXT_TAG} name=`) === true;
+}
+
+// Header only. Sizing a sent paste any other way means walking every byte of
+// it during render, which is what the chip must never do.
+const PASTED_TEXT_BYTES_RE = /^<pasted_text name=[^\n>]* bytes=(\d+)>/;
+const PASTED_TEXT_HEADER_SCAN_CHARS = 1024;
+
+export function pastedTextContentBytes(
+  content: string | undefined,
+): number | undefined {
+  if (content === undefined) return undefined;
+  const bytes = PASTED_TEXT_BYTES_RE.exec(
+    content.slice(0, PASTED_TEXT_HEADER_SCAN_CHARS),
+  )?.[1];
+  return bytes === undefined ? undefined : Number(bytes);
+}
+
+/**
+ * Previews wrapped content without unwrapping it: the body can be megabytes,
+ * and only the opening is ever rendered.
+ */
+export function pastedTextContentPreview(content: string): {
+  text: string;
+  remaining: number;
+} {
+  const headerEnd = content.indexOf("\n");
+  if (headerEnd === -1) return pastedTextPreview(content);
+
+  const start = headerEnd + 1;
+  const closing = `\n</${content.startsWith("<attachment ") ? "attachment" : PASTED_TEXT_TAG}>`;
+  const end = content.endsWith(closing)
+    ? content.length - closing.length
+    : content.length;
+
+  const length = Math.max(end - start, 0);
+  const taken = Math.min(length, PASTED_TEXT_PREVIEW_MAX_CHARS);
+  return {
+    text: content.slice(start, start + taken),
+    remaining: length - taken,
+  };
 }
 
 function clipboardHasFiles(clipboardData: DataTransfer): boolean {
@@ -190,14 +232,6 @@ export function pasteLongTextAsFile(
     onError?.();
   }
   return true;
-}
-
-const ATTACHMENT_WRAPPER_RE =
-  /^<(attachment|pasted_text) name=[^\n>]*>\n([\s\S]*)\n<\/\1>$/;
-
-/** Strips the wrapper TextAttachmentAdapter adds on send, for previews. */
-export function unwrapAttachmentText(text: string): string {
-  return ATTACHMENT_WRAPPER_RE.exec(text)?.[2] ?? text;
 }
 
 /** Renders an opening rather than the whole paste, which can be megabytes. */

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -15,6 +15,8 @@ export const PASTED_TEXT_MIN_LINES = 40;
 const PASTED_TEXT_NAME_MAX_CHARS = 32;
 // Enough for the name after whitespace collapses, without copying a line.
 const PASTED_TEXT_NAME_SCAN_CHARS = 256;
+// Blank lines are stepped over one at a time, so the walk needs its own bound.
+const PASTED_TEXT_NAME_TOTAL_SCAN_CHARS = 64 * 1024;
 const PASTED_TEXT_FALLBACK_NAME = "Pasted text";
 const PASTED_TEXT_TAG = "pasted_text";
 // A preview is for reading, so render an opening rather than megabytes.
@@ -58,8 +60,12 @@ export function shouldAttachPastedText(text: string): boolean {
 // line for nothing, so walk to the first non-blank line instead, and never
 // copy more of it than a name can hold.
 function firstTextLine(text: string): string {
+  // Bounded twice over: each slice, so one line cannot be copied whole, and
+  // the walk itself, so a paste of nothing but blank lines cannot be stepped
+  // through a line at a time.
+  const limit = Math.min(text.length, PASTED_TEXT_NAME_TOTAL_SCAN_CHARS);
   let start = 0;
-  while (start < text.length) {
+  while (start < limit) {
     const end = text.indexOf("\n", start);
     const stop = Math.min(
       end === -1 ? text.length : end,

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -7,8 +7,6 @@
 const PASTED_TEXT_MIME = "text/plain";
 export const PASTED_TEXT_MIN_CHARS = 2000;
 export const PASTED_TEXT_MIN_LINES = 40;
-// Past this the paste is too big to hold in memory twice.
-const PASTED_TEXT_MAX_CHARS = 20 * 1024 * 1024;
 const PASTED_TEXT_NAME_RE = /^Pasted_Text_\d+\.txt$/;
 
 type ClipboardTextPasteEvent = {
@@ -29,8 +27,8 @@ function countLines(text: string): number {
   return lines;
 }
 
+// No upper bound: the bigger the paste, the worse it is inline.
 export function shouldAttachPastedText(text: string): boolean {
-  if (text.length > PASTED_TEXT_MAX_CHARS) return false;
   if (text.trim().length === 0) return false;
   return (
     text.length >= PASTED_TEXT_MIN_CHARS ||
@@ -58,14 +56,46 @@ export function isPastedTextFile(
   file: File | undefined,
   name?: string,
 ): boolean {
-  if (file && pastedTextFiles.has(file)) return true;
-  return PASTED_TEXT_NAME_RE.test(name ?? file?.name ?? "");
+  // A live File must match by identity, or a .txt the user named this way
+  // would be mistaken for a paste.
+  if (file) return pastedTextFiles.has(file);
+  return PASTED_TEXT_NAME_RE.test(name ?? "");
 }
 
 function clipboardHasFiles(clipboardData: DataTransfer): boolean {
   if (Array.from(clipboardData.files).some((file) => file.size > 0))
     return true;
   return Array.from(clipboardData.items).some((item) => item.kind === "file");
+}
+
+function clipboardHasLocalFileUri(
+  clipboardData: DataTransfer,
+  types: readonly string[],
+): boolean {
+  return types
+    .filter((type) => type.includes("uri-list") || type.includes("urilist"))
+    .some((type) => {
+      try {
+        return clipboardData
+          .getData(type)
+          .split(/\r?\n/)
+          .some((line) => line.trim().toLowerCase().startsWith("file:"));
+      } catch {
+        return false;
+      }
+    });
+}
+
+// Native (Tauri) images and copied files are advertised by type only, with no
+// entry in files or items, and pasteClipboardFiles reads them itself.
+function clipboardAdvertisesFiles(clipboardData: DataTransfer): boolean {
+  const types = Array.from(clipboardData.types, (type) => type.toLowerCase());
+  return (
+    types.some((type) => type.startsWith("image/")) ||
+    types.includes("files") ||
+    types.some((type) => type.includes("copied-files")) ||
+    clipboardHasLocalFileUri(clipboardData, types)
+  );
 }
 
 function clipboardText(clipboardData: DataTransfer): string {
@@ -87,6 +117,7 @@ export function pasteLongTextAsFile(
   if (!clipboardData) return false;
   // Images and files keep the existing paste path.
   if (clipboardHasFiles(clipboardData)) return false;
+  if (clipboardAdvertisesFiles(clipboardData)) return false;
 
   const text = clipboardText(clipboardData);
   if (!shouldAttachPastedText(text)) return false;

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -208,6 +208,32 @@ export function attachmentsSample(
   return "";
 }
 
+/** The whole body of a sent paste, unwrapped. Empty for any other content. */
+export function pastedTextContentBody(content: string): string {
+  if (!isPastedTextContent(content)) return "";
+  const { start, end } = attachmentBodyRange(content);
+  return content.slice(start, end);
+}
+
+/**
+ * Every pasted body on a message. Chat Search reads `content` only, so without
+ * this a paste stops being findable the moment it moves into an attachment.
+ * Other attachment types were never indexed and stay that way.
+ */
+export function attachmentsPastedText(
+  attachments: readonly AttachmentLike[] | undefined,
+): string {
+  const bodies: string[] = [];
+  for (const attachment of attachments ?? []) {
+    for (const part of attachment.content ?? []) {
+      if (part.type !== "text" || part.text === undefined) continue;
+      const body = pastedTextContentBody(part.text);
+      if (body.length > 0) bodies.push(body);
+    }
+  }
+  return bodies.join(" ");
+}
+
 function clipboardText(clipboardData: DataTransfer): string {
   try {
     return clipboardData.getData("text/plain");

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -7,7 +7,10 @@
 const PASTED_TEXT_MIME = "text/plain";
 export const PASTED_TEXT_MIN_CHARS = 2000;
 export const PASTED_TEXT_MIN_LINES = 40;
-const PASTED_TEXT_NAME_RE = /^Pasted_Text_\d+\.txt$/;
+const PASTED_TEXT_NAME_MAX_CHARS = 32;
+const PASTED_TEXT_FALLBACK_NAME = "Pasted text";
+// Illegal in filenames on at least one platform, plus control characters.
+const UNSAFE_NAME_CHARS = /[\\/:*?"<>|\p{Cc}]/gu;
 
 type ClipboardTextPasteEvent = {
   readonly clipboardData: DataTransfer | null;
@@ -15,9 +18,11 @@ type ClipboardTextPasteEvent = {
   preventDefault: () => void;
 };
 
-// Identity separates a pasted blob from a .txt the user attached. Sent
-// messages keep only the name, so isPastedTextFile falls back to that.
+// Identity separates a pasted blob from a .txt the user attached. A sent
+// message keeps no File, so the attachment id carries it over instead.
 const pastedTextFiles = new WeakSet<File>();
+const pastedTextIds = new Set<string>();
+const PASTED_TEXT_ID_LIMIT = 200;
 
 function countLines(text: string): number {
   let lines = 1;
@@ -36,30 +41,52 @@ export function shouldAttachPastedText(text: string): boolean {
   );
 }
 
-export function pastedTextFileName(now: number = Date.now()): string {
-  return `Pasted_Text_${Math.floor(now / 1000)}.txt`;
+/** Names the file after the opening of the paste, so the chip is readable. */
+export function pastedTextFileName(text: string): string {
+  const firstLine = text.split("\n").find((line) => line.trim().length > 0);
+  const cleaned = (firstLine ?? "")
+    .replace(UNSAFE_NAME_CHARS, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  let snippet = cleaned.slice(0, PASTED_TEXT_NAME_MAX_CHARS);
+  if (cleaned.length > PASTED_TEXT_NAME_MAX_CHARS) {
+    // Prefer a word boundary, but not one that leaves a stub.
+    const lastSpace = snippet.lastIndexOf(" ");
+    if (lastSpace >= PASTED_TEXT_NAME_MAX_CHARS / 2) {
+      snippet = snippet.slice(0, lastSpace);
+    }
+  }
+  snippet = snippet.replace(/[\s.]+$/, "");
+  return `${snippet.length > 0 ? snippet : PASTED_TEXT_FALLBACK_NAME}.txt`;
 }
 
-export function createPastedTextFile(
-  text: string,
-  now: number = Date.now(),
-): File {
-  const file = new File([text], pastedTextFileName(now), {
+export function createPastedTextFile(text: string): File {
+  const file = new File([text], pastedTextFileName(text), {
     type: PASTED_TEXT_MIME,
-    lastModified: now,
+    lastModified: Date.now(),
   });
   pastedTextFiles.add(file);
   return file;
 }
 
-export function isPastedTextFile(
-  file: File | undefined,
-  name?: string,
-): boolean {
-  // A live File must match by identity, or a .txt the user named this way
-  // would be mistaken for a paste.
-  if (file) return pastedTextFiles.has(file);
-  return PASTED_TEXT_NAME_RE.test(name ?? "");
+/** A live File must match by identity: the name no longer marks a paste. */
+export function isPastedTextFile(file: File | undefined): boolean {
+  return file !== undefined && pastedTextFiles.has(file);
+}
+
+/** Sending keeps the attachment id, which is how the chip survives the send. */
+export function rememberPastedTextAttachment(id: string): void {
+  if (pastedTextIds.has(id)) return;
+  if (pastedTextIds.size >= PASTED_TEXT_ID_LIMIT) {
+    const oldest = pastedTextIds.values().next().value;
+    if (oldest !== undefined) pastedTextIds.delete(oldest);
+  }
+  pastedTextIds.add(id);
+}
+
+export function isPastedTextAttachment(id: string): boolean {
+  return pastedTextIds.has(id);
 }
 
 function clipboardHasFiles(clipboardData: DataTransfer): boolean {

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -8,7 +8,12 @@ const PASTED_TEXT_MIME = "text/plain";
 export const PASTED_TEXT_MIN_CHARS = 2000;
 export const PASTED_TEXT_MIN_LINES = 40;
 const PASTED_TEXT_NAME_MAX_CHARS = 32;
+// Enough for the name after whitespace collapses, without copying a line.
+const PASTED_TEXT_NAME_SCAN_CHARS = 256;
 const PASTED_TEXT_FALLBACK_NAME = "Pasted text";
+const PASTED_TEXT_TAG = "pasted_text";
+// A preview is for reading, so render an opening rather than megabytes.
+export const PASTED_TEXT_PREVIEW_MAX_CHARS = 100_000;
 // Illegal in filenames on at least one platform, plus control characters.
 const UNSAFE_NAME_CHARS = /[\\/:*?"<>|\p{Cc}]/gu;
 
@@ -19,10 +24,8 @@ type ClipboardTextPasteEvent = {
 };
 
 // Identity separates a pasted blob from a .txt the user attached. A sent
-// message keeps no File, so the attachment id carries it over instead.
+// message keeps no File, so the wrapper below carries it over instead.
 const pastedTextFiles = new WeakSet<File>();
-const pastedTextIds = new Set<string>();
-const PASTED_TEXT_ID_LIMIT = 200;
 
 function countLines(text: string): number {
   let lines = 1;
@@ -32,19 +35,38 @@ function countLines(text: string): number {
   return lines;
 }
 
-// No upper bound: the bigger the paste, the worse it is inline.
+// No upper bound, and whitespace is not exempt: the bigger the paste, the
+// worse it is inline.
 export function shouldAttachPastedText(text: string): boolean {
-  if (text.trim().length === 0) return false;
+  if (text.length === 0) return false;
   return (
     text.length >= PASTED_TEXT_MIN_CHARS ||
     countLines(text) >= PASTED_TEXT_MIN_LINES
   );
 }
 
+// Splitting a multi-megabyte paste to read one line allocates every other
+// line for nothing, so walk to the first non-blank line instead, and never
+// copy more of it than a name can hold.
+function firstTextLine(text: string): string {
+  let start = 0;
+  while (start < text.length) {
+    const end = text.indexOf("\n", start);
+    const stop = Math.min(
+      end === -1 ? text.length : end,
+      start + PASTED_TEXT_NAME_SCAN_CHARS,
+    );
+    const line = text.slice(start, stop);
+    if (line.trim().length > 0) return line;
+    if (end === -1) return "";
+    start = end + 1;
+  }
+  return "";
+}
+
 /** Names the file after the opening of the paste, so the chip is readable. */
 export function pastedTextFileName(text: string): string {
-  const firstLine = text.split("\n").find((line) => line.trim().length > 0);
-  const cleaned = (firstLine ?? "")
+  const cleaned = firstTextLine(text)
     .replace(UNSAFE_NAME_CHARS, " ")
     .replace(/\s+/g, " ")
     .trim();
@@ -75,18 +97,21 @@ export function isPastedTextFile(file: File | undefined): boolean {
   return file !== undefined && pastedTextFiles.has(file);
 }
 
-/** Sending keeps the attachment id, which is how the chip survives the send. */
-export function rememberPastedTextAttachment(id: string): void {
-  if (pastedTextIds.has(id)) return;
-  if (pastedTextIds.size >= PASTED_TEXT_ID_LIMIT) {
-    const oldest = pastedTextIds.values().next().value;
-    if (oldest !== undefined) pastedTextIds.delete(oldest);
-  }
-  pastedTextIds.add(id);
+/**
+ * Wraps an attachment for the model. A paste gets its own tag, which is also
+ * the only marker that survives a reload, since the File does not.
+ */
+export function attachmentContentText(
+  name: string,
+  text: string,
+  pasted: boolean,
+): string {
+  const tag = pasted ? PASTED_TEXT_TAG : "attachment";
+  return `<${tag} name=${name}>\n${text}\n</${tag}>`;
 }
 
-export function isPastedTextAttachment(id: string): boolean {
-  return pastedTextIds.has(id);
+export function isPastedTextContent(text: string | undefined): boolean {
+  return text?.startsWith(`<${PASTED_TEXT_TAG} name=`) === true;
 }
 
 function clipboardHasFiles(clipboardData: DataTransfer): boolean {
@@ -149,17 +174,40 @@ export function pasteLongTextAsFile(
   const text = clipboardText(clipboardData);
   if (!shouldAttachPastedText(text)) return false;
 
+  // Build the file first: if that throws, the browser can still paste.
+  let file: File;
+  try {
+    file = createPastedTextFile(text);
+  } catch {
+    return false;
+  }
+
   event.preventDefault();
-  void Promise.resolve(addFile(createPastedTextFile(text))).catch(() =>
-    onError?.(),
-  );
+  try {
+    void Promise.resolve(addFile(file)).catch(() => onError?.());
+  } catch {
+    // addFile can throw before it ever returns a promise to catch on.
+    onError?.();
+  }
   return true;
 }
 
 const ATTACHMENT_WRAPPER_RE =
-  /^<attachment name=[^\n>]*>\n([\s\S]*)\n<\/attachment>$/;
+  /^<(attachment|pasted_text) name=[^\n>]*>\n([\s\S]*)\n<\/\1>$/;
 
 /** Strips the wrapper TextAttachmentAdapter adds on send, for previews. */
 export function unwrapAttachmentText(text: string): string {
-  return ATTACHMENT_WRAPPER_RE.exec(text)?.[1] ?? text;
+  return ATTACHMENT_WRAPPER_RE.exec(text)?.[2] ?? text;
+}
+
+/** Renders an opening rather than the whole paste, which can be megabytes. */
+export function pastedTextPreview(text: string): {
+  text: string;
+  remaining: number;
+} {
+  const remaining = Math.max(text.length - PASTED_TEXT_PREVIEW_MAX_CHARS, 0);
+  return {
+    text: remaining > 0 ? text.slice(0, PASTED_TEXT_PREVIEW_MAX_CHARS) : text,
+    remaining,
+  };
 }

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -14,6 +14,8 @@ const PASTED_TEXT_FALLBACK_NAME = "Pasted text";
 const PASTED_TEXT_TAG = "pasted_text";
 // A preview is for reading, so render an opening rather than megabytes.
 export const PASTED_TEXT_PREVIEW_MAX_CHARS = 100_000;
+// A title only ever uses the first line of this.
+const ATTACHMENT_SAMPLE_CHARS = 512;
 // Illegal in filenames on at least one platform, plus control characters.
 const UNSAFE_NAME_CHARS = /[\\/:*?"<>|\p{Cc}]/gu;
 
@@ -131,6 +133,26 @@ export function pastedTextContentBytes(
   return bytes === undefined ? undefined : Number(bytes);
 }
 
+// Where the body sits inside the wrapper, so callers can slice out the piece
+// they need instead of unwrapping megabytes. Unwrapped content is all body.
+function attachmentBodyRange(content: string): { start: number; end: number } {
+  const tag = content.startsWith("<attachment name=")
+    ? "attachment"
+    : isPastedTextContent(content)
+      ? PASTED_TEXT_TAG
+      : undefined;
+  const headerEnd = tag === undefined ? -1 : content.indexOf("\n");
+  if (headerEnd === -1) return { start: 0, end: content.length };
+
+  const closing = `\n</${tag}>`;
+  return {
+    start: headerEnd + 1,
+    end: content.endsWith(closing)
+      ? Math.max(content.length - closing.length, headerEnd + 1)
+      : content.length,
+  };
+}
+
 /**
  * Previews wrapped content without unwrapping it: the body can be megabytes,
  * and only the opening is ever rendered.
@@ -139,21 +161,46 @@ export function pastedTextContentPreview(content: string): {
   text: string;
   remaining: number;
 } {
-  const headerEnd = content.indexOf("\n");
-  if (headerEnd === -1) return pastedTextPreview(content);
-
-  const start = headerEnd + 1;
-  const closing = `\n</${content.startsWith("<attachment ") ? "attachment" : PASTED_TEXT_TAG}>`;
-  const end = content.endsWith(closing)
-    ? content.length - closing.length
-    : content.length;
-
-  const length = Math.max(end - start, 0);
+  const { start, end } = attachmentBodyRange(content);
+  const length = end - start;
   const taken = Math.min(length, PASTED_TEXT_PREVIEW_MAX_CHARS);
   return {
     text: content.slice(start, start + taken),
     remaining: length - taken,
   };
+}
+
+/**
+ * The opening of an attachment's body, for naming a thread. A paste-only
+ * message has no inline text, so this is all the title has to work from.
+ */
+export function attachmentContentSample(
+  content: string,
+  max: number = ATTACHMENT_SAMPLE_CHARS,
+): string {
+  const { start, end } = attachmentBodyRange(content);
+  return content.slice(start, Math.min(end, start + max)).trim();
+}
+
+type AttachmentLike = {
+  readonly content?: readonly {
+    readonly type: string;
+    readonly text?: string;
+  }[];
+};
+
+/** The same opening, taken from the first attachment that carries text. */
+export function attachmentsSample(
+  attachments: readonly AttachmentLike[] | undefined,
+): string {
+  for (const attachment of attachments ?? []) {
+    for (const part of attachment.content ?? []) {
+      if (part.type !== "text" || part.text === undefined) continue;
+      const sample = attachmentContentSample(part.text);
+      if (sample.length > 0) return sample;
+    }
+  }
+  return "";
 }
 
 function clipboardHasFiles(clipboardData: DataTransfer): boolean {

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -222,17 +222,25 @@ export function attachmentsSample(
   return "";
 }
 
-/** The whole body of a sent paste, unwrapped. Empty for any other content. */
-export function pastedTextContentBody(content: string): string {
-  if (!isPastedTextContent(content)) return "";
+/**
+ * A pasted body without its wrapper, for anything that shows the text as the
+ * user pasted it: copy, exports, fine-tuning rows. Other content is untouched.
+ */
+export function unwrapPastedTextContent(content: string): string {
+  if (!isPastedTextContent(content)) return content;
   const { start, end } = attachmentBodyRange(content);
   return content.slice(start, end);
 }
 
+/** The whole body of a sent paste, unwrapped. Empty for any other content. */
+export function pastedTextContentBody(content: string): string {
+  return isPastedTextContent(content) ? unwrapPastedTextContent(content) : "";
+}
+
 /**
- * Every pasted body on a message. Chat Search reads `content` only, so without
- * this a paste stops being findable the moment it moves into an attachment.
- * Other attachment types were never indexed and stay that way.
+ * Every pasted body on a message, for the paths that read `content` alone and
+ * would otherwise lose the paste: Chat Search and copying a message. Other
+ * attachment types are not included, since neither path ever had them.
  */
 export function attachmentsPastedText(
   attachments: readonly AttachmentLike[] | undefined,
@@ -245,7 +253,7 @@ export function attachmentsPastedText(
       if (body.length > 0) bodies.push(body);
     }
   }
-  return bodies.join(" ");
+  return bodies.join("\n\n");
 }
 
 function clipboardText(clipboardData: DataTransfer): string {

--- a/studio/frontend/src/features/chat/utils/pasted-text.ts
+++ b/studio/frontend/src/features/chat/utils/pasted-text.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Long pastes become a .txt attachment instead of flooding the composer.
+// TextAttachmentAdapter still sends the full text to the model.
+
+const PASTED_TEXT_MIME = "text/plain";
+export const PASTED_TEXT_MIN_CHARS = 2000;
+export const PASTED_TEXT_MIN_LINES = 40;
+// Past this the paste is too big to hold in memory twice.
+const PASTED_TEXT_MAX_CHARS = 20 * 1024 * 1024;
+const PASTED_TEXT_NAME_RE = /^Pasted_Text_\d+\.txt$/;
+
+type ClipboardTextPasteEvent = {
+  readonly clipboardData: DataTransfer | null;
+  readonly defaultPrevented: boolean;
+  preventDefault: () => void;
+};
+
+// Identity separates a pasted blob from a .txt the user attached. Sent
+// messages keep only the name, so isPastedTextFile falls back to that.
+const pastedTextFiles = new WeakSet<File>();
+
+function countLines(text: string): number {
+  let lines = 1;
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] === "\n") lines += 1;
+  }
+  return lines;
+}
+
+export function shouldAttachPastedText(text: string): boolean {
+  if (text.length > PASTED_TEXT_MAX_CHARS) return false;
+  if (text.trim().length === 0) return false;
+  return (
+    text.length >= PASTED_TEXT_MIN_CHARS ||
+    countLines(text) >= PASTED_TEXT_MIN_LINES
+  );
+}
+
+export function pastedTextFileName(now: number = Date.now()): string {
+  return `Pasted_Text_${Math.floor(now / 1000)}.txt`;
+}
+
+export function createPastedTextFile(
+  text: string,
+  now: number = Date.now(),
+): File {
+  const file = new File([text], pastedTextFileName(now), {
+    type: PASTED_TEXT_MIME,
+    lastModified: now,
+  });
+  pastedTextFiles.add(file);
+  return file;
+}
+
+export function isPastedTextFile(
+  file: File | undefined,
+  name?: string,
+): boolean {
+  if (file && pastedTextFiles.has(file)) return true;
+  return PASTED_TEXT_NAME_RE.test(name ?? file?.name ?? "");
+}
+
+function clipboardHasFiles(clipboardData: DataTransfer): boolean {
+  if (Array.from(clipboardData.files).some((file) => file.size > 0))
+    return true;
+  return Array.from(clipboardData.items).some((item) => item.kind === "file");
+}
+
+function clipboardText(clipboardData: DataTransfer): string {
+  try {
+    return clipboardData.getData("text/plain");
+  } catch {
+    return "";
+  }
+}
+
+/** Attaches an oversized text paste. True means the caller must not paste. */
+export function pasteLongTextAsFile(
+  event: ClipboardTextPasteEvent,
+  addFile: (file: File) => void | Promise<void>,
+  onError?: () => void,
+): boolean {
+  if (event.defaultPrevented) return false;
+  const { clipboardData } = event;
+  if (!clipboardData) return false;
+  // Images and files keep the existing paste path.
+  if (clipboardHasFiles(clipboardData)) return false;
+
+  const text = clipboardText(clipboardData);
+  if (!shouldAttachPastedText(text)) return false;
+
+  event.preventDefault();
+  void Promise.resolve(addFile(createPastedTextFile(text))).catch(() =>
+    onError?.(),
+  );
+  return true;
+}
+
+const ATTACHMENT_WRAPPER_RE =
+  /^<attachment name=[^\n>]*>\n([\s\S]*)\n<\/attachment>$/;
+
+/** Strips the wrapper TextAttachmentAdapter adds on send, for previews. */
+export function unwrapAttachmentText(text: string): string {
+  return ATTACHMENT_WRAPPER_RE.exec(text)?.[1] ?? text;
+}

--- a/studio/frontend/tests/composer-paste-draft.test.ts
+++ b/studio/frontend/tests/composer-paste-draft.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const store = new Map<string, string>();
+let failWrites = false;
+
+// The draft helpers read window at call time, so a stub is enough here.
+(globalThis as { window?: unknown }).window = {
+  localStorage: {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      if (failWrites) throw new Error("QuotaExceededError");
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  },
+};
+
+const {
+  clearComposerDraft,
+  composerDraftKey,
+  composerPasteDraftKey,
+  readComposerDraft,
+  readPasteDraft,
+  writeComposerDraft,
+  writePasteDraft,
+} = await import("../src/features/chat/utils/composer-draft.ts");
+
+test.beforeEach(() => {
+  store.clear();
+  failWrites = false;
+});
+
+test("an unsent paste survives a reload", () => {
+  const key = composerPasteDraftKey("t1");
+  const paste = `Deploy log\n${"line\n".repeat(500)}`;
+
+  writePasteDraft(key, [paste]);
+  assert.deepEqual(readPasteDraft(key), [paste]);
+
+  // Several pastes keep their order, and clearing removes the slot.
+  writePasteDraft(key, [paste, "second"]);
+  assert.deepEqual(readPasteDraft(key), [paste, "second"]);
+  writePasteDraft(key, []);
+  assert.deepEqual(readPasteDraft(key), []);
+});
+
+test("the paste slot is separate from the text draft", () => {
+  // Typing must never rewrite a paste that can run to megabytes, so the two
+  // live under different keys.
+  assert.notEqual(composerDraftKey("t1"), composerPasteDraftKey("t1"));
+  assert.notEqual(composerPasteDraftKey("t1"), composerPasteDraftKey("t2"));
+
+  writeComposerDraft(composerDraftKey("t1"), "typed");
+  writePasteDraft(composerPasteDraftKey("t1"), ["pasted"]);
+  clearComposerDraft("t1");
+  assert.equal(readComposerDraft(composerDraftKey("t1")), null);
+  assert.deepEqual(readPasteDraft(composerPasteDraftKey("t1")), []);
+});
+
+test("a paste too big for the quota does not cost the typed draft", () => {
+  writeComposerDraft(composerDraftKey("t1"), "typed");
+  failWrites = true;
+
+  writePasteDraft(composerPasteDraftKey("t1"), ["x".repeat(64)]);
+  assert.equal(readComposerDraft(composerDraftKey("t1")), "typed");
+  assert.deepEqual(readPasteDraft(composerPasteDraftKey("t1")), []);
+});
+
+test("a corrupt paste slot reads as empty rather than throwing", () => {
+  const key = composerPasteDraftKey("t1");
+  for (const raw of ["not json", '{"text":"a"}', "[1,2]", ""]) {
+    store.set(key, raw);
+    assert.deepEqual(readPasteDraft(key), []);
+  }
+  // Non-string entries are dropped, the rest survive.
+  store.set(key, JSON.stringify(["keep", 5, null, "also"]));
+  assert.deepEqual(readPasteDraft(key), ["keep", "also"]);
+});

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -8,9 +8,11 @@ import {
   PASTED_TEXT_MIN_CHARS,
   PASTED_TEXT_MIN_LINES,
   createPastedTextFile,
+  isPastedTextAttachment,
   isPastedTextFile,
   pasteLongTextAsFile,
   pastedTextFileName,
+  rememberPastedTextAttachment,
   shouldAttachPastedText,
   unwrapAttachmentText,
 } from "../src/features/chat/utils/pasted-text.ts";
@@ -72,24 +74,64 @@ test("bulk pastes become attachments by length or by line count", () => {
   );
 });
 
-test("pasted text files are named and recognised", () => {
-  const name = pastedTextFileName(1_786_400_000_000);
-  assert.equal(name, "Pasted_Text_1786400000.txt");
-
-  const file = createPastedTextFile(
-    "a".repeat(PASTED_TEXT_MIN_CHARS),
-    1_786_400_000_000,
+test("the file is named after the opening of the paste", () => {
+  assert.equal(
+    pastedTextFileName("Introducing Unsloth"),
+    "Introducing Unsloth.txt",
   );
-  assert.equal(file.name, name);
+  // Leading blank lines are skipped.
+  assert.equal(
+    pastedTextFileName("\n\n  Release notes  \nbody"),
+    "Release notes.txt",
+  );
+  // Long openings cut on a word boundary, short ones are not padded.
+  assert.equal(
+    pastedTextFileName(
+      "Introducing Unsloth Studio, the fastest way to finetune",
+    ),
+    "Introducing Unsloth Studio, the.txt",
+  );
+  assert.equal(
+    pastedTextFileName(`${"z".repeat(60)} tail`),
+    `${"z".repeat(32)}.txt`,
+  );
+  // Path separators and control characters cannot reach the filename.
+  assert.equal(
+    pastedTextFileName("src/lib\\util:\tmain"),
+    "src lib util main.txt",
+  );
+  assert.equal(pastedTextFileName("\n   \n"), "Pasted text.txt");
+  assert.equal(pastedTextFileName("///"), "Pasted text.txt");
+});
+
+test("pasted text files are recognised by identity", () => {
+  const file = createPastedTextFile(
+    "Deploy log\n".repeat(PASTED_TEXT_MIN_LINES),
+  );
+  assert.equal(file.name, "Deploy log.txt");
   assert.equal(file.type, "text/plain");
-  assert.equal(file.size, PASTED_TEXT_MIN_CHARS);
   assert.equal(isPastedTextFile(file), true);
   // A .txt the user actually attached keeps the normal file tile.
   assert.equal(
-    isPastedTextFile(new File(["hi"], "notes.txt", { type: "text/plain" })),
+    isPastedTextFile(
+      new File(["hi"], "Deploy log.txt", { type: "text/plain" }),
+    ),
     false,
   );
-  assert.equal(isPastedTextFile(undefined, "Pasted_Text_1786400000.txt"), true);
+  assert.equal(isPastedTextFile(undefined), false);
+});
+
+test("the attachment id carries the chip through a send", () => {
+  assert.equal(isPastedTextAttachment("attachment-1"), false);
+  rememberPastedTextAttachment("attachment-1");
+  assert.equal(isPastedTextAttachment("attachment-1"), true);
+  // Re-registering the same id must not evict it.
+  rememberPastedTextAttachment("attachment-1");
+  for (let index = 0; index < 200; index += 1) {
+    rememberPastedTextAttachment(`filler-${index}`);
+  }
+  assert.equal(isPastedTextAttachment("attachment-1"), false);
+  assert.equal(isPastedTextAttachment("filler-199"), true);
 });
 
 test("a long text paste is swallowed and handed over as a file", async () => {
@@ -142,12 +184,10 @@ test("a paste too big to hold inline still attaches", () => {
   assert.equal(shouldAttachPastedText(huge), true);
 });
 
-test("a .txt the user named like a paste keeps the normal tile", () => {
-  const lookalike = new File(["hi"], "Pasted_Text_1786400000.txt", {
-    type: "text/plain",
-  });
+test("a .txt named like a pasted one keeps the normal tile", () => {
+  const pasted = createPastedTextFile("Release notes\nbody");
+  const lookalike = new File(["hi"], pasted.name, { type: "text/plain" });
   assert.equal(isPastedTextFile(lookalike), false);
-  assert.equal(isPastedTextFile(lookalike, lookalike.name), false);
 });
 
 test("native image and file payloads stay on the file paste path", () => {

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -21,6 +21,7 @@ import {
   pastedTextContentBytes,
   pastedTextContentPreview,
   pastedTextFileName,
+  pastedTextOf,
   pastedTextPreview,
   shouldAttachPastedText,
 } from "../src/features/chat/utils/pasted-text.ts";
@@ -136,6 +137,17 @@ test("pasted text files are recognised by identity", () => {
     false,
   );
   assert.equal(isPastedTextFile(undefined), false);
+});
+
+test("the pasted text is kept beside the file, not re-read from it", () => {
+  // Draft autosave runs on a keystroke, so it cannot await File.text().
+  const text = `Deploy log\n${"line\n".repeat(200)}`;
+  assert.equal(pastedTextOf(createPastedTextFile(text)), text);
+  assert.equal(
+    pastedTextOf(new File(["hi"], "notes.txt", { type: "text/plain" })),
+    undefined,
+  );
+  assert.equal(pastedTextOf(undefined), undefined);
 });
 
 test("the sent wrapper is what marks a paste after the File is gone", () => {

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PASTED_TEXT_MIN_CHARS,
+  PASTED_TEXT_MIN_LINES,
+  createPastedTextFile,
+  isPastedTextFile,
+  pasteLongTextAsFile,
+  pastedTextFileName,
+  shouldAttachPastedText,
+  unwrapAttachmentText,
+} from "../src/features/chat/utils/pasted-text.ts";
+
+type ClipboardStub = {
+  readonly files: readonly File[];
+  readonly items: readonly { kind: string }[];
+  getData: (type: string) => string;
+};
+
+function clipboard(text: string, files: readonly File[] = []): ClipboardStub {
+  return {
+    files,
+    items: files.map(() => ({ kind: "file" })),
+    getData: (type) => (type === "text/plain" ? text : ""),
+  };
+}
+
+function pasteEvent(clipboardData: ClipboardStub | null) {
+  let defaultPrevented = false;
+  return {
+    clipboardData: clipboardData as unknown as DataTransfer | null,
+    get defaultPrevented() {
+      return defaultPrevented;
+    },
+    preventDefault: () => {
+      defaultPrevented = true;
+    },
+  };
+}
+
+test("short pastes stay inline", () => {
+  assert.equal(shouldAttachPastedText(""), false);
+  assert.equal(shouldAttachPastedText("   \n  "), false);
+  assert.equal(shouldAttachPastedText("what does this function do?"), false);
+  assert.equal(
+    shouldAttachPastedText("a".repeat(PASTED_TEXT_MIN_CHARS - 1)),
+    false,
+  );
+  assert.equal(
+    shouldAttachPastedText("line\n".repeat(PASTED_TEXT_MIN_LINES - 2)),
+    false,
+  );
+});
+
+test("bulk pastes become attachments by length or by line count", () => {
+  assert.equal(shouldAttachPastedText("a".repeat(PASTED_TEXT_MIN_CHARS)), true);
+  // Many short lines (a log tail, a stack trace) are just as unusable inline.
+  assert.equal(
+    shouldAttachPastedText("x\n".repeat(PASTED_TEXT_MIN_LINES)),
+    true,
+  );
+});
+
+test("pasted text files are named and recognised", () => {
+  const name = pastedTextFileName(1_786_400_000_000);
+  assert.equal(name, "Pasted_Text_1786400000.txt");
+
+  const file = createPastedTextFile(
+    "a".repeat(PASTED_TEXT_MIN_CHARS),
+    1_786_400_000_000,
+  );
+  assert.equal(file.name, name);
+  assert.equal(file.type, "text/plain");
+  assert.equal(file.size, PASTED_TEXT_MIN_CHARS);
+  assert.equal(isPastedTextFile(file), true);
+  // A .txt the user actually attached keeps the normal file tile.
+  assert.equal(
+    isPastedTextFile(new File(["hi"], "notes.txt", { type: "text/plain" })),
+    false,
+  );
+  assert.equal(isPastedTextFile(undefined, "Pasted_Text_1786400000.txt"), true);
+});
+
+test("a long text paste is swallowed and handed over as a file", async () => {
+  const text = "a".repeat(PASTED_TEXT_MIN_CHARS);
+  const added: File[] = [];
+  const event = pasteEvent(clipboard(text));
+
+  assert.equal(
+    pasteLongTextAsFile(event, (file) => {
+      added.push(file);
+    }),
+    true,
+  );
+  assert.equal(event.defaultPrevented, true);
+  assert.equal(added.length, 1);
+  assert.equal(await added[0]?.text(), text);
+});
+
+test("normal pastes and file pastes fall through untouched", () => {
+  const shortPaste = pasteEvent(clipboard("hello"));
+  assert.equal(
+    pasteLongTextAsFile(shortPaste, () => {}),
+    false,
+  );
+  assert.equal(shortPaste.defaultPrevented, false);
+
+  // An image on the clipboard belongs to the file-paste path, even when the
+  // app also offers a long text/plain rendering of it.
+  const withFile = pasteEvent(
+    clipboard("a".repeat(PASTED_TEXT_MIN_CHARS), [
+      new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" }),
+    ]),
+  );
+  assert.equal(
+    pasteLongTextAsFile(withFile, () => {}),
+    false,
+  );
+  assert.equal(withFile.defaultPrevented, false);
+
+  assert.equal(
+    pasteLongTextAsFile(pasteEvent(null), () => {}),
+    false,
+  );
+});
+
+test("previews strip the wrapper the adapter sends to the model", () => {
+  const text = "line one\nline two";
+  assert.equal(
+    unwrapAttachmentText(
+      `<attachment name=Pasted_Text_1.txt>\n${text}\n</attachment>`,
+    ),
+    text,
+  );
+  assert.equal(unwrapAttachmentText(text), text);
+});

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -7,12 +7,14 @@ import test from "node:test";
 import {
   PASTED_TEXT_MIN_CHARS,
   PASTED_TEXT_MIN_LINES,
+  PASTED_TEXT_PREVIEW_MAX_CHARS,
+  attachmentContentText,
   createPastedTextFile,
-  isPastedTextAttachment,
+  isPastedTextContent,
   isPastedTextFile,
   pasteLongTextAsFile,
   pastedTextFileName,
-  rememberPastedTextAttachment,
+  pastedTextPreview,
   shouldAttachPastedText,
   unwrapAttachmentText,
 } from "../src/features/chat/utils/pasted-text.ts";
@@ -102,6 +104,15 @@ test("the file is named after the opening of the paste", () => {
   );
   assert.equal(pastedTextFileName("\n   \n"), "Pasted text.txt");
   assert.equal(pastedTextFileName("///"), "Pasted text.txt");
+  // A single line of megabytes is read through a window, not copied whole.
+  assert.equal(
+    pastedTextFileName("b".repeat(4 * 1024 * 1024)),
+    `${"b".repeat(32)}.txt`,
+  );
+  assert.equal(
+    pastedTextFileName(`${" ".repeat(300)}${"b".repeat(1000)}`),
+    "Pasted text.txt",
+  );
 });
 
 test("pasted text files are recognised by identity", () => {
@@ -121,17 +132,39 @@ test("pasted text files are recognised by identity", () => {
   assert.equal(isPastedTextFile(undefined), false);
 });
 
-test("the attachment id carries the chip through a send", () => {
-  assert.equal(isPastedTextAttachment("attachment-1"), false);
-  rememberPastedTextAttachment("attachment-1");
-  assert.equal(isPastedTextAttachment("attachment-1"), true);
-  // Re-registering the same id must not evict it.
-  rememberPastedTextAttachment("attachment-1");
-  for (let index = 0; index < 200; index += 1) {
-    rememberPastedTextAttachment(`filler-${index}`);
-  }
-  assert.equal(isPastedTextAttachment("attachment-1"), false);
-  assert.equal(isPastedTextAttachment("filler-199"), true);
+test("the sent wrapper is what marks a paste after the File is gone", () => {
+  const pasted = attachmentContentText("Deploy log.txt", "body", true);
+  const attached = attachmentContentText("notes.txt", "body", false);
+
+  assert.equal(
+    pasted,
+    "<pasted_text name=Deploy log.txt>\nbody\n</pasted_text>",
+  );
+  assert.equal(attached, "<attachment name=notes.txt>\nbody\n</attachment>");
+  // This is the marker a reloaded message still has, so it decides the chip.
+  assert.equal(isPastedTextContent(pasted), true);
+  assert.equal(isPastedTextContent(attached), false);
+  assert.equal(isPastedTextContent(undefined), false);
+  assert.equal(isPastedTextContent("pasted_text elsewhere in the body"), false);
+  // Both wrappers unwrap, and a mismatched pair is left alone.
+  assert.equal(unwrapAttachmentText(pasted), "body");
+  assert.equal(unwrapAttachmentText(attached), "body");
+  assert.equal(
+    unwrapAttachmentText("<attachment name=x.txt>\nbody\n</pasted_text>"),
+    "<attachment name=x.txt>\nbody\n</pasted_text>",
+  );
+});
+
+test("the preview is capped, and says how much it is holding back", () => {
+  const short = pastedTextPreview("all of it");
+  assert.equal(short.text, "all of it");
+  assert.equal(short.remaining, 0);
+
+  const long = pastedTextPreview(
+    "a".repeat(PASTED_TEXT_PREVIEW_MAX_CHARS + 25),
+  );
+  assert.equal(long.text.length, PASTED_TEXT_PREVIEW_MAX_CHARS);
+  assert.equal(long.remaining, 25);
 });
 
 test("a long text paste is swallowed and handed over as a file", async () => {
@@ -182,6 +215,34 @@ test("a paste too big to hold inline still attaches", () => {
   // one case the input cannot survive.
   const huge = "a".repeat(20 * 1024 * 1024 + 1);
   assert.equal(shouldAttachPastedText(huge), true);
+  // Whitespace is no exemption either: it used to skip both thresholds.
+  assert.equal(shouldAttachPastedText(" ".repeat(PASTED_TEXT_MIN_CHARS)), true);
+  assert.equal(
+    shouldAttachPastedText("\n".repeat(PASTED_TEXT_MIN_LINES)),
+    true,
+  );
+  assert.equal(shouldAttachPastedText("   "), false);
+});
+
+test("an attachment that throws on the spot reports instead of vanishing", () => {
+  let errors = 0;
+  const event = pasteEvent(clipboard("a".repeat(PASTED_TEXT_MIN_CHARS)));
+
+  const handled = pasteLongTextAsFile(
+    event,
+    () => {
+      throw new Error("no room for another attachment");
+    },
+    () => {
+      errors += 1;
+    },
+  );
+
+  // The paste is already swallowed at this point, so the toast is the only
+  // thing standing between the user and silently losing the clipboard.
+  assert.equal(handled, true);
+  assert.equal(event.defaultPrevented, true);
+  assert.equal(errors, 1);
 });
 
 test("a .txt named like a pasted one keeps the normal tile", () => {
@@ -223,13 +284,8 @@ test("native image and file payloads stay on the file paste path", () => {
   );
 });
 
-test("previews strip the wrapper the adapter sends to the model", () => {
+test("previews leave unwrapped text alone", () => {
   const text = "line one\nline two";
-  assert.equal(
-    unwrapAttachmentText(
-      `<attachment name=Pasted_Text_1.txt>\n${text}\n</attachment>`,
-    ),
-    text,
-  );
   assert.equal(unwrapAttachmentText(text), text);
+  assert.equal(unwrapAttachmentText(""), "");
 });

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -120,6 +120,14 @@ test("the file is named after the opening of the paste", () => {
     pastedTextFileName(`${" ".repeat(300)}${"b".repeat(1000)}`),
     "Pasted text.txt",
   );
+  // Blank lines are stepped over one at a time, so the walk is bounded too:
+  // naming must not depend on how many of them there are.
+  const started = process.hrtime.bigint();
+  assert.equal(
+    pastedTextFileName(`${"\n".repeat(4 * 1024 * 1024)}Deploy log`),
+    "Pasted text.txt",
+  );
+  assert.ok(Number(process.hrtime.bigint() - started) / 1e6 < 250);
 });
 
 test("pasted text files are recognised by identity", () => {

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -4,11 +4,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { fallbackTitleFromUserText } from "../src/features/chat/utils/chat-title.ts";
 import {
   PASTED_TEXT_MIN_CHARS,
   PASTED_TEXT_MIN_LINES,
   PASTED_TEXT_PREVIEW_MAX_CHARS,
+  attachmentContentSample,
   attachmentContentText,
+  attachmentsSample,
   createPastedTextFile,
   isPastedTextContent,
   isPastedTextFile,
@@ -198,6 +201,52 @@ test("previewing sent content never materialises the body", () => {
     text: "body",
     remaining: 0,
   });
+});
+
+test("a paste-only message still has something to name the thread with", () => {
+  const paste = `Fix the retry backoff\n${"detail\n".repeat(500)}`;
+  const sent = attachmentContentText(
+    pastedTextFileName(paste),
+    paste,
+    true,
+    paste.length,
+  );
+
+  // The composer sends no text at all in this case, so the title comes from
+  // the attachment or the thread stays "New Chat".
+  assert.equal(
+    fallbackTitleFromUserText(attachmentsSample([{ content: [] }])),
+    "New Chat",
+  );
+  assert.equal(
+    fallbackTitleFromUserText(
+      attachmentsSample([{ content: [{ type: "text", text: sent }] }]),
+    ),
+    "Fix the retry backoff",
+  );
+  // Only a bounded opening is read, never the whole body.
+  assert.ok(
+    attachmentsSample([{ content: [{ type: "text", text: sent }] }]).length <=
+      512,
+  );
+  // Non-text parts are skipped, and the first text part wins.
+  assert.equal(
+    attachmentsSample([
+      { content: [{ type: "image" }] },
+      { content: [{ type: "text", text: sent }] },
+    ]),
+    attachmentContentSample(sent),
+  );
+  assert.equal(attachmentsSample(undefined), "");
+});
+
+test("a sample of unwrapped content is left as it is", () => {
+  // PDF and DOCX adapters write their own prefix with no wrapper.
+  assert.equal(
+    attachmentContentSample("[PDF: paper.pdf]\nAbstract"),
+    "[PDF: paper.pdf]\nAbstract",
+  );
+  assert.equal(attachmentContentSample("plain", 3), "pla");
 });
 
 test("the preview is capped, and says how much it is holding back", () => {

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -18,14 +18,21 @@ import {
 type ClipboardStub = {
   readonly files: readonly File[];
   readonly items: readonly { kind: string }[];
+  readonly types: readonly string[];
   getData: (type: string) => string;
 };
 
-function clipboard(text: string, files: readonly File[] = []): ClipboardStub {
+function clipboard(
+  text: string,
+  files: readonly File[] = [],
+  extra: { types?: readonly string[]; data?: Record<string, string> } = {},
+): ClipboardStub {
   return {
     files,
     items: files.map(() => ({ kind: "file" })),
-    getData: (type) => (type === "text/plain" ? text : ""),
+    types: extra.types ?? ["text/plain"],
+    getData: (type) =>
+      type === "text/plain" ? text : (extra.data?.[type] ?? ""),
   };
 }
 
@@ -125,6 +132,54 @@ test("normal pastes and file pastes fall through untouched", () => {
   assert.equal(
     pasteLongTextAsFile(pasteEvent(null), () => {}),
     false,
+  );
+});
+
+test("a paste too big to hold inline still attaches", () => {
+  // Anything the old cap rejected fell back to pasting inline, which is the
+  // one case the input cannot survive.
+  const huge = "a".repeat(20 * 1024 * 1024 + 1);
+  assert.equal(shouldAttachPastedText(huge), true);
+});
+
+test("a .txt the user named like a paste keeps the normal tile", () => {
+  const lookalike = new File(["hi"], "Pasted_Text_1786400000.txt", {
+    type: "text/plain",
+  });
+  assert.equal(isPastedTextFile(lookalike), false);
+  assert.equal(isPastedTextFile(lookalike, lookalike.name), false);
+});
+
+test("native image and file payloads stay on the file paste path", () => {
+  const text = "a".repeat(PASTED_TEXT_MIN_CHARS);
+  // Tauri advertises native payloads by type only, with nothing in files.
+  const svg = pasteEvent(
+    clipboard(text, [], { types: ["text/plain", "image/svg+xml"] }),
+  );
+  assert.equal(
+    pasteLongTextAsFile(svg, () => {}),
+    false,
+  );
+  assert.equal(svg.defaultPrevented, false);
+
+  const copiedFiles = pasteEvent(
+    clipboard(text, [], {
+      types: ["text/plain", "text/uri-list"],
+      data: { "text/uri-list": "file:///tmp/notes.txt" },
+    }),
+  );
+  assert.equal(
+    pasteLongTextAsFile(copiedFiles, () => {}),
+    false,
+  );
+
+  // A plain text/html copy is still text, not a file payload.
+  const richText = pasteEvent(
+    clipboard(text, [], { types: ["text/plain", "text/html"] }),
+  );
+  assert.equal(
+    pasteLongTextAsFile(richText, () => {}),
+    true,
   );
 });
 

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -13,10 +13,11 @@ import {
   isPastedTextContent,
   isPastedTextFile,
   pasteLongTextAsFile,
+  pastedTextContentBytes,
+  pastedTextContentPreview,
   pastedTextFileName,
   pastedTextPreview,
   shouldAttachPastedText,
-  unwrapAttachmentText,
 } from "../src/features/chat/utils/pasted-text.ts";
 
 type ClipboardStub = {
@@ -133,26 +134,70 @@ test("pasted text files are recognised by identity", () => {
 });
 
 test("the sent wrapper is what marks a paste after the File is gone", () => {
-  const pasted = attachmentContentText("Deploy log.txt", "body", true);
-  const attached = attachmentContentText("notes.txt", "body", false);
+  const pasted = attachmentContentText("Deploy log.txt", "body", true, 4);
+  const attached = attachmentContentText("notes.txt", "body", false, 4);
 
   assert.equal(
     pasted,
-    "<pasted_text name=Deploy log.txt>\nbody\n</pasted_text>",
+    "<pasted_text name=Deploy log.txt bytes=4>\nbody\n</pasted_text>",
   );
+  // Only the paste is tagged and sized; a real attachment keeps its wrapper.
   assert.equal(attached, "<attachment name=notes.txt>\nbody\n</attachment>");
-  // This is the marker a reloaded message still has, so it decides the chip.
   assert.equal(isPastedTextContent(pasted), true);
   assert.equal(isPastedTextContent(attached), false);
   assert.equal(isPastedTextContent(undefined), false);
   assert.equal(isPastedTextContent("pasted_text elsewhere in the body"), false);
-  // Both wrappers unwrap, and a mismatched pair is left alone.
-  assert.equal(unwrapAttachmentText(pasted), "body");
-  assert.equal(unwrapAttachmentText(attached), "body");
+});
+
+test("the chip size is read off the header, never measured", () => {
+  const pasted = attachmentContentText("Deploy log.txt", "body", true, 12_483);
+  assert.equal(pastedTextContentBytes(pasted), 12_483);
+  // A name that itself looks like the size must not win over the real one.
   assert.equal(
-    unwrapAttachmentText("<attachment name=x.txt>\nbody\n</pasted_text>"),
-    "<attachment name=x.txt>\nbody\n</pasted_text>",
+    pastedTextContentBytes(
+      attachmentContentText("x bytes=5.txt", "body", true, 99),
+    ),
+    99,
   );
+  assert.equal(pastedTextContentBytes(undefined), undefined);
+  assert.equal(
+    pastedTextContentBytes(attachmentContentText("a.txt", "body", true)),
+    undefined,
+  );
+  assert.equal(
+    pastedTextContentBytes(attachmentContentText("a.txt", "body", false, 4)),
+    undefined,
+  );
+});
+
+test("previewing sent content never materialises the body", () => {
+  const body = "line one\nline two";
+  const pasted = attachmentContentText("a.txt", body, true, 17);
+  assert.deepEqual(pastedTextContentPreview(pasted), {
+    text: body,
+    remaining: 0,
+  });
+  assert.deepEqual(
+    pastedTextContentPreview(attachmentContentText("a.txt", body, false)),
+    { text: body, remaining: 0 },
+  );
+
+  const huge = "z".repeat(PASTED_TEXT_PREVIEW_MAX_CHARS + 40);
+  const cut = pastedTextContentPreview(
+    attachmentContentText("a.txt", huge, true, huge.length),
+  );
+  assert.equal(cut.text.length, PASTED_TEXT_PREVIEW_MAX_CHARS);
+  assert.equal(cut.remaining, 40);
+
+  // Unwrapped or truncated content still previews rather than throwing.
+  assert.deepEqual(pastedTextContentPreview("bare text"), {
+    text: "bare text",
+    remaining: 0,
+  });
+  assert.deepEqual(pastedTextContentPreview("<pasted_text name=a.txt>\nbody"), {
+    text: "body",
+    remaining: 0,
+  });
 });
 
 test("the preview is capped, and says how much it is holding back", () => {
@@ -282,10 +327,4 @@ test("native image and file payloads stay on the file paste path", () => {
     pasteLongTextAsFile(richText, () => {}),
     true,
   );
-});
-
-test("previews leave unwrapped text alone", () => {
-  const text = "line one\nline two";
-  assert.equal(unwrapAttachmentText(text), text);
-  assert.equal(unwrapAttachmentText(""), "");
 });

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -11,11 +11,13 @@ import {
   PASTED_TEXT_PREVIEW_MAX_CHARS,
   attachmentContentSample,
   attachmentContentText,
+  attachmentsPastedText,
   attachmentsSample,
   createPastedTextFile,
   isPastedTextContent,
   isPastedTextFile,
   pasteLongTextAsFile,
+  pastedTextContentBody,
   pastedTextContentBytes,
   pastedTextContentPreview,
   pastedTextFileName,
@@ -238,6 +240,44 @@ test("a paste-only message still has something to name the thread with", () => {
     attachmentContentSample(sent),
   );
   assert.equal(attachmentsSample(undefined), "");
+});
+
+test("chat search still finds what the paste moved out of the message", () => {
+  const body = `Fix the retry backoff\n${"detail\n".repeat(500)}closing line`;
+  const sent = attachmentContentText("Fix.txt", body, true, body.length);
+
+  // The whole body, not the opening: a term late in a paste has to stay
+  // findable or the paste is searchable only by its first line.
+  assert.equal(pastedTextContentBody(sent), body);
+  assert.equal(
+    attachmentsPastedText([{ content: [{ type: "text", text: sent }] }]),
+    body,
+  );
+
+  // Attachments that were never indexed stay that way.
+  assert.equal(pastedTextContentBody("[PDF: paper.pdf]\nAbstract"), "");
+  assert.equal(
+    pastedTextContentBody(attachmentContentText("notes.txt", body, false)),
+    "",
+  );
+  assert.equal(
+    attachmentsPastedText([
+      { content: [{ type: "text", text: "[PDF: paper.pdf]\nAbstract" }] },
+      { content: [{ type: "image" }] },
+    ]),
+    "",
+  );
+  assert.equal(attachmentsPastedText(undefined), "");
+
+  // Several pastes on one message all reach the index.
+  const second = attachmentContentText("Log.txt", "second body", true, 11);
+  assert.equal(
+    attachmentsPastedText([
+      { content: [{ type: "text", text: sent }] },
+      { content: [{ type: "text", text: second }] },
+    ]),
+    `${body} second body`,
+  );
 });
 
 test("a sample of unwrapped content is left as it is", () => {

--- a/studio/frontend/tests/pasted-text-attachment.test.ts
+++ b/studio/frontend/tests/pasted-text-attachment.test.ts
@@ -24,6 +24,7 @@ import {
   pastedTextOf,
   pastedTextPreview,
   shouldAttachPastedText,
+  unwrapPastedTextContent,
 } from "../src/features/chat/utils/pasted-text.ts";
 
 type ClipboardStub = {
@@ -296,8 +297,25 @@ test("chat search still finds what the paste moved out of the message", () => {
       { content: [{ type: "text", text: sent }] },
       { content: [{ type: "text", text: second }] },
     ]),
-    `${body} second body`,
+    `${body}\n\nsecond body`,
   );
+});
+
+test("copies and exports carry the paste, not its wrapper", () => {
+  const body = "Deploy log\nline two";
+  const sent = attachmentContentText("Deploy log.txt", body, true, 19);
+
+  // The marker is an implementation detail; the same text pasted below the
+  // threshold never had one.
+  assert.equal(unwrapPastedTextContent(sent), body);
+  assert.ok(!unwrapPastedTextContent(sent).includes("pasted_text"));
+
+  // Everything else is handed back untouched, including the wrapper a real
+  // attachment has always exported with.
+  const attached = attachmentContentText("notes.txt", body, false);
+  assert.equal(unwrapPastedTextContent(attached), attached);
+  assert.equal(unwrapPastedTextContent("bare text"), "bare text");
+  assert.equal(unwrapPastedTextContent(""), "");
 });
 
 test("a sample of unwrapped content is left as it is", () => {


### PR DESCRIPTION
Pasting a big block of text into the chat composer dumped every line into the input, which buried whatever you were actually asking and made the composer unusable until you cleared it. There was no way to hand over a wall of text as a file.

Long pastes now attach instead of paste.

### Behaviour

- A paste of 2000+ characters or 40+ lines becomes a `.txt` attachment. Anything shorter pastes inline exactly as before.
- The file is named after the opening of the paste, so a pasted release note shows up as `Introducing Unsloth Studio.txt` rather than a timestamp. Path separators and control characters are stripped, the cut prefers a word boundary, and an opening with nothing usable in it falls back to `Pasted text.txt`.
- The chip shows the name and size, with the usual remove button. It is borderless in both themes, and in dark mode it sits a shade under the composer surface.
- Hovering the chip swaps the size for "Show in text field". Clicking it puts the text back into the composer (appended after whatever is already there) and drops the attachment, so nothing is trapped in the chip.
- After sending, the chip stays on the message. Clicking it there opens a read only preview of what was pasted.
- The model still gets the full text: the file goes through the existing `TextAttachmentAdapter`, so no content is lost.
- Pastes carrying images or real files still take the existing file paste path, including the native payloads Tauri advertises through `types` alone. A real `.txt` you attach yourself keeps the normal file tile, since a pasted file is matched by identity rather than by name.

### Changes

- `studio/frontend/src/features/chat/utils/pasted-text.ts` (new): thresholds, naming, file creation and recognition, the paste interception, and the wrapper stripping used by the preview.
- `studio/frontend/src/components/assistant-ui/thread.tsx`: the composer paste handler tries the text path first, then falls through to the file paste path.
- `studio/frontend/src/components/assistant-ui/attachment.tsx`: the chip, the "Show in text field" action, and the preview dialog.
- `studio/frontend/tests/pasted-text-attachment.test.ts` (new): 11 tests covering the thresholds, naming, recognition, interception, and fall through for short pastes, file pastes, native payloads and a missing clipboard.

The compare composer is untouched: it only supports image and audio attachments, so a long paste there still goes inline.

One known limit: the chip on an already sent message is matched by attachment id, which is in memory only. Reload the page and an old pasted attachment renders as a normal file tile with the same name. The text itself is unaffected.

### Testing

- `npm run typecheck` clean.
- `npm test`: 1964 pass, 0 fail (includes the 11 new tests).
- `npm run build` succeeds and serves the new bundle.

The paste path, naming and thresholds are covered by the unit tests. The chip hover and click behaviour has not been clicked through in the browser yet, so a quick manual pass on that would be welcome before merge. Happy to tune the 2000 char / 40 line threshold if it feels too eager.
