### PR TITLE
Studio: detect real GGUF imatrix support, and give the local export its credential

### DIFF
--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -265,7 +265,6 @@ def _is_imatrix(path, imatrix_path):
 
 def _folded(path):
     import unicodedata
-
     return unicodedata.normalize("NFC", os.path.normcase(os.fspath(path)))
 
 
@@ -1214,7 +1213,8 @@ class ExportBackend:
                     unrelocated = []
                     if model_tmp_path.is_dir():
                         unrelocated = sorted(
-                            str(p) for p in model_tmp_path.rglob("*.gguf")
+                            str(p)
+                            for p in model_tmp_path.rglob("*.gguf")
                             if not _is_imatrix(p, imatrix_path)
                         )
                     if unrelocated:

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -158,8 +158,8 @@ def _cpu_offloaded_modules(model) -> int:
 def _accepts_by_keyword(params, name):
     """True if `name` is passable as a keyword, not merely named.
 
-    Every call site passes by keyword, so counting a positional-only parameter as support
-    turns a clean refusal into a TypeError.
+    Every call site passes by keyword, so a positional-only parameter is not support: counting
+    it turns a clean refusal into a TypeError.
     """
     import inspect
 
@@ -230,9 +230,8 @@ def _materialized_imatrix_path(model_dir, imatrix_file):
     """Where unsloth copies a `*.gguf_file` imatrix beside the model, else None.
 
     `_materialize_imatrix` drops that copy in the model directory, so the owned-root scan
-    would otherwise relocate an importance matrix as if it were a converted model. The name
-    is derived from the basename, but callers compare the whole path (see `_is_imatrix`): an
-    imatrix named after the quant would otherwise suppress the real output in `model_gguf/`.
+    would otherwise relocate it as if it were a converted model. Callers compare the whole path
+    (see `_is_imatrix`): a basename match would suppress a real output of the same name.
     """
     if imatrix_file is True:
         name = "imatrix_unsloth.gguf"  # the upstream imatrix_unsloth.gguf_file, renamed
@@ -249,9 +248,8 @@ def _materialized_imatrix_path(model_dir, imatrix_file):
 def _is_imatrix(path, imatrix_path):
     """True when `path` is the materialized imatrix, asked of the filesystem rather than `==`.
 
-    The on-disk spelling is the filesystem's to choose: a folding mount changes case and APFS
-    stores NFD, so `rglob` need not return the name derived from the request. Byte-exact
-    `Path.__eq__` then misses and the imatrix is relocated as if it were a converted model.
+    The on-disk spelling is the filesystem's to choose (a folding mount changes case, APFS
+    stores NFD), so byte-exact `Path.__eq__` misses and the imatrix is relocated as a model.
     """
     if imatrix_path is None:
         return False
@@ -1093,8 +1091,7 @@ class ExportBackend:
                 "Upgrade unsloth and unsloth_zoo, or disable the imatrix option.",
                 None,
             )
-        # Truthiness, as in the guard above: a disabled imatrix must not reach an exporter that
-        # takes no such keyword.
+        # Truthiness, as above: a disabled imatrix must not reach an exporter without the kwarg.
         imatrix_kw = {"imatrix_file": imatrix_file} if imatrix_file else {}
         # Resolution reads a Hub repo, so the local save needs the token too -- kept out of
         # imatrix_kw, which the push below shares and already names token= itself.
@@ -1128,8 +1125,7 @@ class ExportBackend:
                 os.environ.setdefault("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR", LLAMA_CPP_DEFAULT_DIR)
             except Exception:
                 # Not just ImportError: a half-built unsloth_zoo raises RuntimeError or
-                # AttributeError, and this pin is an optimisation, so letting either escape
-                # would fail every GGUF export.
+                # AttributeError, and this pin is an optimisation, not worth failing an export.
                 if not _LLAMA_CPP_SCRIPTS_WARNING_EMITTED:
                     logger.warning(
                         "Unsloth: installed unsloth_zoo does not honor "

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -156,10 +156,10 @@ def _cpu_offloaded_modules(model) -> int:
 
 
 def _accepts_by_keyword(params, name):
-    """True if `name` can actually be passed as a keyword, not merely named.
+    """True if `name` is passable as a keyword, not merely named.
 
-    A positional-only parameter is named and unusable: every call site here passes by
-    keyword, so counting one as support turns a clean refusal into a TypeError.
+    Every call site passes by keyword, so counting a positional-only parameter as support
+    turns a clean refusal into a TypeError.
     """
     import inspect
 
@@ -247,12 +247,11 @@ def _materialized_imatrix_path(model_dir, imatrix_file):
 
 
 def _is_imatrix(path, imatrix_path):
-    """True when `path` is the materialized imatrix, asking the filesystem rather than `==`.
+    """True when `path` is the materialized imatrix, asked of the filesystem rather than `==`.
 
-    The on-disk spelling is the filesystem's to choose: a case-insensitive mount folds case
-    and APFS stores NFD, so the name `rglob` returns need not be the one derived from the
-    request. `Path.__eq__` is byte-exact under posix, so it misses, and the importance matrix
-    is then relocated into the user's export directory and reported as a converted model.
+    The on-disk spelling is the filesystem's to choose: a folding mount changes case and APFS
+    stores NFD, so `rglob` need not return the name derived from the request. Byte-exact
+    `Path.__eq__` then misses and the imatrix is relocated as if it were a converted model.
     """
     if imatrix_path is None:
         return False
@@ -1128,9 +1127,9 @@ class ExportBackend:
                 )
                 os.environ.setdefault("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR", LLAMA_CPP_DEFAULT_DIR)
             except Exception:
