### PR TITLE
Studio: stop telling the model it is sandboxed under Full access

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8909,6 +8909,16 @@ WEB_SEARCH_TOOL = {
 }
 
 
+# Without this a model assumes its output vanished into a scratch dir and says
+# so, which reads as "the file was not really created". Shared by the sandboxed
+# and Full access notes: the workdir is the per-session dir in both modes.
+_CREATED_FILES_NOTE = (
+    " Any file you create here is kept and shown to the user with a download "
+    "link, so name the files you created in your reply -- by file name only, "
+    "since you do not know their absolute path."
+)
+
+
 def _build_sandbox_paths_note() -> str:
     """Platform and working-directory note, on BOTH tool descriptions.
 
@@ -8919,23 +8929,40 @@ def _build_sandbox_paths_note() -> str:
     instead: without it a model assumes the pipe is its only output and declines
     to open a window it believes nobody can see.
     """
-    # Without this a model assumes its output vanished into a scratch dir and
-    # says so, which reads as "the file was not really created".
-    created = (
-        " Any file you create here is kept and shown to the user with a download "
-        "link, so name the files you created in your reply -- by file name only, "
-        "since you do not know their absolute path."
-    )
     if sys.platform != "win32":
         return (
             " Read and write files using relative paths in the current working "
             "directory, which persists for this conversation; absolute paths like "
-            "/mnt/data or /tmp/outputs do not exist." + created
+            "/mnt/data or /tmp/outputs do not exist." + _CREATED_FILES_NOTE
         )
     return (
         " You are on Windows, and this runs on the user's own machine. Read and "
         "write files using relative paths in the current working directory, which "
-        "persists for this conversation." + created
+        "persists for this conversation." + _CREATED_FILES_NOTE
+    )
+
+
+def _build_full_access_paths_note() -> str:
+    """The same note for Full access (permission_mode='full'), where the
+    sandbox is genuinely off.
+
+    _build_sandbox_paths_note describes the sandboxed run, and every claim in it
+    is false under Full access: _build_bypass_env/_bypass_preexec skip the
+    static analysis, the command blocklist and the rlimits, so absolute paths do
+    resolve and the host filesystem is reachable. Handing the sandboxed text to
+    a model in that mode makes it answer "I am sandboxed and cannot see your
+    files" to a question it could have answered with one tool call, so the
+    working-directory advice stays (the workdir really is still the per-session
+    dir) and the isolation claim goes.
+    """
+    platform_note = " You are on Windows." if sys.platform == "win32" else ""
+    return (
+        " The code sandbox is disabled for this conversation and this runs "
+        "directly on the user's own machine, so absolute paths do resolve and "
+        "you can read and write anywhere that account can."
+        + platform_note
+        + " Relative paths still resolve in a working directory that persists "
+        "for this conversation." + _CREATED_FILES_NOTE
     )
 
 
@@ -8966,6 +8993,7 @@ def _build_terminal_shell_note() -> str:
 
 
 _SANDBOX_PATHS_NOTE = _build_sandbox_paths_note()
+_FULL_ACCESS_PATHS_NOTE = _build_full_access_paths_note()
 _TERMINAL_SHELL_NOTE = _build_terminal_shell_note()
 
 PYTHON_TOOL = {
@@ -9006,6 +9034,59 @@ TERMINAL_TOOL = {
         },
     },
 }
