### PR TITLE
Harden the workflow-trigger lint: scan .yaml, and host it outside the workflow it audits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,12 @@
 /tests/ @danielhanchen
 /scripts/ @danielhanchen
 
+# CI definitions. A workflow change can hand a fork PR the base repo's
+# secrets, or skip the very lint that would have caught it, and no CI gate
+# can stop a PR that disables its own gate. Owner review is the control.
+/.github/workflows/ @danielhanchen
+/.github/CODEOWNERS @danielhanchen
+
 # Snapshot data for the notebook linter / Colab oracle. Drift in these
 # files changes the pin floor for every Unsloth notebook, so refreshes
 # must be reviewed by the notebook owners directly. CODEOWNERS later

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -26,8 +26,6 @@
 #                        does not block the supply-chain pattern scan
 #                        (or vice versa).
 #   - npm-scan-packages: npm tarball content scan, no npm install.
-#   - workflow-trigger-lint:
-#                        bans pull_request_target + shared cache keys.
 #   - tests-security:    pytest tests/security regression suite.
 #   - npm-provenance-and-install-scripts:
 #                        npm audit signatures + new-postinstall gate.
@@ -1044,52 +1042,6 @@ jobs:
           name: scan-npm-packages-log
           path: logs-scan-npm.txt
           retention-days: 30
-
-  # ─────────────────────────────────────────────────────────────────────
-  # Workflow-trigger lint. Refuses two patterns that together powered the
-  # TanStack GHSA-g7cv-rxg3-hmpx supply-chain compromise:
-  #
-  #   1. `pull_request_target` -- runs a fork's workflow YAML against
-  #      the base repository's secrets. There is no safe use of this
-  #      trigger for a public open-source project.
-  #
-  #   2. Shared cache keys between PR-triggered workflows and the
-  #      publish workflow. A fork PR can poison the cache; the publish
-  #      workflow then restores the poisoned cache on next run.
-  #
-  # Cheap pure-Python lint, runs in seconds. Fail-closed.
-  # ─────────────────────────────────────────────────────────────────────
-  workflow-trigger-lint:
-    name: workflow-trigger lint (pull_request_target / cache-poisoning)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Harden runner (egress block)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
-        with:
-          egress-policy: block
-          disable-sudo: true
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            codeload.github.com:443
-            objects.githubusercontent.com:443
-            pypi.org:443
-            files.pythonhosted.org:443
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-
-      - name: Install PyYAML
-        run: pip install pyyaml
-
-      - name: Lint workflow triggers + cache keys
-        run: python3 scripts/lint_workflow_triggers.py
 
   # ─────────────────────────────────────────────────────────────────────
   # Regression tests: pin scanner IOC tables and pre-install fixtures.

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -1,0 +1,70 @@
+# Workflow-trigger lint. Refuses two patterns that together powered the
+# TanStack GHSA-g7cv-rxg3-hmpx supply-chain compromise:
+#
+#   1. `pull_request_target` -- runs a fork's workflow YAML against the
+#      base repository's secrets. There is no safe use of this trigger
+#      for a public open-source project.
+#
+#   2. Shared cache keys between PR-triggered workflows and the publish
+#      workflow. A fork PR can poison the cache; the publish workflow
+#      then restores the poisoned cache on next run.
+#
+# This lives in its own workflow, not inside security-audit.yml, for one
+# reason: `on.pull_request` here carries NO `paths` / `paths-ignore`
+# filter, and must never gain one. A gate that only runs for some PRs
+# does not gate workflow changes, which is exactly what it exists to
+# review. security-audit.yml is a heavy nightly audit whose filters are
+# tuned for cost; coupling this lint to them once already opened that
+# hole. scripts/lint_workflow_triggers.py enforces the invariant on
+# whichever workflow runs it, so this file cannot quietly re-acquire a
+# filter.
+#
+# Cheap pure-Python lint, runs in seconds. Fail-closed.
+
+name: Workflow trigger lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-trigger-lint:
+    name: workflow-trigger lint (pull_request_target / cache-poisoning)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Lint workflow triggers + cache keys
+        run: python3 scripts/lint_workflow_triggers.py

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -109,6 +109,8 @@ def _is_trusted_python(token: str) -> bool:
     A relative `./python3` would resolve inside the checkout, where a PR can
     add an executable of that name.
     """
+    if any(op in token for op in _SHELL_OPERATORS):
+        return False        # a substitution runs before the path is used
     path = PurePosixPath(token)
     if not _PYTHON_BASENAME.fullmatch(path.name):
         return False
@@ -253,6 +255,12 @@ def _lint_steps(yaml_doc) -> list[tuple[dict, dict, bool, list[str]]]:
             enforcing, problems = _lint_step_report(str(step.get("run") or ""))
             if not (enforcing or problems):
                 continue
+            if job.get("container") is not None:
+                enforcing = False
+                problems.append(
+                    "its lint job runs in a 'container:', a PR-selected image "
+                    "that controls the shell and environment"
+                )
             shell = _effective_run_setting(yaml_doc, job, step, "shell")
             if shell is not None and shell not in SAFE_SHELLS:
                 enforcing = False

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -100,11 +100,15 @@ def _trigger_set(yaml_doc) -> set[str]:
 # The BASENAME must be a python, so a `/tmp/fakepython` that exits 0 is not
 # mistaken for an interpreter. A directory prefix stays fine.
 _PYTHON_BASENAME = re.compile(r"python(3(\.\d+)?)?")
-# Options that make python print something and exit without running a file.
-_TERMINAL_OPTS = ("-V", "--version", "-h", "--help")
+# An ALLOWLIST, not a denylist. Every round of review found another flag
+# that stops the file running or masks its exit status (-c, -m, --version,
+# and -i, which drops into the REPL after the script and exits 0 even when
+# the lint called sys.exit(1)). Only flags that leave "run this file and
+# return its status" intact are accepted; anything else is not a host.
+_SAFE_OPTS = ("-u", "-E", "-s", "-S", "-B", "-O", "-OO", "-q")
 LINT_SCRIPT_PATH = f"scripts/{LINT_SCRIPT_NAME}"
-# Options that consume the next token, so the script path is not mistaken for
-# their value.
+# Safe, but they consume the next token, so the script path is not mistaken
+# for their value.
 _OPTS_WITH_VALUE = ("-X", "-W", "--check-hash-based-pycs")
 _SHELL_OPERATORS = ("|", "&", ";", ">", "<", "`", "$(")
 
@@ -120,10 +124,12 @@ def _classify_lint_line(line: str) -> tuple[bool, str | None]:
 
     args, i = tokens[1:], 0
     while i < len(args) and args[i].startswith("-"):
-        if args[i].startswith(("-c", "-m")) or args[i] in _TERMINAL_OPTS:
-            # -c / -m run another program; -V / --help exit before the file.
+        if args[i] in _OPTS_WITH_VALUE:
+            i += 2
+        elif args[i] in _SAFE_OPTS:
+            i += 1
+        else:
             return False, None
-        i += 2 if args[i] in _OPTS_WITH_VALUE else 1
 
     rest = args[i:]
     # Exactly the repo-relative path. A suffix match would accept a decoy at
@@ -173,6 +179,12 @@ def _lint_step_report(run: str) -> tuple[bool, list[str]]:
 # `bash -c '"{0}" || true'`, so only the plain executors count.
 SAFE_SHELLS: tuple[str, ...] = ("bash", "sh")
 
+# These redirect execution without the command text changing at all.
+# Non-interactive bash sources BASH_ENV before the step script, so an
+# `exit 0` in that file ends the step before the lint runs; PATH picks the
+# interpreter.
+UNSAFE_ENV_KEYS: tuple[str, ...] = ("BASH_ENV", "ENV", "PATH")
+
 
 def _effective_run_setting(yaml_doc, job: dict, step: dict, key: str) -> str | None:
     """A step's `run` setting, falling back to job then workflow defaults."""
@@ -184,6 +196,30 @@ def _effective_run_setting(yaml_doc, job: dict, step: dict, key: str) -> str | N
         if isinstance(run, dict) and run.get(key):
             return str(run[key])
     return None
+
+
+def _effective_env(yaml_doc, job: dict, step: dict) -> dict:
+    """Workflow, job and step `env`, merged in precedence order."""
+    merged = {}
+    for scope in (yaml_doc, job, step):
+        env = scope.get("env") if isinstance(scope, dict) else None
+        if isinstance(env, dict):
+            merged.update(env)
+    return merged
+
+
+def _pull_request_config_problem(yaml_doc) -> str | None:
+    """`pull_request:` must be bare or a mapping; GitHub rejects anything else."""
+    on = _on_field(yaml_doc)
+    if not isinstance(on, dict) or "pull_request" not in on:
+        return None
+    pr = on["pull_request"]
+    if pr is None or isinstance(pr, dict):
+        return None
+    return (
+        f"its 'pull_request' value is {pr!r}, which is not a valid event "
+        "configuration, so GitHub will not load the workflow at all"
+    )
 
 
 def _lint_steps(yaml_doc) -> list[tuple[dict, dict, bool, list[str]]]:
@@ -213,6 +249,15 @@ def _lint_steps(yaml_doc) -> list[tuple[dict, dict, bool, list[str]]]:
                 problems.append(
                     f"its lint step runs under shell {shell!r}, which can wrap "
                     "the command and drop its exit status"
+                )
+            unsafe_env = sorted(
+                k for k in _effective_env(yaml_doc, job, step) if k in UNSAFE_ENV_KEYS
+            )
+            if unsafe_env:
+                enforcing = False
+                problems.append(
+                    f"its lint step sets {' + '.join(unsafe_env)}, which can "
+                    "redirect the step before the lint runs"
                 )
             workdir = _effective_run_setting(yaml_doc, job, step, "working-directory")
             if workdir is not None:
@@ -313,6 +358,9 @@ def main() -> int:
                     f"{' + '.join(restrictions)}, so a PR adding that skips "
                     "this workflow for its own PR"
                 )
+            config_problem = _pull_request_config_problem(doc)
+            if config_problem:
+                problems.append(config_problem)
             if any(
                 _is_truthy(job.get("continue-on-error"))
                 or _is_truthy(step.get("continue-on-error"))

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -214,9 +214,7 @@ def _lint_steps(yaml_doc) -> list[tuple[dict, dict, bool, list[str]]]:
                     f"its lint step runs under shell {shell!r}, which can wrap "
                     "the command and drop its exit status"
                 )
-            workdir = _effective_run_setting(
-                yaml_doc, job, step, "working-directory"
-            )
+            workdir = _effective_run_setting(yaml_doc, job, step, "working-directory")
             if workdir is not None:
                 enforcing = False
                 problems.append(

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -103,18 +103,33 @@ _OPTS_WITH_VALUE = ("-X", "-W", "--check-hash-based-pycs")
 _SHELL_OPERATORS = ("|", "&", ";", ">", "<", "`", "$(")
 
 
+def _is_trusted_python(token: str) -> bool:
+    """A bare `python3`, or an absolute system path to one.
+
+    A relative `./python3` would resolve inside the checkout, where a PR can
+    add an executable of that name.
+    """
+    path = PurePosixPath(token)
+    if not _PYTHON_BASENAME.fullmatch(path.name):
+        return False
+    return token == path.name or token.startswith(("/usr/", "/bin/", "/opt/"))
+
+
 def _classify_lint_line(line: str) -> tuple[bool, str | None]:
     """(is an enforcing invocation, problem) for one line naming the script."""
     try:
         tokens = shlex.split(line.strip())
     except ValueError:
         return False, None
-    if not tokens or not _PYTHON_BASENAME.fullmatch(PurePosixPath(tokens[0]).name):
-        return False, None  # `echo <script>`, or not python at all
+    if not tokens or not _is_trusted_python(tokens[0]):
+        return False, None  # `echo <script>`, a decoy interpreter, or not python
 
     args, i = tokens[1:], 0
     while i < len(args) and args[i].startswith("-"):
         if args[i] in _OPTS_WITH_VALUE:
+            value = args[i + 1] if i + 1 < len(args) else ""
+            if any(op in value for op in _SHELL_OPERATORS):
+                return False, None      # a substitution runs before python
             i += 2
         elif args[i] in _SAFE_OPTS:
             i += 1
@@ -170,7 +185,15 @@ SAFE_SHELLS: tuple[str, ...] = ("bash", "sh")
 
 # Redirect execution without changing the command: bash sources BASH_ENV
 # before the step script, and PATH picks the interpreter.
-UNSAFE_ENV_KEYS: tuple[str, ...] = ("BASH_ENV", "ENV", "PATH")
+UNSAFE_ENV_KEYS: tuple[str, ...] = (
+    "BASH_ENV",
+    "ENV",
+    "PATH",
+    # `sitecustomize.py` on PYTHONPATH is imported before the script runs.
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTHONSTARTUP",
+)
 
 
 def _effective_run_setting(yaml_doc, job: dict, step: dict, key: str) -> str | None:

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -39,6 +39,15 @@ BANNED_TRIGGERS: tuple[str, ...] = ("pull_request_target",)
 RESTRICTED_TRIGGERS: tuple[str, ...] = ("workflow_run",)
 PUBLISH_WORKFLOW_NAMES: tuple[str, ...] = ("release-desktop.yml",)
 
+# A workflow that runs this script is a "host". `pull_request` resolves the
+# workflow file from the PR merge ref, so a host carrying a `paths` /
+# `paths-ignore` filter can be skipped by the very PR that adds it -- the gate
+# would then never run for workflow changes, which is the hole this whole
+# script exists to close. Hosts must therefore trigger on unfiltered
+# `pull_request`.
+LINT_SCRIPT_NAME = "lint_workflow_triggers.py"
+PATH_FILTER_KEYS: tuple[str, ...] = ("paths", "paths-ignore")
+
 
 def _normalise_on(on_field):
     if isinstance(on_field, str):
@@ -66,11 +75,37 @@ def _extract_cache_keys(path: Path) -> list[str]:
     return keys
 
 
-def _trigger_set(yaml_doc) -> set[str]:
-    on = yaml_doc.get(True)
-    if on is None:
+def _on_field(yaml_doc):
+    # PyYAML resolves a bare `on:` key to the boolean True.
+    on = yaml_doc.get(True) if isinstance(yaml_doc, dict) else None
+    if on is None and isinstance(yaml_doc, dict):
         on = yaml_doc.get("on")
-    return _normalise_on(on)
+    return on
+
+
+def _trigger_set(yaml_doc) -> set[str]:
+    return _normalise_on(_on_field(yaml_doc))
+
+
+def _runs_lint(path: Path) -> bool:
+    """True when the workflow invokes this script from a `run:` step.
+
+    Matched on `run:` rather than anywhere in the file so a workflow that
+    merely mentions the script in a comment is not mistaken for a host.
+    """
+    text = path.read_text(encoding = "utf-8")
+    return re.search(rf"run:[^\n]*{re.escape(LINT_SCRIPT_NAME)}", text) is not None
+
+
+def _pull_request_path_filters(yaml_doc) -> list[str]:
+    """Path-filter keys on the `pull_request` trigger, if any."""
+    on = _on_field(yaml_doc)
+    if not isinstance(on, dict):
+        return []
+    pr = on.get("pull_request")
+    if not isinstance(pr, dict):
+        return []
+    return [k for k in PATH_FILTER_KEYS if k in pr]
 
 
 def main() -> int:
@@ -81,8 +116,26 @@ def main() -> int:
         default = DEFAULT_WORKFLOWS_DIR,
         help = "Override the workflows directory (used by tests).",
     )
+    parser.add_argument(
+        "--require-host",
+        action = "store_true",
+        default = None,
+        help = "Require a workflow that runs this script on unfiltered "
+               "`pull_request`. Defaults on for the live tree, off for a "
+               "fixture directory.",
+    )
+    parser.add_argument(
+        "--no-require-host",
+        dest = "require_host",
+        action = "store_false",
+        help = "Skip the host-wiring check.",
+    )
     args = parser.parse_args()
     workflows_dir = args.workflows_dir
