### PR TITLE
Studio: classify a moved or mixed model folder from the checkpoint, not from directory order

### DIFF
--- a/studio/backend/core/inference/diffusion_families.py
+++ b/studio/backend/core/inference/diffusion_families.py
@@ -606,11 +606,20 @@ def detect_family_for_pick(
     commit hash; the pick the picker then sends is that same opaque path with no family_override,
     so without this the model is shown as text-to-image and refused as an unsupported family
     (#8407)."""
-    fam = detect_family(repo_id, override)
+    fam = None
+    if not override:
+        # The checkpoint's own declaration outranks any guess made from its path. A family keyword
+        # in ANY ancestor segment otherwise shadows the index entirely: a QwenImagePipeline saved
+        # under `.../flux.1/checkpoint` matched FLUX on the directory name and never reached the
+        # index. The listing reads the index, so the two named different families for one
+        # directory and the model was listed as one and instantiated as another.
+        # Remote picks are unaffected: with no local model_index.json this returns None and the
+        # name-based paths below run exactly as before.
+        fam = detect_family_by_pipeline_index(repo_id)
+    if fam is None:
+        fam = detect_family(repo_id, override)
     if fam is None and gguf_filename and not override:
         fam = detect_family(f"{repo_id}/{gguf_filename}", override)
-    if fam is None and not override:
-        fam = detect_family_by_pipeline_index(repo_id)
     return fam
 
 

--- a/studio/backend/core/inference/diffusion_families.py
+++ b/studio/backend/core/inference/diffusion_families.py
@@ -518,21 +518,24 @@ def detect_family_by_pipeline_class(class_name: Optional[str]) -> Optional[Diffu
     (#8407) -- has no name left to match, so the listing dropped it as task=null and the Images
     picker hid a model the load path accepts.
 
-    The task variants are matched too, so a checkpoint saved as an img2img/inpaint/controlnet
-    pipeline resolves to the same family. Exact class names only: this cannot fire on a checkpoint
-    that is not the family it claims to be."""
+    Only the BASE pipeline class matches. The task variants deliberately do not: the loader
+    instantiates ``fam.pipeline_class`` (``diffusion.py:2946``) and never the class the index
+    declared, so answering a family for an inpaint or img2img checkpoint would tag it visible and
+    then load it through the wrong pipeline. An inpaint checkpoint is not merely a differently
+    named base one, it carries its own UNet input shape, so that load fails after selection. This
+    function exists to stop exactly that split between what the listing shows and what the loader
+    accepts, and matching a variant here would reintroduce it one layer down.
+
+    A variant checkpoint therefore stays untagged, which is the same answer it got before the index
+    was consulted at all: no model that used to load stops loading, and none becomes visible that
+    cannot. Exact class names only: this cannot fire on a checkpoint that is not the family it
+    claims to be."""
     key = (class_name or "").strip()
     if not key:
         return None
     for fam in _FAMILIES:
-        for candidate in (
-            fam.pipeline_class,
-            fam.img2img_pipeline_class,
-            fam.inpaint_pipeline_class,
-            fam.controlnet_pipeline_class,
-        ):
-            if candidate and candidate == key:
-                return fam
+        if fam.pipeline_class and fam.pipeline_class == key:
+            return fam
     return None
 
 

--- a/studio/backend/core/inference/diffusion_families.py
+++ b/studio/backend/core/inference/diffusion_families.py
@@ -512,24 +512,15 @@ def supported_family_names() -> tuple[str, ...]:
 def detect_family_by_pipeline_class(class_name: Optional[str]) -> Optional[DiffusionFamily]:
     """The family a saved pipeline's ``model_index.json`` ``_class_name`` names, or None.
 
-    Evidence out of the checkpoint rather than out of its name, the counterpart of reading
-    ``general.architecture`` from a GGUF. A local diffusers pipeline whose directory carries no
-    family keyword -- an HF cache snapshot, whose leaf is a commit hash, is the ordinary case
-    (#8407) -- has no name left to match, so the listing dropped it as task=null and the Images
-    picker hid a model the load path accepts.
+    Evidence out of the checkpoint rather than out of its name, the counterpart of a GGUF's
+    ``general.architecture``: an HF cache snapshot's leaf is a commit hash, so the listing had no
+    name to match and hid a model the load path accepts (#8407).
 
-    Only the BASE pipeline class matches. The task variants deliberately do not: the loader
-    instantiates ``fam.pipeline_class`` (``diffusion.py:2946``) and never the class the index
-    declared, so answering a family for an inpaint or img2img checkpoint would tag it visible and
-    then load it through the wrong pipeline. An inpaint checkpoint is not merely a differently
-    named base one, it carries its own UNet input shape, so that load fails after selection. This
-    function exists to stop exactly that split between what the listing shows and what the loader
-    accepts, and matching a variant here would reintroduce it one layer down.
-
-    A variant checkpoint therefore stays untagged, which is the same answer it got before the index
-    was consulted at all: no model that used to load stops loading, and none becomes visible that
-    cannot. Exact class names only: this cannot fire on a checkpoint that is not the family it
-    claims to be."""
+    Only the BASE class matches. The loader instantiates ``fam.pipeline_class``
+    (``diffusion.py:2946``), never the declared class, so tagging an inpaint or img2img checkpoint
+    would list it and then load it through the wrong pipeline (its UNet input shape differs), which
+    is the listing-versus-loader split this exists to close. A variant stays untagged, the answer
+    it got before the index was read at all."""
     key = (class_name or "").strip()
     if not key:
         return None
@@ -542,17 +533,14 @@ def detect_family_by_pipeline_class(class_name: Optional[str]) -> Optional[Diffu
 def pipeline_class_from_index(path: Optional[str]) -> Optional[str]:
     """The ``_class_name`` the diffusers pipeline saved at ``path`` declares, or None.
 
-    Read with a size cap and no schema assumptions: an index is a small JSON manifest, and neither
-    a listing nor a load may be held up (or brought down) by whatever a scan folder happens to
-    contain. ``_class_name`` is a LIST for a remote-code community pipeline, which Studio cannot
-    load anyway, so only a plain string answers.
+    Size-capped and schema-free: neither a listing nor a load may be held up by whatever a scan
+    folder contains. ``_class_name`` is a LIST for a remote-code community pipeline, which Studio
+    cannot load, so only a plain string answers.
 
-    ``utf-8-sig`` because a hand-authored index is an ordinary thing to find beside a converted
-    checkpoint and Windows PowerShell writes JSON with a BOM; read as ``utf-8`` that file raises
-    and the model stays hidden, which is #8407 again by another road. ``RecursionError`` is caught
-    with the rest because a nesting bomb raises it and it is NOT a ``ValueError``: both callers
-    wrap this in a blanket except that reads a raise as detection having succeeded, so an index
-    this cannot parse has to come back as None rather than as an answer."""
+    ``utf-8-sig`` because PowerShell writes JSON with a BOM and a hand-authored index is ordinary
+    beside a converted checkpoint; read as ``utf-8`` it raises and the model stays hidden, #8407
+    again. ``RecursionError`` (a nesting bomb, not a ``ValueError``) is caught too: both callers
+    wrap this in a blanket except that reads a raise as detection having succeeded."""
     root = Path(path or "")
     if not str(root):
         return None
@@ -574,13 +562,12 @@ def pipeline_class_from_index(path: Optional[str]) -> Optional[str]:
 def detect_family_by_pipeline_index(path: Optional[str]) -> Optional[DiffusionFamily]:
     """The family the pipeline saved at ``path`` declares in its ``model_index.json``, or None.
 
-    The path-shaped counterpart of ``detect_family_by_pipeline_class``, and the one both the
-    listing and the loader use, so a model the picker shows on this evidence is a model
-    ``validate_load_request`` accepts on the same evidence (#8407).
+    The path-shaped counterpart of ``detect_family_by_pipeline_class``, used by BOTH the listing
+    and the loader so the picker and ``validate_load_request`` answer off the same evidence (#8407).
 
     Carries over ``detect_family``'s variant guard: a directory NAMED for a checkpoint the matched
-    family cannot run (``...-layered``) is still refused, so reading the index only ever adds
-    models whose name said nothing, never overrides a name that said no."""
+    family cannot run (``...-layered``) is still refused, so the index only adds models whose name
+    said nothing, never overrides a name that said no."""
     fam = detect_family_by_pipeline_class(pipeline_class_from_index(path))
     if fam is None:
         return None
@@ -604,20 +591,18 @@ def detect_family_for_pick(
     local diffusers pipeline directory. Only fallbacks, so remote picks and overrides behave
     exactly as ``detect_family``. Shared by both engines.
 
-    The index fallback is what keeps the listing and the loader on one answer. The listing
-    classifies a moved pipeline from its ``model_index.json`` because its directory name is a
-    commit hash; the pick the picker then sends is that same opaque path with no family_override,
-    so without this the model is shown as text-to-image and refused as an unsupported family
-    (#8407)."""
+    The index keeps the listing and the loader on one answer: the listing classifies a moved
+    pipeline from its ``model_index.json`` (its directory name is a commit hash), and the pick sent
+    back is that same opaque path with no family_override, so without this the model is shown as
+    text-to-image and then refused as an unsupported family (#8407)."""
     fam = None
     if not override:
-        # The checkpoint's own declaration outranks any guess made from its path. A family keyword
-        # in ANY ancestor segment otherwise shadows the index entirely: a QwenImagePipeline saved
-        # under `.../flux.1/checkpoint` matched FLUX on the directory name and never reached the
-        # index. The listing reads the index, so the two named different families for one
-        # directory and the model was listed as one and instantiated as another.
-        # Remote picks are unaffected: with no local model_index.json this returns None and the
-        # name-based paths below run exactly as before.
+        # The checkpoint's own declaration outranks any guess made from its path: a family keyword
+        # in ANY ancestor segment otherwise shadows the index (a QwenImagePipeline under
+        # `.../flux.1/checkpoint` matched FLUX and never reached it), so the listing, which reads
+        # the index, named one family and the loader another for one directory.
+        # Remote picks are unaffected: with no local index this is None and the name-based paths
+        # below run as before.
         fam = detect_family_by_pipeline_index(repo_id)
     if fam is None:
         fam = detect_family(repo_id, override)

--- a/studio/backend/core/inference/diffusion_families.py
+++ b/studio/backend/core/inference/diffusion_families.py
@@ -508,6 +508,33 @@ def supported_family_names() -> tuple[str, ...]:
     return tuple(fam.name for fam in _FAMILIES)
 
 
+def detect_family_by_pipeline_class(class_name: Optional[str]) -> Optional[DiffusionFamily]:
+    """The family a saved pipeline's ``model_index.json`` ``_class_name`` names, or None.
+
+    Evidence out of the checkpoint rather than out of its name, the counterpart of reading
+    ``general.architecture`` from a GGUF. A local diffusers pipeline whose directory carries no
+    family keyword -- an HF cache snapshot, whose leaf is a commit hash, is the ordinary case
+    (#8407) -- has no name left to match, so the listing dropped it as task=null and the Images
+    picker hid a model the load path accepts.
+
+    The task variants are matched too, so a checkpoint saved as an img2img/inpaint/controlnet
+    pipeline resolves to the same family. Exact class names only: this cannot fire on a checkpoint
+    that is not the family it claims to be."""
+    key = (class_name or "").strip()
+    if not key:
+        return None
+    for fam in _FAMILIES:
+        for candidate in (
+            fam.pipeline_class,
+            fam.img2img_pipeline_class,
+            fam.inpaint_pipeline_class,
+            fam.controlnet_pipeline_class,
+        ):
+            if candidate and candidate == key:
+                return fam
+    return None
+
+
 def detect_family_for_pick(
     repo_id: str,
     gguf_filename: Optional[str] = None,

--- a/studio/backend/core/inference/diffusion_families.py
+++ b/studio/backend/core/inference/diffusion_families.py
@@ -14,6 +14,7 @@ diffusers classes and base repo needed to assemble the full pipeline.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import tempfile
@@ -535,17 +536,74 @@ def detect_family_by_pipeline_class(class_name: Optional[str]) -> Optional[Diffu
     return None
 
 
+def pipeline_class_from_index(path: Optional[str]) -> Optional[str]:
+    """The ``_class_name`` the diffusers pipeline saved at ``path`` declares, or None.
+
+    Read with a size cap and no schema assumptions: an index is a small JSON manifest, and neither
+    a listing nor a load may be held up (or brought down) by whatever a scan folder happens to
+    contain. ``_class_name`` is a LIST for a remote-code community pipeline, which Studio cannot
+    load anyway, so only a plain string answers."""
+    root = Path(path or "")
+    if not str(root):
+        return None
+    for name in ("model_index.json", "modular_model_index.json"):
+        try:
+            index = root / name
+            if not index.is_file() or index.stat().st_size > 1_000_000:
+                continue
+            payload = json.loads(index.read_text(encoding = "utf-8"))
+        except (OSError, ValueError, UnicodeError):
+            continue
+        if isinstance(payload, dict):
+            value = payload.get("_class_name")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def detect_family_by_pipeline_index(path: Optional[str]) -> Optional[DiffusionFamily]:
+    """The family the pipeline saved at ``path`` declares in its ``model_index.json``, or None.
+
+    The path-shaped counterpart of ``detect_family_by_pipeline_class``, and the one both the
+    listing and the loader use, so a model the picker shows on this evidence is a model
+    ``validate_load_request`` accepts on the same evidence (#8407).
+
+    Carries over ``detect_family``'s variant guard: a directory NAMED for a checkpoint the matched
+    family cannot run (``...-layered``) is still refused, so reading the index only ever adds
+    models whose name said nothing, never overrides a name that said no."""
+    fam = detect_family_by_pipeline_class(pipeline_class_from_index(path))
+    if fam is None:
+        return None
+    basename = re.split(r"[/\\]+", str(path).lower())[-1]
+    matched_tokens = (fam.name, *fam.aliases)
+    if any(
+        _token_in_needle(kw, basename) and not any(kw in tok for tok in matched_tokens)
+        for kw in _EDIT_KEYWORDS
+    ):
+        return None
+    return fam
+
+
 def detect_family_for_pick(
     repo_id: str,
     gguf_filename: Optional[str] = None,
     override: Optional[str] = None,
 ) -> Optional[DiffusionFamily]:
     """``detect_family``, falling back to the combined path/filename for a local ``.gguf`` pick
-    where the family keyword lives only in the filename. Only a fallback, so remote picks and
-    overrides behave exactly as ``detect_family``. Shared by both engines."""
+    where the family keyword lives only in the filename, and then to the saved pipeline class of a
+    local diffusers pipeline directory. Only fallbacks, so remote picks and overrides behave
+    exactly as ``detect_family``. Shared by both engines.
+
+    The index fallback is what keeps the listing and the loader on one answer. The listing
+    classifies a moved pipeline from its ``model_index.json`` because its directory name is a
+    commit hash; the pick the picker then sends is that same opaque path with no family_override,
+    so without this the model is shown as text-to-image and refused as an unsupported family
+    (#8407)."""
     fam = detect_family(repo_id, override)
     if fam is None and gguf_filename and not override:
         fam = detect_family(f"{repo_id}/{gguf_filename}", override)
+    if fam is None and not override:
+        fam = detect_family_by_pipeline_index(repo_id)
     return fam
 
 

--- a/studio/backend/core/inference/diffusion_families.py
+++ b/studio/backend/core/inference/diffusion_families.py
@@ -542,7 +542,14 @@ def pipeline_class_from_index(path: Optional[str]) -> Optional[str]:
     Read with a size cap and no schema assumptions: an index is a small JSON manifest, and neither
     a listing nor a load may be held up (or brought down) by whatever a scan folder happens to
     contain. ``_class_name`` is a LIST for a remote-code community pipeline, which Studio cannot
-    load anyway, so only a plain string answers."""
+    load anyway, so only a plain string answers.
+
+    ``utf-8-sig`` because a hand-authored index is an ordinary thing to find beside a converted
+    checkpoint and Windows PowerShell writes JSON with a BOM; read as ``utf-8`` that file raises
+    and the model stays hidden, which is #8407 again by another road. ``RecursionError`` is caught
+    with the rest because a nesting bomb raises it and it is NOT a ``ValueError``: both callers
+    wrap this in a blanket except that reads a raise as detection having succeeded, so an index
+    this cannot parse has to come back as None rather than as an answer."""
     root = Path(path or "")
     if not str(root):
         return None
@@ -551,8 +558,8 @@ def pipeline_class_from_index(path: Optional[str]) -> Optional[str]:
             index = root / name
             if not index.is_file() or index.stat().st_size > 1_000_000:
                 continue
-            payload = json.loads(index.read_text(encoding = "utf-8"))
-        except (OSError, ValueError, UnicodeError):
+            payload = json.loads(index.read_text(encoding = "utf-8-sig"))
+        except (OSError, ValueError, RecursionError):
             continue
         if isinstance(payload, dict):
             value = payload.get("_class_name")

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -4268,7 +4268,6 @@ def _hf_cache_snapshot_repo_id(path: Optional[str]) -> Optional[str]:
     parts = str(path).replace("\\", "/").rstrip("/").split("/")
     if len(parts) >= 3 and parts[-2] == "snapshots" and parts[-3].startswith("models--"):
         from core.inference.model_ids import hf_cache_repo_id
-
         return hf_cache_repo_id(path)
     return None
 
@@ -4293,7 +4292,9 @@ def _local_family_needles(model: "LocalModelInfo") -> tuple[str, ...]:
     basenames still win."""
     needles = [model.model_id, model.display_name, Path(model.id).name]
     try:
-        needles.append(_hf_cache_snapshot_repo_id(model.path) or _hf_cache_snapshot_repo_id(model.id))
+        needles.append(
+            _hf_cache_snapshot_repo_id(model.path) or _hf_cache_snapshot_repo_id(model.id)
+        )
     except Exception:
         pass
     try:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -4117,40 +4117,35 @@ def _arch_to_task(arch: Optional[str], name_hints: tuple[Optional[str], ...] = (
     return "text-generation"
 
 
-# A media checkpoint outranks a text one when both live in the same GGUF folder, and the walk is
-# ordered before anything is read. See _gguf_folder_task. Ranked within the media answers too,
-# because _UNSUPPORTED_DIFFUSION_TASK hides the row from the chat picker AND from the Images and
-# Video ones: a folder holding both a buildable denoiser and an arch this backend cannot assemble
-# has exactly one loadable answer, and returning the other on the strength of where it sorts hides
-# a model that works. Only a folder with no buildable denoiser in it answers unsupported.
+# A media checkpoint outranks a text one in the same GGUF folder (see _gguf_folder_task), and is
+# ranked within the media answers too: _UNSUPPORTED_DIFFUSION_TASK hides the row from the chat
+# picker AND from the Images and Video ones, so a folder holding both a buildable denoiser and an
+# arch this backend cannot assemble has exactly one loadable answer, and returning the other on the
+# strength of where it sorts hides a model that works.
 _LOADABLE_MEDIA_GGUF_TASKS = frozenset({"text-to-image", _VIDEO_GEN_TASK})
-# Enough to reach the denoiser past a bundle's encoders, VAE and LoRAs. Ordered, so the cap takes
-# the same files on every host rather than whatever the walk reached first -- the guarantee is
-# therefore "the first 64 in order decide", and a denoiser sorting past that is not read. Real
-# bundles are a handful of files; a folder deep enough to hit this is a dump, not a checkpoint.
+# Enough to reach the denoiser past a bundle's encoders, VAE and LoRAs. The guarantee is "the first
+# 64 in order decide", the same 64 on every host. A folder deep enough to hit this is a dump.
 _MAX_TASK_CLASSIFY_GGUFS = 64
-# Ordering costs the early exit first-wins had -- the walk can no longer stop at the first GGUF --
-# so bound it, the way _dir_has_downloaded_model and _read_native_context_length already bound
-# theirs. A scan folder is arbitrary: a network mount, or weights beside a huge unrelated subtree
-# that rglob counts every entry of, and this runs once per row inside the listing request. Past the
-# budget the answer comes from what was reached, which is still at least what first-wins looked at.
+# Ordering costs first-wins' early exit, so bound the walk as _dir_has_downloaded_model and
+# _read_native_context_length already do. A scan folder is arbitrary (a network mount, or weights
+# beside a huge unrelated subtree rglob counts every entry of) and this runs once per listed row.
+# Past the budget the answer comes from what was reached, still at least what first-wins saw.
 _TASK_CLASSIFY_WALK_SECONDS = 0.75
-# The header reads get their own budget, started after the walk: a slow walk must not be able to
-# cut the reads short at the encoder and hand back the answer this whole function exists to avoid.
+# The header reads get their own budget, started after the walk, so a slow walk cannot cut them
+# short at the encoder and hand back the answer this function exists to avoid.
 _TASK_CLASSIFY_READ_SECONDS = 1.5
 
 
 def _is_trailing_split_shard(name: str) -> bool:
     """True for shard 2..N of a split GGUF.
 
-    ``gguf-split`` writes the whole KV block into shard 1 only ("Save all metadata in first split
-    only") and gives the rest just ``split.no``, ``split.count`` and ``split.tensors.count``, so a
-    trailing shard carries no ``general.architecture`` AT ALL. Reading one can only fail, and a
-    51-shard repo would cost 51 header reads to answer one question.
+    ``gguf-split`` writes the whole KV block into shard 1 only, so a trailing shard carries no
+    ``general.architecture`` at all: reading one can only fail, and a 51-shard repo would cost 51
+    header reads to answer one question.
 
-    Answers False if the shared pattern cannot be imported, so a rename over there costs the
-    optimisation rather than every folder's task: this runs inside the caller's blanket except,
-    where an ImportError would come back as no classification for anything."""
+    False if the shared pattern cannot be imported, so a rename there costs the optimisation and
+    nothing else: this runs inside the caller's blanket except, where an ImportError would come
+    back as no classification for any folder."""
     try:
         from utils.models.model_config import _GGUF_SPLIT_FILE_RE
     except ImportError:
@@ -4163,12 +4158,11 @@ def _is_trailing_split_shard(name: str) -> bool:
 def _task_classify_sort_key(root: Path, path: Path) -> tuple[str, str]:
     """Order a candidate by its path RELATIVE to the folder, in posix form.
 
-    The whole point of ordering is that the answer stops depending on the filesystem, so the key
-    must carry neither the mount point (which is exactly what moving a Models folder changes) nor
-    the separator: ``\\`` sorts against ``-`` and ``.`` differently than ``/`` does, so a key built
-    from the absolute path can order the same two files one way on Windows and the other way on
-    Linux. Lowercased so a case-insensitive filesystem agrees, with the exact form as a tie-break
-    to keep the order total."""
+    Ordering exists so the answer stops depending on the filesystem, so the key carries neither the
+    mount point (what moving a Models folder changes) nor the separator: ``\\`` sorts against ``-``
+    and ``.`` differently than ``/``, so an absolute-path key can order the same two files one way
+    on Windows and the other on Linux. Lowercased so a case-insensitive filesystem agrees, exact
+    form as tie-break to keep the order total."""
     try:
         rel = path.relative_to(root).as_posix()
     except ValueError:
@@ -4183,30 +4177,25 @@ def _gguf_folder_task(
 ) -> Optional[str]:
     """The task a folder of GGUFs classifies as, ordered and decided by the media file.
 
-    Two bugs, one fix (#8406, #8407). The walk behind this is ``rglob``, i.e. raw directory
-    order, and the answer used to be whichever file it happened to yield first, so one folder
-    classified differently on two machines -- and differently before and after a copy, which is
-    exactly what moving the Models folder does. Sorting makes the answer a property of the
-    contents rather than of the filesystem.
+    Two bugs, one fix (#8406, #8407). The walk is ``rglob``, i.e. raw directory order, and the
+    answer used to be whichever file it yielded first, so a folder classified differently on two
+    machines and differently before and after a copy, which is what moving the Models folder makes.
+    Sorting makes the answer a property of the contents, not of the filesystem.
 
-    Decisive, not first-wins, because a media checkpoint does not ship alone: the community GGUF
-    bundles put the text encoder (t5 / clip / a qwen3 conditioner) beside the denoiser, and
-    ``unsloth/MiniMax-H3-GGUF`` does it too. Answering with the encoder tags a real image or video
-    repo ``text-generation``, which drops it out of the Images picker and offers a DiT in the chat
-    one; answering with the denoiser is right whichever file sorts first. A text repo has no
-    diffusion GGUF in it, so nothing gains a media task this way that did not already have one.
+    Decisive rather than first-wins because a media checkpoint does not ship alone: community
+    bundles put the text encoder (t5 / clip / a qwen3 conditioner) beside the denoiser. Answering
+    with the encoder tags a real image or video repo ``text-generation``, dropping it out of the
+    Images picker and offering a DiT in the chat one. A text repo has no diffusion GGUF in it, so
+    nothing gains a media task that did not already have one.
 
-    Bounded on both halves, because deciding from all of the folder rather than from its first file
-    means neither half can be allowed to run for as long as the folder is big: ``deadline``
-    (time.monotonic, defaulted here) stops the walk, and the candidates are kept to the cap as they
-    are found rather than collected in full, so neither the time nor the memory this costs scales
-    with a subtree that has nothing to do with the model."""
+    Bounded on both halves so neither scales with the folder: ``deadline`` (time.monotonic,
+    defaulted here) stops the walk, and candidates are trimmed to the cap as they are found."""
     if deadline is None:
         deadline = time.monotonic() + _TASK_CLASSIFY_WALK_SECONDS
     fallback: Optional[str] = None
     try:
-        # Trimmed back to the cap as it fills: the cap is what gets read, so a folder holding
-        # thousands of GGUFs should not also cost a list of thousands of paths to read 64 of them.
+        # Trimmed back to the cap as it fills: a folder holding thousands of GGUFs should not cost
+        # a list of thousands of paths to read 64 of them.
         scored: list[tuple[tuple[str, str], Path]] = []
         for path in _iter_gguf_paths(root, deadline):
             name = path.name
@@ -4223,8 +4212,8 @@ def _gguf_folder_task(
     unsupported: Optional[str] = None
     read_deadline = time.monotonic() + _TASK_CLASSIFY_READ_SECONDS
     for index, path in enumerate(paths):
-        # The first read always happens, so a folder still classifies as whatever its first
-        # ordered file says even on a host where the budget was gone before this loop started.
+        # The first read always happens, so a folder still classifies from its first ordered file
+        # even where the budget was gone before this loop started.
         if index and time.monotonic() >= read_deadline:
             break
         try:
@@ -4256,13 +4245,12 @@ def _repo_gguf_task(repo_info) -> Optional[str]:
 def _hf_cache_snapshot_repo_id(path: Optional[str]) -> Optional[str]:
     """``org/name`` when *path* IS a ``models--org--name/snapshots/<sha>`` root, else None.
 
-    ``hf_cache_repo_id`` answers for anything UNDER that directory as well, which is right for its
-    own job (naming the model a loaded file belongs to) and wrong for a needle. A pipeline's
-    component directories -- ``transformer``, ``vae``, ``text_encoder`` -- carry a ``config.json``
-    and weights, so a scan folder registers each of them as a row of its own; handing those rows
-    the parent's repo id makes every one of them detect the family, satisfy ``_local_is_diffusers``
-    and enter the Images picker as a checkpoint that cannot load. So the shape is required to end
-    at the snapshot, and the decode itself is still the strict shared one."""
+    ``hf_cache_repo_id`` also answers for anything UNDER that directory, which is right for its own
+    job and wrong for a needle: a pipeline's ``transformer``, ``vae`` and ``text_encoder`` dirs
+    carry a ``config.json`` and weights, so a scan folder registers each as a row, and handing them
+    the parent's repo id makes every one detect the family, satisfy ``_local_is_diffusers`` and
+    enter the Images picker as a checkpoint that cannot load. Hence the shape must end at the
+    snapshot; the decode itself is still the strict shared one."""
     if not path:
         return None
     parts = str(path).replace("\\", "/").rstrip("/").split("/")
@@ -4279,17 +4267,14 @@ def _local_family_needles(model: "LocalModelInfo") -> tuple[str, ...]:
     resolves it via ``resolve_local_single_file``). Only basenames, so a parent-dir token can't
     match -- with one exception, the encoded repo id below.
 
-    A checkpoint still in Hugging Face cache layout carries its repo id in the
-    ``models--org--name`` directory, and every other needle degrades to the snapshot's
-    basename, which is a commit hash. That is what a moved Models folder registered as a
-    scan folder looks like (#8407): a GGUF still classifies, because its architecture is
-    read out of the file, but a diffusers pipeline -- proven to be one by its
-    ``model_index.json`` -- had no name left to detect a family from and dropped out of the
-    Images picker as task=null. ``hf_cache_repo_id`` answers only for a real
-    ``models--*/snapshots/*`` path AND only for the row that IS the snapshot, so this stays a
-    decode of the id that row lost, not a licence for arbitrary parent-dir tokens to match nor for
-    the pipeline's own component directories to inherit it. Last of the name needles, so the
-    basenames still win."""
+    A checkpoint still in HF cache layout carries its repo id in the ``models--org--name``
+    directory, while every other needle degrades to the snapshot basename, a commit hash. That is
+    a moved Models folder registered as a scan folder (#8407): a GGUF still classifies from its
+    architecture, but a diffusers pipeline, proven to be one by its ``model_index.json``, had no
+    name left and dropped out of the Images picker as task=null. The decode answers only for a real
+    ``models--*/snapshots/*`` path AND only for the row that IS the snapshot, so it recovers the id
+    that row lost without letting arbitrary parent-dir tokens match or component dirs inherit it.
+    Last of the name needles, so the basenames still win."""
     needles = [model.model_id, model.display_name, Path(model.id).name]
     try:
         needles.append(
@@ -4346,10 +4331,10 @@ def _local_model_task(model: "LocalModelInfo") -> Optional[str]:
                 detect_family_by_pipeline_index,
             )
 
-            # The saved pipeline class first: it is evidence out of the checkpoint, where every
-            # needle below is a name, and a moved model's name is the one thing that does not
-            # survive (#8407). The loader reads the index through the same helper, so a model
-            # shown on this evidence is one validate_load_request accepts on it.
+            # The saved pipeline class first: evidence out of the checkpoint, where every needle
+            # below is a name, and a moved model's name is what does not survive (#8407). The
+            # loader reads the index through the same helper, so anything shown on this evidence is
+            # something validate_load_request accepts on it.
             for fam in (
                 detect_family_by_pipeline_index(path),
                 *(detect_family(needle) for needle in _local_family_needles(model)),

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -4118,24 +4118,69 @@ def _arch_to_task(arch: Optional[str], name_hints: tuple[Optional[str], ...] = (
 
 
 # A media checkpoint outranks a text one when both live in the same GGUF folder, and the walk is
-# ordered before anything is read. See _gguf_folder_task.
-_MEDIA_GGUF_TASKS = frozenset({"text-to-image", _VIDEO_GEN_TASK, _UNSUPPORTED_DIFFUSION_TASK})
+# ordered before anything is read. See _gguf_folder_task. Ranked within the media answers too,
+# because _UNSUPPORTED_DIFFUSION_TASK hides the row from the chat picker AND from the Images and
+# Video ones: a folder holding both a buildable denoiser and an arch this backend cannot assemble
+# has exactly one loadable answer, and returning the other on the strength of where it sorts hides
+# a model that works. Only a folder with no buildable denoiser in it answers unsupported.
+_LOADABLE_MEDIA_GGUF_TASKS = frozenset({"text-to-image", _VIDEO_GEN_TASK})
 # Enough to reach the denoiser past a bundle's encoders, VAE and LoRAs. Ordered, so the cap takes
-# the same files on every host rather than whatever the walk reached first.
+# the same files on every host rather than whatever the walk reached first -- the guarantee is
+# therefore "the first 64 in order decide", and a denoiser sorting past that is not read. Real
+# bundles are a handful of files; a folder deep enough to hit this is a dump, not a checkpoint.
 _MAX_TASK_CLASSIFY_GGUFS = 64
+# Ordering costs the early exit first-wins had -- the walk can no longer stop at the first GGUF --
+# so bound it, the way _dir_has_downloaded_model and _read_native_context_length already bound
+# theirs. A scan folder is arbitrary: a network mount, or weights beside a huge unrelated subtree
+# that rglob counts every entry of, and this runs once per row inside the listing request. Past the
+# budget the answer comes from what was reached, which is still at least what first-wins looked at.
+_TASK_CLASSIFY_WALK_SECONDS = 0.75
+# The header reads get their own budget, started after the walk: a slow walk must not be able to
+# cut the reads short at the encoder and hand back the answer this whole function exists to avoid.
+_TASK_CLASSIFY_READ_SECONDS = 1.5
 
 
 def _is_trailing_split_shard(name: str) -> bool:
-    """True for shard 2..N of a split GGUF. Shard 1 carries the full KV block and the rest carry a
-    minimal one, so they are the wrong files to read an architecture from as well as the expensive
-    ones: a 51-shard repo would otherwise cost 51 header reads to answer one question."""
-    from utils.models.model_config import _GGUF_SPLIT_FILE_RE
+    """True for shard 2..N of a split GGUF.
+
+    ``gguf-split`` writes the whole KV block into shard 1 only ("Save all metadata in first split
+    only") and gives the rest just ``split.no``, ``split.count`` and ``split.tensors.count``, so a
+    trailing shard carries no ``general.architecture`` AT ALL. Reading one can only fail, and a
+    51-shard repo would cost 51 header reads to answer one question.
+
+    Answers False if the shared pattern cannot be imported, so a rename over there costs the
+    optimisation rather than every folder's task: this runs inside the caller's blanket except,
+    where an ImportError would come back as no classification for anything."""
+    try:
+        from utils.models.model_config import _GGUF_SPLIT_FILE_RE
+    except ImportError:
+        return False
 
     match = _GGUF_SPLIT_FILE_RE.match(name)
     return match is not None and match.group("index") != "00001"
 
 
-def _gguf_folder_task(root: Path, id_hints: tuple[Optional[str], ...]) -> Optional[str]:
+def _task_classify_sort_key(root: Path, path: Path) -> tuple[str, str]:
+    """Order a candidate by its path RELATIVE to the folder, in posix form.
+
+    The whole point of ordering is that the answer stops depending on the filesystem, so the key
+    must carry neither the mount point (which is exactly what moving a Models folder changes) nor
+    the separator: ``\\`` sorts against ``-`` and ``.`` differently than ``/`` does, so a key built
+    from the absolute path can order the same two files one way on Windows and the other way on
+    Linux. Lowercased so a case-insensitive filesystem agrees, with the exact form as a tie-break
+    to keep the order total."""
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        rel = path.name
+    return (rel.lower(), rel)
+
+
+def _gguf_folder_task(
+    root: Path,
+    id_hints: tuple[Optional[str], ...],
+    deadline: Optional[float] = None,
+) -> Optional[str]:
     """The task a folder of GGUFs classifies as, ordered and decided by the media file.
 
     Two bugs, one fix (#8406, #8407). The walk behind this is ``rglob``, i.e. raw directory
@@ -4149,29 +4194,51 @@ def _gguf_folder_task(root: Path, id_hints: tuple[Optional[str], ...]) -> Option
     ``unsloth/MiniMax-H3-GGUF`` does it too. Answering with the encoder tags a real image or video
     repo ``text-generation``, which drops it out of the Images picker and offers a DiT in the chat
     one; answering with the denoiser is right whichever file sorts first. A text repo has no
-    diffusion GGUF in it, so nothing gains a media task this way that did not already have one."""
+    diffusion GGUF in it, so nothing gains a media task this way that did not already have one.
+
+    Bounded on both halves, because deciding from all of the folder rather than from its first file
+    means neither half can be allowed to run for as long as the folder is big: ``deadline``
+    (time.monotonic, defaulted here) stops the walk, and the candidates are kept to the cap as they
+    are found rather than collected in full, so neither the time nor the memory this costs scales
+    with a subtree that has nothing to do with the model."""
+    if deadline is None:
+        deadline = time.monotonic() + _TASK_CLASSIFY_WALK_SECONDS
     fallback: Optional[str] = None
     try:
-        paths = sorted(
-            (
-                p
-                for p in _iter_gguf_paths(root)
-                if not _is_mmproj_filename(p.name) and not _is_trailing_split_shard(p.name)
-            ),
-            key = lambda p: (str(p).lower(), str(p)),
-        )[:_MAX_TASK_CLASSIFY_GGUFS]
+        # Trimmed back to the cap as it fills: the cap is what gets read, so a folder holding
+        # thousands of GGUFs should not also cost a list of thousands of paths to read 64 of them.
+        scored: list[tuple[tuple[str, str], Path]] = []
+        for path in _iter_gguf_paths(root, deadline):
+            name = path.name
+            if _is_mmproj_filename(name) or _is_trailing_split_shard(name):
+                continue
+            scored.append((_task_classify_sort_key(root, path), path))
+            if len(scored) > _MAX_TASK_CLASSIFY_GGUFS * 2:
+                scored.sort(key = lambda item: item[0])
+                del scored[_MAX_TASK_CLASSIFY_GGUFS:]
+        scored.sort(key = lambda item: item[0])
+        paths = [path for _, path in scored[:_MAX_TASK_CLASSIFY_GGUFS]]
     except Exception:
         return None
-    for path in paths:
+    unsupported: Optional[str] = None
+    read_deadline = time.monotonic() + _TASK_CLASSIFY_READ_SECONDS
+    for index, path in enumerate(paths):
+        # The first read always happens, so a folder still classifies as whatever its first
+        # ordered file says even on a host where the budget was gone before this loop started.
+        if index and time.monotonic() >= read_deadline:
+            break
         try:
             task = _arch_to_task(_gguf_architecture(str(path)), name_hints = id_hints + (path.name,))
         except Exception:
             continue
-        if task in _MEDIA_GGUF_TASKS:
+        if task in _LOADABLE_MEDIA_GGUF_TASKS:
             return task
-        if task is not None and fallback is None:
+        if task == _UNSUPPORTED_DIFFUSION_TASK:
+            if unsupported is None:
+                unsupported = task
+        elif task is not None and fallback is None:
             fallback = task
-    return fallback
+    return unsupported or fallback
 
 
 def _repo_gguf_task(repo_info) -> Optional[str]:
@@ -4184,6 +4251,26 @@ def _repo_gguf_task(repo_info) -> Optional[str]:
         return _gguf_folder_task(Path(repo_info.repo_path), (repo_id,))
     except Exception:
         return None
+
+
+def _hf_cache_snapshot_repo_id(path: Optional[str]) -> Optional[str]:
+    """``org/name`` when *path* IS a ``models--org--name/snapshots/<sha>`` root, else None.
+
+    ``hf_cache_repo_id`` answers for anything UNDER that directory as well, which is right for its
+    own job (naming the model a loaded file belongs to) and wrong for a needle. A pipeline's
+    component directories -- ``transformer``, ``vae``, ``text_encoder`` -- carry a ``config.json``
+    and weights, so a scan folder registers each of them as a row of its own; handing those rows
+    the parent's repo id makes every one of them detect the family, satisfy ``_local_is_diffusers``
+    and enter the Images picker as a checkpoint that cannot load. So the shape is required to end
+    at the snapshot, and the decode itself is still the strict shared one."""
+    if not path:
+        return None
+    parts = str(path).replace("\\", "/").rstrip("/").split("/")
+    if len(parts) >= 3 and parts[-2] == "snapshots" and parts[-3].startswith("models--"):
+        from core.inference.model_ids import hf_cache_repo_id
+
+        return hf_cache_repo_id(path)
+    return None
 
 
 def _local_family_needles(model: "LocalModelInfo") -> tuple[str, ...]:
@@ -4200,12 +4287,13 @@ def _local_family_needles(model: "LocalModelInfo") -> tuple[str, ...]:
     read out of the file, but a diffusers pipeline -- proven to be one by its
     ``model_index.json`` -- had no name left to detect a family from and dropped out of the
     Images picker as task=null. ``hf_cache_repo_id`` answers only for a real
-    ``models--*/snapshots/*`` path, so this stays a decode of the id the row lost, not a
-    licence for arbitrary parent-dir tokens to match. Last, so the basenames still win."""
+    ``models--*/snapshots/*`` path AND only for the row that IS the snapshot, so this stays a
+    decode of the id that row lost, not a licence for arbitrary parent-dir tokens to match nor for
+    the pipeline's own component directories to inherit it. Last of the name needles, so the
+    basenames still win."""
     needles = [model.model_id, model.display_name, Path(model.id).name]
     try:
-        from core.inference.model_ids import hf_cache_repo_id
-        needles.append(hf_cache_repo_id(model.path) or hf_cache_repo_id(model.id))
+        needles.append(_hf_cache_snapshot_repo_id(model.path) or _hf_cache_snapshot_repo_id(model.id))
     except Exception:
         pass
     try:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -312,6 +312,26 @@ def _local_pipeline_index(d: Path) -> bool:
         return False
 
 
+def _local_pipeline_class_name(d: Path) -> Optional[str]:
+    """The ``_class_name`` a diffusers pipeline root declares, or None.
+
+    Read with a size cap and no schema assumptions: an index is a small JSON manifest, and a
+    listing must never be held up (or brought down) by whatever a scan folder happens to contain."""
+    for name in ("model_index.json", "modular_model_index.json"):
+        try:
+            index = d / name
+            if not index.is_file() or index.stat().st_size > 1_000_000:
+                continue
+            payload = json.loads(index.read_text(encoding = "utf-8"))
+        except (OSError, ValueError, UnicodeError):
+            continue
+        if isinstance(payload, dict):
+            value = payload.get("_class_name")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
 def _is_gguf_companion_only_dir(path: Path) -> bool:
     """True for a folder whose entire content is GGUF companions -- a lone mmproj adapter, an
     MTP drafter, or both -- with nothing servable beside them.
@@ -4117,6 +4137,63 @@ def _arch_to_task(arch: Optional[str], name_hints: tuple[Optional[str], ...] = (
     return "text-generation"
 
 
+# A media checkpoint outranks a text one when both live in the same GGUF folder, and the walk is
+# ordered before anything is read. See _gguf_folder_task.
+_MEDIA_GGUF_TASKS = frozenset({"text-to-image", _VIDEO_GEN_TASK, _UNSUPPORTED_DIFFUSION_TASK})
+# Enough to reach the denoiser past a bundle's encoders, VAE and LoRAs. Ordered, so the cap takes
+# the same files on every host rather than whatever the walk reached first.
+_MAX_TASK_CLASSIFY_GGUFS = 64
+
+
+def _is_trailing_split_shard(name: str) -> bool:
+    """True for shard 2..N of a split GGUF. Shard 1 carries the full KV block and the rest carry a
+    minimal one, so they are the wrong files to read an architecture from as well as the expensive
+    ones: a 51-shard repo would otherwise cost 51 header reads to answer one question."""
+    from utils.models.model_config import _GGUF_SPLIT_FILE_RE
+
+    match = _GGUF_SPLIT_FILE_RE.match(name)
+    return match is not None and match.group("index") != "00001"
+
+
+def _gguf_folder_task(root: Path, id_hints: tuple[Optional[str], ...]) -> Optional[str]:
+    """The task a folder of GGUFs classifies as, ordered and decided by the media file.
+
+    Two bugs, one fix (#8406, #8407). The walk behind this is ``rglob``, i.e. raw directory
+    order, and the answer used to be whichever file it happened to yield first, so one folder
+    classified differently on two machines -- and differently before and after a copy, which is
+    exactly what moving the Models folder does. Sorting makes the answer a property of the
+    contents rather than of the filesystem.
+
+    Decisive, not first-wins, because a media checkpoint does not ship alone: the community GGUF
+    bundles put the text encoder (t5 / clip / a qwen3 conditioner) beside the denoiser, and
+    ``unsloth/MiniMax-H3-GGUF`` does it too. Answering with the encoder tags a real image or video
+    repo ``text-generation``, which drops it out of the Images picker and offers a DiT in the chat
+    one; answering with the denoiser is right whichever file sorts first. A text repo has no
+    diffusion GGUF in it, so nothing gains a media task this way that did not already have one."""
+    fallback: Optional[str] = None
+    try:
+        paths = sorted(
+            (
+                p
+                for p in _iter_gguf_paths(root)
+                if not _is_mmproj_filename(p.name) and not _is_trailing_split_shard(p.name)
+            ),
+            key = lambda p: (str(p).lower(), str(p)),
+        )[:_MAX_TASK_CLASSIFY_GGUFS]
+    except Exception:
+        return None
+    for path in paths:
+        try:
+            task = _arch_to_task(_gguf_architecture(str(path)), name_hints = id_hints + (path.name,))
+        except Exception:
+            continue
+        if task in _MEDIA_GGUF_TASKS:
+            return task
+        if task is not None and fallback is None:
+            fallback = task
+    return fallback
+
+
 def _repo_gguf_task(repo_info) -> Optional[str]:
     """HF pipeline task of a cached GGUF repo, from its architecture:
     'text-to-image' for a loadable diffusion arch, the non-loadable diffusion tag
@@ -4124,15 +4201,9 @@ def _repo_gguf_task(repo_info) -> Optional[str]:
     unreadable)."""
     repo_id = getattr(repo_info, "repo_id", None)
     try:
-        for path in _iter_gguf_paths(Path(repo_info.repo_path)):
-            if _is_mmproj_filename(path.name):
-                continue
-            task = _arch_to_task(_gguf_architecture(str(path)), name_hints = (repo_id, path.name))
-            if task is not None:
-                return task
+        return _gguf_folder_task(Path(repo_info.repo_path), (repo_id,))
     except Exception:
-        pass
-    return None
+        return None
 
 
 def _local_family_needles(model: "LocalModelInfo") -> tuple[str, ...]:
@@ -4140,8 +4211,23 @@ def _local_family_needles(model: "LocalModelInfo") -> tuple[str, ...]:
     name, and -- for a bare single-file dir -- the sole checkpoint's filename (a generic folder
     holding one ``qwen-image-*.safetensors`` identifies its family only there, and the load route
     resolves it via ``resolve_local_single_file``). Only basenames, so a parent-dir token can't
-    match."""
+    match -- with one exception, the encoded repo id below.
+
+    A checkpoint still in Hugging Face cache layout carries its repo id in the
+    ``models--org--name`` directory, and every other needle degrades to the snapshot's
+    basename, which is a commit hash. That is what a moved Models folder registered as a
+    scan folder looks like (#8407): a GGUF still classifies, because its architecture is
+    read out of the file, but a diffusers pipeline -- proven to be one by its
+    ``model_index.json`` -- had no name left to detect a family from and dropped out of the
+    Images picker as task=null. ``hf_cache_repo_id`` answers only for a real
+    ``models--*/snapshots/*`` path, so this stays a decode of the id the row lost, not a
+    licence for arbitrary parent-dir tokens to match. Last, so the basenames still win."""
     needles = [model.model_id, model.display_name, Path(model.id).name]
+    try:
+        from core.inference.model_ids import hf_cache_repo_id
+        needles.append(hf_cache_repo_id(model.path) or hf_cache_repo_id(model.id))
+    except Exception:
+        pass
     try:
         from core.inference.diffusion import resolve_local_single_file
         single = resolve_local_single_file(model.path)
@@ -4167,12 +4253,7 @@ def _local_model_task(model: "LocalModelInfo") -> Optional[str]:
             p = Path(path)
             if p.suffix.lower() == ".gguf" and p.is_file():
                 return _arch_to_task(_gguf_architecture(str(p)), name_hints = _id_hints + (p.name,))
-            for f in _iter_gguf_paths(p):
-                if _is_mmproj_filename(f.name):
-                    continue
-                task = _arch_to_task(_gguf_architecture(str(f)), name_hints = _id_hints + (f.name,))
-                if task is not None:
-                    return task
+            return _gguf_folder_task(p, _id_hints)
         except Exception:
             pass
         return None
@@ -4191,10 +4272,18 @@ def _local_model_task(model: "LocalModelInfo") -> Optional[str]:
         # The Images load path 400s AFTER eviction when no image family is supported, so tag only when detection succeeds.
         try:
             from core.inference.diffusion_engine_router import family_buildable_here
-            from core.inference.diffusion_families import detect_family
+            from core.inference.diffusion_families import (
+                detect_family,
+                detect_family_by_pipeline_class,
+            )
 
-            for needle in _local_family_needles(model):
-                fam = detect_family(needle)
+            # The saved pipeline class first: it is evidence out of the checkpoint, where every
+            # needle below is a name, and a moved model's name is the one thing that does not
+            # survive (#8407).
+            for fam in (
+                detect_family_by_pipeline_class(_local_pipeline_class_name(Path(path))),
+                *(detect_family(needle) for needle in _local_family_needles(model)),
+            ):
                 if fam is not None:
                     # A local non-GGUF checkpoint always loads through diffusers, so the pipeline class has to exist here.
                     return (

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -312,26 +312,6 @@ def _local_pipeline_index(d: Path) -> bool:
         return False
 
 
-def _local_pipeline_class_name(d: Path) -> Optional[str]:
-    """The ``_class_name`` a diffusers pipeline root declares, or None.
-
-    Read with a size cap and no schema assumptions: an index is a small JSON manifest, and a
-    listing must never be held up (or brought down) by whatever a scan folder happens to contain."""
-    for name in ("model_index.json", "modular_model_index.json"):
-        try:
-            index = d / name
-            if not index.is_file() or index.stat().st_size > 1_000_000:
-                continue
-            payload = json.loads(index.read_text(encoding = "utf-8"))
-        except (OSError, ValueError, UnicodeError):
-            continue
-        if isinstance(payload, dict):
-            value = payload.get("_class_name")
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-    return None
-
-
 def _is_gguf_companion_only_dir(path: Path) -> bool:
     """True for a folder whose entire content is GGUF companions -- a lone mmproj adapter, an
     MTP drafter, or both -- with nothing servable beside them.
@@ -4274,14 +4254,15 @@ def _local_model_task(model: "LocalModelInfo") -> Optional[str]:
             from core.inference.diffusion_engine_router import family_buildable_here
             from core.inference.diffusion_families import (
                 detect_family,
-                detect_family_by_pipeline_class,
+                detect_family_by_pipeline_index,
             )
 
             # The saved pipeline class first: it is evidence out of the checkpoint, where every
             # needle below is a name, and a moved model's name is the one thing that does not
-            # survive (#8407).
+            # survive (#8407). The loader reads the index through the same helper, so a model
+            # shown on this evidence is one validate_load_request accepts on it.
             for fam in (
-                detect_family_by_pipeline_class(_local_pipeline_class_name(Path(path))),
+                detect_family_by_pipeline_index(path),
                 *(detect_family(needle) for needle in _local_family_needles(model)),
             ):
                 if fam is not None:

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4388,8 +4388,8 @@ def test_a_standalone_h3_denoiser_gguf_is_recognised_by_its_filename():
 
 
 def _arch_gguf(path: Path, architecture: str) -> Path:
-    """A minimal valid GGUF carrying just ``general.architecture``, like the other suites'
-    fabricated headers (``tests/test_llama_cpp_placement.py::_write_gguf``)."""
+    """A minimal valid GGUF carrying just ``general.architecture``, as in
+    ``tests/test_llama_cpp_placement.py::_write_gguf``."""
     import struct
 
     def string(value: str) -> bytes:
@@ -4405,10 +4405,8 @@ def _arch_gguf(path: Path, architecture: str) -> Path:
 def _both_walk_orders(root: Path, monkeypatch, classify):
     """*classify* under both possible ``_iter_gguf_paths`` orders.
 
-    The real walk is ``rglob``, i.e. raw directory order, which differs between filesystems and
-    between a folder and a fresh copy of it -- which is what moving the Models folder makes. The
-    order is the input being varied, so it is forced rather than hoped for.
-    """
+    The real walk is ``rglob``, raw directory order, which differs between filesystems and between
+    a folder and a fresh copy of it. Order is the input being varied, so it is forced."""
     paths = sorted(root.rglob("*.gguf"))
     answers = []
     for order in (paths, list(reversed(paths))):
@@ -4420,14 +4418,10 @@ def _both_walk_orders(root: Path, monkeypatch, classify):
 
 
 def test_a_mixed_gguf_repo_classifies_the_same_in_either_walk_order(tmp_path, monkeypatch):
-    """#8406 / #8407. Community image and video GGUF bundles ship the text encoder beside the
-    denoiser -- ``BlackStone-Yu/Z-Image-Turbo-GGUF`` carries a ``qwen3`` conditioner next to its
-    ``lumina2`` DiT, and ``unsloth/MiniMax-H3-GGUF`` does the same -- so the repo held both
-    answers and returned whichever file the unordered walk yielded first.
-
-    Ordering alone is not enough: it would still hand the answer to whichever name sorts first.
-    The denoiser is what the repo IS, so a media task outranks the encoder's text one.
-    """
+    """#8406 / #8407. Community bundles ship the text encoder beside the denoiser
+    (``BlackStone-Yu/Z-Image-Turbo-GGUF`` puts a ``qwen3`` conditioner next to its ``lumina2``
+    DiT), so the repo held both answers and returned whichever the unordered walk yielded first.
+    Ordering alone would still hand it to whichever name sorts first, so the media task wins."""
     repo_dir = tmp_path / "models--BlackStone-Yu--Z-Image-Turbo-GGUF"
     _arch_gguf(repo_dir / "Qwen3-4B-UD-Q6_K_XL.gguf", "qwen3")
     _arch_gguf(repo_dir / "z_image_turbo-Q6_K.gguf", "lumina2")
@@ -4440,10 +4434,9 @@ def test_a_mixed_gguf_repo_classifies_the_same_in_either_walk_order(tmp_path, mo
 
 
 def test_a_mixed_local_gguf_folder_classifies_the_same_in_either_walk_order(tmp_path, monkeypatch):
-    """The local twin of the above, and the half that made an image model unfindable: with the
-    encoder answering first the folder is tagged ``text-generation``, which drops it out of the
-    Images picker (``taskMatchesFilter`` rejects any task not in the requested set) and offers a
-    diffusion DiT in the chat one."""
+    """The local twin, and the half that made an image model unfindable: with the encoder answering
+    first the folder is tagged ``text-generation``, which drops it out of the Images picker
+    (``taskMatchesFilter``) and offers a diffusion DiT in the chat one."""
     folder = tmp_path / "AI Models" / "flux-bundle"
     _arch_gguf(folder / "t5xxl-Q8_0.gguf", "t5encoder")
     _arch_gguf(folder / "flux1-dev-Q4_K_M.gguf", "flux")
@@ -4461,8 +4454,8 @@ def test_a_mixed_local_gguf_folder_classifies_the_same_in_either_walk_order(tmp_
 
 def test_a_pure_text_gguf_folder_is_never_promoted_to_a_media_task(tmp_path, monkeypatch):
     """The guard on the fix. Preferring the media answer must not invent one: a repo with no
-    diffusion GGUF in it has to stay ``text-generation`` in both orders, or the change would put
-    chat models in the Images picker -- the direction #8406 was filed about."""
+    diffusion GGUF stays ``text-generation`` in both orders, or chat models land in the Images
+    picker, the direction #8406 was filed about."""
     repo_dir = tmp_path / "models--unsloth--DeepSeek-V4-Flash-0731-GGUF"
     _arch_gguf(repo_dir / "DeepSeek-V4-Flash-0731-UD-Q4_K_XL.gguf", "deepseek4")
     _arch_gguf(repo_dir / "dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf", "deepseek4")
@@ -4490,16 +4483,11 @@ def _saved_pipeline(root: Path, class_name: str) -> Path:
 
 
 def test_a_moved_image_pipeline_is_classified_from_its_saved_pipeline_class(tmp_path):
-    """#8407. The reporter changed the Models folder and image models were then not found at all,
-    while chat models were still listed.
-
-    That asymmetry is structural. A GGUF is classified from ``general.architecture``, read out of
-    the file, so a move cannot touch it. A diffusers pipeline was classified from names only, and
-    the name a Hugging Face snapshot directory carries is a commit hash -- so the model the
-    listing had just PROVEN to be a pipeline (it has a ``model_index.json``) came back task=null
-    and the Images picker hid it. The index names the pipeline class; that is evidence out of the
-    checkpoint, exactly like the GGUF architecture read.
-    """
+    """#8407. The reporter moved the Models folder and image models were then not found, while chat
+    models still were. The asymmetry is structural: a GGUF is classified from
+    ``general.architecture`` read out of the file, but a diffusers pipeline was classified from
+    names, and an HF snapshot directory is named for a commit hash, so a model the listing had just
+    PROVEN to be a pipeline came back task=null. The index is evidence out of the checkpoint."""
     snapshot = _saved_pipeline(
         tmp_path / "N-AI-Models" / "0f3d1a2b4c5d6e7f8091a2b3c4d5e6f708192a3b", "FluxPipeline"
     )
@@ -4514,9 +4502,8 @@ def test_a_moved_image_pipeline_is_classified_from_its_saved_pipeline_class(tmp_
 
 
 def test_a_moved_pipeline_that_names_no_known_family_is_still_not_tagged(tmp_path):
-    """The guard on the fix above. Reading the index must not turn into "any pipeline directory is
-    an image model": the Images load path 400s AFTER evicting chat when no family is supported, so
-    a checkpoint whose class matches nothing in the registry stays untagged, as before."""
+    """The guard on the fix above. The Images load path 400s AFTER evicting chat when no family is
+    supported, so a checkpoint whose class matches nothing in the registry stays untagged."""
     snapshot = _saved_pipeline(
         tmp_path / "N-AI-Models" / "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d", "SomeOtherPipeline"
     )
@@ -4531,24 +4518,19 @@ def test_a_moved_pipeline_that_names_no_known_family_is_still_not_tagged(tmp_pat
 
 
 def test_a_moved_image_pipeline_the_picker_shows_is_one_the_loader_accepts(tmp_path):
-    """The other half of #8407, and the invariant the two tests above do not state on their own:
-    the picker and the loader have to read the SAME evidence.
+    """The other half of #8407: the picker and the loader must read the SAME evidence.
 
-    The Images page sends the row's id as ``model_path`` and no ``family_override`` (see
-    ``images-page.tsx`` handleLoad, and the whole frontend has no family_override for images), so
-    the loader gets nothing but the opaque path back. Classifying from ``model_index.json`` in the
-    listing alone therefore turns a hidden model into a visible one that
-    ``validate_load_request`` -> ``detect_family_for_pick`` refuses as an unsupported family: the
-    user finds the moved model, picks it, and the load 400s.
-    """
+    The Images page sends the row's id as ``model_path`` and no ``family_override``
+    (``images-page.tsx`` handleLoad), so the loader gets nothing but the opaque path. Classifying
+    from ``model_index.json`` in the listing alone would turn a hidden model into a visible one
+    that ``validate_load_request`` -> ``detect_family_for_pick`` then refuses with a 400."""
     from core.inference.diffusion import DiffusionBackend
 
     backend = DiffusionBackend.__new__(DiffusionBackend)
     cases = {
-        # A snapshot copied out of the HF cache: the leaf is a commit hash and nothing in the path
-        # names a family. Exactly the directory the hash-named test above made visible.
+        # A snapshot copied out of the HF cache: the leaf is a commit hash, nothing names a family.
         "0f3d1a2b4c5d6e7f8091a2b3c4d5e6f708192a3b": "FluxPipeline",
-        # The same loss with a hand-chosen folder name, which is the ordinary way to keep a model.
+        # The same loss with a hand-chosen folder name.
         "my-image-model": "QwenImagePipeline",
         # A pipeline class the registry does not know stays hidden AND refused.
         "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d": "SomeOtherPipeline",
@@ -4571,9 +4553,9 @@ def test_a_moved_image_pipeline_the_picker_shows_is_one_the_loader_accepts(tmp_p
         assert (
             task == "text-to-image"
         ) == loader_accepts, f"{name}: picker task={task} but loader accepts={loader_accepts}"
-    # And a checkpoint whose NAME says it is a variant the matched family cannot run stays refused
-    # on both sides: reading the index adds a model whose name said nothing, it never overrules a
-    # name that said no.
+    # A checkpoint whose NAME says it is a variant the matched family cannot run stays refused on
+    # both sides: the index adds models whose name said nothing, it never overrules a name that
+    # said no.
     layered = _saved_pipeline(tmp_path / "N-AI-Models" / "qwen-image-layered", "QwenImagePipeline")
     layered_model = SimpleNamespace(
         path = str(layered),
@@ -4589,10 +4571,9 @@ def test_a_moved_image_pipeline_the_picker_shows_is_one_the_loader_accepts(tmp_p
 
 def test_family_needles_recover_the_repo_id_from_the_hf_cache_directory(tmp_path):
     """#8407, the second half of the same loss. A folder still in cache layout carries its repo id
-    in the ``models--org--name`` directory, and a scan folder registered at or inside such a repo
-    leaves every other needle equal to the commit hash. Decoding it is a strict read of a real
-    ``models--*/snapshots/*`` path, so no arbitrary parent directory token can match this way.
-    """
+    in the ``models--org--name`` directory, while every other needle equals the commit hash. The
+    decode is a strict read of a real ``models--*/snapshots/*`` path, so no arbitrary parent
+    directory token can match this way."""
     snapshot = (
         tmp_path
         / "N-AI-Models"
@@ -4624,9 +4605,9 @@ def test_family_needles_recover_the_repo_id_from_the_hf_cache_directory(tmp_path
 
 
 def test_only_the_first_shard_of_a_split_gguf_is_read_to_classify_a_repo(tmp_path, monkeypatch):
-    """llama.cpp writes the full KV block into shard 1 and a minimal one into the rest, so shards
-    2..N are both the wrong files to read an architecture from and the expensive ones: a 51-shard
-    repo would cost 51 header reads to answer one question. They are skipped."""
+    """llama.cpp writes the full KV block into shard 1 only, so shards 2..N are both the wrong
+    files to read an architecture from and the expensive ones: a 51-shard repo would cost 51 header
+    reads to answer one question."""
     repo_dir = tmp_path / "models--unsloth--Big-GGUF"
     _arch_gguf(repo_dir / "Big-Q4_K_M-00001-of-00003.gguf", "llama")
     for index in ("00002", "00003"):
@@ -4639,8 +4620,8 @@ def test_only_the_first_shard_of_a_split_gguf_is_read_to_classify_a_repo(tmp_pat
         "_gguf_architecture",
         lambda path: (read.append(Path(path).name), real(path))[1],
     )
-    # Trailing shards first, which is a walk order the filesystem is free to hand back: without
-    # the skip they are opened, read as unclassifiable, and only then is shard 1 reached.
+    # Trailing shards first, an order the filesystem is free to hand back: without the skip they
+    # are opened and read as unclassifiable before shard 1 is reached.
     monkeypatch.setattr(
         models_route,
         "_iter_gguf_paths",
@@ -4656,16 +4637,15 @@ def test_only_the_first_shard_of_a_split_gguf_is_read_to_classify_a_repo(tmp_pat
 
 
 def test_a_gguf_folder_walk_stops_on_its_budget_instead_of_holding_the_listing(tmp_path):
-    """Ordering the walk means it can no longer stop at the first GGUF, so a folder is now read to
-    the end -- and a scan folder is arbitrary: a network mount, or weights sitting beside a huge
-    unrelated subtree whose every entry ``rglob`` counts (the hazard ``_dir_has_downloaded_model``
-    already caps). This runs once per row inside the listing request, so the walk takes a deadline
-    and gives up on it, exactly as ``_iter_gguf_paths`` was always documented to allow."""
+    """Ordering the walk means it can no longer stop at the first GGUF, so a folder is read to the
+    end, and a scan folder is arbitrary: a network mount, or weights beside a huge unrelated
+    subtree whose every entry ``rglob`` counts (the hazard ``_dir_has_downloaded_model`` already
+    caps). This runs once per listed row, so the walk takes a deadline and gives up on it."""
     folder = tmp_path / "bundle"
     _arch_gguf(folder / "model-Q4_K_M.gguf", "qwen3")
 
     assert models_route._gguf_folder_task(folder, ("someone/model",)) == "text-generation"
-    # A budget already spent buys nothing, which is what a caller in that state is asking for.
+    # A budget already spent buys nothing.
     spent = models_route._gguf_folder_task(
         folder, ("someone/model",), deadline = time.monotonic() - 1
     )
@@ -4675,16 +4655,16 @@ def test_a_gguf_folder_walk_stops_on_its_budget_instead_of_holding_the_listing(t
 def test_a_slow_walk_cannot_hand_back_the_encoder_this_function_exists_to_avoid(
     tmp_path, monkeypatch
 ):
-    """The header reads get a budget of their own, started after the walk. Sharing one would let a
+    """The header reads get their own budget, started after the walk. Sharing one would let a
     folder that was merely slow to enumerate stop after the encoder and answer ``text-generation``,
-    which is the #8406 bug arriving by a different road."""
+    the #8406 bug by another road."""
     folder = tmp_path / "flux-bundle"
     _arch_gguf(folder / "t5xxl-Q8_0.gguf", "t5encoder")
     _arch_gguf(folder / "flux1-dev-Q4_K_M.gguf", "flux")
     ordered = sorted(folder.rglob("*.gguf"))
 
     def _slow_walk(_root, deadline = None):
-        # Spends the whole walk budget before yielding anything, the shape of a cold network mount.
+        # Spends the whole walk budget before yielding anything, like a cold network mount.
         time.sleep(models_route._TASK_CLASSIFY_WALK_SECONDS + 0.05)
         return iter(ordered)
 
@@ -4693,11 +4673,11 @@ def test_a_slow_walk_cannot_hand_back_the_encoder_this_function_exists_to_avoid(
 
 
 def test_the_classify_order_is_the_same_wherever_the_folder_lives(tmp_path):
-    """The point of ordering is that the answer stops depending on the filesystem, so the key is
-    the path RELATIVE to the folder in posix form. An absolute-path key carries the mount point --
-    which is precisely what moving a Models folder changes (#8407) -- and carries the separator,
-    and ``\\`` sorts against ``-`` and ``.`` differently than ``/`` does, so the same two files
-    could order one way on Windows and the other way on Linux."""
+    """Ordering exists so the answer stops depending on the filesystem, so the key is the path
+    RELATIVE to the folder in posix form. An absolute-path key carries the mount point, which is
+    what moving a Models folder changes (#8407), and the separator: ``\\`` sorts against ``-`` and
+    ``.`` differently than ``/``, so the same two files could order one way on Windows and the
+    other on Linux."""
     key = models_route._task_classify_sort_key
     assert key(Path("/srv/models/Repo"), Path("/srv/models/Repo/a/b.gguf")) == key(
         Path("/mnt/elsewhere/Repo"), Path("/mnt/elsewhere/Repo/a/b.gguf")
@@ -4719,8 +4699,8 @@ def test_the_classify_order_is_the_same_wherever_the_folder_lives(tmp_path):
 def test_a_buildable_denoiser_outranks_an_arch_the_backend_cannot_assemble(tmp_path):
     """``_UNSUPPORTED_DIFFUSION_TASK`` hides a row from the chat picker AND from the Images and
     Video ones, so a folder holding both a checkpoint this backend can build and one it cannot has
-    exactly one answer that leads anywhere. Deciding it on which name sorts first hides a model
-    that works, which is the same class of mistake as deciding it on directory order."""
+    exactly one answer that leads anywhere. Deciding on which name sorts first hides a model that
+    works, the same mistake as deciding on directory order."""
     folder = tmp_path / "mixed"
     # "aura" sorts first and is not assemblable here; the FLUX denoiser beside it is.
     _arch_gguf(folder / "aura-flow-Q4_0.gguf", "aura")
@@ -4732,7 +4712,7 @@ def test_a_buildable_denoiser_outranks_an_arch_the_backend_cannot_assemble(tmp_p
     _arch_gguf(video / "z-ltx-video-Q4_0.gguf", "ltxv")
     assert models_route._gguf_folder_task(video, ("someone/ltx-GGUF",)) == "text-to-video"
 
-    # With nothing buildable in it, the folder still reports the unsupported tag rather than
+    # With nothing buildable in it the folder still reports the unsupported tag, rather than
     # falling through to a text one and offering a denoiser in chat.
     unbuildable = tmp_path / "unbuildable"
     _arch_gguf(unbuildable / "sdxl-Q4_0.gguf", "sdxl")
@@ -4744,13 +4724,11 @@ def test_a_buildable_denoiser_outranks_an_arch_the_backend_cannot_assemble(tmp_p
 
 
 def test_a_pipeline_index_this_listing_cannot_read_leaves_the_model_untagged(tmp_path):
-    """The invariant the read has to keep: the Images load path 400s AFTER evicting the chat model
-    when no family is supported, so a model is tagged only when detection SUCCEEDS. A raise out of
-    the index read is not a success, and the caller cannot tell the difference -- it wraps the whole
-    block in ``except Exception`` and answers ``text-to-image``. So the two ways an index can refuse
-    to parse are both answered here, rather than upward: a nesting bomb (``RecursionError``, which
-    is not a ``ValueError`` and so escaped the original tuple), and a BOM, which PowerShell puts on
-    any JSON a user writes by hand on Windows."""
+    """The Images load path 400s AFTER evicting the chat model when no family is supported, so a
+    model is tagged only when detection SUCCEEDS. The caller wraps the whole block in
+    ``except Exception`` and answers ``text-to-image``, so both ways an index can refuse to parse
+    are answered here rather than upward: a nesting bomb (``RecursionError``, not a ``ValueError``,
+    so it escaped the original tuple) and a BOM, which PowerShell puts on hand-written JSON."""
     from core.inference.diffusion_families import pipeline_class_from_index
 
     def read(directory):
@@ -4768,7 +4746,7 @@ def test_a_pipeline_index_this_listing_cannot_read_leaves_the_model_untagged(tmp
     )
     assert read(bom) == "QwenImagePipeline"
 
-    # Plain and non-ASCII indexes still read the same, so this is strictly more that parses.
+    # Plain and non-ASCII indexes still read the same, so this only widens what parses.
     plain = tmp_path / "plain"
     plain.mkdir()
     (plain / "model_index.json").write_text(
@@ -4780,10 +4758,9 @@ def test_a_pipeline_index_this_listing_cannot_read_leaves_the_model_untagged(tmp
 
 def test_a_remote_code_pipeline_class_is_not_read_out_of_its_list_form(tmp_path):
     """A community pipeline whose code ships in its own repo writes
-    ``["<module stem>", "<ClassName>"]`` here, which diffusers treats as remote code -- it resolves
-    the class with ``getattr`` only ``if isinstance(cls_name, str)``. Studio's bar is a diffusers
-    pipeline and it declines models that need ``trust_remote_code``, so this stays unread on
-    purpose: tagging it would advertise a model the load path refuses, and the refusal lands after
+    ``["<module stem>", "<ClassName>"]`` here, which diffusers treats as remote code (it resolves
+    the class with ``getattr`` only ``if isinstance(cls_name, str)``). Studio declines models that
+    need ``trust_remote_code``, so tagging one would advertise a model the load path refuses, after
     the chat model has been evicted."""
     from core.inference.diffusion_families import pipeline_class_from_index
 
@@ -4802,8 +4779,8 @@ def test_a_remote_code_pipeline_class_is_not_read_out_of_its_list_form(tmp_path)
 
 
 def test_a_trailing_shard_check_that_cannot_read_the_pattern_keeps_every_file(monkeypatch):
-    """The skip is an optimisation, so losing it has to cost the optimisation and nothing else.
-    This runs inside ``_gguf_folder_task``'s blanket except, where a raise would come back as no
+    """The skip is an optimisation, so losing it costs the optimisation and nothing else. This runs
+    inside ``_gguf_folder_task``'s blanket except, where a raise would come back as no
     classification for every GGUF folder at once."""
     import builtins
 
@@ -4820,11 +4797,11 @@ def test_a_trailing_shard_check_that_cannot_read_the_pattern_keeps_every_file(mo
 
 def test_a_pipelines_component_dirs_do_not_inherit_the_repo_id(tmp_path):
     """The repo-id needle is for the row that LOST its name, and only that row. A pipeline's
-    component directories each carry a ``config.json`` and weights, so a scan folder registers them
-    as rows of their own -- and they sit UNDER ``models--org--name/snapshots/<sha>``, which
-    ``hf_cache_repo_id`` answers for just as readily as the snapshot itself. Letting them inherit
-    it makes each one detect the family, satisfy ``_local_is_diffusers``, and enter the Images
-    picker as a checkpoint that cannot load: three dead rows per cached pipeline."""
+    component directories carry a ``config.json`` and weights, so a scan folder registers them as
+    rows of their own, and they sit UNDER ``models--org--name/snapshots/<sha>``, which
+    ``hf_cache_repo_id`` answers for as readily as the snapshot. Letting them inherit it makes each
+    detect the family, satisfy ``_local_is_diffusers`` and enter the Images picker as a checkpoint
+    that cannot load: three dead rows per cached pipeline."""
     snapshot = tmp_path / "hub" / "models--black-forest-labs--FLUX.1-dev" / "snapshots" / ("a" * 40)
     _saved_pipeline(snapshot, "FluxPipeline")
 
@@ -4837,7 +4814,7 @@ def test_a_pipelines_component_dirs_do_not_inherit_the_repo_id(tmp_path):
             model_format = "diffusers",
         )
 
-    # The snapshot root is the #8407 case and must still recover the id and classify.
+    # The snapshot root is the #8407 case: it must still recover the id and classify.
     assert "black-forest-labs/FLUX.1-dev" in models_route._local_family_needles(_row(snapshot))
     assert models_route._local_model_task(_row(snapshot)) == "text-to-image"
 
@@ -4869,9 +4846,8 @@ def test_a_pipeline_index_outranks_a_family_keyword_in_an_ancestor_directory(tmp
     ``detect_family_for_pick`` used to try the path name first and consult the index only when that
     answered nothing, so a keyword in ANY ancestor segment shadowed the index. The listing reads the
     index, so the two named different families for one directory and the model was shown as one and
-    instantiated as another, which is the same listing-versus-loader split #8407 is about. Reported
-    against a ``QwenImagePipeline`` saved under a ``flux.1`` parent, which is the shape here.
-    """
+    instantiated as another, the same listing-versus-loader split #8407 is about. Reported against a
+    ``QwenImagePipeline`` saved under a ``flux.1`` parent, the shape used here."""
     from core.inference import diffusion_families as families
 
     checkpoint = tmp_path / "flux.1" / "checkpoint"
@@ -4913,15 +4889,11 @@ def test_reading_the_index_first_leaves_remote_picks_and_overrides_alone(tmp_pat
 def test_a_saved_inpaint_pipeline_is_not_tagged_as_its_base_family():
     """Reading the index must not expose a checkpoint the loader would then mis-instantiate.
 
-    The loader picks ``fam.pipeline_class`` (``diffusion.py:2946``) and never the class the index
-    declared, so answering SDXL for a ``StableDiffusionXLInpaintPipeline`` would list it as
-    text-to-image and then load it through the four-channel base pipeline. An inpaint checkpoint
-    carries its own UNet input shape, so that fails after selection, which is the very
-    listing-versus-loader split this helper exists to close.
-
-    A variant stays untagged, exactly as it was before the index was consulted at all: nothing that
-    used to load stops loading, and nothing becomes visible that cannot.
-    """
+    The loader picks ``fam.pipeline_class`` (``diffusion.py:2946``), never the declared class, so
+    answering SDXL for a ``StableDiffusionXLInpaintPipeline`` would list it as text-to-image and
+    load it through the four-channel base pipeline. An inpaint checkpoint has its own UNet input
+    shape, so that fails after selection, the split this helper exists to close. A variant stays
+    untagged, as before the index was consulted at all."""
     from core.inference import diffusion_families as families
 
     # The base classes still answer, so the moved-pipeline fix (#8407) is intact.

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4530,6 +4530,63 @@ def test_a_moved_pipeline_that_names_no_known_family_is_still_not_tagged(tmp_pat
     assert models_route._local_model_task(model) is None
 
 
+def test_a_moved_image_pipeline_the_picker_shows_is_one_the_loader_accepts(tmp_path):
+    """The other half of #8407, and the invariant the two tests above do not state on their own:
+    the picker and the loader have to read the SAME evidence.
+
+    The Images page sends the row's id as ``model_path`` and no ``family_override`` (see
+    ``images-page.tsx`` handleLoad, and the whole frontend has no family_override for images), so
+    the loader gets nothing but the opaque path back. Classifying from ``model_index.json`` in the
+    listing alone therefore turns a hidden model into a visible one that
+    ``validate_load_request`` -> ``detect_family_for_pick`` refuses as an unsupported family: the
+    user finds the moved model, picks it, and the load 400s.
+    """
+    from core.inference.diffusion import DiffusionBackend
+
+    backend = DiffusionBackend.__new__(DiffusionBackend)
+    cases = {
+        # A snapshot copied out of the HF cache: the leaf is a commit hash and nothing in the path
+        # names a family. Exactly the directory the hash-named test above made visible.
+        "0f3d1a2b4c5d6e7f8091a2b3c4d5e6f708192a3b": "FluxPipeline",
+        # The same loss with a hand-chosen folder name, which is the ordinary way to keep a model.
+        "my-image-model": "QwenImagePipeline",
+        # A pipeline class the registry does not know stays hidden AND refused.
+        "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d": "SomeOtherPipeline",
+    }
+    for name, class_name in cases.items():
+        snapshot = _saved_pipeline(tmp_path / "N-AI-Models" / name, class_name)
+        model = SimpleNamespace(
+            path = str(snapshot),
+            id = str(snapshot),
+            model_id = None,
+            display_name = snapshot.name,
+            model_format = None,
+        )
+        task = models_route._local_model_task(model)
+        try:
+            backend.validate_load_request(model.id)
+            loader_accepts = True
+        except (ValueError, FileNotFoundError, RuntimeError):
+            loader_accepts = False
+        assert (task == "text-to-image") == loader_accepts, (
+            f"{name}: picker task={task} but loader accepts={loader_accepts}"
+        )
+    # And a checkpoint whose NAME says it is a variant the matched family cannot run stays refused
+    # on both sides: reading the index adds a model whose name said nothing, it never overrules a
+    # name that said no.
+    layered = _saved_pipeline(tmp_path / "N-AI-Models" / "qwen-image-layered", "QwenImagePipeline")
+    layered_model = SimpleNamespace(
+        path = str(layered),
+        id = str(layered),
+        model_id = None,
+        display_name = layered.name,
+        model_format = None,
+    )
+    assert models_route._local_model_task(layered_model) is None
+    with pytest.raises(ValueError):
+        backend.validate_load_request(layered_model.id)
+
+
 def test_family_needles_recover_the_repo_id_from_the_hf_cache_directory(tmp_path):
     """#8407, the second half of the same loss. A folder still in cache layout carries its repo id
     in the ``models--org--name`` directory, and a scan folder registered at or inside such a repo

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4382,3 +4382,216 @@ def test_a_standalone_h3_denoiser_gguf_is_recognised_by_its_filename():
     # The conditioner and unrelated GGUFs in the same folder must NOT be claimed as video.
     for name in ("qwen3vl-Q8_0.gguf", "minimax_h3_notes.txt", "llama-Q4_K_M.gguf"):
         assert models_route._arch_to_task(None, (name,)) is None, name
+
+
+# ── #8406 / #8407: GGUF folder classification must not depend on directory order ──
+
+
+def _arch_gguf(path: Path, architecture: str) -> Path:
+    """A minimal valid GGUF carrying just ``general.architecture``, like the other suites'
+    fabricated headers (``tests/test_llama_cpp_placement.py::_write_gguf``)."""
+    import struct
+
+    def string(value: str) -> bytes:
+        data = value.encode()
+        return struct.pack("<Q", len(data)) + data
+
+    path.parent.mkdir(parents = True, exist_ok = True)
+    metadata = string("general.architecture") + struct.pack("<I", 8) + string(architecture)
+    path.write_bytes(struct.pack("<IIQQ", 0x46554747, 3, 0, 1) + metadata)
+    return path
+
+
+def _both_walk_orders(root: Path, monkeypatch, classify):
+    """*classify* under both possible ``_iter_gguf_paths`` orders.
+
+    The real walk is ``rglob``, i.e. raw directory order, which differs between filesystems and
+    between a folder and a fresh copy of it -- which is what moving the Models folder makes. The
+    order is the input being varied, so it is forced rather than hoped for.
+    """
+    paths = sorted(root.rglob("*.gguf"))
+    answers = []
+    for order in (paths, list(reversed(paths))):
+        monkeypatch.setattr(
+            models_route, "_iter_gguf_paths", lambda _root, deadline = None, _o = order: iter(_o)
+        )
+        answers.append(classify())
+    return answers
+
+
+def test_a_mixed_gguf_repo_classifies_the_same_in_either_walk_order(tmp_path, monkeypatch):
+    """#8406 / #8407. Community image and video GGUF bundles ship the text encoder beside the
+    denoiser -- ``BlackStone-Yu/Z-Image-Turbo-GGUF`` carries a ``qwen3`` conditioner next to its
+    ``lumina2`` DiT, and ``unsloth/MiniMax-H3-GGUF`` does the same -- so the repo held both
+    answers and returned whichever file the unordered walk yielded first.
+
+    Ordering alone is not enough: it would still hand the answer to whichever name sorts first.
+    The denoiser is what the repo IS, so a media task outranks the encoder's text one.
+    """
+    repo_dir = tmp_path / "models--BlackStone-Yu--Z-Image-Turbo-GGUF"
+    _arch_gguf(repo_dir / "Qwen3-4B-UD-Q6_K_XL.gguf", "qwen3")
+    _arch_gguf(repo_dir / "z_image_turbo-Q6_K.gguf", "lumina2")
+    repo_info = SimpleNamespace(
+        repo_id = "BlackStone-Yu/Z-Image-Turbo-GGUF", repo_path = str(repo_dir)
+    )
+
+    answers = _both_walk_orders(
+        repo_dir, monkeypatch, lambda: models_route._repo_gguf_task(repo_info)
+    )
+    assert answers == ["text-to-image", "text-to-image"], answers
+
+
+def test_a_mixed_local_gguf_folder_classifies_the_same_in_either_walk_order(tmp_path, monkeypatch):
+    """The local twin of the above, and the half that made an image model unfindable: with the
+    encoder answering first the folder is tagged ``text-generation``, which drops it out of the
+    Images picker (``taskMatchesFilter`` rejects any task not in the requested set) and offers a
+    diffusion DiT in the chat one."""
+    folder = tmp_path / "AI Models" / "flux-bundle"
+    _arch_gguf(folder / "t5xxl-Q8_0.gguf", "t5encoder")
+    _arch_gguf(folder / "flux1-dev-Q4_K_M.gguf", "flux")
+    model = SimpleNamespace(
+        path = str(folder),
+        id = str(folder),
+        model_id = None,
+        display_name = "flux-bundle",
+        model_format = "gguf",
+    )
+
+    answers = _both_walk_orders(folder, monkeypatch, lambda: models_route._local_model_task(model))
+    assert answers == ["text-to-image", "text-to-image"], answers
+
+
+def test_a_pure_text_gguf_folder_is_never_promoted_to_a_media_task(tmp_path, monkeypatch):
+    """The guard on the fix. Preferring the media answer must not invent one: a repo with no
+    diffusion GGUF in it has to stay ``text-generation`` in both orders, or the change would put
+    chat models in the Images picker -- the direction #8406 was filed about."""
+    repo_dir = tmp_path / "models--unsloth--DeepSeek-V4-Flash-0731-GGUF"
+    _arch_gguf(repo_dir / "DeepSeek-V4-Flash-0731-UD-Q4_K_XL.gguf", "deepseek4")
+    _arch_gguf(repo_dir / "dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf", "deepseek4")
+    repo_info = SimpleNamespace(
+        repo_id = "unsloth/DeepSeek-V4-Flash-0731-GGUF", repo_path = str(repo_dir)
+    )
+
+    answers = _both_walk_orders(
+        repo_dir, monkeypatch, lambda: models_route._repo_gguf_task(repo_info)
+    )
+    assert answers == ["text-generation", "text-generation"], answers
+
+
+# ── #8407: a moved image model keeps no name to detect its family from ──
+
+
+def _saved_pipeline(root: Path, class_name: str) -> Path:
+    root.mkdir(parents = True, exist_ok = True)
+    (root / "model_index.json").write_text(json.dumps({"_class_name": class_name}))
+    for component in ("transformer", "vae", "text_encoder"):
+        (root / component).mkdir(parents = True, exist_ok = True)
+        (root / component / "config.json").write_text("{}")
+        (root / component / "diffusion_pytorch_model.safetensors").write_bytes(b"w" * 2048)
+    return root
+
+
+def test_a_moved_image_pipeline_is_classified_from_its_saved_pipeline_class(tmp_path):
+    """#8407. The reporter changed the Models folder and image models were then not found at all,
+    while chat models were still listed.
+
+    That asymmetry is structural. A GGUF is classified from ``general.architecture``, read out of
+    the file, so a move cannot touch it. A diffusers pipeline was classified from names only, and
+    the name a Hugging Face snapshot directory carries is a commit hash -- so the model the
+    listing had just PROVEN to be a pipeline (it has a ``model_index.json``) came back task=null
+    and the Images picker hid it. The index names the pipeline class; that is evidence out of the
+    checkpoint, exactly like the GGUF architecture read.
+    """
+    snapshot = _saved_pipeline(
+        tmp_path / "N-AI-Models" / "0f3d1a2b4c5d6e7f8091a2b3c4d5e6f708192a3b", "FluxPipeline"
+    )
+    model = SimpleNamespace(
+        path = str(snapshot),
+        id = str(snapshot),
+        model_id = None,
+        display_name = snapshot.name,
+        model_format = None,
+    )
+    assert models_route._local_model_task(model) == "text-to-image"
+
+
+def test_a_moved_pipeline_that_names_no_known_family_is_still_not_tagged(tmp_path):
+    """The guard on the fix above. Reading the index must not turn into "any pipeline directory is
+    an image model": the Images load path 400s AFTER evicting chat when no family is supported, so
+    a checkpoint whose class matches nothing in the registry stays untagged, as before."""
+    snapshot = _saved_pipeline(
+        tmp_path / "N-AI-Models" / "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d", "SomeOtherPipeline"
+    )
+    model = SimpleNamespace(
+        path = str(snapshot),
+        id = str(snapshot),
+        model_id = None,
+        display_name = snapshot.name,
+        model_format = None,
+    )
+    assert models_route._local_model_task(model) is None
+
+
+def test_family_needles_recover_the_repo_id_from_the_hf_cache_directory(tmp_path):
+    """#8407, the second half of the same loss. A folder still in cache layout carries its repo id
+    in the ``models--org--name`` directory, and a scan folder registered at or inside such a repo
+    leaves every other needle equal to the commit hash. Decoding it is a strict read of a real
+    ``models--*/snapshots/*`` path, so no arbitrary parent directory token can match this way.
+    """
+    snapshot = (
+        tmp_path
+        / "N-AI-Models"
+        / "models--black-forest-labs--FLUX.1-dev"
+        / "snapshots"
+        / "0f3d1a2b4c5d6e7f8091a2b3c4d5e6f708192a3b"
+    )
+    snapshot.mkdir(parents = True)
+    model = SimpleNamespace(
+        path = str(snapshot),
+        id = str(snapshot),
+        model_id = None,
+        display_name = snapshot.name,
+        model_format = None,
+    )
+    assert "black-forest-labs/FLUX.1-dev" in models_route._local_family_needles(model)
+
+    # A directory that merely sits under a folder named for a family must not gain a needle.
+    plain = tmp_path / "flux" / "my-checkpoint"
+    plain.mkdir(parents = True)
+    plain_model = SimpleNamespace(
+        path = str(plain),
+        id = str(plain),
+        model_id = None,
+        display_name = plain.name,
+        model_format = None,
+    )
+    assert set(models_route._local_family_needles(plain_model)) == {"my-checkpoint"}
+
+
+def test_only_the_first_shard_of_a_split_gguf_is_read_to_classify_a_repo(tmp_path, monkeypatch):
+    """llama.cpp writes the full KV block into shard 1 and a minimal one into the rest, so shards
+    2..N are both the wrong files to read an architecture from and the expensive ones: a 51-shard
+    repo would cost 51 header reads to answer one question. They are skipped."""
+    repo_dir = tmp_path / "models--unsloth--Big-GGUF"
+    _arch_gguf(repo_dir / "Big-Q4_K_M-00001-of-00003.gguf", "llama")
+    for index in ("00002", "00003"):
+        (repo_dir / f"Big-Q4_K_M-{index}-of-00003.gguf").write_bytes(b"not a gguf header")
+
+    read: list[str] = []
+    real = models_route._gguf_architecture
+    monkeypatch.setattr(
+        models_route,
+        "_gguf_architecture",
+        lambda path: (read.append(Path(path).name), real(path))[1],
+    )
+    # Trailing shards first, which is a walk order the filesystem is free to hand back: without
+    # the skip they are opened, read as unclassifiable, and only then is shard 1 reached.
+    monkeypatch.setattr(
+        models_route,
+        "_iter_gguf_paths",
+        lambda _root, deadline = None: iter(sorted(repo_dir.rglob("*.gguf"), reverse = True)),
+    )
+    repo_info = SimpleNamespace(repo_id = "unsloth/Big-GGUF", repo_path = str(repo_dir))
+
+    assert models_route._repo_gguf_task(repo_info) == "text-generation"
+    assert read == ["Big-Q4_K_M-00001-of-00003.gguf"], read

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4908,3 +4908,30 @@ def test_reading_the_index_first_leaves_remote_picks_and_overrides_alone(tmp_pat
     assert families.detect_family_for_pick(
         str(tmp_path / "anon"), gguf_filename = "flux1-dev-Q4_K_M.gguf"
     ) is families.detect_family("x/flux1-dev-Q4_K_M.gguf", None)
+
+
+def test_a_saved_inpaint_pipeline_is_not_tagged_as_its_base_family():
+    """Reading the index must not expose a checkpoint the loader would then mis-instantiate.
+
+    The loader picks ``fam.pipeline_class`` (``diffusion.py:2946``) and never the class the index
+    declared, so answering SDXL for a ``StableDiffusionXLInpaintPipeline`` would list it as
+    text-to-image and then load it through the four-channel base pipeline. An inpaint checkpoint
+    carries its own UNet input shape, so that fails after selection, which is the very
+    listing-versus-loader split this helper exists to close.
+
+    A variant stays untagged, exactly as it was before the index was consulted at all: nothing that
+    used to load stops loading, and nothing becomes visible that cannot.
+    """
+    from core.inference import diffusion_families as families
+
+    # The base classes still answer, so the moved-pipeline fix (#8407) is intact.
+    for base in ("FluxPipeline", "QwenImagePipeline", "StableDiffusionXLPipeline"):
+        assert families.detect_family_by_pipeline_class(base) is not None, base
+
+    for variant in (
+        "StableDiffusionXLInpaintPipeline",
+        "StableDiffusionXLImg2ImgPipeline",
+        "FluxInpaintPipeline",
+        "FluxImg2ImgPipeline",
+    ):
+        assert families.detect_family_by_pipeline_class(variant) is None, variant

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4431,9 +4431,7 @@ def test_a_mixed_gguf_repo_classifies_the_same_in_either_walk_order(tmp_path, mo
     repo_dir = tmp_path / "models--BlackStone-Yu--Z-Image-Turbo-GGUF"
     _arch_gguf(repo_dir / "Qwen3-4B-UD-Q6_K_XL.gguf", "qwen3")
     _arch_gguf(repo_dir / "z_image_turbo-Q6_K.gguf", "lumina2")
-    repo_info = SimpleNamespace(
-        repo_id = "BlackStone-Yu/Z-Image-Turbo-GGUF", repo_path = str(repo_dir)
-    )
+    repo_info = SimpleNamespace(repo_id = "BlackStone-Yu/Z-Image-Turbo-GGUF", repo_path = str(repo_dir))
 
     answers = _both_walk_orders(
         repo_dir, monkeypatch, lambda: models_route._repo_gguf_task(repo_info)

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4825,9 +4825,7 @@ def test_a_pipelines_component_dirs_do_not_inherit_the_repo_id(tmp_path):
     ``hf_cache_repo_id`` answers for just as readily as the snapshot itself. Letting them inherit
     it makes each one detect the family, satisfy ``_local_is_diffusers``, and enter the Images
     picker as a checkpoint that cannot load: three dead rows per cached pipeline."""
-    snapshot = (
-        tmp_path / "hub" / "models--black-forest-labs--FLUX.1-dev" / "snapshots" / ("a" * 40)
-    )
+    snapshot = tmp_path / "hub" / "models--black-forest-labs--FLUX.1-dev" / "snapshots" / ("a" * 40)
     _saved_pipeline(snapshot, "FluxPipeline")
 
     def _row(directory):
@@ -4862,6 +4860,8 @@ def _hf_cache_snapshot_repo_id_ok(snapshot) -> bool:
         and decode(None) is None
         and decode("/plain/folder/model") is None
     )
+
+
 def test_a_pipeline_index_outranks_a_family_keyword_in_an_ancestor_directory(tmp_path):
     """A local pipeline whose path contains another family's keyword must still load as the family
     its own ``model_index.json`` declares.

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4650,3 +4650,215 @@ def test_only_the_first_shard_of_a_split_gguf_is_read_to_classify_a_repo(tmp_pat
 
     assert models_route._repo_gguf_task(repo_info) == "text-generation"
     assert read == ["Big-Q4_K_M-00001-of-00003.gguf"], read
+
+
+# ── The cost of deciding from all of a folder rather than from its first file ──
+
+
+def test_a_gguf_folder_walk_stops_on_its_budget_instead_of_holding_the_listing(tmp_path):
+    """Ordering the walk means it can no longer stop at the first GGUF, so a folder is now read to
+    the end -- and a scan folder is arbitrary: a network mount, or weights sitting beside a huge
+    unrelated subtree whose every entry ``rglob`` counts (the hazard ``_dir_has_downloaded_model``
+    already caps). This runs once per row inside the listing request, so the walk takes a deadline
+    and gives up on it, exactly as ``_iter_gguf_paths`` was always documented to allow."""
+    folder = tmp_path / "bundle"
+    _arch_gguf(folder / "model-Q4_K_M.gguf", "qwen3")
+
+    assert models_route._gguf_folder_task(folder, ("someone/model",)) == "text-generation"
+    # A budget already spent buys nothing, which is what a caller in that state is asking for.
+    spent = models_route._gguf_folder_task(
+        folder, ("someone/model",), deadline = time.monotonic() - 1
+    )
+    assert spent is None
+
+
+def test_a_slow_walk_cannot_hand_back_the_encoder_this_function_exists_to_avoid(
+    tmp_path, monkeypatch
+):
+    """The header reads get a budget of their own, started after the walk. Sharing one would let a
+    folder that was merely slow to enumerate stop after the encoder and answer ``text-generation``,
+    which is the #8406 bug arriving by a different road."""
+    folder = tmp_path / "flux-bundle"
+    _arch_gguf(folder / "t5xxl-Q8_0.gguf", "t5encoder")
+    _arch_gguf(folder / "flux1-dev-Q4_K_M.gguf", "flux")
+    ordered = sorted(folder.rglob("*.gguf"))
+
+    def _slow_walk(_root, deadline = None):
+        # Spends the whole walk budget before yielding anything, the shape of a cold network mount.
+        time.sleep(models_route._TASK_CLASSIFY_WALK_SECONDS + 0.05)
+        return iter(ordered)
+
+    monkeypatch.setattr(models_route, "_iter_gguf_paths", _slow_walk)
+    assert models_route._gguf_folder_task(folder, ("someone/flux-bundle",)) == "text-to-image"
+
+
+def test_the_classify_order_is_the_same_wherever_the_folder_lives(tmp_path):
+    """The point of ordering is that the answer stops depending on the filesystem, so the key is
+    the path RELATIVE to the folder in posix form. An absolute-path key carries the mount point --
+    which is precisely what moving a Models folder changes (#8407) -- and carries the separator,
+    and ``\\`` sorts against ``-`` and ``.`` differently than ``/`` does, so the same two files
+    could order one way on Windows and the other way on Linux."""
+    key = models_route._task_classify_sort_key
+    assert key(Path("/srv/models/Repo"), Path("/srv/models/Repo/a/b.gguf")) == key(
+        Path("/mnt/elsewhere/Repo"), Path("/mnt/elsewhere/Repo/a/b.gguf")
+    )
+    # No separator of either kind survives into the leading component of the key.
+    assert key(Path("/srv/Repo"), Path("/srv/Repo/sub/z_image-Q4.gguf"))[0] == "sub/z_image-q4.gguf"
+
+    first = tmp_path / "here" / "bundle"
+    second = tmp_path / "somewhere" / "else" / "deeper" / "bundle"
+    for folder in (first, second):
+        _arch_gguf(folder / "Qwen3-4B-UD-Q6_K_XL.gguf", "qwen3")
+        _arch_gguf(folder / "z_image_turbo-Q6_K.gguf", "lumina2")
+    hints = ("BlackStone-Yu/Z-Image-Turbo-GGUF",)
+    assert models_route._gguf_folder_task(first, hints) == models_route._gguf_folder_task(
+        second, hints
+    )
+
+
+def test_a_buildable_denoiser_outranks_an_arch_the_backend_cannot_assemble(tmp_path):
+    """``_UNSUPPORTED_DIFFUSION_TASK`` hides a row from the chat picker AND from the Images and
+    Video ones, so a folder holding both a checkpoint this backend can build and one it cannot has
+    exactly one answer that leads anywhere. Deciding it on which name sorts first hides a model
+    that works, which is the same class of mistake as deciding it on directory order."""
+    folder = tmp_path / "mixed"
+    # "aura" sorts first and is not assemblable here; the FLUX denoiser beside it is.
+    _arch_gguf(folder / "aura-flow-Q4_0.gguf", "aura")
+    _arch_gguf(folder / "flux1-dev-Q4_K_M.gguf", "flux")
+    assert models_route._gguf_folder_task(folder, ("someone/mixed-GGUF",)) == "text-to-image"
+
+    video = tmp_path / "mixed-video"
+    _arch_gguf(video / "a-hidream-Q4_0.gguf", "hidream")
+    _arch_gguf(video / "z-ltx-video-Q4_0.gguf", "ltxv")
+    assert models_route._gguf_folder_task(video, ("someone/ltx-GGUF",)) == "text-to-video"
+
+    # With nothing buildable in it, the folder still reports the unsupported tag rather than
+    # falling through to a text one and offering a denoiser in chat.
+    unbuildable = tmp_path / "unbuildable"
+    _arch_gguf(unbuildable / "sdxl-Q4_0.gguf", "sdxl")
+    _arch_gguf(unbuildable / "text-encoder-Q8_0.gguf", "t5encoder")
+    assert (
+        models_route._gguf_folder_task(unbuildable, ("someone/sdxl-GGUF",))
+        == models_route._UNSUPPORTED_DIFFUSION_TASK
+    )
+
+
+def test_a_pipeline_index_this_listing_cannot_read_leaves_the_model_untagged(tmp_path):
+    """The invariant the read has to keep: the Images load path 400s AFTER evicting the chat model
+    when no family is supported, so a model is tagged only when detection SUCCEEDS. A raise out of
+    the index read is not a success, and the caller cannot tell the difference -- it wraps the whole
+    block in ``except Exception`` and answers ``text-to-image``. So the two ways an index can refuse
+    to parse are both answered here, rather than upward: a nesting bomb (``RecursionError``, which
+    is not a ``ValueError`` and so escaped the original tuple), and a BOM, which PowerShell puts on
+    any JSON a user writes by hand on Windows."""
+    from core.inference.diffusion_families import pipeline_class_from_index
+
+    def read(directory):
+        return pipeline_class_from_index(str(directory))
+
+    bomb = tmp_path / "bomb"
+    bomb.mkdir()
+    (bomb / "model_index.json").write_text('{"a":' * 100_000, encoding = "utf-8")
+    assert read(bomb) is None
+
+    bom = tmp_path / "bom"
+    bom.mkdir()
+    (bom / "model_index.json").write_bytes(
+        b"\xef\xbb\xbf" + json.dumps({"_class_name": "QwenImagePipeline"}).encode("utf-8")
+    )
+    assert read(bom) == "QwenImagePipeline"
+
+    # Plain and non-ASCII indexes still read the same, so this is strictly more that parses.
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "model_index.json").write_text(
+        json.dumps({"_class_name": "FluxPipeline", "_name_or_path": "café"}),
+        encoding = "utf-8",
+    )
+    assert read(plain) == "FluxPipeline"
+
+
+def test_a_remote_code_pipeline_class_is_not_read_out_of_its_list_form(tmp_path):
+    """A community pipeline whose code ships in its own repo writes
+    ``["<module stem>", "<ClassName>"]`` here, which diffusers treats as remote code -- it resolves
+    the class with ``getattr`` only ``if isinstance(cls_name, str)``. Studio's bar is a diffusers
+    pipeline and it declines models that need ``trust_remote_code``, so this stays unread on
+    purpose: tagging it would advertise a model the load path refuses, and the refusal lands after
+    the chat model has been evicted."""
+    from core.inference.diffusion_families import pipeline_class_from_index
+
+    root = tmp_path / "9f3c1a2b"
+    root.mkdir()
+    (root / "model_index.json").write_text(
+        json.dumps({"_class_name": ["my_custom_flux", "FluxPipeline"]}), encoding = "utf-8"
+    )
+    assert pipeline_class_from_index(str(root)) is None
+
+    # The plain string form of the same class is still read, so this is a shape check, not a ban.
+    (root / "model_index.json").write_text(
+        json.dumps({"_class_name": "FluxPipeline"}), encoding = "utf-8"
+    )
+    assert pipeline_class_from_index(str(root)) == "FluxPipeline"
+
+
+def test_a_trailing_shard_check_that_cannot_read_the_pattern_keeps_every_file(monkeypatch):
+    """The skip is an optimisation, so losing it has to cost the optimisation and nothing else.
+    This runs inside ``_gguf_folder_task``'s blanket except, where a raise would come back as no
+    classification for every GGUF folder at once."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_model_config(name, *args, **kwargs):
+        if name == "utils.models.model_config":
+            raise ImportError("moved")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_model_config)
+    assert models_route._is_trailing_split_shard("Big-Q4_K_M-00002-of-00003.gguf") is False
+
+
+def test_a_pipelines_component_dirs_do_not_inherit_the_repo_id(tmp_path):
+    """The repo-id needle is for the row that LOST its name, and only that row. A pipeline's
+    component directories each carry a ``config.json`` and weights, so a scan folder registers them
+    as rows of their own -- and they sit UNDER ``models--org--name/snapshots/<sha>``, which
+    ``hf_cache_repo_id`` answers for just as readily as the snapshot itself. Letting them inherit
+    it makes each one detect the family, satisfy ``_local_is_diffusers``, and enter the Images
+    picker as a checkpoint that cannot load: three dead rows per cached pipeline."""
+    snapshot = (
+        tmp_path / "hub" / "models--black-forest-labs--FLUX.1-dev" / "snapshots" / ("a" * 40)
+    )
+    _saved_pipeline(snapshot, "FluxPipeline")
+
+    def _row(directory):
+        return SimpleNamespace(
+            path = str(directory),
+            id = str(directory),
+            model_id = None,
+            display_name = directory.name,
+            model_format = "diffusers",
+        )
+
+    # The snapshot root is the #8407 case and must still recover the id and classify.
+    assert "black-forest-labs/FLUX.1-dev" in models_route._local_family_needles(_row(snapshot))
+    assert models_route._local_model_task(_row(snapshot)) == "text-to-image"
+
+    for component in ("transformer", "vae", "text_encoder"):
+        row = _row(snapshot / component)
+        assert "black-forest-labs/FLUX.1-dev" not in models_route._local_family_needles(row)
+        assert models_route._local_is_diffusers(row) is False
+        assert models_route._local_model_task(row) is None
+
+    # A trailing separator is the same row, not a different shape.
+    assert _hf_cache_snapshot_repo_id_ok(snapshot)
+
+
+def _hf_cache_snapshot_repo_id_ok(snapshot) -> bool:
+    decode = models_route._hf_cache_snapshot_repo_id
+    return (
+        decode(str(snapshot) + "/") == "black-forest-labs/FLUX.1-dev"
+        and decode(str(snapshot).replace("/", "\\")) == "black-forest-labs/FLUX.1-dev"
+        and decode(str(snapshot / "vae")) is None
+        and decode(None) is None
+        and decode("/plain/folder/model") is None
+    )

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4568,9 +4568,9 @@ def test_a_moved_image_pipeline_the_picker_shows_is_one_the_loader_accepts(tmp_p
             loader_accepts = True
         except (ValueError, FileNotFoundError, RuntimeError):
             loader_accepts = False
-        assert (task == "text-to-image") == loader_accepts, (
-            f"{name}: picker task={task} but loader accepts={loader_accepts}"
-        )
+        assert (
+            task == "text-to-image"
+        ) == loader_accepts, f"{name}: picker task={task} but loader accepts={loader_accepts}"
     # And a checkpoint whose NAME says it is a variant the matched family cannot run stays refused
     # on both sides: reading the index adds a model whose name said nothing, it never overrules a
     # name that said no.

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4862,3 +4862,49 @@ def _hf_cache_snapshot_repo_id_ok(snapshot) -> bool:
         and decode(None) is None
         and decode("/plain/folder/model") is None
     )
+def test_a_pipeline_index_outranks_a_family_keyword_in_an_ancestor_directory(tmp_path):
+    """A local pipeline whose path contains another family's keyword must still load as the family
+    its own ``model_index.json`` declares.
+
+    ``detect_family_for_pick`` used to try the path name first and consult the index only when that
+    answered nothing, so a keyword in ANY ancestor segment shadowed the index. The listing reads the
+    index, so the two named different families for one directory and the model was shown as one and
+    instantiated as another, which is the same listing-versus-loader split #8407 is about. Reported
+    against a ``QwenImagePipeline`` saved under a ``flux.1`` parent, which is the shape here.
+    """
+    from core.inference import diffusion_families as families
+
+    checkpoint = tmp_path / "flux.1" / "checkpoint"
+    checkpoint.mkdir(parents = True)
+    (checkpoint / "model_index.json").write_text(
+        json.dumps({"_class_name": "QwenImagePipeline", "_diffusers_version": "0.39.0"})
+    )
+    path = str(checkpoint)
+
+    from_index = families.detect_family_by_pipeline_index(path)
+    assert from_index is not None
+    # The listing classifies on the index, so the loader has to reach the same answer.
+    assert families.detect_family_for_pick(path) is from_index
+    # ... and specifically not the ancestor directory's family.
+    assert families.detect_family(path, None) is not from_index
+
+
+def test_reading_the_index_first_leaves_remote_picks_and_overrides_alone(tmp_path):
+    """The index only ever answers for a local directory that saved one, so a remote repo id, an
+    explicit override and the local-GGUF filename fallback all behave exactly as before."""
+    from core.inference import diffusion_families as families
+
+    for repo_id in ("black-forest-labs/FLUX.1-dev", "Qwen/Qwen-Image"):
+        assert families.detect_family_for_pick(repo_id) is families.detect_family(repo_id, None)
+
+    checkpoint = tmp_path / "flux.1" / "checkpoint"
+    checkpoint.mkdir(parents = True)
+    (checkpoint / "model_index.json").write_text(json.dumps({"_class_name": "QwenImagePipeline"}))
+    # An explicit override still wins over both the index and the path.
+    assert families.detect_family_for_pick(str(checkpoint), override = "flux.1") is (
+        families.detect_family(str(checkpoint), "flux.1")
+    )
+    # A bare directory with no index still resolves through the GGUF filename.
+    assert families.detect_family_for_pick(
+        str(tmp_path / "anon"), gguf_filename = "flux1-dev-Q4_K_M.gguf"
+    ) is families.detect_family("x/flux1-dev-Q4_K_M.gguf", None)


### PR DESCRIPTION
Two model-resolution defects that share one mechanism: the listing decided what a local model IS from evidence that a copy or a rename destroys.

## The GGUF half

`_iter_gguf_paths` walks with `root.rglob("*")`, i.e. raw directory order, and `_repo_gguf_task` and `_local_model_task` returned the task of whichever file it happened to yield first. Community image and video GGUF bundles ship the text encoder beside the denoiser, so such a repo holds both answers and returned a different one on a different filesystem, or after the files were copied elsewhere.

This is not hypothetical. `BlackStone-Yu/Z-Image-Turbo-GGUF` carries `Qwen3-4B-UD-Q6_K_XL.gguf` (`general.architecture = "qwen3"`) in the same flat root as `z_image_turbo-Q6_K.gguf` (`"lumina2"`). A sweep of the Hub found 57 mixed repos, including `MonsterMMORPG/Wan_GGUF`, `second-state/stable-diffusion-3.5-large-GGUF` (which ships `clip_g` and `t5xxl` beside `sd3.5_large`), the `calcuis/*` family, and `unsloth/MiniMax-H3-GGUF` itself (`qwen3vl_32b_minimax_h3-*.gguf` beside the video weights).

Encoder-first tags a real image repo `text-generation`, which drops it out of the Images picker and offers a diffusion DiT in the chat one. Denoiser-first makes the repo an Images row whose pickable file may be the text encoder. And directory order is not stable across a copy, which is exactly what moving the Models folder does.

The walk is now ordered, and the media answer wins: the denoiser is what the repo is. A repo with no diffusion GGUF in it is untouched, so nothing gains an image task this way that did not already have one. Trailing shards of a split are skipped as well: llama.cpp writes the full KV block into shard 1 and a minimal one into the rest, so they were the wrong files to read an architecture from as well as the expensive ones (51 header reads to answer one question on a 51-shard repo).

## The diffusers half

A pipeline was classified from names only. `_local_family_needles` built its hints from `model_id`, `display_name` and `Path(model.id).name`, and for a model still in Hugging Face cache layout every one of those degrades to the 40-hex commit hash.

So a model the listing had already PROVEN to be a pipeline, by finding its `model_index.json`, came back with `task = None`, and `taskMatchesFilter` rejects every null task when a filter is set, so the Images picker hid it. Chat GGUFs beside it stayed visible because their architecture is read out of the file. That asymmetry is the report: image models not found, chat models fine.

Two content-based reads replace the guess. `detect_family_by_pipeline_class` matches the `_class_name` the index declares against the registry's pipeline classes, plus the img2img, inpaint and controlnet variants, on exact class names only. This is the direct counterpart of reading `general.architecture` from a GGUF. And `_local_family_needles` recovers the repo id from a `models--org--name` cache directory through the existing strict `hf_cache_repo_id`, which only answers for a real `models--*/snapshots/*` path, appended last so the basenames still win and no arbitrary parent-directory token can match.

A pipeline whose class matches no shipped family is still left untagged: the Images load path 400s after evicting chat when no family is supported, so a permissive tag would be a pick that can only fail.

## Scope

This fixes the "image models not found" half of #8407. The labelling half, where a scan folder that keeps HF cache layout never becomes a CUSTOM FOLDERS row (`_promote_to_custom_source` returns early for `source == "hf_cache"`), is left alone: it is a presentation decision with a wide blast radius across both pickers, and the issue itself notes the UI states "New downloads only".

For #8406 this removes a real and reachable way for a media and text mix-up to happen, but it does not explain that reporter's specific ref, and the `torch.distributed.Work` half of that issue is separate and already fixed by #7981.

## Tests

Seven regression tests in `tests/test_cached_gguf_routes.py`, including two guards that pin the invariants the change must not break: a pure text repo is never promoted to a media task, and an unknown pipeline class stays untagged. With the source reverted, four of the seven fail; the split-shard one fails against a reverted `routes/models.py` and the unknown-class one against a reverted `diffusion_families.py`.
