### PR TITLE
studio: stop two per-frame main-thread loops stalling the ui on linux

### DIFF
--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -24,13 +24,13 @@ const TooltipTriggerElementCtx = createContext<(element: HTMLElement | null) => 
 
 // Radix sets body pointer-events to none while a modal layer is up. That is also when a hovered
 // trigger stops receiving pointerleave, so a tooltip already on screen hangs over the dialog
-// with nothing able to close it. One observer serves every tooltip.
+// with nothing able to close it. Two shared observers serve every tooltip.
 let modalLayerUp = false;
 const modalLayerListeners = new Set<() => void>();
-let modalLayerObserver: MutationObserver | null = null;
+let bodyLayerObserver: MutationObserver | null = null;
+let stackedLayerObserver: MutationObserver | null = null;
 
-function readModalLayer(): void {
-  modalLayerUp = document.body.style.pointerEvents === "none";
+function notifyModalLayer(): void {
   for (const listener of modalLayerListeners) listener();
 }
 
@@ -41,7 +41,7 @@ function readPointerEvents(style: string | null): string {
   );
 }
 
-function readRelevantLayerMutations(records: MutationRecord[]): void {
+function readStackedLayerMutations(records: MutationRecord[]): void {
   const pointerEventsChanged = records.some(
     (record) =>
       readPointerEvents(record.oldValue) !==
@@ -49,18 +49,41 @@ function readRelevantLayerMutations(records: MutationRecord[]): void {
         (record.target as Element).getAttribute?.("style") ?? null,
       ),
   );
-  if (pointerEventsChanged) readModalLayer();
+  if (pointerEventsChanged) notifyModalLayer();
+}
+
+// stacking only matters while a modal is up; otherwise this fires on every animated inline style.
+function syncStackedLayerObserver(): void {
+  if (!modalLayerUp) {
+    stackedLayerObserver?.disconnect();
+    stackedLayerObserver = null;
+    return;
+  }
+  if (stackedLayerObserver) return;
+  stackedLayerObserver = new MutationObserver(readStackedLayerMutations);
+  stackedLayerObserver.observe(document.body, {
+    attributes: true,
+    attributeFilter: ["style"],
+    attributeOldValue: true,
+    subtree: true,
+  });
+}
+
+function readModalLayer(): void {
+  const next = document.body.style.pointerEvents === "none";
+  if (next === modalLayerUp) return;
+  modalLayerUp = next;
+  syncStackedLayerObserver();
+  notifyModalLayer();
 }
 
 function subscribeModalLayer(listener: () => void): () => void {
   modalLayerListeners.add(listener);
-  if (!modalLayerObserver && typeof MutationObserver !== "undefined") {
-    modalLayerObserver = new MutationObserver(readRelevantLayerMutations);
-    modalLayerObserver.observe(document.body, {
+  if (!bodyLayerObserver && typeof MutationObserver !== "undefined") {
+    bodyLayerObserver = new MutationObserver(readModalLayer);
+    bodyLayerObserver.observe(document.body, {
       attributes: true,
       attributeFilter: ["style"],
-      attributeOldValue: true,
-      subtree: true,
     });
     readModalLayer();
   }

--- a/studio/frontend/src/features/chat/components/research-activity-panel.tsx
+++ b/studio/frontend/src/features/chat/components/research-activity-panel.tsx
@@ -79,6 +79,9 @@ const terminalStatuses = new Set<ResearchRunStatus>([
 ]);
 const ACTIVITY_FOLLOW_SETTLE_MS = 450;
 const ACTIVITY_BOTTOM_THRESHOLD_PX = 24;
+// 2px, not 1, matching use-intent-aware-autoscroll: HiDPI subpixel rounding leaves a fractional
+// gap that a 1px threshold reads as unpinned, which would keep the follow loop running forever.
+const ACTIVITY_PINNED_THRESHOLD_PX = 2;
 
 function useResearchActivityScroll(runId: string) {
   const viewportRef = useRef<HTMLDivElement>(null);
@@ -95,6 +98,8 @@ function useResearchActivityScroll(runId: string) {
     let lastScrollTop = element.scrollTop;
     let followUntil = performance.now() + ACTIVITY_FOLLOW_SETTLE_MS;
     let animationFrame: number | null = null;
+    let settleTimer: number | null = null;
+    let layoutChanged = true;
 
     const distanceFromBottom = () =>
       Math.max(
@@ -106,18 +111,38 @@ function useResearchActivityScroll(runId: string) {
     const requestTick = () => {
       if (animationFrame === null) animationFrame = requestAnimationFrame(tick);
     };
+    // A reflow with no DOM mutation (a `font-display: swap` webfont landing, say) reaches neither
+    // observer, so the rest of the window is covered by one deferred check rather than every frame.
+    const scheduleSettleCheck = () => {
+      if (settleTimer !== null) return;
+      const remaining = followUntil - performance.now();
+      if (remaining <= 0) return;
+      settleTimer = window.setTimeout(() => {
+        settleTimer = null;
+        requestTick();
+      }, remaining);
+    };
     const tick = () => {
       animationFrame = null;
       if (!detached && performance.now() < followUntil) {
-        if (distanceFromBottom() > 1) element.scrollTop = element.scrollHeight;
+        const pinned = distanceFromBottom() <= ACTIVITY_PINNED_THRESHOLD_PX;
+        if (!pinned) element.scrollTop = element.scrollHeight;
         updateAtBottom(true);
-        requestTick();
+        // Chaining on the window alone forced a layout every frame for the whole run; growth that
+        // leaves the view unpinned is the signal, and a quiet frame defers to the settle check.
+        if (layoutChanged || !pinned) {
+          layoutChanged = false;
+          requestTick();
+          return;
+        }
+        scheduleSettleCheck();
         return;
       }
       updateAtBottom(distanceFromBottom() <= ACTIVITY_BOTTOM_THRESHOLD_PX);
     };
     const followLayout = () => {
       if (detached) return;
+      layoutChanged = true;
       followUntil = performance.now() + ACTIVITY_FOLLOW_SETTLE_MS;
       requestTick();
     };
@@ -216,6 +241,7 @@ function useResearchActivityScroll(runId: string) {
 
     return () => {
       if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+      if (settleTimer !== null) window.clearTimeout(settleTimer);
       resizeObserver.disconnect();
       mutationObserver.disconnect();
       element.removeEventListener("scroll", onScroll);

--- a/studio/frontend/src/features/chat/components/research-activity-panel.tsx
+++ b/studio/frontend/src/features/chat/components/research-activity-panel.tsx
@@ -99,6 +99,7 @@ function useResearchActivityScroll(runId: string) {
     let followUntil = performance.now() + ACTIVITY_FOLLOW_SETTLE_MS;
     let animationFrame: number | null = null;
     let settleTimer: number | null = null;
+    let settleCheckDue = false;
     let layoutChanged = true;
 
     const distanceFromBottom = () =>
@@ -119,12 +120,17 @@ function useResearchActivityScroll(runId: string) {
       if (remaining <= 0) return;
       settleTimer = window.setTimeout(() => {
         settleTimer = null;
+        // The timer lands on the deadline and its tick a frame later, so the window has closed by
+        // then; this grants that tick one last follow pass rather than dropping it to the reconcile.
+        settleCheckDue = true;
         requestTick();
       }, remaining);
     };
     const tick = () => {
       animationFrame = null;
-      if (!detached && performance.now() < followUntil) {
+      const settling = settleCheckDue;
+      settleCheckDue = false;
+      if (!detached && (settling || performance.now() < followUntil)) {
         const pinned = distanceFromBottom() <= ACTIVITY_PINNED_THRESHOLD_PX;
         if (!pinned) element.scrollTop = element.scrollHeight;
         updateAtBottom(true);
@@ -149,6 +155,13 @@ function useResearchActivityScroll(runId: string) {
     const detach = () => {
       detached = true;
       followUntil = 0;
+      // A settle check queued by the last quiet frame would otherwise fire mid-scroll and reconcile
+      // isAtBottom back to true whenever the user has moved less than the bottom threshold.
+      if (settleTimer !== null) {
+        window.clearTimeout(settleTimer);
+        settleTimer = null;
+      }
+      settleCheckDue = false;
       updateAtBottom(false);
     };
     const innerScrollWillConsumeUpward = (target: EventTarget | null) => {


### PR DESCRIPTION
Reported in #8483: deep research froze on "Writing the report" on Ubuntu 26.04 under Wayland, the spinner stopped, and the window had to be force quit. A second freeze in the same report happened while closing the research detail pane. Both happened with the activity pane open.

Two always-on loops kept the main thread busy. Neither is Linux-specific in code, but WebKitGTK is slow enough at layout and style that only there do they cross the frame budget.

## Research activity panel

`useResearchActivityScroll` in `studio/frontend/src/features/chat/components/research-activity-panel.tsx` re-armed a 450 ms follow window on every DOM mutation and chained `requestAnimationFrame` unconditionally inside it. A run mutates the activity list several times a second, so the window never expired: `tick` forced a synchronous layout (`scrollHeight`, `scrollTop`, `clientHeight`) and usually wrote `scrollTop` on every frame for the entire run, over a list that grows to hundreds of rows.

The chain now continues only while a mutation arrived since the last frame or the view is unpinned, so it idles when the list is quiet and still follows through a Collapsible height animation, which reports no mutations of its own but unpins the view on every frame.

Two details that the first version got wrong:

- The pinned test uses 2 px, not 1. `use-intent-aware-autoscroll.tsx` already documents why: HiDPI subpixel rounding leaves a fractional gap that a 1 px threshold reads as unpinned. With a 1 px gate the loop would never exit under fractional scaling, which is the display configuration in the report.
- Exiting on a quiet frame abandoned the rest of the settle window. The app declares `font-display: swap`, so a webfont landing 100 to 300 ms later reflows every row and grows the content with no mutation and no border-box resize on the scroller. `scheduleSettleCheck` covers the remainder with one deferred check instead of 27 frames, so `isAtBottom` cannot stick at `true` with the log stranded above the newest activity.

## Tooltip modal layer

`studio/frontend/src/components/ui/tooltip.tsx` installed one `MutationObserver` over `document.body` with `subtree: true`, `attributes: true`, `attributeFilter: ["style"]` and `attributeOldValue: true`, for the whole session. Every inline style write anywhere in the document queued a record and ran two regex executions, including every frame of a motion/react animation, every Radix popper reposition, and every panel resize drag.

Only `document.body.style.pointerEvents` decides the `modalLayerUp` flag, and `createModalBlockStore.update` computes `getModalLayer() && isBlockedByActiveModal(trigger)`, so no descendant change can alter any tooltip's `blocked` state while no modal is up. The observer is now split: a cheap non-subtree one on body's own `style` attribute maintains the flag, and the subtree observer attaches only while a modal is actually open.

## Verification

`npm run typecheck` clean, `npm test` 1960 passing, biome and eslint counts unchanged. No Python changed, so ruff and pytest do not apply, and no GPU checks are relevant to frontend-only work.

Ran the desktop app against this branch on Linux and exercised the affected surfaces: a deep research run with the activity pane open, opening and closing that pane, and the settings dialog with a Select inside it. All worked, with no freeze, no stall and no lost clicks.

Two `download-adopt-and-hydrate.test.ts` cases fail intermittently under full-suite parallelism. They fail the same way on an unmodified tree and pass 5 of 5 in isolation, so they are unrelated to this change.
