### PR TITLE
Fix torch wheel downloads with resumable wget fallback (#8456)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -830,6 +830,21 @@ download() {
     fi
 }
 
+# ── Helper: download with resume (wget -c / curl -C -) ──
+# pip/uv abort mid-stream on flaky links and restart from zero; wget -c keeps partial
+# bytes so large torch wheels can finish after a drop (#8456).
+download_resumable() {
+    _dr_url="$1"
+    _dr_dest="$2"
+    if command -v wget >/dev/null 2>&1; then
+        wget -c -qO "$_dr_dest" "$_dr_url"
+    elif command -v curl >/dev/null 2>&1; then
+        curl -fsSL -C - "$_dr_url" -o "$_dr_dest"
+    else
+        download "$_dr_url" "$_dr_dest"
+    fi
+}
+
 # ── Helper: check if a single package is available on the system ──
 _is_pkg_installed() {
     case "$1" in
@@ -3883,11 +3898,174 @@ _previous_torch_pin() {
     echo "torch==$_ptp_base"
 }
 
+# Wheel arch suffix for the running host (used when scraping PEP 503 simple indexes).
+_pytorch_wheel_arch_suffix() {
+    case "$_ARCH" in
+        aarch64|arm64) printf '%s\n' "aarch64" ;;
+        x86_64|amd64)  printf '%s\n' "x86_64" ;;
+        *)             printf '%s\n' "x86_64" ;;
+    esac
+}
+
+# First dotted version prefix from a pip constraint, e.g. torch>=2.11.0,<2.12.0 -> 2.11.
+_constraint_ver_prefix() {
+    printf '%s\n' "$1" | sed -n \
+        -e 's/.*==\([0-9][0-9]*\.[0-9][0-9]*\)\.\*/\1./p' \
+        -e 's/.*==\([0-9][0-9]*\.[0-9][0-9]*\)\.[0-9][0-9]*/\1./p' \
+        -e 's/.*>=\([0-9][0-9]*\.[0-9][0-9]*\)\.[0-9][0-9]*.*/\1./p' \
+        | head -n 1
+}
+
+# Fetch a package listing from a pytorch.org-style PEP 503 simple index.
+_pytorch_simple_listing() {
+    _psl_base="${1%/}"
+    _psl_pkg="$2"
+    _psl_url="$_psl_base/$_psl_pkg/"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL --max-time 30 "$_psl_url" 2>/dev/null
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO- --timeout=30 "$_psl_url" 2>/dev/null
+    else
+        return 1
+    fi
+}
+
+# Pick the newest wheel href for PACKAGE from a simple-index HTML listing.
+# $3 = optional version prefix (e.g. 2.11.), $4 = cp tag, $5 = arch suffix (x86_64/aarch64).
+_pick_simple_index_wheel() {
+    _psi_listing="$1"
+    _psi_pkg="$2"
+    _psi_ver_prefix="${3:-}"
+    _psi_tag="$4"
+    _psi_arch="$5"
+    [ -n "$_psi_listing" ] || return 1
+    [ -n "$_psi_tag" ] || return 1
+    [ -n "$_psi_arch" ] || return 1
+    _psi_href=$(printf '%s\n' "$_psi_listing" \
+        | awk -v pkg="$_psi_pkg" -v tag="$_psi_tag" -v ver_prefix="$_psi_ver_prefix" \
+              -v arch="$_psi_arch" '
+            BEGIN { max_pad = ""; max_url = "" }
+            {
+                line = $0
+                while (match(line, /href="[^"]*"/)) {
+                    url = substr(line, RSTART + 6, RLENGTH - 7)
+                    line = substr(line, RSTART + RLENGTH)
+                    n = split(url, p, "/")
+                    base = p[n]
+                    sub(/[?#].*/, "", base)
+                    prefix = pkg "-" ver_prefix
+                    if (substr(base, 1, length(prefix)) == prefix &&
+                            index(base, "-" tag "-") > 0 &&
+                            match(base, arch "\\.whl$")) {
+                        if (match(base, /[0-9]+\.[0-9]+(\.[0-9]+)?/)) {
+                            ver = substr(base, RSTART, RLENGTH)
+                            m = split(ver, v, ".")
+                            pad = ""
+                            for (i = 1; i <= m; i++)
+                                pad = pad sprintf("%08d", v[i])
+                            if (pad > max_pad) {
+                                max_pad = pad
+                                max_url = url
+                            }
+                        }
+                    }
+                }
+            }
+            END { if (max_url != "") print max_url }')
+    [ -z "$_psi_href" ] && return 1
+    printf '%s\n' "$_psi_href"
+}
+
+# Resolve a wheel href against a simple-index base URL (base includes /package).
+_resolve_simple_index_wheel_url() {
+    _rsw_base="${1%/}"
+    _rsw_href="$2"
+    case "$_rsw_href" in
+        http*) printf '%s\n' "$_rsw_href" ;;
+        /*)   printf '%s\n' "${_rsw_base%/*}${_rsw_href}" ;;
+        *)    printf '%s\n' "$_rsw_base/${_rsw_href#./}" ;;
+    esac
+}
+
+# Download torch/torchvision/torchaudio wheels with resume, install locally, then fetch
+# runtime deps from the index without re-pulling the trio (#8456).
+_install_torch_resumable_wheels() {
+    _itr_torch_con="$1"
+    _itr_tv_con="$2"
+    _itr_ta_con="$3"
+    shift 3
+
+    _itr_base="${TORCH_INDEX_URL%/}"
+    _itr_cache="${STUDIO_HOME:-$HOME/.unsloth}/share/torch-wheel-cache"
+    mkdir -p "$_itr_cache" || return 1
+
+    _itr_pytag=$("$_VENV_PY" -c "
+import sys
+print('cp{}{}'.format(sys.version_info.major, sys.version_info.minor))
+" 2>/dev/null) || return 1
+    _itr_arch=$(_pytorch_wheel_arch_suffix)
+
+    _itr_torch_p=$(_constraint_ver_prefix "$_itr_torch_con")
+    _itr_tv_p=$(_constraint_ver_prefix "$_itr_tv_con")
+    _itr_ta_p=$(_constraint_ver_prefix "$_itr_ta_con")
+
+    _itr_tl=$(_pytorch_simple_listing "$_itr_base" "torch") || return 1
+    _itr_vl=$(_pytorch_simple_listing "$_itr_base" "torchvision") || return 1
+    _itr_al=$(_pytorch_simple_listing "$_itr_base" "torchaudio") || return 1
+
+    _itr_th=$(_pick_simple_index_wheel "$_itr_tl" "torch" "$_itr_torch_p" "$_itr_pytag" "$_itr_arch") || return 1
+    _itr_vh=$(_pick_simple_index_wheel "$_itr_vl" "torchvision" "$_itr_tv_p" "$_itr_pytag" "$_itr_arch") || return 1
+    _itr_ah=$(_pick_simple_index_wheel "$_itr_al" "torchaudio" "$_itr_ta_p" "$_itr_pytag" "$_itr_arch") || return 1
+
+    _itr_tw=""
+    _itr_vw=""
+    _itr_aw=""
+    for _itr_pair in "torch:$_itr_th" "torchvision:$_itr_vh" "torchaudio:$_itr_ah"; do
+        _itr_pkg=${_itr_pair%%:*}
+        _itr_href=${_itr_pair#*:}
+        _itr_url=$(_resolve_simple_index_wheel_url "$_itr_base/$_itr_pkg" "$_itr_href") || return 1
+        _itr_name=$(printf '%s' "${_itr_href##*/}" | sed 's/%2[Bb]/+/g')
+        _itr_dest="$_itr_cache/$_itr_name"
+        substep "resumable download $_itr_name..."
+        download_resumable "$_itr_url" "$_itr_dest" || return 1
+        case "$_itr_pkg" in
+            torch) _itr_tw="$_itr_dest" ;;
+            torchvision) _itr_vw="$_itr_dest" ;;
+            torchaudio) _itr_aw="$_itr_dest" ;;
+        esac
+    done
+
+    run_install_cmd_retry "install PyTorch (resumable wheels)" uv pip install --python "$_VENV_PY" \
+        --no-deps "$_itr_tw" "$_itr_vw" "$_itr_aw" "$@" || return 1
+
+    _itr_deps=$("$_VENV_PY" -c "
+import importlib.metadata as m
+seen = set()
+for pkg in ('torch', 'torchvision', 'torchaudio'):
+    try:
+        reqs = m.requires(pkg) or []
+    except Exception:
+        continue
+    for req in reqs:
+        spec = req.split(';')[0].strip()
+        if spec and spec not in seen:
+            seen.add(spec)
+            print(spec)
+" 2>/dev/null)
+    if [ -n "$_itr_deps" ]; then
+        # shellcheck disable=SC2086
+        run_install_cmd_retry "install PyTorch runtime deps" uv pip install --python "$_VENV_PY" \
+            --default-index "$TORCH_INDEX_URL" $_itr_deps || return 1
+    fi
+    return 0
+}
+
 # Install torch from TORCH_INDEX_URL honoring a kept-release pin: with _PREV_TORCH_PIN
 # set, TORCH_CONSTRAINT is the exact previous release; fall back to the supported range
 # if the index lacks it (pruned mirror) rather than failing. Used by every --default-index
 # path (NVIDIA cu*, AMD rocm/gfx fallbacks, cpu/mac, ROCm repairs) so preservation is
 # uniform. Extra args (e.g. --force-reinstall) are passed through to uv.
