### PR TITLE
add local tools to self-hosted providers

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1107,6 +1107,14 @@ class ExternalProviderClient:
             else:
                 body["max_tokens"] = max_tokens
 
+        # top_k is a standard OpenAI-compat sampling knob (vLLM, llama.cpp,
+        # Ollama). The frontend advertises and sends it for the self-hosted
+        # family; without this it was silently dropped here, so the sidebar
+        # control had no effect. 0 = "Off" is never sent, mirroring the
+        # Anthropic path.
+        if top_k is not None and top_k > 0:
+            body["top_k"] = top_k
+
         # Drop fields the registry flags as unusable so reasoning-class models
         # with fixed defaults (Kimi k2.6 etc) don't 400 on pydantic defaults
         # the route layer still fills in.

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -90,6 +90,10 @@ BUDGET_EXHAUSTED_NUDGE = (
     "so far, provide your final answer now. Do not call any more tools."
 )
 
+# withheld markup past this never becomes a call, so it is released rather than
+# buffered to the end of a turn that may never terminate.
+MAX_SUPPRESSED_MARKUP_CHARS = 32768
+
 # longest partial marker worth holding back at a delta boundary.
 _MAX_SIGNAL_PREFIX = max(len(signal) for signal in TOOL_XML_SIGNALS) - 1
 
@@ -220,6 +224,7 @@ class _TurnAccumulator:
         self.pending: str = ""
         self.suppressed_tail: str = ""
         self.markup_seen: bool = False
+        self._gate_abandoned: bool = False
         self.reasoning: str = ""
         self.tool_calls: dict[int, dict[str, Any]] = {}
         self.finish_reason: Optional[str] = None
@@ -308,9 +313,24 @@ class _TurnAccumulator:
 
     def _gate_content(self, text: str) -> str:
         """Return the part of ``text`` safe to show; hold or drop tool markup."""
+        if self._gate_abandoned:
+            self.shown += text
+            return text
         if self.markup_seen:
             self.suppressed_tail += text
-            return ""
+            if len(self.suppressed_tail) <= MAX_SUPPRESSED_MARKUP_CHARS:
+                return ""
+            # no real call runs this long, and a turn that never terminates would
+            # otherwise stay invisible to the client, so stop gating and show it.
+            self._gate_abandoned = True
+            released = self.release_suppressed()
+            self.shown += released
+            logger.warning(
+                "External local tool loop released %d chars of unterminated tool "
+                "markup: the turn is being shown as prose",
+                len(released),
+            )
+            return released
         self.pending += text
         marker = _first_signal_index(self.pending)
         if marker is not None:

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -219,6 +219,7 @@ class _TurnAccumulator:
         self.usage: dict[str, Any] = {}
         self.provisional_cards: dict[str, str] = {}
         self._provisional_tool_names = provisional_tool_names
+        self._real_id_slots: set[int] = set()
         self._args_streamed: set[str] = set()
         self._final_chunk: Optional[dict[str, Any]] = None
 
@@ -234,7 +235,8 @@ class _TurnAccumulator:
 
     def feed(self, line: str) -> list[str]:
         if not line.startswith("data:"):
-            return []
+            # an sse comment is the provider's keepalive; dropping it idles the stream out.
+            return [line] if line.startswith(":") else []
         data_str = line[len("data:") :].strip()
         if not data_str or data_str == "[DONE]":
             return []
@@ -334,31 +336,40 @@ class _TurnAccumulator:
                 continue
             index = fragment.get("index")
             slot = index if isinstance(index, int) else position
+            # a server that omits the id still needs one: the replayed call and its tool
+            # message are paired by it, as in llama_cpp.py's accumulator.
+            fallback_id = f"call_{slot}"
             call = self.tool_calls.setdefault(
                 slot,
-                {"id": "", "type": "function", "function": {"name": "", "arguments": ""}},
+                {"id": fallback_id, "type": "function", "function": {"name": "", "arguments": ""}},
             )
             call_id = fragment.get("id")
             if isinstance(call_id, str) and call_id:
                 call["id"] = call_id
+                self._real_id_slots.add(slot)
             function = fragment.get("function")
             if not isinstance(function, dict):
                 continue
             name = function.get("name")
             if isinstance(name, str) and name:
-                call["function"]["name"] = name
+                # a name can be split across deltas the way arguments are.
+                call["function"]["name"] += name
             arguments = function.get("arguments")
             if isinstance(arguments, str):
                 call["function"]["arguments"] += arguments
-            events.extend(self._provisional_events(call, arguments))
+            events.extend(
+                self._provisional_events(call, arguments, has_real_id = slot in self._real_id_slots)
+            )
         return events
 
-    def _provisional_events(self, call: dict[str, Any], fragment: Optional[str]) -> list[str]:
+    def _provisional_events(
+        self, call: dict[str, Any], fragment: Optional[str], *, has_real_id: bool
+    ) -> list[str]:
         """Open an early card for a large payload, then stream its argument text."""
         call_id = call["id"]
         name = call["function"]["name"]
-        # a synthetic id cannot reconcile with the real tool_start, so it would strand a card.
-        if not call_id or not name or name not in self._provisional_tool_names:
+        # a synthetic id may still be replaced by a real one, which would strand the card.
+        if not has_real_id or not name or name not in self._provisional_tool_names:
             return []
         events: list[str] = []
         arguments = call["function"]["arguments"]
