### PR TITLE
Studio: report host VRAM usage when no single GPU's usage can be attributed

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1851,13 +1851,11 @@ def _get_cached_system_gpu_info(logger) -> tuple[dict[str, Any], dict[str, Any]]
             )
             enriched_devices.append(enriched_dev)
 
-        # The tile divides the aggregate by the SUMMED per-device totals, so the two
-        # have to describe the same cards. The utilization probe and the visibility
-        # probe enumerate independently: _torch_get_per_device_info also calls
-        # mem_get_info and drops a device whose call raises, while the aggregate's
-        # own enumeration only reads torch properties and keeps it. A device present
-        # in one and not the other would inflate the percentage and floor free at 0,
-        # so the aggregate rides only on an identical index set (#7452).
+        # The tile divides the aggregate by the SUMMED per-device totals, so both must
+        # describe the same cards. The two probes enumerate independently: visibility
+        # drops a device whose mem_get_info raises, the aggregate side reads torch
+        # properties only and keeps it. A device in one and not the other inflates the
+        # percentage and floors free at 0, so identical index sets only (#7452).
         aggregate_basis_matches = metrics_match and {
             d.get("index") for d in utilization_info.get("devices", [])
         } == {d.get("index") for d in enriched_devices}
@@ -1889,9 +1887,8 @@ def _get_cached_system_gpu_info(logger) -> tuple[dict[str, Any], dict[str, Any]]
             "devices": enriched_devices,
             "backend": visibility_info.get("backend"),
             "gguf_gpu_ids_supported": gpu_ids_supported,
-            # Host-level used VRAM, reported when the per-device figures are unknown
-            # because no counter can be attributed to one card (#7452). Only the
-            # Windows ROCm path sets it, so it is None everywhere else.
+            # Host-level used VRAM, for when no counter is attributable to one card
+            # (#7452). Only the Windows ROCm path sets it; None everywhere else.
             "vram_used_gb_aggregate": utilization_info.get("vram_used_gb_aggregate")
             if aggregate_basis_matches
             else None,

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1878,6 +1878,12 @@ def _get_cached_system_gpu_info(logger) -> tuple[dict[str, Any], dict[str, Any]]
             "devices": enriched_devices,
             "backend": visibility_info.get("backend"),
             "gguf_gpu_ids_supported": gpu_ids_supported,
+            # Host-level used VRAM, reported when the per-device figures are unknown
+            # because no counter can be attributed to one card (#7452). Only the
+            # Windows ROCm path sets it, so it is None everywhere else.
+            "vram_used_gb_aggregate": utilization_info.get("vram_used_gb_aggregate")
+            if metrics_match
+            else None,
         }
 
         # Keep inference placement separate on train-capable hosts where a forced Vulkan llama.cpp

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1851,6 +1851,17 @@ def _get_cached_system_gpu_info(logger) -> tuple[dict[str, Any], dict[str, Any]]
             )
             enriched_devices.append(enriched_dev)
 
+        # The tile divides the aggregate by the SUMMED per-device totals, so the two
+        # have to describe the same cards. The utilization probe and the visibility
+        # probe enumerate independently: _torch_get_per_device_info also calls
+        # mem_get_info and drops a device whose call raises, while the aggregate's
+        # own enumeration only reads torch properties and keeps it. A device present
+        # in one and not the other would inflate the percentage and floor free at 0,
+        # so the aggregate rides only on an identical index set (#7452).
+        aggregate_basis_matches = metrics_match and {
+            d.get("index") for d in utilization_info.get("devices", [])
+        } == {d.get("index") for d in enriched_devices}
+
         try:
             from core.inference.llama_cpp import LlamaCppBackend
             from utils.hardware import DeviceType, get_device
@@ -1882,7 +1893,7 @@ def _get_cached_system_gpu_info(logger) -> tuple[dict[str, Any], dict[str, Any]]
             # because no counter can be attributed to one card (#7452). Only the
             # Windows ROCm path sets it, so it is None everywhere else.
             "vram_used_gb_aggregate": utilization_info.get("vram_used_gb_aggregate")
-            if metrics_match
+            if aggregate_basis_matches
             else None,
         }
 

--- a/studio/backend/tests/test_rocm_multi_gpu_vram_system_wide.py
+++ b/studio/backend/tests/test_rocm_multi_gpu_vram_system_wide.py
@@ -462,7 +462,7 @@ def test_visible_utilization_rocm_fallback_overlays(monkeypatch):
     # No AMD adapter data on this host. On Windows this branch runs ahead of the torch
     # fallback under test, and probing it imports torch, which the CI runner does not
     # install. Off Windows the real function is never reached, so this changes nothing.
