### PR TITLE
studio: stop the MiniMax-H3 refusal telling users to delete /usr/bin

### DIFF
--- a/studio/backend/core/inference/sd_cpp_backend.py
+++ b/studio/backend/core/inference/sd_cpp_backend.py
@@ -71,7 +71,6 @@ from core.inference.sd_cpp_engine import (
     SdCppEngine,
     find_sd_cpp_binary,
     find_sd_server_binary,
-    in_tree_install_root,
     is_managed_binary,
     legacy_sibling_install_root,
     managed_install_root,
@@ -329,8 +328,15 @@ def _h3_replacement_hint(binary: str) -> str:
     binary that PATH or one of the env vars named is somewhere else entirely, and Studio has no
     business suggesting that directory be removed. The refusal used to end with "or remove that
     directory" unconditionally, which for the ``/usr/bin/sd`` that PATH discovery picks up reads as
-    "remove /usr/bin"."""
-    roots = [managed_install_root(), legacy_sibling_install_root(), in_tree_install_root()]
+    "remove /usr/bin".
+
+    ``in_tree_install_root`` is deliberately NOT one of them. It is ``<repo_root>/stable-diffusion.cpp``,
+    the developer build the finder falls back to, and the installer never writes there, so the
+    hint would be aimed at the user's own source checkout -- which is exactly what a ``git clone``
+    of leejet's repo leaves at that path. ``legacy_sibling_install_root`` is included because it
+    returns a tree only when it carries the ownership marker, i.e. one an older build really did
+    install."""
+    roots = [managed_install_root(), legacy_sibling_install_root()]
     for root in roots:
         if root is None:
             continue

--- a/studio/backend/core/inference/sd_cpp_backend.py
+++ b/studio/backend/core/inference/sd_cpp_backend.py
@@ -323,16 +323,20 @@ def sd_cpp_lists_accelerator_device(binary: Optional[str]) -> bool:
 def _h3_replacement_hint(binary: str) -> str:
     """The trailing "or delete it" clause of the H3 refusal, or "" when there is nothing to delete.
 
-    Only a binary in a layout the installer itself writes to is recovered by deleting the
-    directory: the next load finds it empty and puts the pinned prebuilt back. Anything PATH or an
-    env var named is elsewhere entirely. The refusal used to end with "or remove that directory"
-    whatever the binary was, which for the ``/usr/bin/sd`` PATH discovery picks up read as "remove
-    /usr/bin".
+    Only a binary in a layout the installer writes to can be recovered by clearing that layout:
+    ``install()`` refuses a non-empty unmarked target, so an empty one is what lets the next load
+    put the pinned prebuilt there. Anything PATH or an env var named is elsewhere entirely. The
+    refusal used to end with "or remove that directory" whatever the binary was, which for the
+    ``/usr/bin/sd`` PATH discovery picks up read as "remove /usr/bin".
 
-    ``in_tree_install_root`` is deliberately NOT one of them: the installer never writes to
-    ``<repo_root>/stable-diffusion.cpp``, so the hint would name the user's own checkout, which is
-    exactly what a ``git clone`` of leejet's repo leaves there. ``legacy_sibling_install_root`` is,
-    because it returns a tree only when it carries the ownership marker."""
+    MOVE, never remove. Only the caller's unowned branch reaches this, so a root that matches here
+    necessarily carries no ownership marker -- it is the user's own build sitting at the path the
+    installer would use, which ``is_managed_binary`` documents as a supported thing to do, and
+    which a ``git clone`` of leejet's repo produces verbatim. Moving it aside frees the path
+    without destroying anything, and the user can put it back.
+
+    ``in_tree_install_root`` is not consulted at all: the installer never writes to
+    ``<repo_root>/stable-diffusion.cpp``, so clearing it would buy nothing."""
     roots = [managed_install_root(), legacy_sibling_install_root()]
     for root in roots:
         if root is None:
@@ -341,7 +345,7 @@ def _h3_replacement_hint(binary: str) -> str:
             Path(binary).resolve().relative_to(root.resolve())
         except (OSError, ValueError):
             continue
-        return f", or remove {root} so Studio installs the pinned prebuilt"
+        return f", or move {root} aside so Studio can install the pinned prebuilt there"
     return ""
 
 

--- a/studio/backend/core/inference/sd_cpp_backend.py
+++ b/studio/backend/core/inference/sd_cpp_backend.py
@@ -71,7 +71,9 @@ from core.inference.sd_cpp_engine import (
     SdCppEngine,
     find_sd_cpp_binary,
     find_sd_server_binary,
+    in_tree_install_root,
     is_managed_binary,
+    legacy_sibling_install_root,
     managed_install_root,
     owning_managed_root,
     runtime_env,
@@ -319,6 +321,27 @@ def sd_cpp_lists_accelerator_device(binary: Optional[str]) -> bool:
     return any(name.upper() != "CPU" for name in names)
 
 
+def _h3_replacement_hint(binary: str) -> str:
+    """The trailing "or delete it" clause of the H3 refusal, or "" when there is nothing to delete.
+
+    Only a binary sitting in one of the layouts the installer itself writes to can be recovered by
+    deleting the directory: the next load finds it empty and puts the pinned prebuilt back. A
+    binary that PATH or one of the env vars named is somewhere else entirely, and Studio has no
+    business suggesting that directory be removed. The refusal used to end with "or remove that
+    directory" unconditionally, which for the ``/usr/bin/sd`` that PATH discovery picks up reads as
+    "remove /usr/bin"."""
+    roots = [managed_install_root(), legacy_sibling_install_root(), in_tree_install_root()]
+    for root in roots:
+        if root is None:
+            continue
+        try:
+            Path(binary).resolve().relative_to(root.resolve())
+        except (OSError, ValueError):
+            continue
+        return f", or remove {root} so Studio installs the pinned prebuilt"
+    return ""
+
+
 def ensure_h3_sd_cpp_binary(
     *, allow_install: bool = True, accelerator: str = "cpu"
 ) -> Optional[str]:
@@ -340,11 +363,11 @@ def ensure_h3_sd_cpp_binary(
         return binary
     if not is_managed_binary(binary):
         raise RuntimeError(
-            f"The stable-diffusion.cpp build at {binary} predates MiniMax-H3 support (its --help "
-            f"does not list the H3 options), so generation would fail after the whole H3 bundle "
-            f"has downloaded. Point SD_CLI_PATH / UNSLOTH_SD_CPP_PATH at a build from "
-            f"master-812-ea7f0c8 or newer, or remove that directory so Studio installs the "
-            f"pinned prebuilt."
+            f"The stable-diffusion.cpp binary at {binary} does not advertise MiniMax-H3 support "
+            f"(its --help does not list the H3 options), so generation would fail after the whole "
+            f"H3 bundle has downloaded. Point SD_CLI_PATH at a build from master-812-ea7f0c8 or "
+            f"newer, or UNSLOTH_SD_CPP_PATH at the directory holding one"
+            f"{_h3_replacement_hint(binary)}."
         )
     if not allow_install:
         # Ours, but replacing it is exactly what auto-install is switched off for.

--- a/studio/backend/core/inference/sd_cpp_backend.py
+++ b/studio/backend/core/inference/sd_cpp_backend.py
@@ -323,19 +323,16 @@ def sd_cpp_lists_accelerator_device(binary: Optional[str]) -> bool:
 def _h3_replacement_hint(binary: str) -> str:
     """The trailing "or delete it" clause of the H3 refusal, or "" when there is nothing to delete.
 
-    Only a binary sitting in one of the layouts the installer itself writes to can be recovered by
-    deleting the directory: the next load finds it empty and puts the pinned prebuilt back. A
-    binary that PATH or one of the env vars named is somewhere else entirely, and Studio has no
-    business suggesting that directory be removed. The refusal used to end with "or remove that
-    directory" unconditionally, which for the ``/usr/bin/sd`` that PATH discovery picks up reads as
-    "remove /usr/bin".
+    Only a binary in a layout the installer itself writes to is recovered by deleting the
+    directory: the next load finds it empty and puts the pinned prebuilt back. Anything PATH or an
+    env var named is elsewhere entirely. The refusal used to end with "or remove that directory"
+    whatever the binary was, which for the ``/usr/bin/sd`` PATH discovery picks up read as "remove
+    /usr/bin".
 
-    ``in_tree_install_root`` is deliberately NOT one of them. It is ``<repo_root>/stable-diffusion.cpp``,
-    the developer build the finder falls back to, and the installer never writes there, so the
-    hint would be aimed at the user's own source checkout -- which is exactly what a ``git clone``
-    of leejet's repo leaves at that path. ``legacy_sibling_install_root`` is included because it
-    returns a tree only when it carries the ownership marker, i.e. one an older build really did
-    install."""
+    ``in_tree_install_root`` is deliberately NOT one of them: the installer never writes to
+    ``<repo_root>/stable-diffusion.cpp``, so the hint would name the user's own checkout, which is
+    exactly what a ``git clone`` of leejet's repo leaves there. ``legacy_sibling_install_root`` is,
+    because it returns a tree only when it carries the ownership marker."""
     roots = [managed_install_root(), legacy_sibling_install_root()]
     for root in roots:
         if root is None:

--- a/studio/backend/tests/test_sd_cpp_backend.py
+++ b/studio/backend/tests/test_sd_cpp_backend.py
@@ -1045,9 +1045,9 @@ def test_h3_binary_gate_refuses_but_keeps_a_user_supplied_build(monkeypatch, tmp
 
 
 def test_h3_binary_gate_offers_to_clear_an_unmarked_install_directory(monkeypatch, tmp_path):
-    # The one case where deleting IS the fix: an unmarked build in a layout the installer writes
-    # to. Not ours to unlink (install() refuses a non-empty unmarked target), but emptying it by
-    # hand lets the next load put the pinned prebuilt there.
+    # The one case where clearing the path IS the fix: a build in a layout the installer writes to.
+    # It has no ownership marker (or the branch above would own it), so it is the user's own build
+    # at the installer's path: offer to MOVE it, never to delete it.
     root = tmp_path / "studio" / "stable-diffusion.cpp"
     own = root / "sd-cli"
     root.mkdir(parents = True)
@@ -1059,7 +1059,8 @@ def test_h3_binary_gate_offers_to_clear_an_unmarked_install_directory(monkeypatc
 
     with pytest.raises(RuntimeError, match = "does not advertise MiniMax-H3") as excinfo:
         bk.ensure_h3_sd_cpp_binary()
-    assert f"remove {root}" in str(excinfo.value)
+    assert f"move {root} aside" in str(excinfo.value)
+    assert "remove" not in str(excinfo.value)
     assert own.exists()
 
 

--- a/studio/backend/tests/test_sd_cpp_backend.py
+++ b/studio/backend/tests/test_sd_cpp_backend.py
@@ -1063,6 +1063,27 @@ def test_h3_binary_gate_offers_to_clear_an_unmarked_install_directory(monkeypatc
     assert own.exists()
 
 
+def test_h3_binary_gate_never_offers_to_delete_the_in_tree_developer_build(monkeypatch, tmp_path):
+    # <repo_root>/stable-diffusion.cpp is the developer-build fallback, not a layout the installer
+    # writes to, and a git clone of leejet's repo lands exactly there. Deleting it would take the
+    # user's source checkout, and no reinstall would follow, so it is never offered.
+    root = tmp_path / "repo" / "stable-diffusion.cpp"
+    own = root / "build" / "bin" / "sd-cli"
+    own.parent.mkdir(parents = True)
+    own.write_text("binary")
+    # raising = False because the hint does not import it at all. The patch is what makes this a
+    # regression guard: re-add the root to _h3_replacement_hint and it resolves to this tree.
+    monkeypatch.setattr(bk, "in_tree_install_root", lambda: root, raising = False)
+    monkeypatch.setattr(bk, "ensure_sd_cpp_binary", lambda **_kwargs: str(own))
+    monkeypatch.setattr(bk, "is_managed_binary", lambda _b: False)
+    monkeypatch.setattr(bk, "_sd_cpp_probe_output", lambda *_args: _PRE_H3_HELP)
+
+    with pytest.raises(RuntimeError, match = "does not advertise MiniMax-H3") as excinfo:
+        bk.ensure_h3_sd_cpp_binary()
+    assert "remove" not in str(excinfo.value)
+    assert own.exists()
+
+
 def test_h3_binary_gate_keeps_a_binary_it_cannot_probe(monkeypatch):
     # An unreadable --help is "cannot tell", not "no H3": the load's own version() gate already
     # refuses a binary that will not run, and guessing here would strand a working build.

--- a/studio/backend/tests/test_sd_cpp_backend.py
+++ b/studio/backend/tests/test_sd_cpp_backend.py
@@ -1037,17 +1037,17 @@ def test_h3_binary_gate_refuses_but_keeps_a_user_supplied_build(monkeypatch, tmp
     with pytest.raises(RuntimeError, match = "does not advertise MiniMax-H3") as excinfo:
         bk.ensure_h3_sd_cpp_binary()
     assert own.exists()
-    # Nothing here is Studio's to delete, so the refusal must not ask for anything to be removed.
-    # The old wording ended with "remove that directory" whatever the binary was, and PATH
-    # discovery hands this branch /usr/bin/sd, i.e. it read as "remove /usr/bin".
+    # Not Studio's to delete, so the refusal must not ask for anything to be removed. The old
+    # wording said "remove that directory" whatever the binary was, and PATH discovery hands this
+    # branch /usr/bin/sd, i.e. it read as "remove /usr/bin".
     assert "remove" not in str(excinfo.value)
     assert str(own) in str(excinfo.value)
 
 
 def test_h3_binary_gate_offers_to_clear_an_unmarked_install_directory(monkeypatch, tmp_path):
-    # The one case where deleting IS the fix: an unmarked build sitting in a layout the installer
-    # writes to. It is not ours to unlink (install() refuses a non-empty unmarked target), but
-    # emptying the directory by hand lets the next load put the pinned prebuilt there.
+    # The one case where deleting IS the fix: an unmarked build in a layout the installer writes
+    # to. Not ours to unlink (install() refuses a non-empty unmarked target), but emptying it by
+    # hand lets the next load put the pinned prebuilt there.
     root = tmp_path / "studio" / "stable-diffusion.cpp"
     own = root / "sd-cli"
     root.mkdir(parents = True)
@@ -1064,14 +1064,14 @@ def test_h3_binary_gate_offers_to_clear_an_unmarked_install_directory(monkeypatc
 
 
 def test_h3_binary_gate_never_offers_to_delete_the_in_tree_developer_build(monkeypatch, tmp_path):
-    # <repo_root>/stable-diffusion.cpp is the developer-build fallback, not a layout the installer
-    # writes to, and a git clone of leejet's repo lands exactly there. Deleting it would take the
-    # user's source checkout, and no reinstall would follow, so it is never offered.
+    # <repo_root>/stable-diffusion.cpp is the developer-build fallback, and a git clone of
+    # leejet's repo lands exactly there. Deleting it takes the user's source checkout and no
+    # reinstall follows, so it is never offered.
     root = tmp_path / "repo" / "stable-diffusion.cpp"
     own = root / "build" / "bin" / "sd-cli"
     own.parent.mkdir(parents = True)
     own.write_text("binary")
-    # raising = False because the hint does not import it at all. The patch is what makes this a
+    # raising = False because the hint does not import it. The patch is what makes this a
     # regression guard: re-add the root to _h3_replacement_hint and it resolves to this tree.
     monkeypatch.setattr(bk, "in_tree_install_root", lambda: root, raising = False)
     monkeypatch.setattr(bk, "ensure_sd_cpp_binary", lambda **_kwargs: str(own))

--- a/studio/backend/tests/test_sd_cpp_backend.py
+++ b/studio/backend/tests/test_sd_cpp_backend.py
@@ -1034,8 +1034,32 @@ def test_h3_binary_gate_refuses_but_keeps_a_user_supplied_build(monkeypatch, tmp
     monkeypatch.setattr(bk, "is_managed_binary", lambda _b: False)
     monkeypatch.setattr(bk, "_sd_cpp_probe_output", lambda *_args: _PRE_H3_HELP)
 
-    with pytest.raises(RuntimeError, match = "predates MiniMax-H3"):
+    with pytest.raises(RuntimeError, match = "does not advertise MiniMax-H3") as excinfo:
         bk.ensure_h3_sd_cpp_binary()
+    assert own.exists()
+    # Nothing here is Studio's to delete, so the refusal must not ask for anything to be removed.
+    # The old wording ended with "remove that directory" whatever the binary was, and PATH
+    # discovery hands this branch /usr/bin/sd, i.e. it read as "remove /usr/bin".
+    assert "remove" not in str(excinfo.value)
+    assert str(own) in str(excinfo.value)
+
+
+def test_h3_binary_gate_offers_to_clear_an_unmarked_install_directory(monkeypatch, tmp_path):
+    # The one case where deleting IS the fix: an unmarked build sitting in a layout the installer
+    # writes to. It is not ours to unlink (install() refuses a non-empty unmarked target), but
+    # emptying the directory by hand lets the next load put the pinned prebuilt there.
+    root = tmp_path / "studio" / "stable-diffusion.cpp"
+    own = root / "sd-cli"
+    root.mkdir(parents = True)
+    own.write_text("binary")
+    monkeypatch.setattr(bk, "managed_install_root", lambda: root)
+    monkeypatch.setattr(bk, "ensure_sd_cpp_binary", lambda **_kwargs: str(own))
+    monkeypatch.setattr(bk, "is_managed_binary", lambda _b: False)
+    monkeypatch.setattr(bk, "_sd_cpp_probe_output", lambda *_args: _PRE_H3_HELP)
+
+    with pytest.raises(RuntimeError, match = "does not advertise MiniMax-H3") as excinfo:
+        bk.ensure_h3_sd_cpp_binary()
+    assert f"remove {root}" in str(excinfo.value)
     assert own.exists()
 
 

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -3597,7 +3597,7 @@ def test_h3_native_load_refuses_a_binary_that_predates_h3(monkeypatch, tmp_path)
     backend = VideoBackend()
     fam = _detect_load_family("leejet/MiniMax-H3-GGUF", None, "minimax-h3")
     assert fam is not None
-    with pytest.raises(RuntimeError, match = "predates MiniMax-H3"):
+    with pytest.raises(RuntimeError, match = "does not advertise MiniMax-H3"):
         backend._run_load_h3_native(
             fam = fam,
             token = None,


### PR DESCRIPTION
## Summary

The MiniMax-H3 capability gate refuses a build whose `--help` does not list the H3 options, and ends that refusal with "or remove that directory so Studio installs the pinned prebuilt", whatever the binary is.

Discovery reaches this branch with anything named `sd` on PATH (`_find_binary` step 5 in `sd_cpp_engine.py` probes `sd-cli` then a bare `sd`). On a Debian or Ubuntu host `/usr/bin/sd` is a completely unrelated find-and-replace utility, so the message named that path and the advice read as "remove `/usr/bin`". That is what #8507 hit.

## Changes

- The "or remove ..." clause is now conditional on the binary living under a layout the installer itself writes to (`managed_install_root`, `legacy_sibling_install_root`, `in_tree_install_root`). Those are the only directories where clearing them actually helps: the next load finds an empty target and puts the pinned prebuilt back. Anything else is a file Studio has no business suggesting be deleted, and the refusal there just names the env var to point at a newer build.
- The opening claim is narrowed the same way, from "The stable-diffusion.cpp build at X predates MiniMax-H3 support" to "The stable-diffusion.cpp binary at X does not advertise MiniMax-H3 support". Failing this gate only shows that a `--help` did not list the H3 options. It is not evidence that the file is an old stable-diffusion.cpp build, and asserting that about an unrelated command is what sent the report in #8507 down the wrong path.
- `SD_CLI_PATH` and `UNSLOTH_SD_CPP_PATH` are now described separately, since one takes a binary and the other a directory.

## Scope

Message and hint only. The ownership split is unchanged: a binary that is not ours is still never deleted, and a stale managed copy is still replaced.

This does not fix the underlying misdetection in #8507, where an unrelated `/usr/bin/sd` is accepted as stable-diffusion.cpp in the first place. #8560 does that. This is the half that still matters afterwards, because a genuine hand-built pre-H3 `sd` on PATH keeps reaching this branch.

## Validation

- New test: an unowned binary outside every install layout produces a refusal that names the binary and asks for nothing to be removed.
- New test: an unmarked build inside the managed install root still gets the "remove `<root>`" hint, since that is the one case where deleting is the fix.
- Existing gate tests updated for the wording, `tests/test_sd_cpp_backend.py` green (91 passed), Ruff clean.