### PR TITLE
fix(studio): enable /v1/embeddings for loaded embedding GGUFs

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -15282,9 +15282,13 @@ class LlamaCppBackend:
                         mtp_draft_path = (
                             None if _spec_canon in ("dspark", "dflash") else launch_mtp_draft_path
                         ),
-                        dspark_draft_path = (launch_mtp_draft_path if _spec_canon == "dspark" else None),
+                        dspark_draft_path = (
+                            launch_mtp_draft_path if _spec_canon == "dspark" else None
+                        ),
                         dspark_fit_sized = not use_fit,
-                        dflash_draft_path = (launch_mtp_draft_path if _spec_canon == "dflash" else None),
+                        dflash_draft_path = (
+                            launch_mtp_draft_path if _spec_canon == "dflash" else None
+                        ),
                         dflash_fit_sized = not use_fit,
                         drafter_no_vram = _spec_dropped_no_vram,
                         draft_device = _draft_device,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3625,6 +3625,8 @@ class LlamaCppBackend:
         # Whole header walked? Separates "declares no architecture" from "unreadable".
         self._gguf_header_parsed: bool = False
         self._gguf_split_index: Optional[int] = None
+        self._is_embedding: bool = False
+        self._embedding_pooling: str = "mean"
         self._diffusion_visual_bin: Optional[str] = None
         self._healthy = False
         self._load_rss_hwm = (None, 0)  # (pid, peak VmRSS) for load_progress
@@ -3865,6 +3867,11 @@ class LlamaCppBackend:
     def is_diffusion(self) -> bool:
         """True when the loaded GGUF is a block-diffusion model (DiffusionGemma)."""
         return self._is_diffusion
+
+    @property
+    def is_embedding(self) -> bool:
+        """True when the loaded GGUF is served in llama-server embedding mode."""
+        return self._is_embedding
 
     @property
     def swa_full(self) -> bool:
@@ -8526,6 +8533,8 @@ class LlamaCppBackend:
         self._is_diffusion = False
         self._gguf_header_parsed = False
         self._gguf_split_index = None
+        self._is_embedding = False
+        self._embedding_pooling = "mean"
 
         try:
             canvas_seen = False
@@ -8702,6 +8711,28 @@ class LlamaCppBackend:
                 logger.info(
                     f"GGUF metadata: diffusion model detected (architecture={arch}); "
                     "will serve via the diffusion runner"
+                )
+
+            from utils.models.gguf_metadata import (
+                is_gguf_embedding_model,
+                resolve_gguf_embedding_pooling,
+            )
+
+            self._is_embedding = is_gguf_embedding_model(
+                gguf_path,
+                self._model_identifier,
+                arch,
+            )
+            if self._is_embedding:
+                self._embedding_pooling = resolve_gguf_embedding_pooling(
+                    gguf_path,
+                    arch,
+                    self._model_identifier,
+                )
+                logger.info(
+                    "GGUF metadata: embedding model detected (architecture=%s, pooling=%s)",
+                    arch,
+                    self._embedding_pooling,
                 )
 
             # Expand a scalar period straight from the GGUF first.
@@ -13084,12 +13115,20 @@ class LlamaCppBackend:
                 logger.info("Load cancelled after download phase")
                 return False
 
-            # Backstop for everything the pre-teardown probes fail open on: refuse from the
-            # header rather than watching llama-server die as "failed to start".
-            non_chat = self._non_chat_gguf_refusal(model_path)
-            if non_chat:
-                logger.error("Refusing non-chat GGUF: %s (%s)", non_chat, model_path)
-                raise ValueError(non_chat)
+            if self._is_embedding:
+                # Embedding GGUFs have no chat/spec path; skip drafter discovery so a
+                # sibling sidecar cannot pull this load back into chat mode (#8535).
+                _spec_canon = None
+                mtp_draft_path = None
+                dspark_draft_path = None
+                dflash_draft_path = None
+            else:
+                # Backstop for everything the pre-teardown probes fail open on: refuse from the
+                # header rather than watching llama-server die as "failed to start".
+                non_chat = self._non_chat_gguf_refusal(model_path)
+                if non_chat:
+                    logger.error("Refusing non-chat GGUF: %s (%s)", non_chat, model_path)
+                    raise ValueError(non_chat)
 
             # Block-diffusion GGUFs (DiffusionGemma) cannot run on llama-server;
             # serve them with the diffusion runner (same OpenAI-compat interface).
