### PR TITLE
Studio: preserve pre-tool reasoning inside the GGUF tool loop

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17619,7 +17619,7 @@ class LlamaCppBackend:
                     tool_calls = tool_calls[:1]
 
                 assistant_msg: dict = {"role": "assistant", "content": content_text}
-                if reasoning_accum:
+                if reasoning_accum.strip():
                     assistant_msg["reasoning_content"] = reasoning_accum
                 assistant_appended = False
                 # Collect no-op feedback and flush it after the batch, so a

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17608,6 +17608,8 @@ class LlamaCppBackend:
                     tool_calls = tool_calls[:1]
 
                 assistant_msg: dict = {"role": "assistant", "content": content_text}
+                if reasoning_accum:
+                    assistant_msg["reasoning_content"] = reasoning_accum
                 assistant_appended = False
                 # Collect no-op nudges and flush them after the batch, so a no-op
                 # doesn't abort it and drop the parallel calls that follow.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16510,6 +16510,36 @@ class LlamaCppBackend:
         if not self.is_loaded:
             raise RuntimeError("llama-server is not loaded")
 
+        from core.inference.chat_template_helpers import trailing_assistant_text
+
+        # A token-level continuation resumes inside the trailing assistant turn.
+        # Tool calls cannot be represented there portably after the response is
+        # replayed through an arbitrary chat template: templates choose their own
+        # fixed ordering for content, reasoning, and tool_calls. Match llama.cpp's
+        # WebUI and keep this one generation non-agentic instead of manufacturing
+        # a reordered historical turn.
+        if continue_final_message and trailing_assistant_text(messages):
+            for item in self.generate_chat_completion(
+                messages,
+                temperature = temperature,
+                top_p = top_p,
+                top_k = top_k,
+                min_p = min_p,
+                max_tokens = max_tokens,
+                repetition_penalty = repetition_penalty,
+                presence_penalty = presence_penalty,
+                stop = stop,
+                cancel_event = cancel_event,
+                enable_thinking = enable_thinking,
+                reasoning_effort = reasoning_effort,
+                preserve_thinking = preserve_thinking,
+                continue_final_message = True,
+                seed = seed,
+                promote_reasoning_only = promote_reasoning_only,
+            ):
+                yield {"type": "content", "text": item} if isinstance(item, str) else item
+            return
+
         conversation = list(messages)
 
         # Forced first-pass RAG so a doc question doesn't lose to web_search. Emits
@@ -16517,13 +16547,9 @@ class LlamaCppBackend:
         # retrieval call would actually prompt (ask mode); auto never gates the
         # safe search_knowledge_base tool, so retrieval must still run there.
         # off never prompts either, so it also keeps first-pass retrieval.
-        from core.inference.chat_template_helpers import trailing_assistant_text
-
-        # A resumed turn must keep the partial trailing: autoinject appends a tool call
-        # plus its result, moving the boundary so the model opens a fresh answer.
         _skip_autoinject = (
             confirm_tool_calls and not bypass_permissions and permission_mode not in ("auto", "off")
-        ) or bool(continue_final_message and trailing_assistant_text(conversation))
+        )
         _auto = None if _skip_autoinject else build_rag_autoinject(conversation, rag_scope)
         if _auto:
             for _ev in _auto["events"]:
@@ -16700,6 +16726,15 @@ class LlamaCppBackend:
         from core.inference.chat_template_helpers import sweep_cache as _sweep_cache
 
         _markup_cache = _sweep_cache()
+        # Emitting reasoning and replaying it are separate capabilities.
+        # llama-server may return delta.reasoning_content even when a custom
+        # Jinja template never reads that extension field from history.
+        _effective_template = (
+            getattr(self, "_chat_template_override", None)
+            or getattr(self, "_chat_template", None)
+            or ""
+        )
+        _template_replays_reasoning = "reasoning_content" in _effective_template
         for iteration in range(max_tool_iterations + _extra):
             if cancel_event is not None and cancel_event.is_set():
                 return
@@ -16761,11 +16796,6 @@ class LlamaCppBackend:
             )
             if _reasoning_kw is not None:
                 payload["chat_template_kwargs"] = _reasoning_kw
-            # Re-checked per iteration: once a tool result is appended the partial is
-            # no longer trailing, so later turns are normal.
-            if continue_final_message and trailing_assistant_text(conversation):
-                payload["continue_final_message"] = True
-                payload["add_generation_prompt"] = False
             payload["max_tokens"] = (
                 max_tokens
                 if max_tokens is not None
@@ -17610,21 +17640,7 @@ class LlamaCppBackend:
 
                 assistant_msg: dict = {"role": "assistant", "content": content_text}
                 if reasoning_accum:
-                    if payload.get("continue_final_message"):
-                        # The resumed partial came before this reasoning, but templates
-                        # render a separate reasoning field before message content. Keep
-                        # the generated trace in content, with neutral line boundaries,
-                        # so the merge below preserves partial, reasoning, content, then
-                        # tool-call order without inventing model-specific channel tags.
-                        safe_reasoning = neutralize_control_markup(
-                            reasoning_accum,
-                            self.markup_profile,
-                        )
-                        assistant_msg["content"] = f"\n{safe_reasoning}"
-                        if content_text:
-                            assistant_msg["content"] += f"\n{content_text}"
-                    else:
-                        assistant_msg["reasoning_content"] = reasoning_accum
+                    assistant_msg["reasoning_content"] = reasoning_accum
                 assistant_appended = False
                 # Collect no-op nudges and flush them after the batch, so a no-op
                 # doesn't abort it and drop the parallel calls that follow.
@@ -17815,18 +17831,22 @@ class LlamaCppBackend:
                     if _forced_tool_call_pending:
                         _forced_tool_call_pending = False
 
+                # Keep structured reasoning when the selected template will replay
+                # it. Otherwise use neutralized content. A deferred no-op nudge is
+                # also unsafe: it becomes the newest user turn, and templates such
+                # as Gemma 4 then suppress the preceding structured thinking block.
+                if assistant_msg.get("reasoning_content") and (
+                    deferred_noop_msgs or not _template_replays_reasoning
+                ):
+                    assistant_msg["content"] = neutralize_control_markup(
+                        reasoning_accum,
+                        self.markup_profile,
+                    )
+                    if content_text:
+                        assistant_msg["content"] += f"\n{content_text}"
+                    del assistant_msg["reasoning_content"]
+
                 if not assistant_appended and (content_text or reasoning_accum):
-                    # No call in this batch ran, so the assistant turn has no
-                    # tool_calls. Some templates only render structured reasoning
-                    # on tool-call turns; replay it as content before the no-op nudge.
-                    if assistant_msg.get("reasoning_content"):
-                        assistant_msg["content"] = neutralize_control_markup(
-                            reasoning_accum,
-                            self.markup_profile,
-                        )
-                        if content_text:
-                            assistant_msg["content"] += f"\n{content_text}"
-                        del assistant_msg["reasoning_content"]
                     append_assistant_turn(
                         conversation,
                         assistant_msg,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16521,10 +16521,9 @@ class LlamaCppBackend:
             content = conversation[-1].get("content")
             if not isinstance(content, str):
                 return False
-            # Replaced, not mutated: ``conversation`` is a shallow copy, so the trailing
-            # dict can be one the caller still owns (/v1/messages hands its own history
-            # straight through, and it may legitimately end on a tool result). Editing it
-            # in place would leave the nudge in the caller's list and re-send it next turn.
+            # Replaced, not mutated: ``conversation`` copies the list, not the dicts, and
+            # /v1/messages passes a caller's own history through, which may end on a tool
+            # result. An in-place edit would leave the nudge there and re-send it next turn.
             conversation[-1] = {**conversation[-1], "content": f"{content}\n\n{feedback}"}
             return True
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16510,46 +16510,30 @@ class LlamaCppBackend:
         if not self.is_loaded:
             raise RuntimeError("llama-server is not loaded")
 
-        from core.inference.chat_template_helpers import trailing_assistant_text
-
-        # A token-level continuation resumes inside the trailing assistant turn.
-        # Tool calls cannot be represented there portably after the response is
-        # replayed through an arbitrary chat template: templates choose their own
-        # fixed ordering for content, reasoning, and tool_calls. Match llama.cpp's
-        # WebUI and keep this one generation non-agentic instead of manufacturing
-        # a reordered historical turn.
-        if continue_final_message and trailing_assistant_text(messages):
-            for item in self.generate_chat_completion(
-                messages,
-                temperature = temperature,
-                top_p = top_p,
-                top_k = top_k,
-                min_p = min_p,
-                max_tokens = max_tokens,
-                repetition_penalty = repetition_penalty,
-                presence_penalty = presence_penalty,
-                stop = stop,
-                cancel_event = cancel_event,
-                enable_thinking = enable_thinking,
-                reasoning_effort = reasoning_effort,
-                preserve_thinking = preserve_thinking,
-                continue_final_message = True,
-                seed = seed,
-                promote_reasoning_only = promote_reasoning_only,
-            ):
-                yield {"type": "content", "text": item} if isinstance(item, str) else item
-            return
-
         conversation = list(messages)
+
+        def _attach_internal_feedback_to_tool_result(feedback: str) -> bool:
+            """Keep controller instructions inside the current tool exchange."""
+            if not conversation or conversation[-1].get("role") != "tool":
+                return False
+            content = conversation[-1].get("content")
+            if not isinstance(content, str):
+                return False
+            conversation[-1]["content"] = f"{content}\n\n{feedback}"
+            return True
 
         # Forced first-pass RAG so a doc question doesn't lose to web_search. Emits
         # the same tool card + citations a real call would. Skip it only when a
         # retrieval call would actually prompt (ask mode); auto never gates the
         # safe search_knowledge_base tool, so retrieval must still run there.
         # off never prompts either, so it also keeps first-pass retrieval.
+        from core.inference.chat_template_helpers import trailing_assistant_text
+
+        # A resumed turn must keep the partial trailing: autoinject appends a tool call
+        # plus its result, moving the boundary so the model opens a fresh answer.
         _skip_autoinject = (
             confirm_tool_calls and not bypass_permissions and permission_mode not in ("auto", "off")
-        )
+        ) or bool(continue_final_message and trailing_assistant_text(conversation))
         _auto = None if _skip_autoinject else build_rag_autoinject(conversation, rag_scope)
         if _auto:
             for _ev in _auto["events"]:
@@ -16726,15 +16710,6 @@ class LlamaCppBackend:
         from core.inference.chat_template_helpers import sweep_cache as _sweep_cache
 
         _markup_cache = _sweep_cache()
-        # Emitting reasoning and replaying it are separate capabilities.
-        # llama-server may return delta.reasoning_content even when a custom
-        # Jinja template never reads that extension field from history.
-        _effective_template = (
-            getattr(self, "_chat_template_override", None)
-            or getattr(self, "_chat_template", None)
-            or ""
-        )
-        _template_replays_reasoning = "reasoning_content" in _effective_template
         for iteration in range(max_tool_iterations + _extra):
             if cancel_event is not None and cancel_event.is_set():
                 return
@@ -16796,6 +16771,11 @@ class LlamaCppBackend:
             )
             if _reasoning_kw is not None:
                 payload["chat_template_kwargs"] = _reasoning_kw
