### PR TITLE
Studio: two ways past the stdio MCP UI-session gate

### DIFF
--- a/studio/backend/mcp_server.py
+++ b/studio/backend/mcp_server.py
@@ -170,7 +170,11 @@ def create_studio_mcp() -> FastMCP:
         from models.data_recipe import RecipePayload
         from routes.data_recipe.validate import validate
 
-        return _dump(validate(RecipePayload(recipe = recipe)))
+        # Direct call, so the ViaApiKey dependency never runs and its default
+        # would read as a UI session. This surface is a remote static bearer,
+        # so it may not validate a recipe carrying a stdio (local command)
+        # provider; say so explicitly.
+        return _dump(validate(RecipePayload(recipe = recipe), via_api_key = True))
 
     @mcp.tool
     def get_recipe_job_status(job_id: str) -> dict[str, Any]:

--- a/studio/backend/mcp_server.py
+++ b/studio/backend/mcp_server.py
@@ -170,10 +170,9 @@ def create_studio_mcp() -> FastMCP:
         from models.data_recipe import RecipePayload
         from routes.data_recipe.validate import validate
 
-        # Direct call, so the ViaApiKey dependency never runs and its default
-        # would read as a UI session. This surface is a remote static bearer,
-        # so it may not validate a recipe carrying a stdio (local command)
-        # provider; say so explicitly.
+        # Direct call, so the ViaApiKey dependency never runs and its `= False`
+        # default would read as a UI session. This surface is a remote static
+        # bearer, so say so explicitly.
         return _dump(validate(RecipePayload(recipe = recipe), via_api_key = True))
 
     @mcp.tool

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -137,12 +137,9 @@ async def list_mcp_servers(
 ):
     rows = mcp_servers_db.list_servers()
     if via_api_key:
-        # Both fields of a stdio row are secrets: `url` is the argv, which
-        # carries credentials often enough that we never log it raw, and
-        # `headers` is the subprocess env. A key that may not define a local
-        # command does not get to read one back. Drop the whole row rather than
-        # blank the fields, so a redacted url cannot round-trip into update as a
-        # bogus command.
+        # Drop the row, not just its fields: `url` is the argv (carries
+        # credentials), `headers` is the subprocess env, and a blanked url would
+        # round-trip into update as a bogus command.
         rows = [row for row in rows if not is_stdio(row["url"])]
     return [_row_to_response(row) for row in rows]
 

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -132,8 +132,20 @@ def _row_to_response(row: dict) -> McpServerResponse:
 
 
 @router.get("/", response_model = list[McpServerResponse])
-async def list_mcp_servers(current_subject: str = Depends(get_current_subject)):
-    return [_row_to_response(row) for row in mcp_servers_db.list_servers()]
+async def list_mcp_servers(
+    current_subject: str = Depends(get_current_subject),
+    via_api_key: ViaApiKey = False,
+):
+    rows = mcp_servers_db.list_servers()
+    if via_api_key:
+        # Both fields of a stdio row are secrets: `url` is the argv, which
+        # carries credentials often enough that we never log it raw, and
+        # `headers` is the subprocess env. A key that may not define a local
+        # command does not get to read one back. Drop the whole row rather than
+        # blank the fields, so a redacted url cannot round-trip into update as a
+        # bogus command.
+        rows = [row for row in rows if not is_stdio(row["url"])]
+    return [_row_to_response(row) for row in rows]
 
 
 @router.post("/", response_model = McpServerResponse, status_code = 201)

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -133,8 +133,7 @@ def _row_to_response(row: dict) -> McpServerResponse:
 
 @router.get("/", response_model = list[McpServerResponse])
 async def list_mcp_servers(
-    current_subject: str = Depends(get_current_subject),
-    via_api_key: ViaApiKey = False,
+    current_subject: str = Depends(get_current_subject), via_api_key: ViaApiKey = False
 ):
     rows = mcp_servers_db.list_servers()
     if via_api_key:

--- a/studio/backend/tests/test_mcp_stdio_api_key_gate.py
+++ b/studio/backend/tests/test_mcp_stdio_api_key_gate.py
@@ -421,10 +421,8 @@ def test_data_recipe_validate_refuses_stdio_recipe_from_api_key():
 
 
 def test_list_hides_stdio_rows_from_api_keys(tmp_path, monkeypatch, stdio_on):
