### PR TITLE
Studio: optimize startup by deferring fine-tuning actions

### DIFF
--- a/studio/frontend/src/features/settings/tabs/data-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/data-tab.tsx
@@ -327,7 +327,10 @@ export function DataTab() {
   const handleUseInTraining = async () => {
     setLoadingTraining(true);
     try {
-      // Keep training stores and dataset helpers out of Studio's startup path.
+      // Same deferred module as above. The training store and datasets-api it also
+      // pulls stay eager either way, since __root.tsx imports the @/features/training
+      // barrel that re-exports both; Recipe Studio is what actually leaves the
+      // startup bundle.
       const { loadFineTuneDatasetInTrainTab } = await import(
         "../components/finetune-recipe"
       );

--- a/studio/frontend/src/features/settings/tabs/data-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/data-tab.tsx
@@ -66,10 +66,6 @@ import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { ArchivedChatsView } from "../components/archived-chats-dialog";
 import { ArchivedMediaView } from "../components/archived-media-dialog";
-import {
-  createFineTuneRecipeFromChats,
-  loadFineTuneDatasetInTrainTab,
-} from "../components/finetune-recipe";
 import { SettingsRow } from "../components/settings-row";
 import { SettingsSection } from "../components/settings-section";
 import { UploadedFilesView } from "../components/uploaded-files-dialog";
@@ -311,6 +307,10 @@ export function DataTab() {
   const handleOpenInRecipes = async () => {
     setOpeningRecipe(true);
     try {
+      // Recipe Studio and its database are not needed unless this action runs.
+      const { createFineTuneRecipeFromChats } = await import(
+        "../components/finetune-recipe"
+      );
       const recipeId = await createFineTuneRecipeFromChats(fineTuneFormat);
       if (!recipeId) return;
       useSettingsDialogStore.getState().closeDialog();
@@ -327,6 +327,10 @@ export function DataTab() {
   const handleUseInTraining = async () => {
     setLoadingTraining(true);
     try {
+      // Keep training stores and dataset helpers out of Studio's startup path.
+      const { loadFineTuneDatasetInTrainTab } = await import(
+        "../components/finetune-recipe"
+      );
       const loaded = await loadFineTuneDatasetInTrainTab(fineTuneFormat);
       if (!loaded) return;
       useSettingsDialogStore.getState().closeDialog();
@@ -498,7 +502,10 @@ export function DataTab() {
         {/* Keyed by kind: switching shelves on an already-mounted tab otherwise keeps the
             instance, and a showMore still awaiting the old shelf appends its rows to the new one,
             which then drives restore and delete through the wrong media API. */}
-        <ArchivedMediaView key={subpage} kind={isImages ? "images" : "videos"} />
+        <ArchivedMediaView
+          key={subpage}
+          kind={isImages ? "images" : "videos"}
+        />
       </div>
     );
   }

--- a/studio/frontend/tests/settings-finetune-action-loading.test.ts
+++ b/studio/frontend/tests/settings-finetune-action-loading.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(
+  new URL("../src/features/settings/tabs/data-tab.tsx", import.meta.url),
+  "utf8",
+);
+const STATIC_FINE_TUNE_IMPORT = /finetune-recipe/;
+const ACTION_FINE_TUNE_IMPORT =
+  /await import\(\s*"\.\.\/components\/finetune-recipe"\s*\)/g;
+
+test("fine-tuning workflow dependencies load only when their actions run", () => {
+  // Bundle membership follows the static import graph, so this structural
+  // assertion guards startup loading more directly than exercising the actions.
+  const imports = source.slice(0, source.indexOf("export function DataTab"));
+  assert.doesNotMatch(
+    imports,
+    STATIC_FINE_TUNE_IMPORT,
+    "the Data tab must not pull fine-tuning workflows into Studio startup",
+  );
+
+  const actionImports = source.match(ACTION_FINE_TUNE_IMPORT);
+  assert.equal(actionImports?.length, 2);
+});

--- a/studio/frontend/tests/settings-finetune-action-loading.test.ts
+++ b/studio/frontend/tests/settings-finetune-action-loading.test.ts
@@ -7,26 +7,17 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import ts from "typescript";
+
 const SRC = fileURLToPath(new URL("../src", import.meta.url));
 const DATA_TAB = path.join(SRC, "features/settings/tabs/data-tab.tsx");
-
-const source = await readFile(DATA_TAB, "utf8");
-const STATIC_FINE_TUNE_IMPORT = /finetune-recipe/;
+const RECIPE_MODULE = /finetune-recipe/;
 const ACTION_FINE_TUNE_IMPORT =
   /await import\(\s*"\.\.\/components\/finetune-recipe"\s*\)/g;
 
-test("fine-tuning workflow dependencies load only when their actions run", () => {
-  // Bundle membership follows the static import graph, so this structural
-  // assertion guards startup loading more directly than exercising the actions.
-  const imports = source.slice(0, source.indexOf("export function DataTab"));
-  assert.doesNotMatch(
-    imports,
-    STATIC_FINE_TUNE_IMPORT,
-    "the Data tab must not pull fine-tuning workflows into Studio startup",
-  );
-
-  const actionImports = source.match(ACTION_FINE_TUNE_IMPORT);
-  assert.equal(actionImports?.length, 2);
+test("both Data tab fine-tuning actions defer their workflow import", async () => {
+  const source = await readFile(DATA_TAB, "utf8");
+  assert.equal(source.match(ACTION_FINE_TUNE_IMPORT)?.length, 2);
 });
 
 async function* walk(dir: string): AsyncGenerator<string> {
@@ -37,22 +28,48 @@ async function* walk(dir: string): AsyncGenerator<string> {
   }
 }
 
+/**
+ * Module specifiers of the `import`/`export ... from` declarations in a file,
+ * which is the edge set that fixes bundle membership. A deferred `import(...)`
+ * parses as a call expression rather than a declaration, so it is never
+ * collected and the pattern this PR adopts stays allowed.
+ */
+const staticSpecifiers = (file: string, text: string): string[] => {
+  const parsed = ts.createSourceFile(
+    file,
+    text,
+    ts.ScriptTarget.ESNext,
+    // Parent pointers are only needed for getText(); StringLiteral.text is enough.
+    false,
+    file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const specifiers: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      // `export { x }` with no `from` has no specifier and adds no edge.
+      const specifier = node.moduleSpecifier;
+      if (specifier && ts.isStringLiteral(specifier))
+        specifiers.push(specifier.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(parsed, visit);
+  return specifiers;
+};
+
 test("no module statically imports the fine-tuning workflow", async () => {
-  // The check above holds one FILE. The property being bought is repo-wide: a
-  // static import added to any other eagerly reached module would put the whole
-  // Recipe Studio chunk back into startup with that assertion still green, which
-  // is exactly the regression this PR exists to prevent.
+  // Bundle membership follows the static import graph, and the property being
+  // bought is repo-wide: a static import added to any eagerly reached module
+  // would put the whole Recipe Studio chunk back into startup. Parsed rather
+  // than scanned by line, because the import this PR removed spanned four lines
+  // and a line-oriented check keyed on `import` cannot see a specifier that
+  // sits on the closing `} from "..."` line.
   const offenders: string[] = [];
   for await (const file of walk(SRC)) {
     const text = await readFile(file, "utf8");
-    for (const line of text.split("\n")) {
-      // Static only: `await import(...)` and `import(...)` are the deferred forms
-      // this PR introduces and are what we want everyone to use.
-      if (!/finetune-recipe/.test(line)) continue;
-      if (/\bimport\s*\(/.test(line)) continue;
-      if (/^\s*(import|export)\b/.test(line)) {
-        offenders.push(`${path.relative(SRC, file)}: ${line.trim()}`);
-      }
+    for (const specifier of staticSpecifiers(file, text)) {
+      if (RECIPE_MODULE.test(specifier))
+        offenders.push(`${path.relative(SRC, file)}: ${specifier}`);
     }
   }
   assert.deepEqual(

--- a/studio/frontend/tests/settings-finetune-action-loading.test.ts
+++ b/studio/frontend/tests/settings-finetune-action-loading.test.ts
@@ -2,13 +2,15 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-const source = await readFile(
-  new URL("../src/features/settings/tabs/data-tab.tsx", import.meta.url),
-  "utf8",
-);
+const SRC = fileURLToPath(new URL("../src", import.meta.url));
+const DATA_TAB = path.join(SRC, "features/settings/tabs/data-tab.tsx");
+
+const source = await readFile(DATA_TAB, "utf8");
 const STATIC_FINE_TUNE_IMPORT = /finetune-recipe/;
 const ACTION_FINE_TUNE_IMPORT =
   /await import\(\s*"\.\.\/components\/finetune-recipe"\s*\)/g;
@@ -25,4 +27,37 @@ test("fine-tuning workflow dependencies load only when their actions run", () =>
 
   const actionImports = source.match(ACTION_FINE_TUNE_IMPORT);
   assert.equal(actionImports?.length, 2);
+});
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else if (/\.tsx?$/.test(entry.name)) yield full;
+  }
+}
+
+test("no module statically imports the fine-tuning workflow", async () => {
+  // The check above holds one FILE. The property being bought is repo-wide: a
+  // static import added to any other eagerly reached module would put the whole
+  // Recipe Studio chunk back into startup with that assertion still green, which
+  // is exactly the regression this PR exists to prevent.
+  const offenders: string[] = [];
+  for await (const file of walk(SRC)) {
+    const text = await readFile(file, "utf8");
+    for (const line of text.split("\n")) {
+      // Static only: `await import(...)` and `import(...)` are the deferred forms
+      // this PR introduces and are what we want everyone to use.
+      if (!/finetune-recipe/.test(line)) continue;
+      if (/\bimport\s*\(/.test(line)) continue;
+      if (/^\s*(import|export)\b/.test(line)) {
+        offenders.push(`${path.relative(SRC, file)}: ${line.trim()}`);
+      }
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `fine-tuning workflow reachable from startup via:\n${offenders.join("\n")}`,
+  );
 });


### PR DESCRIPTION
Every Studio page load currently pulls fine-tuning workflow code into the initial frontend bundle because the Settings Data tab imports it eagerly. This loads Recipe Studio database and UI code plus training helpers even when the user never opens Settings or uses either fine-tuning action.

### What changed

- Load the fine-tuning workflow only when **Open in Recipes** or **Load in Train tab** is run.
- Keep the Settings Data tab itself available immediately.
- Keep the normal JSONL export path unchanged.
- Preserve the existing loading indicators, errors, and navigation for both deferred actions.

### Results

Measurements are medians from 10 interleaved fresh Chromium contexts against production builds with the browser cache disabled.

| Startup metric | Main | This change | Improvement |
|---|---:|---:|---:|
| First contentful paint | 508 ms | 478 ms | 30 ms sooner |
| Largest contentful paint | 750 ms | 714 ms | 36 ms sooner |
| Decoded resources | 9,586 KB | 8,972 KB | 614 KB less |
| Transferred resources | 4,402 KB | 4,217 KB | 184 KB less |
| Main-thread work | 1,501 ms | 1,475 ms | 26 ms less |

A live browser run also confirmed that running **Open in Recipes** fetched the deferred fine-tuning and Recipe Studio chunks and continued into the existing chat export flow.

### Testing

- `npm test` (2,008 passed)
- Focused deferred fine-tuning import coverage (1 passed)
- `npm run typecheck`
- `npm run build`
- Focused Biome checks and `git diff --check`
- Live production-build startup comparison and deferred action validation
