### PR TITLE
Stop the installer raising the macOS command line developer tools dialog

### DIFF
--- a/.github/scripts/clean-machine-env.sh
+++ b/.github/scripts/clean-machine-env.sh
@@ -45,7 +45,15 @@ printf '#!/usr/bin/env bash\n# Undo clean-machine-env.sh --remove. Safe to run t
 chmod +x "$RESTORE"
 
 # The toolchain we care about: a consumer install must need none of it.
-TOOLS="xcode-select xcrun clang clang++ cc c++ gcc g++ git cmake make brew ninja cargo rustc"
+#
+# The cctools binaries (install_name_tool, lipo, otool, ...) are here for the same reason as
+# clang and git: they live in /Library/Developer/CommandLineTools, so on a Mac without CLT
+# each is a shim whose only observable effect is the "install the command line developer
+# tools" GUI dialog. They were missing, which is why uv's install_name_tool call
+# (astral-sh/uv#14843) and install.sh's lipo probe both shipped green -- untraced in trace
+# mode and unchecked in the absent list.
+TOOLS="xcode-select xcrun clang clang++ cc c++ gcc g++ git cmake make brew ninja cargo rustc
+install_name_tool lipo otool objdump vtool strip nm"
 
 note() { echo "[clean-machine] $*"; }
 

--- a/install.sh
+++ b/install.sh
@@ -2104,6 +2104,24 @@ tauri_log "STEP" "Checking system dependencies"
 # a GUI dialog, so `command -v git` is not enough -- only running it tells the truth.
 _has_working_git() {
     command -v git >/dev/null 2>&1 || return 1
+    # Executing the probe is the problem on macOS: /usr/bin/git is a Command Line Tools
+    # shim, so `git --version` against it raises the "install the command line developer
+    # tools" GUI dialog -- the probe firing the dialog it exists to detect. Answer from the
+    # resolved path instead when it is that exact shim and no toolchain is selected.
+    #
+    # Narrow on purpose. Only /usr/bin/git is a shim: a Homebrew, MacPorts or Xcode.app git
+    # earlier on PATH is a real binary and is still probed by executing it, so a Mac with a
+    # working git but no CLT selected keeps working exactly as before. xcode-select -p only
+    # asks which toolchain is selected and never prompts.
+    # $OS is the platform detected above, not a fresh `uname` call: this can run with a
+    # scrubbed PATH where uname is not resolvable, and a failed probe there would silently
+    # fall through to executing the shim. _CLT_GIT_SHIM is the shim path, overridable so
+    # the branch is testable without a /usr/bin write.
+    if [ "${OS:-}" = "macos" ] &&
+       [ "$(command -v git)" = "${_CLT_GIT_SHIM:-/usr/bin/git}" ] &&
+       ! xcode-select -p >/dev/null 2>&1; then
+        return 1
+    fi
     git --version >/dev/null 2>&1
 }
 
@@ -2576,8 +2594,16 @@ if [ -z "$_USER_PYTHON" ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
         # uv symlinks bin/python to the base interpreter, so dereference with
         # file -L (lipo already follows the link). Trailing || true keeps the
         # installer alive under set -e when neither tool is present.
-        _archs=$(lipo -archs "$VENV_DIR/bin/python" 2>/dev/null \
-            || file -L "$VENV_DIR/bin/python" 2>/dev/null || true)
+        #
+        # file -L FIRST, lipo only as the fallback: lipo is a Command Line Tools shim, so
+        # on a Mac without CLT merely running it raises the "install the command line
+        # developer tools" dialog -- 2>/dev/null hides its stderr but not a GUI dialog.
+        # file is base-system and always answers. Both spellings feed the same case below
+        # ("Mach-O 64-bit executable arm64", or "universal binary ... [x86_64] [arm64]",
+        # against lipo's "arm64" / "x86_64 arm64"), so the branch taken is unchanged.
+        # clean-machine-assert.sh:152 already made exactly this swap for its own use.
+        _archs=$(file -L "$VENV_DIR/bin/python" 2>/dev/null \
+            || lipo -archs "$VENV_DIR/bin/python" 2>/dev/null || true)
         case "$_archs" in
             *arm64*)  _VENV_ARCH=arm64 ;;
             *x86_64*) _VENV_ARCH=x86_64 ;;

--- a/tests/sh/test_macos_clt_gate.sh
+++ b/tests/sh/test_macos_clt_gate.sh
@@ -158,6 +158,36 @@ rm -f "$_BIN"/git
 _r="$(PATH="$_BIN" "$_SH" -c ". '$_FN_FILE'; _has_working_git && echo yes || echo no")"
 assert_eq "absent git -> no" "no" "$_r"
 
