### PR TITLE
security: lockfile audit must block non-registry sources and missing integrity by default

### DIFF
--- a/.github/workflows/lockfile-audit.yml
+++ b/.github/workflows/lockfile-audit.yml
@@ -7,13 +7,14 @@
 # npm or cargo lockfile, on push to main, and on a daily schedule so
 # newly-published IOCs surface even when no PR opens.
 #
-# Default behavior is "advisory": only public indicator-of-compromise
-# strings, known-malicious pinned versions, and structurally broken
-# lockfiles fail the build. Structural anomalies (missing integrity,
-# non-default registry, etc.) are emitted as GitHub Actions warnings
-# but do not block merges. This deliberately keeps the noise floor
-# low while still failing the moment a checked-in lockfile starts
-# pointing at known-bad bytes.
+# Default behavior blocks on public indicator-of-compromise strings,
+# known-malicious pinned versions, structurally broken lockfiles, and
+# dependency provenance/integrity failures (non-registry resolved URL
+# or cargo source, missing integrity hash or cargo checksum) -- those
+# are the pre-install fetches this gate exists to stop before `npm ci`
+# runs lifecycle scripts. Remaining anomalies (an incomplete entry
+# with no `resolved` URL, an unaudited lockfileVersion) are emitted as
+# GitHub Actions warnings; --strict escalates those to blocking too.
 #
 # This workflow is intentionally separate from security-audit.yml:
 #   - security-audit.yml is the umbrella job (pip-audit + npm audit +
@@ -80,8 +81,8 @@ jobs:
         run: python3 -c "import ast; ast.parse(open('scripts/lockfile_supply_chain_audit.py').read())"
 
       - name: Run lockfile supply-chain audit
-        # Default mode: only known-malicious pinned versions, known IOC
-        # strings, and structurally broken lockfiles fail the build.
-        # Missing-integrity and other structural anomalies are emitted
-        # as ::warning:: annotations and do not gate merges.
+        # Default mode fails on known-malicious pinned versions, known
+        # IOC strings, broken lockfiles, and provenance/integrity
+        # failures (non-registry source, missing integrity/checksum).
+        # Lesser anomalies stay ::warning:: unless --strict is passed.
         run: python3 scripts/lockfile_supply_chain_audit.py

--- a/.github/workflows/lockfile-audit.yml
+++ b/.github/workflows/lockfile-audit.yml
@@ -7,14 +7,12 @@
 # npm or cargo lockfile, on push to main, and on a daily schedule so
 # newly-published IOCs surface even when no PR opens.
 #
-# Default behavior blocks on public indicator-of-compromise strings,
+# Default behavior blocks public indicator-of-compromise strings,
 # known-malicious pinned versions, structurally broken lockfiles, and
-# dependency provenance/integrity failures (non-registry resolved URL
-# or cargo source, missing integrity hash or cargo checksum) -- those
-# are the pre-install fetches this gate exists to stop before `npm ci`
-# runs lifecycle scripts. Remaining anomalies (an incomplete entry
-# with no `resolved` URL, an unaudited lockfileVersion) are emitted as
-# GitHub Actions warnings; --strict escalates those to blocking too.
+# provenance/integrity failures (non-registry resolved URL or cargo
+# source, missing integrity hash or cargo checksum) -- the pre-install
+# fetches this gate stops before `npm ci` runs lifecycle scripts.
+# Lesser anomalies warn; --strict escalates them to blocking.
 #
 # This workflow is intentionally separate from security-audit.yml:
 #   - security-audit.yml is the umbrella job (pip-audit + npm audit +
@@ -81,8 +79,7 @@ jobs:
         run: python3 -c "import ast; ast.parse(open('scripts/lockfile_supply_chain_audit.py').read())"
 
       - name: Run lockfile supply-chain audit
-        # Default mode fails on known-malicious pinned versions, known
-        # IOC strings, broken lockfiles, and provenance/integrity
-        # failures (non-registry source, missing integrity/checksum).
-        # Lesser anomalies stay ::warning:: unless --strict is passed.
+        # Blocks known-malicious versions, IOC strings, broken lockfiles,
+        # and provenance/integrity failures. Lesser anomalies stay
+        # ::warning:: unless --strict is passed.
         run: python3 scripts/lockfile_supply_chain_audit.py

