### PR TITLE
tests: drop --single-process from the Chromium launch args

### DIFF
--- a/tests/studio/_playwright_robust.py
+++ b/tests/studio/_playwright_robust.py
@@ -23,8 +23,14 @@ from typing import Any, Callable
 # headless window is backgrounded (run 25586583024 stalled inference + render).
 # TranslateUI strips a pointer-intercepting popup; ipc-flooding-protection off
 # lets rapid clicks through during the slider sweep.
-# `--single-process` is darwin-only (fixes the pipeTransport.js JSON-RPC crash);
-# on Win/Linux it destabilises the renderer.
+# No `--single-process`. It was darwin-only, for a pipeTransport.js JSON-RPC crash,
+# and it caps Chromium at exactly ONE BrowserContext: opening a second one kills the
+# browser with SIGTRAP, and the next new_page() raises "Target page, context or
+# browser has been closed". Closing a context does it too, even with another still
+# open. That is what made "Update banner layout regression" red on every macos-14 run
+# (it needs a context per viewport), and it is why playwright_chat_ui.py had to keep
+# every step inside one context. Measured with chromium-headless-shell 151: with the
+# flag, a second context dies immediately; without it, 12 open/close cycles pass.
 _BASE_CHROMIUM_ARGS = (
     "--disable-dev-shm-usage",
     "--no-sandbox",
@@ -38,13 +44,10 @@ _BASE_CHROMIUM_ARGS = (
 
 
 def chromium_launch_args(platform: str | None = None) -> list[str]:
-    """Chromium launch args for `platform` (defaults to `sys.platform`; pass a
-    string to test the darwin branch on Linux)."""
-    p = sys.platform if platform is None else platform
-    args = list(_BASE_CHROMIUM_ARGS)
-    if p == "darwin":
-        args.append("--single-process")
-    return args
+    """Chromium launch args. Same on every platform; `platform` is accepted so
+    callers that pass one keep working."""
+    del platform
+    return list(_BASE_CHROMIUM_ARGS)
 
 
 # Init script injected into every Playwright context.
@@ -234,8 +237,8 @@ BENIGN_PAGE_ERROR_PATTERNS: tuple[str, ...] = (
 )
 
 BENIGN_CONSOLE_ERROR_PATTERNS: tuple[str, ...] = (
-    # macos-14 buffer-exhaustion under --single-process; the test catches the
-    # underlying request failure via expect_response and retries.
+    # macos-14 buffer exhaustion; the test catches the underlying request
+    # failure via expect_response and retries.
     "net::ERR_NO_BUFFER_SPACE",
     # Intentional fetch aborts (unmount, route change) log a console.error.
     "AbortError",

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -568,8 +568,8 @@ with sync_playwright() as p:
         ),
     )
     page = ctx.new_page()
-    # 60s default (was 30s): macos-14 under --single-process Chromium is
-    # slow enough that renders/webfonts/lazy routes routinely crowd 30s.
+    # 60s default (was 30s): the macos-14 runners are slow enough that
+    # renders/webfonts/lazy routes routinely crowd 30s.
     page.set_default_timeout(60_000)
     page_errors = []
     page.on("pageerror", lambda e: page_errors.append(str(e)))
@@ -2008,10 +2008,10 @@ with sync_playwright() as p:
     # ─────────────────────────────────────────────────────
     step("persisted monitor stays dormant on /login and resumes after auth")
     # Start fresh after the CLI rotation invalidates this browser session.
-    # Stay in the SAME context: macOS Chromium runs --single-process, where
-    # closing the last context kills the browser and a second context cannot
-    # be created. Open the new page before closing the old one; the context
-    # init script covers the new page.
+    # Stay in the SAME context: it keeps the init script and costs nothing to
+    # reuse. This used to be forced, because macOS ran --single-process Chromium,
+    # which allows only one context; that flag is gone now. Open the new page
+    # before closing the old one; the context init script covers the new page.
     try:
         ctx.clear_cookies()
     except Exception as exc:

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -105,7 +105,7 @@ with sync_playwright() as p:
     )
     install_view_transition_killer(ctx)
     page = ctx.new_page()
-    # 60s default for slow macos-14 --single-process Chromium (second Unsloth boot of the job).
+    # 60s default for the slow macos-14 runner (second Unsloth boot of the job).
     page.set_default_timeout(60_000)
     page_errors = []
 


### PR DESCRIPTION
### The failure

"Update banner layout regression (Playwright)" fails on every macos-14 run, on `main` as much as on PR branches. Chromium dies mid-run and Playwright reports:

```
[pid=19540] <process did exit: exitCode=null, signal=SIGTRAP>
playwright._impl._errors.TargetClosedError: BrowserContext.new_page: Target page, context or browser has been closed
```

Around 150 layout assertions pass first, then it dies opening the next viewport's context. I hit it while staging an unrelated PR, went looking for what my change had broken, and found the same red on staging `main` and on PRs 8453, 8461, 8480 and 8499.

### The cause

`--single-process`, which we add on darwin only, for a pipeTransport.js JSON-RPC crash. Under that flag Chromium supports exactly one BrowserContext. Reproduced against chromium-headless-shell 151:

| launch | scenario | result |
| --- | --- | --- |
| no flag | 12 contexts opened and closed | OK |
| `--single-process` | 8 contexts, never closed | TargetClosedError |
| `--single-process` | close 1 of 2, reuse the other | TargetClosedError |
| `--single-process` | 1 context, 8 pages opened and closed | OK |
| `--single-process` | 1 context, resized repeatedly | OK |

A second context kills the browser whether or not the first was closed, so the mechanism is not "closing the last context" as the note in `playwright_chat_ui.py` had it. The banner test opens a context per viewport, since each needs its own init script and route stubs, so it could never pass with the flag on. The same constraint is why `playwright_chat_ui.py` had to keep every step inside one context.

My first attempt was to hold a spare context open for the run. Testing it showed that does nothing, because the second context is itself the problem. Removing the flag is the actual fix.

### The change

`chromium_launch_args` returns the same list everywhere, so the darwin branch goes. The `platform` parameter is kept so existing callers still work.

Replaying the banner test's exact shape with the flag removed, 6 contexts each opened, used for 3 routes and closed:

```
OK: 6 contexts opened+closed, 18 route checks, browser alive
```

Comments in `playwright_chat_ui.py` and `playwright_extra_ui.py` that justified a workaround or a timeout by citing the flag are updated to match. No timeout value, no benign-error allowlist entry and no test behaviour changes, so the suites that pass today keep passing. Staying inside one context in `playwright_chat_ui.py` is left as is; it is no longer forced, but it is still the cheaper thing to do.

### Risk

The flag was there for a reason: a pipeTransport.js JSON-RPC crash on macOS, added in May. If that crash returns it will show up on the macOS Playwright jobs, which are red today anyway, so this cannot make the signal worse than it is. Chromium and Playwright have both moved several versions since.