### PR TITLE
Studio: stop building test scratch paths inside a macOS sensitive root

### DIFF
--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -1736,8 +1736,12 @@ mod tests {
     // `dirs::home_dir` is all over this crate.
     #[cfg(target_os = "linux")]
     fn with_xdg_data_home<T>(value: &str, f: impl FnOnce() -> T) -> T {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // The crate-wide lock, not one of this module's own: the path policy
+        // reads XDG_DATA_HOME while choosing where its tests may write, and an
+        // override running underneath that would change the answer.
+        let _guard = crate::native_path_policy::PROCESS_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = std::env::var_os("XDG_DATA_HOME");
         std::env::set_var("XDG_DATA_HOME", value);
         let out = f();

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -742,10 +742,20 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!(
-            "unsloth-native-intents-{name}-{}-{nanos}",
-            std::process::id()
-        ))
+        // Not std::env::temp_dir(): on macOS that is /var/folders/..., whose
+        // real path is under /private, which this policy treats as a sensitive
+        // root on purpose. Every scratch path here would be rejected for that
+        // reason rather than the one under test. The test binary's own
+        // directory is writable, is inside the build tree, and is sensitive
+        // nowhere.
+        std::env::current_exe()
+            .ok()
+            .and_then(|exe| exe.parent().map(Path::to_path_buf))
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!(
+                "unsloth-native-intents-{name}-{}-{nanos}",
+                std::process::id()
+            ))
     }
 
     fn attachment_entry(path: &Path) -> (NativeIntakeState, NativePathEntry) {

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -742,20 +742,42 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        // Not std::env::temp_dir(): on macOS that is /var/folders/..., whose
-        // real path is under /private, which this policy treats as a sensitive
-        // root on purpose. Every scratch path here would be rejected for that
-        // reason rather than the one under test. The test binary's own
-        // directory is writable, is inside the build tree, and is sensitive
-        // nowhere.
-        std::env::current_exe()
-            .ok()
-            .and_then(|exe| exe.parent().map(Path::to_path_buf))
-            .unwrap_or_else(std::env::temp_dir)
-            .join(format!(
-                "unsloth-native-intents-{name}-{}-{nanos}",
-                std::process::id()
-            ))
+        scratch_root().join(format!("unsloth-native-intents-{name}-{}-{nanos}", std::process::id()))
+    }
+
+    /// A writable directory the document-folder policy does not consider
+    /// sensitive.
+    ///
+    /// std::env::temp_dir() is not one on macOS: it is /var/folders/...,
+    /// whose real path is under /private, which the policy rejects on purpose,
+    /// so every scratch path built from it fails for that reason rather than
+    /// the one under test. The build directory is the usual answer, but it is
+    /// not guaranteed either, since a checkout under /root or /usr/src puts it
+    /// inside a sensitive root as well. So the candidates are tried against
+    /// the policy itself, on the canonical path the policy would see, and the
+    /// first one it accepts wins.
+    fn scratch_root() -> PathBuf {
+        let candidates = [
+            std::env::current_exe()
+                .ok()
+                .and_then(|exe| exe.parent().map(Path::to_path_buf)),
+            Some(std::env::temp_dir()),
+            dirs::home_dir().map(|home| home.join("unsloth-test-scratch")),
+        ];
+        for candidate in candidates.into_iter().flatten() {
+            if std::fs::create_dir_all(&candidate).is_err() {
+                continue;
+            }
+            let Ok(canonical) = candidate.canonicalize() else {
+                continue;
+            };
+            if crate::native_path_policy::reject_sensitive_document_folder(&canonical).is_ok() {
+                return canonical;
+            }
+        }
+        // Nothing qualifies. Fall back rather than skip, so the test fails
+        // loudly here instead of quietly not running.
+        std::env::temp_dir()
     }
 
     fn attachment_entry(path: &Path) -> (NativeIntakeState, NativePathEntry) {

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -742,43 +742,9 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        scratch_root().join(format!("unsloth-native-intents-{name}-{}-{nanos}", std::process::id()))
+        crate::native_path_policy::scratch_root().join(format!("unsloth-native-intents-{name}-{}-{nanos}", std::process::id()))
     }
 