@@ -493,6 +504,14 @@ async def _drain_step_task(task: Optional["asyncio.Future"], cancel_event: threa
     worker actually finishes.
     """
     if task is None:
+        return
+    if task.done():
+        # its worker already returned, and the loop recovers from a tool error below,
+        # so signalling cancellation here would abort the rest of the request.
+        try:
+            task.exception()
+        except (asyncio.CancelledError, Exception):
+            pass
         return
     cancel_event.set()
     while not task.done():
@@ -635,6 +654,9 @@ async def stream_chat_completion_with_local_tools(
 
     try:
         while True:
+            # Stop arrives as a POST that sets this event, so every boundary honours it.
+            if cancel_event.is_set():
+                break
             # past the budget the catalog is dropped, so the last pass has to answer.
             tools_allowed = remaining_iterations > 0 and not controller.force_final_answer
             active_tools = controller.active_tools() if tools_allowed else []
@@ -659,6 +681,8 @@ async def stream_chat_completion_with_local_tools(
             resume_partial_request = False
             try:
                 async for line in gen:
+                    if cancel_event.is_set():
+                        break
                     for forwarded in turn.feed(line):
                         yield forwarded
             finally:
@@ -668,6 +692,11 @@ async def stream_chat_completion_with_local_tools(
                     # httpcore asyncgen cleanup on Python 3.13, suppressed as in the route.
                     pass
             _merge_usage(usage_totals, turn.usage)
+
+            if cancel_event.is_set():
+                for line in _close_provisional_cards(turn, set()):
+                    yield line
+                break
 
             if turn.failed:
                 # the error line already went out, so do not re-prompt from a half-finished turn.
@@ -801,6 +830,8 @@ async def stream_chat_completion_with_local_tools(
             turn_executed_real_tool = False
 
             for raw_call in pending_calls:
+                if cancel_event.is_set():
+                    break
                 decision = controller.prepare_call(raw_call)
                 if not decision.should_execute:
                     completion = controller.record_noop(decision)

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -206,7 +206,15 @@ class _TurnAccumulator:
     parses it into a real call, or releases it when it turns out to be prose.
     """
 
-    def __init__(self, *, provisional_tool_names: frozenset[str] = frozenset()) -> None:
+    def __init__(
+        self,
+        *,
+        provisional_tool_names: frozenset[str] = frozenset(),
+        single_call_only: bool = False,
+    ) -> None:
+        # only the first call survives disable_parallel_tool_use, so the rest must open
+        # no card: it would stream its arguments and then close blank, having never run.
+        self._single_call_only = single_call_only
         self.text: str = ""
         self.shown: str = ""
         self.pending: str = ""
@@ -352,11 +360,14 @@ class _TurnAccumulator:
                 continue
             name = function.get("name")
             if isinstance(name, str) and name:
-                # a name can be split across deltas the way arguments are.
-                call["function"]["name"] += name
+                # replaced, never appended: llama-server re-sends the whole name as it
+                # grows mid-parse (common/chat.cpp compute_diffs), so += would double it.
+                call["function"]["name"] = name
             arguments = function.get("arguments")
             if isinstance(arguments, str):
                 call["function"]["arguments"] += arguments
+            if self._single_call_only and slot != min(self.tool_calls):
+                continue
             events.extend(
                 self._provisional_events(call, arguments, has_real_id = slot in self._real_id_slots)
             )
@@ -550,6 +561,26 @@ def _close_provisional_cards(turn: _TurnAccumulator, resolved: set[str]) -> list
     return lines
 
 
+def _append_user_turn(conversation: list[dict[str, Any]], content: str) -> None:
+    """Append a user turn, merging into a trailing one so roles keep alternating.
+
+    A turn whose only calls were no-ops appends no assistant message, so a bare
+    append would leave two user turns in a row. Unlike the in-process loops this
+    conversation is rendered by the provider, and a strict server rejects that.
+    """
+    if not content:
+        return
+    last = conversation[-1] if conversation else None
+    if (
+        isinstance(last, dict)
+        and last.get("role") == "user"
+        and isinstance(last.get("content"), str)
+    ):
+        conversation[-1] = {**last, "content": f"{last['content']}\n\n{content}"}
+        return
+    conversation.append({"role": "user", "content": content})
+
+
 def _resolve_permission_mode(
     permission_mode: Optional[str], bypass_permissions: bool
 ) -> tuple[str, bool]:
@@ -668,6 +699,7 @@ async def stream_chat_completion_with_local_tools(
                     bypass_permissions = bypass_permissions,
                     permission_mode = permission_mode,
                 ),
+                single_call_only = disable_parallel_tool_use,
             )
             gen = client.stream_chat_completion(
                 messages = conversation,
@@ -819,8 +851,9 @@ async def stream_chat_completion_with_local_tools(
             assistant_message: dict[str, Any] = {
                 "role": "assistant",
                 # markup never replays: the call is carried structurally below.
+                # the full catalog, so a spent one-shot's rehearsal form still strips.
                 "content": strip_tool_markup(
-                    turn.text, final = True, enabled_tool_names = enabled_tool_names
+                    turn.text, final = True, enabled_tool_names = all_tool_names
                 ),
             }
             assistant_tool_calls: list[dict[str, Any]] = []
@@ -992,13 +1025,17 @@ async def stream_chat_completion_with_local_tools(
                     continue_final_message = continue_final_message,
                 )
             conversation.extend(tool_messages)
-            append_deferred_nudges(conversation, nudge_messages)
+            # deferred to after the tool results, so a no-op never splits a call from them.
+            _append_user_turn(
+                conversation,
+                "\n\n".join(dict.fromkeys(message["content"] for message in nudge_messages)),
+            )
             if turn_executed_real_tool:
                 remaining_iterations -= 1
             if remaining_iterations == 0 and not controller.force_final_answer:
                 # the catalog is gone from here on, so say why rather than letting
                 # the next pass ask for a tool that is no longer offered.
-                conversation.append({"role": "user", "content": BUDGET_EXHAUSTED_NUDGE})
+                _append_user_turn(conversation, BUDGET_EXHAUSTED_NUDGE)
 
         usage_line = _usage_chunk_line(model, usage_totals)
         if usage_line is not None:

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -1,0 +1,872 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Local agentic tool loop over a self-hosted OpenAI-compatible provider.
+
+vLLM, Ollama, llama.cpp and generic custom servers do the model half of
+function calling but ship no tool runtime: they emit ``tool_calls`` and stop.
+This module runs Unsloth's own runtime for them. It advertises the local tool
+schemas on ``/v1/chat/completions``, executes the calls the server asks for,
+appends the results, and re-prompts until the model answers. The SSE it emits
+matches what the GGUF and safetensors loops emit, so the frontend renders
+identical tool cards.
+
+Hosted providers are deliberately excluded. OpenAI, Anthropic, Gemini,
+OpenRouter and Kimi run their own server-side tools, already wired through
+``enabled_tools`` in ``external_provider.py``; sending them a local tool
+catalog would duplicate or conflict with those. ``search_knowledge_base``
+(RAG) is excluded everywhere: retrieval stays local-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import threading
+from typing import Any, AsyncGenerator, Callable, Iterable, Optional, Sequence
+
+from loggers import get_logger
+
+from core.inference.tool_call_parser import (
+    MAX_ACT_REPROMPTS,
+    NUDGE_TOOL_CALLS_STATUS,
+    TOOL_XML_SIGNALS,
+    is_reprompt_repeat,
+    is_short_intent_without_action,
+    parse_tool_calls_from_text,
+    reprompt_to_act_message,
+    strip_tool_markup,
+)
+from core.inference.tool_loop_controller import (
+    ToolLoopController,
+    append_deferred_nudges,
+    awaiting_approval_status,
+    tool_event_provenance,
+)
+from core.inference.tool_stream_exec import (
+    TOOL_HEARTBEAT_INTERVAL_S,
+    accepts_output_callback,
+    stream_tool_execution,
+)
+from state.tool_approvals import (
+    TOOL_REJECTED_MESSAGE,
+    abort_tool_decision,
+    begin_tool_decision,
+    new_approval_id,
+    wait_tool_decision,
+)
+
+logger = get_logger(__name__)
+
+
+# these self-hosted servers ship no tool runtime, so ours has nothing to collide with.
+LOCAL_TOOL_LOOP_PROVIDER_TYPES = frozenset({"vllm", "ollama", "llama_cpp", "custom"})
+
+# search_knowledge_base and render_html are excluded: RAG and Canvas stay local-only.
+LOCAL_TOOL_LOOP_TOOL_NAMES = ("web_search", "python", "terminal")
+
+# matches the local loops' default budget (generate_chat_completion_with_tools).
+DEFAULT_MAX_TOOL_ITERATIONS = 25
+
+# only a large streamed payload earns an early card, as in llama_cpp.py.
+PROVISIONAL_ARGS_MIN_CHARS = 256
+
+# a stall after a tool ran costs a re-run on retry, so the local loops allow one.
+MAX_POST_TOOL_REPROMPTS = 1
+
+# sse comment the route writes while a tool blocks; keeps proxies from idling out.
+_SSE_KEEPALIVE = ": keep-alive"
+
+# delay before the first approval keepalive so it cannot coalesce with the gated card.
+TOOL_APPROVAL_FLUSH_DELAY_S = 0.05
+
+# text-form calls are not grammar-bounded the way delta.tool_calls are, so one
+# runaway turn is capped here as it is in the local loops.
+MAX_TEXT_TOOL_CALLS_PER_TURN = 8
+
+# verbatim from the local loops: the last pass answers instead of asking for more tools.
+BUDGET_EXHAUSTED_NUDGE = (
+    "You have used all available tool calls. Based on everything you have found "
+    "so far, provide your final answer now. Do not call any more tools."
+)
+
+# longest partial marker worth holding back at a delta boundary.
+_MAX_SIGNAL_PREFIX = max(len(signal) for signal in TOOL_XML_SIGNALS) - 1
+
+
+def _first_signal_index(text: str) -> Optional[int]:
+    """Offset of the earliest tool marker in ``text``, or None."""
+    found = [text.index(signal) for signal in TOOL_XML_SIGNALS if signal in text]
+    return min(found) if found else None
+
+
+def _holdback_len(text: str) -> int:
+    """How much of the tail could still grow into a tool marker."""
+    for size in range(min(len(text), _MAX_SIGNAL_PREFIX), 0, -1):
+        suffix = text[-size:]
+        if any(signal.startswith(suffix) for signal in TOOL_XML_SIGNALS):
+            return size
+    return 0
+
+
+def local_tool_loop_supported(provider_type: Optional[str]) -> bool:
+    """Whether this provider type may run the local tool loop."""
+    if not provider_type or provider_type not in LOCAL_TOOL_LOOP_PROVIDER_TYPES:
+        return False
+    from core.inference.providers import get_provider_info
+
+    return bool((get_provider_info(provider_type) or {}).get("supports_tool_calling"))
+
+
+def select_local_tool_names(enabled_tools: Optional[Iterable[str]]) -> list[str]:
+    """Filter a request's ``enabled_tools`` down to what this loop may run.
+
+    Order follows ``LOCAL_TOOL_LOOP_TOOL_NAMES`` so the advertised catalog is
+    stable regardless of the order the client listed its pills in.
+    """
+    if not enabled_tools:
+        return []
+    requested = {str(name) for name in enabled_tools}
+    return [name for name in LOCAL_TOOL_LOOP_TOOL_NAMES if name in requested]
+
+
+def _sse(payload: dict[str, Any]) -> str:
+    return f"data: {json.dumps(payload)}"
+
+
+def _status_sse(text: str) -> str:
+    """Tool badge text, already in the ``tool_status`` shape chat-api.ts parses."""
+    return _sse({"type": "tool_status", "content": text})
+
+
+def _first_delta(chunk: dict[str, Any]) -> dict[str, Any]:
+    choices = chunk.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        return {}
+    delta = choices[0].get("delta")
+    return delta if isinstance(delta, dict) else {}
+
+
+def _merge_usage(totals: dict[str, int], usage: Any) -> None:
+    """Sum the countable fields of one turn's usage block into ``totals``."""
+    if not isinstance(usage, dict):
+        return
+    for field in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        value = usage.get(field)
+        if isinstance(value, int):
+            totals[field] = totals.get(field, 0) + value
+
+
+class _TurnAccumulator:
+    """Split one provider turn's SSE into client output and tool-call state.
+
+    ``feed`` returns the lines to forward. ``tool_calls`` fragments are
+    withheld: this loop executes them and emits its own ``tool_start`` /
+    ``tool_end`` events, so forwarding the raw fragments would draw a second,
+    never-resolved tool card. The terminal ``finish_reason`` chunk is withheld
+    too, because the turn is not the response's last one whenever a tool call
+    follows; its content, if any, is still forwarded.
+
+    A call whose arguments are long enough opens a provisional card and streams
+    its argument text, so a slow ``python`` payload renders while the model is
+    still writing it. Same rule and same events as the GGUF loop.
+
+    Content is gated on the way out. A model that writes its call as text rather
+    than as ``delta.tool_calls`` would otherwise leak ``<tool_call>`` markup into
+    the answer, so everything from the first marker on is withheld: the loop
+    parses it into a real call, or releases it when it turns out to be prose.
+    """
+
+    def __init__(
+        self,
+        *,
+        provisional_tool_names: frozenset[str] = frozenset(),
+    ) -> None:
+        self.text: str = ""
+        self.shown: str = ""
+        self.pending: str = ""
+        self.suppressed_tail: str = ""
+        self.markup_seen: bool = False
+        self.reasoning: str = ""
+        self.tool_calls: dict[int, dict[str, Any]] = {}
+        self.finish_reason: Optional[str] = None
+        self.failed: bool = False
+        self.usage: dict[str, int] = {}
+        self.provisional_cards: dict[str, str] = {}
+        self._provisional_tool_names = provisional_tool_names
+        self._args_streamed: set[str] = set()
+        self._final_chunk: Optional[dict[str, Any]] = None
+
+    @property
+    def wants_tools(self) -> bool:
+        return bool(self.tool_calls)
+
+    def final_chunk_line(self) -> Optional[str]:
+        """The withheld terminal chunk, for the response's last turn."""
+        if self._final_chunk is None:
+            return None
+        return _sse(self._final_chunk)
+
+    def feed(self, line: str) -> list[str]:
+        if not line.startswith("data:"):
+            return []
+        data_str = line[len("data:") :].strip()
+        if not data_str or data_str == "[DONE]":
+            return []
+        try:
+            chunk = json.loads(data_str)
+        except (json.JSONDecodeError, ValueError):
+            return []
+        if not isinstance(chunk, dict):
+            return []
+        if "error" in chunk:
+            self.failed = True
+            return [line]
+
+        _merge_usage(self.usage, chunk.pop("usage", None))
+        choices = chunk.get("choices")
+        if not isinstance(choices, list) or not choices:
+            # usage-only chunk, folded into the running totals and re-emitted at the end.
+            return []
+        choice = choices[0] if isinstance(choices[0], dict) else {}
+        delta = _first_delta(chunk)
+        raw_tool_calls = delta.pop("tool_calls", None)
+        extra: list[str] = []
+        if isinstance(raw_tool_calls, list):
+            extra = self._absorb_tool_calls(raw_tool_calls)
+        # ollama names the thinking channel `reasoning`; the local loops and the
+        # frontend both speak `reasoning_content`, so normalize it on the way out
+        # or the thinking block never renders.
+        reasoning = delta.pop("reasoning", None)
+        if isinstance(reasoning, str) and reasoning and not delta.get("reasoning_content"):
+            delta["reasoning_content"] = reasoning
+        thinking = delta.get("reasoning_content")
+        if isinstance(thinking, str) and thinking:
+            self.reasoning += thinking
+        content = delta.get("content")
+        if isinstance(content, str) and content:
+            self.text += content
+            content = self._gate_content(content)
+        else:
+            content = ""
+        if "content" in delta:
+            delta["content"] = content
+            chunk["choices"][0]["delta"] = delta
+
+        finish_reason = choice.get("finish_reason")
+        if isinstance(finish_reason, str) and finish_reason:
+            self.finish_reason = finish_reason
+            terminal = copy.deepcopy(chunk)
+            terminal["choices"][0]["delta"] = {}
+            self._final_chunk = terminal
+            if not content:
+                return extra
+            # the visible text ships now, the terminal marker only if this turn ends the response.
+            carried = copy.deepcopy(chunk)
+            carried["choices"][0]["finish_reason"] = None
+            return extra + [_sse(carried)]
+
+        # a chunk left with nothing to render (tool_calls only, or held-back markup).
+        if not content and not any(delta.get(key) for key in delta):
+            return extra
+        return extra + [_sse(chunk)]
+
+    def _gate_content(self, text: str) -> str:
+        """Return the part of ``text`` safe to show; hold or drop tool markup."""
+        if self.markup_seen:
+            self.suppressed_tail += text
+            return ""
+        self.pending += text
+        marker = _first_signal_index(self.pending)
+        if marker is not None:
+            self.markup_seen = True
+            flushed, self.suppressed_tail = self.pending[:marker], self.pending[marker:]
+            self.pending = ""
+        else:
+            # a tail that could still grow into a marker waits for the next delta.
+            hold = _holdback_len(self.pending)
+            flushed = self.pending[: len(self.pending) - hold] if hold else self.pending
+            self.pending = self.pending[len(self.pending) - hold :] if hold else ""
+        self.shown += flushed
+        return flushed
+
+    def release_pending(self) -> str:
+        """Text held for a marker that never arrived; safe once the turn ends."""
+        held, self.pending = self.pending, ""
+        self.shown += held
+        return held
+
+    def release_suppressed(self) -> str:
+        """Hand back the withheld markup; the caller decides what of it is shown."""
+        held, self.suppressed_tail = self.suppressed_tail, ""
+        self.markup_seen = False
+        return held
+
+    def _absorb_tool_calls(self, fragments: Sequence[Any]) -> list[str]:
+        events: list[str] = []
+        for position, fragment in enumerate(fragments):
+            if not isinstance(fragment, dict):
+                continue
+            index = fragment.get("index")
+            slot = index if isinstance(index, int) else position
+            call = self.tool_calls.setdefault(
+                slot,
+                {"id": "", "type": "function", "function": {"name": "", "arguments": ""}},
+            )
+            call_id = fragment.get("id")
+            if isinstance(call_id, str) and call_id:
+                call["id"] = call_id
+            function = fragment.get("function")
+            if not isinstance(function, dict):
+                continue
+            name = function.get("name")
+            if isinstance(name, str) and name:
+                call["function"]["name"] = name
+            arguments = function.get("arguments")
+            if isinstance(arguments, str):
+                call["function"]["arguments"] += arguments
+            events.extend(self._provisional_events(call, arguments))
+        return events
+
+    def _provisional_events(self, call: dict[str, Any], fragment: Optional[str]) -> list[str]:
+        """Open an early card for a large payload, then stream its argument text."""
+        call_id = call["id"]
+        name = call["function"]["name"]
+        # a synthetic id cannot reconcile with the real tool_start, so it would strand a card.
+        if not call_id or not name or name not in self._provisional_tool_names:
+            return []
+        events: list[str] = []
+        arguments = call["function"]["arguments"]
+        if call_id not in self.provisional_cards:
+            if len(arguments) < PROVISIONAL_ARGS_MIN_CHARS:
+                return []
+            self.provisional_cards[call_id] = name
+            events.append(
+                _sse(
+                    {
+                        "type": "tool_start",
+                        "tool_name": name,
+                        "tool_call_id": call_id,
+                        "arguments": {},
+                        "provenance": tool_event_provenance(provisional = True),
+                    }
+                )
+            )
+        # first event carries the backlog the card missed, later ones just the fragment.
+        if call_id not in self._args_streamed:
+            self._args_streamed.add(call_id)
+            text = arguments
+        else:
+            text = fragment or ""
+        if text:
+            events.append(
+                _sse(
+                    {
+                        "type": "tool_args",
+                        "tool_call_id": call_id,
+                        "tool_name": name,
+                        "text": text,
+                    }
+                )
+            )
+        return events
+
+    def ordered_tool_calls(self) -> list[dict[str, Any]]:
+        return [self.tool_calls[key] for key in sorted(self.tool_calls)]
+
+
+def _usage_chunk_line(model: str, totals: dict[str, int]) -> Optional[str]:
+    """One summed usage chunk for the whole loop, or None when unreported.
+
+    Per-turn usage chunks are withheld while the loop runs, so a multi-turn
+    response reports the shape a single-turn one does instead of a burst of
+    partial counts the client would have to add up itself.
+    """
+    if not totals:
+        return None
+    return _sse(
+        {
+            "id": "chatcmpl-external-tools",
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [],
+            "usage": totals,
+        }
+    )
+
+
+def _content_chunk_line(model: str, text: str) -> str:
+    """A synthetic content delta, used to promote a reasoning-only answer."""
+    return _sse(
+        {
+            "id": "chatcmpl-external-tools",
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+        }
+    )
+
+
+def _tool_names(tools: Sequence[Any]) -> list[str]:
+    names = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        name = (tool.get("function") or {}).get("name")
+        if isinstance(name, str) and name:
+            names.append(name)
+    return names
+
+
+def _provisional_card_names(
+    tools: Sequence[Any],
+    *,
+    confirm_tool_calls: bool,
+    bypass_permissions: bool,
+    permission_mode: str,
+) -> frozenset[str]:
+    """Tools allowed an early card before their arguments finish streaming.
+
+    Same gate as the GGUF loop: a call the user still has to approve shows no
+    early card unless the card is only a text preview of the arguments, or the
+    tool never prompts in auto mode.
+    """
+    from core.inference.tools import has_text_only_provisional_card, is_always_safe_tool
+
+    allowed = set()
+    for name in _tool_names(tools):
+        confirm_gated = (
+            confirm_tool_calls
+            and not bypass_permissions
+            and not (permission_mode == "auto" and is_always_safe_tool(name))
+            and not has_text_only_provisional_card(name)
+        )
+        if not confirm_gated:
+            allowed.add(name)
+    return frozenset(allowed)
+
+
+# returned instead of the generator's stopiteration, which cannot cross a thread boundary.
+_STEP_DONE = object()
+
+
+def _advance_tool_stream(generator: Any, outcome: dict[str, Any]) -> Any:
+    try:
+        return next(generator)
+    except StopIteration as stop:
+        outcome["result"] = stop.value
+        return _STEP_DONE
+
+
+def _close_provisional_cards(turn: _TurnAccumulator, resolved: set[str]) -> list[str]:
+    """End every early card no execution claimed, so none spins forever."""
+    lines = []
+    for call_id, name in turn.provisional_cards.items():
+        if call_id in resolved:
+            continue
+        resolved.add(call_id)
+        lines.append(
+            _sse(
+                {
+                    "type": "tool_end",
+                    "tool_name": name,
+                    "tool_call_id": call_id,
+                    "result": "",
+                    "provenance": tool_event_provenance(provisional = True),
+                }
+            )
+        )
+    return lines
+
+
+def _resolve_permission_mode(
+    permission_mode: Optional[str], bypass_permissions: bool
+) -> tuple[str, bool]:
+    """Normalize the permission pair the way the local loops do."""
+    if permission_mode == "full":
+        return "full", True
+    if bypass_permissions:
+        return "full", True
+    if permission_mode is None:
+        return "auto", False
+    if permission_mode not in ("ask", "auto", "off"):
+        return "ask", False
+    return permission_mode, False
+
+
+async def stream_chat_completion_with_local_tools(
+    client: Any,
+    *,
+    messages: list[dict[str, Any]],
+    model: str,
+    tools: list[dict[str, Any]],
+    session_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    max_tool_iterations: int = DEFAULT_MAX_TOOL_ITERATIONS,
+    tool_call_timeout: Optional[int] = None,
+    auto_heal_tool_calls: bool = True,
+    confirm_tool_calls: bool = False,
+    bypass_permissions: bool = False,
+    permission_mode: Optional[str] = None,
+    disable_parallel_tool_use: bool = False,
+    nudge_tool_calls: Optional[bool] = None,
+    execute_tool: Optional[Callable[..., str]] = None,
+    **stream_kwargs: Any,
+) -> AsyncGenerator[str, None]:
+    """Stream a provider response, executing local tool calls in between.
+
+    Yields OpenAI SSE ``data:`` lines: the provider's content chunks pass
+    through, tool activity is inserted as the ``status`` / ``tool_start`` /
+    ``tool_end`` events the frontend already renders, and one terminal chunk
+    plus ``[DONE]`` close the stream.
+
+    ``permission_mode`` mirrors the local loops: "ask" confirms every call,
+    "auto" only those detected as high-risk, "off" never prompts (the sandbox
+    stays on), "full" is the same switch as ``bypass_permissions``.
+    """
+    if execute_tool is None:
+        from core.inference.tools import execute_tool as _default_execute_tool
+
+        execute_tool = _default_execute_tool
+
+    permission_mode, bypass_permissions = _resolve_permission_mode(
+        permission_mode, bypass_permissions
+    )
+
+    conversation = list(messages)
+    controller = ToolLoopController(tools = tools, auto_heal_tool_calls = auto_heal_tool_calls)
+    all_tool_names = set(_tool_names(tools))
+    cancel_event = threading.Event()
+    usage_totals: dict[str, int] = {}
+    # 9999+ is the local loops' "no limit" sentinel.
+    effective_timeout = (
+        None if tool_call_timeout is not None and tool_call_timeout >= 9999 else tool_call_timeout
+    )
+    remaining_iterations = max(1, max_tool_iterations)
+    executed_calls = 0
+    # budgeted apart from each other so a pre-tool nudge cannot spend the post-tool one.
+    reprompt_count = 0
+    post_tool_reprompts = 0
+    last_reprompt_text = ""
+    # only the opening turn resumes a partial; later turns start from a tool result.
+    continue_final_message = bool(stream_kwargs.pop("continue_final_message", False))
+
+    try:
+        while True:
+            # past the budget the catalog is dropped, so the last pass has to answer.
+            tools_allowed = remaining_iterations > 0
+            active_tools = controller.active_tools() if tools_allowed else []
+            enabled_tool_names = set(_tool_names(active_tools))
+            turn = _TurnAccumulator(
+                provisional_tool_names = _provisional_card_names(
+                    active_tools,
+                    confirm_tool_calls = confirm_tool_calls,
+                    bypass_permissions = bypass_permissions,
+                    permission_mode = permission_mode,
+                ),
+            )
+            gen = client.stream_chat_completion(
+                messages = conversation,
+                model = model,
+                tools = active_tools or None,
+                stream = True,
+                continue_final_message = continue_final_message,
+                **stream_kwargs,
+            )
+            continue_final_message = False
+            try:
+                async for line in gen:
+                    for forwarded in turn.feed(line):
+                        yield forwarded
+            finally:
+                try:
+                    await gen.aclose()
+                except RuntimeError:
+                    # httpcore asyncgen cleanup on Python 3.13, suppressed as in the route.
+                    pass
+            _merge_usage(usage_totals, turn.usage)
+
+            if turn.failed:
+                # the error line already went out, so do not re-prompt from a half-finished turn.
+                return
+
+            # safety net for a model that writes its call as text: llama-server does
+            # the same parse, so the call runs instead of printing itself.
+            text_calls: list[dict[str, Any]] = []
+            healed_calls: list[dict[str, Any]] = []
+            if turn.markup_seen:
+                healed_calls = parse_tool_calls_from_text(
+                    turn.text,
+                    allow_incomplete = True,
+                    enabled_tool_names = all_tool_names,
+                )[:MAX_TEXT_TOOL_CALLS_PER_TURN]
+                # a turn that already carries structured calls runs those; the markup
+                # it also wrote is display-only.
+                if tools_allowed and not turn.wants_tools:
+                    # healing decides what may run; display never depends on it.
+                    text_calls = (
+                        healed_calls
+                        if auto_heal_tool_calls
+                        else parse_tool_calls_from_text(
+                            turn.text,
+                            allow_incomplete = False,
+                            enabled_tool_names = all_tool_names,
+                        )[:MAX_TEXT_TOOL_CALLS_PER_TURN]
+                    )
+            held = turn.release_pending()
+            if held:
+                yield _content_chunk_line(model, held)
+            if turn.suppressed_tail:
+                # whatever survives the display strip was prose around the marker. a
+                # marker that formed no call at all is restored whole, since stripping
+                # an unclosed run to end-of-turn would eat the sentence with it.
+                tail = turn.release_suppressed()
+                visible = strip_tool_markup(
+                    tail, final = True, enabled_tool_names = all_tool_names
+                )
+                if not visible.strip() and not healed_calls:
+                    visible = tail
+                if visible:
+                    turn.shown += visible
+                    yield _content_chunk_line(model, visible)
+            pending_calls = turn.ordered_tool_calls() if turn.wants_tools else text_calls
+            if disable_parallel_tool_use:
+                pending_calls = pending_calls[:1]
+
+            if not pending_calls or not tools_allowed:
+                # tool_calls emitted after the catalog was dropped are ignored, never executed.
+                for line in _close_provisional_cards(turn, set()):
+                    yield line
+                # a stalled turn describes the tool it means to use instead of calling
+                # it. Nudge it once to act, as the local loops do. Gated on an empty
+                # visible turn: OpenAI deltas are append-only, so text already streamed
+                # cannot be taken back the way a cumulative snapshot can.
+                intent_text = (turn.shown or turn.reasoning).strip()
+                already_acted = any(record.executed for record in controller.history)
+                used, cap = (
+                    (post_tool_reprompts, MAX_POST_TOOL_REPROMPTS)
+                    if already_acted
+                    else (reprompt_count, MAX_ACT_REPROMPTS)
+                )
+                if (
+                    tools_allowed
+                    and auto_heal_tool_calls
+                    # none keeps the default-on re-prompt; false disables it.
+                    and (nudge_tool_calls is None or nudge_tool_calls)
+                    and active_tools
+                    and not turn.shown.strip()
+                    and used < cap
+                    and not is_reprompt_repeat(intent_text, last_reprompt_text)
+                    and is_short_intent_without_action(intent_text)
+                ):
+                    reprompt_count += 1
+                    if already_acted:
+                        post_tool_reprompts += 1
+                    last_reprompt_text = intent_text
+                    logger.info(
+                        "External local tool loop re-prompt %d/%d: model responded "
+                        "without calling tools (%d chars)",
+                        used + 1,
+                        cap,
+                        len(intent_text),
+                    )
+                    conversation.append({"role": "assistant", "content": intent_text})
+                    tool_hint = " or ".join(_tool_names(active_tools)) or "an available tool"
+                    conversation.append(
+                        {"role": "user", "content": reprompt_to_act_message(tool_hint)}
+                    )
+                    # blank first so the badge clears, then name the pause so it is not a hang.
+                    yield _status_sse("")
+                    yield _status_sse(NUDGE_TOOL_CALLS_STATUS)
+                    continue
+                # whole reply arrived as reasoning (qwen3-style always-think models):
+                # show it as the response rather than nothing. A length-truncated
+                # thought is not an answer, so it is left in the thinking block.
+                if (
+                    not turn.shown.strip()
+                    and turn.reasoning.strip()
+                    and turn.finish_reason != "length"
+                ):
+                    yield _content_chunk_line(model, turn.reasoning)
+                final_line = turn.final_chunk_line()
+                if final_line is not None:
+                    yield final_line
+                break
+
+            assistant_message: dict[str, Any] = {
+                "role": "assistant",
+                # markup never replays: the call is carried structurally below.
+                "content": strip_tool_markup(
+                    turn.text, final = True, enabled_tool_names = enabled_tool_names
+                ),
+            }
+            assistant_tool_calls: list[dict[str, Any]] = []
+            tool_messages: list[dict[str, Any]] = []
+            nudge_messages: list[dict[str, Any]] = []
+            resolved_provisional: set[str] = set()
+
+            for raw_call in pending_calls:
+                decision = controller.prepare_call(raw_call)
+                if not decision.should_execute:
+                    completion = controller.record_noop(decision)
+                    nudge_messages.append(completion.model_message())
+                    resolved_provisional.add(decision.tool_call_id)
+                    logger.info(
+                        "Suppressed external local tool call as internal no-op: "
+                        f"action={decision.action} tool={decision.tool_name}"
+                    )
+                    continue
+                assistant_tool_calls.append(decision.as_assistant_tool_call())
+
+                needs_confirm = (
+                    bool(confirm_tool_calls)
+                    and not bypass_permissions
+                    and permission_mode != "off"
+                )
+                if needs_confirm and permission_mode == "auto":
+                    from core.inference.tools import is_high_risk_tool_call
+
+                    needs_confirm = is_high_risk_tool_call(decision.tool_name, decision.arguments)
+                approval_id = new_approval_id() if needs_confirm else ""
+                decision_slot = (
+                    begin_tool_decision(session_id, approval_id) if needs_confirm else None
+                )
+                start_event = decision.tool_start_event()
+                start_event["approval_id"] = approval_id
+                start_event["awaiting_confirmation"] = needs_confirm
+
+                try:
+                    # a gated call has not started, so it must not read as running.
+                    yield _status_sse(
+                        awaiting_approval_status(decision.tool_name)
+                        if needs_confirm
+                        else decision.status_text
+                    )
+                    yield _sse(start_event)
+                    verdict = None
+                    if decision_slot is not None:
+                        waiter = asyncio.ensure_future(
+                            asyncio.to_thread(
+                                wait_tool_decision,
+                                decision_slot,
+                                approval_id,
+                                cancel_event,
+                            )
+                        )
+                        try:
+                            # delay the first keepalive so it is a separate write from the gated card.
+                            done, _ = await asyncio.wait(
+                                {waiter}, timeout = TOOL_APPROVAL_FLUSH_DELAY_S
+                            )
+                            while not done:
+                                yield _SSE_KEEPALIVE
+                                done, _ = await asyncio.wait(
+                                    {waiter}, timeout = TOOL_HEARTBEAT_INTERVAL_S
+                                )
+                        finally:
+                            if not waiter.done():
+                                waiter.cancel()
+                        verdict = waiter.result()
+                    if verdict is not None and verdict != "deny":
+                        yield _status_sse(decision.status_text)
+                    if verdict == "deny":
+                        decision_slot = None
+                        resolved_provisional.add(decision.tool_call_id)
+                        yield _sse(
+                            {
+                                "type": "tool_end",
+                                "tool_name": decision.tool_name,
+                                "tool_call_id": decision.tool_call_id,
+                                "result": TOOL_REJECTED_MESSAGE,
+                                "provenance": decision.provenance,
+                            }
+                        )
+                        denied_message: dict[str, Any] = {
+                            "role": "tool",
+                            "name": decision.tool_name,
+                            "content": TOOL_REJECTED_MESSAGE,
+                        }
+                        if decision.tool_call_id:
+                            denied_message["tool_call_id"] = decision.tool_call_id
+                        tool_messages.append(denied_message)
+                        continue
+                    decision_slot = None
+                finally:
+                    if decision_slot is not None:
+                        abort_tool_decision(decision_slot, approval_id)
+
+                def _invoke(output_callback: Callable[[str], None], call = decision) -> str:
+                    kwargs: dict[str, Any] = {
+                        "cancel_event": cancel_event,
+                        "timeout": effective_timeout,
+                        "session_id": session_id,
+                        "thread_id": thread_id,
+                        "disable_sandbox": bypass_permissions,
+                    }
+                    if accepts_output_callback(execute_tool):
+                        kwargs["output_callback"] = output_callback
+                    return execute_tool(call.tool_name, call.arguments, **kwargs)
+
+                # same wrapper the local loops run tools through: live stdout for the
+                # card, and a heartbeat so a long call cannot idle the stream out.
+                tool_stream = stream_tool_execution(
+                    _invoke,
+                    tool_name = decision.tool_name,
+                    tool_call_id = decision.tool_call_id,
+                    cancel_event = cancel_event,
+                )
+                outcome: dict[str, Any] = {}
+                try:
+                    while True:
+                        event = await asyncio.to_thread(
+                            _advance_tool_stream, tool_stream, outcome
+                        )
+                        if event is _STEP_DONE:
+                            break
+                        if event.get("type") == "heartbeat":
+                            yield _SSE_KEEPALIVE
+                        else:
+                            yield _sse(event)
+                    result = outcome.get("result", "")
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001 - reported back to the model
+                    logger.exception("External local tool %s raised: %s", decision.tool_name, exc)
+                    result = f"Error: tool raised an exception: {exc}"
+                finally:
+                    tool_stream.close()
+                completion = controller.record_result(decision, result)
+                executed_calls += 1
+                resolved_provisional.add(decision.tool_call_id)
+                yield _sse(completion.tool_end_event())
+                tool_messages.append(completion.tool_message())
+
+            for line in _close_provisional_cards(turn, resolved_provisional):
+                yield line
+            # an empty status clears the UI badge between iterations.
+            yield _status_sse("")
+            if assistant_tool_calls:
+                assistant_message["tool_calls"] = assistant_tool_calls
+            if assistant_message["content"] or assistant_tool_calls:
+                conversation.append(assistant_message)
+            conversation.extend(tool_messages)
+            append_deferred_nudges(conversation, nudge_messages)
+            remaining_iterations -= 1
+            if remaining_iterations == 0 and not controller.force_final_answer:
+                # the catalog is gone from here on, so say why rather than letting
+                # the next pass ask for a tool that is no longer offered.
+                conversation.append({"role": "user", "content": BUDGET_EXHAUSTED_NUDGE})
+
+        usage_line = _usage_chunk_line(model, usage_totals)
+        if usage_line is not None:
+            yield usage_line
+        yield "data: [DONE]"
+        logger.info(
+            "External local tool loop finished (model=%s, executed_tool_calls=%d)",
+            model,
+            executed_calls,
+        )
+    finally:
+        # a disconnect closes this generator; release any tool still blocking in its thread.
+        cancel_event.set()

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -178,11 +178,7 @@ class _TurnAccumulator:
     parses it into a real call, or releases it when it turns out to be prose.
     """
 
-    def __init__(
-        self,
-        *,
-        provisional_tool_names: frozenset[str] = frozenset(),
-    ) -> None:
+    def __init__(self, *, provisional_tool_names: frozenset[str] = frozenset()) -> None:
         self.text: str = ""
         self.shown: str = ""
         self.pending: str = ""
@@ -527,7 +523,6 @@ async def stream_chat_completion_with_local_tools(
     """
     if execute_tool is None:
         from core.inference.tools import execute_tool as _default_execute_tool
-
         execute_tool = _default_execute_tool
 
     permission_mode, bypass_permissions = _resolve_permission_mode(
@@ -622,9 +617,7 @@ async def stream_chat_completion_with_local_tools(
                 # marker that formed no call at all is restored whole, since stripping
                 # an unclosed run to end-of-turn would eat the sentence with it.
                 tail = turn.release_suppressed()
-                visible = strip_tool_markup(
-                    tail, final = True, enabled_tool_names = all_tool_names
-                )
+                visible = strip_tool_markup(tail, final = True, enabled_tool_names = all_tool_names)
                 if not visible.strip() and not healed_calls:
                     visible = tail
                 if visible:
@@ -720,13 +713,10 @@ async def stream_chat_completion_with_local_tools(
                 assistant_tool_calls.append(decision.as_assistant_tool_call())
 
                 needs_confirm = (
-                    bool(confirm_tool_calls)
-                    and not bypass_permissions
-                    and permission_mode != "off"
+                    bool(confirm_tool_calls) and not bypass_permissions and permission_mode != "off"
                 )
                 if needs_confirm and permission_mode == "auto":
                     from core.inference.tools import is_high_risk_tool_call
-
                     needs_confirm = is_high_risk_tool_call(decision.tool_name, decision.arguments)
                 approval_id = new_approval_id() if needs_confirm else ""
                 decision_slot = (
@@ -819,9 +809,7 @@ async def stream_chat_completion_with_local_tools(
                 outcome: dict[str, Any] = {}
                 try:
                     while True:
-                        event = await asyncio.to_thread(
-                            _advance_tool_stream, tool_stream, outcome
-                        )
+                        event = await asyncio.to_thread(_advance_tool_stream, tool_stream, outcome)
                         if event is _STEP_DONE:
                             break
                         if event.get("type") == "heartbeat":

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -28,6 +28,7 @@ from typing import Any, AsyncGenerator, Callable, Optional, Sequence
 
 from loggers import get_logger
 
+from core.inference.chat_template_helpers import append_assistant_turn
 from core.inference.tool_call_parser import (
     MAX_ACT_REPROMPTS,
     NUDGE_TOOL_CALLS_STATUS,
@@ -146,14 +147,39 @@ def _delta_text(content: Any) -> str:
     return "".join(parts)
 
 
-def _merge_usage(totals: dict[str, int], usage: Any) -> None:
-    """Sum the countable fields of one turn's usage block into ``totals``."""
+# nested count blocks a provider may report alongside the headline totals.
+_USAGE_DETAIL_FIELDS = (
+    "prompt_tokens_details",
+    "completion_tokens_details",
+    "input_tokens_details",
+    "output_tokens_details",
+)
+
+
+def _merge_usage(totals: dict[str, Any], usage: Any) -> None:
+    """Sum every countable field of one turn's usage block into ``totals``.
+
+    Details are summed alongside the headline totals: the frontend reads
+    ``prompt_tokens_details.cached_tokens`` for its cache readout and pricing reads
+    the reasoning slice, so keeping only the totals would make a tool-loop response
+    report less than the same provider's plain stream.
+    """
     if not isinstance(usage, dict):
         return
-    for field in ("prompt_tokens", "completion_tokens", "total_tokens"):
-        value = usage.get(field)
+    for field, value in usage.items():
+        if isinstance(value, bool):
+            continue
         if isinstance(value, int):
             totals[field] = totals.get(field, 0) + value
+            continue
+        if field not in _USAGE_DETAIL_FIELDS or not isinstance(value, dict):
+            continue
+        bucket = totals.setdefault(field, {})
+        if not isinstance(bucket, dict):
+            continue
+        for detail, count in value.items():
+            if isinstance(count, int) and not isinstance(count, bool):
+                bucket[detail] = bucket.get(detail, 0) + count
 
 
 class _TurnAccumulator:
@@ -186,7 +212,7 @@ class _TurnAccumulator:
         self.tool_calls: dict[int, dict[str, Any]] = {}
         self.finish_reason: Optional[str] = None
         self.failed: bool = False
-        self.usage: dict[str, int] = {}
+        self.usage: dict[str, Any] = {}
         self.provisional_cards: dict[str, str] = {}
         self._provisional_tool_names = provisional_tool_names
         self._args_streamed: set[str] = set()
@@ -370,7 +396,7 @@ class _TurnAccumulator:
         return [self.tool_calls[key] for key in sorted(self.tool_calls)]
 
 
-def _usage_chunk_line(model: str, totals: dict[str, int]) -> Optional[str]:
+def _usage_chunk_line(model: str, totals: dict[str, Any]) -> Optional[str]:
     """One summed usage chunk for the whole loop, or None when unreported.
 
     Per-turn usage chunks are withheld while the loop runs, so a multi-turn
@@ -530,10 +556,29 @@ async def stream_chat_completion_with_local_tools(
     )
 
     conversation = list(messages)
+    # only the opening turn resumes a partial; later turns start from a tool result.
+    continue_final_message = bool(stream_kwargs.pop("continue_final_message", False))
+
+    # first-pass retrieval as in the other loops: the nudge promises passages, so send them.
+    skip_autoinject = continue_final_message or (
+        confirm_tool_calls and not bypass_permissions and permission_mode not in ("auto", "off")
+    )
+    autoinject = None
+    if not skip_autoinject:
+        from core.inference.tools import build_rag_autoinject
+
+        autoinject = await asyncio.to_thread(build_rag_autoinject, conversation, rag_scope)
+    if autoinject:
+        for event in autoinject["events"]:
+            yield _sse(event)
+        conversation.extend(autoinject["messages"])
+    # a KB search ran outside the controller, so the loop opens in its post-tool phase.
+    rag_autoinjected = bool(autoinject)
+
     controller = ToolLoopController(tools = tools, auto_heal_tool_calls = auto_heal_tool_calls)
     all_tool_names = set(_tool_names(tools))
     cancel_event = threading.Event()
-    usage_totals: dict[str, int] = {}
+    usage_totals: dict[str, Any] = {}
     # 9999+ is the local loops' "no limit" sentinel.
     effective_timeout = (
         None if tool_call_timeout is not None and tool_call_timeout >= 9999 else tool_call_timeout
@@ -544,8 +589,8 @@ async def stream_chat_completion_with_local_tools(
     reprompt_count = 0
     post_tool_reprompts = 0
     last_reprompt_text = ""
-    # only the opening turn resumes a partial; later turns start from a tool result.
-    continue_final_message = bool(stream_kwargs.pop("continue_final_message", False))
+    # only the request is one-shot; the flag itself still merges the first generated turn.
+    resume_partial_request = continue_final_message
     forced_tool_choice = tool_choice
     tool_denied = False
 
@@ -569,10 +614,10 @@ async def stream_chat_completion_with_local_tools(
                 tools = active_tools or None,
                 tool_choice = forced_tool_choice if active_tools else None,
                 stream = True,
-                continue_final_message = continue_final_message,
+                continue_final_message = resume_partial_request,
                 **stream_kwargs,
             )
-            continue_final_message = False
+            resume_partial_request = False
             try:
                 async for line in gen:
                     for forwarded in turn.feed(line):
@@ -641,7 +686,9 @@ async def stream_chat_completion_with_local_tools(
                 # visible turn: OpenAI deltas are append-only, so text already streamed
                 # cannot be taken back the way a cumulative snapshot can.
                 intent_text = (turn.shown or turn.reasoning).strip()
-                already_acted = any(record.executed for record in controller.history)
+                already_acted = rag_autoinjected or any(
+                    record.executed for record in controller.history
+                )
                 used, cap = (
                     (post_tool_reprompts, MAX_POST_TOOL_REPROMPTS)
                     if already_acted
@@ -670,7 +717,12 @@ async def stream_chat_completion_with_local_tools(
                         cap,
                         len(intent_text),
                     )
-                    conversation.append({"role": "assistant", "content": intent_text})
+                    # merges into a resumed partial; the nudge below is a user turn.
+                    append_assistant_turn(
+                        conversation,
+                        {"role": "assistant", "content": intent_text},
+                        continue_final_message = continue_final_message,
+                    )
                     tool_hint = " or ".join(_tool_names(active_tools)) or "an available tool"
                     conversation.append(
                         {"role": "user", "content": reprompt_to_act_message(tool_hint)}
@@ -836,6 +888,8 @@ async def stream_chat_completion_with_local_tools(
                 completion = controller.record_result(decision, result)
                 executed_calls += 1
                 turn_executed_real_tool = True
+                # opens the post-tool phase; a carried-over stall text would eat its nudge.
+                last_reprompt_text = ""
                 resolved_provisional.add(decision.tool_call_id)
                 yield _sse(completion.tool_end_event())
                 tool_messages.append(completion.tool_message())
@@ -847,7 +901,12 @@ async def stream_chat_completion_with_local_tools(
             if assistant_tool_calls:
                 assistant_message["tool_calls"] = assistant_tool_calls
             if assistant_message["content"] or assistant_tool_calls:
-                conversation.append(assistant_message)
+                # merges into a resumed partial, so a continued tool turn stays one message.
+                append_assistant_turn(
+                    conversation,
+                    assistant_message,
+                    continue_final_message = continue_final_message,
+                )
             conversation.extend(tool_messages)
             append_deferred_nudges(conversation, nudge_messages)
             if turn_executed_real_tool:

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -31,6 +31,7 @@ from loggers import get_logger
 from core.inference.chat_template_helpers import (
     append_assistant_turn,
     neutralize_tool_descriptions,
+    reconciled_tool_choice,
 )
 from core.inference.tool_call_parser import (
     MAX_ACT_REPROMPTS,
@@ -607,6 +608,7 @@ async def stream_chat_completion_with_local_tools(
 
     # the client drops a markup-carrying tool from the catalog it sends, so authorize
     # against the same sanitized list or a withheld tool could still be executed (#7066).
+    requested_tools = tools
     tools = neutralize_tool_descriptions(tools)
     controller = ToolLoopController(tools = tools, auto_heal_tool_calls = auto_heal_tool_calls)
     all_tool_names = set(_tool_names(tools))
@@ -626,7 +628,9 @@ async def stream_chat_completion_with_local_tools(
     last_reprompt_text = ""
     # only the request is one-shot; the flag itself still merges the first generated turn.
     resume_partial_request = continue_final_message
-    forced_tool_choice = tool_choice
+    # the client sees only the sanitized list, so a choice forcing a dropped tool has
+    # to be downgraded here or the request names a function absent from `tools`.
+    forced_tool_choice = reconciled_tool_choice(tool_choice, requested_tools, tools)
     tool_denied = False
 
     try:
@@ -801,7 +805,8 @@ async def stream_chat_completion_with_local_tools(
                 if not decision.should_execute:
                     completion = controller.record_noop(decision)
                     nudge_messages.append(completion.model_message())
-                    resolved_provisional.add(decision.tool_call_id)
+                    # left unresolved on purpose: _close_provisional_cards ends any early
+                    # card this id opened, which no execution will ever close.
                     logger.info(
                         "Suppressed external local tool call as internal no-op: "
                         f"action={decision.action} tool={decision.tool_name}"

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -28,7 +28,10 @@ from typing import Any, AsyncGenerator, Callable, Optional, Sequence
 
 from loggers import get_logger
 
-from core.inference.chat_template_helpers import append_assistant_turn
+from core.inference.chat_template_helpers import (
+    append_assistant_turn,
+    neutralize_tool_descriptions,
+)
 from core.inference.tool_call_parser import (
     MAX_ACT_REPROMPTS,
     NUDGE_TOOL_CALLS_STATUS,
@@ -479,6 +482,33 @@ def _advance_tool_stream(generator: Any, outcome: dict[str, Any]) -> Any:
         return _STEP_DONE
 
 
+async def _drain_step_task(task: Optional["asyncio.Future"], cancel_event: threading.Event) -> None:
+    """Wait for a pending ``next(gen)`` worker before its generator is closed.
+
+    Cancelling the awaiting task does not stop the worker thread, and calling
+    ``close()`` while ``next()`` is still running raises ``ValueError: generator
+    already executing`` and skips the generator's own cleanup. Setting the cancel
+    flag lets a cancel-observing tool return, then the task is shielded until the
+    worker actually finishes.
+    """
+    if task is None:
+        return
+    cancel_event.set()
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancel_event.set()
+            continue
+        except Exception:
+            break
+    if task.done():
+        try:
+            task.exception()
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
 def _close_provisional_cards(turn: _TurnAccumulator, resolved: set[str]) -> list[str]:
     """End every early card no execution claimed, so none spins forever."""
     lines = []
@@ -574,6 +604,9 @@ async def stream_chat_completion_with_local_tools(
     # a KB search ran outside the controller, so the loop opens in its post-tool phase.
     rag_autoinjected = bool(autoinject)
 
+    # the client drops a markup-carrying tool from the catalog it sends, so authorize
+    # against the same sanitized list or a withheld tool could still be executed (#7066).
+    tools = neutralize_tool_descriptions(tools)
     controller = ToolLoopController(tools = tools, auto_heal_tool_calls = auto_heal_tool_calls)
     all_tool_names = set(_tool_names(tools))
     cancel_event = threading.Event()
@@ -631,6 +664,9 @@ async def stream_chat_completion_with_local_tools(
 
             if turn.failed:
                 # the error line already went out, so do not re-prompt from a half-finished turn.
+                # any early card still has to close, or the frontend keeps it spinning.
+                for line in _close_provisional_cards(turn, set()):
+                    yield line
                 return
 
             # safety net for a model that writes its call as text: llama-server does
@@ -867,9 +903,18 @@ async def stream_chat_completion_with_local_tools(
                     cancel_event = cancel_event,
                 )
                 outcome: dict[str, Any] = {}
+                step_task: Optional[asyncio.Future] = None
                 try:
                     while True:
-                        event = await asyncio.to_thread(_advance_tool_stream, tool_stream, outcome)
+                        step_task = asyncio.create_task(
+                            asyncio.to_thread(_advance_tool_stream, tool_stream, outcome)
+                        )
+                        # wait leaves the worker future pending when this coroutine is
+                        # cancelled, so the drain below can still join it; await would
+                        # cancel the future and let close() race the running next().
+                        await asyncio.wait({step_task})
+                        event = step_task.result()
+                        step_task = None
                         if event is _STEP_DONE:
                             break
                         if event.get("type") == "heartbeat":
@@ -883,6 +928,7 @@ async def stream_chat_completion_with_local_tools(
                     logger.exception("External local tool %s raised: %s", decision.tool_name, exc)
                     result = f"Error: tool raised an exception: {exc}"
                 finally:
+                    await _drain_step_task(step_task, cancel_event)
                     tool_stream.close()
                 completion = controller.record_result(decision, result)
                 executed_calls += 1

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -14,8 +14,8 @@ identical tool cards.
 Hosted providers are deliberately excluded. OpenAI, Anthropic, Gemini,
 OpenRouter and Kimi run their own server-side tools, already wired through
 ``enabled_tools`` in ``external_provider.py``; sending them a local tool
-catalog would duplicate or conflict with those. ``search_knowledge_base``
-(RAG) is excluded everywhere: retrieval stays local-only.
+catalog would duplicate or conflict with those. Selected RAG and MCP tools may
+join the self-hosted catalog because Studio still owns their execution.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ import asyncio
 import copy
 import json
 import threading
-from typing import Any, AsyncGenerator, Callable, Iterable, Optional, Sequence
+from typing import Any, AsyncGenerator, Callable, Optional, Sequence
 
 from loggers import get_logger
 
@@ -59,12 +59,6 @@ from state.tool_approvals import (
 
 logger = get_logger(__name__)
 
-
-# these self-hosted servers ship no tool runtime, so ours has nothing to collide with.
-LOCAL_TOOL_LOOP_PROVIDER_TYPES = frozenset({"vllm", "ollama", "llama_cpp", "custom"})
-
-# search_knowledge_base and render_html are excluded: RAG and Canvas stay local-only.
-LOCAL_TOOL_LOOP_TOOL_NAMES = ("web_search", "python", "terminal")
 
 # matches the local loops' default budget (generate_chat_completion_with_tools).
 DEFAULT_MAX_TOOL_ITERATIONS = 25
@@ -112,23 +106,11 @@ def _holdback_len(text: str) -> int:
 
 def local_tool_loop_supported(provider_type: Optional[str]) -> bool:
     """Whether this provider type may run the local tool loop."""
-    if not provider_type or provider_type not in LOCAL_TOOL_LOOP_PROVIDER_TYPES:
+    if not provider_type:
         return False
-    from core.inference.providers import get_provider_info
+    from core.inference.providers import provider_runs_local_tools
 
-    return bool((get_provider_info(provider_type) or {}).get("supports_tool_calling"))
-
-
-def select_local_tool_names(enabled_tools: Optional[Iterable[str]]) -> list[str]:
-    """Filter a request's ``enabled_tools`` down to what this loop may run.
-
-    Order follows ``LOCAL_TOOL_LOOP_TOOL_NAMES`` so the advertised catalog is
-    stable regardless of the order the client listed its pills in.
-    """
-    if not enabled_tools:
-        return []
-    requested = {str(name) for name in enabled_tools}
-    return [name for name in LOCAL_TOOL_LOOP_TOOL_NAMES if name in requested]
+    return provider_runs_local_tools(provider_type)
 
 
 def _sse(payload: dict[str, Any]) -> str:
@@ -146,6 +128,22 @@ def _first_delta(chunk: dict[str, Any]) -> dict[str, Any]:
         return {}
     delta = choices[0].get("delta")
     return delta if isinstance(delta, dict) else {}
+
+
+def _delta_text(content: Any) -> str:
+    """Normalize text from string or structured OpenAI-compatible deltas."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for part in content:
+        if not isinstance(part, dict) or part.get("type") not in ("text", "input_text"):
+            continue
+        text = part.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+    return "".join(parts)
 
 
 def _merge_usage(totals: dict[str, int], usage: Any) -> None:
@@ -240,8 +238,8 @@ class _TurnAccumulator:
         thinking = delta.get("reasoning_content")
         if isinstance(thinking, str) and thinking:
             self.reasoning += thinking
-        content = delta.get("content")
-        if isinstance(content, str) and content:
+        content = _delta_text(delta.get("content"))
+        if content:
             self.text += content
             content = self._gate_content(content)
         else:
@@ -507,6 +505,8 @@ async def stream_chat_completion_with_local_tools(
     permission_mode: Optional[str] = None,
     disable_parallel_tool_use: bool = False,
     nudge_tool_calls: Optional[bool] = None,
+    rag_scope: Any = None,
+    tool_choice: Any = None,
     execute_tool: Optional[Callable[..., str]] = None,
     **stream_kwargs: Any,
 ) -> AsyncGenerator[str, None]:
@@ -538,7 +538,7 @@ async def stream_chat_completion_with_local_tools(
     effective_timeout = (
         None if tool_call_timeout is not None and tool_call_timeout >= 9999 else tool_call_timeout
     )
-    remaining_iterations = max(1, max_tool_iterations)
+    remaining_iterations = max(0, max_tool_iterations)
     executed_calls = 0
     # budgeted apart from each other so a pre-tool nudge cannot spend the post-tool one.
     reprompt_count = 0
@@ -546,11 +546,13 @@ async def stream_chat_completion_with_local_tools(
     last_reprompt_text = ""
     # only the opening turn resumes a partial; later turns start from a tool result.
     continue_final_message = bool(stream_kwargs.pop("continue_final_message", False))
+    forced_tool_choice = tool_choice
+    tool_denied = False
 
     try:
         while True:
             # past the budget the catalog is dropped, so the last pass has to answer.
-            tools_allowed = remaining_iterations > 0
+            tools_allowed = remaining_iterations > 0 and not controller.force_final_answer
             active_tools = controller.active_tools() if tools_allowed else []
             enabled_tool_names = set(_tool_names(active_tools))
             turn = _TurnAccumulator(
@@ -565,6 +567,7 @@ async def stream_chat_completion_with_local_tools(
                 messages = conversation,
                 model = model,
                 tools = active_tools or None,
+                tool_choice = forced_tool_choice if active_tools else None,
                 stream = True,
                 continue_final_message = continue_final_message,
                 **stream_kwargs,
@@ -626,6 +629,8 @@ async def stream_chat_completion_with_local_tools(
             pending_calls = turn.ordered_tool_calls() if turn.wants_tools else text_calls
             if disable_parallel_tool_use:
                 pending_calls = pending_calls[:1]
+            if pending_calls and tools_allowed:
+                forced_tool_choice = None
 
             if not pending_calls or not tools_allowed:
                 # tool_calls emitted after the catalog was dropped are ignored, never executed.
@@ -647,6 +652,7 @@ async def stream_chat_completion_with_local_tools(
                     and auto_heal_tool_calls
                     # none keeps the default-on re-prompt; false disables it.
                     and (nudge_tool_calls is None or nudge_tool_calls)
+                    and not tool_denied
                     and active_tools
                     and not turn.shown.strip()
                     and used < cap
@@ -698,6 +704,7 @@ async def stream_chat_completion_with_local_tools(
             tool_messages: list[dict[str, Any]] = []
             nudge_messages: list[dict[str, Any]] = []
             resolved_provisional: set[str] = set()
+            turn_executed_real_tool = False
 
             for raw_call in pending_calls:
                 decision = controller.prepare_call(raw_call)
@@ -762,6 +769,7 @@ async def stream_chat_completion_with_local_tools(
                         yield _status_sse(decision.status_text)
                     if verdict == "deny":
                         decision_slot = None
+                        tool_denied = True
                         resolved_provisional.add(decision.tool_call_id)
                         yield _sse(
                             {
@@ -792,6 +800,7 @@ async def stream_chat_completion_with_local_tools(
                         "timeout": effective_timeout,
                         "session_id": session_id,
                         "thread_id": thread_id,
+                        "rag_scope": rag_scope,
                         "disable_sandbox": bypass_permissions,
                     }
                     if accepts_output_callback(execute_tool):
@@ -826,6 +835,7 @@ async def stream_chat_completion_with_local_tools(
                     tool_stream.close()
                 completion = controller.record_result(decision, result)
                 executed_calls += 1
+                turn_executed_real_tool = True
                 resolved_provisional.add(decision.tool_call_id)
                 yield _sse(completion.tool_end_event())
                 tool_messages.append(completion.tool_message())
@@ -840,7 +850,8 @@ async def stream_chat_completion_with_local_tools(
                 conversation.append(assistant_message)
             conversation.extend(tool_messages)
             append_deferred_nudges(conversation, nudge_messages)
-            remaining_iterations -= 1
+            if turn_executed_real_tool:
+                remaining_iterations -= 1
             if remaining_iterations == 0 and not controller.force_final_answer:
                 # the catalog is gone from here on, so say why rather than letting
                 # the next pass ask for a tool that is no longer offered.

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -564,6 +564,7 @@ async def stream_chat_completion_with_local_tools(
     rag_scope: Any = None,
     tool_choice: Any = None,
     execute_tool: Optional[Callable[..., str]] = None,
+    cancel_event: Optional[threading.Event] = None,
     **stream_kwargs: Any,
 ) -> AsyncGenerator[str, None]:
     """Stream a provider response, executing local tool calls in between.
@@ -609,7 +610,9 @@ async def stream_chat_completion_with_local_tools(
     tools = neutralize_tool_descriptions(tools)
     controller = ToolLoopController(tools = tools, auto_heal_tool_calls = auto_heal_tool_calls)
     all_tool_names = set(_tool_names(tools))
-    cancel_event = threading.Event()
+    # the route owns it when Stop has to reach a running tool through /inference/cancel.
+    if cancel_event is None:
+        cancel_event = threading.Event()
     usage_totals: dict[str, Any] = {}
     # 9999+ is the local loops' "no limit" sentinel.
     effective_timeout = (

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -566,7 +566,6 @@ async def stream_chat_completion_with_local_tools(
     autoinject = None
     if not skip_autoinject:
         from core.inference.tools import build_rag_autoinject
-
         autoinject = await asyncio.to_thread(build_rag_autoinject, conversation, rag_scope)
     if autoinject:
         for event in autoinject["events"]:

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -671,6 +671,15 @@ async def stream_chat_completion_with_local_tools(
         None if tool_call_timeout is not None and tool_call_timeout >= 9999 else tool_call_timeout
     )
     remaining_iterations = max(0, max_tool_iterations)
+    # every turn counts here, not just the ones that ran a tool: a denied or no-op turn
+    # leaves the budget alone, so without this an all-denied exchange never terminates.
+    # Mirrors the peers' bounded iteration range (safetensors_agentic.py:601).
+    max_total_turns = (
+        remaining_iterations + MAX_ACT_REPROMPTS + MAX_POST_TOOL_REPROMPTS + 1
+        if remaining_iterations > 0
+        else 1
+    )
+    turns_taken = 0
     executed_calls = 0
     # budgeted apart from each other so a pre-tool nudge cannot spend the post-tool one.
     reprompt_count = 0
@@ -687,6 +696,15 @@ async def stream_chat_completion_with_local_tools(
         while True:
             # Stop arrives as a POST that sets this event, so every boundary honours it.
             if cancel_event.is_set():
+                break
+            turns_taken += 1
+            if turns_taken > max_total_turns:
+                logger.warning(
+                    "External local tool loop hit its %d-turn ceiling without a final "
+                    "answer (executed_tool_calls=%d)",
+                    max_total_turns,
+                    executed_calls,
+                )
                 break
             # past the budget the catalog is dropped, so the last pass has to answer.
             tools_allowed = remaining_iterations > 0 and not controller.force_final_answer

--- a/studio/backend/core/inference/external_tool_loop.py
+++ b/studio/backend/core/inference/external_tool_loop.py
@@ -90,10 +90,6 @@ BUDGET_EXHAUSTED_NUDGE = (
     "so far, provide your final answer now. Do not call any more tools."
 )
 
-# withheld markup past this never becomes a call, so it is released rather than
-# buffered to the end of a turn that may never terminate.
-MAX_SUPPRESSED_MARKUP_CHARS = 32768
-
 # longest partial marker worth holding back at a delta boundary.
 _MAX_SIGNAL_PREFIX = max(len(signal) for signal in TOOL_XML_SIGNALS) - 1
 
@@ -224,7 +220,6 @@ class _TurnAccumulator:
         self.pending: str = ""
         self.suppressed_tail: str = ""
         self.markup_seen: bool = False
-        self._gate_abandoned: bool = False
         self.reasoning: str = ""
         self.tool_calls: dict[int, dict[str, Any]] = {}
         self.finish_reason: Optional[str] = None
@@ -313,24 +308,9 @@ class _TurnAccumulator:
 
     def _gate_content(self, text: str) -> str:
         """Return the part of ``text`` safe to show; hold or drop tool markup."""
-        if self._gate_abandoned:
-            self.shown += text
-            return text
         if self.markup_seen:
             self.suppressed_tail += text
-            if len(self.suppressed_tail) <= MAX_SUPPRESSED_MARKUP_CHARS:
-                return ""
-            # no real call runs this long, and a turn that never terminates would
-            # otherwise stay invisible to the client, so stop gating and show it.
-            self._gate_abandoned = True
-            released = self.release_suppressed()
-            self.shown += released
-            logger.warning(
-                "External local tool loop released %d chars of unterminated tool "
-                "markup: the turn is being shown as prose",
-                len(released),
-            )
-            return released
+            return ""
         self.pending += text
         marker = _first_signal_index(self.pending)
         if marker is not None:

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -281,6 +281,7 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
         # payload's base_url when the registry entry has none.
         "base_url": "",
         "default_models": [],
+        "model_capabilities": {"*": {"studio_tools": True}},
         "supports_streaming": True,
         "supports_vision": True,
         "supports_tool_calling": True,
@@ -298,6 +299,7 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
         # User-supplied via provider_base_url.
         "base_url": "",
         "default_models": [],
+        "model_capabilities": {"*": {"studio_tools": True}},
         "supports_streaming": True,
         "supports_vision": True,
         "supports_tool_calling": True,
@@ -314,6 +316,7 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
         "display_name": "Ollama",
         "base_url": "http://localhost:11434/v1",
         "default_models": [],
+        "model_capabilities": {"*": {"studio_tools": True}},
         "supports_streaming": True,
         "supports_vision": True,
         "supports_tool_calling": True,
@@ -330,6 +333,7 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
         "display_name": "llama.cpp",
         "base_url": "http://localhost:8080/v1",
         "default_models": [],
+        "model_capabilities": {"*": {"studio_tools": True}},
         "supports_streaming": True,
         "supports_vision": True,
         "supports_tool_calling": True,
@@ -383,6 +387,12 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
 def get_provider_info(provider_type: str) -> dict[str, Any] | None:
     """Return the registry entry for a provider type, or None if unknown."""
     return PROVIDER_REGISTRY.get(provider_type)
+
+
+def provider_runs_local_tools(provider_type: str) -> bool:
+    """Whether Studio may execute tools for this provider's models."""
+    capabilities = (PROVIDER_REGISTRY.get(provider_type) or {}).get("model_capabilities", {})
+    return bool((capabilities.get("*") or {}).get("studio_tools"))
 
 
 def get_base_url(provider_type: str) -> str | None:
@@ -544,15 +554,9 @@ def validate_provider_base_url(base_url: str) -> str:
 
 
 def list_available_providers() -> list[dict[str, Any]]:
-    """Return all registered providers (for the /registry endpoint).
-
-    Hidden entries are filtered out: they exist only for backend lookups and
-    are surfaced via ``CUSTOM_PROVIDER_PRESETS`` instead of the dropdown.
-    """
+    """Return all registered providers for the registry endpoint."""
     result = []
     for provider_type, info in PROVIDER_REGISTRY.items():
-        if info.get("hidden"):
-            continue
         result.append(
             {
                 "provider_type": provider_type,
@@ -560,6 +564,7 @@ def list_available_providers() -> list[dict[str, Any]]:
                 "base_url": info["base_url"],
                 "default_models": info["default_models"],
                 "model_capabilities": info.get("model_capabilities", {}),
+                "hidden": bool(info.get("hidden", False)),
                 "supports_streaming": info["supports_streaming"],
                 "supports_vision": info.get("supports_vision", False),
                 "supports_tool_calling": info.get("supports_tool_calling", False),

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -227,6 +227,8 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
     },
     "qwen": {
         "display_name": "Qwen",
+        # kept out of the connections picker; the entry still resolves saved connections.
+        "hidden": True,
         "base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         "default_models": [
             "qwen-plus",

--- a/studio/backend/models/providers.py
+++ b/studio/backend/models/providers.py
@@ -22,6 +22,7 @@ class ProviderRegistryEntry(BaseModel):
     )
 
     model_capabilities: dict[str, dict[str, bool]] = Field(default_factory = dict)
+    hidden: bool = False
     supports_streaming: bool = Field(
         True, description = "Whether this provider supports SSE streaming"
     )

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2780,6 +2780,24 @@ def _permission_mode_confirm(payload) -> bool:
     return bool(getattr(payload, "stream", False))
 
 
+def _local_tool_loop_opted_out(payload, provider_type: str) -> bool:
+    """Whether a self-hosted request disabled the local loop rather than lacking it.
+
+    ``tool_choice="none"`` and a zero call budget both empty the catalog on a provider
+    that could otherwise run it. No call can happen, so the confirm-gate guard has
+    nothing to reject and the request should proceed as an ordinary completion.
+    """
+    from core.inference.external_tool_loop import local_tool_loop_supported
+
+    if not local_tool_loop_supported(provider_type):
+        return False
+    if isinstance(payload.tool_choice, str) and payload.tool_choice.strip().lower() == "none":
+        return True
+    return (
+        payload.max_tool_calls_per_message is not None and payload.max_tool_calls_per_message <= 0
+    )
+
+
 def _external_loop_permission_mode(payload) -> Optional[str]:
     """Permission mode for the external local tool loop.
 
@@ -11374,6 +11392,7 @@ async def _proxy_to_external_provider(
         and not payload.bypass_permissions
         and not codex_studio_tool_loop
         and not local_tools
+        and not _local_tool_loop_opted_out(payload, provider_type)
         and (
             payload.enable_tools is True
             or bool(payload.enabled_tools)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11742,7 +11742,11 @@ async def _proxy_to_external_provider(
         base_url = base_url,
     )
     if local_tools:
-        local_tool_nudge = _build_tool_action_nudge(tools = local_tools, model_name = model)
+        local_tool_nudge = _build_tool_action_nudge(
+            tools = local_tools,
+            model_name = model,
+            full_access = bool(payload.bypass_permissions),
+        )
         local_tool_nudge = _apply_rag_nudge(
             local_tool_nudge, local_tools, rag_scope = payload.rag_scope
         )

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2785,8 +2785,10 @@ def _local_tool_loop_opted_out(payload, provider_type: str) -> bool:
     """Whether a self-hosted request disabled the local loop rather than lacking it.
 
     ``tool_choice="none"`` and a zero call budget both empty the catalog on a provider
-    that could otherwise run it. No call can happen, so the confirm-gate guard has
-    nothing to reject and the request should proceed as an ordinary completion.
+    that could otherwise run it, so the confirm-gate guard has nothing to reject and
+    the request proceeds as an ordinary completion. A zero budget is not an opt-out
+    when the request carries its own ``tools``: the passthrough still forwards those
+    schemas, and Studio cannot confirm provider-emitted calls against them.
     """
     from core.inference.external_tool_loop import local_tool_loop_supported
 
@@ -2794,6 +2796,11 @@ def _local_tool_loop_opted_out(payload, provider_type: str) -> bool:
         return False
     if isinstance(payload.tool_choice, str) and payload.tool_choice.strip().lower() == "none":
         return True
+    if payload.tools:
+        # client-supplied schemas are still forwarded by the passthrough, and Studio
+        # cannot confirm provider-emitted calls against them, so a zero local budget
+        # must not opt out of the confirm gate for these requests.
+        return False
     return (
         payload.max_tool_calls_per_message is not None and payload.max_tool_calls_per_message <= 0
     )

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11257,29 +11257,29 @@ def _build_external_messages(
     return result
 
 
-def _external_local_tool_names(payload: ChatCompletionRequest, provider_type: str) -> list[str]:
-    """Local tool names this external request may run, or ``[]`` when it may not.
+async def _external_local_tools(payload: ChatCompletionRequest, provider_type: str) -> list[dict]:
+    """Studio tools this external request may run, or ``[]`` when it may not.
 
     The loop only opens when the request explicitly asks for Unsloth's tool
     runtime on a self-hosted OpenAI-compat server. ``tool_choice="none"`` and
     caller-supplied ``tools`` both opt out: the first is an explicit "no
     tools", the second is passthrough where the caller drives function calling.
     """
-    from core.inference.external_tool_loop import (
-        local_tool_loop_supported,
-        select_local_tool_names,
-    )
-    from state.tool_policy import get_tool_policy
+    from core.inference.external_tool_loop import local_tool_loop_supported
 
-    if get_tool_policy() is False:
-        return []
-    if payload.enable_tools is not True or payload.tools:
+    if not _explicit_studio_tool_loop_requested(payload) or payload.tools:
         return []
     if isinstance(payload.tool_choice, str) and payload.tool_choice.strip().lower() == "none":
         return []
+    if payload.max_tool_calls_per_message is not None and payload.max_tool_calls_per_message <= 0:
+        return []
     if not local_tool_loop_supported(provider_type):
         return []
-    return select_local_tool_names(payload.enabled_tools)
+    return await _select_request_tools(
+        payload,
+        tools_on = payload.enable_tools is True,
+        mcp_allowed = bool(payload.mcp_enabled),
+    )
 
 
 def _append_external_tool_nudge(messages: list[dict], nudge: str) -> list[dict]:
@@ -11343,7 +11343,7 @@ async def _proxy_to_external_provider(
             detail = "Either provider_id or provider_type is required for external provider routing.",
         )
 
-    local_tool_names = _external_local_tool_names(payload, provider_type)
+    local_tools = await _external_local_tools(payload, provider_type)
     codex_studio_tool_loop = (
         provider_type == "openai_codex" and _explicit_studio_tool_loop_requested(payload)
     )
@@ -11351,7 +11351,7 @@ async def _proxy_to_external_provider(
         payload.confirm_tool_calls
         and not payload.bypass_permissions
         and not codex_studio_tool_loop
-        and not local_tool_names
+        and not local_tools
         and (
             payload.enable_tools is True
             or bool(payload.enabled_tools)
@@ -11679,7 +11679,7 @@ async def _proxy_to_external_provider(
             detail = "external_model is required when using an external provider.",
         )
 
-    if local_tool_names and not payload.stream:
+    if local_tools and not payload.stream:
         raise HTTPException(
             status_code = 400,
             detail = openai_error_body(
@@ -11700,13 +11700,14 @@ async def _proxy_to_external_provider(
         provider_type = provider_type,
         base_url = base_url,
     )
-    local_tools: list[dict] = []
-    if local_tool_names:
-        from core.inference.tools import ALL_TOOLS
-        local_tools = [tool for tool in ALL_TOOLS if tool["function"]["name"] in local_tool_names]
+    if local_tools:
+        local_tool_nudge = _build_tool_action_nudge(tools = local_tools, model_name = model)
+        local_tool_nudge = _apply_rag_nudge(
+            local_tool_nudge, local_tools, rag_scope = payload.rag_scope
+        )
         chat_messages = _append_external_tool_nudge(
             chat_messages,
-            _build_tool_action_nudge(tools = local_tools, model_name = model),
+            local_tool_nudge,
         )
     monitor_id = None
     if not getattr(request.state, "skip_api_monitor", False):
@@ -11777,6 +11778,8 @@ async def _proxy_to_external_provider(
                 permission_mode = payload.permission_mode,
                 disable_parallel_tool_use = payload.parallel_tool_calls is False,
                 nudge_tool_calls = payload.nudge_tool_calls,
+                rag_scope = payload.rag_scope,
+                tool_choice = payload.tool_choice,
                 **_provider_stream_kwargs,
             )
         else:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11257,6 +11257,54 @@ def _build_external_messages(
     return result
 
 
+def _external_local_tool_names(payload: ChatCompletionRequest, provider_type: str) -> list[str]:
+    """Local tool names this external request may run, or ``[]`` when it may not.
+
+    The loop only opens when the request explicitly asks for Unsloth's tool
+    runtime on a self-hosted OpenAI-compat server. ``tool_choice="none"`` and
+    caller-supplied ``tools`` both opt out: the first is an explicit "no
+    tools", the second is passthrough where the caller drives function calling.
+    """
+    from core.inference.external_tool_loop import (
+        local_tool_loop_supported,
+        select_local_tool_names,
+    )
+    from state.tool_policy import get_tool_policy
+
+    if get_tool_policy() is False:
+        return []
+    if payload.enable_tools is not True or payload.tools:
+        return []
+    if isinstance(payload.tool_choice, str) and payload.tool_choice.strip().lower() == "none":
+        return []
+    if not local_tool_loop_supported(provider_type):
+        return []
+    return select_local_tool_names(payload.enabled_tools)
+
+
+def _append_external_tool_nudge(messages: list[dict], nudge: str) -> list[dict]:
+    """Append the tool-use nudge to the leading system turn, adding one if absent.
+
+    The local path rebuilds the system prompt wholesale; here the caller's
+    system turn is already inside ``messages``, so the nudge is appended to it
+    instead of replacing it.
+    """
+    if not nudge:
+        return messages
+    head = messages[0] if messages else None
+    if not isinstance(head, dict) or head.get("role") != "system":
+        return [{"role": "system", "content": nudge}, *messages]
+    content = head.get("content")
+    merged = dict(head)
+    if isinstance(content, str):
+        merged["content"] = f"{content.rstrip()}\n\n{nudge}" if content.strip() else nudge
+    elif isinstance(content, list):
+        merged["content"] = [*content, {"type": "text", "text": nudge}]
+    else:
+        return [{"role": "system", "content": nudge}, *messages]
+    return [merged, *messages[1:]]
+
+
 async def _proxy_to_external_provider(
     payload: ChatCompletionRequest,
     request: Request,
@@ -11295,6 +11343,7 @@ async def _proxy_to_external_provider(
             detail = "Either provider_id or provider_type is required for external provider routing.",
         )
 
+    local_tool_names = _external_local_tool_names(payload, provider_type)
     codex_studio_tool_loop = (
         provider_type == "openai_codex" and _explicit_studio_tool_loop_requested(payload)
     )
@@ -11302,6 +11351,7 @@ async def _proxy_to_external_provider(
         payload.confirm_tool_calls
         and not payload.bypass_permissions
         and not codex_studio_tool_loop
+        and not local_tool_names
         and (
             payload.enable_tools is True
             or bool(payload.enabled_tools)
@@ -11629,6 +11679,16 @@ async def _proxy_to_external_provider(
             detail = "external_model is required when using an external provider.",
         )
 
+    if local_tool_names and not payload.stream:
+        raise HTTPException(
+            status_code = 400,
+            detail = openai_error_body(
+                "Local tools require stream=true on an external provider.",
+                status = 400,
+                code = "invalid_request_error",
+                param = "stream",
+            ),
+        )
     # Build messages, preserving multimodal content for vision providers
     from core.inference.providers import get_provider_info as _get_provider_info
 
@@ -11640,6 +11700,17 @@ async def _proxy_to_external_provider(
         provider_type = provider_type,
         base_url = base_url,
     )
+    local_tools: list[dict] = []
+    if local_tool_names:
+        from core.inference.tools import ALL_TOOLS
+
+        local_tools = [
+            tool for tool in ALL_TOOLS if tool["function"]["name"] in local_tool_names
+        ]
+        chat_messages = _append_external_tool_nudge(
+            chat_messages,
+            _build_tool_action_nudge(tools = local_tools, model_name = model),
+        )
     monitor_id = None
     if not getattr(request.state, "skip_api_monitor", False):
         monitor_id = api_monitor.start(
@@ -11665,32 +11736,67 @@ async def _proxy_to_external_provider(
     # `model_fields_set` tracks explicit-vs-default per request.
     _top_k_explicit = payload.top_k if "top_k" in payload.model_fields_set else None
 
+    # built once: the local tool loop re-sends these on every follow-up turn.
+    _provider_stream_kwargs = dict(
+        temperature = payload.temperature,
+        top_p = payload.top_p,
+        # max_completion_tokens covers a request that caps output without max_tokens.
+        max_tokens = _effective_max_tokens(payload),
+        presence_penalty = payload.presence_penalty,
+        top_k = _top_k_explicit,
+        enable_thinking = payload.enable_thinking,
+        reasoning_effort = payload.reasoning_effort,
+        enable_prompt_caching = payload.enable_prompt_caching,
+        compaction_threshold = payload.compaction_threshold,
+        continue_final_message = _continue_final_message(payload),
+    )
+
     async def _stream():
-        gen = client.stream_chat_completion(
-            messages = chat_messages,
-            model = model,
-            temperature = payload.temperature,
-            top_p = payload.top_p,
-            # Honor max_completion_tokens when max_tokens is absent, so a
-            # provider-routed request capped only by the newer field still gets
-            # a limit instead of falling back to the provider default.
-            max_tokens = _effective_max_tokens(payload),
-            presence_penalty = payload.presence_penalty,
-            top_k = _top_k_explicit,
-            enable_thinking = payload.enable_thinking,
-            reasoning_effort = payload.reasoning_effort,
-            enabled_tools = payload.enabled_tools,
-            enable_prompt_caching = payload.enable_prompt_caching,
-            openai_code_exec_container_id = payload.openai_code_exec_container_id,
-            anthropic_code_exec_container_id = payload.anthropic_code_exec_container_id,
-            prompt_cache_ttl = payload.prompt_cache_ttl,
-            compaction_threshold = payload.compaction_threshold,
-            tools = payload.tools,
-            tool_choice = payload.tool_choice,
-            fast_mode = payload.fast_mode,
-            continue_final_message = _continue_final_message(payload),
-            stream = payload.stream,
-        )
+        if local_tools:
+            from core.inference.external_tool_loop import (
+                DEFAULT_MAX_TOOL_ITERATIONS,
+                stream_chat_completion_with_local_tools,
+            )
+
+            gen = stream_chat_completion_with_local_tools(
+                client,
+                messages = chat_messages,
+                model = model,
+                tools = local_tools,
+                session_id = payload.session_id,
+                thread_id = payload.thread_id,
+                max_tool_iterations = payload.max_tool_calls_per_message
+                if payload.max_tool_calls_per_message is not None
+                else DEFAULT_MAX_TOOL_ITERATIONS,
+                tool_call_timeout = payload.tool_call_timeout
+                if payload.tool_call_timeout is not None
+                else 300,
+                auto_heal_tool_calls = payload.auto_heal_tool_calls
+                if payload.auto_heal_tool_calls is not None
+                else True,
+                # same gate as the local loops, so "auto" still prompts on a high-risk call.
+                confirm_tool_calls = _permission_mode_confirm(payload)
+                and not bool(payload.bypass_permissions),
+                bypass_permissions = bool(payload.bypass_permissions),
+                permission_mode = payload.permission_mode,
+                disable_parallel_tool_use = payload.parallel_tool_calls is False,
+                nudge_tool_calls = payload.nudge_tool_calls,
+                **_provider_stream_kwargs,
+            )
+        else:
+            gen = client.stream_chat_completion(
+                messages = chat_messages,
+                model = model,
+                enabled_tools = payload.enabled_tools,
+                openai_code_exec_container_id = payload.openai_code_exec_container_id,
+                anthropic_code_exec_container_id = payload.anthropic_code_exec_container_id,
+                prompt_cache_ttl = payload.prompt_cache_ttl,
+                tools = payload.tools,
+                tool_choice = payload.tool_choice,
+                fast_mode = payload.fast_mode,
+                stream = payload.stream,
+                **_provider_stream_kwargs,
+            )
         try:
             sent_done = False
             stream_failed = False

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11703,10 +11703,7 @@ async def _proxy_to_external_provider(
     local_tools: list[dict] = []
     if local_tool_names:
         from core.inference.tools import ALL_TOOLS
-
-        local_tools = [
-            tool for tool in ALL_TOOLS if tool["function"]["name"] in local_tool_names
-        ]
+        local_tools = [tool for tool in ALL_TOOLS if tool["function"]["name"] in local_tool_names]
         chat_messages = _append_external_tool_nudge(
             chat_messages,
             _build_tool_action_nudge(tools = local_tools, model_name = model),
@@ -11757,7 +11754,6 @@ async def _proxy_to_external_provider(
                 DEFAULT_MAX_TOOL_ITERATIONS,
                 stream_chat_completion_with_local_tools,
             )
-
             gen = stream_chat_completion_with_local_tools(
                 client,
                 messages = chat_messages,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11749,7 +11749,12 @@ async def _proxy_to_external_provider(
         continue_final_message = _continue_final_message(payload),
     )
 
+    # Stop only reaches a running local tool through /inference/cancel when a proxy
+    # swallows the browser's fetch abort, so this loop's event must be registered.
+    local_cancel_event = threading.Event() if local_tools else None
+
     async def _stream():
+        cancel_scope = ExitStack()
         if local_tools:
             from core.inference.external_tool_loop import (
                 DEFAULT_MAX_TOOL_ITERATIONS,
@@ -11780,6 +11785,7 @@ async def _proxy_to_external_provider(
                 nudge_tool_calls = payload.nudge_tool_calls,
                 rag_scope = payload.rag_scope,
                 tool_choice = payload.tool_choice,
+                cancel_event = local_cancel_event,
                 **_provider_stream_kwargs,
             )
         else:
@@ -11795,6 +11801,12 @@ async def _proxy_to_external_provider(
                 fast_mode = payload.fast_mode,
                 stream = payload.stream,
                 **_provider_stream_kwargs,
+            )
+        if local_cancel_event is not None:
+            cancel_scope.enter_context(
+                _TrackedCancel.for_payload(
+                    local_cancel_event, payload, payload.cancel_id, payload.session_id
+                )
             )
         try:
             sent_done = False
@@ -11848,6 +11860,7 @@ async def _proxy_to_external_provider(
             except RuntimeError:
                 pass  # suppress httpcore asyncgen cleanup error (Python 3.13 + httpcore 1.0.x)
             await client.close()
+            cancel_scope.close()
 
     return StreamingResponse(
         _stream(),

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2861,23 +2861,31 @@ class _TrackedCancel:
         thread_id = None,
         model = None,
         kind = "chat",
+        local_model = True,
     ):
         self.event = event
         self.keys = tuple(k for k in keys if k)
         # kind reaches the swap prompt: embeddings and raw completions have no conversation, so
         # naming them chats would offer to stop something the user never started from a thread.
         self._active = active_generations.ActiveGeneration(
-            event, thread_id = thread_id, model = model, kind = kind
+            event, thread_id = thread_id, model = model, kind = kind, local_model = local_model
         )
 
     @classmethod
-    def for_payload(cls, event: threading.Event, payload, *keys):
+    def for_payload(
+        cls,
+        event: threading.Event,
+        payload,
+        *keys,
+        local_model = True,
+    ):
         """Track the run against the conversation its request names."""
         return cls(
             event,
             *keys,
             thread_id = getattr(payload, "thread_id", None),
             model = getattr(payload, "model", None),
+            local_model = local_model,
         )
 
     def __enter__(self):
@@ -11817,9 +11825,15 @@ async def _proxy_to_external_provider(
                 **_provider_stream_kwargs,
             )
         if local_cancel_event is not None:
+            # tracked so deleting the thread stops its tools; flagged non-local so a model
+            # swap neither 409s on this stream nor cancels it.
             cancel_scope.enter_context(
                 _TrackedCancel.for_payload(
-                    local_cancel_event, payload, payload.cancel_id, payload.session_id
+                    local_cancel_event,
+                    payload,
+                    payload.cancel_id,
+                    payload.session_id,
+                    local_model = False,
                 )
             )
         try:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2780,6 +2780,20 @@ def _permission_mode_confirm(payload) -> bool:
     return bool(getattr(payload, "stream", False))
 
 
+def _external_loop_permission_mode(payload) -> Optional[str]:
+    """Permission mode for the external local tool loop.
+
+    ``_fold_full_permission_into_bypass`` resolves an explicit
+    ``confirm_tool_calls=true`` with no mode to "ask", but only for requests without
+    provider routing. An external caller's opt-in would otherwise reach the loop as an
+    unset mode and default to "auto", which prompts on high-risk calls alone and so
+    silently weakens the promise to pause before every call.
+    """
+    if payload.permission_mode is None and payload.confirm_tool_calls is True:
+        return "ask"
+    return payload.permission_mode
+
+
 def _confirm_gate_needs_stream(payload) -> bool:
     """Whether Unsloth's local tool-loop confirm gate still requires stream=true.
 
@@ -11780,7 +11794,7 @@ async def _proxy_to_external_provider(
                 confirm_tool_calls = _permission_mode_confirm(payload)
                 and not bool(payload.bypass_permissions),
                 bypass_permissions = bool(payload.bypass_permissions),
-                permission_mode = payload.permission_mode,
+                permission_mode = _external_loop_permission_mode(payload),
                 disable_parallel_tool_use = payload.parallel_tool_calls is False,
                 nudge_tool_calls = payload.nudge_tool_calls,
                 rag_scope = payload.rag_scope,

--- a/studio/backend/state/active_generations.py
+++ b/studio/backend/state/active_generations.py
@@ -78,9 +78,15 @@ class ActiveGeneration:
 
 
 def snapshot() -> list[dict[str, Any]]:
-    """In-flight generations, newest last. Drops the Event: this is a response."""
+    """Generations a model swap would interrupt, newest last. Drops the Event.
+
+    Non-local entries are left out for the same reason ``count()`` skips them: the
+    swap cannot interrupt an external provider stream, so naming it would prompt the
+    user to stop a chat that the load leaves running. ``cancel_thread`` reads the
+    registry directly, so thread deletion still reaches them.
+    """
     with _LOCK:
-        entries = list(_ACTIVE.values())
+        entries = [e for e in _ACTIVE.values() if e.get("local_model", True)]
     entries.sort(key = lambda e: e["started_at"])
     return [
         {
@@ -100,11 +106,8 @@ def active_thread_ids() -> list[str]:
     A first turn that races persistence has no thread id yet: count() sees it,
     this cannot name it.
     """
-    with _LOCK:
-        entries = [e for e in _ACTIVE.values() if e.get("local_model", True)]
-    entries.sort(key = lambda e: e["started_at"])
     seen: list[str] = []
-    for e in entries:
+    for e in snapshot():
         tid = e["thread_id"]
         if tid and tid not in seen:
             seen.append(tid)

--- a/studio/backend/state/active_generations.py
+++ b/studio/backend/state/active_generations.py
@@ -35,7 +35,7 @@ class ActiveGeneration:
     Each __enter__ mints its own handle, so overlapping uses never clobber.
     """
 
-    __slots__ = ("thread_id", "cancel_event", "model", "kind", "_handle")
+    __slots__ = ("thread_id", "cancel_event", "model", "kind", "local_model", "_handle")
 
     def __init__(
         self,
@@ -44,11 +44,15 @@ class ActiveGeneration:
         thread_id: Optional[str] = None,
         model: Optional[str] = None,
         kind: str = "chat",
+        local_model: bool = True,
     ):
         self.thread_id = thread_id or None
         self.cancel_event = cancel_event
         self.model = model or None
         self.kind = kind
+        # an external provider stream is registered for thread deletion but does not
+        # decode on the local server, so the model-swap guard must not count it.
+        self.local_model = local_model
         self._handle: Optional[str] = None
 
     def __enter__(self) -> "ActiveGeneration":
@@ -59,6 +63,7 @@ class ActiveGeneration:
                 "thread_id": self.thread_id,
                 "model": self.model,
                 "kind": self.kind,
+                "local_model": self.local_model,
                 "started_at": time.time(),
                 "event": self.cancel_event,
             }
@@ -95,8 +100,11 @@ def active_thread_ids() -> list[str]:
     A first turn that races persistence has no thread id yet: count() sees it,
     this cannot name it.
     """
+    with _LOCK:
+        entries = [e for e in _ACTIVE.values() if e.get("local_model", True)]
+    entries.sort(key = lambda e: e["started_at"])
     seen: list[str] = []
-    for e in snapshot():
+    for e in entries:
         tid = e["thread_id"]
         if tid and tid not in seen:
             seen.append(tid)
@@ -104,9 +112,13 @@ def active_thread_ids() -> list[str]:
 
 
 def count() -> int:
-    """Number of generations currently in flight."""
+    """Generations decoding on the local server, which a model swap would interrupt.
+
+    External provider streams are registered here so thread deletion can stop them,
+    but they survive a swap untouched, so they are not counted.
+    """
     with _LOCK:
-        return len(_ACTIVE)
+        return sum(1 for e in _ACTIVE.values() if e.get("local_model", True))
 
 
 def cancel_all() -> int:
@@ -117,7 +129,7 @@ def cancel_all() -> int:
     counted.
     """
     with _LOCK:
-        events = [e["event"] for e in _ACTIVE.values()]
+        events = [e["event"] for e in _ACTIVE.values() if e.get("local_model", True)]
     for ev in events:
         try:
             ev.set()

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -195,7 +195,9 @@ def test_custom_provider_registry_is_hidden():
     info = get_provider_info("custom")
     assert info is not None
     assert info["hidden"] is True
-    assert "custom" not in {p["provider_type"] for p in list_available_providers()}
+    entry = next(p for p in list_available_providers() if p["provider_type"] == "custom")
+    assert entry["hidden"] is True
+    assert entry["model_capabilities"]["*"]["studio_tools"] is True
 
 
 def test_custom_provider_uses_chat_completions_without_auth_key(monkeypatch):

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -236,6 +236,45 @@ def test_custom_provider_uses_chat_completions_without_auth_key(monkeypatch):
     assert any("ok" in line for line in lines)
 
 
+def test_top_k_forwarded_for_openai_compat_connections(monkeypatch):
+    # The sidebar advertises Top-K for the self-hosted OAI-compat family
+    # (vLLM / llama.cpp / Ollama / custom) and the frontend sends it, but the
+    # OpenAI-compat request body dropped it, so the control had no effect.
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content = b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run(top_k):
+        client = _make_custom_client()
+        await _collect(
+            client.stream_chat_completion(
+                messages = [{"role": "user", "content": "ping"}],
+                model = "Qwen/Qwen3-0.6B",
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 64,
+                top_k = top_k,
+            )
+        )
+        await client.close()
+
+    _drive(run(20))
+    assert captured["body"].get("top_k") == 20
+
+    # 0 = "Off" must never be forwarded (some servers reject it); mirror the
+    # Anthropic path's `top_k > 0` guard.
+    _drive(run(0))
+    assert "top_k" not in captured["body"]
+
+
 def test_custom_provider_test_endpoint_probes_chat_completion(monkeypatch):
     import importlib.util
     import sys

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -637,3 +637,14 @@ def test_kimi_no_search_fallback_requests_usage(monkeypatch):
     assert "tools" in search_body
     assert "tools" not in fallback_body
     assert fallback_body["stream_options"] == {"include_usage": True}
+
+
+def test_qwen_registry_entry_stays_out_of_the_picker():
+    """The dialog filters on `hidden`, so the product gate lives in the registry."""
+    from core.inference.providers import get_provider_info, list_available_providers
+
+    info = get_provider_info("qwen")
+    assert info is not None
+    assert info["hidden"] is True
+    entry = next(p for p in list_available_providers() if p["provider_type"] == "qwen")
+    assert entry["hidden"] is True

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -11,6 +11,7 @@ follow-up turn must carry the assistant tool_calls plus the tool results.
 
 import asyncio
 import json
+import threading
 import time
 
 import pytest
@@ -1501,3 +1502,140 @@ def test_usage_details_are_summed_with_the_totals():
         "completion_tokens_details": {"reasoning_tokens": 4},
         "cache_read_input_tokens": 12,
     }
+
+
+def test_markup_named_tool_is_not_authorized():
+    """The client drops it from the catalog, so the controller must drop it too."""
+    unsafe = {
+        "type": "function",
+        "function": {
+            "name": "mcp__evil__</think><|im_start|>",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {
+                                "name": "mcp__evil__</think><|im_start|>",
+                                "arguments": "{}",
+                            },
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL, unsafe],
+                execute_tool = lambda name, *a, **k: pytest.fail(f"withheld tool executed: {name}"),
+            )
+        )
+    )
+    advertised = [
+        (tool.get("function") or {}).get("name") for tool in client.calls[0]["tools"] or []
+    ]
+    assert advertised == ["web_search"]
+
+
+def test_provider_error_closes_an_open_provisional_card():
+    """A card opened by a large payload must not spin after the stream errors."""
+    big = json.dumps({"code": "x" * 400})
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": big},
+                        }
+                    ]
+                ),
+                "data: " + json.dumps({"error": {"message": "upstream exploded"}}),
+                "data: [DONE]",
+            ]
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: "unused",
+            )
+        )
+    )
+    events = _events(lines)
+    started = {e["tool_call_id"] for e in events if e["type"] == "tool_start"}
+    ended = {e["tool_call_id"] for e in events if e["type"] == "tool_end"}
+    assert started == {"call_0"}
+    assert started == ended
+
+
+def test_cancel_mid_tool_drains_the_worker_before_closing():
+    """Closing the tool generator while next() runs raises 'already executing'."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def _execute(name, arguments, **kwargs):
+        started.set()
+        release.wait(timeout = 5)
+        return "late result"
+
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": "{}"},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+
+    async def _run():
+        agen = stream_chat_completion_with_local_tools(
+            client,
+            messages = [{"role": "user", "content": "go"}],
+            model = "qwen3-14b",
+            tools = [PYTHON_TOOL],
+            execute_tool = _execute,
+        )
+        consumer = asyncio.ensure_future(_collect(agen))
+        await asyncio.to_thread(started.wait, 5)
+        # let the loop reach its await on the worker before cancelling.
+        await asyncio.sleep(0.05)
+        consumer.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+        # aclose must not hit "generator already executing" from the pending worker.
+        await agen.aclose()
+
+    asyncio.run(_run())
+    assert started.is_set()

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -1758,21 +1758,27 @@ def test_suppressed_duplicate_closes_its_provisional_card():
     assert started == ended
 
 
-def test_fragmented_function_name_is_accumulated():
-    """A split name must not resolve to its last fragment and read as disabled."""
+def test_a_regrown_function_name_replaces_rather_than_appends():
+    """llama-server re-sends the whole name as it grows (common/chat.cpp), not a suffix."""
     executed = []
     client = _FakeClient(
         [
             [
-                _chunk(tool_calls = [{"index": 0, "id": "c0", "function": {"name": "web_"}}]),
+                _chunk(
+                    tool_calls = [
+                        {"index": 0, "id": "w1", "function": {"name": "web", "arguments": "{"}}
+                    ]
+                ),
                 _chunk(
                     tool_calls = [
                         {
                             "index": 0,
-                            "function": {"name": "search", "arguments": '{"query":"x"}'},
+                            "id": "w1",
+                            "function": {"name": "web_search", "arguments": '"query"'},
                         }
                     ]
                 ),
+                _chunk(tool_calls = [{"index": 0, "function": {"arguments": ': "unsloth"}'}}]),
                 _finish("tool_calls"),
                 "data: [DONE]",
             ],
@@ -1781,7 +1787,7 @@ def test_fragmented_function_name_is_accumulated():
     )
 
     def _execute(name, arguments, **kwargs):
-        executed.append(name)
+        executed.append((name, arguments))
         return "Title: x"
 
     asyncio.run(
@@ -1795,7 +1801,7 @@ def test_fragmented_function_name_is_accumulated():
             )
         )
     )
-    assert executed == ["web_search"]
+    assert executed == [("web_search", {"query": "unsloth"})]
 
 
 def test_tool_call_without_an_id_still_pairs_its_result():
@@ -1946,3 +1952,121 @@ def test_a_set_cancel_event_stops_the_loop():
     assert len(client.calls) == 1
     assert "should never be requested." not in _content(lines)
     assert lines[-1] == "data: [DONE]"
+
+
+def test_a_noop_only_turn_keeps_roles_alternating():
+    """A no-op appends no assistant turn, and a strict server rejects user/user."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {"index": 0, "id": "c0", "function": {"name": "bash", "arguments": "{}"}}
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "ok"), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "run ls"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: pytest.fail("disabled tool must not run"),
+            )
+        )
+    )
+    roles = [message["role"] for message in client.calls[1]["messages"]]
+    assert roles == ["user"]
+    assert "bash" in client.calls[1]["messages"][-1]["content"]
+
+
+def test_budget_nudge_merges_into_a_trailing_noop_nudge():
+    """Both are user turns, so appending the second bare would break alternation."""
+    big_a = json.dumps({"code": "a"})
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {"index": 0, "id": "c0", "function": {"name": "python", "arguments": big_a}}
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "c1",
+                            "function": {"name": "python", "arguments": big_a},
+                        },
+                        {
+                            "index": 1,
+                            "id": "c2",
+                            "function": {"name": "python", "arguments": json.dumps({"code": "b"})},
+                        },
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                max_tool_iterations = 2,
+                execute_tool = lambda *a, **k: "out",
+            )
+        )
+    )
+    roles = [message["role"] for message in client.calls[2]["messages"]]
+    assert all(a != b for a, b in zip(roles, roles[1:]))
+
+
+def test_dropped_parallel_call_opens_no_provisional_card():
+    """Only the first call runs, so a card for the rest would stream then blank out."""
+    big = json.dumps({"code": "z" * 400})
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {"index": 0, "id": "c0", "function": {"name": "python", "arguments": big}},
+                        {"index": 1, "id": "c1", "function": {"name": "python", "arguments": big}},
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                disable_parallel_tool_use = True,
+                execute_tool = lambda *a, **k: "ok",
+            )
+        )
+    )
+    events = _events(lines)
+    assert {e["tool_call_id"] for e in events if e["type"] == "tool_start"} == {"c0"}
+    assert not [e for e in events if e["type"] == "tool_args" and e["tool_call_id"] == "c1"]

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -1681,3 +1681,78 @@ def test_injected_cancel_event_reaches_the_tool():
         )
     )
     assert seen["cancel_event"] is route_event
+
+
+def test_forced_choice_is_downgraded_when_its_tool_is_dropped():
+    """The client sees only the sanitized list, so the forced name must go with it."""
+    unsafe = {
+        "type": "function",
+        "function": {
+            "name": "mcp__evil__</think>",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    client = _FakeClient([[_chunk(content = "no tool needed."), _finish("stop"), "data: [DONE]"]])
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL, unsafe],
+                tool_choice = {
+                    "type": "function",
+                    "function": {"name": "mcp__evil__</think>"},
+                },
+                execute_tool = lambda *a, **k: "unused",
+            )
+        )
+    )
+    assert client.calls[0]["tool_choice"] == "auto"
+
+
+def test_suppressed_duplicate_closes_its_provisional_card():
+    """A no-op call still owns the early card the accumulator opened for it."""
+    big = json.dumps({"code": "y" * 400})
+    repeat = [
+        {
+            "index": 0,
+            "id": "call_1",
+            "function": {"name": "python", "arguments": big},
+        }
+    ]
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": big},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(tool_calls = repeat), _finish("tool_calls"), "data: [DONE]"],
+            [_chunk(content = "done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: "42",
+            )
+        )
+    )
+    events = _events(lines)
+    started = {e["tool_call_id"] for e in events if e["type"] == "tool_start"}
+    ended = {e["tool_call_id"] for e in events if e["type"] == "tool_end"}
+    assert "call_1" in started
+    assert started == ended

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -1313,9 +1313,7 @@ def test_rag_autoinject_runs_before_the_first_provider_turn(monkeypatch):
             "messages": [{"role": "user", "content": "Passage: unsloth trains fast."}],
         },
     )
-    client = _FakeClient(
-        [[_chunk(content = "It trains fast."), _finish("stop"), "data: [DONE]"]]
-    )
+    client = _FakeClient([[_chunk(content = "It trains fast."), _finish("stop"), "data: [DONE]"]])
     lines = asyncio.run(
         _collect(
             stream_chat_completion_with_local_tools(
@@ -1329,9 +1327,7 @@ def test_rag_autoinject_runs_before_the_first_provider_turn(monkeypatch):
     )
     first_turn = client.calls[0]["messages"]
     assert first_turn[-1]["content"] == "Passage: unsloth trains fast."
-    assert any(
-        event.get("tool_name") == "search_knowledge_base" for event in _events(lines)
-    )
+    assert any(event.get("tool_name") == "search_knowledge_base" for event in _events(lines))
 
 
 def test_ask_mode_skips_rag_autoinject(monkeypatch):
@@ -1343,9 +1339,7 @@ def test_ask_mode_skips_rag_autoinject(monkeypatch):
         "build_rag_autoinject",
         lambda conversation, rag_scope: pytest.fail("autoinject must not run under ask"),
     )
-    client = _FakeClient(
-        [[_chunk(content = "Ask me to search."), _finish("stop"), "data: [DONE]"]]
-    )
+    client = _FakeClient([[_chunk(content = "Ask me to search."), _finish("stop"), "data: [DONE]"]])
     asyncio.run(
         _collect(
             stream_chat_completion_with_local_tools(

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -1292,3 +1292,218 @@ def test_denied_call_does_not_trigger_an_action_nudge(monkeypatch):
     assert len(client.calls) == 2
     statuses = [event.get("content") for event in _events(lines) if event["type"] == "tool_status"]
     assert NUDGE_TOOL_CALLS_STATUS not in statuses
+
+
+def test_rag_autoinject_runs_before_the_first_provider_turn(monkeypatch):
+    """The tool nudge promises attached passages, so retrieval must precede turn one."""
+    from core.inference import tools as inference_tools
+
+    monkeypatch.setattr(
+        inference_tools,
+        "build_rag_autoinject",
+        lambda conversation, rag_scope: {
+            "events": [
+                {
+                    "type": "tool_end",
+                    "tool_name": "search_knowledge_base",
+                    "tool_call_id": "auto_0",
+                    "result": "Passage 1",
+                }
+            ],
+            "messages": [{"role": "user", "content": "Passage: unsloth trains fast."}],
+        },
+    )
+    client = _FakeClient(
+        [[_chunk(content = "It trains fast."), _finish("stop"), "data: [DONE]"]]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "what do the docs say"}],
+                model = "qwen3-14b",
+                tools = [RAG_TOOL],
+                rag_scope = {"thread_id": "thread-1"},
+            )
+        )
+    )
+    first_turn = client.calls[0]["messages"]
+    assert first_turn[-1]["content"] == "Passage: unsloth trains fast."
+    assert any(
+        event.get("tool_name") == "search_knowledge_base" for event in _events(lines)
+    )
+
+
+def test_ask_mode_skips_rag_autoinject(monkeypatch):
+    """A retrieval call that would prompt is left to the confirm gate."""
+    from core.inference import tools as inference_tools
+
+    monkeypatch.setattr(
+        inference_tools,
+        "build_rag_autoinject",
+        lambda conversation, rag_scope: pytest.fail("autoinject must not run under ask"),
+    )
+    client = _FakeClient(
+        [[_chunk(content = "Ask me to search."), _finish("stop"), "data: [DONE]"]]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "what do the docs say"}],
+                model = "qwen3-14b",
+                tools = [RAG_TOOL],
+                rag_scope = {"thread_id": "thread-1"},
+                confirm_tool_calls = True,
+                permission_mode = "ask",
+            )
+        )
+    )
+    assert len(client.calls) == 1
+
+
+def test_continued_partial_merges_the_generated_tool_turn():
+    """Two consecutive assistant turns break role alternation on vLLM/llama.cpp."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(content = " and here it is:"),
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": "{}"},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = " done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [
+                    {"role": "user", "content": "compute it"},
+                    {"role": "assistant", "content": "Let me compute that"},
+                ],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                continue_final_message = True,
+                execute_tool = lambda *a, **k: "4",
+            )
+        )
+    )
+    assert client.calls[0]["continue_final_message"] is True
+    assert client.calls[1]["continue_final_message"] is False
+    followup = client.calls[1]["messages"]
+    assert [message["role"] for message in followup] == ["user", "assistant", "tool"]
+    assert followup[1]["content"] == "Let me compute thatand here it is:"
+    assert followup[1]["tool_calls"][0]["function"]["name"] == "python"
+
+
+def test_post_tool_nudge_survives_a_repeated_pre_tool_intent():
+    """A stall repeated after the tool ran is a new phase, not a repeat."""
+    intent = "I will search the web for the 2026 box office totals."
+    client = _FakeClient(
+        [
+            [_chunk(reasoning = intent), _finish("stop"), "data: [DONE]"],
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "web_search", "arguments": "{}"},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(reasoning = intent), _finish("stop"), "data: [DONE]"],
+            [_chunk(content = "The Odyssey led 2026."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "highest grossing movie of 2026"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                execute_tool = lambda *a, **k: "Title: The Odyssey",
+            )
+        )
+    )
+    assert len(client.calls) == 4
+    assert client.calls[3]["messages"][-1]["role"] == "user"
+    assert "web_search" in client.calls[3]["messages"][-1]["content"]
+    assert _content(lines) == "The Odyssey led 2026."
+
+
+def test_usage_details_are_summed_with_the_totals():
+    """Dropping cached/reasoning counts would blank the frontend cache readout."""
+    detailed = "data: " + json.dumps(
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "prompt_tokens_details": {"cached_tokens": 6},
+                "completion_tokens_details": {"reasoning_tokens": 2},
+                "cache_read_input_tokens": 6,
+            },
+        }
+    )
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": "{}"},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                detailed,
+                "data: [DONE]",
+            ],
+            [_chunk(content = "ok"), _finish("stop"), detailed, "data: [DONE]"],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: "ok",
+            )
+        )
+    )
+    usage_chunks = [
+        json.loads(line[len("data:") :].strip())
+        for line in lines
+        if line != "data: [DONE]" and '"usage"' in line
+    ]
+    assert len(usage_chunks) == 1
+    assert usage_chunks[0]["usage"] == {
+        "prompt_tokens": 20,
+        "completion_tokens": 10,
+        "total_tokens": 30,
+        "prompt_tokens_details": {"cached_tokens": 12},
+        "completion_tokens_details": {"reasoning_tokens": 4},
+        "cache_read_input_tokens": 12,
+    }

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -17,9 +17,10 @@ import pytest
 
 from core.inference.external_tool_loop import (
     local_tool_loop_supported,
-    select_local_tool_names,
     stream_chat_completion_with_local_tools,
 )
+from core.inference.providers import PROVIDER_REGISTRY
+from core.inference.tool_call_parser import NUDGE_TOOL_CALLS_STATUS
 
 
 def _chunk(**delta) -> str:
@@ -78,6 +79,20 @@ PYTHON_TOOL = {
     "type": "function",
     "function": {"name": "python", "parameters": {"type": "object", "properties": {}}},
 }
+RAG_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "search_knowledge_base",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+MCP_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "mcp__docs__lookup",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
 
 
 async def _collect(gen) -> list[str]:
@@ -118,25 +133,14 @@ def _content(lines: list[str]) -> str:
 
 
 def test_local_tool_loop_supported_only_for_self_hosted_providers():
-    for provider_type in ("vllm", "ollama", "llama_cpp", "custom"):
-        assert local_tool_loop_supported(provider_type) is True, provider_type
-    # hosted providers ship their own server-side tools; the local loop must
-    # never advertise a competing catalog to them.
-    for provider_type in ("openai", "anthropic", "gemini", "openrouter", "kimi", None, ""):
-        assert local_tool_loop_supported(provider_type) is False, provider_type
-
-
-def test_select_local_tool_names_filters_and_orders():
-    assert select_local_tool_names(["terminal", "web_search", "python"]) == [
-        "web_search",
-        "python",
-        "terminal",
-    ]
-    # rag stays local-only and the hosted builtin names are not local tools.
-    assert select_local_tool_names(["search_knowledge_base"]) == []
-    assert select_local_tool_names(["render_html", "web_fetch", "code_execution"]) == []
-    assert select_local_tool_names(None) == []
-    assert select_local_tool_names([]) == []
+    supported = {
+        provider_type
+        for provider_type in PROVIDER_REGISTRY
+        if local_tool_loop_supported(provider_type)
+    }
+    assert supported == {"vllm", "ollama", "llama_cpp", "custom"}
+    assert local_tool_loop_supported(None) is False
+    assert local_tool_loop_supported("") is False
 
 
 # ── loop ─────────────────────────────────────────────────────────
@@ -253,6 +257,21 @@ def test_answer_without_tool_calls_passes_straight_through():
     assert lines[-1] == "data: [DONE]"
 
 
+def test_structured_content_parts_are_normalized_to_text():
+    client = _FakeClient([[_chunk(content = [{"type": "text", "text": "hello"}]), _finish("stop")]])
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "hi"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+            )
+        )
+    )
+    assert _content(lines) == "hello"
+
+
 def test_iteration_budget_drops_the_catalog_for_the_final_pass():
     tool_turn = [
         _chunk(
@@ -286,6 +305,150 @@ def test_iteration_budget_drops_the_catalog_for_the_final_pass():
     # budget spent: the last request carries no catalog, so the model has to answer.
     assert client.calls[1]["tools"] is None
     assert lines[-1] == "data: [DONE]"
+
+
+def test_forced_tool_choice_applies_until_the_first_call():
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": '{"code":"1"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+            ],
+            [_chunk(content = "done"), _finish("stop")],
+        ]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "run it"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                tool_choice = "required",
+                execute_tool = lambda *a, **k: "1",
+            )
+        )
+    )
+    assert client.calls[0]["tool_choice"] == "required"
+    assert client.calls[1]["tool_choice"] is None
+
+
+def test_zero_iteration_budget_sends_no_tool_catalog():
+    client = _FakeClient([[_chunk(content = "done"), _finish("stop")]])
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "answer"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                max_tool_iterations = 0,
+                execute_tool = lambda *a, **k: pytest.fail("no tool should run"),
+            )
+        )
+    )
+    assert client.calls[0]["tools"] is None
+    assert _content(lines) == "done"
+
+
+def test_selected_mcp_tool_executes_with_rag_scope():
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_mcp",
+                            "function": {
+                                "name": "mcp__docs__lookup",
+                                "arguments": '{"query":"tools"}',
+                            },
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+            ],
+            [_chunk(content = "found it"), _finish("stop")],
+        ]
+    )
+    seen = {}
+
+    def _execute(name, arguments, **kwargs):
+        seen.update(name = name, arguments = arguments, **kwargs)
+        return "result"
+
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "search"}],
+                model = "qwen3-14b",
+                tools = [MCP_TOOL, RAG_TOOL],
+                rag_scope = {"project_id": "project-1"},
+                execute_tool = _execute,
+            )
+        )
+    )
+    assert seen["name"] == "mcp__docs__lookup"
+    assert seen["arguments"] == {"query": "tools"}
+    assert seen["rag_scope"] == {"project_id": "project-1"}
+
+
+def test_duplicate_noop_does_not_spend_a_tool_iteration():
+    def tool_turn(call_id: str, code: str) -> list[str]:
+        return [
+            _chunk(
+                tool_calls = [
+                    {
+                        "index": 0,
+                        "id": call_id,
+                        "function": {
+                            "name": "python",
+                            "arguments": json.dumps({"code": code}),
+                        },
+                    }
+                ]
+            ),
+            _finish("tool_calls"),
+        ]
+
+    client = _FakeClient(
+        [
+            tool_turn("call_1", "1"),
+            tool_turn("call_2", "1"),
+            tool_turn("call_3", "2"),
+            [_chunk(content = "done"), _finish("stop")],
+        ]
+    )
+    executed = []
+
+    def _execute(_name, arguments, **_kwargs):
+        executed.append(arguments["code"])
+        return arguments["code"]
+
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "run both"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                max_tool_iterations = 2,
+                execute_tool = _execute,
+            )
+        )
+    )
+    assert executed == ["1", "2"]
+    assert [bool(call["tools"]) for call in client.calls] == [True, True, True, False]
 
 
 def test_usage_is_summed_into_one_trailing_chunk():
@@ -436,6 +599,52 @@ def test_disabled_tool_call_is_suppressed_and_nudged():
     follow_up = client.calls[1]["messages"]
     assert follow_up[-1]["role"] == "user"
     assert "not enabled" in follow_up[-1]["content"]
+
+
+def test_forced_final_answer_ignores_more_model_tool_calls():
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_disabled",
+                            "function": {
+                                "name": "terminal",
+                                "arguments": '{"command":"ls"}',
+                            },
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+            ],
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_ignored",
+                            "function": {"name": "python", "arguments": '{"code":"1"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+            ],
+        ]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "list files"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: pytest.fail("no tool should run"),
+            )
+        )
+    )
+    assert client.calls[1]["tools"] is None
 
 
 # ── parity with the local loops ──────────────────────────────────
@@ -1042,3 +1251,44 @@ def test_approval_wait_flushes_card_on_a_separate_event_loop_turn():
     card_index = next(i for i, line in enumerate(lines) if '"tool_start"' in line)
     assert lines.index(keepalives[0]) > card_index
     assert first_post_card_turn_advanced is True
+
+
+def test_denied_call_does_not_trigger_an_action_nudge(monkeypatch):
+    import core.inference.external_tool_loop as loop_module
+
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": '{"code":"1"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+            ],
+            [_chunk(reasoning = "I will try Python now."), _finish("stop")],
+        ]
+    )
+    monkeypatch.setattr(loop_module, "begin_tool_decision", lambda *_args: object())
+    monkeypatch.setattr(loop_module, "wait_tool_decision", lambda *_args, **_kwargs: "deny")
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "run it"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                session_id = "sess-1",
+                confirm_tool_calls = True,
+                permission_mode = "ask",
+                execute_tool = lambda *a, **k: pytest.fail("denied tool should not run"),
+            )
+        )
+    )
+    assert len(client.calls) == 2
+    statuses = [event.get("content") for event in _events(lines) if event["type"] == "tool_status"]
+    assert NUDGE_TOOL_CALLS_STATUS not in statuses

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -1,0 +1,1036 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Unit tests for the local tool loop over self-hosted OpenAI-compat providers.
+
+Covers the provider/tool gates that decide whether the loop may run at all, and
+the loop itself against a fake ExternalProviderClient: tool_calls fragments must
+never reach the client, tool cards must be emitted in their place, and the
+follow-up turn must carry the assistant tool_calls plus the tool results.
+"""
+
+import asyncio
+import json
+import time
+
+import pytest
+
+from core.inference.external_tool_loop import (
+    local_tool_loop_supported,
+    select_local_tool_names,
+    stream_chat_completion_with_local_tools,
+)
+
+
+def _chunk(**delta) -> str:
+    return "data: " + json.dumps(
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        }
+    )
+
+
+def _finish(reason: str) -> str:
+    return "data: " + json.dumps(
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": reason}],
+        }
+    )
+
+
+def _usage(prompt: int, completion: int) -> str:
+    return "data: " + json.dumps(
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": prompt,
+                "completion_tokens": completion,
+                "total_tokens": prompt + completion,
+            },
+        }
+    )
+
+
+class _FakeClient:
+    """Replays one canned SSE turn per call and records the request kwargs."""
+
+    def __init__(self, turns):
+        self.turns = [list(turn) for turn in turns]
+        self.calls = []
+
+    async def stream_chat_completion(self, **kwargs):
+        self.calls.append(kwargs)
+        for line in self.turns.pop(0):
+            yield line
+
+
+WEB_SEARCH_TOOL = {
+    "type": "function",
+    "function": {"name": "web_search", "parameters": {"type": "object", "properties": {}}},
+}
+PYTHON_TOOL = {
+    "type": "function",
+    "function": {"name": "python", "parameters": {"type": "object", "properties": {}}},
+}
+
+
+async def _collect(gen) -> list[str]:
+    return [line async for line in gen]
+
+
+def _events(lines: list[str]) -> list[dict]:
+    """Parse the custom tool events out of an SSE line list."""
+    parsed = []
+    for line in lines:
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:") :].strip()
+        if payload == "[DONE]":
+            continue
+        data = json.loads(payload)
+        if isinstance(data, dict) and "type" in data:
+            parsed.append(data)
+    return parsed
+
+
+def _content(lines: list[str]) -> str:
+    """Concatenate the assistant text the client would render."""
+    text = ""
+    for line in lines:
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:") :].strip()
+        if payload == "[DONE]":
+            continue
+        data = json.loads(payload)
+        for choice in data.get("choices") or []:
+            text += (choice.get("delta") or {}).get("content") or ""
+    return text
+
+
+# ── gates ────────────────────────────────────────────────────────
+
+
+def test_local_tool_loop_supported_only_for_self_hosted_providers():
+    for provider_type in ("vllm", "ollama", "llama_cpp", "custom"):
+        assert local_tool_loop_supported(provider_type) is True, provider_type
+    # hosted providers ship their own server-side tools; the local loop must
+    # never advertise a competing catalog to them.
+    for provider_type in ("openai", "anthropic", "gemini", "openrouter", "kimi", None, ""):
+        assert local_tool_loop_supported(provider_type) is False, provider_type
+
+
+def test_select_local_tool_names_filters_and_orders():
+    assert select_local_tool_names(["terminal", "web_search", "python"]) == [
+        "web_search",
+        "python",
+        "terminal",
+    ]
+    # rag stays local-only and the hosted builtin names are not local tools.
+    assert select_local_tool_names(["search_knowledge_base"]) == []
+    assert select_local_tool_names(["render_html", "web_fetch", "code_execution"]) == []
+    assert select_local_tool_names(None) == []
+    assert select_local_tool_names([]) == []
+
+
+# ── loop ─────────────────────────────────────────────────────────
+
+
+def test_tool_call_is_executed_and_never_forwarded_raw():
+    client = _FakeClient(
+        [
+            [
+                _chunk(role="assistant"),
+                _chunk(content="Looking that up. "),
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "web_search", "arguments": '{"query":'},
+                        }
+                    ]
+                ),
+                _chunk(tool_calls=[{"index": 0, "function": {"arguments": '"unsloth"}'}}]),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [
+                _chunk(content="Unsloth is a fine-tuning library."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    executed = []
+
+    def _execute(name, arguments, **kwargs):
+        executed.append((name, arguments, kwargs))
+        return "Title: Unsloth\nURL: https://unsloth.ai"
+
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "what is unsloth"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+                session_id="sess-1",
+                thread_id="thread-1",
+                execute_tool=_execute,
+            )
+        )
+    )
+
+    assert len(executed) == 1
+    name, arguments, kwargs = executed[0]
+    assert (name, arguments) == ("web_search", {"query": "unsloth"})
+    assert kwargs["timeout"] is None
+    assert kwargs["session_id"] == "sess-1"
+    assert kwargs["thread_id"] == "thread-1"
+    assert kwargs["disable_sandbox"] is False
+    # live stdout reaches the card only if the streaming wrapper's sink is forwarded.
+    assert callable(kwargs["output_callback"])
+
+    # no raw tool_calls fragment may reach the client: the frontend would draw a
+    # second card that never resolves.
+    assert all('"tool_calls"' not in line for line in lines if "type" not in line)
+
+    events = _events(lines)
+    starts = [event for event in events if event["type"] == "tool_start"]
+    ends = [event for event in events if event["type"] == "tool_end"]
+    assert len(starts) == 1
+    assert starts[0]["tool_name"] == "web_search"
+    assert starts[0]["arguments"] == {"query": "unsloth"}
+    assert starts[0]["awaiting_confirmation"] is False
+    assert len(ends) == 1
+    assert ends[0]["result"] == "Title: Unsloth\nURL: https://unsloth.ai"
+
+    assert lines[-1] == "data: [DONE]"
+    # only the last turn's finish_reason survives; a mid-loop one would end the
+    # client's stream before the answer.
+    finishes = [
+        json.loads(line[len("data:") :].strip())["choices"][0]["finish_reason"]
+        for line in lines
+        if line != "data: [DONE]" and '"choices"' in line
+    ]
+    assert [reason for reason in finishes if reason] == ["stop"]
+
+    # the follow-up turn replays the assistant tool_calls and the tool result.
+    follow_up = client.calls[1]["messages"]
+    assert follow_up[-2]["role"] == "assistant"
+    assert follow_up[-2]["tool_calls"][0]["function"]["name"] == "web_search"
+    assert follow_up[-1] == {
+        "role": "tool",
+        "name": "web_search",
+        "content": "Title: Unsloth\nURL: https://unsloth.ai",
+        "tool_call_id": "call_0",
+    }
+
+
+def test_answer_without_tool_calls_passes_straight_through():
+    client = _FakeClient(
+        [[_chunk(content="hello"), _finish("stop"), "data: [DONE]"]]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "hi"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+                execute_tool=lambda *a, **k: pytest.fail("no tool should run"),
+            )
+        )
+    )
+    assert len(client.calls) == 1
+    assert client.calls[0]["tools"] == [WEB_SEARCH_TOOL]
+    assert _events(lines) == []
+    assert lines[-1] == "data: [DONE]"
+
+
+def test_iteration_budget_drops_the_catalog_for_the_final_pass():
+    tool_turn = [
+        _chunk(
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_0",
+                    "function": {"name": "python", "arguments": '{"code":"1"}'},
+                }
+            ]
+        ),
+        _finish("tool_calls"),
+        "data: [DONE]",
+    ]
+    client = _FakeClient([tool_turn, [_chunk(content="done"), _finish("stop"), "data: [DONE]"]])
+
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "run it"}],
+                model="qwen3-14b",
+                tools=[PYTHON_TOOL],
+                max_tool_iterations=1,
+                execute_tool=lambda *a, **k: "1",
+            )
+        )
+    )
+    assert len(client.calls) == 2
+    assert client.calls[0]["tools"] == [PYTHON_TOOL]
+    # budget spent: the last request carries no catalog, so the model has to answer.
+    assert client.calls[1]["tools"] is None
+    assert lines[-1] == "data: [DONE]"
+
+
+def test_usage_is_summed_into_one_trailing_chunk():
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": "{}"},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                _usage(10, 5),
+                "data: [DONE]",
+            ],
+            [_chunk(content="ok"), _finish("stop"), _usage(20, 7), "data: [DONE]"],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "go"}],
+                model="qwen3-14b",
+                tools=[PYTHON_TOOL],
+                execute_tool=lambda *a, **k: "ok",
+            )
+        )
+    )
+    usage_chunks = [
+        json.loads(line[len("data:") :].strip())
+        for line in lines
+        if line != "data: [DONE]" and '"usage"' in line
+    ]
+    assert len(usage_chunks) == 1
+    assert usage_chunks[0]["usage"] == {
+        "prompt_tokens": 30,
+        "completion_tokens": 12,
+        "total_tokens": 42,
+    }
+
+
+def test_provider_error_ends_the_loop_without_re_prompting():
+    client = _FakeClient(
+        [
+            [
+                'data: {"error": {"message": "boom", "type": "provider_error"}}',
+                "data: [DONE]",
+            ]
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "go"}],
+                model="qwen3-14b",
+                tools=[PYTHON_TOOL],
+                execute_tool=lambda *a, **k: pytest.fail("no tool should run"),
+            )
+        )
+    )
+    assert len(client.calls) == 1
+    assert lines == ['data: {"error": {"message": "boom", "type": "provider_error"}}']
+
+
+def test_bypass_permissions_disables_the_sandbox():
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": '{"code":"1"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content="1"), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    seen = {}
+
+    def _execute(name, arguments, **kwargs):
+        seen.update(kwargs)
+        return "1"
+
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "go"}],
+                model="qwen3-14b",
+                tools=[PYTHON_TOOL],
+                bypass_permissions=True,
+                confirm_tool_calls=True,
+                execute_tool=_execute,
+            )
+        )
+    )
+    # bypass wins over the confirm gate, so the call runs unprompted with the
+    # sandbox off.
+    assert seen["disable_sandbox"] is True
+
+
+def test_disabled_tool_call_is_suppressed_and_nudged():
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "terminal", "arguments": '{"command":"ls"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content="cannot"), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "list files"}],
+                model="qwen3-14b",
+                tools=[PYTHON_TOOL],
+                execute_tool=lambda *a, **k: pytest.fail("terminal is not enabled"),
+            )
+        )
+    )
+    # tool_status is only the badge text; a suppressed call must draw no card.
+    card_events = {"tool_start", "tool_end", "tool_output", "tool_args"}
+    assert [event["type"] for event in _events(lines) if event["type"] in card_events] == []
+    # the unadvertised call becomes a hidden nudge, never a tool result.
+    follow_up = client.calls[1]["messages"]
+    assert follow_up[-1]["role"] == "user"
+    assert "not enabled" in follow_up[-1]["content"]
+
+
+# ── parity with the local loops ──────────────────────────────────
+
+
+def test_ollama_reasoning_is_renamed_for_the_frontend():
+    """Ollama says `reasoning`; the local loops and the UI say `reasoning_content`."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(reasoning="Thinking about it."),
+                _chunk(content="Done."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "hi"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+            )
+        )
+    )
+    deltas = [
+        (json.loads(line[len("data:") :].strip()).get("choices") or [{}])[0].get("delta") or {}
+        for line in lines
+        if line.startswith("data:") and '"choices"' in line
+    ]
+    assert any(d.get("reasoning_content") == "Thinking about it." for d in deltas)
+    assert all("reasoning" not in d for d in deltas)
+
+
+def test_reasoning_only_answer_is_promoted_to_content():
+    """An always-think model puts its whole reply in `reasoning` and sends no
+    content. The GGUF loop shows that as the answer; so must this one."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(reasoning="The user asked a simple question. "),
+                _chunk(reasoning="Unsloth is a fine-tuning library."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "what is unsloth"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+            )
+        )
+    )
+    assert "Unsloth is a fine-tuning library." in _content(lines)
+
+
+def test_truncated_reasoning_is_not_promoted():
+    """A thought cut off by the token cap is not a final answer."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(reasoning="Unsloth is a fine-tuning library that supports"),
+                _finish("length"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "explain"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+            )
+        )
+    )
+    assert _content(lines) == ""
+
+
+def test_plan_without_action_is_re_prompted_once():
+    """Model describes the search instead of calling it: nudge it to act."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(reasoning="I will search the web for the 2026 box office totals."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+            [
+                _chunk(content="The Odyssey led 2026."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "highest grossing movie of 2026"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+            )
+        )
+    )
+    assert len(client.calls) == 2
+    retry = client.calls[1]["messages"]
+    assert retry[-1]["role"] == "user"
+    assert "web_search" in retry[-1]["content"]
+    # the stalled turn is kept as the assistant turn the nudge answers.
+    assert retry[-2]["role"] == "assistant"
+    # a hidden retry looks like a hang without a badge.
+    statuses = [event["content"] for event in _events(lines) if event["type"] == "tool_status"]
+    assert any(status for status in statuses)
+    assert _content(lines) == "The Odyssey led 2026."
+
+
+def test_visible_text_is_never_re_prompted():
+    """OpenAI deltas are append-only: text already streamed cannot be retracted,
+    so a turn that showed something has to stand as the answer."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(content="I will search the web for that."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "highest grossing movie of 2026"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+            )
+        )
+    )
+    assert len(client.calls) == 1
+    assert _content(lines) == "I will search the web for that."
+
+
+def test_tool_stdout_streams_to_the_card():
+    """python/terminal output has to reach the card while the tool runs."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "function": {"name": "python", "arguments": '{"code":"print(1)"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [
+                _chunk(content="It printed 1."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+
+    def _execute(name, arguments, output_callback=None, **kwargs):
+        output_callback("1\n")
+        return "1"
+
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "print 1"}],
+                model="qwen3-14b",
+                tools=[PYTHON_TOOL],
+                execute_tool=_execute,
+            )
+        )
+    )
+    outputs = [event for event in _events(lines) if event["type"] == "tool_output"]
+    assert [event["text"] for event in outputs] == ["1\n"]
+    assert outputs[0]["tool_call_id"] == "call_1"
+
+
+def test_large_payload_opens_a_provisional_card_and_streams_args():
+    """A long code payload renders while the model is still writing it."""
+    code = "x = 1\n" * 60
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "function": {"name": "python", "arguments": '{"code":"' + code},
+                        }
+                    ]
+                ),
+                _chunk(tool_calls=[{"index": 0, "function": {"arguments": '"}'}}]),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [
+                _chunk(content="Done."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "run it"}],
+                model="qwen3-14b",
+                tools=[PYTHON_TOOL],
+                execute_tool=lambda *a, **k: "ok",
+            )
+        )
+    )
+    events = _events(lines)
+    starts = [event for event in events if event["type"] == "tool_start"]
+    args_events = [event for event in events if event["type"] == "tool_args"]
+    ends = [event for event in events if event["type"] == "tool_end"]
+    assert starts[0]["provenance"].get("provisional") is True
+    assert "".join(event["text"] for event in args_events).endswith('"}')
+    # both starts carry the provider's call id, so the card reconciles instead of
+    # opening a second one, and only the real end closes it.
+    assert {event["tool_call_id"] for event in starts} == {"call_1"}
+    assert len(ends) == 1
+    assert ends[0]["result"] == "ok"
+
+
+def test_text_form_tool_call_runs_and_never_leaks():
+    """Some servers hand back the call as text. It has to execute, and the
+    markup must not reach the transcript."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(content="Let me check that. "),
+                _chunk(content='<tool_call>\n{"name": "web_search", '),
+                _chunk(content='"arguments": {"query": "unsloth"}}\n</tool_call>'),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+            [
+                _chunk(content="Unsloth is a fine-tuning library."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    executed = []
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "what is unsloth"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+                execute_tool=lambda name, args, **kw: executed.append((name, args)) or "result",
+            )
+        )
+    )
+    assert executed == [("web_search", {"query": "unsloth"})]
+    assert _content(lines) == "Let me check that. Unsloth is a fine-tuning library."
+    assert [event["type"] for event in _events(lines) if event["type"] == "tool_start"] == [
+        "tool_start"
+    ]
+    # the replayed assistant turn carries the call structurally, not as markup.
+    assert "<tool_call>" not in json.dumps(client.calls[1]["messages"])
+
+
+def test_unparsed_markup_is_released_as_prose():
+    """A marker that never forms a call is text the user asked for."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(content="Write it as <tool_call> and the server parses it."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "how do tool calls look"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+            )
+        )
+    )
+    assert _content(lines) == "Write it as <tool_call> and the server parses it."
+
+
+def test_partial_marker_at_a_delta_boundary_is_not_split():
+    """A marker split across deltas must still be caught, and a lookalike tail
+    must still be released."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(content="Prefix <tool"),
+                _chunk(content="s are handy."),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "hi"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+            )
+        )
+    )
+    assert _content(lines) == "Prefix <tools are handy."
+
+
+def test_budget_exhausted_turn_is_told_to_answer():
+    """The last pass gets the local loops' nudge, not a silently empty catalog."""
+    call_chunk = _chunk(
+        tool_calls=[
+            {
+                "index": 0,
+                "id": "call_0",
+                "function": {"name": "web_search", "arguments": '{"query":"a"}'},
+            }
+        ]
+    )
+    client = _FakeClient(
+        [
+            [call_chunk, _finish("tool_calls"), "data: [DONE]"],
+            [_chunk(content="Final answer."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "search"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+                max_tool_iterations=1,
+                execute_tool=lambda *a, **k: "ok",
+            )
+        )
+    )
+    assert client.calls[1]["tools"] is None
+    assert "all available tool calls" in client.calls[1]["messages"][-1]["content"]
+
+
+def test_parallel_tool_calls_disabled_runs_only_the_first():
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "web_search", "arguments": '{"query":"a"}'},
+                        },
+                        {
+                            "index": 1,
+                            "id": "call_1",
+                            "function": {"name": "web_search", "arguments": '{"query":"b"}'},
+                        },
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content="Done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    executed = []
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "search twice"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+                disable_parallel_tool_use=True,
+                execute_tool=lambda name, args, **kw: executed.append(args) or "ok",
+            )
+        )
+    )
+    assert executed == [{"query": "a"}]
+
+
+def test_text_markup_never_leaks_when_the_call_cannot_run():
+    """Budget spent, so the attempted call is dropped rather than printed."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "web_search", "arguments": '{"query":"a"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [
+                _chunk(content="Here is what I found. "),
+                _chunk(
+                    content=(
+                        "<tool_call> <function=web_search> <parameter=url> "
+                        "https://example.com/ </tool_call>"
+                    )
+                ),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "search"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+                max_tool_iterations=1,
+                execute_tool=lambda *a, **k: "ok",
+            )
+        )
+    )
+    assert _content(lines) == "Here is what I found. "
+
+
+def test_text_markup_alongside_a_structured_call_never_leaks():
+    """One turn carrying both forms must still show only the prose."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(content="Checking. <tool_call> <function=web_search> "),
+                _chunk(content="<parameter=url> https://example.com/ </tool_call>"),
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "web_search", "arguments": '{"query":"a"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content="Found it."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "search"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+                execute_tool=lambda *a, **k: "ok",
+            )
+        )
+    )
+    assert _content(lines) == "Checking. Found it."
+
+
+def test_unhealed_text_call_is_hidden_even_when_it_cannot_run():
+    """Auto-Heal off blocks execution, never display: markup still stays out."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    content=(
+                        "<tool_call> <function=web_search> <parameter=url> "
+                        "https://example.com/ </tool_call>"
+                    )
+                ),
+                _finish("stop"),
+                "data: [DONE]",
+            ],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages=[{"role": "user", "content": "search"}],
+                model="qwen3-14b",
+                tools=[WEB_SEARCH_TOOL],
+                auto_heal_tool_calls=False,
+                execute_tool=lambda *a, **k: pytest.fail("an unhealed call must not run"),
+            )
+        )
+    )
+    assert "<tool_call>" not in _content(lines)
+
+
+def test_approval_wait_flushes_card_on_a_separate_event_loop_turn():
+    """The first keepalive must not coalesce with the gated card's write."""
+    import core.inference.external_tool_loop as loop_module
+
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": '{"code":"print(1)"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content="1"), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    decided = []
+
+    def _slow_decision(slot, approval_id, cancel_event=None, timeout=None):
+        decided.append(approval_id)
+        time.sleep(0.25)
+        return "allow"
+
+    async def _collect_with_turn_probe(stream):
+        lines = []
+        next_turn = None
+        first_post_card_turn_advanced = None
+        async for line in stream:
+            if next_turn is not None and first_post_card_turn_advanced is None:
+                first_post_card_turn_advanced = next_turn[0]
+            lines.append(line)
+            if '"tool_start"' in line:
+                next_turn = [False]
+                asyncio.get_running_loop().call_soon(next_turn.__setitem__, 0, True)
+        return lines, first_post_card_turn_advanced
+
+    original_wait = loop_module.wait_tool_decision
+    original_flush_delay = loop_module.TOOL_APPROVAL_FLUSH_DELAY_S
+    original_interval = loop_module.TOOL_HEARTBEAT_INTERVAL_S
+    loop_module.wait_tool_decision = _slow_decision
+    loop_module.TOOL_APPROVAL_FLUSH_DELAY_S = 0.01
+    loop_module.TOOL_HEARTBEAT_INTERVAL_S = 0.05
+    try:
+        lines, first_post_card_turn_advanced = asyncio.run(
+            _collect_with_turn_probe(
+                stream_chat_completion_with_local_tools(
+                    client,
+                    messages=[{"role": "user", "content": "print 1"}],
+                    model="qwen3-14b",
+                    tools=[PYTHON_TOOL],
+                    session_id="sess-1",
+                    confirm_tool_calls=True,
+                    permission_mode="ask",
+                    execute_tool=lambda *a, **k: "1",
+                )
+            )
+        )
+    finally:
+        loop_module.wait_tool_decision = original_wait
+        loop_module.TOOL_APPROVAL_FLUSH_DELAY_S = original_flush_delay
+        loop_module.TOOL_HEARTBEAT_INTERVAL_S = original_interval
+
+    assert decided, "the approval gate never ran"
+    starts = [event for event in _events(lines) if event["type"] == "tool_start"]
+    assert starts[0]["awaiting_confirmation"] is True
+    keepalives = [line for line in lines if line.startswith(":")]
+    assert keepalives, "no keepalive was written while the approval was pending"
+    card_index = next(i for i, line in enumerate(lines) if '"tool_start"' in line)
+    assert lines.index(keepalives[0]) > card_index
+    assert first_post_card_turn_advanced is True

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -21,7 +21,7 @@ from core.inference.external_tool_loop import (
     stream_chat_completion_with_local_tools,
 )
 from core.inference.providers import PROVIDER_REGISTRY
