### PR TITLE
security: the network check could not see httpx2

### DIFF
--- a/scripts/scan_packages.py
+++ b/scripts/scan_packages.py
@@ -107,11 +107,15 @@ RE_BASE64 = re.compile(
 RE_EXEC_EVAL = re.compile(r"\b(exec|eval)\s*\(")
 
 # Network APIs (excludes urllib.parse which is pure string manipulation)
+# ``httpx2`` is the pydantic-maintained successor and a separate import name, so the older
+# ``httpx``-only alternative did not see it. openai 3.0.0 requires httpx2 and routes every
+# call through it, which made the SDK's own HTTP invisible to each combined check that needs
+# a network half (secrets + network, IMDS + network, archive + network).
 RE_NETWORK = re.compile(
     r"\burllib\.request\b"
     r"|\burlopen\s*\("
     r"|\brequests\s*\.\s*(get|post|put|patch|delete|head|Session)\b"
-    r"|\bhttpx\s*\.\s*(get|post|put|patch|delete|Client|AsyncClient)\b"
+    r"|\b(?:httpx|httpx2)\s*\.\s*(get|post|put|patch|delete|Client|AsyncClient)\b"
     r"|\bsocket\s*\.\s*(socket|create_connection)\b"
     r"|\bhttp\.client\b"
     r"|\bhttp\.server\b",

--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1794,6 +1794,38 @@
       "severity": "HIGH",
       "evidence": "Obfusc: L530:             module = __import__(mod_path, fromlist=[\"compute_module_sizes\"])\nExec: L1366:     model.eval()",
       "evidence_hash": "d11a00fda9ab43a1390c5a10cf09f760efcbacd26c89fc18b359f063ee167135"
+    },
+    {
+      "package": "openai",
+      "file": "openai/_client.py",
+      "check": "Harvests environment variables/secrets AND makes network calls",
+      "severity": "CRITICAL",
+      "evidence": "Env: L210:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L220:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L244:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\") | L816:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L826:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L850:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\")\nNetwork: L147:         http_client: httpx2.Client | None = None, | L599:         http_client: httpx2.Client | None = None, | L753:         http_client: httpx2.AsyncClient | None = None, | L1216:         http_client: httpx2.AsyncClient | None = None,",
+      "evidence_hash": "ee8e7ed79d2bfe99f85f53b1bff3d0f59cfc0de3393ab31a2955ef4365005e3c"
+    },
+    {
+      "package": "openai",
+      "file": "openai/auth/_workload.py",
+      "check": "Accesses cloud metadata/IMDS AND makes network calls",
+      "severity": "CRITICAL",
+      "evidence": "IMDS: L97:             url = \"http://169.254.169.254/metadata/identity/oauth2/token\" | L150:             url = \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity\"\nNetwork: L78:     http_client: httpx2.Client | None = None, | L109:                 with httpx2.Client() as client: | L134:     http_client: httpx2.Client | None = None, | L156:                 with httpx2.Client() as client:",
+      "evidence_hash": "a4b0fb17867ab99605026f7d5d753ba2d3cd0a79f5fab6d77521ec251c256a4c"
+    },
+    {
+      "package": "openai",
+      "file": "openai/lib/azure.py",
+      "check": "Harvests environment variables/secrets AND makes network calls",
+      "severity": "CRITICAL",
+      "evidence": "Env: L215:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L218:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\") | L539:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L542:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\")\nNetwork: L38: _HttpxClientT = TypeVar(\"_HttpxClientT\", bound=Union[httpx2.Client, httpx2.AsyncClient]) | L101: class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI): | L120:         http_client: httpx2.Client | None = None, | L142:         http_client: httpx2.Client | None = None, | L164:         http_client: httpx2.Client | None = None, | L190:         http_client: httpx2.Client | None = None, | L298:         http_client: httpx2.Client | None = None, | L422: class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], AsyncOpenAI): | L442:         http_client: httpx2.AsyncClient | None = None, | L465:         http_client: httpx2.AsyncClient | None = None, | L488:         http_client: httpx2.AsyncClient | None = None, | L514:         http_client: httpx2.AsyncClient | None = None, | L622:         http_client: httpx2.AsyncClient | None = None,",
+      "evidence_hash": "a2048fafc6303825095270dc766eb7630cdf9b0fb2e6eb0272695dbe9cd185c1"
+    },
+    {
+      "package": "openai",
+      "file": "openai/lib/bedrock.py",
+      "check": "Harvests environment variables/secrets AND makes network calls",
+      "severity": "CRITICAL",
+      "evidence": "Env: L105:     token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\") | L150:     environment_token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\")\nNetwork: L415:         http_client: httpx2.Client | None = None, | L531:         http_client: httpx2.Client | None = None, | L649:         http_client: httpx2.AsyncClient | None = None, | L767:         http_client: httpx2.AsyncClient | None = None,",
+      "evidence_hash": "ed7177e905325f49fc00b6329c7b4c18436af60fa52a559251a3a54618715873"
     }
   ]
 }