+
+    require_host = args.require_host
+    if require_host is None:
+        require_host = workflows_dir.resolve() == DEFAULT_WORKFLOWS_DIR.resolve()
 
     findings: list[str] = []
     # GitHub Actions loads BOTH `.yml` and `.yaml` from .github/workflows/, so
@@ -91,6 +144,7 @@ def main() -> int:
     workflows = sorted(list(workflows_dir.glob("*.yml")) + list(workflows_dir.glob("*.yaml")))
     pr_triggered: list[tuple[Path, list[str]]] = []
     publish_triggered: list[tuple[Path, list[str]]] = []
+    unfiltered_hosts: list[Path] = []
 
     for path in workflows:
         doc = _load_workflow(path)
@@ -115,6 +169,20 @@ def main() -> int:
                         "comment somewhere in the file, with a justification."
                     )
 
+        if _runs_lint(path):
+            filters = _pull_request_path_filters(doc)
+            if filters:
+                findings.append(
+                    f"{path.name}: runs {LINT_SCRIPT_NAME} but its "
+                    f"'pull_request' trigger has {' + '.join(filters)}. A PR "
+                    "adding that filter skips this workflow for its own PR, so "
+                    "the trigger gate never runs on the workflow change it is "
+                    "meant to review. Drop the filter, or host the lint in a "
+                    "workflow that runs on every PR."
+                )
+            elif "pull_request" in triggers:
+                unfiltered_hosts.append(path)
+
         if "pull_request" in triggers:
             pr_triggered.append((path, _extract_cache_keys(path)))
         is_dispatch_only = "workflow_dispatch" in triggers and not (
@@ -122,6 +190,13 @@ def main() -> int:
         )
         if path.name in PUBLISH_WORKFLOW_NAMES or is_dispatch_only:
             publish_triggered.append((path, _extract_cache_keys(path)))
+
+    if require_host and not unfiltered_hosts:
+        findings.append(
+            f"no workflow runs {LINT_SCRIPT_NAME} on an unfiltered "
+            "'pull_request' trigger, so this gate does not cover every PR. "
+            "Restore the workflow-trigger-lint workflow."
+        )
 
     pr_keys = {key for _, keys in pr_triggered for key in keys}
     for pub_path, pub_keys in publish_triggered:

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -88,80 +88,73 @@ def _trigger_set(yaml_doc) -> set[str]:
     return _normalise_on(_on_field(yaml_doc))
 
 
-# Host detection. `echo scripts/lint_workflow_triggers.py` mentions the script
-# without running it, so a real python invocation of the file is required.
+# Host detection. A host must run the repository's own lint script as a plain,
+# standalone command with no arguments: `echo <script>` runs nothing;
+# `/tmp/lint_workflow_triggers.py` is a decoy with the same basename; a
+# pipeline, redirection or `|| true` detaches the step's exit status from the
+# lint's (the default `run:` shell is `bash -e`, without pipefail); and any
+# argument can point it elsewhere or turn it into a no-op, `--help` included.
 _PYTHON = re.compile(r"[\w./-]*python[\w.]*")
-_SEPARATORS = re.compile(r"\|\||&&|[;&|\n]")
-# Options that consume the next token, so the script path cannot be confused
-# with their value.
+LINT_SCRIPT_PATH = f"scripts/{LINT_SCRIPT_NAME}"
+# Options that consume the next token, so the script path is not mistaken for
+# their value.
 _OPTS_WITH_VALUE = ("-X", "-W", "--check-hash-based-pycs")
+_SHELL_OPERATORS = ("|", "&", ";", ">", "<", "`", "$(")
 
 
-def _commands(run: str) -> list[list[str]]:
-    """Argv-ish token lists for each command in a `run` block."""
-    out = []
-    for segment in _SEPARATORS.split(run):
-        segment = segment.strip()
-        if not segment:
-            continue
-        try:
-            tokens = shlex.split(segment)
-        except ValueError:
-            tokens = segment.split()
-        if tokens:
-            out.append(tokens)
-    return out
+def _classify_lint_line(line: str) -> tuple[bool, str | None]:
+    """(is an enforcing invocation, problem) for one line naming the script."""
+    try:
+        tokens = shlex.split(line.strip())
+    except ValueError:
+        return False, None
+    if not tokens or not _PYTHON.fullmatch(tokens[0]):
+        return False, None          # `echo <script>`, or not python at all
 
+    args, i = tokens[1:], 0
+    while i < len(args) and args[i].startswith("-"):
+        if args[i].startswith(("-c", "-m")):
+            return False, None      # runs that program, not this file
+        i += 2 if args[i] in _OPTS_WITH_VALUE else 1
 
-def _invokes_lint(run: str) -> bool:
-    """True when python is asked to EXECUTE this script.
+    rest = args[i:]
+    if not rest or not rest[0].endswith(LINT_SCRIPT_PATH):
+        return False, None
+    if len(rest) == 1:
+        return True, None
 
-    `python3 -c 'pass' scripts/lint_workflow_triggers.py` names the script but
-    runs the `-c` program and exits 0, so the script has to be the executed
-    file rather than any later argument.
-    """
-    for tokens in _commands(run):
-        if not _PYTHON.fullmatch(tokens[0]):
-            continue
-        args, i = tokens[1:], 0
-        while i < len(args) and args[i].startswith("-"):
-            # -c / -m hand the rest to a program that is not this file.
-            if args[i].startswith(("-c", "-m")):
-                break
-            i += 2 if args[i] in _OPTS_WITH_VALUE else 1
-        else:
-            if i < len(args) and args[i].endswith(LINT_SCRIPT_NAME):
-                return True
-    return False
-
-
-# Shell that swallows a non-zero exit, so the step goes green on findings.
-_MASKED = re.compile(
-    rf"{re.escape(LINT_SCRIPT_NAME)}[^\n]*(?:\|\||[;&]\s*(?:true|:)\s*(?:$|\n))",
-    re.MULTILINE,
-)
-# Flags that keep the gate running but stop it gating anything.
-NEUTERING_FLAGS: tuple[str, ...] = ("--workflows-dir", "--no-require-host")
-
-
-def _invocation_problems(run: str) -> list[str]:
-    """Ways a real invocation can still fail to enforce anything."""
-    problems = []
-    if _MASKED.search(run) or "set +e" in run:
-        problems.append(
-            "its lint command swallows a non-zero exit (|| true, ; true, "
-            "set +e), so findings cannot fail the run"
+    trailing = " ".join(rest[1:])
+    if any(op in tok for tok in rest[1:] for op in _SHELL_OPERATORS):
+        return False, (
+            f"its lint command is chained, piped or backgrounded ({trailing}), "
+            "so the step's exit status need not be the lint's"
         )
-    used = [f for f in NEUTERING_FLAGS if f in run]
-    if used:
+    return False, (
+        f"its lint command passes {trailing}, so it does not gate the live "
+        "workflows with its own checks on"
+    )
+
+
+def _lint_step_report(run: str) -> tuple[bool, list[str]]:
+    """(an enforcing invocation is present, problems with lint-ish commands)."""
+    enforcing, problems = False, []
+    for line in run.splitlines():
+        if LINT_SCRIPT_NAME not in line:
+            continue
+        ok, problem = _classify_lint_line(line)
+        enforcing = enforcing or ok
+        if problem:
+            problems.append(problem)
+    if (enforcing or problems) and "set +e" in run:
         problems.append(
-            f"its lint command passes {' + '.join(used)}, so it does not gate the live workflows"
+            "its lint step runs under 'set +e', so a non-zero exit does not "
+            "fail the step"
         )
-    return problems
+    return enforcing, problems
 
 
-def _lint_steps(yaml_doc) -> list[tuple[dict, dict]]:
-    """(job, step) pairs whose `run` actually invokes this script.
+def _lint_steps(yaml_doc) -> list[tuple[dict, dict, bool, list[str]]]:
+    """(job, step, enforcing, problems) for every step that runs the lint.
 
     Reads the parsed steps rather than the raw text: a commented-out
     `# - run: python3 scripts/lint_workflow_triggers.py` executes nothing, and
@@ -176,8 +169,11 @@ def _lint_steps(yaml_doc) -> list[tuple[dict, dict]]:
         if not isinstance(steps, list):
             continue
         for step in steps:
-            if isinstance(step, dict) and _invokes_lint(str(step.get("run") or "")):
-                found.append((job, step))
+            if not isinstance(step, dict):
+                continue
+            enforcing, problems = _lint_step_report(str(step.get("run") or ""))
+            if enforcing or problems:
+                found.append((job, step, enforcing, problems))
     return found
 
 
@@ -196,7 +192,9 @@ def _is_truthy(value) -> bool:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description = __doc__)
+    # No abbreviations: `--workflows-d` must not silently mean
+    # `--workflows-dir`, or a host could smuggle it past review.
+    parser = argparse.ArgumentParser(description = __doc__, allow_abbrev = False)
     parser.add_argument(
         "--workflows-dir",
         type = Path,
@@ -269,32 +267,35 @@ def main() -> int:
             if any(
                 _is_truthy(job.get("continue-on-error"))
                 or _is_truthy(step.get("continue-on-error"))
-                for job, step in lint_steps
+                for job, step, _, _ in lint_steps
             ):
                 problems.append(
                     "its lint step is continue-on-error, so findings cannot fail the run"
                 )
             if any(
-                job.get("if") is not None or step.get("if") is not None for job, step in lint_steps
+                job.get("if") is not None or step.get("if") is not None
+                for job, step, _, _ in lint_steps
             ):
                 problems.append(
                     "its lint step is gated by an 'if:' condition, so the gate "
                     "can be skipped while the run still succeeds"
                 )
-            if any(job.get("needs") is not None for job, _ in lint_steps):
+            if any(job.get("needs") is not None for job, _, _, _ in lint_steps):
                 problems.append(
                     "its lint job declares 'needs:', so a skipped prerequisite "
                     "skips the gate without failing the run"
                 )
-            for _, step in lint_steps:
-                problems.extend(_invocation_problems(str(step.get("run") or "")))
+            for _, _, _, step_problems in lint_steps:
+                problems.extend(step_problems)
             if problems:
                 findings.append(
                     f"{path.name}: runs {LINT_SCRIPT_NAME} but "
                     + ", and ".join(problems)
                     + ". The gate must run, and be able to fail, on every PR."
                 )
-            elif "pull_request" in triggers:
+            elif "pull_request" in triggers and any(
+                enforcing for _, _, enforcing, _ in lint_steps
+            ):
                 unfiltered_hosts.append(path)
 
         if "pull_request" in triggers:

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -94,6 +94,31 @@ _INVOCATION = re.compile(
     rf"(?:^|[;&|]|\n)\s*[\w./-]*python[\w.]*\s+[^\n;&|]*{re.escape(LINT_SCRIPT_NAME)}"
 )
 
+# Shell that swallows a non-zero exit, so the step goes green on findings.
+_MASKED = re.compile(
+    rf"{re.escape(LINT_SCRIPT_NAME)}[^\n]*(?:\|\||[;&]\s*(?:true|:)\s*(?:$|\n))",
+    re.MULTILINE,
+)
+# Flags that keep the gate running but stop it gating anything.
+NEUTERING_FLAGS: tuple[str, ...] = ("--workflows-dir", "--no-require-host")
+
+
+def _invocation_problems(run: str) -> list[str]:
+    """Ways a real invocation can still fail to enforce anything."""
+    problems = []
+    if _MASKED.search(run) or "set +e" in run:
+        problems.append(
+            "its lint command swallows a non-zero exit (|| true, ; true, "
+            "set +e), so findings cannot fail the run"
+        )
+    used = [f for f in NEUTERING_FLAGS if f in run]
+    if used:
+        problems.append(
+            f"its lint command passes {' + '.join(used)}, so it does not "
+            "gate the live workflows"
+        )
+    return problems
+
 
 def _lint_steps(yaml_doc) -> list[tuple[dict, dict]]:
     """(job, step) pairs whose `run` actually invokes this script.
@@ -221,6 +246,8 @@ def main() -> int:
                     "its lint job declares 'needs:', so a skipped prerequisite "
                     "skips the gate without failing the run"
                 )
+            for _, step in lint_steps:
+                problems.extend(_invocation_problems(str(step.get("run") or "")))
             if problems:
                 findings.append(
                     f"{path.name}: runs {LINT_SCRIPT_NAME} but "

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -40,13 +40,13 @@ RESTRICTED_TRIGGERS: tuple[str, ...] = ("workflow_run",)
 PUBLISH_WORKFLOW_NAMES: tuple[str, ...] = ("release-desktop.yml",)
 
 # A workflow that runs this script is a "host". `pull_request` resolves the
-# workflow file from the PR merge ref, so a host carrying a `paths` /
-# `paths-ignore` filter can be skipped by the very PR that adds it -- the gate
-# would then never run for workflow changes, which is the hole this whole
-# script exists to close. Hosts must therefore trigger on unfiltered
-# `pull_request`.
+# workflow file from the PR merge ref, so any narrowing a PR adds to its host
+# takes effect for that same PR -- the gate then never runs on the workflow
+# change it exists to review, which is the hole this whole script closes.
+# `paths` is only the obvious key: `branches`, `branches-ignore` and `types`
+# skip PRs just as well. So a host must trigger on a bare `pull_request:` with
+# no configuration at all, and its lint step must be able to fail the run.
 LINT_SCRIPT_NAME = "lint_workflow_triggers.py"
-PATH_FILTER_KEYS: tuple[str, ...] = ("paths", "paths-ignore")
 
 
 def _normalise_on(on_field):
@@ -87,8 +87,8 @@ def _trigger_set(yaml_doc) -> set[str]:
     return _normalise_on(_on_field(yaml_doc))
 
 
-def _runs_lint(yaml_doc) -> bool:
-    """True when a job step actually runs this script.
+def _lint_steps(yaml_doc) -> list[tuple[dict, dict]]:
+    """(job, step) pairs whose `run` invokes this script.
 
     Reads the parsed steps rather than the raw text: a commented-out
     `# - run: python3 scripts/lint_workflow_triggers.py` executes nothing, and
@@ -96,28 +96,30 @@ def _runs_lint(yaml_doc) -> bool:
     """
     jobs = yaml_doc.get("jobs") if isinstance(yaml_doc, dict) else None
     if not isinstance(jobs, dict):
-        return False
+        return []
+    found = []
     for job in jobs.values():
         steps = job.get("steps") if isinstance(job, dict) else None
         if not isinstance(steps, list):
             continue
         for step in steps:
-            if not isinstance(step, dict):
-                continue
-            if LINT_SCRIPT_NAME in str(step.get("run") or ""):
-                return True
-    return False
+            if isinstance(step, dict) and LINT_SCRIPT_NAME in str(step.get("run") or ""):
+                found.append((job, step))
+    return found
 
 
-def _pull_request_path_filters(yaml_doc) -> list[str]:
-    """Path-filter keys on the `pull_request` trigger, if any."""
+def _pull_request_restrictions(yaml_doc) -> list[str]:
+    """Keys narrowing the `pull_request` trigger. A gate wants none of them."""
     on = _on_field(yaml_doc)
-    if not isinstance(on, dict):
-        return []
-    pr = on.get("pull_request")
-    if not isinstance(pr, dict):
-        return []
-    return [k for k in PATH_FILTER_KEYS if k in pr]
+    pr = on.get("pull_request") if isinstance(on, dict) else None
+    return sorted(pr) if isinstance(pr, dict) else []
+
+
+def _is_truthy(value) -> bool:
+    """YAML truthiness, treating any `${{ ... }}` expression as possibly true."""
+    if isinstance(value, bool):
+        return value
+    return isinstance(value, str) and value.strip().lower() not in ("", "false")
 
 
 def main() -> int:
@@ -181,16 +183,30 @@ def main() -> int:
                         "comment somewhere in the file, with a justification."
                     )
 