-    monkeypatch.setattr(hw, "_rocm_windows_per_device_vram", lambda ids: [])
+    monkeypatch.setattr(hw, "_rocm_windows_per_device_vram", lambda ids: ([], None))
     monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
     monkeypatch.setattr(hw, "_smi_query", lambda *a, **k: None)  # amd-smi unavailable
     monkeypatch.setattr(
@@ -494,7 +494,7 @@ def test_visible_utilization_relative_index_skips_overlay(monkeypatch):
     # No AMD adapter data on this host. On Windows this branch runs ahead of the torch
     # fallback under test, and probing it imports torch, which the CI runner does not
     # install. Off Windows the real function is never reached, so this changes nothing.
-    monkeypatch.setattr(hw, "_rocm_windows_per_device_vram", lambda ids: [])
+    monkeypatch.setattr(hw, "_rocm_windows_per_device_vram", lambda ids: ([], None))
     monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
     monkeypatch.setattr(hw, "_smi_query", lambda *a, **k: None)
     monkeypatch.setattr(

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -8,9 +8,9 @@ torch 2.11.0+rocm7.13. On Windows without a HIP SDK, amd-smi is permanently
 disabled (avoids a UAC/DiskPart prompt) and hipMemGetInfo returns free==total
 (used 0). Two symptoms followed:
 
-  * System tab (/api/system -> get_visible_gpu_utilization) showed ~0 VRAM used
-    on every GPU (torch mem_get_info free==total quirk; see
-    rocm_windows_free_is_untrusted for why the reading is optimistic).
+  * System tab (/api/system -> get_visible_gpu_utilization) showed ~0 VRAM used on
+    every GPU (mem_get_info free==total; see rocm_windows_free_is_untrusted for why
+    the reading is optimistic).
   * get_gpu_utilization()'s Windows fallback SUMMED "GPU Adapter Memory\\Dedicated
     Usage" across all adapters into ONE fake device with only GPU 0's total, so
     the second GPU never appeared.

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -9,7 +9,8 @@ disabled (avoids a UAC/DiskPart prompt) and hipMemGetInfo returns free==total
 (used 0). Two symptoms followed:
 
   * System tab (/api/system -> get_visible_gpu_utilization) showed ~0 VRAM used
-    on every GPU (torch mem_get_info free==total quirk; ROCm/ROCm#1909).
+    on every GPU (torch mem_get_info free==total quirk; see
+    rocm_windows_free_is_untrusted for why the reading is optimistic).
   * get_gpu_utilization()'s Windows fallback SUMMED "GPU Adapter Memory\\Dedicated
     Usage" across all adapters into ONE fake device with only GPU 0's total, so
     the second GPU never appeared.

--- a/studio/backend/tests/test_rocm_windows_vram_7452.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7452.py
@@ -46,13 +46,14 @@ from test_rocm_windows_vram_7072 import (  # noqa: E402, F401  (win_rocm is a fi
     win_rocm,
 )
 
-# The reporter's exact figures: a W7900 and a W7500 sitting idle, plus the
-# Windows Basic Render Driver placeholder counter that every such host carries.
+# The reporter's cards, and his idle used figures as #7072's screenshot showed
+# them (0.22 and 0.14 GiB, which is the 53.0 GiB tile reading 0.36 GiB). One
+# counter instance per visible card and no others, which is the only shape the
+# aggregate is emitted for.
 REPORTER_DEVICES = [("AMD Radeon PRO W7900", 45.0 * GB), ("AMD Radeon PRO W7500", 7.98 * GB)]
 IDLE_ADAPTERS = [
     ("luid_0x00000000_0x0000d1e2_phys_0", 0.22 * GB),  # W7900 idle desktop
     ("luid_0x00000000_0x0000e34a_phys_0", 0.14 * GB),  # W7500 idle desktop
-    ("luid_0x00000000_0x0000f001_phys_0", 3 * MiB),  # Basic Render Driver
 ]
 
 
@@ -93,15 +94,14 @@ def test_gpu_utilization_payload_carries_the_aggregate(win_rocm, monkeypatch):
     assert result["vram_used_gb"] is None
 
 
-def test_loaded_card_keeps_both_the_forced_device_value_and_the_aggregate(win_rocm, monkeypatch):
-    """#7072's own case: a model resident on the W7900. The 40 GiB is capacity-forced
-    onto the 45 GiB card and stays per device, and the aggregate adds the idle card's
-    0.5 GiB, so the tile shows the real total rather than only the attributed part."""
+def test_loaded_card_agrees_with_the_per_device_figures(win_rocm, monkeypatch):
+    """#7072's own case: a model resident on the W7900. 40 GiB exceeds the smaller
+    card, so the ranking is forced and both rows get a value; the aggregate must then
+    equal their sum, or the tile would disagree with the rows underneath it."""
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     loaded = [
         ("luid_0x00000000_0x0000d1e2_phys_0", 40.0 * GB),
         ("luid_0x00000000_0x0000e34a_phys_0", 0.5 * GB),
-        ("luid_0x00000000_0x0000f001_phys_0", 3 * MiB),
     ]
     monkeypatch.setattr(
         hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(loaded))
@@ -110,8 +110,11 @@ def test_loaded_card_keeps_both_the_forced_device_value_and_the_aggregate(win_ro
     result = hw.get_visible_gpu_utilization()
     by_idx = {d["index"]: d for d in result["devices"]}
     assert by_idx[0]["vram_used_gb"] == pytest.approx(40.0, abs = 0.01)
-    assert by_idx[1]["vram_used_gb"] is None
+    assert by_idx[1]["vram_used_gb"] == pytest.approx(0.5, abs = 0.01)
     assert result["vram_used_gb_aggregate"] == pytest.approx(40.5, abs = 0.01)
+    assert result["vram_used_gb_aggregate"] == pytest.approx(
+        sum(d["vram_used_gb"] for d in result["devices"]), abs = 0.01
+    )
 
 
 def test_no_aggregate_when_the_counter_is_unavailable(win_rocm, monkeypatch):
@@ -132,15 +135,12 @@ def test_aggregate_requires_a_counter_per_visible_device():
     agg = hw._rocm_windows_aggregate_used_bytes
     # One counter per visible card: the sum is the visible set's, whatever the pairing.
     assert agg([0.22 * GB, 0.14 * GB], [45 * GB, 8 * GB]) == pytest.approx(0.36 * GB)
-    # Sub-threshold placeholders drop, leaving exactly one counter per card.
-    assert agg([0.22 * GB, 0.14 * GB, 3 * MiB], [45 * GB, 8 * GB]) == pytest.approx(0.36 * GB)
+    # Two identical cards make the ranking degenerate, and the sum does not care.
+    assert agg([10 * GB, 3 * GB], [24 * GB, 24 * GB]) == pytest.approx(13 * GB)
     # Fewer counters than cards: a card has no reading, so the sum is not the total.
     assert agg([5 * GB], [45 * GB, 8 * GB]) is None
-    # More active counters than visible cards: an adapter outside the visibility
-    # mask is in the list and its usage is not ours to add.
+    # More counters than visible cards: an adapter in the list is not one of ours.
     assert agg([40 * GB, 7 * GB, 6 * GB], [45 * GB, 8 * GB]) is None
-    # Every counter below the noise floor: which is the placeholder is unknowable.
-    assert agg([50 * MiB, 10 * MiB, 5 * MiB], [45 * GB, 8 * GB]) is None
     assert agg([], [45 * GB, 8 * GB]) is None
     assert agg([1 * GB], []) is None
 
@@ -154,3 +154,59 @@ def test_aggregate_rejects_a_usage_larger_than_any_visible_card():
     assert agg([40 * GB, 6 * GB], [45 * GB, 4 * GB]) is None
     # Counter order must not matter.
     assert agg([6 * GB, 40 * GB], [45 * GB, 4 * GB]) is None
+
+
+def test_aggregate_never_sums_bytes_that_are_not_on_a_visible_card():
+    """The reason an unexplained instance is refused rather than filtered out.
+
+    ``Get-Counter`` lists every WDDM adapter and the instance names carry no
+    vendor, LUID or PCI key, so a counter cannot be told apart from a foreign
+    adapter's. Dropping the small ones to force a 1:1 count keeps the foreign
+    reading and drops the quiet visible card whenever the foreign adapter is the
+    busier of the two, and the host total then reports bytes that are on no
+    visible card. Each case below is one that a noise filter would have summed.
+    """
+    agg = hw._rocm_windows_aggregate_used_bytes
+    pair = [45 * GB, 8 * GB]
+    # A third AMD card hidden by HIP_VISIBLE_DEVICES, busy at 5 GiB, while the
+    # visible 8 GiB card idles below the 64 MiB noise floor. Truth is 30.03 GiB.
+    assert agg([30 * GB, 5 * GB, 30 * MiB], pair) is None
+    # An NVIDIA card in the same box. Truth is 30.02 GiB.
+    assert agg([30 * GB, 6 * GB, 20 * MiB], pair) is None
+    # An integrated display GPU holding a 1 GiB carveout. Truth is 30.01 GiB.
+    assert agg([30 * GB, 1 * GB, 10 * MiB], pair) is None
+    # A Basic Render Driver / Remote Display placeholder ABOVE the cutoff.
+    assert agg([30 * GB, 200 * MiB, 20 * MiB], pair) is None
+    # One visible card, idle, beside a busy foreign adapter: the worst case, since
+    # a single card's capacity admits almost any foreign reading. Truth is 30 MiB.
+    assert agg([6 * GB, 30 * MiB], [45 * GB]) is None
+    assert agg([6 * GB, 30 * MiB, 3 * MiB], [45 * GB]) is None
+
+
+def test_aggregate_is_stable_across_a_changing_instance_list(win_rocm, monkeypatch):
+    """Counters come and go between polls (a placeholder adapter appears, a card
+    is masked mid-session). Every poll is judged on its own list, so the tile
+    alternates between the real figure and Unknown, never between two figures."""
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
+    polls = [
+        (IDLE_ADAPTERS, pytest.approx(0.36, abs = 0.01)),
+        (IDLE_ADAPTERS + [("luid_0x00000000_0x0000f001_phys_0", 3 * MiB)], None),
+        (IDLE_ADAPTERS + [("luid_0x00000000_0x0000f002_phys_0", 2.0 * GB)], None),
+        (IDLE_ADAPTERS, pytest.approx(0.36, abs = 0.01)),
+    ]
+    for adapters, expected in polls:
+        monkeypatch.setattr(
+            hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(adapters))
+        )
+        result = hw.get_visible_gpu_utilization()
+        assert result["vram_used_gb_aggregate"] == expected
+
+
+def test_aggregate_tolerates_a_wddm_spill_over_the_smaller_card(win_rocm, monkeypatch):
+    """WDDM satisfies an overrun from host RAM, so a usage can exceed the card it
+    sits on. That only has to not fabricate a number: the reading above the LARGEST
+    visible capacity is refused, and one that still fits the ranking is summed as
+    reported rather than clamped."""
+    agg = hw._rocm_windows_aggregate_used_bytes
+    assert agg([9 * GB, 0.3 * GB], [45 * GB, 8 * GB]) == pytest.approx(9.3 * GB)
+    assert agg([46 * GB, 2 * GB], [45 * GB, 8 * GB]) is None

--- a/studio/backend/tests/test_rocm_windows_vram_7452.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7452.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for issue #7452 -- "Stops Reading VRAM Total / Usage on RDNA3".
+
+Reporter: the same host as #7072 (AMD Radeon PRO W7900 45 GiB + W7500 7.98 GiB,
+Windows 10, ROCm 7.13, torch 2.11.0+rocm7.13), six days after the #7072 fix
+(#7238) shipped. The two issues are a regression pair, not duplicates.
+
+#7238 stopped fabricating a per-device usage when the LUID performance counters
+cannot be attributed to torch ordinals: Windows shares no key between the two, so
+usage is paired by capacity ranking and kept only when capacity FORCES it. On
+this reporter's hardware the smaller card is 7.98 GiB, so every usage at or below
+7.98 GiB -- idle, and every small model -- is swappable between the two cards and
+reports Unknown. That is honest per device, but the System tab's aggregate VRAM
+tile also went Unknown, and the aggregate does NOT depend on the pairing: the sum
+of a permutation is the same whichever way round it is. His screenshot shows the
+per-device totals intact (45.0 / 7.98 GiB) with used, free and percent all
+Unknown, which is exactly this.
+
+Mocks: torch, the performance counter and the platform are all faked, because
+there is no AMD GPU and no Windows or ROCm CI in this repository. The fakes are
+imported from test_rocm_windows_vram_7072 so both halves of the regression pair
+are driven by one fixture shape.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils.hardware import hardware as hw
+
+_TESTS_DIR = str(Path(__file__).resolve().parent)
+if _TESTS_DIR not in sys.path:
+    sys.path.insert(0, _TESTS_DIR)
+
+from test_rocm_windows_vram_7072 import (  # noqa: E402, F401  (win_rocm is a fixture)
+    GB,
+    MiB,
+    _adapter_output,
+    _fake_torch,
+    _subprocess_run,
+    win_rocm,
+)
+
+# The reporter's exact figures: a W7900 and a W7500 sitting idle, plus the
+# Windows Basic Render Driver placeholder counter that every such host carries.
+REPORTER_DEVICES = [("AMD Radeon PRO W7900", 45.0 * GB), ("AMD Radeon PRO W7500", 7.98 * GB)]
+IDLE_ADAPTERS = [
+    ("luid_0x00000000_0x0000d1e2_phys_0", 0.22 * GB),  # W7900 idle desktop
+    ("luid_0x00000000_0x0000e34a_phys_0", 0.14 * GB),  # W7500 idle desktop
+    ("luid_0x00000000_0x0000f001_phys_0", 3 * MiB),  # Basic Render Driver
+]
+
+
+# ----------------------------------------------------------------------------- #
+# The System tab tile: aggregate usage survives an unattributable pairing
+# ----------------------------------------------------------------------------- #
+def test_system_tab_reports_aggregate_when_pairing_is_ambiguous(win_rocm, monkeypatch):
+    """0.22 + 0.14 GiB across a 45/7.98 GiB pair: neither usage is capacity-forced,
+    so per device it stays Unknown, but the visible set's total is exactly 0.36 GiB
+    either way round. Before the fix the whole tile read Unknown (#7452)."""
+    monkeypatch.setitem(
+        sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True)
+    )
+    monkeypatch.setattr(
+        hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(IDLE_ADAPTERS))
+    )
+
+    result = hw.get_visible_gpu_utilization()
+    devices = result["devices"]
+    assert len(devices) == 2
+    assert sorted(d["vram_total_gb"] for d in devices) == [7.98, 45.0]
+    # Per device the ranking cannot tell the two apart, so #7238's invariant holds.
+    assert all(d["vram_used_gb"] is None for d in devices)
+    # But the aggregate is pairing-independent, so the tile has a real number.
+    assert result["vram_used_gb_aggregate"] == pytest.approx(0.36, abs = 0.01)
+
+
+def test_gpu_utilization_payload_carries_the_aggregate(win_rocm, monkeypatch):
+    """The floating monitor reads get_gpu_utilization(), so the same figure has to
+    reach that payload and not only the System tab's."""
+    monkeypatch.setitem(
+        sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True)
+    )
+    monkeypatch.setattr(
+        hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(IDLE_ADAPTERS))
+    )
+
+    result = hw.get_gpu_utilization()
+    assert result["vram_used_gb_aggregate"] == pytest.approx(0.36, abs = 0.01)
+    # The legacy primary mirror must not be overwritten by the aggregate.
+    assert result["vram_total_gb"] == 45.0
+    assert result["vram_used_gb"] is None
+
+
+def test_loaded_card_keeps_both_the_forced_device_value_and_the_aggregate(win_rocm, monkeypatch):
+    """#7072's own case: a model resident on the W7900. The 40 GiB is capacity-forced
+    onto the 45 GiB card and stays per device, and the aggregate adds the idle card's
+    0.5 GiB, so the tile shows the real total rather than only the attributed part."""
+    monkeypatch.setitem(
+        sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True)
+    )
+    loaded = [
+        ("luid_0x00000000_0x0000d1e2_phys_0", 40.0 * GB),
+        ("luid_0x00000000_0x0000e34a_phys_0", 0.5 * GB),
+        ("luid_0x00000000_0x0000f001_phys_0", 3 * MiB),
+    ]
+    monkeypatch.setattr(
+        hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(loaded))
+    )
+
+    result = hw.get_visible_gpu_utilization()
+    by_idx = {d["index"]: d for d in result["devices"]}
+    assert by_idx[0]["vram_used_gb"] == pytest.approx(40.0, abs = 0.01)
+    assert by_idx[1]["vram_used_gb"] is None
+    assert result["vram_used_gb_aggregate"] == pytest.approx(40.5, abs = 0.01)
+
+
+def test_no_aggregate_when_the_counter_is_unavailable(win_rocm, monkeypatch):
+    """A localized or missing counter set must stay Unknown rather than become 0:
+    that fabricated zero is the #7072 symptom this pair started from."""
+    monkeypatch.setitem(
+        sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True)
+    )
+    monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output = "__NONE__\n"))
+
+    result = hw.get_visible_gpu_utilization()
+    assert len(result["devices"]) == 2
+    assert result["vram_used_gb_aggregate"] is None
+
+
+# ----------------------------------------------------------------------------- #
+# The aggregate rule itself (pure unit)
+# ----------------------------------------------------------------------------- #
+def test_aggregate_requires_a_counter_per_visible_device():
+    agg = hw._rocm_windows_aggregate_used_bytes
+    # One counter per visible card: the sum is the visible set's, whatever the pairing.
+    assert agg([0.22 * GB, 0.14 * GB], [45 * GB, 8 * GB]) == pytest.approx(0.36 * GB)
+    # Sub-threshold placeholders drop, leaving exactly one counter per card.
+    assert agg([0.22 * GB, 0.14 * GB, 3 * MiB], [45 * GB, 8 * GB]) == pytest.approx(0.36 * GB)
+    # Fewer counters than cards: a card has no reading, so the sum is not the total.
+    assert agg([5 * GB], [45 * GB, 8 * GB]) is None
+    # More active counters than visible cards: an adapter outside the visibility
+    # mask is in the list and its usage is not ours to add.
+    assert agg([40 * GB, 7 * GB, 6 * GB], [45 * GB, 8 * GB]) is None
+    # Every counter below the noise floor: which is the placeholder is unknowable.
+    assert agg([50 * MiB, 10 * MiB, 5 * MiB], [45 * GB, 8 * GB]) is None
+    assert agg([], [45 * GB, 8 * GB]) is None
+    assert agg([1 * GB], []) is None
+
+
+def test_aggregate_rejects_a_usage_larger_than_any_visible_card():
+    """A masked 45 GiB card at 40 GiB beside a visible idle 8 GiB card: the counts
+    can match by accident, but 40 GiB cannot be on an 8 GiB card, so the counter set
+    is not the visible set and the sum would be a hidden GPU's."""
+    agg = hw._rocm_windows_aggregate_used_bytes
+    assert agg([40 * GB, 10 * MiB], [8 * GB]) is None
+    assert agg([40 * GB, 6 * GB], [45 * GB, 4 * GB]) is None
+    # Counter order must not matter.
+    assert agg([6 * GB, 40 * GB], [45 * GB, 4 * GB]) is None