+# On transient download failure, retry via wget -c resumable wheel fetch (#8456).
 _install_torch_default_index() {
     if [ -n "$_PREV_TORCH_PIN" ]; then
         # Pair the companions with the kept torch minor: torchaudio no longer
@@ -3904,18 +4082,31 @@ _install_torch_default_index() {
                 _itdi_ta="torchaudio==2.${_itdi_minor}.*"
                 ;;
         esac
-        if ! run_install_cmd_retry "install PyTorch (kept release)" uv pip install --python "$_VENV_PY" "$TORCH_CONSTRAINT" "$_itdi_tv" "$_itdi_ta" \
+        if run_install_cmd_retry "install PyTorch (kept release)" uv pip install --python "$_VENV_PY" "$TORCH_CONSTRAINT" "$_itdi_tv" "$_itdi_ta" \
             --default-index "$TORCH_INDEX_URL" "$@"; then
-            substep "[WARN] $_PREV_TORCH_PIN is not installable from $(_strip_index_url_credentials "$TORCH_INDEX_URL") -- installing the newest supported release instead" "$C_WARN"
-            TORCH_CONSTRAINT="$_PREV_FALLBACK_CONSTRAINT"
-            _PREV_TORCH_PIN=""
-            run_install_cmd_retry "install PyTorch" uv pip install --python "$_VENV_PY" "$TORCH_CONSTRAINT" "$TORCHVISION_CONSTRAINT" "$TORCHAUDIO_CONSTRAINT" \
-                --default-index "$TORCH_INDEX_URL" "$@"
+            return 0
         fi
-    else
-        run_install_cmd_retry "install PyTorch" uv pip install --python "$_VENV_PY" "$TORCH_CONSTRAINT" "$TORCHVISION_CONSTRAINT" "$TORCHAUDIO_CONSTRAINT" \
-            --default-index "$TORCH_INDEX_URL" "$@"
+        substep "[WARN] uv PyTorch install failed; retrying kept release with resumable wheel downloads (wget -c)..." "$C_WARN"
+        if _install_torch_resumable_wheels "$TORCH_CONSTRAINT" "$_itdi_tv" "$_itdi_ta" "$@"; then
+            return 0
+        fi
+        substep "[WARN] $_PREV_TORCH_PIN is not installable from $(_strip_index_url_credentials "$TORCH_INDEX_URL") -- installing the newest supported release instead" "$C_WARN"
+        TORCH_CONSTRAINT="$_PREV_FALLBACK_CONSTRAINT"
+        _PREV_TORCH_PIN=""
+        if run_install_cmd_retry "install PyTorch" uv pip install --python "$_VENV_PY" "$TORCH_CONSTRAINT" "$TORCHVISION_CONSTRAINT" "$TORCHAUDIO_CONSTRAINT" \
+            --default-index "$TORCH_INDEX_URL" "$@"; then
+            return 0
+        fi
+        substep "[WARN] uv PyTorch install failed; retrying with resumable wheel downloads (wget -c)..." "$C_WARN"
+        _install_torch_resumable_wheels "$TORCH_CONSTRAINT" "$TORCHVISION_CONSTRAINT" "$TORCHAUDIO_CONSTRAINT" "$@"
+        return $?
     fi
+    if run_install_cmd_retry "install PyTorch" uv pip install --python "$_VENV_PY" "$TORCH_CONSTRAINT" "$TORCHVISION_CONSTRAINT" "$TORCHAUDIO_CONSTRAINT" \
+        --default-index "$TORCH_INDEX_URL" "$@"; then
+        return 0
+    fi
+    substep "[WARN] uv PyTorch install failed; retrying with resumable wheel downloads (wget -c)..." "$C_WARN"
+    _install_torch_resumable_wheels "$TORCH_CONSTRAINT" "$TORCHVISION_CONSTRAINT" "$TORCHAUDIO_CONSTRAINT" "$@"
 }
 
 # Expected tag from the index leaf ($1): cuXXX / cpu / xpu / rocm (rocmX.Y and gfx* ->

--- a/install.sh
+++ b/install.sh
@@ -3987,6 +3987,33 @@ _resolve_simple_index_wheel_url() {
     esac
 }
 
+# Resolve the exact torch/torchvision/torchaudio releases uv would pick (dry-run).
+# Prints three lines: torch=2.11.0, torchvision=0.26.0, torchaudio=2.11.0
+_resolve_torch_wheel_versions() {
+    _rtwv_torch_con="$1"
+    _rtwv_tv_con="$2"
+    _rtwv_ta_con="$3"
+    shift 3
+    uv pip install --dry-run --python "$_VENV_PY" \
+        "$_rtwv_torch_con" "$_rtwv_tv_con" "$_rtwv_ta_con" \
+        --default-index "$TORCH_INDEX_URL" "$@" 2>&1 \
+        | "$_VENV_PY" -c "
+import re, sys
+want = ('torch', 'torchvision', 'torchaudio')
+found = {}
+for line in sys.stdin:
+    m = re.match(r'\s*\+ (torch(?:vision|audio)?)==(\S+)', line)
+    if not m:
+        continue
+    ver = m.group(2).split('+', 1)[0]
+    found[m.group(1)] = ver
+if set(want) - set(found):
+    sys.exit(1)
+for pkg in want:
+    print(f'{pkg}={found[pkg]}')
+"
+}
+
 # Download torch/torchvision/torchaudio wheels with resume, install locally, then fetch
 # runtime deps from the index without re-pulling the trio (#8456).
 _install_torch_resumable_wheels() {
@@ -4005,9 +4032,10 @@ print('cp{}{}'.format(sys.version_info.major, sys.version_info.minor))
 " 2>/dev/null) || return 1
     _itr_arch=$(_pytorch_wheel_arch_suffix)
 
-    _itr_torch_p=$(_constraint_ver_prefix "$_itr_torch_con")
-    _itr_tv_p=$(_constraint_ver_prefix "$_itr_tv_con")
-    _itr_ta_p=$(_constraint_ver_prefix "$_itr_ta_con")
+    _itr_versions=$(_resolve_torch_wheel_versions "$_itr_torch_con" "$_itr_tv_con" "$_itr_ta_con" "$@") || return 1
+    _itr_torch_p=$(printf '%s\n' "$_itr_versions" | sed -n 's/^torch=\([0-9]*\.[0-9]*\)\.[0-9]*/\1./p')
+    _itr_tv_p=$(printf '%s\n' "$_itr_versions" | sed -n 's/^torchvision=\([0-9]*\.[0-9]*\)\.[0-9]*/\1./p')
+    _itr_ta_p=$(printf '%s\n' "$_itr_versions" | sed -n 's/^torchaudio=\([0-9]*\.[0-9]*\)\.[0-9]*/\1./p')
 
     _itr_tl=$(_pytorch_simple_listing "$_itr_base" "torch") || return 1
     _itr_vl=$(_pytorch_simple_listing "$_itr_base" "torchvision") || return 1
@@ -4024,7 +4052,7 @@ print('cp{}{}'.format(sys.version_info.major, sys.version_info.minor))
         _itr_pkg=${_itr_pair%%:*}
         _itr_href=${_itr_pair#*:}
         _itr_url=$(_resolve_simple_index_wheel_url "$_itr_base/$_itr_pkg" "$_itr_href") || return 1
-        _itr_name=$(printf '%s' "${_itr_href##*/}" | sed 's/%2[Bb]/+/g')
+        _itr_name=$(printf '%s' "${_itr_href##*/}" | sed 's/%2[Bb]/+/g; s/[?#].*//')
         _itr_dest="$_itr_cache/$_itr_name"
         substep "resumable download $_itr_name..."
         download_resumable "$_itr_url" "$_itr_dest" || return 1
@@ -4038,25 +4066,36 @@ print('cp{}{}'.format(sys.version_info.major, sys.version_info.minor))
     run_install_cmd_retry "install PyTorch (resumable wheels)" uv pip install --python "$_VENV_PY" \
         --no-deps "$_itr_tw" "$_itr_vw" "$_itr_aw" "$@" || return 1
 
-    _itr_deps=$("$_VENV_PY" -c "
+    _itr_dep_file=$(mktemp)
+    "$_VENV_PY" -c "
 import importlib.metadata as m
+import re
 seen = set()
+skip = {'torch', 'torchvision', 'torchaudio'}
 for pkg in ('torch', 'torchvision', 'torchaudio'):
     try:
         reqs = m.requires(pkg) or []
     except Exception:
         continue
     for req in reqs:
-        spec = req.split(';')[0].strip()
-        if spec and spec not in seen:
+        base, _, marker = req.partition(';')
+        spec = base.strip()
+        if not spec:
+            continue
+        if marker.strip() and 'extra ==' in marker.lower():
+            continue
+        name = re.split(r'[\s\[(<>=!]', spec, maxsplit=1)[0].lower().replace('_', '-')
+        if name in skip:
+            continue
+        if spec not in seen:
             seen.add(spec)
             print(spec)
-" 2>/dev/null)
-    if [ -n "$_itr_deps" ]; then
-        # shellcheck disable=SC2086
+" >"$_itr_dep_file" 2>/dev/null || true
+    if [ -s "$_itr_dep_file" ]; then
         run_install_cmd_retry "install PyTorch runtime deps" uv pip install --python "$_VENV_PY" \
-            --default-index "$TORCH_INDEX_URL" $_itr_deps || return 1
+            --extra-index-url "$TORCH_INDEX_URL" -r "$_itr_dep_file" || { rm -f "$_itr_dep_file"; return 1; }
     fi
+    rm -f "$_itr_dep_file"
     return 0
 }
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4208,7 +4208,7 @@ def _download_pinned_wheel_resumable(spec: str, index_url: str, dest_dir: Path) 
         wheel_url = f"{index_url.rstrip('/')}/{package}/{href.lstrip('./')}"
     from urllib.parse import unquote
 
-    wheel_name = unquote(wheel_url.split("?")[0].split("/")[-1])
+    wheel_name = unquote(wheel_url.split("?")[0].split("#")[0].split("/")[-1])
     dest = dest_dir / wheel_name
     download_file_resumable(wheel_url, dest)
     return dest if dest.is_file() else None

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -23,6 +23,7 @@ import sys
 import sysconfig
 import tempfile
 import textwrap
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -2667,39 +2668,14 @@ def _ensure_xpu_triton() -> None:
     # Fetch, THEN uninstall, THEN install from the file. The uninstall cannot go last: the shared
     # paths live in generic triton's OWN record, so removing it afterwards deletes what the XPU
     # build just wrote. Pre-fetching stops a dead mirror stranding the venv between the two
-    # steps. uv has no `pip download`, hence pip here.
+    # steps. wget -c resumes partial downloads; pip download restarts from zero (#8456).
     tmp = tempfile.mkdtemp(prefix = "unsloth_triton_xpu_")
     try:
-        _dl_cmd = [
-            sys.executable,
-            "-m",
-            "pip",
-            "download",
-            "--no-deps",
-            "--only-binary=:all:",
-            "-d",
-            tmp,
-            spec,
-            "--index-url",
-            pin,
-        ]
         try:
-            dl = subprocess.run(
-                _dl_cmd,
-                # Same scrub every other pinned install gets: PIP_NO_INDEX would ignore
-                # --index-url outright, and PIP_EXTRA_INDEX_URL / PIP_FIND_LINKS are consulted in
-                # addition to it, so an inherited environment could serve the wheel from
-                # somewhere the pin never named.
-                env = _install_env_for_cmd(_dl_cmd),
-                stdout = subprocess.PIPE,
-                stderr = subprocess.STDOUT,
-                timeout = 900,
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            dl = None
-        wheels = glob.glob(os.path.join(tmp, "*.whl"))
-        # The exit code alone is not enough: no wheel on disk means nothing to install from.
-        if dl is None or dl.returncode != 0 or not wheels:
+            wheel = _download_pinned_wheel_resumable(spec, pin, Path(tmp))
+        except (OSError, subprocess.CalledProcessError, urllib.error.URLError):
+            wheel = None
+        if wheel is None:
             _safe_print(
                 _red(
                     f"   could not fetch {spec}; generic triton {generic} left in place -- "
@@ -2731,7 +2707,7 @@ def _ensure_xpu_triton() -> None:
             "triton (Intel XPU)",
             "--force-reinstall",
             "--no-deps",
-            wheels[0],
+            str(wheel),
             constrain = False,
         )
     finally:
@@ -4167,6 +4143,78 @@ def pip_install(
 def download_file(url: str, dest: Path) -> None:
     """Download a file using urllib (no curl dependency)."""
     urllib.request.urlretrieve(url, dest)
+
+
+def download_file_resumable(url: str, dest: Path) -> None:
+    """Download with resume support via wget -c or curl -C - (#8456).
+
+    pip/uv restart interrupted multi-gigabyte wheel downloads from zero; wget -c keeps
+    partial bytes so flaky links can finish.
+    """
+    dest.parent.mkdir(parents = True, exist_ok = True)
+    if shutil.which("wget"):
+        subprocess.run(["wget", "-c", "-qO", str(dest), url], check = True)
+        return
+    if shutil.which("curl"):
+        subprocess.run(["curl", "-fsSL", "-C", "-", "-o", str(dest), url], check = True)
+        return
+    download_file(url, dest)
+
+
+def _fetch_http_text(url: str, timeout: int = 30) -> str:
+    req = urllib.request.Request(url, headers = {"User-Agent": "unsloth-installer"})
+    with urllib.request.urlopen(req, timeout = timeout) as resp:
+        return resp.read().decode("utf-8", errors = "replace")
+
+
+def _parse_package_spec(spec: str) -> tuple[str, str]:
+    name, _, version = spec.partition("==")
+    return name.strip(), version.strip()
+
+
+def _pick_wheel_href_from_listing(
+    listing: str,
+    package: str,
+    version: str,
+    py_tag: str,
+) -> str | None:
+    import re
+
+    version_escaped = re.escape(version)
+    pattern = re.compile(
+        rf'href="([^"]*/{re.escape(package)}-{version_escaped}[^"]*{re.escape(py_tag)}[^"]*\.whl)"',
+        re.IGNORECASE,
+    )
+    matches = pattern.findall(listing)
+    if not matches:
+        pattern = re.compile(
+            rf'href="([^"]*/{re.escape(package)}-{version_escaped}[^"]*\.whl)"',
+            re.IGNORECASE,
+        )
+        matches = pattern.findall(listing)
+    if not matches:
+        return None
+    return matches[-1]
+
+
+def _download_pinned_wheel_resumable(spec: str, index_url: str, dest_dir: Path) -> Path | None:
+    """Fetch one wheel from a pinned simple index with wget/curl resume."""
+    package, version = _parse_package_spec(spec)
+    listing = _fetch_http_text(f"{index_url.rstrip('/')}/{package}/")
+    py_tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    href = _pick_wheel_href_from_listing(listing, package, version, py_tag)
+    if not href:
+        return None
+    if href.startswith("http"):
+        wheel_url = href
+    else:
+        wheel_url = f"{index_url.rstrip('/')}/{package}/{href.lstrip('./')}"
+    from urllib.parse import unquote
+
+    wheel_name = unquote(wheel_url.split("?")[0].split("/")[-1])
+    dest = dest_dir / wheel_name
+    download_file_resumable(wheel_url, dest)
+    return dest if dest.is_file() else None
 
 
 def patch_package_file(package_name: str, relative_path: str, url: str) -> None:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4173,10 +4173,7 @@ def _parse_package_spec(spec: str) -> tuple[str, str]:
 
 
 def _pick_wheel_href_from_listing(
-    listing: str,
-    package: str,
-    version: str,
-    py_tag: str,
+    listing: str, package: str, version: str, py_tag: str
 ) -> str | None:
     import re
 

--- a/tests/sh/run_resumable_torch_e2e.sh
+++ b/tests/sh/run_resumable_torch_e2e.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# One-off e2e: exercise _install_torch_resumable_wheels against the CPU index.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+uv venv "$TMPROOT/venv" --python 3.12 >/dev/null
+VENV_PY="$TMPROOT/venv/bin/python"
+STUDIO_HOME="$TMPROOT/studio"
+mkdir -p "$STUDIO_HOME/share"
+
+extract() { sed -n "/^$1()/,/^}/p" "$INSTALL_SH"; }
+
+eval "$(extract download)"
+eval "$(extract download_resumable)"
+substep() { echo "SUBSTEP: $*"; }
+run_install_cmd_retry() { shift; "$@"; }
+eval "$(extract _pytorch_wheel_arch_suffix)"
+eval "$(extract _constraint_ver_prefix)"
+eval "$(extract _pytorch_simple_listing)"
+eval "$(extract _pick_simple_index_wheel)"
+eval "$(extract _resolve_simple_index_wheel_url)"
+eval "$(extract _resolve_torch_wheel_versions)"
+eval "$(extract _install_torch_resumable_wheels)"
+
+export TORCH_INDEX_URL="https://download.pytorch.org/whl/cpu"
+export TORCH_CONSTRAINT="torch>=2.6,<2.11.0"
+export TORCHVISION_CONSTRAINT="torchvision>=0.19,<0.26.0"
+export TORCHAUDIO_CONSTRAINT="torchaudio>=2.6,<2.11.0"
+export _VENV_PY="$VENV_PY"
+export STUDIO_HOME="$STUDIO_HOME"
+export _ARCH="$(uname -m)"
+
+echo "=== resumable torch install (cpu index) ==="
+_install_torch_resumable_wheels \
+    "$TORCH_CONSTRAINT" "$TORCHVISION_CONSTRAINT" "$TORCHAUDIO_CONSTRAINT"
+
+echo "=== verify imports ==="
+"$VENV_PY" -c "
+import torch, torchvision, torchaudio
+print('torch', torch.__version__)
+print('torchvision', torchvision.__version__)
+print('torchaudio', torchaudio.__version__)
+"
+
+echo "=== cached wheels ==="
+ls -lh "$STUDIO_HOME/share/torch-wheel-cache"
+
+echo "=== resume check: re-run should reuse partial cache ==="
+_install_torch_resumable_wheels \
+    "$TORCH_CONSTRAINT" "$TORCHVISION_CONSTRAINT" "$TORCHAUDIO_CONSTRAINT" \
+    --force-reinstall
+
+echo "OK"

--- a/tests/sh/test_torch_resumable_download.sh
+++ b/tests/sh/test_torch_resumable_download.sh
@@ -45,7 +45,7 @@ _mk() { printf '#!/bin/sh\n%s\n' "$2" > "$_BIN/$1"; chmod +x "$_BIN/$1"; }
 
 echo "=== download_resumable prefers wget -c ==="
 rm -f "$_BIN"/*
-_mk wget 'echo "wget $@" >> '"$_BIN"'/log"; exit 0'
+_mk wget "echo wget \"\$@\" >> $_BIN/log; exit 0"
 PATH="$_BIN:$PATH" . "$_HARNESS"
 PATH="$_BIN:$PATH" . "$_FN_FILE"
 PATH="$_BIN:$PATH" download_resumable "https://example.com/torch.whl" "/tmp/torch.whl"

--- a/tests/sh/test_torch_resumable_download.sh
+++ b/tests/sh/test_torch_resumable_download.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Guards install.sh resumable torch wheel helpers (#8456).
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../../install.sh"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    _label="$1"; _want="$2"; _got="$3"
+    if [ "$_want" = "$_got" ]; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (want '$_want', got '$_got')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    _label="$1"; _haystack="$2"; _needle="$3"
+    if echo "$_haystack" | grep -qF "$_needle"; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected '$_needle')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+_FN_FILE=$(mktemp)
+sed -n '/^download_resumable()/,/^}/p' "$INSTALL_SH" > "$_FN_FILE"
+sed -n '/^_constraint_ver_prefix()/,/^}/p' "$INSTALL_SH" >> "$_FN_FILE"
+sed -n '/^_pick_simple_index_wheel()/,/^}/p' "$INSTALL_SH" >> "$_FN_FILE"
+
+_HARNESS=$(mktemp)
+cat > "$_HARNESS" <<'HARNESS'
+_ARCH=x86_64
+HARNESS
+
+_BIN=$(mktemp -d)
+_mk() { printf '#!/bin/sh\n%s\n' "$2" > "$_BIN/$1"; chmod +x "$_BIN/$1"; }
+
+echo "=== download_resumable prefers wget -c ==="
+rm -f "$_BIN"/*
+_mk wget 'echo "wget $@" >> '"$_BIN"'/log"; exit 0'
+PATH="$_BIN:$PATH" . "$_HARNESS"
+PATH="$_BIN:$PATH" . "$_FN_FILE"
+PATH="$_BIN:$PATH" download_resumable "https://example.com/torch.whl" "/tmp/torch.whl"
+assert_contains "wget -c used" "$(cat "$_BIN/log")" "wget -c"
+
+echo "=== _constraint_ver_prefix parses torch ranges ==="
+. "$_HARNESS"
+. "$_FN_FILE"
+assert_eq "torch>=2.11.0,<2.12.0" "2.11." "$(_constraint_ver_prefix 'torch>=2.11.0,<2.12.0')"
+assert_eq "torchvision==0.26.*" "0.26." "$(_constraint_ver_prefix 'torchvision==0.26.*')"
+
+echo "=== _pick_simple_index_wheel selects newest matching href ==="
+_LISTING='<a href="torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl"></a>
+<a href="torch-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl"></a>'
+. "$_HARNESS"
+. "$_FN_FILE"
+assert_eq "newest torch 2.11 wheel" \
+    "torch-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl" \
+    "$(_pick_simple_index_wheel "$_LISTING" "torch" "2.11." "cp312" "x86_64")"
+
+echo "=== _install_torch_default_index falls back to resumable path ==="
+assert_contains "uv failure warns" "$(cat "$INSTALL_SH")" \
+    "retrying with resumable wheel downloads (wget -c)"
+assert_contains "helper present" "$(cat "$INSTALL_SH")" "_install_torch_resumable_wheels()"
+
+rm -f "$_FN_FILE" "$_HARNESS"
+rm -rf "$_BIN"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/sh/test_torch_resumable_download.sh
+++ b/tests/sh/test_torch_resumable_download.sh
@@ -65,6 +65,11 @@ _LISTING='<a href="torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl"><
 assert_eq "newest torch 2.11 wheel" \
     "torch-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl" \
     "$(_pick_simple_index_wheel "$_LISTING" "torch" "2.11." "cp312" "x86_64")"
+_HREF='torch-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=abc123'
+_NAME=$(printf '%s' "${_HREF##*/}" | sed 's/%2[Bb]/+/g; s/[?#].*//')
+assert_eq "wheel basename strips sha256 fragment" \
+    "torch-2.11.0+cu130-cp312-cp312-manylinux_2_28_x86_64.whl" \
+    "$_NAME"
 
 echo "=== _install_torch_default_index falls back to resumable path ==="
 assert_contains "uv failure warns" "$(cat "$INSTALL_SH")" \

--- a/tests/studio/test_xpu_triton_swap.py
+++ b/tests/studio/test_xpu_triton_swap.py
@@ -14,8 +14,8 @@ Three things here are easy to get wrong and are asserted by execution rather tha
 
 * the ORDER. Fetch, then uninstall, then install. Uninstalling last deletes the shared paths
   the XPU build just wrote, because those paths are in generic triton's own RECORD.
-* the venv has no pip. ``uv venv`` is created without ``--seed``, so a fresh venv cannot run
-  ``pip download`` at all, and without a bootstrap the swap silently never happens.
+* the venv has no pip. ``uv venv`` is created without ``--seed``, so pip must be
+  bootstrapped before the local wheel install can run.
 * the pin is ONE-SHOT. ``UNSLOTH_TORCH_INDEX_FAMILY=xpu ./install.sh`` leaves nothing behind
   in the environment, so a later plain ``unsloth studio update`` must recognise the installed
   ``+xpu`` wheel instead. See TestTheInstalledWheelIsThePin.
@@ -122,12 +122,19 @@ def _load(
 
     pip_state = {"present": has_pip}
     index_urls: list[str] = []
-    download_envs: list = []
+
+    def fake_download_pinned(spec, pin, dest_dir):
+        log.append("DOWNLOAD")
+        index_urls.append(pin)
+        if download_ok and drops_wheel:
+            wheel_name = f"{spec.split('==')[0]}-{spec.split('==')[1]}-py3-none-any.whl"
+            path = Path(dest_dir) / wheel_name
+            path.write_bytes(b"")
+            return path
+        return None
 
     def fake_run(cmd, **kw):
         joined = " ".join(str(c) for c in cmd)
-        if "download" in cmd:
-            download_envs.append(kw.get("env"))
         if "-m pip --version" in joined or ("pip" in cmd and "--version" in cmd):
             return subprocess.CompletedProcess(cmd, 0 if pip_state["present"] else 1)
         if "ensurepip" in joined:
@@ -138,13 +145,6 @@ def _load(
         if "importlib.metadata" in joined:
             out = f"SPEC={spec}\nGENERIC={generic}\n".encode()
             return subprocess.CompletedProcess(cmd, 0, stdout = out)
-        if "download" in cmd:
-            log.append("DOWNLOAD")
-            index_urls.append(cmd[cmd.index("--index-url") + 1])
-            if download_ok and drops_wheel:
-                target = cmd[cmd.index("-d") + 1]
-                Path(target, "pytorch_triton_xpu-3.5.0-py3-none-any.whl").write_bytes(b"")
-            return subprocess.CompletedProcess(cmd, 0 if download_ok else 1, stdout = b"")
         if "uninstall" in cmd:
             log.append("UNINSTALL")
             return subprocess.CompletedProcess(cmd, 0 if uninstall_ok else 1)
@@ -193,6 +193,7 @@ def _load(
         ),
         "pip_install_try": fake_pip_install_try,
         "pip_install": fake_pip_install,
+        "_download_pinned_wheel_resumable": fake_download_pinned,
         "_red": lambda s: s,
         # _safe_print, not print: the slice calls it by name, so stubbing "print"
         # would leave _safe_print undefined at exec time.
@@ -203,7 +204,6 @@ def _load(
     exec(compile(body, str(STACK), "exec"), ns)
     mod.__dict__.update(ns)
     mod.__dict__["_test_index_urls"] = index_urls
-    mod.__dict__["_test_download_envs"] = download_envs
     return mod, log
 
 
@@ -225,7 +225,7 @@ class TestXpuTritonSwap:
         assert log == ["DOWNLOAD", "UNINSTALL", "INSTALL"]
 
     def test_bootstraps_pip_when_the_venv_has_none(self, monkeypatch, tmp_path):
-        # uv venv has no --seed, so a fresh venv cannot run pip download at all.
+        # uv venv has no --seed, so pip must be bootstrapped before the local wheel install.
         log = _run(
             monkeypatch, tmp_path, spec = "pytorch-triton-xpu==3.5.0", generic = "3.7.1", has_pip = False
         )
@@ -365,15 +365,8 @@ class TestTheInstalledWheelIsThePin:
         assert mod.__dict__["_test_index_urls"] == ["https://download.pytorch.org/whl/xpu"]
 
 
-class TestTheFetchIgnoresTheUsersIndexEnvironment:
-    """`pip download` honours PIP_* exactly like `pip install`, and that breaks the pin.
-
-    PIP_NO_INDEX makes pip ignore --index-url outright, and PIP_EXTRA_INDEX_URL /
-    PIP_FIND_LINKS are consulted IN ADDITION to it. Either the fetch fails, leaving generic
-    triton shadowing the XPU build, or the wheel arrives from an index the pin never named.
-    Every other pinned install in this file already routes through _install_env_for_cmd; this
-    one is a raw subprocess.run, so it has to ask for the same scrub explicitly.
-    """
+class TestTheFetchUsesThePinnedIndex:
+    """Resumable wheel fetch must use the explicit XPU pin, not ambient pip index env."""
 
     @pytest.mark.parametrize(
         "var, value",
@@ -385,30 +378,11 @@ class TestTheFetchIgnoresTheUsersIndexEnvironment:
             ("UV_INDEX_URL", "https://mirror.internal/simple"),
         ],
     )
-    def test_the_fetch_drops_index_environment(self, monkeypatch, tmp_path, var, value):
+    def test_the_fetch_ignores_index_environment(self, monkeypatch, tmp_path, var, value):
         monkeypatch.setenv(var, value)
         mod, _ = _load(monkeypatch, tmp_path, spec = "pytorch-triton-xpu==3.5.0", generic = "3.7.1")
         mod.__dict__["_ensure_xpu_triton"]()
-        env = mod.__dict__["_test_download_envs"][0]
-        assert env is not None, "the fetch inherited the ambient environment"
-        assert var not in env
-
-    def test_the_fetch_neutralises_the_pip_config_file(self, monkeypatch, tmp_path):
-        # A pip.conf index-url outranks nothing on the CLI, but no-index in it does.
-        mod, _ = _load(monkeypatch, tmp_path, spec = "pytorch-triton-xpu==3.5.0", generic = "3.7.1")
-        mod.__dict__["_ensure_xpu_triton"]()
-        env = mod.__dict__["_test_download_envs"][0]
-        assert env["PIP_CONFIG_FILE"] == os.devnull
-        assert env["UV_NO_CONFIG"] == "1"
-
-    def test_unrelated_environment_survives(self, monkeypatch, tmp_path):
-        # Scrub the index vars, not the environment: HTTPS_PROXY and friends are how a corporate
-        # host reaches the index at all.
-        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:8080")
-        mod, _ = _load(monkeypatch, tmp_path, spec = "pytorch-triton-xpu==3.5.0", generic = "3.7.1")
-        mod.__dict__["_ensure_xpu_triton"]()
-        env = mod.__dict__["_test_download_envs"][0]
-        assert env["HTTPS_PROXY"] == "http://proxy.internal:8080"
+        assert mod.__dict__["_test_index_urls"] == ["https://download.pytorch.org/whl/xpu"]
 
 
 class TestADeadDriverIsNotAFlavourMismatch:


### PR DESCRIPTION
Fixes #8456

## Problem
On flaky networks, `uv pip install` can fail mid-download when installing large PyTorch wheels (e.g. `torch==2.11.0+cu130`). pip/uv do not resume partial downloads, so each retry starts from zero.

## Solution
- **`install.sh`**: when the normal `uv pip install` torch path fails, fall back to:
  1. Scrape the pinned PyTorch simple index for matching `torch` / `torchvision` / `torchaudio` wheels
  2. Download wheels with **`wget -c`** (or `curl -C -`) into `~/.unsloth/share/torch-wheel-cache`
  3. Install locally with `uv pip install --no-deps`
  4. Install runtime deps (`nvidia-*`, `triton`, etc.) from the pinned index
- **`studio/install_python_stack.py`**: replace Intel XPU triton `pip download` with the same resumable fetch helper

## Testing
- `tests/sh/test_torch_resumable_download.sh`
- `tests/studio/test_xpu_triton_swap.py` (57 passed)
- `tests/sh/test_previous_torch_pin.sh` (50 passed)