### PR TITLE
Studio: keep the extras install working under a hardened uv.toml / pip.conf

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3628,6 +3628,40 @@ NO_TORCH_SKIP_PACKAGES = {
     "librosa",
 }
 
+# Requirements that ship NO wheel on PyPI at any version, so the installer has always
+# built them from source. ``antlr4-python3-runtime`` arrives transitively, via
+# ``omegaconf==2.3.1`` pinning it below the 4.13.2 wheel.
+#
+# A user-level ``no-build = true`` (~/.config/uv/uv.toml) or ``only-binary = :all:``
+# (~/.config/pip/pip.conf) makes every one of them unresolvable and takes the whole
+# extras step down with it -- unslothai/unsloth#8530. A PACKAGE-SCOPED --no-binary
+# overrides that global policy for these names only: verified against uv 0.10 and pip
+# 26 that `--no-binary openai-whisper` resolves under `no-build = true` /
+# `only-binary = :all:` while every other requirement still comes from a wheel. That
+# keeps the user's binary-only policy in force everywhere it can actually be honoured,
+# which a blanket --no-build/:none: override would not.
+#
+# Keep in sync with the `nobuild` allowlists that assert the same contract in CI:
+# .github/scripts/clean-machine-assert.sh and .github/scripts/assert-nobuild.ps1.
+SDIST_ONLY_PACKAGES = (
+    "openai-whisper",
+    "argbind",
+    "randomname",
+    "antlr4-python3-runtime",
+)
+
+
+def _sdist_only_build_args() -> list[str]:
+    """``--no-binary`` for each wheel-less requirement, for uv and pip alike.
+
+    Naming a package that the resolution never reaches is harmless (verified), so this
+    is safe next to the NO_TORCH / Windows requirement filtering.
+    """
+    args: list[str] = []
+    for name in SDIST_ONLY_PACKAGES:
+        args += ["--no-binary", name]
+    return args
+
 
 def _select_flash_attn_version(torch_mm: str) -> str | None:
     return flash_attn_package_version(torch_mm)
@@ -3910,6 +3944,42 @@ def _is_pinned_index_cmd(cmd: "list[str] | tuple[str, ...]") -> bool:
     return any(arg in ("--index-url", "--default-index") for arg in cmd)
 
 
+# Restrictive package-manager policy that a pinned install must not inherit from the
+# ENVIRONMENT. The pinned branch already neutralises the config FILES (UV_NO_CONFIG=1 +
+# PIP_CONFIG_FILE=devnull), but these env vars outrank a config file, so a hardened shell
+# could still fail a torch repair the pin was supposed to make deterministic (#8530).
+_PM_POLICY_ENV_VARS = (
+    "UV_NO_BUILD",
+    "UV_NO_BUILD_PACKAGE",
+    "UV_NO_BINARY",
+    "UV_NO_BINARY_PACKAGE",
+    "UV_REQUIRE_HASHES",
+    "UV_EXCLUDE_NEWER",
+    "PIP_ONLY_BINARY",
+    "PIP_NO_BINARY",
+    "PIP_REQUIRE_HASHES",
+)
+
+
+def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
+    """Overrides that stop a hardened user pip config failing the installer's own pip.
+
+    Empty for anything that is not a `pip install` / `pip download` this module drives --
+    including every `uv` command, so the "non-pinned installs inherit the caller env
+    unchanged" contract is untouched on a machine with no hostile pip config.
+
+    ``require-hashes = true`` in ~/.config/pip/pip.conf makes pip reject any requirement
+    without a --hash, which is every requirements file the installer ships; that is what
+    took the pip FALLBACK down in #8530 once uv had already failed. pip applies env vars
+    AFTER config files, so PIP_REQUIRE_HASHES=0 overrides it while pip.conf's index-url,
+    trusted-host, cert and proxy settings all stay in force. Scoped to the child env: the
+    user's own later pip commands are unaffected.
+    """
+    if cmd[:1] == ["uv"] or not any(arg in ("install", "download") for arg in cmd):
+        return {}
+    return {"PIP_REQUIRE_HASHES": "0"}
+
+
 def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     """Return an env with the uv index vars stripped for a pinned-index install.
 
@@ -3917,11 +3987,23 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     the user's mirror. For pinned commands, the uv index/backend vars are removed,
     UV_NO_CONFIG=1 set (a discovered uv.toml outranks the CLI pin), and PIP_CONFIG_FILE
     pointed at os.devnull for the pip fallback. Mirrors install.sh's gate (#6898).
+
+    A non-pinned `pip` command additionally gets hash-required mode switched off, which is
+    the only relaxation that cannot be expressed as a command-line flag; the wheel-less
+    requirements are handled by the package-scoped --no-binary in _sdist_only_build_args()
+    instead of by overriding the user's binary policy wholesale.
     """
     if not _is_pinned_index_cmd(cmd):
-        return None
+        relaxed = _relaxed_pip_policy_env(cmd)
+        if not relaxed:
+            return None
+        env = os.environ.copy()
+        env.update(relaxed)
+        return env
     env = os.environ.copy()
     for name in _UV_INDEX_ENV_VARS:
+        env.pop(name, None)
+    for name in _PM_POLICY_ENV_VARS:
         env.pop(name, None)
     env["UV_NO_CONFIG"] = "1"
     env["PIP_CONFIG_FILE"] = os.devnull
