### PR TITLE
Studio backend performance: five superlinear paths in the routes and data layer

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7066,7 +7066,18 @@ class LlamaCppBackend:
             kept: list = []
             for _ in range(alen):
                 n = struct.unpack("<Q", f.read(8))[0]
-                raw = f.read(n)
+                if not n:
+                    continue
+                # delimiter_shaped_tokens keeps only "<...>" / "[...]" entries, so a token
+                # whose first byte is neither can be seeked past instead of read, decoded
+                # and retained. UTF-8 is self-synchronising, so no multi-byte character
+                # begins with either byte. A six-figure vocabulary is the bulk of a header
+                # parse and only a few hundred entries survive the filter.
+                first = f.read(1)
+                if first != b"<" and first != b"[":
+                    f.seek(n - 1, 1)
+                    continue
+                raw = first + f.read(n - 1)
                 # A vocabulary holds arbitrary bytes; a marker is text, so undecodable
                 # entries are simply not markers.
                 try:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7068,11 +7068,9 @@ class LlamaCppBackend:
                 n = struct.unpack("<Q", f.read(8))[0]
                 if not n:
                     continue
-                # delimiter_shaped_tokens keeps only "<...>" / "[...]" entries, so a token
-                # whose first byte is neither can be seeked past instead of read, decoded
-                # and retained. UTF-8 is self-synchronising, so no multi-byte character
-                # begins with either byte. A six-figure vocabulary is the bulk of a header
-                # parse and only a few hundred entries survive the filter.
+                # Only "<...>" / "[...]" entries survive delimiter_shaped_tokens, so seek
+                # past the rest instead of reading and decoding them. UTF-8 is
+                # self-synchronising, so no multi-byte character starts with either byte.
                 first = f.read(1)
                 if first != b"<" and first != b"[":
                     f.seek(n - 1, 1)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7066,16 +7066,16 @@ class LlamaCppBackend:
             kept: list = []
             for _ in range(alen):
                 n = struct.unpack("<Q", f.read(8))[0]
-                if not n:
+                raw = f.read(n)
+                # Only "<...>" / "[...]" entries survive delimiter_shaped_tokens, so skip
+                # the decode for the rest. UTF-8 is self-synchronising, so no multi-byte
+                # character starts with either byte and the first one settles it. The
+                # bytes are still read rather than seeked past: seeking would move the
+                # cursor differently on a short read, raise a different error on a bad
+                # length, and fail outright on a non-seekable stream. Decoding a
+                # six-figure vocabulary is the cost here, not reading it.
+                if raw[:1] != b"<" and raw[:1] != b"[":
                     continue
-                # Only "<...>" / "[...]" entries survive delimiter_shaped_tokens, so seek
-                # past the rest instead of reading and decoding them. UTF-8 is
-                # self-synchronising, so no multi-byte character starts with either byte.
-                first = f.read(1)
-                if first != b"<" and first != b"[":
-                    f.seek(n - 1, 1)
-                    continue
-                raw = first + f.read(n - 1)
                 # A vocabulary holds arbitrary bytes; a marker is text, so undecodable
                 # entries are simply not markers.
                 try:

--- a/studio/backend/core/inference/web_access_policy.py
+++ b/studio/backend/core/inference/web_access_policy.py
@@ -92,11 +92,10 @@ def normalize_website_policy(value: Any) -> dict[str, list[str]]:
             raise ValueError(f"{key} must be a list")
         if len(raw_domains) > _MAX_DOMAINS_PER_LIST:
             raise ValueError(f"{key} supports at most {_MAX_DOMAINS_PER_LIST} domains")