-                # Not just ImportError: a half-built unsloth_zoo surfaces as RuntimeError or
-                # AttributeError, and this pin is an optimisation. Letting it escape would
-                # take down every GGUF export, imatrix or not.
+                # Not just ImportError: a half-built unsloth_zoo raises RuntimeError or
+                # AttributeError, and this pin is an optimisation, so letting either escape
+                # would fail every GGUF export.
                 if not _LLAMA_CPP_SCRIPTS_WARNING_EMITTED:
                     logger.warning(
                         "Unsloth: installed unsloth_zoo does not honor "

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -166,6 +166,27 @@ def _supports_kwarg(fn, name):
     return name in params or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
+def _imatrix_export_supported(save_fn):
+    """True when this build can apply an imatrix, not merely swallow the keyword: the MLX binding
+    takes `**kwargs` and filters them, so only unsloth_zoo itself settles it."""
+    import inspect
+
+    try:
+        params = inspect.signature(save_fn).parameters
+    except (TypeError, ValueError):
+        return False
+    if "imatrix_file" in params:
+        return True
+    if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return False
+    try:
+        from unsloth_zoo.llama_cpp import resolve_imatrix_file  # noqa: F401
+    except Exception:
+        # Runs before export_gguf's exception boundary, which must return a tuple, not raise.
+        return False
+    return True
+
+
 def _reported_gguf_files(result):
     """Absolute GGUF paths unsloth reported writing, or None if it reported nothing.
 
@@ -1030,16 +1051,25 @@ class ExportBackend:
 
         # Only forward imatrix_file to an unsloth build that accepts it, else older builds raise
         # an unexpected-keyword error even for a plain no-imatrix export.
-        if imatrix_file is not None and not _supports_kwarg(
-            self.current_model.save_pretrained_gguf, "imatrix_file"
-        ):
+        if imatrix_file and not _imatrix_export_supported(self.current_model.save_pretrained_gguf):
             return (
                 False,
                 "This Unsloth build does not support GGUF imatrix export. "
                 "Upgrade unsloth and unsloth_zoo, or disable the imatrix option.",
                 None,
             )
-        imatrix_kw = {"imatrix_file": imatrix_file} if imatrix_file is not None else {}
+        # Truthiness, as in the guard above: a disabled imatrix must not reach an exporter that
+        # takes no such keyword.
+        imatrix_kw = {"imatrix_file": imatrix_file} if imatrix_file else {}
+        # Resolution reads a Hub repo, so the local save needs the token too -- kept out of
+        # imatrix_kw, which the push below shares and already names token= itself.
+        local_token_kw = (
+            {"token": hf_token}
+            if imatrix_file
+            and hf_token
+            and _supports_kwarg(self.current_model.save_pretrained_gguf, "token")
+            else {}
+        )
 
         output_path: Optional[str] = None
         try:
@@ -1095,6 +1125,7 @@ class ExportBackend:
                         self.current_tokenizer,
                         quantization_method = quant_method,
                         **imatrix_kw,
+                        **local_token_kw,
                     )
 
                     # Scan only the owned root; exact reported paths cover external outputs.

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -155,6 +155,18 @@ def _cpu_offloaded_modules(model) -> int:
     return sum(1 for target in device_map.values() if str(target) in ("cpu", "disk"))
 
 
+def _accepts_by_keyword(params, name):
+    """True if `name` can actually be passed as a keyword, not merely named.
+
+    A positional-only parameter is named and unusable: every call site here passes by
+    keyword, so counting one as support turns a clean refusal into a TypeError.
+    """
+    import inspect
+
+    parameter = params.get(name)
+    return parameter is not None and parameter.kind is not inspect.Parameter.POSITIONAL_ONLY
+
+
 def _supports_kwarg(fn, name):
     """True if `fn` accepts keyword `name` directly or via **kwargs."""
     import inspect
@@ -163,7 +175,9 @@ def _supports_kwarg(fn, name):
         params = inspect.signature(fn).parameters
     except (TypeError, ValueError):
         return False
-    return name in params or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+    return _accepts_by_keyword(params, name) or any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
 
 
 def _imatrix_export_supported(save_fn):
@@ -175,7 +189,7 @@ def _imatrix_export_supported(save_fn):
         params = inspect.signature(save_fn).parameters
     except (TypeError, ValueError):
         return False
-    if "imatrix_file" in params:
+    if _accepts_by_keyword(params, "imatrix_file"):
         return True
     if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
         return False
@@ -216,9 +230,9 @@ def _materialized_imatrix_path(model_dir, imatrix_file):
     """Where unsloth copies a `*.gguf_file` imatrix beside the model, else None.
 
     `_materialize_imatrix` drops that copy in the model directory, so the owned-root scan
-    would otherwise relocate an importance matrix as if it were a converted model. Matching
-    the full path, not the basename: an imatrix named after the quant would otherwise
-    suppress the real output in `model_gguf/` as well.
+    would otherwise relocate an importance matrix as if it were a converted model. The name
+    is derived from the basename, but callers compare the whole path (see `_is_imatrix`): an
+    imatrix named after the quant would otherwise suppress the real output in `model_gguf/`.
     """
     if imatrix_file is True:
         name = "imatrix_unsloth.gguf"  # the upstream imatrix_unsloth.gguf_file, renamed
@@ -230,6 +244,29 @@ def _materialized_imatrix_path(model_dir, imatrix_file):
     else:
         return None
     return Path(model_dir) / name
+
+
+def _is_imatrix(path, imatrix_path):
+    """True when `path` is the materialized imatrix, asking the filesystem rather than `==`.
+
+    The on-disk spelling is the filesystem's to choose: a case-insensitive mount folds case
+    and APFS stores NFD, so the name `rglob` returns need not be the one derived from the
+    request. `Path.__eq__` is byte-exact under posix, so it misses, and the importance matrix
+    is then relocated into the user's export directory and reported as a converted model.
+    """
+    if imatrix_path is None:
+        return False
+    try:
+        return os.path.samefile(path, imatrix_path)
+    except OSError:
+        # Either side may be gone by cleanup time; fall back to a folded comparison.
+        return _folded(path) == _folded(imatrix_path)
+
+
+def _folded(path):
+    import unicodedata
+
+    return unicodedata.normalize("NFC", os.path.normcase(os.fspath(path)))
 
 
 def _compressed_export_supported():
@@ -1091,7 +1128,10 @@ class ExportBackend:
                     _resolve_local_convert_script,  # noqa: F401
                 )
                 os.environ.setdefault("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR", LLAMA_CPP_DEFAULT_DIR)
-            except ImportError:
+            except Exception:
+                # Not just ImportError: a half-built unsloth_zoo surfaces as RuntimeError or
+                # AttributeError, and this pin is an optimisation. Letting it escape would
+                # take down every GGUF export, imatrix or not.
                 if not _LLAMA_CPP_SCRIPTS_WARNING_EMITTED:
                     logger.warning(
                         "Unsloth: installed unsloth_zoo does not honor "
@@ -1132,7 +1172,7 @@ class ExportBackend:
                     reported = result if isinstance(result, dict) else {}
                     produced = {p for p in model_tmp_path.rglob("*.gguf") if p.is_file()}
                     produced.update(Path(f) for f in _reported_gguf_files(result) or [])
-                    produced = {p for p in produced if p != imatrix_path}
+                    produced = {p for p in produced if not _is_imatrix(p, imatrix_path)}
                     modelfiles = {p for p in model_tmp_path.rglob("Modelfile") if p.is_file()}
                     reported_modelfile = reported.get("modelfile_location")
                     if reported_modelfile and Path(reported_modelfile).is_file():
@@ -1174,7 +1214,8 @@ class ExportBackend:
                     unrelocated = []
                     if model_tmp_path.is_dir():
                         unrelocated = sorted(
-                            str(p) for p in model_tmp_path.rglob("*.gguf") if p != imatrix_path
+                            str(p) for p in model_tmp_path.rglob("*.gguf")
+                            if not _is_imatrix(p, imatrix_path)
                         )
                     if unrelocated:
                         logger.error(

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -424,3 +425,220 @@ def test_modelfile_relocation_failure_does_not_fail_the_export(monkeypatch, tmp_
     assert success is True, message
     assert (save_dir / "MyModel.Q5_K_M.gguf").is_file()
     assert not (save_dir / "Modelfile").exists()
+
+
+# The upstream imatrix lives in a Hub repo, so the local export needs the token too -- without
+# disturbing the push path, which already passes it explicitly.
+
+
+def _imatrix_model(accepts_token: bool, calls: dict):
+    class _WithToken:
+        def save_pretrained_gguf(
+            self,
+            model_save_path,
+            tokenizer,
+            quantization_method,
+            imatrix_file = None,
+            token = None,
+        ):
+            calls["save"] = {"imatrix_file": imatrix_file, "token": token}
+            _gguf(Path(model_save_path) / "Model.IQ2_XXS.gguf")
+
+        def push_to_hub_gguf(
+            self,
+            repo_id,
+            tokenizer,
+            quantization_method = None,
+            token = None,
+            imatrix_file = None,
+        ):
+            calls["push"] = {"repo_id": repo_id, "token": token, "imatrix_file": imatrix_file}
+
+    class _WithoutToken:
+        def save_pretrained_gguf(
+            self,
+            model_save_path,
+            tokenizer,
+            quantization_method,
+            imatrix_file = None,
+        ):
+            calls["save"] = {"imatrix_file": imatrix_file}
+            _gguf(Path(model_save_path) / "Model.IQ2_XXS.gguf")
+
+    return (_WithToken if accepts_token else _WithoutToken)()
+
+
+def test_local_gguf_export_forwards_the_token_for_the_upstream_imatrix(monkeypatch, tmp_path):
+    calls: dict = {}
+    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _imatrix_model(True, calls))
+
+    success, message, _p = backend.export_gguf(
+        str(save_dir), "iq2_xxs", hf_token = "hf_secret", imatrix_file = True
+    )
+
+    assert success is True, message
+    assert calls["save"] == {"imatrix_file": True, "token": "hf_secret"}
+
+
+def test_hub_push_with_an_imatrix_passes_the_token_exactly_once(monkeypatch, tmp_path):
+    """push_to_hub_gguf already names token=, so the local extra must not reach it as well."""
+    calls: dict = {}
+    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _imatrix_model(True, calls))
+
+    success, message, _p = backend.export_gguf(
+        str(save_dir),
+        "iq2_xxs",
+        push_to_hub = True,
+        repo_id = "org/model",
+        hf_token = "hf_secret",
+        imatrix_file = True,
+    )
+
+    assert success is True, message
+    assert calls["push"] == {"repo_id": "org/model", "token": "hf_secret", "imatrix_file": True}
+
+
+def test_gguf_export_without_an_imatrix_does_not_forward_the_token(monkeypatch, tmp_path):
+    calls: dict = {}
+    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _imatrix_model(True, calls))
+
+    success, message, _p = backend.export_gguf(str(save_dir), "q4_k_m", hf_token = "hf_secret")
+
+    assert success is True, message
+    assert calls["save"] == {"imatrix_file": None, "token": None}
+
+
+def test_older_build_without_token_support_still_exports(monkeypatch, tmp_path):
+    calls: dict = {}
+    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _imatrix_model(False, calls))
+
+    success, message, _p = backend.export_gguf(
+        str(save_dir), "iq2_xxs", hf_token = "hf_secret", imatrix_file = True
+    )
+
+    assert success is True, message
+    assert calls["save"] == {"imatrix_file": True}
+
+
+class _KwargsOnlyModel:
+    """The MLX binding's shape: it accepts anything and filters against an allow-list."""
+
+    def __init__(self, calls):
+        self._calls = calls
+
+    def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method, **kwargs):
+        self._calls["save"] = kwargs
+        _gguf(Path(model_save_path) / "Model.IQ2_XXS.gguf")
+
+
+def test_imatrix_refused_when_unsloth_zoo_cannot_apply_it(monkeypatch, tmp_path):
+    """A kwargs-only binding proves nothing: an older zoo would swallow the imatrix silently."""
+    calls: dict = {}
+    module, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _KwargsOnlyModel(calls))
+    monkeypatch.setattr(module, "_imatrix_export_supported", lambda save_fn: False, raising = True)
+
+    success, message, _p = backend.export_gguf(str(save_dir), "iq2_xxs", imatrix_file = True)
+
+    assert success is False
+    assert "imatrix" in message.lower()
+    assert calls == {}, "must not spend a merge and conversion first"
+
+
+def test_imatrix_export_supported_probes_unsloth_zoo_for_kwargs_only_bindings(
+    monkeypatch, tmp_path
+):
+    module, _b, _s, _cwd = _backend(monkeypatch, tmp_path, object())
+    zoo = sys.modules.get("unsloth_zoo.llama_cpp")
+
+    def named(
+        save_directory,
+        tokenizer,
+        quantization_method,
+        imatrix_file = None,
+    ):
+        pass
+
+    def kwargs_only(save_directory, tokenizer, quantization_method, **kwargs):
+        pass
+
+    def positional_only(save_directory, tokenizer, quantization_method):
+        pass
+
+    # A build that names the argument needs no zoo probe at all.
+    assert module._imatrix_export_supported(named) is True
+    assert module._imatrix_export_supported(positional_only) is False
+
+    fake_zoo = types.ModuleType("unsloth_zoo.llama_cpp")
+    monkeypatch.setitem(sys.modules, "unsloth_zoo.llama_cpp", fake_zoo)
+    assert module._imatrix_export_supported(kwargs_only) is False, "no resolver -> old zoo"
+    fake_zoo.resolve_imatrix_file = lambda *a, **kw: None
+    assert module._imatrix_export_supported(kwargs_only) is True
+    if zoo is not None:
+        monkeypatch.setitem(sys.modules, "unsloth_zoo.llama_cpp", zoo)
+
+
+def test_imatrix_disabled_explicitly_does_not_forward_the_token(monkeypatch, tmp_path):
+    calls: dict = {}
+    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _imatrix_model(True, calls))
+
+    success, message, _p = backend.export_gguf(
+        str(save_dir), "q4_k_m", hf_token = "hf_secret", imatrix_file = False
+    )
+
+    assert success is True, message
+    # Neither the credential nor the disabled flag itself is forwarded.
+    assert calls["save"] == {"imatrix_file": None, "token": None}
+
+
+def test_disabled_imatrix_is_never_blocked_by_the_capability_probe(monkeypatch, tmp_path):
+    """imatrix_file=False asks for no imatrix, so an old zoo must not refuse the export."""
+    calls: dict = {}
+    module, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _KwargsOnlyModel(calls))
+    monkeypatch.setattr(
+        module,
+        "_imatrix_export_supported",
+        lambda save_fn: pytest.fail("no imatrix was requested"),
+        raising = True,
+    )
+
+    success, message, _p = backend.export_gguf(str(save_dir), "q4_k_m", imatrix_file = False)
+
+    assert success is True, message
+
+
+def test_broken_unsloth_zoo_yields_a_failure_tuple_not_an_exception(monkeypatch, tmp_path):
+    """The probe runs before export_gguf's try block, so it must swallow more than ImportError."""
+    module, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _KwargsOnlyModel({}))
+
+    class _Exploding(types.ModuleType):
+        def __getattr__(self, name):
+            raise RuntimeError("partially initialised unsloth_zoo")
+
+    monkeypatch.setitem(sys.modules, "unsloth_zoo.llama_cpp", _Exploding("unsloth_zoo.llama_cpp"))
+
+    success, message, _p = backend.export_gguf(str(save_dir), "iq2_xxs", imatrix_file = True)
+
+    assert success is False
+    assert "imatrix" in message.lower()
+
+
+class _OldSaver:
+    """Predates the imatrix kwarg entirely: no `imatrix_file`, no `**kwargs`."""
+
+    def __init__(self, calls):
+        self._calls = calls
+
+    def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+        self._calls["save"] = quantization_method
+        _gguf(Path(model_save_path) / "Model.Q4_K_M.gguf")
+
+
+def test_disabled_imatrix_does_not_reach_an_older_exporter(monkeypatch, tmp_path):
+    """imatrix_file=False means off, so the keyword must be omitted, not passed as False."""
+    calls: dict = {}
+    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _OldSaver(calls))
+
+    success, message, _p = backend.export_gguf(str(save_dir), "q4_k_m", imatrix_file = False)
+
+    assert success is True, message
+    assert calls["save"] == "q4_k_m"

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -676,8 +676,14 @@ class _ImatrixNamingModel:
     def __init__(self, on_disk_name):
         self.on_disk_name = on_disk_name
 
