### PR TITLE
Add multimodal (vision) embedding fine-tuning to FastSentenceTransformer

### DIFF
--- a/scripts/qwen3_vl_embedding_finetune.py
+++ b/scripts/qwen3_vl_embedding_finetune.py
@@ -15,8 +15,9 @@ How it works
 Pooling layer and accepts ``pixel_values`` / ``image_grid_thw``) and swaps in an
 ``AutoProcessor`` so images become ``pixel_values``. Training rides on the stock
 ``SentenceTransformerTrainer`` + ``MultipleNegativesRankingLoss`` (in-batch negatives,
-i.e. InfoNCE); sentence-transformers' own multimodal data collator tokenizes each
-column through the processor, so no custom collator is needed.
+i.e. InfoNCE); ``SentenceTransformerDataCollator`` hands each column to
+``model.preprocess``, and the module's ``modality_config`` routes
+``{"image": ..., "text": ...}`` through the processor, so no custom collator is needed.
 
 Requirements: a CUDA GPU, ``sentence-transformers>=5.4``, ``transformers>=4.57``.
 

--- a/scripts/qwen3_vl_embedding_finetune.py
+++ b/scripts/qwen3_vl_embedding_finetune.py
@@ -53,11 +53,17 @@ def build_dataset() -> Dataset:
     return Dataset.from_list(
         [
             {
-                "anchor": {"image": "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba", "text": "a photo of a cat"},
+                "anchor": {
+                    "image": "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba",
+                    "text": "a photo of a cat",
+                },
                 "positive": {"text": "a small domesticated feline resting"},
             },
             {
-                "anchor": {"image": "https://images.unsplash.com/photo-1543466835-00a7907e9de1", "text": "a photo of a dog"},
+                "anchor": {
+                    "image": "https://images.unsplash.com/photo-1543466835-00a7907e9de1",
+                    "text": "a photo of a dog",
+                },
                 "positive": {"text": "a domesticated canine looking at the camera"},
             },
         ]
@@ -69,53 +75,54 @@ def main() -> None:
     #    processor_kwargs forwards image-resolution controls to the processor.
     model = FastSentenceTransformer.from_pretrained(
         MODEL_ID,
-        load_in_16bit=True,
-        pooling_mode="lasttoken",  # decoder embedders pool the last token
-        processor_kwargs={"min_pixels": 28 * 28, "max_pixels": 600 * 600},
+        load_in_16bit = True,
+        pooling_mode = "lasttoken",  # decoder embedders pool the last token
+        processor_kwargs = {"min_pixels": 28 * 28, "max_pixels": 600 * 600},
     )
 
     # 2. Attach LoRA. Default finetune_vision_layers=False keeps the vision tower
     #    frozen and tunes only the language projections (cheap, common recipe).
     model = FastSentenceTransformer.get_peft_model(
         model,
-        r=8,
-        lora_alpha=16,
-        finetune_vision_layers=False,
-        finetune_language_layers=True,
+        r = 8,
+        lora_alpha = 16,
+        finetune_vision_layers = False,
+        finetune_language_layers = True,
     )
 
     dataset = build_dataset()
     loss = MultipleNegativesRankingLoss(model)  # == InfoNCE with in-batch negatives
 
     args = SentenceTransformerTrainingArguments(
-        output_dir="outputs/qwen3-vl-embedding",
-        num_train_epochs=1,
-        per_device_train_batch_size=2,
-        learning_rate=1e-4,
-        bf16=True,
-        batch_sampler=BatchSamplers.NO_DUPLICATES,  # avoid a positive as its own negative
-        logging_steps=1,
-        report_to="none",
+        output_dir = "outputs/qwen3-vl-embedding",
+        num_train_epochs = 1,
+        per_device_train_batch_size = 2,
+        learning_rate = 1e-4,
+        bf16 = True,
+        batch_sampler = BatchSamplers.NO_DUPLICATES,  # avoid a positive as its own negative
+        logging_steps = 1,
+        report_to = "none",
     )
 
     trainer = SentenceTransformerTrainer(
-        model=model,
-        args=args,
-        train_dataset=dataset,
-        loss=loss,
+        model = model,
+        args = args,
+        train_dataset = dataset,
+        loss = loss,
     )
     trainer.train()
 
     # 3. Encode a multimodal query and save merged 16-bit weights.
     query = model.encode(
-        {"image": "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba", "text": "kitten close-up"},
-        normalize_embeddings=True,
+        {
+            "image": "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba",
+            "text": "kitten close-up",
+        },
+        normalize_embeddings = True,
     )
     print("query embedding shape:", query.shape)  # -> (2048,)
 
-    model.save_pretrained_merged(
-        "outputs/qwen3-vl-embedding-merged", save_method="merged_16bit"
-    )
+    model.save_pretrained_merged("outputs/qwen3-vl-embedding-merged", save_method = "merged_16bit")
 
 
 if __name__ == "__main__":

--- a/scripts/qwen3_vl_embedding_finetune.py
+++ b/scripts/qwen3_vl_embedding_finetune.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
+"""Fine-tune a multimodal (vision) decoder embedding model with Unsloth.
+
+Example target: ``Qwen/Qwen3-VL-Embedding-2B`` (model_type ``qwen3_vl``, modules
+``Transformer -> Pooling(last-token) -> Normalize``, 2048-dim). This answers the
+feature request "Add Qwen3 VL embedding SFT notebook"
+(https://github.com/unslothai/unsloth/issues/4481).
+
+How it works
+------------
+``FastSentenceTransformer`` loads the base multimodal model via ``AutoModel`` (for
+``qwen3_vl`` that is ``Qwen3VLModel``, which returns ``last_hidden_state`` for the
+Pooling layer and accepts ``pixel_values`` / ``image_grid_thw``) and swaps in an
+``AutoProcessor`` so images become ``pixel_values``. Training rides on the stock
+``SentenceTransformerTrainer`` + ``MultipleNegativesRankingLoss`` (in-batch negatives,
+i.e. InfoNCE); sentence-transformers' own multimodal data collator tokenizes each
+column through the processor, so no custom collator is needed.
+
+Requirements: a CUDA GPU, ``sentence-transformers>=5.4``, ``transformers>=4.57``.
+
+Run:
+    python scripts/qwen3_vl_embedding_finetune.py
+"""
+
+from __future__ import annotations
+
+from datasets import Dataset
+
+from unsloth import FastSentenceTransformer
+from sentence_transformers import (
+    SentenceTransformerTrainer,
+    SentenceTransformerTrainingArguments,
+)
+from sentence_transformers.losses import MultipleNegativesRankingLoss
+from sentence_transformers.training_args import BatchSamplers
+
+
+MODEL_ID = "Qwen/Qwen3-VL-Embedding-2B"
+
+
+def build_dataset() -> Dataset:
+    """A tiny (anchor, positive) contrastive dataset.
+
+    Each column value is either a plain string or a ``{"image": ..., "text": ...}``
+    dict. ``image`` accepts a PIL image, a local path, or a URL. With
+    MultipleNegativesRankingLoss, every other row's positive acts as an in-batch
+    negative, so no explicit negatives are required. Replace these with your own
+    image/text pairs (e.g. product photo -> description, screenshot -> query).
+    """
+    return Dataset.from_list(
+        [
+            {
+                "anchor": {"image": "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba", "text": "a photo of a cat"},
+                "positive": {"text": "a small domesticated feline resting"},
+            },
+            {
+                "anchor": {"image": "https://images.unsplash.com/photo-1543466835-00a7907e9de1", "text": "a photo of a dog"},
+                "positive": {"text": "a domesticated canine looking at the camera"},
+            },
+        ]
+    )
+
+
+def main() -> None:
+    # 1. Load the VLM embedding model. Keep load_in_16bit for encoder-style speed;
+    #    processor_kwargs forwards image-resolution controls to the processor.
+    model = FastSentenceTransformer.from_pretrained(
+        MODEL_ID,
+        load_in_16bit=True,
+        pooling_mode="lasttoken",  # decoder embedders pool the last token
+        processor_kwargs={"min_pixels": 28 * 28, "max_pixels": 600 * 600},
+    )
+
+    # 2. Attach LoRA. Default finetune_vision_layers=False keeps the vision tower
+    #    frozen and tunes only the language projections (cheap, common recipe).
+    model = FastSentenceTransformer.get_peft_model(
+        model,
+        r=8,
+        lora_alpha=16,
+        finetune_vision_layers=False,
+        finetune_language_layers=True,
+    )
+
+    dataset = build_dataset()
+    loss = MultipleNegativesRankingLoss(model)  # == InfoNCE with in-batch negatives
+
+    args = SentenceTransformerTrainingArguments(
+        output_dir="outputs/qwen3-vl-embedding",
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        learning_rate=1e-4,
+        bf16=True,
+        batch_sampler=BatchSamplers.NO_DUPLICATES,  # avoid a positive as its own negative
+        logging_steps=1,
+        report_to="none",
+    )
+
+    trainer = SentenceTransformerTrainer(
+        model=model,
+        args=args,
+        train_dataset=dataset,
+        loss=loss,
+    )
+    trainer.train()
+
+    # 3. Encode a multimodal query and save merged 16-bit weights.
+    query = model.encode(
+        {"image": "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba", "text": "kitten close-up"},
+        normalize_embeddings=True,
+    )
+    print("query embedding shape:", query.shape)  # -> (2048,)
+
+    model.save_pretrained_merged(
+        "outputs/qwen3-vl-embedding-merged", save_method="merged_16bit"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test_fast_sentence_transformer_vlm_embedding.py
+++ b/tests/python/test_fast_sentence_transformer_vlm_embedding.py
@@ -28,15 +28,20 @@ import pytest
 
 
 def _import_fast_sentence_transformer():
-    """Import FastSentenceTransformer or skip. unsloth pulls in torch and may refuse to
-    import without an accelerator; treat any import-time failure as a skip so these
-    logic tests never turn a minimal runner red."""
+    """Import FastSentenceTransformer for the logic tests.
+
+    Skips ONLY when a required heavy dependency is genuinely absent -- an
+    unsupported environment, not a regression. The import of the code under test
+    is then run WITHOUT a catch-all: a syntax error, a missing symbol, or any
+    other import-time regression introduced by this change must fail these tests,
+    not silently skip them. (A previous version wrapped the import in
+    `except Exception: pytest.skip(...)`, which turned every such regression into
+    a green skip.)"""
     pytest.importorskip("torch")
     pytest.importorskip("sentence_transformers")
-    try:
-        from unsloth import FastSentenceTransformer
-    except Exception as exc:  # noqa: BLE001 - unsloth may raise NotImplementedError on CPU-only
-        pytest.skip(f"unsloth not importable in this environment: {exc}")
+    pytest.importorskip("unsloth_zoo")
+    from unsloth import FastSentenceTransformer
+
     return FastSentenceTransformer
 
 

--- a/tests/python/test_fast_sentence_transformer_vlm_embedding.py
+++ b/tests/python/test_fast_sentence_transformer_vlm_embedding.py
@@ -170,10 +170,28 @@ def test_from_pretrained_accepts_processor_kwargs():
     assert params["processor_kwargs"].default is None
 
 
+def _synthetic_image(seed):
+    """A deterministic, network-free RGB image with enough structure that two different
+    seeds cannot collapse to the same embedding."""
+    from PIL import Image
+
+    img = Image.new("RGB", (112, 112), color=(16 * seed % 256, 96, 200 - 16 * seed % 256))
+    for x in range(0, 112, 16):
+        for y in range(0, 112, 16):
+            if (x // 16 + y // 16 + seed) % 2:
+                img.paste((240, 240, 30), (x, y, x + 16, y + 16))
+    return img
+
+
 def test_vlm_embedding_matches_stock_st():
     """End-to-end parity: FastSentenceTransformer must match a stock SentenceTransformer
-    load of the same VLM embedding checkpoint, and must NOT swap in a logits-returning
-    *ForConditionalGeneration model. Opt-in + GPU-only, so default CI is unaffected."""
+    load of the same VLM embedding checkpoint on BOTH text and image inputs, and must NOT
+    swap in a logits-returning *ForConditionalGeneration model. Opt-in + GPU-only.
+
+    The image half is the point of the feature: stock sentence-transformers encodes this
+    checkpoint's images today (see its model card), so a text-only parity check would pass
+    while the vision path stays unreachable -- exactly the bug this file exists to prevent.
+    """
     model_id = os.environ.get("UNSLOTH_VLM_EMBEDDING_PARITY_MODEL")
     if not model_id:
         pytest.skip(
@@ -186,16 +204,24 @@ def test_vlm_embedding_matches_stock_st():
         pytest.skip("FastSentenceTransformer requires CUDA; skipping on CPU-only runner")
     np = pytest.importorskip("numpy")
     pytest.importorskip("sentence_transformers")
+    pytest.importorskip("PIL")
     from sentence_transformers import SentenceTransformer
 
     device = "cuda"
     dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
     texts = ["a photo of a cat", "the capital of France is Paris"]
+    image_inputs = [
+        {"image": _synthetic_image(1), "text": "a yellow checkerboard"},
+        {"image": _synthetic_image(5)},
+    ]
 
     # Control FIRST, before importing unsloth, so its global patches never touch the ref.
     ctrl = SentenceTransformer(model_id, device=device, model_kwargs={"torch_dtype": dtype})
     ctrl_emb = np.asarray(
         ctrl.encode(texts, normalize_embeddings=True, batch_size=2), dtype=np.float32
+    )
+    ctrl_img_emb = np.asarray(
+        ctrl.encode(image_inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
     )
 
     import unsloth  # noqa: F401
@@ -212,6 +238,14 @@ def test_vlm_embedding_matches_stock_st():
         f"returns logits and corrupts the Pooling layer. Expected the base model."
     )
 
+    # The processor, not the tokenizer: on sentence-transformers >= 5.4 `.tokenizer`
+    # unwraps to the inner text tokenizer either way, so it cannot detect the failure.
+    processor = fast[0].processor
+    assert hasattr(processor, "image_processor"), (
+        f"FastSentenceTransformer kept {type(processor).__name__} as the processor; a text "
+        f"tokenizer cannot turn images into pixel_values, so the vision tower is unreachable."
+    )
+
     fast_emb = np.asarray(
         fast.encode(texts, normalize_embeddings=True, batch_size=2), dtype=np.float32
     )
@@ -220,5 +254,27 @@ def test_vlm_embedding_matches_stock_st():
         np.linalg.norm(ctrl_emb, axis=1) * np.linalg.norm(fast_emb, axis=1)
     )
     assert float(cos.min()) > 0.99, (
-        f"VLM embedding parity regressed: min cosine {float(cos.min()):.5f} <= 0.99"
+        f"VLM embedding text parity regressed: min cosine {float(cos.min()):.5f} <= 0.99"
+    )
+
+    fast_img_emb = np.asarray(
+        fast.encode(image_inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
+    )
+
+    img_cos = (ctrl_img_emb * fast_img_emb).sum(1) / (
+        np.linalg.norm(ctrl_img_emb, axis=1) * np.linalg.norm(fast_img_emb, axis=1)
+    )
+    assert float(img_cos.min()) > 0.99, (
+        f"VLM image parity regressed: min cosine {float(img_cos.min()):.5f} <= 0.99"
+    )
+
+    # Two structurally different images must not collapse to the same vector -- that would
+    # mean the image is being dropped and only the prompt/text is reaching the model.
+    pair_cos = float(
+        (fast_img_emb[0] * fast_img_emb[1]).sum()
+        / (np.linalg.norm(fast_img_emb[0]) * np.linalg.norm(fast_img_emb[1]))
+    )
+    assert pair_cos < 0.999, (
+        f"Distinct images produced near-identical embeddings (cos {pair_cos:.5f}); the image "
+        f"input is not reaching the vision tower."
     )

--- a/tests/python/test_fast_sentence_transformer_vlm_embedding.py
+++ b/tests/python/test_fast_sentence_transformer_vlm_embedding.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
+"""Tests for multimodal (vision) decoder embedding support in FastSentenceTransformer
+(e.g. Qwen/Qwen3-VL-Embedding-2B).
+
+Two layers:
+- Fast, no-GPU unit tests for the VLM-detection helper and the get_peft_model vision
+  flags. They import unsloth but never touch weights, so they run wherever unsloth is
+  importable (skipped otherwise).
+- An opt-in, GPU-only end-to-end parity test (UNSLOTH_VLM_EMBEDDING_PARITY_MODEL) that
+  loads a real VLM embedding checkpoint and compares against a stock SentenceTransformer.
+
+Design note: for a VLM embedding model, FastSentenceTransformer must keep
+auto_model = AutoModel (the base model, e.g. Qwen3VLModel, returns last_hidden_state
+which the Pooling layer needs); AutoModelForImageTextToText maps to
+*ForConditionalGeneration, which returns logits and corrupts pooling. The image path is
+enabled by swapping the text tokenizer for an AutoProcessor, not by changing the model
+class.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import types
+
+import pytest
+
+
+def _import_fast_sentence_transformer():
+    """Import FastSentenceTransformer or skip. unsloth pulls in torch and may refuse to
+    import without an accelerator; treat any import-time failure as a skip so these
+    logic tests never turn a minimal runner red."""
+    pytest.importorskip("torch")
+    pytest.importorskip("sentence_transformers")
+    try:
+        from unsloth import FastSentenceTransformer
+    except Exception as exc:  # noqa: BLE001 - unsloth may raise NotImplementedError on CPU-only
+        pytest.skip(f"unsloth not importable in this environment: {exc}")
+    return FastSentenceTransformer
+
+
+def _cfg(**attrs):
+    return types.SimpleNamespace(**attrs)
+
+
+def test_is_vlm_embedding_config_detects_vision_config():
+    FastSentenceTransformer = _import_fast_sentence_transformer()
+    detect = FastSentenceTransformer._is_vlm_embedding_config
+
+    # A Qwen3-VL-Embedding-style config carries a nested vision_config.
+    assert detect(_cfg(model_type="qwen3_vl", vision_config=_cfg(depth=24))) is True
+    # Architecture-name fallback (no vision_config attribute surfaced).
+    assert detect(_cfg(architectures=["Qwen3VLForConditionalGeneration"])) is True
+
+
+def test_is_vlm_embedding_config_rejects_text_models():
+    FastSentenceTransformer = _import_fast_sentence_transformer()
+    detect = FastSentenceTransformer._is_vlm_embedding_config
+
+    assert detect(None) is False
+    # A plain decoder text embedder (e.g. Qwen3-Embedding) must NOT be treated as VLM.
+    assert detect(_cfg(model_type="qwen3", architectures=["Qwen3Model"])) is False
+    assert detect(_cfg(model_type="bert", architectures=["BertModel"])) is False
+
+
+def test_get_peft_model_exposes_vision_lora_flags():
+    FastSentenceTransformer = _import_fast_sentence_transformer()
+    params = inspect.signature(FastSentenceTransformer.get_peft_model).parameters
+
+    # Vision selectors must exist so VLM embedders can restrict LoRA to the language
+    # tower (the cheap, common contrastive-tuning recipe) by default.
+    assert params["finetune_vision_layers"].default is False
+    assert params["finetune_language_layers"].default is True
+    assert params["finetune_attention_modules"].default is True
+    assert params["finetune_mlp_modules"].default is True
+    assert params["finetune_last_n_layers"].default is None
+
+
+def test_from_pretrained_accepts_processor_kwargs():
+    FastSentenceTransformer = _import_fast_sentence_transformer()
+    params = inspect.signature(FastSentenceTransformer.from_pretrained).parameters
+    # min_pixels / max_pixels style image controls must be threadable to the processor.
+    assert "processor_kwargs" in params
+    assert params["processor_kwargs"].default is None
+
+
+def test_vlm_embedding_matches_stock_st():
+    """End-to-end parity: FastSentenceTransformer must match a stock SentenceTransformer
+    load of the same VLM embedding checkpoint, and must NOT swap in a logits-returning
+    *ForConditionalGeneration model. Opt-in + GPU-only, so default CI is unaffected."""
+    model_id = os.environ.get("UNSLOTH_VLM_EMBEDDING_PARITY_MODEL")
+    if not model_id:
+        pytest.skip(
+            "set UNSLOTH_VLM_EMBEDDING_PARITY_MODEL to a vision embedding model "
+            "(e.g. Qwen/Qwen3-VL-Embedding-2B) to run the multimodal parity test"
+        )
+
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("FastSentenceTransformer requires CUDA; skipping on CPU-only runner")
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("sentence_transformers")
+    from sentence_transformers import SentenceTransformer
+
+    device = "cuda"
+    dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+    texts = ["a photo of a cat", "the capital of France is Paris"]
+
+    # Control FIRST, before importing unsloth, so its global patches never touch the ref.
+    ctrl = SentenceTransformer(model_id, device=device, model_kwargs={"torch_dtype": dtype})
+    ctrl_emb = np.asarray(
+        ctrl.encode(texts, normalize_embeddings=True, batch_size=2), dtype=np.float32
+    )
+
+    import unsloth  # noqa: F401
+    from unsloth import FastSentenceTransformer
+
+    fast = FastSentenceTransformer.from_pretrained(
+        model_id, dtype=dtype, load_in_4bit=False, load_in_16bit=True,
+    )
+
+    # Must keep the base multimodal model (returns last_hidden_state), not the LM head.
+    inner_name = fast[0].auto_model.__class__.__name__
+    assert not inner_name.endswith("ForConditionalGeneration"), (
+        f"FastSentenceTransformer loaded {inner_name}; a *ForConditionalGeneration model "
+        f"returns logits and corrupts the Pooling layer. Expected the base model."
+    )
+
+    fast_emb = np.asarray(
+        fast.encode(texts, normalize_embeddings=True, batch_size=2), dtype=np.float32
+    )
+
+    cos = (ctrl_emb * fast_emb).sum(1) / (
+        np.linalg.norm(ctrl_emb, axis=1) * np.linalg.norm(fast_emb, axis=1)
+    )
+    assert float(cos.min()) > 0.99, (
+        f"VLM embedding parity regressed: min cosine {float(cos.min()):.5f} <= 0.99"
+    )

--- a/tests/python/test_fast_sentence_transformer_vlm_embedding.py
+++ b/tests/python/test_fast_sentence_transformer_vlm_embedding.py
@@ -65,10 +65,10 @@ def _cfg(**attrs):
 def _parse_source_module():
     """Compile and parse the module under test without importing it, so these checks
     run on every machine including CPU-only runners with no torch installed."""
-    source = _SOURCE_PATH.read_text(encoding="utf-8")
+    source = _SOURCE_PATH.read_text(encoding = "utf-8")
     # compile() raises SyntaxError on a broken module -> the test fails, never skips.
     compile(source, str(_SOURCE_PATH), "exec")
-    return ast.parse(source, filename=str(_SOURCE_PATH))
+    return ast.parse(source, filename = str(_SOURCE_PATH))
 
 
 def _class_node(tree, name):
@@ -99,9 +99,7 @@ def test_source_module_compiles_and_defines_expected_symbols():
     module_level_assignments = set()
     for node in tree.body:
         if isinstance(node, ast.Assign):
-            module_level_assignments.update(
-                t.id for t in node.targets if isinstance(t, ast.Name)
-            )
+            module_level_assignments.update(t.id for t in node.targets if isinstance(t, ast.Name))
         elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
             module_level_assignments.add(node.target.id)
     assert "_DEFAULT_TARGET_MODULES" in module_level_assignments
@@ -134,9 +132,9 @@ def test_is_vlm_embedding_config_detects_vision_config():
     detect = FastSentenceTransformer._is_vlm_embedding_config
 
     # A Qwen3-VL-Embedding-style config carries a nested vision_config.
-    assert detect(_cfg(model_type="qwen3_vl", vision_config=_cfg(depth=24))) is True
+    assert detect(_cfg(model_type = "qwen3_vl", vision_config = _cfg(depth = 24))) is True
     # Architecture-name fallback (no vision_config attribute surfaced).
-    assert detect(_cfg(architectures=["Qwen3VLForConditionalGeneration"])) is True
+    assert detect(_cfg(architectures = ["Qwen3VLForConditionalGeneration"])) is True
 
 
 def test_is_vlm_embedding_config_rejects_text_models():
@@ -145,8 +143,8 @@ def test_is_vlm_embedding_config_rejects_text_models():
 
     assert detect(None) is False
     # A plain decoder text embedder (e.g. Qwen3-Embedding) must NOT be treated as VLM.
-    assert detect(_cfg(model_type="qwen3", architectures=["Qwen3Model"])) is False
-    assert detect(_cfg(model_type="bert", architectures=["BertModel"])) is False
+    assert detect(_cfg(model_type = "qwen3", architectures = ["Qwen3Model"])) is False
+    assert detect(_cfg(model_type = "bert", architectures = ["BertModel"])) is False
 
 
 def test_get_peft_model_exposes_vision_lora_flags():
@@ -177,10 +175,10 @@ def _synthetic_images():
     collapse check below flaky, which is the whole reason they are this far apart."""
     from PIL import Image
 
-    dark = Image.new("RGB", (112, 112), color=(8, 8, 24))
+    dark = Image.new("RGB", (112, 112), color = (8, 8, 24))
     dark.paste((250, 240, 30), (0, 0, 56, 56))
 
-    light = Image.new("RGB", (112, 112), color=(245, 245, 235))
+    light = Image.new("RGB", (112, 112), color = (245, 245, 235))
     light.paste((10, 40, 160), (56, 56, 112, 112))
 
     return dark, light
@@ -224,22 +222,25 @@ def test_vlm_embedding_matches_stock_st():
     image_only_inputs = [{"image": img_a}, {"image": img_b}]
 
     # Control FIRST, before importing unsloth, so its global patches never touch the ref.
-    ctrl = SentenceTransformer(model_id, device=device, model_kwargs={"torch_dtype": dtype})
+    ctrl = SentenceTransformer(model_id, device = device, model_kwargs = {"torch_dtype": dtype})
     ctrl_emb = np.asarray(
-        ctrl.encode(texts, normalize_embeddings=True, batch_size=2), dtype=np.float32
+        ctrl.encode(texts, normalize_embeddings = True, batch_size = 2), dtype = np.float32
     )
     ctrl_img_text_emb = np.asarray(
-        ctrl.encode(image_text_inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
+        ctrl.encode(image_text_inputs, normalize_embeddings = True, batch_size = 2), dtype = np.float32
     )
     ctrl_img_emb = np.asarray(
-        ctrl.encode(image_only_inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
+        ctrl.encode(image_only_inputs, normalize_embeddings = True, batch_size = 2), dtype = np.float32
     )
 
     import unsloth  # noqa: F401
     from unsloth import FastSentenceTransformer
 
     fast = FastSentenceTransformer.from_pretrained(
-        model_id, dtype=dtype, load_in_4bit=False, load_in_16bit=True,
+        model_id,
+        dtype = dtype,
+        load_in_4bit = False,
+        load_in_16bit = True,
     )
 
     # Must keep the base multimodal model (returns last_hidden_state), not the LM head.
@@ -258,19 +259,19 @@ def test_vlm_embedding_matches_stock_st():
     )
 
     fast_emb = np.asarray(
-        fast.encode(texts, normalize_embeddings=True, batch_size=2), dtype=np.float32
+        fast.encode(texts, normalize_embeddings = True, batch_size = 2), dtype = np.float32
     )
 
     cos = (ctrl_emb * fast_emb).sum(1) / (
-        np.linalg.norm(ctrl_emb, axis=1) * np.linalg.norm(fast_emb, axis=1)
+        np.linalg.norm(ctrl_emb, axis = 1) * np.linalg.norm(fast_emb, axis = 1)
     )
-    assert float(cos.min()) > 0.99, (
-        f"VLM embedding text parity regressed: min cosine {float(cos.min()):.5f} <= 0.99"
-    )
+    assert (
+        float(cos.min()) > 0.99
+    ), f"VLM embedding text parity regressed: min cosine {float(cos.min()):.5f} <= 0.99"
 
     def _cosines(reference, candidate):
         return (reference * candidate).sum(1) / (
-            np.linalg.norm(reference, axis=1) * np.linalg.norm(candidate, axis=1)
+            np.linalg.norm(reference, axis = 1) * np.linalg.norm(candidate, axis = 1)
         )
 
     for label, inputs, reference in (
@@ -278,12 +279,12 @@ def test_vlm_embedding_matches_stock_st():
         ("image", image_only_inputs, ctrl_img_emb),
     ):
         fast_img_emb = np.asarray(
-            fast.encode(inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
+            fast.encode(inputs, normalize_embeddings = True, batch_size = 2), dtype = np.float32
         )
         img_cos = _cosines(reference, fast_img_emb)
-        assert float(img_cos.min()) > 0.99, (
-            f"VLM {label} parity regressed: min cosine {float(img_cos.min()):.5f} <= 0.99"
-        )
+        assert (
+            float(img_cos.min()) > 0.99
+        ), f"VLM {label} parity regressed: min cosine {float(img_cos.min()):.5f} <= 0.99"
 
         # Two deliberately dissimilar images must not collapse to the same vector. With the
         # same text on both rows of the image+text batch, a collapse means only the text is

--- a/tests/python/test_fast_sentence_transformer_vlm_embedding.py
+++ b/tests/python/test_fast_sentence_transformer_vlm_embedding.py
@@ -170,17 +170,20 @@ def test_from_pretrained_accepts_processor_kwargs():
     assert params["processor_kwargs"].default is None
 
 
-def _synthetic_image(seed):
-    """A deterministic, network-free RGB image with enough structure that two different
-    seeds cannot collapse to the same embedding."""
+def _synthetic_images():
+    """Two deterministic, network-free RGB images that are as visually unalike as a pair of
+    112x112 rectangles can be: a dark frame with a bright top-left block, and its inverse
+    with a bright frame and a dark bottom-right block. Near-identical inputs would make the
+    collapse check below flaky, which is the whole reason they are this far apart."""
     from PIL import Image
 
-    img = Image.new("RGB", (112, 112), color=(16 * seed % 256, 96, 200 - 16 * seed % 256))
-    for x in range(0, 112, 16):
-        for y in range(0, 112, 16):
-            if (x // 16 + y // 16 + seed) % 2:
-                img.paste((240, 240, 30), (x, y, x + 16, y + 16))
-    return img
+    dark = Image.new("RGB", (112, 112), color=(8, 8, 24))
+    dark.paste((250, 240, 30), (0, 0, 56, 56))
+
+    light = Image.new("RGB", (112, 112), color=(245, 245, 235))
+    light.paste((10, 40, 160), (56, 56, 112, 112))
+
+    return dark, light
 
 
 def test_vlm_embedding_matches_stock_st():
@@ -210,18 +213,26 @@ def test_vlm_embedding_matches_stock_st():
     device = "cuda"
     dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
     texts = ["a photo of a cat", "the capital of France is Paris"]
-    image_inputs = [
-        {"image": _synthetic_image(1), "text": "a yellow checkerboard"},
-        {"image": _synthetic_image(5)},
+    img_a, img_b = _synthetic_images()
+    # Each encode() call must be modality-homogeneous: sentence-transformers collapses a
+    # mixed-modality batch to the "message" (chat-template) route, which would silently test
+    # a different code path than the one this feature adds.
+    image_text_inputs = [
+        {"image": img_a, "text": "a bright block in the corner"},
+        {"image": img_b, "text": "a bright block in the corner"},
     ]
+    image_only_inputs = [{"image": img_a}, {"image": img_b}]
 
     # Control FIRST, before importing unsloth, so its global patches never touch the ref.
     ctrl = SentenceTransformer(model_id, device=device, model_kwargs={"torch_dtype": dtype})
     ctrl_emb = np.asarray(
         ctrl.encode(texts, normalize_embeddings=True, batch_size=2), dtype=np.float32
     )
+    ctrl_img_text_emb = np.asarray(
+        ctrl.encode(image_text_inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
+    )
     ctrl_img_emb = np.asarray(
-        ctrl.encode(image_inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
+        ctrl.encode(image_only_inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
     )
 
     import unsloth  # noqa: F401
@@ -257,24 +268,31 @@ def test_vlm_embedding_matches_stock_st():
         f"VLM embedding text parity regressed: min cosine {float(cos.min()):.5f} <= 0.99"
     )
 
-    fast_img_emb = np.asarray(
-        fast.encode(image_inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
-    )
+    def _cosines(reference, candidate):
+        return (reference * candidate).sum(1) / (
+            np.linalg.norm(reference, axis=1) * np.linalg.norm(candidate, axis=1)
+        )
 
-    img_cos = (ctrl_img_emb * fast_img_emb).sum(1) / (
-        np.linalg.norm(ctrl_img_emb, axis=1) * np.linalg.norm(fast_img_emb, axis=1)
-    )
-    assert float(img_cos.min()) > 0.99, (
-        f"VLM image parity regressed: min cosine {float(img_cos.min()):.5f} <= 0.99"
-    )
+    for label, inputs, reference in (
+        ("image+text", image_text_inputs, ctrl_img_text_emb),
+        ("image", image_only_inputs, ctrl_img_emb),
+    ):
+        fast_img_emb = np.asarray(
+            fast.encode(inputs, normalize_embeddings=True, batch_size=2), dtype=np.float32
+        )
+        img_cos = _cosines(reference, fast_img_emb)
+        assert float(img_cos.min()) > 0.99, (
+            f"VLM {label} parity regressed: min cosine {float(img_cos.min()):.5f} <= 0.99"
+        )
 
-    # Two structurally different images must not collapse to the same vector -- that would
-    # mean the image is being dropped and only the prompt/text is reaching the model.
-    pair_cos = float(
-        (fast_img_emb[0] * fast_img_emb[1]).sum()
-        / (np.linalg.norm(fast_img_emb[0]) * np.linalg.norm(fast_img_emb[1]))
-    )
-    assert pair_cos < 0.999, (
-        f"Distinct images produced near-identical embeddings (cos {pair_cos:.5f}); the image "
-        f"input is not reaching the vision tower."
-    )
+        # Two deliberately dissimilar images must not collapse to the same vector. With the
+        # same text on both rows of the image+text batch, a collapse means only the text is
+        # reaching the model, i.e. the image was dropped somewhere in preprocessing.
+        pair_cos = float(
+            (fast_img_emb[0] * fast_img_emb[1]).sum()
+            / (np.linalg.norm(fast_img_emb[0]) * np.linalg.norm(fast_img_emb[1]))
+        )
+        assert pair_cos < 0.999, (
+            f"Distinct images produced near-identical {label} embeddings (cos {pair_cos:.5f}); "
+            f"the image input is not reaching the vision tower."
+        )

--- a/tests/python/test_fast_sentence_transformer_vlm_embedding.py
+++ b/tests/python/test_fast_sentence_transformer_vlm_embedding.py
@@ -3,10 +3,15 @@
 """Tests for multimodal (vision) decoder embedding support in FastSentenceTransformer
 (e.g. Qwen/Qwen3-VL-Embedding-2B).
 
-Two layers:
+Three layers:
+- Static source checks that never import unsloth (so they never hit the accelerator
+  gate). They compile unsloth/models/sentence_transformer.py and assert, via ast, that
+  the symbols the rest of this file depends on still exist. These ALWAYS run: a syntax
+  error or a renamed/removed symbol turns this file red even on a CPU-only runner.
 - Fast, no-GPU unit tests for the VLM-detection helper and the get_peft_model vision
-  flags. They import unsloth but never touch weights, so they run wherever unsloth is
-  importable (skipped otherwise).
+  flags. They import unsloth but never touch weights. They skip only on the one
+  explicitly detected condition where unsloth legitimately refuses to import
+  (NotImplementedError with no CUDA device); every other import failure fails.
 - An opt-in, GPU-only end-to-end parity test (UNSLOTH_VLM_EMBEDDING_PARITY_MODEL) that
   loads a real VLM embedding checkpoint and compares against a stock SentenceTransformer.
 
@@ -20,33 +25,108 @@ class.
 
 from __future__ import annotations
 
+import ast
 import inspect
 import os
 import types
+from pathlib import Path
 
 import pytest
 
+# unsloth/models/sentence_transformer.py, located relative to this test file (not the
+# CWD) so the static checks below work from any invocation directory.
+_SOURCE_PATH = (
+    Path(__file__).resolve().parents[2] / "unsloth" / "models" / "sentence_transformer.py"
+)
+
 
 def _import_fast_sentence_transformer():
-    """Import FastSentenceTransformer for the logic tests.
+    """Import FastSentenceTransformer, skipping ONLY on the documented CPU-only refusal.
 
-    Skips ONLY when a required heavy dependency is genuinely absent -- an
-    unsupported environment, not a regression. The import of the code under test
-    is then run WITHOUT a catch-all: a syntax error, a missing symbol, or any
-    other import-time regression introduced by this change must fail these tests,
-    not silently skip them. (A previous version wrapped the import in
-    `except Exception: pytest.skip(...)`, which turned every such regression into
-    a green skip.)"""
-    pytest.importorskip("torch")
+    unsloth raises NotImplementedError when it finds no supported accelerator; that is
+    an environment fact and may skip. Anything else -- SyntaxError, ImportError, a
+    missing symbol -- is a real regression and is re-raised so the test fails."""
+    torch = pytest.importorskip("torch")
     pytest.importorskip("sentence_transformers")
     pytest.importorskip("unsloth_zoo")
-    from unsloth import FastSentenceTransformer
-
+    try:
+        from unsloth import FastSentenceTransformer
+    except NotImplementedError as exc:
+        if torch.cuda.is_available():
+            raise
+        pytest.skip(f"unsloth requires an accelerator; none available: {exc}")
     return FastSentenceTransformer
 
 
 def _cfg(**attrs):
     return types.SimpleNamespace(**attrs)
+
+
+def _parse_source_module():
+    """Compile and parse the module under test without importing it, so these checks
+    run on every machine including CPU-only runners with no torch installed."""
+    source = _SOURCE_PATH.read_text(encoding="utf-8")
+    # compile() raises SyntaxError on a broken module -> the test fails, never skips.
+    compile(source, str(_SOURCE_PATH), "exec")
+    return ast.parse(source, filename=str(_SOURCE_PATH))
+
+
+def _class_node(tree, name):
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found in {_SOURCE_PATH}")
+
+
+def _method_node(cls_node, name):
+    for node in cls_node.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{cls_node.name}.{name} not found in {_SOURCE_PATH}")
+
+
+def _arg_names(func_node):
+    args = func_node.args
+    names = [a.arg for a in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+    return set(names)
+
+
+def test_source_module_compiles_and_defines_expected_symbols():
+    """Always-runs regression guard: never skips, so a syntax error or a renamed symbol
+    in sentence_transformer.py turns this file red even where unsloth cannot import."""
+    tree = _parse_source_module()
+
+    module_level_assignments = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            module_level_assignments.update(
+                t.id for t in node.targets if isinstance(t, ast.Name)
+            )
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            module_level_assignments.add(node.target.id)
+    assert "_DEFAULT_TARGET_MODULES" in module_level_assignments
+
+    cls = _class_node(tree, "FastSentenceTransformer")
+    for method in ("_is_vlm_embedding_config", "from_pretrained", "get_peft_model"):
+        _method_node(cls, method)
+
+
+def test_source_get_peft_model_declares_vision_selectors():
+    """Signature-level mirror of test_get_peft_model_exposes_vision_lora_flags that does
+    not require importing unsloth, so renaming a selector cannot pass as a skip."""
+    cls = _class_node(_parse_source_module(), "FastSentenceTransformer")
+    params = _arg_names(_method_node(cls, "get_peft_model"))
+    for name in (
+        "finetune_vision_layers",
+        "finetune_language_layers",
+        "finetune_attention_modules",
+        "finetune_mlp_modules",
+        "finetune_last_n_layers",
+    ):
+        assert name in params, f"get_peft_model lost the {name} selector"
+
+    from_pretrained_params = _arg_names(_method_node(cls, "from_pretrained"))
+    assert "processor_kwargs" in from_pretrained_params
 
 
 def test_is_vlm_embedding_config_detects_vision_config():

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -36,7 +36,11 @@ from unsloth.models._attn_mask_compat import _prepare_4d_attention_mask_for_sdpa
 import transformers
 from packaging.version import Version
 import re
-from transformers import AutoModel, AutoConfig
+from transformers import AutoModel, AutoConfig, AutoProcessor
+try:
+    from transformers import AutoModelForImageTextToText
+except ImportError:  # older transformers
+    AutoModelForImageTextToText = None
 import tempfile
 from huggingface_hub import HfApi, get_token
 from ..save import unsloth_save_pretrained_torchao, unsloth_save_pretrained_gguf
@@ -1003,6 +1007,7 @@ class FastSentenceTransformer(FastModel):
         cache_dir = None,
         revision = None,
         module_subfolder = "",
+        processor_kwargs = None,
     ):
         """Helper to create and configure a Transformer module."""
         from sentence_transformers.models import Transformer
@@ -1051,6 +1056,14 @@ class FastSentenceTransformer(FastModel):
             original_model_from_pretrained = AutoModel.from_pretrained
             original_processor_from_pretrained = AutoProcessor.from_pretrained
             original_tokenizer_from_pretrained = AutoTokenizer.from_pretrained
+            # Defensive: a future ST version may build a multimodal model via the
+            # VLM auto-class instead of AutoModel. Redirect it to the same
+            # pre-loaded model so we never load weights twice or pick the wrong
+            # (logits-returning) class. None on older transformers.
+            _patch_vlm_auto_model = AutoModelForImageTextToText is not None
+            original_vlm_from_pretrained = (
+                AutoModelForImageTextToText.from_pretrained if _patch_vlm_auto_model else None
+            )
 
             def return_existing_model(*args, **kwargs):
                 if is_requested_model_name(args, kwargs):
@@ -1067,11 +1080,18 @@ class FastSentenceTransformer(FastModel):
                     return tokenizer
                 return original_processor_from_pretrained(*args, **kwargs)
 
+            def return_existing_vlm_model(*args, **kwargs):
+                if is_requested_model_name(args, kwargs):
+                    return model
+                return original_vlm_from_pretrained(*args, **kwargs)
+
             try:
                 # Temporarily redirect Auto* loading to return our pre-loaded objects
                 AutoModel.from_pretrained = return_existing_model
                 AutoProcessor.from_pretrained = return_existing_processor
                 AutoTokenizer.from_pretrained = return_existing_tokenizer
+                if _patch_vlm_auto_model:
+                    AutoModelForImageTextToText.from_pretrained = return_existing_vlm_model
 
                 transformer_init_params = inspect.signature(Transformer.__init__).parameters
                 trust_remote_code_kwargs = {"trust_remote_code": trust_remote_code}
@@ -1085,10 +1105,17 @@ class FastSentenceTransformer(FastModel):
                 else:
                     transformer_kwargs["model_args"] = trust_remote_code_kwargs.copy()
                     transformer_kwargs["config_args"] = trust_remote_code_kwargs.copy()
+                # Thread user-supplied processor controls (e.g. min_pixels /
+                # max_pixels for VLM embedders) into whichever kwarg ST exposes.
+                extra_processor_kwargs = dict(processor_kwargs or {})
                 if "processor_kwargs" in transformer_init_params:
-                    transformer_kwargs["processor_kwargs"] = trust_remote_code_kwargs.copy()
+                    _pk = trust_remote_code_kwargs.copy()
+                    _pk.update(extra_processor_kwargs)
+                    transformer_kwargs["processor_kwargs"] = _pk
                 elif "tokenizer_args" in transformer_init_params:
-                    transformer_kwargs["tokenizer_args"] = trust_remote_code_kwargs.copy()
+                    _pk = trust_remote_code_kwargs.copy()
+                    _pk.update(extra_processor_kwargs)
+                    transformer_kwargs["tokenizer_args"] = _pk
 
                 # Build via Transformer.load so the saved modality_config is honored: plain
                 # Transformer(...) makes ST 5.x infer a "message" modality for chat-template
@@ -1134,6 +1161,8 @@ class FastSentenceTransformer(FastModel):
                 AutoModel.from_pretrained = original_model_from_pretrained
                 AutoProcessor.from_pretrained = original_processor_from_pretrained
                 AutoTokenizer.from_pretrained = original_tokenizer_from_pretrained
+                if _patch_vlm_auto_model:
+                    AutoModelForImageTextToText.from_pretrained = original_vlm_from_pretrained
 
         # On sentence-transformers >=5.4 `tokenizer` is a read-only property backed
         # by `self.processor` (already wired via the redirect above). On older
@@ -1213,6 +1242,7 @@ class FastSentenceTransformer(FastModel):
         trust_remote_code = False,
         cache_dir = None,
         revision = None,
+        processor_kwargs = None,
     ) -> tuple[OrderedDict, bool]:
         """Load modules from modules.json, else fall back to hard-coded modules.
 
@@ -1246,6 +1276,7 @@ class FastSentenceTransformer(FastModel):
                         cache_dir,
                         revision,
                         module_subfolder = module_config.get("path") or "",
+                        processor_kwargs = processor_kwargs,
                     )
                     modules[name] = transformer_module
                 else:
@@ -1289,6 +1320,7 @@ class FastSentenceTransformer(FastModel):
             token,
             cache_dir,
             revision,
+            processor_kwargs = processor_kwargs,
         )
         modules["0"] = transformer_module
 
@@ -1449,6 +1481,24 @@ class FastSentenceTransformer(FastModel):
         return model
 
     @staticmethod
+    def _is_vlm_embedding_config(config):
+        """Detect a multimodal (vision) decoder embedding model from its config.
+
+        Mirrors the VLM detection in loader.py (`vision_config` present, or a
+        `*ForConditionalGeneration` architecture). Used to swap the text
+        tokenizer for an AutoProcessor so images become `pixel_values`, while
+        keeping `auto_model = AutoModel` (the base model returns
+        `last_hidden_state`, which the ST Pooling layer needs -- the
+        `*ForConditionalGeneration` class would return logits and corrupt it).
+        """
+        if config is None:
+            return False
+        if hasattr(config, "vision_config"):
+            return True
+        architectures = getattr(config, "architectures", None) or []
+        return any(str(a).endswith("ForConditionalGeneration") for a in architectures)
+
+    @staticmethod
     def from_pretrained(
         model_name,
         max_seq_length = None,
@@ -1474,6 +1524,7 @@ class FastSentenceTransformer(FastModel):
         unsloth_tiled_mlp = False,
         pooling_mode = "mean",
         for_inference = False,
+        processor_kwargs = None,
         **kwargs,
     ):
         try:
@@ -1564,6 +1615,13 @@ class FastSentenceTransformer(FastModel):
             return st_model
 
         # Load-mode validation already ran before the prefetch above.
+        # Keep AutoModel even for multimodal (VLM) embedding models: for e.g.
+        # `qwen3_vl`, AutoModel maps to the base `Qwen3VLModel` whose forward
+        # returns `last_hidden_state` (what the ST Pooling layer reads) and
+        # accepts `pixel_values` / `image_grid_thw`. AutoModelForImageTextToText
+        # would map to `*ForConditionalGeneration`, which returns logits and
+        # corrupts pooling. The image path is enabled via the processor swap
+        # below, not by changing the model class.
         if "auto_model" not in kwargs:
             kwargs["auto_model"] = AutoModel
 
@@ -1577,6 +1635,11 @@ class FastSentenceTransformer(FastModel):
             model_type = getattr(config, "model_type", "")
         except:
             pass
+
+        # Multimodal (vision) decoder embedding models (e.g. Qwen3-VL-Embedding)
+        # need an AutoProcessor so images are turned into `pixel_values`; the
+        # text-only tokenizer that the load path returns by default cannot.
+        is_vlm_embedding = FastSentenceTransformer._is_vlm_embedding_config(config)
 
         # Fast encoder path: Use native torch.compile for encoder models (6x speedup)
         # This bypasses Unsloth's auto-compiler which adds @torch.compiler.disable decorators
@@ -1856,6 +1919,27 @@ class FastSentenceTransformer(FastModel):
         finally:
             os.environ["UNSLOTH_WARN_UNINITIALIZED"] = old_environ
 
+        # For multimodal embedding models, the load path above returns a
+        # text-only tokenizer (auto_model = AutoModel => is_vlm False in the
+        # vision loader, so it picks AutoTokenizer). Swap in a real processor so
+        # images are turned into `pixel_values`. sentence-transformers' Transformer
+        # module then reads `processor.image_processor` for image inputs, while the
+        # `_create_transformer_module` AutoProcessor redirect hands it this object.
+        if is_vlm_embedding and not hasattr(tokenizer, "image_processor"):
+            try:
+                tokenizer = AutoProcessor.from_pretrained(
+                    model_name,
+                    token = token,
+                    trust_remote_code = trust_remote_code,
+                    revision = revision,
+                    **(processor_kwargs or {}),
+                )
+            except Exception as e:
+                print(
+                    f"Unsloth Warning: Failed to load AutoProcessor for multimodal "
+                    f"embedding model ({e}). Image inputs may not work."
+                )
+
         from sentence_transformers import SentenceTransformer
 
         modules, no_modules = FastSentenceTransformer._load_modules(
@@ -1872,6 +1956,7 @@ class FastSentenceTransformer(FastModel):
             or os.environ.get("SENTENCE_TRANSFORMERS_HOME"),
             # Same revision as the weight load so modules hit the warm (None = default branch).
             revision = revision,
+            processor_kwargs = processor_kwargs,
         )
 
         st_device = device_map
@@ -2024,6 +2109,11 @@ class FastSentenceTransformer(FastModel):
         modules_to_save = None,
         init_lora_weights = True,
         loftq_config = {},
+        finetune_vision_layers = False,
+        finetune_language_layers = True,
+        finetune_attention_modules = True,
+        finetune_mlp_modules = True,
+        finetune_last_n_layers = None,
         **kwargs,
     ):
         from sentence_transformers import SentenceTransformer
@@ -2166,9 +2256,31 @@ class FastSentenceTransformer(FastModel):
 
                 return model
 
-            # Original path for non-fast-encoder models
+            # Original path for non-fast-encoder models (decoder text + VLM embedders)
             transformer_module = model[0]
             inner_model = transformer_module.auto_model
+
+            # For multimodal (vision) embedding models, thread the vision/language
+            # LoRA selectors through to FastModel.get_peft_model, which routes them
+            # to unsloth_zoo.peft_utils.get_peft_regex. Only do this for VLMs so the
+            # existing text-decoder embedding path (which passes an explicit
+            # target_modules list) is byte-for-byte unchanged.
+            inner_config = getattr(inner_model, "config", None)
+            is_vlm_inner = inner_config is not None and hasattr(inner_config, "vision_config")
+            extra_peft_kwargs = {}
+            if is_vlm_inner:
+                extra_peft_kwargs = dict(
+                    finetune_vision_layers = finetune_vision_layers,
+                    finetune_language_layers = finetune_language_layers,
+                    finetune_attention_modules = finetune_attention_modules,
+                    finetune_mlp_modules = finetune_mlp_modules,
+                    finetune_last_n_layers = finetune_last_n_layers,
+                )
+                # The BERT-oriented default target_modules do not exist on a
+                # decoder VLM. Fall back to None so get_peft_regex builds the
+                # correct regex from the finetune_* flags above.
+                if target_modules == ["query", "key", "value", "dense"]:
+                    target_modules = None
 
             peft_model = FastModel.get_peft_model(
                 model = inner_model,
@@ -2187,6 +2299,7 @@ class FastSentenceTransformer(FastModel):
                 modules_to_save = modules_to_save,
                 init_lora_weights = init_lora_weights,
                 loftq_config = loftq_config,
+                **extra_peft_kwargs,
                 **kwargs,
             )
 

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -50,6 +50,12 @@ import shutil
 
 _CREATE_TRANSFORMER_MODULE_LOCK = threading.RLock()
 
+# Default LoRA targets for BERT-style encoder embedders. Kept as a module-level
+# constant so get_peft_model can tell "caller left the default alone" from "caller
+# asked for these modules" without comparing against an inline literal -- these
+# names do not exist on a decoder VLM and would blow up in get_peft_regex.
+_DEFAULT_TARGET_MODULES = ["query", "key", "value", "dense"]
+
 
 def _normalize_save_method(save_method):
     """Fold "MERGED_16BIT" and "merged 16bit" onto "merged_16bit".
@@ -1496,7 +1502,22 @@ class FastSentenceTransformer(FastModel):
         if hasattr(config, "vision_config"):
             return True
         architectures = getattr(config, "architectures", None) or []
-        return any(str(a).endswith("ForConditionalGeneration") for a in architectures)
+        if any(str(a).endswith("ForConditionalGeneration") for a in architectures):
+            return True
+        # Some loaders hand back a wrapper whose real config sits one level down
+        # (e.g. an ST/PEFT wrapper, or a text_config-style split). Check the usual
+        # nesting spots so the same model is not classified differently at load
+        # time and at LoRA time.
+        for attr in ("config", "text_config"):
+            nested = getattr(config, attr, None)
+            if nested is None or nested is config:
+                continue
+            if hasattr(nested, "vision_config"):
+                return True
+            nested_architectures = getattr(nested, "architectures", None) or []
+            if any(str(a).endswith("ForConditionalGeneration") for a in nested_architectures):
+                return True
+        return False
 
     @staticmethod
     def from_pretrained(
@@ -1737,6 +1758,7 @@ class FastSentenceTransformer(FastModel):
 
             # Store metadata for get_peft_model
             st_model._unsloth_fast_encoder = True
+            st_model._unsloth_is_vlm_embedding = is_vlm_embedding
             st_model._compile_mode = compile_mode
             st_model._dtype = dtype
             st_model._load_in_4bit = load_in_4bit
@@ -1935,10 +1957,19 @@ class FastSentenceTransformer(FastModel):
                     **(processor_kwargs or {}),
                 )
             except Exception as e:
-                print(
-                    f"Unsloth Warning: Failed to load AutoProcessor for multimodal "
-                    f"embedding model ({e}). Image inputs may not work."
-                )
+                # Unrecoverable: without a processor the model keeps a text-only
+                # tokenizer that cannot produce `pixel_values`, so training would
+                # fail much later with a confusing error. Fail loudly here instead.
+                raise RuntimeError(
+                    f"Unsloth: Failed to load an AutoProcessor for multimodal embedding "
+                    f"model `{model_name}`: {e}\n"
+                    f"A vision embedding model needs a processor to turn images into "
+                    f"`pixel_values`; the text-only tokenizer cannot. Check that the repo "
+                    f"ships processor files (preprocessor_config.json), that "
+                    f"`trust_remote_code = True` is set if the repo needs it, and that the "
+                    f"image backend (torchvision / Pillow) is installed. Pass "
+                    f"`processor_kwargs` to forward extra processor options."
+                ) from e
 
         from sentence_transformers import SentenceTransformer
 
@@ -1967,6 +1998,10 @@ class FastSentenceTransformer(FastModel):
 
         st_model = SentenceTransformer(modules = modules, device = st_device)
         st_model.no_modules = no_modules
+        # Record the load-time VLM decision so get_peft_model reuses it instead of
+        # re-deriving it from `inner_model.config`, which may be a wrapped/nested
+        # config and classify the same checkpoint differently.
+        st_model._unsloth_is_vlm_embedding = is_vlm_embedding
 
         def _save_pretrained_merged(
             self,
@@ -2090,12 +2125,7 @@ class FastSentenceTransformer(FastModel):
     def get_peft_model(
         model,
         r = 16,
-        target_modules = [
-            "query",
-            "key",
-            "value",
-            "dense",
-        ],
+        target_modules = _DEFAULT_TARGET_MODULES,
         lora_alpha = 16,
         lora_dropout = 0.0,
         bias = "none",
@@ -2265,8 +2295,15 @@ class FastSentenceTransformer(FastModel):
             # to unsloth_zoo.peft_utils.get_peft_regex. Only do this for VLMs so the
             # existing text-decoder embedding path (which passes an explicit
             # target_modules list) is byte-for-byte unchanged.
-            inner_config = getattr(inner_model, "config", None)
-            is_vlm_inner = inner_config is not None and hasattr(inner_config, "vision_config")
+            # Single source of truth: from_pretrained records the decision it made
+            # (via _is_vlm_embedding_config on the prefetched AutoConfig) on the model,
+            # so both call sites agree. Only fall back to inspecting the inner config
+            # for models that were not built by FastSentenceTransformer.from_pretrained.
+            is_vlm_inner = getattr(model, "_unsloth_is_vlm_embedding", None)
+            if is_vlm_inner is None:
+                is_vlm_inner = FastSentenceTransformer._is_vlm_embedding_config(
+                    getattr(inner_model, "config", None)
+                )
             extra_peft_kwargs = {}
             if is_vlm_inner:
                 extra_peft_kwargs = dict(
@@ -2279,7 +2316,10 @@ class FastSentenceTransformer(FastModel):
                 # The BERT-oriented default target_modules do not exist on a
                 # decoder VLM. Fall back to None so get_peft_regex builds the
                 # correct regex from the finetune_* flags above.
-                if target_modules == ["query", "key", "value", "dense"]:
+                if target_modules is _DEFAULT_TARGET_MODULES or (
+                    target_modules is not None
+                    and set(target_modules) == set(_DEFAULT_TARGET_MODULES)
+                ):
                     target_modules = None
 
             peft_model = FastModel.get_peft_model(

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -37,6 +37,7 @@ import transformers
 from packaging.version import Version
 import re
 from transformers import AutoModel, AutoConfig, AutoProcessor
+
 try:
     from transformers import AutoModelForImageTextToText
 except ImportError:  # older transformers


### PR DESCRIPTION
Closes #8596.

`FastSentenceTransformer` loads a multimodal embedding checkpoint with a text-only tokenizer, so images never become `pixel_values` and the vision tower is unreachable. #8596 has the full trace; the short version is that `vision.py` picks the processor from the auto-class, and an embedding model must load through `AutoModel` because pooling reads `last_hidden_state`.

The model class stays `AutoModel`. What changes is processor selection.

## Changes

All in `unsloth/models/sentence_transformer.py`:

- `_is_vlm_embedding_config(config)` detects a VLM embedder from `vision_config` or a `*ForConditionalGeneration` architecture, including one level of config nesting, mirroring the detection in `loader.py`.
- `from_pretrained` keeps `auto_model = AutoModel` and swaps in `AutoProcessor` for VLM embedders after the load. New `processor_kwargs` (`min_pixels` / `max_pixels`) threads through `_load_modules` into `_create_transformer_module` so the image-token budget stays controllable. A failed processor load raises rather than warns, because a text-only tokenizer here fails much later and opaquely.
- The VLM decision is recorded on the model and reused by `get_peft_model`, so load-time and LoRA-time cannot disagree.
- `_create_transformer_module` redirects `AutoModelForImageTextToText.from_pretrained` to the preloaded model, so a future ST version cannot load the weights twice or pick the logits-returning class.
- `get_peft_model` exposes `finetune_vision_layers` / `finetune_language_layers` / `finetune_attention_modules` / `finetune_mlp_modules` / `finetune_last_n_layers` for VLMs only, vision frozen by default.

The existing text embedding path is unchanged, including its default `target_modules`.

Training needs no new code: stock `SentenceTransformerTrainer` with `MultipleNegativesRankingLoss`, and ST's own multimodal collator handles the image columns.

Also adds `tests/python/test_fast_sentence_transformer_vlm_embedding.py` and a runnable example at `scripts/qwen3_vl_embedding_finetune.py`.

## Tests

Two layers that always run, plus one that is opt-in:

- Static checks that never import unsloth, so they cannot skip on a CPU-only runner. They compile the module and assert via `ast` that the symbols the other tests depend on still exist. Without these, a runner with no torch skips the file entirely and a syntax error or renamed symbol passes as green.
- No-GPU unit tests for detection and the `get_peft_model` signature. These skip only when unsloth raises `NotImplementedError` with no CUDA device available, and re-raise if a GPU is present. Every other import failure fails the test.
- An opt-in GPU parity test against stock `SentenceTransformer` on the same checkpoint, enabled with `UNSLOTH_VLM_EMBEDDING_PARITY_MODEL`.

Run on an RTX A6000 with torch 2.11.0+cu128, transformers 5.5.0, sentence-transformers 5.7.0:

```
UNSLOTH_VLM_EMBEDDING_PARITY_MODEL=Qwen/Qwen3-VL-Embedding-2B \
  python -m pytest tests/python/test_fast_sentence_transformer_vlm_embedding.py -v
```

All pass, parity included. End-to-end LoRA SFT on an image+text dataset also runs to completion, `encode({"image": ..., "text": ...})` returns the expected 2048-dim vector, and a `merged_16bit` save round-trips with the processor files intact.

`MODEL_MAPPING_NAMES["qwen3_vl"] == "Qwen3VLModel"` on both transformers `v5.5.0` and `v5.15.0`.

## Note on #4481

[#4481](https://github.com/unslothai/unsloth/issues/4481) asks for a Qwen3-VL embedding SFT notebook. This PR is the prerequisite rather than the notebook itself, so it should not close that issue.
