### PR TITLE
Drop the inert capacity-sweeper dispatch from the desktop release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -58,37 +58,11 @@ concurrency:
   queue: max
 
 jobs:
-  # Ask the sweeper to stand scheduled CI down while this release builds. Same
-  # repository, so this needs no secret: the job's own GITHUB_TOKEN with
-  # actions: write is enough, and there is no credential to rotate or leak.
-  #
-  # Deliberately not a `needs:` of anything. Freeing capacity is an
-  # optimisation, so a failure here must never hold up or fail a release, and
-  # the build must not wait on it either.
-  #
-  # ci-capacity.yml ships inert. Until CI_PREEMPT_ENABLED is set on this
-  # repository it resolves what it would have cancelled, prints that to the job
-  # summary, and touches nothing. That is the intended state for now: this wires
-  # the request up so the dry-run summary shows what a real sweep would free.
-  free-capacity:
-    name: Ask CI to free runner capacity
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Dispatch the capacity sweeper
-        # A release must never fail because the request did not land.
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh workflow run ci-capacity.yml --repo "$GITHUB_REPOSITORY" --ref main \
-            -f mode=sweep \
-            -f events=schedule \
-            -f classes=linux,windows \
-            -f reason="release-desktop run ${GITHUB_RUN_ID}"
-
+  # There is no capacity-sweeper dispatch here. It used to ask ci-capacity.yml to
+  # stand scheduled CI down while a release built, but that workflow is inert
+  # unless the repo variable CI_PREEMPT_ENABLED is the exact string 'true', so
+  # every release spent a runner on a job that resolved what it would have
+  # cancelled and then touched nothing. Queue clearing is done by hand now.
   prepare-version:
     name: Prepare release versions
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removes the `free-capacity` job from `release-desktop.yml`.

## Why

The job dispatches `ci-capacity.yml` to stand scheduled CI down while a release builds. That sweeper is gated on the repo variable `CI_PREEMPT_ENABLED` being the exact string `true`, and it is not set, so it ships inert: it resolves what it *would* have cancelled, prints that to the job summary, and touches nothing.

Observed on the v0.1.70-beta release, run 31508181303: the dispatch job completed `success` in seconds while the release then sat queued behind ~258 other runs. The v0.1.62-beta release before it did the same and waited 24 minutes. Both queues were cleared by hand.

So the job spends a runner and a job slot on every release to send a request that is discarded. Queue clearing is done manually now.

## What changes

- Deletes the `free-capacity` job and its comment block.
- Leaves a short comment in its place recording why there is no sweeper dispatch, so the next person does not re-add one without first enabling `CI_PREEMPT_ENABLED`.
- Nothing else referenced the job: it was deliberately not a `needs:` of anything, so no other job graph changes. Remaining jobs: `prepare-version`, `build`, `publish-release`, `virustotal-scan`.

`ci-capacity.yml` itself is untouched and can still be dispatched by hand. If it is armed later, re-adding this job is a small change.

## Test plan

- [ ] Dispatch a `draft:true` release and confirm the run starts with `prepare-version` and completes normally