-    def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method,
-                             imatrix_file = None, token = None):
+    def save_pretrained_gguf(
+        self,
+        model_save_path,
+        tokenizer,
+        quantization_method,
+        imatrix_file = None,
+        token = None,
+    ):
         _gguf(Path(model_save_path) / "Model.IQ2_XXS.gguf")
         _gguf(Path(model_save_path) / self.on_disk_name)
 
@@ -686,20 +692,27 @@ _NFC = unicodedata.normalize("NFC", "im\u00e4trix")
 _NFD = unicodedata.normalize("NFD", "im\u00e4trix")
 
 
-@pytest.mark.parametrize("on_disk,requested", [
-    ("imatrix_unsloth.gguf", "/x/imatrix_unsloth.gguf_file"),
-    (f"{_NFD}.gguf", f"/x/{_NFC}.gguf_file"),   # APFS stores NFD, the request carried NFC
-    (f"{_NFC}.gguf", f"/x/{_NFD}.gguf_file"),   # and the other way round
-])
+@pytest.mark.parametrize(
+    "on_disk,requested",
+    [
+        ("imatrix_unsloth.gguf", "/x/imatrix_unsloth.gguf_file"),
+        (f"{_NFD}.gguf", f"/x/{_NFC}.gguf_file"),  # APFS stores NFD, the request carried NFC
+        (f"{_NFC}.gguf", f"/x/{_NFD}.gguf_file"),  # and the other way round
+    ],
+)
 def test_the_materialized_imatrix_is_never_exported_as_a_model(
-    monkeypatch, tmp_path, on_disk, requested,
+    monkeypatch, tmp_path, on_disk, requested
 ):
     _m, backend, save_dir, _cwd = _backend(
-        monkeypatch, tmp_path, _ImatrixNamingModel(on_disk),
+        monkeypatch,
+        tmp_path,
+        _ImatrixNamingModel(on_disk),
     )
 
     success, message, _p = backend.export_gguf(
-        str(save_dir), "iq2_xxs", imatrix_file = requested,
+        str(save_dir),
+        "iq2_xxs",
+        imatrix_file = requested,
     )
 
     assert success is True, message
