### PR TITLE
Fix the desktop-auth routes stub so the health test runs again

### DIFF
--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -835,15 +835,13 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     monkeypatch.setattr(backend_main._hw_module, "DEVICE", backend_main._hw_module.DeviceType.CPU)
     monkeypatch.setattr(backend_main._hw_module, "CHAT_ONLY", True)
     monkeypatch.setattr(backend_main._hw_module, "CHAT_ONLY_REASON", "mlx_unavailable")
-    # _hardware_snapshot() is a seqlock read returning None until detection settles, so without
-    # this the authed chat_only fields never publish and the assertions fail on a missing key.
+    # _hardware_snapshot() returns None until detection settles, so chat_only never publishes.
     import threading
 
     _settled = threading.Event()
     _settled.set()
     monkeypatch.setattr(backend_main._hw_module, "DETECTION_COMPLETE", _settled)
-    # On Apple Silicon the MLX self-heal can overturn the settled "mlx_unavailable" verdict, so
-    # health_check() drops the snapshot. Pin the predicate off so a Mac measures what CI does.
+    # On a Mac the MLX self-heal overturns "mlx_unavailable" and health_check() drops the snapshot.
     monkeypatch.setattr(backend_main._hw_module, "is_apple_silicon", lambda: False)
 
     seed_user()
@@ -1083,8 +1081,7 @@ def test_the_router_stub_covers_every_router_main_imports():
     imported = set(re.findall(r"(\w+_router)", block.group(1)))
     assert imported, "the routes import block named no routers; re-derive this"
 
-    # The health test's own stub only: another test's fixture (loaded_local_model registers
-    # routes.inference) would otherwise count as coverage for an import it never sees.
+    # The health test's own stub only: another fixture's stubs would count as coverage here.
     own_src = inspect.getsource(test_health_response_reports_desktop_capability_fields)
     stubbed = set(re.findall(r'"(\w+_router)":', own_src))
     assert stubbed, "the health test's stub dict named no routers; re-derive this"
@@ -1094,8 +1091,7 @@ def test_the_router_stub_covers_every_router_main_imports():
         f"define them, so the routes stand-in will not satisfy that import"
     )
 
-    # Same drift via `from routes.<sub> import router`, which needs a sys.modules entry, not a
-    # dict key. whisper and profile_stats were both missing; the earliest import hid the rest.
+    # Same drift for submodule imports, which need a sys.modules entry rather than a dict key.
     submodules = set(re.findall(r"^from routes\.(\w+) import", main_src, re.M))
     assert submodules, "main.py imports no routes submodule; re-derive this"
     registered = set(re.findall(r'setitem\(\s*sys\.modules,\s*"routes\.(\w+)"', own_src))

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -843,6 +843,11 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     _settled = threading.Event()
     _settled.set()
     monkeypatch.setattr(backend_main._hw_module, "DETECTION_COMPLETE", _settled)
+    # On an Apple Silicon host the settled "mlx_unavailable" verdict is one the MLX
+    # self-heal may still overturn, so health_check() drops the snapshot and the authed
+    # fields below go missing again. Pin the host predicate that gate starts from, so this
+    # test measures the same thing on a Mac as it does in CI.
+    monkeypatch.setattr(backend_main._hw_module, "is_apple_silicon", lambda: False)
 
     seed_user()
     from auth.authentication import create_access_token