-from core.inference.tool_call_parser import NUDGE_TOOL_CALLS_STATUS
+from core.inference.tool_call_parser import MAX_ACT_REPROMPTS, NUDGE_TOOL_CALLS_STATUS
 
 
 def _chunk(**delta) -> str:
@@ -2070,3 +2070,43 @@ def test_dropped_parallel_call_opens_no_provisional_card():
     events = _events(lines)
     assert {e["tool_call_id"] for e in events if e["type"] == "tool_start"} == {"c0"}
     assert not [e for e in events if e["type"] == "tool_args" and e["tool_call_id"] == "c1"]
+
+
+def test_repeated_denials_cannot_loop_forever():
+    """A denied turn runs no tool, so only the turn ceiling bounds the exchange."""
+    denied_call = [{"index": 0, "id": "c0", "function": {"name": "python", "arguments": "{}"}}]
+    # far more turns than the ceiling allows, so an unbounded loop would exhaust them.
+    turns = [
+        [_chunk(tool_calls = denied_call), _finish("tool_calls"), "data: [DONE]"] for _ in range(40)
+    ]
+    client = _FakeClient(turns)
+    calls = {"n": 0}
+
+    def _deny(*a, **k):
+        calls["n"] += 1
+        return "deny"
+
+    with_monkey = pytest.MonkeyPatch()
+    with_monkey.setattr("core.inference.external_tool_loop.wait_tool_decision", _deny)
+    try:
+        asyncio.run(
+            _collect(
+                stream_chat_completion_with_local_tools(
+                    client,
+                    messages = [{"role": "user", "content": "go"}],
+                    model = "qwen3-14b",
+                    tools = [PYTHON_TOOL],
+                    max_tool_iterations = 3,
+                    confirm_tool_calls = True,
+                    permission_mode = "ask",
+                    execute_tool = lambda *a, **k: pytest.fail("denied tool must not run"),
+                )
+            )
+        )
+    finally:
+        with_monkey.undo()
+    from core.inference.external_tool_loop import MAX_POST_TOOL_REPROMPTS
+
+    ceiling = 3 + MAX_ACT_REPROMPTS + MAX_POST_TOOL_REPROMPTS + 1
+    assert len(client.calls) == ceiling
+    assert len(client.calls) < len(turns)

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -1756,3 +1756,193 @@ def test_suppressed_duplicate_closes_its_provisional_card():
     ended = {e["tool_call_id"] for e in events if e["type"] == "tool_end"}
     assert "call_1" in started
     assert started == ended
