### PR TITLE
fix(studio): use --reasoning for launch defaults

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -126,6 +126,14 @@ from state.tool_approvals import (
 
 logger = get_logger(__name__)
 
+_SUPPORTS_REASONING_FLAG_CAPABILITY = "supports_reasoning_flag"
+_ENABLE_THINKING_KWARG = "enable_thinking"
+_PRESERVE_THINKING_KWARG = "preserve_thinking"
+_REASONING_FLAG = "--reasoning"
+_REASONING_ON = "on"
+_REASONING_OFF = "off"
+_CHAT_TEMPLATE_KWARGS_FLAG = "--chat-template-kwargs"
+
 # Floor for a GGUF TTS read, scaled by requested tokens at the call site. This backend
 # decodes in seconds; the subprocess one needs minutes, so they do not share a base.
 _GGUF_AUDIO_READ_TIMEOUT = 300.0
@@ -4295,6 +4303,22 @@ class LlamaCppBackend:
             )
         return {"enable_thinking": enable_thinking}
 
+    def _append_launch_reasoning_args(
+        self, cmd: list[str], thinking_default: bool, server_caps: Mapping[str, object]
+    ) -> None:
+        """Append reasoning defaults, retaining kwargs for older llama-server builds."""
+        reasoning_kwargs = self._reasoning_kwargs(thinking_default)
+        if (
+            server_caps.get(_SUPPORTS_REASONING_FLAG_CAPABILITY)
+            and _ENABLE_THINKING_KWARG in reasoning_kwargs
+        ):
+            enabled = reasoning_kwargs.pop(_ENABLE_THINKING_KWARG)
+            cmd.extend([_REASONING_FLAG, _REASONING_ON if enabled else _REASONING_OFF])
+        if self._supports_preserve_thinking:
+            reasoning_kwargs[_PRESERVE_THINKING_KWARG] = False
+        if reasoning_kwargs:
+            cmd.extend([_CHAT_TEMPLATE_KWARGS_FLAG, json.dumps(reasoning_kwargs)])
+
     def _request_reasoning_kwargs(
         self,
         enable_thinking: Optional[bool],
@@ -5023,6 +5047,7 @@ class LlamaCppBackend:
                 "supports_slot_save": False,
                 "supports_no_mmproj_offload": False,
                 "supports_load_mode": False,
+                _SUPPORTS_REASONING_FLAG_CAPABILITY: False,
                 "spec_draft_ngl_flag": None,
                 "flags": {},
                 "help_probe_ok": False,
@@ -5067,6 +5092,7 @@ class LlamaCppBackend:
         supports_slot_save = False
         supports_no_mmproj_offload = False
         supports_load_mode = False
+        supports_reasoning_flag = False
         spec_draft_ngl_flag = None
         saw_spec_type = False
         probe_ok = False
@@ -5270,6 +5296,7 @@ class LlamaCppBackend:
             # --load-mode supersedes --mlock / --no-mmap, which are deprecated.
             # Pre-initialised above: a failed probe must fall back, not raise.
             supports_load_mode = _is_real("--load-mode")
+            supports_reasoning_flag = _is_real(_REASONING_FLAG)
             # Record WHICH alias this build has: --spec-draft-ngl only landed in
             # b8955, and a build exposing only --gpu-layers-draft would refuse to
             # start on the newer name. Long forms only, since the block parser above
@@ -5338,6 +5365,7 @@ class LlamaCppBackend:
             "supports_slot_save": supports_slot_save,
             "supports_no_mmproj_offload": supports_no_mmproj_offload,
             "supports_load_mode": supports_load_mode,
+            _SUPPORTS_REASONING_FLAG_CAPABILITY: supports_reasoning_flag,
             "spec_draft_ngl_flag": spec_draft_ngl_flag,
             # The whole parsed catalogue, not just the booleans above. The UI
             # validates pass-through args against THIS build rather than a list
@@ -15997,21 +16025,7 @@ class LlamaCppBackend:
                             if size_b <= 9:
                                 thinking_default = False
                     self._reasoning_default = thinking_default
-                    reasoning_kw = self._reasoning_kwargs(thinking_default)
-                    # preserve_thinking is an independent kwarg. Default it OFF
-                    # at launch so direct OpenAI-compatible callers that omit the
-                    # field match the UI's default-off behavior (the bundled
-                    # gemma-4 template also defaults it false; the frontend sends
-                    # preserve_thinking per request once toggled on).
-                    if self._supports_preserve_thinking:
-                        reasoning_kw["preserve_thinking"] = False
-                    cmd.extend(
-                        [
-                            "--chat-template-kwargs",
-                            json.dumps(reasoning_kw),
-                        ]
-                    )
-                    logger.info(f"Reasoning model: {reasoning_kw} by default")
+                    self._append_launch_reasoning_args(cmd, thinking_default, server_caps)
 
                 if launch_mmproj_path and effective_is_vision:
                     cmd.extend(["--mmproj", launch_mmproj_path])

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -459,9 +459,12 @@ logger = get_logger(__name__)
 _SUPPORTS_REASONING_FLAG_CAPABILITY = "supports_reasoning_flag"
 _ENABLE_THINKING_KWARG = "enable_thinking"
 _PRESERVE_THINKING_KWARG = "preserve_thinking"
+_MTP_PROBE_INCONCLUSIVE_CAPABILITY = "mtp_probe_inconclusive"
 _REASONING_FLAG = "--reasoning"
 _REASONING_ON = "on"
 _REASONING_OFF = "off"
+_REASONING_AUTO = "auto"
+_EXPLICIT_REASONING_ENV_VALUES = frozenset({_REASONING_ON, _REASONING_OFF})
 _CHAT_TEMPLATE_KWARGS_FLAG = "--chat-template-kwargs"
 _LLAMA_REASONING_ENV = "LLAMA_ARG_REASONING"
 
@@ -7047,13 +7050,26 @@ class LlamaCppBackend:
     ) -> None:
         """Append reasoning defaults, retaining kwargs for older llama-server builds."""
         reasoning_kwargs = self._reasoning_kwargs(thinking_default)