@@ -1071,6 +1076,7 @@ def test_the_router_stub_covers_every_router_main_imports():
     makes every test in this file die with an ImportError rather than a useful
     message. That is how ``openai_codex_auth_router`` broke main after #8511.
     Comparing the two lists keeps the omission local to this assertion."""
+    import inspect
     import re
     from pathlib import Path
 
@@ -1081,8 +1087,12 @@ def test_the_router_stub_covers_every_router_main_imports():
     imported = set(re.findall(r"(\w+_router)", block.group(1)))
     assert imported, "the routes import block named no routers; re-derive this"
 
-    own_src = Path(__file__).read_text(encoding = "utf-8")
+    # The health test's own stub only, never the whole file: another test's fixture
+    # stubbing part of routes (loaded_local_model registers routes.inference) would
+    # otherwise count as coverage for an import that test never sees.
+    own_src = inspect.getsource(test_health_response_reports_desktop_capability_fields)
     stubbed = set(re.findall(r'"(\w+_router)":', own_src))
+    assert stubbed, "the health test's stub dict named no routers; re-derive this"
     missing = sorted(imported - stubbed)
     assert not missing, (
         f"main.py imports {missing} from routes, but the stub dict in this file does not "
@@ -1094,7 +1104,9 @@ def test_the_router_stub_covers_every_router_main_imports():
     # were both missing while only the first was visible, because the import dies on the
     # earliest one and hides the rest.
     submodules = set(re.findall(r"^from routes\.(\w+) import", main_src, re.M))
+    assert submodules, "main.py imports no routes submodule; re-derive this"
     registered = set(re.findall(r'setitem\(\s*sys\.modules,\s*"routes\.(\w+)"', own_src))
+    assert registered, "the health test registered no routes submodule; re-derive this"
     unstubbed = sorted(submodules - registered)
     assert not unstubbed, (
         f"main.py imports from routes.{{{','.join(unstubbed)}}}, which this file never "

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -835,17 +835,15 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     monkeypatch.setattr(backend_main._hw_module, "DEVICE", backend_main._hw_module.DeviceType.CPU)
     monkeypatch.setattr(backend_main._hw_module, "CHAT_ONLY", True)
     monkeypatch.setattr(backend_main._hw_module, "CHAT_ONLY_REASON", "mlx_unavailable")
-    # _hardware_snapshot() is a seqlock read that returns None until detection settles, so
-    # without this the authed chat_only fields are never published and the assertions below
-    # fail on a missing key rather than a wrong value.
+    # _hardware_snapshot() is a seqlock read returning None until detection settles, so without
+    # this the authed chat_only fields never publish and the assertions fail on a missing key.
     import threading
 
     _settled = threading.Event()
     _settled.set()
     monkeypatch.setattr(backend_main._hw_module, "DETECTION_COMPLETE", _settled)
-    # On Apple Silicon the MLX self-heal may still overturn the settled "mlx_unavailable"
-    # verdict, so health_check() drops the snapshot and the authed fields go missing again.
-    # Pin the host predicate that gate starts from, so a Mac measures what CI does.
+    # On Apple Silicon the MLX self-heal can overturn the settled "mlx_unavailable" verdict, so
+    # health_check() drops the snapshot. Pin the predicate off so a Mac measures what CI does.
     monkeypatch.setattr(backend_main._hw_module, "is_apple_silicon", lambda: False)
 
     seed_user()
@@ -1085,9 +1083,8 @@ def test_the_router_stub_covers_every_router_main_imports():
     imported = set(re.findall(r"(\w+_router)", block.group(1)))
     assert imported, "the routes import block named no routers; re-derive this"
 
-    # The health test's own stub only, never the whole file: another test's fixture
-    # stubbing part of routes (loaded_local_model registers routes.inference) would
-    # otherwise count as coverage for an import that test never sees.
+    # The health test's own stub only: another test's fixture (loaded_local_model registers
+    # routes.inference) would otherwise count as coverage for an import it never sees.
     own_src = inspect.getsource(test_health_response_reports_desktop_capability_fields)
     stubbed = set(re.findall(r'"(\w+_router)":', own_src))
     assert stubbed, "the health test's stub dict named no routers; re-derive this"
@@ -1097,9 +1094,8 @@ def test_the_router_stub_covers_every_router_main_imports():
         f"define them, so the routes stand-in will not satisfy that import"
     )
 
-    # The same drift through the other import form: `from routes.<sub> import router` needs a
-    # sys.modules entry, not a dict key. routes.whisper and routes.profile_stats were both
-    # missing but only the first was visible: the import dies on the earliest and hides the rest.
+    # Same drift via `from routes.<sub> import router`, which needs a sys.modules entry, not a
+    # dict key. whisper and profile_stats were both missing; the earliest import hid the rest.
     submodules = set(re.findall(r"^from routes\.(\w+) import", main_src, re.M))
     assert submodules, "main.py imports no routes submodule; re-derive this"
     registered = set(re.findall(r'setitem\(\s*sys\.modules,\s*"routes\.(\w+)"', own_src))

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -843,10 +843,9 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     _settled = threading.Event()
     _settled.set()
     monkeypatch.setattr(backend_main._hw_module, "DETECTION_COMPLETE", _settled)
-    # On an Apple Silicon host the settled "mlx_unavailable" verdict is one the MLX
-    # self-heal may still overturn, so health_check() drops the snapshot and the authed
-    # fields below go missing again. Pin the host predicate that gate starts from, so this
-    # test measures the same thing on a Mac as it does in CI.
+    # On Apple Silicon the MLX self-heal may still overturn the settled "mlx_unavailable"
+    # verdict, so health_check() drops the snapshot and the authed fields go missing again.
+    # Pin the host predicate that gate starts from, so a Mac measures what CI does.
     monkeypatch.setattr(backend_main._hw_module, "is_apple_silicon", lambda: False)
 
     seed_user()
@@ -1071,11 +1070,10 @@ def test_desktop_auth_provision_has_bounded_timeout():
 
 
 def test_the_router_stub_covers_every_router_main_imports():
-    """The fake ``routes`` module above is a hardcoded dict, so a router added to
-    main.py's ``from routes import (...)`` block without a matching stub entry
-    makes every test in this file die with an ImportError rather than a useful
-    message. That is how ``openai_codex_auth_router`` broke main after #8511.
-    Comparing the two lists keeps the omission local to this assertion."""
+    """The fake ``routes`` module above is a hardcoded dict, so a router added to main.py's
+    ``from routes import (...)`` block without a matching stub entry kills every test in this
+    file with an ImportError rather than a useful message, as ``openai_codex_auth_router`` did
+    after #8511. Comparing the two lists keeps that omission local to this assertion."""
     import inspect
     import re
     from pathlib import Path
