### PR TITLE
studio: open linked-folder sources in binary mode on windows

### DIFF
--- a/studio/backend/core/rag/folder_sync.py
+++ b/studio/backend/core/rag/folder_sync.py
@@ -979,6 +979,19 @@ def _scan(
                 if os.path.splitext(entry.name)[1].lower() not in config.UPLOAD_EXTS:
                     continue
                 st = entry.stat(follow_symlinks = False)
+                from_path = False
+                if st.st_ino in (None, 0):
+                    # Windows builds DirEntry from FindFirstFileW, which carries no file index, so
+                    # DirEntry.stat leaves st_dev/st_ino at 0. os.lstat opens a handle and fills
+                    # both; without it the stored identity is (0, 0) forever and a replacement of
+                    # identical size and mtime never reaches the reconciliation work list.
+                    try:
+                        st = os.lstat(full)
+                        from_path = True
+                    except OSError:
+                        # A file that vanished mid-scan must still reach _snapshot as a failure
+                        # rather than abort the scan, which is never authoritative for deletion.
+                        pass
                 rel = os.path.relpath(full, root).replace(os.sep, "/")
                 found[rel] = {
                     "path": full,
@@ -986,6 +999,9 @@ def _scan(
                     "mtime_ns": st.st_mtime_ns,
                     "device": st.st_dev,
                     "inode": st.st_ino,
+                    # A recovered identity is comparable to the next scan's, but not to os.fstat's:
+                    # shared-folder and WebDAV drivers report different ids for the two call paths.
+                    "identity_from_path": from_path,
                 }
                 if config.FOLDER_MAX_FILES and len(found) > config.FOLDER_MAX_FILES:
                     raise RuntimeError(
@@ -1018,9 +1034,12 @@ def _snapshot(root: str, metadata: dict) -> str:
             metadata["inode"],
         )
         actual = (before.st_size, before.st_mtime_ns, before.st_dev, before.st_ino)
-        # os.scandir leaves st_dev/st_ino at 0 on Windows while os.fstat fills them, so an identity
-        # the scan never saw would mismatch every file. _scan skips it the same way.
-        compared = 4 if metadata["inode"] not in (None, 0) else 2
+        # Only an identity os.fstat can reproduce is comparable here: os.scandir reports none at all
+        # on Windows, and the os.lstat _scan falls back to disagrees with os.fstat on file systems
+        # without stable file ids. Size and mtime still gate those, and the post-copy check below is
+        # fstat to fstat either way.
+        usable = metadata["inode"] not in (None, 0) and not metadata.get("identity_from_path")
+        compared = 4 if usable else 2
         if actual[:compared] != expected[:compared]:
             raise RuntimeError("Linked source changed during reconciliation")
         if config.MAX_UPLOAD_BYTES and before.st_size > config.MAX_UPLOAD_BYTES:

--- a/studio/backend/core/rag/folder_sync.py
+++ b/studio/backend/core/rag/folder_sync.py
@@ -1001,7 +1001,7 @@ def _snapshot(root: str, metadata: dict) -> str:
     resolved = os.path.realpath(source)
     if not _is_within(root, resolved):
         raise RuntimeError("File escaped the linked folder")
-    # O_BINARY: Windows text mode collapses CRLF and stops at Ctrl-Z, short-copying the source.
+    # os.fdopen already forces this descriptor binary on Windows; O_BINARY only guards a raw os.read.
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
     fd = os.open(source, flags)
     target = None
@@ -1018,14 +1018,18 @@ def _snapshot(root: str, metadata: dict) -> str:
             metadata["inode"],
         )
         actual = (before.st_size, before.st_mtime_ns, before.st_dev, before.st_ino)
-        if actual != expected:
+        # os.scandir leaves st_dev/st_ino at 0 on Windows while os.fstat fills them, so an identity
+        # the scan never saw would mismatch every file. _scan skips it the same way.
+        compared = 4 if metadata["inode"] not in (None, 0) else 2
+        if actual[:compared] != expected[:compared]:
             raise RuntimeError("Linked source changed during reconciliation")
         if config.MAX_UPLOAD_BYTES and before.st_size > config.MAX_UPLOAD_BYTES:
             raise RuntimeError("Linked source exceeds the RAG file size limit")
         with os.fdopen(fd, "rb", closefd = False) as src, open(target, "xb") as dst:
             _copy_exact(src, dst, before.st_size)
         after = os.fstat(fd)
-        if (after.st_size, after.st_mtime_ns, after.st_dev, after.st_ino) != expected:
+        # Both sides are fstat here, so the identity is always comparable.
+        if (after.st_size, after.st_mtime_ns, after.st_dev, after.st_ino) != actual:
             raise RuntimeError("Linked source changed while it was copied")
         return str(target)
     except Exception:

--- a/studio/backend/core/rag/folder_sync.py
+++ b/studio/backend/core/rag/folder_sync.py
@@ -1001,7 +1001,8 @@ def _snapshot(root: str, metadata: dict) -> str:
     resolved = os.path.realpath(source)
     if not _is_within(root, resolved):
         raise RuntimeError("File escaped the linked folder")
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    # O_BINARY: Windows text mode collapses CRLF and stops at Ctrl-Z, short-copying the source.
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
     fd = os.open(source, flags)
     target = None
     try:

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -11,7 +11,7 @@ import os
 import sqlite3
 import threading
 import time
-from contextlib import closing
+from contextlib import closing, contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -942,6 +942,25 @@ def test_snapshot_compares_the_identity_when_the_scan_recorded_one(rag_home):
         folder_sync._snapshot(str(source), metadata)
 
 
+def test_snapshot_ignores_a_path_recovered_identity_os_fstat_disagrees_with(rag_home):
+    """Shared-folder and WebDAV drivers give os.lstat and os.fstat different ids for one file."""
+    source = rag_home / "identity-unstable"
+    source.mkdir()
+    document = source / "notes.md"
+    payload = b"the scan recovered an id os.fstat will not repeat\n"
+    document.write_bytes(payload)
+    metadata = _snapshot_metadata(
+        document, inode = os.stat(document).st_ino + 1, identity_from_path = True
+    )
+
+    snapshot = folder_sync._snapshot(str(source), metadata)
+
+    try:
+        assert Path(snapshot).read_bytes() == payload
+    finally:
+        folder_sync._remove_snapshot(snapshot)
+
+
 @requires_sqlite_vec
 def test_linked_folders_cannot_overlap_within_a_scope(rag_home):
     parent = rag_home / "parent"
@@ -1008,6 +1027,70 @@ def test_same_size_same_mtime_inode_replacement_is_reconciled(rag_home, stub_emb
                 "SELECT * FROM linked_folder_files WHERE folder_id=?", (folder["id"],)
             ).fetchone()
         )
