### PR TITLE
Fix broken Cloudflare documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Unsloth lets you run, train, and deploy AI models locally, with support for all 
 * **Image and video:** Run and train [image](https://unsloth.ai/docs/basics/diffusion-image) and video diffusion or multimodal models
 * **Audio:** Use private and unlimited web search, deep research, and RAG.
 * **Hardware:** Supports CPU, NVIDIA, AMD, Intel, macOS, and multi GPU setups.
-* **Remote Access:** Access your local models remotely through secure [Cloudflare](https://unsloth.ai/docs/basics/cloudflare) HTTPS.
+* **Remote Access:** Access your local models remotely through secure [Cloudflare](https://unsloth.ai/docs/basics/how-to-serve-local-llms-anywhere-secure-remote-access-with-cloudflare-and-unsloth) HTTPS.
 
 
 ### Train & Deploy


### PR DESCRIPTION
## Summary
Replace the broken Cloudflare documentation URL in the README with the current secure remote-access guide.

## Why
The broken link is https://unsloth.ai/docs/basics/cloudflare, which returns 404. The working replacement is https://unsloth.ai/docs/basics/how-to-serve-local-llms-anywhere-secure-remote-access-with-cloudflare-and-unsloth, which returns 200 and opens Unsloth's current secure remote-access guide for Cloudflare.

## Validation
- Confirmed the old URL returns 404.
- Confirmed the replacement URL returns 200.
- Confirmed the diff changes only the affected README link.