--- a/studio/backend/tests/test_rocm_windows_vram_7452.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7452.py
@@ -63,9 +63,7 @@ def test_system_tab_reports_aggregate_when_pairing_is_ambiguous(win_rocm, monkey
     """0.22 + 0.14 GiB across a 45/7.98 GiB pair: neither usage is capacity-forced,
     so per device it stays Unknown, but the visible set's total is exactly 0.36 GiB
     either way round. Before the fix the whole tile read Unknown (#7452)."""
-    monkeypatch.setitem(
-        sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True)
-    )
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     monkeypatch.setattr(
         hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(IDLE_ADAPTERS))
     )
@@ -83,9 +81,7 @@ def test_system_tab_reports_aggregate_when_pairing_is_ambiguous(win_rocm, monkey
 def test_gpu_utilization_payload_carries_the_aggregate(win_rocm, monkeypatch):
     """The floating monitor reads get_gpu_utilization(), so the same figure has to
     reach that payload and not only the System tab's."""
-    monkeypatch.setitem(
-        sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True)
-    )
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     monkeypatch.setattr(
         hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(IDLE_ADAPTERS))
     )
@@ -101,9 +97,7 @@ def test_loaded_card_keeps_both_the_forced_device_value_and_the_aggregate(win_ro
     """#7072's own case: a model resident on the W7900. The 40 GiB is capacity-forced
     onto the 45 GiB card and stays per device, and the aggregate adds the idle card's
     0.5 GiB, so the tile shows the real total rather than only the attributed part."""
-    monkeypatch.setitem(
-        sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True)
-    )
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     loaded = [
         ("luid_0x00000000_0x0000d1e2_phys_0", 40.0 * GB),
         ("luid_0x00000000_0x0000e34a_phys_0", 0.5 * GB),
@@ -123,9 +117,7 @@ def test_loaded_card_keeps_both_the_forced_device_value_and_the_aggregate(win_ro
 def test_no_aggregate_when_the_counter_is_unavailable(win_rocm, monkeypatch):
     """A localized or missing counter set must stay Unknown rather than become 0:
     that fabricated zero is the #7072 symptom this pair started from."""
-    monkeypatch.setitem(
-        sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True)
-    )
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output = "__NONE__\n"))
 
     result = hw.get_visible_gpu_utilization()

