### PR TITLE
Detect the Radeon AI PRO R9700 (gfx1201): it carries neither 9070 nor 9080, so name inference found nothing

### DIFF
--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -71,6 +71,7 @@ on:
       - 'tests/studio/test_setup_xpu_runtime_prereport.ps1'
       - 'tests/studio/test_xpu_arm64_torchaudio.ps1'
       - 'tests/studio/test_amd_venv_repair_loop.ps1'
+      - 'tests/studio/test_amd_name_arch_r9700.ps1'
       - 'tests/sh/test_install_sh_xpu_flavor_probe.sh'
       - 'tests/sh/test_setup_xpu_fastpath_escape.sh'
       - 'tests/sh/test_setup_xpu_posix_summary.sh'
@@ -120,6 +121,7 @@ on:
       - 'tests/studio/test_setup_xpu_runtime_prereport.ps1'
       - 'tests/studio/test_xpu_arm64_torchaudio.ps1'
       - 'tests/studio/test_amd_venv_repair_loop.ps1'
+      - 'tests/studio/test_amd_name_arch_r9700.ps1'
       - 'tests/sh/test_install_sh_xpu_flavor_probe.sh'
       - 'tests/sh/test_setup_xpu_fastpath_escape.sh'
       - 'tests/sh/test_setup_xpu_posix_summary.sh'
@@ -227,6 +229,11 @@ jobs:
         if: runner.os == 'Windows'
         shell: powershell
         run: powershell -NoProfile -File tests\studio\test_amd_venv_repair_loop.ps1
+      # Slices the shipped $nameArchTable out of install.ps1 and setup.ps1 and resolves GPU
+      # names through PowerShell's own -match, so no venv, no AMD GPU and no Windows needed.
+      - name: AMD GPU-name arch table tests
+        shell: pwsh
+        run: pwsh -NoProfile -File tests/studio/test_amd_name_arch_r9700.ps1
       - name: POSIX rollback lifecycle tests
         if: runner.os == 'Linux'
         run: sh tests/sh/test_install_rollback_lifecycle.sh

--- a/install.ps1
+++ b/install.ps1
@@ -3344,7 +3344,7 @@ exit 0
             #    (gfx120X/110X/1151/1150/103X); unknown names fall back to CPU.
             elseif ($ROCmGpuLabel) {
                 $nameArchTable = @(
-                    @{ P = "9070|9080";                                           A = "gfx1201" }  # RDNA 4 (Navi 48: RX 9070 XT / 9070 GRE / 9070 / 9080)
+                    @{ P = "9070|9080|R9700";                                     A = "gfx1201" }  # RDNA 4 (Navi 48: RX 9070 XT / 9070 GRE / 9070 / 9080, Radeon AI PRO R9700)
                     @{ P = "9060";                                                A = "gfx1200" }  # RDNA 4 (Navi 44: RX 9060 XT / 9060)
                     @{ P = "8065S|8060S|8050S|8040S|Strix Halo|Ryzen AI Max|AI Max"; A = "gfx1151" }  # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
                     @{ P = "890M|880M|Strix Point|HX 37[05]|AI 9 HX|AI 9 36[05]"; A = "gfx1150" }  # RDNA 3.5 (Strix Point: Radeon 890M/880M, Ryzen AI 9 HX 370/375)

--- a/install.sh
+++ b/install.sh
@@ -2866,7 +2866,7 @@ _amd_arch_index_family_for_gfx() {
 # Map a GPU marketing name to gfx arch (kept in sync with install.ps1 nameArchTable).
 _infer_amd_gfx_arch_from_gpu_name() {
     case "$1" in
-        *9070*|*9080*) echo gfx1201 ;;
+        *9070*|*9080*|*"R9700"*) echo gfx1201 ;;
         *9060*) echo gfx1200 ;;
         *"8065S"*|*"8060S"*|*"8050S"*|*"8040S"*|*"Strix Halo"*|*"Ryzen AI Max"*|*"AI Max"*) echo gfx1151 ;;
         *"890M"*|*"880M"*|*"Strix Point"*|*"HX 37"*|*"AI 9 HX"*|*"AI 9 36"*) echo gfx1150 ;;
@@ -4347,7 +4347,7 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
         # gfx1102 matched BEFORE gfx1100 so the spaceless "RX 7700S" lands on
         # gfx1102 (bash case has no negative lookahead like the PS tables).
         case "$_gpu_disp_mkt" in
