### PR TITLE
Studio: stop a streaming research run re-rendering the whole chat

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -240,6 +240,7 @@ import {
   type ReactNode,
   Fragment,
   createContext,
+  memo,
   useCallback,
   useContext,
   useEffect,
@@ -1327,11 +1328,13 @@ const FOOTER_GAP_BELOW_SPACER_PX = 10;
 // Covers instant responses where isRunning is already false by resize time.
 const RUN_SHRINK_WINDOW_MS = 1000;
 
+// Memoized on three primitive props: chat-page builds this element inline inside a component
+// that subscribes to stores, so without it a parent render reconciles the whole message list.
 export const Thread: FC<{
   hideComposer?: boolean;
   hideWelcome?: boolean;
   targetThreadId?: string;
-}> = ({ hideComposer, hideWelcome, targetThreadId }) => {
+}> = memo(({ hideComposer, hideWelcome, targetThreadId }) => {
   // Intent-aware autoscroll replaces assistant-ui's built-in autoscroll to
   // prevent the streaming-mutation race that snaps the viewport back to the
   // bottom while the user scrolls up (see the hook for the full explanation).
@@ -1642,7 +1645,8 @@ export const Thread: FC<{
       </PageDragContext.Provider>
     </GeneratedImageOverlayProvider>
   );
-};
+});
+Thread.displayName = "Thread";
 
 const GeneratedImageViewportOverlay: FC<{
   hideComposer?: boolean;
@@ -2041,16 +2045,17 @@ const Composer: FC<{
   const researchThreadClaimed = useResearchRunStore((state) =>
     researchThreadId ? Boolean(state.claimedThreadIds[researchThreadId]) : false,
   );
-  const activeResearchRun = useResearchRunStore((state) => {
+  // Derive inside the selector, as useThreadResearchActive does: a bare run selector re-renders
+  // the composer on every streamed research delta.
+  const isResearchActive = useResearchRunStore((state) => {
     const runId = researchThreadId
       ? state.latestRunByThreadId[researchThreadId]
       : undefined;
-    return runId ? state.sessions[runId]?.run : undefined;
+    const run = runId ? state.sessions[runId]?.run : undefined;
+    return Boolean(
+      run && !["completed", "failed", "cancelled"].includes(run.status),
+    );
   });
-  const isResearchActive = Boolean(
-    activeResearchRun &&
-      !["completed", "failed", "cancelled"].includes(activeResearchRun.status),
-  );
   const hasResearchMessage = useAuiState(({ thread }) =>
     thread.messages.some((message) => {
       const custom = (
@@ -5094,47 +5099,53 @@ const ComposerRightControls: FC<{
   );
   const isQueueRunning = Boolean(queueEntry);
   const activeThreadId = useChatRuntimeStore((state) => state.activeThreadId);
-  const activeResearchRun = useResearchRunStore((state) => {
+  // Two primitives rather than the run object: the composer actions only need the id and the
+  // status, and the run identity changes on every streamed research delta.
+  const activeResearchRunId = useResearchRunStore((state) =>
+    activeThreadId ? state.latestRunByThreadId[activeThreadId] : undefined,
+  );
+  const activeResearchRunStatus = useResearchRunStore((state) => {
     const runId = activeThreadId
       ? state.latestRunByThreadId[activeThreadId]
       : undefined;
-    return runId ? state.sessions[runId]?.run : undefined;
+    return runId ? state.sessions[runId]?.run.status : undefined;
   });
   const isResearchActive = Boolean(
-    activeResearchRun &&
-      !["completed", "failed", "cancelled"].includes(activeResearchRun.status),
+    activeResearchRunStatus &&
+      !["completed", "failed", "cancelled"].includes(activeResearchRunStatus),
   );
   const [stoppingResearchRunId, setStoppingResearchRunId] = useState<
     string | null
   >(null);
   const stoppingResearchRunIdRef = useRef<string | null>(null);
   const researchStopping = Boolean(
-    activeResearchRun &&
-      (activeResearchRun.status === "cancelling" ||
-        stoppingResearchRunId === activeResearchRun.id),
+    activeResearchRunStatus &&
+      (activeResearchRunStatus === "cancelling" ||
+        (activeResearchRunId !== undefined &&
+          stoppingResearchRunId === activeResearchRunId)),
   );
   useEffect(() => {
     if (
       !isResearchActive ||
       (stoppingResearchRunIdRef.current &&
-        stoppingResearchRunIdRef.current !== activeResearchRun?.id)
+        stoppingResearchRunIdRef.current !== activeResearchRunId)
     ) {
       stoppingResearchRunIdRef.current = null;
       setStoppingResearchRunId(null);
     }
-  }, [activeResearchRun?.id, isResearchActive]);
+  }, [activeResearchRunId, isResearchActive]);
   const stop = () => {
-    if (isResearchActive && activeResearchRun) {
+    if (isResearchActive && activeResearchRunId) {
       if (
-        activeResearchRun.status === "cancelling" ||
-        stoppingResearchRunIdRef.current === activeResearchRun.id
+        activeResearchRunStatus === "cancelling" ||
+        stoppingResearchRunIdRef.current === activeResearchRunId
       ) {
         return;
       }
       if (isQueueRunning) onStopClick?.();
-      stoppingResearchRunIdRef.current = activeResearchRun.id;
-      setStoppingResearchRunId(activeResearchRun.id);
-      void cancelResearchRun(activeResearchRun.id)
+      stoppingResearchRunIdRef.current = activeResearchRunId;
+      setStoppingResearchRunId(activeResearchRunId);
+      void cancelResearchRun(activeResearchRunId)
         .then((run) => ingestResearchUpdate(run))
         .catch((error) => {
           stoppingResearchRunIdRef.current = null;

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1328,8 +1328,8 @@ const FOOTER_GAP_BELOW_SPACER_PX = 10;
 // Covers instant responses where isRunning is already false by resize time.
 const RUN_SHRINK_WINDOW_MS = 1000;
 
-// Memoized on three primitive props: chat-page builds this element inline inside a component
-// that subscribes to stores, so without it a parent render reconciles the whole message list.
+// Memoized: chat-page renders this inline in a store-subscribing component, so a parent render
+// would otherwise reconcile the whole message list.
 export const Thread: FC<{
   hideComposer?: boolean;
   hideWelcome?: boolean;
@@ -2045,8 +2045,8 @@ const Composer: FC<{
   const researchThreadClaimed = useResearchRunStore((state) =>
     researchThreadId ? Boolean(state.claimedThreadIds[researchThreadId]) : false,
   );
-  // Derive inside the selector, as useThreadResearchActive does: a bare run selector re-renders
-  // the composer on every streamed research delta.
+  // Derive in the selector, as useThreadResearchActive does: a bare run selector re-renders the
+  // composer on every streamed research delta.
   const isResearchActive = useResearchRunStore((state) => {
     const runId = researchThreadId
       ? state.latestRunByThreadId[researchThreadId]
@@ -5099,8 +5099,7 @@ const ComposerRightControls: FC<{
   );
   const isQueueRunning = Boolean(queueEntry);
   const activeThreadId = useChatRuntimeStore((state) => state.activeThreadId);
-  // Two primitives rather than the run object: the composer actions only need the id and the
-  // status, and the run identity changes on every streamed research delta.
+  // Id and status, not the run: run identity changes on every streamed research delta.
   const activeResearchRunId = useResearchRunStore((state) =>
     activeThreadId ? state.latestRunByThreadId[activeThreadId] : undefined,
   );

--- a/studio/frontend/src/components/assistant-ui/tool-code-cell.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-code-cell.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { MAX_HIGHLIGHT_CHARS } from "@/lib/markdown-plugins";
 import { downloadFile, isDownloadCancelled } from "@/lib/native-files";
 import { toast } from "@/lib/toast";
 import { code as codePlugin } from "@streamdown/code";
@@ -18,8 +19,6 @@ const SHIKI_THEME = ["github-light", "github-dark"] as [
   "github-light",
   "github-dark",
 ];
-/** Past this the block stays plain monospace: shiki is not worth the main-thread time. */
-const MAX_HIGHLIGHT_CHARS = 20_000;
 /** Within this many px of the bottom counts as following the stream. */
 const PIN_SLACK_PX = 40;
 

--- a/studio/frontend/src/components/markdown/markdown-preview.tsx
+++ b/studio/frontend/src/components/markdown/markdown-preview.tsx
@@ -1,17 +1,28 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { markdownPluginNeeds } from "@/lib/markdown-plugins";
 import { openLink } from "@/lib/open-link";
 import { safeMarkdownUrl } from "@/lib/safe-markdown-url";
+import { scheduleIdleTask } from "@/lib/schedule-idle-task";
 import { cn } from "@/lib/utils";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
-import { type ComponentProps, type ReactElement, memo } from "react";
+import {
+  type ComponentProps,
+  type ReactElement,
+  memo,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { Streamdown } from "streamdown";
 import "katex/dist/katex.min.css";
 
-const MARKDOWN_PLUGINS = { code, math, mermaid } as const;
+type MarkdownPlugins = NonNullable<
+  ComponentProps<typeof Streamdown>["plugins"]
+>;
 const MARKDOWN_COMPONENTS = {
   a: ({ href, children, ...props }: ComponentProps<"a">) => (
     <a
@@ -34,13 +45,41 @@ type MarkdownPreviewProps = {
   markdown: string;
   className?: string;
   plain?: boolean;
+  /**
+   * Paint the surrounding UI first and parse on the next idle callback. For documents that
+   * arrive in one piece and are large enough that the parse is a visible stall - a finished
+   * deep research report, above all - the wait is the same either way, but the rest of the
+   * window stays interactive through it.
+   */
+  defer?: boolean;
 };
 
 function MarkdownPreviewImpl({
   markdown,
   className,
   plain = false,
+  defer = false,
 }: MarkdownPreviewProps): ReactElement {
+  // Wiring math and mermaid into a document containing neither still costs a pass over every
+  // node; shiki over a very long document costs more than it is worth. Both are decided here
+  // rather than always-on, because the report lands in a single synchronous commit.
+  const plugins = useMemo<MarkdownPlugins>(() => {
+    const needs = markdownPluginNeeds(markdown);
+    const next: MarkdownPlugins = {};
+    if (needs.code) next.code = code;
+    if (needs.math) next.math = math;
+    if (needs.mermaid) next.mermaid = mermaid;
+    return next;
+  }, [markdown]);
+  const [ready, setReady] = useState(!defer);
+  useEffect(() => {
+    if (!defer) {
+      setReady(true);
+      return;
+    }
+    setReady(false);
+    return scheduleIdleTask(() => setReady(true), 200);
+  }, [defer, markdown]);
   const markdownClassName =
     "w-full max-w-none min-w-0 space-y-2 [overflow-wrap:anywhere] [&_*]:max-w-none [&_p]:w-full [&_ul]:w-full [&_ol]:w-full [&_li]:w-full [&_h1]:w-full [&_h2]:w-full [&_h3]:w-full [&_h4]:w-full [&_h5]:w-full [&_h6]:w-full [&_pre]:w-full [&_table]:w-full [&_p]:break-words [&_li]:break-words [&_code]:break-words [&_pre]:whitespace-pre-wrap [&_pre]:break-words";
 
@@ -53,16 +92,20 @@ function MarkdownPreviewImpl({
         className,
       )}
     >
-      <Streamdown
-        mode="static"
-        plugins={MARKDOWN_PLUGINS}
-        components={MARKDOWN_COMPONENTS}
-        urlTransform={safeMarkdownUrl}
-        controls={false}
-        className={markdownClassName}
-      >
-        {markdown.trim() ? markdown : "_Empty note_"}
-      </Streamdown>
+      {ready ? (
+        <Streamdown
+          mode="static"
+          plugins={plugins}
+          components={MARKDOWN_COMPONENTS}
+          urlTransform={safeMarkdownUrl}
+          controls={false}
+          className={markdownClassName}
+        >
+          {markdown.trim() ? markdown : "_Empty note_"}
+        </Streamdown>
+      ) : (
+        <div className={markdownClassName} aria-busy="true" />
+      )}
     </div>
   );
 }

--- a/studio/frontend/src/components/markdown/markdown-preview.tsx
+++ b/studio/frontend/src/components/markdown/markdown-preview.tsx
@@ -71,14 +71,18 @@ function MarkdownPreviewImpl({
     if (needs.mermaid) next.mermaid = mermaid;
     return next;
   }, [markdown]);
-  const [ready, setReady] = useState(!defer);
+  // Readiness belongs to a markdown value, not to the component. Resetting it from an effect is
+  // one commit too late: the render that first sees a new document still sees the old `ready`,
+  // so Streamdown parses the new document synchronously and the result is thrown away when the
+  // effect blanks it a moment later - the stall `defer` exists to avoid, paid twice. Deriving
+  // readiness during render keeps a changed document out of Streamdown until its own idle parse.
+  const [readyMarkdown, setReadyMarkdown] = useState<string | null>(null);
+  const ready = !defer || readyMarkdown === markdown;
   useEffect(() => {
     if (!defer) {
-      setReady(true);
       return;
     }
-    setReady(false);
-    return scheduleIdleTask(() => setReady(true), 200);
+    return scheduleIdleTask(() => setReadyMarkdown(markdown), 200);
   }, [defer, markdown]);
   const markdownClassName =
     "w-full max-w-none min-w-0 space-y-2 [overflow-wrap:anywhere] [&_*]:max-w-none [&_p]:w-full [&_ul]:w-full [&_ol]:w-full [&_li]:w-full [&_h1]:w-full [&_h2]:w-full [&_h3]:w-full [&_h4]:w-full [&_h5]:w-full [&_h6]:w-full [&_pre]:w-full [&_table]:w-full [&_p]:break-words [&_li]:break-words [&_code]:break-words [&_pre]:whitespace-pre-wrap [&_pre]:break-words";

--- a/studio/frontend/src/components/markdown/markdown-preview.tsx
+++ b/studio/frontend/src/components/markdown/markdown-preview.tsx
@@ -46,10 +46,9 @@ type MarkdownPreviewProps = {
   className?: string;
   plain?: boolean;
   /**
-   * Paint the surrounding UI first and parse on the next idle callback. For documents that
-   * arrive in one piece and are large enough that the parse is a visible stall - a finished
-   * deep research report, above all - the wait is the same either way, but the rest of the
-   * window stays interactive through it.
+   * Parse on the next idle callback so the surrounding UI paints first. For a document that
+   * arrives whole and is big enough to stall - a finished research report - the wait is the same
+   * either way, but the window stays interactive through it.
    */
   defer?: boolean;
 };
@@ -60,9 +59,8 @@ function MarkdownPreviewImpl({
   plain = false,
   defer = false,
 }: MarkdownPreviewProps): ReactElement {
-  // Wiring math and mermaid into a document containing neither still costs a pass over every
-  // node; shiki over a very long document costs more than it is worth. Both are decided here
-  // rather than always-on, because the report lands in a single synchronous commit.
+  // Math and mermaid over a document with neither still cost a pass per node, and shiki over a
+  // very long one costs more than it is worth; the report lands in one synchronous commit.
   const plugins = useMemo<MarkdownPlugins>(() => {
     const needs = markdownPluginNeeds(markdown);
     const next: MarkdownPlugins = {};
@@ -71,11 +69,9 @@ function MarkdownPreviewImpl({
     if (needs.mermaid) next.mermaid = mermaid;
     return next;
   }, [markdown]);
-  // Readiness belongs to a markdown value, not to the component. Resetting it from an effect is
-  // one commit too late: the render that first sees a new document still sees the old `ready`,
-  // so Streamdown parses the new document synchronously and the result is thrown away when the
-  // effect blanks it a moment later - the stall `defer` exists to avoid, paid twice. Deriving
-  // readiness during render keeps a changed document out of Streamdown until its own idle parse.
+  // Readiness belongs to the markdown value, not the component: resetting it from an effect is
+  // one commit late, so the new document is parsed synchronously and thrown away - the stall
+  // `defer` exists to avoid, paid twice. Deriving it during render keeps it out of Streamdown.
   const [readyMarkdown, setReadyMarkdown] = useState<string | null>(null);
   const ready = !defer || readyMarkdown === markdown;
   useEffect(() => {

--- a/studio/frontend/src/features/chat/api/research-api.ts
+++ b/studio/frontend/src/features/chat/api/research-api.ts
@@ -285,11 +285,13 @@ export async function* followResearchRun(
     try {
       for await (const event of streamResearchEvents(id, cursor, signal)) {
         cursor = Math.max(cursor, event.id);
-        const eventRun: ResearchRun = event.run ?? {
-          ...currentRun,
-          lastEventSeq: Math.max(currentRun.lastEventSeq, event.id),
-          updatedAt: Math.max(currentRun.updatedAt, event.createdAt),
-        };
+        // Delta-only events carry no run by design (`_DELTA_ONLY_EVENTS` in
+        // routes/research_runs.py), so reuse the run we already hold rather than spreading a
+        // fresh object per event: report/reasoning deltas arrive ~12x/s for the whole synthesis,
+        // and a new identity there re-renders every subscriber that selects the run. The cursor
+        // is tracked separately by `session.lastAppliedSeq`, and a terminal status - the one
+        // thing `isSettledResearchRun` reads `lastEventSeq` for - always arrives with a snapshot.
+        const eventRun: ResearchRun = event.run ?? currentRun;
         const hydratedEvent: ResearchEvent = {
           ...event,
           data: { ...event.data, run: eventRun },

--- a/studio/frontend/src/features/chat/api/research-api.ts
+++ b/studio/frontend/src/features/chat/api/research-api.ts
@@ -287,7 +287,8 @@ export async function* followResearchRun(
         cursor = Math.max(cursor, event.id);
         // Delta-only events carry no run by design (`_DELTA_ONLY_EVENTS` in
         // routes/research_runs.py), so reuse the run we already hold rather than spreading a
-        // fresh object per event: report/reasoning deltas arrive ~12x/s for the whole synthesis,
+        // fresh object per event - reasoning.updated, report.updated and the three phase.*
+        // events: report/reasoning deltas arrive ~12x/s for the whole synthesis,
         // and a new identity there re-renders every subscriber that selects the run. The cursor
         // is tracked separately by `session.lastAppliedSeq`, and a terminal status - the one
         // thing `isSettledResearchRun` reads `lastEventSeq` for - always arrives with a snapshot.

--- a/studio/frontend/src/features/chat/api/research-api.ts
+++ b/studio/frontend/src/features/chat/api/research-api.ts
@@ -286,12 +286,11 @@ export async function* followResearchRun(
       for await (const event of streamResearchEvents(id, cursor, signal)) {
         cursor = Math.max(cursor, event.id);
         // Delta-only events carry no run by design (`_DELTA_ONLY_EVENTS` in
-        // routes/research_runs.py), so reuse the run we already hold rather than spreading a
-        // fresh object per event - reasoning.updated, report.updated and the three phase.*
-        // events: report/reasoning deltas arrive ~12x/s for the whole synthesis,
-        // and a new identity there re-renders every subscriber that selects the run. The cursor
-        // is tracked separately by `session.lastAppliedSeq`, and a terminal status - the one
-        // thing `isSettledResearchRun` reads `lastEventSeq` for - always arrives with a snapshot.
+        // routes/research_runs.py), so reuse the run we hold: report/reasoning deltas arrive
+        // ~12x/s for the whole synthesis, and a fresh object per event re-renders every
+        // subscriber that selects the run. The cursor lives in `session.lastAppliedSeq`, and a
+        // terminal status - all `isSettledResearchRun` reads `lastEventSeq` for - comes with a
+        // snapshot.
         const eventRun: ResearchRun = event.run ?? currentRun;
         const hydratedEvent: ResearchEvent = {
           ...event,

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -317,8 +317,7 @@ const SingleContent = memo(function SingleContent({
       useResearchRunStore.getState().sessions[openResearchRunId]?.run;
     if (openRun && openRun.threadId !== activeThreadId) closeResearchPanel();
   }, [activeThreadId, openResearchRunId, closeResearchPanel]);
-  // A string, not the run: report deltas replace the run object ~12x/s while a research run
-  // streams, and this component owns the thread pane.
+  // A string, not the run: report deltas replace the run ~12x/s, and this owns the thread pane.
   const openResearchThreadId = useResearchRunStore((state) =>
     openResearchRunId
       ? state.sessions[openResearchRunId]?.run.threadId
@@ -1962,8 +1961,8 @@ export function ChatPage({
   const latestResearchRunId = useResearchRunStore((state) =>
     activeThreadId ? state.latestRunByThreadId[activeThreadId] : undefined,
   );
-  // The status string, not the run: this subscription lives in ChatPage itself, so selecting
-  // the run object re-rendered the whole page on every streamed research delta.
+  // Status, not the run: this subscribes in ChatPage itself, so a run selector re-rendered the
+  // whole page on every streamed research delta.
   const latestResearchRunStatus = useResearchRunStore((state) =>
     latestResearchRunId
       ? state.sessions[latestResearchRunId]?.run.status

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -317,8 +317,12 @@ const SingleContent = memo(function SingleContent({
       useResearchRunStore.getState().sessions[openResearchRunId]?.run;
     if (openRun && openRun.threadId !== activeThreadId) closeResearchPanel();
   }, [activeThreadId, openResearchRunId, closeResearchPanel]);
-  const openResearchRun = useResearchRunStore((state) =>
-    openResearchRunId ? state.sessions[openResearchRunId]?.run : undefined,
+  // A string, not the run: report deltas replace the run object ~12x/s while a research run
+  // streams, and this component owns the thread pane.
+  const openResearchThreadId = useResearchRunStore((state) =>
+    openResearchRunId
+      ? state.sessions[openResearchRunId]?.run.threadId
+      : undefined,
   );
   const artifactPanelRef = useRef<PanelImperativeHandle | null>(null);
   const hasInitializedArtifactPanelRef = useRef(false);
@@ -329,8 +333,8 @@ const SingleContent = memo(function SingleContent({
   const [isArtifactSurfaceVisible, setIsArtifactSurfaceVisible] =
     useState(false);
   const researchMatchesThread = Boolean(
-    openResearchRun &&
-      openResearchRun.threadId === (threadId ?? activeThreadId),
+    openResearchThreadId &&
+      openResearchThreadId === (threadId ?? activeThreadId),
   );
   const showResearchPanel = researchMatchesThread && !isMobile;
   // Without a URL threadId the artifact must belong to the active thread.
@@ -1958,8 +1962,12 @@ export function ChatPage({
   const latestResearchRunId = useResearchRunStore((state) =>
     activeThreadId ? state.latestRunByThreadId[activeThreadId] : undefined,
   );
-  const latestResearchRun = useResearchRunStore((state) =>
-    latestResearchRunId ? state.sessions[latestResearchRunId]?.run : undefined,
+  // The status string, not the run: this subscription lives in ChatPage itself, so selecting
+  // the run object re-rendered the whole page on every streamed research delta.
+  const latestResearchRunStatus = useResearchRunStore((state) =>
+    latestResearchRunId
+      ? state.sessions[latestResearchRunId]?.run.status
+      : undefined,
   );
   const openResearchPanel = useResearchRunStore((state) => state.openPanel);
   const openResearchRunId = useResearchRunStore((state) => state.openRunId);
@@ -3482,30 +3490,32 @@ export function ChatPage({
                 </TooltipContent>
               </Tooltip>
             )}
-            {view.mode === "single" && latestResearchRun ? (
+            {view.mode === "single" &&
+            latestResearchRunId &&
+            latestResearchRunStatus ? (
               <Tooltip>
                 <TooltipPrimitive.Trigger asChild={true}>
                   <button
                     type="button"
                     onClick={() => {
-                      if (openResearchRunId === latestResearchRun.id) {
+                      if (openResearchRunId === latestResearchRunId) {
                         closeResearchPanel();
                         return;
                       }
                       setSettingsOpen(false);
                       closeArtifactSurface();
-                      openResearchPanel(latestResearchRun.id);
+                      openResearchPanel(latestResearchRunId);
                     }}
                     className="relative flex size-[30px] cursor-pointer items-center justify-center rounded-[10px] text-nav-fg transition-colors hover:bg-nav-surface-hover hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:text-white"
                     aria-label="Open research activity"
-                    aria-pressed={openResearchRunId === latestResearchRun.id}
+                    aria-pressed={openResearchRunId === latestResearchRunId}
                   >
                     <HugeiconsIcon
                       icon={Telescope02Icon}
                       className="size-icon"
                       strokeWidth={1.75}
                     />
-                    {!['completed', 'failed', 'cancelled'].includes(latestResearchRun.status) ? (
+                    {!['completed', 'failed', 'cancelled'].includes(latestResearchRunStatus) ? (
                       <span className="absolute right-1 top-1 size-1.5 rounded-full bg-primary ring-2 ring-background" />
                     ) : null}
                   </button>

--- a/studio/frontend/src/features/chat/components/research-message.tsx
+++ b/studio/frontend/src/features/chat/components/research-message.tsx
@@ -108,6 +108,7 @@ export function ResearchMessage(): ReactElement {
         <MarkdownPreview
           markdown={run.report}
           className="max-h-none overflow-visible border-0 bg-transparent p-0 text-ui-15p5"
+          defer={true}
         />
         <SourcesGroup sources={sources} allowRemoteIcons={false} />
         <DocumentSourcesGroup sources={documentSources} />

--- a/studio/frontend/src/features/hub/catalog/model-readme.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-readme.tsx
@@ -6,6 +6,11 @@ import { useOnlineStatus } from "@/features/hub/hooks/use-online-status";
 import { LruMap } from "@/features/hub/lib/lru-map";
 import { isHuggingFaceOffline } from "@/features/hub/lib/network";
 import { fingerprintToken } from "@/features/hub/lib/token-fingerprint";
+import {
+  type MarkdownPluginNeeds,
+  markdownPluginNeeds,
+} from "@/lib/markdown-plugins";
+import { scheduleIdleTask } from "@/lib/schedule-idle-task";
 import { cn } from "@/lib/utils";
 import { confirmExternalLink } from "../stores/external-link-confirm";
 import { useHfTokenStore } from "@/features/hub/stores/hf-token-store";
@@ -63,8 +68,6 @@ const README_ALLOWED_TAGS: NonNullable<
   track: ["src", "kind", "srclang", "label", "default"],
 };
 
-const READMEX_NEEDS_MATH = /\$\$|\\\(|\\\[/;
-const READMEX_NEEDS_MERMAID = /```mermaid\b/;
 const README_RENDER_CHAR_LIMIT = 120_000;
 const README_CACHE_TTL_MS = 60_000;
 const README_TRUNCATED_NOTICE =
@@ -254,39 +257,6 @@ function isMissingReadmeError(error: string): boolean {
   return /^No (dataset|model) card available\.$/.test(error);
 }
 
-function scheduleIdleTask(callback: () => void, timeout = 250): () => void {
-  let canceled = false;
-  const run = () => {
-    if (!canceled) callback();
-  };
-
-  if (typeof window === "undefined") {
-    run();
-    return () => {
-      canceled = true;
-    };
-  }
-
-  const idleWindow = window as Window & {
-    requestIdleCallback?: Window["requestIdleCallback"];
-    cancelIdleCallback?: Window["cancelIdleCallback"];
-  };
-
-  if (idleWindow.requestIdleCallback && idleWindow.cancelIdleCallback) {
-    const handle = idleWindow.requestIdleCallback(run, { timeout });
-    return () => {
-      canceled = true;
-      idleWindow.cancelIdleCallback?.(handle);
-    };
-  }
-
-  const handle = globalThis.setTimeout(run, Math.min(timeout, 120));
-  return () => {
-    canceled = true;
-    globalThis.clearTimeout(handle);
-  };
-}
-
 function ReadmePlaceholder({
   kind,
   message,
@@ -366,10 +336,7 @@ async function loadReadmeFromCache({
   }
 }
 
-function loadPlugins(needs: {
-  math: boolean;
-  mermaid: boolean;
-}): ReadmePlugins {
+function loadPlugins(needs: MarkdownPluginNeeds): ReadmePlugins {
   const plugins: ReadmePlugins = { code: streamdownCode };
   if (needs.math) plugins.math = streamdownMath;
   if (needs.mermaid) plugins.mermaid = streamdownMermaid;
@@ -507,12 +474,7 @@ export function ModelReadme({
       });
     };
     const cancelIdle = scheduleIdleTask(() => {
-      applyPlugins(
-        loadPlugins({
-          math: READMEX_NEEDS_MATH.test(body),
-          mermaid: READMEX_NEEDS_MERMAID.test(body),
-        }),
-      );
+      applyPlugins(loadPlugins(markdownPluginNeeds(body)));
     }, 400);
     return () => {
       canceled = true;

--- a/studio/frontend/src/lib/markdown-plugins.ts
+++ b/studio/frontend/src/lib/markdown-plugins.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Which Streamdown plugins a document actually needs.
+ *
+ * Wiring math and mermaid into a document that contains neither still costs a KaTeX pass and a
+ * mermaid pass over every node, on the main thread, in one commit. A deep research report is
+ * ordinary prose with citations, so both are usually pure waste - and the report lands exactly
+ * when the run leaves "Writing the report", which is where issue #8483 froze.
+ *
+ * The detection lives here rather than in a component so the model card renderer and the report
+ * renderer share one rule, and so it is testable without a DOM.
+ */
+
+/** `$$…$$`, `\(…\)` and `\[…\]`; single `$` is too common in prose to treat as math. */
+const NEEDS_MATH = /\$\$|\\\(|\\\[/;
+const NEEDS_MERMAID = /```mermaid\b/;
+
+/** Past this a document stays plain monospace: shiki is not worth the main-thread time. */
+export const MAX_HIGHLIGHT_CHARS = 20_000;
+
+export interface MarkdownPluginNeeds {
+  math: boolean;
+  mermaid: boolean;
+  code: boolean;
+}
+
+export function markdownPluginNeeds(markdown: string): MarkdownPluginNeeds {
+  return {
+    math: NEEDS_MATH.test(markdown),
+    mermaid: NEEDS_MERMAID.test(markdown),
+    code: markdown.length <= MAX_HIGHLIGHT_CHARS,
+  };
+}

--- a/studio/frontend/src/lib/markdown-plugins.ts
+++ b/studio/frontend/src/lib/markdown-plugins.ts
@@ -15,7 +15,13 @@
 
 /** `$$…$$`, `\(…\)` and `\[…\]`; single `$` is too common in prose to treat as math. */
 const NEEDS_MATH = /\$\$|\\\(|\\\[/;
-const NEEDS_MERMAID = /```mermaid\b/;
+// Either fence, three or more of either character: CommonMark opens a fenced code block with
+// backticks or tildes, and the parser hands both to the renderer as lang "mermaid". Matching
+// only backticks would render a tilde-fenced diagram as a plain code block, which is a
+// regression against installing the plugin unconditionally. Deliberately not anchored to the
+// line start, so a fence nested in a list item still counts: over-matching costs one unused
+// plugin, under-matching costs a diagram.
+const NEEDS_MERMAID = /(?:`{3,}|~{3,})[ \t]*mermaid\b/;
 
 /** Past this a document stays plain monospace: shiki is not worth the main-thread time. */
 export const MAX_HIGHLIGHT_CHARS = 20_000;

--- a/studio/frontend/src/lib/markdown-plugins.ts
+++ b/studio/frontend/src/lib/markdown-plugins.ts
@@ -4,23 +4,17 @@
 /**
  * Which Streamdown plugins a document actually needs.
  *
- * Wiring math and mermaid into a document that contains neither still costs a KaTeX pass and a
- * mermaid pass over every node, on the main thread, in one commit. A deep research report is
- * ordinary prose with citations, so both are usually pure waste - and the report lands exactly
- * when the run leaves "Writing the report", which is where issue #8483 froze.
- *
- * The detection lives here rather than in a component so the model card renderer and the report
- * renderer share one rule, and so it is testable without a DOM.
+ * Math and mermaid over a document with neither still cost a pass per node on the main thread,
+ * in the one commit that lands the finished report - where issue #8483 froze. Detection lives
+ * here so the model card and report renderers share one rule, testable without a DOM.
  */
 
 /** `$$…$$`, `\(…\)` and `\[…\]`; single `$` is too common in prose to treat as math. */
 const NEEDS_MATH = /\$\$|\\\(|\\\[/;
-// Either fence, three or more of either character: CommonMark opens a fenced code block with
-// backticks or tildes, and the parser hands both to the renderer as lang "mermaid". Matching
-// only backticks would render a tilde-fenced diagram as a plain code block, which is a
-// regression against installing the plugin unconditionally. Deliberately not anchored to the
-// line start, so a fence nested in a list item still counts: over-matching costs one unused
-// plugin, under-matching costs a diagram.
+// CommonMark fences with three or more backticks or tildes, and both reach the renderer as lang
+// "mermaid", so backticks alone would render a tilde-fenced diagram as a plain code block. Not
+// anchored to the line start, so a fence nested in a list item still counts: over-matching costs
+// one unused plugin, under-matching costs a diagram.
 const NEEDS_MERMAID = /(?:`{3,}|~{3,})[ \t]*mermaid\b/;
 
 /** Past this a document stays plain monospace: shiki is not worth the main-thread time. */

--- a/studio/frontend/src/lib/schedule-idle-task.ts
+++ b/studio/frontend/src/lib/schedule-idle-task.ts
@@ -2,11 +2,9 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 /**
- * Run `callback` once the main thread is idle, or after `timeout` at the latest.
- *
- * Returns a canceller. Falls back to a short setTimeout where requestIdleCallback is missing
- * (Safari and the WebKitGTK webview the desktop app embeds on Linux), and runs synchronously
- * with no window at all, so callers get the same contract everywhere.
+ * Run `callback` once the main thread is idle, or after `timeout` at the latest; returns a
+ * canceller. Falls back to setTimeout without requestIdleCallback (Safari, the WebKitGTK webview
+ * the desktop app embeds on Linux), and runs synchronously with no window.
  */
 export function scheduleIdleTask(
   callback: () => void,

--- a/studio/frontend/src/lib/schedule-idle-task.ts
+++ b/studio/frontend/src/lib/schedule-idle-task.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Run `callback` once the main thread is idle, or after `timeout` at the latest.
+ *
+ * Returns a canceller. Falls back to a short setTimeout where requestIdleCallback is missing
+ * (Safari and the WebKitGTK webview the desktop app embeds on Linux), and runs synchronously
+ * with no window at all, so callers get the same contract everywhere.
+ */
+export function scheduleIdleTask(
+  callback: () => void,
+  timeout = 250,
+): () => void {
+  let canceled = false;
+  const run = () => {
+    if (!canceled) callback();
+  };
+
+  if (typeof window === "undefined") {
+    run();
+    return () => {
+      canceled = true;
+    };
+  }
+
+  const idleWindow = window as Window & {
+    requestIdleCallback?: Window["requestIdleCallback"];
+    cancelIdleCallback?: Window["cancelIdleCallback"];
+  };
+
+  if (idleWindow.requestIdleCallback && idleWindow.cancelIdleCallback) {
+    const handle = idleWindow.requestIdleCallback(run, { timeout });
+    return () => {
+      canceled = true;
+      idleWindow.cancelIdleCallback?.(handle);
+    };
+  }
+
+  const handle = globalThis.setTimeout(run, Math.min(timeout, 120));
+  return () => {
+    canceled = true;
+    globalThis.clearTimeout(handle);
+  };
+}

--- a/studio/frontend/tests/research-render-budget.test.ts
+++ b/studio/frontend/tests/research-render-budget.test.ts
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// #8483: the desktop app froze during a deep research run. Two of the costs are invisible to a
-// rendering test and only show under a real stream, so they are pinned here at the source: what
-// the run-carrying components subscribe to, and how much work the finished report's markdown
-// commit signs up for. Same shape as drag-costs-no-render.test.ts - assert the cheap path, and
-// assert the expensive one is gone.
+// #8483: the desktop app froze during a deep research run. Two costs only show under a real
+// stream, so they are pinned at the source: what run-carrying components subscribe to, and what
+// the finished report's markdown commit signs up for. Like drag-costs-no-render.test.ts: assert
+// the cheap path, assert the expensive one is gone.
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -18,8 +17,8 @@ function source(path: string): string {
 }
 
 test("no research subscriber selects the whole run object", () => {
-  // Each of these re-rendered its subtree on every streamed delta. thread.tsx's
-  // useThreadResearchActive was already correct and is the shape the others now follow.
+  // Each re-rendered its subtree on every streamed delta; thread.tsx's useThreadResearchActive
+  // was already correct and is the shape the others now follow.
   for (const path of [
     "features/chat/chat-page.tsx",
     "components/assistant-ui/thread.tsx",
@@ -61,8 +60,7 @@ test("the report renderer is deferred and its plugins are conditional", () => {
 });
 
 test("deferred readiness belongs to a markdown value, not to the component", () => {
-  // Blanking readiness from a passive effect lands one commit late: the render that first sees a
-  // new document still sees `ready === true`, hands it to Streamdown, and pays the parse twice.
+  // Blanking readiness from a passive effect lands one commit late, so the parse is paid twice.
   // Measured on a 202KB report: a wasted 576ms parse, then a second one, ~1.11s blocked against
   // ~0.66s once readiness is derived during render.
   const preview = source("components/markdown/markdown-preview.tsx");
@@ -84,11 +82,10 @@ test("plugin needs follow the document", () => {
   assert.equal(markdownPluginNeeds("\\[x\\]").math, true);
   // A lone $ is too common in prose (prices, shell prompts) to pull KaTeX in for.
   assert.equal(markdownPluginNeeds("costs $5 to run").math, false);
-  // Nor a balanced pair: the callers this gates install `@streamdown/math`'s bare export, which
-  // pins singleDollarTextMath to false, so `$x^2$` renders literally with the plugin loaded too.
-  // (`markdown-text.tsx` is the one caller that enables it, and it does not use this detector.)
-  // If that ever changes, NEEDS_MATH has to change with it - and "costs $5 and $10" is why a
-  // balanced-pair regex is not the answer.
+  // Nor a balanced pair: these callers install `@streamdown/math`'s bare export, which pins
+  // singleDollarTextMath to false, so `$x^2$` renders literally with the plugin loaded too.
+  // (`markdown-text.tsx` enables it, but does not use this detector.) If that changes, NEEDS_MATH
+  // must change with it - and "costs $5 and $10" is why a balanced-pair regex is not the answer.
   assert.equal(markdownPluginNeeds("the area is $x^2$ per unit").math, false);
   assert.match(
     source("components/markdown/markdown-preview.tsx"),
@@ -96,8 +93,8 @@ test("plugin needs follow the document", () => {
   );
   assert.equal(markdownPluginNeeds("```mermaid\ngraph TD;\n```").mermaid, true);
   assert.equal(markdownPluginNeeds("```python\npass\n```").mermaid, false);
-  // CommonMark opens a fenced block with three-or-more backticks *or* tildes, and allows a
-  // longer fence than three of either. All of these reach the renderer as lang "mermaid".
+  // CommonMark fences with three or more backticks *or* tildes, and allows longer fences. All of
+  // these reach the renderer as lang "mermaid".
   assert.equal(markdownPluginNeeds("~~~mermaid\ngraph TD;\n~~~").mermaid, true);
   assert.equal(markdownPluginNeeds("````mermaid\ngraph TD;\n````").mermaid, true);
   assert.equal(markdownPluginNeeds("~~~~mermaid\ngraph TD;\n~~~~").mermaid, true);

--- a/studio/frontend/tests/research-render-budget.test.ts
+++ b/studio/frontend/tests/research-render-budget.test.ts
@@ -53,11 +53,24 @@ test("Thread is memoized", () => {
 test("the report renderer is deferred and its plugins are conditional", () => {
   const preview = source("components/markdown/markdown-preview.tsx");
   assert.match(preview, /markdownPluginNeeds\(markdown\)/);
-  assert.match(preview, /scheduleIdleTask\(\(\) => setReady\(true\)/);
+  assert.match(preview, /scheduleIdleTask\(\(\) => setReadyMarkdown\(markdown\), 200\)/);
   // The old path: all three plugins, always, in one synchronous commit.
   assert.doesNotMatch(preview, /const MARKDOWN_PLUGINS = \{ code, math, mermaid \}/);
   const message = source("features/chat/components/research-message.tsx");
   assert.match(message, /markdown=\{run\.report\}[\s\S]*?defer=\{true\}/);
+});
+
+test("deferred readiness belongs to a markdown value, not to the component", () => {
+  // Blanking readiness from a passive effect lands one commit late: the render that first sees a
+  // new document still sees `ready === true`, hands it to Streamdown, and pays the parse twice.
+  // Measured on a 202KB report: a wasted 576ms parse, then a second one, ~1.11s blocked against
+  // ~0.66s once readiness is derived during render.
+  const preview = source("components/markdown/markdown-preview.tsx");
+  assert.match(preview, /const ready = !defer \|\| readyMarkdown === markdown;/);
+  assert.match(preview, /scheduleIdleTask\(\(\) => setReadyMarkdown\(markdown\), 200\)/);
+  assert.doesNotMatch(preview, /useState\(!defer\)/);
+  assert.doesNotMatch(preview, /setReady\(false\)/);
+  assert.match(preview, /\{ready \? \(\s*<Streamdown/);
 });
 
 test("plugin needs follow the document", () => {
@@ -71,6 +84,16 @@ test("plugin needs follow the document", () => {
   assert.equal(markdownPluginNeeds("\\[x\\]").math, true);
   // A lone $ is too common in prose (prices, shell prompts) to pull KaTeX in for.
   assert.equal(markdownPluginNeeds("costs $5 to run").math, false);
+  // Nor a balanced pair: the callers this gates install `@streamdown/math`'s bare export, which
+  // pins singleDollarTextMath to false, so `$x^2$` renders literally with the plugin loaded too.
+  // (`markdown-text.tsx` is the one caller that enables it, and it does not use this detector.)
+  // If that ever changes, NEEDS_MATH has to change with it - and "costs $5 and $10" is why a
+  // balanced-pair regex is not the answer.
+  assert.equal(markdownPluginNeeds("the area is $x^2$ per unit").math, false);
+  assert.match(
+    source("components/markdown/markdown-preview.tsx"),
+    /import \{ math \} from "@streamdown\/math";/,
+  );
   assert.equal(markdownPluginNeeds("```mermaid\ngraph TD;\n```").mermaid, true);
   assert.equal(markdownPluginNeeds("```python\npass\n```").mermaid, false);
   // CommonMark opens a fenced block with three-or-more backticks *or* tildes, and allows a

--- a/studio/frontend/tests/research-render-budget.test.ts
+++ b/studio/frontend/tests/research-render-budget.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// #8483: the desktop app froze during a deep research run. Two of the costs are invisible to a
+// rendering test and only show under a real stream, so they are pinned here at the source: what
+// the run-carrying components subscribe to, and how much work the finished report's markdown
+// commit signs up for. Same shape as drag-costs-no-render.test.ts - assert the cheap path, and
+// assert the expensive one is gone.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { markdownPluginNeeds, MAX_HIGHLIGHT_CHARS } from "../src/lib/markdown-plugins.ts";
+
+function source(path: string): string {
+  return readFileSync(new URL(`../src/${path}`, import.meta.url), "utf8");
+}
+
+test("no research subscriber selects the whole run object", () => {
+  // Each of these re-rendered its subtree on every streamed delta. thread.tsx's
+  // useThreadResearchActive was already correct and is the shape the others now follow.
+  for (const path of [
+    "features/chat/chat-page.tsx",
+    "components/assistant-ui/thread.tsx",
+  ]) {
+    const text = source(path);
+    assert.doesNotMatch(
+      text,
+      /state\.sessions\[[^\]]+\]\?\.run;/,
+      `${path} selects a run object out of the research store`,
+    );
+    assert.doesNotMatch(
+      text,
+      /return runId \? state\.sessions\[runId\]\?\.run : undefined;/,
+      `${path} selects a run object out of the research store`,
+    );
+  }
+});
+
+test("chat-page derives the research pane from strings", () => {
+  const page = source("features/chat/chat-page.tsx");
+  assert.match(page, /state\.sessions\[openResearchRunId\]\?\.run\.threadId/);
+  assert.match(page, /state\.sessions\[latestResearchRunId\]\?\.run\.status/);
+});
+
+test("Thread is memoized", () => {
+  const thread = source("components/assistant-ui/thread.tsx");
+  assert.match(thread, /export const Thread: FC<\{[^}]*\}> = memo\(/s);
+  assert.match(thread, /Thread\.displayName = "Thread";/);
+});
+
+test("the report renderer is deferred and its plugins are conditional", () => {
+  const preview = source("components/markdown/markdown-preview.tsx");
+  assert.match(preview, /markdownPluginNeeds\(markdown\)/);
+  assert.match(preview, /scheduleIdleTask\(\(\) => setReady\(true\)/);
+  // The old path: all three plugins, always, in one synchronous commit.
+  assert.doesNotMatch(preview, /const MARKDOWN_PLUGINS = \{ code, math, mermaid \}/);
+  const message = source("features/chat/components/research-message.tsx");
+  assert.match(message, /markdown=\{run\.report\}[\s\S]*?defer=\{true\}/);
+});
+
+test("plugin needs follow the document", () => {
+  assert.deepEqual(markdownPluginNeeds("plain prose with `code` spans"), {
+    math: false,
+    mermaid: false,
+    code: true,
+  });
+  assert.equal(markdownPluginNeeds("a $$x^2$$ b").math, true);
+  assert.equal(markdownPluginNeeds("\\(x\\)").math, true);
+  assert.equal(markdownPluginNeeds("\\[x\\]").math, true);
+  // A lone $ is too common in prose (prices, shell prompts) to pull KaTeX in for.
+  assert.equal(markdownPluginNeeds("costs $5 to run").math, false);
+  assert.equal(markdownPluginNeeds("```mermaid\ngraph TD;\n```").mermaid, true);
+  assert.equal(markdownPluginNeeds("```python\npass\n```").mermaid, false);
+});
+
+test("highlighting is capped, and the cap is one constant", () => {
+  assert.equal(markdownPluginNeeds("x".repeat(MAX_HIGHLIGHT_CHARS)).code, true);
+  assert.equal(
+    markdownPluginNeeds("x".repeat(MAX_HIGHLIGHT_CHARS + 1)).code,
+    false,
+  );
+  const cell = source("components/assistant-ui/tool-code-cell.tsx");
+  assert.match(cell, /import \{ MAX_HIGHLIGHT_CHARS \} from "@\/lib\/markdown-plugins";/);
+  assert.doesNotMatch(cell, /const MAX_HIGHLIGHT_CHARS = /);
+});

--- a/studio/frontend/tests/research-render-budget.test.ts
+++ b/studio/frontend/tests/research-render-budget.test.ts
@@ -73,6 +73,15 @@ test("plugin needs follow the document", () => {
   assert.equal(markdownPluginNeeds("costs $5 to run").math, false);
   assert.equal(markdownPluginNeeds("```mermaid\ngraph TD;\n```").mermaid, true);
   assert.equal(markdownPluginNeeds("```python\npass\n```").mermaid, false);
+  // CommonMark opens a fenced block with three-or-more backticks *or* tildes, and allows a
+  // longer fence than three of either. All of these reach the renderer as lang "mermaid".
+  assert.equal(markdownPluginNeeds("~~~mermaid\ngraph TD;\n~~~").mermaid, true);
+  assert.equal(markdownPluginNeeds("````mermaid\ngraph TD;\n````").mermaid, true);
+  assert.equal(markdownPluginNeeds("~~~~mermaid\ngraph TD;\n~~~~").mermaid, true);
+  assert.equal(markdownPluginNeeds("~~~ mermaid\ngraph TD;\n~~~").mermaid, true);
+  assert.equal(markdownPluginNeeds("~~~python\npass\n~~~").mermaid, false);
+  // Two tildes is strikethrough, not a fence.
+  assert.equal(markdownPluginNeeds("~~mermaid~~ is a tool").mermaid, false);
 });
 
 test("highlighting is capped, and the cap is one constant", () => {

--- a/studio/frontend/tests/research-run-identity.test.ts
+++ b/studio/frontend/tests/research-run-identity.test.ts
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// #8483: the desktop app froze while a deep research run streamed its report. One of the costs
-// was that every delta event minted a new run object, so every component selecting the run
-// re-rendered ~12 times a second for the whole synthesis - including ChatPage, which owns the
-// thread pane. The backend deliberately omits the run from those events
-// (_DELTA_ONLY_EVENTS in studio/backend/routes/research_runs.py); the frontend must not
-// reinvent it.
+// #8483: every delta event minted a new run object, so every component selecting the run
+// re-rendered ~12x/s for the whole synthesis - including ChatPage, which owns the thread pane.
+// The backend omits the run from those events by design (_DELTA_ONLY_EVENTS in
+// studio/backend/routes/research_runs.py); the frontend must not reinvent it.
 
 import assert from "node:assert/strict";
 import { register } from "node:module";

--- a/studio/frontend/tests/research-run-identity.test.ts
+++ b/studio/frontend/tests/research-run-identity.test.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// #8483: the desktop app froze while a deep research run streamed its report. One of the costs
+// was that every delta event minted a new run object, so every component selecting the run
+// re-rendered ~12 times a second for the whole synthesis - including ChatPage, which owns the
+// thread pane. The backend deliberately omits the run from those events
+// (_DELTA_ONLY_EVENTS in studio/backend/routes/research_runs.py); the frontend must not
+// reinvent it.
+
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+
+import {
+  installLocalStorageFake,
+  registerBundlerResolver,
+} from "./helpers/kit.ts";
+
+register("./helpers/settings-api-resolver.mjs", import.meta.url);
+registerBundlerResolver();
+installLocalStorageFake();
+
+const { followResearchRun } = await import(
+  "../src/features/chat/api/research-api.ts"
+);
+
+type AnyRecord = Record<string, unknown>;
+
+const RUN_ID = "run-identity";
+
+function snapshot(overrides: AnyRecord = {}): AnyRecord {
+  return {
+    id: RUN_ID,
+    thread_id: "thread-1",
+    user_message_id: "user-1",
+    status: "running",
+    plan: null,
+    plan_revision: 0,
+    plan_hash: null,
+    steps: [],
+    sources: [],
+    last_event_seq: 0,
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+}
+
+/** One SSE frame in the shape routes/research_runs.py writes. */
+function frame(id: number, event: string, data: AnyRecord): string {
+  return `id: ${id}\nevent: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function sseResponse(frames: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of frames) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function stubFetch(frames: string[], finalSnapshot: AnyRecord): () => void {
+  const original = globalThis.fetch;
+  let streamed = false;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/events")) {
+      if (streamed) {
+        // A second connect would loop forever; hand back an empty stream instead.
+        return sseResponse([]);
+      }
+      streamed = true;
+      return sseResponse(frames);
+    }
+    return new Response(JSON.stringify(finalSnapshot), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+test("delta-only events reuse the run object they were given", async () => {
+  const terminal = snapshot({
+    status: "completed",
+    last_event_seq: 4,
+    updated_at: 9,
+    report: "done",
+  });
+  const restore = stubFetch(
+    [
+      frame(1, "reasoning.updated", {
+        created_at: 2,
+        call_id: "call-1",
+        reasoning_delta: "a",
+      }),
+      frame(2, "report.updated", { created_at: 3, length: 32, delta: 32 }),
+      frame(3, "reasoning.updated", {
+        created_at: 4,
+        call_id: "call-1",
+        reasoning_delta: "b",
+      }),
+      frame(4, "run.completed", { created_at: 9, attempt: 0, run: terminal }),
+    ],
+    terminal,
+  );
+  try {
+    const runs: unknown[] = [];
+    for await (const update of followResearchRun(RUN_ID, {
+      initialRun: snapshot() as never,
+    })) {
+      runs.push(update.run);
+    }
+    // snapshot, three deltas, terminal.
+    assert.equal(runs.length, 5);
+    assert.equal(runs[1], runs[0], "first delta minted a new run object");
+    assert.equal(runs[2], runs[0], "second delta minted a new run object");
+    assert.equal(runs[3], runs[0], "third delta minted a new run object");
+    assert.notEqual(
+      runs[4],
+      runs[0],
+      "the terminal event carries its own snapshot and must replace the run",
+    );
+    assert.equal(
+      (runs[4] as AnyRecord).status,
+      "completed",
+      "the terminal snapshot must still be applied",
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("a run carried by an event still replaces the held run", async () => {
+  const midway = snapshot({ status: "running", last_event_seq: 1, updated_at: 5 });
+  const terminal = snapshot({ status: "completed", last_event_seq: 2, updated_at: 9 });
+  const restore = stubFetch(
+    [
+      frame(1, "phase.started", { created_at: 5, phase: "synthesis", run: midway }),
+      frame(2, "run.completed", { created_at: 9, attempt: 0, run: terminal }),
+    ],
+    terminal,
+  );
+  try {
+    const runs: AnyRecord[] = [];
+    for await (const update of followResearchRun(RUN_ID, {
+      initialRun: snapshot() as never,
+    })) {
+      runs.push(update.run as unknown as AnyRecord);
+    }
+    assert.equal(runs.length, 3);
+    assert.notEqual(runs[1], runs[0]);
+    assert.equal(runs[1].updatedAt, 5);
+    assert.equal(runs[2].status, "completed");
+  } finally {
+    restore();
+  }
+});

--- a/tests/studio/test_deep_research_frontend_contract.py
+++ b/tests/studio/test_deep_research_frontend_contract.py
@@ -299,7 +299,9 @@ def test_research_stop_is_prompt_only_and_deduplicated() -> None:
     activity = source("features/chat/components/research-activity-panel.tsx")
 
     assert "stoppingResearchRunIdRef" in thread
-    assert 'activeResearchRun.status === "cancelling"' in thread
+    # The composer selects the run status, not the run object, so a streamed research delta
+    # does not re-render it. The cancelling guard reads that status.
+    assert 'activeResearchRunStatus === "cancelling"' in thread
     assert 'aria-label={researchStopping ? "Stopping research"' in thread
     assert "cancelResearchRun" not in activity
     assert "Stop research" not in activity


### PR DESCRIPTION
The rest of what I found measuring #8483, after #8525 landed. Independent of #8633, which carries the follow-ups to the loops themselves; the two touch disjoint files. #8633 adds the harness the numbers below come from, so land that first if you want to reproduce them.

## Delta events minted a run object

The backend omits the run from `reasoning.updated` and `report.updated` on purpose (`_DELTA_ONLY_EVENTS` in `routes/research_runs.py` sends the snapshot only for the other event types). `followResearchRun` then rebuilt one anyway:

```ts
const eventRun: ResearchRun = event.run ?? {
  ...currentRun,
  lastEventSeq: Math.max(currentRun.lastEventSeq, event.id),
  updatedAt: Math.max(currentRun.updatedAt, event.createdAt),
};
```

So every subscriber selecting the run got a new identity about 12 times a second for the whole synthesis, carrying semantically identical data. It now reuses the run it already holds. The cursor is tracked separately in `session.lastAppliedSeq`, and `isSettledResearchRun`, the one place that reads `run.lastEventSeq`, additionally requires a terminal status, which never arrives as a delta.

## Four subscribers selected that object

| where | selected | needed |
|---|---|---|
| `chat-page.tsx` (in `ChatPage` itself) | the run | its id and status |
| `chat-page.tsx` (`SingleContent`) | the run | its `threadId` |
| `thread.tsx` (composer pills) | the run | one boolean |
| `thread.tsx` (send/stop actions) | the run | its id and status |

The first is the one that hurt: `ChatPage` owns the thread pane, so a delta re-rendered it, which rebuilt the `Thread` element inline in `SingleContent`'s body, and `Thread` is 6000 lines and was not memoized. All four now select strings or a boolean, `Thread` is memoized on its three primitive props, and `thread.tsx`'s existing `useThreadResearchActive` was already the correct shape and is what the others now follow.

The activity panel keeps its whole-session subscription: it genuinely needs the activities at that rate, and it is only mounted when the pane is open.

## The finished report parsed in one commit

`research-message.tsx` handed the report to `MarkdownPreview`, which wired `code`, `math` and `mermaid` into every document unconditionally, uncapped and undeferred, in one synchronous commit, at exactly the moment the run leaves "Writing the report".

Three changes, all of them things the codebase already knew:

- math and mermaid only when the document contains them, reusing the detection `model-readme.tsx` already applied to model cards. A research report is prose with citations; most contain neither, and skipping them removes the KaTeX pass entirely.
- shiki capped at `MAX_HIGHLIGHT_CHARS`, the same 20k constant `tool-code-cell.tsx` uses with the comment "past this the block stays plain monospace: shiki is not worth the main-thread time". Highlighting is capped, never content.
- an opt-in `defer` prop, used only by the report, that parses on an idle callback so the header, the sources and the composer paint first.

`scheduleIdleTask` and the plugin picker move out of `model-readme.tsx` into `src/lib/` so the model card and the report share one rule instead of two copies.

## Numbers

Medians of 3 through `tests/studio/playwright_research_freeze.py`, a 120 event stream and a 60KB report with fenced code, a table and display math:

| | before | after |
|---|---|---|
| report commit | 1037ms | 928ms |
| style recalcs during the stream | 633 | 566 |

Deferring does not shorten the parse, and I would rather say so than imply otherwise: a 60KB report is still one ~500ms task on this machine. What it changes is that the parse is no longer the first thing the window does when the report lands. Splitting the parse at block boundaries is the next lever if that is not enough, and it is a bigger change to a shared component.

## Verification

`npm run typecheck` clean, `npm test` 2026 passing, eslint no new errors.

`tests/research-run-identity.test.ts` drives the real `followResearchRun` over a scripted SSE stream and asserts the yielded run is reference-identical across consecutive deltas and still replaced by a terminal snapshot; it fails on the unfixed code. `tests/research-render-budget.test.ts` pins the selectors, the memo, the plugin picker and the highlight cap, in the style of the existing `drag-costs-no-render.test.ts`.

No Python changed. What this does not do is prove anything about WebKitGTK: Chromium measures the work, and only the reporter's machine can confirm the freeze is gone.