@@ -714,6 +727,7 @@ def test_a_broken_unsloth_zoo_does_not_fail_a_plain_export(monkeypatch, tmp_path
     AttributeError (partially initialised module), neither of which `except ImportError`
     caught, so it took down every GGUF export -- imatrix or not.
     """
+
     class _Exploding(types.ModuleType):
         def __getattr__(self, name):
             raise RuntimeError("half-built native dep")

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import os
 import sys
 import types
+import unicodedata
 from pathlib import Path
 
 import pytest
@@ -642,3 +643,86 @@ def test_disabled_imatrix_does_not_reach_an_older_exporter(monkeypatch, tmp_path
 
     assert success is True, message
     assert calls["save"] == "q4_k_m"
+
+
+# A probe that says "supported" has to be right about the call it is authorising, and the
+# imatrix it materializes has to stay an input: whichever name the filesystem gave it.
+
+
+def test_a_positional_only_imatrix_parameter_is_not_support(monkeypatch, tmp_path):
+    """Named is not the same as passable by keyword, and every call site uses a keyword."""
+    module, _b, _s, _cwd = _backend(monkeypatch, tmp_path, object())
+
+    namespace: dict = {}
+    exec(
+        "def f(save_directory, tokenizer, quantization_method, imatrix_file = None,"
+        " token = None, /): pass",
+        namespace,
+    )
+
+    with pytest.raises(TypeError):
+        namespace["f"]("d", "t", "q", imatrix_file = True)
+    assert module._imatrix_export_supported(namespace["f"]) is False
+    assert module._supports_kwarg(namespace["f"], "token") is False
+
+
+class _ImatrixNamingModel:
+    """Writes the imatrix under the name the filesystem chose, not the one we asked for.
+
+    A case-insensitive mount folds case and APFS stores NFD, so this is what `rglob` hands
+    back on those hosts.
+    """
+
+    def __init__(self, on_disk_name):
+        self.on_disk_name = on_disk_name
+
+    def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method,
+                             imatrix_file = None, token = None):
+        _gguf(Path(model_save_path) / "Model.IQ2_XXS.gguf")
+        _gguf(Path(model_save_path) / self.on_disk_name)
+
+
+_NFC = unicodedata.normalize("NFC", "im\u00e4trix")
+_NFD = unicodedata.normalize("NFD", "im\u00e4trix")
+
+
+@pytest.mark.parametrize("on_disk,requested", [
+    ("imatrix_unsloth.gguf", "/x/imatrix_unsloth.gguf_file"),
+    (f"{_NFD}.gguf", f"/x/{_NFC}.gguf_file"),   # APFS stores NFD, the request carried NFC
+    (f"{_NFC}.gguf", f"/x/{_NFD}.gguf_file"),   # and the other way round
+])
+def test_the_materialized_imatrix_is_never_exported_as_a_model(
+    monkeypatch, tmp_path, on_disk, requested,
+):
+    _m, backend, save_dir, _cwd = _backend(
+        monkeypatch, tmp_path, _ImatrixNamingModel(on_disk),
+    )
+
+    success, message, _p = backend.export_gguf(
+        str(save_dir), "iq2_xxs", imatrix_file = requested,
+    )
+
+    assert success is True, message
+    landed = sorted(p.name for p in save_dir.iterdir() if p.suffix == ".gguf")
+    assert landed == ["Model.IQ2_XXS.gguf"], f"the imatrix was exported as a model: {landed}"
+
+
+def test_a_broken_unsloth_zoo_does_not_fail_a_plain_export(monkeypatch, tmp_path):
+    """The llama.cpp scripts pin is an optimisation, so it must not be able to fail an export.
+
+    A half-built unsloth_zoo surfaces as RuntimeError (missing native dependency) or
+    AttributeError (partially initialised module), neither of which `except ImportError`
+    caught, so it took down every GGUF export -- imatrix or not.
+    """
+    class _Exploding(types.ModuleType):
+        def __getattr__(self, name):
+            raise RuntimeError("half-built native dep")
+
+    calls: dict = {}
+    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _imatrix_model(True, calls))
+    monkeypatch.setitem(sys.modules, "unsloth_zoo.llama_cpp", _Exploding("unsloth_zoo.llama_cpp"))
+
+    success, message, _p = backend.export_gguf(str(save_dir), "q4_k_m")
+
+    assert success is True, message
+    assert calls["save"] == {"imatrix_file": None, "token": None}

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -717,10 +717,8 @@ def test_the_materialized_imatrix_is_never_exported_as_a_model(
 
 
 def test_a_broken_unsloth_zoo_does_not_fail_a_plain_export(monkeypatch, tmp_path):
-    """The scripts pin is an optimisation, so a half-built zoo must not fail the export.
-
-    It raises RuntimeError or AttributeError, which `except ImportError` did not catch.
-    """
+    """The scripts pin is an optimisation, so a half-built zoo must not fail the export: it
+    raises RuntimeError or AttributeError, which `except ImportError` did not catch."""
 
     class _Exploding(types.ModuleType):
         def __getattr__(self, name):

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -645,12 +645,12 @@ def test_disabled_imatrix_does_not_reach_an_older_exporter(monkeypatch, tmp_path
     assert calls["save"] == "q4_k_m"
 
 
-# A probe that says "supported" has to be right about the call it is authorising, and the
-# imatrix it materializes has to stay an input: whichever name the filesystem gave it.
+# A probe that says "supported" must be right about the call it authorises, and the
+# materialized imatrix must stay an input under whichever name the filesystem gave it.
 
 
 def test_a_positional_only_imatrix_parameter_is_not_support(monkeypatch, tmp_path):
-    """Named is not the same as passable by keyword, and every call site uses a keyword."""
+    """Named is not passable by keyword, and every call site passes one."""
     module, _b, _s, _cwd = _backend(monkeypatch, tmp_path, object())
 
     namespace: dict = {}
@@ -667,11 +667,7 @@ def test_a_positional_only_imatrix_parameter_is_not_support(monkeypatch, tmp_pat
 
 
 class _ImatrixNamingModel:
-    """Writes the imatrix under the name the filesystem chose, not the one we asked for.
-
-    A case-insensitive mount folds case and APFS stores NFD, so this is what `rglob` hands
-    back on those hosts.
-    """
+    """Writes the imatrix under the name the filesystem chose, as a folding or NFD mount does."""
 
     def __init__(self, on_disk_name):
         self.on_disk_name = on_disk_name
@@ -721,11 +717,9 @@ def test_the_materialized_imatrix_is_never_exported_as_a_model(
 
 
 def test_a_broken_unsloth_zoo_does_not_fail_a_plain_export(monkeypatch, tmp_path):
-    """The llama.cpp scripts pin is an optimisation, so it must not be able to fail an export.
+    """The scripts pin is an optimisation, so a half-built zoo must not fail the export.
 
-    A half-built unsloth_zoo surfaces as RuntimeError (missing native dependency) or
-    AttributeError (partially initialised module), neither of which `except ImportError`
-    caught, so it took down every GGUF export -- imatrix or not.
+    It raises RuntimeError or AttributeError, which `except ImportError` did not catch.
     """
 
     class _Exploding(types.ModuleType):

--- a/studio/backend/tests/test_export_imatrix_compressed.py
+++ b/studio/backend/tests/test_export_imatrix_compressed.py
@@ -78,7 +78,8 @@ def test_export_merged_guards_unsupported_compressed_build():
 def test_supports_kwarg_helper():
     # exec just the helper source so the test stays free of export.py's heavy import chain.
     ns = {}
-    exec(_func_src("core/export/export.py", "_supports_kwarg"), ns)
+    for helper in ("_accepts_by_keyword", "_supports_kwarg"):
+        exec(_func_src("core/export/export.py", helper), ns)
     supports = ns["_supports_kwarg"]
 
     def has_it(a, imatrix_file = None):
@@ -90,9 +91,14 @@ def test_supports_kwarg_helper():
     def via_kwargs(a, **kw):
         pass
 
+    # Named but unusable: every call site passes the keyword, so this is not support.
+    positional_only = {}
+    exec("def f(a, imatrix_file = None, /): pass", positional_only)
+
     assert supports(has_it, "imatrix_file") is True
     assert supports(lacks_it, "imatrix_file") is False
     assert supports(via_kwargs, "imatrix_file") is True
+    assert supports(positional_only["f"], "imatrix_file") is False
 
 
 def test_orchestrator_and_worker_pass_imatrix():

--- a/studio/backend/tests/test_export_imatrix_compressed.py
+++ b/studio/backend/tests/test_export_imatrix_compressed.py
@@ -57,15 +57,17 @@ def test_export_gguf_threads_imatrix_to_save_and_push():
     # imatrix_file must reach both save paths, but only via the conditional **imatrix_kw.
     g = _func_src("core/export/export.py", "export_gguf")
     assert g.count("**imatrix_kw") >= 2
-    assert 'imatrix_kw = {"imatrix_file": imatrix_file} if imatrix_file is not None else {}' in g
+    # Truthiness, not `is not None`: a disabled imatrix must not reach an exporter without the kwarg.
+    assert 'imatrix_kw = {"imatrix_file": imatrix_file} if imatrix_file else {}' in g
     # Unconditional pass-through (the old wiring) must be gone.
     assert "imatrix_file = imatrix_file" not in g
 
 
 def test_export_gguf_guards_unsupported_imatrix_build():
-    # An older unsloth without imatrix_file support gets a clean error, not a TypeError.
+    # A build that cannot apply an imatrix gets a clean error, not a TypeError or a silent drop.
+    # The kwarg probe is not enough here: the MLX binding takes **kwargs and filters them.
     g = _func_src("core/export/export.py", "export_gguf")
-    assert "_supports_kwarg(" in g and '"imatrix_file"' in g
+    assert "_imatrix_export_supported(" in g
 
 
 def test_export_merged_guards_unsupported_compressed_build():
@@ -161,6 +163,37 @@ def test_unsloth_save_has_torchao_registry_and_path():
     # torchao aliases must map to (scheme, suffix) so the backend routes to the torchao path.
     assert '"torchao_fp8": ("fp8", "torchao-fp8")' in save_py
     assert '"torchao_int8": ("int8", "torchao-int8")' in save_py
+
+
+@pytest.mark.parametrize("wrapper_name", ["_save_pretrained_gguf", "_push_to_hub_gguf"])
+def test_sentence_transformer_gguf_wrappers_forward_imatrix(wrapper_name):
+    # Both wrappers take **kwargs, so the capability probe treats them as supported once
+    # unsloth_zoo can resolve an imatrix; they therefore have to forward the argument rather than
+    # swallow it. The push wrapper runs a second conversion of its own.
+    st = (_BACKEND.parent.parent / "unsloth" / "models" / "sentence_transformer.py").read_text(
+        encoding = "utf-8"
+    )
+    wrapper = st[st.index(f"def {wrapper_name}(") :]
+    wrapper = wrapper[: wrapper.index("\n# ")]
+    assert "imatrix_file = None," in wrapper
+    assert "imatrix_file = imatrix_file," in wrapper
+
+
+def test_gguf_export_request_falls_back_to_the_load_token():
+    # A local imatrix export resolves from a Hub repo, but the UI only sets `token` for a hub push,
+    # so the GGUF payload has to fall back the way the LoRA payload already does.
+    store = (
+        _BACKEND.parent
+        / "frontend"
+        / "src"
+        / "features"
+        / "export"
+        / "stores"
+        / "export-runtime-store.ts"
+    ).read_text(encoding = "utf-8")
+    gguf = store[store.index("exportGGUF({") :]
+    gguf = gguf[: gguf.index("}),")]
+    assert "hf_token: params.token ?? params.loadToken ?? null," in gguf
 
 
 # -- GGUF multi-quant list ----------------------------------------------------------------------

--- a/studio/backend/tests/test_export_imatrix_compressed.py
+++ b/studio/backend/tests/test_export_imatrix_compressed.py
@@ -173,9 +173,8 @@ def test_unsloth_save_has_torchao_registry_and_path():
 
 @pytest.mark.parametrize("wrapper_name", ["_save_pretrained_gguf", "_push_to_hub_gguf"])
 def test_sentence_transformer_gguf_wrappers_forward_imatrix(wrapper_name):
-    # Both wrappers take **kwargs, so the capability probe treats them as supported once
-    # unsloth_zoo can resolve an imatrix; they therefore have to forward the argument rather than
-    # swallow it. The push wrapper runs a second conversion of its own.
+    # Both take **kwargs, so the probe reads them as supported once unsloth_zoo can resolve an
+    # imatrix; they must therefore forward the argument rather than swallow it.
     st = (_BACKEND.parent.parent / "unsloth" / "models" / "sentence_transformer.py").read_text(
         encoding = "utf-8"
     )

--- a/studio/frontend/src/features/export/stores/export-runtime-store.ts
+++ b/studio/frontend/src/features/export/stores/export-runtime-store.ts
@@ -491,7 +491,9 @@ export const useExportRuntimeStore = create<ExportRuntimeStore>()((set, get) => 
             quantization_method: params.quantLevels,
             push_to_hub: pushToHub,
             repo_id: params.repoId,
-            hf_token: params.token,
+            // A local imatrix export resolves the matrix from a Hub repo, so fall back to the load
+            // token when there is no hub-upload token (both are the same HF token).
+            hf_token: params.token ?? params.loadToken ?? null,
             imatrix: params.useImatrix,
           }),
         );