-            *9070*|*9080*)                                                                                 _gpu_disp_gfx="gfx1201" ;;  # RDNA 4 (Navi 48)
+            *9070*|*9080*|*"R9700"*)                                                                       _gpu_disp_gfx="gfx1201" ;;  # RDNA 4 (Navi 48: RX 9070 / 9080, Radeon AI PRO R9700)
             *9060*)                                                                                        _gpu_disp_gfx="gfx1200" ;;  # RDNA 4 (Navi 44)
             *"8065S"*|*"8060S"*|*"8050S"*|*"8040S"*|*"Strix Halo"*|*"Ryzen AI Max"*|*"AI Max"*) _gpu_disp_gfx="gfx1151" ;;  # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
             *"890M"*|*"880M"*|*"Strix Point"*|*"HX 37"*|*"AI 9 HX"*|*"AI 9 36"*) _gpu_disp_gfx="gfx1150" ;;  # RDNA 3.5 (Strix Point: Radeon 890M/880M, Ryzen AI 9 HX 370/375)

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -980,8 +980,8 @@ def _detect_windows_gfx_arch() -> str | None:
 # (callers then fall back cleanly to CPU).
 _WIN_GPU_NAME_ARCH_TABLE: "list[tuple[str, str]]" = [
     # RDNA 4 (Navi 48: Radeon RX 9070 XT / 9070 GRE / 9070 / 9080, Radeon AI PRO R9700).
-    # R9700 is spelled out because the workstation card's name carries neither 9070 nor
-    # 9080, so it used to match nothing and fall through to CPU torch (#7624, #7307).
+    # R9700 is listed separately: its name holds neither 9070 nor 9080, so it matched
+    # nothing and fell through to CPU torch (#7624, #7307).
     (r"9070|9080|R9700", "gfx1201"),
     (r"9060", "gfx1200"),  # RDNA 4 (Navi 44: Radeon RX 9060 XT / 9060)
     # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -979,7 +979,10 @@ def _detect_windows_gfx_arch() -> str | None:
 # prebuilts / AMD Windows torch indexes support; unknown names return None
 # (callers then fall back cleanly to CPU).
 _WIN_GPU_NAME_ARCH_TABLE: "list[tuple[str, str]]" = [
-    (r"9070|9080", "gfx1201"),  # RDNA 4 (Navi 48: Radeon RX 9070 XT / 9070 GRE / 9070 / 9080)
+    # RDNA 4 (Navi 48: Radeon RX 9070 XT / 9070 GRE / 9070 / 9080, Radeon AI PRO R9700).
+    # R9700 is spelled out because the workstation card's name carries neither 9070 nor
+    # 9080, so it used to match nothing and fall through to CPU torch (#7624, #7307).
+    (r"9070|9080|R9700", "gfx1201"),
     (r"9060", "gfx1200"),  # RDNA 4 (Navi 44: Radeon RX 9060 XT / 9060)
     # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
     (r"8065S|8060S|8050S|8040S|Strix Halo|Ryzen AI Max|AI Max", "gfx1151"),

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2420,7 +2420,7 @@ if (-not $HasNvidiaSmi) {
         #    (gfx120X/110X/1151/1150/103X); unknown names fall back cleanly to CPU.
         elseif ($ROCmGpuLabel) {
             $nameArchTable = @(
-                @{ P = "9070|9080";                                           A = "gfx1201" }  # RDNA 4 (Navi 48: Radeon RX 9070 XT / 9070 GRE / 9070 / 9080)
+                @{ P = "9070|9080|R9700";                                     A = "gfx1201" }  # RDNA 4 (Navi 48: Radeon RX 9070 XT / 9070 GRE / 9070 / 9080, Radeon AI PRO R9700)
                 @{ P = "9060";                                                A = "gfx1200" }  # RDNA 4 (Navi 44: Radeon RX 9060 XT / 9060)
                 @{ P = "8065S|8060S|8050S|8040S|Strix Halo|Ryzen AI Max|AI Max"; A = "gfx1151" }  # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
                 @{ P = "890M|880M|Strix Point|HX 37[05]|AI 9 HX|AI 9 36[05]"; A = "gfx1150" }  # RDNA 3.5 (Strix Point: Radeon 890M/880M, Ryzen AI 9 HX 370/375)

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1842,7 +1842,7 @@ elif [ "$_setup_amd_detected" = true ]; then
         # gfx1102 matched BEFORE gfx1100 so the spaceless "RX 7700S" lands on
         # gfx1102 (bash case has no negative lookahead like the PS tables).
         case "$_setup_mkt" in
-            *9070*|*9080*)                                                                                 _setup_gfx="gfx1201" ;;  # RDNA 4 (Navi 48)
+            *9070*|*9080*|*"R9700"*)                                                                       _setup_gfx="gfx1201" ;;  # RDNA 4 (Navi 48: RX 9070 / 9080, Radeon AI PRO R9700)
             *9060*)                                                                                        _setup_gfx="gfx1200" ;;  # RDNA 4 (Navi 44)
             *"8065S"*|*"8060S"*|*"8050S"*|*"8040S"*|*"Strix Halo"*|*"Ryzen AI Max"*|*"AI Max"*) _setup_gfx="gfx1151" ;;  # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
             *"890M"*|*"880M"*|*"Strix Point"*|*"HX 37"*|*"AI 9 HX"*|*"AI 9 36"*) _setup_gfx="gfx1150" ;;  # RDNA 3.5 (Strix Point: Radeon 890M/880M, Ryzen AI 9 HX 370/375)