-        if _runs_lint(doc):
-            filters = _pull_request_path_filters(doc)
-            if filters:
+        lint_steps = _lint_steps(doc)
+        if lint_steps:
+            problems = []
+            restrictions = _pull_request_restrictions(doc)
+            if restrictions:
+                problems.append(
+                    f"its 'pull_request' trigger is narrowed by "
+                    f"{' + '.join(restrictions)}, so a PR adding that skips "
+                    "this workflow for its own PR"
+                )
+            if any(
+                _is_truthy(job.get("continue-on-error"))
+                or _is_truthy(step.get("continue-on-error"))
+                for job, step in lint_steps
+            ):
+                problems.append(
+                    "its lint step is continue-on-error, so findings cannot "
+                    "fail the run"
+                )
+            if problems:
                 findings.append(
-                    f"{path.name}: runs {LINT_SCRIPT_NAME} but its "
-                    f"'pull_request' trigger has {' + '.join(filters)}. A PR "
-                    "adding that filter skips this workflow for its own PR, so "
-                    "the trigger gate never runs on the workflow change it is "
-                    "meant to review. Drop the filter, or host the lint in a "
-                    "workflow that runs on every PR."
+                    f"{path.name}: runs {LINT_SCRIPT_NAME} but "
+                    + ", and ".join(problems)
+                    + ". The gate must run, and be able to fail, on every PR."
                 )
             elif "pull_request" in triggers:
                 unfiltered_hosts.append(path)

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -118,7 +118,9 @@ def _classify_lint_line(line: str) -> tuple[bool, str | None]:
         i += 2 if args[i] in _OPTS_WITH_VALUE else 1
 
     rest = args[i:]
-    if not rest or not rest[0].endswith(LINT_SCRIPT_PATH):
+    # Exactly the repo-relative path. A suffix match would accept a decoy at
+    # /tmp/scripts/lint_workflow_triggers.py.
+    if not rest or rest[0] not in (LINT_SCRIPT_PATH, f"./{LINT_SCRIPT_PATH}"):
         return False, None
     if len(rest) == 1:
         return True, None
@@ -136,20 +138,47 @@ def _classify_lint_line(line: str) -> tuple[bool, str | None]:
 
 
 def _lint_step_report(run: str) -> tuple[bool, list[str]]:
-    """(an enforcing invocation is present, problems with lint-ish commands)."""
-    enforcing, problems = False, []
-    for line in run.splitlines():
-        if LINT_SCRIPT_NAME not in line:
-            continue
-        ok, problem = _classify_lint_line(line)
-        enforcing = enforcing or ok
-        if problem:
-            problems.append(problem)
-    if (enforcing or problems) and "set +e" in run:
-        problems.append(
-            "its lint step runs under 'set +e', so a non-zero exit does not fail the step"
-        )
+    """(an enforcing invocation is present, problems with lint-ish commands).
+
+    The step body must be the lint command and nothing else. Judging lines in
+    isolation cannot tell a call from a definition, so an invocation parked in
+    an uncalled function or a here-document would read as enforcing while
+    executing nothing. Requiring a single command sidesteps shell parsing.
+    """
+    lines = [
+        line for line in run.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    mentions = [line for line in lines if LINT_SCRIPT_NAME in line]
+    if not mentions:
+        return False, []
+
+    problems = [p for _, p in map(_classify_lint_line, mentions) if p]
+    enforcing = any(ok for ok, _ in map(_classify_lint_line, mentions))
+    if enforcing and len(lines) > 1:
+        return False, problems + [
+            "its lint step runs other shell besides the lint command, so the "
+            "lint need not execute (a function body or here-document is not a "
+            "call)"
+        ]
     return enforcing, problems
+
+
+# A custom `shell:` template can wrap the command in anything, including
+# `bash -c '"{0}" || true'`, so only the plain executors count.
+SAFE_SHELLS: tuple[str, ...] = ("bash", "sh")
+
+
+def _effective_shell(yaml_doc, job: dict, step: dict) -> str | None:
+    """The step's shell, falling back to job then workflow `defaults.run`."""
+    if step.get("shell"):
+        return str(step["shell"])
+    for scope in (job, yaml_doc):
+        defaults = scope.get("defaults") if isinstance(scope, dict) else None
+        run = defaults.get("run") if isinstance(defaults, dict) else None
+        if isinstance(run, dict) and run.get("shell"):
+            return str(run["shell"])
+    return None
 
 
 def _lint_steps(yaml_doc) -> list[tuple[dict, dict, bool, list[str]]]:
@@ -171,8 +200,16 @@ def _lint_steps(yaml_doc) -> list[tuple[dict, dict, bool, list[str]]]:
             if not isinstance(step, dict):
                 continue
             enforcing, problems = _lint_step_report(str(step.get("run") or ""))
-            if enforcing or problems:
-                found.append((job, step, enforcing, problems))
+            if not (enforcing or problems):
+                continue
+            shell = _effective_shell(yaml_doc, job, step)
+            if shell is not None and shell not in SAFE_SHELLS:
+                enforcing = False
+                problems.append(
+                    f"its lint step runs under shell {shell!r}, which can wrap "
+                    "the command and drop its exit status"
+                )
+            found.append((job, step, enforcing, problems))
     return found
 
 

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -25,7 +25,7 @@ import argparse
 import re
 import shlex
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 try:
     import yaml
@@ -38,7 +38,10 @@ DEFAULT_WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
 BANNED_TRIGGERS: tuple[str, ...] = ("pull_request_target",)
 RESTRICTED_TRIGGERS: tuple[str, ...] = ("workflow_run",)
-PUBLISH_WORKFLOW_NAMES: tuple[str, ...] = ("release-desktop.yml",)
+# Matched on the STEM: scanning `.yaml` too means a rename to
+# `release-desktop.yaml` must still classify as a publisher, or a cache key
+# shared with a PR workflow would stop being a finding.
+PUBLISH_WORKFLOW_STEMS: tuple[str, ...] = ("release-desktop",)
 
 # A workflow that runs this script is a "host". `pull_request` resolves the
 # workflow file from the PR merge ref, so any narrowing a PR adds to its host
@@ -94,7 +97,11 @@ def _trigger_set(yaml_doc) -> set[str]:
 # pipeline, redirection or `|| true` detaches the step's exit status from the
 # lint's (the default `run:` shell is `bash -e`, without pipefail); and any
 # argument can point it elsewhere or turn it into a no-op, `--help` included.
-_PYTHON = re.compile(r"[\w./-]*python[\w.]*")
+# The BASENAME must be a python, so a `/tmp/fakepython` that exits 0 is not
+# mistaken for an interpreter. A directory prefix stays fine.
+_PYTHON_BASENAME = re.compile(r"python(3(\.\d+)?)?")
+# Options that make python print something and exit without running a file.
+_TERMINAL_OPTS = ("-V", "--version", "-h", "--help")
 LINT_SCRIPT_PATH = f"scripts/{LINT_SCRIPT_NAME}"
 # Options that consume the next token, so the script path is not mistaken for
 # their value.
@@ -108,13 +115,14 @@ def _classify_lint_line(line: str) -> tuple[bool, str | None]:
         tokens = shlex.split(line.strip())
     except ValueError:
         return False, None
-    if not tokens or not _PYTHON.fullmatch(tokens[0]):
+    if not tokens or not _PYTHON_BASENAME.fullmatch(PurePosixPath(tokens[0]).name):
         return False, None  # `echo <script>`, or not python at all
 
     args, i = tokens[1:], 0
     while i < len(args) and args[i].startswith("-"):
-        if args[i].startswith(("-c", "-m")):
-            return False, None  # runs that program, not this file
+        if args[i].startswith(("-c", "-m")) or args[i] in _TERMINAL_OPTS:
+            # -c / -m run another program; -V / --help exit before the file.
+            return False, None
         i += 2 if args[i] in _OPTS_WITH_VALUE else 1
 
     rest = args[i:]
@@ -166,15 +174,15 @@ def _lint_step_report(run: str) -> tuple[bool, list[str]]:
 SAFE_SHELLS: tuple[str, ...] = ("bash", "sh")
 
 
-def _effective_shell(yaml_doc, job: dict, step: dict) -> str | None:
-    """The step's shell, falling back to job then workflow `defaults.run`."""
-    if step.get("shell"):
-        return str(step["shell"])
+def _effective_run_setting(yaml_doc, job: dict, step: dict, key: str) -> str | None:
+    """A step's `run` setting, falling back to job then workflow defaults."""
+    if step.get(key):
+        return str(step[key])
     for scope in (job, yaml_doc):
         defaults = scope.get("defaults") if isinstance(scope, dict) else None
         run = defaults.get("run") if isinstance(defaults, dict) else None
-        if isinstance(run, dict) and run.get("shell"):
-            return str(run["shell"])
+        if isinstance(run, dict) and run.get(key):
+            return str(run[key])
     return None
 
 
@@ -199,12 +207,22 @@ def _lint_steps(yaml_doc) -> list[tuple[dict, dict, bool, list[str]]]:
             enforcing, problems = _lint_step_report(str(step.get("run") or ""))
             if not (enforcing or problems):
                 continue
-            shell = _effective_shell(yaml_doc, job, step)
+            shell = _effective_run_setting(yaml_doc, job, step, "shell")
             if shell is not None and shell not in SAFE_SHELLS:
                 enforcing = False
                 problems.append(
                     f"its lint step runs under shell {shell!r}, which can wrap "
                     "the command and drop its exit status"
+                )
+            workdir = _effective_run_setting(
+                yaml_doc, job, step, "working-directory"
+            )
+            if workdir is not None:
+                enforcing = False
+                problems.append(
+                    f"its lint step runs in working-directory {workdir!r}, so "
+                    "the command resolves to a different file than this "
+                    "repository's script"
                 )
             found.append((job, step, enforcing, problems))
     return found
@@ -334,7 +352,7 @@ def main() -> int:
         is_dispatch_only = "workflow_dispatch" in triggers and not (
             "push" in triggers or "pull_request" in triggers
         )
-        if path.name in PUBLISH_WORKFLOW_NAMES or is_dispatch_only:
+        if path.stem in PUBLISH_WORKFLOW_STEMS or is_dispatch_only:
             publish_triggered.append((path, _extract_cache_keys(path)))
 
     if require_host and not unfiltered_hosts:

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -87,14 +87,26 @@ def _trigger_set(yaml_doc) -> set[str]:
     return _normalise_on(_on_field(yaml_doc))
 
 
-def _runs_lint(path: Path) -> bool:
-    """True when the workflow invokes this script from a `run:` step.
+def _runs_lint(yaml_doc) -> bool:
+    """True when a job step actually runs this script.
 
-    Matched on `run:` rather than anywhere in the file so a workflow that
-    merely mentions the script in a comment is not mistaken for a host.
+    Reads the parsed steps rather than the raw text: a commented-out
+    `# - run: python3 scripts/lint_workflow_triggers.py` executes nothing, and
+    counting it as a host would let a deleted gate look wired.
     """
-    text = path.read_text(encoding = "utf-8")
-    return re.search(rf"run:[^\n]*{re.escape(LINT_SCRIPT_NAME)}", text) is not None
+    jobs = yaml_doc.get("jobs") if isinstance(yaml_doc, dict) else None
+    if not isinstance(jobs, dict):
+        return False
+    for job in jobs.values():
+        steps = job.get("steps") if isinstance(job, dict) else None
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            if LINT_SCRIPT_NAME in str(step.get("run") or ""):
+                return True
+    return False
 
 
 def _pull_request_path_filters(yaml_doc) -> list[str]:
@@ -169,7 +181,7 @@ def main() -> int:
                         "comment somewhere in the file, with a justification."
                     )
 
-        if _runs_lint(path):
+        if _runs_lint(doc):
             filters = _pull_request_path_filters(doc)
             if filters:
                 findings.append(

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -85,7 +85,12 @@ def main() -> int:
     workflows_dir = args.workflows_dir
 
     findings: list[str] = []
-    workflows = sorted(workflows_dir.glob("*.yml"))
+    # GitHub Actions loads BOTH `.yml` and `.yaml` from .github/workflows/, so
+    # scanning only `*.yml` leaves a rename-away bypass: `evil.yaml` with
+    # `pull_request_target` would run for real and lint clean.
+    workflows = sorted(
+        list(workflows_dir.glob("*.yml")) + list(workflows_dir.glob("*.yaml"))
+    )
     pr_triggered: list[tuple[Path, list[str]]] = []
     publish_triggered: list[tuple[Path, list[str]]] = []
 

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -199,12 +199,10 @@ def main() -> int:
                 for job, step in lint_steps
             ):
                 problems.append(
-                    "its lint step is continue-on-error, so findings cannot "
-                    "fail the run"
+                    "its lint step is continue-on-error, so findings cannot fail the run"
                 )
             if any(
-                job.get("if") is not None or step.get("if") is not None
-                for job, step in lint_steps
+                job.get("if") is not None or step.get("if") is not None for job, step in lint_steps
             ):
                 problems.append(
                     "its lint step is gated by an 'if:' condition, so the gate "

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -88,9 +88,7 @@ def main() -> int:
     # GitHub Actions loads BOTH `.yml` and `.yaml` from .github/workflows/, so
     # scanning only `*.yml` leaves a rename-away bypass: `evil.yaml` with
     # `pull_request_target` would run for real and lint clean.
-    workflows = sorted(
-        list(workflows_dir.glob("*.yml")) + list(workflows_dir.glob("*.yaml"))
-    )
+    workflows = sorted(list(workflows_dir.glob("*.yml")) + list(workflows_dir.glob("*.yaml")))
     pr_triggered: list[tuple[Path, list[str]]] = []
     publish_triggered: list[tuple[Path, list[str]]] = []
 

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -87,8 +87,16 @@ def _trigger_set(yaml_doc) -> set[str]:
     return _normalise_on(_on_field(yaml_doc))
 
 
+# The script named as the argument of a python interpreter, at the start of a
+# command. `echo scripts/lint_workflow_triggers.py` mentions the script without
+# running it, and would otherwise pass for a host.
+_INVOCATION = re.compile(
+    rf"(?:^|[;&|]|\n)\s*[\w./-]*python[\w.]*\s+[^\n;&|]*{re.escape(LINT_SCRIPT_NAME)}"
+)
+
+
 def _lint_steps(yaml_doc) -> list[tuple[dict, dict]]:
-    """(job, step) pairs whose `run` invokes this script.
+    """(job, step) pairs whose `run` actually invokes this script.
 
     Reads the parsed steps rather than the raw text: a commented-out
     `# - run: python3 scripts/lint_workflow_triggers.py` executes nothing, and
@@ -103,7 +111,7 @@ def _lint_steps(yaml_doc) -> list[tuple[dict, dict]]:
         if not isinstance(steps, list):
             continue
         for step in steps:
-            if isinstance(step, dict) and LINT_SCRIPT_NAME in str(step.get("run") or ""):
+            if isinstance(step, dict) and _INVOCATION.search(str(step.get("run") or "")):
                 found.append((job, step))
     return found
 
@@ -207,6 +215,11 @@ def main() -> int:
                 problems.append(
                     "its lint step is gated by an 'if:' condition, so the gate "
                     "can be skipped while the run still succeeds"
+                )
+            if any(job.get("needs") is not None for job, _ in lint_steps):
+                problems.append(
+                    "its lint job declares 'needs:', so a skipped prerequisite "
+                    "skips the gate without failing the run"
                 )
             if problems:
                 findings.append(

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -114,8 +114,7 @@ def _invocation_problems(run: str) -> list[str]:
     used = [f for f in NEUTERING_FLAGS if f in run]
     if used:
         problems.append(
-            f"its lint command passes {' + '.join(used)}, so it does not "
-            "gate the live workflows"
+            f"its lint command passes {' + '.join(used)}, so it does not gate the live workflows"
         )
     return problems
 

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -129,7 +129,7 @@ def _classify_lint_line(line: str) -> tuple[bool, str | None]:
         if args[i] in _OPTS_WITH_VALUE:
             value = args[i + 1] if i + 1 < len(args) else ""
             if any(op in value for op in _SHELL_OPERATORS):
-                return False, None      # a substitution runs before python
+                return False, None  # a substitution runs before python
             i += 2
         elif args[i] in _SAFE_OPTS:
             i += 1

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -202,6 +202,14 @@ def main() -> int:
                     "its lint step is continue-on-error, so findings cannot "
                     "fail the run"
                 )
+            if any(
+                job.get("if") is not None or step.get("if") is not None
+                for job, step in lint_steps
+            ):
+                problems.append(
+                    "its lint step is gated by an 'if:' condition, so the gate "
+                    "can be skipped while the run still succeeds"
+                )
             if problems:
                 findings.append(
                     f"{path.name}: runs {LINT_SCRIPT_NAME} but "

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -110,7 +110,7 @@ def _is_trusted_python(token: str) -> bool:
     add an executable of that name.
     """
     if any(op in token for op in _SHELL_OPERATORS):
-        return False        # a substitution runs before the path is used
+        return False  # a substitution runs before the path is used
     path = PurePosixPath(token)
     if not _PYTHON_BASENAME.fullmatch(path.name):
         return False

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -109,12 +109,12 @@ def _classify_lint_line(line: str) -> tuple[bool, str | None]:
     except ValueError:
         return False, None
     if not tokens or not _PYTHON.fullmatch(tokens[0]):
-        return False, None          # `echo <script>`, or not python at all
+        return False, None  # `echo <script>`, or not python at all
 
     args, i = tokens[1:], 0
     while i < len(args) and args[i].startswith("-"):
         if args[i].startswith(("-c", "-m")):
-            return False, None      # runs that program, not this file
+            return False, None  # runs that program, not this file
         i += 2 if args[i] in _OPTS_WITH_VALUE else 1
 
     rest = args[i:]
@@ -147,8 +147,7 @@ def _lint_step_report(run: str) -> tuple[bool, list[str]]:
             problems.append(problem)
     if (enforcing or problems) and "set +e" in run:
         problems.append(
-            "its lint step runs under 'set +e', so a non-zero exit does not "
-            "fail the step"
+            "its lint step runs under 'set +e', so a non-zero exit does not fail the step"
         )
     return enforcing, problems
 
@@ -293,9 +292,7 @@ def main() -> int:
                     + ", and ".join(problems)
                     + ". The gate must run, and be able to fail, on every PR."
                 )
