### PR TITLE
Studio: isolate the RAG embedder's first GPU allocation so a driver segfault cannot kill the backend

### DIFF
--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -117,7 +117,16 @@ def _rocm_is_possible() -> bool:
     try:
         torch = sys.modules.get("torch")
         if torch is not None:
-            return bool(getattr(getattr(torch, "version", None), "hip", None))
+            if getattr(getattr(torch, "version", None), "hip", None) is not None:
+                return True
+            # AMD SDK wheels leave torch.version.hip unset and only say rocm in the version
+            # string; hardware.py's own ROCm test carries the same fallback. And a torch
+            # that is in sys.modules but still executing has neither yet, which is absence
+            # of evidence, not evidence of absence, so that stays possible.
+            version_string = getattr(torch, "__version__", None)
+            if not isinstance(version_string, str) or not version_string:
+                return True
+            return "rocm" in version_string.lower()
         if sys.platform in ("darwin", "win32"):
             return False
         return os.path.isdir("/sys/class/kfd/kfd/topology/nodes")

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -99,19 +99,27 @@ def _rocm_is_possible() -> bool:
     ``routes/settings.py`` reads that as "not llama" and stops applying its GGUF handling,
     so a valid local .gguf briefly 409s on a host that never had an AMD GPU.
 
-    Each branch is a file-existence test, so it costs nothing on the request path:
+    The signal that actually settles it is ``torch.version.hip``: a build attribute, read
+    without initialising the driver (``utils/hardware/hardware.py::apply_gpu_ids`` relies
+    on exactly that), and it is the ROCm-ness the dangerous query depends on. It is only
+    consulted when torch is ALREADY imported, so this never pays an import of its own.
+
+    Without torch loaded there is no equally exact answer, so each platform falls back to
+    a file-existence test, or to no claim at all:
       * macOS never has ROCm.
       * Linux: ROCm's own kernel driver publishes this topology directory, and
         ``utils/hardware/hardware.py`` already reads it (``_rocm_kfd_gpu_pci_ids``).
-      * Windows: no equivalent node, so use the ROCm install itself -- the same bin
-        directories the probe child needs in order to load amdhip64.dll.
+      * Windows: nothing equivalent. An installed HIP SDK is NOT evidence -- ``main.py``
+        makes the same point where it refuses to let HIP_PATH/ROCM_PATH alone pick a
+        backend, since a CUDA or CPU box can carry the SDK. Claim nothing rather than
+        strand such a host on the provisional answer.
     """
     try:
-        if sys.platform == "darwin":
+        torch = sys.modules.get("torch")
+        if torch is not None:
+            return bool(getattr(getattr(torch, "version", None), "hip", None))
+        if sys.platform in ("darwin", "win32"):
             return False
-        if sys.platform == "win32":
-            from utils.device_allocation_probe import _rocm_dll_directories
-            return bool(_rocm_dll_directories())
         return os.path.isdir("/sys/class/kfd/kfd/topology/nodes")
     except Exception:  # noqa: BLE001 - unsure means possible; the caution is the safe side
         return True
@@ -621,6 +629,15 @@ def _resolve_auto() -> str:
         # real answer, which is what keeps its GGUF classification intact.
         return "sentence-transformers"
 
+    return _resolve_by_gpu_and_binary()
+
+
+def _resolve_by_gpu_and_binary() -> str:
+    """The non-ROCm half of ``auto``: GPU present -> ST, else the GGUF llama-server, or ST
+    if its binary is missing. Exactly what ``_resolve_auto`` was before this file learned
+    about ROCm, and it needs no hardware detection, which is why the request path can call
+    it directly rather than going through the resolver and parking on the detection lock.
+    """
     from core.inference.llama_cpp import LlamaCppBackend
 
     if LlamaCppBackend._get_gpu_free_memory():
@@ -758,7 +775,11 @@ def active_backend_is_llama() -> bool:
             is_rocm = _host_is_rocm()
             if is_rocm is True or (is_rocm is None and _rocm_is_possible()):
                 return False
-            key = _resolve_auto()
+            # Detection may still be running, and ensure_hardware_detected() holds
+            # _DETECT_LOCK across a cold torch import, so going through _resolve_auto here
+            # would park the request on exactly the wait this branch exists to avoid. ROCm
+            # is ruled out by now, and the rest of auto needs no detection at all.
+            key = _resolve_auto() if is_rocm is False else _resolve_by_gpu_and_binary()
         else:
             key = raw
         return key in _LLAMA_ALIASES

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -127,11 +127,56 @@ def _rocm_is_possible() -> bool:
             if not isinstance(version_string, str) or not version_string:
                 return True
             return "rocm" in version_string.lower()
-        if sys.platform in ("darwin", "win32"):
+        installed = _installed_torch_is_rocm()
+        if installed is not None:
+            return installed
+        if sys.platform == "darwin":
             return False
+        if sys.platform == "win32":
+            # Nothing torch-free left to read, and Windows has no KFD node. An installed
+            # HIP SDK is not evidence (main.py makes the same point), but neither is its
+            # absence, so keep the caution rather than the convenience.
+            return True
         return os.path.isdir("/sys/class/kfd/kfd/topology/nodes")
     except Exception:  # noqa: BLE001 - unsure means possible; the caution is the safe side
         return True
+
+
+@lru_cache(maxsize = 1)
+def _installed_torch_is_rocm() -> bool | None:
+    """Is the INSTALLED torch a ROCm build, answered without importing it.
+
+    ``torch/version.py`` is a generated file holding literals -- ``__version__`` and
+    ``hip`` -- and ``find_spec`` locates the package without executing it, so this reads
+    the same two facts hardware detection reads, minutes before torch is imported. That
+    matters on Windows, where there is no KFD node and an installed HIP SDK proves nothing
+    about which wheel is present.
+
+    None means "no answer": torch is missing (in which case the AMD query cannot run at
+    all) or the file is unreadable. Cached, since it is filesystem I/O on a request path
+    and an install does not change under a running backend.
+    """
+    try:
+        import importlib.util
+
+        spec = importlib.util.find_spec("torch")
+        if spec is None or not spec.origin:
+            return None
+        version_py = os.path.join(os.path.dirname(spec.origin), "version.py")
+        with open(version_py, encoding = "utf-8") as handle:
+            source = handle.read()
+    except Exception:  # noqa: BLE001 - no answer, and the caller decides what that means
+        return None
+
+    # hip = '6.3.42134' on a ROCm build, hip: Optional[str] = None otherwise.
+    if re.search(r"^hip\b[^=\n]*=\s*['\"]", source, re.MULTILINE):
+        return True
+    match = re.search(r"^__version__\s*=\s*['\"]([^'\"]+)", source, re.MULTILINE)
+    if match:
+        # AMD SDK wheels leave hip unset and only say rocm here; same fallback as
+        # utils/hardware/hardware.py.
+        return "rocm" in match.group(1).lower()
+    return None
 
 
 def _safe_torch_device() -> str:

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import sys
 import threading
 from contextlib import contextmanager
 from functools import lru_cache
@@ -87,6 +88,33 @@ def _host_is_rocm() -> bool | None:
         return bool(hardware_mod.IS_ROCM)
     except Exception:  # noqa: BLE001 - if we cannot even tell, leave behaviour untouched
         return False
+
+
+def _rocm_is_possible() -> bool:
+    """Could this host be ROCm at all, answered without torch and without detection.
+
+    The point is to keep the "detection has not settled yet" caution narrow. Treating
+    every unsettled host as possibly-ROCm is safe for the crash but too broad to be free:
+    it also hands a CPU or macOS host the provisional sentence-transformers answer, and
+    ``routes/settings.py`` reads that as "not llama" and stops applying its GGUF handling,
+    so a valid local .gguf briefly 409s on a host that never had an AMD GPU.
+
+    Each branch is a file-existence test, so it costs nothing on the request path:
+      * macOS never has ROCm.
+      * Linux: ROCm's own kernel driver publishes this topology directory, and
+        ``utils/hardware/hardware.py`` already reads it (``_rocm_kfd_gpu_pci_ids``).
+      * Windows: no equivalent node, so use the ROCm install itself -- the same bin
+        directories the probe child needs in order to load amdhip64.dll.
+    """
+    try:
+        if sys.platform == "darwin":
+            return False
+        if sys.platform == "win32":
+            from utils.device_allocation_probe import _rocm_dll_directories
+            return bool(_rocm_dll_directories())
+        return os.path.isdir("/sys/class/kfd/kfd/topology/nodes")
+    except Exception:  # noqa: BLE001 - unsure means possible; the caution is the safe side
+        return True
 
 
 def _safe_torch_device() -> str:
@@ -587,9 +615,10 @@ def _resolve_auto() -> str:
         except Exception:  # noqa: BLE001 - detection failing is not this function's problem
             is_rocm = None
 
-    if is_rocm is not False:
-        # None lands here too, and deliberately: until detection settles ROCm cannot be
-        # ruled out, and guessing "not ROCm" would reopen the AMD query below.
+    if is_rocm is True or (is_rocm is None and _rocm_is_possible()):
+        # The None case is detection that would not settle. Only hold back the AMD query
+        # below for a host that could actually be ROCm; a CPU or macOS host still gets its
+        # real answer, which is what keeps its GGUF classification intact.
         return "sentence-transformers"
 
     from core.inference.llama_cpp import LlamaCppBackend
@@ -719,13 +748,15 @@ def active_backend_is_llama() -> bool:
         raw = (config.EMBED_BACKEND or "auto").strip().lower()
         if raw in _AUTO_ALIASES:
             # This runs inside PUT /embedding-model and friends, so it must not sit behind
-            # hardware detection. On ROCm, and while detection is still unsettled and ROCm
-            # cannot be ruled out, answer without asking: auto resolves to
-            # sentence-transformers on every ROCm host, so the answer is False. That also
-            # leaves the ST pickle gate ENGAGED, the conservative direction for a security
-            # check. Only a settled non-ROCm host reaches the resolver, where the GPU query
+            # hardware detection. A ROCm host, and an unsettled host that could be ROCm,
+            # answer without asking: auto resolves to sentence-transformers on every ROCm
+            # host, so False is the real answer and not a placeholder, and it leaves the ST
+            # pickle gate ENGAGED, the conservative direction for a security check.
+            # Everything else reaches the resolver and keeps its llama/GGUF classification,
+            # which settings.py needs to accept a local .gguf; the GPU query it runs there
             # is nvidia-smi and cheap.
-            if _host_is_rocm() is not False:
+            is_rocm = _host_is_rocm()
+            if is_rocm is True or (is_rocm is None and _rocm_is_possible()):
                 return False
             key = _resolve_auto()
         else:

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -141,15 +141,19 @@ def _installed_torch_is_rocm() -> bool | None:
     without executing it, so this reads the same two facts detection reads, long before
     torch is imported. That matters on Windows, which has no KFD node.
 
-    None means no answer: torch is missing, in which case the AMD query cannot run either,
-    or the file is unreadable. Cached, being filesystem I/O on a request path.
+    False also covers torch being absent, which is a definite answer: no torch, no ROCm
+    torch path. None is reserved for an installation that is there but unreadable. Cached,
+    being filesystem I/O on a request path.
     """
     try:
         import importlib.util
 
         spec = importlib.util.find_spec("torch")
         if spec is None or not spec.origin:
-            return None
+            # Absent, not unreadable. There is no ROCm torch path to protect on a
+            # --no-torch install, and saying "unknown" here would make Windows cautious
+            # forever and cost that install the llama/GGUF answer it actually resolves to.
+            return False
         version_py = os.path.join(os.path.dirname(spec.origin), "version.py")
         with open(version_py, encoding = "utf-8") as handle:
             source = handle.read()

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -54,16 +54,14 @@ def _device() -> str:
 def _rocm_gpu_is_fatal() -> bool:
     """True when this host's ROCm stack faults on its first real GPU allocation.
 
-    ROCm is ``DeviceType.CUDA`` internally, so nothing above this point distinguishes a
-    healthy CUDA host from a ROCm wheel built for the wrong gfx arch. That distinction
-    cannot be made in this process: the mismatch does not raise, it SIGSEGVs inside the
-    HIP runtime, and it does so from a daemon thread where it takes uvicorn with it
-    (#8474, host in #7331). So a child is asked to allocate first, and its death is the
-    answer. Asked once per process; nothing is asked off ROCm, so a CUDA, XPU, Apple, CPU
-    or ``--no-torch`` host spawns nothing and behaves exactly as it did before.
+    ROCm is ``DeviceType.CUDA`` internally, so nothing here distinguishes a healthy CUDA
+    host from a ROCm wheel built for the wrong gfx arch. That cannot be decided in this
+    process: the mismatch SIGSEGVs inside the HIP runtime and takes uvicorn with it (#8474,
+    host in #7331). So a child allocates first and its death is the answer. Asked once per
+    process, and never off ROCm, so every other host spawns nothing.
 
-    Only ``_safe_torch_device`` calls this, and it has already settled detection through
-    ``_device()``, so the unknown case below is not the ROCm host going unprobed.
+    Only ``_safe_torch_device`` calls this, after ``_device()`` has settled detection, so
+    the unknown case below is not a ROCm host going unprobed.
     """
     if _host_is_rocm() is not True:
         return False
@@ -75,11 +73,10 @@ def _rocm_gpu_is_fatal() -> bool:
 def _host_is_rocm() -> bool | None:
     """True/False once hardware detection has settled, None while it has not.
 
-    Tri-state on purpose. Detection imports torch, and this is reached from
-    ``active_backend_is_llama()`` on the settings request path, so forcing it there is not
-    an option; but collapsing "not yet known" into False would let that same path fall
-    through to the in-process AMD GPU query this module exists to route around. Callers
-    have to say what they want done with "unknown".
+    Tri-state on purpose. Detection imports torch and this is reached from
+    ``active_backend_is_llama()`` on the settings request path, so forcing it is not an
+    option; but collapsing "not yet known" into False would let that path fall through to
+    the in-process AMD GPU query. Callers decide what "unknown" means for them.
     """
     try:
         from utils.hardware import hardware as hardware_mod
@@ -93,26 +90,20 @@ def _host_is_rocm() -> bool | None:
 def _rocm_is_possible() -> bool:
     """Could this host be ROCm at all, answered without torch and without detection.
 
-    The point is to keep the "detection has not settled yet" caution narrow. Treating
-    every unsettled host as possibly-ROCm is safe for the crash but too broad to be free:
-    it also hands a CPU or macOS host the provisional sentence-transformers answer, and
-    ``routes/settings.py`` reads that as "not llama" and stops applying its GGUF handling,
-    so a valid local .gguf briefly 409s on a host that never had an AMD GPU.
+    Keeps the "detection has not settled" caution narrow. Treating every unsettled host as
+    possibly-ROCm is safe for the crash but too broad: it hands a CPU or macOS host the
+    provisional answer, which ``routes/settings.py`` reads as "not llama" and drops its
+    GGUF handling, so a valid local .gguf briefly 409s on a host with no AMD GPU.
 
-    The signal that actually settles it is ``torch.version.hip``: a build attribute, read
-    without initialising the driver (``utils/hardware/hardware.py::apply_gpu_ids`` relies
-    on exactly that), and it is the ROCm-ness the dangerous query depends on. It is only
-    consulted when torch is ALREADY imported, so this never pays an import of its own.
-
-    Without torch loaded there is no equally exact answer, so each platform falls back to
-    a file-existence test, or to no claim at all:
+    ``torch.version.hip`` settles it exactly: a build attribute, read without initialising
+    the driver (``hardware.py::apply_gpu_ids`` relies on that), and the ROCm-ness the
+    dangerous query turns on. Consulted only when torch is already imported, then read off
+    disk, and only then does each platform fall back to a file test or to no claim:
       * macOS never has ROCm.
       * Linux: ROCm's own kernel driver publishes this topology directory, and
         ``utils/hardware/hardware.py`` already reads it (``_rocm_kfd_gpu_pci_ids``).
-      * Windows: nothing equivalent. An installed HIP SDK is NOT evidence -- ``main.py``
-        makes the same point where it refuses to let HIP_PATH/ROCM_PATH alone pick a
-        backend, since a CUDA or CPU box can carry the SDK. Claim nothing rather than
-        strand such a host on the provisional answer.
+      * Windows: nothing equivalent, and an installed HIP SDK is NOT evidence -- ``main.py``
+        refuses to let HIP_PATH/ROCM_PATH alone pick a backend for the same reason.
     """
     try:
         torch = sys.modules.get("torch")
@@ -146,15 +137,12 @@ def _rocm_is_possible() -> bool:
 def _installed_torch_is_rocm() -> bool | None:
     """Is the INSTALLED torch a ROCm build, answered without importing it.
 
-    ``torch/version.py`` is a generated file holding literals -- ``__version__`` and
-    ``hip`` -- and ``find_spec`` locates the package without executing it, so this reads
-    the same two facts hardware detection reads, minutes before torch is imported. That
-    matters on Windows, where there is no KFD node and an installed HIP SDK proves nothing
-    about which wheel is present.
+    ``torch/version.py`` holds generated literals and ``find_spec`` locates the package
+    without executing it, so this reads the same two facts detection reads, long before
+    torch is imported. That matters on Windows, which has no KFD node.
 
-    None means "no answer": torch is missing (in which case the AMD query cannot run at
-    all) or the file is unreadable. Cached, since it is filesystem I/O on a request path
-    and an install does not change under a running backend.
+    None means no answer: torch is missing, in which case the AMD query cannot run either,
+    or the file is unreadable. Cached, being filesystem I/O on a request path.
     """
     try:
         import importlib.util