+        env_reasoning = os.environ.get(_LLAMA_REASONING_ENV, "").strip().lower()
+        if env_reasoning == _REASONING_AUTO:
+            explicit_env_reasoning = None
+        else:
+            explicit_env_reasoning = (
+                env_reasoning if env_reasoning in _EXPLICIT_REASONING_ENV_VALUES else None
+            )
+        if explicit_env_reasoning is not None:
+            self._reasoning_default = explicit_env_reasoning == _REASONING_ON
         if (
             server_caps.get(_SUPPORTS_REASONING_FLAG_CAPABILITY)
             and _ENABLE_THINKING_KWARG in reasoning_kwargs
         ):
             enabled = reasoning_kwargs.pop(_ENABLE_THINKING_KWARG)
-            if not os.environ.get(_LLAMA_REASONING_ENV, "").strip():
+            if explicit_env_reasoning is None:
                 cmd.extend([_REASONING_FLAG, _REASONING_ON if enabled else _REASONING_OFF])
+        elif explicit_env_reasoning is not None and server_caps.get(
+            _MTP_PROBE_INCONCLUSIVE_CAPABILITY
+        ):
+            reasoning_kwargs.pop(_ENABLE_THINKING_KWARG, None)
         if self._supports_preserve_thinking:
             reasoning_kwargs[_PRESERVE_THINKING_KWARG] = self._preserve_thinking_default
         if reasoning_kwargs:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -456,6 +456,14 @@ from utils.gguf_archs import (
 
 logger = get_logger(__name__)
 
+_SUPPORTS_REASONING_FLAG_CAPABILITY = "supports_reasoning_flag"
+_ENABLE_THINKING_KWARG = "enable_thinking"
+_PRESERVE_THINKING_KWARG = "preserve_thinking"
+_REASONING_FLAG = "--reasoning"
+_REASONING_ON = "on"
+_REASONING_OFF = "off"
+_CHAT_TEMPLATE_KWARGS_FLAG = "--chat-template-kwargs"
+
 # Floor for a GGUF TTS read, scaled by requested tokens at the call site. This backend
 # decodes in seconds; the subprocess one needs minutes, so they do not share a base.
 _GGUF_AUDIO_READ_TIMEOUT = 300.0
@@ -7033,6 +7041,22 @@ class LlamaCppBackend:
             )
         return {"enable_thinking": enable_thinking}
 