-            elif "pull_request" in triggers and any(
-                enforcing for _, _, enforcing, _ in lint_steps
-            ):
+            elif "pull_request" in triggers and any(enforcing for _, _, enforcing, _ in lint_steps):
                 unfiltered_hosts.append(path)
 
         if "pull_request" in triggers:

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -38,18 +38,14 @@ DEFAULT_WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
 BANNED_TRIGGERS: tuple[str, ...] = ("pull_request_target",)
 RESTRICTED_TRIGGERS: tuple[str, ...] = ("workflow_run",)
-# Matched on the STEM: scanning `.yaml` too means a rename to
-# `release-desktop.yaml` must still classify as a publisher, or a cache key
-# shared with a PR workflow would stop being a finding.
+# Stem, not filename: `.yaml` is scanned too, and a renamed publisher must
+# still be classified as one.
 PUBLISH_WORKFLOW_STEMS: tuple[str, ...] = ("release-desktop",)
 
-# A workflow that runs this script is a "host". `pull_request` resolves the
+# A workflow running this script is a "host". `pull_request` resolves the
 # workflow file from the PR merge ref, so any narrowing a PR adds to its host
-# takes effect for that same PR -- the gate then never runs on the workflow
-# change it exists to review, which is the hole this whole script closes.
-# `paths` is only the obvious key: `branches`, `branches-ignore` and `types`
-# skip PRs just as well. So a host must trigger on a bare `pull_request:` with
-# no configuration at all, and its lint step must be able to fail the run.
+# applies to that same PR, and the gate misses the change it exists to review.
+# Hence: a bare `pull_request:`, and a step that can fail.
 LINT_SCRIPT_NAME = "lint_workflow_triggers.py"
 
 
@@ -91,20 +87,14 @@ def _trigger_set(yaml_doc) -> set[str]:
     return _normalise_on(_on_field(yaml_doc))
 
 
-# Host detection. A host must run the repository's own lint script as a plain,
-# standalone command with no arguments: `echo <script>` runs nothing;
-# `/tmp/lint_workflow_triggers.py` is a decoy with the same basename; a
-# pipeline, redirection or `|| true` detaches the step's exit status from the
-# lint's (the default `run:` shell is `bash -e`, without pipefail); and any
-# argument can point it elsewhere or turn it into a no-op, `--help` included.
-# The BASENAME must be a python, so a `/tmp/fakepython` that exits 0 is not
-# mistaken for an interpreter. A directory prefix stays fine.
+# A host runs this repo's script as a plain command with no arguments. Each
+# clause below is a way that looked satisfied while nothing was enforced: a
+# decoy path, a fake interpreter, a `|| true` (the default `run:` shell is
+# `bash -e`, no pipefail), or an argument that makes it exit early.
 _PYTHON_BASENAME = re.compile(r"python(3(\.\d+)?)?")
-# An ALLOWLIST, not a denylist. Every round of review found another flag
-# that stops the file running or masks its exit status (-c, -m, --version,
-# and -i, which drops into the REPL after the script and exits 0 even when
-# the lint called sys.exit(1)). Only flags that leave "run this file and
-# return its status" intact are accepted; anything else is not a host.
+# Allowlist, not denylist: too many flags skip the file or mask its status
+# (-c, -m, --version, and -i, which exits 0 from the REPL even after
+# sys.exit(1)). Anything unrecognised fails closed.
 _SAFE_OPTS = ("-u", "-E", "-s", "-S", "-B", "-O", "-OO", "-q")
 LINT_SCRIPT_PATH = f"scripts/{LINT_SCRIPT_NAME}"
 # Safe, but they consume the next token, so the script path is not mistaken
@@ -175,14 +165,11 @@ def _lint_step_report(run: str) -> tuple[bool, list[str]]:
     return enforcing, problems
 
 
-# A custom `shell:` template can wrap the command in anything, including
-# `bash -c '"{0}" || true'`, so only the plain executors count.
+# A `shell:` template can wrap the command, e.g. `bash -c '"{0}" || true'`.
 SAFE_SHELLS: tuple[str, ...] = ("bash", "sh")
 
-# These redirect execution without the command text changing at all.
-# Non-interactive bash sources BASH_ENV before the step script, so an
-# `exit 0` in that file ends the step before the lint runs; PATH picks the
-# interpreter.
+# Redirect execution without changing the command: bash sources BASH_ENV
+# before the step script, and PATH picks the interpreter.
 UNSAFE_ENV_KEYS: tuple[str, ...] = ("BASH_ENV", "ENV", "PATH")
 
 

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -145,10 +145,7 @@ def _lint_step_report(run: str) -> tuple[bool, list[str]]:
     an uncalled function or a here-document would read as enforcing while
     executing nothing. Requiring a single command sidesteps shell parsing.
     """
-    lines = [
-        line for line in run.splitlines()
-        if line.strip() and not line.strip().startswith("#")
-    ]
+    lines = [line for line in run.splitlines() if line.strip() and not line.strip().startswith("#")]
     mentions = [line for line in lines if LINT_SCRIPT_NAME in line]
     if not mentions:
         return False, []

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -87,12 +88,52 @@ def _trigger_set(yaml_doc) -> set[str]:
     return _normalise_on(_on_field(yaml_doc))
 
 
-# The script named as the argument of a python interpreter, at the start of a
-# command. `echo scripts/lint_workflow_triggers.py` mentions the script without
-# running it, and would otherwise pass for a host.
-_INVOCATION = re.compile(
-    rf"(?:^|[;&|]|\n)\s*[\w./-]*python[\w.]*\s+[^\n;&|]*{re.escape(LINT_SCRIPT_NAME)}"
-)
+# Host detection. `echo scripts/lint_workflow_triggers.py` mentions the script
+# without running it, so a real python invocation of the file is required.
+_PYTHON = re.compile(r"[\w./-]*python[\w.]*")
+_SEPARATORS = re.compile(r"\|\||&&|[;&|\n]")
+# Options that consume the next token, so the script path cannot be confused
+# with their value.
+_OPTS_WITH_VALUE = ("-X", "-W", "--check-hash-based-pycs")
+
+
+def _commands(run: str) -> list[list[str]]:
+    """Argv-ish token lists for each command in a `run` block."""
+    out = []
+    for segment in _SEPARATORS.split(run):
+        segment = segment.strip()
+        if not segment:
+            continue
+        try:
+            tokens = shlex.split(segment)
+        except ValueError:
+            tokens = segment.split()
+        if tokens:
+            out.append(tokens)
+    return out
+
+
+def _invokes_lint(run: str) -> bool:
+    """True when python is asked to EXECUTE this script.
+
+    `python3 -c 'pass' scripts/lint_workflow_triggers.py` names the script but
+    runs the `-c` program and exits 0, so the script has to be the executed
+    file rather than any later argument.
+    """
+    for tokens in _commands(run):
+        if not _PYTHON.fullmatch(tokens[0]):
+            continue
+        args, i = tokens[1:], 0
+        while i < len(args) and args[i].startswith("-"):
+            # -c / -m hand the rest to a program that is not this file.
+            if args[i].startswith(("-c", "-m")):
+                break
+            i += 2 if args[i] in _OPTS_WITH_VALUE else 1
+        else:
+            if i < len(args) and args[i].endswith(LINT_SCRIPT_NAME):
+                return True
+    return False
+
 
 # Shell that swallows a non-zero exit, so the step goes green on findings.
 _MASKED = re.compile(
@@ -135,7 +176,7 @@ def _lint_steps(yaml_doc) -> list[tuple[dict, dict]]:
         if not isinstance(steps, list):
             continue
         for step in steps:
-            if isinstance(step, dict) and _INVOCATION.search(str(step.get("run") or "")):
+            if isinstance(step, dict) and _invokes_lint(str(step.get("run") or "")):
                 found.append((job, step))
     return found
 

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -121,8 +121,8 @@ def main() -> int:
         action = "store_true",
         default = None,
         help = "Require a workflow that runs this script on unfiltered "
-               "`pull_request`. Defaults on for the live tree, off for a "
-               "fixture directory.",
+        "`pull_request`. Defaults on for the live tree, off for a "
+        "fixture directory.",
     )
     parser.add_argument(
         "--no-require-host",

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -113,21 +113,33 @@ def test_lint_rejects_a_narrowed_host(tmp_path, key, value):
 
 
 @pytest.mark.parametrize("where", ["step", "job"])
-def test_lint_rejects_a_non_blocking_host(tmp_path, where):
-    """`continue-on-error` means findings cannot fail the run."""
+@pytest.mark.parametrize(
+    "key, value, expected",
+    [
+        ("continue-on-error", "true", "continue-on-error"),
+        ("if", "${{ false }}", "'if:' condition"),
+    ],
+)
+def test_lint_rejects_a_host_that_cannot_fail(tmp_path, where, key, value, expected):
+    """A host that runs but cannot fail, or is skipped, is not a gate.
+
+    `continue-on-error` makes findings advisory; a false `if:` skips the step
+    entirely. Either way the workflow goes green with the lint never enforcing
+    anything.
+    """
     wf = tmp_path / "wf"
     wf.mkdir()
     if where == "step":
-        body = _host_workflow(step_extra = "        continue-on-error: true\n")
+        body = _host_workflow(step_extra = f"        {key}: {value}\n")
     else:
         body = _host_workflow().replace(
             "    runs-on: ubuntu-latest\n",
-            "    runs-on: ubuntu-latest\n    continue-on-error: true\n",
+            f"    runs-on: ubuntu-latest\n    {key}: {value}\n",
         )
     (wf / "host.yml").write_text(body)
     proc = _run(wf, require_host = True)
     assert proc.returncode == 1
-    assert "continue-on-error" in proc.stderr
+    assert expected in proc.stderr
 
 
 def test_lint_accepts_unfiltered_host(tmp_path):
@@ -212,15 +224,30 @@ def _codeowners_rules(text: str) -> list[tuple[str, list[str]]]:
 
 
 def _pattern_matches(pattern: str, path: str) -> bool:
+    """Approximate GitHub's CODEOWNERS matching, erring toward matching.
+
+    A directory pattern owns everything beneath it, so every directory prefix
+    of the path is a candidate. Patterns are globbed rather than compared
+    literally: `**/workflows/` is a valid rule that a substring search misses.
+    An unanchored pattern may start at any depth.
+    """
     if pattern == "*":
         return True
     anchored = pattern.startswith("/")
-    body = pattern.lstrip("/")
-    if body.endswith("/"):
-        return path.startswith(body) if anchored else f"/{path}".find(f"/{body}") >= 0
-    if anchored:
-        return fnmatch.fnmatch(path, body) or path.startswith(f"{body}/")
-    return fnmatch.fnmatch(path, body) or fnmatch.fnmatch(path.rsplit("/", 1)[-1], body)
+    is_dir = pattern.endswith("/")
+    body = pattern.strip("/")
+    segments = path.split("/")
+
+    candidates = ["/".join(segments[:i]) for i in range(1, len(segments))]
+    if not is_dir:
+        candidates.append(path)
+    if not anchored:
+        candidates += [
+            "/".join(segments[j:i])
+            for i in range(1, len(segments) + 1)
+            for j in range(1, i)
+        ]
+    return any(fnmatch.fnmatch(c, body) for c in candidates)
 
 
 def _effective_owners(text: str, path: str) -> list[str]:
@@ -277,8 +304,20 @@ def test_workflow_changes_require_code_owner_review():
         (f"/{CODEOWNERS_PROBES[0]} @someone-else", ["@someone-else"]),
         # A pattern with no owners is valid, and clears ownership.
         (f"/{CODEOWNERS_PROBES[0]}", []),
+        # Globbed and unanchored directory patterns are valid rules too.
+        ("**/workflows/ @someone-else", ["@someone-else"]),
+        ("workflows/ @someone-else", ["@someone-else"]),
+        (".github/*/ @someone-else", ["@someone-else"]),
     ],
-    ids = ["catch-all", "parent-dir", "narrower-file", "ownerless"],
+    ids = [
+        "catch-all",
+        "parent-dir",
+        "narrower-file",
+        "ownerless",
+        "globbed-dir",
+        "unanchored-dir",
+        "wildcard-segment",
+    ],
 )
 def test_codeowners_guard_catches_a_later_rule(override, expected):
     """The guard must fail whichever way a trailing rule takes precedence."""

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -149,7 +149,10 @@ def test_lint_rejects_a_host_that_cannot_fail(tmp_path, where, key, value, expec
         ("python3 scripts/lint_workflow_triggers.py ; true", "chained"),
         ("python3 scripts/lint_workflow_triggers.py | tee lint.log", "chained"),
         ("python3 scripts/lint_workflow_triggers.py &", "chained"),
-        ("set -e\n          set +e\n          python3 scripts/lint_workflow_triggers.py", "set +e"),
+        (
+            "set +e\n          python3 scripts/lint_workflow_triggers.py",
+            "other shell besides the lint command",
+        ),
         (
             "python3 scripts/lint_workflow_triggers.py --workflows-dir /tmp/empty",
             "--workflows-dir",
@@ -163,7 +166,7 @@ def test_lint_rejects_a_host_that_cannot_fail(tmp_path, where, key, value, expec
         "semi-true",
         "pipe-tee",
         "background",
-        "set-plus-e",
+        "extra-shell",
         "elsewhere-dir",
         "self-check-off",
         "abbreviated-flag",
@@ -214,6 +217,78 @@ def test_lint_does_not_count_a_non_running_command_as_a_host(tmp_path, command):
     proc = _run(wf, require_host = True)
     assert proc.returncode == 1
     assert "does not cover every PR" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        # A decoy under any prefix, not just a bare /tmp path.
+        "python3 /tmp/scripts/lint_workflow_triggers.py",
+        # Defining a function is not calling it.
+        "never_called() {\n            python3 scripts/lint_workflow_triggers.py\n          }",
+        # A here-document is data, not a command.
+        "cat <<'EOF'\n          python3 scripts/lint_workflow_triggers.py\n          EOF",
+    ],
+    ids = ["prefixed-decoy", "uncalled-function", "heredoc"],
+)
+def test_lint_rejects_an_unexecuted_lint_command(tmp_path, body):
+    """Text that looks like the invocation but never runs it is not a host."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py",
+            f"run: |\n          {body}",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "does not cover every PR" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "where",
+    ["step", "job-defaults", "workflow-defaults"],
+)
+def test_lint_rejects_a_custom_shell(tmp_path, where):
+    """A shell template can wrap the command and drop its exit status."""
+    evil = "bash -c '\"{0}\" || true'"
+    body = _host_workflow()
+    if where == "step":
+        body = body.replace(
+            "      - run: python3 scripts/lint_workflow_triggers.py\n",
+            "      - run: python3 scripts/lint_workflow_triggers.py\n"
+            f"        shell: {evil}\n",
+        )
+    elif where == "job-defaults":
+        body = body.replace(
+            "    runs-on: ubuntu-latest\n",
+            "    runs-on: ubuntu-latest\n"
+            f"    defaults:\n      run:\n        shell: {evil}\n",
+        )
+    else:
+        body = body.replace(
+            "jobs:\n", f"defaults:\n  run:\n    shell: {evil}\njobs:\n"
+        )
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(body)
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "shell" in proc.stderr
+
+
+def test_lint_accepts_an_explicit_plain_shell(tmp_path):
+    """`shell: bash` is ordinary and must keep working."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "      - run: python3 scripts/lint_workflow_triggers.py\n",
+            "      - run: python3 scripts/lint_workflow_triggers.py\n"
+            "        shell: bash\n",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 0, proc.stderr
 
 
 def test_lint_rejects_a_host_job_with_needs(tmp_path):

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -72,42 +72,69 @@ def test_lint_rejects_pull_request_target_in_yaml_extension(tmp_path):
     assert "BANNED trigger 'pull_request_target'" in proc.stderr
 
 
-def _host_workflow(filter_key: str | None) -> str:
-    """A workflow that runs the lint, optionally with a path filter."""
-    flt = f"    {filter_key}:\n      - 'studio/**'\n" if filter_key else ""
+def _host_workflow(restriction: str = "", step_extra: str = "") -> str:
+    """A workflow that runs the lint, optionally narrowed or non-blocking."""
     return (
         "name: host\n"
         "on:\n"
-        "  pull_request:\n" + flt + "jobs:\n"
+        "  pull_request:\n" + restriction + "jobs:\n"
         "  lint:\n"
         "    runs-on: ubuntu-latest\n"
         "    steps:\n"
-        "      - run: python3 scripts/lint_workflow_triggers.py\n"
+        "      - run: python3 scripts/lint_workflow_triggers.py\n" + step_extra
     )
 
 
-@pytest.mark.parametrize("filter_key", ["paths", "paths-ignore"])
-def test_lint_rejects_path_filter_on_its_own_host(tmp_path, filter_key):
-    """A host with a path filter can be skipped by the PR that adds it.
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("paths", "      - 'studio/**'\n"),
+        ("paths-ignore", "      - 'studio/**'\n"),
+        ("branches", "      - some-other-branch\n"),
+        ("branches-ignore", "      - main\n"),
+        ("types", "      - closed\n"),
+    ],
+)
+def test_lint_rejects_a_narrowed_host(tmp_path, key, value):
+    """A host narrowed any way can be skipped by the PR that narrows it.
 
     `pull_request` resolves the workflow file from the PR merge ref, so the
-    filter takes effect for its own PR and the gate never runs on the change
-    it exists to review. Both filter keys are the same bypass.
+    restriction takes effect for its own PR and the gate never runs on the
+    change it exists to review. `paths` is only the most obvious key: a
+    branch or event-type restriction skips ordinary PRs just as well.
     """
     wf = tmp_path / "wf"
     wf.mkdir()