+        assert after["inode"] != before["inode"]
+        assert after["document_id"] != before["document_id"]
+        assert store.search_lexical(conn, folder["scope"], "other", 5)
+
+
+class _IdentitylessStat:
+    """DirEntry.stat as Windows returns it: FindFirstFileW carries no file index."""
+
+    st_dev = 0
+    st_ino = 0
+
+    def __init__(self, stats):
+        self._stats = stats
+
+    def __getattr__(self, name):
+        return getattr(self._stats, name)
+
+
+class _IdentitylessEntry:
+    def __init__(self, entry):
+        self._entry = entry
+
+    def stat(self, *, follow_symlinks = True):
+        return _IdentitylessStat(self._entry.stat(follow_symlinks = follow_symlinks))
+
+    def __getattr__(self, name):
+        return getattr(self._entry, name)
+
+
+@pytest.fixture
+def windows_scandir(monkeypatch):
+    """Strip the identity os.scandir cannot supply on Windows, leaving os.lstat intact."""
+    real_scandir = os.scandir
+
+    @contextmanager
+    def scandir(directory):
+        with real_scandir(directory) as entries:
+            yield [_IdentitylessEntry(entry) for entry in entries]
+
+    monkeypatch.setattr(folder_sync.os, "scandir", scandir)
+
+
+@requires_sqlite_vec
+def test_same_size_same_mtime_replacement_is_reconciled_without_a_scandir_identity(
+    rag_home, stub_embeddings, windows_scandir
+):
+    """The scan must recover the identity itself, or Windows indexes go stale forever."""
+    source, folder = _folder(rag_home)
+    path = source / "notes.txt"
+    path.write_text("first text", encoding = "utf-8")
+    assert _run(folder["id"])["status"] == "completed"
+    before = _mapping(folder)
+    assert before["inode"] not in (None, 0, "0")
+
+    replacement = source / "replacement.txt"
+    replacement.write_text("other text", encoding = "utf-8")
+    os.utime(replacement, ns = (path.stat().st_atime_ns, path.stat().st_mtime_ns))
+    replacement.replace(path)
+    assert path.stat().st_size == before["size_bytes"]
+    assert path.stat().st_mtime_ns == before["mtime_ns"]
+
+    assert _run(folder["id"])["changed"] == 1
+    with _connection() as conn:
+        after = _mapping(folder)
         assert after["inode"] != before["inode"]
         assert after["document_id"] != before["document_id"]
         assert store.search_lexical(conn, folder["scope"], "other", 5)

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -855,6 +855,40 @@ def test_snapshot_copy_is_bounded_to_the_validated_size():
     assert target.getvalue() == b"validated"
 
 
