### PR TITLE
Studio: stop an untyped Responses event killing the chat stream

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -5453,13 +5453,21 @@ class ExternalProviderClient:
                         }
                         return f"data: {_json.dumps(chunk)}"
 
+                    # The Responses type can arrive on the SSE `event:` line instead of
+                    # inside the JSON, so carry the name until the event is dispatched.
+                    event_name = ""
+
                     try:
                         while True:
                             try:
                                 line = await lines_gen.__anext__()
                             except StopAsyncIteration:
                                 break
-                            if not line or line.startswith("event:"):
+                            if not line:
+                                event_name = ""
+                                continue
+                            if line.startswith("event:"):
+                                event_name = line[len("event:") :].strip()
                                 continue
                             if not line.startswith("data:"):
                                 continue
@@ -5498,7 +5506,12 @@ class ExternalProviderClient:
                             except _json.JSONDecodeError:
                                 continue
 
-                            event_type = response_event_type(event)
+                            try:
+                                event_type = response_event_type(event, event_name)
+                            except ValueError:
+                                # An untyped payload was ignored here long before the
+                                # validator existed; raising kills the whole stream.
+                                continue
                             _record_openai_response_id(event)
 
                             if event_type == "response.output_text.delta":

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -1,3 +1,4 @@
+import ast
 import importlib.util
 import asyncio
 import hashlib
@@ -8,6 +9,7 @@ import secrets
 import sqlite3
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -781,45 +783,36 @@ def test_desktop_capabilities_json_reports_rollout_safe_flags():
     assert isinstance(body["version"], str)
 
 
-def test_health_response_reports_desktop_capability_fields(monkeypatch):
+def _stub_routes_from_main(monkeypatch):
+    """Stand `routes` up from what main.py actually imports.
+
+    A hand-listed stub goes stale the moment a router is added, and the failure is an
+    ImportError in an unrelated health test, so read the import statements instead.
+    """
+    tree = ast.parse((Path(__file__).resolve().parents[1] / "main.py").read_text(encoding = "utf-8"))
+    routers, submodules = set(), set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not node.module:
+            continue
+        if node.module == "routes":
+            routers.update(alias.name for alias in node.names)
+        elif node.module.startswith("routes."):
+            submodules.add(node.module.split(".", 1)[1])
+
     routes_module = ModuleType("routes")
     routes_module.__path__ = []
-    settings_module = ModuleType("routes.settings")
-    settings_module.router = APIRouter()
-    llama_module = ModuleType("routes.llama")
-    llama_module.router = APIRouter()
-    prompts_module = ModuleType("routes.prompts")
-    prompts_module.router = APIRouter()
-    preview_module = ModuleType("routes.preview")
-    preview_module.router = APIRouter()
-
-    for name, router in {
-        "auth_router": APIRouter(),
-        "chat_history_router": APIRouter(),
-        "data_recipe_router": APIRouter(),
-        "datasets_router": APIRouter(),
-        "export_router": APIRouter(),
-        "inference_router": APIRouter(),
-        "inference_studio_router": APIRouter(),
-        "mcp_servers_router": APIRouter(),
-        "models_router": APIRouter(),
-        "providers_router": APIRouter(),
-        "rag_router": APIRouter(),
-        "research_runs_router": APIRouter(),
-        "settings_router": settings_module.router,
-        "training_history_router": APIRouter(),
-        "training_router": APIRouter(),
-        "video_router": APIRouter(),
-    }.items():
-        setattr(routes_module, name, router)
-    routes_module.settings = settings_module
-    routes_module.llama = llama_module
-
+    for name in routers:
+        setattr(routes_module, name, APIRouter())
     monkeypatch.setitem(sys.modules, "routes", routes_module)
-    monkeypatch.setitem(sys.modules, "routes.settings", settings_module)
-    monkeypatch.setitem(sys.modules, "routes.llama", llama_module)
-    monkeypatch.setitem(sys.modules, "routes.prompts", prompts_module)
-    monkeypatch.setitem(sys.modules, "routes.preview", preview_module)
+    for name in submodules:
+        submodule = ModuleType(f"routes.{name}")
+        submodule.router = APIRouter()
+        setattr(routes_module, name, submodule)
+        monkeypatch.setitem(sys.modules, f"routes.{name}", submodule)
+
+
+def test_health_response_reports_desktop_capability_fields(monkeypatch):
+    _stub_routes_from_main(monkeypatch)
 
     import studio.backend.main as backend_main
 
@@ -828,6 +821,12 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     monkeypatch.setattr(backend_main._hw_module, "DEVICE", backend_main._hw_module.DeviceType.CPU)
     monkeypatch.setattr(backend_main._hw_module, "CHAT_ONLY", True)
     monkeypatch.setattr(backend_main._hw_module, "CHAT_ONLY_REASON", "mlx_unavailable")
+    # The verdict only ships once the event says detection settled. Set it here rather than
+    # letting the endpoint kick a real detection: that imports torch and probes the host,
+    # which does not finish inside the one-second health budget on every runner.
+    settled = threading.Event()
+    settled.set()
+    monkeypatch.setattr(backend_main._hw_module, "DETECTION_COMPLETE", settled)
 
     seed_user()
     from auth.authentication import create_access_token

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -672,7 +672,7 @@ def test_a_responses_type_on_the_sse_event_line_is_honoured(monkeypatch):
     # upstream that only sends it there used to have every delta dropped.
     chunks = _stream_openai_responses(
         monkeypatch,
-        b"event: response.output_text.delta\ndata: {\"delta\": \"hello\"}\n\n"
+        b'event: response.output_text.delta\ndata: {"delta": "hello"}\n\n'
         b"event: response.completed\ndata: {}\n\n"
         b"data: [DONE]\n\n",
     )
