### PR TITLE
Studio: require managed backend for linked folders

### DIFF
--- a/studio/frontend/src/features/native-intents/use-native-readiness.ts
+++ b/studio/frontend/src/features/native-intents/use-native-readiness.ts
@@ -20,13 +20,21 @@ export function useNativePathLeasesSupported(): boolean {
         controller = new AbortController();
         fetch(apiUrl("/api/health"), { signal: controller.signal })
           .then((response) => response.json())
-          .then((health) => {
+          .then(async (health) => {
             if (disposed) return;
-            if (health?.native_path_leases_supported === true) {
-              setSupported(true);
-            } else {
+            if (health?.native_path_leases_supported !== true) {
               check(5000);
+              return;
             }
+            // The health bit says the backend holds a key, not that it holds
+            // OURS. A survivor adopted from a dead previous app has one of its
+            // own, so the grant would fail on the signature instead. Only the
+            // app knows which backend it spawned.
+            const { invoke } = await import("@tauri-apps/api/core");
+            const usable = await invoke<boolean>("native_path_leases_usable");
+            if (disposed) return;
+            if (usable) setSupported(true);
+            else check(5000);
           })
           .catch(() => {
             if (!disposed) check(5000);

--- a/studio/frontend/src/features/rag/components/linked-folders-manager.tsx
+++ b/studio/frontend/src/features/rag/components/linked-folders-manager.tsx
@@ -72,7 +72,7 @@ export function LinkedFoldersManager({
           <p className="text-xs leading-snug text-muted-foreground">
             {manager.desktopSupported
               ? "Keep supported documents indexed as this folder changes."
-              : "Existing linked folders stay synced; link new folders in the desktop app."}
+              : "Existing linked folders stay synced; linking requires the managed desktop backend."}
           </p>
         </div>
         {scope ? (
@@ -86,7 +86,7 @@ export function LinkedFoldersManager({
             title={
               manager.desktopSupported
                 ? "Choose a local folder"
-                : "Requires the desktop app"
+                : "Requires the managed desktop backend"
             }
           >
             {manager.mutating ? (

--- a/studio/frontend/src/features/rag/components/use-linked-folders.ts
+++ b/studio/frontend/src/features/rag/components/use-linked-folders.ts
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { pickNativeDocumentFolder } from "@/features/native-intents";
+import {
+  pickNativeDocumentFolder,
+  useNativePathLeasesSupported,
+} from "@/features/native-intents";
 import { isTauri } from "@/lib/api-base";
 import { createScopedSingleFlightRequest } from "@/lib/single-flight-request";
 import { toast } from "@/lib/toast";
@@ -36,6 +39,7 @@ export function useLinkedFolders(
   const [stateScopeKey, setStateScopeKey] = useState(scopeKey);
   const [loading, setLoading] = useState(true);
   const [mutating, setMutating] = useState(false);
+  const nativePathLeasesSupported = useNativePathLeasesSupported();
   const controllers = useRef(new Map<string, AbortController>());
   const refreshGate = useRef(
     createScopedSingleFlightRequest<
@@ -225,7 +229,7 @@ export function useLinkedFolders(
   }, [refresh, scopeKey]);
 
   const link = useCallback(async () => {
-    if (!scopeType || !scopeId || !isTauri) return;
+    if (!scopeType || !scopeId || !isTauri || !nativePathLeasesSupported) return;
     const operationScopeKey = scopeKey;
     setMutating(true);
     try {
@@ -251,7 +255,14 @@ export function useLinkedFolders(
     } finally {
       setMutating(false);
     }
-  }, [scopeKey, scopeType, scopeId, trackJob, onSourcesChanged]);
+  }, [
+    scopeKey,
+    scopeType,
+    scopeId,
+    nativePathLeasesSupported,
+    trackJob,
+    onSourcesChanged,
+  ]);
 
   const run = useCallback(
     async (folderId: string, mode: "sync" | "rebuild") => {
@@ -322,7 +333,7 @@ export function useLinkedFolders(
     jobs: stateScopeKey === scopeKey ? jobs : {},
     loading: stateScopeKey === scopeKey ? loading : true,
     mutating,
-    desktopSupported: isTauri,
+    desktopSupported: isTauri && nativePathLeasesSupported,
     link,
     sync: (folderId: string) => run(folderId, "sync"),
     rebuild: (folderId: string) => run(folderId, "rebuild"),

--- a/studio/frontend/tests/linked-folders-lease-gate.test.ts
+++ b/studio/frontend/tests/linked-folders-lease-gate.test.ts
@@ -26,6 +26,13 @@ const MANAGER = readFileSync(
   "utf8",
 );
 
+const COMMANDS = readFileSync(
+  fileURLToPath(
+    new URL("../../src-tauri/src/commands.rs", import.meta.url),
+  ),
+  "utf8",
+);
+
 const READINESS = readFileSync(
   fileURLToPath(
     new URL("../src/features/native-intents/use-native-readiness.ts", import.meta.url),
@@ -85,7 +92,7 @@ test("the unsupported branch names the managed backend, not the desktop app", ()
 test("the capability is read from /api/health and only latches on true", () => {
   assert.match(
     READINESS,
-    /native_path_leases_supported\s*===\s*true/,
+    /native_path_leases_supported\s*!==\s*true/,
     "an absent field on an older backend must not read as supported",
   );
   assert.ok(
@@ -94,10 +101,34 @@ test("the capability is read from /api/health and only latches on true", () => {
   );
 });
 
-test("an adopted backend is restarted when the current lease key is transient", () => {
-  assert.match(PREFLIGHT, /snapshot\.is_adopted\s*&&\s*!lease_secret_persisted/);
+test("the health bit alone does not enable the picker inside the app", () => {
+  // A survivor adopted from a dead previous app holds a lease key of its own, so
+  // it answers true while every grant this app signs fails on the signature.
   assert.ok(
-    PREFLIGHT.includes("native_path_lease_secret_not_persisted"),
-    "a transient key must make an adopted survivor stale instead of ready",
+    READINESS.includes("native_path_leases_usable"),
+    "the hook must also ask the app whether the live backend is one it spawned",
+  );
+  const gate = READINESS.slice(READINESS.indexOf("native_path_leases_usable"));
+  assert.match(
+    gate,
+    /if\s*\(usable\)\s*setSupported\(true\)/,
+    "setSupported must be reached only when the app confirms the backend is ours",
+  );
+});
+
+test("an adopted backend keeps running and only loses lease-backed actions", () => {
+  // The earlier shape made an adopted survivor Stale, and owned_stale routes
+  // through startRepair(), which stops the backend and runs a network update.
+  // That is a heavy remedy for a key mismatch, and it fails offline, so the
+  // survivor is left alone and the capability is reported instead.
+  assert.ok(
+    !PREFLIGHT.includes("native_path_lease_secret_not_persisted") &&
+      !PREFLIGHT.includes("native_path_lease_secret_not_shared"),
+    "an adopted survivor must not be forced stale over the lease key",
+  );
+  assert.match(
+    COMMANDS,
+    /fn native_path_leases_usable[\s\S]*?snapshot\.is_adopted/,
+    "the app must answer usable=false for a backend it adopted rather than spawned",
   );
 });

--- a/studio/frontend/tests/linked-folders-lease-gate.test.ts
+++ b/studio/frontend/tests/linked-folders-lease-gate.test.ts
@@ -117,10 +117,8 @@ test("the health bit alone does not enable the picker inside the app", () => {
 });
 
 test("an adopted backend keeps running and only loses lease-backed actions", () => {
-  // The earlier shape made an adopted survivor Stale, and owned_stale routes
-  // through startRepair(), which stops the backend and runs a network update.
-  // That is a heavy remedy for a key mismatch, and it fails offline, so the
-  // survivor is left alone and the capability is reported instead.
+  // owned_stale routes through startRepair(), which runs a network update, so a
+  // key mismatch must not force one: report the capability, leave it running.
   assert.ok(
     !PREFLIGHT.includes("native_path_lease_secret_not_persisted") &&
       !PREFLIGHT.includes("native_path_lease_secret_not_shared"),

--- a/studio/frontend/tests/linked-folders-lease-gate.test.ts
+++ b/studio/frontend/tests/linked-folders-lease-gate.test.ts
@@ -33,6 +33,11 @@ const READINESS = readFileSync(
   "utf8",
 );
 
+const PREFLIGHT = readFileSync(
+  fileURLToPath(new URL("../../src-tauri/src/preflight.rs", import.meta.url)),
+  "utf8",
+);
+
 test("the picker is gated on the backend capability, not on isTauri alone", () => {
   assert.match(
     HOOK,
@@ -86,5 +91,13 @@ test("the capability is read from /api/health and only latches on true", () => {
   assert.ok(
     READINESS.includes("useState(false)"),
     "the hook must start unsupported, so the picker is never live before it is known",
+  );
+});
+
+test("an adopted backend is restarted when the current lease key is transient", () => {
+  assert.match(PREFLIGHT, /snapshot\.is_adopted\s*&&\s*!lease_secret_persisted/);
+  assert.ok(
+    PREFLIGHT.includes("native_path_lease_secret_not_persisted"),
+    "a transient key must make an adopted survivor stale instead of ready",
   );
 });

--- a/studio/frontend/tests/linked-folders-lease-gate.test.ts
+++ b/studio/frontend/tests/linked-folders-lease-gate.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The picker used to be gated on `isTauri` alone. Inside the desktop app that is
+// true even when the backend the app ATTACHED to was not the one it spawned, and
+// only a spawned backend holds UNSLOTH_STUDIO_NATIVE_PATH_LEASE_SECRET. So the
+// button was live, the folder lease was signed, and the backend answered
+// `400 Native path grants require the managed desktop backend.` -- issue 8416.
+//
+// Two things therefore have to hold together, and neither is worth much alone:
+// the button must be dead when the capability is missing, AND `link()` must
+// refuse even if something clicks it anyway, because a disabled attribute is not
+// a guarantee.
+//
+// There is no React renderer in this suite, so this asserts on the source the
+// way ~50 sibling tests do. That catches the gate being dropped, which is the
+// regression that put the 400 in front of users.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HOOK = readFileSync(
+  fileURLToPath(
+    new URL("../src/features/rag/components/use-linked-folders.ts", import.meta.url),
+  ),
+  "utf8",
+);
+
+const MANAGER = readFileSync(
+  fileURLToPath(
+    new URL("../src/features/rag/components/linked-folders-manager.tsx", import.meta.url),
+  ),
+  "utf8",
+);
+
+const READINESS = readFileSync(
+  fileURLToPath(
+    new URL("../src/features/native-intents/use-native-readiness.ts", import.meta.url),
+  ),
+  "utf8",
+);
+
+test("the picker is gated on the backend capability, not on isTauri alone", () => {
+  assert.match(
+    HOOK,
+    /desktopSupported:\s*isTauri\s*&&\s*nativePathLeasesSupported/,
+    "desktopSupported must require the lease capability as well as Tauri",
+  );
+  assert.ok(
+    HOOK.includes("useNativePathLeasesSupported()"),
+    "the capability must come from the shared readiness hook, not a local fetch",
+  );
+});
+
+test("link() refuses without the capability, not just the button", () => {
+  const body = HOOK.slice(
+    HOOK.indexOf("const link = useCallback("),
+    HOOK.indexOf("const run = useCallback("),
+  );
+  assert.ok(body.length > 0, "link() should still exist");
+  assert.match(
+    body,
+    /if\s*\([^)]*!nativePathLeasesSupported[^)]*\)\s*return/,
+    "link() must bail before pickNativeDocumentFolder when leases are unsupported",
+  );
+  // A stale closure would re-enable the old behaviour the moment the capability
+  // flipped, so the dependency has to be declared.
+  assert.ok(
+    body.includes("nativePathLeasesSupported") &&
+      HOOK.slice(HOOK.indexOf("const link = useCallback("))
+        .includes("nativePathLeasesSupported,"),
+    "nativePathLeasesSupported must be in link()'s dependency list",
+  );
+});
+
+test("the unsupported branch names the managed backend, not the desktop app", () => {
+  // The old copy told a desktop user to "link new folders in the desktop app"
+  // while they were standing in the desktop app. Whatever the wording becomes,
+  // it must not say that again.
+  assert.ok(
+    !MANAGER.includes("link new folders in the desktop app"),
+    "the unsupported copy must not tell a desktop user to use the desktop app",
+  );
+  assert.ok(
+    MANAGER.includes("managed desktop backend"),
+    "the unsupported copy and tooltip should name the managed backend",
+  );
+});
+
+test("the capability is read from /api/health and only latches on true", () => {
+  assert.match(
+    READINESS,
+    /native_path_leases_supported\s*===\s*true/,
+    "an absent field on an older backend must not read as supported",
+  );
+  assert.ok(
+    READINESS.includes("useState(false)"),
+    "the hook must start unsupported, so the picker is never live before it is known",
+  );
+});

--- a/studio/frontend/tests/linked-folders-lease-gate.test.ts
+++ b/studio/frontend/tests/linked-folders-lease-gate.test.ts
@@ -1,20 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// The picker used to be gated on `isTauri` alone. Inside the desktop app that is
-// true even when the backend the app ATTACHED to was not the one it spawned, and
-// only a spawned backend holds UNSLOTH_STUDIO_NATIVE_PATH_LEASE_SECRET. So the
-// button was live, the folder lease was signed, and the backend answered
-// `400 Native path grants require the managed desktop backend.` -- issue 8416.
-//
-// Two things therefore have to hold together, and neither is worth much alone:
-// the button must be dead when the capability is missing, AND `link()` must
-// refuse even if something clicks it anyway, because a disabled attribute is not
-// a guarantee.
-//
-// There is no React renderer in this suite, so this asserts on the source the
-// way ~50 sibling tests do. That catches the gate being dropped, which is the
-// regression that put the 400 in front of users.
+// Issue 8416: gated on `isTauri` alone, the picker stayed live when the app
+// attached to a backend it had not spawned, and only a spawned backend holds
+// UNSLOTH_STUDIO_NATIVE_PATH_LEASE_SECRET, so the lease came back 400. The
+// button must be dead without the capability AND `link()` must refuse anyway.
+// No React renderer here, so this asserts on source, like ~50 sibling tests.
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -65,8 +56,7 @@ test("link() refuses without the capability, not just the button", () => {
     /if\s*\([^)]*!nativePathLeasesSupported[^)]*\)\s*return/,
     "link() must bail before pickNativeDocumentFolder when leases are unsupported",
   );
-  // A stale closure would re-enable the old behaviour the moment the capability
-  // flipped, so the dependency has to be declared.
+  // A stale closure would restore the old behaviour once the capability flips.
   assert.ok(
     body.includes("nativePathLeasesSupported") &&
       HOOK.slice(HOOK.indexOf("const link = useCallback("))
@@ -76,9 +66,7 @@ test("link() refuses without the capability, not just the button", () => {
 });
 
 test("the unsupported branch names the managed backend, not the desktop app", () => {
-  // The old copy told a desktop user to "link new folders in the desktop app"
-  // while they were standing in the desktop app. Whatever the wording becomes,
-  // it must not say that again.
+  // The old copy told a desktop user to use the desktop app they were already in.
   assert.ok(
     !MANAGER.includes("link new folders in the desktop app"),
     "the unsupported copy must not tell a desktop user to use the desktop app",

--- a/studio/frontend/tests/linked-folders-lease-gate.test.ts
+++ b/studio/frontend/tests/linked-folders-lease-gate.test.ts
@@ -128,7 +128,8 @@ test("an adopted backend keeps running and only loses lease-backed actions", () 
   );
   assert.match(
     COMMANDS,
-    /fn native_path_leases_usable[\s\S]*?snapshot\.is_adopted/,
-    "the app must answer usable=false for a backend it adopted rather than spawned",
+    /fn native_path_leases_usable[\s\S]*?Some\(snapshot\) if !snapshot\.is_adopted/,
+    "usable must require a spawned, non-adopted backend, not merely the absence " +
+      "of an adopted one: attached_ready installs no snapshot at all",
   );
 });

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -814,7 +814,7 @@ mod tests {
             String::new()
         };
         format!(
-            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{ROOT_ID}"{owner}}}"#
+            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":true,"studio_root_id":"{ROOT_ID}"{owner}}}"#
         )
     }
 

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -813,10 +813,8 @@ mod tests {
         } else {
             String::new()
         };
-        // Only an owned backend can advertise lease support: the secret comes
-        // from the desktop spawn. `ready_health(false)` stands in for a server
-        // the user started from a terminal, so giving it the capability would
-        // model a backend that does not exist.
+        // Only an owned backend can advertise lease support; ready_health(false)
+        // stands in for a terminal-started server, which never can.
         let leases = if include_owner {
             r#""native_path_leases_supported":true,"#
         } else {

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -4,7 +4,7 @@ use crate::process::{self, BackendState, ShutdownFlag};
 use crate::update;
 use log::{error, info, warn};
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter};
 
 const BACKEND_STARTUP_GRACE_PERIOD: Duration = Duration::from_secs(5 * 60);
 const HEALTH_WATCHDOG_INTERVAL: Duration = Duration::from_secs(15);
@@ -99,16 +99,8 @@ pub async fn desktop_preflight(
     diagnostics: tauri::State<'_, DiagnosticsState>,
 ) -> Result<crate::preflight::DesktopPreflightResult, String> {
     let started = Instant::now();
-    let lease_secret_predates_this_process = app
-        .try_state::<crate::native_intents::NativeIntakeState>()
-        .map(|state| state.lease_secret_predates_this_process())
-        .unwrap_or(false);
     let (result, adopted_watchdog_generation) =
-        crate::preflight::desktop_preflight_result_with_state(
-            state.inner(),
-            lease_secret_predates_this_process,
-        )
-        .await?;
+        crate::preflight::desktop_preflight_result_with_state(state.inner()).await?;
     diagnostics::record_preflight(&diagnostics, &result);
 
     info!(
@@ -622,6 +614,24 @@ pub async fn start_backend_update(
 }
 
 /// Repair a stale managed Unsloth install.
+/// Whether a native path lease this app signs can actually be verified.
+///
+/// The lease key is per process, so only a backend THIS process spawned holds
+/// it. A survivor adopted from a dead previous app advertises
+/// `native_path_leases_supported` because it has a key of its own, which is not
+/// ours -- the boolean on /api/health cannot tell the two apart, and every grant
+/// would fail on the signature. Restarting the survivor would also fix it, but
+/// adoption exists so a backend that may be mid-training is not killed, and the
+/// only restart path the UI has runs a network update.
+#[tauri::command]
+pub async fn native_path_leases_usable(
+    backend_state: tauri::State<'_, BackendState>,
+) -> Result<bool, String> {
+    Ok(!process::owned_backend_snapshot(backend_state.inner())?
+        .map(|snapshot| snapshot.is_adopted)
+        .unwrap_or(false))
+}
+
 #[tauri::command]
 pub async fn start_managed_repair(
     app: AppHandle,

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -99,14 +99,14 @@ pub async fn desktop_preflight(
     diagnostics: tauri::State<'_, DiagnosticsState>,
 ) -> Result<crate::preflight::DesktopPreflightResult, String> {
     let started = Instant::now();
-    let lease_secret_persisted = app
+    let lease_secret_predates_this_process = app
         .try_state::<crate::native_intents::NativeIntakeState>()
-        .map(|state| state.lease_secret_persisted())
+        .map(|state| state.lease_secret_predates_this_process())
         .unwrap_or(false);
     let (result, adopted_watchdog_generation) =
         crate::preflight::desktop_preflight_result_with_state(
             state.inner(),
-            lease_secret_persisted,
+            lease_secret_predates_this_process,
         )
         .await?;
     diagnostics::record_preflight(&diagnostics, &result);

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -4,7 +4,7 @@ use crate::process::{self, BackendState, ShutdownFlag};
 use crate::update;
 use log::{error, info, warn};
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 
 const BACKEND_STARTUP_GRACE_PERIOD: Duration = Duration::from_secs(5 * 60);
 const HEALTH_WATCHDOG_INTERVAL: Duration = Duration::from_secs(15);
@@ -99,8 +99,16 @@ pub async fn desktop_preflight(
     diagnostics: tauri::State<'_, DiagnosticsState>,
 ) -> Result<crate::preflight::DesktopPreflightResult, String> {
     let started = Instant::now();
+    let lease_secret_persisted = app
+        .try_state::<crate::native_intents::NativeIntakeState>()
+        .map(|state| state.lease_secret_persisted())
+        .unwrap_or(false);
     let (result, adopted_watchdog_generation) =
-        crate::preflight::desktop_preflight_result_with_state(state.inner()).await?;
+        crate::preflight::desktop_preflight_result_with_state(
+            state.inner(),
+            lease_secret_persisted,
+        )
+        .await?;
     diagnostics::record_preflight(&diagnostics, &result);
 
     info!(

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -813,8 +813,17 @@ mod tests {
         } else {
             String::new()
         };
+        // Only an owned backend can advertise lease support: the secret comes
+        // from the desktop spawn. `ready_health(false)` stands in for a server
+        // the user started from a terminal, so giving it the capability would
+        // model a backend that does not exist.
+        let leases = if include_owner {
+            r#""native_path_leases_supported":true,"#
+        } else {
+            ""
+        };
         format!(
-            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":true,"studio_root_id":"{ROOT_ID}"{owner}}}"#
+            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,{leases}"studio_root_id":"{ROOT_ID}"{owner}}}"#
         )
     }
 

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -616,17 +616,12 @@ pub async fn start_backend_update(
 /// Repair a stale managed Unsloth install.
 /// Whether a native path lease this app signs can actually be verified.
 ///
-/// The lease key is per process, so only a backend THIS process spawned holds
-/// it. Two others advertise `native_path_leases_supported` on /api/health and
-/// cannot verify a thing we sign, and the boolean cannot tell any of them apart:
-/// a survivor adopted from a dead previous app, which has a key of its own, and
-/// a terminal-started backend the app merely attached to, which has whatever was
-/// in its environment. So this answers from a positive fact -- there is a
-/// spawned, non-adopted backend -- rather than from the absence of a bad one.
-///
-/// Restarting the ones that disagree would also work, but adoption exists so a
-/// backend that may be mid-training is not killed, and the only restart path the
-/// UI has runs a network update.
+/// The key is per process, so only a backend THIS process spawned holds it. An
+/// adopted survivor and an attached terminal-started backend both advertise
+/// `native_path_leases_supported` with a key that is not ours, and the boolean
+/// cannot tell them apart, so answer from the positive fact instead. Restarting
+/// them would also work, but adoption exists so a possibly mid-training backend
+/// is not killed, and the UI's only restart path runs a network update.
 #[tauri::command]
 pub async fn native_path_leases_usable(
     backend_state: tauri::State<'_, BackendState>,

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -617,19 +617,24 @@ pub async fn start_backend_update(
 /// Whether a native path lease this app signs can actually be verified.
 ///
 /// The lease key is per process, so only a backend THIS process spawned holds
-/// it. A survivor adopted from a dead previous app advertises
-/// `native_path_leases_supported` because it has a key of its own, which is not
-/// ours -- the boolean on /api/health cannot tell the two apart, and every grant
-/// would fail on the signature. Restarting the survivor would also fix it, but
-/// adoption exists so a backend that may be mid-training is not killed, and the
-/// only restart path the UI has runs a network update.
+/// it. Two others advertise `native_path_leases_supported` on /api/health and
+/// cannot verify a thing we sign, and the boolean cannot tell any of them apart:
+/// a survivor adopted from a dead previous app, which has a key of its own, and
+/// a terminal-started backend the app merely attached to, which has whatever was
+/// in its environment. So this answers from a positive fact -- there is a
+/// spawned, non-adopted backend -- rather than from the absence of a bad one.
+///
+/// Restarting the ones that disagree would also work, but adoption exists so a
+/// backend that may be mid-training is not killed, and the only restart path the
+/// UI has runs a network update.
 #[tauri::command]
 pub async fn native_path_leases_usable(
     backend_state: tauri::State<'_, BackendState>,
 ) -> Result<bool, String> {
-    Ok(!process::owned_backend_snapshot(backend_state.inner())?
-        .map(|snapshot| snapshot.is_adopted)
-        .unwrap_or(false))
+    Ok(
+        matches!(process::owned_backend_snapshot(backend_state.inner())?,
+            Some(snapshot) if !snapshot.is_adopted),
+    )
 }
 
 #[tauri::command]

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -107,6 +107,7 @@ struct HealthDesktopOwner {
 #[derive(Debug, Deserialize)]
 struct HealthResponse {
     version: Option<String>,
+    native_path_leases_supported: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -800,9 +801,14 @@ fn ready_for_use_status(health: Option<&HealthResponse>) -> OwnedBackendReadines
     let version = health
         .and_then(|h| h.version.as_deref())
         .filter(|v| !v.is_empty());
-    match crate::preflight::backend_version_stale_reason(version) {
-        Some(reason) => OwnedBackendReadiness::Stale { reason },
-        None => OwnedBackendReadiness::Ready,
+    if let Some(reason) = crate::preflight::backend_version_stale_reason(version) {
+        return OwnedBackendReadiness::Stale { reason };
+    }
+    match health.and_then(|health| health.native_path_leases_supported) {
+        Some(true) => OwnedBackendReadiness::Ready,
+        _ => OwnedBackendReadiness::Stale {
+            reason: "native_path_leases_unsupported".to_string(),
+        },
     }
 }
 
@@ -820,13 +826,15 @@ async fn health_ready_status(
                 let Some(version) = authenticated_version else {
                     return Err("desktop_auth_health_unverified".to_string());
                 };
-                return match crate::preflight::backend_version_stale_reason(Some(version)) {
-                    None => Ok(OwnedBackendReadiness::Ready),
-                    Some(reason) if reason == "desktop_backend_version_too_old" => {
+                if let Some(reason) = crate::preflight::backend_version_stale_reason(Some(version))
+                {
+                    return if reason == "desktop_backend_version_too_old" {
                         Ok(OwnedBackendReadiness::Stale { reason })
-                    }
-                    Some(reason) => Err(reason),
-                };
+                    } else {
+                        Err(reason)
+                    };
+                }
+                return Ok(ready_for_use_status(health.as_ref()));
             }
             Ok(ready_for_use_status(health.as_ref()))
         }
@@ -1441,7 +1449,10 @@ mod tests {
     async fn authenticated_health_uses_login_bearer_and_accepts_ready_version() {
         let (port, seen, server) = http_sequence_server(vec![
             ("200 OK", r#"{"access_token":"test-access-token"}"#),
-            ("200 OK", r#"{"version":"2026.8.4"}"#),
+            (
+                "200 OK",
+                r#"{"version":"2026.8.4","native_path_leases_supported":true}"#,
+            ),
         ])
         .await;
 
@@ -1456,6 +1467,31 @@ mod tests {
         assert!(seen[1]
             .to_ascii_lowercase()
             .contains("authorization: bearer test-access-token"));
+    }
+
+    #[tokio::test]
+    async fn authenticated_health_marks_missing_or_disabled_native_leases_stale() {
+        for health in [
+            r#"{"version":"2026.8.4"}"#,
+            r#"{"version":"2026.8.4","native_path_leases_supported":false}"#,
+        ] {
+            let (port, _, server) = http_sequence_server(vec![
+                ("200 OK", r#"{"access_token":"test-access-token"}"#),
+                ("200 OK", health),
+            ])
+            .await;
+
+            let readiness = authenticated_health_ready_status(port, "desktop-test-secret")
+                .await
+                .unwrap();
+            server.await.unwrap();
+
+            assert!(matches!(
+                readiness,
+                OwnedBackendReadiness::Stale { reason }
+                    if reason == "native_path_leases_unsupported"
+            ));
+        }
     }
 
     #[tokio::test]

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -217,6 +217,49 @@ fn home_dir_or_error() -> Result<PathBuf, String> {
     dirs::home_dir().ok_or_else(|| "could not resolve the home directory".to_string())
 }
 
+fn lease_secret_path_for_home(home: &Path) -> PathBuf {
+    managed_run_dir(home).join(".native_path_lease_secret")
+}
+
+/// The install's native path lease secret, created on first use.
+///
+/// Per-install, not per-process, because a backend outlives the app that
+/// spawned it: when the previous app pid is dead the preflight ADOPTS the
+/// survivor rather than restarting it. A freshly minted per-process secret
+/// would leave that adopted backend verifying with the old key, so the picker
+/// (which only sees the boolean `native_path_leases_supported`) stays live and
+/// every grant fails the signature check. Same key, same file, no restart.
+///
+/// Kept beside the owner metadata, which already stores the desktop owner token
+/// in the same 0700 dir at 0600 -- a strictly stronger credential, since it
+/// buys a desktop-login. An unreadable or too-short file is replaced: the old
+/// secret is unrecoverable either way, so minting is all that is left.
+pub(crate) fn ensure_native_path_lease_secret() -> Result<Vec<u8>, String> {
+    ensure_native_path_lease_secret_at(&lease_secret_path_for_home(&home_dir_or_error()?))
+}
+
+fn ensure_native_path_lease_secret_at(path: &Path) -> Result<Vec<u8>, String> {
+    if let Ok(raw) = std::fs::read_to_string(path) {
+        if let Some(secret) = crate::native_backend_lease::decode_secret_env(raw.trim()) {
+            if secret.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES {
+                return Ok(secret);
+            }
+        }
+    }
+    let secret = crate::native_backend_lease::new_lease_secret();
+    let parent = path
+        .parent()
+        .ok_or_else(|| "lease secret path has no parent".to_string())?;
+    std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    set_private_dir_permissions(parent);
+    write_private_file(
+        path,
+        crate::native_backend_lease::encode_secret_env(&secret).as_bytes(),
+    )?;
+    set_private_file_permissions(path);
+    Ok(secret)
+}
+
 fn ensure_studio_root_id_at(
     path: &Path,
     create_when_missing: bool,
@@ -1324,6 +1367,67 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         dir.join("desktop_backend.json")
+    }
+
+    fn temp_lease_secret_path(test_name: &str) -> PathBuf {
+        temp_metadata_path(test_name)
+            .parent()
+            .unwrap()
+            .join(".native_path_lease_secret")
+    }
+
+    #[test]
+    fn an_adopted_backend_and_the_next_app_process_share_one_lease_secret() {
+        // The whole point. Two app processes, one install: the second must sign
+        // with the key the survivor it adopted was spawned with, or the picker
+        // is live and every grant fails the signature check.
+        let path = temp_lease_secret_path("lease-shared");
+        let first = ensure_native_path_lease_secret_at(&path).unwrap();
+        let second = ensure_native_path_lease_secret_at(&path).unwrap();
+
+        assert_eq!(first, second);
+        assert!(first.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES);
+    }
+
+    #[test]
+    fn a_lease_secret_below_the_backend_floor_is_replaced() {
+        // The backend refuses anything under 32 bytes, so keeping a short one
+        // would advertise leases that cannot verify.
+        let path = temp_lease_secret_path("lease-short");
+        std::fs::write(
+            &path,
+            crate::native_backend_lease::encode_secret_env(b"too-short"),
+        )
+        .unwrap();
+
+        let secret = ensure_native_path_lease_secret_at(&path).unwrap();
+
+        assert!(secret.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES);
+        assert_eq!(secret, ensure_native_path_lease_secret_at(&path).unwrap());
+    }
+
+    #[test]
+    fn an_unreadable_lease_secret_is_replaced_rather_than_failing_the_app() {
+        let path = temp_lease_secret_path("lease-garbage");
+        std::fs::write(&path, "not base64url!!!").unwrap();
+
+        let secret = ensure_native_path_lease_secret_at(&path).unwrap();
+
+        assert!(secret.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES);
+    }
+
+    #[test]
+    fn the_persisted_lease_secret_round_trips_through_the_child_env_encoding() {
+        // What process.rs hands the backend is the encoded form, and the backend
+        // decodes it with the same alphabet.
+        let path = temp_lease_secret_path("lease-roundtrip");
+        let secret = ensure_native_path_lease_secret_at(&path).unwrap();
+        let encoded = crate::native_backend_lease::encode_secret_env(&secret);
+
+        assert_eq!(
+            crate::native_backend_lease::decode_secret_env(&encoded),
+            Some(secret)
+        );
     }
 
     fn closed_port() -> u16 {

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -218,55 +218,6 @@ fn home_dir_or_error() -> Result<PathBuf, String> {
     dirs::home_dir().ok_or_else(|| "could not resolve the home directory".to_string())
 }
 
-fn lease_secret_path_for_home(home: &Path) -> PathBuf {
-    managed_run_dir(home).join(".native_path_lease_secret")
-}
-
-/// The install's native path lease secret, created on first use.
-///
-/// Per-install, not per-process, because a backend outlives the app that
-/// spawned it: when the previous app pid is dead the preflight ADOPTS the
-/// survivor rather than restarting it. A freshly minted per-process secret
-/// would leave that adopted backend verifying with the old key, so the picker
-/// (which only sees the boolean `native_path_leases_supported`) stays live and
-/// every grant fails the signature check. Same key, same file, no restart.
-///
-/// Kept beside the owner metadata, which already stores the desktop owner token
-/// in the same 0700 dir at 0600 -- a strictly stronger credential, since it
-/// buys a desktop-login. An unreadable or too-short file is replaced: the old
-/// secret is unrecoverable either way, so minting is all that is left.
-///
-/// Reports whether the key was LOADED rather than minted. Only a loaded key can
-/// be one a surviving backend already holds: on the first launch after an
-/// upgrade from a release that kept the key in memory, the file is absent, so
-/// the key written here is new to everyone and a survivor still verifies with
-/// the one it was spawned with.
-pub(crate) fn ensure_native_path_lease_secret() -> Result<(Vec<u8>, bool), String> {
-    ensure_native_path_lease_secret_at(&lease_secret_path_for_home(&home_dir_or_error()?))
-}
-
-fn ensure_native_path_lease_secret_at(path: &Path) -> Result<(Vec<u8>, bool), String> {
-    if let Ok(raw) = std::fs::read_to_string(path) {
-        if let Some(secret) = crate::native_backend_lease::decode_secret_env(raw.trim()) {
-            if secret.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES {
-                return Ok((secret, true));
-            }
-        }
-    }
-    let secret = crate::native_backend_lease::new_lease_secret();
-    let parent = path
-        .parent()
-        .ok_or_else(|| "lease secret path has no parent".to_string())?;
-    std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-    set_private_dir_permissions(parent);
-    write_private_file(
-        path,
-        crate::native_backend_lease::encode_secret_env(&secret).as_bytes(),
-    )?;
-    set_private_file_permissions(path);
-    Ok((secret, false))
-}
-
 fn ensure_studio_root_id_at(
     path: &Path,
     create_when_missing: bool,
@@ -1381,73 +1332,6 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         dir.join("desktop_backend.json")
-    }
-
-    fn temp_lease_secret_path(test_name: &str) -> PathBuf {
-        temp_metadata_path(test_name)
-            .parent()
-            .unwrap()
-            .join(".native_path_lease_secret")
-    }
-
-    #[test]
-    fn an_adopted_backend_and_the_next_app_process_share_one_lease_secret() {
-        // The whole point. Two app processes, one install: the second must sign
-        // with the key the survivor it adopted was spawned with, or the picker
-        // is live and every grant fails the signature check.
-        let path = temp_lease_secret_path("lease-shared");
-        let (first, first_loaded) = ensure_native_path_lease_secret_at(&path).unwrap();
-        let (second, second_loaded) = ensure_native_path_lease_secret_at(&path).unwrap();
-
-        assert_eq!(first, second);
-        assert!(first.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES);
-        // Minted here, loaded there: only the second process may trust a survivor.
-        assert!(!first_loaded);
-        assert!(second_loaded);
-    }
-
-    #[test]
-    fn a_lease_secret_below_the_backend_floor_is_replaced() {
-        // The backend refuses anything under 32 bytes, so keeping a short one
-        // would advertise leases that cannot verify.
-        let path = temp_lease_secret_path("lease-short");
-        std::fs::write(
-            &path,
-            crate::native_backend_lease::encode_secret_env(b"too-short"),
-        )
-        .unwrap();
-
-        let (secret, loaded) = ensure_native_path_lease_secret_at(&path).unwrap();
-
-        assert!(secret.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES);
-        // Replacing counts as minting: whoever held the short key cannot verify this one.
-        assert!(!loaded);
-        assert_eq!(secret, ensure_native_path_lease_secret_at(&path).unwrap().0);
-    }
-
-    #[test]
-    fn an_unreadable_lease_secret_is_replaced_rather_than_failing_the_app() {
-        let path = temp_lease_secret_path("lease-garbage");
-        std::fs::write(&path, "not base64url!!!").unwrap();
-
-        let (secret, loaded) = ensure_native_path_lease_secret_at(&path).unwrap();
-
-        assert!(secret.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES);
-        assert!(!loaded);
-    }
-
-    #[test]
-    fn the_persisted_lease_secret_round_trips_through_the_child_env_encoding() {
-        // What process.rs hands the backend is the encoded form, and the backend
-        // decodes it with the same alphabet.
-        let path = temp_lease_secret_path("lease-roundtrip");
-        let (secret, _) = ensure_native_path_lease_secret_at(&path).unwrap();
-        let encoded = crate::native_backend_lease::encode_secret_env(&secret);
-
-        assert_eq!(
-            crate::native_backend_lease::decode_secret_env(&encoded),
-            Some(secret)
-        );
     }
 
     fn closed_port() -> u16 {

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -235,15 +235,21 @@ fn lease_secret_path_for_home(home: &Path) -> PathBuf {
 /// in the same 0700 dir at 0600 -- a strictly stronger credential, since it
 /// buys a desktop-login. An unreadable or too-short file is replaced: the old
 /// secret is unrecoverable either way, so minting is all that is left.
-pub(crate) fn ensure_native_path_lease_secret() -> Result<Vec<u8>, String> {
+///
+/// Reports whether the key was LOADED rather than minted. Only a loaded key can
+/// be one a surviving backend already holds: on the first launch after an
+/// upgrade from a release that kept the key in memory, the file is absent, so
+/// the key written here is new to everyone and a survivor still verifies with
+/// the one it was spawned with.
+pub(crate) fn ensure_native_path_lease_secret() -> Result<(Vec<u8>, bool), String> {
     ensure_native_path_lease_secret_at(&lease_secret_path_for_home(&home_dir_or_error()?))
 }
 
-fn ensure_native_path_lease_secret_at(path: &Path) -> Result<Vec<u8>, String> {
+fn ensure_native_path_lease_secret_at(path: &Path) -> Result<(Vec<u8>, bool), String> {
     if let Ok(raw) = std::fs::read_to_string(path) {
         if let Some(secret) = crate::native_backend_lease::decode_secret_env(raw.trim()) {
             if secret.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES {
-                return Ok(secret);
+                return Ok((secret, true));
             }
         }
     }
@@ -258,7 +264,7 @@ fn ensure_native_path_lease_secret_at(path: &Path) -> Result<Vec<u8>, String> {
         crate::native_backend_lease::encode_secret_env(&secret).as_bytes(),
     )?;
     set_private_file_permissions(path);
-    Ok(secret)
+    Ok((secret, false))
 }
 
 fn ensure_studio_root_id_at(
@@ -1390,11 +1396,14 @@ mod tests {
         // with the key the survivor it adopted was spawned with, or the picker
         // is live and every grant fails the signature check.
         let path = temp_lease_secret_path("lease-shared");
-        let first = ensure_native_path_lease_secret_at(&path).unwrap();
-        let second = ensure_native_path_lease_secret_at(&path).unwrap();
+        let (first, first_loaded) = ensure_native_path_lease_secret_at(&path).unwrap();
+        let (second, second_loaded) = ensure_native_path_lease_secret_at(&path).unwrap();
 
         assert_eq!(first, second);
         assert!(first.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES);
+        // Minted here, loaded there: only the second process may trust a survivor.
+        assert!(!first_loaded);
+        assert!(second_loaded);
     }
 
     #[test]
@@ -1408,10 +1417,12 @@ mod tests {
         )
         .unwrap();
 
-        let secret = ensure_native_path_lease_secret_at(&path).unwrap();
+        let (secret, loaded) = ensure_native_path_lease_secret_at(&path).unwrap();
 
         assert!(secret.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES);
-        assert_eq!(secret, ensure_native_path_lease_secret_at(&path).unwrap());
+        // Replacing counts as minting: whoever held the short key cannot verify this one.
+        assert!(!loaded);
+        assert_eq!(secret, ensure_native_path_lease_secret_at(&path).unwrap().0);
     }
 
     #[test]
@@ -1419,9 +1430,10 @@ mod tests {
         let path = temp_lease_secret_path("lease-garbage");
         std::fs::write(&path, "not base64url!!!").unwrap();
 
-        let secret = ensure_native_path_lease_secret_at(&path).unwrap();
+        let (secret, loaded) = ensure_native_path_lease_secret_at(&path).unwrap();
 
         assert!(secret.len() >= crate::native_backend_lease::MIN_LEASE_SECRET_BYTES);
+        assert!(!loaded);
     }
 
     #[test]
@@ -1429,7 +1441,7 @@ mod tests {
         // What process.rs hands the backend is the encoded form, and the backend
         // decodes it with the same alphabet.
         let path = temp_lease_secret_path("lease-roundtrip");
-        let secret = ensure_native_path_lease_secret_at(&path).unwrap();
+        let (secret, _) = ensure_native_path_lease_secret_at(&path).unwrap();
         let encoded = crate::native_backend_lease::encode_secret_env(&secret);
 
         assert_eq!(

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -1537,6 +1537,7 @@ fn main() {
             commands::open_models_dir,
             commands::start_backend_update,
             commands::start_managed_repair,
+            commands::native_path_leases_usable,
             commands::cancel_pending_elevation,
             commands::install_system_packages,
             desktop_auth::desktop_auth,

--- a/studio/src-tauri/src/native_backend_lease.rs
+++ b/studio/src-tauri/src/native_backend_lease.rs
@@ -91,12 +91,6 @@ pub fn encode_secret_env(secret: &[u8]) -> String {
     URL_SAFE_NO_PAD.encode(secret)
 }
 
-/// Inverse of `encode_secret_env`; `None` when the text is not the encoding we
-/// wrote, which for a persisted secret means "unusable", not "empty".
-pub fn decode_secret_env(encoded: &str) -> Option<Vec<u8>> {
-    URL_SAFE_NO_PAD.decode(encoded).ok()
-}
-
 pub fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/studio/src-tauri/src/native_backend_lease.rs
+++ b/studio/src-tauri/src/native_backend_lease.rs
@@ -78,12 +78,23 @@ pub struct NativePathLeaseResponse {
     pub expires_at_ms: u64,
 }
 
+/// Lockstep with `_MIN_LEASE_SECRET_BYTES` in
+/// `studio/backend/utils/native_path_leases.py`: a shorter secret is refused
+/// there, so a shorter one here would advertise leases the backend rejects.
+pub const MIN_LEASE_SECRET_BYTES: usize = 32;
+
 pub fn new_lease_secret() -> Vec<u8> {
-    rand::random::<[u8; 32]>().to_vec()
+    rand::random::<[u8; MIN_LEASE_SECRET_BYTES]>().to_vec()
 }
 
 pub fn encode_secret_env(secret: &[u8]) -> String {
     URL_SAFE_NO_PAD.encode(secret)
+}
+
+/// Inverse of `encode_secret_env`; `None` when the text is not the encoding we
+/// wrote, which for a persisted secret means "unusable", not "empty".
+pub fn decode_secret_env(encoded: &str) -> Option<Vec<u8>> {
+    URL_SAFE_NO_PAD.decode(encoded).ok()
 }
 
 pub fn now_ms() -> u64 {

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -111,6 +111,7 @@ struct NativeIntakeInner {
 pub struct NativeIntakeState {
     inner: Mutex<NativeIntakeInner>,
     lease_secret: Vec<u8>,
+    lease_secret_persisted: bool,
 }
 
 pub fn new_native_intake_state() -> NativeIntakeState {
@@ -118,20 +119,28 @@ pub fn new_native_intake_state() -> NativeIntakeState {
     // still holds the key it was spawned with. See
     // desktop_backend_owner::ensure_native_path_lease_secret. A home we cannot
     // write to falls back to a process-local key, which is what this always was.
-    let lease_secret = crate::desktop_backend_owner::ensure_native_path_lease_secret()
-        .unwrap_or_else(|error| {
-            log::warn!("Could not persist the native path lease secret: {error}");
-            crate::native_backend_lease::new_lease_secret()
-        });
+    let (lease_secret, lease_secret_persisted) =
+        match crate::desktop_backend_owner::ensure_native_path_lease_secret() {
+            Ok(secret) => (secret, true),
+            Err(error) => {
+                log::warn!("Could not persist the native path lease secret: {error}");
+                (crate::native_backend_lease::new_lease_secret(), false)
+            }
+        };
     NativeIntakeState {
         inner: Mutex::new(NativeIntakeInner::default()),
         lease_secret,
+        lease_secret_persisted,
     }
 }
 
 impl NativeIntakeState {
     pub fn lease_secret_env(&self) -> String {
         encode_secret_env(&self.lease_secret)
+    }
+
+    pub fn lease_secret_persisted(&self) -> bool {
+        self.lease_secret_persisted
     }
 
     #[allow(dead_code)]

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -111,7 +111,7 @@ struct NativeIntakeInner {
 pub struct NativeIntakeState {
     inner: Mutex<NativeIntakeInner>,
     lease_secret: Vec<u8>,
-    lease_secret_persisted: bool,
+    lease_secret_predates_this_process: bool,
 }
 
 pub fn new_native_intake_state() -> NativeIntakeState {
@@ -119,9 +119,12 @@ pub fn new_native_intake_state() -> NativeIntakeState {
     // still holds the key it was spawned with. See
     // desktop_backend_owner::ensure_native_path_lease_secret. A home we cannot
     // write to falls back to a process-local key, which is what this always was.
-    let (lease_secret, lease_secret_persisted) =
+    let (lease_secret, lease_secret_predates_this_process) =
         match crate::desktop_backend_owner::ensure_native_path_lease_secret() {
-            Ok(secret) => (secret, true),
+            // Loaded, not merely written: a key minted here is new to every
+            // backend alive, including one this install left running before the
+            // upgrade that added the file.
+            Ok((secret, loaded)) => (secret, loaded),
             Err(error) => {
                 log::warn!("Could not persist the native path lease secret: {error}");
                 (crate::native_backend_lease::new_lease_secret(), false)
@@ -130,7 +133,7 @@ pub fn new_native_intake_state() -> NativeIntakeState {
     NativeIntakeState {
         inner: Mutex::new(NativeIntakeInner::default()),
         lease_secret,
-        lease_secret_persisted,
+        lease_secret_predates_this_process,
     }
 }
 
@@ -139,8 +142,10 @@ impl NativeIntakeState {
         encode_secret_env(&self.lease_secret)
     }
 
-    pub fn lease_secret_persisted(&self) -> bool {
-        self.lease_secret_persisted
+    /// True only when this process ADOPTED an existing key, which is the one
+    /// condition under which a surviving backend can verify what we sign.
+    pub fn lease_secret_predates_this_process(&self) -> bool {
+        self.lease_secret_predates_this_process
     }
 
     #[allow(dead_code)]

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -114,9 +114,18 @@ pub struct NativeIntakeState {
 }
 
 pub fn new_native_intake_state() -> NativeIntakeState {
+    // Per-install, not per-process: a backend adopted from a dead previous app
+    // still holds the key it was spawned with. See
+    // desktop_backend_owner::ensure_native_path_lease_secret. A home we cannot
+    // write to falls back to a process-local key, which is what this always was.
+    let lease_secret = crate::desktop_backend_owner::ensure_native_path_lease_secret()
+        .unwrap_or_else(|error| {
+            log::warn!("Could not persist the native path lease secret: {error}");
+            crate::native_backend_lease::new_lease_secret()
+        });
     NativeIntakeState {
         inner: Mutex::new(NativeIntakeInner::default()),
-        lease_secret: crate::native_backend_lease::new_lease_secret(),
+        lease_secret,
     }
 }
 

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -113,15 +113,10 @@ pub struct NativeIntakeState {
     lease_secret: Vec<u8>,
 }
 
-/// Per process, and deliberately not persisted.
-///
-/// A key on disk would be shared with a backend this process did not spawn,
-/// which is the only way an ADOPTED survivor could verify what we sign -- but it
-/// also outlives every backend restart, and the backend only remembers spent
-/// nonces in memory, so a consumed lease could be replayed against a replacement
-/// process inside the two minute TTL. The adopted case is handled where it
-/// belongs instead: the preflight reports that leases are unusable and the UI
-/// greys the picker, rather than the app holding a long-lived signing key.
+/// Per process, and deliberately not persisted: a key on disk outlives every
+/// backend restart, and spent nonces are only remembered in memory, so a
+/// consumed lease could be replayed against a replacement inside the TTL. The
+/// adopted-survivor case is answered by `native_path_leases_usable` instead.
 pub fn new_native_intake_state() -> NativeIntakeState {
     NativeIntakeState {
         inner: Mutex::new(NativeIntakeInner::default()),

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -111,41 +111,27 @@ struct NativeIntakeInner {
 pub struct NativeIntakeState {
     inner: Mutex<NativeIntakeInner>,
     lease_secret: Vec<u8>,
-    lease_secret_predates_this_process: bool,
 }
 
+/// Per process, and deliberately not persisted.
+///
+/// A key on disk would be shared with a backend this process did not spawn,
+/// which is the only way an ADOPTED survivor could verify what we sign -- but it
+/// also outlives every backend restart, and the backend only remembers spent
+/// nonces in memory, so a consumed lease could be replayed against a replacement
+/// process inside the two minute TTL. The adopted case is handled where it
+/// belongs instead: the preflight reports that leases are unusable and the UI
+/// greys the picker, rather than the app holding a long-lived signing key.
 pub fn new_native_intake_state() -> NativeIntakeState {
-    // Per-install, not per-process: a backend adopted from a dead previous app
-    // still holds the key it was spawned with. See
-    // desktop_backend_owner::ensure_native_path_lease_secret. A home we cannot
-    // write to falls back to a process-local key, which is what this always was.
-    let (lease_secret, lease_secret_predates_this_process) =
-        match crate::desktop_backend_owner::ensure_native_path_lease_secret() {
-            // Loaded, not merely written: a key minted here is new to every
-            // backend alive, including one this install left running before the
-            // upgrade that added the file.
-            Ok((secret, loaded)) => (secret, loaded),
-            Err(error) => {
-                log::warn!("Could not persist the native path lease secret: {error}");
-                (crate::native_backend_lease::new_lease_secret(), false)
-            }
-        };
     NativeIntakeState {
         inner: Mutex::new(NativeIntakeInner::default()),
-        lease_secret,
-        lease_secret_predates_this_process,
+        lease_secret: crate::native_backend_lease::new_lease_secret(),
     }
 }
 
 impl NativeIntakeState {
     pub fn lease_secret_env(&self) -> String {
         encode_secret_env(&self.lease_secret)
-    }
-
-    /// True only when this process ADOPTED an existing key, which is the one
-    /// condition under which a surviving backend can verify what we sign.
-    pub fn lease_secret_predates_this_process(&self) -> bool {
-        self.lease_secret_predates_this_process
     }
 
     #[allow(dead_code)]

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -779,8 +779,18 @@ exit 1
 
     fn desktop_ready_health_with_owner(root_id: &str, include_owner: bool) -> String {
         let owner = desktop_owner_json(include_owner);
+        // Tied to the owner on purpose. The lease secret comes from the desktop
+        // spawn, so an owned backend reports the capability and an ownerless one
+        // (started from a terminal) never can. A fixture that reports both an
+        // absent owner and lease support describes a backend that cannot exist,
+        // and would hide exactly the case these tests are here to pin.
+        let leases = if include_owner {
+            r#""native_path_leases_supported":true,"#
+        } else {
+            ""
+        };
         format!(
-            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":true,"studio_root_id":"{root_id}"{owner}}}"#
+            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,{leases}"studio_root_id":"{root_id}"{owner}}}"#
         )
     }
 
@@ -905,7 +915,14 @@ exit 1
     }
 
     #[tokio::test]
-    async fn same_root_backend_without_native_path_leases_is_an_external_conflict() {
+    async fn terminal_started_backend_without_native_path_leases_stays_adoptable() {
+        // The lease secret is per-process and only the desktop spawn sets it,
+        // so this is what EVERY terminal-started server looks like, not an edge
+        // case. Refusing it would take "attach to a server I started myself",
+        // which use-tauri-backend.ts supports on purpose, away from every such
+        // user in order to grey out one button. The picker is gated in the UI
+        // instead: use-linked-folders.ts reads the same capability off
+        // /api/health and says so in the panel.
         let probe = probe_test_backend(
             format!(
                 r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":false,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
@@ -914,10 +931,64 @@ exit 1
         )
         .await;
 
+        assert!(matches!(probe, BackendProbe::Ready { .. }));
+    }
+
+    #[tokio::test]
+    async fn backend_predating_the_lease_capability_field_stays_adoptable() {
+        // Absent, not false: the field arrived with native GGUF intake, so a
+        // backend built before it reports nothing at all. Option<bool> makes
+        // that indistinguishable from `false` unless it is spelled out.
+        let probe = probe_test_backend(
+            format!(
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
+            ),
+            "401 Unauthorized",
+        )
+        .await;
+
+        assert!(matches!(probe, BackendProbe::Ready { .. }));
+    }
+
+    #[tokio::test]
+    async fn owned_backend_without_native_path_leases_is_stale_not_a_conflict() {
+        // A backend this app owns and cannot lease from is a defect in our own
+        // spawn. That one IS ours to restart, and the restart re-injects the
+        // secret, so it is Stale (repairable) rather than a conflict the user
+        // has to resolve by hand.
+        let probe = probe_test_backend(
+            format!(
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":false,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
+                desktop_owner_json(true)
+            ),
+            "401 Unauthorized",
+        )
+        .await;
+
+        assert!(matches!(
+            probe,
+            BackendProbe::Old { reason, .. } if reason == "native_path_leases_unsupported"
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_stale_version_is_still_reported_as_a_version_problem() {
+        // Ordering guard. The lease check used to run first, so a backend that
+        // genuinely needed an update was told its leases were unsupported, and
+        // the reason string that reaches diagnostics and the user-facing
+        // message named the wrong cause.
+        let probe = probe_test_backend(
+            format!(
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.1","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":false,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
+            ),
+            "401 Unauthorized",
+        )
+        .await;
+
         assert!(matches!(
             probe,
             BackendProbe::ExternalConflict { reason, .. }
-                if reason == "native_path_leases_unsupported"
+                if reason == "desktop_backend_version_too_old"
         ));
     }
 
@@ -925,7 +996,7 @@ exit 1
     async fn stale_same_root_without_desktop_owner_is_external_conflict() {
         let probe = probe_test_backend(
             format!(
-                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.1","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":true,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.1","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
             ),
             "401 Unauthorized",
         )

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -780,7 +780,7 @@ exit 1
     fn desktop_ready_health_with_owner(root_id: &str, include_owner: bool) -> String {
         let owner = desktop_owner_json(include_owner);
         format!(
-            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{root_id}"{owner}}}"#
+            r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":true,"studio_root_id":"{root_id}"{owner}}}"#
         )
     }
 
@@ -866,7 +866,7 @@ exit 1
         // protocol-compatible backend into a conflict the user has to kill.
         let probe = probe_test_backend(
             format!(
-                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":1,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":true,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
                 desktop_owner_json(true)
             ),
             "401 Unauthorized",
@@ -905,10 +905,27 @@ exit 1
     }
 
     #[tokio::test]
+    async fn same_root_backend_without_native_path_leases_is_an_external_conflict() {
+        let probe = probe_test_backend(
+            format!(
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":false,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
+            ),
+            "401 Unauthorized",
+        )
+        .await;
+
+        assert!(matches!(
+            probe,
+            BackendProbe::ExternalConflict { reason, .. }
+                if reason == "native_path_leases_unsupported"
+        ));
+    }
+
+    #[tokio::test]
     async fn stale_same_root_without_desktop_owner_is_external_conflict() {
         let probe = probe_test_backend(
             format!(
-                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.1","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
+                r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.1","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":true,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
             ),
             "401 Unauthorized",
         )

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -214,7 +214,6 @@ pub async fn desktop_preflight_result() -> DesktopPreflightResult {
 
 pub async fn desktop_preflight_result_with_state(
     state: &crate::process::BackendState,
-    lease_secret_predates_this_process: bool,
 ) -> Result<(DesktopPreflightResult, Option<(u64, bool)>), String> {
     let (managed, backend, owned) = tokio::join!(
         probe_managed_install(),
@@ -243,12 +242,7 @@ pub async fn desktop_preflight_result_with_state(
         )
         .await
         {
-            OwnedBackendProbe::Verified(mut verified) => {
-                if snapshot.is_adopted && !lease_secret_predates_this_process {
-                    verified.readiness = OwnedBackendReadiness::Stale {
-                        reason: "native_path_lease_secret_not_shared".to_string(),
-                    };
-                }
+            OwnedBackendProbe::Verified(verified) => {
                 if snapshot.port.is_none() {
                     crate::process::record_owned_backend_port_if_current(
                         state,
@@ -304,12 +298,7 @@ pub async fn desktop_preflight_result_with_state(
     };
 
     match owned {
-        OwnedBackendProbe::Verified(mut verified) => {
-            if !lease_secret_predates_this_process {
-                verified.readiness = OwnedBackendReadiness::Stale {
-                    reason: "native_path_lease_secret_not_shared".to_string(),
-                };
-            }
+        OwnedBackendProbe::Verified(verified) => {
             let result = choose_owned_preflight(&managed, &verified);
             let adopted = crate::process::adopt_verified_backend(state, verified)?;
             let watchdog_generation =

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -779,11 +779,9 @@ exit 1
 
     fn desktop_ready_health_with_owner(root_id: &str, include_owner: bool) -> String {
         let owner = desktop_owner_json(include_owner);
-        // Tied to the owner on purpose. The lease secret comes from the desktop
-        // spawn, so an owned backend reports the capability and an ownerless one
-        // (started from a terminal) never can. A fixture that reports both an
-        // absent owner and lease support describes a backend that cannot exist,
-        // and would hide exactly the case these tests are here to pin.
+        // Tied to the owner on purpose: the secret comes from the desktop spawn,
+        // so an ownerless (terminal-started) backend can never report it. Both at
+        // once describes a backend that cannot exist.
         let leases = if include_owner {
             r#""native_path_leases_supported":true,"#
         } else {
@@ -916,13 +914,10 @@ exit 1
 
     #[tokio::test]
     async fn terminal_started_backend_without_native_path_leases_stays_adoptable() {
-        // The lease secret is per-process and only the desktop spawn sets it,
-        // so this is what EVERY terminal-started server looks like, not an edge
-        // case. Refusing it would take "attach to a server I started myself",
-        // which use-tauri-backend.ts supports on purpose, away from every such
-        // user in order to grey out one button. The picker is gated in the UI
-        // instead: use-linked-folders.ts reads the same capability off
-        // /api/health and says so in the panel.
+        // What EVERY terminal-started server looks like, not an edge case.
+        // Refusing it would drop the attach use-tauri-backend.ts supports on
+        // purpose, to grey out one button that use-linked-folders.ts already
+        // greys out from the same capability.
         let probe = probe_test_backend(
             format!(
                 r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":false,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
@@ -936,9 +931,8 @@ exit 1
 
     #[tokio::test]
     async fn backend_predating_the_lease_capability_field_stays_adoptable() {
-        // Absent, not false: the field arrived with native GGUF intake, so a
-        // backend built before it reports nothing at all. Option<bool> makes
-        // that indistinguishable from `false` unless it is spelled out.
+        // Absent, not false: a backend predating the field reports nothing, and
+        // Option<bool> makes that indistinguishable from `false` untested.
         let probe = probe_test_backend(
             format!(
                 r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,
@@ -952,10 +946,8 @@ exit 1
 
     #[tokio::test]
     async fn owned_backend_without_native_path_leases_is_stale_not_a_conflict() {
-        // A backend this app owns and cannot lease from is a defect in our own
-        // spawn. That one IS ours to restart, and the restart re-injects the
-        // secret, so it is Stale (repairable) rather than a conflict the user
-        // has to resolve by hand.
+        // A defect in our own spawn, and ours to restart, so Stale (repairable)
+        // rather than a conflict the user has to resolve by hand.
         let probe = probe_test_backend(
             format!(
                 r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.8.4","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":false,"studio_root_id":"{EXPECTED_ROOT_ID}"{}}}"#,
@@ -973,10 +965,8 @@ exit 1
 
     #[tokio::test]
     async fn a_stale_version_is_still_reported_as_a_version_problem() {
-        // Ordering guard. The lease check used to run first, so a backend that
-        // genuinely needed an update was told its leases were unsupported, and
-        // the reason string that reaches diagnostics and the user-facing
-        // message named the wrong cause.
+        // Ordering guard: the lease check used to run first, so a backend that
+        // really needed an update reported the wrong cause to diagnostics.
         let probe = probe_test_backend(
             format!(
                 r#"{{"status":"healthy","service":"Unsloth UI Backend","version":"2026.5.1","desktop_protocol_version":1,"desktop_manageability_version":2,"supports_desktop_auth":true,"supports_desktop_backend_ownership":true,"native_path_leases_supported":false,"studio_root_id":"{EXPECTED_ROOT_ID}"}}"#,

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -214,7 +214,7 @@ pub async fn desktop_preflight_result() -> DesktopPreflightResult {
 
 pub async fn desktop_preflight_result_with_state(
     state: &crate::process::BackendState,
-    lease_secret_persisted: bool,
+    lease_secret_predates_this_process: bool,
 ) -> Result<(DesktopPreflightResult, Option<(u64, bool)>), String> {
     let (managed, backend, owned) = tokio::join!(
         probe_managed_install(),
@@ -244,9 +244,9 @@ pub async fn desktop_preflight_result_with_state(
         .await
         {
             OwnedBackendProbe::Verified(mut verified) => {
-                if snapshot.is_adopted && !lease_secret_persisted {
+                if snapshot.is_adopted && !lease_secret_predates_this_process {
                     verified.readiness = OwnedBackendReadiness::Stale {
-                        reason: "native_path_lease_secret_not_persisted".to_string(),
+                        reason: "native_path_lease_secret_not_shared".to_string(),
                     };
                 }
                 if snapshot.port.is_none() {
@@ -305,9 +305,9 @@ pub async fn desktop_preflight_result_with_state(
 
     match owned {
         OwnedBackendProbe::Verified(mut verified) => {
-            if !lease_secret_persisted {
+            if !lease_secret_predates_this_process {
                 verified.readiness = OwnedBackendReadiness::Stale {
-                    reason: "native_path_lease_secret_not_persisted".to_string(),
+                    reason: "native_path_lease_secret_not_shared".to_string(),
                 };
             }
             let result = choose_owned_preflight(&managed, &verified);

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -214,6 +214,7 @@ pub async fn desktop_preflight_result() -> DesktopPreflightResult {
 
 pub async fn desktop_preflight_result_with_state(
     state: &crate::process::BackendState,
+    lease_secret_persisted: bool,
 ) -> Result<(DesktopPreflightResult, Option<(u64, bool)>), String> {
     let (managed, backend, owned) = tokio::join!(
         probe_managed_install(),
@@ -242,7 +243,12 @@ pub async fn desktop_preflight_result_with_state(
         )
         .await
         {
-            OwnedBackendProbe::Verified(verified) => {
+            OwnedBackendProbe::Verified(mut verified) => {
+                if snapshot.is_adopted && !lease_secret_persisted {
+                    verified.readiness = OwnedBackendReadiness::Stale {
+                        reason: "native_path_lease_secret_not_persisted".to_string(),
+                    };
+                }
                 if snapshot.port.is_none() {
                     crate::process::record_owned_backend_port_if_current(
                         state,
@@ -298,7 +304,12 @@ pub async fn desktop_preflight_result_with_state(
     };
 
     match owned {
-        OwnedBackendProbe::Verified(verified) => {
+        OwnedBackendProbe::Verified(mut verified) => {
+            if !lease_secret_persisted {
+                verified.readiness = OwnedBackendReadiness::Stale {
+                    reason: "native_path_lease_secret_not_persisted".to_string(),
+                };
+            }
             let result = choose_owned_preflight(&managed, &verified);
             let adopted = crate::process::adopt_verified_backend(state, verified)?;
             let watchdog_generation =

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -20,6 +20,7 @@ pub(super) struct BackendHealth {
     desktop_manageability_version: Option<u16>,
     supports_desktop_auth: Option<bool>,
     supports_desktop_backend_ownership: Option<bool>,
+    native_path_leases_supported: Option<bool>,
     studio_root_id: Option<String>,
     desktop_owner: Option<DesktopOwnerHealth>,
     version: Option<String>,
@@ -68,6 +69,9 @@ pub(super) async fn backend_health(client: &reqwest::Client, port: u16) -> Optio
     let supports_desktop_backend_ownership = json
         .get("supports_desktop_backend_ownership")
         .and_then(|v| v.as_bool());
+    let native_path_leases_supported = json
+        .get("native_path_leases_supported")
+        .and_then(|v| v.as_bool());
     let studio_root_id = json
         .get("studio_root_id")
         .and_then(|v| v.as_str())
@@ -91,6 +95,7 @@ pub(super) async fn backend_health(client: &reqwest::Client, port: u16) -> Optio
         desktop_manageability_version,
         supports_desktop_auth,
         supports_desktop_backend_ownership,
+        native_path_leases_supported,
         studio_root_id,
         desktop_owner,
         version,
@@ -154,6 +159,9 @@ fn backend_capability_stale_reason(health: &BackendHealth) -> Option<String> {
     }
     if health.supports_desktop_backend_ownership != Some(true) {
         return Some("desktop_backend_ownership_unsupported".to_string());
+    }
+    if health.native_path_leases_supported != Some(true) {
+        return Some("native_path_leases_unsupported".to_string());
     }
     // Unauthenticated /api/health gates `version` behind a bearer, and the bits
     // above predate the floor, so no version means "auth-gated", not "old".
@@ -378,6 +386,7 @@ mod tests {
             desktop_manageability_version: None,
             supports_desktop_auth: None,
             supports_desktop_backend_ownership: None,
+            native_path_leases_supported: None,
             studio_root_id: studio_root_id.map(str::to_string),
             desktop_owner: None,
             version: None,

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -170,16 +170,12 @@ fn backend_capability_stale_reason(health: &BackendHealth) -> Option<String> {
 
 /// Deliberately NOT part of `backend_capability_stale_reason`.
 ///
-/// The lease secret is a per-process environment variable that only the desktop
-/// spawn sets (`process.rs`), so "does not support native path leases" does not
-/// mean "too old to talk to". It means "this app did not start it", and it is
-/// permanently true of a backend the user started from a terminal.
-///
-/// Folding it in with the protocol bits would therefore make every
-/// terminal-started same-root backend an ExternalConflict, and the app would
-/// refuse to start against a server it can otherwise drive perfectly -- to fix a
-/// folder picker that `use-linked-folders.ts` already greys out with a message
-/// naming the reason. Apply it only where a restart is ours to perform.
+/// Only the desktop spawn sets the lease secret (`process.rs`), so this does not
+/// mean "too old to talk to", it means "this app did not start it" -- permanently
+/// true of a terminal-started backend. Folded in with the protocol bits it would
+/// make every one of those an ExternalConflict and the app would refuse to start,
+/// to fix a picker `use-linked-folders.ts` already greys out. Apply it only where
+/// a restart is ours to perform.
 fn backend_native_lease_stale_reason(health: &BackendHealth) -> Option<String> {
     if health.native_path_leases_supported != Some(true) {
         return Some("native_path_leases_unsupported".to_string());
@@ -203,8 +199,7 @@ pub(super) async fn probe_ownerless_spawned_backend(port: u16) -> BackendProbe {
     if let Some(reason) = backend_capability_stale_reason(&health) {
         return BackendProbe::Old { port, reason };
     }
-    // This backend is one WE spawned, so a missing lease secret is a defect in
-    // our own start and a restart fixes it.
+    // One WE spawned: a missing secret is a defect in our own start, so restart.
     if let Some(reason) = backend_native_lease_stale_reason(&health) {
         return BackendProbe::Old { port, reason };
     }
@@ -279,11 +274,9 @@ pub(super) async fn backend_desktop_auth_status(
             BackendProbe::Old { port, reason }
         };
     }
-    // Only for a backend this app owns: that one is ours to stop and start
-    // again, and the restart re-injects the secret. An ownerless same-root
-    // backend is a terminal-started server we cannot repair by restarting, and
-    // blocking on it would make the app unstartable for a user who runs
-    // `unsloth studio` themselves. See backend_native_lease_stale_reason.
+    // Owned only: ours to restart, and the restart re-injects the secret. An
+    // ownerless same-root backend is terminal-started, so blocking on it would
+    // make the app unstartable. See backend_native_lease_stale_reason.
     if !same_root_external {
         if let Some(reason) = backend_native_lease_stale_reason(health) {
             return BackendProbe::Old { port, reason };

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -160,15 +160,31 @@ fn backend_capability_stale_reason(health: &BackendHealth) -> Option<String> {
     if health.supports_desktop_backend_ownership != Some(true) {
         return Some("desktop_backend_ownership_unsupported".to_string());
     }
-    if health.native_path_leases_supported != Some(true) {
-        return Some("native_path_leases_unsupported".to_string());
-    }
     // Unauthenticated /api/health gates `version` behind a bearer, and the bits
     // above predate the floor, so no version means "auth-gated", not "old".
     match health.version.as_deref() {
         Some(version) if !version.is_empty() => backend_version_stale_reason(Some(version)),
         _ => None,
     }
+}
+
+/// Deliberately NOT part of `backend_capability_stale_reason`.
+///
+/// The lease secret is a per-process environment variable that only the desktop
+/// spawn sets (`process.rs`), so "does not support native path leases" does not
+/// mean "too old to talk to". It means "this app did not start it", and it is
+/// permanently true of a backend the user started from a terminal.
+///
+/// Folding it in with the protocol bits would therefore make every
+/// terminal-started same-root backend an ExternalConflict, and the app would
+/// refuse to start against a server it can otherwise drive perfectly -- to fix a
+/// folder picker that `use-linked-folders.ts` already greys out with a message
+/// naming the reason. Apply it only where a restart is ours to perform.
+fn backend_native_lease_stale_reason(health: &BackendHealth) -> Option<String> {
+    if health.native_path_leases_supported != Some(true) {
+        return Some("native_path_leases_unsupported".to_string());
+    }
+    None
 }
 
 #[derive(Serialize)]
@@ -185,6 +201,11 @@ pub(super) async fn probe_ownerless_spawned_backend(port: u16) -> BackendProbe {
         return BackendProbe::Missing;
     };
     if let Some(reason) = backend_capability_stale_reason(&health) {
+        return BackendProbe::Old { port, reason };
+    }
+    // This backend is one WE spawned, so a missing lease secret is a defect in
+    // our own start and a restart fixes it.
+    if let Some(reason) = backend_native_lease_stale_reason(&health) {
         return BackendProbe::Old { port, reason };
     }
 
@@ -257,6 +278,16 @@ pub(super) async fn backend_desktop_auth_status(
         } else {
             BackendProbe::Old { port, reason }
         };
+    }
+    // Only for a backend this app owns: that one is ours to stop and start
+    // again, and the restart re-injects the secret. An ownerless same-root
+    // backend is a terminal-started server we cannot repair by restarting, and
+    // blocking on it would make the app unstartable for a user who runs
+    // `unsloth studio` themselves. See backend_native_lease_stale_reason.
+    if !same_root_external {
+        if let Some(reason) = backend_native_lease_stale_reason(health) {
+            return BackendProbe::Old { port, reason };
+        }
     }
 
     let url = format!("http://127.0.0.1:{port}/api/auth/desktop-login");


### PR DESCRIPTION
## Summary

- require attached desktop backends to advertise native path lease support
- gate linked-folder selection on the backend capability instead of Tauri alone
- show an actionable managed-backend requirement when linking is unavailable

## Root cause

The desktop preflight could attach to a same-install backend started outside the current Tauri process. That backend does not inherit the per-process `UNSLOTH_STUDIO_NATIVE_PATH_LEASE_SECRET`, while the linked-folder UI enabled its picker based only on `isTauri`. The resulting signed folder lease reached a backend that could not verify it and returned `Native path grants require the managed desktop backend.`

## Verification

- `npm run typecheck`
- `npm test -- --test-name-pattern='linked folder'` (1,965 passing)
- `npx eslint src/features/rag/components/use-linked-folders.ts src/features/rag/components/linked-folders-manager.tsx`
- `rustfmt --check --edition 2021 src/preflight/backend.rs`
- `git diff --check`

`cargo test preflight` could not compile in this Linux environment because the system packages for `javascriptcoregtk-4.1` and `webkit2gtk-4.1` are unavailable.

Fixes #8416