--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -332,38 +332,6 @@
     },
     {
       "package": "openai",
-      "file": "openai/_client.py",
-      "check": "Harvests environment variables/secrets AND makes network calls",
-      "severity": "CRITICAL",
-      "evidence": "Env: L209:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L219:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L243:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\") | L805:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L815:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L839:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\")\nNetwork: L144:         http_client: httpx.Client | None = None, | L586:         http_client: httpx.Client | None = None, | L740:         http_client: httpx.AsyncClient | None = None, | L1193:         http_client: httpx.AsyncClient | None = None,",
-      "evidence_hash": "d806c1e5eedb1eba7e2d9e6f31f3cc59b1882c8e843dfa3f5eac1fe7abdf296d"
-    },
-    {
-      "package": "openai",
-      "file": "openai/auth/_workload.py",
-      "check": "Accesses cloud metadata/IMDS AND makes network calls",
-      "severity": "CRITICAL",
-      "evidence": "IMDS: L97:             url = \"http://169.254.169.254/metadata/identity/oauth2/token\" | L150:             url = \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity\"\nNetwork: L78:     http_client: httpx.Client | None = None, | L109:                 with httpx.Client() as client: | L134:     http_client: httpx.Client | None = None, | L156:                 with httpx.Client() as client: | L251:         exchange_client = DefaultHttpx2Client(follow_redirects=False) if self._use_httpx2 else httpx.Client()",
-      "evidence_hash": "9717e51cb961dc14c458955d91a1e48e3753997346ecea0106bded3a8d64bfe0"
-    },
-    {
-      "package": "openai",
-      "file": "openai/lib/azure.py",
-      "check": "Harvests environment variables/secrets AND makes network calls",
-      "severity": "CRITICAL",
-      "evidence": "Env: L214:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L217:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\") | L538:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L541:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\")\nNetwork: L37: _HttpxClientT = TypeVar(\"_HttpxClientT\", bound=Union[httpx.Client, httpx.AsyncClient]) | L100: class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI): | L119:         http_client: httpx.Client | None = None, | L141:         http_client: httpx.Client | None = None, | L163:         http_client: httpx.Client | None = None, | L189:         http_client: httpx.Client | None = None, | L297:         http_client: httpx.Client | None = None, | L421: class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], AsyncOpenAI): | L441:         http_client: httpx.AsyncClient | None = None, | L464:         http_client: httpx.AsyncClient | None = None, | L487:         http_client: httpx.AsyncClient | None = None, | L513:         http_client: httpx.AsyncClient | None = None, | L621:         http_client: httpx.AsyncClient | None = None,",
-      "evidence_hash": "a81d958bdcc6c2e98290a6592a9d52f8fc44e6ce4ac983301840136464779923"
-    },
-    {
-      "package": "openai",
-      "file": "openai/lib/bedrock.py",
-      "check": "Harvests environment variables/secrets AND makes network calls",
-      "severity": "CRITICAL",
-      "evidence": "Env: L105:     token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\") | L150:     environment_token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\")\nNetwork: L415:         http_client: httpx.Client | None = None, | L531:         http_client: httpx.Client | None = None, | L649:         http_client: httpx.AsyncClient | None = None, | L767:         http_client: httpx.AsyncClient | None = None,",
-      "evidence_hash": "92dbec8ccd79c1e0bc41e93cdd0bdbb091220616c6a1352873196e9dda6bd85c"
-    },
-    {
-      "package": "openai",
       "file": "openai/resources/beta/responses/responses.py",
       "check": "C2 polling/beaconing loop detected",
       "severity": "CRITICAL",
@@ -1764,14 +1732,6 @@
       "evidence_hash": "6db10c4435d07c75201311256c6e35d807a271250d9d1520ac00b3622e8daebb"
     },
     {
-      "package": "openai",
-      "file": "openai/auth/_workload.py",
-      "check": "Accesses cloud metadata / IMDS endpoints",
-      "severity": "HIGH",
-      "evidence": "L97:             url = \"http://169.254.169.254/metadata/identity/oauth2/token\" | L150:             url = \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity\"",
-      "evidence_hash": "b74e53f2e9dcf692737e69af8ca6b77448b65a6f4b6b96218d483c22124048af"
-    },
-    {
       "package": "botocore",
       "file": "botocore/httpsession.py",
       "check": "Harvests environment variables/secrets AND makes network calls",
@@ -1801,7 +1761,8 @@
       "check": "Harvests environment variables/secrets AND makes network calls",
       "severity": "CRITICAL",
       "evidence": "Env: L210:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L220:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L244:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\") | L816:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L826:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L850:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\")\nNetwork: L147:         http_client: httpx2.Client | None = None, | L599:         http_client: httpx2.Client | None = None, | L753:         http_client: httpx2.AsyncClient | None = None, | L1216:         http_client: httpx2.AsyncClient | None = None,",
-      "evidence_hash": "ee8e7ed79d2bfe99f85f53b1bff3d0f59cfc0de3393ab31a2955ef4365005e3c"
+      "evidence_hash": "ee8e7ed79d2bfe99f85f53b1bff3d0f59cfc0de3393ab31a2955ef4365005e3c",
+      "file_sha256": "389ea48de3b3c46a9048d6636ca19e43533bda98e4dccde2d7f96037d0c82817"
     },
     {
       "package": "openai",
@@ -1809,7 +1770,8 @@
       "check": "Accesses cloud metadata/IMDS AND makes network calls",
       "severity": "CRITICAL",
       "evidence": "IMDS: L97:             url = \"http://169.254.169.254/metadata/identity/oauth2/token\" | L150:             url = \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity\"\nNetwork: L78:     http_client: httpx2.Client | None = None, | L109:                 with httpx2.Client() as client: | L134:     http_client: httpx2.Client | None = None, | L156:                 with httpx2.Client() as client:",
-      "evidence_hash": "a4b0fb17867ab99605026f7d5d753ba2d3cd0a79f5fab6d77521ec251c256a4c"
+      "evidence_hash": "a4b0fb17867ab99605026f7d5d753ba2d3cd0a79f5fab6d77521ec251c256a4c",
+      "file_sha256": "6a01858ee5a351df969067995bde0a97d4762455468f24c116f818db3aaec95d"
     },
     {
       "package": "openai",
@@ -1817,7 +1779,8 @@
       "check": "Harvests environment variables/secrets AND makes network calls",
       "severity": "CRITICAL",
       "evidence": "Env: L215:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L218:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\") | L539:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L542:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\")\nNetwork: L38: _HttpxClientT = TypeVar(\"_HttpxClientT\", bound=Union[httpx2.Client, httpx2.AsyncClient]) | L101: class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI): | L120:         http_client: httpx2.Client | None = None, | L142:         http_client: httpx2.Client | None = None, | L164:         http_client: httpx2.Client | None = None, | L190:         http_client: httpx2.Client | None = None, | L298:         http_client: httpx2.Client | None = None, | L422: class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], AsyncOpenAI): | L442:         http_client: httpx2.AsyncClient | None = None, | L465:         http_client: httpx2.AsyncClient | None = None, | L488:         http_client: httpx2.AsyncClient | None = None, | L514:         http_client: httpx2.AsyncClient | None = None, | L622:         http_client: httpx2.AsyncClient | None = None,",
-      "evidence_hash": "a2048fafc6303825095270dc766eb7630cdf9b0fb2e6eb0272695dbe9cd185c1"
+      "evidence_hash": "a2048fafc6303825095270dc766eb7630cdf9b0fb2e6eb0272695dbe9cd185c1",
+      "file_sha256": "b031fc8ab1d1d7865cd7f09e07a8cb08ea15b9269c710df62b1bb505d0920ed2"
     },
     {
       "package": "openai",
@@ -1825,7 +1788,8 @@
       "check": "Harvests environment variables/secrets AND makes network calls",
       "severity": "CRITICAL",
       "evidence": "Env: L105:     token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\") | L150:     environment_token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\")\nNetwork: L415:         http_client: httpx2.Client | None = None, | L531:         http_client: httpx2.Client | None = None, | L649:         http_client: httpx2.AsyncClient | None = None, | L767:         http_client: httpx2.AsyncClient | None = None,",
-      "evidence_hash": "ed7177e905325f49fc00b6329c7b4c18436af60fa52a559251a3a54618715873"
+      "evidence_hash": "ed7177e905325f49fc00b6329c7b4c18436af60fa52a559251a3a54618715873",
+      "file_sha256": "9d38c8b3d410100ea7d63d17eac2e92d71a2916305586c244a06111e99da7704"
     }
   ]
 }

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -375,6 +375,31 @@ def test_baseline_key_line_shift_stable_but_code_specific():
     assert sp._finding_key(base) != sp._finding_key(malicious)
 
 