@@ -685,8 +685,8 @@ def test_an_untyped_responses_event_does_not_kill_the_stream(monkeypatch):
     # Raising instead loses the whole reply, including the deltas that follow.
     chunks = _stream_openai_responses(
         monkeypatch,
-        b"data: {\"choices\": [{\"delta\": {\"content\": \"ignored\"}}]}\n\n"
-        b"event: response.output_text.delta\ndata: {\"delta\": \"kept\"}\n\n"
+        b'data: {"choices": [{"delta": {"content": "ignored"}}]}\n\n'
+        b'event: response.output_text.delta\ndata: {"delta": "kept"}\n\n'
         b"data: [DONE]\n\n",
     )
 

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -635,3 +635,59 @@ def test_kimi_no_search_fallback_requests_usage(monkeypatch):
     assert "tools" in search_body
     assert "tools" not in fallback_body
     assert fallback_body["stream_options"] == {"include_usage": True}
+
+
+def _stream_openai_responses(monkeypatch, body: bytes) -> list[str]:
+    """Drive one Responses stream through the openai provider and return its chunks."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content = body,
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+    collected: list[str] = []
+
+    async def run():
+        client = _make_openai_client()
+        collected.extend(
+            await _collect(
+                client.stream_chat_completion(
+                    messages = [{"role": "user", "content": "hi"}],
+                    model = "gpt-5",
+                    max_tokens = 16,
+                )
+            )
+        )
+        await client.close()
+
+    _drive(run())
+    return collected
+
+
+def test_a_responses_type_on_the_sse_event_line_is_honoured(monkeypatch):
+    # Responses carries the type on the `event:` line as well as in the payload, and an
+    # upstream that only sends it there used to have every delta dropped.
+    chunks = _stream_openai_responses(
+        monkeypatch,
+        b"event: response.output_text.delta\ndata: {\"delta\": \"hello\"}\n\n"
+        b"event: response.completed\ndata: {}\n\n"
+        b"data: [DONE]\n\n",
+    )
+
+    assert any("hello" in chunk for chunk in chunks)
+
+
+def test_an_untyped_responses_event_does_not_kill_the_stream(monkeypatch):
+    # A payload with no type anywhere was ignored long before the type validator existed.
+    # Raising instead loses the whole reply, including the deltas that follow.
+    chunks = _stream_openai_responses(
+        monkeypatch,
+        b"data: {\"choices\": [{\"delta\": {\"content\": \"ignored\"}}]}\n\n"
+        b"event: response.output_text.delta\ndata: {\"delta\": \"kept\"}\n\n"
+        b"data: [DONE]\n\n",
+    )
+
+    assert any("kept" in chunk for chunk in chunks)


### PR DESCRIPTION
Backend CI is red on `main` and has been since #8511. Three of the four failing tests are one
bug; the fourth was already fixed by #8564.

### The Responses reader loses whole replies

`#8511` swapped the OpenAI Responses SSE reader from

```python
event_type = event.get("type")
```

to `response_event_type(event)`, which **raises** when the type is missing. The same loop
discards the SSE `event:` line, which is the other place the Responses type is carried, so there
are two ways to lose an entire reply:

* an event whose type is only on the `event:` line: `ValueError: Responses event type is missing`
  propagates out of `stream_chat_completion` and the chat dies;
* an event with no type anywhere: previously skipped, now fatal.

The `openai` provider routes to `/v1/responses` on a user-supplied `base_url`, so any proxy or
OpenAI-compatible server that puts the type on the event line takes the whole chat down. The
Codex reader in this repo already threads the event name into `response_event_type`
(`openai_codex_client.py`); this does the same for the external-provider reader and goes back to
skipping an event whose type cannot be determined.

Covered by two new tests in `tests/test_external_provider_usage_chunk.py`. Both mutation-checked:
dropping the event name reds the first, removing the skip reds the second, and each also reds one
of the tests that is failing on `main` today.

### The health capability test

`tests/test_desktop_auth.py::test_health_response_reports_desktop_capability_fields` builds a fake
`routes` package from a hand-written list of router names. `#8511` added `openai_codex_auth_router`
to `main.py`, the list did not get it, and the test dies with

```
ImportError: cannot import name 'openai_codex_auth_router' from 'routes' (unknown location)
```

Two submodules (`routes.whisper`, `routes.profile_stats`) were missing too. The stub is now built
from `main.py`'s own import statements, so the next router added cannot stale it again.

The same test also waited on real hardware detection settling inside the one second health budget
(`_HEALTH_DETECT_BUDGET_S`); `start_background_detection()` had not set `DETECTION_COMPLETE` after
12 seconds here, with or without GPUs visible, so the endpoint served the provisional reply and the
test raised `KeyError: 'chat_only_reason'`. It now marks detection settled, which is what the
`DEVICE` / `CHAT_ONLY` / `CHAT_ONLY_REASON` patches beside it were already simulating.

### Not included

`tests/test_warm_window_review_fixes.py::test_the_warm_epoch_is_retired_before_any_shutdown_await`
was the fourth red leg. It fails at `88262f590` and passes at `dac7b51a0`, so #8564 already fixed
it.

### Checks

* `tests/test_external_provider_usage_chunk.py` 23 passed, `tests/test_gemini_provider.py` and
  `tests/test_desktop_auth.py` clear of the four failures.
* Full backend suite as CI runs it: the only remaining `test_desktop_auth` failures are three
  pre-existing bootstrap-password cases that fail identically on an unmodified `main` worktree
  here. No failure in either provider test file.
* `ruff check` clean, `scripts/run_ruff_format.py` no changes.