--- a/scripts/lockfile_supply_chain_audit.py
+++ b/scripts/lockfile_supply_chain_audit.py
@@ -617,17 +617,15 @@ def audit_cargo_lockfile(path: Path) -> list[Finding]:
 
 # Finding kinds split into BLOCKING vs ADVISORY for the default run mode.
 # Blocking = public attack indicators (known-malicious version, IOC
-# string) plus the provenance/integrity checks this script exists to
-# enforce before `npm ci` / `cargo fetch` runs lifecycle and build
-# scripts. Advisory = incomplete-but-not-fetchable anomalies that warn
-# but don't block. --strict makes every finding blocking.
+# string) plus the provenance/integrity checks this gate must enforce
+# before `npm ci` / `cargo fetch` runs lifecycle scripts. Advisory =
+# incomplete-but-not-fetchable anomalies. --strict blocks everything.
 BLOCKING_KINDS: frozenset[str] = frozenset(
     {
         "blocked-known-malicious",
         "known-ioc-string",
-        # Provenance / integrity: a non-registry URL or an unverifiable
-        # tarball is exactly the pre-install fetch this gate must stop,
-        # so warning-only here would let attacker code onto the runner.
+        # A non-registry URL or an unverifiable tarball is the exact
+        # pre-install fetch this gate exists to stop.
         "non-registry-resolved-url",
         "missing-integrity-hash",
         "non-registry-cargo-source",

--- a/scripts/lockfile_supply_chain_audit.py
+++ b/scripts/lockfile_supply_chain_audit.py
@@ -617,12 +617,21 @@ def audit_cargo_lockfile(path: Path) -> list[Finding]:
 
 # Finding kinds split into BLOCKING vs ADVISORY for the default run mode.
 # Blocking = public attack indicators (known-malicious version, IOC
-# string). Advisory = structural anomalies that warn but don't block.
-# --strict makes every finding blocking.
+# string) plus the provenance/integrity checks this script exists to
+# enforce before `npm ci` / `cargo fetch` runs lifecycle and build
+# scripts. Advisory = incomplete-but-not-fetchable anomalies that warn
+# but don't block. --strict makes every finding blocking.
 BLOCKING_KINDS: frozenset[str] = frozenset(
     {
         "blocked-known-malicious",
         "known-ioc-string",
+        # Provenance / integrity: a non-registry URL or an unverifiable
+        # tarball is exactly the pre-install fetch this gate must stop,
+        # so warning-only here would let attacker code onto the runner.
+        "non-registry-resolved-url",
+        "missing-integrity-hash",
+        "non-registry-cargo-source",
+        "missing-cargo-checksum",
         # A structurally broken lockfile might hide a real attack.
         "malformed-lockfile",
         "missing-lockfile",
@@ -769,7 +778,8 @@ def main(argv: list[str] | None = None) -> int:
     print(
         "[lockfile-audit] Refusing to proceed. Each blocking finding "
         "above is either a public indicator-of-compromise, a known-"
-        "malicious pinned version, or a structurally broken lockfile. "
+        "malicious pinned version, an unverifiable / non-registry "
+        "dependency source, or a structurally broken lockfile. "
         "Investigate before running `npm ci` or `cargo fetch`.",
         file = sys.stderr,
     )

--- a/scripts/lockfile_supply_chain_audit.py
+++ b/scripts/lockfile_supply_chain_audit.py
@@ -679,11 +679,13 @@ def main(argv: list[str] | None = None) -> int:
         action = "store_true",
         help = (
             "Treat every finding as blocking (exit 1). "
-            "Default mode only blocks on known-malicious versions, "
-            "indicator-of-compromise strings, or structurally broken "
-            "lockfiles; everything else is printed as an advisory "
-            "warning with exit 0. CI should use the default; local "
-            "audits aiming for zero noise can opt in via --strict."
+            "Default mode already blocks on known-malicious versions, "
+            "indicator-of-compromise strings, structurally broken "
+            "lockfiles, and dependency provenance/integrity failures "
+            "(non-registry npm URL or cargo source, missing integrity "
+            "hash or cargo checksum). Remaining anomalies, such as an "
+            "entry with no resolved URL, are printed as an advisory "
+            "warning with exit 0; --strict escalates those too."
         ),
     )
     args = parser.parse_args(argv)

--- a/tests/security/test_lockfile_supply_chain_audit.py
+++ b/tests/security/test_lockfile_supply_chain_audit.py
@@ -170,8 +170,7 @@ def test_malicious_cargo_lockfile_refused(tmp_path):
 
 
 def test_malicious_cargo_lockfile_default_mode_blocks(tmp_path):
-    """Default (non-strict) mode must also refuse a non-registry cargo source: this is a
-    pre-install fetch gate, so provenance findings block without needing --strict."""
+    """Default mode refuses a non-registry cargo source; provenance blocks without --strict."""
     lockfile = tmp_path / "Cargo.lock"
     lockfile.write_text(_MALICIOUS_CARGO_LOCK)
     proc = _run_auditor(
@@ -200,8 +199,8 @@ def test_provenance_kinds_block_by_default():
 
 
 def test_non_registry_npm_tarball_blocks_by_default(tmp_path):
-    """A file:/git: tarball with a valid-looking integrity must not pass the default
-    audit; otherwise `npm ci` runs its lifecycle scripts on the runner."""
+    """A file: tarball with a valid-looking integrity must not pass the default audit,
+    or `npm ci` runs its lifecycle scripts on the runner."""
     lockfile = tmp_path / "package-lock.json"
     lockfile.write_text(
         json.dumps(
@@ -266,8 +265,7 @@ def test_gha_escape_collapses_finding_to_one_line():
 
 
 def test_blocking_finding_emitted_as_single_line_annotation(tmp_path):
-    """The ::error:: annotation must be one physical line (%0A-escaped). Regression for
-    PR #5604, which emitted this same finding as an advisory ::warning::."""
+    """The ::error:: annotation must be one physical line (%0A-escaped)."""
     lockfile = tmp_path / "Cargo.lock"
     lockfile.write_text(_MALICIOUS_CARGO_LOCK)
     proc = _run_auditor(
@@ -290,7 +288,7 @@ def test_blocking_finding_emitted_as_single_line_annotation(tmp_path):
 
 def test_advisory_finding_emitted_as_single_line_annotation(tmp_path):
     """The advisory ::warning:: path stays %0A-escaped too. `missing-resolved-url` is
-    incompleteness, not a fetchable source, so it remains advisory and exits 0."""
+    incompleteness, not a fetchable source, so it stays advisory."""
     lockfile = tmp_path / "package-lock.json"
     lockfile.write_text(
         json.dumps(

--- a/tests/security/test_lockfile_supply_chain_audit.py
+++ b/tests/security/test_lockfile_supply_chain_audit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -168,8 +169,9 @@ def test_malicious_cargo_lockfile_refused(tmp_path):
     assert "git+https://example.com" in combined
 
 
-def test_malicious_cargo_lockfile_default_mode_advisory(tmp_path):
-    """Default mode emits non-registry-cargo-source as advisory ::warning:: but exits 0."""
+def test_malicious_cargo_lockfile_default_mode_blocks(tmp_path):
+    """Default (non-strict) mode must also refuse a non-registry cargo source: this is a
+    pre-install fetch gate, so provenance findings block without needing --strict."""
     lockfile = tmp_path / "Cargo.lock"
     lockfile.write_text(_MALICIOUS_CARGO_LOCK)
     proc = _run_auditor(
@@ -177,13 +179,53 @@ def test_malicious_cargo_lockfile_default_mode_advisory(tmp_path):
         npm_lockfiles = [FIXTURES / "clean_lockfile.json"],
         cargo_lockfiles = [lockfile],
     )
-    assert proc.returncode == 0, (
-        f"expected exit 0 (advisory), got {proc.returncode}\n"
+    assert proc.returncode == 1, (
+        f"expected exit 1 (blocking), got {proc.returncode}\n"
         f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
     )
     combined = proc.stdout + proc.stderr
     assert "non-registry-cargo-source" in combined
-    assert "advisory finding" in combined
+    assert "blocking finding" in combined
+
+
+def test_provenance_kinds_block_by_default():
+    """The four provenance/integrity kinds must stay in BLOCKING_KINDS."""
+    for kind in (
+        "non-registry-resolved-url",
+        "missing-integrity-hash",
+        "non-registry-cargo-source",
+        "missing-cargo-checksum",
+    ):
+        assert kind in lsa.BLOCKING_KINDS, f"{kind} must block in default mode"
+
+
+def test_non_registry_npm_tarball_blocks_by_default(tmp_path):
+    """A file:/git: tarball with a valid-looking integrity must not pass the default
+    audit; otherwise `npm ci` runs its lifecycle scripts on the runner."""
+    lockfile = tmp_path / "package-lock.json"
+    lockfile.write_text(
+        json.dumps(
+            {
+                "name": "victim",
+                "version": "1.0.0",
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"name": "victim", "version": "1.0.0"},
+                    "node_modules/evil-pkg": {
+                        "version": "1.0.0",
+                        "resolved": "file:evil-pkg-1.0.0.tgz",
+                        "integrity": "sha512-" + "A" * 86 + "==",
+                    },
+                },
+            }
+        )
+    )
+    proc = _run_auditor(root = tmp_path, npm_lockfiles = [lockfile])
+    assert proc.returncode == 1, (
+        f"expected exit 1 (blocking), got {proc.returncode}\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    assert "non-registry-resolved-url" in proc.stdout + proc.stderr
 
 
 def test_audit_cargo_lockfile_direct_call(tmp_path):
@@ -223,8 +265,9 @@ def test_gha_escape_collapses_finding_to_one_line():
     assert "bad stuff" in escaped
 
 
-def test_advisory_finding_emitted_as_single_line_annotation(tmp_path):
-    """Advisory ::warning:: must be one physical line (%0A-escaped). Regression for PR #5604."""
+def test_blocking_finding_emitted_as_single_line_annotation(tmp_path):
+    """The ::error:: annotation must be one physical line (%0A-escaped). Regression for
+    PR #5604, which emitted this same finding as an advisory ::warning::."""
     lockfile = tmp_path / "Cargo.lock"
     lockfile.write_text(_MALICIOUS_CARGO_LOCK)
     proc = _run_auditor(
@@ -232,19 +275,46 @@ def test_advisory_finding_emitted_as_single_line_annotation(tmp_path):
         npm_lockfiles = [FIXTURES / "clean_lockfile.json"],
         cargo_lockfiles = [lockfile],
     )
-    warning_lines = [line for line in proc.stderr.splitlines() if line.startswith("::warning::")]
-    assert warning_lines, (
-        "expected at least one ::warning:: annotation; " f"stderr was:\n{proc.stderr}"
-    )
-    for line in warning_lines:
+    error_lines = [line for line in proc.stderr.splitlines() if line.startswith("::error::")]
+    assert error_lines, "expected at least one ::error:: annotation; " f"stderr was:\n{proc.stderr}"
+    for line in error_lines:
         # One physical line: kind/package/detail joined via %0A, not split.
         assert "%0A" in line, (
-            f"::warning:: line has no %0A escape; multi-line text "
+            f"::error:: line has no %0A escape; multi-line text "
             f"would be truncated by GH Actions:\n{line}"
         )
         assert "non-registry-cargo-source" in line
         assert "package:" in line
         assert "detail:" in line
+
+
+def test_advisory_finding_emitted_as_single_line_annotation(tmp_path):
+    """The advisory ::warning:: path stays %0A-escaped too. `missing-resolved-url` is
+    incompleteness, not a fetchable source, so it remains advisory and exits 0."""
+    lockfile = tmp_path / "package-lock.json"
+    lockfile.write_text(
+        json.dumps(
+            {
+                "name": "victim",
+                "version": "1.0.0",
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"name": "victim", "version": "1.0.0"},
+                    "node_modules/incomplete-pkg": {"version": "1.0.0"},
+                },
+            }
+        )
+    )
+    proc = _run_auditor(root = tmp_path, npm_lockfiles = [lockfile])
+    assert proc.returncode == 0, (
+        f"expected exit 0 (advisory), got {proc.returncode}\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    warning_lines = [line for line in proc.stderr.splitlines() if line.startswith("::warning::")]
+    assert warning_lines, f"expected a ::warning:: annotation; stderr was:\n{proc.stderr}"
+    for line in warning_lines:
+        assert "%0A" in line
+        assert "missing-resolved-url" in line
 
 
 # ---------------------------------------------------------------------------

--- a/tests/security/test_lockfile_supply_chain_audit.py
+++ b/tests/security/test_lockfile_supply_chain_audit.py
@@ -276,7 +276,7 @@ def test_blocking_finding_emitted_as_single_line_annotation(tmp_path):
         cargo_lockfiles = [lockfile],
     )
     error_lines = [line for line in proc.stderr.splitlines() if line.startswith("::error::")]
-    assert error_lines, "expected at least one ::error:: annotation; " f"stderr was:\n{proc.stderr}"
+    assert error_lines, f"expected at least one ::error:: annotation; stderr was:\n{proc.stderr}"
     for line in error_lines:
         # One physical line: kind/package/detail joined via %0A, not split.
         assert "%0A" in line, (


### PR DESCRIPTION
## Problem

`scripts/lockfile_supply_chain_audit.py` is the pre-install gate: it runs immediately before `npm ci` in five workflows, and those `npm ci` steps deliberately keep lifecycle scripts enabled because `vite build` needs them (esbuild native binary postinstall).

The script correctly detects the four structural conditions it exists to stop:

- `non-registry-resolved-url` (npm tarball fetched from somewhere other than the registry)
- `missing-integrity-hash`
- `non-registry-cargo-source`
- `missing-cargo-checksum`

but #5604 left all four out of `BLOCKING_KINDS`, so in default mode they print a `::warning::` and the script exits 0. No workflow passes `--strict`. The gate has been open since that commit.

Reproduced on `main` with a lockfile pointing at a local tarball plus a plausible looking integrity value:

```
::warning::  [non-registry-resolved-url] .../package-lock.json%0A
    package: node_modules/evil-pkg%0A
    detail:  resolved='file:evil-pkg-1.0.0.tgz'; only https://registry.npmjs.org/ is permitted.
[lockfile-audit] OK: 1 advisory finding(s), 0 blocking.
DEFAULT_RC=0
STRICT_RC=1
```

Exit 0 means a green check and the next step runs `npm ci`, which executes the package's `postinstall` on the runner.

The reasoning behind the advisory classification does not hold up. An integrity hash written by whoever also wrote the `resolved` URL proves nothing; it is a fingerprint of bytes the attacker chose. Registry origin is the only thing that makes the hash meaningful, so origin and integrity both belong on the blocking side. The known-malicious version table and IOC strings that did stay blocking only catch attacks somebody already published indicators for; the structural check is the layer that catches a novel one.

## Fix

Move those four kinds into `BLOCKING_KINDS`. Kinds that describe an incomplete entry rather than a fetchable source (`missing-resolved-url`, `unsupported-lockfile-version`) stay advisory, which keeps the noise floor low. `--strict` still escalates everything.

## No existing job changes colour

| Check | Result |
| --- | --- |
| All 4 checked-in lockfiles, default mode | exit 0, 0 findings |
| Same, `--strict` | exit 0, clean even under the strictest setting |
| `tests/security/` | 292 passed, 6 skipped |
| PoC lockfile after the fix | exit 1, blocks before `npm ci` |

`studio-tauri-smoke.yml` runs `npm install --prefix studio @tauri-apps/cli@2.10.1` before the audit, so it mutates `studio/package-lock.json` on the runner. Simulated with npm 11.9.0: the only change is the root dependency range `"2.10.1"` to `"^2.10.1"`, no package entries change, and the mutated lockfile still audits clean.

This is CI only. Nothing in Studio, Desktop, the installers or the notebooks imports this script, so there is no user facing behaviour change.

The one intended behaviour change: a future PR that deliberately adds a git or `file:` dependency now fails instead of warning. Cargo already has `CARGO_SOURCE_ALLOWLIST` for that case (it is how `fix-path-env` is pinned), and npm has `NPM_REGISTRY_PREFIXES_ALLOWED`.

## Tests

- `test_malicious_cargo_lockfile_default_mode_advisory` asserted the old exit 0 behaviour. Replaced with `test_malicious_cargo_lockfile_default_mode_blocks`.
- Added `test_provenance_kinds_block_by_default` and `test_non_registry_npm_tarball_blocks_by_default` (the PoC, as a test).
- The GitHub Actions annotation escaping test now targets the `::error::` path, and a new advisory case using `missing-resolved-url` keeps the `::warning::` path covered.