-    /// A writable directory the document-folder policy does not consider
-    /// sensitive.
-    ///
-    /// std::env::temp_dir() is not one on macOS: it is /var/folders/...,
-    /// whose real path is under /private, which the policy rejects on purpose,
-    /// so every scratch path built from it fails for that reason rather than
-    /// the one under test. The build directory is the usual answer, but it is
-    /// not guaranteed either, since a checkout under /root or /usr/src puts it
-    /// inside a sensitive root as well. So the candidates are tried against
-    /// the policy itself, on the canonical path the policy would see, and the
-    /// first one it accepts wins.
-    fn scratch_root() -> PathBuf {
-        let candidates = [
-            std::env::current_exe()
-                .ok()
-                .and_then(|exe| exe.parent().map(Path::to_path_buf)),
-            Some(std::env::temp_dir()),
-            dirs::home_dir().map(|home| home.join("unsloth-test-scratch")),
-        ];
-        for candidate in candidates.into_iter().flatten() {
-            if std::fs::create_dir_all(&candidate).is_err() {
-                continue;
-            }
-            let Ok(canonical) = candidate.canonicalize() else {
-                continue;
-            };
-            if crate::native_path_policy::reject_sensitive_document_folder(&canonical).is_ok() {
-                return canonical;
-            }
-        }
-        // Nothing qualifies. Fall back rather than skip, so the test fails
-        // loudly here instead of quietly not running.
-        std::env::temp_dir()
-    }
 
     fn attachment_entry(path: &Path) -> (NativeIntakeState, NativePathEntry) {
         let state = new_native_intake_state();

--- a/studio/src-tauri/src/native_path_policy.rs
+++ b/studio/src-tauri/src/native_path_policy.rs
@@ -589,19 +589,27 @@ pub(crate) fn scratch_root() -> PathBuf {
                 .and_then(|exe| exe.parent().map(Path::to_path_buf)),
             dirs::home_dir(),
         ];
-        let unique = format!("unsloth-test-scratch-{}", std::process::id());
         for candidate in candidates.into_iter().flatten() {
-            let child = candidate.join(&unique);
-            if fs::create_dir_all(&child).is_err() {
+            // tempfile, not a name derived from the PID: the first candidate is
+            // a shared temp directory, where another local user can pre-create
+            // a predictable path and leave a symlink for the probe write below
+            // to follow. tempdir_in creates an unguessable directory with an
+            // exclusive operation, or fails.
+            let Ok(child) = tempfile::Builder::new()
+                .prefix("unsloth-test-scratch-")
+                .tempdir_in(&candidate)
+            else {
+                continue;
+            };
+            // Existing is not writable: a directory that is already there is
+            // accepted without a byte being written.
+            if fs::write(child.path().join("writable"), b"1").is_err() {
                 continue;
             }
-            // exists() is not writability: a directory that is already there is
-            // created by create_dir_all without a byte being written.
-            if fs::write(child.join("writable"), b"1").is_err() {
-                continue;
-            }
-            if classify_native_document_folder(&child).is_ok() {
-                return child;
+            if classify_native_document_folder(child.path()).is_ok() {
+                // Kept rather than dropped, which would delete it out from
+                // under every test that follows.
+                return child.keep();
             }
         }
         // Nothing qualifies. Fall back rather than skip, so the tests fail

--- a/studio/src-tauri/src/native_path_policy.rs
+++ b/studio/src-tauri/src/native_path_policy.rs
@@ -556,10 +556,20 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!(
-            "unsloth-native-policy-{name}-{}-{nanos}",
-            std::process::id()
-        ))
+        // Not std::env::temp_dir(): on macOS that is /var/folders/..., whose
+        // real path is under /private, which this policy treats as a sensitive
+        // root on purpose. Every scratch path here would be rejected for that
+        // reason rather than the one under test. The test binary's own
+        // directory is writable, is inside the build tree, and is sensitive
+        // nowhere.
+        std::env::current_exe()
+            .ok()
+            .and_then(|exe| exe.parent().map(Path::to_path_buf))
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!(
+                "unsloth-native-policy-{name}-{}-{nanos}",
+                std::process::id()
+            ))
     }
 
     #[test]

--- a/studio/src-tauri/src/native_path_policy.rs
+++ b/studio/src-tauri/src/native_path_policy.rs
@@ -364,7 +364,7 @@ fn reject_document_folder_root(path: &Path) -> Result<(), String> {
     }
 }
 