+
+# Full access (permission_mode='full') runs these two without the sandbox, so it
+# gets its own pair of schemas rather than a per-request rebuild: the notes are
+# platform-derived constants, and the sandboxed pair stays the module default so
+# every existing importer keeps the safe wording.
+PYTHON_TOOL_FULL_ACCESS = {
+    "type": "function",
+    "function": {
+        **PYTHON_TOOL["function"],
+        "description": "Execute Python code on the user's own machine and return stdout/stderr."
+        + _FULL_ACCESS_PATHS_NOTE,
+    },
+}
+
+TERMINAL_TOOL_FULL_ACCESS = {
+    "type": "function",
+    "function": {
+        **TERMINAL_TOOL["function"],
+        "description": "Execute a terminal command on the user's own machine and return stdout/stderr."
+        + _FULL_ACCESS_PATHS_NOTE
+        + _TERMINAL_SHELL_NOTE,
+    },
+}
+
+_FULL_ACCESS_TOOL_BY_NAME = {
+    "python": PYTHON_TOOL_FULL_ACCESS,
+    "terminal": TERMINAL_TOOL_FULL_ACCESS,
+}
+
+
+def apply_full_access_tool_descriptions(tools: list[dict]) -> list[dict]:
+    """Swap python/terminal for their Full access schemas.
+
+    Only the two sandboxed built-ins are touched; web_search, render_html,
+    search_knowledge_base and MCP tools are passed through untouched, and a list
+    without either built-in is returned as-is so callers can apply this
+    unconditionally. The input list is never mutated -- ALL_TOOLS entries are
+    module globals shared across requests.
+    """
+    if not tools:
+        return tools
+    swapped = False
+    out: list[dict] = []
+    for tool in tools:
+        name = (tool.get("function") or {}).get("name") if isinstance(tool, dict) else None
+        replacement = _FULL_ACCESS_TOOL_BY_NAME.get(name)
+        if replacement is None:
+            out.append(tool)
+        else:
+            out.append(replacement)
+            swapped = True
+    return out if swapped else tools
+
 
 RENDER_HTML_TOOL = {
     "type": "function",

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8974,39 +8974,29 @@ _FULL_ACCESS_SUBSTITUTIONS = (
 
 
 # What "the sandbox is off" actually means for paths, per tool. Shared by both
-# platform substitutions, because the split is the shim, not the OS.
+# platform substitutions: the split is the shim, not the OS. _build_bypass_env
+# keeps _SANDBOX_SITE_DIR on PYTHONPATH for BOTH tools, so sitecustomize.py still
+# loads, and being a CPython startup hook is what separates them. Measured:
 #
-# _build_bypass_env keeps _SANDBOX_SITE_DIR on PYTHONPATH, so sitecustomize.py
-# still loads. It is a CPython startup hook, which is what splits the two tools.
-# Measured against it:
-#
-#   python, parent exists   -> writes the real absolute path
-#   python, absent convention prefix -> _remap keeps the SUFFIX relative to the
-#                              workdir (/mnt/data/reports/out.csv -> ./reports/
-#                              out.csv) and returns before the generic fallback,
-#                              so no basename collapse and no anti-clobber: an
-#                              existing ./out.csv is overwritten
-#   python, any other missing parent -> the generic fallback keeps only the base
-#                              name, and declines (open raises) when that name is
-#                              already taken in the workdir by an UNRELATED file.
-#                              The .unsloth_sandbox_remap.json sidecar carries the
-#                              healed mapping across calls, so rewriting the same
-#                              invented path re-serves its own target instead
-#   python, prefix present  -> a real /mnt/data mount is never shadowed, so a
-#                              prefix is only special while it is absent
-#   python, unpatched API   -> only open/io.open/os.open and the mkdir family are
-#                              wrapped, so os.rename / os.symlink raise instead;
-#                              shutil.copy is the awkward middle, writing the
-#                              rewritten file through open and then raising in
-#                              copymode against the path it was handed
-#   terminal, plain shell   -> no shim, so the shell's own rules
-#   terminal, launching python -> _build_bypass_env sets PYTHONPATH for the
-#                              terminal subprocess too, so that Python is patched
-#                              exactly like the python tool
-#
-# Hence no categorical claim about /mnt/data in either: on a host where it is a
-# real mount, Full access can read and write it like any other directory, and
-# the general parent-directory rule already covers it when it is absent.
+#   python, parent exists    -> writes the real absolute path
+#   python, absent prefix    -> _remap keeps the SUFFIX under the workdir
+#                               (/mnt/data/reports/out.csv -> ./reports/out.csv)
+#                               and returns before the generic fallback, so no
+#                               basename collapse and no anti-clobber
+#   python, other missing parent -> the fallback keeps only the base name, and
+#                               raises when an UNRELATED file holds it; the
+#                               .unsloth_sandbox_remap.json sidecar lets a rewrite
+#                               of the same invented path re-serve its own target
+#   python, prefix present   -> a real /mnt/data mount is never shadowed, so a
+#                               prefix is special only while absent, which is why
+#                               the clause names one inside a conditional and
+#                               never categorically
+#   python, unpatched API    -> only open/io.open/os.open and the mkdir family are
+#                               wrapped: os.rename and os.symlink raise, while
+#                               shutil.copy writes the rewritten file through open
+#                               and then raises in copymode
+#   terminal                 -> the shell's own rules, except for Python it
+#                               launches, which is patched like the python tool
 _FULL_ACCESS_CLAUSE = {
     "python": (
         " The code sandbox is disabled, so absolute paths under a directory that "
@@ -9017,12 +9007,11 @@ _FULL_ACCESS_CLAUSE = {
         "already sitting there; under any other missing directory only the base "
         "name is kept, and the write fails outright if that name is taken by an "
         "unrelated file, though rewriting the same absolute path just replaces "
-        "what your own earlier call left there. Both "
-        "reach only open() and the mkdir calls, so os.rename, os.symlink and the "
-        "like are never rewritten and simply fail, and a helper such as "
-        "shutil.copy can write the rewritten file and still raise on a later "
-        "step. Report where a file actually landed rather than the path you asked "
-        "for."
+        "what your own earlier call left there. Both reach only open() and the "
+        "mkdir calls, so os.rename, os.symlink and the like are never rewritten "
+        "and simply fail, and a helper such as shutil.copy can write the "
+        "rewritten file and still raise on a later step. Report where a file "
+        "actually landed rather than the path you asked for."
     ),
     "terminal": (
         " The code sandbox is disabled, so absolute paths do resolve as the shell "

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8988,7 +8988,10 @@ _FULL_ACCESS_SUBSTITUTIONS = (
 #                              existing ./out.csv is overwritten
 #   python, any other missing parent -> the generic fallback keeps only the base
 #                              name, and declines (open raises) when that name is
-#                              already taken in the workdir
+#                              already taken in the workdir by an UNRELATED file.
+#                              The .unsloth_sandbox_remap.json sidecar carries the
+#                              healed mapping across calls, so rewriting the same
+#                              invented path re-serves its own target instead
 #   python, prefix present  -> a real /mnt/data mount is never shadowed, so a
 #                              prefix is only special while it is absent
 #   python, unpatched API   -> only open/io.open/os.open and the mkdir family are
@@ -9012,7 +9015,9 @@ _FULL_ACCESS_CLAUSE = {
         "/mnt/outputs, /tmp/outputs, /home/sandbox, /workspace) the rest of the "
         "path is kept relative to the working directory, replacing any file "
         "already sitting there; under any other missing directory only the base "
-        "name is kept, and the write fails outright if that name is taken. Both "
+        "name is kept, and the write fails outright if that name is taken by an "
+        "unrelated file, though rewriting the same absolute path just replaces "
+        "what your own earlier call left there. Both "
         "reach only open() and the mkdir calls, so os.rename, os.symlink and the "
         "like are never rewritten and simply fail, and a helper such as "
         "shutil.copy can write the rewritten file and still raise on a later "

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8956,7 +8956,8 @@ _FULL_ACCESS_SUBSTITUTIONS = (
     # here; Windows already has one.
     (
         "; absolute paths like /mnt/data or /tmp/outputs do not exist.",
-        ". This runs on the machine running Unsloth Studio.{clause}",
+        ". This runs wherever Unsloth Studio is running, which may be a remote host "
+        "or a container with only some paths mounted.{clause}",
     ),
     # Windows already says where the code runs and never denies absolute paths,
     # so there is nothing false to remove; state the capability instead. "the
@@ -8965,7 +8966,9 @@ _FULL_ACCESS_SUBSTITUTIONS = (
     # Studio, which is then not the device the user is looking at.
     (
         " You are on Windows, and this runs on the user's own machine.",
-        " You are on Windows, and this runs on the machine running Unsloth Studio.{clause}",
+        " You are on Windows, and this runs wherever Unsloth Studio is running, "
+        "which may be a remote host or a container with only some paths "
+        "mounted.{clause}",
     ),
 )
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8952,19 +8952,9 @@ _FULL_ACCESS_SUBSTITUTIONS = (
     # below, which both tools carry.
     ("Execute Python code in a sandbox and", "Execute Python code and"),
     # POSIX: real absolute paths DO resolve with the sandbox off, so a blanket
-    # denial is wrong. The two named conventions stay denied, because they are
-    # still handled specially: _build_bypass_env keeps _SANDBOX_SITE_DIR on
-    # PYTHONPATH, so sandbox_site/sitecustomize.py goes on healing an absent
-    # /mnt/data or /tmp/outputs onto the workdir in bypass runs too. Promising
-    # that every absolute path resolves would make the model report a write to
-    # /mnt/data that actually landed in the working directory. The tail differs
-    # per tool, see _FULL_ACCESS_ABSENT_PREFIX_TAIL.
-    (
-        "; absolute paths like /mnt/data or /tmp/outputs do not exist.",
-        ". The code sandbox is disabled, so absolute paths on the machine running "
-        "Unsloth Studio do resolve; /mnt/data and /tmp/outputs are still not real "
-        "there{tail}",
-    ),
+    # denial is wrong -- but so is a blanket promise, and by different amounts
+    # per tool, so the clause itself comes from _FULL_ACCESS_POSIX_CLAUSE.
+    ("; absolute paths like /mnt/data or /tmp/outputs do not exist.", "{clause}"),
     # Windows already says where the code runs and never denies absolute paths,
     # so there is nothing false to remove; state the capability instead. "the
     # user's own machine" is narrowed at the same time: --secure and -H 0.0.0.0
@@ -8978,14 +8968,34 @@ _FULL_ACCESS_SUBSTITUTIONS = (
 )
 
 
-# sitecustomize.py is a CPython startup hook, so the /mnt/data heal reaches the
-# python tool and any Python the terminal tool launches -- but NOT a plain shell
-# redirect, where `printf x > /mnt/data/out` on a host without /mnt/data simply
-# fails. Telling terminal its writes are redirected would have the model report a
-# command that errored as having landed in the working directory.
-_FULL_ACCESS_ABSENT_PREFIX_TAIL = {
-    "python": ", and writes to them are redirected into the working directory.",
-    "terminal": ", so write to the working directory instead.",
+# What "absolute paths work" actually means under bypass, per tool.
+#
+# _build_bypass_env keeps _SANDBOX_SITE_DIR on PYTHONPATH, so sitecustomize.py
+# still loads. It is a CPython startup hook, which is what splits the two tools:
+# it patches the python tool (and any Python the terminal tool launches), while a
+# plain shell redirect gets nothing. Measured against the shim:
+#
+#   python, parent exists   -> writes the real absolute path
+#   python, parent missing  -> CREATE is redirected to <cwd>/<basename>, and the
+#                              requested path is never made (this covers the
+#                              /mnt/data family and any other invented root)
+#   terminal, parent missing -> the shell just fails, no redirect
+#
+# So python must not promise that every absolute path resolves (the model would
+# report a write that went elsewhere), and terminal must not promise a redirect
+# it never gets (it would report an errored command as having landed).
+_FULL_ACCESS_POSIX_CLAUSE = {
+    "python": (
+        ". The code sandbox is disabled, so absolute paths under a directory that "
+        "exists do resolve on the machine running Unsloth Studio; creating a file "
+        "under a directory that does not exist, /mnt/data and /tmp/outputs "
+        "included, silently redirects it into the working directory instead."
+    ),
+    "terminal": (
+        ". The code sandbox is disabled, so absolute paths on the machine running "
+        "Unsloth Studio do resolve; /mnt/data and /tmp/outputs are still not real "
+        "there, so write to the working directory instead."
+    ),
 }
 
 
@@ -9001,9 +9011,9 @@ def _to_full_access(description: str, tool_name: str) -> str:
     workdir is the per-session dir either way (_build_bypass_env repoints HOME /
     TMPDIR / TEMP / TMP at it), and so is the download-link note.
     """
-    tail = _FULL_ACCESS_ABSENT_PREFIX_TAIL[tool_name]
+    clause = _FULL_ACCESS_POSIX_CLAUSE[tool_name]
     for sandboxed, full_access in _FULL_ACCESS_SUBSTITUTIONS:
-        description = description.replace(sandboxed, full_access.format(tail = tail))
+        description = description.replace(sandboxed, full_access.format(clause = clause))
     return description
 
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8984,7 +8984,10 @@ _FULL_ACCESS_SUBSTITUTIONS = (
 #                              anti-clobber branch declines and open raises
 #   python, prefix present  -> a real /mnt/data mount is never shadowed, so the
 #                              rule is the parent directory, not a prefix list
-#   terminal                -> no shim in a plain shell, so the shell's own rules
+#   terminal, plain shell   -> no shim, so the shell's own rules
+#   terminal, launching python -> _build_bypass_env sets PYTHONPATH for the
+#                              terminal subprocess too, so that Python is patched
+#                              exactly like the python tool
 #
 # Hence no categorical claim about /mnt/data in either: on a host where it is a
 # real mount, Full access can read and write it like any other directory, and
@@ -8998,8 +9001,10 @@ _FULL_ACCESS_CLAUSE = {
         "actually landed rather than assuming the path you asked for."
     ),
     "terminal": (
-        " The code sandbox is disabled, so absolute paths do resolve, exactly as "
-        "the shell resolves them."
+        " The code sandbox is disabled, so absolute paths do resolve as the shell "
+        "resolves them. Python you launch from here is the exception: it loads the "
+        "same shim as the python tool, so a create under a directory that does not "
+        "exist lands in the working directory under its base name instead."
     ),
 }
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8957,12 +8957,13 @@ _FULL_ACCESS_SUBSTITUTIONS = (
     # PYTHONPATH, so sandbox_site/sitecustomize.py goes on healing an absent
     # /mnt/data or /tmp/outputs onto the workdir in bypass runs too. Promising
     # that every absolute path resolves would make the model report a write to
-    # /mnt/data that actually landed in the working directory.
+    # /mnt/data that actually landed in the working directory. The tail differs
+    # per tool, see _FULL_ACCESS_ABSENT_PREFIX_TAIL.
     (
         "; absolute paths like /mnt/data or /tmp/outputs do not exist.",
         ". The code sandbox is disabled, so absolute paths on the machine running "
         "Unsloth Studio do resolve; /mnt/data and /tmp/outputs are still not real "
-        "there, and writes to them are redirected into the working directory.",
+        "there{tail}",
     ),
     # Windows already says where the code runs and never denies absolute paths,
     # so there is nothing false to remove; state the capability instead. "the
@@ -8977,7 +8978,18 @@ _FULL_ACCESS_SUBSTITUTIONS = (
 )
 
 
-def _to_full_access(description: str) -> str:
+# sitecustomize.py is a CPython startup hook, so the /mnt/data heal reaches the
+# python tool and any Python the terminal tool launches -- but NOT a plain shell
+# redirect, where `printf x > /mnt/data/out` on a host without /mnt/data simply
+# fails. Telling terminal its writes are redirected would have the model report a
+# command that errored as having landed in the working directory.
+_FULL_ACCESS_ABSENT_PREFIX_TAIL = {
+    "python": ", and writes to them are redirected into the working directory.",
+    "terminal": ", so write to the working directory instead.",
+}
+
+
+def _to_full_access(description: str, tool_name: str) -> str:
     """Rewrite a sandboxed tool description for Full access.
 
     Under bypass_permissions the loops pass disable_sandbox=True:
@@ -8989,8 +9001,9 @@ def _to_full_access(description: str) -> str:
     workdir is the per-session dir either way (_build_bypass_env repoints HOME /
     TMPDIR / TEMP / TMP at it), and so is the download-link note.
     """
+    tail = _FULL_ACCESS_ABSENT_PREFIX_TAIL[tool_name]
     for sandboxed, full_access in _FULL_ACCESS_SUBSTITUTIONS:
-        description = description.replace(sandboxed, full_access)
+        description = description.replace(sandboxed, full_access.format(tail = tail))
     return description
 
 
@@ -9071,7 +9084,7 @@ PYTHON_TOOL_FULL_ACCESS = {
     "type": "function",
     "function": {
         **PYTHON_TOOL["function"],
-        "description": _to_full_access(PYTHON_TOOL["function"]["description"]),
+        "description": _to_full_access(PYTHON_TOOL["function"]["description"], "python"),
     },
 }
 
@@ -9079,7 +9092,7 @@ TERMINAL_TOOL_FULL_ACCESS = {
     "type": "function",
     "function": {
         **TERMINAL_TOOL["function"],
-        "description": _to_full_access(TERMINAL_TOOL["function"]["description"]),
+        "description": _to_full_access(TERMINAL_TOOL["function"]["description"], "terminal"),
     },
 }
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8991,6 +8991,11 @@ _FULL_ACCESS_SUBSTITUTIONS = (
 #                              already taken in the workdir
 #   python, prefix present  -> a real /mnt/data mount is never shadowed, so a
 #                              prefix is only special while it is absent
+#   python, unpatched API   -> only open/io.open/os.open and the mkdir family are
+#                              wrapped, so os.rename / os.symlink raise instead;
+#                              shutil.copy is the awkward middle, writing the
+#                              rewritten file through open and then raising in
+#                              copymode against the path it was handed
 #   terminal, plain shell   -> no shim, so the shell's own rules
 #   terminal, launching python -> _build_bypass_env sets PYTHONPATH for the
 #                              terminal subprocess too, so that Python is patched
@@ -9007,8 +9012,12 @@ _FULL_ACCESS_CLAUSE = {
         "/mnt/outputs, /tmp/outputs, /home/sandbox, /workspace) the rest of the "
         "path is kept relative to the working directory, replacing any file "
         "already sitting there; under any other missing directory only the base "
-        "name is kept, and the write fails outright if that name is taken. Report "
-        "where a file actually landed rather than the path you asked for."
+        "name is kept, and the write fails outright if that name is taken. Both "
+        "reach only open() and the mkdir calls, so os.rename, os.symlink and the "
+        "like are never rewritten and simply fail, and a helper such as "
+        "shutil.copy can write the rewritten file and still raise on a later "
+        "step. Report where a file actually landed rather than the path you asked "
+        "for."
     ),
     "terminal": (
         " The code sandbox is disabled, so absolute paths do resolve as the shell "

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8981,12 +8981,16 @@ _FULL_ACCESS_SUBSTITUTIONS = (
 # Measured against it:
 #
 #   python, parent exists   -> writes the real absolute path
-#   python, parent missing  -> CREATE is redirected to <cwd>/<basename> and the
-#                              requested path is never made, EXCEPT when that
-#                              name is already taken in the workdir, where the
-#                              anti-clobber branch declines and open raises
-#   python, prefix present  -> a real /mnt/data mount is never shadowed, so the
-#                              rule is the parent directory, not a prefix list
+#   python, absent convention prefix -> _remap keeps the SUFFIX relative to the
+#                              workdir (/mnt/data/reports/out.csv -> ./reports/
+#                              out.csv) and returns before the generic fallback,
+#                              so no basename collapse and no anti-clobber: an
+#                              existing ./out.csv is overwritten
+#   python, any other missing parent -> the generic fallback keeps only the base
+#                              name, and declines (open raises) when that name is
+#                              already taken in the workdir
+#   python, prefix present  -> a real /mnt/data mount is never shadowed, so a
+#                              prefix is only special while it is absent
 #   terminal, plain shell   -> no shim, so the shell's own rules
 #   terminal, launching python -> _build_bypass_env sets PYTHONPATH for the
 #                              terminal subprocess too, so that Python is patched
@@ -8998,16 +9002,19 @@ _FULL_ACCESS_SUBSTITUTIONS = (
 _FULL_ACCESS_CLAUSE = {
     "python": (
         " The code sandbox is disabled, so absolute paths under a directory that "
-        "exists do resolve. Creating a file under a directory that does not exist "
-        "is redirected into the working directory under the same base name, and "
-        "fails outright if that name is already taken there, so say where a file "
-        "actually landed rather than assuming the path you asked for."
+        "exists do resolve. Two different rewrites apply when the directory does "
+        "not exist: under a code-interpreter convention prefix (/mnt/data, "
+        "/mnt/outputs, /tmp/outputs, /home/sandbox, /workspace) the rest of the "
+        "path is kept relative to the working directory, replacing any file "
+        "already sitting there; under any other missing directory only the base "
+        "name is kept, and the write fails outright if that name is taken. Report "
+        "where a file actually landed rather than the path you asked for."
     ),
     "terminal": (
         " The code sandbox is disabled, so absolute paths do resolve as the shell "
         "resolves them. Python you launch from here is the exception: it loads the "
-        "same shim as the python tool, so a create under a directory that does not "
-        "exist lands in the working directory under its base name instead."
+        "same shim as the python tool and gets the same rewrites, so a create "
+        "under a directory that does not exist lands in the working directory."
     ),
 }
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8951,10 +8951,13 @@ _FULL_ACCESS_SUBSTITUTIONS = (
     # dropped, not reworded: where the code runs is said once, by the paths note
     # below, which both tools carry.
     ("Execute Python code in a sandbox and", "Execute Python code and"),
-    # POSIX: real absolute paths DO resolve with the sandbox off, so a blanket
-    # denial is wrong -- but so is a blanket promise, and by different amounts
-    # per tool, so the clause itself comes from _FULL_ACCESS_POSIX_CLAUSE.
-    ("; absolute paths like /mnt/data or /tmp/outputs do not exist.", "{clause}"),
+    # POSIX: a blanket denial is wrong with the sandbox off, and so is a blanket
+    # promise. POSIX has no sentence saying where the code runs, so it is added
+    # here; Windows already has one.
+    (
+        "; absolute paths like /mnt/data or /tmp/outputs do not exist.",
+        ". This runs on the machine running Unsloth Studio.{clause}",
+    ),
     # Windows already says where the code runs and never denies absolute paths,
     # so there is nothing false to remove; state the capability instead. "the
     # user's own machine" is narrowed at the same time: --secure and -H 0.0.0.0
@@ -8962,39 +8965,41 @@ _FULL_ACCESS_SUBSTITUTIONS = (
     # Studio, which is then not the device the user is looking at.
     (
         " You are on Windows, and this runs on the user's own machine.",
-        " You are on Windows, and this runs on the machine running Unsloth Studio. "
-        "The code sandbox is disabled, so absolute paths there do resolve.",
+        " You are on Windows, and this runs on the machine running Unsloth Studio.{clause}",
     ),
 )
 
 
-# What "absolute paths work" actually means under bypass, per tool.
+# What "the sandbox is off" actually means for paths, per tool. Shared by both
+# platform substitutions, because the split is the shim, not the OS.
 #
 # _build_bypass_env keeps _SANDBOX_SITE_DIR on PYTHONPATH, so sitecustomize.py
-# still loads. It is a CPython startup hook, which is what splits the two tools:
-# it patches the python tool (and any Python the terminal tool launches), while a
-# plain shell redirect gets nothing. Measured against the shim:
+# still loads. It is a CPython startup hook, which is what splits the two tools.
+# Measured against it:
 #
 #   python, parent exists   -> writes the real absolute path
-#   python, parent missing  -> CREATE is redirected to <cwd>/<basename>, and the
-#                              requested path is never made (this covers the
-#                              /mnt/data family and any other invented root)
-#   terminal, parent missing -> the shell just fails, no redirect
+#   python, parent missing  -> CREATE is redirected to <cwd>/<basename> and the
+#                              requested path is never made, EXCEPT when that
+#                              name is already taken in the workdir, where the
+#                              anti-clobber branch declines and open raises
+#   python, prefix present  -> a real /mnt/data mount is never shadowed, so the
+#                              rule is the parent directory, not a prefix list
+#   terminal                -> no shim in a plain shell, so the shell's own rules
 #
-# So python must not promise that every absolute path resolves (the model would
-# report a write that went elsewhere), and terminal must not promise a redirect
-# it never gets (it would report an errored command as having landed).
-_FULL_ACCESS_POSIX_CLAUSE = {
+# Hence no categorical claim about /mnt/data in either: on a host where it is a
+# real mount, Full access can read and write it like any other directory, and
+# the general parent-directory rule already covers it when it is absent.
+_FULL_ACCESS_CLAUSE = {
     "python": (
-        ". The code sandbox is disabled, so absolute paths under a directory that "
-        "exists do resolve on the machine running Unsloth Studio; creating a file "
-        "under a directory that does not exist, /mnt/data and /tmp/outputs "
-        "included, silently redirects it into the working directory instead."
+        " The code sandbox is disabled, so absolute paths under a directory that "
+        "exists do resolve. Creating a file under a directory that does not exist "
+        "is redirected into the working directory under the same base name, and "
+        "fails outright if that name is already taken there, so say where a file "
+        "actually landed rather than assuming the path you asked for."
     ),
     "terminal": (
-        ". The code sandbox is disabled, so absolute paths on the machine running "
-        "Unsloth Studio do resolve; /mnt/data and /tmp/outputs are still not real "
-        "there, so write to the working directory instead."
+        " The code sandbox is disabled, so absolute paths do resolve, exactly as "
+        "the shell resolves them."
     ),
 }
 
@@ -9011,7 +9016,7 @@ def _to_full_access(description: str, tool_name: str) -> str:
     workdir is the per-session dir either way (_build_bypass_env repoints HOME /
     TMPDIR / TEMP / TMP at it), and so is the download-link note.
     """
-    clause = _FULL_ACCESS_POSIX_CLAUSE[tool_name]
+    clause = _FULL_ACCESS_CLAUSE[tool_name]
     for sandboxed, full_access in _FULL_ACCESS_SUBSTITUTIONS:
         description = description.replace(sandboxed, full_access.format(clause = clause))
     return description

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8951,19 +8951,28 @@ _FULL_ACCESS_SUBSTITUTIONS = (
     # dropped, not reworded: where the code runs is said once, by the paths note
     # below, which both tools carry.
     ("Execute Python code in a sandbox and", "Execute Python code and"),
-    # POSIX: absolute paths DO resolve with the sandbox off, so the clause is not
-    # merely unhelpful, it is wrong.
+    # POSIX: real absolute paths DO resolve with the sandbox off, so a blanket
+    # denial is wrong. The two named conventions stay denied, because they are
+    # still handled specially: _build_bypass_env keeps _SANDBOX_SITE_DIR on
+    # PYTHONPATH, so sandbox_site/sitecustomize.py goes on healing an absent
+    # /mnt/data or /tmp/outputs onto the workdir in bypass runs too. Promising
+    # that every absolute path resolves would make the model report a write to
+    # /mnt/data that actually landed in the working directory.
     (
         "; absolute paths like /mnt/data or /tmp/outputs do not exist.",
-        ". The code sandbox is disabled, so this runs directly on the user's own "
-        "machine and absolute paths do resolve.",
+        ". The code sandbox is disabled, so absolute paths on the machine running "
+        "Unsloth Studio do resolve; /mnt/data and /tmp/outputs are still not real "
+        "there, and writes to them are redirected into the working directory.",
     ),
     # Windows already says where the code runs and never denies absolute paths,
-    # so there is nothing false to remove; state the capability instead.
+    # so there is nothing false to remove; state the capability instead. "the
+    # user's own machine" is narrowed at the same time: --secure and -H 0.0.0.0
+    # are documented remote modes (README), and the tools run on the host serving
+    # Studio, which is then not the device the user is looking at.
     (
         " You are on Windows, and this runs on the user's own machine.",
-        " You are on Windows, and this runs on the user's own machine. The code "
-        "sandbox is disabled, so absolute paths do resolve.",
+        " You are on Windows, and this runs on the machine running Unsloth Studio. "
+        "The code sandbox is disabled, so absolute paths there do resolve.",
     ),
 )
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -8909,16 +8909,6 @@ WEB_SEARCH_TOOL = {
 }
 
 
-# Without this a model assumes its output vanished into a scratch dir and says
-# so, which reads as "the file was not really created". Shared by the sandboxed
-# and Full access notes: the workdir is the per-session dir in both modes.
-_CREATED_FILES_NOTE = (
-    " Any file you create here is kept and shown to the user with a download "
-    "link, so name the files you created in your reply -- by file name only, "
-    "since you do not know their absolute path."
-)
-
-
 def _build_sandbox_paths_note() -> str:
     """Platform and working-directory note, on BOTH tool descriptions.
 
@@ -8929,41 +8919,70 @@ def _build_sandbox_paths_note() -> str:
     instead: without it a model assumes the pipe is its only output and declines
     to open a window it believes nobody can see.
     """
+    # Without this a model assumes its output vanished into a scratch dir and
+    # says so, which reads as "the file was not really created".
+    created = (
+        " Any file you create here is kept and shown to the user with a download "
+        "link, so name the files you created in your reply -- by file name only, "
+        "since you do not know their absolute path."
+    )
     if sys.platform != "win32":
         return (
             " Read and write files using relative paths in the current working "
             "directory, which persists for this conversation; absolute paths like "
-            "/mnt/data or /tmp/outputs do not exist." + _CREATED_FILES_NOTE
+            "/mnt/data or /tmp/outputs do not exist." + created
         )
     return (
         " You are on Windows, and this runs on the user's own machine. Read and "
         "write files using relative paths in the current working directory, which "
-        "persists for this conversation." + _CREATED_FILES_NOTE
+        "persists for this conversation." + created
     )
 
 
-def _build_full_access_paths_note() -> str:
-    """The same note for Full access (permission_mode='full'), where the
-    sandbox is genuinely off.
+# Full access (permission_mode='full') edits, applied to the sandboxed text
+# rather than writing a second copy of it. Everything the two modes share -- the
+# relative-path advice, the persisted workdir, the download-link note -- is prose
+# that gets tuned over time, and a parallel copy would drift out of sync in
+# silence. Only the claims the sandbox makes true are touched. A rewording that
+# stops one of these matching is caught by test_full_access_tool_prompt.py, which
+# asserts the sandboxed markers are gone from the result on both platforms.
+_FULL_ACCESS_SUBSTITUTIONS = (
+    # The only sentence in the python description that names the sandbox. Just
+    # dropped, not reworded: where the code runs is said once, by the paths note
+    # below, which both tools carry.
+    ("Execute Python code in a sandbox and", "Execute Python code and"),
+    # POSIX: absolute paths DO resolve with the sandbox off, so the clause is not
+    # merely unhelpful, it is wrong.
+    (
+        "; absolute paths like /mnt/data or /tmp/outputs do not exist.",
+        ". The code sandbox is disabled, so this runs directly on the user's own "
+        "machine and absolute paths do resolve.",
+    ),
+    # Windows already says where the code runs and never denies absolute paths,
+    # so there is nothing false to remove; state the capability instead.
+    (
+        " You are on Windows, and this runs on the user's own machine.",
+        " You are on Windows, and this runs on the user's own machine. The code "
+        "sandbox is disabled, so absolute paths do resolve.",
+    ),
+)
 
-    _build_sandbox_paths_note describes the sandboxed run, and every claim in it
-    is false under Full access: _build_bypass_env/_bypass_preexec skip the
-    static analysis, the command blocklist and the rlimits, so absolute paths do
-    resolve and the host filesystem is reachable. Handing the sandboxed text to
-    a model in that mode makes it answer "I am sandboxed and cannot see your
-    files" to a question it could have answered with one tool call, so the
-    working-directory advice stays (the workdir really is still the per-session
-    dir) and the isolation claim goes.
+
+def _to_full_access(description: str) -> str:
+    """Rewrite a sandboxed tool description for Full access.
+
+    Under bypass_permissions the loops pass disable_sandbox=True:
+    _build_bypass_env / _bypass_preexec skip the static analysis, the command
+    blocklist and the rlimits, so the host filesystem really is reachable.
+    Handing a model the sandboxed text in that mode makes it answer "I am
+    sandboxed and cannot see your files" to a question one tool call would have
+    answered. Untouched clauses are the ones still true in both modes: the
+    workdir is the per-session dir either way (_build_bypass_env repoints HOME /
+    TMPDIR / TEMP / TMP at it), and so is the download-link note.
     """
-    platform_note = " You are on Windows." if sys.platform == "win32" else ""
-    return (
-        " The code sandbox is disabled for this conversation and this runs "
-        "directly on the user's own machine, so absolute paths do resolve and "
-        "you can read and write anywhere that account can."
-        + platform_note
-        + " Relative paths still resolve in a working directory that persists "
-        "for this conversation." + _CREATED_FILES_NOTE
-    )
+    for sandboxed, full_access in _FULL_ACCESS_SUBSTITUTIONS:
+        description = description.replace(sandboxed, full_access)
+    return description
 
 
 def _build_terminal_shell_note() -> str:
@@ -8993,7 +9012,6 @@ def _build_terminal_shell_note() -> str:
 
 
 _SANDBOX_PATHS_NOTE = _build_sandbox_paths_note()
-_FULL_ACCESS_PATHS_NOTE = _build_full_access_paths_note()
 _TERMINAL_SHELL_NOTE = _build_terminal_shell_note()
 
 PYTHON_TOOL = {
@@ -9035,16 +9053,16 @@ TERMINAL_TOOL = {
     },
 }
 
-# Full access (permission_mode='full') runs these two without the sandbox, so it
-# gets its own pair of schemas rather than a per-request rebuild: the notes are
-# platform-derived constants, and the sandboxed pair stays the module default so
-# every existing importer keeps the safe wording.
+# Full access runs these two without the sandbox, so it gets its own pair of
+# schemas rather than a per-request rebuild: the descriptions are
+# platform-derived constants either way. The sandboxed pair stays the module
+# default, so every existing importer keeps the safe wording. The shell note is
+# unaffected by the substitutions and carries through as-is.
 PYTHON_TOOL_FULL_ACCESS = {
     "type": "function",
     "function": {
         **PYTHON_TOOL["function"],
-        "description": "Execute Python code on the user's own machine and return stdout/stderr."
-        + _FULL_ACCESS_PATHS_NOTE,
+        "description": _to_full_access(PYTHON_TOOL["function"]["description"]),
     },
 }
 
@@ -9052,9 +9070,7 @@ TERMINAL_TOOL_FULL_ACCESS = {
     "type": "function",
     "function": {
         **TERMINAL_TOOL["function"],
-        "description": "Execute a terminal command on the user's own machine and return stdout/stderr."
-        + _FULL_ACCESS_PATHS_NOTE
-        + _TERMINAL_SHELL_NOTE,
+        "description": _to_full_access(TERMINAL_TOOL["function"]["description"]),
     },
 }
 

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1711,6 +1711,33 @@ class ChatCountTokensRequest(BaseModel):
         None,
         description = "[x-unsloth] Strip leaked tool-call markup from replayed history",
     )
+    permission_mode: Optional[str] = Field(
+        None,
+        description = "[x-unsloth] Permission level the completion would send. Only 'full' changes "
+        "the prompt: it swaps the python/terminal descriptions for the unsandboxed pair and adds a "
+        "sentence to the tool nudge, so a count that omits it prices a prompt the completion will "
+        "not send.",
+    )
+    bypass_permissions: Optional[bool] = Field(
+        None,
+        description = "[x-unsloth] Equivalent of permission_mode='full'. Declared explicitly (not "
+        "left to extra='allow') so an omitted flag reads as None instead of raising AttributeError.",
+    )
+
+    @field_validator("permission_mode", mode = "before")
+    @classmethod
+    def _coerce_permission_mode(cls, value: Any) -> Any:
+        return _normalize_permission_mode(value)
+
+    @model_validator(mode = "after")
+    def _fold_full_permission_into_bypass(self) -> "ChatCountTokensRequest":
+        """Mirrors ChatCompletionRequest: the prompt builders read only the
+        bypass flag, so 'full' has to reach them the same way here."""
+        if self.permission_mode == "full":
+            self.bypass_permissions = True
+        elif self.bypass_permissions:
+            self.permission_mode = "full"
+        return self
 
 
 class ToolConfirmRequest(BaseModel):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11201,7 +11201,9 @@ async def _proxy_to_external_provider(
                     full_access = True,
                     full_access_only = True,
                 )
-                chat_messages = _append_to_system_message(chat_messages, _codex_full_access_nudge)
+                chat_messages = _append_to_codex_instructions(
+                    chat_messages, _codex_full_access_nudge
+                )
         cancel_event = threading.Event()
         cancel_keys = tuple(key for key in (payload.cancel_id, payload.session_id) if key)
 
@@ -17960,6 +17962,28 @@ def _validate_anthropic_client_tools(tools) -> None:
                 status_code = 400,
                 detail = "Client tool is missing required field 'name'.",
             )
+
+
+def _append_to_codex_instructions(messages: list[dict], addition: str) -> list[dict]:
+    """Append text to the leading system message, or prepend one.
+
+    Not _append_to_system_message: that one also accepts a `developer` turn, but
+    _responses_input folds only `system` turns into the Responses instructions
+    and drops every other role bar user/assistant/tool, so text parked on a
+    developer message never reaches the model. `developer` is an accepted
+    ChatMessage role, so a request can carry one and no system turn at all.
+    """
+    if not addition:
+        return messages
+    copied = [dict(msg) for msg in messages]
+    for msg in copied:
+        if msg.get("role") != "system":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            msg["content"] = content.rstrip() + "\n\n" + addition
+            return copied
+    return [{"role": "system", "content": addition}, *copied]
 
 
 def _append_to_system_message(messages: list[dict], addition: str) -> list[dict]:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3055,6 +3055,18 @@ _TOOL_CODE_TIP = (
     "Use code execution for math, calculations, data processing, or to parse "
     "and analyze information from tool results."
 )
+# Full access (permission_mode='full') only, and only alongside python/terminal.
+# The schemas alone do not undo the model's prior: asked "can you see the files
+# on my laptop", a local chat model answers "no, I am sandboxed" from training
+# data rather than reading its own tool list, so the environment is stated
+# outright and the guess is redirected to a tool call.
+_TOOL_FULL_ACCESS_TIP = (
+    "Tool calls run on the user's own machine with the code sandbox and the "
+    "approval prompts disabled, so you can inspect and change the user's real "
+    "files and system. When the user asks what you can see or do on their "
+    "machine, check with a tool call instead of assuming you are isolated "
+    "from it."
+)
 _TOOL_ARTIFACT_TIP = (
     "For HTML, CSS, or JavaScript canvas requests, call render_html once when "
     "it is available with one complete self-contained HTML document in the code "
@@ -3064,7 +3076,12 @@ _TOOL_ARTIFACT_TIP = (
 )
 
 
-def _build_tool_action_nudge(*, tools: list[dict], model_name: str) -> str:
+def _build_tool_action_nudge(
+    *,
+    tools: list[dict],
+    model_name: str,
+    full_access: bool = False,
+) -> str:
     tool_names = {
         (tool.get("function") or {}).get("name")
         for tool in tools
@@ -3083,6 +3100,8 @@ def _build_tool_action_nudge(*, tools: list[dict], model_name: str) -> str:
         tool_tip_parts.append(_TOOL_WEB_COMPACT_TIP if compact_web_tip else _TOOL_WEB_EXPANDED_TIP)
     if has_code:
         tool_tip_parts.append(_TOOL_CODE_TIP)
+        if full_access:
+            tool_tip_parts.append(_TOOL_FULL_ACCESS_TIP)
     if has_artifact:
         tool_tip_parts.append(_TOOL_ARTIFACT_TIP)
     return (
@@ -3111,8 +3130,16 @@ async def _select_request_tools(
     caller's opt-in (empty when MCP-only), the RAG tool dropped without a
     retrieval scope, then enabled MCP tools appended. An empty result means the
     caller should skip the tool loop, so a model-emitted built-in call can't
-    piggy-back on the empty allow-list."""
-    from core.inference.tools import ALL_TOOLS, get_enabled_mcp_tools
+    piggy-back on the empty allow-list.
+
+    Under Full access the python/terminal schemas are swapped for the ones that
+    describe the unsandboxed run, since that is what the loop actually does
+    (disable_sandbox = bypass_permissions)."""
+    from core.inference.tools import (
+        ALL_TOOLS,
+        apply_full_access_tool_descriptions,
+        get_enabled_mcp_tools,
+    )
 
     if not tools_on:
         # MCP-only request: skip built-ins, leave room for MCP tools.
@@ -3125,6 +3152,11 @@ async def _select_request_tools(
     # Drop the RAG tool without a scope: nothing to search over.
     if not payload.rag_scope:
         tools = [t for t in tools if t["function"]["name"] != "search_knowledge_base"]
+    # Built-ins only, so this runs before the MCP append: an MCP tool's
+    # description is the server's to write, and Full access says nothing about
+    # how that server runs.
+    if payload.bypass_permissions:
+        tools = apply_full_access_tool_descriptions(tools)
     if mcp_allowed:
         tools = tools + await get_enabled_mcp_tools()
     return tools
@@ -12441,6 +12473,7 @@ async def openai_chat_completions(
             _nudge = _build_tool_action_nudge(
                 tools = tools_to_use,
                 model_name = model_name,
+                full_access = bool(payload.bypass_permissions),
             )
 
             # Nudge the model to ground in attached documents instead of memory.
@@ -13924,6 +13957,7 @@ async def openai_chat_completions(
         _sf_nudge = _build_tool_action_nudge(
             tools = _sf_tools_to_use,
             model_name = model_name,
+            full_access = bool(payload.bypass_permissions),
         )
 
         # RAG nudge, mirroring the GGUF path.
@@ -17961,6 +17995,7 @@ async def chat_count_tokens(
                     _build_tool_action_nudge(
                         tools = tools_to_use,
                         model_name = _llama_public_model_id(llama_backend, payload.model),
+                        full_access = bool(payload.bypass_permissions),
                     ),
                     tools_to_use,
                     rag_scope = payload.rag_scope,
@@ -18676,7 +18711,7 @@ async def anthropic_messages(
                     err_type = "invalid_request_error",
                 ),
             )
-        from core.inference.tools import ALL_TOOLS
+        from core.inference.tools import ALL_TOOLS, apply_full_access_tool_descriptions
 
         # ask/auto (and an omitted mode selecting a gate-needing terminal/python
         # tool) were already rejected before the auto-switch above, so an invalid
@@ -18687,11 +18722,17 @@ async def anthropic_messages(
             requested_studio_tools,
             payload.enabled_tools,
         )
+        # Mirrors _select_request_tools: this path builds its own selection, so
+        # the Full access swap has to be repeated rather than inherited.
+        _full_access = bool(getattr(payload, "bypass_permissions", False))
+        if _full_access:
+            openai_tools = apply_full_access_tool_descriptions(openai_tools)
 
         # Build tool-use system prompt nudge (same logic as /chat/completions)
         _nudge = _build_tool_action_nudge(
             tools = openai_tools,
             model_name = model_name,
+            full_access = _full_access,
         )
 
         if _nudge:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3061,10 +3061,11 @@ _TOOL_CODE_TIP = (
 # data rather than reading its own tool list, so the environment is stated
 # outright and the guess is redirected to a tool call.
 _TOOL_FULL_ACCESS_TIP = (
-    "Tool calls run on the user's own machine with the code sandbox and the "
-    "approval prompts disabled, so you can inspect and change the user's real "
-    "files and system. When the user asks what you can see or do on their "
-    "machine, check with a tool call instead of assuming you are isolated "
+    "Tool calls run on the machine running Unsloth Studio, with the code sandbox "
+    "and the approval prompts disabled, so you can inspect and change the real "
+    "files and system there. That machine is not always the device the user is "
+    "viewing this on: Studio can be served remotely. When asked what you can see "
+    "or do on it, check with a tool call instead of assuming you are isolated "
     "from it."
 )
 _TOOL_ARTIFACT_TIP = (
@@ -3081,7 +3082,11 @@ def _build_tool_action_nudge(
     tools: list[dict],
     model_name: str,
     full_access: bool = False,
+    full_access_only: bool = False,
 ) -> str:
+    """``full_access_only`` returns the Full access sentence alone, for a caller
+    that wants to state the environment without also introducing the general
+    tool guidance (and the date) to a path that has never carried it."""
     tool_names = {
         (tool.get("function") or {}).get("name")
         for tool in tools
@@ -3092,6 +3097,8 @@ def _build_tool_action_nudge(
     has_artifact = "render_html" in tool_names
     if not (has_web or has_code or has_artifact):
         return ""
+    if full_access_only:
+        return _TOOL_FULL_ACCESS_TIP if (full_access and has_code) else ""
 
     model_size_b = _extract_model_size_b(model_name)
     compact_web_tip = model_size_b is not None and model_size_b < 9
@@ -11127,6 +11134,20 @@ async def _proxy_to_external_provider(
             # The Studio loop owns its schemas. Do not also expose a caller-supplied
             # catalog: Codex would return calls that this server is not authorized to run.
             tool_payloads = studio_tool_payloads
+            # This path runs python/terminal locally too (the loop passes
+            # disable_sandbox = bypass_permissions), so Full access has the same
+            # false-isolation problem here, and the swapped schemas alone do not
+            # settle it. Only the Full access sentence is added: this path has
+            # never carried the general tool nudge, and widening it would change
+            # every non-Full-access Codex run as a side effect.
+            if payload.bypass_permissions:
+                _codex_full_access_nudge = _build_tool_action_nudge(
+                    tools = studio_tool_payloads,
+                    model_name = model,
+                    full_access = True,
+                    full_access_only = True,
+                )
+                chat_messages = _append_to_system_message(chat_messages, _codex_full_access_nudge)
         cancel_event = threading.Event()
         cancel_keys = tuple(key for key in (payload.cancel_id, payload.session_id) if key)
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3112,12 +3112,13 @@ def _full_access_tip(code_tools: list[str]) -> str:
     else:
         subject = "The " + " and ".join(code_tools) + " tools run"
     return (
-        subject + " on the machine running Unsloth Studio, with the code sandbox "
-        "and the approval prompts disabled, so you can inspect and change the real "
-        "files and system there. That machine is not always the device the user is "
-        "viewing this on: Studio can be served remotely. When asked what you can "
-        "see or do on it, check with a tool call instead of assuming you are "
-        "isolated from it."
+        subject + " where Unsloth Studio is running, with the code sandbox and the "
+        "approval prompts disabled, so you can inspect and change whatever that "
+        "process can reach. That is not necessarily the device the user is viewing "
+        "this on, and it may be a remote host or a container that mounts only some "
+        "of its host's paths. When asked what you can see or do, check with a tool "
+        "call rather than assuming you are isolated from it, and report what the "
+        "call actually returned rather than what a whole machine would hold."
     )
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3061,12 +3061,12 @@ _TOOL_CODE_TIP = (
 # data rather than reading its own tool list, so the environment is stated
 # outright and the guess is redirected to a tool call.
 _TOOL_FULL_ACCESS_TIP = (
-    "Tool calls run on the machine running Unsloth Studio, with the code sandbox "
-    "and the approval prompts disabled, so you can inspect and change the real "
-    "files and system there. That machine is not always the device the user is "
-    "viewing this on: Studio can be served remotely. When asked what you can see "
-    "or do on it, check with a tool call instead of assuming you are isolated "
-    "from it."
+    "The python and terminal tools run on the machine running Unsloth Studio, "
+    "with the code sandbox and the approval prompts disabled, so you can inspect "
+    "and change the real files and system there. That machine is not always the "
+    "device the user is viewing this on: Studio can be served remotely. When "
+    "asked what you can see or do on it, check with a tool call instead of "
+    "assuming you are isolated from it."
 )
 _TOOL_ARTIFACT_TIP = (
     "For HTML, CSS, or JavaScript canvas requests, call render_html once when "

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3097,14 +3097,30 @@ _TOOL_CODE_TIP = (
 # on my laptop", a local chat model answers "no, I am sandboxed" from training
 # data rather than reading its own tool list, so the environment is stated
 # outright and the guess is redirected to a tool call.
-_TOOL_FULL_ACCESS_TIP = (
-    "The python and terminal tools run on the machine running Unsloth Studio, "
-    "with the code sandbox and the approval prompts disabled, so you can inspect "
-    "and change the real files and system there. That machine is not always the "
-    "device the user is viewing this on: Studio can be served remotely. When "
-    "asked what you can see or do on it, check with a tool call instead of "
-    "assuming you are isolated from it."
-)
+# Fixed order so the sentence reads the same whichever way the caller listed them.
+_LOCAL_CODE_TOOLS = ("python", "terminal")
+
+
+def _full_access_tip(code_tools: list[str]) -> str:
+    """The Full access sentence, naming only the code tools actually selected.
+
+    enabled_tools=["python"] leaves terminal out of the request's schemas, so
+    naming it here would advertise a tool the loop would refuse to run.
+    """
+    if len(code_tools) == 1:
+        subject = f"The {code_tools[0]} tool runs"
+    else:
+        subject = "The " + " and ".join(code_tools) + " tools run"
+    return (
+        subject + " on the machine running Unsloth Studio, with the code sandbox "
+        "and the approval prompts disabled, so you can inspect and change the real "
+        "files and system there. That machine is not always the device the user is "
+        "viewing this on: Studio can be served remotely. When asked what you can "
+        "see or do on it, check with a tool call instead of assuming you are "
+        "isolated from it."
+    )
+
+
 _TOOL_ARTIFACT_TIP = (
     "For HTML, CSS, or JavaScript canvas requests, call render_html once when "
     "it is available with one complete self-contained HTML document in the code "
@@ -3130,12 +3146,13 @@ def _build_tool_action_nudge(
         if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
     }
     has_web = "web_search" in tool_names
-    has_code = "python" in tool_names or "terminal" in tool_names
+    code_tools = [name for name in _LOCAL_CODE_TOOLS if name in tool_names]
+    has_code = bool(code_tools)
     has_artifact = "render_html" in tool_names
     if not (has_web or has_code or has_artifact):
         return ""
     if full_access_only:
-        return _TOOL_FULL_ACCESS_TIP if (full_access and has_code) else ""
+        return _full_access_tip(code_tools) if (full_access and has_code) else ""
 
     model_size_b = _extract_model_size_b(model_name)
     compact_web_tip = model_size_b is not None and model_size_b < 9
@@ -3145,7 +3162,7 @@ def _build_tool_action_nudge(
     if has_code:
         tool_tip_parts.append(_TOOL_CODE_TIP)
         if full_access:
-            tool_tip_parts.append(_TOOL_FULL_ACCESS_TIP)
+            tool_tip_parts.append(_full_access_tip(code_tools))
     if has_artifact:
         tool_tip_parts.append(_TOOL_ARTIFACT_TIP)
     return (

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3092,11 +3092,10 @@ _TOOL_CODE_TIP = (
     "Use code execution for math, calculations, data processing, or to parse "
     "and analyze information from tool results."
 )
-# Full access (permission_mode='full') only, and only alongside python/terminal.
-# The schemas alone do not undo the model's prior: asked "can you see the files
-# on my laptop", a local chat model answers "no, I am sandboxed" from training
-# data rather than reading its own tool list, so the environment is stated
-# outright and the guess is redirected to a tool call.
+# Full access only, and only alongside python/terminal. The schemas alone do not
+# undo the model's prior: asked "can you see the files on my laptop" it answers
+# "no, I am sandboxed" from training data rather than reading its own tool list,
+# so the environment is stated outright and the guess sent to a tool call.
 # Fixed order so the sentence reads the same whichever way the caller listed them.
 _LOCAL_CODE_TOOLS = ("python", "terminal")
 
@@ -11189,12 +11188,11 @@ async def _proxy_to_external_provider(
             # The Studio loop owns its schemas. Do not also expose a caller-supplied
             # catalog: Codex would return calls that this server is not authorized to run.
             tool_payloads = studio_tool_payloads
-            # This path runs python/terminal locally too (the loop passes
-            # disable_sandbox = bypass_permissions), so Full access has the same
-            # false-isolation problem here, and the swapped schemas alone do not
-            # settle it. Only the Full access sentence is added: this path has
-            # never carried the general tool nudge, and widening it would change
-            # every non-Full-access Codex run as a side effect.
+            # This path runs python/terminal locally too (disable_sandbox =
+            # bypass_permissions), so it has the same false-isolation problem.
+            # Only the Full access sentence is added: the path has never carried
+            # the general tool nudge, and widening it would change every
+            # non-Full-access Codex run as a side effect.
             if payload.bypass_permissions:
                 _codex_full_access_nudge = _build_tool_action_nudge(
                     tools = studio_tool_payloads,

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -18,9 +18,11 @@ other mode keeps the sandboxed wording verbatim.
 """
 
 import asyncio
+import sys
 
 import pytest
 
+from core.inference import tools
 from core.inference.tools import (
     ALL_TOOLS,
     PYTHON_TOOL,
@@ -80,6 +82,36 @@ def test_full_access_schemas_keep_name_and_parameters():
         assert full["type"] == sandboxed["type"]
         assert full["function"]["name"] == sandboxed["function"]["name"]
         assert full["function"]["parameters"] == sandboxed["function"]["parameters"]
+
+
+@pytest.mark.parametrize("platform", ["linux", "darwin", "win32"])
+def test_the_substitutions_land_on_every_platform(monkeypatch, platform):
+    """The module constants are built once for the host platform, so a Linux
+    runner would never exercise the Windows branch. Rebuild the note per
+    platform and re-derive, which is also the guard against a rewording of
+    _build_sandbox_paths_note silently turning the substitutions into no-ops:
+    the sandboxed markers would survive into the result below."""
+    monkeypatch.setattr(sys, "platform", platform)
+    sandboxed = "Execute Python code in a sandbox and return stdout/stderr." + (
+        tools._build_sandbox_paths_note()
+    )
+    full = tools._to_full_access(sandboxed)
+
+    assert full != sandboxed
+    assert "in a sandbox" not in full
+    assert "do not exist" not in full
+    assert "sandbox is disabled" in full
+    assert "absolute paths do resolve" in full
+    # True in both modes, so untouched.
+    assert "persists for this conversation" in full
+    assert "download link" in full
+    if platform == "win32":
+        assert "You are on Windows" in full
+        assert "/mnt/data" not in full
+    else:
+        # The POSIX clause naming ChatGPT's /mnt/data is what gets rewritten.
+        assert "/mnt/data" in sandboxed
+        assert "/mnt/data" not in full
 
 
 def test_python_full_access_description_still_omits_the_shell():

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""What the model is TOLD about its environment under Full access.
+
+permission_mode='full' folds to bypass_permissions=True, which the tool loops
+pass on as disable_sandbox=True: the static analysis, the command blocklist and
+the rlimit pre-exec are all skipped and absolute host paths resolve. The
+python/terminal schemas used to be module constants describing the sandboxed
+run regardless, and the tool nudge never mentioned the mode at all, so the model
+was told it was isolated from a machine it could in fact read. Asked "are you
+able to see the files on my laptop", it answered "no, I operate in a sandboxed
+environment" without ever calling a tool.
+
+These tests pin the two halves of the fix: the schemas swap under Full access,
+and the nudge states the mode so the model checks instead of guessing. Every
+other mode keeps the sandboxed wording verbatim.
+"""
+
+import asyncio
+
+import pytest
+
+from core.inference.tools import (
+    ALL_TOOLS,
+    PYTHON_TOOL,
+    PYTHON_TOOL_FULL_ACCESS,
+    TERMINAL_TOOL,
+    TERMINAL_TOOL_FULL_ACCESS,
+    apply_full_access_tool_descriptions,
+)
+from models.inference import ChatCompletionRequest, ChatCountTokensRequest
+from routes.inference import _build_tool_action_nudge, _select_request_tools
+
+
+def _desc(tool: dict) -> str:
+    return tool["function"]["description"]
+
+
+def _named(tools: list[dict], name: str) -> dict:
+    return next(t for t in tools if t["function"]["name"] == name)
+
+
+# ── Schemas ───────────────────────────────────────────────────────────
+
+
+def test_sandboxed_descriptions_are_unchanged():
+    """The default pair is what every existing importer gets."""
+    assert "in a sandbox" in _desc(PYTHON_TOOL)
+    assert "do not exist" in _desc(PYTHON_TOOL) or "Windows" in _desc(PYTHON_TOOL)
+    assert "return stdout/stderr" in _desc(TERMINAL_TOOL)
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [PYTHON_TOOL_FULL_ACCESS, TERMINAL_TOOL_FULL_ACCESS],
+    ids = ["python", "terminal"],
+)
+def test_full_access_descriptions_drop_the_isolation_claim(tool):
+    description = _desc(tool)
+    assert "in a sandbox" not in description
+    # The one claim that is outright false with the sandbox off.
+    assert "do not exist" not in description
+    assert "sandbox is disabled" in description
+    assert "user's own machine" in description
+    # The workdir really is still the per-session dir in bypass mode
+    # (_build_bypass_env repoints HOME/TMPDIR/TEMP/TMP at it), so the relative
+    # path advice and the download-link note both have to survive.
+    assert "persists for this conversation" in description
+    assert "download link" in description
+
+
+def test_full_access_schemas_keep_name_and_parameters():
+    """Only the description changes: a differing name or schema would break the
+    dispatcher and every caller that matches on them."""
+    for sandboxed, full in (
+        (PYTHON_TOOL, PYTHON_TOOL_FULL_ACCESS),
+        (TERMINAL_TOOL, TERMINAL_TOOL_FULL_ACCESS),
+    ):
+        assert full["type"] == sandboxed["type"]
+        assert full["function"]["name"] == sandboxed["function"]["name"]
+        assert full["function"]["parameters"] == sandboxed["function"]["parameters"]
+
+
+def test_python_full_access_description_still_omits_the_shell():
+    """Same reason as the sandboxed one: naming a shell there points a model at
+    subprocess/os.system instead of the terminal tool."""
+    assert "shell" not in _desc(PYTHON_TOOL_FULL_ACCESS).lower()
+
+
+def test_terminal_full_access_keeps_the_shell_note():
+    """The shell note is platform-derived and applies in either mode; dropping
+    it on Windows brings back the cmd/bash confusion it exists to prevent."""
+    for marker in ("cmd, not bash", "bash (Git for Windows)"):
+        assert (marker in _desc(TERMINAL_TOOL)) == (marker in _desc(TERMINAL_TOOL_FULL_ACCESS))
+
+
+def test_swap_leaves_other_tools_alone_and_does_not_mutate():
+    before = list(ALL_TOOLS)
+    swapped = apply_full_access_tool_descriptions(list(ALL_TOOLS))
+    assert _named(swapped, "python") is PYTHON_TOOL_FULL_ACCESS
+    assert _named(swapped, "terminal") is TERMINAL_TOOL_FULL_ACCESS
+    for name in ("web_search", "render_html", "search_knowledge_base"):
+        assert _named(swapped, name) is _named(ALL_TOOLS, name)
+    # The module global is shared across requests, so the swap must not touch it.
+    assert ALL_TOOLS == before
+    assert _desc(_named(ALL_TOOLS, "python")) == _desc(PYTHON_TOOL)
+
+
+def test_swap_is_a_no_op_without_the_sandboxed_builtins():
+    tools = [t for t in ALL_TOOLS if t["function"]["name"] == "web_search"]
+    assert apply_full_access_tool_descriptions(tools) is tools
+    assert apply_full_access_tool_descriptions([]) == []
+
+
+# ── Request-level selection ───────────────────────────────────────────
+
+
+def _select(**payload_kwargs) -> list[dict]:
+    payload = ChatCompletionRequest(
+        model = "test-model",
+        messages = [{"role": "user", "content": "hi"}],
+        enable_tools = True,
+        enabled_tools = ["python", "terminal", "web_search"],
+        stream = True,
+        **payload_kwargs,
+    )
+    return asyncio.run(_select_request_tools(payload, tools_on = True, mcp_allowed = False))
+
+
+@pytest.mark.parametrize("mode", ["ask", "auto", "off"])
+def test_non_full_modes_keep_the_sandboxed_schemas(mode):
+    tools = _select(permission_mode = mode)
+    assert _desc(_named(tools, "python")) == _desc(PYTHON_TOOL)
+    assert _desc(_named(tools, "terminal")) == _desc(TERMINAL_TOOL)
+
+
+def test_omitted_mode_keeps_the_sandboxed_schemas():
+    tools = _select()
+    assert _desc(_named(tools, "python")) == _desc(PYTHON_TOOL)
+
+
+@pytest.mark.parametrize(
+    "payload_kwargs",
+    [{"permission_mode": "full"}, {"bypass_permissions": True}],
+    ids = ["permission_mode", "legacy_bypass_flag"],
+)
+def test_full_access_selection_swaps_the_schemas(payload_kwargs):
+    """Both spellings fold to bypass_permissions=True, so both must swap."""
+    tools = _select(**payload_kwargs)
+    assert _desc(_named(tools, "python")) == _desc(PYTHON_TOOL_FULL_ACCESS)
+    assert _desc(_named(tools, "terminal")) == _desc(TERMINAL_TOOL_FULL_ACCESS)
+    assert _named(tools, "web_search") is _named(ALL_TOOLS, "web_search")
+
+
+# ── Nudge ─────────────────────────────────────────────────────────────
+
+_CODE_TOOLS = [PYTHON_TOOL, TERMINAL_TOOL]
+_WEB_ONLY = [t for t in ALL_TOOLS if t["function"]["name"] == "web_search"]
+
+
+def test_nudge_is_unchanged_without_full_access():
+    plain = _build_tool_action_nudge(tools = _CODE_TOOLS, model_name = "test-8B")
+    assert "sandbox" not in plain
+    assert "code execution" in plain
+    assert plain == _build_tool_action_nudge(
+        tools = _CODE_TOOLS, model_name = "test-8B", full_access = False
+    )
+
+
+def test_nudge_states_the_environment_under_full_access():
+    nudge = _build_tool_action_nudge(tools = _CODE_TOOLS, model_name = "test-8B", full_access = True)
+    assert "user's own machine" in nudge
+    assert "code sandbox and the approval prompts disabled" in nudge
+    # The actual reported failure: the model asserted isolation instead of
+    # checking, so the nudge has to redirect that guess to a tool call.
+    assert "check with a tool call" in nudge
+
+
+def test_full_access_tip_needs_a_code_tool():
+    """web_search alone runs nothing locally, so the sandbox sentence would be
+    noise (and false)."""
+    nudge = _build_tool_action_nudge(tools = _WEB_ONLY, model_name = "test-8B", full_access = True)
+    assert "user's own machine" not in nudge
+    assert nudge == _build_tool_action_nudge(tools = _WEB_ONLY, model_name = "test-8B")
+
+
+def test_full_access_tip_needs_tools_at_all():
+    assert _build_tool_action_nudge(tools = [], model_name = "test-8B", full_access = True) == ""
+
+
+# ── Token count parity ────────────────────────────────────────────────
+
+
+def _count_request(**kwargs) -> ChatCountTokensRequest:
+    return ChatCountTokensRequest(
+        model = "test-model",
+        messages = [{"role": "user", "content": "hi"}],
+        enable_tools = True,
+        enabled_tools = ["python", "terminal"],
+        **kwargs,
+    )
+
+
+def test_count_request_reads_the_flag_when_omitted():
+    """The count route reaches for payload.bypass_permissions unconditionally,
+    so the field has to exist rather than arrive via extra='allow'."""
+    assert _count_request().bypass_permissions is None
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"permission_mode": "full"}, {"bypass_permissions": True}],
+    ids = ["permission_mode", "legacy_bypass_flag"],
+)
+def test_count_request_folds_full_access(kwargs):
+    request = _count_request(**kwargs)
+    assert request.bypass_permissions is True
+    assert request.permission_mode == "full"
+
+
+@pytest.mark.parametrize("mode", ["ask", "auto", "off"])
+def test_count_request_leaves_other_modes_alone(mode):
+    assert _count_request(permission_mode = mode).bypass_permissions is None
+
+
+def test_count_request_selection_matches_the_completion():
+    """The whole point of carrying the flag: the counted tool list is the one
+    the completion will render."""
+    counted = asyncio.run(
+        _select_request_tools(
+            _count_request(permission_mode = "full"), tools_on = True, mcp_allowed = False
+        )
+    )
+    assert _desc(_named(counted, "python")) == _desc(PYTHON_TOOL_FULL_ACCESS)

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -134,7 +134,10 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform, tool_na
         assert "the rest of the path is kept relative to the working directory" in full
         assert "replacing any file already sitting there" in full
         assert "only the base name is kept" in full
-        assert "fails outright if that name is taken" in full
+        # Measured: a DIFFERENT invented path with the same basename raises, but
+        # rewriting the SAME invented path is permitted via the remap sidecar.
+        assert "fails outright if that name is taken by an unrelated file" in full
+        assert "rewriting the same absolute path just replaces" in full
         # Only open/io.open/os.open and the mkdir family are wrapped. Measured:
         # os.rename and os.symlink raise, and shutil.copy writes the rewritten
         # file through open and then raises in copymode.

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -117,13 +117,16 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform, tool_na
     # paths resolve" would have the model report a write that went elsewhere.
     if platform != "win32":
         assert "/mnt/data" in full
-        # sitecustomize is a CPython startup hook: it heals an absent /mnt/data
-        # for python (and any python terminal launches), but a plain shell
-        # redirect just fails, so only python may promise the redirect.
+        # sitecustomize is a CPython startup hook: it patches python (and any
+        # python terminal launches), while a plain shell redirect gets nothing.
         if tool_name == "python":
-            assert "redirected into the working directory" in full
+            # Measured: parent exists -> real path; parent missing -> <cwd>/base.
+            # So the promise has to be conditional, never blanket.
+            assert "absolute paths under a directory that exists do resolve" in full
+            assert "silently redirects it into the working directory" in full
+            assert "absolute paths on the machine running Unsloth Studio do resolve" not in full
         else:
-            assert "redirected" not in full
+            assert "redirect" not in full
             assert "write to the working directory instead" in full
     # True in both modes, so untouched.
     assert "persists for this conversation" in full

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -33,8 +33,9 @@ from core.inference.tools import (
 )
 from models.inference import ChatCompletionRequest, ChatCountTokensRequest
 from routes.inference import (
-    _full_access_tip,
+    _append_to_codex_instructions,
     _build_tool_action_nudge,
+    _full_access_tip,
     _select_request_tools,
 )
 
@@ -115,19 +116,23 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform, tool_na
     # _build_bypass_env keeps _SANDBOX_SITE_DIR on PYTHONPATH, so sitecustomize
     # still heals these onto the workdir under Full access. A blanket "absolute
     # paths resolve" would have the model report a write that went elsewhere.
-    if platform != "win32":
-        assert "/mnt/data" in full
-        # sitecustomize is a CPython startup hook: it patches python (and any
-        # python terminal launches), while a plain shell redirect gets nothing.
-        if tool_name == "python":
-            # Measured: parent exists -> real path; parent missing -> <cwd>/base.
-            # So the promise has to be conditional, never blanket.
-            assert "absolute paths under a directory that exists do resolve" in full
-            assert "silently redirects it into the working directory" in full
-            assert "absolute paths on the machine running Unsloth Studio do resolve" not in full
-        else:
-            assert "redirect" not in full
-            assert "write to the working directory instead" in full
+    # The clause is per tool on BOTH platforms: the split is the shim, not the OS.
+    # sitecustomize is a CPython startup hook, so it patches python (and any
+    # python the terminal launches) wherever it runs, while a plain shell gets
+    # nothing. Measured: parent exists -> real path; parent missing -> <cwd>/base,
+    # unless that name is taken, where it raises.
+    if tool_name == "python":
+        assert "absolute paths under a directory that exists do resolve" in full
+        assert "redirected into the working directory under the same base name" in full
+        assert "fails outright if that name is already taken" in full
+    else:
+        assert "absolute paths do resolve, exactly as the shell resolves them" in full
+        assert "redirect" not in full
+    # No categorical claim about the convention paths in either: on a host where
+    # /mnt/data is a real mount the shim never shadows it, so "not real" is wrong,
+    # and the parent-directory rule already covers the absent case.
+    assert "/mnt/data" not in full
+    assert "not real there" not in full
     # True in both modes, so untouched.
     assert "persists for this conversation" in full
     assert "download link" in full
@@ -307,6 +312,37 @@ def _count_request(**kwargs) -> ChatCountTokensRequest:
         enabled_tools = ["python", "terminal"],
         **kwargs,
     )
+
+
+# ── Codex studio-tools instructions ───────────────────────────────────
+
+
+def test_codex_instructions_skip_a_developer_message():
+    """_responses_input folds only `system` turns into the Responses
+    instructions and drops every other role bar user/assistant/tool, so a nudge
+    appended to a `developer` turn would never reach the model. `developer` is an
+    accepted ChatMessage role, so this shape is reachable."""
+    messages = [
+        {"role": "developer", "content": "house style"},
+        {"role": "user", "content": "hi"},
+    ]
+    out = _append_to_codex_instructions(messages, "NUDGE")
+    assert out[0] == {"role": "system", "content": "NUDGE"}
+    assert out[1] == messages[0]
+    assert messages[0]["content"] == "house style"
+
+
+def test_codex_instructions_extend_an_existing_system_message():
+    messages = [{"role": "system", "content": "base"}, {"role": "user", "content": "hi"}]
+    out = _append_to_codex_instructions(messages, "NUDGE")
+    assert out[0]["content"] == "base\n\nNUDGE"
+    assert len(out) == 2
+    assert messages[0]["content"] == "base"
+
+
+def test_codex_instructions_are_a_no_op_without_an_addition():
+    messages = [{"role": "user", "content": "hi"}]
+    assert _append_to_codex_instructions(messages, "") is messages
 
 
 def test_count_request_reads_the_flag_when_omitted():

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -126,8 +126,11 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform, tool_na
         assert "redirected into the working directory under the same base name" in full
         assert "fails outright if that name is already taken" in full
     else:
-        assert "absolute paths do resolve, exactly as the shell resolves them" in full
-        assert "redirect" not in full
+        assert "absolute paths do resolve as the shell resolves them" in full
+        # _build_bypass_env sets PYTHONPATH for the terminal subprocess too, so
+        # python launched from a shell command carries the same shim.
+        assert "Python you launch from here is the exception" in full
+        assert "lands in the working directory under its base name" in full
     # No categorical claim about the convention paths in either: on a host where
     # /mnt/data is a real mount the shim never shadows it, so "not real" is wrong,
     # and the parent-directory rule already covers the absent case.

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -69,7 +69,10 @@ def test_full_access_descriptions_drop_the_isolation_claim(tool):
     # The one claim that is outright false with the sandbox off.
     assert "do not exist" not in description
     assert "sandbox is disabled" in description
-    assert "machine running Unsloth Studio" in description
+    assert "wherever Unsloth Studio is running" in description
+    # Docker is a documented deployment, where only mounted paths are visible,
+    # so the reach is the Studio process's, not a whole machine's.
+    assert "container with only some paths mounted" in description
     # The remote modes (--secure / -H 0.0.0.0, README) put the tools on the host
     # serving Studio, not on the device the user is looking at, so the prompt
     # must not claim the two are the same.
@@ -113,6 +116,7 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform, tool_na
     assert "sandbox is disabled" in full
     assert "do resolve" in full
     assert "user's own machine" not in full
+    assert "wherever Unsloth Studio is running" in full
     # _build_bypass_env keeps _SANDBOX_SITE_DIR on PYTHONPATH, so sitecustomize
     # still heals these onto the workdir under Full access. A blanket "absolute
     # paths resolve" would have the model report a write that went elsewhere.
@@ -231,23 +235,27 @@ def test_nudge_is_unchanged_without_full_access():
 
 def test_nudge_states_the_environment_under_full_access():
     nudge = _build_tool_action_nudge(tools = _CODE_TOOLS, model_name = "test-8B", full_access = True)
-    assert "machine running Unsloth Studio" in nudge
+    assert "where Unsloth Studio is running" in nudge
     assert "code sandbox and the approval prompts disabled" in nudge
+    # Containerized Studio sees only its mounts, so the claim is scoped to what
+    # the process can reach rather than to the machine.
+    assert "whatever that process can reach" in nudge
+    assert "container that mounts only some" in nudge
     # Scoped to the two local tools: execute_tool passes disable_sandbox to
     # python/terminal only, web_search is a network call, and an MCP tool may run
     # on a remote server, so an unqualified "tool calls run here" is wrong when
     # any of those are enabled alongside.
-    assert nudge.count("The python and terminal tools run on") == 1
+    assert nudge.count("The python and terminal tools run where") == 1
 
 
 @pytest.mark.parametrize(
     ("enabled", "expected"),
     [
-        (["python"], "The python tool runs on"),
-        (["terminal"], "The terminal tool runs on"),
-        (["python", "terminal"], "The python and terminal tools run on"),
+        (["python"], "The python tool runs where"),
+        (["terminal"], "The terminal tool runs where"),
+        (["python", "terminal"], "The python and terminal tools run where"),
         # Order comes from _LOCAL_CODE_TOOLS, not from the caller's list.
-        (["terminal", "python"], "The python and terminal tools run on"),
+        (["terminal", "python"], "The python and terminal tools run where"),
     ],
     ids = ["python_only", "terminal_only", "both", "reversed"],
 )
@@ -258,11 +266,11 @@ def test_the_tip_names_only_the_selected_code_tools(enabled, expected):
     nudge = _build_tool_action_nudge(tools = tools, model_name = "test-8B", full_access = True)
     assert expected in nudge
     for absent in {"python", "terminal"} - set(enabled):
-        assert f"The {absent} tool runs on" not in nudge
-        assert f"and {absent} tools run on" not in nudge
+        assert f"The {absent} tool runs where" not in nudge
+        assert f"and {absent} tools run where" not in nudge
     # Studio can be served remotely, so the tools' host is not necessarily the
     # device in front of the user.
-    assert "not always the device the user is viewing this on" in nudge
+    assert "not necessarily the device the user is viewing this on" in nudge
     # The actual reported failure: the model asserted isolation instead of
     # checking, so the nudge has to redirect that guess to a tool call.
     assert "check with a tool call" in nudge
@@ -296,7 +304,7 @@ def test_full_access_tip_needs_a_code_tool():
     """web_search alone runs nothing locally, so the sandbox sentence would be
     noise (and false)."""
     nudge = _build_tool_action_nudge(tools = _WEB_ONLY, model_name = "test-8B", full_access = True)
-    assert "machine running Unsloth Studio" not in nudge
+    assert "where Unsloth Studio is running" not in nudge
     assert nudge == _build_tool_action_nudge(tools = _WEB_ONLY, model_name = "test-8B")
 
 

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -214,6 +214,11 @@ def test_nudge_states_the_environment_under_full_access():
     nudge = _build_tool_action_nudge(tools = _CODE_TOOLS, model_name = "test-8B", full_access = True)
     assert "machine running Unsloth Studio" in nudge
     assert "code sandbox and the approval prompts disabled" in nudge
+    # Scoped to the two local tools: execute_tool passes disable_sandbox to
+    # python/terminal only, web_search is a network call, and an MCP tool may run
+    # on a remote server, so an unqualified "tool calls run here" is wrong when
+    # any of those are enabled alongside.
+    assert nudge.count("The python and terminal tools run on") == 1
     # Studio can be served remotely, so the tools' host is not necessarily the
     # device in front of the user.
     assert "not always the device the user is viewing this on" in nudge

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -33,7 +33,7 @@ from core.inference.tools import (
 )
 from models.inference import ChatCompletionRequest, ChatCountTokensRequest
 from routes.inference import (
-    _TOOL_FULL_ACCESS_TIP,
+    _full_access_tip,
     _build_tool_action_nudge,
     _select_request_tools,
 )
@@ -93,7 +93,8 @@ def test_full_access_schemas_keep_name_and_parameters():
 
 
 @pytest.mark.parametrize("platform", ["linux", "darwin", "win32"])
-def test_the_substitutions_land_on_every_platform(monkeypatch, platform):
+@pytest.mark.parametrize("tool_name", ["python", "terminal"])
+def test_the_substitutions_land_on_every_platform(monkeypatch, platform, tool_name):
     """The module constants are built once for the host platform, so a Linux
     runner would never exercise the Windows branch. Rebuild the note per
     platform and re-derive, which is also the guard against a rewording of
@@ -103,7 +104,7 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform):
     sandboxed = "Execute Python code in a sandbox and return stdout/stderr." + (
         tools._build_sandbox_paths_note()
     )
-    full = tools._to_full_access(sandboxed)
+    full = tools._to_full_access(sandboxed, tool_name)
 
     assert full != sandboxed
     assert "in a sandbox" not in full
@@ -116,7 +117,14 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform):
     # paths resolve" would have the model report a write that went elsewhere.
     if platform != "win32":
         assert "/mnt/data" in full
-        assert "redirected into the working directory" in full
+        # sitecustomize is a CPython startup hook: it heals an absent /mnt/data
+        # for python (and any python terminal launches), but a plain shell
+        # redirect just fails, so only python may promise the redirect.
+        if tool_name == "python":
+            assert "redirected into the working directory" in full
+        else:
+            assert "redirected" not in full
+            assert "write to the working directory instead" in full
     # True in both modes, so untouched.
     assert "persists for this conversation" in full
     assert "download link" in full
@@ -219,6 +227,28 @@ def test_nudge_states_the_environment_under_full_access():
     # on a remote server, so an unqualified "tool calls run here" is wrong when
     # any of those are enabled alongside.
     assert nudge.count("The python and terminal tools run on") == 1
+
+
+@pytest.mark.parametrize(
+    ("enabled", "expected"),
+    [
+        (["python"], "The python tool runs on"),
+        (["terminal"], "The terminal tool runs on"),
+        (["python", "terminal"], "The python and terminal tools run on"),
+        # Order comes from _LOCAL_CODE_TOOLS, not from the caller's list.
+        (["terminal", "python"], "The python and terminal tools run on"),
+    ],
+    ids = ["python_only", "terminal_only", "both", "reversed"],
+)
+def test_the_tip_names_only_the_selected_code_tools(enabled, expected):
+    """enabled_tools=["python"] leaves terminal out of the request's schemas, so
+    naming it would advertise a tool the loop would refuse to run."""
+    tools = [t for t in ALL_TOOLS if t["function"]["name"] in enabled]
+    nudge = _build_tool_action_nudge(tools = tools, model_name = "test-8B", full_access = True)
+    assert expected in nudge
+    for absent in {"python", "terminal"} - set(enabled):
+        assert f"The {absent} tool runs on" not in nudge
+        assert f"and {absent} tools run on" not in nudge
     # Studio can be served remotely, so the tools' host is not necessarily the
     # device in front of the user.
     assert "not always the device the user is viewing this on" in nudge
@@ -233,7 +263,7 @@ def test_full_access_only_returns_the_sentence_alone():
     only = _build_tool_action_nudge(
         tools = _CODE_TOOLS, model_name = "test-8B", full_access = True, full_access_only = True
     )
-    assert only == _TOOL_FULL_ACCESS_TIP
+    assert only == _full_access_tip(["python", "terminal"])
     assert "The current date is" not in only
     assert "Tools are available when they materially improve" not in only
 

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -32,7 +32,11 @@ from core.inference.tools import (
     apply_full_access_tool_descriptions,
 )
 from models.inference import ChatCompletionRequest, ChatCountTokensRequest
-from routes.inference import _build_tool_action_nudge, _select_request_tools
+from routes.inference import (
+    _TOOL_FULL_ACCESS_TIP,
+    _build_tool_action_nudge,
+    _select_request_tools,
+)
 
 
 def _desc(tool: dict) -> str:
@@ -64,7 +68,11 @@ def test_full_access_descriptions_drop_the_isolation_claim(tool):
     # The one claim that is outright false with the sandbox off.
     assert "do not exist" not in description
     assert "sandbox is disabled" in description
-    assert "user's own machine" in description
+    assert "machine running Unsloth Studio" in description
+    # The remote modes (--secure / -H 0.0.0.0, README) put the tools on the host
+    # serving Studio, not on the device the user is looking at, so the prompt
+    # must not claim the two are the same.
+    assert "user's own machine" not in description
     # The workdir really is still the per-session dir in bypass mode
     # (_build_bypass_env repoints HOME/TMPDIR/TEMP/TMP at it), so the relative
     # path advice and the download-link note both have to survive.
@@ -101,17 +109,19 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform):
     assert "in a sandbox" not in full
     assert "do not exist" not in full
     assert "sandbox is disabled" in full
-    assert "absolute paths do resolve" in full
+    assert "do resolve" in full
+    assert "user's own machine" not in full
+    # _build_bypass_env keeps _SANDBOX_SITE_DIR on PYTHONPATH, so sitecustomize
+    # still heals these onto the workdir under Full access. A blanket "absolute
+    # paths resolve" would have the model report a write that went elsewhere.
+    if platform != "win32":
+        assert "/mnt/data" in full
+        assert "redirected into the working directory" in full
     # True in both modes, so untouched.
     assert "persists for this conversation" in full
     assert "download link" in full
     if platform == "win32":
         assert "You are on Windows" in full
-        assert "/mnt/data" not in full
-    else:
-        # The POSIX clause naming ChatGPT's /mnt/data is what gets rewritten.
-        assert "/mnt/data" in sandboxed
-        assert "/mnt/data" not in full
 
 
 def test_python_full_access_description_still_omits_the_shell():
@@ -202,18 +212,45 @@ def test_nudge_is_unchanged_without_full_access():
 
 def test_nudge_states_the_environment_under_full_access():
     nudge = _build_tool_action_nudge(tools = _CODE_TOOLS, model_name = "test-8B", full_access = True)
-    assert "user's own machine" in nudge
+    assert "machine running Unsloth Studio" in nudge
     assert "code sandbox and the approval prompts disabled" in nudge
+    # Studio can be served remotely, so the tools' host is not necessarily the
+    # device in front of the user.
+    assert "not always the device the user is viewing this on" in nudge
     # The actual reported failure: the model asserted isolation instead of
     # checking, so the nudge has to redirect that guess to a tool call.
     assert "check with a tool call" in nudge
+
+
+def test_full_access_only_returns_the_sentence_alone():
+    """The Codex studio-tools path has never carried the general tool nudge, so
+    it takes the Full access sentence without the date or the base guidance."""
+    only = _build_tool_action_nudge(
+        tools = _CODE_TOOLS, model_name = "test-8B", full_access = True, full_access_only = True
+    )
+    assert only == _TOOL_FULL_ACCESS_TIP
+    assert "The current date is" not in only
+    assert "Tools are available when they materially improve" not in only
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"full_access": False}, {"full_access": True, "tools": _WEB_ONLY}],
+    ids = ["not_full_access", "no_code_tool"],
+)
+def test_full_access_only_is_empty_when_it_does_not_apply(kwargs):
+    tools = kwargs.pop("tools", _CODE_TOOLS)
+    assert (
+        _build_tool_action_nudge(tools = tools, model_name = "test-8B", full_access_only = True, **kwargs)
+        == ""
+    )
 
 
 def test_full_access_tip_needs_a_code_tool():
     """web_search alone runs nothing locally, so the sandbox sentence would be
     noise (and false)."""
     nudge = _build_tool_action_nudge(tools = _WEB_ONLY, model_name = "test-8B", full_access = True)
-    assert "user's own machine" not in nudge
+    assert "machine running Unsloth Studio" not in nudge
     assert nudge == _build_tool_action_nudge(tools = _WEB_ONLY, model_name = "test-8B")
 
 

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -135,6 +135,11 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform, tool_na
         assert "replacing any file already sitting there" in full
         assert "only the base name is kept" in full
         assert "fails outright if that name is taken" in full
+        # Only open/io.open/os.open and the mkdir family are wrapped. Measured:
+        # os.rename and os.symlink raise, and shutil.copy writes the rewritten
+        # file through open and then raises in copymode.
+        assert "reach only open() and the mkdir calls" in full
+        assert "shutil.copy can write the rewritten file and still raise" in full
     else:
         assert "absolute paths do resolve as the shell resolves them" in full
         # _build_bypass_env sets PYTHONPATH for the terminal subprocess too, so

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -127,19 +127,29 @@ def test_the_substitutions_land_on_every_platform(monkeypatch, platform, tool_na
     # unless that name is taken, where it raises.
     if tool_name == "python":
         assert "absolute paths under a directory that exists do resolve" in full
-        assert "redirected into the working directory under the same base name" in full
-        assert "fails outright if that name is already taken" in full
+        # Two branches, measured: an absent convention prefix keeps the SUFFIX
+        # (/mnt/data/reports/out.csv -> ./reports/out.csv) and overwrites an
+        # existing file; any other missing parent keeps only the base name and
+        # raises when that name is taken. Describing one as both was wrong.
+        assert "the rest of the path is kept relative to the working directory" in full
+        assert "replacing any file already sitting there" in full
+        assert "only the base name is kept" in full
+        assert "fails outright if that name is taken" in full
     else:
         assert "absolute paths do resolve as the shell resolves them" in full
         # _build_bypass_env sets PYTHONPATH for the terminal subprocess too, so
         # python launched from a shell command carries the same shim.
         assert "Python you launch from here is the exception" in full
-        assert "lands in the working directory under its base name" in full
+        assert "gets the same rewrites" in full
     # No categorical claim about the convention paths in either: on a host where
     # /mnt/data is a real mount the shim never shadows it, so "not real" is wrong,
     # and the parent-directory rule already covers the absent case.
-    assert "/mnt/data" not in full
+    # /mnt/data may be named, but only inside the conditional describing what
+    # happens while it is ABSENT; a real mount is never shadowed, so no
+    # categorical "not real" claim may survive.
     assert "not real there" not in full
+    if tool_name == "python":
+        assert "when the directory does not exist" in full
     # True in both modes, so untouched.
     assert "persists for this conversation" in full
     assert "download link" in full

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1680,10 +1680,9 @@ export async function buildLocalTokenCountExtras(
     // request that never mentions them, so every pill being off has to say so.
     // The permission level rides along because `--enable-tools` still outranks
     // that false in _effective_enable_tools, so a CLI policy can inject
-    // python/terminal into a pill-less request; the completion sends the level
-    // on every local chat, and without it here the count would price the
-    // sandboxed schemas against an unsandboxed completion. Inert whenever the
-    // false stands and no tool list is built.
+    // python/terminal into a pill-less request and the count would otherwise
+    // price sandboxed schemas against an unsandboxed completion. Inert whenever
+    // the false stands and no tool list is built.
     return { enable_tools: false, bypass_permissions: bypassPermissions };
   }
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1676,7 +1676,12 @@ export async function buildLocalTokenCountExtras(
     !mcpEnabledForChat &&
     !ragOn
   ) {
-    return {};
+    // No pill is on, but a CLI policy (unsloth run --enable-tools) can still make
+    // the backend inject python/terminal, and the completion sends the permission
+    // level on every local chat. Carry the flag so that count renders the same
+    // Full access prompt the completion will. Without a policy the backend never
+    // builds a tool list for a count, so the flag is inert.
+    return { bypass_permissions: bypassPermissions };
   }
 
   return {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1660,6 +1660,7 @@ export async function buildLocalTokenCountExtras(
     ragMode,
     ragTopK,
     autoHealToolCalls,
+    bypassPermissions,
   } = useChatRuntimeStore.getState();
   if (!supportsTools) return {};
 
@@ -1682,6 +1683,9 @@ export async function buildLocalTokenCountExtras(
     enable_tools: true,
     // Auto-Heal off leaves leaked tool markup in the real prompt, so the count keeps it.
     auto_heal_tool_calls: autoHealToolCalls,
+    // Full access swaps the python/terminal descriptions and adds a nudge
+    // sentence, so the count needs the flag to price the same prompt.
+    bypass_permissions: bypassPermissions,
     enabled_tools: [
       ...(ragOn ? ["search_knowledge_base"] : []),
       ...(toolsEnabled ? ["web_search"] : []),


### PR DESCRIPTION
## The report

Someone set the composer permission pill to **Full access**, with the Code pill on, and asked the model whether it could see the files on their laptop. It replied:

> No, I **cannot** see any files on your laptop, access your hard drive, or view anything on your screen. [...] For security and privacy reasons, I operate in a "sandboxed" environment, meaning I am completely isolated from your personal device and its local storage.

It never called a tool. It had `terminal` in hand and the sandbox was off.

## Why

`permission_mode="full"` folds to `bypass_permissions=True` (`models/inference.py`), which the tool loops pass on as `disable_sandbox=True` (`llama_cpp.py`, `safetensors_agentic.py`, `openai_codex_tool_loop.py`). In `tools.py` that flag skips `_check_code_safety`, skips the command blocklist, swaps `_build_safe_env` for `_build_bypass_env` and `_sandbox_preexec` for `_bypass_preexec`. Absolute host paths resolve; the rlimits are gone.

That is the whole effect. Nothing the model can see changes with it:

- `PYTHON_TOOL` and `TERMINAL_TOOL` are module-level constants, computed once at import from `_build_sandbox_paths_note()`. The python description opens with `"Execute Python code in a sandbox"`, and on POSIX both carry `"absolute paths like /mnt/data or /tmp/outputs do not exist"`. Under Full access both claims are false, and there was no way for them to vary per request.
- `_build_tool_action_nudge()` took only `(tools, model_name)`. No branch anywhere told the model which of ask / auto / off / full was active, or whether the sandbox was on.

So the only description of its own environment the model gets says it is sandboxed, and it answers accordingly. The Windows branch of the note already says "this runs on the user's own machine"; the POSIX branch has no equivalent, which is why this reads worst on a laptop.

## The fix

**Schemas.** `tools.py` gains `PYTHON_TOOL_FULL_ACCESS` / `TERMINAL_TOOL_FULL_ACCESS`, built from a new `_build_full_access_paths_note()`, and `apply_full_access_tool_descriptions()` to swap them in. Only the description differs: name and `parameters` are shared with the sandboxed pair, and the platform-derived terminal shell note still applies. The sandboxed pair stays the module default and `ALL_TOOLS` is untouched, so every existing importer keeps the safe wording and the module globals are never mutated.

What survives into the Full access text, deliberately: the relative-path advice and the download-link note. `_build_bypass_env` still repoints `HOME` / `TMPDIR` / `TEMP` / `TMP` at the per-session workdir, so relative paths really do land there in both modes. What goes is the isolation claim and "absolute paths do not exist".

**Nudge.** `_build_tool_action_nudge()` takes `full_access` and, when a code tool is present, appends a sentence stating that tool calls run on the user's own machine with the sandbox and approvals off, and that a question about what it can see on that machine should be answered with a tool call rather than a guess. The schema change alone does not undo the model's prior about what a chat assistant can reach, which is what actually produced the reply above. Gated on a code tool being present: with `web_search` alone the sentence would be noise, and false.

**Wiring.** The swap lives in `_select_request_tools`, which covers the GGUF loop, the safetensors loop, the token-count mirror, and the Codex studio-tools path. The Anthropic-compat server-tool loop builds its own selection from `ALL_TOOLS`, so it repeats both the swap and the nudge flag. Built-ins only, and before the MCP append, so an MCP tool's description stays the server's to write.

**Token count parity.** The Full access descriptions are a different length, so a count that omits the flag prices a prompt the completion will not send. `ChatCountTokensRequest` gains `permission_mode` / `bypass_permissions` with the same fold as `ChatCompletionRequest` (declared explicitly rather than left to `extra="allow"`, so an omitted flag reads as `None` instead of raising `AttributeError`), and `buildLocalTokenCountExtras` sends the flag.

## What does not change

- ask / auto / off keep the sandboxed descriptions and the unchanged nudge, byte for byte. Pinned by test.
- No change to what any tool is permitted to do. This is purely what the model is told about a mode it was already running in.
- Full access still requires the existing danger confirmation before it can be turned on, and still attaches no tools on its own: it is an approval policy, and the Code pill is what puts `python` / `terminal` in the request.

## Testing

New `studio/backend/tests/test_full_access_tool_prompt.py`, 25 tests: the sandboxed pair is unchanged; the Full access pair drops the isolation claim, keeps the workdir and download-link advice, shares name and parameters, keeps the shell note, and still omits any mention of a shell from the python description; the swap leaves other tools alone and does not mutate `ALL_TOOLS`; ask / auto / off / omitted all keep the sandboxed schemas while both spellings of Full access swap them; the nudge is byte-identical without `full_access` and states the environment with it; the count request folds the mode and selects the same tools as the completion.

Also run locally against the backend CI dependency set:

- `tests/test_windows_bash_shell.py`, `test_sandbox_files_and_storage_roots.py`, `test_permission_mode.py`, `test_bypass_permissions.py`, `test_nudge_tool_calls_wiring.py`: 2146 passed, 4 skipped.
- `ruff check studio/backend`: clean, and `scripts/run_ruff_format.py` applied with the pinned `ruff==0.6.9`.
- Frontend `npm run typecheck`: clean.