--- a/studio/backend/tests/test_rocm_windows_vram_7452.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7452.py
@@ -210,3 +210,77 @@ def test_aggregate_tolerates_a_wddm_spill_over_the_smaller_card(win_rocm, monkey
     agg = hw._rocm_windows_aggregate_used_bytes
     assert agg([9 * GB, 0.3 * GB], [45 * GB, 8 * GB]) == pytest.approx(9.3 * GB)
     assert agg([46 * GB, 2 * GB], [45 * GB, 8 * GB]) is None
+
+
+# ----------------------------------------------------------------------------- #
+# The aggregate and the rows have to describe the same cards
+# ----------------------------------------------------------------------------- #
+
+
+def _merged_gpu_info(monkeypatch, visibility, utilization):
+    """Run main's payload merge over two stubbed probes and return the training half.
+
+    Both probes are function-local imports from utils.hardware, so they are patched
+    on the package. The module-level cache is cleared first or a neighbouring test's
+    payload is returned instead of this one.
+    """
+    import main
+    import utils.hardware as uh
+
+    monkeypatch.setattr(uh, "get_backend_visible_gpu_info", lambda: visibility)
+    monkeypatch.setattr(uh, "get_visible_gpu_utilization", lambda: utilization)
+    monkeypatch.setattr(main, "_system_gpu_cache", None, raising = False)
+    gpu_info, _ = main._get_cached_system_gpu_info(main.logger)
+    return gpu_info
+
+
+def _probe_pair(visible_indices, util_indices, aggregate):
+    visibility = {
+        "available": True,
+        "backend": "rocm",
+        "devices": [
+            {"index": i, "name": f"card{i}", "memory_total_gb": 45.0 if i == 0 else 7.98}
+            for i in visible_indices
+        ],
+    }
+    utilization = {
+        "backend": "rocm",
+        "devices": [{"index": i, "vram_used_gb": None} for i in util_indices],
+        "vram_used_gb_aggregate": aggregate,
+    }
+    return visibility, utilization
+
+
+def test_aggregate_is_dropped_when_the_probes_enumerate_different_cards(monkeypatch):
+    """The tile divides the aggregate by the SUMMED totals of the rows it shows, so
+    a total taken over cards the rows do not list reads above 100 percent and the
+    free figure clamps to 0. metrics_match cannot catch it: on the only path that
+    sets an aggregate, Windows ROCm, both probes label themselves "rocm", so it is
+    unconditionally true and constrains nothing about which cards were counted.
+
+    The two probes really do enumerate independently -- the visibility side calls
+    mem_get_info per device and drops one that raises, the aggregate side reads
+    torch properties only and keeps it -- so the sets can differ with both probes
+    reporting success.
+    """
+    visibility, utilization = _probe_pair([0], [0, 1], 46.0)
+    gpu_info = _merged_gpu_info(monkeypatch, visibility, utilization)
+    shown_total = sum(d["memory_total_gb"] for d in gpu_info["devices"])
+    assert utilization["vram_used_gb_aggregate"] > shown_total  # the wrong number
+    assert gpu_info["vram_used_gb_aggregate"] is None
+
+
+def test_aggregate_survives_when_both_probes_name_the_same_cards(monkeypatch):
+    """The reporter's own host, and the case the fix exists for: identical index
+    sets, so the aggregate is a total over exactly the rows on screen."""
+    visibility, utilization = _probe_pair([0, 1], [0, 1], 0.36)
+    gpu_info = _merged_gpu_info(monkeypatch, visibility, utilization)
+    assert gpu_info["vram_used_gb_aggregate"] == 0.36
+
+
+def test_aggregate_is_dropped_when_the_sets_merely_overlap(monkeypatch):
+    """Equal counts are not enough. Two cards each, but index 1 against index 2:
+    the aggregate counts a card that has no row, and a row has no counter."""
+    visibility, utilization = _probe_pair([0, 1], [0, 2], 46.0)
+    gpu_info = _merged_gpu_info(monkeypatch, visibility, utilization)
+    assert gpu_info["vram_used_gb_aggregate"] is None

--- a/studio/backend/tests/test_rocm_windows_vram_7452.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7452.py
@@ -4,24 +4,22 @@
 """Regression tests for issue #7452 -- "Stops Reading VRAM Total / Usage on RDNA3".
 
 Reporter: the same host as #7072 (AMD Radeon PRO W7900 45 GiB + W7500 7.98 GiB,
-Windows 10, ROCm 7.13, torch 2.11.0+rocm7.13), six days after the #7072 fix
-(#7238) shipped. The two issues are a regression pair, not duplicates.
+Windows 10, ROCm 7.13, torch 2.11.0+rocm7.13), six days after the #7072 fix (#7238)
+shipped, so the two are a regression pair rather than duplicates.
 
 #7238 stopped fabricating a per-device usage when the LUID performance counters
 cannot be attributed to torch ordinals: Windows shares no key between the two, so
-usage is paired by capacity ranking and kept only when capacity FORCES it. On
-this reporter's hardware the smaller card is 7.98 GiB, so every usage at or below
-7.98 GiB -- idle, and every small model -- is swappable between the two cards and
-reports Unknown. That is honest per device, but the System tab's aggregate VRAM
-tile also went Unknown, and the aggregate does NOT depend on the pairing: the sum
-of a permutation is the same whichever way round it is. His screenshot shows the
-per-device totals intact (45.0 / 7.98 GiB) with used, free and percent all
-Unknown, which is exactly this.
+usage is paired by capacity ranking and kept only when capacity FORCES it. Here the
+smaller card is 7.98 GiB, so every usage at or below that -- idle, and every small
+model -- is swappable between the cards and reports Unknown. Honest per device, but
+the System tab's aggregate VRAM tile went Unknown too, and the aggregate does NOT
+depend on the pairing: the sum of a permutation is the same whichever way round. His
+screenshot shows the per-device totals intact (45.0 / 7.98 GiB) with used, free and
+percent all Unknown.
 
-Mocks: torch, the performance counter and the platform are all faked, because
-there is no AMD GPU and no Windows or ROCm CI in this repository. The fakes are
-imported from test_rocm_windows_vram_7072 so both halves of the regression pair
-are driven by one fixture shape.
+Mocks: torch, the performance counter and the platform are all faked (no AMD GPU and
+no Windows or ROCm CI in this repository), imported from test_rocm_windows_vram_7072
+so both halves of the pair are driven by one fixture shape.
 """
 
 from __future__ import annotations
@@ -46,10 +44,9 @@ from test_rocm_windows_vram_7072 import (  # noqa: E402, F401  (win_rocm is a fi
     win_rocm,
 )
 
-# The reporter's cards, and his idle used figures as #7072's screenshot showed
-# them (0.22 and 0.14 GiB, which is the 53.0 GiB tile reading 0.36 GiB). One
-# counter instance per visible card and no others, which is the only shape the
-# aggregate is emitted for.
+# The reporter's cards and his idle used figures from #7072's screenshot (0.22 and
+# 0.14 GiB, the 53.0 GiB tile reading 0.36 GiB). One counter instance per visible
+# card and no others, the only shape the aggregate is emitted for.
 REPORTER_DEVICES = [("AMD Radeon PRO W7900", 45.0 * GB), ("AMD Radeon PRO W7500", 7.98 * GB)]
 IDLE_ADAPTERS = [
     ("luid_0x00000000_0x0000d1e2_phys_0", 0.22 * GB),  # W7900 idle desktop
@@ -61,9 +58,9 @@ IDLE_ADAPTERS = [
 # The System tab tile: aggregate usage survives an unattributable pairing
 # ----------------------------------------------------------------------------- #
 def test_system_tab_reports_aggregate_when_pairing_is_ambiguous(win_rocm, monkeypatch):
-    """0.22 + 0.14 GiB across a 45/7.98 GiB pair: neither usage is capacity-forced,
-    so per device it stays Unknown, but the visible set's total is exactly 0.36 GiB
-    either way round. Before the fix the whole tile read Unknown (#7452)."""
+    """0.22 + 0.14 GiB across a 45/7.98 GiB pair: neither usage is capacity-forced, so
+    per device stays Unknown, but the total is 0.36 GiB either way round. Before the
+    fix the whole tile read Unknown (#7452)."""
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     monkeypatch.setattr(
         hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(IDLE_ADAPTERS))
@@ -80,8 +77,8 @@ def test_system_tab_reports_aggregate_when_pairing_is_ambiguous(win_rocm, monkey
 
 
 def test_gpu_utilization_payload_carries_the_aggregate(win_rocm, monkeypatch):
-    """The floating monitor reads get_gpu_utilization(), so the same figure has to
-    reach that payload and not only the System tab's."""
+    """The floating monitor reads get_gpu_utilization(), so the figure has to reach
+    that payload too, not only the System tab's."""
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     monkeypatch.setattr(
         hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(IDLE_ADAPTERS))
@@ -96,8 +93,8 @@ def test_gpu_utilization_payload_carries_the_aggregate(win_rocm, monkeypatch):
 
 def test_loaded_card_agrees_with_the_per_device_figures(win_rocm, monkeypatch):
     """#7072's own case: a model resident on the W7900. 40 GiB exceeds the smaller
-    card, so the ranking is forced and both rows get a value; the aggregate must then
-    equal their sum, or the tile would disagree with the rows underneath it."""
+    card, so the ranking is forced and both rows get a value; the aggregate must equal
+    their sum or the tile disagrees with the rows underneath it."""
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     loaded = [
         ("luid_0x00000000_0x0000d1e2_phys_0", 40.0 * GB),
@@ -118,8 +115,8 @@ def test_loaded_card_agrees_with_the_per_device_figures(win_rocm, monkeypatch):
 
 
 def test_no_aggregate_when_the_counter_is_unavailable(win_rocm, monkeypatch):
-    """A localized or missing counter set must stay Unknown rather than become 0:
-    that fabricated zero is the #7072 symptom this pair started from."""
+    """A localized or missing counter set stays Unknown rather than becoming 0: that
+    fabricated zero is the #7072 symptom this pair started from."""
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output = "__NONE__\n"))
 
@@ -146,9 +143,9 @@ def test_aggregate_requires_a_counter_per_visible_device():
 
 
 def test_aggregate_rejects_a_usage_larger_than_any_visible_card():
-    """A masked 45 GiB card at 40 GiB beside a visible idle 8 GiB card: the counts
-    can match by accident, but 40 GiB cannot be on an 8 GiB card, so the counter set
-    is not the visible set and the sum would be a hidden GPU's."""
+    """A masked 45 GiB card at 40 GiB beside a visible idle 8 GiB card: the counts can
+    match by accident, but 40 GiB cannot be on an 8 GiB card, so the counter set is
+    not the visible set and the sum would be a hidden GPU's."""
     agg = hw._rocm_windows_aggregate_used_bytes
     assert agg([40 * GB, 10 * MiB], [8 * GB]) is None
     assert agg([40 * GB, 6 * GB], [45 * GB, 4 * GB]) is None
@@ -159,12 +156,12 @@ def test_aggregate_rejects_a_usage_larger_than_any_visible_card():
 def test_aggregate_never_sums_bytes_that_are_not_on_a_visible_card():
     """The reason an unexplained instance is refused rather than filtered out.
 
-    ``Get-Counter`` lists every WDDM adapter and the instance names carry no
-    vendor, LUID or PCI key, so a counter cannot be told apart from a foreign
-    adapter's. Dropping the small ones to force a 1:1 count keeps the foreign
-    reading and drops the quiet visible card whenever the foreign adapter is the
-    busier of the two, and the host total then reports bytes that are on no
-    visible card. Each case below is one that a noise filter would have summed.
+    ``Get-Counter`` lists every WDDM adapter and the instance names carry no vendor,
+    LUID or PCI key, so a counter cannot be told apart from a foreign adapter's.
+    Dropping the small ones to force a 1:1 count keeps the foreign reading and drops
+    the quiet visible card whenever the foreign adapter is the busier of the two, and
+    the host total then reports bytes on no visible card. Each case below is one that
+    a noise filter would have summed.
     """
     agg = hw._rocm_windows_aggregate_used_bytes
     pair = [45 * GB, 8 * GB]
@@ -184,9 +181,9 @@ def test_aggregate_never_sums_bytes_that_are_not_on_a_visible_card():
 
 
 def test_aggregate_is_stable_across_a_changing_instance_list(win_rocm, monkeypatch):
-    """Counters come and go between polls (a placeholder adapter appears, a card
-    is masked mid-session). Every poll is judged on its own list, so the tile
-    alternates between the real figure and Unknown, never between two figures."""
+    """Counters come and go between polls (a placeholder adapter appears, a card is
+    masked mid-session). Every poll is judged on its own list, so the tile alternates
+    between the real figure and Unknown, never between two figures."""
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(REPORTER_DEVICES, free_equals_total = True))
     polls = [
         (IDLE_ADAPTERS, pytest.approx(0.36, abs = 0.01)),
@@ -203,10 +200,9 @@ def test_aggregate_is_stable_across_a_changing_instance_list(win_rocm, monkeypat
 
 
 def test_aggregate_tolerates_a_wddm_spill_over_the_smaller_card(win_rocm, monkeypatch):
-    """WDDM satisfies an overrun from host RAM, so a usage can exceed the card it
-    sits on. That only has to not fabricate a number: the reading above the LARGEST
-    visible capacity is refused, and one that still fits the ranking is summed as
-    reported rather than clamped."""
+    """WDDM satisfies an overrun from host RAM, so a usage can exceed the card it sits
+    on. That only has to not fabricate a number: a reading above the LARGEST visible
+    capacity is refused, one that still fits the ranking is summed as reported."""
     agg = hw._rocm_windows_aggregate_used_bytes
     assert agg([9 * GB, 0.3 * GB], [45 * GB, 8 * GB]) == pytest.approx(9.3 * GB)
     assert agg([46 * GB, 2 * GB], [45 * GB, 8 * GB]) is None
@@ -220,9 +216,9 @@ def test_aggregate_tolerates_a_wddm_spill_over_the_smaller_card(win_rocm, monkey
 def _merged_gpu_info(monkeypatch, visibility, utilization):
     """Run main's payload merge over two stubbed probes and return the training half.
 
-    Both probes are function-local imports from utils.hardware, so they are patched
-    on the package. The module-level cache is cleared first or a neighbouring test's
-    payload is returned instead of this one.
+    Both probes are function-local imports from utils.hardware, so they are patched on
+    the package. The module-level cache is cleared first, or a neighbouring test's
+    payload comes back instead.
     """
     import main
     import utils.hardware as uh
@@ -252,16 +248,14 @@ def _probe_pair(visible_indices, util_indices, aggregate):
 
 
 def test_aggregate_is_dropped_when_the_probes_enumerate_different_cards(monkeypatch):
-    """The tile divides the aggregate by the SUMMED totals of the rows it shows, so
-    a total taken over cards the rows do not list reads above 100 percent and the
-    free figure clamps to 0. metrics_match cannot catch it: on the only path that
-    sets an aggregate, Windows ROCm, both probes label themselves "rocm", so it is
-    unconditionally true and constrains nothing about which cards were counted.
-
-    The two probes really do enumerate independently -- the visibility side calls
-    mem_get_info per device and drops one that raises, the aggregate side reads
-    torch properties only and keeps it -- so the sets can differ with both probes
-    reporting success.
+    """The tile divides the aggregate by the SUMMED totals of the rows it shows, so a
+    total taken over cards the rows do not list reads above 100 percent and free
+    clamps to 0. metrics_match cannot catch it: on the only path that sets an
+    aggregate, Windows ROCm, both probes label themselves "rocm", so it is
+    unconditionally true and says nothing about which cards were counted. The probes
+    really do enumerate independently -- visibility calls mem_get_info per device and
+    drops one that raises, the aggregate side reads torch properties only and keeps
+    it -- so the sets can differ with both probes reporting success.
     """
     visibility, utilization = _probe_pair([0], [0, 1], 46.0)
     gpu_info = _merged_gpu_info(monkeypatch, visibility, utilization)

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1596,26 +1596,40 @@ def _rocm_windows_aggregate_used_bytes(
     bijection it is the same whichever way round the usages go, so the System tab
     keeps a real figure where per-device honestly cannot.
 
-    Emitted only when the counters are exactly the visible set: one supra-threshold
-    counter per device (sub-threshold extras are the Basic Render Driver style
-    placeholders) and no usage above its ranked capacity, which is the same
-    bijection _match_adapter_used_to_devices already requires. Same residual
-    assumption as that function: a sub-threshold counter is taken for a placeholder
-    rather than an idle visible card. ``None`` when that does not hold.
+    Emitted only when the counter list IS the visible set, which is established by
+    cardinality alone: ``Get-Counter`` returns an instance for every WDDM adapter,
+    so a visible card is always somewhere in the list, and a list exactly as long
+    as the visible set therefore contains those cards and nothing else.
+
+    Deliberately NOT the noise filter _match_adapter_used_to_devices uses. Dropping
+    the sub-threshold counters and summing the rest is safe for per-device
+    attribution, which only ever emits a capacity-FORCED value, but not for a sum,
+    which emits every counter it kept. The counters carry no vendor, LUID or PCI
+    key, so a retained counter cannot be told apart from a foreign adapter: a card
+    hidden by ``HIP_VISIBLE_DEVICES``, an iGPU, an NVIDIA card in the same box or a
+    Basic Render Driver placeholder above the cutoff. Whenever such an adapter is
+    busier than one visible card is idle, the filter drops the visible card and
+    keeps the foreign one, and the sum silently gains bytes that are on no visible
+    card at all. A host total that is confidently wrong is worse than Unknown, so
+    an unexplained instance means ``None``.
+
+    Extra instances are common, so this is narrow on purpose. Widening it needs the
+    counters joined to devices on LUID or PCI bus id rather than on capacity rank,
+    which is the same key _match_adapter_used_to_devices lacks.
     """
     n = len(device_totals)
     if n == 0 or not adapter_useds:
         return None
-    useds = sorted(adapter_useds, reverse = True)
-    if len(useds) > n:
-        useds = [u for u in useds if u >= _ROCM_WIN_ADAPTER_MIN_BYTES]
-    # Fewer counters than devices means a visible card has no reading of its own,
-    # so the sum is not the visible set's total.
-    if len(useds) != n:
+    # More counters than devices: an adapter in the list is not one of ours and
+    # there is no key that says which. Fewer: a visible card has no reading of its
+    # own, so the sum is not the visible set's total. Either way, unknown.
+    if len(adapter_useds) != n:
         return None
+    useds = sorted(adapter_useds, reverse = True)
     ranked_totals = sorted(device_totals, reverse = True)
-    # A usage above its ranked capacity cannot be on any visible card, so an adapter
-    # outside the visibility mask is in the list and its bytes are not ours to add.
+    # A usage above its ranked capacity cannot be on any visible card, so the list
+    # is not the visible set after all even at matching length (a reading was
+    # dropped while parsing, or a counter is not a dedicated-VRAM figure).
     for rank in range(n):
         if useds[rank] > ranked_totals[rank]:
             return None

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1601,10 +1601,14 @@ def _rocm_windows_aggregate_used_bytes(
     small model report unknown (#7452). The SUM does not need the pairing -- over a
     bijection it is the same whichever way round the usages go -- so the System tab
     keeps a real figure where per-device honestly cannot. Emitted only when the
-    counter list IS the visible set, established by cardinality alone:
-    ``Get-Counter`` returns an instance for every WDDM adapter, so a visible card is
-    always in the list and a list exactly as long as the visible set therefore holds
-    those cards and nothing else.
+    counter list IS the visible set, established by cardinality alone. That rests on
+    one ASSUMPTION, stated as such because it is not confirmed against Microsoft's
+    counter documentation: that ``Get-Counter`` emits exactly one instance per WDDM
+    adapter, so a visible card is always in the list and a list exactly as long as
+    the visible set therefore holds those cards and nothing else. It fails closed if
+    that is wrong: a second instance for one adapter makes the list longer than the
+    visible set, which returns None rather than a total. Verify it before widening
+    this, not before trusting it.
 
     Deliberately NOT the noise filter _match_adapter_used_to_devices uses. Dropping
     sub-threshold counters and summing the rest is safe for per-device attribution,

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1060,11 +1060,23 @@ def _torch_get_physical_gpu_count() -> Optional[int]:
 def rocm_windows_free_is_untrusted() -> bool:
     """Whether ``mem_get_info``'s FREE half must be treated as an over-report.
 
-    On Windows ROCm the driver's free figure does not track residency: it is
-    commonly returned unchanged as VRAM fills, so it reads at or near ``total`` on
-    a card that is nearly full (ROCm/librocdxg#57, ROCm/TheRock#3724, and
-    ggml-org/llama.cpp#24836 on the reading being OS-dependent). The TOTAL half is
-    fine, and every other platform is left alone.
+    AMD documents this. The hipMemGetInfo reference carries the warning verbatim:
+    "On Windows, the free memory only accounts for memory allocated by this
+    process and may be optimistic." WDDM virtualises video memory, so a process is
+    told its own budget rather than the card's residency, and a fresh process sees
+    free at or near total whatever else is resident. An AMD engineer states the
+    same in ROCm/librocdxg#57, with a measured 24410 MiB of 24560 reported free on
+    a deliberately filled card, and confirms it is the intended Windows model
+    rather than a defect. Corroborating symptom in ROCm/TheRock#3724: torch OOM on
+    Windows while reporting 52.71 GiB of a 53.92 GiB card free.
+
+    Near ``total``, not equal to it, which is why callers cap instead of testing
+    for a sentinel value. The TOTAL half is fine.
+
+    Every other platform is left alone, WSL included and deliberately: AMD keeps
+    the WSL2 reading consistent with native Linux, where free tracks physical
+    residency, and ``sys.platform`` is "linux" there, so this predicate is False
+    and the accurate figure is passed through uncapped.
 
     One predicate for the whole backend so the sentinel is recognised in one place
     (#7452 reporting side, #8403 guard side).

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1060,26 +1060,21 @@ def _torch_get_physical_gpu_count() -> Optional[int]:
 def rocm_windows_free_is_untrusted() -> bool:
     """Whether ``mem_get_info``'s FREE half must be treated as an over-report.
 
-    AMD documents this. The hipMemGetInfo reference carries the warning verbatim:
-    "On Windows, the free memory only accounts for memory allocated by this
-    process and may be optimistic." WDDM virtualises video memory, so a process is
-    told its own budget rather than the card's residency, and a fresh process sees
-    free at or near total whatever else is resident. An AMD engineer states the
-    same in ROCm/librocdxg#57, with a measured 24410 MiB of 24560 reported free on
-    a deliberately filled card, and confirms it is the intended Windows model
-    rather than a defect. Corroborating symptom in ROCm/TheRock#3724: torch OOM on
-    Windows while reporting 52.71 GiB of a 53.92 GiB card free.
+    AMD documents this: the hipMemGetInfo reference warns "On Windows, the free
+    memory only accounts for memory allocated by this process and may be optimistic."
+    WDDM virtualises video memory, so a process is told its own budget rather than
+    the card's residency and a fresh process sees free at or near total whatever else
+    is resident. An AMD engineer confirms in ROCm/librocdxg#57 that this is the
+    intended Windows model rather than a defect, measuring 24410 MiB of 24560
+    reported free on a deliberately filled card; ROCm/TheRock#3724 is the same
+    symptom, torch OOM while reporting 52.71 GiB of a 53.92 GiB card free.
 
-    Near ``total``, not equal to it, which is why callers cap instead of testing
-    for a sentinel value. The TOTAL half is fine.
-
-    Every other platform is left alone, WSL included and deliberately: AMD keeps
-    the WSL2 reading consistent with native Linux, where free tracks physical
-    residency, and ``sys.platform`` is "linux" there, so this predicate is False
-    and the accurate figure is passed through uncapped.
-
-    One predicate for the whole backend so the sentinel is recognised in one place
-    (#7452 reporting side, #8403 guard side).
+    Near ``total``, not equal to it, so callers cap instead of testing for a
+    sentinel. The TOTAL half is fine. Every other platform is left alone, WSL
+    included and deliberately: AMD keeps the WSL2 reading consistent with native
+    Linux, where free tracks physical residency, and ``sys.platform`` is "linux"
+    there, so this is False and the accurate figure passes through uncapped. One
+    predicate for the whole backend (#7452 reporting side, #8403 guard side).
     """
     return sys.platform == "win32" and IS_ROCM
 
@@ -1088,10 +1083,9 @@ def _torch_get_per_device_info(device_indices: list[int]) -> list[Dict[str, Any]
     """Query torch for per-GPU name, total VRAM, and used VRAM.
 
     ``used_gb`` is ``None`` on Windows ROCm when the driver reports ``free ==
-    total``: that 0 means unknown, not empty. This is the DISPLAY path, so it
-    reports unknown rather than a pessimistic ceiling; a ceiling is the right
-    answer for a refusal and the wrong one for a number shown to the user as
-    measured.
+    total``: that 0 means unknown, not empty. This is the DISPLAY path, so unknown
+    rather than a pessimistic ceiling, which is the right answer for a refusal and
+    the wrong one for a number shown to the user as measured.
     """
     mod, _ = _torch_get_device_module()
     if mod is None:
@@ -1604,44 +1598,40 @@ def _rocm_windows_aggregate_used_bytes(
 
     Per-device attribution needs capacity to FORCE a pairing, and on an asymmetric
     pair (45 GiB + 8 GiB) nothing at or below 8 GiB is forced, so idle and every
-    small model report unknown (#7452). The SUM does not need the pairing: over a
-    bijection it is the same whichever way round the usages go, so the System tab
-    keeps a real figure where per-device honestly cannot.
-
-    Emitted only when the counter list IS the visible set, which is established by
-    cardinality alone: ``Get-Counter`` returns an instance for every WDDM adapter,
-    so a visible card is always somewhere in the list, and a list exactly as long
-    as the visible set therefore contains those cards and nothing else.
+    small model report unknown (#7452). The SUM does not need the pairing -- over a
+    bijection it is the same whichever way round the usages go -- so the System tab
+    keeps a real figure where per-device honestly cannot. Emitted only when the
+    counter list IS the visible set, established by cardinality alone:
+    ``Get-Counter`` returns an instance for every WDDM adapter, so a visible card is
+    always in the list and a list exactly as long as the visible set therefore holds
+    those cards and nothing else.
 
     Deliberately NOT the noise filter _match_adapter_used_to_devices uses. Dropping
-    the sub-threshold counters and summing the rest is safe for per-device
-    attribution, which only ever emits a capacity-FORCED value, but not for a sum,
-    which emits every counter it kept. The counters carry no vendor, LUID or PCI
-    key, so a retained counter cannot be told apart from a foreign adapter: a card
-    hidden by ``HIP_VISIBLE_DEVICES``, an iGPU, an NVIDIA card in the same box or a
-    Basic Render Driver placeholder above the cutoff. Whenever such an adapter is
-    busier than one visible card is idle, the filter drops the visible card and
-    keeps the foreign one, and the sum silently gains bytes that are on no visible
-    card at all. A host total that is confidently wrong is worse than Unknown, so
-    an unexplained instance means ``None``.
-
-    Extra instances are common, so this is narrow on purpose. Widening it needs the
-    counters joined to devices on LUID or PCI bus id rather than on capacity rank,
-    which is the same key _match_adapter_used_to_devices lacks.
+    sub-threshold counters and summing the rest is safe for per-device attribution,
+    which only ever emits a capacity-FORCED value, but not for a sum, which emits
+    every counter it kept. The counters carry no vendor, LUID or PCI key, so a
+    retained counter cannot be told apart from a foreign adapter: a card hidden by
+    ``HIP_VISIBLE_DEVICES``, an iGPU, an NVIDIA card in the same box or a Basic
+    Render Driver placeholder above the cutoff. Whenever such an adapter is busier
+    than one visible card is idle, the filter drops the visible card and keeps the
+    foreign one, and the sum silently gains bytes on no visible card at all. A host
+    total that is confidently wrong is worse than Unknown, so an unexplained instance
+    means ``None``. Extra instances are common, so this is narrow on purpose;
+    widening it needs the counters joined to devices on LUID or PCI bus id rather
+    than on capacity rank, the same key _match_adapter_used_to_devices lacks.
     """
     n = len(device_totals)
     if n == 0 or not adapter_useds:
         return None
-    # More counters than devices: an adapter in the list is not one of ours and
-    # there is no key that says which. Fewer: a visible card has no reading of its
-    # own, so the sum is not the visible set's total. Either way, unknown.
+    # More counters than devices: one is not ours, and no key says which. Fewer: a
+    # visible card has no reading. Either way the sum is not the visible set's.
     if len(adapter_useds) != n:
         return None
     useds = sorted(adapter_useds, reverse = True)
     ranked_totals = sorted(device_totals, reverse = True)
-    # A usage above its ranked capacity cannot be on any visible card, so the list
-    # is not the visible set after all even at matching length (a reading was
-    # dropped while parsing, or a counter is not a dedicated-VRAM figure).
+    # A usage above its ranked capacity is on no visible card, so even at matching
+    # length the list is not the visible set (a reading was dropped while parsing, or
+    # a counter is not a dedicated-VRAM figure).
     for rank in range(n):
         if useds[rank] > ranked_totals[rank]:
             return None
@@ -1655,11 +1645,11 @@ def _rocm_windows_per_device_vram(
     used from the per-adapter Dedicated Usage counter.
 
     Returns ``([{index, visible_ordinal, name, used_gb, total_gb}], aggregate_gb)``
-    per visible GPU (``used_gb`` may be ``None`` when the counter is unavailable or
-    the pairing is not capacity-forced), or ``([], None)`` when torch can't
-    enumerate devices so callers fall through to the torch last resort. The second
-    element is the visible set's total used VRAM, which survives a pairing that no
-    single device can claim (#7452), or ``None`` when even that is not established.
+    per visible GPU (``used_gb`` is ``None`` when the counter is unavailable or the
+    pairing is not capacity-forced), or ``([], None)`` when torch can't enumerate
+    devices so callers fall through to the torch last resort. ``aggregate_gb`` is the
+    visible set's total used VRAM, which survives a pairing no single device can
+    claim (#7452), and ``None`` when even that is not established.
     """
     if platform.system() != "Windows":
         return [], None
@@ -2160,8 +2150,8 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
                     "parent_visible_gpu_ids": win_numeric_ids or [],
                     "devices": devices,
                     "index_kind": win_index_kind,
-                    # Host-level used VRAM for the System tab tile: known even when
-                    # no single device's usage is attributable (#7452).
+                    # Host total for the System tab tile: known even when no single
+                    # device's usage is attributable (#7452).
                     "vram_used_gb_aggregate": win_aggregate,
                 }
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1057,11 +1057,29 @@ def _torch_get_physical_gpu_count() -> Optional[int]:
         return None
 
 
+def rocm_windows_free_is_untrusted() -> bool:
+    """Whether ``mem_get_info``'s FREE half must be treated as an over-report.
+
+    On Windows ROCm the driver's free figure does not track residency: it is
+    commonly returned unchanged as VRAM fills, so it reads at or near ``total`` on
+    a card that is nearly full (ROCm/librocdxg#57, ROCm/TheRock#3724, and
+    ggml-org/llama.cpp#24836 on the reading being OS-dependent). The TOTAL half is
+    fine, and every other platform is left alone.
+
+    One predicate for the whole backend so the sentinel is recognised in one place
+    (#7452 reporting side, #8403 guard side).
+    """
+    return sys.platform == "win32" and IS_ROCM
+
+
 def _torch_get_per_device_info(device_indices: list[int]) -> list[Dict[str, Any]]:
     """Query torch for per-GPU name, total VRAM, and used VRAM.
 
-    ``used_gb`` is ``None`` on Windows ROCm when ``hipMemGetInfo`` reports
-    ``free == total`` (ROCm/ROCm#1909): that 0 means unknown, not empty.
+    ``used_gb`` is ``None`` on Windows ROCm when the driver reports ``free ==
+    total``: that 0 means unknown, not empty. This is the DISPLAY path, so it
+    reports unknown rather than a pessimistic ceiling; a ceiling is the right
+    answer for a refusal and the wrong one for a number shown to the user as
+    measured.
     """
     mod, _ = _torch_get_device_module()
     if mod is None:
@@ -1069,7 +1087,7 @@ def _torch_get_per_device_info(device_indices: list[int]) -> list[Dict[str, Any]
 
     device = get_device()
     # free==total is a Windows-ROCm-only quirk.
-    _win_rocm = sys.platform == "win32" and IS_ROCM
+    _win_rocm = rocm_windows_free_is_untrusted()
     devices = []
     for ordinal, phys_idx in enumerate(device_indices):
         try:
@@ -1567,19 +1585,61 @@ def _match_adapter_used_to_devices(
     return assigned
 
 
-def _rocm_windows_per_device_vram(device_indices: list[int]) -> list[Dict[str, Any]]:
+def _rocm_windows_aggregate_used_bytes(
+    adapter_useds: list[float], device_totals: list[float]
+) -> Optional[float]:
+    """Total VRAM used across the visible devices, when the counters cover them 1:1.
+
+    Per-device attribution needs capacity to FORCE a pairing, and on an asymmetric
+    pair (45 GiB + 8 GiB) nothing at or below 8 GiB is forced, so idle and every
+    small model report unknown (#7452). The SUM does not need the pairing: over a
+    bijection it is the same whichever way round the usages go, so the System tab
+    keeps a real figure where per-device honestly cannot.
+
+    Emitted only when the counters are exactly the visible set: one supra-threshold
+    counter per device (sub-threshold extras are the Basic Render Driver style
+    placeholders) and no usage above its ranked capacity, which is the same
+    bijection _match_adapter_used_to_devices already requires. Same residual
+    assumption as that function: a sub-threshold counter is taken for a placeholder
+    rather than an idle visible card. ``None`` when that does not hold.
+    """
+    n = len(device_totals)
+    if n == 0 or not adapter_useds:
+        return None
+    useds = sorted(adapter_useds, reverse = True)
+    if len(useds) > n:
+        useds = [u for u in useds if u >= _ROCM_WIN_ADAPTER_MIN_BYTES]
+    # Fewer counters than devices means a visible card has no reading of its own,
+    # so the sum is not the visible set's total.
+    if len(useds) != n:
+        return None
+    ranked_totals = sorted(device_totals, reverse = True)
+    # A usage above its ranked capacity cannot be on any visible card, so an adapter
+    # outside the visibility mask is in the list and its bytes are not ours to add.
+    for rank in range(n):
+        if useds[rank] > ranked_totals[rank]:
+            return None
+    return float(sum(useds))
+
+
+def _rocm_windows_per_device_vram(
+    device_indices: list[int],
+) -> tuple[list[Dict[str, Any]], Optional[float]]:
     """Per-GPU VRAM on Windows AMD/ROCm: total from torch properties (reliable),
     used from the per-adapter Dedicated Usage counter.
 
-    Returns ``{index, visible_ordinal, name, used_gb, total_gb}`` per visible GPU
-    (``used_gb`` may be ``None`` when the counter is unavailable), or ``[]`` when
-    torch can't enumerate devices so callers fall through to the torch last resort.
+    Returns ``([{index, visible_ordinal, name, used_gb, total_gb}], aggregate_gb)``
+    per visible GPU (``used_gb`` may be ``None`` when the counter is unavailable or
+    the pairing is not capacity-forced), or ``([], None)`` when torch can't
+    enumerate devices so callers fall through to the torch last resort. The second
+    element is the visible set's total used VRAM, which survives a pairing that no
+    single device can claim (#7452), or ``None`` when even that is not established.
     """
     if platform.system() != "Windows":
-        return []
+        return [], None
     mod, _ = _torch_get_device_module()
     if mod is None:
-        return []
+        return [], None
     # Totals/names from torch properties (mem_get_info's free==total quirk zeroes used).
     dev_meta: list[Dict[str, Any]] = []
     for ordinal, phys_idx in enumerate(device_indices):
@@ -1596,14 +1656,17 @@ def _rocm_windows_per_device_vram(device_indices: list[int]) -> list[Dict[str, A
         except Exception as e:
             logger.debug("torch property probe failed for ordinal %d: %s", ordinal, e)
     if not dev_meta:
-        return []
+        return [], None
 
     adapters = _rocm_windows_perf_counter_vram_by_adapter()
+    aggregate_gb: Optional[float] = None
     if adapters:
-        assigned = _match_adapter_used_to_devices(
-            [used for _, used in adapters],
-            [d["total_bytes"] for d in dev_meta],
-        )
+        adapter_useds = [used for _, used in adapters]
+        totals = [d["total_bytes"] for d in dev_meta]
+        assigned = _match_adapter_used_to_devices(adapter_useds, totals)
+        aggregate_bytes = _rocm_windows_aggregate_used_bytes(adapter_useds, totals)
+        if aggregate_bytes is not None:
+            aggregate_gb = round(aggregate_bytes / (1024**3), 2)
     else:
         # Counter unavailable: show every GPU with a correct total, used unknown.
         assigned = [None] * len(dev_meta)
@@ -1621,7 +1684,7 @@ def _rocm_windows_per_device_vram(device_indices: list[int]) -> list[Dict[str, A
                 "total_gb": total_gb,
             }
         )
-    return devices
+    return devices, aggregate_gb
 
 
 def _rocm_windows_device_payload_entry(
@@ -1718,7 +1781,7 @@ def get_gpu_utilization() -> Dict[str, Any]:
             _win_ids = _get_parent_visible_gpu_spec().get("numeric_ids")
             if not _win_ids:
                 _win_ids = list(range(_torch_get_physical_gpu_count() or 0))
-            _win_devices = _rocm_windows_per_device_vram(_win_ids)
+            _win_devices, _win_aggregate = _rocm_windows_per_device_vram(_win_ids)
             if _win_devices:
                 # A single visible GPU can own the aggregate 3D-engine utilization;
                 # across several GPUs the sum isn't per-device, so leave it unset.
@@ -1731,6 +1794,7 @@ def get_gpu_utilization() -> Dict[str, Any]:
                         _rocm_windows_device_payload_entry(device, _wd, _win_util)
                         for _wd in _win_devices
                     ],
+                    vram_used_gb_aggregate = _win_aggregate,
                 )
 
         # Fallback Linux ROCm
@@ -2040,7 +2104,7 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
             else:
                 win_ids = list(range(_torch_get_physical_gpu_count() or 0))
                 win_index_kind = "relative"
-            win_devices = _rocm_windows_per_device_vram(win_ids)
+            win_devices, win_aggregate = _rocm_windows_per_device_vram(win_ids)
             if win_devices:
                 devices = []
                 for wd in win_devices:
@@ -2070,6 +2134,9 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
                     "parent_visible_gpu_ids": win_numeric_ids or [],
                     "devices": devices,
                     "index_kind": win_index_kind,
+                    # Host-level used VRAM for the System tab tile: known even when
+                    # no single device's usage is attributable (#7452).
+                    "vram_used_gb_aggregate": win_aggregate,
                 }
 
     # Torch-based fallback for CUDA (nvidia-smi unavailable, AMD ROCm) and XPU (Intel)

--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -7,6 +7,7 @@ import {
   useMonitorFrameStore,
   useMonitorOverlayStore,
 } from "@/features/settings";
+import { resolveGpuVramUsedGb } from "@/hooks/gpu-vram";
 import { aggregateGpuMemoryTotalGb, useSystemInfo } from "@/hooks/use-system";
 import { useT } from "@/i18n";
 import {
@@ -466,13 +467,11 @@ function FloatingMonitorPanel({
   const devices = displayedGpu?.devices ?? [];
   const vramTotal = aggregateGpuMemoryTotalGb(devices);
   // null usage = unknown (e.g. Windows ROCm perf counter): treating it as 0
-  // fabricates a 0-used readout, so the aggregate is unknown if any device is.
-  const vramUsageKnown =
-    devices.length > 0 &&
-    devices.every((device) => Number.isFinite(device.vram_used_gb));
-  const vramUsed = vramUsageKnown
-    ? devices.reduce((sum, device) => sum + (device.vram_used_gb ?? 0), 0)
-    : 0;
+  // fabricates a 0-used readout. The host-level figure can still be known when
+  // no single device's is, which is the #7452 case.
+  const resolvedVramUsed = resolveGpuVramUsedGb(displayedGpu);
+  const vramUsageKnown = resolvedVramUsed !== null;
+  const vramUsed = resolvedVramUsed ?? 0;
   const vramPercent = clampPercent(
     vramUsageKnown && vramTotal > 0 ? (vramUsed / vramTotal) * 100 : 0,
   );

--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -466,9 +466,8 @@ function FloatingMonitorPanel({
     : 0;
   const devices = displayedGpu?.devices ?? [];
   const vramTotal = aggregateGpuMemoryTotalGb(devices);
-  // null usage = unknown (e.g. Windows ROCm perf counter): treating it as 0
-  // fabricates a 0-used readout. The host-level figure can still be known when
-  // no single device's is, which is the #7452 case.
+  // null usage = unknown (e.g. Windows ROCm perf counter); 0 would fabricate a
+  // readout. The host figure can still be known when no device's is (#7452).
   const resolvedVramUsed = resolveGpuVramUsedGb(displayedGpu);
   const vramUsageKnown = resolvedVramUsed !== null;
   const vramUsed = resolvedVramUsed ?? 0;

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -11,6 +11,10 @@ import {
   pickHuggingFaceCacheDir,
 } from "@/features/native-intents";
 import {
+  gpuVramUsedIsPerDevice,
+  resolveGpuVramUsedGb,
+} from "@/hooks/gpu-vram";
+import {
   aggregateGpuMemoryTotalGb,
   useSystemInfo,
   type GpuDevice,
@@ -239,14 +243,12 @@ export function ResourcesTab() {
     const diskUsed = Math.max(0, diskTotal - diskFree);
     const vramTotal = aggregateGpuMemoryTotalGb(devices);
     // null usage = unknown (e.g. Windows ROCm perf counter): treating it as 0
-    // fabricates a 0-used total, so the aggregate is unknown if any device is.
-    const vramUsageKnown =
-      devices.length > 0 &&
-      devices.every((device) => isFiniteNumber(device.vram_used_gb));
-    const vramUsed = vramUsageKnown
-      ? devices.reduce((sum, device) => sum + (device.vram_used_gb ?? 0), 0)
-      : null;
-    const vramFree = vramUsageKnown
+    // fabricates a 0-used total, so a device's own row stays unknown. The
+    // host-level figure can still be known when no device's is (#7452).
+    const perDeviceKnown = gpuVramUsedIsPerDevice(devices);
+    const vramUsed = resolveGpuVramUsedGb(displayedGpu);
+    const vramUsageKnown = vramUsed !== null;
+    const vramFree = perDeviceKnown
       ? devices.reduce(
           (sum, device) =>
             sum +
@@ -257,7 +259,9 @@ export function ResourcesTab() {
               )),
           0,
         )
-      : null;
+      : vramUsed !== null
+        ? Math.max(0, vramTotal - vramUsed)
+        : null;
     const vramPercent =
       vramUsageKnown && isFiniteNumber(vramUsed) && vramTotal > 0
         ? (vramUsed / vramTotal) * 100

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -242,9 +242,9 @@ export function ResourcesTab() {
     const diskFree = systemInfo.disk?.free_gb ?? 0;
     const diskUsed = Math.max(0, diskTotal - diskFree);
     const vramTotal = aggregateGpuMemoryTotalGb(devices);
-    // null usage = unknown (e.g. Windows ROCm perf counter): treating it as 0
-    // fabricates a 0-used total, so a device's own row stays unknown. The
-    // host-level figure can still be known when no device's is (#7452).
+    // null usage = unknown (e.g. Windows ROCm perf counter); 0 would fabricate a
+    // total, so the device's own row stays unknown. The host figure can still be
+    // known when no device's is (#7452).
     const perDeviceKnown = gpuVramUsedIsPerDevice(devices);
     const vramUsed = resolveGpuVramUsedGb(displayedGpu);
     const vramUsageKnown = vramUsed !== null;

--- a/studio/frontend/src/hooks/gpu-vram.ts
+++ b/studio/frontend/src/hooks/gpu-vram.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Split out of use-system.ts so the VRAM reading rules can be unit tested without
+// pulling the auth and React graph in behind them. Typed structurally, so
+// SystemGpuInfo and GpuDevice satisfy these without importing them.
+
+export interface VramReportingDevice {
+  vram_used_gb?: number;
+}
+
+export interface VramReportingGpu {
+  devices?: VramReportingDevice[];
+  /** Used VRAM across the visible GPUs when no single device's usage could be
+   * attributed. Windows ROCm only; null everywhere else. See #7452. */
+  vram_used_gb_aggregate?: number | null;
+}
+
+/** Whether every device reports its own usage, so the per-device figures can be
+ * summed and each row can show a real number. */
+export function gpuVramUsedIsPerDevice(
+  devices: VramReportingDevice[],
+): boolean {
+  return (
+    devices.length > 0 &&
+    devices.every((device) => Number.isFinite(device.vram_used_gb))
+  );
+}
+
+/** Used VRAM across the GPUs, or null when it is genuinely unknown.
+ *
+ * Per-device usage is the preferred source. On Windows ROCm there is no shared
+ * key between the LUID usage counters and torch ordinals, so a usage that fits
+ * more than one card cannot be attributed to either and every device reports
+ * unknown -- which is idle and every small model on an asymmetric pair. The sum
+ * does not depend on that attribution, so the backend still reports it, and
+ * rendering Unknown for a figure it already has is what #7452 was.
+ *
+ * Never falls back to 0: a fabricated 0 used / full free is the #7072 symptom
+ * this pair started from. */
+export function resolveGpuVramUsedGb(
+  gpu: VramReportingGpu | null | undefined,
+): number | null {
+  const devices = gpu?.devices ?? [];
+  if (gpuVramUsedIsPerDevice(devices)) {
+    return devices.reduce((sum, device) => sum + (device.vram_used_gb ?? 0), 0);
+  }
+  const aggregate = gpu?.vram_used_gb_aggregate;
+  return Number.isFinite(aggregate) ? (aggregate as number) : null;
+}

--- a/studio/frontend/src/hooks/gpu-vram.ts
+++ b/studio/frontend/src/hooks/gpu-vram.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Split out of use-system.ts so the VRAM reading rules can be unit tested without
-// pulling the auth and React graph in behind them. Typed structurally, so
-// SystemGpuInfo and GpuDevice satisfy these without importing them.
+// Split out of use-system.ts so the VRAM rules can be unit tested without pulling
+// the auth and React graph in behind them. Typed structurally, so SystemGpuInfo and
+// GpuDevice satisfy these without importing them.
 
 export interface VramReportingDevice {
   vram_used_gb?: number;
@@ -16,8 +16,7 @@ export interface VramReportingGpu {
   vram_used_gb_aggregate?: number | null;
 }
 
-/** Whether every device reports its own usage, so the per-device figures can be
- * summed and each row can show a real number. */
+/** Whether every device reports its own usage, so each row and their sum are real. */
 export function gpuVramUsedIsPerDevice(
   devices: VramReportingDevice[],
 ): boolean {
@@ -29,15 +28,14 @@ export function gpuVramUsedIsPerDevice(
 
 /** Used VRAM across the GPUs, or null when it is genuinely unknown.
  *
- * Per-device usage is the preferred source. On Windows ROCm there is no shared
- * key between the LUID usage counters and torch ordinals, so a usage that fits
- * more than one card cannot be attributed to either and every device reports
- * unknown -- which is idle and every small model on an asymmetric pair. The sum
- * does not depend on that attribution, so the backend still reports it, and
- * rendering Unknown for a figure it already has is what #7452 was.
+ * Per-device usage is preferred. On Windows ROCm nothing keys the LUID usage
+ * counters to torch ordinals, so a usage that fits more than one card cannot be
+ * attributed to either and every device reports unknown -- which is idle and every
+ * small model on an asymmetric pair. The sum does not depend on that attribution,
+ * so the backend still reports it, and rendering Unknown for a figure it already
+ * has is what #7452 was.
  *
- * Never falls back to 0: a fabricated 0 used / full free is the #7072 symptom
- * this pair started from. */
+ * Never falls back to 0: a fabricated 0 used / full free is the #7072 symptom. */
 export function resolveGpuVramUsedGb(
   gpu: VramReportingGpu | null | undefined,
 ): number | null {

--- a/studio/frontend/src/hooks/use-system.ts
+++ b/studio/frontend/src/hooks/use-system.ts
@@ -21,6 +21,9 @@ export interface GpuDevice {
 export interface SystemGpuInfo {
   available: boolean;
   backend?: string;
+  /** Used VRAM across the visible GPUs when no single device's usage could be
+   * attributed. Windows ROCm only; null everywhere else. See #7452. */
+  vram_used_gb_aggregate?: number | null;
   /** Whether GGUF loads accept explicit gpu_ids in the device records'
    * declared index space. */
   gguf_gpu_ids_supported?: boolean;

--- a/studio/frontend/tests/rocm-windows-vram-aggregate.test.ts
+++ b/studio/frontend/tests/rocm-windows-vram-aggregate.test.ts
@@ -11,8 +11,8 @@ import {
   type VramReportingGpu,
 } from "../src/hooks/gpu-vram.ts";
 
-// The payload shape as /api/system actually sends it: the helpers read two of
-// these fields structurally and the rest ride along, which is what the tile gets.
+// The payload as /api/system sends it: the helpers read two fields structurally and
+// the rest ride along, which is what the tile gets.
 interface SystemGpuPayload extends VramReportingGpu {
   available: boolean;
   backend?: string;
@@ -23,12 +23,10 @@ interface SystemGpuPayload extends VramReportingGpu {
   })[];
 }
 
-// Issue #7452, reported on a Windows 10 ROCm host with an AMD Radeon PRO W7900
-// (45 GiB) beside a W7500 (7.98 GiB). Windows shares no key between the LUID VRAM
-// counters and torch ordinals, so a usage that fits both cards cannot be pinned to
-// either and every device reads Unknown -- which on that pair is idle and every
-// small model. The backend still knows the host total, and the tile rendered
-// Unknown anyway.
+// Issue #7452: a Windows 10 ROCm host, AMD Radeon PRO W7900 (45 GiB) beside a W7500
+// (7.98 GiB). Nothing keys the LUID VRAM counters to torch ordinals, so a usage that
+// fits both cards reads Unknown on every device -- idle and every small model here.
+// The backend still knows the host total; the tile rendered Unknown anyway.
 function reporterGpu(
   overrides: Partial<SystemGpuPayload> = {},
 ): SystemGpuPayload {
@@ -59,7 +57,7 @@ test("per-device usage wins over the aggregate when every device reports", () =>
       },
       { index: 1, memory_total_gb: 7.98, vram_used_gb: 0.5 },
     ],
-    // Deliberately NOT 40.5. An aggregate equal to the per-device sum would pass
+    // Deliberately NOT 40.5: an aggregate equal to the per-device sum would pass
     // whichever source won, so it would not pin the precedence at all.
     vram_used_gb_aggregate: 99.0,
   });
@@ -68,8 +66,8 @@ test("per-device usage wins over the aggregate when every device reports", () =>
 });
 
 test("a partially attributed pair falls back to the aggregate, not a short sum", () => {
-  // 40 GiB is capacity-forced onto the W7900; the idle card's 0.5 GiB is not.
-  // Summing the known half alone would under-report the tile by that card.
+  // 40 GiB is capacity-forced onto the W7900, the idle card's 0.5 GiB is not;
+  // summing the known half alone would under-report the tile by that card.
   const gpu: SystemGpuPayload = reporterGpu({
     devices: [
       { index: 0, memory_total_gb: 45.0, vram_used_gb: 40.0 },

--- a/studio/frontend/tests/rocm-windows-vram-aggregate.test.ts
+++ b/studio/frontend/tests/rocm-windows-vram-aggregate.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  gpuVramUsedIsPerDevice,
+  resolveGpuVramUsedGb,
+  type VramReportingDevice,
+  type VramReportingGpu,
+} from "../src/hooks/gpu-vram.ts";
+
+// The payload shape as /api/system actually sends it: the helpers read two of
+// these fields structurally and the rest ride along, which is what the tile gets.
+interface SystemGpuPayload extends VramReportingGpu {
+  available: boolean;
+  backend?: string;
+  devices?: (VramReportingDevice & {
+    index?: number;
+    name?: string;
+    memory_total_gb?: number;
+  })[];
+}
+
+// Issue #7452, reported on a Windows 10 ROCm host with an AMD Radeon PRO W7900
+// (45 GiB) beside a W7500 (7.98 GiB). Windows shares no key between the LUID VRAM
+// counters and torch ordinals, so a usage that fits both cards cannot be pinned to
+// either and every device reads Unknown -- which on that pair is idle and every
+// small model. The backend still knows the host total, and the tile rendered
+// Unknown anyway.
+function reporterGpu(
+  overrides: Partial<SystemGpuPayload> = {},
+): SystemGpuPayload {
+  return {
+    available: true,
+    backend: "rocm",
+    devices: [
+      { index: 0, name: "AMD Radeon PRO W7900", memory_total_gb: 45.0 },
+      { index: 1, name: "AMD Radeon PRO W7500", memory_total_gb: 7.98 },
+    ],
+    vram_used_gb_aggregate: 0.36,
+    ...overrides,
+  };
+}
+
+test("unattributable per-device usage still reports the host total", () => {
+  assert.equal(resolveGpuVramUsedGb(reporterGpu()), 0.36);
+  assert.equal(gpuVramUsedIsPerDevice(reporterGpu().devices ?? []), false);
+});
+
+test("per-device usage wins over the aggregate when every device reports", () => {
+  const gpu: SystemGpuPayload = reporterGpu({
+    devices: [
+      {
+        index: 0,
+        memory_total_gb: 45.0,
+        vram_used_gb: 40.0,
+      },
+      { index: 1, memory_total_gb: 7.98, vram_used_gb: 0.5 },
+    ],
+    vram_used_gb_aggregate: 40.5,
+  });
+  assert.equal(gpuVramUsedIsPerDevice(gpu.devices ?? []), true);
+  assert.equal(resolveGpuVramUsedGb(gpu), 40.5);
+});
+
+test("a partially attributed pair falls back to the aggregate, not a short sum", () => {
+  // 40 GiB is capacity-forced onto the W7900; the idle card's 0.5 GiB is not.
+  // Summing the known half alone would under-report the tile by that card.
+  const gpu: SystemGpuPayload = reporterGpu({
+    devices: [
+      { index: 0, memory_total_gb: 45.0, vram_used_gb: 40.0 },
+      { index: 1, memory_total_gb: 7.98 },
+    ],
+    vram_used_gb_aggregate: 40.5,
+  });
+  assert.equal(resolveGpuVramUsedGb(gpu), 40.5);
+});
+
+test("no aggregate stays unknown rather than becoming zero", () => {
+  // A fabricated 0 used / full free is exactly what #7072 reported.
+  assert.equal(
+    resolveGpuVramUsedGb(reporterGpu({ vram_used_gb_aggregate: null })),
+    null,
+  );
+  assert.equal(
+    resolveGpuVramUsedGb(reporterGpu({ vram_used_gb_aggregate: undefined })),
+    null,
+  );
+  assert.equal(resolveGpuVramUsedGb(null), null);
+  assert.equal(
+    resolveGpuVramUsedGb({ devices: [] }),
+    null,
+  );
+});

--- a/studio/frontend/tests/rocm-windows-vram-aggregate.test.ts
+++ b/studio/frontend/tests/rocm-windows-vram-aggregate.test.ts
@@ -59,7 +59,9 @@ test("per-device usage wins over the aggregate when every device reports", () =>
       },
       { index: 1, memory_total_gb: 7.98, vram_used_gb: 0.5 },
     ],
-    vram_used_gb_aggregate: 40.5,
+    // Deliberately NOT 40.5. An aggregate equal to the per-device sum would pass
+    // whichever source won, so it would not pin the precedence at all.
+    vram_used_gb_aggregate: 99.0,
   });
   assert.equal(gpuVramUsedIsPerDevice(gpu.devices ?? []), true);
   assert.equal(resolveGpuVramUsedGb(gpu), 40.5);


### PR DESCRIPTION
## Problem

On a Windows ROCm host with two asymmetric AMD cards the System tab and the floating monitor show `Unknown / 53.0 GiB` used VRAM, with `Unknown used` and `Unknown free` on every device row. Reported in #7452 (Radeon PRO W7900 45 GiB plus W7500 7.98 GiB, Windows 10, ROCm 7.13).

Worth stating precisely, because the issue title is shorthand: per-device **totals are correct** in the reporter's own screenshot (`45.0 GiB total`, `7.98 GiB total`). Only the usage side is blank. Totals come from `torch.get_device_properties`, which is reliable. Nothing here claims to fix a total.

This is a regression from the fix for #7072 (#7238), by the same reporter six days later, and it cannot be fixed by reverting: #7238 exists because the old code fabricated per-device usage.

Windows shares no key between the LUID `GPU Adapter Memory` counter instances and torch ordinals, so #7238 pairs usage to devices by capacity ranking and keeps a value only when capacity forces it. On a 45 GiB plus 7.98 GiB pair, nothing at or below 7.98 GiB is forced, so idle and every small model report unknown, and the aggregate tile, which requires every device to be known, goes blank with them.

## Fix

The pairing is unresolvable but the sum is not: over a bijection the total is the same whichever way round the counters go. Report it.

- `_rocm_windows_aggregate_used_bytes` emits the visible set's total used only when the counter list **is** that set, established by cardinality: `Get-Counter` returns an instance for every WDDM adapter, so a visible card is always somewhere in the list, and a list exactly as long as the visible set therefore contains those cards and nothing else. Plus the existing check that no usage sits above its ranked capacity.
- The utilization payloads and `/api/system` carry it as `vram_used_gb_aggregate`, and only when the utilization probe's index set matches the payload's devices, so the tile cannot divide a two-card total by a one-card capacity.
- The VRAM tile prefers the per-device sum, falls back to the aggregate, and otherwise stays Unknown. It never falls back to 0, which was the #7072 symptom.

Per-device rows are unchanged: a value still appears only when capacity forces it.

## Why not the noise filter

The first cut of this reused the sub-threshold filter that `_match_adapter_used_to_devices` applies, dropping counters under 64 MiB to force a one-per-device count. That is safe for per-device attribution, which only ever emits a value capacity **forces**, but it is not safe for a sum, which emits every counter it kept.

The instance names carry no vendor, LUID or PCI key, so a retained counter cannot be told apart from a foreign adapter's. Whenever a foreign adapter is busier than one visible card is idle, the filter dropped the visible card and kept the foreign one, and the host total silently gained bytes that are on no visible card. Six cases, all reproduced against the code:

| counters | visible cards | truth | filtered sum |
| --- | --- | --- | --- |
| 30 GiB, 5 GiB, 30 MiB | 45 + 8 GiB | 30.03 GiB | 35.0 GiB (a card hidden by `HIP_VISIBLE_DEVICES`) |
| 30 GiB, 6 GiB, 20 MiB | 45 + 8 GiB | 30.02 GiB | 36.0 GiB (an NVIDIA card in the same box) |
| 30 GiB, 1 GiB, 10 MiB | 45 + 8 GiB | 30.01 GiB | 31.0 GiB (an iGPU carveout) |
| 30 GiB, 200 MiB, 20 MiB | 45 + 8 GiB | 30.02 GiB | 30.20 GiB (a placeholder above the cutoff) |
| 6 GiB, 30 MiB | 45 GiB | 0.03 GiB | 6.0 GiB (one idle card, one busy NVIDIA) |
| 6 GiB, 30 MiB, 3 MiB | 45 GiB | 0.03 GiB | 6.0 GiB |

The last two are the worst: a single card's capacity admits almost any foreign reading, and the per-device path returns unknown there, so the aggregate would have been the only wrong number on the page. All six now report Unknown. A host total that is confidently wrong is worse than no host total.

The cardinality rule is narrower on purpose, and it is narrow: any unexplained adapter instance suppresses the aggregate. Widening it needs the counters joined on LUID or PCI bus id rather than on capacity rank.

## Sources

- AMD's `hipMemGetInfo` reference: "On Windows, the free memory only accounts for memory allocated by this process and may be optimistic."
- [ROCm/librocdxg#57](https://github.com/ROCm/librocdxg/issues/57), open. Its title is about WSL2, but in it an AMD engineer gives the mechanism: WDDM virtualises video memory, so HIP reports a per-process budget and a fresh process sees free at or near total whatever else is resident. Measured at 24410 MiB of 24560 on a deliberately filled card. Recorded there as intended Windows behaviour, not a defect.
- Microsoft documents `GPU Adapter Memory` as per adapter across all processes, against `GPU Process Memory` which is per process, and warns that summing the per-process set double-counts shared memory. There is no published reference page for the counter set, and no documented LUID to ordinal mapping.

ROCm/ROCm#1909, which the repo used to cite for this, is dropped: it names no operating system, its repro is `rocm-smi` on Linux, and it closed with no fix.

## Not fixed here

Per-device attribution on an asymmetric pair cannot be recovered from this data source. It needs a real key. Correction to an earlier draft of this description: HIP does expose one, `hipDeviceProp_t.luid` is populated on Windows, and the `GPU Adapter Memory` instance names are LUID-keyed, so the join is available in principle. It is PyTorch that surfaces nothing, so reaching it means a HIP call outside torch. Worth doing separately. Note the low half of the instance LUID is 8 hex digits (`0x00012FBF` observed), and `phys_N` is the index inside a linked adapter, not an adapter ordinal.

Two coverage caveats stated plainly. If the reporter's host carries any adapter instance beyond its two cards, the aggregate stays Unknown there and this does not fix his tile; the counter dump needed to settle that is not in the issue. And if his counter query returns nothing at all, the pre-existing fallback already reported Unknown and this changes nothing either. Neither case regresses anything.

## Verification

`studio/backend/tests/test_rocm_windows_vram_7452.py` (9 tests) drives the reporter's figures through `get_visible_gpu_utilization` and `get_gpu_utilization`, covers the six wrong-number cases above, a changing instance list across polls, a WDDM spill over the smaller card, and the aggregate rule as a unit. `studio/frontend/tests/rocm-windows-vram-aggregate.test.ts` (4 tests) covers the tile's source selection; its precedence case previously set the aggregate equal to the per-device sum, so it passed whichever source won, and now uses a differing value.

Anti-vacuity, run rather than assumed: with only `hardware.py` reverted and the tests kept, the two new soundness tests fail and pass again on restore. On the frontend, deleting the new module only yields a module-not-found error, so the check was redone by restoring the pre-PR inline logic under the same exported surface: 2 of 4 fail, and they are the two #7452 behaviours.

Upgrade order tested in both directions, executed over 28 payload combinations. A new frontend against an old backend, with the key absent and as `undefined`, `null`, `NaN`, the string `"0.36"` and `Infinity`, renders Unknown in every case and never leaks `undefined`, `NaN` or a fabricated 0. An old frontend against a new backend is unaffected: the pre-PR code reads only `devices[].vram_used_gb`, and there is no schema validation on `/api/system` that could reject an unknown key (no zod, ajv, io-ts or similar anywhere in the frontend), so the extra key is inert.

No new dependency, no persisted state, no schema change.

`test_rocm_windows_vram_7072.py` (15) and `test_rocm_multi_gpu_vram_system_wide.py` (27) still pass, 51 in that slice altogether. Frontend `npm test` is 1957 passing, and the new file is matched by the runner's glob, verified rather than assumed.

There is no AMD or Windows CI in this repository, so torch, the performance counter and the platform are mocked, and none of this is hardware validation.

Fixes #7452