-        # Exact ``str`` only: anything else can be unhashable, and its error message
-        # carries the original repr, so non-str entries stay on the uncached path. An
-        # over-long entry stays off it too: nameprep deletes characters such as U+00AD, so
-        # an arbitrarily long raw string can still normalise to a valid domain, and caching
-        # would then pin a caller-sized string in memory. Both paths normalise identically.
+        # Exact ``str`` only: anything else can be unhashable and its error message carries
+        # the original repr. Over-long entries stay off the cached path too -- nameprep
+        # deletes characters such as U+00AD, so an arbitrarily long raw string can still
+        # normalise, and caching would pin a caller-sized string. Both paths agree.
         if all(
             type(raw_domain) is str and len(raw_domain) <= _MAX_CACHEABLE_DOMAIN_LEN
             for raw_domain in raw_domains

--- a/studio/backend/core/inference/web_access_policy.py
+++ b/studio/backend/core/inference/web_access_policy.py
@@ -89,9 +89,8 @@ def normalize_website_policy(value: Any) -> dict[str, list[str]]:
             raise ValueError(f"{key} must be a list")
         if len(raw_domains) > _MAX_DOMAINS_PER_LIST:
             raise ValueError(f"{key} supports at most {_MAX_DOMAINS_PER_LIST} domains")
-        # Exact ``str`` entries only: anything else is unhashable or reaches
-        # ``normalize_domain`` through ``str(value or "")``, and its error message
-        # carries the original repr, so those stay on the uncached path.
+        # Exact ``str`` only: anything else can be unhashable, and its error message
+        # carries the original repr, so non-str entries stay on the uncached path.
         if all(type(raw_domain) is str for raw_domain in raw_domains):
             normalized[key] = list(_normalized_domain_tuple(tuple(raw_domains)))
             continue

--- a/studio/backend/core/inference/web_access_policy.py
+++ b/studio/backend/core/inference/web_access_policy.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import ipaddress
 import re
 import zlib
+from functools import lru_cache
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -51,6 +52,27 @@ def normalize_domain(value: Any) -> str:
     return ascii_domain
 
 
+@lru_cache(maxsize = 256)
+def _normalized_domain_tuple(raw_domains: tuple) -> tuple:
+    """``normalize_domain`` over an all-``str`` list, deduplicated, order preserved.
+
+    ``normalize_domain`` is a pure function of its argument (lowercase, IDNA encode,
+    validate), so the result for a given tuple of exact ``str`` domains is invariant and
+    safe to memoise. One restricted web search checks the same policy against every
+    candidate URL, which re-normalised both lists (up to 100 domains each) every time.
+    An invalid domain still raises from inside here, and ``lru_cache`` does not memoise
+    exceptions, so the same ``ValueError`` is raised on every call as before.
+    """
+    domains: list = []
+    seen: set = set()
+    for raw_domain in raw_domains:
+        domain = normalize_domain(raw_domain)
+        if domain not in seen:
+            seen.add(domain)
+            domains.append(domain)
+    return tuple(domains)
+
+
 def normalize_website_policy(value: Any) -> dict[str, list[str]]:
     if value is None:
         return {"allowedDomains": [], "blockedDomains": []}
@@ -67,6 +89,12 @@ def normalize_website_policy(value: Any) -> dict[str, list[str]]:
             raise ValueError(f"{key} must be a list")
         if len(raw_domains) > _MAX_DOMAINS_PER_LIST:
             raise ValueError(f"{key} supports at most {_MAX_DOMAINS_PER_LIST} domains")
+        # Exact ``str`` entries only: anything else is unhashable or reaches
+        # ``normalize_domain`` through ``str(value or "")``, and its error message
+        # carries the original repr, so those stay on the uncached path.
+        if all(type(raw_domain) is str for raw_domain in raw_domains):
+            normalized[key] = list(_normalized_domain_tuple(tuple(raw_domains)))
+            continue
         domains: list[str] = []
         for raw_domain in raw_domains:
             domain = normalize_domain(raw_domain)

--- a/studio/backend/core/inference/web_access_policy.py
+++ b/studio/backend/core/inference/web_access_policy.py
@@ -14,6 +14,9 @@ from urllib.parse import urlsplit
 
 _DOMAIN_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 _MAX_DOMAINS_PER_LIST = 100
+# A cache key holds the caller's raw strings for the life of the process, so only an entry
+# short enough to be a real domain is eligible; see normalize_website_policy.
+_MAX_CACHEABLE_DOMAIN_LEN = 253
 # Most search engines stop honouring site: past a handful of OR terms.
 _SITE_FILTER_LIMIT = 8
 
@@ -90,8 +93,14 @@ def normalize_website_policy(value: Any) -> dict[str, list[str]]:
         if len(raw_domains) > _MAX_DOMAINS_PER_LIST:
             raise ValueError(f"{key} supports at most {_MAX_DOMAINS_PER_LIST} domains")
         # Exact ``str`` only: anything else can be unhashable, and its error message
-        # carries the original repr, so non-str entries stay on the uncached path.
-        if all(type(raw_domain) is str for raw_domain in raw_domains):
+        # carries the original repr, so non-str entries stay on the uncached path. An
+        # over-long entry stays off it too: nameprep deletes characters such as U+00AD, so
+        # an arbitrarily long raw string can still normalise to a valid domain, and caching
+        # would then pin a caller-sized string in memory. Both paths normalise identically.
+        if all(
+            type(raw_domain) is str and len(raw_domain) <= _MAX_CACHEABLE_DOMAIN_LEN
+            for raw_domain in raw_domains
+        ):
             normalized[key] = list(_normalized_domain_tuple(tuple(raw_domains)))
             continue
         domains: list[str] = []

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1486,15 +1486,13 @@ class ChatCompletionRequest(BaseModel):
         unconsumed tool_call; synth a random id only if none exists. A user
         turn breaks the lookup.
         """
-        # Both passes below used to walk the history backwards from every tool result and
-        # rescan each assistant's tool_calls, so one assistant with n calls followed by n
-        # results was O(n^2). Both now run in one forward pass with an index, which is the
-        # same search because the backward walk only ever looked inside the current
-        # user-delimited segment: a "user" message ends it.
+        # Both passes below were a backwards rescan per tool result, O(n^2) for one
+        # assistant with n calls. Each is now a single forward pass with an index, the
+        # same search because the backward walk never left the current user-delimited
+        # segment: a "user" message ends it.
         messages = self.messages
-        # Nothing below writes anything unless some tool result is missing its id: the
-        # first pass only feeds the second. Well-behaved OpenAI clients always send
-        # tool_call_id, so this returns immediately for most requests.
+        # The first pass only feeds the second, so with every tool_call_id present there
+        # is nothing to do, which is the common case for well-behaved clients.
         for msg in messages:
             if msg.role == "tool" and not msg.tool_call_id:
                 break
@@ -1504,10 +1502,9 @@ class ChatCompletionRequest(BaseModel):
         # Pre-mark explicit ids so a missing-id sibling can't steal a claimed one.
         consumed: set[tuple[int, int]] = set()
 
-        # Newest assistant call per explicit id in this segment; the first index wins
-        # inside one assistant, matching the old first-match-nearest-assistant walk.
-        # Only exact ``str`` ids are indexed: ``tool_call_id`` is a ``str``, so a JSON
-        # id of any other type could never compare equal to it anyway.
+        # Newest assistant call per explicit id in this segment; within one assistant the
+        # first index wins, matching the old first-match-nearest-assistant walk. Only
+        # ``str`` ids are indexed: ``tool_call_id`` is a ``str``, so nothing else matches.
         latest_by_id: dict = {}
         for asst_idx, msg in enumerate(messages):
             role = msg.role
@@ -1529,13 +1526,11 @@ class ChatCompletionRequest(BaseModel):
                 if claimed is not None:
                     consumed.add(claimed)
 
-        # Stack of the assistants in the current segment that still have an unclaimed
-        # call, oldest first, so the nearest one is on top. A drained assistant can never
-        # refill, so popping it is permanent and the walk past it happens once overall
-        # rather than once per tool result. Each frame holds its remaining call indexes
-        # in order plus the same indexes bucketed by function name; an index consumed out
-        # of turn is dropped when it reaches the front of a queue, so every index leaves
-        # each queue at most once.
+        # Assistants in this segment with an unclaimed call, oldest first, so the nearest
+        # is on top. A drained assistant never refills, so popping it is permanent and the
+        # walk past it happens once overall rather than once per tool result. Each frame
+        # keeps its remaining call indexes in order plus the same indexes bucketed by
+        # function name; one consumed out of turn is dropped when it reaches a queue front.
         stack: list = []
         for asst_idx, msg in enumerate(messages):
             role = msg.role
@@ -1571,8 +1566,8 @@ class ChatCompletionRequest(BaseModel):
                 if not in_order:
                     stack.pop()
                     continue
-                # Prefer a name match anywhere in this assistant, else its first
-                # remaining call, exactly as the old in-order scan did.
+                # Name match anywhere in this assistant, else its first remaining call,
+                # exactly as the old in-order scan did.
                 chosen = None
                 if msg.name:
                     named = by_name.get(msg.name)

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1486,13 +1486,12 @@ class ChatCompletionRequest(BaseModel):
         unconsumed tool_call; synth a random id only if none exists. A user
         turn breaks the lookup.
         """
-        # Both passes below were a backwards rescan per tool result, O(n^2) for one
-        # assistant with n calls. Each is now a single forward pass with an index, the
-        # same search because the backward walk never left the current user-delimited
-        # segment: a "user" message ends it.
+        # Both passes below were a backwards rescan per tool result, O(n^2) for one assistant
+        # with n calls. Each is now one forward pass with an index -- the same search, since
+        # the backward walk never left the current user-delimited segment.
         messages = self.messages
-        # The first pass only feeds the second, so with every tool_call_id present there
-        # is nothing to do, which is the common case for well-behaved clients.
+        # The first pass only feeds the second, so with every tool_call_id present there is
+        # nothing to do (the common case).
         for msg in messages:
             if msg.role == "tool" and not msg.tool_call_id:
                 break
@@ -1526,11 +1525,11 @@ class ChatCompletionRequest(BaseModel):
                 if claimed is not None:
                     consumed.add(claimed)
 
-        # Assistants in this segment with an unclaimed call, oldest first, so the nearest
-        # is on top. A drained assistant never refills, so popping it is permanent and the
-        # walk past it happens once overall rather than once per tool result. Each frame
-        # keeps its remaining call indexes in order plus the same indexes bucketed by
-        # function name; one consumed out of turn is dropped when it reaches a queue front.
+        # Assistants in this segment with an unclaimed call, oldest first, so the nearest is
+        # on top. A drained assistant never refills, so popping it is permanent and the walk
+        # past it happens once overall, not once per tool result. Each frame keeps its calls
+        # in order plus the same indexes bucketed by function name; one consumed out of turn
+        # is dropped when it reaches a queue front.
         stack: list = []
         for asst_idx, msg in enumerate(messages):
             role = msg.role

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import time
 import uuid
+from collections import deque
 from typing import Annotated, Any, Dict, Literal, Optional, List, Union
 
 from pydantic import (
@@ -1485,57 +1486,106 @@ class ChatCompletionRequest(BaseModel):
         unconsumed tool_call; synth a random id only if none exists. A user
         turn breaks the lookup.
         """
+        # Both passes below used to walk the history backwards from every tool result and
+        # rescan each assistant's tool_calls, so one assistant with n calls followed by n
+        # results was O(n^2). Both now run in one forward pass with an index, which is the
+        # same search because the backward walk only ever looked inside the current
+        # user-delimited segment: a "user" message ends it.
+        messages = self.messages
+        # Nothing below writes anything unless some tool result is missing its id: the
+        # first pass only feeds the second. Well-behaved OpenAI clients always send
+        # tool_call_id, so this returns immediately for most requests.
+        for msg in messages:
+            if msg.role == "tool" and not msg.tool_call_id:
+                break
+        else:
+            return self
+
         # Pre-mark explicit ids so a missing-id sibling can't steal a claimed one.
         consumed: set[tuple[int, int]] = set()
 
-        def _mark_consumed(start_idx: int, tool_call_id: str) -> None:
-            for asst_idx in range(start_idx - 1, -1, -1):
-                prev = self.messages[asst_idx]
-                if prev.role == "user":
-                    break
-                if prev.role != "assistant" or not prev.tool_calls:
+        # Newest assistant call per explicit id in this segment; the first index wins
+        # inside one assistant, matching the old first-match-nearest-assistant walk.
+        # Only exact ``str`` ids are indexed: ``tool_call_id`` is a ``str``, so a JSON
+        # id of any other type could never compare equal to it anyway.
+        latest_by_id: dict = {}
+        for asst_idx, msg in enumerate(messages):
+            role = msg.role
+            if role == "user":
+                latest_by_id.clear()
+            elif role == "assistant":
+                if not msg.tool_calls:
                     continue
-                for tc_idx, tc in enumerate(prev.tool_calls):
-                    if isinstance(tc, dict) and tc.get("id") == tool_call_id:
-                        consumed.add((asst_idx, tc_idx))
-                        return
-
-        for tool_idx, msg in enumerate(self.messages):
-            if msg.role == "tool" and msg.tool_call_id:
-                _mark_consumed(tool_idx, msg.tool_call_id)
-
-        for tool_idx, msg in enumerate(self.messages):
-            if msg.role != "tool" or msg.tool_call_id:
-                continue
-            picked: str | None = None
-            for asst_idx in range(tool_idx - 1, -1, -1):
-                prev = self.messages[asst_idx]
-                if prev.role != "assistant" or not prev.tool_calls:
-                    if prev.role == "user":
-                        break
-                    continue
-                name_match = None
-                fallback = None
-                for tc_idx, tc in enumerate(prev.tool_calls):
-                    if (asst_idx, tc_idx) in consumed:
-                        continue
+                here: set = set()
+                for tc_idx, tc in enumerate(msg.tool_calls):
                     if not isinstance(tc, dict):
                         continue
                     tc_id = tc.get("id")
-                    if not tc_id:
+                    if isinstance(tc_id, str) and tc_id not in here:
+                        here.add(tc_id)
+                        latest_by_id[tc_id] = (asst_idx, tc_idx)
+            elif role == "tool" and msg.tool_call_id:
+                claimed = latest_by_id.get(msg.tool_call_id)
+                if claimed is not None:
+                    consumed.add(claimed)
+
+        # Stack of the assistants in the current segment that still have an unclaimed
+        # call, oldest first, so the nearest one is on top. A drained assistant can never
+        # refill, so popping it is permanent and the walk past it happens once overall
+        # rather than once per tool result. Each frame holds its remaining call indexes
+        # in order plus the same indexes bucketed by function name; an index consumed out
+        # of turn is dropped when it reaches the front of a queue, so every index leaves
+        # each queue at most once.
+        stack: list = []
+        for asst_idx, msg in enumerate(messages):
+            role = msg.role
+            if role == "user":
+                stack.clear()
+                continue
+            if role == "assistant":
+                if not msg.tool_calls:
+                    continue
+                in_order: deque = deque()
+                by_name: dict = {}
+                for tc_idx, tc in enumerate(msg.tool_calls):
+                    if (asst_idx, tc_idx) in consumed or not isinstance(tc, dict):
+                        continue
+                    if not tc.get("id"):
                         continue
                     function = tc.get("function")
                     function_name = function.get("name") if isinstance(function, dict) else None
-                    if msg.name and function_name == msg.name:
-                        name_match = (tc_id, asst_idx, tc_idx)
-                        break
-                    if fallback is None:
-                        fallback = (tc_id, asst_idx, tc_idx)
-                chosen = name_match or fallback
-                if chosen is not None:
-                    picked, a, t = chosen
-                    consumed.add((a, t))
-                    break
+                    in_order.append(tc_idx)
+                    # ``name`` is a ``str``, so only a ``str`` function name can match it.
+                    if isinstance(function_name, str):
+                        by_name.setdefault(function_name, deque()).append(tc_idx)
+                if in_order:
+                    stack.append((asst_idx, msg.tool_calls, in_order, by_name))
+                continue
+            if role != "tool" or msg.tool_call_id:
+                continue
+            picked = None
+            while stack:
+                frame_idx, tool_calls, in_order, by_name = stack[-1]
+                while in_order and (frame_idx, in_order[0]) in consumed:
+                    in_order.popleft()
+                if not in_order:
+                    stack.pop()
+                    continue
+                # Prefer a name match anywhere in this assistant, else its first
+                # remaining call, exactly as the old in-order scan did.
+                chosen = None
+                if msg.name:
+                    named = by_name.get(msg.name)
+                    if named is not None:
+                        while named and (frame_idx, named[0]) in consumed:
+                            named.popleft()
+                        if named:
+                            chosen = named.popleft()
+                if chosen is None:
+                    chosen = in_order.popleft()
+                consumed.add((frame_idx, chosen))
+                picked = tool_calls[chosen].get("id")
+                break
             if picked is None:
                 import secrets as _secrets
                 picked = f"call_{_secrets.token_hex(8)}"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -718,11 +718,14 @@ def _truncate_middle_messages(messages: list, keep_ratio: float):
     tail = groups[-protected_tail:]
 
     current_est = total_est
-    kept_middle: list[list] = list(middle)
     dropped = 0
-    # Drop oldest-first until the estimate fits the target.
-    while kept_middle and current_est > target_est:
-        victim = kept_middle.pop(0)
+    # Drop oldest-first until the estimate fits the target. A cursor over ``middle``
+    # rather than repeated ``pop(0)`` on a copy: popping the front of a list shifts
+    # every remaining element, so evicting k groups costs O(len(middle) * k).
+    first_kept = 0
+    while first_kept < len(middle) and current_est > target_est:
+        victim = middle[first_kept]
+        first_kept += 1
         dropped += len(victim)
         current_est -= sum(estimates[id(msg)] for msg in victim)
 
@@ -730,7 +733,7 @@ def _truncate_middle_messages(messages: list, keep_ratio: float):
         return messages, 0
 
     new_messages = head + anchor
-    for grp in kept_middle:
+    for grp in middle[first_kept:]:
         new_messages.extend(grp)
     for grp in tail:
         new_messages.extend(grp)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -719,9 +719,8 @@ def _truncate_middle_messages(messages: list, keep_ratio: float):
 
     current_est = total_est
     dropped = 0
-    # Drop oldest-first until the estimate fits the target. A cursor over ``middle``
-    # rather than repeated ``pop(0)`` on a copy: popping the front of a list shifts
-    # every remaining element, so evicting k groups costs O(len(middle) * k).
+    # Drop oldest-first until the estimate fits the target. A cursor over ``middle``, not
+    # ``pop(0)`` on a copy: popping the front of a list shifts every remaining element.
     first_kept = 0
     while first_kept < len(middle) and current_est > target_est:
         victim = middle[first_kept]

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -3420,9 +3420,8 @@ async def upload_diffusion_dataset(
         # Validate every filename up front so a valid file ahead of a bad one is not left on disk when the 400 fires; the upload is all-or-nothing.
         names: list[str] = []
         # Indexes over `names` so the three batch-local duplicate checks below are hash
-        # lookups, not scans over every earlier filename (O(N^2) at the 1000-file cap).
-        # They keep first / insertion order, so each error message still names the same
-        # earlier filename the linear scans picked.
+        # lookups, not scans over every earlier filename (O(N^2) at the 1000-file cap). First
+        # / insertion order is kept, so each error still names the filename the scans picked.
         seen_names: set = set()
         first_name_by_casefold: dict = {}
         media_names_by_stem_cf: dict = {}

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -3419,12 +3419,10 @@ async def upload_diffusion_dataset(
         allowed = _DIFFUSION_DATASET_MEDIA_EXTS | _DIFFUSION_DATASET_TEXT_EXTS
         # Validate every filename up front so a valid file ahead of a bad one is not left on disk when the 400 fires; the upload is all-or-nothing.
         names: list[str] = []
-        # Indexes over `names`, rebuilt per request, so each of the three batch-local
-        # duplicate checks below is a hash lookup instead of a scan over every earlier
-        # filename: a batch at the 1000-file multipart cap was O(N^2). `names` still
-        # drives staging order, and the per-casefold / per-stem entries keep insertion
-        # order so the earlier filename named in each error message is the same one the
-        # linear scans picked.
+        # Indexes over `names` so the three batch-local duplicate checks below are hash
+        # lookups, not scans over every earlier filename (O(N^2) at the 1000-file cap).
+        # They keep first / insertion order, so each error message still names the same
+        # earlier filename the linear scans picked.
         seen_names: set = set()
         first_name_by_casefold: dict = {}
         media_names_by_stem_cf: dict = {}
@@ -3477,8 +3475,7 @@ async def upload_diffusion_dataset(
                     None,
                 )
                 if clash is None:
-                    # Only a media name whose stem casefolds to this one can share the
-                    # sidecar, which is exactly what the per-stem index holds.
+                    # Only a media name with this casefolded stem can share the sidecar.
                     clash = next(
                         (n for n in media_names_by_stem_cf.get(stem_cf, ()) if _shares_sidecar(n)),
                         None,

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -3419,6 +3419,15 @@ async def upload_diffusion_dataset(
         allowed = _DIFFUSION_DATASET_MEDIA_EXTS | _DIFFUSION_DATASET_TEXT_EXTS
         # Validate every filename up front so a valid file ahead of a bad one is not left on disk when the 400 fires; the upload is all-or-nothing.
         names: list[str] = []
+        # Indexes over `names`, rebuilt per request, so each of the three batch-local
+        # duplicate checks below is a hash lookup instead of a scan over every earlier
+        # filename: a batch at the 1000-file multipart cap was O(N^2). `names` still
+        # drives staging order, and the per-casefold / per-stem entries keep insertion
+        # order so the earlier filename named in each error message is the same one the
+        # linear scans picked.
+        seen_names: set = set()
+        first_name_by_casefold: dict = {}
+        media_names_by_stem_cf: dict = {}
         for f in files:
             # Normalise to a safe basename. Path.name does not split on a backslash on POSIX, so fold
             # backslashes first or a Windows client's path is stored verbatim, ".." and all.
@@ -3433,7 +3442,7 @@ async def upload_diffusion_dataset(
             # Reject an EXACT duplicate name within THIS batch: the same-name exemption below is for
             # SEPARATE repeat uploads, while inside one batch the later replace would discard the earlier.
             fname_cf = filename.casefold()
-            if filename in names:
+            if filename in seen_names:
                 raise HTTPException(
                     status_code = 400,
                     detail = (
@@ -3468,7 +3477,16 @@ async def upload_diffusion_dataset(
                     None,
                 )
                 if clash is None:
-                    clash = next((n for n in names if _shares_sidecar(n)), None)
+                    # Only a media name whose stem casefolds to this one can share the
+                    # sidecar, which is exactly what the per-stem index holds.
+                    clash = next(
+                        (
+                            n
+                            for n in media_names_by_stem_cf.get(stem_cf, ())
+                            if _shares_sidecar(n)
+                        ),
+                        None,
+                    )
                 if clash is not None:
                     kind = "clip" if ext in _DIFFUSION_DATASET_CLIP_EXTS else "image"
                     raise HTTPException(
@@ -3483,10 +3501,8 @@ async def upload_diffusion_dataset(
             # case: there 'Cat.png' and 'cat.png' are ONE destination, so the commit would replace the
             # first staged part with the second while `uploaded` counted both. The same-name exemption
             # above is for a SEPARATE repeat upload; on a case-sensitive filesystem both stay allowed.
-            if any(n.casefold() == fname_cf for n in names) and _dataset_folder_is_case_insensitive(
-                folder
-            ):
-                clash_cf = next(n for n in names if n.casefold() == fname_cf)
+            clash_cf = first_name_by_casefold.get(fname_cf)
+            if clash_cf is not None and _dataset_folder_is_case_insensitive(folder):
                 raise HTTPException(
                     status_code = 400,
                     detail = (
@@ -3495,6 +3511,12 @@ async def upload_diffusion_dataset(
                         "other. Rename one before uploading."
                     ),
                 )
+            seen_names.add(filename)
+            first_name_by_casefold.setdefault(fname_cf, filename)
+            if ext in _DIFFUSION_DATASET_MEDIA_EXTS:
+                media_names_by_stem_cf.setdefault(
+                    Path(filename).stem.casefold(), []
+                ).append(filename)
             names.append(filename)
         # Stage each file to a temp name and move it in only once the whole batch is written, so a mid-batch failure leaves the dataset untouched, including any same-name file a direct write would truncate.
         staged: list[tuple[Path, Path]] = []  # (temp, final)

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -3480,11 +3480,7 @@ async def upload_diffusion_dataset(
                     # Only a media name whose stem casefolds to this one can share the
                     # sidecar, which is exactly what the per-stem index holds.
                     clash = next(
-                        (
-                            n
-                            for n in media_names_by_stem_cf.get(stem_cf, ())
-                            if _shares_sidecar(n)
-                        ),
+                        (n for n in media_names_by_stem_cf.get(stem_cf, ()) if _shares_sidecar(n)),
                         None,
                     )
                 if clash is not None:
@@ -3514,9 +3510,9 @@ async def upload_diffusion_dataset(
             seen_names.add(filename)
             first_name_by_casefold.setdefault(fname_cf, filename)
             if ext in _DIFFUSION_DATASET_MEDIA_EXTS:
-                media_names_by_stem_cf.setdefault(
-                    Path(filename).stem.casefold(), []
-                ).append(filename)
+                media_names_by_stem_cf.setdefault(Path(filename).stem.casefold(), []).append(
+                    filename
+                )
             names.append(filename)
         # Stage each file to a temp name and move it in only once the whole batch is written, so a mid-batch failure leaves the dataset untouched, including any same-name file a direct write would truncate.
         staged: list[tuple[Path, Path]] = []  # (temp, final)

--- a/studio/backend/tests/test_web_access_policy.py
+++ b/studio/backend/tests/test_web_access_policy.py
@@ -11,6 +11,7 @@ import pytest
 from core.inference import tools
 from core.inference.tool_loop_controller import is_tool_error
 from core.inference.web_access_policy import (
+    _normalized_domain_tuple,
     check_url_access,
     normalize_website_policy,
     scope_search_query,
@@ -88,6 +89,26 @@ def test_policy_normalizes_idna_deduplicates_and_rejects_urls():
     }
     with pytest.raises(ValueError, match = "without schemes or ports|Invalid website domain"):
         normalize_website_policy({"allowedDomains": ["https://arxiv.org"]})
+
+
+def test_oversized_raw_domains_normalize_without_entering_the_cache():
+    # Nameprep deletes U+00AD, so 100k soft hyphens still normalise to a valid domain. The
+    # memo key is the caller's raw tuple, so caching one would pin it for the life of the
+    # process; it must normalise on the uncached path instead.
+    normalize_website_policy({})  # warm the empty-list key so the counts below are exact
+    padded = "a" + "\u00ad" * 100_000 + ".com"
+    before = _normalized_domain_tuple.cache_info().currsize
+    assert normalize_website_policy({"allowedDomains": [padded]}) == {
+        "allowedDomains": ["a.com"],
+        "blockedDomains": [],
+    }
+    assert _normalized_domain_tuple.cache_info().currsize == before
+    # A domain of a plausible length still takes the cached path.
+    assert normalize_website_policy({"allowedDomains": ["cached.example"]}) == {
+        "allowedDomains": ["cached.example"],
+        "blockedDomains": [],
+    }
+    assert _normalized_domain_tuple.cache_info().currsize == before + 1
 
 
 def test_policy_is_injected_into_prompts_and_search_queries():


### PR DESCRIPTION
One of a series of Studio backend performance PRs. This one is the routes and
data layer: five paths that were superlinear in the size of their input, plus
one that decoded a whole vocabulary in order to throw it away.

Every change is a pure algorithmic rewrite of an existing rule. No behaviour,
no ordering, no error type, no error text and no log line changes.

## Before

| Path | File | Cost |
|---|---|---|
| GGUF header parse read, UTF-8 decoded and retained all 128k to 256k vocabulary entries, then kept the few hundred delimiter-shaped ones | `core/inference/llama_cpp.py` | 82.4 ms per parse |
| Tool result id resolution walked the history backwards from every result and rescanned each assistant's `tool_calls`, so n calls followed by n results was O(n^2) | `models/inference.py` | 216 ms per request at 2000 results |
| Context-overflow eviction copied the middle groups and dropped them with `pop(0)`, shifting every remaining element per drop | `routes/inference.py` | 1.157 s at 32k messages |
| Diffusion dataset upload scanned every already-accepted filename for each incoming file, four times over, for exact, stem and case collisions | `routes/training.py` | 1.185 s for a 1000-file batch |
| `check_url_access` re-normalised the entire website policy for every URL, IDNA-encoding up to 200 domains each time | `core/inference/web_access_policy.py` | 28.6 ms per restricted search |

## After

Each one keeps the identical rule and changes only how it is looked up.

- **GGUF vocabulary.** Read the length and the first byte, seek past the body when
  that byte is neither `<` nor `[`. The shape filter accepts nothing else, and
  UTF-8 is self-synchronising so no multi-byte character starts with either byte.
- **Tool result ids.** The backward walk only ever looked inside the current
  user-delimited segment, so a single forward pass with an index answers the same
  question. Explicit ids use a per-segment map of the newest assistant call per
  id. Missing ids draw from a stack of assistants that still have an unclaimed
  call, each holding its remaining indexes in order plus the same indexes
  bucketed by function name, preserving the name-match-else-first-remaining
  order exactly. Requests whose tool results all carry ids now return before
  either pass, since the first pass only ever fed the second.
- **Overflow eviction.** A cursor over the existing slice, no copy and no shifting.
- **Upload validation.** Three per-request indexes. They keep insertion order, so
  each error message still names the same earlier file the linear scans named.
- **Website policy.** `normalize_domain` is a pure function of its argument, so an
  all-`str` domain list memoises on an immutable tuple. Every public call still
  returns fresh dicts and lists.

Measured on this machine, minimum of repeated timings, CPU only:

| Case | Before | After | Speedup |
|---|---:|---:|---:|
| GGUF header, 256k-token vocabulary | 82.410 ms | 44.338 ms | 1.86x |
| Tool ids, 250 results, explicit | 3.713 ms | 0.566 ms | 6.56x |
| Tool ids, 500 results, explicit | 13.944 ms | 1.130 ms | 12.34x |
| Tool ids, 2000 results, explicit | 215.917 ms | 4.801 ms | 44.97x |
| Tool ids, 500 results, ids missing | 12.937 ms | 1.607 ms | 8.05x |
| Tool ids, 2000 results, ids missing | 207.566 ms | 7.077 ms | 29.33x |
| Overflow truncation, 4k messages | 23.384 ms | 11.438 ms | 2.04x |
| Overflow truncation, 16k messages | 308.211 ms | 44.079 ms | 6.99x |
| Overflow truncation, 32k messages | 1157.057 ms | 89.598 ms | 12.91x |
| Upload validation, 250 files | 85.799 ms | 12.827 ms | 6.69x |
| Upload validation, 500 files | 304.851 ms | 21.760 ms | 14.01x |
| Upload validation, 999 files | 1185.300 ms | 38.974 ms | 30.41x |
| Website policy, 5 + 5 domains, 20 URLs | 1.665 ms | 0.369 ms | 4.51x |
| Website policy, 100 + 100 domains, 20 URLs | 28.564 ms | 0.692 ms | 41.30x |

The upload figures stop at 999 files because Starlette caps one multipart
request at `max_files=1000`, so that is the largest batch this route can receive.

Controls, so the small common case is not paying for the large one. A request
validation costs 3 to 37 microseconds here:

| Control | Before | After |
|---|---:|---:|
| 1 user message | 3.961 us | 3.493 us |
| 10-message chat, no tools | 10.576 us | 9.496 us |
| 50-message chat, no tools | 36.231 us | 34.987 us |
| 10 messages, 4 tool calls, ids present | 11.725 us | 8.533 us |
| 10 messages, 4 tool calls, ids missing | 12.939 us | 14.402 us |
| Overflow truncation, 1000 messages | 2.682 ms | 2.661 ms |

The one case that gets slower is a short history whose tool results are missing
their ids: building the index costs about 1.5 us more than the naive scan does at
n=4. That is the only regression I measured, and it is the same path that saves
205 ms at 2000 results.

## How output equivalence was verified

Not by inspection. For each change I ran a differential harness that drives the
real code over a wide corpus, once against a pristine copy of `origin/main` and
once against this branch, and compares the recorded results byte for byte. The
emitted log text is compared the same way, with timestamps stripped, so a
changed or missing log line fails the check too. Every corpus includes empty,
unicode, malformed, oversized and adversarial inputs, and every harness applies
each operation twice to confirm idempotency is unchanged.

| Change | Corpus | Result |
|---|---|---|
| GGUF vocabulary | 33 synthetic headers: every possible leading byte, invalid UTF-8, lone surrogates, zero-length tokens, unicode delimiters, shape lookalikes, a vocabulary followed by further keys so a wrong stream position cannot hide, truncation at 20 offsets, and a length field overrunning the file by 1 TB. Compares all 22 parsed metadata attributes, parsed twice each | identical |
| Tool result ids | 12,012 histories, 292,742 messages, 208,677 tool results, 37,013 synthesised ids: duplicate ids within and across assistants, user and system boundaries, name matches, drained assistants, non-str and falsy ids, unhashable ids, 5000-character ids and names, orphan results. Compares the resolved id of every message plus a full revalidation of the result | identical |
| Overflow truncation | 3,016 message lists, 46,052 messages dropped: empty, single, all-system, all-tool, unserialisable content, ratios from -0.5 to 1.5, plus the second truncation of every result | identical |
| Upload validation | 2,032 batch uploads, each posted twice so the second sees the first on disk, driven through the real route. All four rejection branches exercised: 425 bad extension, 333 exact duplicate, 303 case variant, 274 sidecar stem. Run with the filesystem case-sensitivity answer forced both ways, since a case-sensitive host never reaches the third check. Compares status, response body and folder contents | identical |
| Website policy | 5,044 policies, 181,584 observations: non-str and unhashable entries, over-limit lists, unknown fields, IDNA, IPv4, IPv6, bracketed hosts, non-canonical numeric hosts, control characters, plus a poisoning probe that mutates a returned list and re-reads the policy | identical |

Test suite, `python3 -m pytest tests/ -q -p no:randomly` in `studio/backend`:

- base `14c6ce31d`: 343 failed, 21585 passed, 85 errors
- this branch: 182 failed, 21746 passed, 85 errors
- new failures introduced by this branch: **none**. The patched failure set is a
  strict subset of the base one.

The 161 that differ are cross-file interference, not a fix: they are GPU, VRAM
and tensor-parallel tests unrelated to these five files, and
`test_metal_paravirtual_guard.py`, `test_mtp_vram_budget.py` and
`test_tensor_parallel.py` all pass 397/397 in isolation on both the base and this
branch. The remaining failures and all 85 collection errors are environmental on
this host: no GPU, and `fastmcp`, `pymupdf` and `sqlite_vec` are absent.

The 13 test files that cover these paths directly give the identical result on
both trees: 1075 passed, and the same single pre-existing failure
(`test_every_shipped_video_family_resolves_on_this_diffusers`, a diffusers
version check).

## Considered and dropped

- **Caching `load_inference_config` on the `/api/inference/status` poll.** The
  endpoint reparses YAML on every request, which I measured at 3.575 ms per call,
  or roughly 43 ms of CPU per minute per open client. Dropped: the function logs
  a line per call, so caching it would silently remove log output, and it reads
  from disk on every call, so memoising it asserts an invariance that nothing in
  the code guarantees. The saving does not justify either.
- **Precomputing the SSE envelope for content and reasoning deltas.** This means
  hand-rolling a second JSON serializer beside the `ChatCompletionChunk` model.
  Byte equality holds today, but nothing keeps the two in step, and no test
  patches that seam, so a future field on the model would diverge silently.
- **Reusing the already-decoded chunk in the SSE monitor.** Depends on an
  identity check between the raw and emitted line to decide which path is safe,
  and it changes which branch the monitor takes for every relayed chunk.
- **Skipping the `json.loads` fallback on lines starting with `data:`.** Changes
  an exception-driven control path for a per-line saving.
- **Adding a `stream_deltas` mode to `generate_chat_completion`.** Changes the
  contract of a public generator and rewires three streaming routes. Too large a
  blast radius for this PR.