-    (wf / "host.yml").write_text(_host_workflow(filter_key))
+    (wf / "host.yml").write_text(_host_workflow(f"    {key}:\n{value}"))
     proc = _run(wf, require_host = True)
     assert proc.returncode == 1
-    assert filter_key in proc.stderr
+    assert key in proc.stderr
     assert "host.yml" in proc.stderr
 
 
-def test_lint_accepts_unfiltered_host(tmp_path):
-    """An unfiltered `pull_request` host satisfies the wiring requirement."""
+@pytest.mark.parametrize("where", ["step", "job"])
+def test_lint_rejects_a_non_blocking_host(tmp_path, where):
+    """`continue-on-error` means findings cannot fail the run."""
     wf = tmp_path / "wf"
     wf.mkdir()
-    (wf / "host.yml").write_text(_host_workflow(None))
+    if where == "step":
+        body = _host_workflow(step_extra = "        continue-on-error: true\n")
+    else:
+        body = _host_workflow().replace(
+            "    runs-on: ubuntu-latest\n",
+            "    runs-on: ubuntu-latest\n    continue-on-error: true\n",
+        )
+    (wf / "host.yml").write_text(body)
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "continue-on-error" in proc.stderr
+
+
+def test_lint_accepts_unfiltered_host(tmp_path):
+    """A bare `pull_request:` host that can fail satisfies the requirement."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "host.yml").write_text(_host_workflow())
     proc = _run(wf, require_host = True)
     assert proc.returncode == 0, proc.stderr
 
@@ -171,10 +198,15 @@ def test_workflow_trigger_lint_host_exists_and_is_unfiltered():
 
 
 def _codeowners_rules(text: str) -> list[tuple[str, list[str]]]:
+    """Rules in file order, INCLUDING ownerless ones.
+
+    A pattern with no owners is valid CODEOWNERS and clears ownership for what
+    it matches, so skipping those lines would miss a silent carve-out.
+    """
     rules = []
     for line in text.splitlines():
         fields = line.split("#", 1)[0].split()
-        if len(fields) > 1:
+        if fields:
             rules.append((fields[0], fields[1:]))
     return rules
 
@@ -207,14 +239,28 @@ CODEOWNERS_PROBES = (
 
 
 def test_workflow_changes_require_code_owner_review():
-    """CODEOWNERS must give @danielhanchen the EFFECTIVE ownership.
+    """Every workflow must keep an EFFECTIVE code owner.
 
     The lint cannot stop a PR that disables the lint's own host workflow, so
     owner review is the merge-time control. GitHub applies only the last
     matching pattern, so checking that a rule exists somewhere is not enough:
-    a broader rule appended below would silently take over.
+    a later rule, broad or narrow, silently takes over. Any workflow can hand
+    a fork PR the base repo's secrets, so every one of them is checked, not
+    just the lint host. Delegating a workflow to another maintainer is fine;
+    leaving one unowned is not.
     """
     text = (REPO_ROOT / ".github" / "CODEOWNERS").read_text(encoding = "utf-8")
+    workflows = sorted(
+        p.relative_to(REPO_ROOT).as_posix()
+        for p in (REPO_ROOT / ".github" / "workflows").iterdir()
+        if p.suffix in (".yml", ".yaml")
+    )
+    assert workflows, "no workflow files found"
+    for probe in workflows:
+        assert _effective_owners(text, probe), (
+            f"CODEOWNERS leaves {probe} with no effective owner; a later "
+            "pattern overrode the .github/workflows/ rule."
+        )
     for probe in CODEOWNERS_PROBES:
         owners = _effective_owners(text, probe)
         assert "@danielhanchen" in owners, (
@@ -223,15 +269,22 @@ def test_workflow_changes_require_code_owner_review():
         )
 
 
-def test_codeowners_guard_catches_a_later_broader_rule():
-    """The guard itself must fail when a trailing rule takes precedence."""
+@pytest.mark.parametrize(
+    "override, expected",
+    [
+        ("* @someone-else", ["@someone-else"]),
+        ("/.github/ @someone-else", ["@someone-else"]),
+        (f"/{CODEOWNERS_PROBES[0]} @someone-else", ["@someone-else"]),
+        # A pattern with no owners is valid, and clears ownership.
+        (f"/{CODEOWNERS_PROBES[0]}", []),
+    ],
+    ids = ["catch-all", "parent-dir", "narrower-file", "ownerless"],
+)
+def test_codeowners_guard_catches_a_later_rule(override, expected):
+    """The guard must fail whichever way a trailing rule takes precedence."""
     text = (REPO_ROOT / ".github" / "CODEOWNERS").read_text(encoding = "utf-8")
-    for override in ("* @someone-else", "/.github/ @someone-else"):
-        for probe in CODEOWNERS_PROBES:
-            owners = _effective_owners(f"{text}\n{override}\n", probe)
-            assert owners == ["@someone-else"], (
-                f"{override!r} should win for {probe}, got {owners}"
-            )
+    owners = _effective_owners(f"{text}\n{override}\n", CODEOWNERS_PROBES[0])
+    assert owners == expected, f"{override!r} should win, got {owners}"
 
 
 def test_lint_rejects_unjustified_workflow_run(tmp_path):

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -51,6 +51,46 @@ def test_lint_rejects_pull_request_target(tmp_path):
     assert "GHSA-g7cv-rxg3-hmpx" in proc.stderr
 
 
+def test_lint_rejects_pull_request_target_in_yaml_extension(tmp_path):
+    """GitHub Actions also loads `.yaml`; the lint must not stop at `.yml`."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "bad.yaml").write_text(
+        "name: bad\n"
+        "on:\n"
+        "  pull_request_target:\n"
+        "    branches: [main]\n"
+        "jobs:\n"
+        "  build:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: echo evil\n"
+    )
+    proc = _run(wf)
+    assert proc.returncode == 1
+    assert "bad.yaml" in proc.stderr
+    assert "BANNED trigger 'pull_request_target'" in proc.stderr
+
+
+def test_security_audit_runs_on_every_pull_request():
+    """The lint job is wired inside security-audit.yml, so that workflow must
+    not carry a `paths` filter -- a filter that omits `.github/workflows/**`
+    would let a PR add a dangerous workflow without ever running the lint."""
+    yaml = pytest.importorskip("yaml")
+    doc = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "security-audit.yml").read_text(
+            encoding = "utf-8",
+        )
+    )
+    on = doc.get(True, doc.get("on"))
+    assert isinstance(on, dict) and "pull_request" in on
+    pr = on["pull_request"] or {}
+    assert "paths" not in pr, (
+        "security-audit.yml gained a pull_request `paths` filter; the "
+        "workflow-trigger lint would stop running for workflow-file PRs."
+    )
+
+
 def test_lint_rejects_unjustified_workflow_run(tmp_path):
     """`workflow_run` requires an explicit allow-comment in the YAML."""
     wf = tmp_path / "wf"

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -502,8 +502,7 @@ def test_lint_rejects_expansion_in_the_interpreter_token(tmp_path):
     (wf / "host.yml").write_text(
         _host_workflow().replace(
             "run: python3 scripts/lint_workflow_triggers.py",
-            'run: |\n          "/usr/$(printf bin)/python3" '
-            "scripts/lint_workflow_triggers.py",
+            'run: |\n          "/usr/$(printf bin)/python3" ' "scripts/lint_workflow_triggers.py",
         )
     )
     proc = _run(wf, require_host = True)

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -77,8 +77,7 @@ def _host_workflow(filter_key: str | None) -> str:
     return (
         "name: host\n"
         "on:\n"
-        "  pull_request:\n" + flt +
-        "jobs:\n"
+        "  pull_request:\n" + flt + "jobs:\n"
         "  lint:\n"
         "    runs-on: ubuntu-latest\n"
         "    steps:\n"
@@ -155,9 +154,9 @@ def test_comment_mention_is_not_a_host(tmp_path):
 def test_workflow_trigger_lint_host_exists_and_is_unfiltered():
     """End to end on the live tree, with the host requirement forced on."""
     proc = _run(REPO_ROOT / ".github" / "workflows", require_host = True)
-    assert proc.returncode == 0, (
-        f"live tree failed lint:\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
-    )
+    assert (
+        proc.returncode == 0
+    ), f"live tree failed lint:\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
 
 
 def test_workflow_changes_require_code_owner_review():

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -13,12 +13,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "lint_workflow_triggers.py"
 
 
-def _run(workflows_dir: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [sys.executable, str(SCRIPT), "--workflows-dir", str(workflows_dir)],
-        capture_output = True,
-        text = True,
-    )
+def _run(workflows_dir: Path, require_host: bool = False) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, str(SCRIPT), "--workflows-dir", str(workflows_dir)]
+    if require_host:
+        cmd.append("--require-host")
+    return subprocess.run(cmd, capture_output = True, text = True)
 
 
 def test_lint_passes_on_current_workflows():
@@ -72,23 +71,111 @@ def test_lint_rejects_pull_request_target_in_yaml_extension(tmp_path):
     assert "BANNED trigger 'pull_request_target'" in proc.stderr
 
 
-def test_security_audit_runs_on_every_pull_request():
-    """The lint job is wired inside security-audit.yml, so that workflow must
-    not carry a `paths` filter -- a filter that omits `.github/workflows/**`
-    would let a PR add a dangerous workflow without ever running the lint."""
-    yaml = pytest.importorskip("yaml")
-    doc = yaml.safe_load(
-        (REPO_ROOT / ".github" / "workflows" / "security-audit.yml").read_text(
-            encoding = "utf-8",
-        )
+def _host_workflow(filter_key: str | None) -> str:
+    """A workflow that runs the lint, optionally with a path filter."""
+    flt = f"    {filter_key}:\n      - 'studio/**'\n" if filter_key else ""
+    return (
+        "name: host\n"
+        "on:\n"
+        "  pull_request:\n" + flt +
+        "jobs:\n"
+        "  lint:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: python3 scripts/lint_workflow_triggers.py\n"
     )
-    on = doc.get(True, doc.get("on"))
-    assert isinstance(on, dict) and "pull_request" in on
-    pr = on["pull_request"] or {}
-    assert "paths" not in pr, (
-        "security-audit.yml gained a pull_request `paths` filter; the "
-        "workflow-trigger lint would stop running for workflow-file PRs."
+
+
+@pytest.mark.parametrize("filter_key", ["paths", "paths-ignore"])
+def test_lint_rejects_path_filter_on_its_own_host(tmp_path, filter_key):
+    """A host with a path filter can be skipped by the PR that adds it.
+
+    `pull_request` resolves the workflow file from the PR merge ref, so the
+    filter takes effect for its own PR and the gate never runs on the change
+    it exists to review. Both filter keys are the same bypass.
+    """
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "host.yml").write_text(_host_workflow(filter_key))
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert filter_key in proc.stderr
+    assert "host.yml" in proc.stderr
+
+
+def test_lint_accepts_unfiltered_host(tmp_path):
+    """An unfiltered `pull_request` host satisfies the wiring requirement."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "host.yml").write_text(_host_workflow(None))
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_lint_rejects_missing_host(tmp_path):
+    """Deleting the gate's workflow must fail the gate, not silently pass."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "unrelated.yml").write_text(
+        "name: unrelated\n"
+        "on:\n"
+        "  pull_request:\n"
+        "jobs:\n"
+        "  build:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: echo hi\n"
     )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "does not cover every PR" in proc.stderr
+
+
+def test_comment_mention_is_not_a_host(tmp_path):
+    """Naming the script in a comment must not count as running it."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "mentions.yml").write_text(
+        "name: mentions\n"
+        "on:\n"
+        "  pull_request:\n"
+        "    paths:\n"
+        "      - 'studio/**'\n"
+        "jobs:\n"
+        "  build:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      # scripts/lint_workflow_triggers.py needs PyYAML\n"
+        "      - run: echo hi\n"
+    )
+    proc = _run(wf)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_workflow_trigger_lint_host_exists_and_is_unfiltered():
+    """End to end on the live tree, with the host requirement forced on."""
+    proc = _run(REPO_ROOT / ".github" / "workflows", require_host = True)
+    assert proc.returncode == 0, (
+        f"live tree failed lint:\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_workflow_changes_require_code_owner_review():
+    """CODEOWNERS must cover `.github/workflows/`.
+
+    The lint cannot stop a PR that disables the lint's own host workflow, so
+    the merge-time control is owner review on workflow changes.
+    """
+    owners = (REPO_ROOT / ".github" / "CODEOWNERS").read_text(encoding = "utf-8")
+    rules = [
+        line.split("#", 1)[0].strip()
+        for line in owners.splitlines()
+        if line.split("#", 1)[0].strip()
+    ]
+    for pattern in ("/.github/workflows/", "/.github/CODEOWNERS"):
+        assert any(
+            r.split()[0] == pattern and len(r.split()) > 1 for r in rules
+        ), f"CODEOWNERS has no owner rule for {pattern}"
 
 
 def test_lint_rejects_unjustified_workflow_run(tmp_path):

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -96,12 +96,10 @@ def _host_workflow(restriction: str = "", step_extra: str = "") -> str:
     ],
 )
 def test_lint_rejects_a_narrowed_host(tmp_path, key, value):
