### PR TITLE
Studio: ask macOS for zombie status with the flavor that answers

### DIFF
--- a/studio/src-tauri/src/process_identity.rs
+++ b/studio/src-tauri/src/process_identity.rs
@@ -222,23 +222,24 @@ fn is_zombie_impl(pid: u32) -> bool {
 
 #[cfg(target_os = "macos")]
 fn is_zombie_impl(pid: u32) -> bool {
-    // SZOMB from sys/proc.h, which libc does not re-export.
-    const SZOMB: u32 = 5;
     if pid > i32::MAX as u32 {
         return false;
     }
-    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
-    let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+    // The short flavor, not PROC_PIDTBSDINFO: that one refuses a zombie and
+    // returns nothing, so asking it whether a process is a zombie can only ever
+    // answer no. Verified on macos-14, where the full flavor failed this.
+    let mut info: libc::proc_bsdshortinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_bsdshortinfo>() as libc::c_int;
     let written = unsafe {
         libc::proc_pidinfo(
             pid as i32,
-            libc::PROC_PIDTBSDINFO,
+            libc::PROC_PIDT_SHORTBSDINFO,
             0,
             &mut info as *mut _ as *mut libc::c_void,
             size,
         )
     };
-    written == size && info.pbi_status == SZOMB
+    written == size && info.pbsi_status == libc::SZOMB
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]


### PR DESCRIPTION
Follow-up to #8459, which is merged. The zombie check it added does nothing on macOS.

`proc_pidinfo(PROC_PIDTBSDINFO)` refuses a zombie and returns nothing, so asking it whether a process is a zombie can only ever answer no. `PROC_PIDT_SHORTBSDINFO` does report one, and libc exposes `SZOMB`, so the local constant goes too.

## Why it matters

The desktop app spawns the backend and never waits on it, so a crashed backend stays a zombie for as long as the app runs. Its per-port record then keeps blocking every repair and update for that whole time, on a process whose socket is long gone. That is what the check was added to prevent, and on macOS it was not preventing it.

## How it was caught

By running the desktop suite on a real `macos-14` runner. Two tests fail there on the merged code:

```
test process_identity::tests::a_zombie_is_not_a_live_process ... FAILED
test preflight::pid_records::system_tests::a_record_for_an_unreaped_process_is_ignored ... FAILED
```

Both use a real killed-but-unreaped child rather than a stub, which is why they catch it. A `cargo check` for `aarch64-apple-darwin` compiles this code but never runs it, and that is all the original PR had for the Apple path.