@@ -4432,6 +4514,9 @@ def install_python_stack() -> int:
     pip_install(
         "Installing additional unsloth dependencies",
         "--no-cache-dir",
+        # extras.txt is where the wheel-less requirements live, so a user-level
+        # no-build/only-binary policy fails this step first (#8530).
+        *_sdist_only_build_args(),
         req = REQ_ROOT / "extras.txt",
     )
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3651,16 +3651,29 @@ SDIST_ONLY_PACKAGES = (
 )
 
 
-def _sdist_only_build_args() -> list[str]:
-    """``--no-binary`` for each wheel-less requirement, for uv and pip alike.
+def _sdist_only_build_args(*names: str) -> list[str]:
+    """``--no-binary`` for each named wheel-less requirement, for uv and pip alike.
 
     Naming a package that the resolution never reaches is harmless (verified), so this
     is safe next to the NO_TORCH / Windows requirement filtering.
     """
     args: list[str] = []
-    for name in SDIST_ONLY_PACKAGES:
+    for name in names:
         args += ["--no-binary", name]
     return args
+
+
+def _extras_sdist_only_packages() -> tuple[str, ...]:
+    """SDIST_ONLY_PACKAGES plus any this interpreter alone resolves to an sdist."""
+    names = list(SDIST_ONLY_PACKAGES)
+    # extras.txt pins MeCab==0.996.5 on macOS cp314 and up, the last release carrying an
+    # sdist: 0.996.12 added cp314 wheels for Linux and win_amd64 only, so that host has no
+    # binary candidate. Everywhere else 0.996.13 resolves to a wheel, and MeCab is a C
+    # extension, so exempting it unconditionally would force a compiler-dependent build
+    # on hosts that never needed one.
+    if IS_MACOS and sys.version_info >= (3, 14):
+        names.append("MeCab")
+    return tuple(names)
 
 
 def _select_flash_attn_version(torch_mm: str) -> str | None:
@@ -4516,7 +4529,7 @@ def install_python_stack() -> int:
         "--no-cache-dir",
         # extras.txt is where the wheel-less requirements live, so a user-level
         # no-build/only-binary policy fails this step first (#8530).
-        *_sdist_only_build_args(),
+        *_sdist_only_build_args(*_extras_sdist_only_packages()),
         req = REQ_ROOT / "extras.txt",
     )
 
@@ -4653,6 +4666,12 @@ def install_python_stack() -> int:
     pip_install(
         "Installing the pinned Diffusers revision",
         "--no-cache-dir",
+        # The pin is a source ARCHIVE, and uv refuses to build one under a user-level
+        # no-build, so a hardened config failed here even once extras.txt succeeded
+        # (#8530). Only for the archive: python < 3.10 resolves a released wheel that
+        # must not be forced through a source build. (pip's only-binary does not reach a
+        # direct URL requirement, so this matters for the uv path.)
+        *(_sdist_only_build_args("diffusers") if sys.version_info >= (3, 10) else []),
         req = REQ_ROOT / "diffusers-pin.txt",
     )
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3628,20 +3628,17 @@ NO_TORCH_SKIP_PACKAGES = {
     "librosa",
 }
 
-# Requirements that ship NO wheel on PyPI at any version, so the installer has always
-# built them from source. ``antlr4-python3-runtime`` arrives transitively, via
-# ``omegaconf==2.3.1`` pinning it below the 4.13.2 wheel.
+# Requirements with NO wheel on PyPI at any version, so the installer has always built
+# them from source. antlr4-python3-runtime arrives transitively: omegaconf==2.3.1 pins it
+# below the 4.13.2 wheel.
 #
-# A user-level ``no-build = true`` (~/.config/uv/uv.toml) or ``only-binary = :all:``
-# (~/.config/pip/pip.conf) makes every one of them unresolvable and takes the whole
-# extras step down with it -- unslothai/unsloth#8530. A PACKAGE-SCOPED --no-binary
-# overrides that global policy for these names only: verified against uv 0.10 and pip
-# 26 that `--no-binary openai-whisper` resolves under `no-build = true` /
-# `only-binary = :all:` while every other requirement still comes from a wheel. That
-# keeps the user's binary-only policy in force everywhere it can actually be honoured,
-# which a blanket --no-build/:none: override would not.
+# A user-level `no-build = true` (uv.toml) or `only-binary = :all:` (pip.conf) makes all
+# of them unresolvable and fails the whole extras step (#8530). A PACKAGE-SCOPED
+# --no-binary overrides that policy for these names only, so the user's binary-only
+# policy still applies everywhere it can be honoured -- a blanket --no-build or
+# `:none:` override would discard it entirely.
 #
-# Keep in sync with the `nobuild` allowlists that assert the same contract in CI:
+# Keep in sync with the CI `nobuild` allowlists asserting the same contract:
 # .github/scripts/clean-machine-assert.sh and .github/scripts/assert-nobuild.ps1.
 SDIST_ONLY_PACKAGES = (
     "openai-whisper",
@@ -3666,11 +3663,9 @@ def _sdist_only_build_args(*names: str) -> list[str]:
 def _extras_sdist_only_packages() -> tuple[str, ...]:
     """SDIST_ONLY_PACKAGES plus any this interpreter alone resolves to an sdist."""
     names = list(SDIST_ONLY_PACKAGES)
-    # extras.txt pins MeCab==0.996.5 on macOS cp314 and up, the last release carrying an
-    # sdist: 0.996.12 added cp314 wheels for Linux and win_amd64 only, so that host has no
-    # binary candidate. Everywhere else 0.996.13 resolves to a wheel, and MeCab is a C
-    # extension, so exempting it unconditionally would force a compiler-dependent build
-    # on hosts that never needed one.
+    # extras.txt pins MeCab==0.996.5 on macOS cp314+, the last release carrying an sdist.
+    # Conditional because MeCab is a C extension: everywhere else 0.996.13 resolves to a
+    # wheel, and exempting it there would force a compiler-dependent build.
     if IS_MACOS and sys.version_info >= (3, 14):
         names.append("MeCab")
     return tuple(names)
@@ -3957,10 +3952,10 @@ def _is_pinned_index_cmd(cmd: "list[str] | tuple[str, ...]") -> bool:
     return any(arg in ("--index-url", "--default-index") for arg in cmd)
 
 
-# Restrictive package-manager policy that a pinned install must not inherit from the
-# ENVIRONMENT. The pinned branch already neutralises the config FILES (UV_NO_CONFIG=1 +
-# PIP_CONFIG_FILE=devnull), but these env vars outrank a config file, so a hardened shell
-# could still fail a torch repair the pin was supposed to make deterministic (#8530).
+# Restrictive policy a pinned install must not inherit from the ENVIRONMENT. The pinned
+# branch neutralises the config FILES (UV_NO_CONFIG=1 + PIP_CONFIG_FILE=devnull), but an
+# env var outranks a config file, so a hardened shell could still fail a torch repair the
+# pin was supposed to make deterministic (#8530).
 _PM_POLICY_ENV_VARS = (
     "UV_NO_BUILD",
     "UV_NO_BUILD_PACKAGE",
@@ -3977,16 +3972,14 @@ _PM_POLICY_ENV_VARS = (
 def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
     """Overrides that stop a hardened user pip config failing the installer's own pip.
 
