### PR TITLE
Studio: finish the backend CI cleanup #8506 started

### DIFF
--- a/studio/backend/core/inference/stt_sidecar.py
+++ b/studio/backend/core/inference/stt_sidecar.py
@@ -928,8 +928,15 @@ def _training_active() -> bool:
         return False
 
 
-def _clear_device_cache(device: Optional[str]) -> None:
-    gc.collect()
+def _clear_device_cache(device: Optional[str], collect: bool = True) -> None:
+    """Drop the unreferenced model, then hand its blocks back to the allocator.
+
+    ``collect = False`` for a caller that has just collected and dropped nothing since: a full
+    collection is not free (a long-lived backend reaches millions of tracked objects, where one
+    pass costs about a second), and the cancel path below runs this twice in a row while it
+    holds the model lock that ``wait_for_load_to_settle`` waits on."""
+    if collect:
+        gc.collect()
     try:
         import torch
         if device == "cuda":
@@ -1347,8 +1354,14 @@ class WhisperSttSidecar:
             except SttLoadCancelledError:
                 candidate = None
                 if resident_released:
+                    # _release_engine_locked already collected, and the candidate was dropped
+                    # before it ran, so nothing has become garbage since. This second call is
+                    # only here to empty the cache of the device this LOAD picked, which need
+                    # not be the resident's, so it keeps the sweep and skips the collection.
                     self._release_engine_locked()
-                _clear_device_cache(device)
+                    _clear_device_cache(device, collect = False)
+                else:
+                    _clear_device_cache(device)
                 raise
             finally:
                 self._end_load(cancel_event)

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -860,3 +860,38 @@ def healthy_diffusers(monkeypatch):
         if _real is not None and hasattr(_real, attr):
             setattr(proxy, attr, getattr(_real, attr))
     monkeypatch.setitem(sys.modules, "diffusers", proxy)
+
+
+@pytest.fixture
+def real_prequant_safe_globals(monkeypatch):
+    """Stand in for the allowlist entries this host cannot import, and hand back the real resolver.
+
+    The file header promises these tests run without torchao, and the Backend CI image keeps that
+    promise literally: it installs torch and transformers and no torchao at all. Production then
+    resolves not one entry of ``_PREQUANT_SAFE_GLOBALS``, the registration floor ("TorchVersion
+    plus at least one real torchao class") is not met, every load refuses, and 19 tests in here
+    fail on ``assert None is not None`` -- saying nothing whatever about the loader they are
+    about. ``test_diffusion_convrot.py`` loads through the same registration and needs it too,
+    which is why this lives here rather than in one of the two files. The tests also swap ``sys.modules["torch"]`` for a bare module while a load runs, so
+    even ``torch.torch_version`` is unimportable at that moment, torchao or no torchao.
+
+    Standing in only for the names that did NOT resolve keeps a host that has torchao testing the
+    real classes. Which names a given release actually ships is asked separately, by
+    ``test_the_registration_floor_needs_a_real_torchao``, which skips rather than pretends -- and
+    ``test_the_registration_refuses_when_nothing_resolves`` pins the refusal itself, so the gate
+    that the CI image trips is still under test rather than merely worked around.
+    """
+    import core.inference.diffusion_prequant as pq
+
+    resolver = pq._prequant_safe_globals
+    resolved = {name: obj for obj, name in resolver()}
+    pairs = [
+        (resolved.get(f"{module}.{name}") or type(name, (), {}), f"{module}.{name}")
+        for module, name in pq._PREQUANT_SAFE_GLOBALS
+    ]
+    monkeypatch.setattr(pq, "_prequant_safe_globals", lambda: pairs)
+    # Per test rather than per process: the memo is a module global, so one test's registration
+    # would otherwise decide the answer for every test that ran after it.
+    monkeypatch.setattr(pq, "_SAFE_GLOBALS_REGISTERED", None)
+    monkeypatch.setattr(pq, "_RESOLVED_SAFE_GLOBALS", set())
+    return resolver

--- a/studio/backend/tests/test_diffusion_convrot.py
+++ b/studio/backend/tests/test_diffusion_convrot.py
@@ -50,6 +50,7 @@ def _pin_prequant_safe_globals(real_prequant_safe_globals):
     """Apply the shared stand-in allowlist (see conftest) to every test in this module."""
     return real_prequant_safe_globals
 