@@ -182,10 +170,9 @@ def _installed_torch_is_rocm() -> bool | None:
 def _safe_torch_device() -> str:
     """``_device()``, except that a ROCm GPU which cannot allocate resolves to CPU.
 
-    Degrading to CPU rather than to the llama-server GGUF embedder is deliberate: it is
-    the same backend and the same model, so the vectors are unchanged and no knowledge
-    base needs reindexing. bge-small is small enough that CPU is a slowdown, not a loss
-    of function.
+    Degrading to CPU rather than to the llama-server GGUF embedder is deliberate: same
+    backend, same model, so the vectors are unchanged and no knowledge base needs
+    reindexing. bge-small on CPU is a slowdown, not a loss of function.
     """
     device = _device()
     if device != "cuda":
@@ -507,9 +494,9 @@ def _get(model_name: str | None = None):
             from utils.hf_cache_settings import active_hf_hub_cache
 
             device = _safe_torch_device()
-            # A GPU we were pushed off is not the same as a host that never had one: fp16
-            # is a win on the GPU and a slow, patchily supported path on CPU. Only the
-            # degraded case switches, so a genuine CPU/Apple host loads exactly as before.
+            # A GPU we were pushed off is not a host that never had one: fp16 wins on the
+            # GPU and is slow and patchily supported on CPU. Only the degraded case
+            # switches, so a genuine CPU/Apple host loads exactly as before.
             degraded_to_cpu = device == "cpu" and _device() == "cuda"
             logger.info("loading embedding model %s on %s", name, device)
             _guard_model_security(name, local_only)
@@ -655,22 +642,21 @@ def _resolve_auto() -> str:
     -- or ST if its binary is missing.
 
     The GPU check is torch-free on NVIDIA (nvidia-smi) but NOT on AMD, where
-    ``_get_gpu_free_memory`` falls back to torch ``mem_get_info`` in this process. On
-    anything that might be ROCm this function therefore answers without asking it: a ROCm
-    host resolves to sentence-transformers whatever the GPU turns out to be, since a
-    working GPU takes it and a condemned one is placed on CPU by ``_safe_torch_device``.
-    That is what keeps this function from steering an affected host into the very crash it
-    exists to route around. Returning early also keeps the llama.cpp plumbing unimported.
-    Note that no allocation probe runs here: the device decision belongs to the load.
+    ``_get_gpu_free_memory`` falls back to torch ``mem_get_info`` in this process. So
+    anything that might be ROCm answers without asking it, which is what stops this
+    function steering an affected host into the crash it exists to route around. The answer
+    is the same either way: a working ROCm GPU takes sentence-transformers, a condemned one
+    is placed on CPU by ``_safe_torch_device``. No allocation probe runs here; the device
+    decision belongs to the load.
 
-    This settles hardware detection if it has not settled, so the answer is final and safe
-    for ``_get_backend`` to cache. Callers that must not block on detection (there is one,
-    ``active_backend_is_llama``) decide the ROCm case themselves and never get here.
+    Settles detection if it has not settled, so the answer is final and safe for
+    ``_get_backend`` to cache. ``active_backend_is_llama`` must not block on detection and
+    so decides the ROCm case itself rather than coming here.
     """
     is_rocm = _host_is_rocm()
     if is_rocm is None:
-        # get_device() imports torch and caches under its own lock. The builder can afford
-        # that; it is the request path that cannot, and it does not come here.
+        # get_device() imports torch under its own lock: affordable for the builder,
+        # not for the request path, which does not come here.
         try:
             get_device()
             is_rocm = _host_is_rocm()
@@ -678,9 +664,9 @@ def _resolve_auto() -> str:
             is_rocm = None
 
     if is_rocm is True or (is_rocm is None and _rocm_is_possible()):
-        # The None case is detection that would not settle. Only hold back the AMD query
-        # below for a host that could actually be ROCm; a CPU or macOS host still gets its
-        # real answer, which is what keeps its GGUF classification intact.
+        # None here is detection that would not settle. Hold back the AMD query only for a
+        # host that could be ROCm, so a CPU or macOS host keeps its real answer, and with
+        # it its GGUF classification.
         return "sentence-transformers"
 
     return _resolve_by_gpu_and_binary()
@@ -689,8 +675,8 @@ def _resolve_auto() -> str:
 def _resolve_by_gpu_and_binary() -> str:
     """The non-ROCm half of ``auto``: GPU present -> ST, else the GGUF llama-server, or ST
     if its binary is missing. Exactly what ``_resolve_auto`` was before this file learned
-    about ROCm, and it needs no hardware detection, which is why the request path can call
-    it directly rather than going through the resolver and parking on the detection lock.
+    about ROCm. Needs no hardware detection, so the request path calls it directly instead
+    of going through the resolver and parking on the detection lock.
     """
     from core.inference.llama_cpp import LlamaCppBackend
 
@@ -818,21 +804,17 @@ def active_backend_is_llama() -> bool:
             return isinstance(backend, LlamaServerBackend)
         raw = (config.EMBED_BACKEND or "auto").strip().lower()
         if raw in _AUTO_ALIASES:
-            # This runs inside PUT /embedding-model and friends, so it must not sit behind
-            # hardware detection. A ROCm host, and an unsettled host that could be ROCm,
-            # answer without asking: auto resolves to sentence-transformers on every ROCm
-            # host, so False is the real answer and not a placeholder, and it leaves the ST
-            # pickle gate ENGAGED, the conservative direction for a security check.
-            # Everything else reaches the resolver and keeps its llama/GGUF classification,
-            # which settings.py needs to accept a local .gguf; the GPU query it runs there
-            # is nvidia-smi and cheap.
+            # Runs inside PUT /embedding-model, so it must not sit behind hardware
+            # detection. A ROCm host, or an unsettled one that could be ROCm, answers
+            # without asking: auto resolves to sentence-transformers on every ROCm host, so
+            # False is the real answer, and it leaves the ST pickle gate ENGAGED, the
+            # conservative direction for a security check. Everything else keeps the
+            # llama/GGUF classification settings.py needs to accept a local .gguf.
             is_rocm = _host_is_rocm()
             if is_rocm is True or (is_rocm is None and _rocm_is_possible()):
                 return False
-            # Detection may still be running, and ensure_hardware_detected() holds
-            # _DETECT_LOCK across a cold torch import, so going through _resolve_auto here
-            # would park the request on exactly the wait this branch exists to avoid. ROCm
-            # is ruled out by now, and the rest of auto needs no detection at all.
+            # ensure_hardware_detected() holds _DETECT_LOCK across a cold torch import, so
+            # _resolve_auto here would park the request on the wait this branch avoids.
             key = _resolve_auto() if is_rocm is False else _resolve_by_gpu_and_binary()
         else:
             key = raw

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -60,24 +60,33 @@ def _rocm_gpu_is_fatal() -> bool:
     (#8474, host in #7331). So a child is asked to allocate first, and its death is the
     answer. Asked once per process; nothing is asked off ROCm, so a CUDA, XPU, Apple, CPU
     or ``--no-torch`` host spawns nothing and behaves exactly as it did before.
-    """
-    try:
-        from utils.hardware import hardware as hardware_mod
 
-        # Read the flag, never force the detection that sets it: detection imports torch,
-        # and this is reachable from active_backend_is_llama() well before the coordinated
-        # warm is meant to pay that cost. Nothing is lost by declining here -- the place
-        # that actually allocates, _safe_torch_device, calls _device() first, which
-        # settles detection, so the guard that matters is never the one skipped.
-        if not hardware_mod.DETECTION_COMPLETE.is_set():
-            return False
-        if not hardware_mod.IS_ROCM:
-            return False
-    except Exception:  # noqa: BLE001 - if we cannot even tell, leave behaviour untouched
+    Only ``_safe_torch_device`` calls this, and it has already settled detection through
+    ``_device()``, so the unknown case below is not the ROCm host going unprobed.
+    """
+    if _host_is_rocm() is not True:
         return False
     from utils.device_allocation_probe import probe_torch_device_allocation
 
     return not probe_torch_device_allocation("cuda:0").ok
+
+
+def _host_is_rocm() -> bool | None:
+    """True/False once hardware detection has settled, None while it has not.
+
+    Tri-state on purpose. Detection imports torch, and this is reached from
+    ``active_backend_is_llama()`` on the settings request path, so forcing it there is not
+    an option; but collapsing "not yet known" into False would let that same path fall
+    through to the in-process AMD GPU query this module exists to route around. Callers
+    have to say what they want done with "unknown".
+    """
+    try:
+        from utils.hardware import hardware as hardware_mod
+        if not hardware_mod.DETECTION_COMPLETE.is_set():
+            return None
+        return bool(hardware_mod.IS_ROCM)
+    except Exception:  # noqa: BLE001 - if we cannot even tell, leave behaviour untouched
+        return False
 
 
 def _safe_torch_device() -> str:
@@ -556,15 +565,31 @@ def _resolve_auto() -> str:
     -- or ST if its binary is missing.
 
     The GPU check is torch-free on NVIDIA (nvidia-smi) but NOT on AMD, where
-    ``_get_gpu_free_memory`` falls back to torch ``mem_get_info`` in this process. So the
-    allocation probe has to be consulted FIRST on ROCm: a condemned host used to be
-    steered by this function straight into the crash it was trying to route around.
+    ``_get_gpu_free_memory`` falls back to torch ``mem_get_info`` in this process. On
+    anything that might be ROCm this function therefore answers without asking it: a ROCm
+    host resolves to sentence-transformers whatever the GPU turns out to be, since a
+    working GPU takes it and a condemned one is placed on CPU by ``_safe_torch_device``.
+    That is what keeps this function from steering an affected host into the very crash it
+    exists to route around. Returning early also keeps the llama.cpp plumbing unimported.
+    Note that no allocation probe runs here: the device decision belongs to the load.
+
+    This settles hardware detection if it has not settled, so the answer is final and safe
+    for ``_get_backend`` to cache. Callers that must not block on detection (there is one,
+    ``active_backend_is_llama``) decide the ROCm case themselves and never get here.
     """
-    if _rocm_gpu_is_fatal():
-        # Stay on sentence-transformers, which _safe_torch_device() will place on CPU.
-        # Picking llama-server here would embed into a different vector space and force a
-        # reindex, for a host whose only problem is that it cannot use its GPU. Returning
-        # before the import below also keeps the llama.cpp plumbing out of this process.
+    is_rocm = _host_is_rocm()
+    if is_rocm is None:
+        # get_device() imports torch and caches under its own lock. The builder can afford
+        # that; it is the request path that cannot, and it does not come here.
+        try:
+            get_device()
+            is_rocm = _host_is_rocm()
+        except Exception:  # noqa: BLE001 - detection failing is not this function's problem
+            is_rocm = None
+
+    if is_rocm is not False:
+        # None lands here too, and deliberately: until detection settles ROCm cannot be
+        # ruled out, and guessing "not ROCm" would reopen the AMD query below.
         return "sentence-transformers"
 
     from core.inference.llama_cpp import LlamaCppBackend
@@ -692,7 +717,19 @@ def active_backend_is_llama() -> bool:
                 return False
             return isinstance(backend, LlamaServerBackend)
         raw = (config.EMBED_BACKEND or "auto").strip().lower()
-        key = _resolve_auto() if raw in _AUTO_ALIASES else raw
+        if raw in _AUTO_ALIASES:
+            # This runs inside PUT /embedding-model and friends, so it must not sit behind
+            # hardware detection. On ROCm, and while detection is still unsettled and ROCm
+            # cannot be ruled out, answer without asking: auto resolves to
+            # sentence-transformers on every ROCm host, so the answer is False. That also
+            # leaves the ST pickle gate ENGAGED, the conservative direction for a security
+            # check. Only a settled non-ROCm host reaches the resolver, where the GPU query
+            # is nvidia-smi and cheap.
+            if _host_is_rocm() is not False:
+                return False
+            key = _resolve_auto()
+        else:
+            key = raw
         return key in _LLAMA_ALIASES
     except Exception:  # noqa: BLE001 - a backend probe must never block saving
         return False

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -50,6 +50,58 @@ def _device() -> str:
     return _TORCH_DEVICE.get(get_device(), "cpu")
 
 
+def _rocm_gpu_is_fatal() -> bool:
+    """True when this host's ROCm stack faults on its first real GPU allocation.
+
+    ROCm is ``DeviceType.CUDA`` internally, so nothing above this point distinguishes a
+    healthy CUDA host from a ROCm wheel built for the wrong gfx arch. That distinction
+    cannot be made in this process: the mismatch does not raise, it SIGSEGVs inside the
+    HIP runtime, and it does so from a daemon thread where it takes uvicorn with it
+    (#8474, host in #7331). So a child is asked to allocate first, and its death is the
+    answer. Asked once per process; nothing is asked off ROCm, so a CUDA, XPU, Apple, CPU
+    or ``--no-torch`` host spawns nothing and behaves exactly as it did before.
+    """
+    try:
+        from utils.hardware import hardware as hardware_mod
+
+        # Read the flag, never force the detection that sets it: detection imports torch,
+        # and this is reachable from active_backend_is_llama() well before the coordinated
+        # warm is meant to pay that cost. Nothing is lost by declining here -- the place
+        # that actually allocates, _safe_torch_device, calls _device() first, which
+        # settles detection, so the guard that matters is never the one skipped.
+        if not hardware_mod.DETECTION_COMPLETE.is_set():
+            return False
+        if not hardware_mod.IS_ROCM:
+            return False
+    except Exception:  # noqa: BLE001 - if we cannot even tell, leave behaviour untouched
+        return False
+    from utils.device_allocation_probe import probe_torch_device_allocation
+
+    return not probe_torch_device_allocation("cuda:0").ok
+
+
+def _safe_torch_device() -> str:
+    """``_device()``, except that a ROCm GPU which cannot allocate resolves to CPU.
+
+    Degrading to CPU rather than to the llama-server GGUF embedder is deliberate: it is
+    the same backend and the same model, so the vectors are unchanged and no knowledge
+    base needs reindexing. bge-small is small enough that CPU is a slowdown, not a loss
+    of function.
+    """
+    device = _device()
+    if device != "cuda":
+        return device
+    if _rocm_gpu_is_fatal():
+        logger.warning(
+            "this host's ROCm GPU crashed an isolated allocation probe, so it cannot be "
+            "used in this process without killing the backend; loading the embedding "
+            "model on CPU instead. Embeddings are unchanged, so no knowledge base needs "
+            "reindexing. Usually a torch wheel built for a different gfx arch."
+        )
+        return "cpu"
+    return device
+
+
 _torchao_stub_done = False
 
 
@@ -355,13 +407,17 @@ def _get(model_name: str | None = None):
             from sentence_transformers import SentenceTransformer
             from utils.hf_cache_settings import active_hf_hub_cache
 
-            device = _device()
+            device = _safe_torch_device()
+            # A GPU we were pushed off is not the same as a host that never had one: fp16
+            # is a win on the GPU and a slow, patchily supported path on CPU. Only the
+            # degraded case switches, so a genuine CPU/Apple host loads exactly as before.
+            degraded_to_cpu = device == "cpu" and _device() == "cuda"
             logger.info("loading embedding model %s on %s", name, device)
             _guard_model_security(name, local_only)
             st_kwargs = dict(
                 device = device,
                 cache_folder = active_hf_hub_cache(),
-                model_kwargs = dtype_kwargs("float16"),
+                model_kwargs = dtype_kwargs("float32" if degraded_to_cpu else "float16"),
             )
             load_target = name
             if local_only:
@@ -497,7 +553,20 @@ _AUTO_ALIASES = frozenset({"auto", ""})
 def _resolve_auto() -> str:
     """Pick a backend for ``auto``: sentence-transformers when a CUDA/ROCm GPU is
     present (torch fp16 wins bulk indexing), else the torch-free GGUF llama-server
-    -- or ST if its binary is missing. GPU check is torch-free (nvidia-smi)."""
+    -- or ST if its binary is missing.
+
+    The GPU check is torch-free on NVIDIA (nvidia-smi) but NOT on AMD, where
+    ``_get_gpu_free_memory`` falls back to torch ``mem_get_info`` in this process. So the
+    allocation probe has to be consulted FIRST on ROCm: a condemned host used to be
+    steered by this function straight into the crash it was trying to route around.
+    """
+    if _rocm_gpu_is_fatal():
+        # Stay on sentence-transformers, which _safe_torch_device() will place on CPU.
+        # Picking llama-server here would embed into a different vector space and force a
+        # reindex, for a host whose only problem is that it cannot use its GPU. Returning
+        # before the import below also keeps the llama.cpp plumbing out of this process.
+        return "sentence-transformers"
+
     from core.inference.llama_cpp import LlamaCppBackend
 
     if LlamaCppBackend._get_gpu_free_memory():

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -502,8 +502,13 @@ def _warm_rag_embedder() -> None:
         from core.rag import embeddings
 
         embeddings.warm()
-    except Exception:
-        pass
+    except Exception as _rag_exc:
+        # Warming is an optimization: the first real request loads the embedder itself.
+        # Logged rather than swallowed so a host that never gets a warm embedder says why
+        # once. A driver fault is NOT reachable here -- it is not an exception, which is
+        # the whole point of the isolated probe in utils/device_allocation_probe.py.
+        import structlog as _structlog
+        _structlog.get_logger(__name__).debug("RAG embedder warm skipped: %s", _rag_exc)
 
 
 _post_warm_thread: Optional[threading.Thread] = None

--- a/studio/backend/tests/test_device_allocation_probe.py
+++ b/studio/backend/tests/test_device_allocation_probe.py
@@ -136,6 +136,55 @@ def test_child_env_strips_the_native_path_secret(monkeypatch):
     assert env["PYTHONIOENCODING"] == "utf-8"
 
 
+def test_windows_child_registers_the_rocm_dll_directories(monkeypatch, tmp_path):
+    # os.add_dll_directory registrations are process-local, so a fresh child does not
+    # inherit main.py's. Without this a healthy Windows AMD GPU cannot even import torch in
+    # the child, and the fail-closed verdict would condemn it to CPU for the process.
+    rocm_bin = tmp_path / "rocm" / "bin"
+    rocm_bin.mkdir(parents = True)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("HIP_PATH", str(tmp_path / "rocm"))
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+
+    probe_torch_device_allocation("cuda:0")
+
+    env = calls[0][1]["env"]
+    assert str(rocm_bin) in env[probe_mod.ROCM_DLL_DIRS_ENV_VAR].split(os.pathsep)
+    script = calls[0][0][2]
+    # The registration has to precede the import, not merely be present.
+    assert script.index("add_dll_directory") < script.index("import torch")
+
+
+def test_rocm_dll_directories_are_empty_off_windows(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("HIP_PATH", str(tmp_path))
+    assert probe_mod._rocm_dll_directories() == []
+
+
+def test_non_windows_child_env_has_no_dll_variable(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+    probe_torch_device_allocation("cuda:0")
+    assert probe_mod.ROCM_DLL_DIRS_ENV_VAR not in calls[0][1]["env"]
+
+
+def test_rocm_dll_directories_prefers_the_newest_version(monkeypatch, tmp_path):
+    root = tmp_path / "AMD" / "ROCm"
+    for version in ("6.3", "10.0", "7.0"):
+        (root / version / "bin").mkdir(parents = True)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("HIP_PATH", raising = False)
+    monkeypatch.delenv("ROCM_PATH", raising = False)
+    monkeypatch.setenv("ProgramFiles", str(tmp_path))
+
+    found = probe_mod._rocm_dll_directories()
+
+    # Numeric sort, so 10.0 outranks 7.0 rather than sorting as a string.
+    assert [Path(p).parent.name for p in found] == ["10.0", "7.0", "6.3"]
+
+
 # --- every way it fails closed ---------------------------------------------------
 
 
@@ -281,7 +330,16 @@ def test_describe_exit_names_the_signal():
 
 def test_parent_side_never_imports_torch():
     # This module is imported by the RAG embedder, which is deliberately torch-optional
-    # and runs in the lean main process (see tests/test_startup_defers_torch.py).
+    # and runs in the lean main process (see tests/test_startup_defers_torch.py). Walk the
+    # AST rather than the text: the child script is a string literal here and the prose
+    # around it names the import it is careful to place correctly.
+    import ast
+
     source = (_BACKEND_DIR / "utils" / "device_allocation_probe.py").read_text(encoding = "utf-8")
-    module_level = source.split('_CHILD_SCRIPT = """')[0]
-    assert "import torch" not in module_level
+    imported = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            imported.add(node.module.split(".")[0])
+    assert "torch" not in imported

--- a/studio/backend/tests/test_device_allocation_probe.py
+++ b/studio/backend/tests/test_device_allocation_probe.py
@@ -105,7 +105,7 @@ def test_child_runs_this_interpreter_with_hidden_window_kwargs(monkeypatch):
     argv, kwargs = calls[0]
     assert argv[0] == sys.executable
     assert argv[1] == "-c"
-    assert argv[-1] == "cuda:1"  # the device is passed as argv, never interpolated
+    assert argv[-2] == "cuda:1"  # the device is passed as argv, never interpolated
     for key, value in windows_hidden_subprocess_kwargs().items():
         assert key in kwargs
     assert kwargs["stdout"] is subprocess.PIPE
@@ -157,17 +157,17 @@ def test_windows_child_registers_the_rocm_dll_directories(monkeypatch, tmp_path)
     assert script.index("add_dll_directory") < script.index("import torch")
 
 
-def test_child_is_bound_to_the_backend_lifetime(monkeypatch):
-    # The child can sit in a cold torch import, or wedged in a driver ioctl, for the whole
-    # timeout. A Studio killed in that window must not leave it running against the GPU the
-    # next backend is about to probe, so it gets the same binding as the other GPU children.
+def test_child_is_tracked_without_a_pre_exec_hook(monkeypatch):
+    # preexec_fn would fork this multithreaded server and run Python before exec, where a
+    # lock another uvicorn thread held at fork time is still held; the child can hang there
+    # while the parent waits inside Popen, before any timeout applies. Python's docs call
+    # it unsafe in the presence of threads. Shutdown tracking must not reintroduce it.
     from utils import process_lifetime
 
     adopted: list = []
     forgotten: list = []
     monkeypatch.setattr(process_lifetime, "adopt_pid", adopted.append)
     monkeypatch.setattr(process_lifetime, "forget_pid", forgotten.append)
-    monkeypatch.setattr(process_lifetime, "child_popen_kwargs", lambda *a, **k: {"preexec_fn": id})
 
     calls: list = []
     proc = _FakeProc()
@@ -175,9 +175,55 @@ def test_child_is_bound_to_the_backend_lifetime(monkeypatch):
 
     probe_torch_device_allocation("cuda:0")
 
-    assert calls[0][1].get("preexec_fn") is id  # parent-death binding on Linux
+    assert "preexec_fn" not in calls[0][1]
     assert adopted == [proc.pid]
     assert forgotten == [proc.pid]  # exited cleanly, so the record is released
+
+
+def test_the_child_bounds_its_own_life(monkeypatch):
+    # With no parent-death hook, an orphaned probe has to stop by itself rather than sit on
+    # the GPU the next backend will want.
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+
+    probe_torch_device_allocation("cuda:0")
+
+    argv = calls[0][0]
+    assert float(argv[-1]) == probe_mod._CHILD_SELF_LIMIT_SECONDS
+    # Past the parent's own deadline, so in a normal run the parent always decides first.
+    assert probe_mod._CHILD_SELF_LIMIT_SECONDS > probe_mod.PROBE_TIMEOUT_SECONDS
+    script = argv[2]
+    assert "os._exit" in script  # a wedged driver will not run a clean shutdown
+    assert script.index("threading.Timer") < script.index("import torch")
+    # A Timer is a Thread and is NOT daemon by default. Without this the child cannot exit
+    # until the watchdog fires, so every probe on every host times out. Caught live.
+    assert "daemon = True" in script
+
+
+def test_the_child_script_exits_promptly(tmp_path):
+    # Runs the real child, with torch stubbed out, so the watchdog cannot silently make a
+    # healthy probe hang. This is the check that caught the non-daemon Timer.
+    stub = tmp_path / "torch.py"
+    stub.write_text(
+        "class _Dev:\n"
+        "    type = 'cpu'\n"
+        "class _T:\n"
+        "    device = _Dev()\n"
+        "    def zero_(self):\n"
+        "        pass\n"
+        "def empty(*a, **k):\n"
+        "    return _T()\n"
+    )
+    env = {**os.environ, "PYTHONPATH": str(tmp_path)}
+    done = subprocess.run(
+        [sys.executable, "-c", probe_mod._CHILD_SCRIPT, "cpu", "300"],
+        capture_output = True,
+        text = True,
+        env = env,
+        timeout = 60,
+    )
+    assert done.returncode == 0, done.stderr
+    assert "ok" in done.stdout
 
 
 def test_a_stuck_child_stays_adopted_until_the_reaper_collects_it(monkeypatch):

--- a/studio/backend/tests/test_device_allocation_probe.py
+++ b/studio/backend/tests/test_device_allocation_probe.py
@@ -369,6 +369,26 @@ def test_a_child_that_dies_within_the_grace_needs_no_reaper(monkeypatch):
     assert threading.active_count() <= before
 
 
+def test_a_read_failure_fails_closed_and_tears_the_child_down(monkeypatch):
+    # A Windows pipe/handle failure, or a read error under resource pressure. This function
+    # promises never to raise and to treat every unknown outcome as unsafe, and the child
+    # may still be running, so it has to be torn down rather than left to its watchdog.
+    proc = _FakeProc()
+
+    def _boom(timeout = None):
+        proc.calls.append("communicate")
+        raise OSError("handle is invalid")
+
+    proc.communicate = _boom  # type: ignore[method-assign]
+    _patch_popen(monkeypatch, proc)
+
+    result = probe_torch_device_allocation("cuda:0")
+
+    assert result.ok is False
+    assert "could not be read" in result.reason
+    assert "terminate" in proc.calls
+
+
 def test_spawn_failure_fails_closed_without_raising(monkeypatch):
     def boom(argv, **kwargs):
         raise OSError("no fork headroom")

--- a/studio/backend/tests/test_device_allocation_probe.py
+++ b/studio/backend/tests/test_device_allocation_probe.py
@@ -14,6 +14,7 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -245,6 +246,30 @@ def test_timeout_escalates_to_kill_and_always_reaps(monkeypatch):
     assert proc.calls.count("kill") == 1
     # terminate drain, kill drain: the child is waited on, never left as a zombie.
     assert proc.calls.count("communicate") == 3
+
+
+def test_a_child_that_outlives_sigkill_is_still_reaped(monkeypatch):
+    # SIGKILL is not delivered while a task sits in an uninterruptible driver wait, which
+    # is exactly the wedged-GPU case this module exists to survive. Dropping the last
+    # reference there would leave an unreaped stray, so it is handed to a reaper instead.
+    proc = _FakeProc(returncode = -int(signal.SIGKILL), timeouts = 3)
+    waited = threading.Event()
+    proc.wait = lambda: waited.set()  # type: ignore[method-assign]
+    _patch_popen(monkeypatch, proc)
+
+    assert probe_torch_device_allocation("cuda:0").ok is False
+    assert waited.wait(timeout = 5), "abandoned child was never waited on"
+
+
+def test_a_child_that_dies_within_the_grace_needs_no_reaper(monkeypatch):
+    proc = _FakeProc(returncode = -int(signal.SIGTERM), timeouts = 1)
+    before = threading.active_count()
+    _patch_popen(monkeypatch, proc)
+
+    probe_torch_device_allocation("cuda:0")
+
+    assert "kill" not in proc.calls
+    assert threading.active_count() <= before
 
 
 def test_spawn_failure_fails_closed_without_raising(monkeypatch):

--- a/studio/backend/tests/test_device_allocation_probe.py
+++ b/studio/backend/tests/test_device_allocation_probe.py
@@ -157,6 +157,57 @@ def test_windows_child_registers_the_rocm_dll_directories(monkeypatch, tmp_path)
     assert script.index("add_dll_directory") < script.index("import torch")
 
 
+def test_child_is_bound_to_the_backend_lifetime(monkeypatch):
+    # The child can sit in a cold torch import, or wedged in a driver ioctl, for the whole
+    # timeout. A Studio killed in that window must not leave it running against the GPU the
+    # next backend is about to probe, so it gets the same binding as the other GPU children.
+    from utils import process_lifetime
+
+    adopted: list = []
+    forgotten: list = []
+    monkeypatch.setattr(process_lifetime, "adopt_pid", adopted.append)
+    monkeypatch.setattr(process_lifetime, "forget_pid", forgotten.append)
+    monkeypatch.setattr(process_lifetime, "child_popen_kwargs", lambda *a, **k: {"preexec_fn": id})
+
+    calls: list = []
+    proc = _FakeProc()
+    _patch_popen(monkeypatch, proc, calls)
+
+    probe_torch_device_allocation("cuda:0")
+
+    assert calls[0][1].get("preexec_fn") is id  # parent-death binding on Linux
+    assert adopted == [proc.pid]
+    assert forgotten == [proc.pid]  # exited cleanly, so the record is released
+
+
+def test_a_stuck_child_stays_adopted_until_the_reaper_collects_it(monkeypatch):
+    from utils import process_lifetime
+
+    forgotten: list = []
+    monkeypatch.setattr(process_lifetime, "adopt_pid", lambda pid: None)
+    monkeypatch.setattr(process_lifetime, "forget_pid", forgotten.append)
+
+    proc = _FakeProc(returncode = -int(signal.SIGKILL), timeouts = 3)
+    proc.returncode = None  # never exited: still alive after the kill
+    reaped = threading.Event()
+
+    def _wait():
+        reaped.set()
+
+    proc.wait = _wait  # type: ignore[method-assign]
+    _patch_popen(monkeypatch, proc)
+
+    probe_torch_device_allocation("cuda:0")
+
+    assert reaped.wait(timeout = 5)
+    # Released by the reaper once it was really gone, not while it was still running.
+    for _ in range(50):
+        if forgotten:
+            break
+        threading.Event().wait(0.05)
+    assert forgotten == [proc.pid]
+
+
 def test_rocm_dll_directories_are_empty_off_windows(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setenv("HIP_PATH", str(tmp_path))
@@ -333,12 +384,21 @@ def test_unrelated_env_change_does_not_invalidate_the_verdict(monkeypatch):
     assert len(calls) == 1
 
 
-def test_no_verdict_is_written_to_disk(monkeypatch, tmp_path):
-    # A cached negative that outlived a driver repair would pin a healthy host to CPU.
+def test_no_verdict_survives_the_process(monkeypatch, tmp_path):
+    # A cached negative that outlived a driver repair would pin a healthy host to CPU with
+    # no way to tell why, so the memo is process-local. Asserted as the property that
+    # matters: a fresh process re-probes. (The studio home does gain a child-lifetime
+    # record here, which is the reaper's, not a verdict.)
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path))
-    _patch_popen(monkeypatch, _FakeProc(returncode = -int(signal.SIGSEGV)))
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(returncode = -int(signal.SIGSEGV)), calls)
+
     probe_torch_device_allocation("cuda:0")
-    assert list(tmp_path.rglob("*")) == []
+    probe_mod._clear_probe_cache()  # stands in for the next process starting cold
+    probe_torch_device_allocation("cuda:0")
+
+    assert len(calls) == 2
+    assert not list(tmp_path.rglob("*probe*"))
 
 
 # --- exit description -------------------------------------------------------------

