### PR TITLE
Install torchao in Backend CI, and stop one test's allowlist answer leaking into the rest

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -97,6 +97,13 @@ jobs:
           # keeps the install ~250 MB / ~1 min on a clean runner.
           pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple 'torch>=2.4,<2.11'
           pip install 'transformers>=4.51,<5.5'
+          # torchao: the pre-quant allowlist is built by importing the torchao tensor
+          # constructors a checkpoint names, and registration refuses unless at least one of
+          # them resolves. Without it every pre-quant load returns None and 21 tests across
+          # test_diffusion_prequant.py and test_diffusion_convrot.py fail on an install that is
+          # simply missing a dependency they need. CPU-only is fine: it declines to load its cpp
+          # extensions under torch < 2.11 and the pure-Python constructors still import.
+          pip install torchao
 
       - name: Backend tests
         working-directory: studio/backend

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -158,6 +158,34 @@ def _isolate_xet_health_state():
 
 
 @pytest.fixture(autouse = True)
+def _confine_prequant_registration_memo():
+    """Keep one test's answer about the pre-quant allowlist from becoming every later test's.
+
+    ``diffusion_prequant`` asks once whether this torch can register the constructor allowlist and
+    memoises the answer, INCLUDING the failure, in a module global. That is right in a process
+    where torch never changes. It is wrong in this suite, where several files put a fake torch in
+    ``sys.modules``: the question gets asked while the fake is installed, the answer is False, and
+    ``monkeypatch`` restores ``sys.modules`` but not the memo. Every later real load then refuses.
+
+    Measured on main: after ``test_diffusion_backend.py`` the memo reads False, where it reads None
+    when that file runs alone. In a full-suite run that turned 20 tests across
+    ``test_diffusion_prequant.py`` and ``test_diffusion_convrot.py`` red, all with the same
+    ``assert None is not None``, while every one of them passed when its file ran by itself.
+
+    Restored rather than cleared, so nothing re-registers 22k times and a test that sets the memo
+    deliberately still sees its own value.
+    """
+    from core.inference import diffusion_prequant
+
+    registered = diffusion_prequant._SAFE_GLOBALS_REGISTERED
+    resolved = set(diffusion_prequant._RESOLVED_SAFE_GLOBALS)
+    yield
+    diffusion_prequant._SAFE_GLOBALS_REGISTERED = registered
+    diffusion_prequant._RESOLVED_SAFE_GLOBALS.clear()
+    diffusion_prequant._RESOLVED_SAFE_GLOBALS.update(resolved)
+
+
+@pytest.fixture(autouse = True)
 def _isolate_audio_gallery(monkeypatch, tmp_path):
     """Keep generated-clip persistence out of the developer's real gallery.
 


### PR DESCRIPTION
Backend CI is red on `main`. Run [31510463188](https://github.com/unslothai/unsloth/actions/runs/31510463188), a push on main, fails 23 tests, and the same 23 fail on every open PR that runs the workflow. This fixes 21 of them.

## The cause: torchao is not installed in Backend CI

`diffusion_prequant` builds its `torch.serialization` allowlist by importing the torchao tensor constructors a pre-quant checkpoint names, and registration refuses unless at least one of them resolves:

```python
if "torch.torch_version.TorchVersion" in resolved and any(
    name.startswith("torchao.") for name in resolved
):
```

The Backend CI install step lists studio.txt, a set of extras, CPU torch and transformers. It has never listed torchao. So no `torchao.` name resolves, registration answers False, `load_prequantized_transformer` returns None on every path, and 21 tests fail with `assert None is not None` plus one `RuntimeError: this torch cannot register the pre-quant constructor allowlist`. Nothing about the code under test is wrong; the environment is missing a dependency those tests need.

Reproduced directly. In an otherwise CI-identical environment (Python 3.12, torch 2.10.0, transformers 5.4.0), removing torchao:

```
without torchao   21 failed, 103 passed     <- the CI set, in isolation
with torchao      124 passed
```

CPU-only is fine. torchao 0.18.0 against the exact `torch==2.10.0+cpu` wheel prints "Skipping import of cpp extensions" and every constructor module the allowlist reads still imports.

## Also here: a real test-isolation leak

Found first, while chasing the above, and worth keeping even though it is not what reddens CI.

`diffusion_prequant` memoises its one-time registration answer, deliberately including the failure, in a module global. Several test files put a fake torch in `sys.modules`. The question gets asked while the fake is installed, the answer is False, `monkeypatch` restores `sys.modules` on teardown, and the memo is not restored with it:

```
after test_diffusion_backend.py    registered=False resolved=0
that file alone                    registered=None  resolved=0
```

On a machine that HAS torchao this is enough on its own to redden the same 20 tests in a full-suite run while each file passes alone. It is latent on CI today only because torchao's absence already forces the same answer. The autouse fixture in `conftest.py` snapshots and restores the memo per test; restored rather than cleared, so nothing re-registers 22k times and a test that sets the memo deliberately still sees its own value.

Measured with torchao present, full backend suite, the command CI runs: 21 failed before the fixture, 1 after.

## Remaining

`test_openai_auto_switch.py::test_an_expired_positive_hit_refreshes_before_switching` is a separate defect: it reproduces in isolation, is unaffected by either change here, and is not addressed. `_maybe_auto_switch_model` raises a 404 through `_reject_unservable_model` where the test expects the hook to return quietly. Which side is wrong is a question about the intended contract, so it wants its own look.

## Noticed, not fixed

Under torchao 0.18 five of the twenty allowlist entries no longer resolve, all on the int8 path upstream deprecated in pytorch/ao#2752 (`AffineQuantizedTensor`, `PlainAQTTensorImpl`, `PlainLayout`, `LinearActivationQuantizedTensor`, `_int8_symm_per_token_reduced_range_quant`). Registration still succeeds, since the floor and the fp8, mxfp8 and nvfp4 schemes are unaffected, and the per-scheme gate declines int8 rather than failing. It does mean an int8 pre-quant checkpoint is unloadable on current torchao, which is its own question.