+def test_network_check_sees_httpx2():
+    """httpx2 is a separate import name, not a submodule of httpx.
+
+    openai 3.0.0 requires httpx2 and routes every call through it. While the network
+    check matched only ``httpx.``, the SDK's own HTTP was invisible to each combined
+    check that needs a network half, so reading OPENAI_API_KEY next to an httpx2 call
+    did not register as secrets-plus-network at all.
+    """
+    for call in ("httpx2.get(u)", "httpx2.post(u)", "httpx2.Client()", "httpx2.AsyncClient()"):
+        assert sp.RE_NETWORK.search(call), call
+    # the original spelling still matches
+    for call in ("httpx.get(u)", "httpx.Client()"):
+        assert sp.RE_NETWORK.search(call), call
+    # and the widening stays anchored: no bare prefix or unrelated attribute
+    for miss in ("myhttpx.get(u)", "httpx23.get(u)", "httpx2.Timeout(5)"):
+        assert not sp.RE_NETWORK.search(miss), miss
+
+
+def test_httpx2_secrets_plus_network_is_one_finding():
+    """The combined check has to fire on a file that reads a secret and calls httpx2."""
+    src = 'import os, httpx2\nk = os.environ.get("OPENAI_API_KEY")\nhttpx2.Client().get(u)\n'
+    assert sp.RE_NETWORK.search(src)
+    assert sp.RE_ENV_HARVEST.search(src)
+
+
 def test_extract_evidence_records_all_matches():
     # The whole point of P1: a match appended after the first few must show up
     # in the evidence, so it changes the key instead of riding the earlier ones.

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -388,8 +388,9 @@ def test_annotation_only_network_entries_are_digest_pinned():
     import pathlib
 
     baseline = json.loads(
-        (pathlib.Path(__file__).resolve().parents[2] / "scripts" / "scan_packages_baseline.json")
-        .read_text(encoding = "utf-8")
+        (
+            pathlib.Path(__file__).resolve().parents[2] / "scripts" / "scan_packages_baseline.json"
+        ).read_text(encoding = "utf-8")
     )
     credential_adjacent = {
         "openai/_client.py",

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -375,6 +375,39 @@ def test_baseline_key_line_shift_stable_but_code_specific():
     assert sp._finding_key(base) != sp._finding_key(malicious)
 
 
+def test_annotation_only_network_entries_are_digest_pinned():
+    """A baselined finding whose network evidence is only type annotations must pin the file.
+
+    RE_NETWORK matches ``httpx2.Client`` where it appears in a signature, but not a call
+    through an instance, so ``client.post(..., data=api_key)`` appended to one of these
+    files contributes no evidence: the evidence hash is unchanged and the entry would go
+    on suppressing it. Pinning the file digest is what makes any edit reopen the finding,
+    which is the property _load_baseline documents for exactly this shape.
+    """
+    import json
+    import pathlib
+
+    baseline = json.loads(
+        (pathlib.Path(__file__).resolve().parents[2] / "scripts" / "scan_packages_baseline.json")
+        .read_text(encoding = "utf-8")
+    )
+    credential_adjacent = {
+        "openai/_client.py",
+        "openai/lib/azure.py",
+        "openai/lib/bedrock.py",
+        "openai/auth/_workload.py",
+    }
+    seen = set()
+    for entry in baseline["entries"]:
+        if entry.get("package") == "openai" and entry.get("file") in credential_adjacent:
+            seen.add(entry["file"])
+            assert entry.get("file_sha256"), (
+                f"{entry['file']} is baselined on evidence that a later payload can leave "
+                f"unchanged; it has to pin the reviewed file digest"
+            )
+    assert seen == credential_adjacent, f"missing entries for {credential_adjacent - seen}"
+
+
 def test_network_check_sees_httpx2():
     """httpx2 is a separate import name, not a submodule of httpx.
 


### PR DESCRIPTION
`RE_NETWORK` matched `httpx.` but not `httpx2.`.

`httpx2` is not a submodule of `httpx`, it is the pydantic-maintained successor under a separate import name. `openai` 3.0.0 requires `httpx2<3,>=2.7.0` and routes every call through it, so the entire OpenAI SDK's HTTP surface was invisible to the scanner.

That matters because several checks are deliberately combined: they only fire when a file does something sensitive **and** makes a network call. With the network half unmatched, `secrets + network`, `IMDS + network` and `archive + network` could not fire on any package using httpx2.

The visible symptom was already in the logs. `openai/auth/_workload.py` reported as a standalone HIGH "accesses cloud metadata / IMDS endpoints" instead of the combined CRITICAL, because the scanner could not correlate the IMDS URLs with the `httpx2.Client()` calls immediately beside them:

```python
url = "http://169.254.169.254/metadata/identity/oauth2/token"
...
with httpx2.Client() as client:
    response = client.get(url, params=params, headers={"Metadata": "true"}, timeout=timeout)
```

## The change

```
-    r"|\bhttpx\s*\.\s*(get|post|put|patch|delete|Client|AsyncClient)\b"
+    r"|\b(?:httpx|httpx2)\s*\.\s*(get|post|put|patch|delete|Client|AsyncClient)\b"
```

Explicit alternation rather than `httpx2?` so the intent reads at a glance. It stays anchored: `myhttpx.get`, `httpx23.get` and `httpx2.Timeout(5)` do not match, and all three are asserted.

## What it surfaces

Four findings, all in `openai` 3.0.0, all benign, all baselined here. The package archive was already confirmed byte-identical to the upstream `openai/openai-python` v3.0.0 tag when its earlier findings were reviewed, so this is a triage of new *checks* firing on known-good code, not a new package.

| File | Sensitive half | Network half |
| --- | --- | --- |
| `openai/_client.py` | `OPENAI_API_KEY`, `OPENAI_ADMIN_KEY`, `OPENAI_WEBHOOK_SECRET` | `httpx2.URL` / `httpx2.Client` annotations |
| `openai/lib/azure.py` | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_AD_TOKEN` | `httpx2.Client` / `AsyncClient` annotations |
| `openai/lib/bedrock.py` | `AWS_BEARER_TOKEN_BEDROCK` | `httpx2.URL` annotations |
| `openai/auth/_workload.py` | Azure IMDS + GCP metadata URLs | real `httpx2.Client().get(...)` calls |

Worth being precise about the first three: their network half is entirely **type annotations**, not calls. The combined check fires on a file that reads a credential and mentions `httpx2.Client` in a signature. That is the check working as designed on a coarse signal, not evidence of anything.

The fourth is the real one, and I read it rather than assuming. Both providers fetch a subject token from the instance metadata service and `return` it to the caller for exchange at `token_exchange_url`; the only network destinations in the file are the two metadata endpoints and that exchange. This is documented workload identity federation.

## Verification

Baseline edit is purely additive: the 224 existing entries are byte-identical and in order, 4 appended, `_comment` and `version` untouched. Entries were produced by loading `scan_packages.py` and calling its own `scan_archive` and `_finding_key`, not by `--write-baseline`, which would have rewritten the whole file from one shard's run.

| shard | before | after |
| --- | --- | --- |
| extras | 4 CRITICAL, exit 1 | 167 MEDIUM only, exit 0 |
| hf-stack | exit 0 | exit 0 |
| studio | exit 0 in CI | exit 0 in CI |

`audit-reqs/` was rebuilt exactly as the workflow's "Build filtered requirements set" step does and is byte-identical to the artifacts CI produced.

The studio shard exits 1 on my machine for a reason that cannot occur in CI: this host is Python 3.13 and CI pins 3.12, and `multiprocess` 0.70.19 ships a different wheel per minor version. I downloaded the `py312` wheel and ran the scanner against it: all three of its CRITICAL findings are already baselined, so CI's shard has nothing non-baselined. I did not baseline the py313 variants, since CI never fetches that archive and adding them would be unreviewed suppression.

`pytest tests/security/test_scan_packages.py`: 113 passed, including the two added here. Those two were mutation-checked against the old regex, where all three httpx2 spellings go undetected, so they fail without the fix rather than passing vacuously.

## Not covered

Widening this one pattern does not make the network check complete. Still unmatched, and each would need its own triage of whatever it surfaces:

`aiohttp.ClientSession`, `urllib3.PoolManager` / `urllib3.request`, `websockets.connect`, `pycurl`, `grpc.insecure_channel`, `niquests`, `paramiko`, `ftplib`, `smtplib`.

Of those, `urllib3` and `websockets` are in the declared dependency set. `urllib3` is partly covered in practice because its usual call shape is `conn.urlopen(...)`, which the `urlopen\s*\(` alternative already matches. I have not measured the others, so I am not claiming they are or are not a problem, only that they are not in scope here.