--- a/studio/frontend/tests/export-gguf-token-fallback.test.ts
+++ b/studio/frontend/tests/export-gguf-token-fallback.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+
+register("./helpers/export-store-resolver.mjs", import.meta.url);
+
+const stub = await import("./helpers/export-api-stub.mjs");
+const { useExportRuntimeStore } = await import(
+  "../src/features/export/stores/export-runtime-store.ts"
+);
+
+// A local imatrix export resolves the matrix from a Hub repo, so it needs a credential --
+// but export-page.tsx only sets `token` for a hub push. The GGUF request therefore falls
+// back to the load token, the way the LoRA request already does. Asserting the emitted
+// request body rather than the source text, so a refactor of the same behaviour still passes
+// and a change of behaviour still fails.
+
+function params(overrides: Record<string, unknown>) {
+  return {
+    sourceMode: "model",
+    checkpointPath: null,
+    source: "unsloth/Qwen3-0.6B",
+    modelSource: "hf",
+    trustRemoteCode: false,
+    exportMethod: "gguf",
+    isAdapter: false,
+    quantLevels: ["iq2_xxs"],
+    saveDirectory: "out",
+    destination: "local",
+    privateRepo: false,
+    summary: {},
+    ...overrides,
+  } as unknown as Parameters<
+    ReturnType<typeof useExportRuntimeStore.getState>["runExport"]
+  >[0];
+}
+
+async function ggufRequest(overrides: Record<string, unknown>) {
+  stub.resetStub();
+  await useExportRuntimeStore.getState().runExport(params(overrides));
+  const call = stub.calls.find((entry) => entry.name === "exportGGUF");
+  assert.ok(call, "no GGUF export request was made");
+  return call.args[0] as Record<string, unknown>;
+}
+
+test("a local imatrix export falls back to the load token", async () => {
+  const body = await ggufRequest({
+    useImatrix: true,
+    loadToken: "hf_load",
+    token: undefined,
+    destination: "local",
+  });
+
+  assert.equal(body.hf_token, "hf_load");
+  assert.equal(body.imatrix, true);
+  assert.equal(body.push_to_hub, false);
+});
+
+test("a hub push prefers its own upload token over the load token", async () => {
+  const body = await ggufRequest({
+    useImatrix: true,
+    loadToken: "hf_load",
+    token: "hf_upload",
+    destination: "hub",
+    repoId: "org/model",
+  });
+
+  assert.equal(body.hf_token, "hf_upload");
+  assert.equal(body.repo_id, "org/model");
+  assert.equal(body.push_to_hub, true);
+});
+
+test("no token anywhere sends null rather than undefined", async () => {
+  const body = await ggufRequest({ useImatrix: true, loadToken: null, token: undefined });
+
+  // undefined would be dropped by JSON.stringify and the field would go missing entirely.
+  assert.equal(body.hf_token, null);
+  assert.ok("hf_token" in body);
+});
+
+test("the fallback matches the LoRA request, which already had it", async () => {
+  const gguf = await ggufRequest({ useImatrix: true, loadToken: "hf_load", token: undefined });
+
+  stub.resetStub();
+  await useExportRuntimeStore.getState().runExport(
+    params({ exportMethod: "lora", loadToken: "hf_load", token: undefined }),
+  );
+  const lora = stub.calls.find((entry) => entry.name === "exportLoRA");
+  assert.ok(lora, "no LoRA export request was made");
+
+  assert.equal(gguf.hf_token, (lora.args[0] as Record<string, unknown>).hf_token);
+});
+
+test("the load phase keeps using the load token on its own", async () => {
+  stub.resetStub();
+  await useExportRuntimeStore.getState().runExport(
+    params({ useImatrix: true, loadToken: "hf_load", token: "hf_upload", destination: "hub",
+             repoId: "org/model" }),
+  );
+  const load = stub.calls.find((entry) => entry.name === "loadCheckpoint");
+  assert.ok(load, "no load request was made");
+  assert.equal((load.args[0] as Record<string, unknown>).hf_token, "hf_load");
+});

