### PR TITLE
Studio: drag to reorder pinned models in the hub

### DIFF
--- a/studio/frontend/src/features/hub/catalog/models-catalog-lists.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-catalog-lists.tsx
@@ -308,9 +308,14 @@ export function DownloadedList({
   // Pinned repos surface first regardless of the active sort, which still orders within groups.
   const pinnedIds = usePinnedModelsStore((s) => s.pinned);
   const movePinned = usePinnedModelsStore((s) => s.movePinned);
+  const beginPinnedDrag = usePinnedModelsStore((s) => s.beginPinnedDrag);
+  const endPinnedDrag = usePinnedModelsStore((s) => s.endPinnedDrag);
   // Ref, not state: dragenter can fire before a dragstart re-render commits.
   const dragPinKeyRef = useRef<string | null>(null);
-  const [dragPinKey, setDragPinKey] = useState<string | null>(null);
+  // Dimming keys off the dragged CELL, not off its pin key: one repo cached in
+  // two formats yields two rows sharing a single pin key, and dimming both
+  // would report the untouched twin as the thing being dragged.
+  const [dragRowKey, setDragRowKey] = useState<string | null>(null);
   const pinnedSet = useMemo(() => new Set(pinnedIds), [pinnedIds]);
   const inventoryItems = useMemo<InventoryItem[]>(() => {
     const merged: InventoryItem[] = [
@@ -486,17 +491,25 @@ export function DownloadedList({
             }}
           >
             {pinnedItems.map((item) => {
-              const itemPinKey = item.row.repoId
-                ? pinKey(item.row.repoId)
-                : null;
+              const rowKey = `${item.variant}-${item.row.id}`;
+              // movePinned can only move a key that is in the pinned list, and
+              // pins also exist as `repoId::quant` (written by the GGUF quant
+              // menus). Deriving the key without checking membership would let
+              // a row advertise a drag that every movePinned call silently
+              // found nothing to do. pinnedCount selects this slice on the same
+              // predicate today, so the check holds the two in lockstep rather
+              // than trusting them to stay identical.
+              const itemPinKey =
+                item.row.repoId && pinnedSet.has(pinKey(item.row.repoId))
+                  ? pinKey(item.row.repoId)
+                  : null;
               return (
                 <div
-                  key={`${item.variant}-${item.row.id}`}
+                  key={rowKey}
                   className="min-w-0"
                   style={{
                     height: cellHeightPx,
-                    opacity:
-                      dragPinKey && dragPinKey === itemPinKey ? 0.4 : undefined,
+                    opacity: dragRowKey === rowKey ? 0.4 : undefined,
                   }}
                   draggable={itemPinKey != null}
                   onDragStart={(event) => {
@@ -505,11 +518,18 @@ export function DownloadedList({
                     // Firefox will not start a drag without data.
                     event.dataTransfer.setData("text/plain", itemPinKey);
                     dragPinKeyRef.current = itemPinKey;
-                    setDragPinKey(itemPinKey);
+                    setDragRowKey(rowKey);
+                    // Reordering happens live on dragenter; this snapshot is
+                    // what a cancelled drag rolls back to.
+                    beginPinnedDrag();
                   }}
                   onDragEnd={() => {
                     dragPinKeyRef.current = null;
-                    setDragPinKey(null);
+                    setDragRowKey(null);
+                    // Escape, or a release outside any cell, reaches dragend
+                    // without a drop. A drop already committed and cleared the
+                    // session, so this call is then a no-op.
+                    endPinnedDrag(false);
                   }}
                   onDragOver={(event) => {
                     if (dragPinKeyRef.current) event.preventDefault();
@@ -523,7 +543,8 @@ export function DownloadedList({
                   onDrop={(event) => {
                     event.preventDefault();
                     dragPinKeyRef.current = null;
-                    setDragPinKey(null);
+                    setDragRowKey(null);
+                    endPinnedDrag(true);
                   }}
                 >
                   {renderInventoryRow(item)}

--- a/studio/frontend/src/features/hub/catalog/models-catalog-lists.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-catalog-lists.tsx
@@ -498,9 +498,15 @@ export function DownloadedList({
               // a row advertise a drag that every movePinned call silently
               // found nothing to do. pinnedCount selects this slice on the same
               // predicate today, so the check holds the two in lockstep rather
-              // than trusting them to stay identical.
+              // than trusting them to stay identical. Datasets are excluded
+              // outright: pin keys carry no repo type, so a dataset whose
+              // repoId also names a pinned model reaches this grid, and the row
+              // menu offers datasets no pin action, so a drag here must not
+              // reorder the user's model pins from the dataset list.
               const itemPinKey =
-                item.row.repoId && pinnedSet.has(pinKey(item.row.repoId))
+                !isDataset &&
+                item.row.repoId &&
+                pinnedSet.has(pinKey(item.row.repoId))
                   ? pinKey(item.row.repoId)
                   : null;
               return (

--- a/studio/frontend/src/features/hub/catalog/models-catalog-lists.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-catalog-lists.tsx
@@ -16,7 +16,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Ref } from "react";
 import type { HubFailure } from "@/features/hub/lib/network";
-import { useLayoutEffect, useMemo, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   inventoryRowMatches,
   scoreInventoryRow,
@@ -307,6 +307,10 @@ export function DownloadedList({
 }) {
   // Pinned repos surface first regardless of the active sort, which still orders within groups.
   const pinnedIds = usePinnedModelsStore((s) => s.pinned);
+  const movePinned = usePinnedModelsStore((s) => s.movePinned);
+  // Ref, not state: dragenter can fire before a dragstart re-render commits.
+  const dragPinKeyRef = useRef<string | null>(null);
+  const [dragPinKey, setDragPinKey] = useState<string | null>(null);
   const pinnedSet = useMemo(() => new Set(pinnedIds), [pinnedIds]);
   const inventoryItems = useMemo<InventoryItem[]>(() => {
     const merged: InventoryItem[] = [
@@ -481,15 +485,51 @@ export function DownloadedList({
               paddingBottom: rowHeightPx - cellHeightPx,
             }}
           >
-            {pinnedItems.map((item) => (
-              <div
-                key={`${item.variant}-${item.row.id}`}
-                className="min-w-0"
-                style={{ height: cellHeightPx }}
-              >
-                {renderInventoryRow(item)}
-              </div>
-            ))}
+            {pinnedItems.map((item) => {
+              const itemPinKey = item.row.repoId
+                ? pinKey(item.row.repoId)
+                : null;
+              return (
+                <div
+                  key={`${item.variant}-${item.row.id}`}
+                  className="min-w-0"
+                  style={{
+                    height: cellHeightPx,
+                    opacity:
+                      dragPinKey && dragPinKey === itemPinKey ? 0.4 : undefined,
+                  }}
+                  draggable={itemPinKey != null}
+                  onDragStart={(event) => {
+                    if (!itemPinKey) return;
+                    event.dataTransfer.effectAllowed = "move";
+                    // Firefox will not start a drag without data.
+                    event.dataTransfer.setData("text/plain", itemPinKey);
+                    dragPinKeyRef.current = itemPinKey;
+                    setDragPinKey(itemPinKey);
+                  }}
+                  onDragEnd={() => {
+                    dragPinKeyRef.current = null;
+                    setDragPinKey(null);
+                  }}
+                  onDragOver={(event) => {
+                    if (dragPinKeyRef.current) event.preventDefault();
+                  }}
+                  onDragEnter={() => {
+                    const dragKey = dragPinKeyRef.current;
+                    if (dragKey && itemPinKey && dragKey !== itemPinKey) {
+                      movePinned(dragKey, itemPinKey);
+                    }
+                  }}
+                  onDrop={(event) => {
+                    event.preventDefault();
+                    dragPinKeyRef.current = null;
+                    setDragPinKey(null);
+                  }}
+                >
+                  {renderInventoryRow(item)}
+                </div>
+              );
+            })}
           </div>
           {unpinnedItems.length > 0 && (
             <div className="px-1 pb-2 pt-2 text-ui-11 font-semibold uppercase tracking-wider text-muted-foreground">

--- a/studio/frontend/src/features/model-picker/components/model-selector/pinned-models.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pinned-models.ts
@@ -63,6 +63,7 @@ function writePinned(pinned: string[]): void {
 interface PinnedModelsState {
   pinned: string[];
   togglePinned: (repoId: string, quant?: string) => void;
+  movePinned: (fromKey: string, toKey: string) => void;
 }
 
 export const usePinnedModelsStore = create<PinnedModelsState>((set) => ({
@@ -75,6 +76,16 @@ export const usePinnedModelsStore = create<PinnedModelsState>((set) => ({
       const next = state.pinned.includes(key)
         ? state.pinned.filter((id) => id !== key)
         : [key, ...state.pinned];
+      writePinned(next);
+      return { pinned: next };
+    }),
+  movePinned: (fromKey, toKey) =>
+    set((state) => {
+      const from = state.pinned.indexOf(fromKey);
+      const to = state.pinned.indexOf(toKey);
+      if (from < 0 || to < 0 || from === to) return state;
+      const next = [...state.pinned];
+      next.splice(to, 0, ...next.splice(from, 1));
       writePinned(next);
       return { pinned: next };
     }),

--- a/studio/frontend/src/features/model-picker/components/model-selector/pinned-models.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pinned-models.ts
@@ -60,10 +60,49 @@ function writePinned(pinned: string[]): void {
   }
 }
 
+// A drag reorders live under the cursor, so `movePinned` runs on every
+// dragenter. Persisting each of those would write localStorage dozens of times
+// per drag and, worse, would make a drag the user cancels with Escape or by
+// releasing outside the grid permanent: dragend can clear the drag marker but
+// cannot undo writes. So a drag session snapshots the order up front, keeps
+// every intermediate move in memory only, and either commits once on drop or
+// restores the snapshot when the drag ends without one.
+let dragSnapshot: string[] | null = null;
+
+function sameOrder(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((key, index) => key === b[index]);
+}
+
+/** Same keys in the same multiset, order ignored. */
+function sameKeys(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const counts = new Map<string, number>();
+  for (const key of a) counts.set(key, (counts.get(key) ?? 0) + 1);
+  for (const key of b) {
+    const left = counts.get(key);
+    if (!left) return false;
+    counts.set(key, left - 1);
+  }
+  return true;
+}
+
 interface PinnedModelsState {
   pinned: string[];
   togglePinned: (repoId: string, quant?: string) => void;
+  /**
+   * Move `fromKey` into `toKey`'s slot. Both keys must already be pinned;
+   * anything else is a no-op. Outside a drag session the new order is
+   * persisted immediately, inside one it is held until `endPinnedDrag`.
+   */
   movePinned: (fromKey: string, toKey: string) => void;
+  /** Snapshot the current order so a cancelled drag can be undone. */
+  beginPinnedDrag: () => void;
+  /**
+   * End a drag session. `commit` persists the reordered list; otherwise the
+   * snapshot taken by `beginPinnedDrag` is restored. Idempotent, because drop
+   * is followed by dragend and only the first of the two may decide.
+   */
+  endPinnedDrag: (commit: boolean) => void;
 }
 
 export const usePinnedModelsStore = create<PinnedModelsState>((set) => ({
@@ -86,8 +125,32 @@ export const usePinnedModelsStore = create<PinnedModelsState>((set) => ({
       if (from < 0 || to < 0 || from === to) return state;
       const next = [...state.pinned];
       next.splice(to, 0, ...next.splice(from, 1));
-      writePinned(next);
+      if (dragSnapshot === null) writePinned(next);
       return { pinned: next };
+    }),
+  beginPinnedDrag: () =>
+    set((state) => {
+      dragSnapshot = [...state.pinned];
+      return state;
+    }),
+  endPinnedDrag: (commit) =>
+    set((state) => {
+      const snapshot = dragSnapshot;
+      dragSnapshot = null;
+      if (snapshot === null) return state;
+      if (commit) {
+        // Nothing moved, so there is nothing to persist.
+        if (sameOrder(snapshot, state.pinned)) return state;
+        writePinned(state.pinned);
+        return state;
+      }
+      // Another window may have rewritten the list mid-drag via the storage
+      // listener below. Restoring a snapshot that no longer describes the same
+      // set of pins would resurrect pins the user just removed elsewhere, so
+      // the newer list wins and only a pure reorder is rolled back.
+      if (!sameKeys(snapshot, state.pinned)) return state;
+      if (sameOrder(snapshot, state.pinned)) return state;
+      return { pinned: snapshot };
     }),
 }));
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/pinned-models.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pinned-models.ts
@@ -69,21 +69,17 @@ function writePinned(pinned: string[]): void {
 // restores the snapshot when the drag ends without one.
 let dragSnapshot: string[] | null = null;
 
+// Another window can rewrite the whole list mid-drag through the storage
+// listener below, which makes the snapshot stale: it describes an order that is
+// no longer in localStorage. Rolling back to it would leave this window
+// disagreeing with the record silently, since a cancel writes nothing, and the
+// next write from here would persist that stale order over the other window's
+// change. So the listener records the order it installed and the session falls
+// back to that instead. Null unless a storage event landed inside the session.
+let dragExternalOrder: string[] | null = null;
+
 function sameOrder(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((key, index) => key === b[index]);
-}
-
-/** Same keys in the same multiset, order ignored. */
-function sameKeys(a: readonly string[], b: readonly string[]): boolean {
-  if (a.length !== b.length) return false;
-  const counts = new Map<string, number>();
-  for (const key of a) counts.set(key, (counts.get(key) ?? 0) + 1);
-  for (const key of b) {
-    const left = counts.get(key);
-    if (!left) return false;
-    counts.set(key, left - 1);
-  }
-  return true;
 }
 
 interface PinnedModelsState {
@@ -131,33 +127,41 @@ export const usePinnedModelsStore = create<PinnedModelsState>((set) => ({
   beginPinnedDrag: () =>
     set((state) => {
       dragSnapshot = [...state.pinned];
+      dragExternalOrder = null;
       return state;
     }),
   endPinnedDrag: (commit) =>
     set((state) => {
       const snapshot = dragSnapshot;
+      const external = dragExternalOrder;
       dragSnapshot = null;
+      dragExternalOrder = null;
       if (snapshot === null) return state;
+      // What this window and localStorage last agreed on: the order another
+      // window installed mid-drag if there was one, else the pre-drag snapshot.
+      const base = external ?? snapshot;
       if (commit) {
-        // Nothing moved, so there is nothing to persist.
-        if (sameOrder(snapshot, state.pinned)) return state;
+        // Nothing moved on top of that, so there is nothing to persist.
+        if (sameOrder(base, state.pinned)) return state;
         writePinned(state.pinned);
         return state;
       }
-      // Another window may have rewritten the list mid-drag via the storage
-      // listener below. Restoring a snapshot that no longer describes the same
-      // set of pins would resurrect pins the user just removed elsewhere, so
-      // the newer list wins and only a pure reorder is rolled back.
-      if (!sameKeys(snapshot, state.pinned)) return state;
-      if (sameOrder(snapshot, state.pinned)) return state;
-      return { pinned: snapshot };
+      // A cancel writes nothing, so it has to land on the order that is already
+      // in localStorage. That is the snapshot for an ordinary drag and the
+      // other window's list when one landed mid-drag, whatever it did to the
+      // keys; the moves this drag previewed on top of it are dropped either way.
+      if (sameOrder(base, state.pinned)) return state;
+      return { pinned: base };
     }),
 }));
 
 if (typeof window !== "undefined") {
   window.addEventListener("storage", (event) => {
     if (event.key === KEY || event.key === null) {
-      usePinnedModelsStore.setState({ pinned: readPinned() });
+      const next = readPinned();
+      // A drag in flight rolls back to this instead of its own snapshot.
+      if (dragSnapshot !== null) dragExternalOrder = next;
+      usePinnedModelsStore.setState({ pinned: next });
     }
   });
 }

--- a/studio/frontend/tests/helpers/kit.ts
+++ b/studio/frontend/tests/helpers/kit.ts
@@ -28,10 +28,14 @@ export type StorageFake = {
 /**
  * An in-memory localStorage, installed on globalThis under both names the app reads it
  * by. The returned map is the backing store, so a test can stage records before import.
+ *
+ * The window it installs keeps the listeners registered against it, so `fireWindowEvent`
+ * can deliver a cross-tab "storage" event to a store that subscribed on construction.
  */
 export function installLocalStorageFake(): {
   store: Map<string, string>;
   storage: StorageFake;
+  fireWindowEvent: (type: string, event: unknown) => number;
 } {
   const store = new Map<string, string>();
   const storage: StorageFake = {
@@ -43,18 +47,36 @@ export function installLocalStorageFake(): {
       store.delete(key);
     },
   };
+  const listeners = new Map<string, Set<(event: unknown) => void>>();
   Object.assign(globalThis, {
     // A location too: lib/api-base reads its protocol, pulled in transitively.
     // Stores that sync across tabs subscribe to "storage" on construction.
     window: {
       localStorage: storage,
       location: { protocol: "http:" },
-      addEventListener: () => undefined,
-      removeEventListener: () => undefined,
+      addEventListener: (type: string, fn: (event: unknown) => void) => {
+        const set = listeners.get(type) ?? new Set<(event: unknown) => void>();
+        set.add(fn);
+        listeners.set(type, set);
+      },
+      removeEventListener: (type: string, fn: (event: unknown) => void) => {
+        listeners.get(type)?.delete(fn);
+      },
     },
     localStorage: storage,
   });
-  return { store, storage };
+  return {
+    store,
+    storage,
+    /** Deliver `event` to every window listener for `type`. Returns how many ran. */
+    fireWindowEvent: (type: string, event: unknown) => {
+      const set = listeners.get(type);
+      for (const fn of set ?? []) {
+        fn(event);
+      }
+      return set?.size ?? 0;
+    },
+  };
 }
 
 /** The chat-runtime store as it stands before anything has hydrated it. */

--- a/studio/frontend/tests/pinned-models-reorder.test.ts
+++ b/studio/frontend/tests/pinned-models-reorder.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { usePinnedModelsStore } = await import(
+  "../src/features/model-picker/components/model-selector/pinned-models.ts"
+);
+
+function setPinned(pinned: string[]) {
+  usePinnedModelsStore.setState({ pinned });
+}
+
+test("movePinned moves a key before a later key", () => {
+  setPinned(["a", "b", "c", "d"]);
+  usePinnedModelsStore.getState().movePinned("a", "c");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "b",
+    "c",
+    "a",
+    "d",
+  ]);
+});
+
+test("movePinned moves a key back to an earlier position", () => {
+  setPinned(["a", "b", "c", "d"]);
+  usePinnedModelsStore.getState().movePinned("d", "b");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "a",
+    "d",
+    "b",
+    "c",
+  ]);
+});
+
+test("movePinned ignores unknown keys and self-moves", () => {
+  setPinned(["a", "b"]);
+  usePinnedModelsStore.getState().movePinned("missing", "a");
+  usePinnedModelsStore.getState().movePinned("a", "missing");
+  usePinnedModelsStore.getState().movePinned("a", "a");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a", "b"]);
+});
+
+test("movePinned keeps keys not shown in the current view in place", () => {
+  // A dataset pin ("hidden") sits between model pins; moving models around it
+  // must not lose or reorder it relative to untouched neighbours.
+  setPinned(["m1", "hidden", "m2", "m3"]);
+  usePinnedModelsStore.getState().movePinned("m3", "m1");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "m3",
+    "m1",
+    "hidden",
+    "m2",
+  ]);
+});

--- a/studio/frontend/tests/pinned-models-reorder.test.ts
+++ b/studio/frontend/tests/pinned-models-reorder.test.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import { installLocalStorageFake, registerBundlerResolver } from "./helpers/kit.ts";
@@ -467,4 +468,36 @@ test("a storage event with no drag in flight just replaces the list", () => {
   store.movePinned("c", "b");
   store.endPinnedDrag(false);
   assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "a", "b"]);
+});
+
+// Pin keys carry no repo type, and model and dataset repos are separate
+// namespaces on the Hub, so one id can name both (huggingface/documentation-images,
+// nvidia/PhysicalAI-Robotics-GR00T-X-Embodiment-Sim). An on-device dataset whose
+// repoId also names a pinned model therefore lands in the hub's Pinned grid. The
+// row menu offers datasets no pin action, so the drag must not offer one either,
+// or dragging dataset rows persistently reorders the user's model pins.
+test("the hub's pinned grid never makes a dataset row draggable", async () => {
+  const lists = await readFile(
+    new URL(
+      "../src/features/hub/catalog/models-catalog-lists.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(
+    lists,
+    /const itemPinKey =\s*!isDataset &&\s*item\.row\.repoId &&\s*pinnedSet\.has\(pinKey\(item\.row\.repoId\)\)/,
+  );
+  // The invariant the gate keeps: the row menu withholds pin/unpin for datasets.
+  const rows = await readFile(
+    new URL(
+      "../src/features/hub/catalog/models-catalog-rows.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(
+    rows,
+    /pin=\{\s*isDataset \|\| !deletableRepoId\s*\?\s*undefined/,
+  );
 });

--- a/studio/frontend/tests/pinned-models-reorder.test.ts
+++ b/studio/frontend/tests/pinned-models-reorder.test.ts
@@ -4,16 +4,28 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { registerBundlerResolver } from "./helpers/kit.ts";
+import { installLocalStorageFake, registerBundlerResolver } from "./helpers/kit.ts";
 
 registerBundlerResolver();
 
-const { usePinnedModelsStore } = await import(
+// Installed before the import so the store hydrates from it and its writes land
+// somewhere the persistence cases below can read back.
+const { store: storageStore } = installLocalStorageFake();
+
+const { pinKey, usePinnedModelsStore } = await import(
   "../src/features/model-picker/components/model-selector/pinned-models.ts"
 );
 
+const STORAGE_KEY = "unsloth_pinned_models";
+
 function setPinned(pinned: string[]) {
   usePinnedModelsStore.setState({ pinned });
+  storageStore.clear();
+}
+
+function storedPinned(): string[] | null {
+  const raw = storageStore.get(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
 }
 
 test("movePinned moves a key before a later key", () => {
@@ -46,9 +58,13 @@ test("movePinned ignores unknown keys and self-moves", () => {
   assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a", "b"]);
 });
 
-test("movePinned keeps keys not shown in the current view in place", () => {
-  // A dataset pin ("hidden") sits between model pins; moving models around it
-  // must not lose or reorder it relative to untouched neighbours.
+test("movePinned keeps keys not shown in the current view in relative order", () => {
+  // The pinned list is one global order shared by the hub's On Device list and
+  // the model selector's Pinned section, and the hub only ever shows the repo
+  // keys. A quant pin the hub cannot show ("hidden") therefore has to survive a
+  // hub reorder. It keeps its position relative to every pin the drag did not
+  // touch, which is not the same as keeping its index: one key moving past it
+  // necessarily shifts it by one slot.
   setPinned(["m1", "hidden", "m2", "m3"]);
   usePinnedModelsStore.getState().movePinned("m3", "m1");
   assert.deepEqual(usePinnedModelsStore.getState().pinned, [
@@ -57,4 +73,240 @@ test("movePinned keeps keys not shown in the current view in place", () => {
     "hidden",
     "m2",
   ]);
+});
+
+test("movePinned leaves every untouched key in its original relative order", () => {
+  // The invariant behind the case above, stated directly: exactly one key moves.
+  const before = ["a", "b::Q4_K_M", "c", "d::Q8_0", "e"];
+  setPinned([...before]);
+  usePinnedModelsStore.getState().movePinned("e", "b::Q4_K_M");
+  const after = usePinnedModelsStore.getState().pinned;
+  assert.deepEqual([...after].sort(), [...before].sort(), "no key is lost");
+  const untouched = before.filter((key) => key !== "e");
+  assert.deepEqual(
+    after.filter((key) => key !== "e"),
+    untouched,
+    "the keys the drag did not touch keep their order",
+  );
+});
+
+// --- the drop convention ---------------------------------------------------
+// The dragged cell lands in the slot the pointer is over, which is what makes
+// reorder-on-dragenter stable: after the move the pointer sits on the dragged
+// cell itself, so the next dragenter is a self-move and does nothing. Getting
+// there means a forward drag inserts AFTER the target and a backward drag
+// inserts BEFORE it, so both are pinned down here on purpose.
+
+test("dragging forward puts the moved key after the target", () => {
+  setPinned(["a", "b", "c", "d"]);
+  usePinnedModelsStore.getState().movePinned("a", "c");
+  const after = usePinnedModelsStore.getState().pinned;
+  assert.deepEqual(after, ["b", "c", "a", "d"]);
+  assert.equal(after.indexOf("a"), 2, "the moved key takes the target's index");
+});
+
+test("dragging backward puts the moved key before the target", () => {
+  setPinned(["a", "b", "c", "d"]);
+  usePinnedModelsStore.getState().movePinned("d", "b");
+  const after = usePinnedModelsStore.getState().pinned;
+  assert.deepEqual(after, ["a", "d", "b", "c"]);
+  assert.equal(after.indexOf("d"), 1, "the moved key takes the target's index");
+});
+
+test("moving onto an adjacent key swaps the two, in either direction", () => {
+  setPinned(["a", "b", "c"]);
+  usePinnedModelsStore.getState().movePinned("a", "b");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["b", "a", "c"]);
+  usePinnedModelsStore.getState().movePinned("c", "a");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["b", "c", "a"]);
+});
+
+test("moving to the first and last key reaches both ends", () => {
+  setPinned(["a", "b", "c"]);
+  usePinnedModelsStore.getState().movePinned("c", "a");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "a", "b"]);
+  usePinnedModelsStore.getState().movePinned("c", "b");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a", "b", "c"]);
+});
+
+// --- degenerate inputs -----------------------------------------------------
+
+test("movePinned on an empty or single-entry list is inert", () => {
+  setPinned([]);
+  usePinnedModelsStore.getState().movePinned("a", "b");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, []);
+  setPinned(["a"]);
+  usePinnedModelsStore.getState().movePinned("a", "a");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a"]);
+});
+
+test("movePinned with both keys missing changes nothing", () => {
+  setPinned(["a", "b"]);
+  usePinnedModelsStore.getState().movePinned("x", "y");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a", "b"]);
+});
+
+test("a duplicated key in stored order does not lose an entry", () => {
+  // readPinned takes localStorage at its word, so a list written by an older
+  // build can hold the same key twice. Moving it must still leave the list
+  // well formed rather than dropping one of the copies.
+  setPinned(["a", "b", "a"]);
+  usePinnedModelsStore.getState().movePinned("a", "b");
+  const after = usePinnedModelsStore.getState().pinned;
+  assert.equal(after.length, 3);
+  assert.equal(after.filter((key) => key === "a").length, 2);
+  assert.equal(after.filter((key) => key === "b").length, 1);
+});
+
+// --- key shapes ------------------------------------------------------------
+
+test("a quant pin reorders like any other key", () => {
+  setPinned(["r1::Q4_K_M", "r2", "r3"]);
+  usePinnedModelsStore.getState().movePinned("r3", "r1::Q4_K_M");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "r3",
+    "r1::Q4_K_M",
+    "r2",
+  ]);
+});
+
+test("a repo key never moves a pin that was stored per quant", () => {
+  // The hub's On Device list keys its cells by repo id alone, so a repo that is
+  // only pinned per quant is not in its Pinned section at all and no repo-keyed
+  // drag can reach it. Asserted so the two surfaces cannot drift apart quietly.
+  setPinned(["r1::Q4_K_M", "r2"]);
+  usePinnedModelsStore.getState().movePinned(pinKey("r1"), "r2");
+  usePinnedModelsStore.getState().movePinned("r2", pinKey("r1"));
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["r1::Q4_K_M", "r2"]);
+});
+
+// --- persistence -----------------------------------------------------------
+
+test("a move persists the new order, and a no-op writes nothing", () => {
+  setPinned(["a", "b", "c"]);
+  assert.equal(storedPinned(), null, "no write before the move");
+  usePinnedModelsStore.getState().movePinned("c", "a");
+  assert.deepEqual(storedPinned(), ["c", "a", "b"]);
+
+  setPinned(["a", "b", "c"]);
+  usePinnedModelsStore.getState().movePinned("a", "a");
+  usePinnedModelsStore.getState().movePinned("a", "missing");
+  assert.equal(storedPinned(), null, "a rejected move must not touch storage");
+});
+
+// --- drag sessions ---------------------------------------------------------
+// A drag reorders live on every dragenter, so the store holds those moves in
+// memory and either commits once on drop or rolls back to the snapshot taken at
+// dragstart. Without that, a drag cancelled with Escape or released outside the
+// grid stayed applied and was already written to localStorage.
+
+test("a cancelled drag restores the order it started from", () => {
+  setPinned(["a", "b", "c", "d"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("a", "b");
+  store.movePinned("a", "c");
+  assert.deepEqual(
+    usePinnedModelsStore.getState().pinned,
+    ["b", "c", "a", "d"],
+    "the live preview still moves during the drag",
+  );
+  store.endPinnedDrag(false);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a", "b", "c", "d"]);
+});
+
+test("a cancelled drag leaves localStorage untouched", () => {
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("a", "c");
+  assert.equal(storedPinned(), null, "no write while the drag is in flight");
+  store.endPinnedDrag(false);
+  assert.equal(storedPinned(), null);
+});
+
+test("a dropped drag commits the new order exactly once", () => {
+  setPinned(["a", "b", "c", "d"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("d", "c");
+  store.movePinned("d", "b");
+  store.movePinned("d", "a");
+  assert.equal(storedPinned(), null, "the preview moves do not persist");
+  store.endPinnedDrag(true);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "d",
+    "a",
+    "b",
+    "c",
+  ]);
+  assert.deepEqual(storedPinned(), ["d", "a", "b", "c"]);
+});
+
+test("endPinnedDrag is idempotent, so dragend after drop cannot undo it", () => {
+  // The browser fires drop and then dragend on the source. The drop commits and
+  // closes the session; the dragend that follows must not roll anything back.
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("c", "a");
+  store.endPinnedDrag(true);
+  store.endPinnedDrag(false);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "a", "b"]);
+  assert.deepEqual(storedPinned(), ["c", "a", "b"]);
+});
+
+test("ending a drag that never moved anything writes nothing", () => {
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.endPinnedDrag(true);
+  assert.equal(storedPinned(), null);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a", "b", "c"]);
+});
+
+test("endPinnedDrag without a session in flight is inert", () => {
+  setPinned(["a", "b"]);
+  usePinnedModelsStore.getState().endPinnedDrag(false);
+  usePinnedModelsStore.getState().endPinnedDrag(true);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a", "b"]);
+  assert.equal(storedPinned(), null);
+});
+
+test("outside a drag session movePinned still persists on every call", () => {
+  // The store is shared with surfaces that have no drag at all, so the plain
+  // call has to keep writing through.
+  setPinned(["a", "b", "c"]);
+  usePinnedModelsStore.getState().movePinned("a", "b");
+  assert.deepEqual(storedPinned(), ["b", "a", "c"]);
+});
+
+test("a pin added in another window mid-drag survives a cancel", () => {
+  // pinned-models installs a window "storage" listener that replaces the list
+  // wholesale. If that lands mid-drag the snapshot no longer describes the same
+  // set of pins, and restoring it would resurrect a pin the user just removed
+  // or drop one they just added. The newer list wins instead.
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("a", "c");
+  usePinnedModelsStore.setState({ pinned: ["b", "c", "a", "new"] });
+  store.endPinnedDrag(false);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "b",
+    "c",
+    "a",
+    "new",
+  ]);
+});
+
+test("a cancel rolls back even when a same-set write landed mid-drag", () => {
+  // Same keys, different order: that is a pure reorder, so the rollback is safe
+  // and the drag the user abandoned leaves nothing behind.
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("a", "c");
+  store.endPinnedDrag(false);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a", "b", "c"]);
 });

--- a/studio/frontend/tests/pinned-models-reorder.test.ts
+++ b/studio/frontend/tests/pinned-models-reorder.test.ts
@@ -10,7 +10,7 @@ registerBundlerResolver();
 
 // Installed before the import so the store hydrates from it and its writes land
 // somewhere the persistence cases below can read back.
-const { store: storageStore } = installLocalStorageFake();
+const { store: storageStore, fireWindowEvent } = installLocalStorageFake();
 
 const { pinKey, usePinnedModelsStore } = await import(
   "../src/features/model-picker/components/model-selector/pinned-models.ts"
@@ -26,6 +26,25 @@ function setPinned(pinned: string[]) {
 function storedPinned(): string[] | null {
   const raw = storageStore.get(STORAGE_KEY);
   return raw ? JSON.parse(raw) : null;
+}
+
+/**
+ * Another Studio window rewriting the pin list: the record changes underneath
+ * this window and a "storage" event follows, which is the only way the list can
+ * change without this window's store doing it. Goes through the real listener,
+ * so what the store learns is exactly what a second window would teach it.
+ */
+function externalWrite(pinned: string[], key: string | null = STORAGE_KEY) {
+  storageStore.set(STORAGE_KEY, JSON.stringify(pinned));
+  if (fireWindowEvent("storage", { key }) !== 1) {
+    // Otherwise every case below would pass by doing nothing at all.
+    throw new Error("the store did not subscribe to storage on construction");
+  }
+}
+
+/** Forget the record without touching the store, so a later write is visible. */
+function forgetStoredWrites() {
+  storageStore.delete(STORAGE_KEY);
 }
 
 test("movePinned moves a key before a later key", () => {
@@ -281,16 +300,21 @@ test("outside a drag session movePinned still persists on every call", () => {
   assert.deepEqual(storedPinned(), ["b", "a", "c"]);
 });
 
+// --- another window writing mid-drag ---------------------------------------
+// pinned-models installs a window "storage" listener that replaces the list
+// wholesale, so a second Studio window can rewrite the order underneath a drag
+// that is still in flight. A snapshot taken before that write no longer
+// describes what is in localStorage, so restoring it would put this window out
+// of step with the record and the next write from here would clobber the other
+// window's change. Whenever a storage event lands mid-drag the order it
+// installed is what the session falls back to, whatever it did to the keys.
+
 test("a pin added in another window mid-drag survives a cancel", () => {
-  // pinned-models installs a window "storage" listener that replaces the list
-  // wholesale. If that lands mid-drag the snapshot no longer describes the same
-  // set of pins, and restoring it would resurrect a pin the user just removed
-  // or drop one they just added. The newer list wins instead.
   setPinned(["a", "b", "c"]);
   const store = usePinnedModelsStore.getState();
   store.beginPinnedDrag();
   store.movePinned("a", "c");
-  usePinnedModelsStore.setState({ pinned: ["b", "c", "a", "new"] });
+  externalWrite(["b", "c", "a", "new"]);
   store.endPinnedDrag(false);
   assert.deepEqual(usePinnedModelsStore.getState().pinned, [
     "b",
@@ -298,15 +322,149 @@ test("a pin added in another window mid-drag survives a cancel", () => {
     "a",
     "new",
   ]);
+  assert.deepEqual(storedPinned(), ["b", "c", "a", "new"], "and no write back");
 });
 
-test("a cancel rolls back even when a same-set write landed mid-drag", () => {
-  // Same keys, different order: that is a pure reorder, so the rollback is safe
-  // and the drag the user abandoned leaves nothing behind.
+test("a pin removed in another window mid-drag stays removed after a cancel", () => {
+  // The mirror image: rolling the snapshot back would resurrect "b".
   setPinned(["a", "b", "c"]);
   const store = usePinnedModelsStore.getState();
   store.beginPinnedDrag();
   store.movePinned("a", "c");
+  externalWrite(["c", "a"]);
+  store.endPinnedDrag(false);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "a"]);
+  assert.deepEqual(storedPinned(), ["c", "a"]);
+});
+
+test("a reorder in another window mid-drag survives a cancel", () => {
+  // Same keys, different order. The pre-drag snapshot is just as stale here as
+  // it is when the key set changed: localStorage holds the other window's
+  // order, so restoring the snapshot would leave this window disagreeing with
+  // the record while writing nothing to say so.
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("a", "c");
+  externalWrite(["c", "b", "a"]);
+  assert.deepEqual(
+    usePinnedModelsStore.getState().pinned,
+    ["c", "b", "a"],
+    "the storage listener replaces the list mid-drag",
+  );
+  store.endPinnedDrag(false);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "b", "a"]);
+  assert.deepEqual(storedPinned(), ["c", "b", "a"], "and no write back");
+});
+
+test("a cancel after another window reordered cannot clobber it on the next pin", () => {
+  // Why the case above matters: nothing is lost at the moment of the rollback,
+  // since a cancel writes nothing. The damage lands on the next write from this
+  // window, which persists the whole list.
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("a", "c");
+  externalWrite(["c", "b", "a"]);
+  store.endPinnedDrag(false);
+  usePinnedModelsStore.getState().togglePinned("d");
+  assert.deepEqual(storedPinned(), ["d", "c", "b", "a"]);
+});
+
+test("a drag cancelled after another window wrote drops its own preview too", () => {
+  // The moves made after the storage event are still just a preview, and the
+  // user abandoned them. Falling back to the order the other window installed
+  // discards them without writing anything.
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  externalWrite(["c", "b", "a"]);
+  store.movePinned("c", "a");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["b", "a", "c"]);
+  store.endPinnedDrag(false);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "b", "a"]);
+  assert.deepEqual(storedPinned(), ["c", "b", "a"]);
+});
+
+test("a drop after another window wrote mid-drag commits what is on screen", () => {
+  // A drop is the user saying they meant it, so the last writer wins, but it
+  // wins on top of the other window's list rather than the stale snapshot.
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("a", "b");
+  externalWrite(["c", "b", "a", "new"]);
+  store.movePinned("new", "c");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "new",
+    "c",
+    "b",
+    "a",
+  ]);
+  store.endPinnedDrag(true);
+  assert.deepEqual(storedPinned(), ["new", "c", "b", "a"]);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "new",
+    "c",
+    "b",
+    "a",
+  ]);
+});
+
+test("a drop that only re-applies another window's order writes nothing", () => {
+  // The storage event already put that order in localStorage. "Nothing moved"
+  // is measured against it, not against the snapshot from before it landed.
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("a", "c");
+  externalWrite(["c", "b", "a"]);
+  forgetStoredWrites();
+  store.endPinnedDrag(true);
+  assert.equal(storedPinned(), null, "no redundant write");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "b", "a"]);
+});
+
+test("a storage event for another key does not look like a cross-window pin write", () => {
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("a", "c");
+  fireWindowEvent("storage", { key: "unsloth_something_else" });
+  assert.deepEqual(
+    usePinnedModelsStore.getState().pinned,
+    ["b", "c", "a"],
+    "the listener ignores it",
+  );
   store.endPinnedDrag(false);
   assert.deepEqual(usePinnedModelsStore.getState().pinned, ["a", "b", "c"]);
+});
+
+test("a cross-window write is only remembered for the drag it landed in", () => {
+  // The next drag starts from a clean session, so an ordinary cancel after one
+  // that saw a storage event still rolls back.
+  setPinned(["a", "b", "c"]);
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  externalWrite(["c", "b", "a"]);
+  store.endPinnedDrag(false);
+  storageStore.clear();
+
+  store.beginPinnedDrag();
+  store.movePinned("c", "a");
+  store.endPinnedDrag(false);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "b", "a"]);
+  assert.equal(storedPinned(), null);
+});
+
+test("a storage event with no drag in flight just replaces the list", () => {
+  setPinned(["a", "b", "c"]);
+  externalWrite(["c", "a", "b"]);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "a", "b"]);
+  // And it becomes the order the next drag snapshots and rolls back to.
+  const store = usePinnedModelsStore.getState();
+  store.beginPinnedDrag();
+  store.movePinned("c", "b");
+  store.endPinnedDrag(false);
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, ["c", "a", "b"]);
 });


### PR DESCRIPTION
Implements #8537. Pinned models in the hub's On Device list can now be reordered by dragging one pin onto another. Order lives in the existing pinned-models store (an ordered array in localStorage), so the model selector's pinned section follows the same order automatically. Native HTML5 drag and drop no new dependencies. Closes #8537