-    Empty for anything that is not a `pip install` / `pip download` this module drives --
-    including every `uv` command, so the "non-pinned installs inherit the caller env
-    unchanged" contract is untouched on a machine with no hostile pip config.
+    Empty for anything that is not a `pip install` / `pip download` this module drives,
+    every `uv` command included, so the "non-pinned installs inherit the caller env
+    unchanged" contract holds on a machine with no hostile pip config.
 
-    ``require-hashes = true`` in ~/.config/pip/pip.conf makes pip reject any requirement
-    without a --hash, which is every requirements file the installer ships; that is what
-    took the pip FALLBACK down in #8530 once uv had already failed. pip applies env vars
-    AFTER config files, so PIP_REQUIRE_HASHES=0 overrides it while pip.conf's index-url,
-    trusted-host, cert and proxy settings all stay in force. Scoped to the child env: the
-    user's own later pip commands are unaffected.
+    `require-hashes = true` makes pip reject any requirement without a --hash, which is
+    every requirements file we ship; that is what took the pip FALLBACK down in #8530
+    once uv had failed. pip applies env vars AFTER config files, so PIP_REQUIRE_HASHES=0
+    overrides it while pip.conf's index-url, trusted-host, cert and proxy stay in force.
     """
     if cmd[:1] == ["uv"] or not any(arg in ("install", "download") for arg in cmd):
         return {}
@@ -4001,10 +3994,9 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     UV_NO_CONFIG=1 set (a discovered uv.toml outranks the CLI pin), and PIP_CONFIG_FILE
     pointed at os.devnull for the pip fallback. Mirrors install.sh's gate (#6898).
 
-    A non-pinned `pip` command additionally gets hash-required mode switched off, which is
-    the only relaxation that cannot be expressed as a command-line flag; the wheel-less
-    requirements are handled by the package-scoped --no-binary in _sdist_only_build_args()
-    instead of by overriding the user's binary policy wholesale.
+    A non-pinned `pip` command also gets hash-required mode switched off, the one
+    relaxation with no command-line equivalent; the wheel-less requirements go through
+    the package-scoped --no-binary in _sdist_only_build_args() instead.
     """
     if not _is_pinned_index_cmd(cmd):
         relaxed = _relaxed_pip_policy_env(cmd)
@@ -4666,11 +4658,10 @@ def install_python_stack() -> int:
     pip_install(
         "Installing the pinned Diffusers revision",
         "--no-cache-dir",
-        # The pin is a source ARCHIVE, and uv refuses to build one under a user-level
-        # no-build, so a hardened config failed here even once extras.txt succeeded
-        # (#8530). Only for the archive: python < 3.10 resolves a released wheel that
-        # must not be forced through a source build. (pip's only-binary does not reach a
-        # direct URL requirement, so this matters for the uv path.)
+        # The pin is a source ARCHIVE, which uv refuses to build under a user-level
+        # no-build, so a hardened host failed here even once extras.txt succeeded
+        # (#8530). Guarded: python < 3.10 resolves a released wheel from this file that
+        # must not be forced through a source build.
         *(_sdist_only_build_args("diffusers") if sys.version_info >= (3, 10) else []),
         req = REQ_ROOT / "diffusers-pin.txt",
     )

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -290,12 +290,10 @@ class TestPinnedIndexClearsUvEnv:
 class TestSdistOnlyBuildArgs:
     """A hardened user config must not be able to fail the extras step.
 
-    unslothai/unsloth#8530: `no-build = true` in ~/.config/uv/uv.toml (and
-    `only-binary = :all:` in ~/.config/pip/pip.conf) makes every wheel-less requirement
-    in extras.txt unresolvable, so `unsloth studio update` died at "unsloth extras".
-    A PACKAGE-SCOPED --no-binary overrides that policy for those names only, leaving the
-    user's binary-only policy in force for every other requirement -- verified against
-    uv 0.10 and pip 26: dropping one name from the flags makes that name refused again.
+    #8530: `no-build = true` (uv.toml) or `only-binary = :all:` (pip.conf) makes every
+    wheel-less requirement in extras.txt unresolvable, so the install died at "unsloth
+    extras". A PACKAGE-SCOPED --no-binary overrides that for those names only -- verified
+    against uv 0.10 and pip 26: drop one name and that name is refused again.
     """
 
     def test_emits_no_binary_for_every_sdist_only_package(self):