@@ -15022,6 +15061,8 @@ class LlamaCppBackend:
                 # when the binary advertises it (older/custom binaries may not).
                 if server_caps.get("supports_metrics"):
                     cmd.append("--metrics")
+                if self._is_embedding:
+                    cmd.extend(["--embeddings", "--pooling", self._embedding_pooling])
                 self._slot_save_dir = None
                 self._slot_save_binary = None
                 self._prompt_cache_disabled = False
@@ -15227,24 +15268,27 @@ class LlamaCppBackend:
                             strip_template = False,
                             strip_split_mode = False,
                         )
-                spec_flags = self._build_speculative_flags(
-                    speculative_type = speculative_type,
-                    spec_draft_n_max = spec_draft_n_max,
-                    extra_args = extra_args,
-                    model_identifier = model_identifier,
-                    model_path = model_path,
-                    gpus = bool(_detected_gpus),
-                    binary = binary,
-                    mtp_draft_path = (
-                        None if _spec_canon in ("dspark", "dflash") else launch_mtp_draft_path
-                    ),
-                    dspark_draft_path = (launch_mtp_draft_path if _spec_canon == "dspark" else None),
-                    dspark_fit_sized = not use_fit,
-                    dflash_draft_path = (launch_mtp_draft_path if _spec_canon == "dflash" else None),
-                    dflash_fit_sized = not use_fit,
-                    drafter_no_vram = _spec_dropped_no_vram,
-                    draft_device = _draft_device,
-                )
+                if self._is_embedding:
+                    spec_flags = []
+                else:
+                    spec_flags = self._build_speculative_flags(
+                        speculative_type = speculative_type,
+                        spec_draft_n_max = spec_draft_n_max,
+                        extra_args = extra_args,
+                        model_identifier = model_identifier,
+                        model_path = model_path,
+                        gpus = bool(_detected_gpus),
+                        binary = binary,
+                        mtp_draft_path = (
+                            None if _spec_canon in ("dspark", "dflash") else launch_mtp_draft_path
+                        ),
+                        dspark_draft_path = (launch_mtp_draft_path if _spec_canon == "dspark" else None),
+                        dspark_fit_sized = not use_fit,
+                        dflash_draft_path = (launch_mtp_draft_path if _spec_canon == "dflash" else None),
+                        dflash_fit_sized = not use_fit,
+                        drafter_no_vram = _spec_dropped_no_vram,
+                        draft_device = _draft_device,
+                    )
                 # _build_speculative_flags judged the stripped list, so a user
                 # --spec-type the drop removed left the requested mode reading "auto"
                 # while the caller's extras still mean "the user owns it" (None).

--- a/studio/backend/tests/test_gguf_metadata.py
+++ b/studio/backend/tests/test_gguf_metadata.py
@@ -510,7 +510,10 @@ def test_resolve_gguf_embedding_pooling_defaults_by_name(tmp_path: Path):
         tmp_path / "nomic-embed.gguf",
         {"general.architecture": "nomic-bert"},
     )