--- a/studio/backend/tests/test_device_allocation_probe.py
+++ b/studio/backend/tests/test_device_allocation_probe.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Isolated device-allocation probe (#8474), every boundary mocked.
+
+The fault this guards against cannot be provoked in CI -- there is no AMD silicon and no
+ROCm here -- so the child is faked and the thing under test is the CLASSIFICATION: that a
+child killed by a signal, a Windows native fault, any nonzero exit, a timeout and a failed
+spawn all come back as "do not allocate in this process", and that a healthy child is the
+only thing that comes back ok.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from utils import device_allocation_probe as probe_mod  # noqa: E402
+from utils.device_allocation_probe import (  # noqa: E402
+    DeviceAllocationProbeResult,
+    describe_exit,
+    probe_torch_device_allocation,
+)
+
+
+@pytest.fixture(autouse = True)
+def _clear_cache():
+    probe_mod._clear_probe_cache()
+    yield
+    probe_mod._clear_probe_cache()
+
+
+class _FakeProc:
+    """Popen stand-in. ``timeouts`` is how many communicate() calls raise before one
+    returns, so a test can drive the terminate -> grace -> kill ladder."""
+
+    def __init__(
+        self,
+        returncode = 0,
+        stderr = "",
+        timeouts = 0,
+    ):
+        self.returncode = returncode
+        self.pid = 4242
+        self._stderr = stderr
+        self._timeouts = timeouts
+        self.calls: list[str] = []
+
+    def communicate(self, timeout = None):
+        self.calls.append("communicate")
+        if self._timeouts > 0:
+            self._timeouts -= 1
+            raise subprocess.TimeoutExpired(cmd = "probe", timeout = timeout or 0)
+        return "ok\n", self._stderr
+
+    def terminate(self):
+        self.calls.append("terminate")
+
+    def kill(self):
+        self.calls.append("kill")
+
+
+def _patch_popen(
+    monkeypatch,
+    proc,
+    recorder = None,
+):
+    def fake_popen(argv, **kwargs):
+        if recorder is not None:
+            recorder.append((argv, kwargs))
+        return proc
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    return recorder
+
+
+# --- the passing case -------------------------------------------------------------
+
+
+def test_healthy_child_passes(monkeypatch):
+    _patch_popen(monkeypatch, _FakeProc(returncode = 0))
+    result = probe_torch_device_allocation("cuda:0")
+    assert isinstance(result, DeviceAllocationProbeResult)
+    assert result.ok is True
+    assert result.device == "cuda:0"
+    assert result.returncode == 0
+    assert result.reason is None
+
+
+def test_child_runs_this_interpreter_with_hidden_window_kwargs(monkeypatch):
+    from utils.subprocess_compat import windows_hidden_subprocess_kwargs
+
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+    probe_torch_device_allocation("cuda:1")
+
+    argv, kwargs = calls[0]
+    assert argv[0] == sys.executable
+    assert argv[1] == "-c"
+    assert argv[-1] == "cuda:1"  # the device is passed as argv, never interpolated
+    for key, value in windows_hidden_subprocess_kwargs().items():
+        assert key in kwargs
+    assert kwargs["stdout"] is subprocess.PIPE
+    assert kwargs["stderr"] is subprocess.PIPE
+    assert "shell" not in kwargs
+
+
+def test_child_allocates_writes_and_synchronizes(monkeypatch):
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+    probe_torch_device_allocation("cuda:0")
+
+    script = calls[0][0][2]
+    assert "torch.empty(1, device = device)" in script
+    assert "tensor.zero_()" in script  # an allocation that is never written can be elided
+    assert "torch.cuda.synchronize" in script  # else an async fault escapes the child
+
+
+def test_child_env_strips_the_native_path_secret(monkeypatch):
+    from utils import native_path_leases
+
+    monkeypatch.setenv(native_path_leases.LEASE_SECRET_ENV, "super-secret")
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+    probe_torch_device_allocation("cuda:0")
+
+    env = calls[0][1]["env"]
+    assert native_path_leases.LEASE_SECRET_ENV not in env
+    assert env["PYTHONIOENCODING"] == "utf-8"
+
+
+# --- every way it fails closed ---------------------------------------------------
+
+
+def test_sigsegv_fails_closed(monkeypatch):
+    _patch_popen(monkeypatch, _FakeProc(returncode = -int(signal.SIGSEGV)))
+    result = probe_torch_device_allocation("cuda:0")
+    assert result.ok is False
+    assert "SIGSEGV" in result.reason
+
+
+@pytest.mark.parametrize("returncode", [-int(signal.SIGABRT), -int(signal.SIGILL), -4, -7, -8])
+def test_other_hard_faults_fail_closed(monkeypatch, returncode):
+    _patch_popen(monkeypatch, _FakeProc(returncode = returncode))
+    assert probe_torch_device_allocation("cuda:0").ok is False
+
+
+def test_windows_unsigned_access_violation_fails_closed(monkeypatch):
+    _patch_popen(monkeypatch, _FakeProc(returncode = 0xC0000005))
+    result = probe_torch_device_allocation("cuda:0")
+    assert result.ok is False
+    assert "0xC0000005" in result.reason
+
+
+def test_windows_signed_access_violation_fails_closed(monkeypatch):
+    # The same status handed back as a signed 32-bit int, which is how it can arrive.
+    _patch_popen(monkeypatch, _FakeProc(returncode = 0xC0000005 - 0x100000000))
+    result = probe_torch_device_allocation("cuda:0")
+    assert result.ok is False
+    assert "0xC0000005" in result.reason
+
+
+def test_ordinary_nonzero_exit_fails_closed(monkeypatch):
+    # No torch, a bad device string, an ImportError: not a driver fault, but still no
+    # evidence this device can allocate, so it must not be used in-process either.
+    _patch_popen(monkeypatch, _FakeProc(returncode = 1, stderr = "ModuleNotFoundError: torch"))
+    result = probe_torch_device_allocation("cuda:0")
+    assert result.ok is False
+    assert "exit code 1" in result.reason
+
+
+def test_timeout_fails_closed_and_is_not_reported_as_a_fault(monkeypatch):
+    # One timeout on the real wait, then terminate is enough. The returncode after our
+    # own terminate must NOT be described as the driver's doing.
+    proc = _FakeProc(returncode = -int(signal.SIGTERM), timeouts = 1)
+    _patch_popen(monkeypatch, proc)
+    result = probe_torch_device_allocation("cuda:0")
+    assert result.ok is False
+    assert result.reason == "probe timed out"
+    assert "SIGTERM" not in result.reason
+    assert "terminate" in proc.calls
+
+
+def test_timeout_escalates_to_kill_and_always_reaps(monkeypatch):
+    proc = _FakeProc(returncode = -int(signal.SIGKILL), timeouts = 3)
+    _patch_popen(monkeypatch, proc)
+    assert probe_torch_device_allocation("cuda:0").ok is False
+    assert proc.calls.count("terminate") == 1
+    assert proc.calls.count("kill") == 1
+    # terminate drain, kill drain: the child is waited on, never left as a zombie.
+    assert proc.calls.count("communicate") == 3
+
+
+def test_spawn_failure_fails_closed_without_raising(monkeypatch):
+    def boom(argv, **kwargs):
+        raise OSError("no fork headroom")
+
+    monkeypatch.setattr(subprocess, "Popen", boom)
+    result = probe_torch_device_allocation("cuda:0")
+    assert result.ok is False
+    assert result.returncode is None
+    assert "could not start" in result.reason
+
+
+# --- memoization ------------------------------------------------------------------
+
+
+def test_result_is_cached_per_process(monkeypatch):
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+    first = probe_torch_device_allocation("cuda:0")
+    second = probe_torch_device_allocation("cuda:0")
+    assert first is second
+    assert len(calls) == 1
+
+
+def test_each_device_is_probed_separately(monkeypatch):
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+    probe_torch_device_allocation("cuda:0")
+    probe_torch_device_allocation("cuda:1")
+    assert len(calls) == 2
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "CUDA_VISIBLE_DEVICES",
+        "HIP_VISIBLE_DEVICES",
+        "ROCR_VISIBLE_DEVICES",
+        "HSA_OVERRIDE_GFX_VERSION",
+    ],
+)
+def test_device_identity_env_change_invalidates_the_verdict(monkeypatch, var):
+    # HSA_OVERRIDE_GFX_VERSION is the spoof behind #7331: the same "cuda:0" can mean
+    # different kernels before and after it changes, so a cached verdict cannot stand.
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+    monkeypatch.delenv(var, raising = False)
+    probe_torch_device_allocation("cuda:0")
+    monkeypatch.setenv(var, "11.0.0")
+    probe_torch_device_allocation("cuda:0")
+    assert len(calls) == 2
+
+
+def test_unrelated_env_change_does_not_invalidate_the_verdict(monkeypatch):
+    calls: list = []
+    _patch_popen(monkeypatch, _FakeProc(), calls)
+    probe_torch_device_allocation("cuda:0")
+    monkeypatch.setenv("SOME_UNRELATED_VARIABLE", "1")
+    probe_torch_device_allocation("cuda:0")
+    assert len(calls) == 1
+
+
+def test_no_verdict_is_written_to_disk(monkeypatch, tmp_path):
+    # A cached negative that outlived a driver repair would pin a healthy host to CPU.
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path))
+    _patch_popen(monkeypatch, _FakeProc(returncode = -int(signal.SIGSEGV)))
+    probe_torch_device_allocation("cuda:0")
+    assert list(tmp_path.rglob("*")) == []
+
+
+# --- exit description -------------------------------------------------------------
+
+
+def test_describe_exit_is_quiet_about_success():
+    assert describe_exit(0) is None
+    assert describe_exit(None) is None
+
+
+def test_describe_exit_names_the_signal():
+    assert "SIGSEGV" in describe_exit(-int(signal.SIGSEGV))
+
+
+def test_parent_side_never_imports_torch():
+    # This module is imported by the RAG embedder, which is deliberately torch-optional
+    # and runs in the lean main process (see tests/test_startup_defers_torch.py).
+    source = (_BACKEND_DIR / "utils" / "device_allocation_probe.py").read_text(encoding = "utf-8")
+    module_level = source.split('_CHILD_SCRIPT = """')[0]
+    assert "import torch" not in module_level

--- a/studio/backend/tests/test_device_allocation_probe.py
+++ b/studio/backend/tests/test_device_allocation_probe.py
@@ -369,6 +369,37 @@ def test_a_child_that_dies_within_the_grace_needs_no_reaper(monkeypatch):
     assert threading.active_count() <= before
 
 
+def test_a_read_failure_during_teardown_does_not_escape(monkeypatch):
+    # The first wait times out, so teardown starts; the post-kill read then fails. That
+    # error is raised inside the timeout handling, so it needs the same treatment, and the
+    # child is not confirmed dead, so it still has to reach the reaper.
+    proc = _FakeProc(returncode = None, timeouts = 1)
+    reaped = threading.Event()
+    proc.wait = lambda: reaped.set()  # type: ignore[method-assign]
+    original = proc.communicate
+
+    def _fail_after_first(timeout = None):
+        try:
+            return original(timeout = timeout)
+        except subprocess.TimeoutExpired:
+            raise
+        finally:
+            proc.communicate = _boom  # type: ignore[method-assign]
+
+    def _boom(timeout = None):
+        proc.calls.append("communicate")
+        raise OSError("handle is invalid")
+
+    proc.communicate = _fail_after_first  # type: ignore[method-assign]
+    _patch_popen(monkeypatch, proc)
+
+    result = probe_torch_device_allocation("cuda:0")
+
+    assert result.ok is False
+    assert result.reason == "probe timed out"
+    assert reaped.wait(timeout = 5), "unconfirmed child was never handed to the reaper"
+
+
 def test_a_read_failure_fails_closed_and_tears_the_child_down(monkeypatch):
     # A Windows pipe/handle failure, or a read error under resource pressure. This function
     # promises never to raise and to treat every unknown outcome as unsafe, and the child

--- a/studio/backend/tests/test_rag_embed_llama_server.py
+++ b/studio/backend/tests/test_rag_embed_llama_server.py
@@ -323,9 +323,29 @@ def test_installed_torch_is_read_without_importing_torch(monkeypatch, tmp_path):
     )
     assert embeddings._installed_torch_is_rocm() is True
 
+    # Absent is a definite answer, not an unknown: no torch, no ROCm torch path. A
+    # --no-torch install resolves to llama-server, and calling this unknown would make
+    # Windows cautious forever and reject the local GGUF that install is meant to take.
     embeddings._installed_torch_is_rocm.cache_clear()
     monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
-    assert embeddings._installed_torch_is_rocm() is None  # torch absent: query cannot run
+    assert embeddings._installed_torch_is_rocm() is False
+
+    # Present but unreadable stays unknown, which is what the caution is reserved for.
+    embeddings._installed_torch_is_rocm.cache_clear()
+    (package / "version.py").unlink()
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+    assert embeddings._installed_torch_is_rocm() is None
+
+
+def test_a_no_torch_windows_install_keeps_its_gguf_answer(monkeypatch):
+    # --no-torch on Windows: detection never settles when the torch warm is disabled, and
+    # auto really does resolve to llama-server there, so PUT /embedding-model must accept a
+    # local GGUF rather than send it through the sentence-transformers verification path.
+    _no_torch_loaded(monkeypatch, installed = False)
+    monkeypatch.setattr(embeddings.sys, "platform", "win32")
+    _mock_auto(monkeypatch, gpus = [], binary = "/bin/llama-server")
+    assert embeddings._rocm_is_possible() is False
+    assert embeddings.active_backend_is_llama() is True
 
 
 def test_rocm_is_possible_reads_torch_hip_when_torch_is_already_loaded(monkeypatch):

--- a/studio/backend/tests/test_rag_embed_llama_server.py
+++ b/studio/backend/tests/test_rag_embed_llama_server.py
@@ -149,6 +149,92 @@ def test_auto_does_not_query_gpu_memory_after_a_failed_rocm_probe(monkeypatch):
     assert embeddings._resolve_auto() == "sentence-transformers"
 
 
+def _forbid_gpu_query(monkeypatch):
+    """Make the in-process AMD GPU-memory query a test failure if it is reached."""
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    def _must_not_run():
+        raise AssertionError("_get_gpu_free_memory reached; its AMD path runs torch here")
+
+    monkeypatch.setattr(LlamaCppBackend, "_get_gpu_free_memory", staticmethod(_must_not_run))
+    monkeypatch.setattr(
+        LlamaCppBackend, "_find_llama_server_binary", staticmethod(lambda: "/bin/llama-server")
+    )
+
+
+def _forbid_probe(monkeypatch):
+    """Make the isolated allocation probe a test failure if it is reached."""
+    from utils import device_allocation_probe as probe_mod
+
+    def _must_not_run(device = "cuda:0"):
+        raise AssertionError("allocation probe reached on a request path")
+
+    monkeypatch.setattr(probe_mod, "probe_torch_device_allocation", _must_not_run)
+
+
+def test_settings_gate_does_not_block_on_detection_or_probe(monkeypatch):
+    # active_backend_is_llama() runs inside PUT /embedding-model. Before detection settles
+    # it must not force detection, must not run the probe (a cold torch import is allowed
+    # 120s), and must not reach the AMD GPU query. Answering False keeps the ST pickle gate
+    # engaged, which is the safe direction for a security check.
+    import threading
+
+    from utils.hardware import hardware as hardware_mod
+
+    monkeypatch.setattr(config, "EMBED_BACKEND", "auto")
+    monkeypatch.setattr(hardware_mod, "DETECTION_COMPLETE", threading.Event())  # unset
+    monkeypatch.setattr(
+        embeddings, "get_device", lambda: (_ for _ in ()).throw(AssertionError("forced detection"))
+    )
+    _forbid_gpu_query(monkeypatch)
+    _forbid_probe(monkeypatch)
+
+    assert embeddings.active_backend_is_llama() is False
+
+
+def test_settings_gate_does_not_probe_on_a_settled_rocm_host(monkeypatch):
+    _mock_rocm_probe(monkeypatch, is_rocm = True, probe_ok = False)
+    monkeypatch.setattr(config, "EMBED_BACKEND", "auto")
+    _forbid_gpu_query(monkeypatch)
+    _forbid_probe(monkeypatch)
+
+    assert embeddings.active_backend_is_llama() is False
+
+
+def test_settings_gate_still_reports_llama_on_a_settled_non_rocm_host(monkeypatch):
+    # The NVIDIA/CPU path keeps its old answer: nvidia-smi is torch-free and cheap.
+    _mock_rocm_probe(monkeypatch, is_rocm = False, probe_ok = True)
+    _mock_auto(monkeypatch, gpus = [], binary = "/bin/llama-server")
+    assert embeddings.active_backend_is_llama() is True
+
+
+def test_builder_settles_detection_rather_than_guessing(monkeypatch):
+    # The backend builder caches its answer, so unlike the request path it must not commit
+    # a provisional one: it settles detection first and then decides.
+    import threading
+
+    from utils.hardware import hardware as hardware_mod
+    from utils.hardware.hardware import DeviceType
+
+    monkeypatch.setattr(config, "EMBED_BACKEND", "auto")
+    event = threading.Event()
+    monkeypatch.setattr(hardware_mod, "DETECTION_COMPLETE", event)
+    monkeypatch.setattr(hardware_mod, "IS_ROCM", False)
+
+    settled = {"count": 0}
+
+    def _detect():
+        settled["count"] += 1
+        event.set()
+        return DeviceType.CPU
+
+    monkeypatch.setattr(embeddings, "get_device", _detect)
+    _mock_auto(monkeypatch, gpus = [], binary = "/bin/llama-server")
+
+    assert embeddings._resolve_auto() == "llama-server"
+    assert settled["count"] == 1
+
+
 def test_auto_is_unchanged_after_a_passing_rocm_probe(monkeypatch):
     _stub_st_load(monkeypatch)
     _mock_rocm_probe(monkeypatch, is_rocm = True, probe_ok = True)

--- a/studio/backend/tests/test_rag_embed_llama_server.py
+++ b/studio/backend/tests/test_rag_embed_llama_server.py
@@ -99,6 +99,71 @@ def test_explicit_backend_overrides_auto(monkeypatch):
     assert isinstance(embeddings._get_backend(), LlamaServerBackend)
 
 
+def _mock_rocm_probe(monkeypatch, *, is_rocm, probe_ok):
+    """Pin ROCm-ness and the isolated allocation probe's verdict (#8474)."""
+    import threading
+
+    from utils import device_allocation_probe as probe_mod
+    from utils.hardware import hardware as hardware_mod
+    from utils.hardware.hardware import DeviceType
+
+    monkeypatch.setattr(embeddings, "get_device", lambda: DeviceType.CUDA)
+    monkeypatch.setattr(hardware_mod, "IS_ROCM", is_rocm)
+    detected = threading.Event()
+    detected.set()
+    monkeypatch.setattr(hardware_mod, "DETECTION_COMPLETE", detected)
+    monkeypatch.setattr(
+        probe_mod,
+        "probe_torch_device_allocation",
+        lambda device = "cuda:0": probe_mod.DeviceAllocationProbeResult(
+            ok = probe_ok,
+            device = device,
+            returncode = 0 if probe_ok else -11,
+            reason = None if probe_ok else "killed by SIGSEGV",
+            duration_seconds = 0.1,
+        ),
+    )
+
+
+def test_auto_does_not_query_gpu_memory_after_a_failed_rocm_probe(monkeypatch):
+    # _get_gpu_free_memory falls back to torch mem_get_info in THIS process on AMD, so on
+    # a condemned host auto-resolution used to steer into the very crash it should avoid.
+    # The probe has to be consulted first.
+    _stub_st_load(monkeypatch)
+    _mock_rocm_probe(monkeypatch, is_rocm = True, probe_ok = False)
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    monkeypatch.setattr(config, "EMBED_BACKEND", "auto")
+
+    def _must_not_run():
+        raise AssertionError("_get_gpu_free_memory reached on a condemned ROCm host")
+
+    monkeypatch.setattr(LlamaCppBackend, "_get_gpu_free_memory", staticmethod(_must_not_run))
+    monkeypatch.setattr(
+        LlamaCppBackend, "_find_llama_server_binary", staticmethod(lambda: "/bin/llama-server")
+    )
+
+    # Sentence-transformers, not llama-server: the model and therefore the vector space
+    # stays the same, so no knowledge base needs reindexing. The device moves, not the
+    # backend.
+    assert embeddings._resolve_auto() == "sentence-transformers"
+
+
+def test_auto_is_unchanged_after_a_passing_rocm_probe(monkeypatch):
+    _stub_st_load(monkeypatch)
+    _mock_rocm_probe(monkeypatch, is_rocm = True, probe_ok = True)
+    _mock_auto(monkeypatch, gpus = [(0, 40000)], binary = "/bin/llama-server")
+    assert embeddings._resolve_auto() == "sentence-transformers"
+
+
+def test_auto_on_a_non_rocm_host_still_asks_gpu_memory(monkeypatch):
+    # The NVIDIA path must be byte-identical to before: nvidia-smi decides, no probe.
+    _stub_st_load(monkeypatch)
+    _mock_rocm_probe(monkeypatch, is_rocm = False, probe_ok = False)
+    _mock_auto(monkeypatch, gpus = [], binary = "/bin/llama-server")
+    assert embeddings._resolve_auto() == "llama-server"
+
+
 def test_llama_backend_imports_no_torch():
     # Clean subprocess so the parent's imports don't mask a regression.
     backend_dir = Path(__file__).resolve().parents[1]

