### PR TITLE
fix grouped_gemm crash on the documented gather_indices=None default

### DIFF
--- a/tests/test_grouped_gemm_optional_gather_indices.py
+++ b/tests/test_grouped_gemm_optional_gather_indices.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""`grouped_gemm(gather_indices = None)` must survive when nothing permutes.
+
+The signature defaults `gather_indices` to None and the wrapper only asserts it
+is present when `permute_x` or `permute_y` is set, but it then normalised it
+with an unconditional `gather_indices.view(-1)`, so the documented default died
+with `AttributeError: 'NoneType' object has no attribute 'view'` (#8627). The
+same unconditional dereference sat in `grouped_gemm_dX`, which reads
+`gather_indices.shape[0]` to size dX, so the backward pass failed identically
+once the forward was fixed.
+
+Calling the kernel on activations that are already in expert-contiguous order is
+a documented use of `permute_x = False`, and none of the three Triton kernels
+touch `gather_indices_ptr` outside their `PERMUTE_X or PERMUTE_Y` branches, so
+the caller should not have to pass a `torch.arange` the kernel never reads.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import torch  # noqa: E402
+
+pytest.importorskip("triton", reason = "the grouped GEMM is a Triton kernel")
+
+try:
+    from unsloth.kernels.moe.grouped_gemm.interface import grouped_gemm
+except Exception as exc:  # pragma: no cover - depends on the installed stack
+    pytest.skip(f"grouped_gemm is unimportable here: {exc}", allow_module_level = True)
+
+
+CUDA = torch.cuda.is_available()
+requires_cuda = pytest.mark.skipif(not CUDA, reason = "grouped GEMM needs a real CUDA device")
+
+NUM_EXPERTS = 2
+TOKENS_PER_EXPERT = 4
+TOTAL_TOKENS = NUM_EXPERTS * TOKENS_PER_EXPERT
+# The dX and dW kernels static_assert that N and K divide the autotuned block
+# sizes, and those go up to 256.
+N = K = 256
+
+
+def _operands(device, requires_grad = False):
+    X = torch.randn(TOTAL_TOKENS, K, device = device, dtype = torch.bfloat16)
+    W = torch.randn(NUM_EXPERTS, N, K, device = device, dtype = torch.bfloat16)
+    m_sizes = torch.full((NUM_EXPERTS,), TOKENS_PER_EXPERT, device = device, dtype = torch.int32)
+    return X.requires_grad_(requires_grad), W.requires_grad_(requires_grad), m_sizes
+
+
+# ---- the contract, without a GPU ----------------------------------------
+
+
+def test_the_default_survives_the_wrapper_when_nothing_permutes():
+    """On CPU the call has to die inside `grouped_gemm_forward` on its device
+    assert. An AttributeError instead means the wrapper dereferenced None."""
+    X, W, m_sizes = _operands("cpu")
+    with pytest.raises(AssertionError, match = "must be on CUDA"):
+        grouped_gemm(
+            X = X,
+            W = W,
+            m_sizes = m_sizes,
+            topk = 1,
+            permute_x = False,
+            permute_y = False,
+            autotune = True,
+        )
+
+
+@pytest.mark.parametrize("permute_x, permute_y", [(True, False), (False, True)])
+def test_permuting_without_indices_still_fails_with_the_explicit_message(permute_x, permute_y):
+    """The guard is the whole reason the parameter can be optional, so it must
+    keep firing ahead of anything that would dereference None."""
+    X, W, m_sizes = _operands("cpu")
+    with pytest.raises(AssertionError, match = "gather_indices is required"):
+        grouped_gemm(
+            X = X,
+            W = W,
+            m_sizes = m_sizes,
+            topk = 1,
+            permute_x = permute_x,
+            permute_y = permute_y,
+            autotune = True,
+        )
+
+
+# ---- the numerics, on a real device --------------------------------------
+
+
+@requires_cuda
+def test_forward_matches_the_dummy_index_workaround():
+    """`torch.arange(total_tokens)` is what callers pass today to get past the
+    crash, and the kernel never reads it, so both paths must agree exactly."""
+    X, W, m_sizes = _operands("cuda")
+    dummy = torch.arange(TOTAL_TOKENS, device = "cuda", dtype = torch.int32)
+
+    without = grouped_gemm(
+        X = X, W = W, m_sizes = m_sizes, topk = 1,
+        permute_x = False, permute_y = False, autotune = True,
+    )
+    with_dummy = grouped_gemm(
+        X = X, W = W, m_sizes = m_sizes, topk = 1, gather_indices = dummy,
+        permute_x = False, permute_y = False, autotune = True,
+    )
+
+    assert without.shape == (TOTAL_TOKENS, N)
+    assert torch.equal(without, with_dummy)
+
+    reference = torch.cat(
+        [
+            X[e * TOKENS_PER_EXPERT : (e + 1) * TOKENS_PER_EXPERT] @ W[e].T
+            for e in range(NUM_EXPERTS)
+        ]
+    )
+    torch.testing.assert_close(without, reference)
+
+
+@requires_cuda
+def test_backward_matches_the_dummy_index_workaround():
+    """`grouped_gemm_dX` sized its output off `gather_indices.shape[0]`, so the
+    backward pass has to be exercised separately from the forward."""
+    grads = {}
+    for name, gather_indices in (
+        ("none", None),
+        ("dummy", torch.arange(TOTAL_TOKENS, device = "cuda", dtype = torch.int32)),
+    ):
+        torch.manual_seed(0)
+        X, W, m_sizes = _operands("cuda", requires_grad = True)
+        grouped_gemm(
+            X = X, W = W, m_sizes = m_sizes, topk = 1, gather_indices = gather_indices,
+            permute_x = False, permute_y = False, autotune = True,
+        ).sum().backward()
+        grads[name] = (X.grad, W.grad)
+
+    assert torch.equal(grads["none"][0], grads["dummy"][0])
+    assert torch.equal(grads["none"][1], grads["dummy"][1])
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_grouped_gemm_optional_gather_indices.py
+++ b/tests/test_grouped_gemm_optional_gather_indices.py
@@ -100,12 +100,23 @@ def test_forward_matches_the_dummy_index_workaround():
     dummy = torch.arange(TOTAL_TOKENS, device = "cuda", dtype = torch.int32)
 
     without = grouped_gemm(
-        X = X, W = W, m_sizes = m_sizes, topk = 1,
-        permute_x = False, permute_y = False, autotune = True,
+        X = X,
+        W = W,
+        m_sizes = m_sizes,
+        topk = 1,
+        permute_x = False,
+        permute_y = False,
+        autotune = True,
     )
     with_dummy = grouped_gemm(
-        X = X, W = W, m_sizes = m_sizes, topk = 1, gather_indices = dummy,
-        permute_x = False, permute_y = False, autotune = True,
+        X = X,
+        W = W,
+        m_sizes = m_sizes,
+        topk = 1,
+        gather_indices = dummy,
+        permute_x = False,
+        permute_y = False,
+        autotune = True,
     )
 
     assert without.shape == (TOTAL_TOKENS, N)
@@ -132,8 +143,14 @@ def test_backward_matches_the_dummy_index_workaround():
         torch.manual_seed(0)
         X, W, m_sizes = _operands("cuda", requires_grad = True)
         grouped_gemm(
-            X = X, W = W, m_sizes = m_sizes, topk = 1, gather_indices = gather_indices,
-            permute_x = False, permute_y = False, autotune = True,
+            X = X,
+            W = W,
+            m_sizes = m_sizes,
+            topk = 1,
+            gather_indices = gather_indices,
+            permute_x = False,
+            permute_y = False,
+            autotune = True,
         ).sum().backward()
         grads[name] = (X.grad, W.grad)
 

--- a/tests/test_grouped_gemm_optional_gather_indices.py
+++ b/tests/test_grouped_gemm_optional_gather_indices.py
@@ -132,9 +132,15 @@ def test_forward_matches_the_dummy_index_workaround():
 
 
 @requires_cuda
-def test_backward_matches_the_dummy_index_workaround():
+@pytest.mark.parametrize("topk", [1, 2, 4])
+def test_backward_matches_the_dummy_index_workaround(topk):
     """`grouped_gemm_dX` sized its output off `gather_indices.shape[0]`, so the
-    backward pass has to be exercised separately from the forward."""
+    backward pass has to be exercised separately from the forward.
+
+    Parametrised on topk because at topk = 1 the replacement (`M_total`) and the
+    thing it replaces coincide, so that case alone cannot tell a correct fix from
+    one that only holds when dX's `[NUM_TOKENS * TOPK, K]` output is `M_total`.
+    """
     grads = {}
     for name, gather_indices in (
         ("none", None),
@@ -146,7 +152,7 @@ def test_backward_matches_the_dummy_index_workaround():
             X = X,
             W = W,
             m_sizes = m_sizes,
-            topk = 1,
+            topk = topk,
             gather_indices = gather_indices,
             permute_x = False,
             permute_y = False,
@@ -154,6 +160,7 @@ def test_backward_matches_the_dummy_index_workaround():
         ).sum().backward()
         grads[name] = (X.grad, W.grad)
 
+    assert grads["none"][0].shape == grads["dummy"][0].shape
     assert torch.equal(grads["none"][0], grads["dummy"][0])
     assert torch.equal(grads["none"][1], grads["dummy"][1])
 

--- a/unsloth/kernels/moe/grouped_gemm/interface.py
+++ b/unsloth/kernels/moe/grouped_gemm/interface.py
@@ -340,7 +340,7 @@ def grouped_gemm_dX(
     """
     dX backward kernel
     grad_output: (M, N)
-    gather_indices: (total_tokens,), indices of tokens assigned to each expert.  E.g., slicing gather_indices by cumsum of m_sizes gives the indices of tokens assigned to each expert.
+    gather_indices: (total_tokens,), indices of tokens assigned to each expert.  E.g., slicing gather_indices by cumsum of m_sizes gives the indices of tokens assigned to each expert. May be None when neither `permute_x` nor `permute_y` is True.
     m_sizes: tokens assigned to each expert which correspond to the size of M in the respective GEMMs in the grouped GEMM.
     topk: number of experts chosen per token.
     `permute_x`: whether X was permuted on load in the forward pass, typically only used for the first grouped GEMM in an MoE MLP to group tokens by expert.
@@ -406,7 +406,12 @@ def grouped_gemm_dX(
     assert M_total % topk == 0, f"M_total ({M_total}) must be divisible by topk ({topk})"
     num_tokens = M_total // topk
 
-    total_tokens = gather_indices.shape[0]
+    # the kernel only reads gather_indices under permute_x / permute_y, so it stays optional otherwise
+    if permute_x or permute_y:
+        assert (
+            gather_indices is not None
+        ), "gather_indices must be provided when permute_x or permute_y is True"
+    total_tokens = gather_indices.shape[0] if gather_indices is not None else M_total
     assert total_tokens == M_total, f"Total tokens ({total_tokens}) must match M_total ({M_total})"
 
     # Note that the output shape is [NUM_TOKENS * TOPK, K] even when `permute_x` is True since we need to accumulate gradients across all experts chosen by the token.
@@ -962,7 +967,8 @@ def grouped_gemm(
 
     X = X.view(-1, X.shape[-1])
     m_sizes = m_sizes.view(-1)
-    gather_indices = gather_indices.view(-1)
+    if gather_indices is not None:
+        gather_indices = gather_indices.view(-1)
 
     return GroupedGemm.apply(
         X,


### PR DESCRIPTION
Fixes #8627.

## The bug

`grouped_gemm()` defaults `gather_indices` to `None` and only asserts it is present when `permute_x` or `permute_y` is set:

```python
if permute_x or permute_y:
    assert gather_indices is not None, \
        "gather_indices is required when either permute_x or permute_y is True"
```

A few lines below it normalised the argument unconditionally:

```python
gather_indices = gather_indices.view(-1)
```

so passing the documented default with both permutes off raised `AttributeError: 'NoneType' object has no attribute 'view'`.

`grouped_gemm_dX` carried the same unconditional dereference, `gather_indices.shape[0]`, used to size `dX`. Fixing only the wrapper moves the identical crash into the backward pass, so both are fixed here. `grouped_gemm_forward` and `grouped_gemm_dW` were already guarded and needed no change.

## Why it is worth fixing

None of the three Triton kernels read `gather_indices_ptr` outside their `PERMUTE_X or PERMUTE_Y` branches, so the pointer is genuinely unused on this path. Calling the grouped GEMM directly on activations that are already in expert-contiguous order is a documented use of `permute_x=False`:

> When `permute_x` is False, `X` is expected to be of shape (total_tokens, K) ... AND already permuted to grouped expert order

Today that path requires a dummy `torch.arange(total_tokens)` the kernel never reads.

No in-tree caller is affected: `unsloth/models/glm4_moe.py`, `unsloth/kernels/moe/tests/moe_utils.py` and the reference MoE blocks all pass `gather_indices` unconditionally. This is a public-API contract bug, not a training-path bug.

## Tests

New `tests/test_grouped_gemm_optional_gather_indices.py`:

- two CPU-runnable cases pin the contract: the `None` default reaches `grouped_gemm_forward`'s CUDA device assert rather than an `AttributeError`, and `permute_x` / `permute_y` without indices still fail with the explicit message
- two CUDA cases check the numerics: forward and backward with `gather_indices=None` against the `torch.arange` workaround, plus forward against a reference per-expert matmul

Verified on an RTX 3080 (sm_86), torch 2.13.0+cu130, triton 3.7.1. All 5 pass. Against unpatched `interface.py` 3 of 5 fail with the reported `AttributeError`; reverting only the `grouped_gemm_dX` half leaves the backward case failing, which is why both sites are in this change.