--- a/tests/studio/install/test_rocm_arch_table_parity.py
+++ b/tests/studio/install/test_rocm_arch_table_parity.py
@@ -292,10 +292,9 @@ def _match_ps(rows: list[tuple[str, str]], gpu_name: str) -> str | None:
 _GPU_NAME_LEAF_CASES = [
     ("AMD Radeon RX 9070 XT", "gfx120X-all"),
     ("AMD Radeon RX 9070", "gfx120X-all"),
-    # The workstation Navi 48. Its name carries neither "9070" nor "9080", so every copy of
-    # the table returned None and a host without the HIP SDK, where name inference is the
-    # only path left, was told it had no GPU and got CPU torch. Hardware-confirmed as
-    # gfx1201 in #7624 and #7307; reported as "not detected" on PR #8398.
+    # Workstation Navi 48, gfx1201 per rocminfo in #7624 / #7307. Its name holds neither
+    # "9070" nor "9080", so every table returned None and a host without the HIP SDK, where
+    # name inference is the only path left, got CPU torch ("not detected", PR #8398).
     ("AMD Radeon AI PRO R9700", "gfx120X-all"),
     ("AMD Radeon RX 9060 XT", "gfx120X-all"),
     ("AMD Radeon 8060S Graphics", "gfx1151"),
@@ -339,8 +338,8 @@ _AMD_DOCUMENTED_ARCH = {
     "AMD Radeon RX 9070": "gfx1201",
     "AMD Radeon RX 9060 XT": "gfx1200",
     "AMD Radeon RX 9060": "gfx1200",
-    # Navi 48 again, as the Radeon AI PRO R9000 series workstation card. Sourced from the
-    # two reporters' own rocminfo output (#7624, #7307) rather than from these tables.
+    # Navi 48 again, as the R9000 series workstation card. Sourced from the reporters'
+    # own rocminfo output (#7624, #7307), not from these tables.
     "AMD Radeon AI PRO R9700": "gfx1201",
     # RDNA 3 -- Navi 31 / 32 / 33.
     "AMD Radeon RX 7900 XTX": "gfx1100",
@@ -488,9 +487,9 @@ class TestGpuNameArchParity:
         ],
     )
     def test_the_r9700_arm_does_not_swallow_older_cards(self, gpu_name):
-        """The Radeon AI PRO R9700 arm is spelled "R9700", not a bare "9700", because ATI
-        shipped a Radeon 9700 PRO in 2002 and the loose token would hand that card RDNA 4
-        wheels. None of these pre-RDNA names may resolve to anything."""
+        """The arm is spelled "R9700", not a bare "9700": ATI shipped a Radeon 9700 PRO in
+        2002 and the loose token would hand that card RDNA 4 wheels. None of these pre-RDNA
+        names may resolve to anything."""
         for where, rows in _name_tables().items():
             got = _resolve(where, rows, gpu_name)
             assert got is None, f"{where}: {gpu_name!r} matched {got!r}"