@@ -341,10 +339,9 @@ class TestSdistOnlyBuildArgs:
         """extras.txt pins MeCab==0.996.5 on macOS cp314+, which ships only an sdist.
 
         MeCab is a C extension, so an unconditional exemption would force a
-        compiler-dependent source build on every other host, which is a worse bug than
-        the one being fixed. Verified against uv 0.10: 0.996.5 is refused under
-        `no-build = true` for macOS cp314 and resolves with --no-binary MeCab, while
-        0.996.13 still comes from a wheel elsewhere.
+        compiler-dependent build on every other host -- a worse bug than the one being
+        fixed. Verified against uv 0.10: 0.996.5 is refused under `no-build = true` for
+        macOS cp314 and resolves with --no-binary MeCab; 0.996.13 stays a wheel elsewhere.
         """
         with (
             mock.patch.object(ips, "IS_MACOS", is_macos),
@@ -426,11 +423,10 @@ class TestSdistOnlyBuildArgs:
 class TestHardenedPipConfigRelaxation:
     """`require-hashes = true` in pip.conf killed the pip FALLBACK in #8530.
 
-    Every requirements file the installer ships is pinned but unhashed, so hash-required
-    mode can never be satisfied. pip applies env vars AFTER config files, so
-    PIP_REQUIRE_HASHES=0 in the child env overrides it while pip.conf's index-url,
-    trusted-host, cert and proxy settings all stay in force. There is no command-line
-    equivalent, which is why this one knob is handled through the environment.
+    Every requirements file we ship is pinned but unhashed, so hash-required mode can
+    never be satisfied. pip applies env vars AFTER config files, so PIP_REQUIRE_HASHES=0
+    in the child env overrides it while pip.conf's index-url, trusted-host, cert and
+    proxy stay in force. It has no command-line equivalent, hence the env var.
     """
 
     HOSTILE = {

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -366,12 +366,10 @@ class TestSdistOnlyBuildArgs:
             req = next((k for k in node.keywords if k.arg == "req"), None)
             if req is None or "diffusers-pin.txt" not in ast.unparse(req.value):
                 continue
-            splat = " ".join(
-                ast.unparse(a.value) for a in node.args if isinstance(a, ast.Starred)
-            )
-            assert "_sdist_only_build_args('diffusers')" in splat, (
-                f"the diffusers pin at line {node.lineno} must exempt the source archive"
-            )
+            splat = " ".join(ast.unparse(a.value) for a in node.args if isinstance(a, ast.Starred))
+            assert (
+                "_sdist_only_build_args('diffusers')" in splat
+            ), f"the diffusers pin at line {node.lineno} must exempt the source archive"
             assert "version_info >= (3, 10)" in splat, (
                 "the exemption must be guarded so the pre-3.10 wheel is not forced "
                 f"through a source build (line {node.lineno})"

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -301,9 +301,9 @@ class TestSdistOnlyBuildArgs:
     def test_emits_no_binary_for_every_sdist_only_package(self):
         args = ips._sdist_only_build_args()
         for name in ips.SDIST_ONLY_PACKAGES:
-            assert ["--no-binary", name] == args[args.index(name) - 1 : args.index(name) + 1], (
-                f"{name} must be passed as a package-scoped --no-binary, got: {args}"
-            )
+            assert ["--no-binary", name] == args[
+                args.index(name) - 1 : args.index(name) + 1
+            ], f"{name} must be passed as a package-scoped --no-binary, got: {args}"
         assert len(args) == 2 * len(ips.SDIST_ONLY_PACKAGES)
 
     def test_openai_whisper_is_covered(self):
@@ -341,9 +341,7 @@ class TestSdistOnlyBuildArgs:
             req = next((k for k in node.keywords if k.arg == "req"), None)
             if req is None or "extras.txt" not in ast.unparse(req.value):
                 continue
-            starred = [
-                ast.unparse(a.value) for a in node.args if isinstance(a, ast.Starred)
-            ]
+            starred = [ast.unparse(a.value) for a in node.args if isinstance(a, ast.Starred)]
             assert "_sdist_only_build_args()" in starred, (
                 f"the extras.txt install at line {node.lineno} must splat "
                 "_sdist_only_build_args() or a hardened uv.toml fails it again"

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -287,6 +287,182 @@ class TestPinnedIndexClearsUvEnv:
         assert env is None
 
 
+class TestSdistOnlyBuildArgs:
+    """A hardened user config must not be able to fail the extras step.
+
+    unslothai/unsloth#8530: `no-build = true` in ~/.config/uv/uv.toml (and
+    `only-binary = :all:` in ~/.config/pip/pip.conf) makes every wheel-less requirement
+    in extras.txt unresolvable, so `unsloth studio update` died at "unsloth extras".
+    A PACKAGE-SCOPED --no-binary overrides that policy for those names only, leaving the
+    user's binary-only policy in force for every other requirement -- verified against
+    uv 0.10 and pip 26: dropping one name from the flags makes that name refused again.
+    """
+
+    def test_emits_no_binary_for_every_sdist_only_package(self):
+        args = ips._sdist_only_build_args()
+        for name in ips.SDIST_ONLY_PACKAGES:
+            assert ["--no-binary", name] == args[args.index(name) - 1 : args.index(name) + 1], (
+                f"{name} must be passed as a package-scoped --no-binary, got: {args}"
+            )
+        assert len(args) == 2 * len(ips.SDIST_ONLY_PACKAGES)
+
+    def test_openai_whisper_is_covered(self):
+        """The package named in the issue, and the transitive one behind omegaconf."""
+        assert "openai-whisper" in ips.SDIST_ONLY_PACKAGES
+        # omegaconf==2.3.1 pins antlr4-python3-runtime below the 4.13.2 wheel, so it
+        # arrives as a transitive sdist and fails no-build even though extras.txt
+        # never names it.
+        assert "antlr4-python3-runtime" in ips.SDIST_ONLY_PACKAGES
+
+    def test_flags_survive_translation_to_uv(self):
+        """uv is the primary path, so the flags must reach _build_uv_cmd intact."""
+        cmd = ips._build_uv_cmd(tuple(ips._sdist_only_build_args()))
+        for name in ips.SDIST_ONLY_PACKAGES:
+            assert name in cmd
+        assert cmd.count("--no-binary") == len(ips.SDIST_ONLY_PACKAGES)
+
+    def test_flags_survive_translation_to_pip(self):
+        """And the pip FALLBACK must carry them too, for the uv-less/uv-broken case."""
+        cmd = ips._build_pip_cmd(tuple(ips._sdist_only_build_args()))
+        for name in ips.SDIST_ONLY_PACKAGES:
+            assert name in cmd
+        assert cmd.count("--no-binary") == len(ips.SDIST_ONLY_PACKAGES)
+
+    def test_the_extras_step_actually_passes_them(self):
+        """The helper existing is not the fix; the extras call site using it is.
+
+        extras.txt is the manifest that carries the wheel-less requirements, and its
+        pip_install() is fatal, so this is the call that #8530 died on.
+        """
+        tree = ast.parse(Path(ips.__file__).read_text(encoding = "utf-8"))
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and getattr(node.func, "id", None) == "pip_install"):
+                continue
+            req = next((k for k in node.keywords if k.arg == "req"), None)
+            if req is None or "extras.txt" not in ast.unparse(req.value):
+                continue
+            starred = [
+                ast.unparse(a.value) for a in node.args if isinstance(a, ast.Starred)
+            ]
+            assert "_sdist_only_build_args()" in starred, (
+                f"the extras.txt install at line {node.lineno} must splat "
+                "_sdist_only_build_args() or a hardened uv.toml fails it again"
+            )
+            return
+        pytest.fail("no pip_install(req=.../extras.txt) call found")
+
+    def test_matches_the_ci_nobuild_allowlists(self):
+        """CI already ratifies exactly these as audited pure-Python sdist builds.
+
+        If the two lists drift, either CI fails a legitimate build or we exempt a
+        package nobody audited, so pin them together.
+        """
+        repo = Path(ips.__file__).resolve().parents[1]
+        shell = (repo / ".github/scripts/clean-machine-assert.sh").read_text(encoding = "utf-8")
+        allow = shell[shell.index('_allow="$(printf') :]
+        allow = allow[: allow.index("\n")]
+        ps1 = (repo / ".github/scripts/assert-nobuild.ps1").read_text(encoding = "utf-8")
+        for name in ips.SDIST_ONLY_PACKAGES:
+            assert name in allow, f"{name} missing from clean-machine-assert.sh nobuild allowlist"
+            assert f"'{name}'" in ps1, f"{name} missing from assert-nobuild.ps1 allowlist"
+
+
+class TestHardenedPipConfigRelaxation:
+    """`require-hashes = true` in pip.conf killed the pip FALLBACK in #8530.
+
+    Every requirements file the installer ships is pinned but unhashed, so hash-required
+    mode can never be satisfied. pip applies env vars AFTER config files, so
+    PIP_REQUIRE_HASHES=0 in the child env overrides it while pip.conf's index-url,
+    trusted-host, cert and proxy settings all stay in force. There is no command-line
+    equivalent, which is why this one knob is handled through the environment.
+    """
+
+    HOSTILE = {
+        "PIP_REQUIRE_HASHES": "1",
+        "PIP_ONLY_BINARY": ":all:",
+        "UV_NO_BUILD": "1",
+        "UV_EXCLUDE_NEWER": "2024-01-01T00:00:00Z",
+    }
+
+    def test_uv_commands_are_left_alone(self):
+        """uv reads none of the PIP_* vars, and its own no-build is handled by the
+        package-scoped --no-binary, so a uv command must still inherit the env
+        unchanged -- the mirror contract at test_non_pinned_install_keeps_user_mirror."""
+        with mock.patch.dict(os.environ, self.HOSTILE):
+            assert ips._install_env_for_cmd(["uv", "pip", "install", "-r", "extras.txt"]) is None
+
+    def test_non_pinned_pip_install_relaxes_hash_mode(self):
+        with mock.patch.dict(os.environ, self.HOSTILE):
+            env = ips._install_env_for_cmd(["python", "-m", "pip", "install", "-r", "extras.txt"])
+        assert env is not None, "the pip fallback must not inherit require-hashes"
+        assert env["PIP_REQUIRE_HASHES"] == "0"
+
+    def test_non_pinned_pip_keeps_the_user_mirror_and_binary_policy(self):
+        """Only hash mode is relaxed. The mirror stays, and so does only-binary --
+        the wheel-less packages are exempted per-package on the command line instead."""
+        with mock.patch.dict(
+            os.environ,
+            dict(self.HOSTILE, PIP_INDEX_URL = "https://mirror.corp/simple"),
+        ):
+            env = ips._install_env_for_cmd(["python", "-m", "pip", "install", "x"])
+        assert env["PIP_INDEX_URL"] == "https://mirror.corp/simple"
+        assert env["PIP_ONLY_BINARY"] == ":all:"
+        assert "PIP_CONFIG_FILE" not in env, "a non-pinned install must still read pip.conf"
+        assert "UV_NO_CONFIG" not in env, "a non-pinned install must still read uv.toml"
+
+    def test_non_install_commands_are_untouched(self):
+        """run() routes EVERY command through this helper, not just installs."""
+        with mock.patch.dict(os.environ, self.HOSTILE):
+            assert ips._install_env_for_cmd(["python", "-m", "pip", "--version"]) is None
+            assert ips._install_env_for_cmd(["python", "-m", "ensurepip", "--upgrade"]) is None
+
+    def test_pinned_cmd_strips_restrictive_policy_env(self):
+        """The pinned branch neutralises the config FILES, but an env var outranks a
+        config file, so a hardened shell could still fail a torch repair the pin was
+        supposed to make deterministic."""
+        with mock.patch.dict(os.environ, self.HOSTILE):
+            env = ips._install_env_for_cmd(
+                ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
+            )
+        assert env is not None
+        for name in ("PIP_REQUIRE_HASHES", "PIP_ONLY_BINARY", "UV_NO_BUILD", "UV_EXCLUDE_NEWER"):
+            assert name not in env, f"{name} must be cleared for a pinned install"
+        # The pre-existing pinned contract is unchanged.
+        assert env["UV_NO_CONFIG"] == "1" and env["PIP_CONFIG_FILE"] == os.devnull
+
+    def test_the_parent_environment_is_never_mutated(self):
+        """The relaxation is a child-env override. Leaking it into os.environ would
+        weaken the user's policy for their own later pip commands in this session."""
+        with mock.patch.dict(os.environ, self.HOSTILE):
+            ips._install_env_for_cmd(["python", "-m", "pip", "install", "x"])
+            ips._install_env_for_cmd(["uv", "pip", "install", "x", "--index-url", "https://y"])
+            assert os.environ["PIP_REQUIRE_HASHES"] == "1"
+            assert os.environ["UV_NO_BUILD"] == "1"
+
+    def test_the_pip_fallback_receives_the_relaxation(self):
+        """End of the real path: uv fails, pip_install falls back through run(), and
+        that pip command is the one #8530 died on."""
+        seen: dict = {}
+
+        def _fake_run(label, cmd, *a, **kw):
+            seen["env"] = ips._install_env_for_cmd(cmd)
+            seen["cmd"] = cmd
+
+        with (
+            mock.patch.object(ips, "USE_UV", True),
+            mock.patch.object(ips, "subprocess") as sp,
+            mock.patch.object(ips, "run", _fake_run),
+            mock.patch.dict(os.environ, self.HOSTILE),
+        ):
+            sp.run.return_value = mock.Mock(returncode = 1, stdout = "")
+            sp.PIPE, sp.STDOUT = -1, -2
+            ips.pip_install("deps", *ips._sdist_only_build_args())
+
+        assert seen["env"]["PIP_REQUIRE_HASHES"] == "0"
+        for name in ips.SDIST_ONLY_PACKAGES:
+            assert name in seen["cmd"], "the fallback lost the source-build exemptions"
+
+
 class TestProgressLineNotes:
     """_progress() leaves the cursor mid-line, so anything printed between two
     progress steps must close that line first. Before centralising this, a real

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -299,7 +299,7 @@ class TestSdistOnlyBuildArgs:
     """
 
     def test_emits_no_binary_for_every_sdist_only_package(self):
-        args = ips._sdist_only_build_args()
+        args = ips._sdist_only_build_args(*ips.SDIST_ONLY_PACKAGES)
         for name in ips.SDIST_ONLY_PACKAGES:
             assert ["--no-binary", name] == args[
                 args.index(name) - 1 : args.index(name) + 1
@@ -316,17 +316,71 @@ class TestSdistOnlyBuildArgs:
 
     def test_flags_survive_translation_to_uv(self):
         """uv is the primary path, so the flags must reach _build_uv_cmd intact."""
-        cmd = ips._build_uv_cmd(tuple(ips._sdist_only_build_args()))
+        cmd = ips._build_uv_cmd(tuple(ips._sdist_only_build_args(*ips.SDIST_ONLY_PACKAGES)))
         for name in ips.SDIST_ONLY_PACKAGES:
             assert name in cmd
         assert cmd.count("--no-binary") == len(ips.SDIST_ONLY_PACKAGES)
 
     def test_flags_survive_translation_to_pip(self):
         """And the pip FALLBACK must carry them too, for the uv-less/uv-broken case."""
-        cmd = ips._build_pip_cmd(tuple(ips._sdist_only_build_args()))
+        cmd = ips._build_pip_cmd(tuple(ips._sdist_only_build_args(*ips.SDIST_ONLY_PACKAGES)))
         for name in ips.SDIST_ONLY_PACKAGES:
             assert name in cmd
         assert cmd.count("--no-binary") == len(ips.SDIST_ONLY_PACKAGES)
+
+    @pytest.mark.parametrize(
+        "is_macos, version, expected",
+        [
+            (True, (3, 14, 0), True),
+            (True, (3, 13, 12), False),
+            (False, (3, 14, 0), False),
+            (False, (3, 13, 12), False),
+        ],
+    )
+    def test_mecab_is_exempted_only_where_it_has_no_wheel(self, is_macos, version, expected):
+        """extras.txt pins MeCab==0.996.5 on macOS cp314+, which ships only an sdist.
+
+        MeCab is a C extension, so an unconditional exemption would force a
+        compiler-dependent source build on every other host, which is a worse bug than
+        the one being fixed. Verified against uv 0.10: 0.996.5 is refused under
+        `no-build = true` for macOS cp314 and resolves with --no-binary MeCab, while
+        0.996.13 still comes from a wheel elsewhere.
+        """
+        with (
+            mock.patch.object(ips, "IS_MACOS", is_macos),
+            mock.patch.object(sys, "version_info", version),
+        ):
+            names = ips._extras_sdist_only_packages()
+        assert ("MeCab" in names) is expected
+        # The unconditional ones are always present.
+        assert set(ips.SDIST_ONLY_PACKAGES) <= set(names)
+
+    def test_the_diffusers_pin_is_exempted_on_the_archive_path(self):
+        """The pin is a source ARCHIVE, and uv's no-build refuses to build one, so the
+        install still died here after extras.txt was fixed.
+
+        Guarded on python >= 3.10 because diffusers-pin.txt resolves a released wheel
+        below that, which must not be forced through a source build.
+        """
+        tree = ast.parse(Path(ips.__file__).read_text(encoding = "utf-8"))
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and getattr(node.func, "id", None) == "pip_install"):
+                continue
+            req = next((k for k in node.keywords if k.arg == "req"), None)
+            if req is None or "diffusers-pin.txt" not in ast.unparse(req.value):
+                continue
+            splat = " ".join(
+                ast.unparse(a.value) for a in node.args if isinstance(a, ast.Starred)
+            )
+            assert "_sdist_only_build_args('diffusers')" in splat, (
+                f"the diffusers pin at line {node.lineno} must exempt the source archive"
+            )
+            assert "version_info >= (3, 10)" in splat, (
+                "the exemption must be guarded so the pre-3.10 wheel is not forced "
+                f"through a source build (line {node.lineno})"
+            )
+            return
+        pytest.fail("no pip_install(req=.../diffusers-pin.txt) call found")
 
     def test_the_extras_step_actually_passes_them(self):
         """The helper existing is not the fix; the extras call site using it is.
@@ -342,9 +396,13 @@ class TestSdistOnlyBuildArgs:
             if req is None or "extras.txt" not in ast.unparse(req.value):
                 continue
             starred = [ast.unparse(a.value) for a in node.args if isinstance(a, ast.Starred)]
-            assert "_sdist_only_build_args()" in starred, (
+            assert any("_sdist_only_build_args(" in s for s in starred), (
                 f"the extras.txt install at line {node.lineno} must splat "
                 "_sdist_only_build_args() or a hardened uv.toml fails it again"
+            )
+            assert any("_extras_sdist_only_packages()" in s for s in starred), (
+                "the extras install must use the platform-aware list so the macOS "
+                "cp314 MeCab sdist is exempted too"
             )
             return
         pytest.fail("no pip_install(req=.../extras.txt) call found")
@@ -454,7 +512,7 @@ class TestHardenedPipConfigRelaxation:
         ):
             sp.run.return_value = mock.Mock(returncode = 1, stdout = "")
             sp.PIPE, sp.STDOUT = -1, -2
-            ips.pip_install("deps", *ips._sdist_only_build_args())
+            ips.pip_install("deps", *ips._sdist_only_build_args(*ips.SDIST_ONLY_PACKAGES))
 
         assert seen["env"]["PIP_REQUIRE_HASHES"] == "0"
         for name in ips.SDIST_ONLY_PACKAGES:

--- a/tests/studio/test_xpu_triton_swap.py
+++ b/tests/studio/test_xpu_triton_swap.py
@@ -46,12 +46,18 @@ def _load_real_index_env_scrub():
     ns: dict = {"os": _os}
     for anchor, end, keep in (
         ("_UV_INDEX_ENV_VARS = (", "\n)\n", 2),
+        # _install_env_for_cmd calls both of these, and they resolve from this namespace
+        # at CALL time, so omitting either only shows up as a NameError once a test
+        # actually invokes the scrub.
+        ("_PM_POLICY_ENV_VARS = (", "\n)\n", 2),
+        ("def _relaxed_pip_policy_env(", "\n\ndef ", 0),
         ("def _is_pinned_index_cmd(", "\n\ndef ", 0),
         ("def _install_env_for_cmd(", "\n\ndef ", 0),
     ):
         start = src.index(anchor)
         exec(compile(src[start : src.index(end, start) + keep], str(STACK), "exec"), ns)
     assert "PIP_NO_INDEX" in ns["_UV_INDEX_ENV_VARS"], "extraction lost the pip vars"
+    assert "PIP_REQUIRE_HASHES" in ns["_PM_POLICY_ENV_VARS"], "extraction lost the policy vars"
     return ns["_install_env_for_cmd"]
 
 


### PR DESCRIPTION
Fixes #8530.

## The problem

Studio would not install on a machine carrying security-hardened package-manager config. The reporter had the [docker/safe-defaults](https://github.com/docker/safe-defaults) `uv.toml` plus a matching `pip.conf`:

```toml
# ~/.config/uv/uv.toml
no-build = true            # equivalent to `uv --no-build`
exclude-newer = "3 days"
python-downloads = "never"
```

```ini
# ~/.config/pip/pip.conf
[global]
only-binary = :all:
require-hashes = true
require-virtualenv = true
```

The install died at `unsloth extras`:

```
× No solution found when resolving dependencies:
╰─▶ Because openai-whisper==20250625 has no usable wheels and you require
    openai-whisper==20250625, we can conclude that your requirements are unsatisfiable.

    hint: Wheels are required for `openai-whisper` because building from source is
    disabled for all packages (i.e., with `--no-build`)

  uv failed, falling back to pip...
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==
```

Two independent causes:

1. `studio/backend/requirements/extras.txt` carries requirements that ship **no wheel on PyPI at any version**: `openai-whisper==20250625`, `argbind==0.3.9`, `randomname==0.2.1`, plus `antlr4-python3-runtime==4.9.3`, which arrives transitively because `omegaconf==2.3.1` pins it below the 4.13.2 wheel. `no-build = true` makes all four unresolvable. These are not an accident: they are already audited and allowlisted for source builds by the `nobuild` contract in `.github/scripts/clean-machine-assert.sh` and `.github/scripts/assert-nobuild.ps1`.
2. The pip fallback then inherited `require-hashes = true`, which no requirements file we ship can satisfy, since they are pinned but unhashed.

`_install_env_for_cmd()` only neutralises ambient config for commands that pin an index, and the extras install pins nothing, so it inherited both.

## The fix

**Package-scoped `--no-binary` for the four wheel-less requirements.** Verified against uv 0.10 and pip 26 that `--no-binary openai-whisper` resolves under both `no-build = true` and `only-binary = :all:`, while every other requirement still comes from a wheel. Dropping a name from the flags makes that name refused again, so the exemption really is per-package. A blanket `--no-build` / `--no-binary :none:` override would have thrown the user's binary policy away wholesale, on exactly the kind of machine where an unexpected source build is most likely to fail.

**`PIP_REQUIRE_HASHES=0` in the child environment of the installer's own pip commands.** Hash-required mode has no command-line negation, so this is the one knob that has to go through the environment. pip applies environment variables *after* config files, so `pip.conf`'s `index-url`, `trusted-host`, `cert` and `proxy` all stay in force. It is scoped to commands this module runs, never `uv` commands, and never written to `os.environ`, so a user's own later pip commands keep their policy. `require-virtualenv` is deliberately left alone: the fallback already runs the venv interpreter, so it is satisfied.

**Pinned-index installs additionally drop the restrictive `UV_*` / `PIP_*` variables.** That branch already neutralised the config *files*, but an environment variable outranks a config file, so a hardened shell could still fail a torch repair the pin was supposed to make deterministic.

What is deliberately *not* changed: a non-pinned install still inherits the user's index and mirror configuration, exactly as before. `test_non_pinned_install_keeps_user_mirror` and `test_non_pinned_cmd_keeps_uv_config_discovery` pass unmodified, and all 40 pre-existing tests in that file are untouched.

## Verification

Reproduced end to end against the reporter's exact config, using a throwaway `XDG_CONFIG_HOME`:

| | before | after |
| --- | --- | --- |
| `uv pip install -r extras.txt` | fails on `openai-whisper` no usable wheels | resolves the full manifest |
| pip fallback | `ERROR: In --require-hashes mode...` | resolves the full manifest |
| `argbind` with its flag removed | n/a | still refused, so the user's `no-build` still applies |

13 new tests in `tests/python/test_install_python_stack.py` covering the flag construction for both uv and pip, the extras call site actually passing them, drift between the constant and the two CI `nobuild` allowlists, the relaxation applying to pip but not uv, non-install commands staying untouched, `os.environ` never being mutated, and the real uv-fails-then-pip fallback carrying both. Each was mutation-checked: reverting any part of the fix fails them.

`tests/studio/test_xpu_triton_swap.py` needed a two-line update. It `exec`s a *source slice* of `_install_env_for_cmd` into a namespace built by hand, and names resolve there at call time, so a helper missing from that namespace only surfaces as a `NameError` once a test invokes the scrub. Both new names are now extracted from the module rather than stubbed, keeping that test's "the module's own code, not a re-implementation" property.

Full `tests/python/` + `tests/studio/` run: 4140 passed, failure set identical to `main` apart from tests that are environment dependent on both (a live-server class that returns HTTP 401 here, and 8 pre-existing errors in `test_chat_thread_title_cas.py`).

## Left for follow-ups

- `exclude-newer = "3 days"` selected unsloth 2026.8.9 rather than the newest release, so a freshly published fix stays hidden for three days. Non-fatal, and a package-scoped `--exclude-newer-package` exemption wants a uv version-floor check first (`UV_MIN_VERSION="0.9.3"`).
- An ambient `no-deps`, `dry-run`, `target` or `exact` can make an install exit 0 with an incomplete or misdirected venv, which is a quieter failure than this one. `pip check`'s result is currently discarded.
- `install_wheel()` in `studio/backend/utils/wheel_utils.py` and `mlx_repair.py` build their own child env and so still inherit `require-hashes` for direct-URL wheel installs.
- uv's own `[pip] require-hashes` key has no command-line negation either, so it would need config-file surgery; it was not part of this report.