--- a/studio/frontend/tests/export-gguf-token-fallback.test.ts
+++ b/studio/frontend/tests/export-gguf-token-fallback.test.ts
@@ -12,11 +12,9 @@ const { useExportRuntimeStore } = await import(
   "../src/features/export/stores/export-runtime-store.ts"
 );
 
-// A local imatrix export resolves the matrix from a Hub repo, so it needs a credential --
-// but export-page.tsx only sets `token` for a hub push. The GGUF request therefore falls
-// back to the load token, the way the LoRA request already does. Asserting the emitted
-// request body rather than the source text, so a refactor of the same behaviour still passes
-// and a change of behaviour still fails.
+// A local imatrix export resolves the matrix from a Hub repo, but export-page.tsx only sets
+// `token` for a hub push, so the GGUF request falls back to the load token as the LoRA request
+// already does. Asserting the emitted body, not the source, so a refactor still passes.
 
 function params(overrides: Record<string, unknown>) {
   return {

--- a/studio/frontend/tests/helpers/export-api-stub.d.mts
+++ b/studio/frontend/tests/helpers/export-api-stub.d.mts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Types for export-api-stub.mjs so a .ts test can read the recorded calls without `any`.
+
+export declare const calls: { name: string; args: unknown[] }[];
+export declare const responses: Map<string, unknown>;
+
+export declare function resetStub(): void;
+
+export declare const loadCheckpoint: (...args: unknown[]) => Promise<unknown>;
+export declare const exportGGUF: (...args: unknown[]) => Promise<unknown>;
+export declare const exportMerged: (...args: unknown[]) => Promise<unknown>;
+export declare const exportLoRA: (...args: unknown[]) => Promise<unknown>;
+export declare const cleanupExport: (...args: unknown[]) => Promise<unknown>;
+export declare const cancelExport: (...args: unknown[]) => Promise<unknown>;
+export declare const getExportStatus: (...args: unknown[]) => Promise<unknown>;
+
+export declare function isRecoverableTransportError(): boolean;

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -163,6 +163,7 @@ def _save_pretrained_gguf(
     max_shard_size = "5GB",
     temporary_location = "_unsloth_temporary_saved_buffers",
     maximum_memory_usage = 0.85,
+    imatrix_file = None,
     **kwargs,
 ):
     """
@@ -212,6 +213,7 @@ def _save_pretrained_gguf(
         max_shard_size = max_shard_size,
         temporary_location = temporary_location,
         maximum_memory_usage = maximum_memory_usage,
+        imatrix_file = imatrix_file,
     )
 
     # 5. Move GGUF files from the subdirectory (0_Transformer) to the root save_directory
@@ -298,6 +300,7 @@ def _push_to_hub_gguf(
     create_pr = False,
     revision = None,
     tags = None,
+    imatrix_file = None,
     **kwargs,
 ):
     """
@@ -389,6 +392,7 @@ def _push_to_hub_gguf(
             max_shard_size = max_shard_size,
             temporary_location = temporary_location,
             maximum_memory_usage = maximum_memory_usage,
+            imatrix_file = imatrix_file,
         )
 
         gguf_files = result.get("gguf_files", [])


### PR DESCRIPTION
## The bug

Two gaps in the GGUF imatrix wiring, both invisible until an export failed.

**The capability probe cannot detect what it claims to detect.** `export_gguf` guards against builds that lack imatrix support with `_supports_kwarg`, which accepts any function whose signature ends in `**kwargs`. The MLX binding's does. That proves nothing: the binding filters keyword arguments against an allow-list, so an unsloth-zoo predating MLX imatrix support accepts `imatrix_file`, drops it, and `llama-quantize` runs without `--imatrix`. The user gets llama.cpp's raw "this quantization requires an importance matrix" error after paying for a full merge and BF16 conversion, instead of a clear message before any work starts. `unsloth_zoo>=2026.8.10` permits exactly this combination.

**The local export had no credential for the imatrix.** Resolving `imatrix_file=True` reads a Hub repo, but only the push path passed the request's token. A local export of a gated or private base model therefore reported that no upstream imatrix exists, while the same export to the Hub succeeded — the feature behaved differently depending on the destination.

## What changed

`_imatrix_export_supported` replaces the kwarg probe for the imatrix guard. It accepts an exporter that *names* `imatrix_file` (the CUDA path), and for a kwargs-only binding falls back to importing `resolve_imatrix_file` from unsloth-zoo, which is the marker for the support actually being present.

Three properties of that probe are deliberate and worth reviewing:

- It runs only when an imatrix was actually requested, so an export that passes `imatrix_file=False` can never be refused by it.
- Any import failure counts as unsupported, not just `ImportError`. The probe runs before `export_gguf`'s exception boundary, and the method is contracted to return a `(success, message, path)` tuple rather than raise.
- The CUDA path never reaches the unsloth-zoo probe, since its signature names the argument.

The local save now receives `hf_token` when an imatrix was requested and the exporter accepts it. The credential is kept out of the `imatrix_kw` dictionary that the local-save and Hub-push call sites share, because the push already names `token=` explicitly and would otherwise receive it twice — a `TypeError` on every authenticated imatrix push.

## Validation

```bash
python -m pytest studio/backend/tests/test_export_gguf_discovery.py studio/backend/tests/test_export_imatrix_compressed.py studio/backend/tests/test_export_absolute_paths.py -q
```

80 pass. The new coverage goes in the behavioural harness that runs `export_gguf` for real against a fake model, rather than the AST string matching used for the original imatrix wiring, which documents itself as deliberately import-free.

Each behaviour was mutation-checked — reverting it fails exactly its own test:

- restoring the kwarg-trusting probe
- letting the unsloth-zoo probe pass unconditionally
- gating the probe on `is not None`, so a disabled imatrix gets refused
- narrowing the probe's exception handling back to `ImportError`
- putting the token back into the shared dictionary, so the Hub push receives it twice
- dropping the token forwarding entirely

The AST test asserting the guard exists was also updated: it still matched `_supports_kwarg`, which appears elsewhere in the function, so it stayed green even with the real guard deleted.

## Risks and scope

Exports that request no imatrix are unaffected — the probe does not run for them, and no token is forwarded.

Companion change in `unsloth-zoo` (unslothai/unsloth-zoo#1052) adds the MLX-side imatrix support this probe looks for. The two are independent and can land in either order: with an older unsloth-zoo this change produces the clean "upgrade" message instead of a silent failure, and with the newer one it forwards the credential the MLX path now accepts.