+# On macOS the probe must ANSWER FROM THE PATH, never execute /usr/bin/git: running the
+# CLT shim is what raises the "install the command line developer tools" GUI dialog. The
+# git stub here records execution, so an empty marker file is the proof it stayed unrun.
+echo "=== macOS: the CLT git shim is never executed ==="
+rm -f "$_BIN"/*
+_RAN="$(mktemp -u)"
+rm -f "$_RAN"
+_mk git "echo ran >> '$_RAN'; exit 1"
+_mk xcode-select 'exit 1'          # no toolchain selected == a clean Mac
+_r="$(PATH="$_BIN" OS=macos _CLT_GIT_SHIM="$_BIN/git" "$_SH" -c \
+    ". '$_FN_FILE'; _has_working_git && echo yes || echo no")"
+assert_eq "clean Mac + shim git -> no" "no" "$_r"
+if [ -f "$_RAN" ]; then
+    assert_eq "shim git was NOT executed (no GUI dialog)" "not-executed" "executed"
+else
+    assert_eq "shim git was NOT executed (no GUI dialog)" "not-executed" "not-executed"
+fi
+
+# A real git elsewhere on PATH (Homebrew) must still be probed by executing it, so a Mac
+# with a working git but no CLT selected keeps working exactly as before.
+rm -f "$_RAN"
+_r="$(PATH="$_BIN" OS=macos _CLT_GIT_SHIM=/usr/bin/git "$_SH" -c \
+    ". '$_FN_FILE'; _has_working_git && echo yes || echo no")"
+assert_eq "clean Mac + non-shim working git -> probed" "no" "$_r"
+if [ -f "$_RAN" ]; then
+    assert_eq "non-shim git WAS executed" "executed" "executed"
+else
+    assert_eq "non-shim git WAS executed" "executed" "not-executed"
+fi
+
 rm -rf "$_BIN" "$_FN_FILE" "$_HARNESS"
 
 echo ""


### PR DESCRIPTION
## The problem

On a Mac that has never had the Xcode Command Line Tools installed, `/usr/bin/git`, `lipo`, `install_name_tool`, `clang` and around 90 others are not real binaries. They are libxcselect shims: each calls `xcselect_invoke_xcrun`, and when no developer dir resolves it posts to `com.apple.dt.CommandLineTools.installondemand` over a CFMessagePort in the GUI session, which draws the "requires the command line developer tools" dialog naming the tool.

The dialog needs the shim to be **executed**. Resolving its path does not fire it, which is why `command -v git` is both safe and useless: `/usr/bin/git` exists on every Mac whether or not the tools are installed.

Users installing on a fresh Mac are getting that dialog.

## What this fixes

Two places on the consumer path execute a shim.

**`_has_working_git` ran `git --version`** to decide whether git works, so on a clean Mac the probe raised the dialog it exists to detect. It now answers from the resolved path when that path is exactly `/usr/bin/git` and no toolchain is selected.

Deliberately narrow. A Homebrew, MacPorts or Xcode.app git earlier on PATH is a real binary and is still probed by executing it, so a Mac with a working git but no CLT selected behaves exactly as before. An earlier version of this gated on "no CLT implies no working git" and broke that case; `tests/sh/test_macos_clt_gate.sh` caught it. `xcode-select -p` only asks which toolchain is selected and never prompts (it is absent from its own man page's shim list), which is the same idiom Homebrew, Salt, Chef, MacPorts and nvm all use.

**The venv arch probe called `lipo` first**, falling back to `file -L`. `lipo` is a shim, and `2>/dev/null` hides its stderr but not a GUI dialog. `file` is base system and always answers, so the order is swapped. Both spellings feed the same `case` below, matching `Mach-O 64-bit executable arm64` or `universal binary ... [x86_64] [arm64]` against `lipo`'s `arm64` / `x86_64 arm64`, so the branch taken is unchanged. `clean-machine-assert.sh:152` already made exactly this swap for its own use.

## Why CI never caught it

The cctools binaries were missing from `clean-machine-env.sh`'s `TOOLS` list, so trace mode generated no wrapper for them and the absent list never checked them. `install_name_tool`, `lipo`, `otool`, `objdump`, `vtool`, `strip` and `nm` are added, which is what makes any of this regression testable.

`tests/sh/test_macos_clt_gate.sh` gains two cases pinning the contract:

- with a shim git and no toolchain selected, the probe answers no **without executing it**, proven by a stub that records execution into a marker file
- with a real git elsewhere on PATH, the stub **is** executed

The first assertion passed vacuously when written (a wrong temp path meant the marker could never be created) and was corrected by making its pair fail first. 18 to 23 passing.

## The remaining source, which this PR does not fix

The dialog most users actually see comes from `uv`, not from this repo. `install_name_tool` appears nowhere in our tree.

uv shells out to a bare `install_name_tool` to fix the managed CPython dylib's install name (`crates/uv-python/src/macos_dylib.rs`), reached from `installation.rs` on any automatic managed-Python download. Two aggravating details:

- `install.sh` passes `--python-preference only-managed` to stop uv executing the `/usr/bin/python3` shim, but that forces the managed CPython download, which is exactly what triggers `install_name_tool`. The existing mitigation makes the dialog more likely, not less.
- `uv python install` iterates `downloaded.chain(satisfied)`, so it re-invokes `install_name_tool` on already-installed interpreters. The dialog recurs rather than appearing once.

Upstream is aware and unfixed: [astral-sh/uv#14843](https://github.com/astral-sh/uv/issues/14843) is open, and [astral-sh/uv#14893](https://github.com/astral-sh/uv/issues/14893) ("Provide a way to skip install_name_tool invocation?") was filed by the Anki developer with the identical bundled-uv symptom. The proposed `xcode-select -p` guard is unmerged, and [PR #14869](https://github.com/astral-sh/uv/pull/14869) is unmerged too.

There is no supported way to silence it from our side. `XCODE_SELECT_NO_PROMPT` and `defaults write` keys do not exist, in the man page, in `libxcselect.dylib`'s symbols, or anywhere else. The two real options, both larger than this PR and worth deciding separately:

1. Bundle the Python runtime in the app, pre-relocated on CI where CLT exists, with `UV_NO_MANAGED_PYTHON=1`. Removes the call by construction and is robust to uv changing internals. Costs bundle size and we own Python updates.
2. Set `DEVELOPER_DIR` to a sentinel only once `xcode-select -p` has already failed, converting the dialog into a silent non-zero exit. Cheap, but it rests on undocumented `was_default` gating and turns a visible prompt into a silent failure.

Note that CI can verify the call never happens (trace mode, now wired up) but cannot verify the dialog itself, which needs a GUI bootstrap namespace a headless runner does not have.