-    assert resolve_gguf_embedding_pooling(str(p), "nomic-bert", "nomic-ai/nomic-embed-text-v1.5-GGUF") == "mean"
+    assert (
+        resolve_gguf_embedding_pooling(str(p), "nomic-bert", "nomic-ai/nomic-embed-text-v1.5-GGUF")
+        == "mean"
+    )
     p2 = _write_synthetic_gguf(
         tmp_path / "bge.gguf",
         {"general.architecture": "bert"},

--- a/studio/backend/tests/test_gguf_metadata.py
+++ b/studio/backend/tests/test_gguf_metadata.py
@@ -11,13 +11,17 @@ from pathlib import Path
 from typing import Iterable, Mapping
 
 from utils.models.gguf_metadata import (
+    is_gguf_embedding_architecture,
+    is_gguf_embedding_model,
     is_mmproj_by_metadata,
     mmproj_accepts_image,
     pairing_score,
     read_gguf_context_length,
     read_gguf_general_metadata,
+    read_gguf_pooling_type,
     read_gguf_staged_dims,
     read_mmproj_audio_capability,
+    resolve_gguf_embedding_pooling,
 )
 
 
@@ -454,3 +458,61 @@ def test_declared_audio_false_is_not_an_audio_claim(tmp_path: Path):
     """A vision projector writing audio=False is still a vision tower."""
     p = _projector(tmp_path, **{"clip.has_vision_encoder": True, "clip.has_audio_encoder": False})
     assert mmproj_accepts_image(p) is True
+
+
+# --- embedding GGUF helpers --------------------------------------------
+
+
+def test_is_gguf_embedding_architecture_recognises_encoder_arches():
+    assert is_gguf_embedding_architecture("nomic-bert")
+    assert is_gguf_embedding_architecture("NOMIC-BERT-MOE")
+    assert not is_gguf_embedding_architecture("llama")
+    assert not is_gguf_embedding_architecture(None)
+
+
+def test_is_gguf_embedding_model_from_architecture(tmp_path: Path):
+    p = _write_synthetic_gguf(
+        tmp_path / "nomic.gguf",
+        {"general.architecture": "nomic-bert"},
+    )
+    assert is_gguf_embedding_model(str(p)) is True
+    assert is_gguf_embedding_model(str(p), model_identifier = "org/chat-gguf") is True
+
+
+def test_is_gguf_embedding_model_from_name_hint(tmp_path: Path):
+    p = _write_synthetic_gguf(
+        tmp_path / "nomic-embed-text-v1.5-Q8_0.gguf",
+        {"general.architecture": "unknown-chat"},
+    )
+    assert is_gguf_embedding_model(str(p)) is True
+
+
+def test_read_gguf_pooling_type_maps_uint(tmp_path: Path):
+    p = _write_synthetic_gguf(
+        tmp_path / "nomic.gguf",
+        {"general.architecture": "nomic-bert-moe"},
+        extra_uint32 = {"nomic-bert-moe.pooling_type": 1},
+    )
+    assert read_gguf_pooling_type(str(p)) == "mean"
+
+
+def test_resolve_gguf_embedding_pooling_prefers_metadata(tmp_path: Path):
+    p = _write_synthetic_gguf(
+        tmp_path / "bge.gguf",
+        {"general.architecture": "bert"},
+        extra_uint32 = {"bert.pooling_type": 2},
+    )
+    assert resolve_gguf_embedding_pooling(str(p), "bert", "BAAI/bge-base-en-v1.5-GGUF") == "cls"
+
+
+def test_resolve_gguf_embedding_pooling_defaults_by_name(tmp_path: Path):
+    p = _write_synthetic_gguf(
+        tmp_path / "nomic-embed.gguf",
+        {"general.architecture": "nomic-bert"},
+    )
+    assert resolve_gguf_embedding_pooling(str(p), "nomic-bert", "nomic-ai/nomic-embed-text-v1.5-GGUF") == "mean"
+    p2 = _write_synthetic_gguf(
+        tmp_path / "bge.gguf",
+        {"general.architecture": "bert"},
+    )
+    assert resolve_gguf_embedding_pooling(str(p2), "bert", "BAAI/bge-small-en-v1.5-GGUF") == "cls"

--- a/studio/backend/utils/models/gguf_metadata.py
+++ b/studio/backend/utils/models/gguf_metadata.py
@@ -561,3 +561,116 @@ def pairing_score(
         return 60 if w_base.lower() == p_base.lower() else -1
 
     return 0
+
+
+# GGUF ``general.architecture`` values that only serve embeddings in llama.cpp.
+# Matches gguf-py MODEL_ARCH names for encoder / embedding checkpoints.
+GGUF_EMBEDDING_ARCHITECTURES: frozenset[str] = frozenset(
+    {
+        "bert",
+        "modern-bert",
+        "nomic-bert",
+        "nomic-bert-moe",
+        "neo-bert",
+        "jina-bert-v2",
+        "jina-bert-v3",
+        "eurobert",
+        "gemma-embedding",
+        "pangu-embedded",
+        "llama-embed",
+    }
+)
+
+_POOLING_TYPE_BY_CODE: dict[int, str] = {
+    0: "none",
+    1: "mean",
+    2: "cls",
+    3: "last",
+    4: "rank",
+}
+
+# Name hints for bare .gguf files whose architecture is not yet in the set above.
+_EMBEDDING_NAME_HINTS: tuple[str, ...] = (
+    "nomic-embed",
+    "embed-text",
+    "embedding",
+    "bge-",
+    "gte-",
+    "e5-",
+    "minilm",
+)
+
+
+def is_gguf_embedding_architecture(architecture: Optional[str]) -> bool:
+    """True when ``architecture`` is a dedicated llama.cpp embedding arch."""
+    return bool(architecture and architecture.strip().lower() in GGUF_EMBEDDING_ARCHITECTURES)
+
+
+def read_gguf_pooling_type(path: str) -> Optional[str]:
+    """Return the GGUF ``{arch}.pooling_type`` as a llama-server ``--pooling`` value."""
+    found = _parse_gguf_arch_uints(path, frozenset({"pooling_type"}))
+    if not found or "pooling_type" not in found:
+        return None
+    return _POOLING_TYPE_BY_CODE.get(int(found["pooling_type"]))
+
+
+def is_gguf_embedding_model(
+    gguf_path: str,
+    model_identifier: Optional[str] = None,
+    architecture: Optional[str] = None,
+) -> bool:
+    """Whether a GGUF should be launched with ``--embeddings`` for /v1/embeddings."""
+    arch = (architecture or "").strip().lower()
+    if not arch:
+        meta = read_gguf_general_metadata(gguf_path)
+        arch = ((meta or {}).get("general.architecture") or "").strip().lower()
+    if is_gguf_embedding_architecture(arch):
+        return True
+
+    if model_identifier:
+        ident = model_identifier.strip()
+        if ident:
+            try:
+                from utils.models.model_config import is_embedding_model
+
+                if is_embedding_model(ident):
+                    return True
+            except Exception:
+                pass
+            low = ident.lower()
+            if any(needle in low for needle in _EMBEDDING_NAME_HINTS):
+                return True
+
+    try:
+        low_path = Path(gguf_path).name.lower()
+        if any(needle in low_path for needle in _EMBEDDING_NAME_HINTS):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def resolve_gguf_embedding_pooling(
+    gguf_path: str,
+    architecture: Optional[str] = None,
+    model_identifier: Optional[str] = None,
+) -> str:
+    """Pick a ``--pooling`` value for an embedding GGUF load."""
+    pooling = read_gguf_pooling_type(gguf_path)
+    if pooling and pooling != "none":
+        return pooling
+
+    hints = " ".join(
+        x
+        for x in (
+            (architecture or ""),
+            model_identifier or "",
+            gguf_path,
+        )
+        if x
+    ).lower()
+    if "bge" in hints or ("bert" in hints and "nomic" not in hints):
+        return "cls"
+    if "nomic" in hints:
+        return "mean"
+    return "mean"

--- a/studio/backend/utils/models/gguf_metadata.py
+++ b/studio/backend/utils/models/gguf_metadata.py
@@ -632,7 +632,6 @@ def is_gguf_embedding_model(
         if ident:
             try:
                 from utils.models.model_config import is_embedding_model
-
                 if is_embedding_model(ident):
                     return True
             except Exception:


### PR DESCRIPTION
## Summary

Fixes #8535

When a dedicated embedding GGUF (e.g. nomic-embed, BGE) is loaded in Studio, external clients hitting the OpenAI-compatible localhost API received:

```json
{"error":{"code":501,"message":"This server does not support embeddings. Start it with --embeddings"}}
```

This change detects embedding-only GGUF architectures at load time and starts `llama-server` with `--embeddings` and an appropriate `--pooling` value.

## Changes

- Add `is_gguf_embedding_model()` / `resolve_gguf_embedding_pooling()` helpers in `gguf_metadata.py`
- Recognise llama.cpp embedding architectures (`nomic-bert`, `bert`, `gemma-embedding`, etc.)
- Pass `--embeddings --pooling <type>` when launching embedding GGUFs
- Skip speculative-decoding flags for embedding loads

## Test plan

- [x] `pytest studio/backend/tests/test_gguf_metadata.py` (34 passed)