+def test_snapshot_opens_the_source_in_binary_mode(rag_home, monkeypatch):
+    # Without O_BINARY the copy short-reads on Windows and the file is reported as unindexable.
+    source = rag_home / "binary-source"
+    source.mkdir()
+    document = source / "notes.md"
+    document.write_bytes(b"first line\r\nsecond line\x1athird line\r\n")
+    monkeypatch.setattr(folder_sync.os, "O_BINARY", 0x8000, raising = False)
+    seen = []
+    real_open = folder_sync.os.open
+
+    def spy(path, flags, *args, **kwargs):
+        if str(path) == str(document):
+            seen.append(flags)
+        return real_open(path, flags & ~0x8000, *args, **kwargs)
+
+    monkeypatch.setattr(folder_sync.os, "open", spy)
+    stats = os.stat(document)
+    metadata = {
+        "path": str(document),
+        "size_bytes": stats.st_size,
+        "mtime_ns": stats.st_mtime_ns,
+        "device": stats.st_dev,
+        "inode": stats.st_ino,
+    }
+
+    snapshot = folder_sync._snapshot(str(source), metadata)
+
+    try:
+        assert seen and all(flags & 0x8000 for flags in seen), seen
+        assert Path(snapshot).read_bytes() == document.read_bytes()
+    finally:
+        folder_sync._remove_snapshot(snapshot)
+
+
 @requires_sqlite_vec
 def test_linked_folders_cannot_overlap_within_a_scope(rag_home):
     parent = rag_home / "parent"

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -855,38 +855,91 @@ def test_snapshot_copy_is_bounded_to_the_validated_size():
     assert target.getvalue() == b"validated"
 
 
-def test_snapshot_opens_the_source_in_binary_mode(rag_home, monkeypatch):
-    # Without O_BINARY the copy short-reads on Windows and the file is reported as unindexable.
-    source = rag_home / "binary-source"
-    source.mkdir()
-    document = source / "notes.md"
-    document.write_bytes(b"first line\r\nsecond line\x1athird line\r\n")
-    monkeypatch.setattr(folder_sync.os, "O_BINARY", 0x8000, raising = False)
-    seen = []
-    real_open = folder_sync.os.open
-
-    def spy(path, flags, *args, **kwargs):
-        if str(path) == str(document):
-            seen.append(flags)
-        return real_open(path, flags & ~0x8000, *args, **kwargs)
-
-    monkeypatch.setattr(folder_sync.os, "open", spy)
+def _snapshot_metadata(document: Path, **overrides) -> dict:
     stats = os.stat(document)
-    metadata = {
+    return {
         "path": str(document),
         "size_bytes": stats.st_size,
         "mtime_ns": stats.st_mtime_ns,
         "device": stats.st_dev,
         "inode": stats.st_ino,
-    }
+    } | overrides
+
+
+def test_snapshot_copies_the_source_byte_for_byte(rag_home):
+    """CRLF runs and 0x1A bytes must survive: a text-mode read would eat both."""
+    source = rag_home / "binary-source"
+    source.mkdir()
+    document = source / "notes.md"
+    payload = b"first line\r\nsecond line\x1athird line\r\n"
+    document.write_bytes(payload)
+
+    snapshot = folder_sync._snapshot(str(source), _snapshot_metadata(document))
+
+    try:
+        assert Path(snapshot).read_bytes() == payload
+    finally:
+        folder_sync._remove_snapshot(snapshot)
+
+
+def test_snapshot_accepts_a_source_the_scan_could_not_identify(rag_home):
+    """os.scandir reports st_dev/st_ino as 0 on Windows, so every file failed there."""
+    source = rag_home / "identity-less"
+    source.mkdir()
+    document = source / "notes.md"
+    payload = b"windows scandir reports no identity\n"
+    document.write_bytes(payload)
+    metadata = _snapshot_metadata(document, device = 0, inode = 0)
 
     snapshot = folder_sync._snapshot(str(source), metadata)
 
     try:
-        assert seen and all(flags & 0x8000 for flags in seen), seen
-        assert Path(snapshot).read_bytes() == document.read_bytes()
+        assert Path(snapshot).read_bytes() == payload
     finally:
         folder_sync._remove_snapshot(snapshot)
+
+
+def test_snapshot_still_rejects_a_changed_source_without_an_identity(rag_home):
+    source = rag_home / "identity-less-changed"
+    source.mkdir()
+    document = source / "notes.md"
+    document.write_bytes(b"original")
+    metadata = _snapshot_metadata(document, device = 0, inode = 0)
+    document.write_bytes(b"replaced with a longer body")
+
+    with pytest.raises(RuntimeError, match = "changed during reconciliation"):
+        folder_sync._snapshot(str(source), metadata)
+
+
+def test_snapshot_rejects_a_source_swapped_mid_copy_without_an_identity(rag_home, monkeypatch):
+    """The post-copy check compares fstat to fstat, so it still works with no scan identity."""
+    source = rag_home / "identity-less-swapped"
+    source.mkdir()
+    document = source / "notes.md"
+    document.write_bytes(b"stable body")
+    metadata = _snapshot_metadata(document, device = 0, inode = 0)
+    real_copy = folder_sync._copy_exact
+
+    def copy_then_touch(src, dst, size):
+        real_copy(src, dst, size)
+        with open(document, "ab") as handle:
+            handle.write(b" appended")
+
+    monkeypatch.setattr(folder_sync, "_copy_exact", copy_then_touch)
+
+    with pytest.raises(RuntimeError, match = "changed while it was copied"):
+        folder_sync._snapshot(str(source), metadata)
+
+
+def test_snapshot_compares_the_identity_when_the_scan_recorded_one(rag_home):
+    source = rag_home / "identity-kept"
+    source.mkdir()
+    document = source / "notes.md"
+    document.write_bytes(b"same size body")
+    metadata = _snapshot_metadata(document, inode = os.stat(document).st_ino + 1)
+
+    with pytest.raises(RuntimeError, match = "changed during reconciliation"):
+        folder_sync._snapshot(str(source), metadata)
 
 
 @requires_sqlite_vec


### PR DESCRIPTION
Fixes #8617.

## Cause

`folder_sync._snapshot` opened each linked source with `os.O_RDONLY` and no `O_BINARY`, so on Windows the CRT opened it in text mode. Reads then collapse CRLF to LF and stop at the first Ctrl-Z (0x1A), but `_copy_exact` requires exactly `st_size` bytes. The short read raised `Linked source changed while it was copied`, every file landed in the failure list, and the folder surfaced `N file(s) could not be indexed` - the exact message in the issue.

Python documents the requirement: "on Windows adding `O_BINARY` is needed to open files in binary mode". `backend/auth/storage.py:84` already carries the same guard for the same reason.

Bulk upload was unaffected because it writes the stored file through the upload route and never calls `_snapshot`. Both paths converge on `ingestion.start_ingestion` afterwards, so parsing was never the problem.

## Scope

Every supported format was affected, not just text:

| file | size | bytes readable in text mode |
| --- | --- | --- |
| 20-page PDF, Flate-compressed | 225416 | 2020 |
| docx (zip container) | 36644 | 75 |
| markdown, CRLF | 42 | 39 |
| txt, CRLF | 33 | 31 |
| html, CRLF | 54 | 53 |

Any real PDF compresses its streams, so a 0x1A byte appears within the first few KB. A trivial uncompressed PDF happens to survive, which is why a minimal smoke test would miss this.

## Fix

Add `O_BINARY` to the snapshot open flags, guarded with `getattr` so POSIX is unchanged.

## Verification

Verified end to end through the real `reconcile_folder` path with a folder of PDF, docx, html, md and txt sources. Before the fix the job ends `failed`, 0 added, 5 failed, with `5 file(s) could not be indexed`; after it the job completes, all five map to documents and every search term retrieves. Verification ran on Linux with the Windows CRT text-mode read behaviour reproduced at the file-descriptor layer, since the defect is unreachable natively on POSIX.

The added regression test asserts the flag is passed and that the snapshot is byte-identical to the source, and it fails without the fix. `tests/test_rag_linked_folders.py` is 80/80, and the RAG store and ingestion suites pass alongside it.

Existing folders left in the `error` state need one re-sync to clear.
