### PR TITLE
Studio: drop a duplicate import that breaks the frontend build

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -43,7 +43,6 @@ import {
   resolveInitialConfig,
 } from "../model-config/per-model-config";
 import { ModelConfigPage } from "./model-config-page";
-import { HubModelPicker, hasDownloadedModels } from "./model-selector/pickers";
 import {
   type ExternalConnectionRef,
   missingExternalModel,


### PR DESCRIPTION
## Problem

`model-selector.tsx` imports `HubModelPicker` and `hasDownloadedModels` from `./model-selector/pickers` twice, at line 46 and line 53. `tsc` rejects that:

```
src/features/model-picker/components/model-selector.tsx(46,10): error TS2300: Duplicate identifier 'HubModelPicker'.
src/features/model-picker/components/model-selector.tsx(46,26): error TS2300: Duplicate identifier 'hasDownloadedModels'.
src/features/model-picker/components/model-selector.tsx(53,10): error TS2300: Duplicate identifier 'HubModelPicker'.
src/features/model-picker/components/model-selector.tsx(53,26): error TS2300: Duplicate identifier 'hasDownloadedModels'.
```

The vite build exits 2, which currently fails three jobs on every PR:

- `Tauri Linux debug build (no codesign)`, at the `Frontend build (npm ci, vite)` step
- `linux ubuntu2404-arm-root`, at `Install (root)`
- `mac macos-26 / mask / file`, at `Install`

The two install jobs run `studio setup`, which runs the same `npm run build`, so all three are the one error:

```
error          npm run build failed (exit code 2)
error          studio setup failed (exit code 2)
```

Introduced by #8470, which added the second copy above the `pill-tabs` import while the first was already sitting above the `missing-external-model` import.

## Fix

Remove the stray copy at line 46 and keep the one at line 53, which is already in alphabetical order inside the `./model-selector/` import group (`audio-picker-policy`, `model-catalog`, `pickers`, `pill-tabs`, `source-tabs`).

One line deleted, no behavior change. Both symbols are still imported once and both call sites (`hasDownloadedModels()` and `<HubModelPicker>`) resolve unchanged.