+
+
+def test_fragmented_function_name_is_accumulated():
+    """A split name must not resolve to its last fragment and read as disabled."""
+    executed = []
+    client = _FakeClient(
+        [
+            [
+                _chunk(tool_calls = [{"index": 0, "id": "c0", "function": {"name": "web_"}}]),
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "function": {"name": "search", "arguments": '{"query":"x"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "found it."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+
+    def _execute(name, arguments, **kwargs):
+        executed.append(name)
+        return "Title: x"
+
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                execute_tool = _execute,
+            )
+        )
+    )
+    assert executed == ["web_search"]
+
+
+def test_tool_call_without_an_id_still_pairs_its_result():
+    """An omitted id would leave the replayed call and its tool message unlinked."""
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [{"index": 0, "function": {"name": "python", "arguments": "{}"}}]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: "4",
+            )
+        )
+    )
+    followup = client.calls[1]["messages"]
+    assistant, tool_message = followup[-2], followup[-1]
+    assert assistant["tool_calls"][0]["id"] == "call_0"
+    assert tool_message["tool_call_id"] == "call_0"
+
+
+def test_provider_keepalive_comments_are_forwarded():
+    """Swallowing them lets an nginx or tunnel idle limit close a healthy stream."""
+    client = _FakeClient(
+        [
+            [
+                ": ping",
+                _chunk(content = "hi"),
+                _finish("stop"),
+                "data: [DONE]",
+            ]
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+            )
+        )
+    )
+    assert ": ping" in lines
+
+
+def test_a_raising_tool_does_not_cancel_the_request():
+    """The error is handed back to the model, so the shared event must stay clear."""
+    route_event = threading.Event()
+    calls = []
+
+    def _execute(name, arguments, **kwargs):
+        calls.append(name)
+        if len(calls) == 1:
+            raise RuntimeError("boom")
+        return "second call ran"
+
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {"index": 0, "id": "c0", "function": {"name": "python", "arguments": "{}"}}
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "c1",
+                            "function": {"name": "python", "arguments": '{"code":"2"}'},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                cancel_event = route_event,
+                execute_tool = _execute,
+            )
+        )
+    )
+    # a cancelled request would break before the second turn ever reached the tool.
+    assert calls == ["python", "python"]
+    assert _content(lines) == "done."
+
+
+def test_a_set_cancel_event_stops_the_loop():
+    """Stop arrives as a POST that sets the event; the loop must not keep generating."""
+    route_event = threading.Event()
+
+    def _execute(name, arguments, **kwargs):
+        route_event.set()
+        return "cancelled mid-run"
+
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {"index": 0, "id": "c0", "function": {"name": "python", "arguments": "{}"}}
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "should never be requested."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                cancel_event = route_event,
+                execute_tool = _execute,
+            )
+        )
+    )
+    assert len(client.calls) == 1
+    assert "should never be requested." not in _content(lines)
+    assert lines[-1] == "data: [DONE]"

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -1639,3 +1639,45 @@ def test_cancel_mid_tool_drains_the_worker_before_closing():
 
     asyncio.run(_run())
     assert started.is_set()