+            # Re-checked per iteration: once a tool result is appended the partial is
+            # no longer trailing, so later turns are normal.
+            if continue_final_message and trailing_assistant_text(conversation):
+                payload["continue_final_message"] = True
+                payload["add_generation_prompt"] = False
             payload["max_tokens"] = (
                 max_tokens
                 if max_tokens is not None
@@ -17642,8 +17622,8 @@ class LlamaCppBackend:
                 if reasoning_accum:
                     assistant_msg["reasoning_content"] = reasoning_accum
                 assistant_appended = False
-                # Collect no-op nudges and flush them after the batch, so a no-op
-                # doesn't abort it and drop the parallel calls that follow.
+                # Collect no-op feedback and flush it after the batch, so a
+                # suppressed call never drops a later parallel call.
                 deferred_noop_msgs: list = []
 
                 # The text-path provisional card uses the parser's default id ("call_0");
@@ -17831,30 +17811,33 @@ class LlamaCppBackend:
                     if _forced_tool_call_pending:
                         _forced_tool_call_pending = False
 
-                # Keep structured reasoning when the selected template will replay
-                # it. Otherwise use neutralized content. A deferred no-op nudge is
-                # also unsafe: it becomes the newest user turn, and templates such
-                # as Gemma 4 then suppress the preceding structured thinking block.
-                if assistant_msg.get("reasoning_content") and (
-                    deferred_noop_msgs or not _template_replays_reasoning
-                ):
-                    assistant_msg["content"] = neutralize_control_markup(
-                        reasoning_accum,
-                        self.markup_profile,
+                if deferred_noop_msgs and assistant_appended:
+                    # A mixed execute/no-op batch already has a real tool result.
+                    # Keep the controller feedback with that result instead of
+                    # appending a newer user turn, which can make templates hide
+                    # this turn's structured reasoning.
+                    feedback = "\n\n".join(
+                        dict.fromkeys(message["content"] for message in deferred_noop_msgs)
                     )
-                    if content_text:
-                        assistant_msg["content"] += f"\n{content_text}"
-                    del assistant_msg["reasoning_content"]
-
-                if not assistant_appended and (content_text or reasoning_accum):
-                    append_assistant_turn(
-                        conversation,
-                        assistant_msg,
-                        continue_final_message = continue_final_message,
-                    )
-                    assistant_appended = True
-
-                append_deferred_nudges(conversation, deferred_noop_msgs)
+                    if not _attach_internal_feedback_to_tool_result(feedback):
+                        append_deferred_nudges(conversation, deferred_noop_msgs)
+                else:
+                    if not assistant_appended and (content_text or reasoning_accum):
+                        if assistant_msg.get("reasoning_content"):
+                            assistant_msg["content"] = neutralize_control_markup(
+                                reasoning_accum,
+                                self.markup_profile,
+                            )
+                            if content_text:
+                                assistant_msg["content"] += f"\n{content_text}"
+                            del assistant_msg["reasoning_content"]
+                        append_assistant_turn(
+                            conversation,
+                            assistant_msg,
+                            continue_final_message = continue_final_message,
+                        )
+                        assistant_appended = True
+                    append_deferred_nudges(conversation, deferred_noop_msgs)
 
                 # Close provisional cards not resolved by execution/no-op handling.
                 for _pid, _pname in provisional_started_tool_calls.items():
@@ -17917,16 +17900,13 @@ class LlamaCppBackend:
         # the final streaming pass to produce a useful answer instead of
         # continuing to request tools.
         if max_tool_iterations > 0 and _append_budget_exhausted_nudge:
-            conversation.append(
-                {
-                    "role": "user",
-                    "content": (
-                        "You have used all available tool calls. Based on "
-                        "everything you have found so far, provide your final "
-                        "answer now. Do not call any more tools."
-                    ),
-                }
+            budget_feedback = (
+                "You have used all available tool calls. Based on "
+                "everything you have found so far, provide your final "
+                "answer now. Do not call any more tools."
             )
+            if not _attach_internal_feedback_to_tool_result(budget_feedback):
+                conversation.append({"role": "user", "content": budget_feedback})
 
         # Clear status.
         yield {"type": "status", "text": ""}

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -95,6 +95,7 @@ from utils.subprocess_compat import (
 )
 from utils.process_lifetime import child_popen_kwargs as _child_popen_kwargs
 from core.inference.tool_call_parser import (
+    BUDGET_EXHAUSTED_NUDGE,
     MAX_ACT_REPROMPTS as _MAX_REPROMPTS,
     NUDGE_TOOL_CALLS_STATUS as _NUDGE_TOOL_CALLS_STATUS,
     REPROMPT_MAX_CHARS as _REPROMPT_MAX_CHARS,
@@ -107,6 +108,7 @@ from core.inference.tool_loop_controller import (
     ToolLoopController,
     append_deferred_nudges,
     awaiting_approval_status,
+    deferred_nudge_text,
     tool_event_provenance,
 )
 from state.tool_approvals import (
@@ -17816,13 +17818,17 @@ class LlamaCppBackend:
                     # Keep the controller feedback with that result instead of
                     # appending a newer user turn, which can make templates hide
                     # this turn's structured reasoning.
-                    feedback = "\n\n".join(
-                        dict.fromkeys(message["content"] for message in deferred_noop_msgs)
-                    )
-                    if not _attach_internal_feedback_to_tool_result(feedback):
+                    if not _attach_internal_feedback_to_tool_result(
+                        deferred_nudge_text(deferred_noop_msgs)
+                    ):
                         append_deferred_nudges(conversation, deferred_noop_msgs)
                 else:
-                    if not assistant_appended and (content_text or reasoning_accum):
+                    # A blank trace is not a turn: reuse the same emptiness test as
+                    # the field above so a whitespace-only split never appends an
+                    # empty assistant message.
+                    if not assistant_appended and (
+                        content_text or assistant_msg.get("reasoning_content")
+                    ):
                         if assistant_msg.get("reasoning_content"):
                             assistant_msg["content"] = neutralize_control_markup(
                                 reasoning_accum,
@@ -17900,13 +17906,8 @@ class LlamaCppBackend:
         # the final streaming pass to produce a useful answer instead of
         # continuing to request tools.
         if max_tool_iterations > 0 and _append_budget_exhausted_nudge:
-            budget_feedback = (
-                "You have used all available tool calls. Based on "
-                "everything you have found so far, provide your final "
-                "answer now. Do not call any more tools."
-            )
-            if not _attach_internal_feedback_to_tool_result(budget_feedback):
-                conversation.append({"role": "user", "content": budget_feedback})
+            if not _attach_internal_feedback_to_tool_result(BUDGET_EXHAUSTED_NUDGE):
+                conversation.append({"role": "user", "content": BUDGET_EXHAUSTED_NUDGE})
 
         # Clear status.
         yield {"type": "status", "text": ""}

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16521,7 +16521,11 @@ class LlamaCppBackend:
             content = conversation[-1].get("content")
             if not isinstance(content, str):
                 return False
-            conversation[-1]["content"] = f"{content}\n\n{feedback}"
+            # Replaced, not mutated: ``conversation`` is a shallow copy, so the trailing
+            # dict can be one the caller still owns (/v1/messages hands its own history
+            # straight through, and it may legitimately end on a tool result). Editing it
+            # in place would leave the nudge in the caller's list and re-send it next turn.
+            conversation[-1] = {**conversation[-1], "content": f"{content}\n\n{feedback}"}
             return True
 
         # Forced first-pass RAG so a doc question doesn't lose to web_search. Emits

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17608,7 +17608,10 @@ class LlamaCppBackend:
                     tool_calls = tool_calls[:1]
 
                 assistant_msg: dict = {"role": "assistant", "content": content_text}
-                if reasoning_accum:
+                # A resumed partial precedes this iteration's new reasoning. The
+                # standard field renders before message content, which would
+                # reverse that order after the partial is merged below.
+                if reasoning_accum and not payload.get("continue_final_message"):
                     assistant_msg["reasoning_content"] = reasoning_accum
                 assistant_appended = False
                 # Collect no-op nudges and flush them after the batch, so a no-op

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17630,6 +17630,9 @@ class LlamaCppBackend:
                 # Collect no-op feedback and flush it after the batch, so a
                 # suppressed call never drops a later parallel call.
                 deferred_noop_msgs: list = []
+                # Which tools those no-ops were about, so the flush below can tell
+                # whether the trailing result belongs to the same tool.
+                deferred_noop_tools: set = set()
 
                 # The text-path provisional card uses the parser's default id ("call_0");
                 # a Mistral-style call carries its own id and would open a duplicate. Reuse
@@ -17670,6 +17673,7 @@ class LlamaCppBackend:
                             }
                         completion = tool_controller.record_noop(decision)
                         deferred_noop_msgs.append(completion.model_message())
+                        deferred_noop_tools.add(decision.tool_name)
                         if _forced_tool_call_pending:
                             _forced_tool_call_pending = False
                         logger.info(
@@ -17816,15 +17820,26 @@ class LlamaCppBackend:
                     if _forced_tool_call_pending:
                         _forced_tool_call_pending = False
 
-                if deferred_noop_msgs and assistant_appended:
-                    # A mixed execute/no-op batch already has a real tool result.
-                    # Keep the controller feedback with that result instead of
-                    # appending a newer user turn, which can make templates hide
-                    # this turn's structured reasoning.
+                # A mixed execute/no-op batch already has a real tool result, so keeping the
+                # feedback with that result beats appending a newer user turn, which makes
+                # templates hide this turn's structured reasoning. Only when the result is
+                # the SAME tool the feedback is about: templates label the whole block with
+                # the result's own tool name (gemma-4.jinja resolves tool_call_id -> name and
+                # wraps the body), so folding a note about tool A into tool B's result reads
+                # as B's own output. Then the user turn is the lesser loss.
+                _fold_target_matches = (
+                    len(deferred_noop_tools) == 1
+                    and bool(conversation)
+                    and conversation[-1].get("role") == "tool"
+                    and conversation[-1].get("name") in deferred_noop_tools
+                )
+                if deferred_noop_msgs and assistant_appended and _fold_target_matches:
                     if not _attach_internal_feedback_to_tool_result(
                         deferred_nudge_text(deferred_noop_msgs)
                     ):
                         append_deferred_nudges(conversation, deferred_noop_msgs)
+                elif deferred_noop_msgs and assistant_appended:
+                    append_deferred_nudges(conversation, deferred_noop_msgs)
                 else:
                     # A blank trace is not a turn: reuse the same emptiness test as
                     # the field above so a whitespace-only split never appends an

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17852,6 +17852,13 @@ class LlamaCppBackend:
                                 reasoning_accum,
                                 self.markup_profile,
                             )
+                            _continued_partial = (
+                                trailing_assistant_text(conversation)
+                                if continue_final_message
+                                else None
+                            )
+                            if _continued_partial and not _continued_partial.endswith("\n"):
+                                assistant_msg["content"] = f"\n{assistant_msg['content']}"
                             if content_text:
                                 assistant_msg["content"] += f"\n{content_text}"
                             del assistant_msg["reasoning_content"]

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17608,11 +17608,18 @@ class LlamaCppBackend:
                     tool_calls = tool_calls[:1]
 
                 assistant_msg: dict = {"role": "assistant", "content": content_text}
-                # A resumed partial precedes this iteration's new reasoning. The
-                # standard field renders before message content, which would
-                # reverse that order after the partial is merged below.
-                if reasoning_accum and not payload.get("continue_final_message"):
-                    assistant_msg["reasoning_content"] = reasoning_accum
+                if reasoning_accum:
+                    if payload.get("continue_final_message"):
+                        # The resumed partial came before this reasoning, but templates
+                        # render a separate reasoning field before message content. Keep
+                        # the generated trace in content, with neutral line boundaries,
+                        # so the merge below preserves partial, reasoning, content, then
+                        # tool-call order without inventing model-specific channel tags.
+                        assistant_msg["content"] = f"\n{reasoning_accum}"
+                        if content_text:
+                            assistant_msg["content"] += f"\n{content_text}"
+                    else:
+                        assistant_msg["reasoning_content"] = reasoning_accum
                 assistant_appended = False
                 # Collect no-op nudges and flush them after the batch, so a no-op
                 # doesn't abort it and drop the parallel calls that follow.
@@ -17642,13 +17649,6 @@ class LlamaCppBackend:
                     )
 
                     if not decision.should_execute:
-                        if content_text and not assistant_appended:
-                            append_assistant_turn(
-                                conversation,
-                                assistant_msg,
-                                continue_final_message = continue_final_message,
-                            )
-                            assistant_appended = True
                         if provisional_match:
                             # A provisional tool card is already on screen for this
                             # id; close it so it never dangles when the controller
@@ -17809,6 +17809,22 @@ class LlamaCppBackend:
 
                     if _forced_tool_call_pending:
                         _forced_tool_call_pending = False
+
+                if not assistant_appended and (content_text or reasoning_accum):
+                    # No call in this batch ran, so the assistant turn has no
+                    # tool_calls. Some templates only render structured reasoning
+                    # on tool-call turns; replay it as content before the no-op nudge.
+                    if assistant_msg.get("reasoning_content"):
+                        assistant_msg["content"] = reasoning_accum
+                        if content_text:
+                            assistant_msg["content"] += f"\n{content_text}"
+                        del assistant_msg["reasoning_content"]
+                    append_assistant_turn(
+                        conversation,
+                        assistant_msg,
+                        continue_final_message = continue_final_message,
+                    )
+                    assistant_appended = True
 
                 append_deferred_nudges(conversation, deferred_noop_msgs)
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16732,6 +16732,7 @@ class LlamaCppBackend:
             # in the first 1-2 chunks without a non-streaming penalty.
             from core.inference.chat_template_helpers import (
                 append_assistant_turn,
+                neutralize_control_markup,
                 neutralize_control_markup_in_messages,
             )
 
@@ -17615,7 +17616,11 @@ class LlamaCppBackend:
                         # the generated trace in content, with neutral line boundaries,
                         # so the merge below preserves partial, reasoning, content, then
                         # tool-call order without inventing model-specific channel tags.
-                        assistant_msg["content"] = f"\n{reasoning_accum}"
+                        safe_reasoning = neutralize_control_markup(
+                            reasoning_accum,
+                            self.markup_profile,
+                        )
+                        assistant_msg["content"] = f"\n{safe_reasoning}"
                         if content_text:
                             assistant_msg["content"] += f"\n{content_text}"
                     else:
@@ -17815,7 +17820,10 @@ class LlamaCppBackend:
                     # tool_calls. Some templates only render structured reasoning
                     # on tool-call turns; replay it as content before the no-op nudge.
                     if assistant_msg.get("reasoning_content"):
-                        assistant_msg["content"] = reasoning_accum
+                        assistant_msg["content"] = neutralize_control_markup(
+                            reasoning_accum,
+                            self.markup_profile,
+                        )
                         if content_text:
                             assistant_msg["content"] += f"\n{content_text}"
                         del assistant_msg["reasoning_content"]

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -330,15 +330,23 @@ def strip_result_for_model(result: str, tool_name: "str | None" = None) -> str:
     return result
 
 
+def deferred_nudge_text(msgs: Sequence[dict]) -> str:
+    """Join a batch's no-op nudges into one deduped body.
+
+    Callers that keep the feedback inside the tool exchange need the text
+    without the ``role=user`` wrapper, so both forms stay in sync here.
+    """
+    return "\n\n".join(dict.fromkeys(msg["content"] for msg in msgs))
+
+
 def append_deferred_nudges(conversation: list, msgs: Sequence[dict]) -> None:
     """Append a batch's no-op nudges as one deduped ``role=user`` message.
 
     Deferred to after the batch's tool results so a no-op never splits an
     assistant's ``tool_calls`` from their ``role=tool`` results.
     """
-    contents = list(dict.fromkeys(msg["content"] for msg in msgs))
-    if contents:
-        conversation.append({"role": "user", "content": "\n\n".join(contents)})
+    if msgs:
+        conversation.append({"role": "user", "content": deferred_nudge_text(msgs)})
 
 
 def _tool_name_from_schema(tool: Mapping[str, Any]) -> str:

--- a/studio/backend/tests/test_gemma4_chat_template_override.py
+++ b/studio/backend/tests/test_gemma4_chat_template_override.py
@@ -285,12 +285,11 @@ def test_preserve_thinking_on_keeps_prior_reasoning():
 
 
 @pytest.mark.parametrize("tpl", [BUNDLED, EDGE])
-def test_inlined_mixed_noop_reasoning_survives_newest_user_nudge(tpl):
-    messages = _convo_with_prior_tool_reasoning()
-    assert "SECRET_THOUGHT" not in _render_with(tpl, messages)
-
-    messages[1]["content"] = messages[1].pop("reasoning_content")
-    assert "SECRET_THOUGHT" in _render_with(tpl, messages)
+def test_current_tool_reasoning_survives_a_suppressed_call_result(tpl):
+    messages = _convo_with_prior_tool_reasoning()[:-1]
+    messages[2]["content"] += "\n\nThe duplicate call was not executed."
+    rendered = _render_with(tpl, messages)
+    assert rendered.index("SECRET_THOUGHT") < rendered.index("The duplicate call was not executed.")
 
 
 def test_enable_thinking_gates_think_token():

--- a/studio/backend/tests/test_gemma4_chat_template_override.py
+++ b/studio/backend/tests/test_gemma4_chat_template_override.py
@@ -284,6 +284,15 @@ def test_preserve_thinking_on_keeps_prior_reasoning():
     assert "SECRET_THOUGHT" in _render(_convo_with_prior_tool_reasoning(), preserve_thinking = True)
 
 
+@pytest.mark.parametrize("tpl", [BUNDLED, EDGE])
+def test_inlined_mixed_noop_reasoning_survives_newest_user_nudge(tpl):
+    messages = _convo_with_prior_tool_reasoning()
+    assert "SECRET_THOUGHT" not in _render_with(tpl, messages)
+
+    messages[1]["content"] = messages[1].pop("reasoning_content")
+    assert "SECRET_THOUGHT" in _render_with(tpl, messages)
+
+
 def test_enable_thinking_gates_think_token():
     assert "<|think|>" in _render([{"role": "user", "content": "hi"}], enable_thinking = True)
     assert "<|think|>" not in _render([{"role": "user", "content": "hi"}], enable_thinking = False)

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -835,8 +835,41 @@ def test_blank_reasoning_noop_turn_adds_no_empty_assistant_message(monkeypatch):
 
 def test_noop_reasoning_continuation_separates_partial_from_inlined_trace(monkeypatch):
     """A suppressed call must not weld inlined reasoning onto a resumed partial."""
+    def fake_execute_tool(name, arguments, **_kwargs):
+        raise AssertionError(f"unexpected tool execution: {name} {arguments}")
+
+    monkeypatch.setattr("core.inference.tools.execute_tool", fake_execute_tool)
+
+    for partial in ("PARTIAL_TEXT", "PARTIAL_TEXT\n"):
+        tool_stream = [_sse({"reasoning_content": "TRACE_ABC"})] + _structured_tool_call(
+            "python", {"code": "print(1)"}, "call_continued_noop"
+        )
+        final_stream = [_sse({"content": "I cannot run Python here."}), _done()]
+        payloads: list[dict] = []
+        backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+        list(
+            backend.generate_chat_completion_with_tools(
+                messages = [
+                    {"role": "user", "content": "continue"},
+                    {"role": "assistant", "content": partial},
+                ],
+                tools = [{"type": "function", "function": {"name": "web_search"}}],
+                continue_final_message = True,
+                max_tool_iterations = 1,
+            )
+        )
+
+        continued = next(
+            message for message in payloads[1]["messages"] if message.get("role") == "assistant"
+        )
+        assert continued == {"role": "assistant", "content": "PARTIAL_TEXT\nTRACE_ABC"}
+
+
+def test_noop_reasoning_without_continuation_adds_clean_assistant_turn(monkeypatch):
+    """A trailing assistant turn is not merged unless continuation is requested."""
     tool_stream = [_sse({"reasoning_content": "TRACE_ABC"})] + _structured_tool_call(
-        "python", {"code": "print(1)"}, "call_continued_noop"
+        "python", {"code": "print(1)"}, "call_separate_noop"
     )
     final_stream = [_sse({"content": "I cannot run Python here."}), _done()]
     payloads: list[dict] = []
@@ -850,19 +883,22 @@ def test_noop_reasoning_continuation_separates_partial_from_inlined_trace(monkey
     list(
         backend.generate_chat_completion_with_tools(
             messages = [
-                {"role": "user", "content": "continue"},
-                {"role": "assistant", "content": "PARTIAL_TEXT"},
+                {"role": "user", "content": "new turn"},
+                {"role": "assistant", "content": "EARLIER_ANSWER"},
             ],
             tools = [{"type": "function", "function": {"name": "web_search"}}],
-            continue_final_message = True,
+            continue_final_message = False,
             max_tool_iterations = 1,
         )
     )
 
-    continued = next(
+    assistant_messages = [
         message for message in payloads[1]["messages"] if message.get("role") == "assistant"
-    )
-    assert continued == {"role": "assistant", "content": "PARTIAL_TEXT\nTRACE_ABC"}
+    ]
+    assert assistant_messages == [
+        {"role": "assistant", "content": "EARLIER_ANSWER"},
+        {"role": "assistant", "content": "TRACE_ABC"},
+    ]
 
 
 def test_noop_feedback_is_not_folded_into_another_tool_s_result(monkeypatch):
@@ -923,6 +959,61 @@ def test_noop_feedback_is_not_folded_into_another_tool_s_result(monkeypatch):
         for message in messages
         if message.get("role") == "user" and "not executed" in message.get("content", "")
     ]
+
+
+def test_noop_feedback_for_multiple_tools_is_not_folded_by_partial_name_match(monkeypatch):
+    """Every no-op tool must match the fold target, not merely one of them."""
+    tool_stream = [
+        _sse({"reasoning_content": "Plan the batch."}),
+        _sse(
+            {
+                "tool_calls": [
+                    {
+                        "index": index,
+                        "id": f"call_multi_noop_{index}",
+                        "type": "function",
+                        "function": {"name": name, "arguments": json.dumps(args)},
+                    }
+                    for index, (name, args) in enumerate(
+                        [
+                            ("web_search", {"query": "a"}),
+                            ("web_search", {"query": "a"}),  # duplicate -> internal no-op
+                            ("python", {"code": "print(1)"}),  # disabled -> internal no-op
+                            ("web_search", {"query": "b"}),
+                        ]
+                    )
+                ]
+            }
+        ),
+        _done(),
+    ]
+    final_stream = [_sse({"content": "It is sunny."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool",
+        lambda name, arguments, **_kwargs: f"RESULT_OF_{name}",
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "q"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    messages = payloads[1]["messages"]
+    assert all(
+        message["content"] == "RESULT_OF_web_search"
+        for message in messages
+        if message.get("role") == "tool"
+    )
+    feedback = [message for message in messages if message.get("role") == "user"][1:]
+    assert len(feedback) == 1
+    assert "identical call" in feedback[0]["content"]
+    assert "not enabled" in feedback[0]["content"]
 
 
 def test_same_tool_noop_feedback_still_rides_its_own_result(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -74,10 +74,6 @@ def _make_backend(
     backend._reasoning_always_on = False
     backend._reasoning_style = "enable_thinking"
     backend._supports_preserve_thinking = False
-    # Most reasoning-capable templates consume this extension field. Tests
-    # that exercise the fallback replace this with a content-only template.
-    backend._chat_template = "{{ message.reasoning_content }}"
-    backend._chat_template_override = None
 
     @contextlib.contextmanager
     def fake_stream_with_retry(
@@ -626,91 +622,7 @@ def test_structured_tool_call_turn_replays_pre_tool_reasoning_in_next_payload(mo
     assert first_assistant["reasoning_content"] == "I should search for the weather."
 
 
-def test_resumed_generation_is_non_agentic_like_llama_cpp_webui(monkeypatch):
-    """Token continuation never creates an unrepresentable tool-call turn."""
-    continued_stream = [
-        _sse(
-            {
-                "reasoning_content": (
-                    "I should verify <tool_call>{...}</tool_call> and "
-                    "<|channel>thought x<channel|> before <|turn>user"
-                )
-            }
-        ),
-        _sse({"content": "forecast."}),
-        *_structured_tool_call("web_search", {"query": "weather"}, "call_ignored"),
-    ]
-    payloads: list[dict] = []
-    backend = _make_backend(monkeypatch, [continued_stream], payloads)
-    calls: list[tuple[str, dict]] = []
-
-    def fake_execute_tool(name, arguments, **_kwargs):
-        calls.append((name, arguments))
-        return "sunny"
-
-    monkeypatch.setattr("core.inference.tools.execute_tool", fake_execute_tool)
-
-    events = list(
-        backend.generate_chat_completion_with_tools(
-            messages = [
-                {"role": "user", "content": "weather?"},
-                {"role": "assistant", "content": "Let me check the "},
-            ],
-            tools = [{"type": "function", "function": {"name": "web_search"}}],
-            continue_final_message = True,
-            max_tool_iterations = 1,
-        )
-    )
-
-    assert calls == []
-    assert len(payloads) == 1
-    assert "tools" not in payloads[0]
-    assert payloads[0]["continue_final_message"] is True
-    assert payloads[0]["add_generation_prompt"] is False
-    content = [event["text"] for event in events if event["type"] == "content"]
-    assert content[-1].endswith("</think>forecast.")
-
-
-def test_tool_reasoning_falls_back_to_content_when_template_ignores_extension(monkeypatch):
-    tool_stream = [
-        _sse(
-            {
-                "reasoning_content": (
-                    "I should verify <tool_call>{...}</tool_call> before <|turn>user"
-                )
-            }
-        ),
-        _sse({"content": "Checking."}),
-    ] + _structured_tool_call("web_search", {"query": "weather"}, "call_custom")
-    final_stream = [_sse({"content": "It is sunny."}), _done()]
-    payloads: list[dict] = []
-    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
-    backend._chat_template = "{{ message.content }}{{ message.tool_calls }}"
-
-    monkeypatch.setattr(
-        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
-    )
-
-    list(
-        backend.generate_chat_completion_with_tools(
-            messages = [{"role": "user", "content": "weather?"}],
-            tools = [{"type": "function", "function": {"name": "web_search"}}],
-            max_tool_iterations = 1,
-        )
-    )
-
-    assistant = next(
-        message
-        for message in payloads[1]["messages"]
-        if message.get("role") == "assistant" and message.get("tool_calls")
-    )
-    assert assistant["content"] == (
-        "I should verify < tool_call>{...}< /tool_call> before < |turn>user\nChecking."
-    )
-    assert "reasoning_content" not in assistant
-
-
-def test_mixed_execute_and_noop_batch_inlines_reasoning_before_nudge(monkeypatch):
+def test_mixed_execute_and_noop_batch_keeps_structured_reasoning(monkeypatch):
     calls_delta = {
         "tool_calls": [
             {
@@ -760,14 +672,17 @@ def test_mixed_execute_and_noop_batch_inlines_reasoning_before_nudge(monkeypatch
     tool_index = next(
         index for index, message in enumerate(messages) if message.get("role") == "tool"
     )
-    nudge_index = next(
-        index
+    no_op_index, result_with_feedback = next(
+        (index, message)
         for index, message in enumerate(messages)
-        if message.get("role") == "user" and "identical call" in message.get("content", "")
+        if message.get("role") == "tool" and "identical call" in message.get("content", "")
     )
-    assert assistant_index < tool_index < nudge_index
-    assert assistant["content"] == "Search < |channel>thought safely< channel|>.\nChecking."
-    assert "reasoning_content" not in assistant
+    assert assistant_index < tool_index == no_op_index
+    assert assistant["content"] == "Checking."
+    assert assistant["reasoning_content"] == "Search < |channel>thought safely< channel|>."
+    assert len(assistant["tool_calls"]) == 1
+    assert result_with_feedback["tool_call_id"] == "call_mixed_0"
+    assert not any(message.get("role") == "user" for message in messages[1:])
 
 
 def test_textual_tool_call_turn_replays_reasoning_only_trace_in_next_payload(monkeypatch):
@@ -1487,19 +1402,18 @@ def test_same_turn_duplicate_does_not_drop_later_parallel_call(monkeypatch):
     ]
 
     # The next generation's conversation must be well-formed: the assistant lists
-    # only the executed calls (no orphan for the duplicate), the two tool results
-    # follow contiguously, and the no-op nudge lands after them, never between.
+    # only the executed calls (no orphan for the duplicate), and the two tool results
+    # follow contiguously. Hidden feedback is attached to the final result so it does
+    # not create a newer user turn that can suppress this assistant's reasoning.
     conv = payloads[1]["messages"]
     asst = next(m for m in conv if m["role"] == "assistant" and m.get("tool_calls"))
     assert [tc.get("id") for tc in asst["tool_calls"]] == ["call_a1", "call_b"]
     after = conv[conv.index(asst) + 1 :]
     assert [m["role"] for m in after[:2]] == ["tool", "tool"]
     assert [m.get("tool_call_id") for m in after[:2]] == ["call_a1", "call_b"]
-    assert after[2]["role"] == "user"  # deferred duplicate nudge, after the results
-    assert after[2]["content"].startswith(
-        "One earlier request to call tool 'web_search' in this batch was not executed"
-    )
-    assert "previous tool request" not in after[2]["content"].lower()
+    assert len(after) == 2
+    assert "One earlier request to call tool 'web_search'" in after[1]["content"]
+    assert "previous tool request" not in after[1]["content"].lower()
 
 
 def test_same_turn_repeated_render_html_does_not_emit_second_provisional_start(monkeypatch):
@@ -1564,13 +1478,13 @@ def test_same_turn_repeated_render_html_does_not_emit_second_provisional_start(m
     ]
     assert len(payloads) == 2
     assert "tools" not in payloads[1]
-    render_nudges = [
+    render_feedback = [
         message
         for message in payloads[1]["messages"]
-        if message.get("role") == "user"
+        if message.get("role") == "tool"
         and "Do not call render_html again" in message.get("content", "")
     ]
-    assert len(render_nudges) == 1
+    assert len(render_feedback) == 1
 
 
 def test_disabled_tool_call_is_internal_noop(monkeypatch):
@@ -1642,6 +1556,7 @@ def test_disabled_tool_call_is_internal_noop(monkeypatch):
     )
     assert reasoning_turn_index < nudge_index
     assert "reasoning_content" not in reasoning_turn
+    assert "tool_calls" not in reasoning_turn
 
 
 def test_render_html_success_does_not_reprompt_render_html_intent(monkeypatch):
@@ -4349,10 +4264,11 @@ def test_gguf_valid_tool_calls_respect_max_tool_iterations(monkeypatch):
     # Exactly two executed tool rounds, then one final-answer pass.
     assert len(calls) == 2, calls
     assert len(payloads) == 3, len(payloads)
-    # The final pass is the budget-exhausted nudge and carries no tools.
+    # The final pass carries no tool schemas. Its controller feedback stays in
+    # the latest tool result rather than opening a newer user turn.
     assert _tool_names(payloads[2]) == [], _tool_names(payloads[2])
     assert any(
-        m.get("role") == "user" and "used all available tool calls" in m.get("content", "")
+        m.get("role") == "tool" and "used all available tool calls" in m.get("content", "")
         for m in payloads[2]["messages"]
     ), payloads[2]["messages"]
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -74,6 +74,10 @@ def _make_backend(
     backend._reasoning_always_on = False
     backend._reasoning_style = "enable_thinking"
     backend._supports_preserve_thinking = False
+    # Most reasoning-capable templates consume this extension field. Tests
+    # that exercise the fallback replace this with a content-only template.
+    backend._chat_template = "{{ message.reasoning_content }}"
+    backend._chat_template_override = None
 
     @contextlib.contextmanager
     def fake_stream_with_retry(
@@ -622,9 +626,9 @@ def test_structured_tool_call_turn_replays_pre_tool_reasoning_in_next_payload(mo
     assert first_assistant["reasoning_content"] == "I should search for the weather."
 
 
-def test_resumed_tool_call_preserves_and_neutralizes_reasoning_in_order(monkeypatch):
-    """Inlined reasoning keeps order without replaying its control markup."""
-    tool_stream = [
+def test_resumed_generation_is_non_agentic_like_llama_cpp_webui(monkeypatch):
+    """Token continuation never creates an unrepresentable tool-call turn."""
+    continued_stream = [
         _sse(
             {
                 "reasoning_content": (
@@ -634,19 +638,19 @@ def test_resumed_tool_call_preserves_and_neutralizes_reasoning_in_order(monkeypa
             }
         ),
         _sse({"content": "forecast."}),
-    ] + _structured_tool_call("web_search", {"query": "weather"}, "call_continued")
-    final_stream = [
-        _sse({"content": "It is sunny."}),
-        _done(),
+        *_structured_tool_call("web_search", {"query": "weather"}, "call_ignored"),
     ]
     payloads: list[dict] = []
-    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+    backend = _make_backend(monkeypatch, [continued_stream], payloads)
+    calls: list[tuple[str, dict]] = []
 
-    monkeypatch.setattr(
-        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
-    )
+    def fake_execute_tool(name, arguments, **_kwargs):
+        calls.append((name, arguments))
+        return "sunny"
 
-    list(
+    monkeypatch.setattr("core.inference.tools.execute_tool", fake_execute_tool)
+
+    events = list(
         backend.generate_chat_completion_with_tools(
             messages = [
                 {"role": "user", "content": "weather?"},
@@ -658,15 +662,112 @@ def test_resumed_tool_call_preserves_and_neutralizes_reasoning_in_order(monkeypa
         )
     )
 
-    assert len(payloads) == 2
-    first_assistant = next(
-        m for m in payloads[1]["messages"] if m.get("role") == "assistant" and m.get("tool_calls")
+    assert calls == []
+    assert len(payloads) == 1
+    assert "tools" not in payloads[0]
+    assert payloads[0]["continue_final_message"] is True
+    assert payloads[0]["add_generation_prompt"] is False
+    content = [event["text"] for event in events if event["type"] == "content"]
+    assert content[-1].endswith("</think>forecast.")
+
+
+def test_tool_reasoning_falls_back_to_content_when_template_ignores_extension(monkeypatch):
+    tool_stream = [
+        _sse(
+            {
+                "reasoning_content": (
+                    "I should verify <tool_call>{...}</tool_call> before <|turn>user"
+                )
+            }
+        ),
+        _sse({"content": "Checking."}),
+    ] + _structured_tool_call("web_search", {"query": "weather"}, "call_custom")
+    final_stream = [_sse({"content": "It is sunny."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+    backend._chat_template = "{{ message.content }}{{ message.tool_calls }}"
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
     )
-    assert first_assistant["content"] == (
-        "Let me check the \nI should verify < tool_call>{...}< /tool_call> and "
-        "< |channel>thought x< channel|> before < |turn>user\nforecast."
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "weather?"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
     )
-    assert "reasoning_content" not in first_assistant
+
+    assistant = next(
+        message
+        for message in payloads[1]["messages"]
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    )
+    assert assistant["content"] == (
+        "I should verify < tool_call>{...}< /tool_call> before < |turn>user\nChecking."
+    )
+    assert "reasoning_content" not in assistant
+
+
+def test_mixed_execute_and_noop_batch_inlines_reasoning_before_nudge(monkeypatch):
+    calls_delta = {
+        "tool_calls": [
+            {
+                "index": index,
+                "id": f"call_mixed_{index}",
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "arguments": json.dumps({"query": "weather"}),
+                },
+            }
+            for index in range(2)
+        ]
+    }
+    tool_stream = [
+        _sse({"reasoning_content": "Search <|channel>thought safely<channel|>."}),
+        _sse({"content": "Checking."}),
+        _sse(calls_delta),
+        _done(),
+    ]
+    final_stream = [_sse({"content": "It is sunny."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+    calls: list[tuple[str, dict]] = []
+
+    def fake_execute_tool(name, arguments, **_kwargs):
+        calls.append((name, arguments))
+        return "sunny"
+
+    monkeypatch.setattr("core.inference.tools.execute_tool", fake_execute_tool)
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "weather?"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    assert calls == [("web_search", {"query": "weather"})]
+    messages = payloads[1]["messages"]
+    assistant_index, assistant = next(
+        (index, message)
+        for index, message in enumerate(messages)
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    )
+    tool_index = next(
+        index for index, message in enumerate(messages) if message.get("role") == "tool"
+    )
+    nudge_index = next(
+        index
+        for index, message in enumerate(messages)
+        if message.get("role") == "user" and "identical call" in message.get("content", "")
+    )
+    assert assistant_index < tool_index < nudge_index
+    assert assistant["content"] == "Search < |channel>thought safely< channel|>.\nChecking."
+    assert "reasoning_content" not in assistant
 
 
 def test_textual_tool_call_turn_replays_reasoning_only_trace_in_next_payload(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -833,6 +833,38 @@ def test_blank_reasoning_noop_turn_adds_no_empty_assistant_message(monkeypatch):
     )
 
 
+def test_noop_reasoning_continuation_separates_partial_from_inlined_trace(monkeypatch):
+    """A suppressed call must not weld inlined reasoning onto a resumed partial."""
+    tool_stream = [_sse({"reasoning_content": "TRACE_ABC"})] + _structured_tool_call(
+        "python", {"code": "print(1)"}, "call_continued_noop"
+    )
+    final_stream = [_sse({"content": "I cannot run Python here."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    def fake_execute_tool(name, arguments, **_kwargs):
+        raise AssertionError(f"unexpected tool execution: {name} {arguments}")
+
+    monkeypatch.setattr("core.inference.tools.execute_tool", fake_execute_tool)
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [
+                {"role": "user", "content": "continue"},
+                {"role": "assistant", "content": "PARTIAL_TEXT"},
+            ],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            continue_final_message = True,
+            max_tool_iterations = 1,
+        )
+    )
+
+    continued = next(
+        message for message in payloads[1]["messages"] if message.get("role") == "assistant"
+    )
+    assert continued == {"role": "assistant", "content": "PARTIAL_TEXT\nTRACE_ABC"}
+
+
 def test_noop_feedback_is_not_folded_into_another_tool_s_result(monkeypatch):
     """Feedback about tool A must never ride tool B's result.
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -587,6 +587,115 @@ def test_reasoning_before_bare_json_tool_closes_think_block(monkeypatch):
     assert not any('"name"' in t for t in content_before_tool)
 
 
+def test_structured_tool_call_turn_replays_pre_tool_reasoning_in_next_payload(monkeypatch):
+    """llama-server sends reasoning in delta.reasoning_content, so content
+    alone drops it, meaning history must carry it or iteration 2 can't see it."""
+    tool_stream = [
+        _sse({"reasoning_content": "I should search "}),
+        _sse({"reasoning_content": "for the weather."}),
+        _sse({"content": "Let me check that.\n\n"}),
+    ] + _structured_tool_call("web_search", {"query": "weather"}, "call_r")
+    final_stream = [
+        _sse({"content": "It is sunny."}),
+        _done(),
+    ]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "weather?"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    assert len(payloads) == 2
+    first_assistant = next(
+        m
+        for m in payloads[1]["messages"]
+        if m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert first_assistant["content"] == "Let me check that.\n\n"
+    assert first_assistant["reasoning_content"] == "I should search for the weather."
+
+
+def test_textual_tool_call_turn_replays_reasoning_only_trace_in_next_payload(monkeypatch):
+    """A reasoning only tool turn has empty content, so without the field the
+    trace left the conversation entirely."""
+    tool_stream = [
+        _sse({"reasoning_content": "I must search before answering."}),
+        _sse(
+            {
+                "content": '<tool_call>{"name":"web_search","arguments":{"query":"weather"}}</tool_call>'
+            }
+        ),
+        _done(),
+    ]
+    final_stream = [
+        _sse({"content": "It is sunny."}),
+        _done(),
+    ]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "weather?"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    assert len(payloads) == 2
+    first_assistant = next(
+        m
+        for m in payloads[1]["messages"]
+        if m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert first_assistant["content"] == ""
+    assert first_assistant["reasoning_content"] == "I must search before answering."
+
+
+def test_tool_call_turn_without_reasoning_adds_no_reasoning_content(monkeypatch):
+    """Non-reasoning models keep their history unchanged."""
+    tool_stream = _structured_tool_call("web_search", {"query": "weather"}, "call_plain")
+    final_stream = [
+        _sse({"content": "It is sunny."}),
+        _done(),
+    ]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "weather?"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    assert len(payloads) == 2
+    first_assistant = next(
+        m
+        for m in payloads[1]["messages"]
+        if m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert "reasoning_content" not in first_assistant
+
+
 def test_consumed_tool_final_pass_emits_latest_reasoning_summary(monkeypatch):
     tool_stream = [
         _sse({"reasoning_content": "Need a render."}),

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -836,12 +836,10 @@ def test_blank_reasoning_noop_turn_adds_no_empty_assistant_message(monkeypatch):
 def test_tool_loop_does_not_mutate_the_caller_s_messages(monkeypatch):
     """The caller's own message dicts stay untouched across a fold.
 
-    ``conversation`` copies the list, not the dicts. Today every fold target is a
-    result this loop just built, so nothing caller-owned is reachable -- this pins
-    that. It is worth pinning because the entry points are not all internal:
-    /v1/messages hands a client's own history straight through, and that history may
-    end on a tool result, so a fold that moved to a different target would silently
-    leave the hidden instruction in the client's list and replay it next request.
+    ``conversation`` copies the list, not the dicts. Every fold target is a result this
+    loop just built, so nothing caller-owned is reachable today; pinning it matters
+    because /v1/messages passes a client's own history through, and a fold that moved
+    to a different target would leave the hidden instruction in that client's list.
     """
     messages = [
         {"role": "user", "content": "weather?"},

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -753,6 +753,35 @@ def test_tool_call_turn_without_reasoning_adds_no_reasoning_content(monkeypatch)
     assert "reasoning_content" not in first_assistant
 
 
+def test_tool_call_turn_with_blank_reasoning_adds_no_reasoning_content(monkeypatch):
+    """Whitespace split from a closed thinking prefill is not a trace."""
+    tool_stream = [_sse({"reasoning_content": "\n\n"})] + _structured_tool_call(
+        "web_search", {"query": "weather"}, "call_blank"
+    )
+    final_stream = [_sse({"content": "It is sunny."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "weather?"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    first_assistant = next(
+        message
+        for message in payloads[1]["messages"]
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    )
+    assert "reasoning_content" not in first_assistant
+
+
 def test_consumed_tool_final_pass_emits_latest_reasoning_summary(monkeypatch):
     tool_stream = [
         _sse({"reasoning_content": "Need a render."}),

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -622,8 +622,8 @@ def test_structured_tool_call_turn_replays_pre_tool_reasoning_in_next_payload(mo
     assert first_assistant["reasoning_content"] == "I should search for the weather."
 
 
-def test_resumed_tool_call_does_not_move_new_reasoning_before_partial(monkeypatch):
-    """A reasoning field renders before content, but a resumed partial came first."""
+def test_resumed_tool_call_preserves_partial_then_reasoning_order(monkeypatch):
+    """A separate reasoning field would render before the resumed partial."""
     tool_stream = [
         _sse({"reasoning_content": "I should verify that."}),
         _sse({"content": "forecast."}),
@@ -655,7 +655,7 @@ def test_resumed_tool_call_does_not_move_new_reasoning_before_partial(monkeypatc
     first_assistant = next(
         m for m in payloads[1]["messages"] if m.get("role") == "assistant" and m.get("tool_calls")
     )
-    assert first_assistant["content"] == "Let me check the forecast."
+    assert first_assistant["content"] == ("Let me check the \nI should verify that.\nforecast.")
     assert "reasoning_content" not in first_assistant
 
 
@@ -1464,6 +1464,7 @@ def test_same_turn_repeated_render_html_does_not_emit_second_provisional_start(m
 
 def test_disabled_tool_call_is_internal_noop(monkeypatch):
     disabled_python = [
+        _sse({"reasoning_content": "Python is needed to calculate this."}),
         _sse(
             {
                 "tool_calls": [
@@ -1506,6 +1507,19 @@ def test_disabled_tool_call_is_internal_noop(monkeypatch):
         if message.get("role") == "user" and "not enabled" in message.get("content", "")
     ]
     assert len(disabled_nudges) == 1
+    reasoning_turn_index, reasoning_turn = next(
+        (index, message)
+        for index, message in enumerate(payloads[1]["messages"])
+        if message.get("role") == "assistant"
+        and message.get("content") == "Python is needed to calculate this."
+    )
+    nudge_index = next(
+        index
+        for index, message in enumerate(payloads[1]["messages"])
+        if message.get("role") == "user" and "not enabled" in message.get("content", "")
+    )
+    assert reasoning_turn_index < nudge_index
+    assert "reasoning_content" not in reasoning_turn
 
 
 def test_render_html_success_does_not_reprompt_render_html_intent(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -622,10 +622,17 @@ def test_structured_tool_call_turn_replays_pre_tool_reasoning_in_next_payload(mo
     assert first_assistant["reasoning_content"] == "I should search for the weather."
 
 
-def test_resumed_tool_call_preserves_partial_then_reasoning_order(monkeypatch):
-    """A separate reasoning field would render before the resumed partial."""
+def test_resumed_tool_call_preserves_and_neutralizes_reasoning_in_order(monkeypatch):
+    """Inlined reasoning keeps order without replaying its control markup."""
     tool_stream = [
-        _sse({"reasoning_content": "I should verify that."}),
+        _sse(
+            {
+                "reasoning_content": (
+                    "I should verify <tool_call>{...}</tool_call> and "
+                    "<|channel>thought x<channel|> before <|turn>user"
+                )
+            }
+        ),
         _sse({"content": "forecast."}),
     ] + _structured_tool_call("web_search", {"query": "weather"}, "call_continued")
     final_stream = [
@@ -655,7 +662,10 @@ def test_resumed_tool_call_preserves_partial_then_reasoning_order(monkeypatch):
     first_assistant = next(
         m for m in payloads[1]["messages"] if m.get("role") == "assistant" and m.get("tool_calls")
     )
-    assert first_assistant["content"] == ("Let me check the \nI should verify that.\nforecast.")
+    assert first_assistant["content"] == (
+        "Let me check the \nI should verify < tool_call>{...}< /tool_call> and "
+        "< |channel>thought x< channel|> before < |turn>user\nforecast."
+    )
     assert "reasoning_content" not in first_assistant
 
 
@@ -1464,7 +1474,14 @@ def test_same_turn_repeated_render_html_does_not_emit_second_provisional_start(m
 
 def test_disabled_tool_call_is_internal_noop(monkeypatch):
     disabled_python = [
-        _sse({"reasoning_content": "Python is needed to calculate this."}),
+        _sse(
+            {
+                "reasoning_content": (
+                    "Python needs <tool_call>{...}</tool_call> and "
+                    "<|channel>thought x<channel|> before <|turn>user"
+                )
+            }
+        ),
         _sse(
             {
                 "tool_calls": [
@@ -1511,7 +1528,11 @@ def test_disabled_tool_call_is_internal_noop(monkeypatch):
         (index, message)
         for index, message in enumerate(payloads[1]["messages"])
         if message.get("role") == "assistant"
-        and message.get("content") == "Python is needed to calculate this."
+        and message.get("content")
+        == (
+            "Python needs < tool_call>{...}< /tool_call> and "
+            "< |channel>thought x< channel|> before < |turn>user"
+        )
     )
     nudge_index = next(
         index

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -616,9 +616,7 @@ def test_structured_tool_call_turn_replays_pre_tool_reasoning_in_next_payload(mo
 
     assert len(payloads) == 2
     first_assistant = next(
-        m
-        for m in payloads[1]["messages"]
-        if m.get("role") == "assistant" and m.get("tool_calls")
+        m for m in payloads[1]["messages"] if m.get("role") == "assistant" and m.get("tool_calls")
     )
     assert first_assistant["content"] == "Let me check that.\n\n"
     assert first_assistant["reasoning_content"] == "I should search for the weather."
@@ -657,9 +655,7 @@ def test_textual_tool_call_turn_replays_reasoning_only_trace_in_next_payload(mon
 
     assert len(payloads) == 2
     first_assistant = next(
-        m
-        for m in payloads[1]["messages"]
-        if m.get("role") == "assistant" and m.get("tool_calls")
+        m for m in payloads[1]["messages"] if m.get("role") == "assistant" and m.get("tool_calls")
     )
     assert first_assistant["content"] == ""
     assert first_assistant["reasoning_content"] == "I must search before answering."
@@ -689,9 +685,7 @@ def test_tool_call_turn_without_reasoning_adds_no_reasoning_content(monkeypatch)
 
     assert len(payloads) == 2
     first_assistant = next(
-        m
-        for m in payloads[1]["messages"]
-        if m.get("role") == "assistant" and m.get("tool_calls")
+        m for m in payloads[1]["messages"] if m.get("role") == "assistant" and m.get("tool_calls")
     )
     assert "reasoning_content" not in first_assistant
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -622,6 +622,43 @@ def test_structured_tool_call_turn_replays_pre_tool_reasoning_in_next_payload(mo
     assert first_assistant["reasoning_content"] == "I should search for the weather."
 
 
+def test_resumed_tool_call_does_not_move_new_reasoning_before_partial(monkeypatch):
+    """A reasoning field renders before content, but a resumed partial came first."""
+    tool_stream = [
+        _sse({"reasoning_content": "I should verify that."}),
+        _sse({"content": "forecast."}),
+    ] + _structured_tool_call("web_search", {"query": "weather"}, "call_continued")
+    final_stream = [
+        _sse({"content": "It is sunny."}),
+        _done(),
+    ]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [
+                {"role": "user", "content": "weather?"},
+                {"role": "assistant", "content": "Let me check the "},
+            ],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            continue_final_message = True,
+            max_tool_iterations = 1,
+        )
+    )
+
+    assert len(payloads) == 2
+    first_assistant = next(
+        m for m in payloads[1]["messages"] if m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert first_assistant["content"] == "Let me check the forecast."
+    assert "reasoning_content" not in first_assistant
+
+
 def test_textual_tool_call_turn_replays_reasoning_only_trace_in_next_payload(monkeypatch):
     """A reasoning only tool turn has empty content, so without the field the
     trace left the conversation entirely."""

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -782,6 +782,57 @@ def test_tool_call_turn_with_blank_reasoning_adds_no_reasoning_content(monkeypat
     assert "reasoning_content" not in first_assistant
 
 
+def test_blank_reasoning_noop_turn_adds_no_empty_assistant_message(monkeypatch):
+    """A blank trace on a suppressed call must not open an empty model turn."""
+    tool_stream = [
+        _sse({"reasoning_content": "\n\n"}),
+        _sse(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_blank_noop",
+                        "type": "function",
+                        "function": {
+                            "name": "python",
+                            "arguments": json.dumps({"code": "print(1)"}),
+                        },
+                    }
+                ]
+            }
+        ),
+        _done(),
+    ]
+    final_stream = [_sse({"content": "I cannot run Python here."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    def fake_execute_tool(name, arguments, **_kwargs):
+        raise AssertionError(f"unexpected tool execution: {name} {arguments}")
+
+    monkeypatch.setattr("core.inference.tools.execute_tool", fake_execute_tool)
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "run python"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    assert not [
+        message
+        for message in payloads[1]["messages"]
+        if message.get("role") == "assistant"
+        and not message.get("tool_calls")
+        and not str(message.get("content") or "").strip()
+    ]
+    assert any(
+        message.get("role") == "user" and "not enabled" in message.get("content", "")
+        for message in payloads[1]["messages"]
+    )
+
+
 def test_consumed_tool_final_pass_emits_latest_reasoning_summary(monkeypatch):
     tool_stream = [
         _sse({"reasoning_content": "Need a render."}),

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -835,6 +835,7 @@ def test_blank_reasoning_noop_turn_adds_no_empty_assistant_message(monkeypatch):
 
 def test_noop_reasoning_continuation_separates_partial_from_inlined_trace(monkeypatch):
     """A suppressed call must not weld inlined reasoning onto a resumed partial."""
+
     def fake_execute_tool(name, arguments, **_kwargs):
         raise AssertionError(f"unexpected tool execution: {name} {arguments}")
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -833,6 +833,114 @@ def test_blank_reasoning_noop_turn_adds_no_empty_assistant_message(monkeypatch):
     )
 
 
+def test_noop_feedback_is_not_folded_into_another_tool_s_result(monkeypatch):
+    """Feedback about tool A must never ride tool B's result.
+
+    Templates label the whole block with the result's OWN tool name (gemma-4.jinja
+    resolves tool_call_id -> name and wraps the body), so a note about a suppressed
+    ``python`` call folded into a ``web_search`` result reads as web_search's output.
+    Only a same-tool result may carry it; otherwise the user turn is the lesser loss.
+    """
+    tool_stream = [
+        _sse({"reasoning_content": "Plan the batch."}),
+        _sse(
+            {
+                "tool_calls": [
+                    {
+                        "index": index,
+                        "id": f"call_mixed_{index}",
+                        "type": "function",
+                        "function": {"name": name, "arguments": json.dumps(args)},
+                    }
+                    for index, (name, args) in enumerate(
+                        [
+                            ("web_search", {"query": "a"}),
+                            ("python", {"code": "print(1)"}),  # disabled -> internal no-op
+                            ("web_search", {"query": "b"}),
+                        ]
+                    )
+                ]
+            }
+        ),
+        _done(),
+    ]
+    final_stream = [_sse({"content": "It is sunny."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool",
+        lambda name, arguments, **_kwargs: f"RESULT_OF_{name}",
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "q"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    messages = payloads[1]["messages"]
+    for message in messages:
+        if message.get("role") == "tool":
+            assert "not executed" not in message["content"], message
+            assert message["content"] == "RESULT_OF_web_search"
+    assert [
+        message
+        for message in messages
+        if message.get("role") == "user" and "not executed" in message.get("content", "")
+    ]
+
+
+def test_same_tool_noop_feedback_still_rides_its_own_result(monkeypatch):
+    """The fold is kept where attribution is unambiguous: a duplicate names the
+    same tool as the result it lands on, so no newer user turn is opened."""
+    tool_stream = [
+        _sse({"reasoning_content": "Plan the batch."}),
+        _sse(
+            {
+                "tool_calls": [
+                    {
+                        "index": index,
+                        "id": f"call_dup_{index}",
+                        "type": "function",
+                        "function": {
+                            "name": "web_search",
+                            "arguments": json.dumps(args),
+                        },
+                    }
+                    for index, args in enumerate(
+                        [{"query": "a"}, {"query": "a"}, {"query": "b"}]
+                    )
+                ]
+            }
+        ),
+        _done(),
+    ]
+    final_stream = [_sse({"content": "It is sunny."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "q"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    messages = payloads[1]["messages"]
+    assert not [m for m in messages[1:] if m.get("role") == "user"]
+    assert any(
+        m.get("role") == "tool" and "not executed" in m["content"] for m in messages
+    )
+
+
 def test_tool_loop_does_not_mutate_the_caller_s_messages(monkeypatch):
     """The caller's own message dicts stay untouched across a fold.
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -833,6 +833,72 @@ def test_blank_reasoning_noop_turn_adds_no_empty_assistant_message(monkeypatch):
     )
 
 
+def test_tool_loop_does_not_mutate_the_caller_s_messages(monkeypatch):
+    """The caller's own message dicts stay untouched across a fold.
+
+    ``conversation`` copies the list, not the dicts. Today every fold target is a
+    result this loop just built, so nothing caller-owned is reachable -- this pins
+    that. It is worth pinning because the entry points are not all internal:
+    /v1/messages hands a client's own history straight through, and that history may
+    end on a tool result, so a fold that moved to a different target would silently
+    leave the hidden instruction in the client's list and replay it next request.
+    """
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "earlier",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": "web_search", "tool_call_id": "earlier", "content": "cloudy"},
+    ]
+    before = copy.deepcopy(messages)
+
+    tool_stream = [
+        _sse({"reasoning_content": "One search is enough."}),
+        _sse(
+            {
+                "tool_calls": [
+                    {
+                        "index": index,
+                        "id": f"call_own_{index}",
+                        "type": "function",
+                        "function": {
+                            "name": "web_search",
+                            "arguments": json.dumps({"query": "weather"}),
+                        },
+                    }
+                    for index in range(2)  # the second is a duplicate -> internal no-op
+                ]
+            }
+        ),
+        _done(),
+    ]
+    final_stream = [_sse({"content": "It is sunny."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [tool_stream, final_stream], payloads)
+
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool", lambda name, arguments, **_kwargs: "sunny"
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = messages,
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+        )
+    )
+
+    assert messages == before
+
+
 def test_consumed_tool_final_pass_emits_latest_reasoning_summary(monkeypatch):
     tool_stream = [
         _sse({"reasoning_content": "Need a render."}),

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -910,9 +910,7 @@ def test_same_tool_noop_feedback_still_rides_its_own_result(monkeypatch):
                             "arguments": json.dumps(args),
                         },
                     }
-                    for index, args in enumerate(
-                        [{"query": "a"}, {"query": "a"}, {"query": "b"}]
-                    )
+                    for index, args in enumerate([{"query": "a"}, {"query": "a"}, {"query": "b"}])
                 ]
             }
         ),
@@ -936,9 +934,7 @@ def test_same_tool_noop_feedback_still_rides_its_own_result(monkeypatch):
 
     messages = payloads[1]["messages"]
     assert not [m for m in messages[1:] if m.get("role") == "user"]
-    assert any(
-        m.get("role") == "tool" and "not executed" in m["content"] for m in messages
-    )
+    assert any(m.get("role") == "tool" and "not executed" in m["content"] for m in messages)
 
 
 def test_tool_loop_does_not_mutate_the_caller_s_messages(monkeypatch):

--- a/studio/backend/tests/test_tool_output_streaming.py
+++ b/studio/backend/tests/test_tool_output_streaming.py
@@ -33,6 +33,7 @@ _TESTS_DIR = str(Path(__file__).resolve().parent)
 if _TESTS_DIR not in sys.path:
     sys.path.insert(0, _TESTS_DIR)
 
+from core.inference.tool_call_parser import BUDGET_EXHAUSTED_NUDGE
 from core.inference.tool_stream_exec import (
     TOOL_OUTPUT_STREAM_MAX_CHARS,
     stream_tool_execution,
@@ -771,11 +772,15 @@ def test_gguf_loop_final_tool_message_unchanged_by_streaming(monkeypatch):
     # The role=tool message fed to the model is byte-identical: streaming is purely
     # observational and must not perturb parsing/nudging/healing.
     assert _tool_messages(payloads_streaming) == _tool_messages(payloads_plain)
+    # The tool's own output is still verbatim and still leads the message. What
+    # follows it is the budget-exhausted instruction, which now rides the last tool
+    # result instead of opening a newer user turn: templates gate replayed reasoning
+    # on the newest user turn, so a nudge there hides this turn's thinking.
     assert _tool_messages(payloads_streaming) == [
         {
             "role": "tool",
             "name": "python",
-            "content": result_text,
+            "content": f"{result_text}\n\n{BUDGET_EXHAUSTED_NUDGE}",
             "tool_call_id": "call_1",
         }
     ]


### PR DESCRIPTION
## Problem

It appears that reasoning generated before a tool call within a single turn isn't being passed to the reasoning that occurs after the tool result. This became apparent to me when I was playing with tool calling an mcp web search and it was repeating web searches that were performed in tool calls earlier than the last, asking itself the same questions it answered earlier in the turn and was repeatedly referring back to my prompt like it was the first time reading it.

## Root cause

Looks like reasoning comes from `delta.reasoning_content`, which `generate_chat_completion_with_tools` combines into `reasoning_accum`. But when the loop builds the assistant history message after collecting the tool call:

```python
assistant_msg = {"role": "assistant", "content": content_text}
```

`reasoning_accum` is never attached, and the next iteration rebuilds its request from `conversation`. So the first reasoning block is dropped. Looks like this dates back to a rewrite that occurred in https://github.com/unslothai/unsloth/pull/4639. I noticed this related PR https://github.com/unslothai/unsloth/pull/8366, but seems like this only fixed the problem for next turns, not within the same turn.

## Fix

Attach the accumulated reasoning to the assistant history message when it exists:

```python
if reasoning_accum:
    assistant_msg["reasoning_content"] = reasoning_accum
```

## Repro

Using `Muse-Glimmer-30B-GGUF:UD-Q8_K_XL`, I prompted it to come up with a random string, call the Python code tool with a random calculation, then continue reasoning and recall the earlier string. Prior to these changes, it was able to see the tool call result, but had no knowledge of the random string or any prior reasoning. After applying these changes, it was able to (in the thinking) immediately recall the string it came up with from the reasoning prior to the tool call.

## Tests

Added new regression tests in `tests/test_llama_cpp_tool_loop.py` that give the turn fake responses and check what gets sent back on the second iteration:

`test_structured_tool_call_turn_replays_pre_tool_reasoning_in_next_payload`

Emits two reasoning chunks, a response within the same turn (that some models do), and a tool call. Then checks the second request includes the reasoning.

`test_textual_tool_call_turn_replays_reasoning_only_trace_in_next_payload`

Single reasoning chunk, and a tool call embedded with XML in the content text. Checks the reasoning survives despite content being empty (gets stripped). Prior to these changes the reasoning gets dropped entirely.

`test_tool_call_turn_without_reasoning_adds_no_reasoning_content`

No reasoning chunk (mimicking non-thinking models, or thinking toggled off) to make sure non-thinking behaviour is untouched by this change.