-    """A host narrowed any way can be skipped by the PR that narrows it.
+    """A host narrowed any way is skipped by the PR that narrows it.
 
-    `pull_request` resolves the workflow file from the PR merge ref, so the
-    restriction takes effect for its own PR and the gate never runs on the
-    change it exists to review. `paths` is only the most obvious key: a
-    branch or event-type restriction skips ordinary PRs just as well.
+    The merge ref carries the restriction, so it applies to that PR. A branch
+    or event-type filter skips ordinary PRs as well as `paths` does.
     """
     wf = tmp_path / "wf"
     wf.mkdir()
@@ -121,11 +119,9 @@ def test_lint_rejects_a_narrowed_host(tmp_path, key, value):
     ],
 )
 def test_lint_rejects_a_host_that_cannot_fail(tmp_path, where, key, value, expected):
-    """A host that runs but cannot fail, or is skipped, is not a gate.
+    """A host that cannot fail, or is skipped, is not a gate.
 
-    `continue-on-error` makes findings advisory; a false `if:` skips the step
-    entirely. Either way the workflow goes green with the lint never enforcing
-    anything.
+    `continue-on-error` makes findings advisory; a false `if:` skips the step.
     """
     wf = tmp_path / "wf"
     wf.mkdir()
@@ -176,10 +172,8 @@ def test_lint_rejects_a_host_that_cannot_fail(tmp_path, where, key, value, expec
 def test_lint_rejects_a_defanged_invocation(tmp_path, command, expected):
     """Running the script is not enough; it has to be able to gate.
 
-    A pipeline or `|| true` detaches the step's exit status from the lint's
-    (the default `run:` shell is `bash -e`, with no pipefail), and any
-    argument can point it away from the live tree, switch off its own wiring
-    check, or make it exit before scanning at all.
+    A pipeline or `|| true` detaches the step's status from the lint's, and an
+    argument can redirect it, disable its wiring check, or exit early.
     """
     wf = tmp_path / "wf"
     wf.mkdir()
@@ -532,8 +526,8 @@ def test_lint_rejects_missing_host(tmp_path):
 def test_commented_mention_is_not_a_host(tmp_path, mention):
     """A mention that executes nothing must not register as a host.
 
-    The commented-out `run:` line is the dangerous one: it would let a repo
-    with the real host workflow deleted still satisfy `--require-host`.
+    The commented-out `run:` is the dangerous one: it would satisfy
+    `--require-host` with the real workflow deleted.
     """
     wf = tmp_path / "wf"
     wf.mkdir()

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -442,6 +442,60 @@ def test_lint_rejects_a_non_mapping_pull_request_value(tmp_path, value):
     assert "not a valid event configuration" in proc.stderr
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A repo-root `./python3` can be added by the PR itself.
+        "./python3 scripts/lint_workflow_triggers.py",
+        "bin/python3 scripts/lint_workflow_triggers.py",
+        # A substitution in an option value runs before python does.
+        "python3 -W \"$(touch pwned)\" scripts/lint_workflow_triggers.py",
+    ],
+    ids = ["relative-interpreter", "repo-path-interpreter", "expansion-in-value"],
+)
+def test_lint_rejects_pr_controlled_interpreters(tmp_path, command):
+    """The interpreter and its option values must not come from the checkout."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py", f"run: {command}"
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "does not cover every PR" in proc.stderr
+
+
+@pytest.mark.parametrize("interpreter", ["python3", "python", "/usr/bin/python3"])
+def test_lint_accepts_trusted_interpreters(tmp_path, interpreter):
+    """A bare command or a system path stays acceptable."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py",
+            f"run: {interpreter} scripts/lint_workflow_triggers.py",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.parametrize("key", ["PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP"])
+def test_lint_rejects_python_startup_env(tmp_path, key):
+    """`sitecustomize.py` on PYTHONPATH runs before the lint and can exit 0."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "      - run: python3 scripts/lint_workflow_triggers.py\n",
+            "      - run: python3 scripts/lint_workflow_triggers.py\n"
+            f"        env:\n          {key}: ./pr-controlled\n",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert key in proc.stderr
+
+
 def test_lint_rejects_a_host_job_with_needs(tmp_path):
     """A skipped prerequisite skips the lint job without failing the run."""
     wf = tmp_path / "wf"

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -371,6 +371,83 @@ def test_publish_cache_key_collision_found_under_both_suffixes(tmp_path, suffix)
     assert "cache key" in proc.stderr
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        # -i drops into the REPL after the script; on EOF the interpreter
+        # exits 0 even though the lint called sys.exit(1).
+        "python3 -i scripts/lint_workflow_triggers.py",
+        # Anything outside the allowlist fails closed.
+        "python3 -d scripts/lint_workflow_triggers.py",
+        "python3 -uB scripts/lint_workflow_triggers.py",
+    ],
+    ids = ["interactive", "unknown-flag", "combined-flag"],
+)
+def test_lint_rejects_flags_outside_the_allowlist(tmp_path, command):
+    """Only flags that leave run-this-file-and-return-its-status intact count."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py", f"run: {command}"
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "does not cover every PR" in proc.stderr
+
+
+@pytest.mark.parametrize("flag", ["-u", "-E", "-s", "-B", "-q", "-O"])
+def test_lint_accepts_allowlisted_flags(tmp_path, flag):
+    """The allowlist must not reject ordinary interpreter flags."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py",
+            f"run: python3 {flag} scripts/lint_workflow_triggers.py",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.parametrize("scope", ["step", "job", "workflow"])
+@pytest.mark.parametrize("key", ["BASH_ENV", "PATH"])
+def test_lint_rejects_execution_redirecting_env(tmp_path, scope, key):
+    """`BASH_ENV` runs before the step script; `PATH` picks the interpreter."""
+    body = _host_workflow()
+    entry = f"env:\n  {key}: /tmp/x\n"
+    if scope == "step":
+        body = body.replace(
+            "      - run: python3 scripts/lint_workflow_triggers.py\n",
+            "      - run: python3 scripts/lint_workflow_triggers.py\n"
+            f"        env:\n          {key}: /tmp/x\n",
+        )
+    elif scope == "job":
+        body = body.replace(
+            "    runs-on: ubuntu-latest\n",
+            f"    runs-on: ubuntu-latest\n    env:\n      {key}: /tmp/x\n",
+        )
+    else:
+        body = body.replace("jobs:\n", entry + "jobs:\n")
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(body)
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert key in proc.stderr
+
+
+@pytest.mark.parametrize("value", ["false", "true", "[opened]", "'yes'"])
+def test_lint_rejects_a_non_mapping_pull_request_value(tmp_path, value):
+    """GitHub will not load such a workflow, so it cannot be the gate."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace("  pull_request:\n", f"  pull_request: {value}\n")
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "not a valid event configuration" in proc.stderr
+
+
 def test_lint_rejects_a_host_job_with_needs(tmp_path):
     """A skipped prerequisite skips the lint job without failing the run."""
     wf = tmp_path / "wf"

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import shutil
 import subprocess
 import sys
@@ -130,25 +131,35 @@ def test_lint_rejects_missing_host(tmp_path):
     assert "does not cover every PR" in proc.stderr
 
 
-def test_comment_mention_is_not_a_host(tmp_path):
-    """Naming the script in a comment must not count as running it."""
+@pytest.mark.parametrize(
+    "mention",
+    [
+        "      # scripts/lint_workflow_triggers.py needs PyYAML\n",
+        "      # - run: python3 scripts/lint_workflow_triggers.py\n",
+    ],
+    ids = ["prose", "commented-run-step"],
+)
+def test_commented_mention_is_not_a_host(tmp_path, mention):
+    """A mention that executes nothing must not register as a host.
+
+    The commented-out `run:` line is the dangerous one: it would let a repo
+    with the real host workflow deleted still satisfy `--require-host`.
+    """
     wf = tmp_path / "wf"
     wf.mkdir()
     (wf / "mentions.yml").write_text(
         "name: mentions\n"
         "on:\n"
         "  pull_request:\n"
-        "    paths:\n"
-        "      - 'studio/**'\n"
         "jobs:\n"
         "  build:\n"
         "    runs-on: ubuntu-latest\n"
-        "    steps:\n"
-        "      # scripts/lint_workflow_triggers.py needs PyYAML\n"
+        "    steps:\n" + mention +
         "      - run: echo hi\n"
     )
-    proc = _run(wf)
-    assert proc.returncode == 0, proc.stderr
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "does not cover every PR" in proc.stderr
 
 
 def test_workflow_trigger_lint_host_exists_and_is_unfiltered():
@@ -159,22 +170,68 @@ def test_workflow_trigger_lint_host_exists_and_is_unfiltered():
     ), f"live tree failed lint:\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
 
 
+def _codeowners_rules(text: str) -> list[tuple[str, list[str]]]:
+    rules = []
+    for line in text.splitlines():
+        fields = line.split("#", 1)[0].split()
+        if len(fields) > 1:
+            rules.append((fields[0], fields[1:]))
+    return rules
+
+
+def _pattern_matches(pattern: str, path: str) -> bool:
+    if pattern == "*":
+        return True
+    anchored = pattern.startswith("/")
+    body = pattern.lstrip("/")
+    if body.endswith("/"):
+        return path.startswith(body) if anchored else f"/{path}".find(f"/{body}") >= 0
+    if anchored:
+        return fnmatch.fnmatch(path, body) or path.startswith(f"{body}/")
+    return fnmatch.fnmatch(path, body) or fnmatch.fnmatch(path.rsplit("/", 1)[-1], body)
+
+
+def _effective_owners(text: str, path: str) -> list[str]:
+    """Owners GitHub would require, i.e. the LAST matching rule wins."""
+    owners: list[str] = []
+    for pattern, people in _codeowners_rules(text):
+        if _pattern_matches(pattern, path):
+            owners = people
+    return owners
+
+
+CODEOWNERS_PROBES = (
+    ".github/workflows/workflow-trigger-lint.yml",
+    ".github/CODEOWNERS",
+)
+
+
 def test_workflow_changes_require_code_owner_review():
-    """CODEOWNERS must cover `.github/workflows/`.
+    """CODEOWNERS must give @danielhanchen the EFFECTIVE ownership.
 
     The lint cannot stop a PR that disables the lint's own host workflow, so
-    the merge-time control is owner review on workflow changes.
+    owner review is the merge-time control. GitHub applies only the last
+    matching pattern, so checking that a rule exists somewhere is not enough:
+    a broader rule appended below would silently take over.
     """
-    owners = (REPO_ROOT / ".github" / "CODEOWNERS").read_text(encoding = "utf-8")
-    rules = [
-        line.split("#", 1)[0].strip()
-        for line in owners.splitlines()
-        if line.split("#", 1)[0].strip()
-    ]
-    for pattern in ("/.github/workflows/", "/.github/CODEOWNERS"):
-        assert any(
-            r.split()[0] == pattern and len(r.split()) > 1 for r in rules
-        ), f"CODEOWNERS has no owner rule for {pattern}"
+    text = (REPO_ROOT / ".github" / "CODEOWNERS").read_text(encoding = "utf-8")
+    for probe in CODEOWNERS_PROBES:
+        owners = _effective_owners(text, probe)
+        assert "@danielhanchen" in owners, (
+            f"CODEOWNERS gives {probe} effective owners {owners or '(none)'}; "
+            "a later pattern overrode the workflow rule."
+        )
+
+
+def test_codeowners_guard_catches_a_later_broader_rule():
+    """The guard itself must fail when a trailing rule takes precedence."""
+    text = (REPO_ROOT / ".github" / "CODEOWNERS").read_text(encoding = "utf-8")
+    for override in ("* @someone-else", "/.github/ @someone-else"):
+        for probe in CODEOWNERS_PROBES:
+            owners = _effective_owners(f"{text}\n{override}\n", probe)
+            assert owners == ["@someone-else"], (
+                f"{override!r} should win for {probe}, got {owners}"
+            )
 
 
 def test_lint_rejects_unjustified_workflow_run(tmp_path):

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -496,6 +496,35 @@ def test_lint_rejects_python_startup_env(tmp_path, key):
     assert key in proc.stderr
 
 
+def test_lint_rejects_expansion_in_the_interpreter_token(tmp_path):
+    """Bash substitutes before the trusted-path test can mean anything."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py",
+            'run: |\n          "/usr/$(printf bin)/python3" '
+            "scripts/lint_workflow_triggers.py",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "does not cover every PR" in proc.stderr
+
+
+def test_lint_rejects_a_containerized_host(tmp_path):
+    """A PR-selected image controls the shell and environment."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "    runs-on: ubuntu-latest\n",
+            "    runs-on: ubuntu-latest\n    container: alpine:latest\n",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "container" in proc.stderr
+
+
 def test_lint_rejects_a_host_job_with_needs(tmp_path):
     """A skipped prerequisite skips the lint job without failing the run."""
     wf = tmp_path / "wf"

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -193,8 +193,7 @@ def test_commented_mention_is_not_a_host(tmp_path, mention):
         "jobs:\n"
         "  build:\n"
         "    runs-on: ubuntu-latest\n"
-        "    steps:\n" + mention +
-        "      - run: echo hi\n"
+        "    steps:\n" + mention + "      - run: echo hi\n"
     )
     proc = _run(wf, require_host = True)
     assert proc.returncode == 1
@@ -243,9 +242,7 @@ def _pattern_matches(pattern: str, path: str) -> bool:
         candidates.append(path)
     if not anchored:
         candidates += [
-            "/".join(segments[j:i])
-            for i in range(1, len(segments) + 1)
-            for j in range(1, i)
+            "/".join(segments[j:i]) for i in range(1, len(segments) + 1) for j in range(1, i)
         ]
     return any(fnmatch.fnmatch(c, body) for c in candidates)
 

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -171,8 +171,19 @@ def test_lint_rejects_a_host_that_only_mentions_the_script(tmp_path):
             "python3 scripts/lint_workflow_triggers.py --no-require-host",
             "--no-require-host",
         ),
+        # -c / -m run something else and treat the path as a bare argument.
+        ("python3 -c 'pass' scripts/lint_workflow_triggers.py", "does not cover"),
+        ("python3 -m json.tool scripts/lint_workflow_triggers.py", "does not cover"),
     ],
-    ids = ["or-true", "semi-true", "set-plus-e", "elsewhere-dir", "self-check-off"],
+    ids = [
+        "or-true",
+        "semi-true",
+        "set-plus-e",
+        "elsewhere-dir",
+        "self-check-off",
+        "dash-c",
+        "dash-m",
+    ],
 )
 def test_lint_rejects_a_defanged_invocation(tmp_path, command, expected):
     """Running the script is not enough; it has to be able to gate.