--- a/tests/studio/install/test_rocm_arch_table_parity.py
+++ b/tests/studio/install/test_rocm_arch_table_parity.py
@@ -292,6 +292,11 @@ def _match_ps(rows: list[tuple[str, str]], gpu_name: str) -> str | None:
 _GPU_NAME_LEAF_CASES = [
     ("AMD Radeon RX 9070 XT", "gfx120X-all"),
     ("AMD Radeon RX 9070", "gfx120X-all"),
+    # The workstation Navi 48. Its name carries neither "9070" nor "9080", so every copy of
+    # the table returned None and a host without the HIP SDK, where name inference is the
+    # only path left, was told it had no GPU and got CPU torch. Hardware-confirmed as
+    # gfx1201 in #7624 and #7307; reported as "not detected" on PR #8398.
+    ("AMD Radeon AI PRO R9700", "gfx120X-all"),
     ("AMD Radeon RX 9060 XT", "gfx120X-all"),
     ("AMD Radeon 8060S Graphics", "gfx1151"),
     ("AMD Ryzen AI Max+ 395 w/ Radeon 8060S Graphics", "gfx1151"),
@@ -334,6 +339,9 @@ _AMD_DOCUMENTED_ARCH = {
     "AMD Radeon RX 9070": "gfx1201",
     "AMD Radeon RX 9060 XT": "gfx1200",
     "AMD Radeon RX 9060": "gfx1200",
+    # Navi 48 again, as the Radeon AI PRO R9000 series workstation card. Sourced from the
+    # two reporters' own rocminfo output (#7624, #7307) rather than from these tables.
+    "AMD Radeon AI PRO R9700": "gfx1201",
     # RDNA 3 -- Navi 31 / 32 / 33.
     "AMD Radeon RX 7900 XTX": "gfx1100",
     "AMD Radeon PRO W7900": "gfx1100",
@@ -469,6 +477,23 @@ class TestGpuNameArchParity:
         for where, rows in _name_tables().items():
             got = _resolve(where, rows, "NVIDIA GeForce RTX 4090")
             assert got is None, f"{where}: RTX 4090 matched {got!r}"
+
+    @pytest.mark.parametrize(
+        "gpu_name",
+        [
+            "ATI Radeon 9700 PRO",
+            "ATI Radeon 9800 PRO",
+            "AMD Radeon R9 Fury X",
+            "AMD Radeon Pro WX 9100",
+        ],
+    )
+    def test_the_r9700_arm_does_not_swallow_older_cards(self, gpu_name):
+        """The Radeon AI PRO R9700 arm is spelled "R9700", not a bare "9700", because ATI
+        shipped a Radeon 9700 PRO in 2002 and the loose token would hand that card RDNA 4
+        wheels. None of these pre-RDNA names may resolve to anything."""
+        for where, rows in _name_tables().items():
+            got = _resolve(where, rows, gpu_name)
+            assert got is None, f"{where}: {gpu_name!r} matched {got!r}"
 
     def test_inferred_arch_always_has_an_index_family(self):
         """Every arch a name table can produce must be routable to an AMD wheel

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -3707,6 +3707,10 @@ class TestGfxArchNameFallback:
             ("AMD Ryzen AI 9 HX 370 w/ Radeon 890M", "gfx1150"),
             ("AMD Radeon RX 9070 XT", "gfx1201"),
             ("AMD Radeon RX 9070", "gfx1201"),  # Navi 48 like the XT, not Navi 44
+            # Navi 48 workstation card, gfx1201 per #7624 / #7307. The name holds neither
+            # "9070" nor "9080", so it matched nothing and the install fell back to CPU.
+            ("AMD Radeon AI PRO R9700", "gfx1201"),
+            ("ATI Radeon 9700 PRO", None),  # a bare "9700" arm would claim this 2002 card
             ("AMD Radeon RX 9060 XT", "gfx1200"),  # Navi 44
             ("AMD Radeon RX 7700S", "gfx1102"),  # (?!S) lookahead must not hit gfx1101
             ("AMD Radeon RX 7700 XT", "gfx1101"),  # Navi 32

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -3707,7 +3707,7 @@ class TestGfxArchNameFallback:
             ("AMD Ryzen AI 9 HX 370 w/ Radeon 890M", "gfx1150"),
             ("AMD Radeon RX 9070 XT", "gfx1201"),
             ("AMD Radeon RX 9070", "gfx1201"),  # Navi 48 like the XT, not Navi 44
-            # Navi 48 workstation card, gfx1201 per #7624 / #7307. The name holds neither
+            # Navi 48 workstation card, gfx1201 per #7624 / #7307. Its name holds neither
             # "9070" nor "9080", so it matched nothing and the install fell back to CPU.
             ("AMD Radeon AI PRO R9700", "gfx1201"),
             ("ATI Radeon 9700 PRO", None),  # a bare "9700" arm would claim this 2002 card

--- a/tests/studio/test_amd_name_arch_r9700.ps1
+++ b/tests/studio/test_amd_name_arch_r9700.ps1
@@ -1,0 +1,118 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# Behavioural test for the $nameArchTable GPU-name -> gfx inference in install.ps1 and
+# studio/setup.ps1, on the Radeon AI PRO R9700 (Navi 48, gfx1201; issues #7624 and #7307).
+# The card's name carries neither "9070" nor "9080", so the first-match-wins table used to
+# return nothing on a host with no HIP SDK and the installer fell back to CPU torch, which
+# surfaces as "GPU not detected" on a single-R9700 Windows box.
+# The Python parity suite evaluates these rows with Python's re; this runs them through
+# PowerShell's own -match, which is the engine that actually ships.
+# Run: pwsh -NoProfile -File tests/studio/test_amd_name_arch_r9700.ps1
+
+$ErrorActionPreference = "Stop"
+$root = (Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, "..", ".."))).Path
+
+$failures = 0
+function Check($name, $cond) {
+    if ($cond) { Write-Host "  PASS  $name" }
+    else { Write-Host "  FAIL  $name" -ForegroundColor Red; $script:failures++ }
+}
+
+# Returns the shipped `$nameArchTable = @( ... )` literal, sliced on balanced parens so the
+# rows under test are the ones in the file rather than a copy pasted into this test.
+function Get-NameArchTableSource($path) {
+    # CRLF normalised: these installers ship with Windows line endings and every source-text
+    # match below would silently miss otherwise.
+    $src = (Get-Content -Raw $path) -replace "`r`n", "`n"
+    $start = $src.IndexOf('$nameArchTable = @(')
+    if ($start -lt 0) { throw "$path : `$nameArchTable = @( was not found (renamed or restructured?)" }
+    $i = $src.IndexOf("(", $start)
+    $depth = 0
+    while ($i -lt $src.Length) {
+        if ($src[$i] -eq "(") { $depth++ }
+        elseif ($src[$i] -eq ")") { $depth--; if ($depth -eq 0) { return $src.Substring($start, $i - $start + 1) } }
+        $i++
+    }
+    throw "$path : unterminated `$nameArchTable"
+}
+
+# First-match-wins, exactly as both installers consume the table.
+function Resolve-Arch($table, $name) {
+    foreach ($row in $table) { if ($name -match $row.P) { return $row.A } }
+    return $null
+}
+
+# The card as its reporters saw it, plus the spellings WMI and amd-smi vary between.
+$r9700Names = @(
+    "AMD Radeon AI PRO R9700",
+    "AMD Radeon(TM) AI PRO R9700",
+    "Radeon AI PRO R9700",
+    "AMD Radeon AI PRO R9700 32GB"
+)
+
+# Every other name the table already answers for, so the new alternation is shown not to
+# steal a row from a neighbour, plus names that must keep resolving to nothing. The ATI
+# Radeon 9700 PRO is the reason the pattern is "R9700" and not a bare "9700": that 2002
+# card would match a loose token and be handed RDNA 4 wheels.
+$otherNames = @(
+    @{ N = "AMD Radeon RX 9070 XT";        A = "gfx1201" },
+    @{ N = "AMD Radeon RX 9070 GRE";       A = "gfx1201" },
+    @{ N = "AMD Radeon RX 9060 XT";        A = "gfx1200" },
+    @{ N = "AMD Radeon 8060S Graphics";    A = "gfx1151" },
+    @{ N = "AMD Radeon 890M Graphics";     A = "gfx1150" },
+    @{ N = "AMD Radeon 860M Graphics";     A = "gfx1152" },
+    @{ N = "AMD Radeon RX 7900 XTX";       A = "gfx1100" },
+    @{ N = "AMD Radeon PRO W7900";         A = "gfx1100" },
+    @{ N = "AMD Radeon RX 7800 XT";        A = "gfx1101" },
+    @{ N = "AMD Radeon PRO V710";          A = "gfx1101" },
+    @{ N = "AMD Radeon RX 7700S";          A = "gfx1102" },
+    @{ N = "AMD Radeon PRO W7600";         A = "gfx1102" },
+    @{ N = "AMD Radeon 780M Graphics";     A = "gfx1103" },
+    @{ N = "AMD Radeon RX 6900 XT";        A = "gfx1030" },
+    @{ N = "AMD Radeon RX 6600 XT";        A = "gfx1032" },
+    @{ N = "AMD Radeon RX 6500 XT";        A = "gfx1034" },
+    @{ N = "ATI Radeon 9700 PRO";          A = $null },
+    @{ N = "ATI Radeon 9800 PRO";          A = $null },
+    @{ N = "AMD Radeon R9 Fury X";         A = $null },
+    @{ N = "AMD Radeon RX 5700 XT";        A = $null },
+    @{ N = "AMD Radeon Pro WX 9100";       A = $null },
+    @{ N = "AMD Instinct MI300X";          A = $null },
+    @{ N = "NVIDIA GeForce RTX 4090";      A = $null },
+    @{ N = "Microsoft Basic Display Adapter"; A = $null }
+)
+
+foreach ($file in @("install.ps1", "studio/setup.ps1")) {
+    $path = Join-Path $root $file
+    Write-Host ""
+    Write-Host "=== $file ==="
+
+    $tableSrc = Get-NameArchTableSource $path
+    $nameArchTable = $null
+    Invoke-Expression ("`$nameArchTable = " + $tableSrc.Substring($tableSrc.IndexOf("@(")))
+    # Guard against a vacuous pass: an empty or truncated slice would resolve everything to
+    # $null and every negative case below would "pass".
+    Check "the shipped nameArchTable was found and parsed" ($nameArchTable -and $nameArchTable.Count -ge 12)
+    Check "every parsed row has a pattern and an arch" (@($nameArchTable | Where-Object { -not $_.P -or -not $_.A }).Count -eq 0)
+
+    foreach ($name in $r9700Names) {
+        Check "'$name' -> gfx1201" ((Resolve-Arch $nameArchTable $name) -eq "gfx1201")
+    }
+    foreach ($row in $otherNames) {
+        $got = Resolve-Arch $nameArchTable $row.N
+        if ($null -eq $row.A) { Check "'$($row.N)' still matches nothing" ($null -eq $got) }
+        else { Check "'$($row.N)' -> $($row.A)" ($got -eq $row.A) }
+    }
+
+    # The R9700 alternation must live on the gfx1201 arm specifically. Resolving correctly
+    # would also be satisfied by an arm added anywhere, and a later arm would be shadowed
+    # the day another row grows a pattern that matches first.
+    $gfx1201Rows = @($nameArchTable | Where-Object { $_.A -eq "gfx1201" })
+    Check "exactly one gfx1201 arm" ($gfx1201Rows.Count -eq 1)
+    Check "the gfx1201 arm carries R9700" ($gfx1201Rows[0].P -match "R9700")
+    Check "no other arm carries R9700" (@($nameArchTable | Where-Object { $_.A -ne "gfx1201" -and $_.P -match "R9700" }).Count -eq 0)
+}
+
+Write-Host ""
+if ($failures -gt 0) { Write-Host "$failures check(s) FAILED" -ForegroundColor Red; exit 1 }
+Write-Host "All checks passed" -ForegroundColor Green

--- a/tests/studio/test_amd_name_arch_r9700.ps1
+++ b/tests/studio/test_amd_name_arch_r9700.ps1
@@ -3,11 +3,10 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 # Behavioural test for the $nameArchTable GPU-name -> gfx inference in install.ps1 and
 # studio/setup.ps1, on the Radeon AI PRO R9700 (Navi 48, gfx1201; issues #7624 and #7307).
-# The card's name carries neither "9070" nor "9080", so the first-match-wins table used to
-# return nothing on a host with no HIP SDK and the installer fell back to CPU torch, which
-# surfaces as "GPU not detected" on a single-R9700 Windows box.
+# Its name holds neither "9070" nor "9080", so on a host with no HIP SDK the table returned
+# nothing and the installer fell back to CPU torch ("GPU not detected").
 # The Python parity suite evaluates these rows with Python's re; this runs them through
-# PowerShell's own -match, which is the engine that actually ships.
+# PowerShell's own -match, the engine that actually ships.
 # Run: pwsh -NoProfile -File tests/studio/test_amd_name_arch_r9700.ps1
 
 $ErrorActionPreference = "Stop"
@@ -22,8 +21,8 @@ function Check($name, $cond) {
 # Returns the shipped `$nameArchTable = @( ... )` literal, sliced on balanced parens so the
 # rows under test are the ones in the file rather than a copy pasted into this test.
 function Get-NameArchTableSource($path) {
-    # CRLF normalised: these installers ship with Windows line endings and every source-text
-    # match below would silently miss otherwise.
+    # CRLF normalised: these installers ship with Windows line endings, else every
+    # source-text match below silently misses.
     $src = (Get-Content -Raw $path) -replace "`r`n", "`n"
     $start = $src.IndexOf('$nameArchTable = @(')
     if ($start -lt 0) { throw "$path : `$nameArchTable = @( was not found (renamed or restructured?)" }
@@ -52,9 +51,9 @@ $r9700Names = @(
 )
 
 # Every other name the table already answers for, so the new alternation is shown not to
-# steal a row from a neighbour, plus names that must keep resolving to nothing. The ATI
-# Radeon 9700 PRO is the reason the pattern is "R9700" and not a bare "9700": that 2002
-# card would match a loose token and be handed RDNA 4 wheels.
+# steal a neighbour's row, plus names that must keep resolving to nothing. The ATI Radeon
+# 9700 PRO is why the pattern is "R9700" and not a bare "9700": that 2002 card would match
+# a loose token and be handed RDNA 4 wheels.
 $otherNames = @(
     @{ N = "AMD Radeon RX 9070 XT";        A = "gfx1201" },
     @{ N = "AMD Radeon RX 9070 GRE";       A = "gfx1201" },
@@ -90,8 +89,8 @@ foreach ($file in @("install.ps1", "studio/setup.ps1")) {
     $tableSrc = Get-NameArchTableSource $path
     $nameArchTable = $null
     Invoke-Expression ("`$nameArchTable = " + $tableSrc.Substring($tableSrc.IndexOf("@(")))
-    # Guard against a vacuous pass: an empty or truncated slice would resolve everything to
-    # $null and every negative case below would "pass".
+    # Guard against a vacuous pass: an empty or truncated slice resolves everything to
+    # $null, so every negative case below would "pass".
     Check "the shipped nameArchTable was found and parsed" ($nameArchTable -and $nameArchTable.Count -ge 12)
     Check "every parsed row has a pattern and an arch" (@($nameArchTable | Where-Object { -not $_.P -or -not $_.A }).Count -eq 0)
 
@@ -104,9 +103,9 @@ foreach ($file in @("install.ps1", "studio/setup.ps1")) {
         else { Check "'$($row.N)' -> $($row.A)" ($got -eq $row.A) }
     }
 
-    # The R9700 alternation must live on the gfx1201 arm specifically. Resolving correctly
-    # would also be satisfied by an arm added anywhere, and a later arm would be shadowed
-    # the day another row grows a pattern that matches first.
+    # The alternation must live on the gfx1201 arm specifically: an arm added anywhere would
+    # also resolve correctly today, but a later one gets shadowed the day another row grows
+    # a pattern that matches first.
     $gfx1201Rows = @($nameArchTable | Where-Object { $_.A -eq "gfx1201" })
     Check "exactly one gfx1201 arm" ($gfx1201Rows.Count -eq 1)
     Check "the gfx1201 arm carries R9700" ($gfx1201Rows[0].P -match "R9700")

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -501,10 +501,9 @@ def test_the_installer_keeps_a_parked_adapter_when_it_is_the_only_one(tmp_path):
 
 @requires_pwsh
 def test_a_lone_r9700_is_detected_by_both_scans(tmp_path):
-    """The report on PR #8398: "New install on windows 11 machine, R9700 Pro single GPU, not
-    detected". One healthy adapter and no HIP SDK, so the marketing name is the only evidence
-    left, and "AMD Radeon AI PRO R9700" holds neither "9070" nor "9080". Both scans have to
-    reach gfx1201 (#7624, #7307) or the install lands on CPU torch with no GPU reported."""
+    """Reported on PR #8398: single R9700 on Windows 11, not detected. One healthy adapter
+    and no HIP SDK, so the name is the only evidence left, and it holds neither "9070" nor
+    "9080". Both scans must reach gfx1201 (#7624, #7307) or the install lands on CPU torch."""
     assert _run(tmp_path, [(_R9700, 0)])["arch"] == "gfx1201"
     assert _run_installer_scan(tmp_path, [(_R9700, 0)])["arch"] == "gfx1201"
 

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -39,6 +39,7 @@ requires_pwsh = pytest.mark.skipif(shutil.which("pwsh") is None, reason = "Power
 _RADEON = "AMD Radeon(TM) 8060S Graphics"  # Strix Halo iGPU  -> gfx1151
 _RX9070 = "AMD Radeon RX 9070 XT"  # RDNA 4 discrete  -> gfx1201
 _R780M = "AMD Radeon 780M Graphics"  # Phoenix iGPU     -> gfx1103, a shadowing arch
+_R9700 = "AMD Radeon AI PRO R9700"  # RDNA 4 workstation -> gfx1201 (#7624, #7307)
 _ARC = "Intel(R) Arc(TM) A770 Graphics"
 
 HANDOFF = "_UNSLOTH_ROCM_GFX_ARCH_HANDOFF"
@@ -322,6 +323,8 @@ def test_the_adapter_name_reaches_inference_whole(tmp_path):
     [
         (_RADEON, "gfx1151"),
         (_RX9070, "gfx1201"),
+        (_R9700, "gfx1201"),
+        ("ATI Radeon 9700 PRO", None),
         ("AMD Radeon RX 9060 XT", "gfx1200"),
         ("AMD Radeon 890M Graphics", "gfx1150"),
         ("AMD Radeon 860M Graphics", "gfx1152"),
@@ -494,6 +497,16 @@ def test_the_installer_keeps_a_parked_adapter_when_it_is_the_only_one(tmp_path):
     peer there is nothing to prefer."""
     out = _run_installer_scan(tmp_path, [("AMD Radeon RX 9070 XT", 45)])
     assert out["arch"] == "gfx1201"
+
+
+@requires_pwsh
+def test_a_lone_r9700_is_detected_by_both_scans(tmp_path):
+    """The report on PR #8398: "New install on windows 11 machine, R9700 Pro single GPU, not
+    detected". One healthy adapter and no HIP SDK, so the marketing name is the only evidence
+    left, and "AMD Radeon AI PRO R9700" holds neither "9070" nor "9080". Both scans have to
+    reach gfx1201 (#7624, #7307) or the install lands on CPU torch with no GPU reported."""
+    assert _run(tmp_path, [(_R9700, 0)])["arch"] == "gfx1201"
+    assert _run_installer_scan(tmp_path, [(_R9700, 0)])["arch"] == "gfx1201"
 
 
 @requires_pwsh


### PR DESCRIPTION
### What the user sees

A Windows 11 box with a single AMD Radeon AI PRO R9700 installs and reports no GPU at all: the
installer says `gpu none (chat-only / GGUF)`, PyTorch lands on the CPU wheels, and nothing in the
UI offers the card. Reported by @aelfwyne on #8398 ("New install on windows 11 machine, R9700 Pro
single GPU, not detected").

This is not the PowerShell scalar-unroll defect that #8398 fixed (#8335). That one dropped a lone
healthy adapter before inference ever ran. This one is a gap in the table inference feeds.

### The mechanism

Six copies of the GPU-name to gfx-arch table match RDNA 4 Navi 48 on the pattern `9070|9080`:

```
@{ P = "9070|9080"; A = "gfx1201" }     # install.ps1 / studio/setup.ps1
*9070*|*9080*) echo gfx1201 ;;           # install.sh (twice), studio/setup.sh
(r"9070|9080", "gfx1201"),               # studio/install_python_stack.py
```

The workstation Navi 48 is branded **Radeon AI PRO R9700**. That string contains neither `9070`
nor `9080`, so a first-match-wins walk of the table falls off the end, no arch is inferred, and
every caller treats "no arch" as "not an AMD GPU we can serve" and routes to CPU torch.

Checked against the shipped tables before the fix:

```
"AMD Radeon AI PRO R9700"  ->  (no match)
"AMD Radeon RX 9070 XT"    ->  gfx1201
```

### Why the other R9700 reporters never hit it

Name inference is the last resort. It only runs when `rocminfo` / `amd-smi` / `hipinfo` fail to
report a `gcnArchName`. Both hardware reporters who confirmed this card as gfx1201 had a working
HIP SDK or `amd-smi`, so the probe answered first and the table was never consulted:

- #7624, "AMD Radeon AI PRO R9700 (gfx1201, discrete, 32GB VRAM)" on Windows 11
- #7307, "two Radeon AI PRO R9700s (gfx1201, 32 GB each)", pulling the rocm-gfx120X bundle

Both back it with real `rocminfo` / torch output, which is where the gfx1201 mapping in this PR
comes from. A plain Windows host with no SDK has only the marketing name to go on, which is why
the single-card case is the one that surfaced.

### Files touched

All six copies of the name table, each keeping its own idiom:

| File | Site |
| --- | --- |
| `install.ps1` | `$nameArchTable`, gfx1201 row |
| `install.sh` | `_infer_amd_gfx_arch_from_gpu_name()` |
| `install.sh` | `case "$_gpu_disp_mkt"` (detection banner and the `UNSLOTH_ROCM_GFX_ARCH` tip) |
| `studio/setup.ps1` | `$nameArchTable`, gfx1201 row |
| `studio/setup.sh` | `case "$_setup_mkt"` |
| `studio/install_python_stack.py` | `_WIN_GPU_NAME_ARCH_TABLE` |

The token is `R9700`, not a bare `9700`. ATI shipped a Radeon 9700 PRO in 2002, and a loose token
would match it and hand a 24-year-old card RDNA 4 wheels. `R9700` matches every spelling of the
real adapter (`AMD Radeon AI PRO R9700`, `AMD Radeon(TM) AI PRO R9700`, with or without a capacity
suffix) and nothing else in any row of any table.

### What I deliberately did not add

AMD's product page mentions an R9600 series and an R9000S series in passing, with no published
arch and no report in this tracker. Navi 44 would be the guess, and a wrong arch is worse than a
missing one because it installs the wrong wheels, so those stay out until someone shows up with
one. There is no RDNA 4 Radeon PRO W-series product to add.

### Verification

- Placement is asserted, not just resolution: `R9700` has to sit on the gfx1201 arm, and on no
  other arm, in both `.ps1` copies.
- Ordering and false-match sweep run through the real engines, not by eye: the shell arms through
  an actual `case` evaluation, the PowerShell rows through PowerShell's own `-match`. Every name
  the tables already answered for resolves unchanged, and `ATI Radeon 9700 PRO`, `ATI Radeon 9800
  PRO`, `AMD Radeon R9 Fury X`, `AMD Radeon Pro WX 9100`, `AMD Radeon RX 5700 XT` and
  `AMD Instinct MI300X` all still match nothing.
- Every new assertion was checked against its own mutant: each of the six sites was reverted one
  at a time and the covering suite fails; loosening `R9700` to `9700` fails all four suites. No
  assertion survived its mutant.

Tests extended:

- `tests/studio/install/test_rocm_arch_table_parity.py` - the R9700 joins `_GPU_NAME_LEAF_CASES`
  and `_AMD_DOCUMENTED_ARCH`, so all six copies plus the spoof fixture are held to the same
  answer and to the right wheel index leaf, and the cross-file contract between
  `_WIN_GPU_NAME_ARCH_TABLE`, `_GFX_TO_AMD_INDEX_ARCH` and the `.ps1` tables covers the new entry.
  Plus a guard that the arm does not swallow the pre-RDNA cards.
- `tests/studio/install/test_rocm_support.py` - `_gfx_arch_from_gpu_name()` mapping.
- `tests/test_windows_amd_gpu_scan_fallback.py` - a lone R9700 adapter driven through the shipped
  `install.ps1` and `studio/setup.ps1` scan blocks under pwsh, which is @aelfwyne's exact host
  shape.
- `tests/studio/test_amd_name_arch_r9700.ps1` (new) - evaluates the shipped `$nameArchTable` rows
  under PowerShell's own regex engine rather than Python's, with a "was found" guard so a renamed
  or truncated table fails loudly instead of passing vacuously.
  Wired into `cross-platform-parity-ci.yml` next to the other `pwsh` installer tests, so it runs
  on ubuntu and windows rather than only by hand.

Suites run serially:

```
tests/studio/install/test_rocm_arch_table_parity.py    86 passed
tests/studio/install/test_rocm_support.py             488 passed, 1 skipped
tests/test_windows_amd_gpu_scan_fallback.py            82 passed
tests/python/test_cross_platform_parity.py             76 passed
tests/studio/install/test_rocm_rdna_routing.py         23 passed
tests/studio/install/test_rocm_gfx_spoof_7331.py       72 passed
pwsh tests/studio/test_amd_name_arch_r9700.ps1        all checks passed
```

Thanks to @aelfwyne for the report, and to the reporters on #7624 and #7307 for the hardware
confirmation this mapping rests on.