+
 GROUP = 16  # a power of 4, small enough to keep the test model tiny
 
 

--- a/studio/backend/tests/test_diffusion_convrot.py
+++ b/studio/backend/tests/test_diffusion_convrot.py
@@ -44,6 +44,12 @@ from core.inference.diffusion_convrot import (  # noqa: E402
     rotation_metadata_error,
 )
 
+
+@pytest.fixture(autouse = True)
+def _pin_prequant_safe_globals(real_prequant_safe_globals):
+    """Apply the shared stand-in allowlist (see conftest) to every test in this module."""
+    return real_prequant_safe_globals
+
 GROUP = 16  # a power of 4, small enough to keep the test model tiny
 
 

--- a/studio/backend/tests/test_diffusion_prequant.py
+++ b/studio/backend/tests/test_diffusion_prequant.py
@@ -29,35 +29,9 @@ from core.inference.diffusion_prequant import (
 
 
 @pytest.fixture(autouse = True)
-def real_prequant_safe_globals(monkeypatch):
-    """Stand in for the allowlist entries this host cannot import, and hand back the real resolver.
-
-    The file header promises these tests run without torchao, and the Backend CI image keeps that
-    promise literally: it installs torch and transformers and no torchao at all. Production then
-    resolves not one entry of ``_PREQUANT_SAFE_GLOBALS``, the registration floor ("TorchVersion
-    plus at least one real torchao class") is not met, every load refuses, and 19 tests in here
-    fail on ``assert None is not None`` -- saying nothing whatever about the loader they are
-    about. The tests also swap ``sys.modules["torch"]`` for a bare module while a load runs, so
-    even ``torch.torch_version`` is unimportable at that moment, torchao or no torchao.
-
-    Standing in only for the names that did NOT resolve keeps a host that has torchao testing the
-    real classes. Which names a given release actually ships is asked separately, by
-    ``test_the_registration_floor_needs_a_real_torchao``, which skips rather than pretends -- and
-    ``test_the_registration_refuses_when_nothing_resolves`` pins the refusal itself, so the gate
-    that the CI image trips is still under test rather than merely worked around.
-    """
-    resolver = pq._prequant_safe_globals
-    resolved = {name: obj for obj, name in resolver()}
-    pairs = [
-        (resolved.get(f"{module}.{name}") or type(name, (), {}), f"{module}.{name}")
-        for module, name in pq._PREQUANT_SAFE_GLOBALS
-    ]
-    monkeypatch.setattr(pq, "_prequant_safe_globals", lambda: pairs)
-    # Per test rather than per process: the memo is a module global, so one test's registration
-    # would otherwise decide the answer for every test that ran after it.
-    monkeypatch.setattr(pq, "_SAFE_GLOBALS_REGISTERED", None)
-    monkeypatch.setattr(pq, "_RESOLVED_SAFE_GLOBALS", set())
-    return resolver
+def _pin_prequant_safe_globals(real_prequant_safe_globals):
+    """Apply the shared stand-in allowlist (see conftest) to every test in this module."""
+    return real_prequant_safe_globals
 
 
 # ── resolve_prequant_source ──────────────────────────────────────────────────────

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1308,8 +1308,11 @@ def test_a_cancelled_send_is_only_discarded_once(monkeypatch):
     real_discard = research_runs.ResearchSupervisor._discard_task
 
     async def _counting_discard(self, run_id, task, what):
-        discards.append(what)
-        return await real_discard(self, run_id, task, what)
+        started = time.monotonic()
+        try:
+            return await real_discard(self, run_id, task, what)
+        finally:
+            discards.append((what, time.monotonic() - started))
 
     monkeypatch.setattr(research_runs.ResearchSupervisor, "_discard_task", _counting_discard)
 
@@ -1345,12 +1348,15 @@ def test_a_cancelled_send_is_only_discarded_once(monkeypatch):
 
     supervisor._check_active = _cancelled
 
-    started = time.monotonic()
     with pytest.raises(research_runs.RunCancelled):
         asyncio.run(supervisor._stream_completion(run, [{"role": "user"}], report_progress = False))
-    elapsed = time.monotonic() - started
-    assert [w for w in discards if w == "send"] == ["send"], f"discards: {discards}"
-    assert elapsed < 1.0, f"cancellation took {elapsed:.2f}s, more than one cleanup bound"
+    assert [w for w, _ in discards if w == "send"] == ["send"], f"discards: {discards}"
+    # Measured over the cleanup itself rather than over the test's wall clock. The bound is a
+    # TIMER, so a second one shows up as time spent waiting; everything before the cancellation
+    # is fixed setup that has nothing to do with this guarantee, and on a shared two-core runner
+    # that setup alone reached 0.9s and failed the old whole-test budget on machine speed.
+    waited = sum(seconds for _w, seconds in discards)
+    assert waited < 2 * research_runs._STREAM_CLEANUP_TIMEOUT_SECONDS, f"discards: {discards}"
 
 
 def test_a_cancelled_stream_iterator_is_only_discarded_once(monkeypatch):
@@ -1364,8 +1370,11 @@ def test_a_cancelled_stream_iterator_is_only_discarded_once(monkeypatch):
     real_discard = research_runs.ResearchSupervisor._discard_task
 
     async def _counting_discard(self, run_id, task, what):
-        discards.append(what)
-        return await real_discard(self, run_id, task, what)
+        started = time.monotonic()
+        try:
+            return await real_discard(self, run_id, task, what)
+        finally:
+            discards.append((what, time.monotonic() - started))
 
     monkeypatch.setattr(research_runs.ResearchSupervisor, "_discard_task", _counting_discard)
 
@@ -1400,13 +1409,13 @@ def test_a_cancelled_stream_iterator_is_only_discarded_once(monkeypatch):
 
     supervisor._check_active = _cancelled
 
-    started = time.monotonic()
     with pytest.raises(research_runs.RunCancelled):
         asyncio.run(supervisor._stream_completion(run, [{"role": "user"}], report_progress = False))
-    elapsed = time.monotonic() - started
-    iterator_discards = [w for w in discards if w == "stream_iterator"]
+    iterator_discards = [w for w, _ in discards if w == "stream_iterator"]
     assert len(iterator_discards) == 1, f"discarded {len(iterator_discards)} times: {discards}"
-    assert elapsed < 1.0, f"cancellation took {elapsed:.2f}s, more than one cleanup bound"
+    # The time spent WAITING on cleanup, not the test's wall clock: see the send-side test above.
+    waited = sum(seconds for _w, seconds in discards)
+    assert waited < 2 * research_runs._STREAM_CLEANUP_TIMEOUT_SECONDS, f"discards: {discards}"
 
 
 def test_stream_completion_first_output_timeout_survives_iterator_cleanup(monkeypatch):

--- a/studio/backend/tests/test_stt_sidecar.py
+++ b/studio/backend/tests/test_stt_sidecar.py
@@ -775,6 +775,14 @@ def test_accelerator_load_failure_retries_on_cpu(monkeypatch):
 
 
 def test_pending_load_can_be_cancelled_without_waiting_for_model_lock(monkeypatch):
+    # The bound that carries the contract is the CANCEL thread's: it must come back while the
+    # build still holds the model lock, so two seconds against an indefinite wait is the whole
+    # question. The other waits below are liveness only -- they say "this must happen", and the
+    # assertion after each is what fails if it does not. Two seconds there was a budget on
+    # runner speed instead: after the build is released the load thread still has to be
+    # scheduled and run the cancel path's two full gc.collect()s, which a loaded two-core CI
+    # runner did not finish inside it.
+    settle = 30.0
     _install_fake_torch(monkeypatch)
     sidecar = WhisperSttSidecar(keep_alive_seconds = 0)
     build_started = threading.Event()
@@ -783,7 +791,7 @@ def test_pending_load_can_be_cancelled_without_waiting_for_model_lock(monkeypatc
 
     def build(_repo, _device, _dtype, _cancel_event):
         build_started.set()
-        assert release_build.wait(timeout = 2)
+        assert release_build.wait(timeout = settle)
         return object(), object()
 
     def run_load():
@@ -798,19 +806,19 @@ def test_pending_load_can_be_cancelled_without_waiting_for_model_lock(monkeypatc
 
     load_thread = threading.Thread(target = run_load)
     load_thread.start()
-    assert build_started.wait(timeout = 2)
+    assert build_started.wait(timeout = settle)
 
     result = []
     cancel_thread = threading.Thread(target = lambda: result.append(sidecar.cancel_pending_load()))
     cancel_thread.start()
-    cancel_thread.join(timeout = 2)
+    cancel_thread.join(timeout = 2)  # the contract: back while the build still holds the lock
 
     assert not cancel_thread.is_alive()
     assert result == [True]
     assert load_thread.is_alive()
 
     release_build.set()
-    load_thread.join(timeout = 2)
+    load_thread.join(timeout = settle)
 
     assert not load_thread.is_alive()
     assert len(errors) == 1


### PR DESCRIPTION
Follow-up to #8506, which cleared most of the Backend CI reds. Two things it left.

## test_diffusion_convrot.py was on the same footing as the pre-quant tests

#8506 diagnosed this exactly right: the Backend tests job installs torch and transformers and no torchao, so `_register_prequant_safe_globals` never meets its floor, every load refuses, and the assertions land on the refusal instead of the loader. It fixed `test_diffusion_prequant.py` with an autouse stand-in fixture.

`test_diffusion_convrot.py` loads through the same registration (`_load_rotated` -> `pq`) and did not get the fixture, so two of its tests still fail on a runner without torchao:

```
FAILED tests/test_diffusion_convrot.py::test_loader_installs_the_rotation_the_checkpoint_records
FAILED tests/test_diffusion_convrot.py::test_loader_leaves_a_plain_checkpoint_alone
```

Rather than copy a 25-line fixture into a second file and let the two drift, the fixture moves to `tests/conftest.py` without `autouse`, and each of the two modules opts in with a one-line autouse alias. Every existing use of `real_prequant_safe_globals` as a named parameter keeps working, and nothing else in the suite picks it up.

## The STT cancel timeout is a real 2 second cliff, not a flake

#8506 saw `test_pending_load_can_be_cancelled_without_waiting_for_model_lock` fail in the same run, could not reproduce it, and set it aside. There is a mechanism.

The cancel path ran two full `gc.collect()` passes back to back while holding the model lock that `wait_for_load_to_settle` waits on:

```python
if resident_released:
    self._release_engine_locked()   # collects
_clear_device_cache(device)         # collects again
```

A whole-suite session ends around 2.7M tracked objects, where a single pass costs about a second, so the load thread's `join(timeout = 2)` sits right on the edge. Reproduced by inflating the heap: two collects of 1.9s and 1.6s, failing at the same line, passing below the cliff.

`_release_engine_locked` already collects, and `candidate` is dropped before it runs, so nothing has become garbage in between. The second call keeps its cache sweep, because the device this load picked need not be the resident's, and skips the collection. The branch where no resident was released is unchanged.

Also here: `test_research_runs_hardening.py` timed the whole test rather than the cleanup, so it measured runner speed. It now asserts on the sum of the discard waits, which is what "one cleanup bound, not two" actually means.

## Verification

The CI condition is torchao being absent, which this host does not reproduce on its own (torchao is installed but only partly importable). Blocking it with a `ModuleNotFoundError`-raising `meta_path` finder reproduces the failures exactly.

| | torchao blocked | torchao present |
| --- | --- | --- |
| before | 2 failed, 123 passed, 1 skipped | 125 passed, 1 pre-existing failure |
| after | 125 passed, 1 skipped | 125 passed, 1 pre-existing failure |

The pre-existing failure in the right-hand column is `test_the_registration_floor_needs_a_real_torchao`, which fails on `main` on this host for the same reason and is not touched here.

Affected suites together, torchao blocked: 328 passed, 7 skipped, 1 failed. The one failure is `test_decoding_stops_as_soon_as_the_request_is_cancelled`, which needs PyAV and fails identically on `main` here.

The research and STT changes rest on measured mechanism rather than a red-to-green flip I could run locally, since neither failure reproduces on this machine. The research change removes the dependency on runner speed entirely; the STT change removes the 2 second cliff and halves the stall behind it.