--- a/studio/backend/tests/test_rag_embed_llama_server.py
+++ b/studio/backend/tests/test_rag_embed_llama_server.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -226,12 +227,30 @@ def test_resolver_keeps_the_gguf_answer_for_an_impossible_rocm_host(monkeypatch)
     assert embeddings._resolve_auto() == "llama-server"
 
 
+def test_settings_gate_never_waits_on_hardware_detection(monkeypatch):
+    # ensure_hardware_detected() holds _DETECT_LOCK across a cold torch import, so a
+    # request reaching get_device() while background detection runs parks for the whole
+    # pass. ROCm is already ruled out here, and the rest of auto needs no detection.
+    _unsettled_detection(monkeypatch, rocm_possible = False)
+    monkeypatch.setattr(
+        embeddings, "get_device", lambda: (_ for _ in ()).throw(AssertionError("forced detection"))
+    )
+    _mock_auto(monkeypatch, gpus = [], binary = "/bin/llama-server")
+    assert embeddings.active_backend_is_llama() is True
+
+
+def _no_torch_loaded(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch", raising = False)
+
+
 def test_rocm_is_possible_is_false_on_macos(monkeypatch):
+    _no_torch_loaded(monkeypatch)
     monkeypatch.setattr(embeddings.sys, "platform", "darwin")
     assert embeddings._rocm_is_possible() is False
 
 
 def test_rocm_is_possible_follows_the_kfd_node_on_linux(monkeypatch):
+    _no_torch_loaded(monkeypatch)
     monkeypatch.setattr(embeddings.sys, "platform", "linux")
     seen: list = []
 
@@ -245,14 +264,26 @@ def test_rocm_is_possible_follows_the_kfd_node_on_linux(monkeypatch):
     assert seen == ["/sys/class/kfd/kfd/topology/nodes"]
 
 
-def test_rocm_is_possible_follows_the_rocm_install_on_windows(monkeypatch):
-    from utils import device_allocation_probe as probe_mod
-
+def test_an_installed_hip_sdk_alone_is_not_a_rocm_host(monkeypatch):
+    # main.py makes the same point where it refuses to let HIP_PATH/ROCM_PATH pick a
+    # backend: a CUDA or CPU box can carry the SDK. Claiming ROCm from it would strand
+    # such a host on the provisional answer and cost it its GGUF handling.
+    _no_torch_loaded(monkeypatch)
     monkeypatch.setattr(embeddings.sys, "platform", "win32")
-    monkeypatch.setattr(probe_mod, "_rocm_dll_directories", lambda: [])
     assert embeddings._rocm_is_possible() is False
-    monkeypatch.setattr(probe_mod, "_rocm_dll_directories", lambda: [r"C:\rocm\bin"])
+
+
+def test_rocm_is_possible_reads_torch_hip_when_torch_is_already_loaded(monkeypatch):
+    # A build attribute, so reading it initialises no driver, and it is the exact ROCm-ness
+    # the dangerous query depends on. Only consulted when torch is already imported.
+    monkeypatch.setattr(embeddings.sys, "platform", "win32")
+    monkeypatch.setitem(
+        sys.modules, "torch", SimpleNamespace(version = SimpleNamespace(hip = "6.3.42134"))
+    )
     assert embeddings._rocm_is_possible() is True
+
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(version = SimpleNamespace(hip = None)))
+    assert embeddings._rocm_is_possible() is False
 
 
 def test_settings_gate_does_not_probe_on_a_settled_rocm_host(monkeypatch):

--- a/studio/backend/tests/test_rag_embed_llama_server.py
+++ b/studio/backend/tests/test_rag_embed_llama_server.py
@@ -192,6 +192,69 @@ def test_settings_gate_does_not_block_on_detection_or_probe(monkeypatch):
     assert embeddings.active_backend_is_llama() is False
 
 
+def _unsettled_detection(monkeypatch, *, rocm_possible):
+    """Detection still running, with ROCm-possibility pinned torch-free."""
+    import threading
+
+    from utils.hardware import hardware as hardware_mod
+
+    monkeypatch.setattr(config, "EMBED_BACKEND", "auto")
+    monkeypatch.setattr(hardware_mod, "DETECTION_COMPLETE", threading.Event())  # unset
+    monkeypatch.setattr(embeddings, "_rocm_is_possible", lambda: rocm_possible)
+
+
+def test_a_cpu_host_keeps_its_gguf_classification_while_detection_runs(monkeypatch):
+    # settings.py reads this to decide whether a local .gguf needs HF verification. A host
+    # that can never be ROCm must keep its real answer during the detection window, or a
+    # valid local .gguf transiently 409s on a machine that has no AMD GPU at all.
+    _unsettled_detection(monkeypatch, rocm_possible = False)
+    _mock_auto(monkeypatch, gpus = [], binary = "/bin/llama-server")
+    assert embeddings.active_backend_is_llama() is True
+
+
+def test_a_possibly_rocm_host_still_holds_back_while_detection_runs(monkeypatch):
+    _unsettled_detection(monkeypatch, rocm_possible = True)
+    _forbid_gpu_query(monkeypatch)
+    _forbid_probe(monkeypatch)
+    assert embeddings.active_backend_is_llama() is False
+
+
+def test_resolver_keeps_the_gguf_answer_for_an_impossible_rocm_host(monkeypatch):
+    _unsettled_detection(monkeypatch, rocm_possible = False)
+    monkeypatch.setattr(embeddings, "get_device", lambda: None)  # detection stays unsettled
+    _mock_auto(monkeypatch, gpus = [], binary = "/bin/llama-server")
+    assert embeddings._resolve_auto() == "llama-server"
+
+
+def test_rocm_is_possible_is_false_on_macos(monkeypatch):
+    monkeypatch.setattr(embeddings.sys, "platform", "darwin")
+    assert embeddings._rocm_is_possible() is False
+
+
+def test_rocm_is_possible_follows_the_kfd_node_on_linux(monkeypatch):
+    monkeypatch.setattr(embeddings.sys, "platform", "linux")
+    seen: list = []
+
+    def _isdir(path):
+        seen.append(path)
+        return False
+
+    monkeypatch.setattr(embeddings.os.path, "isdir", _isdir)
+    assert embeddings._rocm_is_possible() is False
+    # ROCm's own kernel driver publishes this; hardware.py reads the same tree.
+    assert seen == ["/sys/class/kfd/kfd/topology/nodes"]
+
+
+def test_rocm_is_possible_follows_the_rocm_install_on_windows(monkeypatch):
+    from utils import device_allocation_probe as probe_mod
+
+    monkeypatch.setattr(embeddings.sys, "platform", "win32")
+    monkeypatch.setattr(probe_mod, "_rocm_dll_directories", lambda: [])
+    assert embeddings._rocm_is_possible() is False
+    monkeypatch.setattr(probe_mod, "_rocm_dll_directories", lambda: [r"C:\rocm\bin"])
+    assert embeddings._rocm_is_possible() is True
+
+
 def test_settings_gate_does_not_probe_on_a_settled_rocm_host(monkeypatch):
     _mock_rocm_probe(monkeypatch, is_rocm = True, probe_ok = False)
     monkeypatch.setattr(config, "EMBED_BACKEND", "auto")

--- a/studio/backend/tests/test_rag_embed_llama_server.py
+++ b/studio/backend/tests/test_rag_embed_llama_server.py
@@ -239,8 +239,11 @@ def test_settings_gate_never_waits_on_hardware_detection(monkeypatch):
     assert embeddings.active_backend_is_llama() is True
 
 
-def _no_torch_loaded(monkeypatch):
+def _no_torch_loaded(monkeypatch, *, installed = None):
+    """torch not imported. ``installed`` is what the torch-free on-disk read reports."""
     monkeypatch.delitem(sys.modules, "torch", raising = False)
+    embeddings._installed_torch_is_rocm.cache_clear()
+    monkeypatch.setattr(embeddings, "_installed_torch_is_rocm", lambda: installed)
 
 
 def test_rocm_is_possible_is_false_on_macos(monkeypatch):
@@ -266,11 +269,63 @@ def test_rocm_is_possible_follows_the_kfd_node_on_linux(monkeypatch):
 
 def test_an_installed_hip_sdk_alone_is_not_a_rocm_host(monkeypatch):
     # main.py makes the same point where it refuses to let HIP_PATH/ROCM_PATH pick a
-    # backend: a CUDA or CPU box can carry the SDK. Claiming ROCm from it would strand
-    # such a host on the provisional answer and cost it its GGUF handling.
-    _no_torch_loaded(monkeypatch)
+    # backend: a CUDA or CPU box can carry the SDK. What decides is the installed wheel,
+    # which is readable before torch is imported.
+    _no_torch_loaded(monkeypatch, installed = False)
     monkeypatch.setattr(embeddings.sys, "platform", "win32")
     assert embeddings._rocm_is_possible() is False
+
+
+def test_a_windows_rocm_wheel_is_seen_before_torch_is_imported(monkeypatch):
+    # The startup window, and the standing case when the torch warm is disabled: detection
+    # unsettled and torch not yet imported. Windows has no KFD node, so the wheel on disk
+    # is the only thing that can keep this host off the in-process AMD query.
+    _no_torch_loaded(monkeypatch, installed = True)
+    monkeypatch.setattr(embeddings.sys, "platform", "win32")
+    assert embeddings._rocm_is_possible() is True
+
+
+def test_windows_stays_cautious_when_the_wheel_cannot_be_read(monkeypatch):
+    _no_torch_loaded(monkeypatch, installed = None)
+    monkeypatch.setattr(embeddings.sys, "platform", "win32")
+    assert embeddings._rocm_is_possible() is True
+
+
+def test_installed_torch_is_read_without_importing_torch(monkeypatch, tmp_path):
+    # torch/version.py is generated literals, and find_spec locates the package without
+    # executing it, so this reads what detection reads long before torch is imported.
+    import importlib.util
+
+    embeddings._installed_torch_is_rocm.cache_clear()
+    package = tmp_path / "torch"
+    package.mkdir()
+    (package / "__init__.py").write_text("raise AssertionError('torch was imported')")
+
+    def _fake_find_spec(name):
+        assert name == "torch"
+        return SimpleNamespace(origin = str(package / "__init__.py"))
+
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+
+    (package / "version.py").write_text(
+        "__version__ = '2.9.1+rocm6.3'\nhip: Optional[str] = '6.3.42134'\n"
+    )
+    assert embeddings._installed_torch_is_rocm() is True
+
+    embeddings._installed_torch_is_rocm.cache_clear()
+    (package / "version.py").write_text("__version__ = '2.9.1+cu128'\nhip: Optional[str] = None\n")
+    assert embeddings._installed_torch_is_rocm() is False
+
+    # AMD SDK wheel: hip unset, rocm only in the version string.
+    embeddings._installed_torch_is_rocm.cache_clear()
+    (package / "version.py").write_text(
+        "__version__ = '2.11.0+rocm7.1'\nhip: Optional[str] = None\n"
+    )
+    assert embeddings._installed_torch_is_rocm() is True
+
+    embeddings._installed_torch_is_rocm.cache_clear()
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    assert embeddings._installed_torch_is_rocm() is None  # torch absent: query cannot run
 
 
 def test_rocm_is_possible_reads_torch_hip_when_torch_is_already_loaded(monkeypatch):

--- a/studio/backend/tests/test_rag_embed_llama_server.py
+++ b/studio/backend/tests/test_rag_embed_llama_server.py
@@ -282,8 +282,34 @@ def test_rocm_is_possible_reads_torch_hip_when_torch_is_already_loaded(monkeypat
     )
     assert embeddings._rocm_is_possible() is True
 
-    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(version = SimpleNamespace(hip = None)))
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        SimpleNamespace(version = SimpleNamespace(hip = None), __version__ = "2.9.1+cu128"),
+    )
     assert embeddings._rocm_is_possible() is False
+
+
+def test_an_amd_sdk_wheel_without_hip_metadata_is_still_rocm(monkeypatch):
+    # AMD SDK wheels leave torch.version.hip unset and only say rocm in the version string.
+    # hardware.py's own ROCm test carries the same fallback (utils/hardware/hardware.py).
+    monkeypatch.setattr(embeddings.sys, "platform", "linux")
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        SimpleNamespace(version = SimpleNamespace(hip = None), __version__ = "2.9.1+rocm6.3"),
+    )
+    assert embeddings._rocm_is_possible() is True
+
+
+def test_a_half_imported_torch_is_treated_as_possibly_rocm(monkeypatch):
+    # torch can be in sys.modules while still executing, so neither attribute is there yet.
+    # That is absence of evidence, and the caution has to keep the safe side.
+    monkeypatch.setattr(embeddings.sys, "platform", "linux")
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace())
+    assert embeddings._rocm_is_possible() is True
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(version = SimpleNamespace()))
+    assert embeddings._rocm_is_possible() is True
 
 
 def test_settings_gate_does_not_probe_on_a_settled_rocm_host(monkeypatch):

--- a/studio/backend/tests/test_rag_embeddings.py
+++ b/studio/backend/tests/test_rag_embeddings.py
@@ -251,3 +251,193 @@ def test_st_encode_failure_without_llama_binary_reraises(monkeypatch):
     embeddings._reset_backend()
     with pytest.raises(RuntimeError, match = "CUDA error during encode"):
         embeddings.encode(["alpha", "beta"])