@@ -214,6 +225,29 @@ def test_lint_rejects_a_host_job_with_needs(tmp_path):
     proc = _run(wf, require_host = True)
     assert proc.returncode == 1
     assert "needs:" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python3 scripts/lint_workflow_triggers.py",
+        "python3 -u scripts/lint_workflow_triggers.py",
+        "python scripts/lint_workflow_triggers.py",
+        "python3 -X utf8 scripts/lint_workflow_triggers.py",
+    ],
+    ids = ["plain", "dash-u", "python", "dash-X-with-value"],
+)
+def test_lint_accepts_ordinary_invocations(tmp_path, command):
+    """Tightening host detection must not reject normal ways to run it."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py", f"run: {command}"
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 0, proc.stderr
 
 
 def test_lint_accepts_unfiltered_host(tmp_path):
@@ -338,14 +372,19 @@ def _pattern_matches(pattern: str, path: str) -> bool:
     A pattern that NAMES a directory owns everything beneath it, so directory
     prefixes of the path are candidates. A pattern with a wildcard in it does
     not: GitHub documents `docs/*` as matching `docs/getting-started.md` but
-    not `docs/build-app/troubleshooting.md`. An unanchored pattern may start
-    at any depth.
+    not `docs/build-app/troubleshooting.md`.
+
+    Only a pattern with no internal separator floats to any depth, gitignore
+    style. A leading slash anchors, and so does an internal one, so
+    `workflows/lint.yml` is root-relative and does NOT match
+    `.github/workflows/lint.yml`; a bare `workflows/` still matches at any
+    depth.
     """
     if pattern == "*":
         return True
-    anchored = pattern.startswith("/")
     is_dir = pattern.endswith("/")
     body = pattern.strip("/")
+    anchored = pattern.startswith("/") or "/" in body
     rx = _pattern_regex(body)
     segments = path.split("/")
 
@@ -427,6 +466,10 @@ def test_workflow_changes_require_code_owner_review():
         # Unanchored patterns may start at any depth.
         ("workflows/", ".github/workflows/lint.yml", True),
         ("**/workflows/", ".github/workflows/lint.yml", True),
+        # An internal slash anchors at the root, gitignore style, so this
+        # names a top-level workflows/ and not the one under .github/.
+        ("workflows/lint.yml", ".github/workflows/lint.yml", False),
+        ("workflows/lint.yml", "workflows/lint.yml", True),
         # Non-matches.
         ("/unsloth/", ".github/workflows/lint.yml", False),
         ("/unsloth", "unsloth_zoo/x.py", False),

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import fnmatch
+import re
 import shutil
 import subprocess
 import sys
@@ -157,6 +157,43 @@ def test_lint_rejects_a_host_that_only_mentions_the_script(tmp_path):
     assert "does not cover every PR" in proc.stderr
 
 
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        ("python3 scripts/lint_workflow_triggers.py || true", "swallows"),
+        ("python3 scripts/lint_workflow_triggers.py ; true", "swallows"),
+        ("set +e\n          python3 scripts/lint_workflow_triggers.py", "swallows"),
+        (
+            "python3 scripts/lint_workflow_triggers.py --workflows-dir /tmp/empty",
+            "--workflows-dir",
+        ),
+        (
+            "python3 scripts/lint_workflow_triggers.py --no-require-host",
+            "--no-require-host",
+        ),
+    ],
+    ids = ["or-true", "semi-true", "set-plus-e", "elsewhere-dir", "self-check-off"],
+)
+def test_lint_rejects_a_defanged_invocation(tmp_path, command, expected):
+    """Running the script is not enough; it has to be able to gate.
+
+    `|| true` swallows the exit code, and the flags point it away from the
+    live tree or switch off its own wiring check. Each leaves a workflow that
+    looks wired and enforces nothing.
+    """
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py",
+            f"run: |\n          {command}",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert expected in proc.stderr
+
+
 def test_lint_rejects_a_host_job_with_needs(tmp_path):
     """A skipped prerequisite skips the lint job without failing the run."""
     wf = tmp_path / "wf"
@@ -259,16 +296,32 @@ def _codeowners_rules(text: str) -> list[tuple[str, list[str]]]:
     return rules
 
 
-def _glob_variants(pattern: str) -> list[str]:
-    """Expand `**/`, which wildmatch lets match ZERO directories.
+def _pattern_regex(pattern: str) -> re.Pattern:
+    """CODEOWNERS globbing: `*` stops at `/`, `**` crosses directories.
 
-    `fnmatch` has no way to express that, so `/.github/**/workflows/` would
-    miss `.github/workflows/...` and hide a real override.
+    `fnmatch` gets both halves wrong here. Its `*` consumes `/`, so
+    `/.github/*` would wrongly claim nested workflow files and fail a valid
+    CODEOWNERS change; and it cannot express `**/` matching zero directories,
+    so `/.github/**/workflows/` would wrongly miss one.
     """
-    head, sep, tail = pattern.partition("**/")
-    if not sep:
-        return [pattern]
-    return [f"{head}{prefix}{t}" for t in _glob_variants(tail) for prefix in ("**/", "")]
+    out, i = [], 0
+    while i < len(pattern):
+        if pattern.startswith("**/", i):
+            out.append("(?:[^/]+/)*")
+            i += 3
+        elif pattern.startswith("**", i):
+            out.append(".*")
+            i += 2
+        elif pattern[i] == "*":
+            out.append("[^/]*")
+            i += 1
+        elif pattern[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(pattern[i]))
+            i += 1
+    return re.compile("".join(out) + r"\Z")
 
 
 def _is_valid_owner(token: str) -> bool:
@@ -280,28 +333,34 @@ def _is_valid_owner(token: str) -> bool:
 
 
 def _pattern_matches(pattern: str, path: str) -> bool:
-    """Approximate GitHub's CODEOWNERS matching, erring toward matching.
+    """Approximate GitHub's CODEOWNERS matching.
 
-    A directory pattern owns everything beneath it, so every directory prefix
-    of the path is a candidate. Patterns are globbed rather than compared
-    literally: `**/workflows/` is a valid rule that a substring search misses.
-    An unanchored pattern may start at any depth.
+    A pattern that NAMES a directory owns everything beneath it, so directory
+    prefixes of the path are candidates. A pattern with a wildcard in it does
+    not: GitHub documents `docs/*` as matching `docs/getting-started.md` but
+    not `docs/build-app/troubleshooting.md`. An unanchored pattern may start
+    at any depth.
     """
     if pattern == "*":
         return True
     anchored = pattern.startswith("/")
     is_dir = pattern.endswith("/")
     body = pattern.strip("/")
+    rx = _pattern_regex(body)
     segments = path.split("/")
 
-    candidates = ["/".join(segments[:i]) for i in range(1, len(segments))]
-    if not is_dir:
-        candidates.append(path)
-    if not anchored:
-        candidates += [
-            "/".join(segments[j:i]) for i in range(1, len(segments) + 1) for j in range(1, i)
-        ]
-    return any(fnmatch.fnmatch(c, variant) for c in candidates for variant in _glob_variants(body))
+    def matches(candidate: str) -> bool:
+        parts = candidate.split("/")
+        starts = [0] if anchored else range(len(parts))
+        return any(rx.match("/".join(parts[j:])) for j in starts)
+
+    prefixes = ["/".join(segments[:i]) for i in range(1, len(segments))]
+    if is_dir:
+        return any(matches(p) for p in prefixes)
+    if matches(path):
+        return True
+    # A plain path may name a directory, and then owns everything under it.
+    return not any(ch in body for ch in "*?") and any(matches(p) for p in prefixes)
 
 
 def _effective_owners(text: str, path: str) -> list[str]:
@@ -350,6 +409,36 @@ def test_workflow_changes_require_code_owner_review():
             f"CODEOWNERS gives {probe} effective owners {owners or '(none)'}; "
             "a later pattern overrode the workflow rule."
         )
+
+
+@pytest.mark.parametrize(
+    "pattern, path, matches",
+    [
+        # `*` stops at a directory boundary, like GitHub's `docs/*` example.
+        ("/.github/*", ".github/workflows/lint.yml", False),
+        ("/.github/*", ".github/CODEOWNERS", True),
+        # `**` crosses them, and `**/` may match zero.
+        ("/.github/**", ".github/workflows/lint.yml", True),
+        ("/.github/**/workflows/", ".github/workflows/lint.yml", True),
+        ("/.github/**/workflows/", ".github/a/b/workflows/lint.yml", True),
+        # A plain path naming a directory owns everything beneath it.
+        ("/.github/workflows/", ".github/workflows/lint.yml", True),
+        ("/scripts", "scripts/data/x.txt", True),
+        # Unanchored patterns may start at any depth.
+        ("workflows/", ".github/workflows/lint.yml", True),
+        ("**/workflows/", ".github/workflows/lint.yml", True),
+        # Non-matches.
+        ("/unsloth/", ".github/workflows/lint.yml", False),
+        ("/unsloth", "unsloth_zoo/x.py", False),
+    ],
+)
+def test_codeowners_pattern_semantics(pattern, path, matches):
+    """The matcher must model GitHub, in both directions.
+
+    Under-matching hides a rule that steals ownership; over-matching fails a
+    valid CODEOWNERS change that never touched the workflows.
+    """
+    assert _pattern_matches(pattern, path) is matches
 
 
 @pytest.mark.parametrize(

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -328,9 +328,7 @@ def test_lint_rejects_a_changed_working_directory(tmp_path, where):
             "    defaults:\n      run:\n        working-directory: /tmp\n",
         )
     else:
-        body = body.replace(
-            "jobs:\n", "defaults:\n  run:\n    working-directory: /tmp\njobs:\n"
-        )
+        body = body.replace("jobs:\n", "defaults:\n  run:\n    working-directory: /tmp\njobs:\n")
     (wf := tmp_path / "wf").mkdir()
     (wf / "host.yml").write_text(body)
     proc = _run(wf, require_host = True)

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -268,11 +268,7 @@ def _glob_variants(pattern: str) -> list[str]:
     head, sep, tail = pattern.partition("**/")
     if not sep:
         return [pattern]
-    return [
-        f"{head}{prefix}{t}"
-        for t in _glob_variants(tail)
-        for prefix in ("**/", "")
-    ]
+    return [f"{head}{prefix}{t}" for t in _glob_variants(tail) for prefix in ("**/", "")]
 
 
 def _is_valid_owner(token: str) -> bool:
@@ -305,11 +301,7 @@ def _pattern_matches(pattern: str, path: str) -> bool:
         candidates += [
             "/".join(segments[j:i]) for i in range(1, len(segments) + 1) for j in range(1, i)
         ]
-    return any(
-        fnmatch.fnmatch(c, variant)
-        for c in candidates
-        for variant in _glob_variants(body)
-    )
+    return any(fnmatch.fnmatch(c, variant) for c in candidates for variant in _glob_variants(body))
 
 
 def _effective_owners(text: str, path: str) -> list[str]:

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -257,19 +257,15 @@ def test_lint_rejects_a_custom_shell(tmp_path, where):
     if where == "step":
         body = body.replace(
             "      - run: python3 scripts/lint_workflow_triggers.py\n",
-            "      - run: python3 scripts/lint_workflow_triggers.py\n"
-            f"        shell: {evil}\n",
+            f"      - run: python3 scripts/lint_workflow_triggers.py\n        shell: {evil}\n",
         )
     elif where == "job-defaults":
         body = body.replace(
             "    runs-on: ubuntu-latest\n",
-            "    runs-on: ubuntu-latest\n"
-            f"    defaults:\n      run:\n        shell: {evil}\n",
+            f"    runs-on: ubuntu-latest\n    defaults:\n      run:\n        shell: {evil}\n",
         )
     else:
-        body = body.replace(
-            "jobs:\n", f"defaults:\n  run:\n    shell: {evil}\njobs:\n"
-        )
+        body = body.replace("jobs:\n", f"defaults:\n  run:\n    shell: {evil}\njobs:\n")
     (wf := tmp_path / "wf").mkdir()
     (wf / "host.yml").write_text(body)
     proc = _run(wf, require_host = True)
