### PR TITLE
Stop the remote GGUF guard reserving an output buffer for the first slot

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5925,6 +5925,15 @@ def _cached_repo_gguf_bytes(repo: str, hint: str = "") -> int:
 # truncated header drops the token array. Above Llama 4 / Gemma 3 (256k), the widest shipping.
 _ASSUMED_MAX_VOCAB = 262144
 
+# Companion ceiling for the activation scratch (4 * n_embd * ubatch * 4), used when the
+# header is unreadable because the weights are still remote. 8192 is the widest n_embd
+# shipping at a size that plausibly loads beside a training run: Llama-3-70B and
+# Qwen2.5-72B are 8192, DeepSeek-V3 7168, Gemma-3-27B 5376, and the 4B-32B tier 2560-5120.
+# The 405B class reaches 16384 and is deliberately not covered: 16384 is exactly
+# _ASSUMED_MAX_VOCAB / 16, so a ceiling there would make this term one whole ceiling
+# output buffer and charge the dropped first slot straight back under another name.
+_ASSUMED_MAX_EMBD = 8192
+
 
 def _estimate_gguf_kv_gb(
     gguf_path: str,
@@ -6172,13 +6181,22 @@ def _remote_gguf_compute_reserve_gb(
         # (every slot under tensor mode), so n_batch = n_ubatch = 32768 on two
         # slots is ~32 GiB the mask does not cover. Omitting it let the guard admit
         # an uncached load that then OOMs the training job it exists to protect.
-        # The activation scratch needs embedding_length and stays uncharged: it is
-        # the small half, and over-reserving here denies the load outright.
         # Scaled per device only in tensor mode, mirroring the local branch: a
         # layer split folds the flat buffer in once (_flat_buffer(False)), and
         # only tensor mode replicates it on every card.
-        # The remote header is unknown, so reserve as if it enables embeddings.
-        _out_slots = max(1, n_parallel)
+        #
+        # Slots past the first, counted the way the local branch counts them. The
+        # measured chat buffers behind _estimate_compute_buffer_bytes are
+        # {1:36, 2:492, 4:1388, 8:3220} MiB: one slot reserves the activation scratch
+        # and no output buffer. Charging one anyway put 0.58 GiB on every uncached
+        # load, 16x the measured single-slot buffer, and left the same model costing
+        # 0.58 GiB more remote than cached -- the divergence the split gate above
+        # exists to avoid, in the direction that 409s a load which would have fit.
+        # An embedding GGUF does output its whole first micro-batch, which is what
+        # motivated charging it, but its real vocab sits far below the 262144 ceiling
+        # assumed here, so from two slots on the ceiling already covers the slot this
+        # drops.
+        _out_slots = n_parallel if tensor_parallel else max(0, n_parallel - 1)
         out_buffer_bytes = (
             _ASSUMED_MAX_VOCAB
             * effective_ubatch
@@ -6187,7 +6205,23 @@ def _remote_gguf_compute_reserve_gb(
             * (devices if tensor_parallel else 1)
             * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
         )
-        return (mask_bytes + out_buffer_bytes) / (1024**3)
+        # The other flat term, and the whole of the 36 MiB a single chat slot reserves.
+        # _estimate_compute_buffer_bytes charges act_scratch = 4 * n_embd * ubatch * 4 on
+        # every load whatever the slot count, so dropping the first output buffer without
+        # this would leave a one-slot remote load with no flat allowance at all while the
+        # same model, once cached, still charges the scratch: the same remote-vs-cached
+        # divergence, now in the direction that OOMs the training job. The ceiling above
+        # cannot absorb it, because at one slot it multiplies by zero. n_embd is as
+        # unreadable as the vocab, so it takes the same treatment, a ceiling.
+        act_scratch_bytes = (
+            4
+            * _ASSUMED_MAX_EMBD
+            * effective_ubatch
+            * 4
+            * (2 * devices if tensor_parallel else 1)
+            * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
+        )
+        return (mask_bytes + out_buffer_bytes + act_scratch_bytes) / (1024**3)
     return 0.0
 
 

--- a/studio/backend/tests/test_batch_sizes_per_load.py
+++ b/studio/backend/tests/test_batch_sizes_per_load.py
@@ -794,13 +794,9 @@ def test_the_remote_reserve_tracks_what_the_cached_path_charges():
     backend._vocab_size, backend._embedding_length = 151936, 5120
 
     def cached_flat_gb(n_parallel, embedding):
-        with patch.object(
-            type(backend), "is_embedding_gguf", property(lambda self: embedding)
-        ):
+        with patch.object(type(backend), "is_embedding_gguf", property(lambda self: embedding)):
             return (
-                backend._estimate_compute_buffer_bytes(
-                    n_ubatch = 512, n_parallel = n_parallel
-                )
+                backend._estimate_compute_buffer_bytes(n_ubatch = 512, n_parallel = n_parallel)
                 / 1024**3
             )
 
@@ -815,7 +811,5 @@ def test_the_remote_reserve_tracks_what_the_cached_path_charges():
     # that answers 409. Above one slot the gap widens legitimately, since the vocab ceiling
     # is wider than any real model's.
     one_ceiling_buffer = (route._ASSUMED_MAX_VOCAB * 512 * 4) / 1024**3
-    gap_at_one_slot = route._remote_gguf_compute_reserve_gb(n_parallel = 1) - cached_flat_gb(
-        1, False
-    )
+    gap_at_one_slot = route._remote_gguf_compute_reserve_gb(n_parallel = 1) - cached_flat_gb(1, False)
     assert 0 <= gap_at_one_slot < one_ceiling_buffer / 4, gap_at_one_slot

--- a/studio/backend/tests/test_batch_sizes_per_load.py
+++ b/studio/backend/tests/test_batch_sizes_per_load.py
@@ -269,7 +269,12 @@ def test_remote_gguf_guard_counts_explicit_micro_batch():
         big = route._estimate_gguf_required_gb(
             config, max_seq_length = 32768, n_batch = 65536, n_ubatch = 65536
         )
-    assert base > 1.5
+    # the defaults emit no flag but still launch at a 512-token micro-batch, whose mask
+    # is 32768 x 512 x 2 x 1.5 = 48 MiB over the 1 GiB of weights, plus the 72 MiB
+    # activation scratch every load reserves whatever its slot count
+    assert base == pytest.approx(
+        1.0 + (32768 * 512 * 2 * 1.5 + 4 * 8192 * 512 * 4 * 1.15) / 1024**3
+    )
     # ctx-capped ubatch (32768) x ctx x 2 x 1.5 mask safety ~= 3 GiB on top
     assert big > base + 2.0
 
@@ -665,12 +670,20 @@ def test_the_remote_guard_charges_the_flat_output_buffer():
         big_2 = _gb(n_parallel = 2, n_batch = 32768, n_ubatch = 32768)
         typical_4 = _gb(n_parallel = 4, n_batch = 2048, n_ubatch = 512)
 
-    # Unset fields still launch at llama.cpp's known default 512-token micro-batch.
-    assert blank_1 > 1.5
+    # Unset fields still launch at llama.cpp's known default 512-token micro-batch, so
+    # its mask is charged, and so is the activation scratch, but one slot reserves no
+    # output buffer (the measured 36 MiB at one slot IS the scratch).
+    assert blank_1 == pytest.approx(
+        1.0 + (32768 * 512 * 2 * 1.5 + 4 * 8192 * 512 * 4 * 1.15) / 1024**3
+    )
+    # three output buffers for four slots, 0.575 GiB each at the default micro-batch
     assert blank_4 > blank_1 + 1.5
-    # The remote header may enable embeddings, so the first output buffer is charged.
-    assert big_1 > blank_1 + 30.0
-    # 262144 * 32768 * 4 = 32 GiB for the second slot too.
+    # one slot pays the mask and the scratch, no output buffer: the mask is
+    # 32768 x 32768 x 2 x 1.5 = 3 GiB and the scratch 4 x 8192 x 32768 x 4 x 1.15 = 4.6 GiB
+    assert big_1 == pytest.approx(
+        1.0 + (32768 * 32768 * 2 * 1.5 + 4 * 8192 * 32768 * 4 * 1.15) / 1024**3
+    )
+    # 262144 * 32768 * 4 = 32 GiB for the second slot, which the mask alone missed
     assert big_2 > big_1 + 30.0
     # and it stays proportionate where the values are ordinary
     assert typical_4 < 4.0
@@ -703,3 +716,106 @@ def test_the_remote_guard_charges_the_flat_output_buffer():
     assert layer_2 - layer_1 < 30.0
     # tensor mode replicates the whole buffer on every card, so it does roughly double
     assert tensor_2 > tensor_1 * 1.8
+
+
+def test_the_remote_guard_charges_the_single_slot_activation_scratch():
+    """One slot reserves no output buffer, but it does reserve the activation scratch:
+    4 * n_embd * ubatch * 4 is the whole of the 36 MiB _estimate_compute_buffer_bytes was
+    measured against at --parallel 1, and that branch charges it at every slot count. So
+    the ceiling output buffer, which multiplies by (slots - 1), covers nothing at one slot
+    and a one-slot remote estimate would carry the KQ mask alone. That is the guard reading
+    LOW against the same model once it is cached -- 4.6 GiB low at an explicit 32768-token
+    micro-batch -- which is the direction that admits a load and OOMs the training run.
+    The remote estimate must not fall under what the cached path charges for the same
+    launch."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from routes import inference as route
+
+    config = SimpleNamespace(
+        gguf_file = None,
+        gguf_mmproj_file = None,
+        gguf_mtp_file = None,
+        gguf_hf_repo = "owner/repo",
+        gguf_variant = "Q4_K_M",
+    )
+    remote_variant = SimpleNamespace(quant = "Q4_K_M", size_bytes = 1024**3)
+    with (
+        patch(
+            "utils.models.model_config.list_gguf_variants",
+            return_value = ([remote_variant], False),
+        ),
+        patch.object(route, "_remote_gguf_companion_bytes", return_value = 0),
+    ):
+        one_slot = route._estimate_gguf_required_gb(
+            config, max_seq_length = 32768, n_parallel = 1, n_batch = 32768, n_ubatch = 32768
+        )
+        one_slot_default = route._estimate_gguf_required_gb(
+            config, max_seq_length = 32768, n_parallel = 1
+        )
+
+    # what the same weights cost once they are on disk and the header is readable
+    cached = LlamaCppBackend.__new__(LlamaCppBackend)
+    cached._vocab_size = 151936
+    cached._embedding_length = 8192  # Llama-3-70B / Qwen2.5-72B, the ceiling assumed remotely
+    cached._pooling_type = None  # a chat GGUF, so no first-slot output buffer either side
+    weights_and_mask = 1.0 + 32768 * 32768 * 2 * 1.5 / 1024**3
+    cached_flat = cached._estimate_compute_buffer_bytes(n_ubatch = 32768, n_parallel = 1) / 1024**3
+    assert cached_flat > 4.5  # the scratch is 4.6 GiB here, not a rounding term
+    assert one_slot == pytest.approx(weights_and_mask + cached_flat)
+    # and the same holds at the default micro-batch, where it is only 72 MiB
+    cached_flat_default = (
+        cached._estimate_compute_buffer_bytes(n_ubatch = 512, n_parallel = 1) / 1024**3
+    )
+    assert one_slot_default == pytest.approx(
+        1.0 + 32768 * 512 * 2 * 1.5 / 1024**3 + cached_flat_default
+    )
+
+
+def test_the_remote_reserve_tracks_what_the_cached_path_charges():
+    """The invariant behind the slot count. A remote estimate and a cached one price the
+    same launch, and the guard 409s on the difference, so remote must sit just ABOVE
+    cached for a chat model rather than half a gigabyte above it. Measured here against
+    _estimate_compute_buffer_bytes, the header-readable branch this one stands in for.
+
+    The residual: a remote EMBEDDING GGUF reads low, because that branch charges an output
+    buffer at every slot and this one cannot know it is an embedding model. It is bounded
+    by the model's real vocab and those repos are small (Qwen3-Embedding-0.6B is the large
+    end), so it is the same small-half under-charge the activation scratch used to be,
+    where charging it costs every chat load half a gigabyte of headroom.
+    """
+    from unittest.mock import patch
+
+    from core.inference.llama_cpp import LlamaCppBackend
+    from routes import inference as route
+
+    backend = LlamaCppBackend()
+    backend._vocab_size, backend._embedding_length = 151936, 5120
+
+    def cached_flat_gb(n_parallel, embedding):
+        with patch.object(
+            type(backend), "is_embedding_gguf", property(lambda self: embedding)
+        ):
+            return (
+                backend._estimate_compute_buffer_bytes(
+                    n_ubatch = 512, n_parallel = n_parallel
+                )
+                / 1024**3
+            )
+
+    for slots in (1, 2, 4):
+        remote = route._remote_gguf_compute_reserve_gb(n_parallel = slots)
+        cached = cached_flat_gb(slots, False)
+        # Never under the cached figure: that is the direction that OOMs the training job.
+        assert remote >= cached, (slots, remote, cached)
+
+    # And at one slot, not a whole output buffer over it either, which is what charging the
+    # first slot did: 0.575 GiB of headroom taken from every uncached chat load, on a guard
+    # that answers 409. Above one slot the gap widens legitimately, since the vocab ceiling
+    # is wider than any real model's.
+    one_ceiling_buffer = (route._ASSUMED_MAX_VOCAB * 512 * 4) / 1024**3
+    gap_at_one_slot = route._remote_gguf_compute_reserve_gb(n_parallel = 1) - cached_flat_gb(
+        1, False
+    )
+    assert 0 <= gap_at_one_slot < one_ceiling_buffer / 4, gap_at_one_slot


### PR DESCRIPTION
Rebased onto current `main`, which now carries #8641's extraction of the reserve into `_remote_gguf_compute_reserve_gb`. This PR keeps that extraction and changes only what it charges.

### Which PR introduced what

| Failure | Introduced by | Fixed by |
| --- | --- | --- |
| `ImportError: cannot import name 'openai_codex_auth_router'` | #8551, which added the router to `main.py` without the test stub | #8590, merged |
| `ValueError: Responses event type is missing` (2 tests) | #8551, which added `response_event_type` and wired only `openai_codex_client` to pass the SSE event name | #8608, merged |
| `TestEstimateGgufRequiredGb` off by 0.575732421875 GB (8 tests) | #8524 | #8641 made the tests green; this PR settles the charge |

### Why the charge is the part still open

#8524 made two changes to the remote branch. The default micro-batch is right and stays: a request that emits no batch flags still launches at llama.cpp's 512, and the local branch already charges against that default.

The slot count is the other one. `max(1, n_parallel)` reserves an output buffer for the first slot, and the local branch, which reads the header and is fitted to measured allocations, does not:

```
output_slots = par if self.is_embedding_gguf else max(0, par - 1)
# Matches measured chat {1:36, 2:492, 4:1388, 8:3220} MiB.
```

One slot reserves the activation scratch and no output buffer. The remote branch stands in for that same computation on a model whose header cannot be read yet, and the two are meant to agree; a comment already in this function names the failure mode, "the same model 409s while remote and loads once cached". Charging the first slot made every uncached chat load read 0.58 GB heavier than the identical cached one, on an estimator whose only consumer answers 409.

So the slot count returns to the local branch's form, and the activation scratch it was standing in for is charged explicitly under a ceiling, the way the vocab already is. Without that a one-slot remote load would carry the KQ mask alone, which is the same remote-vs-cached divergence pointing the other way.

### Measured

Against `_estimate_compute_buffer_bytes` for a 152k-vocab, 5120-wide chat model at the default micro-batch:

```
1 slot    cached 0.0449 GiB    remote 0.0726 GiB    +0.028
2 slots   cached 0.3782 GiB    remote 0.6476 GiB    +0.269
```

Remote now sits just above cached instead of half a gigabyte above it. `test_the_remote_reserve_tracks_what_the_cached_path_charges` pins both directions: never under the cached figure, and at one slot not a whole ceiling output buffer over it.

Suites that touch the estimator or the buffers it models: 818 passed (`test_batch_sizes_per_load`, `test_chat_load_during_training`, `test_mtp_drafter_companion`, `test_compute_buffer`, `test_embedding_gguf_launch`, `test_kv_cache_estimation`, `test_diffusion_memory`).

### The residual, stated plainly

A remote embedding GGUF now reads low, by 0.31 GB at one slot for a 152k vocab, because the cached branch charges an output buffer at every slot and this one cannot tell an embedding repo from a chat repo before the header is readable. #8524's own comment records that there is no reliable pre-load probe for it. The under-charge is bounded by the model's real vocab and those repos are small; the alternative is half a gigabyte of headroom taken from every uncached chat load. That trade is the reviewable decision here, and it reverses part of a merged PR, so it deserves a second opinion rather than my word for it.

### Not measured

No llama-server was launched. The single-slot 36 MiB figure is the one already recorded in the estimator, not a fresh reading, and the embedding residual is derived from the vocab ceiling rather than observed.
