### PR TITLE
Add no-chat-history toggle for shared Studio hosts

### DIFF
--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -60,6 +60,23 @@ router = APIRouter()
 logger = get_logger(__name__)
 
 
+def _chat_history_storage_disabled() -> bool:
+    try:
+        from utils.no_chat_history_settings import get_no_chat_history_enabled
+
+        return get_no_chat_history_enabled()
+    except Exception:
+        return False
+
+
+def _reject_chat_history_writes() -> None:
+    if _chat_history_storage_disabled():
+        raise HTTPException(
+            status_code = 403,
+            detail = "Chat history storage is disabled on this server.",
+        )
+
+
 class ChatThread(BaseModel):
     id: str
     title: str = "New Chat"
@@ -285,6 +302,8 @@ def list_threads(
     include_archived: bool = Query(True),
     current_subject: str = Depends(get_current_subject),
 ):
+    if _chat_history_storage_disabled():
+        return ChatThreadListResponse(threads = [])
     threads = list_chat_threads(
         model_type = model_type,
         pair_id = pair_id,
@@ -309,6 +328,7 @@ def _deleted_thread_error(thread_id: str) -> HTTPException:
 
 @router.post("/threads", response_model = ChatThread)
 def save_thread(payload: ChatThread, current_subject: str = Depends(get_current_subject)):
+    _reject_chat_history_writes()
     if payload.projectId and get_chat_project(payload.projectId) is None:
         raise _missing_project_error(payload.projectId)
     try:
@@ -325,6 +345,8 @@ def save_thread(payload: ChatThread, current_subject: str = Depends(get_current_
 
 @router.get("/threads/{thread_id}", response_model = ChatThread)
 def get_thread(thread_id: str, current_subject: str = Depends(get_current_subject)):
+    if _chat_history_storage_disabled():
+        raise HTTPException(status_code = 404, detail = f"Thread {thread_id} not found")
     thread = get_chat_thread(thread_id)
     if thread is None:
         raise HTTPException(status_code = 404, detail = f"Thread {thread_id} not found")
@@ -337,6 +359,7 @@ def patch_thread(
     payload: ChatThreadPatch,
     current_subject: str = Depends(get_current_subject),
 ):
+    _reject_chat_history_writes()
     patch = payload.model_dump(exclude_unset = True)
     expected_title = patch.pop("expectedTitle", None)
     expected_opening_message_id = patch.pop("expectedOpeningMessageId", None)
@@ -543,6 +566,8 @@ def list_attachments(
     current_subject: str = Depends(get_current_subject),
 ) -> dict:
     """One bounded page of chat uploads for the settings Data tab."""
+    if _chat_history_storage_disabled():
+        return {"attachments": [], "nextOffset": None}
     attachments, next_offset = list_chat_attachments_page(limit = limit, offset = offset)
     return {"attachments": attachments, "nextOffset": next_offset}
 
@@ -675,6 +700,8 @@ def delete_attachment(
 def list_projects(
     include_archived: bool = Query(False), current_subject: str = Depends(get_current_subject)
 ):
+    if _chat_history_storage_disabled():
+        return ChatProjectListResponse(projects = [])
     return ChatProjectListResponse(
         projects = [
             ChatProject(**(ensure_chat_project_workspace(project["id"]) or project))
@@ -685,11 +712,17 @@ def list_projects(
 
 @router.post("/projects", response_model = ChatProject)
 def save_project(payload: ChatProject, current_subject: str = Depends(get_current_subject)):
+    _reject_chat_history_writes()
     return ChatProject(**upsert_chat_project(payload.model_dump()))
 
 
 @router.get("/projects/{project_id}", response_model = ChatProject)
 def get_project(project_id: str, current_subject: str = Depends(get_current_subject)):
+    if _chat_history_storage_disabled():
+        raise HTTPException(
+            status_code = 404,
+            detail = f"Project {project_id} not found",
+        )
     project = ensure_chat_project_workspace(project_id)
     if project is None:
         raise HTTPException(
@@ -705,6 +738,7 @@ def patch_project(
     payload: ChatProjectPatch,
     current_subject: str = Depends(get_current_subject),
 ):
+    _reject_chat_history_writes()
     patch = payload.model_dump(exclude_unset = True)
     for field in ("name", "archived", "createdAt", "updatedAt"):
         if field in patch and patch[field] is None:
@@ -904,6 +938,8 @@ async def delete_project(
 
 @router.get("/threads/{thread_id}/messages", response_model = ChatMessageListResponse)
 def get_thread_messages(thread_id: str, current_subject: str = Depends(get_current_subject)):
+    if _chat_history_storage_disabled():
+        return ChatMessageListResponse(messages = [])
     if get_chat_thread(thread_id) is None:
         raise HTTPException(status_code = 404, detail = f"Thread {thread_id} not found")
     return ChatMessageListResponse(
@@ -916,6 +952,10 @@ def batch_thread_messages(
     payload: ChatMessagesBatchRequest, current_subject: str = Depends(get_current_subject)
 ):
     """One round-trip per sidebar/search rebuild instead of N. Unknown thread ids return empty lists."""
+    if _chat_history_storage_disabled():
+        return ChatMessagesBatchResponse(
+            messagesByThreadId = {tid: [] for tid in payload.threadIds},
+        )
     by_thread: dict[str, list[ChatMessage]] = {tid: [] for tid in payload.threadIds}
     for m in list_chat_messages_for_threads(payload.threadIds):
         tid = m["threadId"]
@@ -930,6 +970,8 @@ def get_thread_message(
     message_id: str,
     current_subject: str = Depends(get_current_subject),
 ):
+    if _chat_history_storage_disabled():
+        raise HTTPException(status_code = 404, detail = f"Thread {thread_id} not found")
     if get_chat_thread(thread_id) is None:
         raise HTTPException(status_code = 404, detail = f"Thread {thread_id} not found")
     message = get_chat_message(thread_id, message_id)
@@ -945,6 +987,7 @@ def save_thread_message(
     payload: ChatMessage,
     current_subject: str = Depends(get_current_subject),
 ):
+    _reject_chat_history_writes()
     if thread_id != payload.threadId or message_id != payload.id:
         raise HTTPException(status_code = 400, detail = "Message id mismatch")
     if get_chat_thread(thread_id) is None:
@@ -971,6 +1014,7 @@ def replace_thread_messages(
     payload: ChatMessageSyncRequest,
     current_subject: str = Depends(get_current_subject),
 ):
+    _reject_chat_history_writes()
     mismatched_ids = [message.id for message in payload.messages if message.threadId != thread_id]
     if mismatched_ids:
         preview = ", ".join(mismatched_ids[:5])
@@ -1009,6 +1053,8 @@ def replace_thread_messages(
 
 @router.get("/count", response_model = ChatCountResponse)
 def count_threads(current_subject: str = Depends(get_current_subject)):
+    if _chat_history_storage_disabled():
+        return ChatCountResponse(count = 0)
     return ChatCountResponse(count = count_chat_threads())
 
 
@@ -1026,6 +1072,7 @@ def record_import_ledger(
     payload: ChatImportLedgerRecordRequest, current_subject: str = Depends(get_current_subject)
 ):
     """Mark each legacy thread id as imported. Idempotent."""
+    _reject_chat_history_writes()
     accepted, inserted = upsert_chat_legacy_imports(payload.threadIds)
     return ChatImportLedgerRecordResponse(accepted = accepted, inserted = inserted)
 
@@ -1139,6 +1186,7 @@ def fork_thread(
     `containerSnapshotWarning` and the fork still succeeds with a
     clean sandbox.
     """
+    _reject_chat_history_writes()
     import uuid
 
     source = get_chat_thread(thread_id)
@@ -1191,12 +1239,24 @@ def get_fork_count(
     message_id: str,
     current_subject: str = Depends(get_current_subject),
 ):
+    if _chat_history_storage_disabled():
+        return ChatForkCountResponse(count = 0)
     return ChatForkCountResponse(count = count_forks_for_message(thread_id, message_id))
 
 
 @router.get("/export", response_model = ChatExportResponse)
 def export_history(current_subject: str = Depends(get_current_subject)):
     from datetime import datetime, timezone
+
+    if _chat_history_storage_disabled():
+        return ChatExportResponse(
+            exportedAt = datetime.now(timezone.utc).isoformat(),
+            version = 1,
+            threadCount = 0,
+            projects = [],
+            threads = [],
+            messages = [],
+        )
     projects, threads, messages = build_chat_history_export()
     return ChatExportResponse(
         exportedAt = datetime.now(timezone.utc).isoformat(),

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -63,7 +63,6 @@ logger = get_logger(__name__)
 def _chat_history_storage_disabled() -> bool:
     try:
         from utils.no_chat_history_settings import get_no_chat_history_enabled
-
         return get_no_chat_history_enabled()
     except Exception:
         return False

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -44,6 +44,12 @@ from utils.helper_precache_settings import (
     helper_model_disabled_by_env,
     set_helper_precache_enabled,
 )
+from utils.no_chat_history_settings import (
+    DEFAULT_NO_CHAT_HISTORY_ENABLED,
+    get_no_chat_history_enabled,
+    no_chat_history_forced_by_env,
+    set_no_chat_history_enabled,
+)
 from picker.schemas import MAX_CHAT_TEMPLATE_BYTES, chat_template_byte_length
 from utils.coding_agents import CODING_AGENTS, detect_installed_coding_agents
 from utils.model_memory_settings import (
@@ -195,6 +201,16 @@ class HelperPrecacheResponse(BaseModel):
     enabled: bool
     default_enabled: bool = DEFAULT_HELPER_PRECACHE_ENABLED
     disabled_by_env: bool
+
+
+class NoChatHistoryPayload(BaseModel):
+    enabled: bool
+
+
+class NoChatHistoryResponse(BaseModel):
+    enabled: bool
+    default_enabled: bool = DEFAULT_NO_CHAT_HISTORY_ENABLED
+    forced_by_env: bool
 
 
 class ModelMemoryPayload(BaseModel):
@@ -370,6 +386,13 @@ def _helper_precache_response(enabled: bool | None = None) -> HelperPrecacheResp
     )
 
 
+def _no_chat_history_response(enabled: bool | None = None) -> NoChatHistoryResponse:
+    return NoChatHistoryResponse(
+        enabled = get_no_chat_history_enabled() if enabled is None else enabled,
+        forced_by_env = no_chat_history_forced_by_env(),
+    )
+
+
 # Distinct from None, which is a real launch this policy does not govern.
 _NO_LAUNCH = object()
 
@@ -520,6 +543,30 @@ def update_helper_precache(
             log = logger,
         ) from exc
     return _helper_precache_response(enabled)
+
+
+@router.get("/no-chat-history", response_model = NoChatHistoryResponse)
+def get_no_chat_history(
+    current_subject: str = Depends(get_current_subject),
+) -> NoChatHistoryResponse:
+    return _no_chat_history_response()
+
+
+@router.put("/no-chat-history", response_model = NoChatHistoryResponse)
+def update_no_chat_history(
+    payload: NoChatHistoryPayload, current_subject: str = Depends(get_current_subject)
+) -> NoChatHistoryResponse:
+    try:
+        enabled = set_no_chat_history_enabled(payload.enabled)
+    except ValueError as exc:
+        raise log_and_http_error(
+            exc,
+            400,
+            safe_error_detail(exc, fallback = "Invalid no chat history setting."),
+            event = "settings.update_no_chat_history_failed",
+            log = logger,
+        ) from exc
+    return _no_chat_history_response(enabled)
 
 
 @router.get("/model-memory", response_model = ModelMemoryResponse)

--- a/studio/backend/tests/test_no_chat_history_settings.py
+++ b/studio/backend/tests/test_no_chat_history_settings.py
@@ -19,14 +19,14 @@ from routes import chat_history, settings as settings_route
 from utils import no_chat_history_settings
 
 
-def _install_fake_studio_db(monkeypatch, *, stored=None):
+def _install_fake_studio_db(monkeypatch, *, stored = None):
     storage_pkg = types.ModuleType("storage")
     studio_db = types.ModuleType("storage.studio_db")
     values: dict[str, object] = {}
     if stored is not None:
         values[no_chat_history_settings.NO_CHAT_HISTORY_SETTING_KEY] = stored
 
-    def get_app_setting(key, fallback=None):
+    def get_app_setting(key, fallback = None):
         return values.get(key, fallback)
 
     def upsert_app_settings(settings):
@@ -41,14 +41,14 @@ def _install_fake_studio_db(monkeypatch, *, stored=None):
 
 
 def test_no_chat_history_defaults_off_when_setting_missing(monkeypatch):
-    monkeypatch.delenv(no_chat_history_settings.NO_CHAT_HISTORY_ENV, raising=False)
+    monkeypatch.delenv(no_chat_history_settings.NO_CHAT_HISTORY_ENV, raising = False)
     _install_fake_studio_db(monkeypatch)
 
     assert no_chat_history_settings.get_no_chat_history_enabled() is False
 
 
 def test_no_chat_history_env_forces_enabled(monkeypatch):
-    _install_fake_studio_db(monkeypatch, stored=False)
+    _install_fake_studio_db(monkeypatch, stored = False)
     monkeypatch.setenv(no_chat_history_settings.NO_CHAT_HISTORY_ENV, "true")
 
     assert no_chat_history_settings.get_no_chat_history_enabled() is True
@@ -57,11 +57,11 @@ def test_no_chat_history_env_forces_enabled(monkeypatch):
 
 def test_settings_route_persists_no_chat_history_toggle(monkeypatch):
     values = _install_fake_studio_db(monkeypatch)
-    monkeypatch.delenv(no_chat_history_settings.NO_CHAT_HISTORY_ENV, raising=False)
+    monkeypatch.delenv(no_chat_history_settings.NO_CHAT_HISTORY_ENV, raising = False)
 
     response = settings_route.update_no_chat_history(
-        settings_route.NoChatHistoryPayload(enabled=True),
-        current_subject="test-user",
+        settings_route.NoChatHistoryPayload(enabled = True),
+        current_subject = "test-user",
     )
 
     assert response.enabled is True
@@ -76,8 +76,8 @@ def test_settings_route_rejects_toggle_when_env_locked(monkeypatch):
 
     with pytest.raises(Exception):
         settings_route.update_no_chat_history(
-            settings_route.NoChatHistoryPayload(enabled=False),
-            current_subject="test-user",
+            settings_route.NoChatHistoryPayload(enabled = False),
+            current_subject = "test-user",
         )
 
 
@@ -88,7 +88,7 @@ def test_list_threads_returns_empty_when_history_disabled(monkeypatch):
         lambda: True,
     )
 
-    response = chat_history.list_threads(current_subject="test-user")
+    response = chat_history.list_threads(current_subject = "test-user")
 
     assert response.threads == []
 
@@ -103,11 +103,11 @@ def test_save_thread_rejects_when_history_disabled(monkeypatch):
     with pytest.raises(Exception) as exc:
         chat_history.save_thread(
             chat_history.ChatThread(
-                id="thread-1",
-                modelType="base",
-                createdAt=1,
+                id = "thread-1",
+                modelType = "base",
+                createdAt = 1,
             ),
-            current_subject="test-user",
+            current_subject = "test-user",
         )
 
     assert exc.value.status_code == 403

--- a/studio/backend/tests/test_no_chat_history_settings.py
+++ b/studio/backend/tests/test_no_chat_history_settings.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for the no-chat-history server policy."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from routes import chat_history, settings as settings_route
+from utils import no_chat_history_settings
+
+
+def _install_fake_studio_db(monkeypatch, *, stored=None):
+    storage_pkg = types.ModuleType("storage")
+    studio_db = types.ModuleType("storage.studio_db")
+    values: dict[str, object] = {}
+    if stored is not None:
+        values[no_chat_history_settings.NO_CHAT_HISTORY_SETTING_KEY] = stored
+
+    def get_app_setting(key, fallback=None):
+        return values.get(key, fallback)
+
+    def upsert_app_settings(settings):
+        values.update(settings)
+        return dict(values)
+
+    studio_db.get_app_setting = get_app_setting
+    studio_db.upsert_app_settings = upsert_app_settings
+    monkeypatch.setitem(sys.modules, "storage", storage_pkg)
+    monkeypatch.setitem(sys.modules, "storage.studio_db", studio_db)
+    return values
+
+
+def test_no_chat_history_defaults_off_when_setting_missing(monkeypatch):
+    monkeypatch.delenv(no_chat_history_settings.NO_CHAT_HISTORY_ENV, raising=False)
+    _install_fake_studio_db(monkeypatch)
+
+    assert no_chat_history_settings.get_no_chat_history_enabled() is False
+
+
+def test_no_chat_history_env_forces_enabled(monkeypatch):
+    _install_fake_studio_db(monkeypatch, stored=False)
+    monkeypatch.setenv(no_chat_history_settings.NO_CHAT_HISTORY_ENV, "true")
+
+    assert no_chat_history_settings.get_no_chat_history_enabled() is True
+    assert no_chat_history_settings.no_chat_history_forced_by_env() is True
+
+
+def test_settings_route_persists_no_chat_history_toggle(monkeypatch):
+    values = _install_fake_studio_db(monkeypatch)
+    monkeypatch.delenv(no_chat_history_settings.NO_CHAT_HISTORY_ENV, raising=False)
+
+    response = settings_route.update_no_chat_history(
+        settings_route.NoChatHistoryPayload(enabled=True),
+        current_subject="test-user",
+    )
+
+    assert response.enabled is True
+    assert response.default_enabled is False
+    assert response.forced_by_env is False
+    assert values[no_chat_history_settings.NO_CHAT_HISTORY_SETTING_KEY] is True
+
+
+def test_settings_route_rejects_toggle_when_env_locked(monkeypatch):
+    _install_fake_studio_db(monkeypatch)
+    monkeypatch.setenv(no_chat_history_settings.NO_CHAT_HISTORY_ENV, "1")
+
+    with pytest.raises(Exception):
+        settings_route.update_no_chat_history(
+            settings_route.NoChatHistoryPayload(enabled=False),
+            current_subject="test-user",
+        )
+
+
+def test_list_threads_returns_empty_when_history_disabled(monkeypatch):
+    monkeypatch.setattr(
+        chat_history,
+        "_chat_history_storage_disabled",
+        lambda: True,
+    )
+
+    response = chat_history.list_threads(current_subject="test-user")
+
+    assert response.threads == []
+
+
+def test_save_thread_rejects_when_history_disabled(monkeypatch):
+    monkeypatch.setattr(
+        chat_history,
+        "_chat_history_storage_disabled",
+        lambda: True,
+    )
+
+    with pytest.raises(Exception) as exc:
+        chat_history.save_thread(
+            chat_history.ChatThread(
+                id="thread-1",
+                modelType="base",
+                createdAt=1,
+            ),
+            current_subject="test-user",
+        )
+
+    assert exc.value.status_code == 403

--- a/studio/backend/utils/no_chat_history_settings.py
+++ b/studio/backend/utils/no_chat_history_settings.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Persisted policy for disabling chat history on shared Studio hosts."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+NO_CHAT_HISTORY_SETTING_KEY = "no_chat_history"
+DEFAULT_NO_CHAT_HISTORY_ENABLED = False
+NO_CHAT_HISTORY_ENV = "UNSLOTH_NO_CHAT_HISTORY"
+
+
+def _coerce_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    return None
+
+
+def no_chat_history_forced_by_env() -> bool:
+    return os.environ.get(NO_CHAT_HISTORY_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def get_no_chat_history_enabled() -> bool:
+    if no_chat_history_forced_by_env():
+        return True
+    try:
+        from storage.studio_db import get_app_setting
+
+        stored = get_app_setting(NO_CHAT_HISTORY_SETTING_KEY, None)
+    except Exception:
+        stored = None
+    parsed = _coerce_bool(stored)
+    return parsed if parsed is not None else DEFAULT_NO_CHAT_HISTORY_ENABLED
+
+
+def set_no_chat_history_enabled(value: Any) -> bool:
+    if no_chat_history_forced_by_env():
+        raise ValueError(
+            "Chat history policy is locked by UNSLOTH_NO_CHAT_HISTORY and cannot be changed.",
+        )
+    parsed = _coerce_bool(value)
+    if parsed is None:
+        raise ValueError("No chat history setting must be true or false.")
+
+    from storage.studio_db import upsert_app_settings
+
+    upsert_app_settings({NO_CHAT_HISTORY_SETTING_KEY: parsed})
+    return parsed

--- a/studio/backend/utils/no_chat_history_settings.py
+++ b/studio/backend/utils/no_chat_history_settings.py
@@ -39,7 +39,6 @@ def get_no_chat_history_enabled() -> bool:
         return True
     try:
         from storage.studio_db import get_app_setting
-
         stored = get_app_setting(NO_CHAT_HISTORY_SETTING_KEY, None)
     except Exception:
         stored = None

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -25,6 +25,7 @@ import { backfillModelOverrides } from "@/features/model-picker/api/migrate-mode
 import { usePersonalizationSync } from "@/features/profile";
 import { RemoteCodeConsentDialog } from "@/features/security";
 import { SettingsDialog, useSettingsDialogStore } from "@/features/settings";
+import { NoChatHistoryBootstrap } from "@/features/settings/components/no-chat-history-bootstrap";
 import { useTrainingUnloadGuard } from "@/features/training";
 import { TransformersUpgradeDialog } from "@/features/transformers-upgrade";
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
@@ -327,7 +328,9 @@ function RootLayout() {
         const chatRuntime = useChatRuntimeStore.getState();
         chatRuntime.setActiveThreadId(null);
         chatRuntime.setActiveProjectId(null);
-        chatRuntime.setIncognito(false);
+        if (!chatRuntime.incognitoLocked) {
+          chatRuntime.setIncognito(false);
+        }
         void navigate({
           to: "/chat",
           search: { new: crypto.randomUUID() },
@@ -349,12 +352,15 @@ function RootLayout() {
     if (anyRunning) return;
     chatRuntime.setActiveProjectId(null);
     chatRuntime.setActiveThreadId(null);
-    chatRuntime.setIncognito(false);
+    if (!chatRuntime.incognitoLocked) {
+      chatRuntime.setIncognito(false);
+    }
   }, [isChatRoute]);
 
   const content = (
     <>
       <PersonalizationSyncMount />
+      <NoChatHistoryBootstrap />
       {!isAuthFlowRoute && <SettingsDialog />}
       {/* Opens itself when API traffic arrives; hides on the full monitor page. */}
       {!isAuthFlowRoute && <ApiMonitorOverlay />}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1847,6 +1847,7 @@ export function ChatPage({
   const settingsOpen = useChatRuntimeStore((s) => s.settingsPanelOpen);
   const setSettingsOpen = useChatRuntimeStore((s) => s.setSettingsPanelOpen);
   const incognito = useChatRuntimeStore((s) => s.incognito);
+  const incognitoLocked = useChatRuntimeStore((s) => s.incognitoLocked);
   const setIncognito = useChatRuntimeStore((s) => s.setIncognito);
   const incognitoLabel = incognito
     ? "Turn off temporary chat"
@@ -2356,10 +2357,11 @@ export function ChatPage({
   // never implies a saved thread is temporary.
   useEffect(() => {
     const onFreshSingleChat = view.mode === "single" && !view.threadId;
+    if (incognitoLocked) return;
     if (incognito && !onFreshSingleChat) {
       setIncognito(false);
     }
-  }, [view, incognito, setIncognito]);
+  }, [view, incognito, incognitoLocked, setIncognito]);
 
   const selectedArtifact = useSelectedChatArtifact();
   const artifactSurface = useChatArtifactsStore((state) => state.surface);
@@ -3451,7 +3453,7 @@ export function ChatPage({
                 className="h-[var(--studio-chat-control-height,34px)]"
               />
             ) : null}
-            {view.mode === "single" && (
+            {view.mode === "single" && !incognitoLocked && (
               <Tooltip>
                 <TooltipPrimitive.Trigger asChild={true}>
                   <button

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1168,6 +1168,8 @@ type ChatRuntimeStore = {
    * backend settings, so a refresh always exits incognito.
    */
   incognito: boolean;
+  /** When true, the server policy forces temporary chat and the toggle is hidden. */
+  incognitoLocked: boolean;
   settingsPanelOpen: boolean;
   editingMessageId: string | null;
   pendingAudioBase64: string | null;
@@ -1246,6 +1248,7 @@ type ChatRuntimeStore = {
   setActiveThreadId: (threadId: string | null) => void;
   setActiveProjectId: (projectId: string | null) => void;
   setIncognito: (incognito: boolean) => void;
+  setIncognitoLocked: (locked: boolean) => void;
   setSettingsPanelOpen: (open: boolean) => void;
   setEditingMessageId: (id: string | null) => void;
   clearCheckpoint: () => void;
@@ -1687,6 +1690,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   queuedSettingsEpoch: 0,
   activeProjectId: null,
   incognito: false,
+  incognitoLocked: false,
   settingsPanelOpen: false,
   editingMessageId: null,
   pendingAudioBase64: null,
@@ -2040,6 +2044,10 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     })),
   setActiveProjectId: (activeProjectId) => set({ activeProjectId }),
   setIncognito: (incognito) => {
+    const state = get();
+    if (!incognito && state.incognitoLocked) {
+      return;
+    }
     if (incognito) saveBool(CHAT_DEEP_RESEARCH_ENABLED_KEY, false);
     set(
       incognito
@@ -2047,6 +2055,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         : { incognito },
     );
   },
+  setIncognitoLocked: (incognitoLocked) => set({ incognitoLocked }),
   setSettingsPanelOpen: (settingsPanelOpen) => set({ settingsPanelOpen }),
   setEditingMessageId: (id) => set({ editingMessageId: id }),
   clearCheckpoint: () => {

--- a/studio/frontend/src/features/settings/api/no-chat-history.ts
+++ b/studio/frontend/src/features/settings/api/no-chat-history.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { readFastApiError } from "@/lib/format-fastapi-error";
+
+const NO_CHAT_HISTORY_EVENT = "unsloth-no-chat-history-change";
+
+export type NoChatHistorySettings = {
+  enabled: boolean;
+  defaultEnabled: boolean;
+  forcedByEnv: boolean;
+};
+
+type ApiNoChatHistorySettings = {
+  enabled: boolean;
+  // biome-ignore lint/style/useNamingConvention: API schema
+  default_enabled: boolean;
+  // biome-ignore lint/style/useNamingConvention: API schema
+  forced_by_env: boolean;
+};
+
+let cachedNoChatHistory: NoChatHistorySettings | null = null;
+let inFlightNoChatHistory: Promise<NoChatHistorySettings> | null = null;
+
+export function subscribeNoChatHistorySettings(
+  listener: (settings: NoChatHistorySettings) => void,
+) {
+  const handleChange = (event: Event) => {
+    listener((event as CustomEvent<NoChatHistorySettings>).detail);
+  };
+  window.addEventListener(NO_CHAT_HISTORY_EVENT, handleChange);
+  return () => window.removeEventListener(NO_CHAT_HISTORY_EVENT, handleChange);
+}
+
+function fromApi(settings: ApiNoChatHistorySettings): NoChatHistorySettings {
+  return {
+    enabled: settings.enabled,
+    defaultEnabled: settings.default_enabled,
+    forcedByEnv: settings.forced_by_env,
+  };
+}
+
+function cacheNoChatHistory(settings: NoChatHistorySettings) {
+  cachedNoChatHistory = settings;
+  window.dispatchEvent(
+    new CustomEvent(NO_CHAT_HISTORY_EVENT, { detail: settings }),
+  );
+  return settings;
+}
+
+async function fetchNoChatHistorySettings(): Promise<NoChatHistorySettings> {
+  const res = await authFetch("/api/settings/no-chat-history");
+  if (!res.ok) {
+    throw new Error(
+      await readFastApiError(res, "Failed to load chat history settings"),
+    );
+  }
+  return fromApi(await res.json());
+}
+
+export async function loadNoChatHistorySettings({ force = false } = {}) {
+  if (cachedNoChatHistory && !force) {
+    return cachedNoChatHistory;
+  }
+  inFlightNoChatHistory ??= fetchNoChatHistorySettings()
+    .then(cacheNoChatHistory)
+    .finally(() => {
+      inFlightNoChatHistory = null;
+    });
+  return inFlightNoChatHistory;
+}
+
+export async function updateNoChatHistorySettings(
+  enabled: boolean,
+): Promise<NoChatHistorySettings> {
+  const res = await authFetch("/api/settings/no-chat-history", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      await readFastApiError(res, "Failed to update chat history settings"),
+    );
+  }
+  return cacheNoChatHistory(fromApi(await res.json()));
+}
+
+export function getCachedNoChatHistoryEnabled(): boolean {
+  return cachedNoChatHistory?.enabled ?? false;
+}

--- a/studio/frontend/src/features/settings/components/no-chat-history-bootstrap.tsx
+++ b/studio/frontend/src/features/settings/components/no-chat-history-bootstrap.tsx
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useChatRuntimeStore } from "@/features/chat";
+import { useEffect } from "react";
+import {
+  loadNoChatHistorySettings,
+  subscribeNoChatHistorySettings,
+} from "../api/no-chat-history";
+
+function applyNoChatHistoryPolicy(enabled: boolean) {
+  const store = useChatRuntimeStore.getState();
+  store.setIncognitoLocked(enabled);
+  if (enabled) {
+    store.setIncognito(true);
+  }
+}
+
+export function NoChatHistoryBootstrap() {
+  useEffect(() => {
+    let active = true;
+    void loadNoChatHistorySettings()
+      .then((settings) => {
+        if (!active) return;
+        applyNoChatHistoryPolicy(settings.enabled);
+      })
+      .catch(() => {
+        // Fail open: a settings outage must not block chat.
+      });
+    const unsubscribe = subscribeNoChatHistorySettings((settings) => {
+      if (!active) return;
+      applyNoChatHistoryPolicy(settings.enabled);
+    });
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+  return null;
+}

--- a/studio/frontend/src/features/settings/settings-search.ts
+++ b/studio/frontend/src/features/settings/settings-search.ts
@@ -104,6 +104,7 @@ export const SETTINGS_SEARCH_INDEX: Record<SettingsTab, TranslationKey[]> = {
     "settings.data.archivedChats",
     "settings.data.archiveAllChats",
     "settings.data.confirmBeforeDeleting",
+    "settings.data.noChatHistory.label",
     "settings.data.uploadedFiles",
     "settings.chat.exportHistory",
     "settings.chat.exportConversations",

--- a/studio/frontend/src/features/settings/tabs/data-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/data-tab.tsx
@@ -78,6 +78,11 @@ import {
   type FineTuneAction,
   useSettingsPanelPrefsStore,
 } from "../stores/settings-panel-prefs-store";
+import {
+  type NoChatHistorySettings,
+  loadNoChatHistorySettings,
+  updateNoChatHistorySettings,
+} from "../api/no-chat-history";
 
 // display order, and the guard against a persisted action this build dropped.
 const FINE_TUNE_ACTIONS: FineTuneAction[] = ["export", "train", "recipes"];
@@ -112,6 +117,12 @@ export function DataTab() {
   const [fineTuneExporting, setFineTuneExporting] = useState(false);
   const [openingRecipe, setOpeningRecipe] = useState(false);
   const [loadingTraining, setLoadingTraining] = useState(false);
+  const [noChatHistory, setNoChatHistory] =
+    useState<NoChatHistorySettings | null>(null);
+  const [noChatHistoryError, setNoChatHistoryError] = useState<string | null>(
+    null,
+  );
+  const [isSavingNoChatHistory, setIsSavingNoChatHistory] = useState(false);
   // Chat-only hosts redirect /studio back to /chat, so loading a dataset in
   // the Train tab would upload it and then strand the user; gate the action
   // the same way the sidebar gates Train.
@@ -148,6 +159,27 @@ export function DataTab() {
       cancelled = true;
     };
   }, [archivedRequested, consumeArchivedChatsRequest]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadNoChatHistorySettings()
+      .then((settings) => {
+        if (cancelled) return;
+        setNoChatHistory(settings);
+        setNoChatHistoryError(null);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setNoChatHistoryError(
+          error instanceof Error
+            ? error.message
+            : t("settings.data.noChatHistory.loadError"),
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
 
   useEffect(() => {
     if (!ragAvailabilityUnknown) return;
@@ -195,6 +227,28 @@ export function DataTab() {
   useEffect(() => {
     void countAllChats().then(setCount);
   }, []);
+
+  const saveNoChatHistory = async (enabled: boolean) => {
+    setIsSavingNoChatHistory(true);
+    setNoChatHistoryError(null);
+    try {
+      const settings = await updateNoChatHistorySettings(enabled);
+      setNoChatHistory(settings);
+      const store = useChatRuntimeStore.getState();
+      store.setIncognitoLocked(settings.enabled);
+      if (settings.enabled) {
+        store.setIncognito(true);
+      }
+    } catch (error) {
+      setNoChatHistoryError(
+        error instanceof Error
+          ? error.message
+          : t("settings.data.noChatHistory.saveError"),
+      );
+    } finally {
+      setIsSavingNoChatHistory(false);
+    }
+  };
 
   const handleExport = async () => {
     setExporting(true);
@@ -667,6 +721,32 @@ export function DataTab() {
             checked={confirmDeleteChats}
             onCheckedChange={setConfirmDeleteChats}
           />
+        </SettingsRow>
+
+        <SettingsRow
+          label={t("settings.data.noChatHistory.label")}
+          description={t("settings.data.noChatHistory.description")}
+        >
+          <div className="flex flex-col items-end gap-1">
+            <Switch
+              checked={noChatHistory?.enabled ?? false}
+              disabled={
+                !noChatHistory ||
+                isSavingNoChatHistory ||
+                noChatHistory.forcedByEnv
+              }
+              onCheckedChange={(enabled) => void saveNoChatHistory(enabled)}
+            />
+            {noChatHistory?.forcedByEnv ? (
+              <span className="max-w-[260px] text-right text-xs text-muted-foreground">
+                {t("settings.data.noChatHistory.forcedByEnv")}
+              </span>
+            ) : noChatHistoryError ? (
+              <span className="max-w-[260px] text-right text-xs text-destructive">
+                {noChatHistoryError}
+              </span>
+            ) : null}
+          </div>
         </SettingsRow>
 
         <SettingsRow

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -967,6 +967,15 @@ export const en = {
       exportFailed: "Could not export chats",
       description:
         "Manage chat history and uploaded files stored on this device.",
+      noChatHistory: {
+        label: "Don't store chat history",
+        description:
+          "Keep every chat temporary so concurrent users on a shared Studio host do not see each other's conversations. New messages are not saved to studio.db.",
+        forcedByEnv:
+          "Locked by UNSLOTH_NO_CHAT_HISTORY. Restart without it to change this in Settings.",
+        loadError: "Failed to load chat history policy.",
+        saveError: "Failed to update chat history policy.",
+      },
       archivedChats: "Archived chats",
       archivedChatsDescription: "View and manage chats you have archived.",
       archivedImages: "Archived images",


### PR DESCRIPTION
## Summary

Fixes #8602

Adds a lightweight server-wide **Don't store chat history** policy for teams sharing one Studio instance (e.g. bound to `0.0.0.0` with Tailscale). When enabled:

- Every chat runs in temporary/incognito mode (nothing written to `studio.db`)
- Shared history is hidden from list/export APIs
- New thread/message writes are rejected server-side (403)

## How to use

**Settings → Data → Don't store chat history** (toggle)

Or lock at launch:

```bash
UNSLOTH_NO_CHAT_HISTORY=1 unsloth studio --host 0.0.0.0
```

When the env var is set, the toggle is read-only in Settings.

## Test plan

- [x] `studio/backend/tests/test_no_chat_history_settings.py` (6 cases)
- [x] Settings API persists toggle and respects env lock
- [x] Chat history routes return empty lists / 403 writes when disabled