@@ -283,8 +279,7 @@ def test_lint_accepts_an_explicit_plain_shell(tmp_path):
     (wf / "host.yml").write_text(
         _host_workflow().replace(
             "      - run: python3 scripts/lint_workflow_triggers.py\n",
-            "      - run: python3 scripts/lint_workflow_triggers.py\n"
-            "        shell: bash\n",
+            "      - run: python3 scripts/lint_workflow_triggers.py\n        shell: bash\n",
         )
     )
     proc = _run(wf, require_host = True)

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -142,6 +142,43 @@ def test_lint_rejects_a_host_that_cannot_fail(tmp_path, where, key, value, expec
     assert expected in proc.stderr
 
 
+def test_lint_rejects_a_host_that_only_mentions_the_script(tmp_path):
+    """`echo <script>` runs nothing, so it must not satisfy the wiring check."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py",
+            "run: echo scripts/lint_workflow_triggers.py",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "does not cover every PR" in proc.stderr
+
+
+def test_lint_rejects_a_host_job_with_needs(tmp_path):
+    """A skipped prerequisite skips the lint job without failing the run."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "  lint:\n    runs-on: ubuntu-latest\n",
+            "  setup:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    if: ${{ false }}\n"
+            "    steps:\n"
+            "      - run: echo hi\n"
+            "  lint:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    needs: setup\n",
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "needs:" in proc.stderr
+
+
 def test_lint_accepts_unfiltered_host(tmp_path):
     """A bare `pull_request:` host that can fail satisfies the requirement."""
     wf = tmp_path / "wf"
@@ -222,6 +259,30 @@ def _codeowners_rules(text: str) -> list[tuple[str, list[str]]]:
     return rules
 
 
+def _glob_variants(pattern: str) -> list[str]:
+    """Expand `**/`, which wildmatch lets match ZERO directories.
+
+    `fnmatch` has no way to express that, so `/.github/**/workflows/` would
+    miss `.github/workflows/...` and hide a real override.
+    """
+    head, sep, tail = pattern.partition("**/")
+    if not sep:
+        return [pattern]
+    return [
+        f"{head}{prefix}{t}"
+        for t in _glob_variants(tail)
+        for prefix in ("**/", "")
+    ]
+
+
+def _is_valid_owner(token: str) -> bool:
+    """GitHub only requests review from an @user, an @org/team, or an email."""
+    if token.startswith("@"):
+        return len(token) > 1
+    local, _, domain = token.partition("@")
+    return bool(local and "." in domain)
+
+
 def _pattern_matches(pattern: str, path: str) -> bool:
     """Approximate GitHub's CODEOWNERS matching, erring toward matching.
 
@@ -244,7 +305,11 @@ def _pattern_matches(pattern: str, path: str) -> bool:
         candidates += [
             "/".join(segments[j:i]) for i in range(1, len(segments) + 1) for j in range(1, i)
         ]
-    return any(fnmatch.fnmatch(c, body) for c in candidates)
+    return any(
+        fnmatch.fnmatch(c, variant)
+        for c in candidates
+        for variant in _glob_variants(body)
+    )
 
 
 def _effective_owners(text: str, path: str) -> list[str]:
@@ -281,9 +346,11 @@ def test_workflow_changes_require_code_owner_review():
     )
     assert workflows, "no workflow files found"
     for probe in workflows:
-        assert _effective_owners(text, probe), (
-            f"CODEOWNERS leaves {probe} with no effective owner; a later "
-            "pattern overrode the .github/workflows/ rule."
+        owners = [o for o in _effective_owners(text, probe) if _is_valid_owner(o)]
+        assert owners, (
+            f"CODEOWNERS leaves {probe} with no effective owner GitHub could "
+            "request review from; a later pattern overrode the "
+            ".github/workflows/ rule."
         )
     for probe in CODEOWNERS_PROBES:
         owners = _effective_owners(text, probe)
@@ -291,6 +358,34 @@ def test_workflow_changes_require_code_owner_review():
             f"CODEOWNERS gives {probe} effective owners {owners or '(none)'}; "
             "a later pattern overrode the workflow rule."
         )
+
+
+@pytest.mark.parametrize(
+    "token, valid",
+    [
+        ("@danielhanchen", True),
+        ("@unslothai/maintainers", True),
+        ("danielhanchen@gmail.com", True),
+        ("not-an-owner", False),
+        ("@", False),
+    ],
+)
+def test_owner_token_validity(token, valid):
+    """An unusable owner token leaves a path effectively unowned.
+
+    GitHub cannot request review from a bare word, so counting it as an owner
+    would let a trailing rule quietly disown a workflow.
+    """
+    assert _is_valid_owner(token) is valid
+
+
+def test_invalid_owner_does_not_count_as_ownership():
+    """The realistic mistake: a later rule naming a non-owner."""
+    text = (REPO_ROOT / ".github" / "CODEOWNERS").read_text(encoding = "utf-8")
+    probe = CODEOWNERS_PROBES[0]
+    owners = _effective_owners(f"{text}\n/{probe} not-an-owner\n", probe)
+    assert owners == ["not-an-owner"]
+    assert not [o for o in owners if _is_valid_owner(o)]
 
 
 @pytest.mark.parametrize(
@@ -305,6 +400,8 @@ def test_workflow_changes_require_code_owner_review():
         ("**/workflows/ @someone-else", ["@someone-else"]),
         ("workflows/ @someone-else", ["@someone-else"]),
         (".github/*/ @someone-else", ["@someone-else"]),
+        # `**/` may match zero directories.
+        ("/.github/**/workflows/ @someone-else", ["@someone-else"]),
     ],
     ids = [
         "catch-all",
@@ -314,6 +411,7 @@ def test_workflow_changes_require_code_owner_review():
         "globbed-dir",
         "unanchored-dir",
         "wildcard-segment",
+        "double-star-zero-dirs",
     ],
 )
 def test_codeowners_guard_catches_a_later_rule(override, expected):

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -449,7 +449,7 @@ def test_lint_rejects_a_non_mapping_pull_request_value(tmp_path, value):
         "./python3 scripts/lint_workflow_triggers.py",
         "bin/python3 scripts/lint_workflow_triggers.py",
         # A substitution in an option value runs before python does.
-        "python3 -W \"$(touch pwned)\" scripts/lint_workflow_triggers.py",
+        'python3 -W "$(touch pwned)" scripts/lint_workflow_triggers.py',
     ],
     ids = ["relative-interpreter", "repo-path-interpreter", "expansion-in-value"],
 )

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -286,6 +286,93 @@ def test_lint_accepts_an_explicit_plain_shell(tmp_path):
     assert proc.returncode == 0, proc.stderr
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A fake interpreter that merely contains "python" in its name.
+        "/tmp/fakepython scripts/lint_workflow_triggers.py",
+        # Flags that make python print and exit before running the file.
+        "python3 --version scripts/lint_workflow_triggers.py",
+        "python3 -V scripts/lint_workflow_triggers.py",
+        "python3 --help scripts/lint_workflow_triggers.py",
+    ],
+    ids = ["fake-interpreter", "version-long", "version-short", "help-before-path"],
+)
+def test_lint_rejects_a_non_running_interpreter(tmp_path, command):
+    """The interpreter must be a python that actually executes the file."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py", f"run: {command}"
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "does not cover every PR" in proc.stderr
+
+
+@pytest.mark.parametrize("where", ["step", "job-defaults", "workflow-defaults"])
+def test_lint_rejects_a_changed_working_directory(tmp_path, where):
+    """`working-directory` resolves the command to a different file."""
+    body = _host_workflow()
+    if where == "step":
+        body = body.replace(
+            "      - run: python3 scripts/lint_workflow_triggers.py\n",
+            "      - run: python3 scripts/lint_workflow_triggers.py\n"
+            "        working-directory: /tmp\n",
+        )
+    elif where == "job-defaults":
+        body = body.replace(
+            "    runs-on: ubuntu-latest\n",
+            "    runs-on: ubuntu-latest\n"
+            "    defaults:\n      run:\n        working-directory: /tmp\n",
+        )
+    else:
+        body = body.replace(
+            "jobs:\n", "defaults:\n  run:\n    working-directory: /tmp\njobs:\n"
+        )
+    (wf := tmp_path / "wf").mkdir()
+    (wf / "host.yml").write_text(body)
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "working-directory" in proc.stderr
+
+
+@pytest.mark.parametrize("suffix", [".yml", ".yaml"])
+def test_publish_cache_key_collision_found_under_both_suffixes(tmp_path, suffix):
+    """Scanning `.yaml` is pointless if publisher classification misses it."""
+    (wf := tmp_path / "wf").mkdir()
+    (wf / f"release-desktop{suffix}").write_text(
+        "name: release\n"
+        "on:\n"
+        "  push:\n"
+        "    branches: [main]\n"
+        "  workflow_dispatch:\n"
+        "jobs:\n"
+        "  build:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/cache@v4\n"
+        "        with:\n"
+        "          key: shared-cache-key\n"
+    )
+    (wf / "pr.yml").write_text(
+        "name: pr\n"
+        "on:\n"
+        "  pull_request:\n"
+        "jobs:\n"
+        "  build:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/cache@v4\n"
+        "        with:\n"
+        "          key: shared-cache-key\n"
+    )
+    proc = _run(wf)
+    assert proc.returncode == 1
+    assert "cache key" in proc.stderr
+
+
 def test_lint_rejects_a_host_job_with_needs(tmp_path):
     """A skipped prerequisite skips the lint job without failing the run."""
     wf = tmp_path / "wf"

--- a/tests/security/test_lint_workflow_triggers.py
+++ b/tests/security/test_lint_workflow_triggers.py
@@ -142,55 +142,41 @@ def test_lint_rejects_a_host_that_cannot_fail(tmp_path, where, key, value, expec
     assert expected in proc.stderr
 
 
-def test_lint_rejects_a_host_that_only_mentions_the_script(tmp_path):
-    """`echo <script>` runs nothing, so it must not satisfy the wiring check."""
-    wf = tmp_path / "wf"
-    wf.mkdir()
-    (wf / "host.yml").write_text(
-        _host_workflow().replace(
-            "run: python3 scripts/lint_workflow_triggers.py",
-            "run: echo scripts/lint_workflow_triggers.py",
-        )
-    )
-    proc = _run(wf, require_host = True)
-    assert proc.returncode == 1
-    assert "does not cover every PR" in proc.stderr
-
-
 @pytest.mark.parametrize(
     "command, expected",
     [
-        ("python3 scripts/lint_workflow_triggers.py || true", "swallows"),
-        ("python3 scripts/lint_workflow_triggers.py ; true", "swallows"),
-        ("set +e\n          python3 scripts/lint_workflow_triggers.py", "swallows"),
+        ("python3 scripts/lint_workflow_triggers.py || true", "chained"),
+        ("python3 scripts/lint_workflow_triggers.py ; true", "chained"),
+        ("python3 scripts/lint_workflow_triggers.py | tee lint.log", "chained"),
+        ("python3 scripts/lint_workflow_triggers.py &", "chained"),
+        ("set -e\n          set +e\n          python3 scripts/lint_workflow_triggers.py", "set +e"),
         (
             "python3 scripts/lint_workflow_triggers.py --workflows-dir /tmp/empty",
             "--workflows-dir",
         ),
-        (
-            "python3 scripts/lint_workflow_triggers.py --no-require-host",
-            "--no-require-host",
-        ),
-        # -c / -m run something else and treat the path as a bare argument.
-        ("python3 -c 'pass' scripts/lint_workflow_triggers.py", "does not cover"),
-        ("python3 -m json.tool scripts/lint_workflow_triggers.py", "does not cover"),
+        ("python3 scripts/lint_workflow_triggers.py --no-require-host", "--no-require-host"),
+        ("python3 scripts/lint_workflow_triggers.py --workflows-d /tmp/empty", "--workflows-d"),
+        ("python3 scripts/lint_workflow_triggers.py --help", "--help"),
     ],
     ids = [
         "or-true",
         "semi-true",
+        "pipe-tee",
+        "background",
         "set-plus-e",
         "elsewhere-dir",
         "self-check-off",
-        "dash-c",
-        "dash-m",
+        "abbreviated-flag",
+        "help",
     ],
 )
 def test_lint_rejects_a_defanged_invocation(tmp_path, command, expected):
     """Running the script is not enough; it has to be able to gate.
 
-    `|| true` swallows the exit code, and the flags point it away from the
-    live tree or switch off its own wiring check. Each leaves a workflow that
-    looks wired and enforces nothing.
+    A pipeline or `|| true` detaches the step's exit status from the lint's
+    (the default `run:` shell is `bash -e`, with no pipefail), and any
+    argument can point it away from the live tree, switch off its own wiring
+    check, or make it exit before scanning at all.
     """
     wf = tmp_path / "wf"
     wf.mkdir()
@@ -203,6 +189,31 @@ def test_lint_rejects_a_defanged_invocation(tmp_path, command, expected):
     proc = _run(wf, require_host = True)
     assert proc.returncode == 1
     assert expected in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python3 -c 'pass' scripts/lint_workflow_triggers.py",
+        "python3 -m json.tool scripts/lint_workflow_triggers.py",
+        "echo scripts/lint_workflow_triggers.py",
+        # A decoy with the right basename but not this repository's script.
+        "python3 /tmp/lint_workflow_triggers.py",
+    ],
+    ids = ["dash-c", "dash-m", "echo", "decoy-path"],
+)
+def test_lint_does_not_count_a_non_running_command_as_a_host(tmp_path, command):
+    """None of these execute the repository's lint, so none is a host."""
+    wf = tmp_path / "wf"
+    wf.mkdir()
+    (wf / "host.yml").write_text(
+        _host_workflow().replace(
+            "run: python3 scripts/lint_workflow_triggers.py", f"run: {command}"
+        )
+    )
+    proc = _run(wf, require_host = True)
+    assert proc.returncode == 1
+    assert "does not cover every PR" in proc.stderr
 
 
 def test_lint_rejects_a_host_job_with_needs(tmp_path):


### PR DESCRIPTION
`scripts/lint_workflow_triggers.py` is the gate that bans `pull_request_target`, unjustified `workflow_run`, and PR-to-release cache-key collisions. Two things stopped it from covering the PRs it exists to review.

## 1. It only scanned `*.yml`

GitHub Actions loads both `.yml` and `.yaml` out of `.github/workflows/`, so the gate had a rename-away bypass: an `evil.yaml` carrying `pull_request_target` would be picked up and run by Actions for real, while the lint reported `OK: scanned N workflow file(s)` and exited 0.

Verified against the pre-patch script: `evil.yaml` gave `OK: scanned 0 workflow file(s)`, rc=0. After, rc=1 naming the file. There are no `.yaml` workflows in the tree today, so this is prevention rather than remediation of a live bypass.

## 2. It was hosted in a workflow that could skip itself

The lint job lived inside `security-audit.yml` and inherited that workflow's triggers, so its coverage was only ever as broad as an unrelated heavy nightly audit's filter policy. That is how the hole was born in the first place.

The obvious guard does not work. `pull_request` resolves the workflow file from the PR merge ref, so a restriction added by a PR takes effect for that same PR. A pytest assertion that the host is unrestricted cannot fire, because it runs inside the workflow being skipped. So the structure changed instead:

- The lint moved to its own `.github/workflows/workflow-trigger-lint.yml`, on `pull_request` with no filter, plus `push: main` and `workflow_dispatch`.
- The wiring check moved out of pytest and into the linter, which now inspects whichever workflow runs it.

### What the linter requires of its own host

A host must trigger on a bare `pull_request:` with no configuration at all. `paths` was only the obvious key; `branches`, `branches-ignore` and `types` skip PRs just as effectively, and an inverted rule covers whatever GitHub adds next.

The host's lint step must also be able to fail. Rejected: `continue-on-error`, an `if:` condition, `needs:` on the job (a skipped prerequisite skips the gate silently), and a `run` that does not execute this repository's script as a plain standalone command with no arguments. That last rule is one check rather than a list of tricks, and it covers a commented-out step, `echo <script>`, `python3 -c 'pass' <script>`, a decoy `/tmp/lint_workflow_triggers.py` with the same basename, `|| true`, a `| tee` pipeline (the default `run:` shell is `bash -e`, with no `pipefail`), `--help`, and `--workflows-dir` pointed somewhere empty. `allow_abbrev = False` stops `--workflows-d` meaning `--workflows-dir`.

Finally, if no unfiltered host exists at all, that is itself a finding, so deleting the workflow fails the gate rather than silently passing it.

## 3. The part CI cannot do

None of the above stops the PR that disables the host, because that PR's own run is the one being skipped. `.github/CODEOWNERS` now owns `.github/workflows/` and `.github/CODEOWNERS` itself, making owner review the merge-time control. That closes the "merged without a reviewer catching it" step the original report listed as a required assumption for exploitation.

A test resolves the effective owners the way GitHub does, applying only the last matching rule, and asserts every workflow keeps an owner it could actually request review from. Delegating a workflow to another maintainer stays fine; leaving one unowned does not.

## Scope

CI only. The lint script runs from one Actions step and is not imported anywhere; nothing in Studio, Desktop, or the notebooks touches any file here. No user-facing behaviour changes, and the linter stays read-only, so reruns are no-ops.

## Verification

```
$ python3 -m pytest -q tests/security/test_lint_workflow_triggers.py
66 passed

$ python3 scripts/lint_workflow_triggers.py
OK: scanned 39 workflow file(s); no pull_request_target, no unjustified workflow_run, no PR/publish cache-key collision.
```

Every rule above was checked by mutating a copy of the live `.github/workflows/` tree and confirming rc=1, not only against synthetic fixtures. The `-c` claim was confirmed by running `python3 -c 'pass' scripts/lint_workflow_triggers.py` directly: rc=0, nothing scanned.

The test file is large for the size of the script. That is deliberate: most of it pins behaviour in BOTH directions, because two of the bugs found during review were the guard over-matching and failing valid CODEOWNERS changes, not under-matching. `test_lint_accepts_ordinary_invocations` and `test_codeowners_pattern_semantics` exist to stop the gate becoming a tax on unrelated work.

## Not covered

Uppercase extensions, since Actions only accepts lowercase. Proving an `if:` expression is always true, which needs a GitHub expression evaluator and would be worse wrong than absent. Validating owner handles against a maintainer list or the API, which needs network in a unit test or a list that fails on a new maintainer's first PR. GitHub already reports ineligible code owners itself.