+    def _append_launch_reasoning_args(
+        self, cmd: list[str], thinking_default: bool, server_caps: Mapping[str, object]
+    ) -> None:
+        """Append reasoning defaults, retaining kwargs for older llama-server builds."""
+        reasoning_kwargs = self._reasoning_kwargs(thinking_default)
+        if (
+            server_caps.get(_SUPPORTS_REASONING_FLAG_CAPABILITY)
+            and _ENABLE_THINKING_KWARG in reasoning_kwargs
+        ):
+            enabled = reasoning_kwargs.pop(_ENABLE_THINKING_KWARG)
+            cmd.extend([_REASONING_FLAG, _REASONING_ON if enabled else _REASONING_OFF])
+        if self._supports_preserve_thinking:
+            reasoning_kwargs[_PRESERVE_THINKING_KWARG] = self._preserve_thinking_default
+        if reasoning_kwargs:
+            cmd.extend([_CHAT_TEMPLATE_KWARGS_FLAG, json.dumps(reasoning_kwargs)])
+
     def _request_reasoning_kwargs(
         self,
         enable_thinking: Optional[bool],
@@ -7852,6 +7876,7 @@ class LlamaCppBackend:
                 "supports_slot_save": False,
                 "supports_no_mmproj_offload": False,
                 "supports_load_mode": False,
+                _SUPPORTS_REASONING_FLAG_CAPABILITY: False,
                 "spec_draft_ngl_flag": None,
                 "spec_draft_cache_k_flag": None,
                 "spec_draft_cache_v_flag": None,
@@ -7899,6 +7924,7 @@ class LlamaCppBackend:
         supports_slot_save = False
         supports_no_mmproj_offload = False
         supports_load_mode = False
+        supports_reasoning_flag = False
         spec_draft_ngl_flag = None
         spec_draft_cache_k_flag = None
         spec_draft_cache_v_flag = None
@@ -8126,6 +8152,7 @@ class LlamaCppBackend:
             # --load-mode supersedes --mlock / --no-mmap, which are deprecated.
             # Pre-initialised above: a failed probe must fall back, not raise.
             supports_load_mode = _is_real("--load-mode")
+            supports_reasoning_flag = _is_real(_REASONING_FLAG)
             # Record WHICH alias this build has: --spec-draft-ngl only landed in
             # b8955, and a build exposing only --gpu-layers-draft would refuse to
             # start on the newer name. Long forms only, since the block parser above
@@ -8216,6 +8243,7 @@ class LlamaCppBackend:
             "supports_slot_save": supports_slot_save,
             "supports_no_mmproj_offload": supports_no_mmproj_offload,
             "supports_load_mode": supports_load_mode,
+            _SUPPORTS_REASONING_FLAG_CAPABILITY: supports_reasoning_flag,
             "spec_draft_ngl_flag": spec_draft_ngl_flag,
             "spec_draft_cache_k_flag": spec_draft_cache_k_flag,
             "spec_draft_cache_v_flag": spec_draft_cache_v_flag,
@@ -22666,20 +22694,7 @@ class LlamaCppBackend:
                             if size_b <= 9:
                                 thinking_default = False
                     self._reasoning_default = thinking_default
-                    reasoning_kw = self._reasoning_kwargs(thinking_default)
-                    # preserve_thinking is independent of the thinking gate.
-                    # Qwen3.8 defaults it on; Qwen3.6, Gemma 4, and every other
-                    # supporting family keep the existing off default. The
-                    # frontend receives the same resolved value via load/status.
-                    if self._supports_preserve_thinking:
-                        reasoning_kw["preserve_thinking"] = self._preserve_thinking_default
-                    cmd.extend(
-                        [
-                            "--chat-template-kwargs",
-                            json.dumps(reasoning_kw),
-                        ]
-                    )
-                    logger.info(f"Reasoning model: {reasoning_kw} by default")
+                    self._append_launch_reasoning_args(cmd, thinking_default, server_caps)
 
                 if launch_mmproj_path and effective_is_vision:
                     cmd.extend(["--mmproj", launch_mmproj_path])

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -463,6 +463,7 @@ _REASONING_FLAG = "--reasoning"
 _REASONING_ON = "on"
 _REASONING_OFF = "off"
 _CHAT_TEMPLATE_KWARGS_FLAG = "--chat-template-kwargs"
+_LLAMA_REASONING_ENV = "LLAMA_ARG_REASONING"
 
 # Floor for a GGUF TTS read, scaled by requested tokens at the call site. This backend
 # decodes in seconds; the subprocess one needs minutes, so they do not share a base.
@@ -7051,7 +7052,8 @@ class LlamaCppBackend:
             and _ENABLE_THINKING_KWARG in reasoning_kwargs
         ):
             enabled = reasoning_kwargs.pop(_ENABLE_THINKING_KWARG)
-            cmd.extend([_REASONING_FLAG, _REASONING_ON if enabled else _REASONING_OFF])
+            if not os.environ.get(_LLAMA_REASONING_ENV, "").strip():
+                cmd.extend([_REASONING_FLAG, _REASONING_ON if enabled else _REASONING_OFF])
         if self._supports_preserve_thinking:
             reasoning_kwargs[_PRESERVE_THINKING_KWARG] = self._preserve_thinking_default
         if reasoning_kwargs:

--- a/studio/backend/tests/test_launch_reasoning_args.py
+++ b/studio/backend/tests/test_launch_reasoning_args.py
@@ -2,6 +2,8 @@ import struct
 import subprocess
 from unittest.mock import patch
 
+import pytest
+
 from core.inference.llama_cpp import GgufLoadIntent, LlamaCppBackend
 
 
@@ -25,10 +27,12 @@ _REASONING_STYLE = "enable_thinking"
 _REASONING_CAPABILITY = "supports_reasoning_flag"
 _PROBE_INCONCLUSIVE_CAPABILITY = "mtp_probe_inconclusive"
 _REASONING_FLAG = "--reasoning"
+_LLAMA_REASONING_ENV = "LLAMA_ARG_REASONING"
 _NO_REASONING_PRESERVE_FLAG = "--no-reasoning-preserve"
 _CHAT_TEMPLATE_KWARGS_FLAG = "--chat-template-kwargs"
 _ENABLE_THINKING_KWARG = "enable_thinking"
 _REASONING_ON = "on"
+_REASONING_OFF = "off"
 _SERVER_COMMAND = "llama-server"
 _MODERN_HELP = "--reasoning VALUE\n"
 _MISSING_BINARY_FILENAME = "missing"
@@ -117,7 +121,29 @@ def _backend(style = _REASONING_STYLE, supports_preserve = False):
     backend._reasoning_style = style
     backend._architecture = None
     backend._supports_preserve_thinking = supports_preserve
+    backend._preserve_thinking_default = False
     return backend
