### PR TITLE
Retire the warm's detection epoch before the first shutdown await

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -766,6 +766,13 @@ async def lifespan(app: FastAPI):
     # Before any shutdown await: a warm finishing during one would still read the lifespan as current.
     _stop_post_warm_thread()
 
+    # Same for the coordinated warm: retiring its epoch stops it at the next stage boundary.
+    # run_lifespan_shutdown() also invalidates, but only after several awaits, through which the
+    # warm keeps importing for a stopped lifespan. Retiring twice is harmless; getattr for tests.
+    _invalidate_detection = getattr(_hw_module, "invalidate_detection", None)
+    if _invalidate_detection is not None:
+        _invalidate_detection()
+
     from core.inference.openai_codex_auth import shutdown_flows
 
     await shutdown_flows()
@@ -774,13 +781,6 @@ async def lifespan(app: FastAPI):
         stop_auto_sync()
     except Exception as exc:
         _lifespan_log.warning("linked-folder auto-sync failed at shutdown: %s", exc)
-
-    # Same for the coordinated warm: retiring its epoch stops it at the next stage boundary.
-    # run_lifespan_shutdown() also invalidates, but only after several awaits, through which the
-    # warm keeps importing for a stopped lifespan. Retiring twice is harmless; getattr for tests.
-    _invalidate_detection = getattr(_hw_module, "invalidate_detection", None)
-    if _invalidate_detection is not None:
-        _invalidate_detection()
 
     _idle_task = getattr(app.state, "idle_unload_task", None)
     if _idle_task is not None:


### PR DESCRIPTION
`tests/test_warm_window_review_fixes.py::test_the_warm_epoch_is_retired_before_any_shutdown_await` is red on `origin/main`:

```
AssertionError: the epoch is retired at line 781, after the first shutdown await at 771;
                the warm keeps importing through that gap
```

This is a real ordering regression, not a stale test. `#8511` inserted `await shutdown_flows()` between `_stop_post_warm_thread()` and the epoch-retire block that had been sitting immediately after it. The region opens with the comment "Before any shutdown await", and the retire block's own comment still states the invariant it lost:

> `run_lifespan_shutdown()` also invalidates, but only after several awaits, through which the warm keeps importing for a stopped lifespan.

So the coordinated warm now keeps importing across that await for a lifespan that has already stopped, which is exactly what the block was placed early to prevent.

The fix moves those six lines back above the await. `invalidate_detection` is a synchronous module-level call with no dependency on `shutdown_flows` or `stop_auto_sync`, so moving it earlier cannot reorder anything else, and retiring twice is explicitly harmless per the existing comment.

Verification:

- `tests/test_warm_window_review_fixes.py`: 100 passed, against 1 failed and 99 passed on the merge base.
- Every other test referencing `invalidate_detection` or `shutdown_flows` (`tests/test_lifespan_restart_rewarms.py`): 108 passed together, no change.
- The mutation proof is free here, since `origin/main` is the mutant and it fails on exactly this assertion.

This is the second of the two failures currently red on main. The other, the desktop-auth routes stub, is #8590.