+
+
+def test_injected_cancel_event_reaches_the_tool():
+    """The route registers this event so Stop can reach a running tool."""
+    route_event = threading.Event()
+    seen = {}
+
+    def _execute(name, arguments, **kwargs):
+        seen["cancel_event"] = kwargs["cancel_event"]
+        return "ok"
+
+    client = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls = [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "function": {"name": "python", "arguments": "{}"},
+                        }
+                    ]
+                ),
+                _finish("tool_calls"),
+                "data: [DONE]",
+            ],
+            [_chunk(content = "done."), _finish("stop"), "data: [DONE]"],
+        ]
+    )
+    asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                cancel_event = route_event,
+                execute_tool = _execute,
+            )
+        )
+    )
+    assert seen["cancel_event"] is route_event

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -146,10 +146,10 @@ def test_tool_call_is_executed_and_never_forwarded_raw():
     client = _FakeClient(
         [
             [
-                _chunk(role="assistant"),
-                _chunk(content="Looking that up. "),
+                _chunk(role = "assistant"),
+                _chunk(content = "Looking that up. "),
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_0",
@@ -157,12 +157,12 @@ def test_tool_call_is_executed_and_never_forwarded_raw():
                         }
                     ]
                 ),
-                _chunk(tool_calls=[{"index": 0, "function": {"arguments": '"unsloth"}'}}]),
+                _chunk(tool_calls = [{"index": 0, "function": {"arguments": '"unsloth"}'}}]),
                 _finish("tool_calls"),
                 "data: [DONE]",
             ],
             [
-                _chunk(content="Unsloth is a fine-tuning library."),
+                _chunk(content = "Unsloth is a fine-tuning library."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
@@ -178,12 +178,12 @@ def test_tool_call_is_executed_and_never_forwarded_raw():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "what is unsloth"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
-                session_id="sess-1",
-                thread_id="thread-1",
-                execute_tool=_execute,
+                messages = [{"role": "user", "content": "what is unsloth"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                session_id = "sess-1",
+                thread_id = "thread-1",
+                execute_tool = _execute,
             )
         )
     )
@@ -235,17 +235,15 @@ def test_tool_call_is_executed_and_never_forwarded_raw():
 
 
 def test_answer_without_tool_calls_passes_straight_through():
-    client = _FakeClient(
-        [[_chunk(content="hello"), _finish("stop"), "data: [DONE]"]]
-    )
+    client = _FakeClient([[_chunk(content = "hello"), _finish("stop"), "data: [DONE]"]])
     lines = asyncio.run(
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "hi"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
-                execute_tool=lambda *a, **k: pytest.fail("no tool should run"),
+                messages = [{"role": "user", "content": "hi"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                execute_tool = lambda *a, **k: pytest.fail("no tool should run"),
             )
         )
     )
@@ -258,7 +256,7 @@ def test_answer_without_tool_calls_passes_straight_through():
 def test_iteration_budget_drops_the_catalog_for_the_final_pass():
     tool_turn = [
         _chunk(
-            tool_calls=[
+            tool_calls = [
                 {
                     "index": 0,
                     "id": "call_0",
@@ -269,17 +267,17 @@ def test_iteration_budget_drops_the_catalog_for_the_final_pass():
         _finish("tool_calls"),
         "data: [DONE]",
     ]
-    client = _FakeClient([tool_turn, [_chunk(content="done"), _finish("stop"), "data: [DONE]"]])
+    client = _FakeClient([tool_turn, [_chunk(content = "done"), _finish("stop"), "data: [DONE]"]])
 
     lines = asyncio.run(
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "run it"}],
-                model="qwen3-14b",
-                tools=[PYTHON_TOOL],
-                max_tool_iterations=1,
-                execute_tool=lambda *a, **k: "1",
+                messages = [{"role": "user", "content": "run it"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                max_tool_iterations = 1,
+                execute_tool = lambda *a, **k: "1",
             )
         )
     )
@@ -295,7 +293,7 @@ def test_usage_is_summed_into_one_trailing_chunk():
         [
             [
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_0",
@@ -307,17 +305,17 @@ def test_usage_is_summed_into_one_trailing_chunk():
                 _usage(10, 5),
                 "data: [DONE]",
             ],
-            [_chunk(content="ok"), _finish("stop"), _usage(20, 7), "data: [DONE]"],
+            [_chunk(content = "ok"), _finish("stop"), _usage(20, 7), "data: [DONE]"],
         ]
     )
     lines = asyncio.run(
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "go"}],
-                model="qwen3-14b",
-                tools=[PYTHON_TOOL],
-                execute_tool=lambda *a, **k: "ok",
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: "ok",
             )
         )
     )