+
+
+# --- a ROCm GPU that faults on its first allocation (#8474) -----------------------
+#
+# The fault is a SIGSEGV in the HIP runtime, so it is not an exception and cannot be
+# provoked here. What is asserted is that the isolated probe's verdict is what decides
+# the device, and that a condemned host lands on CPU with the SAME backend and model --
+# so its vectors are unchanged and no knowledge base needs reindexing.
+
+
+def _mock_device(
+    monkeypatch,
+    *,
+    torch_device,
+    is_rocm,
+    probe_ok = True,
+    detected = True,
+):
+    """Pin the device the embedder would pick, the ROCm flag, and the probe verdict."""
+    from utils import device_allocation_probe as probe_mod
+    from utils.hardware import hardware as hardware_mod
+    from utils.hardware.hardware import DeviceType
+
+    unsloth_device = {
+        "cuda": DeviceType.CUDA,
+        "xpu": DeviceType.XPU,
+        "cpu": DeviceType.CPU,
+    }[torch_device]
+    monkeypatch.setattr(embeddings, "get_device", lambda: unsloth_device)
+    monkeypatch.setattr(hardware_mod, "IS_ROCM", is_rocm)
+    event = threading.Event()
+    if detected:
+        event.set()
+    monkeypatch.setattr(hardware_mod, "DETECTION_COMPLETE", event)
+
+    probes: list[str] = []
+
+    def _fake_probe(device = "cuda:0"):
+        probes.append(device)
+        return probe_mod.DeviceAllocationProbeResult(
+            ok = probe_ok,
+            device = device,
+            returncode = 0 if probe_ok else -11,
+            reason = None if probe_ok else "killed by SIGSEGV",
+            duration_seconds = 0.1,
+        )
+
+    monkeypatch.setattr(probe_mod, "probe_torch_device_allocation", _fake_probe)
+    return probes
+
+
+def test_failed_rocm_probe_moves_the_embedder_to_cpu(monkeypatch):
+    probes = _mock_device(monkeypatch, torch_device = "cuda", is_rocm = True, probe_ok = False)
+    assert embeddings._safe_torch_device() == "cpu"
+    assert probes == ["cuda:0"]
+
+
+def test_passing_rocm_probe_keeps_the_embedder_on_the_gpu(monkeypatch):
+    probes = _mock_device(monkeypatch, torch_device = "cuda", is_rocm = True, probe_ok = True)
+    assert embeddings._safe_torch_device() == "cuda"
+    assert probes == ["cuda:0"]
+
+
+@pytest.mark.parametrize(
+    ("torch_device", "expected"),
+    [("cuda", "cuda"), ("xpu", "xpu"), ("cpu", "cpu")],
+)
+def test_non_rocm_hosts_are_never_probed(monkeypatch, torch_device, expected):
+    # NVIDIA, Intel XPU, Apple and CPU must behave exactly as they did before: no child
+    # process, no new failure mode, no added startup cost.
+    probes = _mock_device(monkeypatch, torch_device = torch_device, is_rocm = False)
+    assert embeddings._safe_torch_device() == expected
+    assert probes == []
+
+
+def test_rocm_probe_is_not_run_for_a_non_gpu_device(monkeypatch):
+    # ROCm build flags with no usable GPU: there is no device to probe.
+    probes = _mock_device(monkeypatch, torch_device = "cpu", is_rocm = True)
+    assert embeddings._safe_torch_device() == "cpu"
+    assert probes == []
+
+
+def test_the_probe_never_forces_hardware_detection(monkeypatch):
+    # Detection imports torch. _resolve_auto can be reached (via active_backend_is_llama)
+    # long before the coordinated warm is meant to pay that cost, so an undetected host
+    # declines to probe rather than dragging torch into the lean main process.
+    probes = _mock_device(
+        monkeypatch, torch_device = "cuda", is_rocm = True, probe_ok = False, detected = False
+    )
+    assert embeddings._rocm_gpu_is_fatal() is False
+    assert probes == []
+
+
+def _observe_st_load(monkeypatch, tmp_path):
+    """Capture the kwargs the SentenceTransformer constructor is handed."""
+    observed = {}
+
+    class FakeSentenceTransformer:
+        def __init__(self, name, **kwargs):
+            observed["name"] = name
+            observed.update(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        SimpleNamespace(SentenceTransformer = FakeSentenceTransformer),
+    )
+    monkeypatch.setattr(embeddings, "_install_torchao_stub_once", lambda: None)
+    monkeypatch.setattr(embeddings, "_guard_model_security", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "utils.hf_cache_settings.active_hf_hub_cache",
+        lambda: str(tmp_path / "hub"),
+    )
+    embeddings._model = None
+    embeddings._name = None
+    return observed
+
+
+def test_degraded_cpu_load_drops_fp16(monkeypatch, tmp_path):
+    # fp16 is a win on the GPU and a slow, patchily supported path on CPU, so the host we
+    # pushed off its GPU must not inherit the GPU dtype.
+    observed = _observe_st_load(monkeypatch, tmp_path)
+    _mock_device(monkeypatch, torch_device = "cuda", is_rocm = True, probe_ok = False)
+
+    embeddings._get("Org/Embedder")
+
+    assert observed["device"] == "cpu"
+    assert list(observed["model_kwargs"].values()) == ["float32"]
+
+
+def test_a_genuine_cpu_host_loads_exactly_as_before(monkeypatch, tmp_path):
+    # Not a regression dressed up as a fix: a host that never had a GPU keeps the fp16
+    # load it has always done.
+    observed = _observe_st_load(monkeypatch, tmp_path)
+    _mock_device(monkeypatch, torch_device = "cpu", is_rocm = False)
+
+    embeddings._get("Org/Embedder")
+
+    assert observed["device"] == "cpu"
+    assert list(observed["model_kwargs"].values()) == ["float16"]
+
+
+def test_gpu_load_keeps_fp16(monkeypatch, tmp_path):
+    observed = _observe_st_load(monkeypatch, tmp_path)
+    _mock_device(monkeypatch, torch_device = "cuda", is_rocm = True, probe_ok = True)
+
+    embeddings._get("Org/Embedder")
+
+    assert observed["device"] == "cuda"
+    assert list(observed["model_kwargs"].values()) == ["float16"]
+
+
+def test_cpu_degradation_does_not_bypass_the_security_gate(monkeypatch, tmp_path):
+    # Moving to CPU is a device decision, not a licence to load a flagged pickle.
+    _observe_st_load(monkeypatch, tmp_path)
+    _mock_device(monkeypatch, torch_device = "cuda", is_rocm = True, probe_ok = False)
+
+    def _blocked(*_a, **_k):
+        raise embeddings.UnsafeEmbeddingModelError("flagged repo")
+
+    monkeypatch.setattr(embeddings, "_guard_model_security", _blocked)
+    with pytest.raises(embeddings.UnsafeEmbeddingModelError):
+        embeddings._get("Org/Embedder")
+
+
+def test_degraded_host_still_embeds_end_to_end(monkeypatch):
+    # The point of the whole change: on the #7331 host the warm completes, the embedder
+    # works, and the backend is still running afterwards.
+    _mock_device(monkeypatch, torch_device = "cuda", is_rocm = True, probe_ok = False)
+    loaded = {}
+
+    class _CpuModel:
+        tokenizer = None
+
+        def encode(self, texts, **_kw):
+            return np.zeros((len(texts), 4), dtype = np.float32)
+
+    def _fake_get(model_name = None):
+        loaded["device"] = embeddings._safe_torch_device()
+        return _CpuModel()
+
+    monkeypatch.setattr(embeddings, "_get", _fake_get)
+    embeddings._reset_backend()
+
+    embeddings.warm()
+    out = embeddings.encode(["alpha", "beta"])
+
+    assert loaded["device"] == "cpu"
+    assert out.shape == (2, 4)
+    assert isinstance(embeddings._get_backend(), embeddings._SentenceTransformersBackend)

--- a/studio/backend/utils/device_allocation_probe.py
+++ b/studio/backend/utils/device_allocation_probe.py
@@ -235,6 +235,31 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
     return process.returncode, stderr or "", None
 
 
+def _reap_later(process: subprocess.Popen) -> None:
+    """Wait on a child that outlived SIGKILL, on a daemon thread, forever.
+
+    SIGKILL cannot be caught, but it also cannot land while the process sits in an
+    uninterruptible driver wait: the signal is only delivered once the ioctl returns, and a
+    wedged GPU is precisely how a task ends up there. Since that is the scenario this
+    module exists to survive, dropping the last reference to such a child is the one way it
+    becomes an unreaped stray. Hold it and let the thread collect the corpse whenever the
+    driver finally lets go. Daemon, so it never delays shutdown.
+    """
+    threading.Thread(
+        target = _wait_forever,
+        args = (process,),
+        daemon = True,
+        name = f"device-probe-reaper-{process.pid}",
+    ).start()
+
+
+def _wait_forever(process: subprocess.Popen) -> None:
+    try:
+        process.wait()
+    except Exception:  # noqa: BLE001 - nothing to do but stop holding the reference
+        pass
+
+
 def _terminate_and_drain(process: subprocess.Popen) -> str:
     """Terminate, give it a moment, kill, and always drain and reap, so an overrunning
     probe cannot leave a zombie or a held pipe behind."""
@@ -253,7 +278,9 @@ def _terminate_and_drain(process: subprocess.Popen) -> str:
         try:
             _, stderr = process.communicate(timeout = _TERMINATE_GRACE_SECONDS)
         except subprocess.TimeoutExpired:
-            pass
+            # Still alive after SIGKILL: stuck in the driver. Hand it to a reaper rather
+            # than returning and letting the last reference go.
+            _reap_later(process)
     except OSError:
         pass
     return stderr or ""

--- a/studio/backend/utils/device_allocation_probe.py
+++ b/studio/backend/utils/device_allocation_probe.py
@@ -280,25 +280,25 @@ def _terminate_and_drain(process: subprocess.Popen) -> str:
     """Terminate, give it a moment, kill, and always drain and reap, so an overrunning
     probe cannot leave a zombie or a held pipe behind."""
     stderr = ""
-    try:
-        process.terminate()
-    except OSError:
-        pass
-    try:
-        _, stderr = process.communicate(timeout = _TERMINATE_GRACE_SECONDS)
-    except subprocess.TimeoutExpired:
+    # Escalate in one loop rather than nesting, so every attempt is covered by the same
+    # handler. The nested form grew a gap: an OSError raised inside the timeout branch was
+    # not a sibling of the outer OSError handler and escaped a function that must not raise.
+    for signal_child in (process.terminate, process.kill):
         try:
-            process.kill()
+            signal_child()
         except OSError:
             pass
         try:
             _, stderr = process.communicate(timeout = _TERMINATE_GRACE_SECONDS)
+            return stderr or ""
         except subprocess.TimeoutExpired:
-            # Still alive after SIGKILL: stuck in the driver. Hand it to a reaper rather
-            # than returning and letting the last reference go.
-            _reap_later(process)
-    except OSError:
-        pass
+            continue  # still alive, escalate
+        except OSError:
+            break  # pipes are unusable, so there is nothing left to drain
+
+    # Not confirmed dead: either it outlived SIGKILL, stuck in the driver, or we could not
+    # read it. Either way the last reference must not simply be dropped.
+    _reap_later(process)
     return stderr or ""
 
 

--- a/studio/backend/utils/device_allocation_probe.py
+++ b/studio/backend/utils/device_allocation_probe.py
@@ -233,6 +233,12 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
             # the signal WE sent, and reporting that as the driver's fault would be a lie.
             stderr = _terminate_and_drain(process)
             return process.returncode, stderr, "probe timed out"
+        except OSError as read_error:
+            # A pipe or handle failure, or a read error under resource pressure. The child
+            # may still be running and we have no verdict from it, so tear it down and fail
+            # closed rather than letting this escape a function that promises not to raise.
+            stderr = _terminate_and_drain(process)
+            return process.returncode, stderr, f"probe could not be read ({read_error})"
 
         return process.returncode, stderr or "", None
     finally:

--- a/studio/backend/utils/device_allocation_probe.py
+++ b/studio/backend/utils/device_allocation_probe.py
@@ -66,13 +66,32 @@ _DEVICE_IDENTITY_ENV_VARS = (
     "HSA_OVERRIDE_GFX_VERSION",
 )
 
+# Windows ROCm bin directories for the child, os.pathsep-joined. See _rocm_dll_directories.
+ROCM_DLL_DIRS_ENV_VAR = "UNSLOTH_STUDIO_PROBE_ROCM_DLL_DIRS"
+
 # Allocate, WRITE, then synchronize. Device execution is asynchronous, so an allocation
 # that faults in the kernel can outlive the statement that queued it -- without the
 # synchronize the child can exit 0 while the fault is still in flight, which is the one
 # way this probe could report a false pass. torch.empty alone is too weak for the same
 # reason: it need not touch the device at all.
+#
+# The DLL block runs BEFORE ``import torch``: Python 3.8+ ignores PATH for extension
+# modules, and os.add_dll_directory registrations are process-local, so a fresh child does
+# not inherit the parent's. Without it a healthy Windows AMD GPU fails to import torch at
+# all and this probe would report the host as condemned. main.py and core/training/worker.py
+# do the same thing at their own process starts, for the same reason.
 _CHILD_SCRIPT = """
+import os
 import sys
+
+if sys.platform == "win32":
+    _handles = []
+    for _d in os.environ.get("UNSLOTH_STUDIO_PROBE_ROCM_DLL_DIRS", "").split(os.pathsep):
+        if _d and os.path.isdir(_d):
+            try:
+                _handles.append(os.add_dll_directory(_d))
+            except (OSError, AttributeError):
+                pass
 
 import torch
 
@@ -85,6 +104,46 @@ elif tensor.device.type == "xpu":
     torch.xpu.synchronize(tensor.device)
 print("ok")
 """
+
+
+def _rocm_dll_directories() -> list[str]:
+    """Windows ROCm ``bin`` directories, newest version first. Empty off Windows.
+
+    Same discovery as ``main.py`` and ``core/training/worker.py``; it lives here too
+    because the child is a bare ``-c`` script with no backend directory on its path (that
+    isolation is deliberate), and computing the list parent-side keeps it testable.
+    """
+    if sys.platform != "win32":
+        return []
+
+    candidates: list[str] = []
+    for var in ("HIP_PATH", "ROCM_PATH"):
+        value = os.environ.get(var)
+        if value:
+            candidates.append(os.path.join(value, "bin"))
+
+    default_root = os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "AMD", "ROCm")
+
+    def _version_key(name: str) -> tuple:
+        # Numeric tuple key so "10.0" sorts after "7.0".
+        parts = []
+        for chunk in name.split("."):
+            try:
+                parts.append((0, int(chunk)))
+            except ValueError:
+                parts.append((1, chunk))
+        return tuple(parts)
+
+    try:
+        if os.path.isdir(default_root):
+            for version in sorted(os.listdir(default_root), key = _version_key, reverse = True):
+                bin_dir = os.path.join(default_root, version, "bin")
+                if os.path.isdir(bin_dir):
+                    candidates.append(bin_dir)
+    except OSError:
+        pass
+
+    return [d for d in candidates if os.path.isdir(d)]
 
 
 @dataclass(frozen = True)
@@ -146,6 +205,9 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
     from utils.subprocess_compat import windows_hidden_subprocess_kwargs
 
     env = utf8_child_env(child_env_without_native_path_secret())
