### PR TITLE
Stop the PowerShell progress bar throttling installer downloads to 0.65 MB/s

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -56,13 +56,11 @@ function Install-UnslothStudio {
     $PSDefaultParameterValues = $_UnslothKeptDefaults
 
     # Windows PowerShell 5.1 redraws the Invoke-WebRequest progress bar on every read, and the
-    # redraw dominates the transfer: on a windows-latest runner the same 43 MB file took 70.79s
-    # with the bar on and 0.34s with it off, a 208x difference on a link that was never the
-    # limit. That is the multi-minute "slow download" users report, and it hits every
-    # Invoke-WebRequest below -- the Python installer (~28 MB) and the uv archive. -UseBasicParsing
-    # does NOT avoid it; only this preference does. PowerShell 7 is unaffected, so this is a no-op
-    # there. Same scoping rule as the table above: no scope qualifier, so the caller's own
-    # preference is untouched once the install returns.
+    # redraw, not the link, sets the rate: on a windows-latest runner the python.org installer
+    # (27.8 MB) took 41.34s with the bar on against 0.08s with it off, and the uv archive the
+    # same. That is the multi-minute "slow download" users report. -UseBasicParsing does NOT
+    # avoid it and PowerShell 7 never had the cost; only this preference does. Same scoping rule
+    # as the table above: no qualifier, so the caller's own preference survives "irm ... | iex".
     $ProgressPreference = 'SilentlyContinue'
 
     # The kept proxies travel to studio/setup.ps1 (launched -NoProfile by unsloth_cli, and it

--- a/install.ps1
+++ b/install.ps1
@@ -55,6 +55,16 @@ function Install-UnslothStudio {
     # shadows the caller's table for this scope and below only.
     $PSDefaultParameterValues = $_UnslothKeptDefaults
 
+    # Windows PowerShell 5.1 redraws the Invoke-WebRequest progress bar on every read, and the
+    # redraw dominates the transfer: on a windows-latest runner the same 43 MB file took 70.79s
+    # with the bar on and 0.34s with it off, a 208x difference on a link that was never the
+    # limit. That is the multi-minute "slow download" users report, and it hits every
+    # Invoke-WebRequest below -- the Python installer (~28 MB) and the uv archive. -UseBasicParsing
+    # does NOT avoid it; only this preference does. PowerShell 7 is unaffected, so this is a no-op
+    # there. Same scoping rule as the table above: no scope qualifier, so the caller's own
+    # preference is untouched once the install returns.
+    $ProgressPreference = 'SilentlyContinue'
+
     # The kept proxies travel to studio/setup.ps1 (launched -NoProfile by unsloth_cli, and it
     # downloads the VC++ runtime and the uv installer) as JSON in _UNSLOTH_PS_PROXY_DEFAULTS,
     # since a PowerShell variable does not cross a process boundary. Credentials do not travel:

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -22,11 +22,10 @@
 $ErrorActionPreference = "Stop"
 
 # This script is spawned as powershell.exe -- Windows PowerShell 5.1 (see the PSModulePath note
-# below) -- where the Invoke-WebRequest progress bar is redrawn on every read and costs far more
-# than the transfer: measured on a windows-latest runner, the same 43 MB file took 70.79s with the
-# bar on against 0.34s with it off. The VC++ runtime download (~25 MB, Ensure-VCRedist) is the one
-# that hits users here, and -UseBasicParsing does not help; only this preference does. Script
-# scope, and this process is short-lived and started -NoProfile, so nothing outlives it.
+# below) -- where the Invoke-WebRequest progress bar is redrawn on every read and sets the rate
+# instead of the link: the VC++ runtime (24.4 MB, Ensure-VCRedist) took 38.18s with the bar on
+# against 0.29s with it off on a windows-latest runner. -UseBasicParsing does not help; only this
+# preference does. Script scope, in a separate short-lived process, so nothing outlives it.
 $ProgressPreference = 'SilentlyContinue'
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -20,6 +20,15 @@
 #>
 
 $ErrorActionPreference = "Stop"
+
+# This script is spawned as powershell.exe -- Windows PowerShell 5.1 (see the PSModulePath note
+# below) -- where the Invoke-WebRequest progress bar is redrawn on every read and costs far more
+# than the transfer: measured on a windows-latest runner, the same 43 MB file took 70.79s with the
+# bar on against 0.34s with it off. The VC++ runtime download (~25 MB, Ensure-VCRedist) is the one
+# that hits users here, and -UseBasicParsing does not help; only this preference does. Script
+# scope, and this process is short-lived and started -NoProfile, so nothing outlives it.
+$ProgressPreference = 'SilentlyContinue'
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $PackageDir = Split-Path -Parent $ScriptDir
 


### PR DESCRIPTION
## The problem

Windows users report the installer taking many minutes. The cause is Windows PowerShell 5.1: it redraws the `Invoke-WebRequest` progress bar on every read, and the redraw costs far more than the transfer.

The rate does not scale with the connection. All three installer downloads land at 0.64-0.68 MB/s regardless of file size or host, so the progress bar caps throughput at roughly 0.65 MB/s. A user on gigabit waits exactly as long as one on DSL, which is why the reports read as "my connection is fast, why is this crawling".

`studio/setup.ps1` is spawned as `powershell.exe` by `unsloth studio update` (the PSModulePath note at the top of that file spells this out), so 5.1 is the interpreter that actually runs it in production.

## Measured

Same `windows-latest` runner, same URLs, seconds apart, on the real production endpoints:

| call site | before | after | speedup |
| --- | --- | --- | --- |
| `install.ps1` python.org installer (27.8 MB) | 41.34s (0.67 MB/s) | 0.08s (347 MB/s) | 517x |
| `install.ps1` uv archive (18.2 MB) | 26.82s (0.68 MB/s) | 0.09s (202 MB/s) | 298x |
| `studio/setup.ps1` vc_redist.x64.exe (24.4 MB) | 38.18s (0.64 MB/s) | 0.29s (84 MB/s) | 132x |

106.3s to 0.46s across the three.

Since the cost is CPU work per read chunk rather than transfer, the win depends on the user's link. Projected over the same 70 MB:

| connection | before | after |
| --- | --- | --- |
| 5 Mbps | ~110s | ~110s (no change, already the bottleneck) |
| 25 Mbps | ~107s | ~22s |
| 100 Mbps | ~107s | ~6s |
| 1 Gbps | ~107s | ~0.6s |

## The change

`$ProgressPreference = 'SilentlyContinue'` in both entry points. `-UseBasicParsing` does not avoid this, only the preference does. PowerShell 7 is unaffected, so this is a no-op there.

Both assignments are scoped deliberately:

- `install.ps1` sets it inside `Install-UnslothStudio` with no scope qualifier, the same shadowing the prologue already relies on for `$PSDefaultParameterValues`. The documented entry point is `irm ... | iex`, which runs in the user's own session, so a global assignment would permanently disable their progress bars.
- `studio/setup.ps1` sets it at script scope in a short-lived `-NoProfile` child process.

## Verification

Nothing about what gets installed changes, and this was tested rather than assumed.

**Bytes identical.** Each of the three URLs was fetched twice, once with the bar on and once off, and SHA256 compared. All three matched.

**Caller preference preserved.** Asserted explicitly, since the `irm | iex` shape makes scope leakage the one real hazard here.

**Install output identical.** A full install with the unpatched scripts, then a fresh install with the patched ones, both manifested (recursive path plus SHA256, volatile paths excluded) and diffed: 41290 files, 6 differing.

**Control for those 6.** Two installs with the *same* unpatched scripts differ in exactly the same 6 files (`studio_install_id`, `launch-studio.ps1`, `unsloth_install_manifest.json`, the two `*_PREBUILT_INFO.json`, the editable-install finder). They carry per-install ids and timestamps, so 41284 of 41290 files are identical and this change accounts for none of the difference.

**Idempotent.** Running the patched install a second time over the top differs in one file, `unsloth_install_manifest.json`.

## Ruled out

Worth recording, since these were the obvious suspects:

- **Windows Defender.** A/B on the same runner with real-time protection genuinely enabled (`Set-MpPreference`, confirmed `RTP=True OnAccess=True Ioav=True`) against off, and against an excluded folder: 0.24/0.25/0.19s versus 0.38/0.18s versus 0.37/0.33s. No effect. On-access copy 0.02s, hash 0.07s, `Get-AuthenticodeSignature` with Mark-of-the-Web attached 0.42s. The binary is validly signed.
- **The CDN and every mirror.** python.org 36-241 MB/s, aka.ms 87-146 MB/s, releases.astral.sh 99-176 MB/s, github 41-187 MB/s, measured from ubuntu-latest, macos-14 and windows-latest. No throttling anywhere, so no alternative endpoints are needed.
- **The VC++ redistributable.** A real install-time cost on a fresh machine, but not a download-speed one.

## Not covered here

These measurements are the installer's own downloads. The browser download of the release `.exe` was fast from every vantage point tested, so if users report that specific download as slow it is a separate problem.