@@ -347,10 +345,10 @@ def test_provider_error_ends_the_loop_without_re_prompting():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "go"}],
-                model="qwen3-14b",
-                tools=[PYTHON_TOOL],
-                execute_tool=lambda *a, **k: pytest.fail("no tool should run"),
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: pytest.fail("no tool should run"),
             )
         )
     )
@@ -363,7 +361,7 @@ def test_bypass_permissions_disables_the_sandbox():
         [
             [
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_0",
@@ -374,7 +372,7 @@ def test_bypass_permissions_disables_the_sandbox():
                 _finish("tool_calls"),
                 "data: [DONE]",
             ],
-            [_chunk(content="1"), _finish("stop"), "data: [DONE]"],
+            [_chunk(content = "1"), _finish("stop"), "data: [DONE]"],
         ]
     )
     seen = {}
@@ -387,12 +385,12 @@ def test_bypass_permissions_disables_the_sandbox():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "go"}],
-                model="qwen3-14b",
-                tools=[PYTHON_TOOL],
-                bypass_permissions=True,
-                confirm_tool_calls=True,
-                execute_tool=_execute,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                bypass_permissions = True,
+                confirm_tool_calls = True,
+                execute_tool = _execute,
             )
         )
     )
@@ -406,7 +404,7 @@ def test_disabled_tool_call_is_suppressed_and_nudged():
         [
             [
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_0",
@@ -417,17 +415,17 @@ def test_disabled_tool_call_is_suppressed_and_nudged():
                 _finish("tool_calls"),
                 "data: [DONE]",
             ],
-            [_chunk(content="cannot"), _finish("stop"), "data: [DONE]"],
+            [_chunk(content = "cannot"), _finish("stop"), "data: [DONE]"],
         ]
     )
     lines = asyncio.run(
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "list files"}],
-                model="qwen3-14b",
-                tools=[PYTHON_TOOL],
-                execute_tool=lambda *a, **k: pytest.fail("terminal is not enabled"),
+                messages = [{"role": "user", "content": "list files"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: pytest.fail("terminal is not enabled"),
             )
         )
     )