@@ -1099,10 +1097,9 @@ def test_the_router_stub_covers_every_router_main_imports():
         f"define them, so the routes stand-in will not satisfy that import"
     )
 
-    # The same drift through the other import form: `from routes.<sub> import router`
-    # needs a sys.modules entry, not a dict key. routes.whisper and routes.profile_stats
-    # were both missing while only the first was visible, because the import dies on the
-    # earliest one and hides the rest.
+    # The same drift through the other import form: `from routes.<sub> import router` needs a
+    # sys.modules entry, not a dict key. routes.whisper and routes.profile_stats were both
+    # missing but only the first was visible: the import dies on the earliest and hides the rest.
     submodules = set(re.findall(r"^from routes\.(\w+) import", main_src, re.M))
     assert submodules, "main.py imports no routes submodule; re-derive this"
     registered = set(re.findall(r'setitem\(\s*sys\.modules,\s*"routes\.(\w+)"', own_src))

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -792,6 +792,10 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     prompts_module.router = APIRouter()
     preview_module = ModuleType("routes.preview")
     preview_module.router = APIRouter()
+    whisper_module = ModuleType("routes.whisper")
+    whisper_module.router = APIRouter()
+    profile_stats_module = ModuleType("routes.profile_stats")
+    profile_stats_module.router = APIRouter()
 
     for name, router in {
         "auth_router": APIRouter(),
@@ -803,6 +807,7 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
         "inference_studio_router": APIRouter(),
         "mcp_servers_router": APIRouter(),
         "models_router": APIRouter(),
+        "openai_codex_auth_router": APIRouter(),
         "providers_router": APIRouter(),
         "rag_router": APIRouter(),
         "research_runs_router": APIRouter(),
@@ -820,6 +825,8 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     monkeypatch.setitem(sys.modules, "routes.llama", llama_module)
     monkeypatch.setitem(sys.modules, "routes.prompts", prompts_module)
     monkeypatch.setitem(sys.modules, "routes.preview", preview_module)
+    monkeypatch.setitem(sys.modules, "routes.whisper", whisper_module)
+    monkeypatch.setitem(sys.modules, "routes.profile_stats", profile_stats_module)
 
     import studio.backend.main as backend_main
 
@@ -828,6 +835,14 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     monkeypatch.setattr(backend_main._hw_module, "DEVICE", backend_main._hw_module.DeviceType.CPU)
     monkeypatch.setattr(backend_main._hw_module, "CHAT_ONLY", True)
     monkeypatch.setattr(backend_main._hw_module, "CHAT_ONLY_REASON", "mlx_unavailable")
+    # _hardware_snapshot() is a seqlock read that returns None until detection settles, so
+    # without this the authed chat_only fields are never published and the assertions below
+    # fail on a missing key rather than a wrong value.
+    import threading
+
+    _settled = threading.Event()
+    _settled.set()
+    monkeypatch.setattr(backend_main._hw_module, "DETECTION_COMPLETE", _settled)
 
     seed_user()
     from auth.authentication import create_access_token
@@ -1048,3 +1063,40 @@ def test_desktop_auth_provision_has_bounded_timeout():
     assert m is not None
     seconds = int(m.group(1))
     assert 5 <= seconds <= 120
+
+
+def test_the_router_stub_covers_every_router_main_imports():
+    """The fake ``routes`` module above is a hardcoded dict, so a router added to
+    main.py's ``from routes import (...)`` block without a matching stub entry
+    makes every test in this file die with an ImportError rather than a useful
+    message. That is how ``openai_codex_auth_router`` broke main after #8511.
+    Comparing the two lists keeps the omission local to this assertion."""
+    import re
+    from pathlib import Path
+
+    backend = Path(__file__).resolve().parent.parent
+    main_src = (backend / "main.py").read_text(encoding = "utf-8")
+    block = re.search(r"from routes import \(([^)]*)\)", main_src, re.S)
+    assert block is not None, "main.py no longer has a parenthesised routes import; re-derive this"
+    imported = set(re.findall(r"(\w+_router)", block.group(1)))
+    assert imported, "the routes import block named no routers; re-derive this"
+
+    own_src = Path(__file__).read_text(encoding = "utf-8")
+    stubbed = set(re.findall(r'"(\w+_router)":', own_src))
+    missing = sorted(imported - stubbed)
+    assert not missing, (
+        f"main.py imports {missing} from routes, but the stub dict in this file does not "
+        f"define them, so the routes stand-in will not satisfy that import"
+    )
+
+    # The same drift through the other import form: `from routes.<sub> import router`
+    # needs a sys.modules entry, not a dict key. routes.whisper and routes.profile_stats
+    # were both missing while only the first was visible, because the import dies on the
+    # earliest one and hides the rest.
+    submodules = set(re.findall(r"^from routes\.(\w+) import", main_src, re.M))
+    registered = set(re.findall(r'setitem\(\s*sys\.modules,\s*"routes\.(\w+)"', own_src))
+    unstubbed = sorted(submodules - registered)
+    assert not unstubbed, (
+        f"main.py imports from routes.{{{','.join(unstubbed)}}}, which this file never "
+        f"registers in sys.modules, so the real package would be imported instead"
+    )


### PR DESCRIPTION
`tests/test_desktop_auth.py` builds a stand-in `routes` module from a hardcoded list. `main.py`'s imports have drifted past it, so the health test dies during import and never reaches the behaviour it checks. It fails on `origin/main` today, on every Python version, and every PR that merges main inherits it.

There are three separate drifts, and each one hides the next, which is why this looks like a single failure:

1. `openai_codex_auth_router` is imported by `main.py` but absent from the router dict, so the `from routes import (...)` block raises `ImportError: cannot import name 'openai_codex_auth_router' from 'routes'`.
2. `routes.whisper` and `routes.profile_stats` are imported as submodules but never registered in `sys.modules`, so the import falls through to the real package and raises `ModuleNotFoundError`. Only the first of the two is visible until it is fixed.
3. `_hardware_snapshot()` returns `None` until `DETECTION_COMPLETE` is set. The test sets `DEVICE`, `CHAT_ONLY` and `CHAT_ONLY_REASON` but not that event, so the authed `chat_only` fields are never published and the assertion fails on a missing key rather than a wrong value.

The last one is worth noting for anyone touching that endpoint: the snapshot is a seqlock read that deliberately publishes nothing mid-pass, so a test that patches the underlying globals has to declare detection settled as well.

Also adds a guard covering both import forms, the router dict and the `sys.modules` registrations, so the next router added to `main.py` fails one named assertion instead of taking the whole file out. Verified by removing the whisper registration and the router entry in turn and confirming the guard fails on each.

`tests/test_desktop_auth.py`: 3 failed, 45 passed, against 4 failed, 43 passed on the merge base. The three that remain are pre-existing bootstrap-password failures unrelated to this change, which reproduce identically on `origin/main` and pass in CI.

This does not fix `tests/test_warm_window_review_fixes.py::test_the_warm_epoch_is_retired_before_any_shutdown_await`, which is also red on main. That one is a real source-order regression, not stub drift: the warm's detection epoch is retired at line 781, after the first shutdown await at 771, so the warm keeps importing through the gap. It needs someone who owns that shutdown path.