-    """A key that may not define a command may not read one back either. Both
-    fields of a stdio row are secrets: `url` is the argv, which carries
-    credentials often enough that it is never logged raw, and `headers` is the
-    subprocess env."""
+    """A key that may not define a command may not read one back: `url` is the
+    argv (carries credentials) and `headers` is the subprocess env."""
     import routes.mcp_servers as routes_mcp
 
     _reset_db(tmp_path, monkeypatch)
@@ -469,8 +467,7 @@ def test_list_shows_stdio_rows_to_a_ui_session(tmp_path, monkeypatch, stdio_on):
 def test_studio_mcp_surface_refuses_stdio_recipes():
     """mcp_server.py calls the validate route function directly, so the ViaApiKey
     dependency never runs and its `= False` default would read as a UI session.
-    That surface is a remote static bearer, so the call site must pass True
-    itself; otherwise the gate is dead there."""
+    That remote static bearer surface must pass True itself or the gate is dead."""
     import inspect
 
     import mcp_server

--- a/studio/backend/tests/test_mcp_stdio_api_key_gate.py
+++ b/studio/backend/tests/test_mcp_stdio_api_key_gate.py
@@ -415,3 +415,66 @@ def test_data_recipe_validate_refuses_stdio_recipe_from_api_key():
     with pytest.raises(HTTPException) as exc:
         validate(payload, via_api_key = True)
     assert exc.value.status_code == 403
+
+
+# ── reading back a command the gate would not let a key define ──────
+
+
+def test_list_hides_stdio_rows_from_api_keys(tmp_path, monkeypatch, stdio_on):
+    """A key that may not define a command may not read one back either. Both
+    fields of a stdio row are secrets: `url` is the argv, which carries
+    credentials often enough that it is never logged raw, and `headers` is the
+    subprocess env."""
+    import routes.mcp_servers as routes_mcp
+
+    _reset_db(tmp_path, monkeypatch)
+    mcp_servers_db.create_server(
+        id = "stdio1",
+        display_name = "FS",
+        url = "npx server --token sk-argv-secret",
+        headers_json = '{"API_KEY": "sk-env-secret"}',
+    )
+    mcp_servers_db.create_server(
+        id = "http1",
+        display_name = "R",
+        url = "https://example.com/mcp",
+        headers_json = '{"Authorization": "Bearer t"}',
+    )
+
+    keyed = asyncio.run(routes_mcp.list_mcp_servers(current_subject = "u", via_api_key = True))
+    assert [row.id for row in keyed] == ["http1"]
+    serialized = repr([row.model_dump() for row in keyed])
+    assert "sk-argv-secret" not in serialized
+    assert "sk-env-secret" not in serialized
+    # http(s) MCP stays fully usable from a key, headers included.
+    assert keyed[0].headers == {"Authorization": "Bearer t"}
+
+
+def test_list_shows_stdio_rows_to_a_ui_session(tmp_path, monkeypatch, stdio_on):
+    import routes.mcp_servers as routes_mcp
+
+    _reset_db(tmp_path, monkeypatch)
+    mcp_servers_db.create_server(
+        id = "stdio1",
+        display_name = "FS",
+        url = "npx server --token sk-argv-secret",
+        headers_json = '{"API_KEY": "sk-env-secret"}',
+    )
+    rows = asyncio.run(routes_mcp.list_mcp_servers(current_subject = "u", via_api_key = False))
+    assert [row.id for row in rows] == ["stdio1"]
+    assert rows[0].url == "npx server --token sk-argv-secret"
+    assert rows[0].headers == {"API_KEY": "sk-env-secret"}
+
+
+def test_studio_mcp_surface_refuses_stdio_recipes():
+    """mcp_server.py calls the validate route function directly, so the ViaApiKey
+    dependency never runs and its `= False` default would read as a UI session.
+    That surface is a remote static bearer, so the call site must pass True
+    itself; otherwise the gate is dead there."""
+    import inspect
+
+    import mcp_server
+
+    assert "validate(RecipePayload(recipe = recipe), via_api_key = True)" in inspect.getsource(
+        mcp_server
+    )


### PR DESCRIPTION
A stdio MCP server is a local command. The MCP client parses the stored address into argv and hands it to FastMCP's `StdioTransport`, which starts the process as the backend user, outside the tool sandbox. That is the intended feature for someone sitting at their own machine, and this PR keeps it that way: a loopback bind still defaults it on, so the MCP Servers dialog works with no env var, exactly as before.

What was not intended is the credential that could reach it.

## The problem

Every route in `routes/mcp_servers.py` depends only on `get_current_subject`, which accepts an `sk-unsloth` API key as readily as the UI's session JWT. That key is the remote, long-lived, exportable one. We hand it out for programmatic access and for Cloudflare remote access, and the README says so plainly:

> anyone with the link and API key can use it and run code: keep your API key private

So a leaked inference key could `POST /api/mcp/servers/test` with a command in the `url` field and have it spawned on the spot, with no storage round trip:

```
Authorization: Bearer sk-unsloth-...
{"url": "/bin/sh -c '<anything>'"}
```

Sandboxed tool execution and arbitrary local process execution are different grants, and only the first one was ever offered.

`POST /api/data-recipe/mcp/tools` was the same hole in a cleaner form: `command`, `args` and `env` come straight from the request body and are spawned immediately.

## The fix

Gate the command paths on an interactive UI session, reusing `require_ui_session` from `routes/provider_credentials.py` rather than inventing a mechanism.

- `create`, `update`, `import`, `test` and `refresh` now take `authenticated_via_api_key` and run a new `_guard_stdio`. The guard fires **only when the address is a stdio command**. An `http(s)` MCP server is data rather than code, so managing one stays open to API keys.
- `update` keys off the resulting address **or the stored row**, not just the payload. Editing a stdio row is privileged even when no url is sent, since it can re-enable the row or rewrite the env the subprocess is handed.
- `import` applies the guard per entry, inside the existing per-entry error handling, so an API key's http entries still import instead of the whole batch failing.
- The guard runs **after** `_validate_url`, so a host with stdio disabled keeps answering 400 rather than 403. The response does not reveal whether the gate is open.
- `/api/data-recipe/mcp/tools` gets the same rule, reported per provider so http providers in the same request still list.
- `delete` and `list` are deliberately left open. One de-privileges, the other is read-only, and gating delete would strand rows for API-only clients.

Each registration or probe now writes one audit line carrying `stdio_log_id` (executable basename plus a short digest), never the raw address, the argv or the headers. Argv routinely carries credentials, and for a stdio row `headers_json` is the subprocess environment. `_stdio_log_id` loses its underscore so the routes can share that redaction.

## What deliberately did not change

The loopback auto-default stays. Removing it would have meant every local Studio and Desktop user had to set an environment variable and restart before adding an MCP server, which fixes the hole by breaking the feature.

No frontend change. The MCP Servers dialog and the desktop app both authenticate with a session JWT, so a local user adding `npx -y @modelcontextprotocol/server-filesystem /tmp` sees no difference: same field, same Test connection button, no env var, no new prompt.

No other caller is affected. The CLI, the Tauri Rust side and the Colab notebook never call these routes, and the internal keys minted by Deep Research and data recipe jobs only ever reach `/v1`.

The chat path is untouched. An API key can still invoke stdio MCP tools that a UI session already registered, which is the documented "Studio as an API server with my tools" flow. `--disable-tools` and `enabled_tools` remain the lever there.

Nothing here is stateful: no new setting, no schema change, no migration, so re-running is a no-op.

## Tests

291 pass across the MCP, tool policy and provider suites. New coverage:

- 403 with **no spawn** for an API key on create, test, refresh, and a rename-only edit of a stdio row
- a mixed import creating the http entry and reporting the stdio one, without failing the batch
- the 400-not-403 ordering guard on a stdio-disabled host
- delete of a stdio row still allowed, documenting the carve-out
- `test_http_management_still_open_to_api_keys`: create, update, test and refresh on `https://x/mcp` all still succeed with an API key
- a log hygiene test asserting a token in argv and the values in the env never reach the record

Route handlers are called directly in tests, so an omitted `via_api_key` receives the `Depends` sentinel, which is truthy and fails closed. Existing stdio call sites now pass `via_api_key = False`.
