### PR TITLE
CI: run the Studio desktop unit tests on macOS

### DIFF
--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -325,3 +325,54 @@ jobs:
       - name: Rust release type check (studio/src-tauri)
         working-directory: studio/src-tauri
         run: cargo check --all-targets --release
+
+  macos-unit-tests:
+    name: Rust unit tests (macos)
+    runs-on: macos-14
+    # A cold cache compiles both the debug and the release dependency tree.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '24'
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable @ 2026-03-27
+
+      - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          # Save only on main. This action defaults to saving on every ref, and
+          # a PR-scoped rust cache (550-840MB here) can only be restored by
+          # re-runs of that same PR while still counting against the 10GB
+          # per-repo budget, evicting main's copy that every PR can restore.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: studio/src-tauri -> target
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Lockfile supply-chain audit (pre-install scan)
+        run: python scripts/lockfile_supply_chain_audit.py
+
+      # tauri-build resolves frontendDist at compile time, so dist/ must exist
+      # before cargo test, exactly as in the Linux and Windows jobs.
+      - name: Frontend build (npm ci, vite)
+        working-directory: studio/frontend
+        run: |
+          npm ci --no-fund --no-audit
+          npm run build
+
+      - name: Rust unit tests (studio/src-tauri)
+        working-directory: studio/src-tauri
+        run: cargo test --no-fail-fast
+
+      # `cargo test` builds only the debug profile, and the browser guard is
+      # installed under `not(debug_assertions)`, so nothing above compiles its
+      # call site. Check the release profile so that path cannot rot.
+      - name: Rust release type check (studio/src-tauri)
+        working-directory: studio/src-tauri
+        run: cargo check --all-targets --release

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -328,7 +328,10 @@ jobs:
 
   macos-unit-tests:
     name: Rust unit tests (macos)
-    runs-on: macos-14
+    # Not macos-14: it browns out from 2026-10-05 and is removed 2026-11-02,
+    # which the other macOS workflows here have already moved off. Both are
+    # Apple Silicon, so this job keeps testing the arm64 paths.
+    runs-on: macos-15
     # A cold cache compiles both the debug and the release dependency tree.
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
`studio-tauri-smoke.yml` runs `cargo test` on `ubuntu-22.04` and `windows-latest`. Nothing runs it on macOS, so the Apple code paths in `studio/src-tauri` have never been executed by CI.

That is not theoretical. Running the suite on a real `macos-14` runner turned up four failures on main:

- two document-folder tests that build scratch paths from `std::env::temp_dir()`, which on macOS lives under `/private` and is refused by the sensitive-root policy on purpose (#8485)
- two zombie tests, because `proc_pidinfo(PROC_PIDTBSDINFO)` refuses a zombie, so the check added in #8459 cannot work on macOS at all (#8484)

The second one shipped. A `cargo check` for `aarch64-apple-darwin` compiles Apple-only code but never runs it, and that was all the Apple path had.

This job mirrors the existing Windows one, which is there for the same reason: same toolchain setup, same lockfile audit, same frontend build before `cargo test` since `tauri-build` resolves `frontendDist` at compile time, and the same release type check so the `not(debug_assertions)` paths cannot rot.

**Merge order:** after #8484 and #8485. Before those land, this job arrives red on the failures they fix.