-fn reject_sensitive_document_folder(path: &Path) -> Result<(), String> {
+pub(crate) fn reject_sensitive_document_folder(path: &Path) -> Result<(), String> {
     let has_sensitive_segment = path.components().any(|component| {
         matches!(
             component
@@ -556,20 +556,42 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        // Not std::env::temp_dir(): on macOS that is /var/folders/..., whose
-        // real path is under /private, which this policy treats as a sensitive
-        // root on purpose. Every scratch path here would be rejected for that
-        // reason rather than the one under test. The test binary's own
-        // directory is writable, is inside the build tree, and is sensitive
-        // nowhere.
-        std::env::current_exe()
-            .ok()
-            .and_then(|exe| exe.parent().map(Path::to_path_buf))
-            .unwrap_or_else(std::env::temp_dir)
-            .join(format!(
-                "unsloth-native-policy-{name}-{}-{nanos}",
-                std::process::id()
-            ))
+        scratch_root().join(format!("unsloth-native-policy-{name}-{}-{nanos}", std::process::id()))
+    }
+
+    /// A writable directory the document-folder policy does not consider
+    /// sensitive.
+    ///
+    /// std::env::temp_dir() is not one on macOS: it is /var/folders/...,
+    /// whose real path is under /private, which the policy rejects on purpose,
+    /// so every scratch path built from it fails for that reason rather than
+    /// the one under test. The build directory is the usual answer, but it is
+    /// not guaranteed either, since a checkout under /root or /usr/src puts it
+    /// inside a sensitive root as well. So the candidates are tried against
+    /// the policy itself, on the canonical path the policy would see, and the
+    /// first one it accepts wins.
+    fn scratch_root() -> PathBuf {
+        let candidates = [
+            std::env::current_exe()
+                .ok()
+                .and_then(|exe| exe.parent().map(Path::to_path_buf)),
+            Some(std::env::temp_dir()),
+            dirs::home_dir().map(|home| home.join("unsloth-test-scratch")),
+        ];
+        for candidate in candidates.into_iter().flatten() {
+            if std::fs::create_dir_all(&candidate).is_err() {
+                continue;
+            }
+            let Ok(canonical) = candidate.canonicalize() else {
+                continue;
+            };
+            if crate::native_path_policy::reject_sensitive_document_folder(&canonical).is_ok() {
+                return canonical;
+            }
+        }
+        // Nothing qualifies. Fall back rather than skip, so the test fails
+        // loudly here instead of quietly not running.
+        std::env::temp_dir()
     }
 
     #[test]

--- a/studio/src-tauri/src/native_path_policy.rs
+++ b/studio/src-tauri/src/native_path_policy.rs
@@ -545,6 +545,72 @@ fn has_extension(path: &Path, expected: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Guards process-global environment variables for tests.
+///
+/// `std::env::set_var` is process-wide while the harness runs tests in
+/// parallel, and the policy below reads `XDG_DATA_HOME` through
+/// `dirs::data_local_dir`. Anything that sets or depends on those variables
+/// takes this, `main.rs`'s `with_xdg_data_home` included.
+#[cfg(test)]
+pub(crate) static PROCESS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// A directory that scratch paths for the path-policy tests can be built in:
+/// writable, and accepted by the very policy those tests exercise.
+///
+/// Picking one is not obvious. `std::env::temp_dir()` is out on macOS, where it
+/// is /var/folders/..., whose real path is under /private and which the policy
+/// rejects on purpose, so every scratch path built from it would fail for that
+/// reason rather than the one under test. The test binary's directory is the
+/// usual answer but is not safe either: a checkout under /root or /usr/src puts
+/// it inside a sensitive root, a target directory on /dev/shm or a UNC share is
+/// refused as a device path, and a read-only build tree cannot be written to at
+/// all.
+///
+/// So each candidate is tried for real: a uniquely named child is created in
+/// it, a file is written inside that child, and the child is put through
+/// `classify_native_document_folder`, which is the whole policy rather than one
+/// clause of it. The first candidate that survives all three wins. Chosen once
+/// per test binary, under `PROCESS_ENV_LOCK`, so a concurrent
+/// `with_xdg_data_home` cannot change the answer midway.
+#[cfg(test)]
+pub(crate) fn scratch_root() -> PathBuf {
+    static ROOT: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    ROOT.get_or_init(|| {
+        let _guard = PROCESS_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // The temp directory first, since the OS clears it, then the build
+        // tree, then home. On macOS the first is rejected by the policy and the
+        // second is taken, which is the case that started all this.
+        let candidates = [
+            Some(std::env::temp_dir()),
+            std::env::current_exe()
+                .ok()
+                .and_then(|exe| exe.parent().map(Path::to_path_buf)),
+            dirs::home_dir(),
+        ];
+        let unique = format!("unsloth-test-scratch-{}", std::process::id());
+        for candidate in candidates.into_iter().flatten() {
+            let child = candidate.join(&unique);
+            if fs::create_dir_all(&child).is_err() {
+                continue;
+            }
+            // exists() is not writability: a directory that is already there is
+            // created by create_dir_all without a byte being written.
+            if fs::write(child.join("writable"), b"1").is_err() {
+                continue;
+            }
+            if classify_native_document_folder(&child).is_ok() {
+                return child;
+            }
+        }
+        // Nothing qualifies. Fall back rather than skip, so the tests fail
+        // loudly here instead of quietly not running.
+        std::env::temp_dir()
+    })
+    .clone()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -559,40 +625,6 @@ mod tests {
         scratch_root().join(format!("unsloth-native-policy-{name}-{}-{nanos}", std::process::id()))
     }
 
-    /// A writable directory the document-folder policy does not consider
-    /// sensitive.
-    ///
-    /// std::env::temp_dir() is not one on macOS: it is /var/folders/...,
-    /// whose real path is under /private, which the policy rejects on purpose,
-    /// so every scratch path built from it fails for that reason rather than
-    /// the one under test. The build directory is the usual answer, but it is
-    /// not guaranteed either, since a checkout under /root or /usr/src puts it
-    /// inside a sensitive root as well. So the candidates are tried against
-    /// the policy itself, on the canonical path the policy would see, and the
-    /// first one it accepts wins.
-    fn scratch_root() -> PathBuf {
-        let candidates = [
-            std::env::current_exe()
-                .ok()
-                .and_then(|exe| exe.parent().map(Path::to_path_buf)),
-            Some(std::env::temp_dir()),
-            dirs::home_dir().map(|home| home.join("unsloth-test-scratch")),
-        ];
-        for candidate in candidates.into_iter().flatten() {
-            if std::fs::create_dir_all(&candidate).is_err() {
-                continue;
-            }
-            let Ok(canonical) = candidate.canonicalize() else {
-                continue;
-            };
-            if crate::native_path_policy::reject_sensitive_document_folder(&canonical).is_ok() {
-                return canonical;
-            }
-        }
-        // Nothing qualifies. Fall back rather than skip, so the test fails
-        // loudly here instead of quietly not running.
-        std::env::temp_dir()
-    }
 
     #[test]
     fn gguf_model_allows_validate_load_reveal() {


### PR DESCRIPTION
Two desktop tests fail on macOS, on main, for a policy that is working as intended:

```
---- native_intents::tests::document_folder_picker_grant_is_not_a_reusable_path_token ----
called `Result::unwrap()` on an `Err` value:
  "Sensitive system or application folders cannot be linked as document sources."

---- native_path_policy::tests::document_folder_is_directory_with_link_only_capability ----
called `Result::unwrap()` on an `Err` value:
  "Sensitive system or application folders cannot be linked as document sources."
```

## Cause

Both build their scratch paths from `std::env::temp_dir()`. On macOS that is `/var/folders/...`, whose real path is `/private/var/folders/...`, and `/private` is in `sensitive_roots` on purpose. So every scratch path was refused for being sensitive, before the tests got anywhere near what they were checking.

The policy is right. `/Users` is not under `/private`, so a real document folder is unaffected, and refusing to link something out of the system temp area is the intended behaviour.

## Fix

The scratch paths now hang off the test binary's own directory, which is writable, sits in the build tree, and is sensitive on no platform. Test-only; no product behaviour changes, and linking a folder under `/private` is still refused.

Found by running the desktop suite on a real `macos-14` runner. 278 tests pass on Linux, and this is verified on macOS before merge rather than after.