@@ -448,8 +446,8 @@ def test_ollama_reasoning_is_renamed_for_the_frontend():
     client = _FakeClient(
         [
             [
-                _chunk(reasoning="Thinking about it."),
-                _chunk(content="Done."),
+                _chunk(reasoning = "Thinking about it."),
+                _chunk(content = "Done."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
@@ -459,9 +457,9 @@ def test_ollama_reasoning_is_renamed_for_the_frontend():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "hi"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
+                messages = [{"role": "user", "content": "hi"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
             )
         )
     )
@@ -480,8 +478,8 @@ def test_reasoning_only_answer_is_promoted_to_content():
     client = _FakeClient(
         [
             [
-                _chunk(reasoning="The user asked a simple question. "),
-                _chunk(reasoning="Unsloth is a fine-tuning library."),
+                _chunk(reasoning = "The user asked a simple question. "),
+                _chunk(reasoning = "Unsloth is a fine-tuning library."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
@@ -491,9 +489,9 @@ def test_reasoning_only_answer_is_promoted_to_content():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "what is unsloth"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
+                messages = [{"role": "user", "content": "what is unsloth"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
             )
         )
     )
@@ -505,7 +503,7 @@ def test_truncated_reasoning_is_not_promoted():
     client = _FakeClient(
         [
             [
-                _chunk(reasoning="Unsloth is a fine-tuning library that supports"),
+                _chunk(reasoning = "Unsloth is a fine-tuning library that supports"),
                 _finish("length"),
                 "data: [DONE]",
             ],
@@ -515,9 +513,9 @@ def test_truncated_reasoning_is_not_promoted():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "explain"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
+                messages = [{"role": "user", "content": "explain"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
             )
         )
     )
@@ -529,12 +527,12 @@ def test_plan_without_action_is_re_prompted_once():
     client = _FakeClient(
         [
             [
-                _chunk(reasoning="I will search the web for the 2026 box office totals."),
+                _chunk(reasoning = "I will search the web for the 2026 box office totals."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
             [
-                _chunk(content="The Odyssey led 2026."),
+                _chunk(content = "The Odyssey led 2026."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
@@ -544,9 +542,9 @@ def test_plan_without_action_is_re_prompted_once():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "highest grossing movie of 2026"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
+                messages = [{"role": "user", "content": "highest grossing movie of 2026"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
             )
         )
     )
@@ -568,7 +566,7 @@ def test_visible_text_is_never_re_prompted():
     client = _FakeClient(
         [
             [
-                _chunk(content="I will search the web for that."),
+                _chunk(content = "I will search the web for that."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
@@ -578,9 +576,9 @@ def test_visible_text_is_never_re_prompted():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "highest grossing movie of 2026"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
+                messages = [{"role": "user", "content": "highest grossing movie of 2026"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
             )
         )
     )
@@ -594,7 +592,7 @@ def test_tool_stdout_streams_to_the_card():
         [
             [
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_1",
@@ -606,14 +604,19 @@ def test_tool_stdout_streams_to_the_card():
                 "data: [DONE]",
             ],
             [
-                _chunk(content="It printed 1."),
+                _chunk(content = "It printed 1."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
         ]
     )
 
-    def _execute(name, arguments, output_callback=None, **kwargs):
+    def _execute(
+        name,
+        arguments,
+        output_callback = None,
+        **kwargs,
+    ):
         output_callback("1\n")
         return "1"
 
@@ -621,10 +624,10 @@ def test_tool_stdout_streams_to_the_card():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "print 1"}],
-                model="qwen3-14b",
-                tools=[PYTHON_TOOL],
-                execute_tool=_execute,
+                messages = [{"role": "user", "content": "print 1"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = _execute,
             )
         )
     )
@@ -640,7 +643,7 @@ def test_large_payload_opens_a_provisional_card_and_streams_args():
         [
             [
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_1",
@@ -648,12 +651,12 @@ def test_large_payload_opens_a_provisional_card_and_streams_args():
                         }
                     ]
                 ),
-                _chunk(tool_calls=[{"index": 0, "function": {"arguments": '"}'}}]),
+                _chunk(tool_calls = [{"index": 0, "function": {"arguments": '"}'}}]),
                 _finish("tool_calls"),
                 "data: [DONE]",
             ],
             [
-                _chunk(content="Done."),
+                _chunk(content = "Done."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
@@ -663,10 +666,10 @@ def test_large_payload_opens_a_provisional_card_and_streams_args():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "run it"}],
-                model="qwen3-14b",
-                tools=[PYTHON_TOOL],
-                execute_tool=lambda *a, **k: "ok",
+                messages = [{"role": "user", "content": "run it"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: "ok",
             )
         )
     )
@@ -689,14 +692,14 @@ def test_text_form_tool_call_runs_and_never_leaks():
     client = _FakeClient(
         [
             [
-                _chunk(content="Let me check that. "),
-                _chunk(content='<tool_call>\n{"name": "web_search", '),
-                _chunk(content='"arguments": {"query": "unsloth"}}\n</tool_call>'),
+                _chunk(content = "Let me check that. "),
+                _chunk(content = '<tool_call>\n{"name": "web_search", '),
+                _chunk(content = '"arguments": {"query": "unsloth"}}\n</tool_call>'),
                 _finish("stop"),
                 "data: [DONE]",
             ],
             [
-                _chunk(content="Unsloth is a fine-tuning library."),
+                _chunk(content = "Unsloth is a fine-tuning library."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
@@ -707,10 +710,10 @@ def test_text_form_tool_call_runs_and_never_leaks():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "what is unsloth"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
-                execute_tool=lambda name, args, **kw: executed.append((name, args)) or "result",
+                messages = [{"role": "user", "content": "what is unsloth"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                execute_tool = lambda name, args, **kw: executed.append((name, args)) or "result",
             )
         )
     )
@@ -728,7 +731,7 @@ def test_unparsed_markup_is_released_as_prose():
     client = _FakeClient(
         [
             [
-                _chunk(content="Write it as <tool_call> and the server parses it."),
+                _chunk(content = "Write it as <tool_call> and the server parses it."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
@@ -738,9 +741,9 @@ def test_unparsed_markup_is_released_as_prose():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "how do tool calls look"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
+                messages = [{"role": "user", "content": "how do tool calls look"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
             )
         )
     )
@@ -753,8 +756,8 @@ def test_partial_marker_at_a_delta_boundary_is_not_split():
     client = _FakeClient(
         [
             [
-                _chunk(content="Prefix <tool"),
-                _chunk(content="s are handy."),
+                _chunk(content = "Prefix <tool"),
+                _chunk(content = "s are handy."),
                 _finish("stop"),
                 "data: [DONE]",
             ],
@@ -764,9 +767,9 @@ def test_partial_marker_at_a_delta_boundary_is_not_split():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "hi"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
+                messages = [{"role": "user", "content": "hi"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
             )
         )
     )
@@ -776,7 +779,7 @@ def test_partial_marker_at_a_delta_boundary_is_not_split():
 def test_budget_exhausted_turn_is_told_to_answer():
     """The last pass gets the local loops' nudge, not a silently empty catalog."""
     call_chunk = _chunk(
-        tool_calls=[
+        tool_calls = [
             {
                 "index": 0,
                 "id": "call_0",
@@ -787,18 +790,18 @@ def test_budget_exhausted_turn_is_told_to_answer():
     client = _FakeClient(
         [
             [call_chunk, _finish("tool_calls"), "data: [DONE]"],
-            [_chunk(content="Final answer."), _finish("stop"), "data: [DONE]"],
+            [_chunk(content = "Final answer."), _finish("stop"), "data: [DONE]"],
         ]
     )
     asyncio.run(
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "search"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
-                max_tool_iterations=1,
-                execute_tool=lambda *a, **k: "ok",
+                messages = [{"role": "user", "content": "search"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                max_tool_iterations = 1,
+                execute_tool = lambda *a, **k: "ok",
             )
         )
     )
@@ -811,7 +814,7 @@ def test_parallel_tool_calls_disabled_runs_only_the_first():
         [
             [
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_0",
@@ -827,7 +830,7 @@ def test_parallel_tool_calls_disabled_runs_only_the_first():
                 _finish("tool_calls"),
                 "data: [DONE]",
             ],
-            [_chunk(content="Done."), _finish("stop"), "data: [DONE]"],
+            [_chunk(content = "Done."), _finish("stop"), "data: [DONE]"],
         ]
     )
     executed = []
@@ -835,11 +838,11 @@ def test_parallel_tool_calls_disabled_runs_only_the_first():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "search twice"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
-                disable_parallel_tool_use=True,
-                execute_tool=lambda name, args, **kw: executed.append(args) or "ok",
+                messages = [{"role": "user", "content": "search twice"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                disable_parallel_tool_use = True,
+                execute_tool = lambda name, args, **kw: executed.append(args) or "ok",
             )
         )
     )
@@ -852,7 +855,7 @@ def test_text_markup_never_leaks_when_the_call_cannot_run():
         [
             [
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_0",
@@ -864,9 +867,9 @@ def test_text_markup_never_leaks_when_the_call_cannot_run():
                 "data: [DONE]",
             ],
             [
-                _chunk(content="Here is what I found. "),
+                _chunk(content = "Here is what I found. "),
                 _chunk(
-                    content=(
+                    content = (
                         "<tool_call> <function=web_search> <parameter=url> "
                         "https://example.com/ </tool_call>"
                     )
@@ -880,11 +883,11 @@ def test_text_markup_never_leaks_when_the_call_cannot_run():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "search"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
-                max_tool_iterations=1,
-                execute_tool=lambda *a, **k: "ok",
+                messages = [{"role": "user", "content": "search"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                max_tool_iterations = 1,
+                execute_tool = lambda *a, **k: "ok",
             )
         )
     )
@@ -896,10 +899,10 @@ def test_text_markup_alongside_a_structured_call_never_leaks():
     client = _FakeClient(
         [
             [
-                _chunk(content="Checking. <tool_call> <function=web_search> "),
-                _chunk(content="<parameter=url> https://example.com/ </tool_call>"),
+                _chunk(content = "Checking. <tool_call> <function=web_search> "),
+                _chunk(content = "<parameter=url> https://example.com/ </tool_call>"),
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_0",
@@ -910,17 +913,17 @@ def test_text_markup_alongside_a_structured_call_never_leaks():
                 _finish("tool_calls"),
                 "data: [DONE]",
             ],
-            [_chunk(content="Found it."), _finish("stop"), "data: [DONE]"],
+            [_chunk(content = "Found it."), _finish("stop"), "data: [DONE]"],
         ]
     )
     lines = asyncio.run(
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "search"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
-                execute_tool=lambda *a, **k: "ok",
+                messages = [{"role": "user", "content": "search"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                execute_tool = lambda *a, **k: "ok",
             )
         )
     )
@@ -933,7 +936,7 @@ def test_unhealed_text_call_is_hidden_even_when_it_cannot_run():
         [
             [
                 _chunk(
-                    content=(
+                    content = (
                         "<tool_call> <function=web_search> <parameter=url> "
                         "https://example.com/ </tool_call>"
                     )
@@ -947,11 +950,11 @@ def test_unhealed_text_call_is_hidden_even_when_it_cannot_run():
         _collect(
             stream_chat_completion_with_local_tools(
                 client,
-                messages=[{"role": "user", "content": "search"}],
-                model="qwen3-14b",
-                tools=[WEB_SEARCH_TOOL],
-                auto_heal_tool_calls=False,
-                execute_tool=lambda *a, **k: pytest.fail("an unhealed call must not run"),
+                messages = [{"role": "user", "content": "search"}],
+                model = "qwen3-14b",
+                tools = [WEB_SEARCH_TOOL],
+                auto_heal_tool_calls = False,
+                execute_tool = lambda *a, **k: pytest.fail("an unhealed call must not run"),
             )
         )
     )
@@ -966,7 +969,7 @@ def test_approval_wait_flushes_card_on_a_separate_event_loop_turn():
         [
             [
                 _chunk(
-                    tool_calls=[
+                    tool_calls = [
                         {
                             "index": 0,
                             "id": "call_0",
@@ -977,12 +980,17 @@ def test_approval_wait_flushes_card_on_a_separate_event_loop_turn():
                 _finish("tool_calls"),
                 "data: [DONE]",
             ],
-            [_chunk(content="1"), _finish("stop"), "data: [DONE]"],
+            [_chunk(content = "1"), _finish("stop"), "data: [DONE]"],
         ]
     )
     decided = []
 
-    def _slow_decision(slot, approval_id, cancel_event=None, timeout=None):
+    def _slow_decision(
+        slot,
+        approval_id,
+        cancel_event = None,
+        timeout = None,
+    ):
         decided.append(approval_id)
         time.sleep(0.25)
         return "allow"
@@ -1011,13 +1019,13 @@ def test_approval_wait_flushes_card_on_a_separate_event_loop_turn():
             _collect_with_turn_probe(
                 stream_chat_completion_with_local_tools(
                     client,
-                    messages=[{"role": "user", "content": "print 1"}],
-                    model="qwen3-14b",
-                    tools=[PYTHON_TOOL],
-                    session_id="sess-1",
-                    confirm_tool_calls=True,
-                    permission_mode="ask",
-                    execute_tool=lambda *a, **k: "1",
+                    messages = [{"role": "user", "content": "print 1"}],
+                    model = "qwen3-14b",
+                    tools = [PYTHON_TOOL],
+                    session_id = "sess-1",
+                    confirm_tool_calls = True,
+                    permission_mode = "ask",
+                    execute_tool = lambda *a, **k: "1",
                 )
             )
         )

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -2070,3 +2070,36 @@ def test_dropped_parallel_call_opens_no_provisional_card():
     events = _events(lines)
     assert {e["tool_call_id"] for e in events if e["type"] == "tool_start"} == {"c0"}
     assert not [e for e in events if e["type"] == "tool_args" and e["tool_call_id"] == "c1"]
+
+
+def test_unterminated_markup_is_released_instead_of_buffered_forever():
+    """A runaway turn must not stay invisible: the client sees the text instead."""
+    from core.inference.external_tool_loop import MAX_SUPPRESSED_MARKUP_CHARS
+
+    runaway = "x" * (MAX_SUPPRESSED_MARKUP_CHARS + 64)
+    client = _FakeClient(
+        [
+            [
+                _chunk(content = "<tool_call>"),
+                _chunk(content = runaway),
+                _chunk(content = " still going"),
+                _finish("length"),
+                "data: [DONE]",
+            ]
+        ]
+    )
+    lines = asyncio.run(
+        _collect(
+            stream_chat_completion_with_local_tools(
+                client,
+                messages = [{"role": "user", "content": "go"}],
+                model = "qwen3-14b",
+                tools = [PYTHON_TOOL],
+                execute_tool = lambda *a, **k: "unused",
+            )
+        )
+    )
+    shown = _content(lines)
+    assert runaway in shown
+    # once released the gate stays open, so later deltas stream as they arrive.
+    assert shown.endswith(" still going")

--- a/studio/backend/tests/test_external_tool_loop.py
+++ b/studio/backend/tests/test_external_tool_loop.py
@@ -2070,36 +2070,3 @@ def test_dropped_parallel_call_opens_no_provisional_card():
     events = _events(lines)
     assert {e["tool_call_id"] for e in events if e["type"] == "tool_start"} == {"c0"}
     assert not [e for e in events if e["type"] == "tool_args" and e["tool_call_id"] == "c1"]
-
-
-def test_unterminated_markup_is_released_instead_of_buffered_forever():
-    """A runaway turn must not stay invisible: the client sees the text instead."""
-    from core.inference.external_tool_loop import MAX_SUPPRESSED_MARKUP_CHARS
-
-    runaway = "x" * (MAX_SUPPRESSED_MARKUP_CHARS + 64)
-    client = _FakeClient(
-        [
-            [
-                _chunk(content = "<tool_call>"),
-                _chunk(content = runaway),
-                _chunk(content = " still going"),
-                _finish("length"),
-                "data: [DONE]",
-            ]
-        ]
-    )
-    lines = asyncio.run(
-        _collect(
-            stream_chat_completion_with_local_tools(
-                client,
-                messages = [{"role": "user", "content": "go"}],
-                model = "qwen3-14b",
-                tools = [PYTHON_TOOL],
-                execute_tool = lambda *a, **k: "unused",
-            )
-        )
-    )
-    shown = _content(lines)
-    assert runaway in shown
-    # once released the gate stays open, so later deltas stream as they arrive.
-    assert shown.endswith(" still going")

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -51,6 +51,7 @@ from routes.inference import (
     _effective_max_tokens,
     _effective_openai_max_tokens,
     _effective_openai_max_tokens_from_values,
+    _external_local_tools,
     _extract_content_parts,
     _friendly_error,
     _friendly_upstream_error,
@@ -354,6 +355,41 @@ class TestChatCompletionRequestToolFields:
 
     def test_tool_choice_string_required(self):
         assert self._make(tool_choice = "required").tool_choice == "required"
+
+    def test_external_local_tools_use_registry_gate(self, monkeypatch):
+        from routes import inference as inference_route
+
+        selected = [{"type": "function", "function": {"name": "mcp_lookup"}}]
+        captured = {}
+
+        async def fake_select(payload, *, tools_on, mcp_allowed):
+            captured.update(tools_on = tools_on, mcp_allowed = mcp_allowed)
+            return selected
+
+        monkeypatch.setattr(inference_route, "_select_request_tools", fake_select)
+        payload = self._make(
+            enable_tools = True,
+            mcp_enabled = True,
+            stream = True,
+        )
+        assert asyncio.run(_external_local_tools(payload, "ollama")) == selected
+        assert captured == {"tools_on": True, "mcp_allowed": True}
+        assert asyncio.run(_external_local_tools(payload, "openai")) == []
+
+    def test_external_local_tools_honor_zero_budget(self, monkeypatch):
+        from routes import inference as inference_route
+
+        async def fail_select(*_args, **_kwargs):
+            raise AssertionError("zero tool budget must skip tool selection")
+
+        monkeypatch.setattr(inference_route, "_select_request_tools", fail_select)
+        payload = self._make(
+            enable_tools = True,
+            enabled_tools = ["python"],
+            max_tool_calls_per_message = 0,
+            stream = True,
+        )
+        assert asyncio.run(_external_local_tools(payload, "vllm")) == []
 
     def test_tool_choice_string_none(self):
         assert self._make(tool_choice = "none").tool_choice == "none"

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -555,6 +555,41 @@ class TestChatCompletionRequestToolFields:
         assert body["error"]["param"] == "confirm_tool_calls"
         assert "only supported for local streaming tools" in body["error"]["message"]
 
+    def test_confirm_tool_calls_zero_budget_does_not_bypass_client_tools(self, monkeypatch):
+        # A zero local budget empties Studio's catalog, but client-supplied tools are
+        # still forwarded by the passthrough. Studio cannot confirm those provider-emitted
+        # calls, so confirm_tool_calls must still be rejected rather than let the request
+        # proceed with unconfirmed tool calls.
+        class _UnusedBackend:
+            is_loaded = False
+
+        client = self._v1_client(monkeypatch, _UnusedBackend())
+        resp = client.post(
+            "/v1/chat/completions",
+            json = {
+                "messages": [{"role": "user", "content": "hi"}],
+                "provider_type": "llama_cpp",
+                "external_model": "m",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "my_tool",
+                            "description": "x",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "max_tool_calls_per_message": 0,
+                "confirm_tool_calls": True,
+            },
+        )
+
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["param"] == "confirm_tool_calls"
+        assert "only supported for local streaming tools" in body["error"]["message"]
+
     def test_confirm_tool_calls_allowed_for_codex_studio_tools(self, monkeypatch):
         from routes import inference as inference_route
 

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -3243,6 +3243,26 @@ def test_external_loop_permission_mode_keeps_the_legacy_confirm_contract():
     )
 
 
+def test_external_stream_is_absent_from_the_model_swap_snapshot():
+    # /active-generations names the chats a swap would interrupt; a swap leaves an
+    # external stream running, so listing it would prompt to stop it for nothing.
+    import threading
+
+    from routes.inference import _TrackedCancel
+    from state import active_generations
+
+    event = threading.Event()
+    payload = ChatCompletionRequest(
+        messages = [{"role": "user", "content": "hi"}],
+        thread_id = "T",
+        provider_type = "vllm",
+    )
+    with _TrackedCancel.for_payload(event, payload, "cancel-1", local_model = False):
+        assert all(e["thread_id"] != "T" for e in active_generations.snapshot())
+        # deletion reads the registry directly, so it still reaches the run
+        assert active_generations.cancel_thread("T") == 1
+
+
 def test_external_stream_is_tracked_but_not_counted_as_local():
     # It must stay cancellable by thread deletion while staying invisible to the
     # model-swap guard, which assumes every entry decodes on the local llama server.

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -3309,14 +3309,11 @@ def test_explicit_tool_opt_out_does_not_trip_the_confirm_guard():
         "type": "function",
         "function": {"name": "my_tool", "parameters": {"type": "object", "properties": {}}},
     }
-    assert _local_tool_loop_opted_out(
-        req(max_tool_calls_per_message = 0, tools = [client_tool]), "vllm"
-    ) is False
+    assert (
+        _local_tool_loop_opted_out(req(max_tool_calls_per_message = 0, tools = [client_tool]), "vllm")
+        is False
+    )
     # an empty tools list is still "no client tools": a zero budget opts out.
-    assert _local_tool_loop_opted_out(
-        req(max_tool_calls_per_message = 0, tools = []), "vllm"
-    ) is True
+    assert _local_tool_loop_opted_out(req(max_tool_calls_per_message = 0, tools = []), "vllm") is True
     # tool_choice="none" stays an opt-out even with client tools: no call can happen.
-    assert _local_tool_loop_opted_out(
-        req(tool_choice = "none", tools = [client_tool]), "vllm"
-    ) is True
+    assert _local_tool_loop_opted_out(req(tool_choice = "none", tools = [client_tool]), "vllm") is True

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -3241,3 +3241,28 @@ def test_external_loop_permission_mode_keeps_the_legacy_confirm_contract():
     assert (
         _external_loop_permission_mode(req(confirm_tool_calls = False, provider_type = "vllm")) is None
     )
+
+
+def test_external_stream_is_tracked_but_not_counted_as_local():
+    # It must stay cancellable by thread deletion while staying invisible to the
+    # model-swap guard, which assumes every entry decodes on the local llama server.
+    import threading
+
+    from routes.inference import _CANCEL_REGISTRY, _TrackedCancel
+    from state import active_generations
+
+    event = threading.Event()
+    payload = ChatCompletionRequest(
+        messages = [{"role": "user", "content": "hi"}],
+        thread_id = "T",
+        provider_type = "vllm",
+    )
+    before = active_generations.count()
+    with _TrackedCancel.for_payload(event, payload, "cancel-1", "session-1", local_model = False):
+        assert event in _CANCEL_REGISTRY["cancel-1"]
+        assert active_generations.count() == before
+        assert "T" not in active_generations.active_thread_ids()
+        # deleting the thread still has to stop it
+        assert active_generations.cancel_thread("T") == 1
+        assert event.is_set()
+    assert "cancel-1" not in _CANCEL_REGISTRY

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -3303,3 +3303,20 @@ def test_explicit_tool_opt_out_does_not_trip_the_confirm_guard():
     # a request that did not opt out is unaffected.
     assert _local_tool_loop_opted_out(req(), "vllm") is False
     assert _local_tool_loop_opted_out(req(tool_choice = "auto"), "vllm") is False
+    # a zero budget must not opt out when client-supplied tools are forwarded by the
+    # passthrough: Studio cannot confirm provider-emitted calls against them.
+    client_tool = {
+        "type": "function",
+        "function": {"name": "my_tool", "parameters": {"type": "object", "properties": {}}},
+    }
+    assert _local_tool_loop_opted_out(
+        req(max_tool_calls_per_message = 0, tools = [client_tool]), "vllm"
+    ) is False
+    # an empty tools list is still "no client tools": a zero budget opts out.
+    assert _local_tool_loop_opted_out(
+        req(max_tool_calls_per_message = 0, tools = []), "vllm"
+    ) is True
+    # tool_choice="none" stays an opt-out even with client tools: no call can happen.
+    assert _local_tool_loop_opted_out(
+        req(tool_choice = "none", tools = [client_tool]), "vllm"
+    ) is True

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -3211,3 +3211,33 @@ def test_auto_mode_prompts_on_dangerous_python_work(code):
 @pytest.mark.parametrize("name", _DANGEROUS_MCP)
 def test_auto_mode_prompts_on_dangerous_mcp_work(name):
     assert is_high_risk_tool_call(f"{MCP_TOOL_PREFIX}{name}", {"code": "x"}) is True
+
+
+def test_external_loop_permission_mode_keeps_the_legacy_confirm_contract():
+    # The validator only folds confirm_tool_calls=true into "ask" for requests without
+    # provider routing, so an external one would reach the loop unset and default to
+    # "auto", prompting on high-risk calls alone despite the explicit opt-in.
+    from routes.inference import _external_loop_permission_mode
+
+    def req(**kw):
+        return ChatCompletionRequest(messages = [{"role": "user", "content": "hi"}], **kw)
+
+    external = req(
+        confirm_tool_calls = True,
+        enable_tools = True,
+        provider_type = "vllm",
+        stream = True,
+    )
+    assert external.permission_mode is None
+    assert _external_loop_permission_mode(external) == "ask"
+    # An explicit mode always wins, and a request that never opted in stays unset.
+    assert (
+        _external_loop_permission_mode(
+            req(confirm_tool_calls = True, permission_mode = "auto", provider_type = "vllm")
+        )
+        == "auto"
+    )
+    assert _external_loop_permission_mode(req(provider_type = "vllm")) is None
+    assert (
+        _external_loop_permission_mode(req(confirm_tool_calls = False, provider_type = "vllm")) is None
+    )

--- a/studio/backend/tests/test_permission_mode.py
+++ b/studio/backend/tests/test_permission_mode.py
@@ -3266,3 +3266,20 @@ def test_external_stream_is_tracked_but_not_counted_as_local():
         assert active_generations.cancel_thread("T") == 1
         assert event.is_set()
     assert "cancel-1" not in _CANCEL_REGISTRY
+
+
+def test_explicit_tool_opt_out_does_not_trip_the_confirm_guard():
+    # tool_choice="none" and a zero budget empty the catalog on a provider that could
+    # run the loop, so no call can happen and the request is an ordinary completion.
+    from routes.inference import _local_tool_loop_opted_out
+
+    def req(**kw):
+        return ChatCompletionRequest(messages = [{"role": "user", "content": "hi"}], **kw)
+
+    assert _local_tool_loop_opted_out(req(tool_choice = "none"), "vllm") is True
+    assert _local_tool_loop_opted_out(req(max_tool_calls_per_message = 0), "ollama") is True
+    # a provider that cannot run the loop is still rejected by the guard.
+    assert _local_tool_loop_opted_out(req(tool_choice = "none"), "openai") is False
+    # a request that did not opt out is unaffected.
+    assert _local_tool_loop_opted_out(req(), "vllm") is False
+    assert _local_tool_loop_opted_out(req(tool_choice = "auto"), "vllm") is False

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -101,6 +101,7 @@ import {
   useResearchRunStore,
 } from "@/features/chat/stores/research-run-store";
 import { parseExternalModelId } from "@/features/chat/external-providers";
+import { useExternalLocalTools } from "@/features/chat/hooks/use-external-local-tools";
 import { toolStatusKind } from "@/features/chat/utils/tool-status";
 import {
   CONTINUATION_RUN_CONFIG_KEY,
@@ -4154,15 +4155,28 @@ const WebSearchToggle: FC = () => {
       ? externalProviders.find((p) => p.id === externalSelection.providerId)
       : undefined;
   const isKimiExternal = selectedExternalProvider?.providerType === "kimi";
+  // the pill needs the connection's local-tools opt-in, else the click explains why.
+  const externalLocalTools = useExternalLocalTools();
+  const setLocalToolsNotice = useChatRuntimeStore(
+    (s) => s.setLocalToolsNoticeProvider,
+  );
+  const localToolsOptInMissing =
+    externalLocalTools.supported && !externalLocalTools.enabled;
   // Disable only when a loaded model lacks the capability; with no model the
   // tool can still be pre-selected, matching the + menu.
-  const disabled = modelLoaded && !(supportsTools || supportsBuiltinWebSearch);
+  const disabled =
+    modelLoaded &&
+    !(supportsTools || supportsBuiltinWebSearch || externalLocalTools.supported);
 
   return (
     <button
       type="button"
       disabled={disabled}
       onClick={() => {
+        if (localToolsOptInMissing) {
+          setLocalToolsNotice(externalLocalTools.provider?.name ?? "");
+          return;
+        }
         const next = !toolsEnabled;
         setToolsEnabled(next);
         // Kimi's $web_search builtin requires thinking=disabled (see
@@ -4175,7 +4189,9 @@ const WebSearchToggle: FC = () => {
       }}
       className="composer-pill-btn"
       data-pill-label="Search"
-      data-active={toolsEnabled && !disabled ? "true" : "false"}
+      data-active={
+        toolsEnabled && !disabled && !localToolsOptInMissing ? "true" : "false"
+      }
       aria-label={toolsEnabled ? "Disable web search" : "Enable web search"}
     >
       <PillGlyph>
@@ -4200,18 +4216,41 @@ const CodeToolsToggle: FC = () => {
   );
   const codeToolsEnabled = useChatRuntimeStore((s) => s.codeToolsEnabled);
   const setCodeToolsEnabled = useChatRuntimeStore((s) => s.setCodeToolsEnabled);
+  // same local-tools opt-in as the Search pill above.
+  const externalLocalTools = useExternalLocalTools();
+  const setLocalToolsNotice = useChatRuntimeStore(
+    (s) => s.setLocalToolsNoticeProvider,
+  );
+  const localToolsOptInMissing =
+    externalLocalTools.supported && !externalLocalTools.enabled;
   // Disable only when a loaded model lacks the capability; with no model the
   // tool can still be pre-selected, matching the + menu.
-  const disabled = modelLoaded && !(supportsTools || supportsBuiltinCodeExecution);
+  const disabled =
+    modelLoaded &&
+    !(
+      supportsTools ||
+      supportsBuiltinCodeExecution ||
+      externalLocalTools.supported
+    );
 
   return (
     <button
       type="button"
       disabled={disabled}
-      onClick={() => setCodeToolsEnabled(!codeToolsEnabled)}
+      onClick={() => {
+        if (localToolsOptInMissing) {
+          setLocalToolsNotice(externalLocalTools.provider?.name ?? "");
+          return;
+        }
+        setCodeToolsEnabled(!codeToolsEnabled);
+      }}
       className="composer-pill-btn"
       data-pill-label="Code"
-      data-active={codeToolsEnabled && !disabled ? "true" : "false"}
+      data-active={
+        codeToolsEnabled && !disabled && !localToolsOptInMissing
+          ? "true"
+          : "false"
+      }
       aria-label={
         codeToolsEnabled ? "Disable code execution" : "Enable code execution"
       }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4769,8 +4769,10 @@ export function createOpenAIStreamAdapter(
 
       // Stop handle for when this conversation is not the visible one, which cancelByThreadId
       // cannot reach. Aborting this run's own controller closes just its request, and the
-      // listener above posts its cancel_id so llama-server stops decoding too. For an
-      // external provider the abort is the stop, since its cancel_id is never registered.
+      // listener above posts its cancel_id so llama-server stops decoding too. For a plain
+      // external passthrough the abort is the stop (nothing runs locally); the external
+      // local-tools loop registers its cancel event under the request's cancel_id, so the
+      // explicit /cancel POST reaches it even when a Colab/proxy swallows the abort.
       runtime.registerThreadServerCancel(threadKey, serverCancel);
       try {
         if (runSignal.aborted) {
@@ -5144,6 +5146,10 @@ export function createOpenAIStreamAdapter(
                       ? { session_id: sandboxSessionId }
                       : {}),
                     ...(resolvedThreadId ? { thread_id: resolvedThreadId } : {}),
+                    // the loop runs tools on this machine, so its cancel event is
+                    // registered under this id; without it a swallowed fetch abort
+                    // (Colab/proxy) would leave python/terminal/MCP/RAG running.
+                    cancel_id: cancelId,
                     permission_mode: permissionMode,
                     ...(permissionMode === "auto"
                       ? {}

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -57,7 +57,7 @@ import {
   parseExternalModelId,
 
   providerLocalToolsEnabled,
-  providerModelSupportsStudioTools,
+  providerStudioToolsEnabled,
   providerModelSupportsVision,
   supportsProviderPromptCacheTtl,
   supportsProviderPromptCaching,
@@ -4013,11 +4013,10 @@ export function createOpenAIStreamAdapter(
           )
         : null;
 
-      const externalUsesStudioTools =
-        providerModelSupportsStudioTools(
-          externalProvider?.providerType,
-          externalSelection?.modelId,
-        ) === true;
+      const externalUsesStudioTools = providerStudioToolsEnabled(
+        externalProvider,
+        externalSelection?.modelId,
+      );
 
       const supportsStudioToolsForThisTurn = isExternalRequest
         ? externalUsesStudioTools
@@ -5060,6 +5059,7 @@ export function createOpenAIStreamAdapter(
                       ? {}
                       : { confirm_tool_calls: permissionMode === "ask" }),
                     bypass_permissions: bypassPermissions,
+                    nudge_tool_calls: runtime.nudgeToolCalls,
                     max_tool_calls_per_message: runtime.maxToolCallsPerMessage,
                     tool_call_timeout:
                       runtime.toolCallTimeout >= 9999
@@ -5140,7 +5140,12 @@ export function createOpenAIStreamAdapter(
                       : { confirm_tool_calls: permissionMode === "ask" }),
                     bypass_permissions: bypassPermissions,
                     auto_heal_tool_calls: runtime.autoHealToolCalls,
+                    nudge_tool_calls: runtime.nudgeToolCalls,
                     max_tool_calls_per_message: runtime.maxToolCallsPerMessage,
+                    tool_call_timeout:
+                      runtime.toolCallTimeout >= 9999
+                        ? 9999
+                        : runtime.toolCallTimeout * 60,
                   }
                 : {}),
               provider_id: externalProvider.id,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4112,6 +4112,16 @@ export function createOpenAIStreamAdapter(
       const localCodeEnabledForThisTurn = Boolean(
         externalLocalToolsEnabled && externalSelection && codeToolsEnabled,
       );
+      // the local runtime also executes RAG and MCP calls, not only Search and Code.
+      const localToolRuntimeForThisTurn = Boolean(
+        externalLocalToolsEnabled &&
+          externalSelection &&
+          (toolsEnabled ||
+            codeToolsEnabled ||
+            mcpEnabledForChat ||
+            ragEnabled ||
+            projectRagEnabled),
+      );
       // Fetch pill is independent of Search (Anthropic bills web_fetch
       // separately). Sourced from `webFetchToolsEnabled`; on providers
       // without web_fetch the toggle is forced off in chat-page setState.
@@ -5128,7 +5138,7 @@ export function createOpenAIStreamAdapter(
                     // server tools.
                     { enable_tools: false }),
               // local tools need the sandbox session, thread scope and permission gate.
-              ...(localWebSearchEnabledForThisTurn || localCodeEnabledForThisTurn
+              ...(localToolRuntimeForThisTurn
                 ? {
                     ...(sandboxSessionId
                       ? { session_id: sandboxSessionId }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5150,6 +5150,9 @@ export function createOpenAIStreamAdapter(
                     // registered under this id; without it a swallowed fetch abort
                     // (Colab/proxy) would leave python/terminal/MCP/RAG running.
                     cancel_id: cancelId,
+                    // the loop aggregates provider usage and emits a trailing
+                    // choices: [] chunk; the proxy drops it unless we opt in.
+                    stream_options: { include_usage: true },
                     permission_mode: permissionMode,
                     ...(permissionMode === "auto"
                       ? {}

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -56,6 +56,7 @@ import {
   loadExternalProviders,
   parseExternalModelId,
 
+  providerLocalToolsEnabled,
   providerModelSupportsStudioTools,
   providerModelSupportsVision,
   supportsProviderPromptCacheTtl,
@@ -4102,6 +4103,16 @@ export function createOpenAIStreamAdapter(
             externalProvider.baseUrl,
           ),
       );
+      // a self-hosted connection runs web_search, python and terminal on this machine.
+      const externalLocalToolsEnabled = providerLocalToolsEnabled(
+        externalProvider,
+      );
+      const localWebSearchEnabledForThisTurn = Boolean(
+        externalLocalToolsEnabled && externalSelection && toolsEnabled,
+      );
+      const localCodeEnabledForThisTurn = Boolean(
+        externalLocalToolsEnabled && externalSelection && codeToolsEnabled,
+      );
       // Fetch pill is independent of Search (Anthropic bills web_fetch
       // separately). Sourced from `webFetchToolsEnabled`; on providers
       // without web_fetch the toggle is forced off in chat-page setState.
@@ -4808,10 +4819,12 @@ export function createOpenAIStreamAdapter(
           tools: {
             search:
               webSearchEnabledForThisTurn ||
+              localWebSearchEnabledForThisTurn ||
               (!isExternalRequest && supportsTools && toolsEnabled),
             fetch: webFetchEnabledForThisTurn,
             code:
               codeExecEnabledForThisTurn ||
+              localCodeEnabledForThisTurn ||
               (!isExternalRequest && supportsTools && codeToolsEnabled),
             images: imageGenerationEnabledForThisTurn,
             mcp:
@@ -5088,11 +5101,16 @@ export function createOpenAIStreamAdapter(
                 : webSearchEnabledForThisTurn ||
                     webFetchEnabledForThisTurn ||
                     codeExecEnabledForThisTurn ||
-                    imageGenerationEnabledForThisTurn
+                    imageGenerationEnabledForThisTurn ||
+                    localWebSearchEnabledForThisTurn ||
+                    localCodeEnabledForThisTurn
                   ? {
                       enable_tools: true,
                       enabled_tools: [
-                        ...(webSearchEnabledForThisTurn ? ["web_search"] : []),
+                        ...(webSearchEnabledForThisTurn ||
+                        localWebSearchEnabledForThisTurn
+                          ? ["web_search"]
+                          : []),
                         ...(webFetchEnabledForThisTurn ? ["web_fetch"] : []),
                         ...(codeExecEnabledForThisTurn
                           ? ["code_execution"]
@@ -5100,12 +5118,31 @@ export function createOpenAIStreamAdapter(
                         ...(imageGenerationEnabledForThisTurn
                           ? ["image_generation"]
                           : []),
+                        ...(localCodeEnabledForThisTurn
+                          ? ["python", "terminal"]
+                          : []),
                       ],
                     }
                   : // Explicit false: an omitted field falls back to the
                     // server's tools-on default, which would bill provider
                     // server tools.
                     { enable_tools: false }),
+              // local tools need the sandbox session, thread scope and permission gate.
+              ...(localWebSearchEnabledForThisTurn || localCodeEnabledForThisTurn
+                ? {
+                    ...(sandboxSessionId
+                      ? { session_id: sandboxSessionId }
+                      : {}),
+                    ...(resolvedThreadId ? { thread_id: resolvedThreadId } : {}),
+                    permission_mode: permissionMode,
+                    ...(permissionMode === "auto"
+                      ? {}
+                      : { confirm_tool_calls: permissionMode === "ask" }),
+                    bypass_permissions: bypassPermissions,
+                    auto_heal_tool_calls: runtime.autoHealToolCalls,
+                    max_tool_calls_per_message: runtime.maxToolCallsPerMessage,
+                  }
+                : {}),
               provider_id: externalProvider.id,
               provider_type: externalBackendProviderType,
               external_model: externalSelection.modelId,

--- a/studio/frontend/src/features/chat/api/providers-api.ts
+++ b/studio/frontend/src/features/chat/api/providers-api.ts
@@ -22,6 +22,7 @@ export interface ProviderRegistryEntry {
   supports_streaming: boolean;
   supports_vision: boolean;
   supports_tool_calling: boolean;
+  hidden?: boolean;
   /** remote = fetch /models; curated = huge catalogs — UI uses defaults + manual IDs only */
   model_list_mode?: "remote" | "curated";
 

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2214,11 +2214,18 @@ export function ChatPage({
     const storedWebFetchToolsEnabled = loadOptionalBool(
       CHAT_WEB_FETCH_TOOLS_ENABLED_KEY,
     );
-    const nextToolsEnabled = supportsBuiltinWebSearch
-      ? isKimi
-        ? false
-        : (storedToolsEnabled ?? searchOnByDefault)
-      : false;
+    // a self-hosted connection runs Search and Code locally, so its saved pill
+    // state must survive even though it ships no provider-side builtin.
+    const studioToolsEnabled = providerStudioToolsEnabled(
+      provider,
+      selection.modelId,
+    );
+    const nextToolsEnabled =
+      supportsBuiltinWebSearch || studioToolsEnabled
+        ? isKimi
+          ? false
+          : (storedToolsEnabled ?? searchOnByDefault)
+        : false;
     useChatRuntimeStore.setState({
       supportsReasoning: reasoningCaps.supportsReasoning,
       reasoningAlwaysOn: reasoningCaps.reasoningAlwaysOn,
@@ -2234,15 +2241,16 @@ export function ChatPage({
           : true
         : state.reasoningEnabled,
       supportsPreserveThinking: false,
-      supportsTools: providerStudioToolsEnabled(provider, selection.modelId),
+      supportsTools: studioToolsEnabled,
       supportsBuiltinWebSearch,
       supportsBuiltinCodeExecution,
       supportsBuiltinImageGeneration,
       supportsBuiltinWebFetch,
       toolsEnabled: nextToolsEnabled,
-      codeToolsEnabled: supportsBuiltinCodeExecution
-        ? (storedCodeToolsEnabled ?? false)
-        : false,
+      codeToolsEnabled:
+        supportsBuiltinCodeExecution || studioToolsEnabled
+          ? (storedCodeToolsEnabled ?? false)
+          : false,
       imageToolsEnabled: supportsBuiltinImageGeneration
         ? (storedImageToolsEnabled ?? false)
         : false,
@@ -2753,11 +2761,17 @@ export function ChatPage({
         const storedWebFetchToolsEnabled = loadOptionalBool(
           CHAT_WEB_FETCH_TOOLS_ENABLED_KEY,
         );
-        const nextToolsEnabled = supportsBuiltinWebSearch
-          ? isKimi
-            ? false
-            : (storedToolsEnabled ?? searchOnByDefault)
-          : false;
+        // mirror of the sibling effect: a self-hosted connection runs these locally.
+        const studioToolsEnabled = providerStudioToolsEnabled(
+          selectedProvider,
+          selectedExternal?.modelId,
+        );
+        const nextToolsEnabled =
+          supportsBuiltinWebSearch || studioToolsEnabled
+            ? isKimi
+              ? false
+              : (storedToolsEnabled ?? searchOnByDefault)
+            : false;
         useChatRuntimeStore.setState({
           activeGgufVariant: null,
           ggufContextLength: null,
@@ -2783,18 +2797,16 @@ export function ChatPage({
               : true
             : store.reasoningEnabled,
           supportsPreserveThinking: false,
-          supportsTools: providerStudioToolsEnabled(
-            selectedProvider,
-            selectedExternal?.modelId,
-          ),
+          supportsTools: studioToolsEnabled,
           supportsBuiltinWebSearch,
           supportsBuiltinCodeExecution,
           supportsBuiltinImageGeneration,
           supportsBuiltinWebFetch,
           toolsEnabled: nextToolsEnabled,
-          codeToolsEnabled: supportsBuiltinCodeExecution
-            ? (storedCodeToolsEnabled ?? false)
-            : false,
+          codeToolsEnabled:
+            supportsBuiltinCodeExecution || studioToolsEnabled
+              ? (storedCodeToolsEnabled ?? false)
+              : false,
           imageToolsEnabled: supportsBuiltinImageGeneration
             ? (storedImageToolsEnabled ?? false)
             : false,

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -139,7 +139,7 @@ import {
   isExternalModelId,
   parseExternalModelId,
 
-  providerModelSupportsStudioTools,
+  providerStudioToolsEnabled,
 } from "./external-providers";
 import { useChatModelRuntime } from "./hooks/use-chat-model-runtime";
 import type { SelectedModelInput } from "./hooks/use-chat-model-runtime";
@@ -2234,11 +2234,7 @@ export function ChatPage({
           : true
         : state.reasoningEnabled,
       supportsPreserveThinking: false,
-      supportsTools:
-        providerModelSupportsStudioTools(
-          provider?.providerType,
-          selection.modelId,
-        ) === true,
+      supportsTools: providerStudioToolsEnabled(provider, selection.modelId),
       supportsBuiltinWebSearch,
       supportsBuiltinCodeExecution,
       supportsBuiltinImageGeneration,
@@ -2787,11 +2783,10 @@ export function ChatPage({
               : true
             : store.reasoningEnabled,
           supportsPreserveThinking: false,
-          supportsTools:
-            providerModelSupportsStudioTools(
-              selectedProvider?.providerType,
-              selectedExternal?.modelId,
-            ) === true,
+          supportsTools: providerStudioToolsEnabled(
+            selectedProvider,
+            selectedExternal?.modelId,
+          ),
           supportsBuiltinWebSearch,
           supportsBuiltinCodeExecution,
           supportsBuiltinImageGeneration,

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -184,6 +184,7 @@ import {
   SharedComposer,
 } from "./shared-composer";
 import { BypassPermissionsConfirmDialog } from "./bypass-permissions-menu-item";
+import { LocalToolsNoticeDialog } from "./local-tools-notice-dialog";
 import {
   CHAT_CODE_TOOLS_ENABLED_KEY,
   CHAT_IMAGE_TOOLS_ENABLED_KEY,
@@ -3294,6 +3295,8 @@ export function ChatPage({
           render their own copy and the shared-composer menu would have none. It
           also portals to body, so gate it on `active` like the tour above. */}
       {active && <BypassPermissionsConfirmDialog />}
+      {/* single app-level mount because both composers access store state */}
+      {active && <LocalToolsNoticeDialog />}
       <div className="relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden">
         <NativeModelDropOverlay state={nativeModelDropState} />
         {/* Fade under the top bar so messages dissolve as they scroll

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -63,6 +63,7 @@ import {
   LEGACY_CUSTOM_PROVIDER_TYPE,
   CUSTOM_PROVIDER_DISPLAY_NAME,
   removeExternalProviderApiKey,
+  supportsProviderLocalTools,
   supportsProviderReasoningToggle,
   supportsRemoteModelCatalog,
   toExternalBackendProviderType,
@@ -178,6 +179,7 @@ export function ChatProvidersSettings({
     CUSTOM_PROVIDER_DISPLAY_NAME,
   );
   const [isReasoningModel, setIsReasoningModel] = useState(false);
+  const [enableLocalTools, setEnableLocalTools] = useState(false);
   const reduceMotion = useReducedMotion();
   const connectionsEnabled = useExternalProvidersStore(
     (s) => s.connectionsEnabled,
@@ -189,6 +191,7 @@ export function ChatProvidersSettings({
   // llama.cpp hides the key field. Ollama and vLLM show an optional key:
   // Ollama cloud and secured vLLM need one; local servers leave it empty.
   const showReasoningToggle = supportsProviderReasoningToggle(providerType);
+  const showLocalToolsToggle = supportsProviderLocalTools(providerType);
 
   const registryByType = useMemo(
     () => new Map(registry.map((entry) => [entry.provider_type, entry])),
@@ -389,6 +392,7 @@ export function ChatProvidersSettings({
     setModelSearchQuery("");
     setCustomProviderName(customProviderDisplayName(providerType));
     setIsReasoningModel(false);
+    setEnableLocalTools(false);
   }
 
   function openAddProvider() {
@@ -700,6 +704,9 @@ export function ChatProvidersSettings({
         isReasoningModel: supportsProviderReasoningToggle(uiProviderType)
           ? isReasoningModel
           : undefined,
+        enableLocalTools: supportsProviderLocalTools(uiProviderType)
+          ? enableLocalTools
+          : undefined,
         createdAt,
         updatedAt,
       };
@@ -844,6 +851,11 @@ export function ChatProvidersSettings({
                 )
                   ? isReasoningModel
                   : undefined,
+                enableLocalTools: supportsProviderLocalTools(
+                  existing.providerType,
+                )
+                  ? enableLocalTools
+                  : undefined,
                 updatedAt,
               }
             : provider,
@@ -878,6 +890,11 @@ export function ChatProvidersSettings({
     setIsReasoningModel(
       supportsProviderReasoningToggle(provider.providerType)
         ? provider.isReasoningModel === true
+        : false,
+    );
+    setEnableLocalTools(
+      supportsProviderLocalTools(provider.providerType)
+        ? provider.enableLocalTools === true
         : false,
     );
     if (
@@ -1271,6 +1288,42 @@ export function ChatProvidersSettings({
                     />
                     This server runs a reasoning model
                   </label>
+                </div>
+              ) : null}
+
+              {showLocalToolsToggle ? (
+                <div className="grid grid-cols-[minmax(140px,0.8fr)_minmax(0,1.2fr)] items-start gap-4 px-4 py-3 @max-[520px]:grid-cols-1">
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <Label
+                      htmlFor="provider-local-tools"
+                      className="text-sm font-medium"
+                    >
+                      Local tools
+                    </Label>
+                    <p className="text-xs leading-snug text-muted-foreground">
+                      Off by default.
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <label
+                      htmlFor="provider-local-tools"
+                      className="flex cursor-pointer items-center gap-2 text-sm"
+                    >
+                      <Checkbox
+                        id="provider-local-tools"
+                        checked={enableLocalTools}
+                        onCheckedChange={(checked) =>
+                          setEnableLocalTools(checked === true)
+                        }
+                      />
+                      Let this model use Search and Code
+                    </label>
+                    <p className="text-xs leading-snug text-muted-foreground">
+                      Web search and code execution run on this machine, in the
+                      same sandbox local models use. Only enable it for a
+                      tool-calling model on a server you trust.
+                    </p>
+                  </div>
                 </div>
               ) : null}
             </div>

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -81,8 +81,6 @@ const PROVIDER_FORM_EASE: [number, number, number, number] = [
 const PROVIDER_FORM_DURATION = 0.2;
 const CUSTOM_PROVIDER_MISSING_KEY_MESSAGE =
   "No API key found. Add a valid API key for this connection.";
-const HIDDEN_PROVIDER_TYPES = new Set(["qwen"]);
-
 function parseManualModelIds(text: string): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
@@ -1129,10 +1127,7 @@ export function ChatProvidersSettings({
                     <SelectSeparator />
                     <SelectGroup>
                       {registry
-                        .filter(
-                          (entry) =>
-                            !HIDDEN_PROVIDER_TYPES.has(entry.provider_type),
-                        )
+                        .filter((entry) => !entry.hidden)
                         .map((entry) => (
                           <SelectItem
                             key={entry.provider_type}

--- a/studio/frontend/src/features/chat/external-providers.ts
+++ b/studio/frontend/src/features/chat/external-providers.ts
@@ -196,7 +196,19 @@ export function providerModelSupportsStudioTools(
 ): boolean | null {
   if (!providerType || !modelId) return null;
   hydrateProviderModelCapabilities();
-  const value = REGISTRY_MODEL_CAPABILITIES.get(providerType)?.[modelId]?.studio_tools;
+  const capabilities = REGISTRY_MODEL_CAPABILITIES.get(providerType);
+  const modelValue = capabilities?.[modelId]?.studio_tools;
+  if (typeof modelValue === "boolean") return modelValue;
+  const providerValue = capabilities?.["*"]?.studio_tools;
+  return typeof providerValue === "boolean" ? providerValue : null;
+}
+
+export function providerTypeSupportsStudioTools(
+  providerType: string | null | undefined,
+): boolean | null {
+  if (!providerType) return null;
+  hydrateProviderModelCapabilities();
+  const value = REGISTRY_MODEL_CAPABILITIES.get(providerType)?.["*"]?.studio_tools;
   return typeof value === "boolean" ? value : null;
 }
 
@@ -224,6 +236,11 @@ export const CUSTOM_PROVIDER_PRESETS = [
     modelIdsPlaceholder: "gpt-oss:20b\nqwen3:14b",
   },
 ] as const;
+
+const LOCAL_TOOL_PROVIDER_FALLBACK = new Set<string>([
+  ...CUSTOM_PROVIDER_PRESETS.map((preset) => preset.providerType),
+  LEGACY_CUSTOM_PROVIDER_TYPE,
+]);
 
 const CUSTOM_PROVIDER_LABELS: Record<string, string> = {
   [LEGACY_CUSTOM_PROVIDER_TYPE]: CUSTOM_PROVIDER_DISPLAY_NAME,
@@ -262,18 +279,12 @@ export function isCustomProviderType(
   return providerType in CUSTOM_PROVIDER_LABELS;
 }
 
-// mirrors LOCAL_TOOL_LOOP_PROVIDER_TYPES in backend/core/inference/external_tool_loop.py.
-const LOCAL_TOOLS_PROVIDER_TYPES = new Set<string>([
-  "vllm",
-  "ollama",
-  "llama_cpp",
-  LEGACY_CUSTOM_PROVIDER_TYPE,
-]);
-
 export function supportsProviderLocalTools(
   providerType: string | null | undefined,
 ): boolean {
-  return providerType != null && LOCAL_TOOLS_PROVIDER_TYPES.has(providerType);
+  const capability = providerTypeSupportsStudioTools(providerType);
+  if (capability !== null) return capability;
+  return providerType != null && LOCAL_TOOL_PROVIDER_FALLBACK.has(providerType);
 }
 
 /** whether local tools are enabled for this connection. */
@@ -285,6 +296,21 @@ export function providerLocalToolsEnabled(
     supportsProviderLocalTools(provider.providerType) &&
     provider.enableLocalTools === true
   );
+}
+
+export function providerStudioToolsEnabled(
+  provider: ExternalProviderConfig | null | undefined,
+  modelId: string | null | undefined,
+): boolean {
+  if (
+    !provider ||
+    providerModelSupportsStudioTools(provider.providerType, modelId) !== true
+  ) {
+    return false;
+  }
+  return providerTypeSupportsStudioTools(provider.providerType) === true
+    ? providerLocalToolsEnabled(provider)
+    : true;
 }
 
 /** OpenAI-compat custom types that may expose GET /v1/models. */

--- a/studio/frontend/src/features/chat/external-providers.ts
+++ b/studio/frontend/src/features/chat/external-providers.ts
@@ -37,6 +37,12 @@ export interface ExternalProviderConfig {
   /** User-pinned: the loaded vLLM model supports `enable_thinking`. */
   isReasoningModel?: boolean;
   /**
+   * enable unsloth's local tools (web_search, python, terminal) for this
+   * server. off by default since tools run on the studio host; only for
+   * provider types `supportsProviderLocalTools` accepts.
+   */
+  enableLocalTools?: boolean;
+  /**
    * Default idle-timeout (minutes) for new OpenAI shell containers. Pre-fills the
    * "Create container" dialog and is the TTL the auto-create-per-thread path POSTs
    * to /v1/containers. OpenAI's hard default is 20. Only for OpenAI cloud.
@@ -256,6 +262,31 @@ export function isCustomProviderType(
   return providerType in CUSTOM_PROVIDER_LABELS;
 }
 
+// mirrors LOCAL_TOOL_LOOP_PROVIDER_TYPES in backend/core/inference/external_tool_loop.py.
+const LOCAL_TOOLS_PROVIDER_TYPES = new Set<string>([
+  "vllm",
+  "ollama",
+  "llama_cpp",
+  LEGACY_CUSTOM_PROVIDER_TYPE,
+]);
+
+export function supportsProviderLocalTools(
+  providerType: string | null | undefined,
+): boolean {
+  return providerType != null && LOCAL_TOOLS_PROVIDER_TYPES.has(providerType);
+}
+
+/** whether local tools are enabled for this connection. */
+export function providerLocalToolsEnabled(
+  provider: ExternalProviderConfig | null | undefined,
+): boolean {
+  if (!provider) return false;
+  return (
+    supportsProviderLocalTools(provider.providerType) &&
+    provider.enableLocalTools === true
+  );
+}
+
 /** OpenAI-compat custom types that may expose GET /v1/models. */
 const REMOTE_MODEL_CATALOG_CUSTOM_PROVIDER_TYPES = new Set([
   LEGACY_CUSTOM_PROVIDER_TYPE,
@@ -424,6 +455,9 @@ function normalizeProvider(raw: ExternalProviderConfig): ExternalProviderConfig 
         : undefined,
     isReasoningModel: supportsProviderReasoningToggle(providerType)
       ? raw.isReasoningModel === true
+      : undefined,
+    enableLocalTools: supportsProviderLocalTools(providerType)
+      ? raw.enableLocalTools === true
       : undefined,
     openaiContainerTtlMinutes:
       providerType === "openai" &&

--- a/studio/frontend/src/features/chat/external-providers.ts
+++ b/studio/frontend/src/features/chat/external-providers.ts
@@ -302,15 +302,18 @@ export function providerStudioToolsEnabled(
   provider: ExternalProviderConfig | null | undefined,
   modelId: string | null | undefined,
 ): boolean {
-  if (
-    !provider ||
-    providerModelSupportsStudioTools(provider.providerType, modelId) !== true
-  ) {
-    return false;
+  if (!provider) return false;
+  const capability = providerModelSupportsStudioTools(
+    provider.providerType,
+    modelId,
+  );
+  if (capability === false) return false;
+  // a self-hosted type still resolves through the static fallback while the registry
+  // capability cache is empty, so an opted-in connection keeps sending its tools.
+  if (supportsProviderLocalTools(provider.providerType)) {
+    return providerLocalToolsEnabled(provider);
   }
-  return providerTypeSupportsStudioTools(provider.providerType) === true
-    ? providerLocalToolsEnabled(provider)
-    : true;
+  return capability === true;
 }
 
 /** OpenAI-compat custom types that may expose GET /v1/models. */

--- a/studio/frontend/src/features/chat/hooks/use-external-local-tools.ts
+++ b/studio/frontend/src/features/chat/hooks/use-external-local-tools.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  type ExternalProviderConfig,
+  parseExternalModelId,
+  providerLocalToolsEnabled,
+  supportsProviderLocalTools,
+} from "../external-providers";
+import { useChatRuntimeStore } from "../stores/chat-runtime-store";
+import { useExternalProvidersStore } from "../stores/external-providers-store";
+
+export interface ExternalLocalToolsState {
+  /** the external provider connection, or null. */
+  provider: ExternalProviderConfig | null;
+  /** whether the external provider connection supports running local tools. */
+  supported: boolean;
+  /** whether the user enabled local tools in settings. */
+  enabled: boolean;
+}
+
+const NO_LOCAL_TOOLS: ExternalLocalToolsState = {
+  provider: null,
+  supported: false,
+  enabled: false,
+};
+
+/**
+ * check whether the selected external connection can run unsloth's local tools.
+ * when `supported && !enabled`, search/code pills show an opt-in notice.
+ */
+export function useExternalLocalTools(): ExternalLocalToolsState {
+  const checkpoint = useChatRuntimeStore((s) => s.params.checkpoint);
+  const connectionsEnabled = useExternalProvidersStore(
+    (s) => s.connectionsEnabled,
+  );
+  const providers = useExternalProvidersStore((s) => s.providers);
+
+  const selection = parseExternalModelId(checkpoint);
+  if (!selection || !connectionsEnabled) return NO_LOCAL_TOOLS;
+  const provider =
+    providers.find((entry) => entry.id === selection.providerId) ?? null;
+  if (!provider || !supportsProviderLocalTools(provider.providerType)) {
+    return NO_LOCAL_TOOLS;
+  }
+  return {
+    provider,
+    supported: true,
+    enabled: providerLocalToolsEnabled(provider),
+  };
+}

--- a/studio/frontend/src/features/chat/hooks/use-rag-tool-disabled.ts
+++ b/studio/frontend/src/features/chat/hooks/use-rag-tool-disabled.ts
@@ -3,7 +3,7 @@
 
 import {
   parseExternalModelId,
-  providerModelSupportsStudioTools,
+  providerStudioToolsEnabled,
 } from "../external-providers";
 import { useExternalProvidersStore } from "../stores/external-providers-store";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
@@ -24,9 +24,6 @@ export function useRagToolDisabled(): boolean {
     : undefined;
   const externalWithoutStudioTools =
     externalSelection !== null &&
-    providerModelSupportsStudioTools(
-      externalProvider?.providerType,
-      externalSelection.modelId,
-    ) !== true;
+    !providerStudioToolsEnabled(externalProvider, externalSelection.modelId);
   return modelLoaded && (externalWithoutStudioTools || !supportsTools);
 }

--- a/studio/frontend/src/features/chat/local-tools-notice-dialog.tsx
+++ b/studio/frontend/src/features/chat/local-tools-notice-dialog.tsx
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useSettingsDialogStore } from "@/features/settings/stores/settings-dialog-store";
+import { useChatRuntimeStore } from "./stores/chat-runtime-store";
+
+/**
+ * alerts when search or code is clicked on an external openai-compat connection
+ * without opting into the local tool runtime. Mounted once at chat-page root
+ * and driven by store state like BypassPermissionsConfirmDialog: both composers
+ * share one copy and Compare mode never duplicates it.
+ */
+export function LocalToolsNoticeDialog() {
+  const providerName = useChatRuntimeStore((s) => s.localToolsNoticeProvider);
+  const setProviderName = useChatRuntimeStore(
+    (s) => s.setLocalToolsNoticeProvider,
+  );
+  const openSettings = useSettingsDialogStore((s) => s.openDialog);
+
+  return (
+    <AlertDialog
+      open={providerName !== null}
+      onOpenChange={(open) => {
+        if (!open) setProviderName(null);
+      }}
+    >
+      <AlertDialogContent size="sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Local tools are off</AlertDialogTitle>
+          <AlertDialogDescription>
+            Web search and code execution run on this machine. Turn on Local
+            tools for {providerName || "this connection"} to enable the Search
+            and Code pills.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Close</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => {
+              setProviderName(null);
+              openSettings("connections");
+            }}
+          >
+            Open settings
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -799,8 +799,10 @@ export function SharedComposer({
           ))) ||
     imageModeDisablesCode;
   // opted-out connection: the pill is live but toggling it would send nothing.
+  // Compare resolves a model per pane while this hook only sees the global
+  // checkpoint, so gating there would block both panes over the wrong connection.
   const localToolsOptInMissing =
-    externalLocalTools.supported && !externalLocalTools.enabled;
+    !isCompareMode && externalLocalTools.supported && !externalLocalTools.enabled;
   // Images pill lights only on OpenAI cloud Responses-API models and the
   // Gemini Nano Banana family. No local tool runtime fallback.
   const showImagePill = supportsBuiltinImageGeneration;

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -111,7 +111,7 @@ import {
   parseExternalModelId,
   providerModelSupportsVision,
 
-  providerModelSupportsStudioTools,
+  providerStudioToolsEnabled,
 } from "./external-providers";
 import { compareModelDisplayName } from "./lib/external-model-label";
 import { useExternalProvidersStore } from "./stores/external-providers-store";
@@ -807,11 +807,10 @@ export function SharedComposer({
   // Fetch pill: Anthropic-only (web_fetch_20250910 / web_fetch_20260209).
   const webFetchDisabled = !modelLoaded || !supportsBuiltinWebFetch;
   const showWebFetchPill = supportsBuiltinWebFetch;
-  const externalUsesStudioTools =
-    providerModelSupportsStudioTools(
-      selectedExternalProvider?.providerType,
-      externalSelection?.modelId,
-    ) === true;
+  const externalUsesStudioTools = providerStudioToolsEnabled(
+    selectedExternalProvider,
+    externalSelection?.modelId,
+  );
   const ragDisabled =
     modelLoaded && ((!externalUsesStudioTools && isExternalModel) || !supportsTools);
   const showRagPill = !isExternalModel || externalUsesStudioTools;

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -115,6 +115,7 @@ import {
 } from "./external-providers";
 import { compareModelDisplayName } from "./lib/external-model-label";
 import { useExternalProvidersStore } from "./stores/external-providers-store";
+import { useExternalLocalTools } from "./hooks/use-external-local-tools";
 import { useComposerPillFit } from "@/hooks/use-composer-pill-fit";
 import { useIsMobile } from "@/hooks/use-mobile";
 import {
@@ -769,19 +770,37 @@ export function SharedComposer({
   // gate strictly on provider builtin support.
   const isGeminiImageTier =
     isExternalGemini && supportsBuiltinImageGeneration;
+  // the pills stay clickable without the opt-in so the click can explain why.
+  const externalLocalTools = useExternalLocalTools();
+  const setLocalToolsNotice = useChatRuntimeStore(
+    (s) => s.setLocalToolsNoticeProvider,
+  );
+  const showLocalToolsNotice = () =>
+    setLocalToolsNotice(externalLocalTools.provider?.name ?? "");
   // Disable only when a loaded model lacks the capability; with no model the
   // tool can still be pre-selected, matching the + menu.
   const searchDisabled =
     modelLoaded &&
     (isGeminiImageTier
       ? !supportsBuiltinWebSearch
-      : !(supportsTools || supportsBuiltinWebSearch));
+      : !(
+          supportsTools ||
+          supportsBuiltinWebSearch ||
+          externalLocalTools.supported
+        ));
   const codeDisabled =
     (modelLoaded &&
       (isGeminiImageTier
         ? true
-        : !(supportsTools || supportsBuiltinCodeExecution))) ||
+        : !(
+            supportsTools ||
+            supportsBuiltinCodeExecution ||
+            externalLocalTools.supported
+          ))) ||
     imageModeDisablesCode;
+  // opted-out connection: the pill is live but toggling it would send nothing.
+  const localToolsOptInMissing =
+    externalLocalTools.supported && !externalLocalTools.enabled;
   // Images pill lights only on OpenAI cloud Responses-API models and the
   // Gemini Nano Banana family. No local tool runtime fallback.
   const showImagePill = supportsBuiltinImageGeneration;
@@ -2099,11 +2118,15 @@ export function SharedComposer({
               <DropdownMenuItem
                 disabled={searchDisabled}
                 className={
-                  toolsEnabled && !searchDisabled
+                  toolsEnabled && !searchDisabled && !localToolsOptInMissing
                     ? "text-primary font-medium"
                     : undefined
                 }
                 onSelect={() => {
+                  if (localToolsOptInMissing) {
+                    showLocalToolsNotice();
+                    return;
+                  }
                   const next = !toolsEnabled;
                   setToolsEnabled(next);
                   // Mirror the Search pill: Kimi forbids search + thinking together.
@@ -2115,7 +2138,7 @@ export function SharedComposer({
               >
                 <GlobeIcon />
                 Web search
-                {toolsEnabled && !searchDisabled ? (
+                {toolsEnabled && !searchDisabled && !localToolsOptInMissing ? (
                   <HugeiconsIcon
                     icon={Tick02Icon}
                     strokeWidth={2}
@@ -2126,11 +2149,17 @@ export function SharedComposer({
               <DropdownMenuItem
                 disabled={codeDisabled}
                 className={
-                  codeToolsEnabled && !codeDisabled
+                  codeToolsEnabled && !codeDisabled && !localToolsOptInMissing
                     ? "text-primary font-medium"
                     : undefined
                 }
-                onSelect={() => setCodeToolsEnabled(!codeToolsEnabled)}
+                onSelect={() => {
+                  if (localToolsOptInMissing) {
+                    showLocalToolsNotice();
+                    return;
+                  }
+                  setCodeToolsEnabled(!codeToolsEnabled);
+                }}
               >
                 {/* Scale, not width: an oversized box pushed the label out of
                     line. */}
@@ -2140,7 +2169,7 @@ export function SharedComposer({
                   className="scale-[1.12]"
                 />
                 Code
-                {codeToolsEnabled && !codeDisabled ? (
+                {codeToolsEnabled && !codeDisabled && !localToolsOptInMissing ? (
                   <HugeiconsIcon
                     icon={Tick02Icon}
                     strokeWidth={2}
@@ -2210,6 +2239,10 @@ export function SharedComposer({
             type="button"
             disabled={searchDisabled}
             onClick={() => {
+              if (localToolsOptInMissing) {
+                showLocalToolsNotice();
+                return;
+              }
               const next = !toolsEnabled;
               setToolsEnabled(next);
               // Kimi's $web_search builtin requires thinking=disabled
@@ -2222,7 +2255,11 @@ export function SharedComposer({
             }}
             className="composer-pill-btn"
             data-pill-label="Search"
-            data-active={toolsEnabled && !searchDisabled ? "true" : "false"}
+            data-active={
+              toolsEnabled && !searchDisabled && !localToolsOptInMissing
+                ? "true"
+                : "false"
+            }
             aria-label={
               toolsEnabled ? "Disable web search" : "Enable web search"
             }
@@ -2235,10 +2272,20 @@ export function SharedComposer({
           <button
             type="button"
             disabled={codeDisabled}
-            onClick={() => setCodeToolsEnabled(!codeToolsEnabled)}
+            onClick={() => {
+              if (localToolsOptInMissing) {
+                showLocalToolsNotice();
+                return;
+              }
+              setCodeToolsEnabled(!codeToolsEnabled);
+            }}
             className="composer-pill-btn"
             data-pill-label="Code"
-            data-active={codeToolsEnabled && !codeDisabled ? "true" : "false"}
+            data-active={
+              codeToolsEnabled && !codeDisabled && !localToolsOptInMissing
+                ? "true"
+                : "false"
+            }
             aria-label={
               codeToolsEnabled
                 ? "Disable code execution"

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1011,6 +1011,10 @@ type ChatRuntimeStore = {
   /** Whether the "Enable Bypass Permissions?" warning dialog is open. Lifted out
    *  of the composer menu so confirming/cancelling it doesn't leave the menu frozen. */
   bypassConfirmOpen: boolean;
+  /** connection name with an open "local tools off" notice, or null. set
+   *  when a Search/Code pill is clicked on an external OpenAI-compatible
+   *  connection that hasn't opted into local tool runtime. */
+  localToolsNoticeProvider: string | null;
   /**
    * Per-chat set of tool names the user chose to auto-approve via "Always
    * allow". Keyed by UI confirmation scope, not necessarily the backend
@@ -1274,6 +1278,7 @@ type ChatRuntimeStore = {
   setBypassPermissions: (enabled: boolean) => void;
   setPermissionMode: (mode: PermissionMode) => void;
   setBypassConfirmOpen: (open: boolean) => void;
+  setLocalToolsNoticeProvider: (providerName: string | null) => void;
   allowToolAlways: (sessionId: string, toolName: string) => void;
   setToolConfirmation: (
     toolCallId: string,
@@ -1610,6 +1615,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   bypassPermissions: false,
   permissionMode: INITIAL_PERMISSION_MODE,
   bypassConfirmOpen: false,
+  localToolsNoticeProvider: null,
   alwaysAllowToolsBySession: new Map<string, Set<string>>(),
   toolConfirmations: {},
   webFetchToolsEnabled: loadBool(CHAT_WEB_FETCH_TOOLS_ENABLED_KEY, false),
@@ -2390,6 +2396,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     }),
   setBypassConfirmOpen: (bypassConfirmOpen) =>
     set(() => ({ bypassConfirmOpen })),
+  setLocalToolsNoticeProvider: (localToolsNoticeProvider) =>
+    set(() => ({ localToolsNoticeProvider })),
   allowToolAlways: (sessionId, toolName) =>
     set((state) => {
       const current = state.alwaysAllowToolsBySession.get(sessionId);

--- a/studio/frontend/src/features/chat/sync-external-providers.ts
+++ b/studio/frontend/src/features/chat/sync-external-providers.ts
@@ -25,6 +25,7 @@ import {
   removeExternalProviderApiKey,
 
   setProviderModelCapabilities,
+  supportsProviderLocalTools,
   supportsProviderPromptCaching,
   supportsProviderPromptCacheTtl,
   supportsProviderReasoningToggle,
@@ -119,6 +120,9 @@ export function mergeLocalProviderOptions(
         : synced.promptCacheTtl,
     isReasoningModel: supportsProviderReasoningToggle(providerType)
       ? (existing.isReasoningModel ?? synced.isReasoningModel)
+      : undefined,
+    enableLocalTools: supportsProviderLocalTools(providerType)
+      ? (existing.enableLocalTools ?? synced.enableLocalTools ?? false)
       : undefined,
     openaiContainerTtlMinutes:
       providerType === "openai" &&
@@ -240,6 +244,9 @@ export async function syncExternalProvidersFromBackend(
           : undefined,
         isReasoningModel: supportsProviderReasoningToggle(uiProviderType)
           ? existing?.isReasoningModel === true
+          : undefined,
+        enableLocalTools: supportsProviderLocalTools(uiProviderType)
+          ? existing?.enableLocalTools === true
           : undefined,
         createdAt: existing?.createdAt ?? createdAt,
         updatedAt,

--- a/studio/frontend/tests/external-local-tools.test.ts
+++ b/studio/frontend/tests/external-local-tools.test.ts
@@ -127,3 +127,25 @@ test("an unknown connection syncs to the off default", () => {
   assert.equal(merged.enableLocalTools, undefined);
   assert.equal(providerLocalToolsEnabled(merged), false);
 });
+
+test("an empty capability cache still honors the self-hosted opt-in", () => {
+  // the registry fetch can fail or land after first paint; the picker already
+  // falls back for these types, so the payload gate has to agree.
+  setProviderModelCapabilities("vllm", undefined);
+  assert.equal(
+    providerStudioToolsEnabled(
+      provider("vllm", { enableLocalTools: true }),
+      "qwen3-14b",
+    ),
+    true,
+  );
+  assert.equal(providerStudioToolsEnabled(provider("vllm"), "qwen3-14b"), false);
+  // a hosted provider has no fallback, so it stays off until the registry loads.
+  assert.equal(
+    providerStudioToolsEnabled(
+      provider("openai", { enableLocalTools: true }),
+      "gpt-5",
+    ),
+    false,
+  );
+});

--- a/studio/frontend/tests/external-local-tools.test.ts
+++ b/studio/frontend/tests/external-local-tools.test.ts
@@ -12,9 +12,13 @@ import { registerStoreStubResolver } from "./helpers/kit.ts";
 
 registerStoreStubResolver();
 
-const { providerLocalToolsEnabled, supportsProviderLocalTools } = await import(
-  "../src/features/chat/external-providers.ts"
-);
+const {
+  providerLocalToolsEnabled,
+  providerModelSupportsStudioTools,
+  providerStudioToolsEnabled,
+  setProviderModelCapabilities,
+  supportsProviderLocalTools,
+} = await import("../src/features/chat/external-providers.ts");
 const { mergeLocalProviderOptions } = await import(
   "../src/features/chat/sync-external-providers.ts"
 );
@@ -73,6 +77,31 @@ test("the opt-in defaults off and never applies to a hosted provider", () => {
   );
   assert.equal(providerLocalToolsEnabled(null), false);
   assert.equal(providerLocalToolsEnabled(undefined), false);
+});
+
+test("registry wildcard capability still requires the connection opt-in", () => {
+  setProviderModelCapabilities("vllm", {
+    "*": { studio_tools: true },
+  });
+  assert.equal(providerModelSupportsStudioTools("vllm", "any-model"), true);
+  assert.equal(providerStudioToolsEnabled(provider("vllm"), "any-model"), false);
+  assert.equal(
+    providerStudioToolsEnabled(
+      provider("vllm", { enableLocalTools: true }),
+      "any-model",
+    ),
+    true,
+  );
+});
+
+test("curated per-model Studio tools need no connection opt-in", () => {
+  setProviderModelCapabilities("openai_codex", {
+    "gpt-test": { studio_tools: true },
+  });
+  assert.equal(
+    providerStudioToolsEnabled(provider("openai_codex"), "gpt-test"),
+    true,
+  );
 });
 
 test("a backend sync keeps the browser-local opt-in", () => {

--- a/studio/frontend/tests/external-local-tools.test.ts
+++ b/studio/frontend/tests/external-local-tools.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// the per-connection local-tools opt-in: which provider types may offer it,
+// when it counts as on, and that a backend sync never resurrects or loses it.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ExternalProviderConfig } from "../src/features/chat/external-providers.ts";
+import { registerStoreStubResolver } from "./helpers/kit.ts";
+
+registerStoreStubResolver();
+
+const { providerLocalToolsEnabled, supportsProviderLocalTools } = await import(
+  "../src/features/chat/external-providers.ts"
+);
+const { mergeLocalProviderOptions } = await import(
+  "../src/features/chat/sync-external-providers.ts"
+);
+
+function provider(
+  providerType: string,
+  overrides: Partial<ExternalProviderConfig> = {},
+): ExternalProviderConfig {
+  return {
+    id: "p1",
+    providerType,
+    name: "My server",
+    baseUrl: "http://localhost:8000/v1",
+    models: ["qwen3-14b"],
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+test("only self-hosted OpenAI-compat connections offer the local-tools opt-in", () => {
+  // mirrors local_tool_loop_provider_types in
+  // studio/backend/core/inference/external_tool_loop.py.
+  for (const providerType of ["vllm", "ollama", "llama_cpp", "custom"]) {
+    assert.equal(supportsProviderLocalTools(providerType), true, providerType);
+  }
+  for (const providerType of [
+    "openai",
+    "anthropic",
+    "gemini",
+    "openrouter",
+    "kimi",
+    "mistral",
+  ]) {
+    assert.equal(supportsProviderLocalTools(providerType), false, providerType);
+  }
+  assert.equal(supportsProviderLocalTools(null), false);
+  assert.equal(supportsProviderLocalTools(undefined), false);
+});
+
+test("the opt-in defaults off and never applies to a hosted provider", () => {
+  assert.equal(providerLocalToolsEnabled(provider("vllm")), false);
+  assert.equal(
+    providerLocalToolsEnabled(provider("vllm", { enableLocalTools: false })),
+    false,
+  );
+  assert.equal(
+    providerLocalToolsEnabled(provider("vllm", { enableLocalTools: true })),
+    true,
+  );
+  // a stale flag on a hosted connection must not light the pills: those
+  // providers run their own server-side tools.
+  assert.equal(
+    providerLocalToolsEnabled(provider("openai", { enableLocalTools: true })),
+    false,
+  );
+  assert.equal(providerLocalToolsEnabled(null), false);
+  assert.equal(providerLocalToolsEnabled(undefined), false);
+});
+
+test("a backend sync keeps the browser-local opt-in", () => {
+  // the backend never stores this flag, so the rebuilt config carries no value
+  // and the local one has to survive the merge.
+  const merged = mergeLocalProviderOptions(
+    provider("vllm", { enableLocalTools: true }),
+    provider("vllm"),
+  );
+  assert.equal(merged.enableLocalTools, true);
+});
+
+test("a sync of a hosted connection clears the opt-in", () => {
+  const merged = mergeLocalProviderOptions(
+    provider("openai", { enableLocalTools: true }),
+    provider("openai"),
+  );
+  assert.equal(merged.enableLocalTools, undefined);
+});
+
+test("an unknown connection syncs to the off default", () => {
+  const merged = mergeLocalProviderOptions(undefined, provider("ollama"));
+  assert.equal(merged.enableLocalTools, undefined);
+  assert.equal(providerLocalToolsEnabled(merged), false);
+});


### PR DESCRIPTION
## What changed

- add a Studio-owned tool loop for vLLM, Ollama, llama.cpp, and custom OpenAI-compatible connections
- expose Search, Code, selected MCP tools, and RAG through the shared registry-driven selector
- require an explicit per-connection Local tools opt-in before Studio can execute code or access the host
- preserve usage, finish reasons, reasoning deltas, structured content, partial tool markers, provisional cards, and stalled-model recovery across provider turns
- honor forced tool choices, zero and multi-turn budgets, timeouts, disabled nudges, parallel-call settings, Full access schemas, denials, and automatic high-risk approval checks
- flush gated approval cards on a separately scheduled write so Tauri shows Allow and Deny before the stream blocks

## Why this supersedes #8626

This includes the registry wildcard and shared MCP/RAG selection strengths from #8626, then covers the safety and stream behavior that implementation does not:

- local execution stays behind a visible connection-level trust opt-in
- permission mode auto still prompts for high-risk calls
- the approval card gets a proven 50 ms separate-write flush instead of a same-tick keepalive that can coalesce
- provider usage and terminal finish reasons survive the local loop
- Ollama reasoning and reasoning-only answers render correctly
- text-form calls, split tool markers, structured content parts, large streamed arguments, duplicates, denials, forced choices, and stuck-model retries have focused coverage

Fixes #7282. Supersedes #8626 and #7330.

Credit to @khalidejaz for #8626. Its provider-level `studio_tools` wildcard and shared `_select_request_tools` path were the right architecture for self-hosted MCP and RAG support, and those ideas are incorporated here.

## Verification

- 35 focused backend tests passed
- frontend typecheck passed
- 2,020 frontend tests passed
- Ruff and diff checks passed
- manually verified external-provider and native approval flows in the Tauri desktop app; both tool cards and Allow/Deny controls appear immediately