### PR TITLE
Match a custom provider's max output cap on the model id

### DIFF
--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { providerModelSupportsStudioTools } from "./external-providers";
+import {
+  LEGACY_CUSTOM_PROVIDER_TYPE,
+  providerModelSupportsStudioTools,
+} from "./external-providers";
 
 /**
  * Per-provider sampling parameter capability matrix.
@@ -156,8 +159,15 @@ export function getExternalMaxOutputTokens(
         : providerType;
   if (effectiveProvider === "openai_codex") return 128000;
 
+  // A custom OpenAI-compatible connection has no provider of its own, so the
+  // model id is the only signal there is. Matching it against every family the
+  // way an OpenRouter id is mapped beats falling back to the generic cap for a
+  // model we do know: `deepseek-v4-flash` behind a custom endpoint is still a
+  // DeepSeek model.
+  const matchOnModelIdAlone = effectiveProvider === LEGACY_CUSTOM_PROVIDER_TYPE;
+
   for (const entry of EXTERNAL_MAX_OUTPUT_TOKENS_BY_MODEL) {
-    if (entry.providerType !== effectiveProvider) continue;
+    if (!matchOnModelIdAlone && entry.providerType !== effectiveProvider) continue;
     if (entry.prefixes.some((prefix) => stripped.startsWith(prefix))) {
       return entry.cap;
     }

--- a/studio/frontend/tests/provider-capabilities-current-models.test.ts
+++ b/studio/frontend/tests/provider-capabilities-current-models.test.ts
@@ -134,3 +134,27 @@ test("new Anthropic and OpenAI ids keep their max-output cap and code pill", () 
     true,
   );
 });
+
+test("a custom OpenAI-compatible provider gets the family cap for a known model id", () => {
+  // A custom connection resolves to the legacy "custom" provider type, which
+  // matches no row in the cap table, so every model behind it used to fall back
+  // to the generic 32k even when the id names a family we have a cap for.
+  assert.equal(getExternalMaxOutputTokens("custom", "deepseek-v4-flash"), 384000);
+  assert.equal(getExternalMaxOutputTokens("custom", "deepseek-chat"), 384000);
+  assert.equal(getExternalMaxOutputTokens("custom", "gpt-5.5"), 128000);
+  assert.equal(getExternalMaxOutputTokens("custom", "claude-opus-5"), 128000);
+  assert.equal(getExternalMaxOutputTokens("custom", "gemini-3-pro"), 65536);
+});
+
+test("a custom provider serving an unknown model still gets the generic cap", () => {
+  assert.equal(getExternalMaxOutputTokens("custom", "my-finetune-v1"), 32768);
+  assert.equal(getExternalMaxOutputTokens("custom", ""), 32768);
+});
+
+test("first-party providers still gate on their own provider type", () => {
+  // deepseek's 384k row must not leak into another provider that happens to
+  // serve a similarly named model.
+  assert.equal(getExternalMaxOutputTokens("openai", "deepseek-v4-flash"), 32768);
+  assert.equal(getExternalMaxOutputTokens("anthropic", "gpt-5.5"), 32768);
+  assert.equal(getExternalMaxOutputTokens("gemini", "claude-opus-5"), 32768);
+});


### PR DESCRIPTION
Closes #8509.

## The bug

`getExternalMaxOutputTokens` gates every row of the cap table on `providerType`:

```ts
for (const entry of EXTERNAL_MAX_OUTPUT_TOKENS_BY_MODEL) {
  if (entry.providerType !== effectiveProvider) continue;
  ...
}
return EXTERNAL_MAX_OUTPUT_TOKENS;   // 32768
```

A custom OpenAI-compatible connection resolves to `LEGACY_CUSTOM_PROVIDER_TYPE` (`"custom"`) whenever its display name or base URL differs from the built-in OpenAI row, which `resolveProviderType` in `sync-external-providers.ts` decides. `"custom"` matches no row in the table, so the loop can only ever fall through and every model behind that connection is capped at 32k, including ones we have a documented cap for.

The reporter's case: `providerType = "custom"`, `modelId = "deepseek-v4-flash"`, and the table has `{ providerType: "deepseek", prefixes: ["deepseek"], cap: 384000 }`. The id matches the family, the provider type does not, so the Max Tokens slider stops at 32768.

## Fix

Drop the provider gate for that one provider type and match on the model id alone. That is the same treatment an OpenRouter id already gets through `_inferProviderFromOpenrouterId`: the id is the only signal a pass-through connection carries, so use it.

First-party providers keep the gate, so one family's cap cannot leak into another. An unknown id behind a custom endpoint still falls back to the generic 32k.

## Tests

Three added to `tests/provider-capabilities-current-models.test.ts`:

- a custom provider gets the family cap for a known id, across DeepSeek, OpenAI, Anthropic and Gemini
- a custom provider serving an unknown id, and an empty id, still get the generic cap
- first-party providers still gate on their own type, so `getExternalMaxOutputTokens("openai", "deepseek-v4-flash")` stays 32768

```
                                                              before   after
a custom OpenAI-compatible provider gets the family cap        FAIL     pass
a custom provider serving an unknown model gets the generic     pass     pass
first-party providers still gate on their own provider type     pass     pass
```

`node --experimental-strip-types --test tests/provider-capabilities-current-models.test.ts` gives 10 passed / 1 failed against `main` and 11 passed with this change.

The whole frontend suite: 1574 passed / 51 failed on a clean tree, 1577 passed / 51 failed with this change, so the three added tests are the only difference and the 51 are pre-existing.

## One question rather than a decision

The same reasoning applies to the `CUSTOM_PROVIDER_PRESETS` types (`llama_cpp`, `vllm`, `ollama`), which are also absent from the table and also fall back to 32k. I left them alone because a local server's real ceiling is its own `--n-predict` or context budget rather than the hosted family's, so inheriting a 384k cap there felt like the wrong default rather than a fix. Happy to extend it if you would rather all pass-through types behaved the same.