+
+
+@pytest.mark.parametrize(
+    ("thinking_default", "reasoning_override"),
+    ((True, _REASONING_OFF), (False, _REASONING_ON)),
+)
+def test_modern_launch_honors_reasoning_env_override(
+    monkeypatch,
+    thinking_default,
+    reasoning_override,
+):
+    monkeypatch.setenv(_LLAMA_REASONING_ENV, reasoning_override)
+    command = [_SERVER_COMMAND]
+
+    _backend()._append_launch_reasoning_args(
+        command,
+        thinking_default,
+        {_REASONING_CAPABILITY: True},
+    )
+
+    assert _REASONING_FLAG not in command
 
 
 def test_launch_reasoning_args_use_modern_flag_with_old_binary_fallback(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_launch_reasoning_args.py
+++ b/studio/backend/tests/test_launch_reasoning_args.py
@@ -33,6 +33,7 @@ _CHAT_TEMPLATE_KWARGS_FLAG = "--chat-template-kwargs"
 _ENABLE_THINKING_KWARG = "enable_thinking"
 _REASONING_ON = "on"
 _REASONING_OFF = "off"
+_REASONING_AUTO = "auto"
 _SERVER_COMMAND = "llama-server"
 _MODERN_HELP = "--reasoning VALUE\n"
 _MISSING_BINARY_FILENAME = "missing"
@@ -124,6 +125,7 @@ def _backend(style = _REASONING_STYLE, supports_preserve = False):
     backend._architecture = None
     backend._supports_preserve_thinking = supports_preserve
     backend._preserve_thinking_default = False
+    backend._reasoning_default = True
     return backend
 
 
@@ -135,15 +137,48 @@ def test_modern_launch_honors_reasoning_env_override(
     monkeypatch, thinking_default, reasoning_override
 ):
     monkeypatch.setenv(_LLAMA_REASONING_ENV, reasoning_override)
+    backend = _backend()
     command = [_SERVER_COMMAND]
 
-    _backend()._append_launch_reasoning_args(
+    backend._append_launch_reasoning_args(
         command,
         thinking_default,
         {_REASONING_CAPABILITY: True},
     )
 
     assert _REASONING_FLAG not in command
+    assert backend._reasoning_default is (reasoning_override == _REASONING_ON)
+
+
+def test_modern_launch_treats_auto_env_as_absent_override(monkeypatch):
+    monkeypatch.setenv(_LLAMA_REASONING_ENV, _REASONING_AUTO)
+    command = [_SERVER_COMMAND]
+
+    _backend()._append_launch_reasoning_args(
+        command,
+        False,
+        {_REASONING_CAPABILITY: True},
+    )
+
+    assert command == [_SERVER_COMMAND, _REASONING_FLAG, _REASONING_OFF]
+
+
+def test_inconclusive_probe_preserves_explicit_reasoning_env(monkeypatch):
+    monkeypatch.setenv(_LLAMA_REASONING_ENV, _REASONING_ON)
+    backend = _backend()
+    command = [_SERVER_COMMAND]
+
+    backend._append_launch_reasoning_args(
+        command,
+        False,
+        {
+            _REASONING_CAPABILITY: False,
+            _PROBE_INCONCLUSIVE_CAPABILITY: True,
+        },
+    )
+
+    assert command == [_SERVER_COMMAND]
+    assert backend._reasoning_default is True
 
 
 def test_launch_reasoning_args_use_modern_flag_with_old_binary_fallback(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_launch_reasoning_args.py
+++ b/studio/backend/tests/test_launch_reasoning_args.py
@@ -130,9 +130,7 @@ def _backend(style = _REASONING_STYLE, supports_preserve = False):
     ((True, _REASONING_OFF), (False, _REASONING_ON)),
 )
 def test_modern_launch_honors_reasoning_env_override(
-    monkeypatch,
-    thinking_default,
-    reasoning_override,
+    monkeypatch, thinking_default, reasoning_override
 ):
     monkeypatch.setenv(_LLAMA_REASONING_ENV, reasoning_override)
     command = [_SERVER_COMMAND]

--- a/studio/backend/tests/test_launch_reasoning_args.py
+++ b/studio/backend/tests/test_launch_reasoning_args.py
@@ -38,8 +38,7 @@ _SUBPROCESS_RUN_TARGET = "core.inference.llama_cpp.subprocess.run"
 _PRESERVE_ONLY_KWARGS = '{"preserve_thinking": false}'
 _OLD_KWARGS = '{"enable_thinking": false, "preserve_thinking": false}'
 _REASONING_TEMPLATE = (
-    "{% if enable_thinking %}thinking{% endif %}"
-    "{% if preserve_thinking %}history{% endif %}"
+    "{% if enable_thinking %}thinking{% endif %}{% if preserve_thinking %}history{% endif %}"
 )
 
 
@@ -122,11 +121,12 @@ def _backend(style = _REASONING_STYLE, supports_preserve = False):
 
 
 def test_launch_reasoning_args_use_modern_flag_with_old_binary_fallback(tmp_path, monkeypatch):
-    assert LlamaCppBackend.probe_server_capabilities(
-        str(tmp_path / _MISSING_BINARY_FILENAME)
-    ).get(
-        _REASONING_CAPABILITY, False
-    ) is False
+    assert (
+        LlamaCppBackend.probe_server_capabilities(str(tmp_path / _MISSING_BINARY_FILENAME)).get(
+            _REASONING_CAPABILITY, False
+        )
+        is False
+    )
     binary = tmp_path / _SERVER_COMMAND
     binary.write_text(_FAKE_BINARY_CONTENT, encoding = _UTF8_ENCODING)
     monkeypatch.setattr(
@@ -147,9 +147,7 @@ def test_launch_reasoning_args_use_modern_flag_with_old_binary_fallback(tmp_path
     backend = _backend(supports_preserve = True)
 
     modern_command = [_SERVER_COMMAND]
-    backend._append_launch_reasoning_args(
-        modern_command, True, modern_capabilities
-    )
+    backend._append_launch_reasoning_args(modern_command, True, modern_capabilities)
     assert modern_command == [
         _SERVER_COMMAND,
         _REASONING_FLAG,
@@ -160,14 +158,8 @@ def test_launch_reasoning_args_use_modern_flag_with_old_binary_fallback(tmp_path
     assert _NO_REASONING_PRESERVE_FLAG not in modern_command
 
     old_command = [_SERVER_COMMAND]
-    backend._append_launch_reasoning_args(
-        old_command, False, {_REASONING_CAPABILITY: False}
-    )
-    assert old_command == [
-        _SERVER_COMMAND,
-        _CHAT_TEMPLATE_KWARGS_FLAG,
-        _OLD_KWARGS,
-    ]
+    backend._append_launch_reasoning_args(old_command, False, {_REASONING_CAPABILITY: False})
+    assert old_command == [_SERVER_COMMAND, _CHAT_TEMPLATE_KWARGS_FLAG, _OLD_KWARGS]
 
 
 def test_load_command_uses_reasoning_flag(tmp_path):

--- a/studio/backend/tests/test_launch_reasoning_args.py
+++ b/studio/backend/tests/test_launch_reasoning_args.py
@@ -40,6 +40,8 @@ _FAKE_BINARY_CONTENT = "stub"
 _UTF8_ENCODING = "utf-8"
 _SUBPROCESS_RUN_TARGET = "core.inference.llama_cpp.subprocess.run"
 _PRESERVE_ONLY_KWARGS = '{"preserve_thinking": false}'
+_PRESERVE_DEFAULT_KWARGS = '{"preserve_thinking": true}'
+_REASONING_EFFORT_KWARGS = '{"reasoning_effort": "high"}'
 _OLD_KWARGS = '{"enable_thinking": false, "preserve_thinking": false}'
 _REASONING_TEMPLATE = (
     "{% if enable_thinking %}thinking{% endif %}{% if preserve_thinking %}history{% endif %}"
@@ -68,8 +70,8 @@ def _load_backend(tmp_path):
     )
 
     backend = LlamaCppBackend()
-    backend._get_gpu_memory = lambda binary = None: []
-    backend._get_gpu_free_memory = lambda binary = None: []
+    backend._get_gpu_memory = lambda *args, **kwargs: []
+    backend._get_gpu_free_memory = lambda *args, **kwargs: []
     backend._read_gguf_metadata = lambda path: None
     backend._can_estimate_kv = lambda: False
     backend._get_gguf_size_bytes = lambda path: _MODEL_SIZE_BYTES
@@ -79,7 +81,7 @@ def _load_backend(tmp_path):
     backend._amd_apu_wants_unified_memory = lambda *args, **kwargs: False
     backend._find_llama_server_binary = lambda include_denied = False: _FAKE_BINARY
     backend._is_vulkan_backend = lambda binary = None: False
-    backend._wait_for_health = lambda timeout: True
+    backend._wait_for_health = lambda *args, **kwargs: True
     backend._detect_audio_type_strict = lambda: None
     backend._apply_detected_audio = lambda detected: True
     return backend, gguf
@@ -184,6 +186,35 @@ def test_launch_reasoning_args_use_modern_flag_with_old_binary_fallback(tmp_path
     old_command = [_SERVER_COMMAND]
     backend._append_launch_reasoning_args(old_command, False, {_REASONING_CAPABILITY: False})
     assert old_command == [_SERVER_COMMAND, _CHAT_TEMPLATE_KWARGS_FLAG, _OLD_KWARGS]
+
+
+def test_modern_launch_preserves_model_thinking_default():
+    backend = _backend(supports_preserve = True)
+    backend._preserve_thinking_default = True
+    command = [_SERVER_COMMAND]
+
+    backend._append_launch_reasoning_args(command, True, {_REASONING_CAPABILITY: True})
+
+    assert command == [
+        _SERVER_COMMAND,
+        _REASONING_FLAG,
+        _REASONING_ON,
+        _CHAT_TEMPLATE_KWARGS_FLAG,
+        _PRESERVE_DEFAULT_KWARGS,
+    ]
+
+
+def test_modern_launch_keeps_reasoning_effort_in_template_kwargs():
+    command = [_SERVER_COMMAND]
+
+    _backend(style = "reasoning_effort")._append_launch_reasoning_args(
+        command,
+        True,
+        {_REASONING_CAPABILITY: True},
+    )
+
+    assert _REASONING_FLAG not in command
+    assert command == [_SERVER_COMMAND, _CHAT_TEMPLATE_KWARGS_FLAG, _REASONING_EFFORT_KWARGS]
 
 
 def test_load_command_uses_reasoning_flag(tmp_path):

--- a/studio/backend/tests/test_launch_reasoning_args.py
+++ b/studio/backend/tests/test_launch_reasoning_args.py
@@ -1,0 +1,190 @@
+import struct
+import subprocess
+from unittest.mock import patch
+
+from core.inference.llama_cpp import GgufLoadIntent, LlamaCppBackend
+
+
+_REAL_POPEN = subprocess.Popen
+_MODEL_FILENAME = "model.gguf"
+_MODEL_ARCHITECTURE = "llama"
+_ARCHITECTURE_METADATA_KEY = "general.architecture"
+_GGUF_STRING_LENGTH_FORMAT = "<Q"
+_GGUF_METADATA_TYPE_FORMAT = "<I"
+_GGUF_HEADER_FORMAT = "<IIQQ"
+_GGUF_MAGIC = 0x46554747
+_GGUF_VERSION = 3
+_GGUF_TENSOR_COUNT = 0
+_GGUF_METADATA_COUNT = 1
+_GGUF_STRING_METADATA_TYPE = 8
+_MODEL_SIZE_BYTES = 1024
+_FAKE_BINARY = "/fake/llama-server"
+_FAKE_PROCESS_PID = 123
+_MODEL_IDENTIFIER = "test"
+_REASONING_STYLE = "enable_thinking"
+_REASONING_CAPABILITY = "supports_reasoning_flag"
+_PROBE_INCONCLUSIVE_CAPABILITY = "mtp_probe_inconclusive"
+_REASONING_FLAG = "--reasoning"
+_NO_REASONING_PRESERVE_FLAG = "--no-reasoning-preserve"
+_CHAT_TEMPLATE_KWARGS_FLAG = "--chat-template-kwargs"
+_ENABLE_THINKING_KWARG = "enable_thinking"
+_REASONING_ON = "on"
+_SERVER_COMMAND = "llama-server"
+_MODERN_HELP = "--reasoning VALUE\n"
+_MISSING_BINARY_FILENAME = "missing"
+_FAKE_BINARY_CONTENT = "stub"
+_UTF8_ENCODING = "utf-8"
+_SUBPROCESS_RUN_TARGET = "core.inference.llama_cpp.subprocess.run"
+_PRESERVE_ONLY_KWARGS = '{"preserve_thinking": false}'
+_OLD_KWARGS = '{"enable_thinking": false, "preserve_thinking": false}'
+_REASONING_TEMPLATE = (
+    "{% if enable_thinking %}thinking{% endif %}"
+    "{% if preserve_thinking %}history{% endif %}"
+)
+
+
+def _load_backend(tmp_path):
+    gguf = tmp_path / _MODEL_FILENAME
+    encoded_architecture = _MODEL_ARCHITECTURE.encode()
+    encoded_key = _ARCHITECTURE_METADATA_KEY.encode()
+    string = lambda value: struct.pack(_GGUF_STRING_LENGTH_FORMAT, len(value)) + value
+    metadata = (
+        string(encoded_key)
+        + struct.pack(_GGUF_METADATA_TYPE_FORMAT, _GGUF_STRING_METADATA_TYPE)
+        + string(encoded_architecture)
+    )
+    gguf.write_bytes(
+        struct.pack(
+            _GGUF_HEADER_FORMAT,
+            _GGUF_MAGIC,
+            _GGUF_VERSION,
+            _GGUF_TENSOR_COUNT,
+            _GGUF_METADATA_COUNT,
+        )
+        + metadata
+    )
+
+    backend = LlamaCppBackend()
+    backend._get_gpu_memory = lambda binary = None: []
+    backend._get_gpu_free_memory = lambda binary = None: []
+    backend._read_gguf_metadata = lambda path: None
+    backend._can_estimate_kv = lambda: False
+    backend._get_gguf_size_bytes = lambda path: _MODEL_SIZE_BYTES
+    backend._mmproj_vram_bytes = lambda path: 0
+    backend._resolve_launch_mmproj_path = lambda **kwargs: None
+    backend._apu_ram_shortfall_message = lambda *args, **kwargs: None
+    backend._amd_apu_wants_unified_memory = lambda *args, **kwargs: False
+    backend._find_llama_server_binary = lambda include_denied = False: _FAKE_BINARY
+    backend._is_vulkan_backend = lambda binary = None: False
+    backend._wait_for_health = lambda timeout: True
+    backend._detect_audio_type_strict = lambda: None
+    backend._apply_detected_audio = lambda detected: True
+    return backend, gguf
+
+
+def _launch(backend, gguf, **load_kwargs):
+    captured = {}
+
+    def fake_popen(command, **kwargs):
+        if command[0] != _FAKE_BINARY:
+            return _REAL_POPEN(command, **kwargs)
+        captured["cmd"] = list(command)
+        return type(
+            "Process",
+            (),
+            {
+                "pid": _FAKE_PROCESS_PID,
+                "stdout": (),
+                "poll": lambda self: None,
+                "terminate": lambda self: None,
+                "wait": lambda self, timeout = None: 0,
+                "kill": lambda self: None,
+            },
+        )()
+
+    with patch.object(subprocess, "Popen", side_effect = fake_popen):
+        assert backend.load_model(
+            GgufLoadIntent(
+                gguf_path = str(gguf),
+                model_identifier = _MODEL_IDENTIFIER,
+                **load_kwargs,
+            )
+        )
+    return captured
+
+
+def _backend(style = _REASONING_STYLE, supports_preserve = False):
+    backend = LlamaCppBackend.__new__(LlamaCppBackend)
+    backend._reasoning_style = style
+    backend._architecture = None
+    backend._supports_preserve_thinking = supports_preserve
+    return backend
+
+
+def test_launch_reasoning_args_use_modern_flag_with_old_binary_fallback(tmp_path, monkeypatch):
+    assert LlamaCppBackend.probe_server_capabilities(
+        str(tmp_path / _MISSING_BINARY_FILENAME)
+    ).get(
+        _REASONING_CAPABILITY, False
+    ) is False
+    binary = tmp_path / _SERVER_COMMAND
+    binary.write_text(_FAKE_BINARY_CONTENT, encoding = _UTF8_ENCODING)
+    monkeypatch.setattr(
+        LlamaCppBackend,
+        "_llama_server_env_for_binary",
+        classmethod(lambda cls, path: {}),
+    )
+    monkeypatch.setattr(
+        _SUBPROCESS_RUN_TARGET,
+        lambda *args, **kwargs: __import__("subprocess").CompletedProcess(
+            args[0], 0, _MODERN_HELP, ""
+        ),
+    )
+    LlamaCppBackend._capability_cache.clear()
+    modern_capabilities = LlamaCppBackend.probe_server_capabilities(str(binary))
+    assert modern_capabilities[_REASONING_CAPABILITY] is True
+
+    backend = _backend(supports_preserve = True)
+
+    modern_command = [_SERVER_COMMAND]
+    backend._append_launch_reasoning_args(
+        modern_command, True, modern_capabilities
+    )
+    assert modern_command == [
+        _SERVER_COMMAND,
+        _REASONING_FLAG,
+        _REASONING_ON,
+        _CHAT_TEMPLATE_KWARGS_FLAG,
+        _PRESERVE_ONLY_KWARGS,
+    ]
+    assert _NO_REASONING_PRESERVE_FLAG not in modern_command
+
+    old_command = [_SERVER_COMMAND]
+    backend._append_launch_reasoning_args(
+        old_command, False, {_REASONING_CAPABILITY: False}
+    )
+    assert old_command == [
+        _SERVER_COMMAND,
+        _CHAT_TEMPLATE_KWARGS_FLAG,
+        _OLD_KWARGS,
+    ]
+
+
+def test_load_command_uses_reasoning_flag(tmp_path):
+    backend, gguf = _load_backend(tmp_path)
+    backend.probe_server_capabilities = lambda binary = None: {
+        _REASONING_CAPABILITY: True,
+        _PROBE_INCONCLUSIVE_CAPABILITY: False,
+    }
+
+    command = _launch(
+        backend,
+        gguf,
+        chat_template_override = _REASONING_TEMPLATE,
+    )["cmd"]
+
+    assert _REASONING_FLAG in command
+    assert command[command.index(_REASONING_FLAG) + 1] == _REASONING_ON
+    kwargs = command[command.index(_CHAT_TEMPLATE_KWARGS_FLAG) + 1]
+    assert _ENABLE_THINKING_KWARG not in kwargs
+    assert _NO_REASONING_PRESERVE_FLAG not in command


### PR DESCRIPTION
## Summary

- detect whether the installed `llama-server` exposes `--reasoning`
- use `--reasoning on|off` for `enable_thinking` on modern builds
- retain `--chat-template-kwargs` for older builds, independent `preserve_thinking` state, and `reasoning_effort`-style templates
- preserve inherited `LLAMA_ARG_REASONING` overrides from `unsloth start`

Fixes #7526

## Test verification (RED → GREEN)

Rebased PR head with the original regression test only:

```text
FAILED test_modern_launch_honors_reasoning_env_override[True-off]
assert '--reasoning' not in ['llama-server', '--reasoning', 'on']
```

Patched branch:

```text
4 passed in 1.50s
review-fix diff coverage: 3/3 changed executable lines covered
```

Follow-up test-only guards from Apoze's reviewed commit were cherry-picked and kept credited. After rebasing onto current `main`, the rebased baseline needed the launch test double updated for current keyworded GPU/health probes before the file could run:

```text
baseline ./run-ci.sh: 1 failed, 3 passed
final ./run-ci.sh: 6 passed
```

One current-main Python 3.13 sentinel drift was then corrected test-only after CI exposed it:

```text
test_non_gguf_reload_settings.py::TestNonGgufStatusReportsWhatTheLoadAskedFor::test_the_non_gguf_status_branch_publishes_them
1 passed
```

One current-main repo CPU sentinel drift was also corrected test-only after CI exposed the model picker's centralized `selectMeta` load-id shape:

```text
tests/studio/test_model_picker_contracts.py::test_a_pinned_cached_row_loads_from_the_id_the_backend_pinned
1 passed
```

## Validation

- `./run-ci.sh` upstream baseline: 296 backend tests + 6 CLI reasoning tests passed
- `./run-ci.sh` patched branch: 300 backend tests + 6 CLI reasoning tests passed
- `./run-ci.sh` after this follow-up commit: `git diff --check`, Ruff, and `tests/test_launch_reasoning_args.py` passed (`6 passed`)
- selected adjacent launch/reasoning backend tests plus the Python 3.13 and repo CPU sentinel failures passed (`545 passed`)
- Ruff and `git diff --check`: passed
