### PR TITLE
Desktop: Keep server stopped across webview reloads

### DIFF
--- a/studio/frontend/src/hooks/server-stop-intent.ts
+++ b/studio/frontend/src/hooks/server-stop-intent.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The "the user stopped the server on purpose" marker.
+//
+// sessionStorage outlives webview reloads but not the app process, so an explicit stop
+// holds across Reload while a fresh launch still auto-starts.
+export const USER_STOPPED_KEY = "unsloth_server_user_stopped";
+
+// Every access is wrapped: private browsing, blocked cookies and opaque webview origins
+// all throw on access, and the read below runs before the startup screen has any state to
+// fall back on. An escaping throw would reject the mount effect's floating promise and
+// leave the screen on "checking" with no way out.
+
+/** True when this webview session carries a stop the user asked for. */
+export function hasServerStopIntent(): boolean {
+  try {
+    return sessionStorage.getItem(USER_STOPPED_KEY) !== null;
+  } catch {
+    // Unreadable storage cannot be holding an intent, so treat it as a fresh session
+    // and auto-start, which is what a build before this marker existed did.
+    return false;
+  }
+}
+
+/** Record a stop so it survives a reload of this webview. */
+export function markServerStopIntent(): void {
+  try {
+    sessionStorage.setItem(USER_STOPPED_KEY, "1");
+  } catch {
+    // The stop itself still happens; only its survival across a reload is lost.
+  }
+}
+
+/** Drop the marker, so the next mount is free to start the server again. */
+export function clearServerStopIntent(): void {
+  try {
+    sessionStorage.removeItem(USER_STOPPED_KEY);
+  } catch {
+    // Same.
+  }
+}

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -237,18 +237,19 @@ export function useTauriBackend() {
   }, [status]);
 
   async function checkInstallAndStart() {
+    // Honor a persisted stop before preflight: the native command side-effects
+    // (it can adopt a still-reaping backend, reset the intentional-stop flag,
+    // and arm a watchdog that later fires server-crashed over this screen).
+    if (sessionStorage.getItem(USER_STOPPED_KEY)) {
+      setBackendStatus("stopped");
+      return;
+    }
     try {
       const { invoke } = await import("@tauri-apps/api/core");
 
       const preflight = await invoke<DesktopPreflightResult>("desktop_preflight");
       switch (preflight.disposition) {
         case "attached_ready": {
-          if (sessionStorage.getItem(USER_STOPPED_KEY)) {
-            setIsExternalServer(false);
-            stopExternalServerPoll();
-            setBackendStatus("stopped");
-            return;
-          }
           if (!preflight.port) {
             setBackendError("Desktop preflight found a backend without a port.");
             return;
@@ -262,13 +263,6 @@ export function useTauriBackend() {
           return;
         }
         case "owned_ready":
-          // A stop mid-reap can still probe as owned_ready; honor the intent.
-          if (sessionStorage.getItem(USER_STOPPED_KEY)) {
-            setIsExternalServer(false);
-            stopExternalServerPoll();
-            setBackendStatus("stopped");
-            return;
-          }
           if (!preflight.port) {
             setBackendError("Desktop preflight found an owned backend without a port.");
             return;
@@ -283,10 +277,6 @@ export function useTauriBackend() {
         case "managed_ready":
           setIsExternalServer(false);
           stopExternalServerPoll();
-          if (sessionStorage.getItem(USER_STOPPED_KEY)) {
-            setBackendStatus("stopped");
-            return;
-          }
           setBackendStatus("starting");
           await startManagedServer();
           return;

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -131,6 +131,8 @@ export function useTauriBackend() {
   const [error, setError] = useState<string | null>(null);
   // Guard against double startServer calls
   const startingRef = useRef(false);
+  // Guard against double stopServer calls
+  const stoppingRef = useRef(false);
   // Guard against React Strict Mode double-mount
   const mountedRef = useRef(false);
   // Track the discovered port from server-port event
@@ -389,7 +391,20 @@ export function useTauriBackend() {
     await startManagedServer();
   }
 
+  // One stop at a time. The tray toggle branches on statusRef, which stays "running" until
+  // the invoke resolves, so a second tray Stop otherwise runs a second shutdown against the
+  // backend the first is still taking down. Mirrors the startingRef guard on the start path.
   async function stopServer() {
+    if (stoppingRef.current) return;
+    stoppingRef.current = true;
+    try {
+      await runStopServer();
+    } finally {
+      stoppingRef.current = false;
+    }
+  }
+
+  async function runStopServer() {
     if (isExternalServer) {
       // We attached to a server we didn't spawn: can't kill it, just disconnect the UI.
       startingRef.current = false;

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -262,6 +262,13 @@ export function useTauriBackend() {
           return;
         }
         case "owned_ready":
+          // A stop mid-reap can still probe as owned_ready; honor the intent.
+          if (sessionStorage.getItem(USER_STOPPED_KEY)) {
+            setIsExternalServer(false);
+            stopExternalServerPoll();
+            setBackendStatus("stopped");
+            return;
+          }
           if (!preflight.port) {
             setBackendError("Desktop preflight found an owned backend without a port.");
             return;

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -65,6 +65,10 @@ interface DesktopPreflightResult {
 
 const MANAGED_STARTUP_POLL_MS = 500;
 
+// sessionStorage outlives webview reloads but not the app process, so an
+// explicit stop holds across Reload while a fresh launch still auto-starts.
+const USER_STOPPED_KEY = "unsloth_server_user_stopped";
+
 type TauriInvoke = typeof import("@tauri-apps/api/core").invoke;
 type ManagedStartupResult =
   | { status: "ready"; port: number }
@@ -266,6 +270,10 @@ export function useTauriBackend() {
         case "managed_ready":
           setIsExternalServer(false);
           stopExternalServerPoll();
+          if (sessionStorage.getItem(USER_STOPPED_KEY)) {
+            setBackendStatus("stopped");
+            return;
+          }
           setBackendStatus("starting");
           await startManagedServer();
           return;
@@ -301,6 +309,7 @@ export function useTauriBackend() {
       return;
     }
     startingRef.current = true;
+    sessionStorage.removeItem(USER_STOPPED_KEY);
     setStartupMessage(INITIAL_STARTUP_MESSAGE);
     portRef.current = null;
     startTimedOutRef.current = false;
@@ -385,6 +394,7 @@ export function useTauriBackend() {
     }
     const { invoke } = await import("@tauri-apps/api/core");
     await invoke("stop_server");
+    sessionStorage.setItem(USER_STOPPED_KEY, "1");
     startingRef.current = false;
     setBackendStatus("stopped");
   }
@@ -419,6 +429,7 @@ export function useTauriBackend() {
 
   const retry = useCallback(() => {
     clearAuthFailure();
+    sessionStorage.removeItem(USER_STOPPED_KEY);
     setError(null);
     setLogs([]);
     startingRef.current = false;

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -243,6 +243,12 @@ export function useTauriBackend() {
       const preflight = await invoke<DesktopPreflightResult>("desktop_preflight");
       switch (preflight.disposition) {
         case "attached_ready": {
+          if (sessionStorage.getItem(USER_STOPPED_KEY)) {
+            setIsExternalServer(false);
+            stopExternalServerPoll();
+            setBackendStatus("stopped");
+            return;
+          }
           if (!preflight.port) {
             setBackendError("Desktop preflight found a backend without a port.");
             return;
@@ -389,12 +395,20 @@ export function useTauriBackend() {
       startingRef.current = false;
       setIsExternalServer(false);
       stopExternalServerPoll();
+      sessionStorage.setItem(USER_STOPPED_KEY, "1");
       setBackendStatus("stopped");
       return;
     }
     const { invoke } = await import("@tauri-apps/api/core");
-    await invoke("stop_server");
+    // Record intent before the await: reaping can block ~15s and a reload
+    // mid-await would lose the marker. Roll back if the stop fails.
     sessionStorage.setItem(USER_STOPPED_KEY, "1");
+    try {
+      await invoke("stop_server");
+    } catch (e) {
+      sessionStorage.removeItem(USER_STOPPED_KEY);
+      throw e;
+    }
     startingRef.current = false;
     setBackendStatus("stopped");
   }

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -32,6 +32,11 @@ import {
   startupMessageFromLog,
   type StartupMessage,
 } from "@/components/tauri/startup-messages";
+import {
+  clearServerStopIntent,
+  hasServerStopIntent,
+  markServerStopIntent,
+} from "./server-stop-intent";
 
 export type BackendStatus =
   | "checking"
@@ -64,10 +69,6 @@ interface DesktopPreflightResult {
 }
 
 const MANAGED_STARTUP_POLL_MS = 500;
-
-// sessionStorage outlives webview reloads but not the app process, so an
-// explicit stop holds across Reload while a fresh launch still auto-starts.
-const USER_STOPPED_KEY = "unsloth_server_user_stopped";
 
 type TauriInvoke = typeof import("@tauri-apps/api/core").invoke;
 type ManagedStartupResult =
@@ -240,7 +241,7 @@ export function useTauriBackend() {
     // Honor a persisted stop before preflight: the native command side-effects
     // (it can adopt a still-reaping backend, reset the intentional-stop flag,
     // and arm a watchdog that later fires server-crashed over this screen).
-    if (sessionStorage.getItem(USER_STOPPED_KEY)) {
+    if (hasServerStopIntent()) {
       setBackendStatus("stopped");
       return;
     }
@@ -307,12 +308,14 @@ export function useTauriBackend() {
   }
 
   async function startManagedServer() {
+    // Ahead of the re-entry guard: a start the user asked for retires the stop they
+    // asked for earlier, whether or not this particular call goes on to do the work.
+    clearServerStopIntent();
     // Prevent double-start race condition
     if (startingRef.current) {
       return;
     }
     startingRef.current = true;
-    sessionStorage.removeItem(USER_STOPPED_KEY);
     setStartupMessage(INITIAL_STARTUP_MESSAGE);
     portRef.current = null;
     startTimedOutRef.current = false;
@@ -392,18 +395,18 @@ export function useTauriBackend() {
       startingRef.current = false;
       setIsExternalServer(false);
       stopExternalServerPoll();
-      sessionStorage.setItem(USER_STOPPED_KEY, "1");
+      markServerStopIntent();
       setBackendStatus("stopped");
       return;
     }
     const { invoke } = await import("@tauri-apps/api/core");
     // Record intent before the await: reaping can block ~15s and a reload
     // mid-await would lose the marker. Roll back if the stop fails.
-    sessionStorage.setItem(USER_STOPPED_KEY, "1");
+    markServerStopIntent();
     try {
       await invoke("stop_server");
     } catch (e) {
-      sessionStorage.removeItem(USER_STOPPED_KEY);
+      clearServerStopIntent();
       throw e;
     }
     startingRef.current = false;
@@ -440,7 +443,7 @@ export function useTauriBackend() {
 
   const retry = useCallback(() => {
     clearAuthFailure();
-    sessionStorage.removeItem(USER_STOPPED_KEY);
+    clearServerStopIntent();
     setError(null);
     setLogs([]);
     startingRef.current = false;

--- a/studio/frontend/tests/desktop-stop-intent.test.ts
+++ b/studio/frontend/tests/desktop-stop-intent.test.ts
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import test from "node:test";
+
+// The marker module is import-free, so it needs no bundler resolver. The hook around it is
+// a React hook that cannot be rendered here, so its call sites are asserted against source,
+// the way the rest of the desktop startup tests do it.
+import {
+  USER_STOPPED_KEY,
+  clearServerStopIntent,
+  hasServerStopIntent,
+  markServerStopIntent,
+} from "../src/hooks/server-stop-intent.ts";
+
+type Storage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+};
+
+/** An in-memory sessionStorage installed under the name the module reads it by. */
+function installSessionStorage(): Map<string, string> {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+  Object.assign(globalThis, { sessionStorage: storage });
+  return store;
+}
+
+/** Storage that throws on every access, as an opaque origin's does. */
+function installThrowingSessionStorage(): void {
+  const boom = () => {
+    throw new DOMException("The operation is insecure.", "SecurityError");
+  };
+  Object.assign(globalThis, {
+    sessionStorage: { getItem: boom, setItem: boom, removeItem: boom },
+  });
+}
+
+function uninstallSessionStorage(): void {
+  Reflect.deleteProperty(globalThis, "sessionStorage");
+}
+
+function hookSource(): Promise<string> {
+  return readFile(
+    new URL("../src/hooks/use-tauri-backend.ts", import.meta.url),
+    "utf8",
+  );
+}
+
+test("a fresh session carries no stop intent", () => {
+  installSessionStorage();
+  assert.equal(hasServerStopIntent(), false);
+  uninstallSessionStorage();
+});
+
+test("a marked stop reads back, and clearing drops it", () => {
+  const store = installSessionStorage();
+
+  markServerStopIntent();
+  assert.equal(hasServerStopIntent(), true);
+  // Written under the one key, so a reload of the same webview finds it.
+  assert.deepEqual([...store.keys()], [USER_STOPPED_KEY]);
+
+  clearServerStopIntent();
+  assert.equal(hasServerStopIntent(), false);
+  assert.equal(store.size, 0);
+  uninstallSessionStorage();
+});
+
+test("marking twice is not two stops to clear", () => {
+  installSessionStorage();
+  markServerStopIntent();
+  markServerStopIntent();
+  clearServerStopIntent();
+  assert.equal(hasServerStopIntent(), false);
+  uninstallSessionStorage();
+});
+
+test("storage that throws never reaches the caller", () => {
+  installThrowingSessionStorage();
+
+  // An opaque origin throws SecurityError on every access. The read runs before the
+  // startup screen has any state to fall back on, so a throw would strand it on
+  // "checking"; the writes sit in front of the stop invoke, which has to happen anyway.
+  assert.equal(
+    hasServerStopIntent(),
+    false,
+    "unreadable storage must read as no intent",
+  );
+  assert.doesNotThrow(() => markServerStopIntent());
+  assert.doesNotThrow(() => clearServerStopIntent());
+
+  uninstallSessionStorage();
+});
+
+test("storage missing entirely reads as a fresh session", () => {
+  uninstallSessionStorage();
+
+  // Not a hypothetical: bare node has no web storage, and neither does a webview with
+  // storage disabled. A ReferenceError has to be absorbed the same as a SecurityError.
+  assert.equal(hasServerStopIntent(), false);
+  assert.doesNotThrow(() => markServerStopIntent());
+  assert.doesNotThrow(() => clearServerStopIntent());
+});
+
+test("the marker key belongs to nothing else in the app", async () => {
+  const files: string[] = [];
+  async function walk(dir: URL) {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const child = new URL(
+        `${entry.name}${entry.isDirectory() ? "/" : ""}`,
+        dir,
+      );
+      if (entry.isDirectory()) {
+        await walk(child);
+      } else if (/\.tsx?$/.test(entry.name)) {
+        files.push(child.pathname);
+      }
+    }
+  }
+  await walk(new URL("../src/", import.meta.url));
+
+  const owners: string[] = [];
+  for (const file of files) {
+    if ((await readFile(file, "utf8")).includes(`"${USER_STOPPED_KEY}"`)) {
+      owners.push(file);
+    }
+  }
+
+  // One declaration and no second reader: a key two features write would let an unrelated
+  // preference reset put the desktop server on the stopped screen.
+  assert.deepEqual(
+    owners.map((f) => f.slice(f.indexOf("/src/"))),
+    ["/src/hooks/server-stop-intent.ts"],
+  );
+});
+
+test("the hook reaches storage only through the guarded helpers", async () => {
+  const hook = await hookSource();
+
+  // A raw sessionStorage call in the hook is the bug this module exists to prevent: the
+  // read in checkInstallAndStart sits outside its try, so a SecurityError there rejects
+  // the mount effect's floating promise and the startup screen never leaves "checking".
+  assert.doesNotMatch(
+    hook,
+    /sessionStorage/,
+    "the hook is back to touching sessionStorage directly",
+  );
+  assert.match(
+    hook,
+    /import \{\s*clearServerStopIntent,\s*hasServerStopIntent,\s*markServerStopIntent,\s*\} from "\.\/server-stop-intent";/,
+  );
+});
+
+test("a persisted stop is honored before preflight runs", async () => {
+  const hook = await hookSource();
+
+  const body = hook.slice(
+    hook.indexOf("async function checkInstallAndStart()"),
+    hook.indexOf("async function startManagedServer()"),
+  );
+  const guard = body.indexOf("hasServerStopIntent()");
+  const preflight = body.indexOf(
+    'invoke<DesktopPreflightResult>("desktop_preflight")',
+  );
+
+  assert.ok(guard > 0 && preflight > 0);
+  // desktop_preflight is not a query: adopt_backend clears intentional_stop and bumps the
+  // generation, and the command then arms a health watchdog for it, which later fires
+  // server-crashed over the stopped screen. So the check has to come first, not just
+  // before the start.
+  assert.ok(
+    guard < preflight,
+    "the stop check moved behind preflight, whose adoption side effects it exists to skip",
+  );
+  assert.match(
+    body.slice(guard, preflight),
+    /setBackendStatus\("stopped"\);\s*return;/,
+    "the honored stop no longer parks the screen on stopped",
+  );
+});
+
+test("stopping records the intent before the shutdown it can outlive", async () => {
+  const hook = await hookSource();
+  const body = hook.slice(
+    hook.indexOf("async function stopServer()"),
+    hook.indexOf("async function startInstall()"),
+  );
+
+  // Reaping the backend blocks for up to ~15s. A reload inside that window has to find
+  // the marker already written, so the order here is load bearing.
+  const mark = body.indexOf("markServerStopIntent();\n    try {");
+  const invoke = body.indexOf('await invoke("stop_server")');
+  assert.ok(
+    mark > 0 && invoke > mark,
+    "the marker is written after the stop it must survive",
+  );
+
+  // A stop that failed left the backend up, so the marker has to come back off or the
+  // next reload shows a stopped screen over a running server.
+  assert.match(
+    body,
+    /catch \(e\) \{\s*clearServerStopIntent\(\);\s*throw e;\s*\}/,
+    "a failed stop keeps a marker it did not earn",
+  );
+
+  // The detached branch has no process to kill, but the reload still has to keep the UI
+  // off the user's external server rather than re-attaching to it.
+  const external = body.slice(0, body.indexOf("const { invoke }"));
+  assert.match(
+    external,
+    /stopExternalServerPoll\(\);\s*markServerStopIntent\(\);/,
+  );
+});
+
+test("every deliberate start drops the marker", async () => {
+  const hook = await hookSource();
+
+  const managed = hook.slice(
+    hook.indexOf("async function startManagedServer()"),
+    hook.indexOf("async function startRepair()"),
+  );
+  const clear = managed.indexOf("clearServerStopIntent()");
+  const guard = managed.indexOf("if (startingRef.current)");
+  assert.ok(
+    clear > 0 && guard > clear,
+    "a re-entrant start returns with the marker still set",
+  );
+
+  // Retry is the only way off the error screen and the tray's way back on from stopped.
+  const retry = hook.slice(
+    hook.indexOf("const retry = useCallback"),
+    hook.indexOf("const retryInstall"),
+  );
+  assert.match(retry, /clearServerStopIntent\(\);/);
+  assert.match(retry, /checkInstallAndStart\(\);/);
+});

--- a/studio/frontend/tests/desktop-stop-intent.test.ts
+++ b/studio/frontend/tests/desktop-stop-intent.test.ts
@@ -224,6 +224,37 @@ test("stopping records the intent before the shutdown it can outlive", async () 
   );
 });
 
+test("a second stop cannot run while the first is in flight", async () => {
+  const hook = await hookSource();
+
+  // The tray item is never disabled and the toggle branches on statusRef, which stays
+  // "running" for the whole invoke, so two Stop clicks reach stopServer concurrently.
+  const tray = hook.slice(hook.indexOf('register<void>("tray-toggle-server"'));
+  assert.match(
+    tray.slice(0, tray.indexOf("});")),
+    /statusRef\.current === "running"\)\s*\{\s*stopServer\(\);/,
+  );
+
+  const guard = hook.slice(
+    hook.indexOf("async function stopServer()"),
+    hook.indexOf("async function runStopServer()"),
+  );
+
+  // Two concurrent stops both mark the intent, and on an adopted backend the loser can
+  // fail against the port the winner is taking down. Its rollback then drops the marker
+  // the winner earned, so the next reload starts a server the user asked to stop.
+  assert.match(
+    guard,
+    /if \(stoppingRef\.current\) return;\s*stoppingRef\.current = true;/,
+    "a second stop still runs while the first is in flight",
+  );
+  assert.match(
+    guard,
+    /finally \{\s*stoppingRef\.current = false;\s*\}/,
+    "a failed stop strands the guard and no later stop can run",
+  );
+});
+
 test("every deliberate start drops the marker", async () => {
   const hook = await hookSource();
 


### PR DESCRIPTION
Stopping the server from the tray only lived in React state, so right-click > reload re-ran startup and silently restarted the backend. Track the stop intent in sessionStorage, which survives reloads but clears on app relaunch reload now returns to the stopped screen, while fresh launches still auto-start.