+    dll_dirs = _rocm_dll_directories()
+    if dll_dirs:
+        env[ROCM_DLL_DIRS_ENV_VAR] = os.pathsep.join(dll_dirs)
     try:
         process = subprocess.Popen(
             [sys.executable, "-c", _CHILD_SCRIPT, device],

--- a/studio/backend/utils/device_allocation_probe.py
+++ b/studio/backend/utils/device_allocation_probe.py
@@ -202,6 +202,7 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
     a non-None ``failure_reason`` means the child never delivered a verdict of its own."""
     from utils.child_stdio import utf8_child_env
     from utils.native_path_leases import child_env_without_native_path_secret
+    from utils.process_lifetime import adopt_pid, child_popen_kwargs, forget_pid
     from utils.subprocess_compat import windows_hidden_subprocess_kwargs
 
     env = utf8_child_env(child_env_without_native_path_secret())
@@ -217,6 +218,11 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
             encoding = "utf-8",
             errors = "replace",
             env = env,
+            # This child can sit in a cold torch import, or wedged in a driver ioctl, for
+            # the whole timeout. Without the parent-death binding, a Studio that is killed
+            # in that window leaves it reparented and running, where it holds the very GPU
+            # the next backend is about to probe. Same treatment as the other GPU children.
+            **child_popen_kwargs(),
             **windows_hidden_subprocess_kwargs(),
         )
     except OSError as spawn_error:
@@ -224,15 +230,22 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
         # device, and "learned nothing" fails closed.
         return None, "", f"probe could not start ({spawn_error})"
 
+    adopt_pid(process.pid)  # terminate_all backstop for a graceful shutdown
     try:
-        _, stderr = process.communicate(timeout = PROBE_TIMEOUT_SECONDS)
-    except subprocess.TimeoutExpired:
-        # Classify BEFORE cleaning up: after the terminate/kill below, returncode is the
-        # signal WE sent, and reporting that as the driver's fault would be a lie.
-        stderr = _terminate_and_drain(process)
-        return process.returncode, stderr, "probe timed out"
+        try:
+            _, stderr = process.communicate(timeout = PROBE_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            # Classify BEFORE cleaning up: after the terminate/kill below, returncode is
+            # the signal WE sent, and reporting that as the driver's fault would be a lie.
+            stderr = _terminate_and_drain(process)
+            return process.returncode, stderr, "probe timed out"
 
-    return process.returncode, stderr or "", None
+        return process.returncode, stderr or "", None
+    finally:
+        # A child handed to the reaper is still alive, so it stays adopted; the reaper
+        # forgets it once it is really gone.
+        if process.returncode is not None:
+            forget_pid(process.pid)
 
 
 def _reap_later(process: subprocess.Popen) -> None:
@@ -257,6 +270,11 @@ def _wait_forever(process: subprocess.Popen) -> None:
     try:
         process.wait()
     except Exception:  # noqa: BLE001 - nothing to do but stop holding the reference
+        pass
+    try:
+        from utils.process_lifetime import forget_pid
+        forget_pid(process.pid)
+    except Exception:  # noqa: BLE001 - the reaper is best effort by definition
         pass
 
 

--- a/studio/backend/utils/device_allocation_probe.py
+++ b/studio/backend/utils/device_allocation_probe.py
@@ -3,30 +3,24 @@
 
 """Ask a short-lived child process whether a torch device can actually allocate.
 
-A GPU runtime that does not match the silicon it is driving does not raise: it
-faults. On the gfx1151 host in #7331 a ROCm 6.3 wheel built for gfx1100 reported
-``torch.cuda.is_available() == True``, enumerated the device correctly, and then
-died with SIGSEGV inside ``libamdhip64`` on the first real allocation. Signal
-disposition is per process, so that fault killed uvicorn -- from a daemon thread,
-past an ``except Exception``, because a signal never becomes a Python exception
-(#8474).
+A GPU runtime that does not match its silicon does not raise, it faults. On the
+gfx1151 host in #7331 a gfx1100 ROCm wheel reported ``is_available() == True``,
+enumerated the device, then died with SIGSEGV in ``libamdhip64`` on the first real
+allocation, past an ``except Exception`` because a signal is not an exception, and
+took uvicorn with it since signal disposition is per process (#8474).
 
-So the question "can this device allocate" cannot be answered in the process that
-has to survive the answer. It is answered in a child, and the child dying IS the
-answer. The parent side of this module imports only the standard library: it must
-stay importable on a ``--no-torch`` install, and it must not be what finally drags
-torch into the lean main process (see ``tests/test_startup_defers_torch.py``).
+So the question cannot be answered in the process that must survive the answer. It
+is answered in a child, and the child dying IS the answer. The parent side imports
+only the standard library: it must stay importable on ``--no-torch``, and must not
+be what drags torch into the lean main process (tests/test_startup_defers_torch.py).
 
 Deliberately NOT here:
-  * no ``multiprocessing`` -- uvicorn is multithreaded and HIP/CUDA are
-    fork-hostile, and ``set_start_method`` is process-global state we do not own
-  * no model load -- the caller would have to load it again in-process, paying the
-    download, the deserialization and the security gate twice
-  * no on-disk cache -- a negative verdict that outlived a driver or wheel repair
-    would pin a healthy machine to CPU with no way to tell why
-
-The verdict is memoized for the process only, keyed by the device and by every
-environment variable that can change which silicon that device names.
+  * no ``multiprocessing`` -- uvicorn is multithreaded, HIP/CUDA are fork-hostile,
+    and ``set_start_method`` is process-global state we do not own
+  * no model load -- the parent would load it again, paying the download, the
+    deserialization and the security gate twice
+  * no on-disk cache -- a negative verdict outliving a driver or wheel repair would
+    pin a healthy machine to CPU with no way to tell why
 """
 
 from __future__ import annotations
@@ -40,28 +34,23 @@ import time
 from dataclasses import dataclass
 from typing import Optional
 
-# Plain stdlib logging, as in core/rag/embeddings.py: the caller is the torch-optional
-# embedder, and this module should add no import weight of its own.
+# stdlib logging, as in core/rag/embeddings.py: this must add no import weight.
 logger = logging.getLogger(__name__)
 
-# A cold ROCm torch import on a slow host is minutes, not seconds, and every caller of
-# this probe is off the request/boot critical path. Being generous here costs a late
-# warm; being stingy condemns a healthy host to CPU.
+# A cold ROCm torch import runs to minutes. Being generous costs a late load; being
+# stingy condemns a healthy host to CPU.
 PROBE_TIMEOUT_SECONDS = 120.0
-# The child's own deadline. Comfortably past the parent's, so in a normal run the parent
-# always decides first and this only ever fires for a child whose parent is gone.
+# Past the parent's deadline, so it only ever fires for a child whose parent is gone.
 _CHILD_SELF_LIMIT_SECONDS = 300.0
 # Grace between terminate and kill when the child overran, mirroring the sidecars.
 _TERMINATE_GRACE_SECONDS = 5.0
 # Child stderr is a torch traceback or a driver's parting words; keep the tail only.
 _STDERR_TAIL_CHARS = 600
-# Above this, a negative exit code is a signed Windows status rather than a signal.
-# POSIX signal numbers stop at 64 (NSIG); the headroom costs nothing.
+# Above this a negative exit code is a signed Windows status, not a signal (NSIG is 64).
 _MAX_SIGNAL_NUMBER = 128
 
-# Variables that decide WHICH physical device a device string names, or which kernels
-# the runtime believes it should emit. A change to any of them invalidates the verdict:
-# HSA_OVERRIDE_GFX_VERSION is exactly the spoof that produced #7331.
+# These decide which physical device a device string names, or which kernels the runtime
+# emits, so a change invalidates the verdict. HSA_OVERRIDE_GFX_VERSION is the #7331 spoof.
 _DEVICE_IDENTITY_ENV_VARS = (
     "CUDA_VISIBLE_DEVICES",
     "HIP_VISIBLE_DEVICES",
@@ -72,27 +61,21 @@ _DEVICE_IDENTITY_ENV_VARS = (
 # Windows ROCm bin directories for the child, os.pathsep-joined. See _rocm_dll_directories.
 ROCM_DLL_DIRS_ENV_VAR = "UNSLOTH_STUDIO_PROBE_ROCM_DLL_DIRS"
 
-# Allocate, WRITE, then synchronize. Device execution is asynchronous, so an allocation
-# that faults in the kernel can outlive the statement that queued it -- without the
-# synchronize the child can exit 0 while the fault is still in flight, which is the one
-# way this probe could report a false pass. torch.empty alone is too weak for the same
-# reason: it need not touch the device at all.
-#
-# The DLL block runs BEFORE ``import torch``: Python 3.8+ ignores PATH for extension
-# modules, and os.add_dll_directory registrations are process-local, so a fresh child does
-# not inherit the parent's. Without it a healthy Windows AMD GPU fails to import torch at
-# all and this probe would report the host as condemned. main.py and core/training/worker.py
-# do the same thing at their own process starts, for the same reason.
+# Allocate, WRITE, then synchronize: execution is asynchronous, so without the sync a
+# fault can still be in flight when the child exits 0, which is the one way this reports a
+# false pass. torch.empty alone is too weak for the same reason -- it need not touch the
+# device. The DLL block precedes the import because Python ignores PATH for extension
+# modules and add_dll_directory does not survive into a child, so a healthy Windows AMD GPU
+# would fail to import torch at all. main.py and core/training/worker.py do the same.
 _CHILD_SCRIPT = """
 import os
 import sys
 import threading
 
-# Self-limit. The parent cannot bind this child to its own death without a pre-exec hook,
-# and that hook is what makes a fork of a multithreaded server able to deadlock, so the
-# child bounds itself instead: a Studio killed mid-probe leaves something that exits on its
-# own rather than an orphan holding the GPU. Daemon timer, so a normal run is unaffected,
-# and os._exit because a wedged driver is exactly where a clean shutdown will not run.
+# Self-limit: binding to the parent's death needs a pre-exec hook, and that hook is what
+# lets a fork of a multithreaded server deadlock, so a Studio killed mid-probe leaves
+# something that exits on its own. os._exit because a wedged driver will not shut down
+# cleanly.
 _watchdog = threading.Timer(float(sys.argv[2]), lambda: os._exit(70))
 _watchdog.daemon = True  # a Timer is a Thread and is NOT daemon by default; without this
 _watchdog.start()        # the child cannot exit until it fires and every probe times out
@@ -122,9 +105,9 @@ print("ok")
 def _rocm_dll_directories() -> list[str]:
     """Windows ROCm ``bin`` directories, newest version first. Empty off Windows.
 
-    Same discovery as ``main.py`` and ``core/training/worker.py``; it lives here too
-    because the child is a bare ``-c`` script with no backend directory on its path (that
-    isolation is deliberate), and computing the list parent-side keeps it testable.
+    Same discovery as ``main.py`` and ``core/training/worker.py``, repeated because the
+    child is a bare ``-c`` script with no backend directory on its path. Computing it
+    parent-side keeps it testable.
     """
     if sys.platform != "win32":
         return []
@@ -184,18 +167,15 @@ def _cache_key(device: str) -> tuple:
 def describe_exit(returncode: Optional[int]) -> Optional[str]:
     """A human-readable cause for a nonzero child exit, for logs only.
 
-    Mirrors ``LlamaCppBackend._is_signal_crash`` rather than importing it: that lives in
-    the llama.cpp inference plumbing, and the RAG embedder which calls this probe is
-    deliberately torch-optional and must not pull that module in to read one predicate.
+    Mirrors ``LlamaCppBackend._is_signal_crash`` rather than importing it: the caller is
+    torch-optional and must not pull in llama.cpp plumbing to read one predicate.
     """
     if returncode is None or returncode == 0:
         return None
 
-    # A POSIX signal arrives as a small negative number. Windows reports a native fault as
-    # an NTSTATUS-shaped status instead, and can hand it over signed or unsigned. The two
-    # cannot be told apart by sign alone: -11 (SIGSEGV) and -1073741819 (0xC0000005 signed)
-    # are both negative, and masking either to 32 bits lands above 0xC0000000. Magnitude is
-    # what separates them -- no signal number comes near _MAX_SIGNAL_NUMBER.
+    # Sign alone cannot separate a POSIX signal from a Windows NTSTATUS: -11 (SIGSEGV) and
+    # -1073741819 (0xC0000005 signed) are both negative, and masking either to 32 bits lands
+    # above 0xC0000000. Magnitude can.
     if returncode < 0 and -returncode <= _MAX_SIGNAL_NUMBER:
         signal_number = -returncode
         try:
@@ -231,15 +211,12 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
             encoding = "utf-8",
             errors = "replace",
             env = env,
-            # Deliberately NO preexec_fn, so no child_popen_kwargs() here. The other GPU
-            # children take the PDEATHSIG hook from it, but that hook forks this
-            # multithreaded, possibly torch-initialised server and runs Python before exec;
-            # a lock another uvicorn thread held at fork time is still held in the child,
-            # which can hang it before exec while the parent waits inside Popen, where the
-            # timeout below does not yet apply. Python's own docs call preexec_fn unsafe in
-            # the presence of threads for exactly this. It also disables subprocess's vfork
-            # fast path. The child self-limits instead, which bounds an orphan without
-            # forking a hook, and adopt_pid still gives shutdown its backstop.
+            # Deliberately NO preexec_fn, hence no child_popen_kwargs(). The long-lived GPU
+            # children take its PDEATHSIG hook, but that forks this multithreaded server and
+            # runs Python before exec, where a lock another uvicorn thread held at fork time
+            # is still held; the child can hang there while the parent waits inside Popen,
+            # ahead of the timeout below. Python's docs call it unsafe with threads, and it
+            # also disables the vfork fast path. The child self-limits instead.
             **windows_hidden_subprocess_kwargs(),
         )
     except OSError as spawn_error:
@@ -268,12 +245,10 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
 def _reap_later(process: subprocess.Popen) -> None:
     """Wait on a child that outlived SIGKILL, on a daemon thread, forever.
 
-    SIGKILL cannot be caught, but it also cannot land while the process sits in an
-    uninterruptible driver wait: the signal is only delivered once the ioctl returns, and a
-    wedged GPU is precisely how a task ends up there. Since that is the scenario this
-    module exists to survive, dropping the last reference to such a child is the one way it
-    becomes an unreaped stray. Hold it and let the thread collect the corpse whenever the
-    driver finally lets go. Daemon, so it never delays shutdown.
+    SIGKILL cannot land while a task sits in an uninterruptible driver wait -- it is
+    delivered once the ioctl returns, and a wedged GPU is how a task gets there. That being
+    the scenario this module exists to survive, dropping the last reference is the one way
+    such a child becomes an unreaped stray.
     """
     threading.Thread(
         target = _wait_forever,

--- a/studio/backend/utils/device_allocation_probe.py
+++ b/studio/backend/utils/device_allocation_probe.py
@@ -48,6 +48,9 @@ logger = logging.getLogger(__name__)
 # this probe is off the request/boot critical path. Being generous here costs a late
 # warm; being stingy condemns a healthy host to CPU.
 PROBE_TIMEOUT_SECONDS = 120.0
+# The child's own deadline. Comfortably past the parent's, so in a normal run the parent
+# always decides first and this only ever fires for a child whose parent is gone.
+_CHILD_SELF_LIMIT_SECONDS = 300.0
 # Grace between terminate and kill when the child overran, mirroring the sidecars.
 _TERMINATE_GRACE_SECONDS = 5.0
 # Child stderr is a torch traceback or a driver's parting words; keep the tail only.
@@ -83,6 +86,16 @@ ROCM_DLL_DIRS_ENV_VAR = "UNSLOTH_STUDIO_PROBE_ROCM_DLL_DIRS"
 _CHILD_SCRIPT = """
 import os
 import sys
+import threading
+
+# Self-limit. The parent cannot bind this child to its own death without a pre-exec hook,
+# and that hook is what makes a fork of a multithreaded server able to deadlock, so the
+# child bounds itself instead: a Studio killed mid-probe leaves something that exits on its
+# own rather than an orphan holding the GPU. Daemon timer, so a normal run is unaffected,
+# and os._exit because a wedged driver is exactly where a clean shutdown will not run.
+_watchdog = threading.Timer(float(sys.argv[2]), lambda: os._exit(70))
+_watchdog.daemon = True  # a Timer is a Thread and is NOT daemon by default; without this
+_watchdog.start()        # the child cannot exit until it fires and every probe times out
 
 if sys.platform == "win32":
     _handles = []
@@ -202,7 +215,7 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
     a non-None ``failure_reason`` means the child never delivered a verdict of its own."""
     from utils.child_stdio import utf8_child_env
     from utils.native_path_leases import child_env_without_native_path_secret
-    from utils.process_lifetime import adopt_pid, child_popen_kwargs, forget_pid
+    from utils.process_lifetime import adopt_pid, forget_pid
     from utils.subprocess_compat import windows_hidden_subprocess_kwargs
 
     env = utf8_child_env(child_env_without_native_path_secret())
@@ -211,18 +224,22 @@ def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
         env[ROCM_DLL_DIRS_ENV_VAR] = os.pathsep.join(dll_dirs)
     try:
         process = subprocess.Popen(
-            [sys.executable, "-c", _CHILD_SCRIPT, device],
+            [sys.executable, "-c", _CHILD_SCRIPT, device, str(_CHILD_SELF_LIMIT_SECONDS)],
             stdout = subprocess.PIPE,
             stderr = subprocess.PIPE,
             text = True,
             encoding = "utf-8",
             errors = "replace",
             env = env,
-            # This child can sit in a cold torch import, or wedged in a driver ioctl, for
-            # the whole timeout. Without the parent-death binding, a Studio that is killed
-            # in that window leaves it reparented and running, where it holds the very GPU
-            # the next backend is about to probe. Same treatment as the other GPU children.
-            **child_popen_kwargs(),
+            # Deliberately NO preexec_fn, so no child_popen_kwargs() here. The other GPU
+            # children take the PDEATHSIG hook from it, but that hook forks this
+            # multithreaded, possibly torch-initialised server and runs Python before exec;
+            # a lock another uvicorn thread held at fork time is still held in the child,
+            # which can hang it before exec while the parent waits inside Popen, where the
+            # timeout below does not yet apply. Python's own docs call preexec_fn unsafe in
+            # the presence of threads for exactly this. It also disables subprocess's vfork
+            # fast path. The child self-limits instead, which bounds an orphan without
+            # forking a hook, and adopt_pid still gives shutdown its backstop.
             **windows_hidden_subprocess_kwargs(),
         )
     except OSError as spawn_error:

--- a/studio/backend/utils/device_allocation_probe.py
+++ b/studio/backend/utils/device_allocation_probe.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Ask a short-lived child process whether a torch device can actually allocate.
+
+A GPU runtime that does not match the silicon it is driving does not raise: it
+faults. On the gfx1151 host in #7331 a ROCm 6.3 wheel built for gfx1100 reported
+``torch.cuda.is_available() == True``, enumerated the device correctly, and then
+died with SIGSEGV inside ``libamdhip64`` on the first real allocation. Signal
+disposition is per process, so that fault killed uvicorn -- from a daemon thread,
+past an ``except Exception``, because a signal never becomes a Python exception
+(#8474).
+
+So the question "can this device allocate" cannot be answered in the process that
+has to survive the answer. It is answered in a child, and the child dying IS the
+answer. The parent side of this module imports only the standard library: it must
+stay importable on a ``--no-torch`` install, and it must not be what finally drags
+torch into the lean main process (see ``tests/test_startup_defers_torch.py``).
+
+Deliberately NOT here:
+  * no ``multiprocessing`` -- uvicorn is multithreaded and HIP/CUDA are
+    fork-hostile, and ``set_start_method`` is process-global state we do not own
+  * no model load -- the caller would have to load it again in-process, paying the
+    download, the deserialization and the security gate twice
+  * no on-disk cache -- a negative verdict that outlived a driver or wheel repair
+    would pin a healthy machine to CPU with no way to tell why
+
+The verdict is memoized for the process only, keyed by the device and by every
+environment variable that can change which silicon that device names.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+# Plain stdlib logging, as in core/rag/embeddings.py: the caller is the torch-optional
+# embedder, and this module should add no import weight of its own.
+logger = logging.getLogger(__name__)
+
+# A cold ROCm torch import on a slow host is minutes, not seconds, and every caller of
+# this probe is off the request/boot critical path. Being generous here costs a late
+# warm; being stingy condemns a healthy host to CPU.
+PROBE_TIMEOUT_SECONDS = 120.0
+# Grace between terminate and kill when the child overran, mirroring the sidecars.
+_TERMINATE_GRACE_SECONDS = 5.0
+# Child stderr is a torch traceback or a driver's parting words; keep the tail only.
+_STDERR_TAIL_CHARS = 600
+# Above this, a negative exit code is a signed Windows status rather than a signal.
+# POSIX signal numbers stop at 64 (NSIG); the headroom costs nothing.
+_MAX_SIGNAL_NUMBER = 128
+
+# Variables that decide WHICH physical device a device string names, or which kernels
+# the runtime believes it should emit. A change to any of them invalidates the verdict:
+# HSA_OVERRIDE_GFX_VERSION is exactly the spoof that produced #7331.
+_DEVICE_IDENTITY_ENV_VARS = (
+    "CUDA_VISIBLE_DEVICES",
+    "HIP_VISIBLE_DEVICES",
+    "ROCR_VISIBLE_DEVICES",
+    "HSA_OVERRIDE_GFX_VERSION",
+)
+
+# Allocate, WRITE, then synchronize. Device execution is asynchronous, so an allocation
+# that faults in the kernel can outlive the statement that queued it -- without the
+# synchronize the child can exit 0 while the fault is still in flight, which is the one
+# way this probe could report a false pass. torch.empty alone is too weak for the same
+# reason: it need not touch the device at all.
+_CHILD_SCRIPT = """
+import sys
+
+import torch
+
+device = sys.argv[1]
+tensor = torch.empty(1, device = device)
+tensor.zero_()
+if tensor.device.type == "cuda":
+    torch.cuda.synchronize(tensor.device)
+elif tensor.device.type == "xpu":
+    torch.xpu.synchronize(tensor.device)
+print("ok")
+"""
+
+
+@dataclass(frozen = True)
+class DeviceAllocationProbeResult:
+    """Verdict for one device. ``ok`` is the only field a caller should branch on;
+    ``returncode`` and ``reason`` exist to make the log line say something useful."""
+
+    ok: bool
+    device: str
+    returncode: Optional[int]
+    reason: Optional[str]
+    duration_seconds: float
+
+
+_cache_lock = threading.Lock()
+_cache: dict[tuple, DeviceAllocationProbeResult] = {}
+
+
+def _cache_key(device: str) -> tuple:
+    return (device, sys.executable) + tuple(
+        os.environ.get(name) for name in _DEVICE_IDENTITY_ENV_VARS
+    )
+
+
+def describe_exit(returncode: Optional[int]) -> Optional[str]:
+    """A human-readable cause for a nonzero child exit, for logs only.
+
+    Mirrors ``LlamaCppBackend._is_signal_crash`` rather than importing it: that lives in
+    the llama.cpp inference plumbing, and the RAG embedder which calls this probe is
+    deliberately torch-optional and must not pull that module in to read one predicate.
+    """
+    if returncode is None or returncode == 0:
+        return None
+
+    # A POSIX signal arrives as a small negative number. Windows reports a native fault as
+    # an NTSTATUS-shaped status instead, and can hand it over signed or unsigned. The two
+    # cannot be told apart by sign alone: -11 (SIGSEGV) and -1073741819 (0xC0000005 signed)
+    # are both negative, and masking either to 32 bits lands above 0xC0000000. Magnitude is
+    # what separates them -- no signal number comes near _MAX_SIGNAL_NUMBER.
+    if returncode < 0 and -returncode <= _MAX_SIGNAL_NUMBER:
+        signal_number = -returncode
+        try:
+            import signal
+            return f"killed by {signal.Signals(signal_number).name}"
+        except (ImportError, ValueError):
+            return f"killed by signal {signal_number}"
+
+    unsigned = returncode & 0xFFFFFFFF
+    if unsigned >= 0xC0000000:
+        return f"native fault, exit status 0x{unsigned:08X}"
+    return f"exit code {returncode}"
+
+
+def _run_child(device: str) -> tuple[Optional[int], str, Optional[str]]:
+    """Run the probe child. Returns ``(returncode, stderr_tail, failure_reason)``, where
+    a non-None ``failure_reason`` means the child never delivered a verdict of its own."""
+    from utils.child_stdio import utf8_child_env
+    from utils.native_path_leases import child_env_without_native_path_secret
+    from utils.subprocess_compat import windows_hidden_subprocess_kwargs
+
+    env = utf8_child_env(child_env_without_native_path_secret())
+    try:
+        process = subprocess.Popen(
+            [sys.executable, "-c", _CHILD_SCRIPT, device],
+            stdout = subprocess.PIPE,
+            stderr = subprocess.PIPE,
+            text = True,
+            encoding = "utf-8",
+            errors = "replace",
+            env = env,
+            **windows_hidden_subprocess_kwargs(),
+        )
+    except OSError as spawn_error:
+        # No interpreter, no fork headroom, no permission. We learned nothing about the
+        # device, and "learned nothing" fails closed.
+        return None, "", f"probe could not start ({spawn_error})"
+
+    try:
+        _, stderr = process.communicate(timeout = PROBE_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        # Classify BEFORE cleaning up: after the terminate/kill below, returncode is the
+        # signal WE sent, and reporting that as the driver's fault would be a lie.
+        stderr = _terminate_and_drain(process)
+        return process.returncode, stderr, "probe timed out"
+
+    return process.returncode, stderr or "", None
+
+
+def _terminate_and_drain(process: subprocess.Popen) -> str:
+    """Terminate, give it a moment, kill, and always drain and reap, so an overrunning
+    probe cannot leave a zombie or a held pipe behind."""
+    stderr = ""
+    try:
+        process.terminate()
+    except OSError:
+        pass
+    try:
+        _, stderr = process.communicate(timeout = _TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+        except OSError:
+            pass
+        try:
+            _, stderr = process.communicate(timeout = _TERMINATE_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            pass
+    except OSError:
+        pass
+    return stderr or ""
+
+
+def probe_torch_device_allocation(device: str = "cuda:0") -> DeviceAllocationProbeResult:
+    """Whether a torch tensor can be allocated, written and synchronized on *device*.
+
+    Never raises and never returns "unknown": anything we could not establish -- a
+    signal, a nonzero exit, a timeout, a failed spawn -- comes back ``ok = False``, so a
+    caller reading ``.ok`` degrades rather than gambles. Memoized per process.
+    """
+    key = _cache_key(device)
+    with _cache_lock:
+        cached = _cache.get(key)
+    if cached is not None:
+        return cached
+
+    started = time.monotonic()
+    returncode, stderr, failure_reason = _run_child(device)
+    duration = time.monotonic() - started
+
+    ok = failure_reason is None and returncode == 0
+    reason = failure_reason or describe_exit(returncode)
+    result = DeviceAllocationProbeResult(
+        ok = ok,
+        device = device,
+        returncode = returncode,
+        reason = reason,
+        duration_seconds = duration,
+    )
+
+    if ok:
+        logger.debug("device allocation probe passed for %s in %.1fs", device, duration)
+    else:
+        tail = (stderr or "").strip()[-_STDERR_TAIL_CHARS:]
+        logger.warning(
+            "device allocation probe failed for %s (%s) after %.1fs%s",
+            device,
+            reason,
+            duration,
+            f": {tail}" if tail else "",
+        )
+
+    with _cache_lock:
+        # Another thread may have raced us to the same verdict; either is correct, so
+        # keep whichever landed first and let both callers see one value.
+        return _cache.setdefault(key, result)
+
+
+def _clear_probe_cache() -> None:
+    """Drop memoized verdicts (test teardown only)."""
+    with _cache_lock:
+        _cache.clear()


### PR DESCRIPTION
Closes #8474.

## What happens today

On the gfx1151 Strix Halo host in #7331, the Studio backend dies with a bare `Segmentation fault`.

#8480 fixed the wheel mismatch that triggers it. This is the separate reason a mismatched wheel takes down the whole backend rather than one feature: the RAG embedder makes the process's first GPU **allocation** in-process, with nothing between it and a signal.

The embedder walks to `SentenceTransformer(load_target, device = "cuda")`. `_device()` maps `DeviceType.CUDA` to `"cuda"`, and ROCm is `DeviceType.CUDA` internally, so there is no ROCm branch, no arch check, no isolation and no CPU fallback anywhere before the load.

The handlers that look like they cover this cannot. `except Exception as st_err` in `embeddings.py` is a Python handler; a SIGSEGV inside `libamdhip64` never becomes a Python exception, and signal disposition is per process, so the fault takes uvicorn with it.

**Rebased onto #8564, which changed the trigger but not the hazard.** That PR removed the eager `_warm_rag_embedder` startup warm, so embeddings now stay cold until something actually asks for vectors. The crash is therefore no longer at startup: it moves to first embedding use, reached from `core/rag/ingestion.py`, `core/rag/retrieval.py`, `core/rag/web_rank.py` and the `rag-folder-sync` thread. All four funnel through the same `_get_backend()` -> `_get()` allocation, in the backend process, so the process still dies; a user now just has to touch RAG first. This PR no longer changes `main.py` at all.

The reporter's own data narrows this usefully: on that host `torch.cuda.is_available()` returns `True` and the GPU enumerates correctly. Detection and device-property queries survive. Only the first real allocation dies. So the fix belongs at the allocation site, not at the detection layer.

## The fix

The question "can this device allocate" cannot be answered in the process that has to survive the answer. A short-lived child is asked to allocate first, and the child dying is the answer.

New `studio/backend/utils/device_allocation_probe.py`. The child allocates one element, writes to it, and synchronizes. The synchronize is the part that matters: device execution is asynchronous, so without it an allocation that faults in the kernel can outlive the statement that queued it and the child exits 0 while the fault is still in flight. `torch.empty` alone is too weak for the same reason.

Everything that is not a clean exit fails closed: a signal, any nonzero exit, a timeout, a failed spawn. Timeout is classified before the terminate/kill ladder, so the signal we sent is never reported as the driver's doing. The parent side imports only the standard library, so it stays importable on a `--no-torch` install and is not what finally drags torch into the lean main process.

Three things were deliberately left out. No `multiprocessing`: uvicorn is multithreaded, HIP and CUDA are fork-hostile, and `set_start_method` is process-global state this module does not own. No model load in the child: the parent would have to load it again, paying the download, the deserialization and the security gate twice. No on-disk cache: a negative verdict that outlived a driver or wheel repair would pin a healthy machine to CPU with no way to tell why. The verdict is memoized per process, keyed by the device and by `CUDA_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES` and `HSA_OVERRIDE_GFX_VERSION`, since that last one is exactly the spoof behind #7331.

## Degrading to CPU, not to llama-server

`_build_st_backend_or_fallback` already degrades to the GGUF llama-server embedder, and it would have been the smaller diff to reuse. It is the wrong target here: llama-server embeds into a different vector space, so every knowledge base already indexed with sentence-transformers would need reindexing, for a host whose only problem is that it cannot use its GPU.

A condemned host keeps the sentence-transformers backend and moves the device to CPU. Same backend, same model, identical vectors, no reindex. `bge-small` is small enough that this is a slowdown, not a loss of function. llama-server remains the fallback for genuine Python-level load failures, unchanged.

The degraded load also drops fp16, which is a win on the GPU and a slow, patchily supported path on CPU. Only the degraded case switches: a host that never had a GPU still loads exactly as it did before. That pre-existing fp16-on-CPU load for genuine CPU and Apple hosts is untouched here.

## `_resolve_auto` was steering into the crash

`_resolve_auto()` picks the backend by asking `LlamaCppBackend._get_gpu_free_memory()`, and its docstring claimed that check is "torch-free (nvidia-smi)". That is true on NVIDIA and false on AMD, where it falls back to torch `mem_get_info` in this process. So the one genuinely pre-load step was actively steering an affected host toward the fault rather than away from it. The docstring is corrected.

A ROCm host now answers without asking it, because the answer is fixed: auto resolves to sentence-transformers whatever the GPU turns out to be, since a working GPU takes it and a condemned one is placed on CPU at the load. No allocation probe runs there either; the device decision belongs to the load site.

## Deciding "is this ROCm" without importing torch or waiting for detection

`active_backend_is_llama()` runs inside `PUT /embedding-model` via `routes/settings.py:_llama_backend_active`, feeding the ST pickle security gate and deciding whether a local `.gguf` needs HF verification. It therefore cannot block, and it cannot be wrong.

It cannot block: hardware detection imports torch under `_DETECT_LOCK`, and the probe child is allowed a 120s cold import, so neither may sit on that path. Detection state is tri-state (`None` while unsettled) and the request path never forces it.

It cannot be wrong either, because answering "possibly ROCm" too eagerly is not free: `settings.py` reads that as "not llama" and drops its GGUF handling, so a valid local `.gguf` gets a transient 409 on a host that never had an AMD GPU. Several plausible signals turned out to be wrong in one direction or the other, and the review found each of them:

- treating every unsettled host as possibly-ROCm caught CPU and macOS hosts
- an installed HIP SDK is not evidence, and `main.py` already refuses to let `HIP_PATH`/`ROCM_PATH` alone pick a backend, for exactly that reason
- `torch.version.hip` alone is narrower than detection's own test, which also falls back to `rocm` in `torch.__version__` for AMD SDK wheels, and a torch that is in `sys.modules` while still executing has neither attribute yet

What settles it is the installed wheel. `torch/version.py` is generated literals, and `find_spec` locates the package without executing it, so the same two facts detection uses are readable while torch is still unimported. Absent torch is a definite non-ROCm answer rather than an unknown, which matters on a `--no-torch` Windows install where detection never settles and auto really does resolve to llama-server.

## The probe child

Three things the child needs that are not obvious:

**Windows ROCm DLL directories.** `os.add_dll_directory` registrations are process-local, so a fresh interpreter does not inherit `main.py`'s and cannot find `amdhip64.dll`. It would fail to import torch, exit nonzero, and failing closed would condemn a healthy AMD GPU for the life of the process. `core/training/worker.py` already carries this note for its own child. The directories are discovered parent-side, which keeps the version ordering testable, and registered before the import.

**No pre-exec hook.** The repo's lifetime helper binds children with `preexec_fn`, and that forks this multithreaded server and runs Python before exec, where a lock another uvicorn thread held at fork time is still held. The child can hang there while the parent waits inside `Popen`, ahead of the timeout. Python's own docs call `preexec_fn` unsafe in the presence of threads. The long-lived GPU workers accept that trade; a short probe should not.

**So the child bounds itself**, with a watchdog past the parent's own deadline, which covers the orphan case the hook was wanted for. `adopt_pid` still gives shutdown its backstop. That watchdog needed `daemon` set explicitly: a `Timer` is a `Thread` and is not daemon by default, so the first version could not exit until it fired and every probe on every host timed out. Running the real child is what caught it.

## Cost on unaffected hosts

The probe only runs on ROCm, and only at the embedder load. NVIDIA, Intel XPU, Apple, CPU-only and `--no-torch` installs spawn no child and behave byte-identically to before. A healthy ROCm host pays one child once per process.

`main.py` is untouched: #8564 deleted the warm this PR originally logged around, and that deletion is taken as-is.

## Tests

70 new tests. `tests/test_device_allocation_probe.py` (39) fakes the child and pins the classification: SIGSEGV, SIGABRT/SIGILL/SIGBUS/SIGFPE, a Windows access violation in both its signed and unsigned forms, any ordinary nonzero exit, a timeout, a failed spawn and a failed read all come back "do not allocate in this process"; the teardown escalates terminate to kill and hands anything not confirmed dead to the reaper; memoization holds per device and breaks on each of the four device-identity variables; the Windows DLL directories are registered, newest version first, strictly before the import; and the child script is executed against a stubbed torch to prove it exits promptly.

That last one is not ceremony. Three bugs in this PR were found by running things rather than reading them: a signed `0xC0000005` read as "killed by signal 1073741819", the naive fix for it then misreading `-11` as a native fault (`-11 & 0xFFFFFFFF` also lands above `0xC0000000`, so sign cannot separate them, only magnitude), and a watchdog `Timer` left non-daemon, which made the child unable to exit until it fired and so timed out every probe on every host.

`test_rag_embeddings.py` gains 10, covering the device decision: a failed probe moves the embedder to CPU and a passing one leaves it on the GPU; NVIDIA, XPU, Apple and CPU are never probed; the degraded load uses float32 while a genuine CPU host still gets float16; the security gate is not bypassed by the CPU fallback; and an end-to-end case asserting that on the #7331 shape the load completes, encode returns vectors and the process is still alive.

`test_rag_embed_llama_server.py` gains 21, covering the request path and the ROCm signal: the settings gate fails the test if it forces detection, reaches the probe, or reaches the AMD GPU query; a CPU, macOS, non-ROCm or `--no-torch` host keeps its llama/GGUF answer; an installed HIP SDK alone does not make a host ROCm while an AMD SDK wheel without `hip` metadata does; a half-imported torch stays cautious; and the on-disk read is exercised against a fake package whose `__init__` raises if anything imports it.

Locally, `studio/backend/tests/`: 22384 passed, with a failing set byte-identical to the pre-change baseline on this machine (that set is missing optional backend deps, not code). Staging CI is green, 11 workflows, after one network flake fetching the diffusers archive passed on re-run.

The probe was also run for real against a healthy NVIDIA `cuda:0`: passes in ~2s, and a bad ordinal or a garbage device string fails closed with a truncated reason rather than raising.

There is no AMD hardware and no ROCm CI in this repo, so the ROCm behaviour, including the Windows DLL path, is mock-based throughout and has not been validated on real silicon.

## Not in this change

`llama_cpp._get_gpu_free_memory()`'s torch fallback, `hardware.py`'s torch memory and property fallbacks, and `embed_llama_server.py`'s auto GPU selection all have the same torch-on-ROCm shape and could consume the same cached verdict. They are left alone because on the #7331 host those calls demonstrably succeeded, and widening this PR on speculation is how a startup fix becomes a hardware-detection rewrite.

Also untouched: the in-process `pipe.to(device)` in the diffusion and video backends, which is a real second in-process allocation site but not a startup one, and the fact that the `rag-folder-sync` thread reaches the embedder without any user action while not being gated by `UNSLOTH_STUDIO_DISABLE_TORCH_WARM`. That thread goes through the same `_get_backend()` choke point, so it inherits this fix; the env-var asymmetry is separate.