### PR TITLE
Drop the duplicate HubModelPicker import in model-selector

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -50,7 +50,6 @@ import {
 } from "./model-selector/missing-external-model";
 import type { CommunityModelPolicy } from "./model-selector/audio-picker-policy";
 import type { CatalogGroup } from "./model-selector/model-catalog";
-import { HubModelPicker, hasDownloadedModels } from "./model-selector/pickers";
 import { PillTabs } from "./model-selector/pill-tabs";
 import { isFineTunedSource } from "./model-selector/source-tabs";
 import type {


### PR DESCRIPTION
#8470 left a second, byte identical import in `studio/frontend/src/features/model-picker/components/model-selector.tsx`:

```
46: import { HubModelPicker, hasDownloadedModels } from "./model-selector/pickers";
53: import { HubModelPicker, hasDownloadedModels } from "./model-selector/pickers";
```

TypeScript rejects that with `TS2300: Duplicate identifier 'HubModelPicker'` (and the same for `hasDownloadedModels`), so `npm run build` exits 2 and `studio setup` exits 2 with it. It fails on `main` and on every branch cut from `main`, which takes down the installer jobs that run studio setup: `Install + load (macos-26)`, `Install + load (macos-26-intel)`, `linux ubuntu2404-arm-root`, `mac macos-26 / mask / file` and `win windows-11-arm / winget=visible`.

This removes the duplicate line and nothing else. The two lines were identical, so the remaining import at line 46 keeps the same bindings and ordering.
