### PR TITLE
Fix the two remaining things keeping Backend CI red

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -5453,13 +5453,24 @@ class ExternalProviderClient:
                         }
                         return f"data: {_json.dumps(chunk)}"
 
+                    # The SSE event name, kept for the data line it belongs to. A Responses
+                    # stream carries the type in both places, the `event:` field and the
+                    # payload's `type`, and a payload that omits it is still a valid event.
+                    # Dropping the field meant one such event raised and killed the stream;
+                    # the Codex client reads the same helper's event_name for this reason.
+                    sse_event_name = ""
                     try:
                         while True:
                             try:
                                 line = await lines_gen.__anext__()
                             except StopAsyncIteration:
                                 break
-                            if not line or line.startswith("event:"):
+                            if not line:
+                                # Blank line dispatches the event, so the name stops here.
+                                sse_event_name = ""
+                                continue
+                            if line.startswith("event:"):
+                                sse_event_name = line[len("event:") :].strip()
                                 continue
                             if not line.startswith("data:"):
                                 continue
@@ -5498,7 +5509,7 @@ class ExternalProviderClient:
                             except _json.JSONDecodeError:
                                 continue
 
-                            event_type = response_event_type(event)
+                            event_type = response_event_type(event, sse_event_name)
                             _record_openai_response_id(event)
 
                             if event_type == "response.output_text.delta":

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -6100,6 +6100,37 @@ def _estimate_gguf_kv_gb(
         return 0.0
 
 
+def _remote_compute_reserve_gb(
+    *,
+    mask_bytes: float,
+    effective_ubatch: int,
+    n_parallel: int,
+    devices: int,
+    tensor_parallel: bool,
+) -> float:
+    """The compute buffers a remote GGUF is charged for, in GB: the KQ mask plus the
+    output buffer.
+
+    Split out of the sizing walk so it can be measured on its own, and so a test about
+    which drafter gets priced can silence it the way it already silences the KV estimate.
+
+    The remote header is unknown, so the output buffer is reserved as if the model
+    enables embeddings, where llama.cpp keeps one per slot rather than one per slot past
+    the first.
+    """
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    out_buffer_bytes = (
+        _ASSUMED_MAX_VOCAB
+        * effective_ubatch
+        * 4
+        * max(1, n_parallel)
+        * (devices if tensor_parallel else 1)
+        * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
+    )
+    return (mask_bytes + out_buffer_bytes) / (1024**3)
+
+
 def _estimate_gguf_required_gb(
     config: ModelConfig,
     hf_token: Optional[str] = None,
@@ -6414,17 +6445,13 @@ def _estimate_gguf_required_gb(
                 # Scaled per device only in tensor mode, mirroring the local branch: a
                 # layer split folds the flat buffer in once (_flat_buffer(False)), and
                 # only tensor mode replicates it on every card.
-                # The remote header is unknown, so reserve as if it enables embeddings.
-                _out_slots = max(1, n_parallel)
-                out_buffer_bytes = (
-                    _ASSUMED_MAX_VOCAB
-                    * effective_ubatch
-                    * 4
-                    * _out_slots
-                    * (devices if tensor_parallel else 1)
-                    * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
+                total_gb += _remote_compute_reserve_gb(
+                    mask_bytes = mask_bytes,
+                    effective_ubatch = effective_ubatch,
+                    n_parallel = n_parallel,
+                    devices = devices,
+                    tensor_parallel = tensor_parallel,
                 )
-                total_gb += (mask_bytes + out_buffer_bytes) / (1024**3)
             return total_gb
         return None
     except Exception as e:

--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1967,10 +1967,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             tensor_parallel = False,
         )
         expected = (
-            self.route._ASSUMED_MAX_VOCAB
-            * 512
-            * 4
-            * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
+            self.route._ASSUMED_MAX_VOCAB * 512 * 4 * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
         ) / (1024**3)
         self.assertAlmostEqual(one, expected, places = 9)
         self.assertGreater(one, 0.0)

--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1461,6 +1461,10 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             with (
                 patch.object(mc, "list_gguf_variants", return_value = ([variant], False)),
                 patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
+                # The remote compute buffers are charged whatever the drafter or
+                # companions turn out to be, and have their own tests, so silence them
+                # rather than restating their size in the expected total.
+                patch.object(self.route, "_remote_compute_reserve_gb", return_value = 0.0),
                 self._dflash_capable(),
             ):
                 gb = self.route._estimate_gguf_required_gb(
@@ -1493,6 +1497,10 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             patch.object(
                 self.route, "_remote_gguf_companion_bytes", return_value = 2 * 1024**3
             ) as comp,
+            # The remote compute buffers are charged whatever the drafter turns out to
+            # be, and have their own tests, so silence them rather than restating
+            # their size in the expected total.
+            patch.object(self.route, "_remote_compute_reserve_gb", return_value = 0.0),
             self._dspark_capable(),
         ):
             gb = self.route._estimate_gguf_required_gb(
@@ -1892,6 +1900,10 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             patch.object(mc, "list_gguf_variants", lambda repo, hf_token = None: ([variant], False)),
             patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
             patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            # These price DRAFTERS, and the remote compute buffers are charged whatever the
+            # drafter turns out to be, so silence them the way the KV estimate above is
+            # silenced rather than restating their size in every expected total.
+            patch.object(self.route, "_remote_compute_reserve_gb", return_value = 0.0),
             patch("huggingface_hub.model_info", side_effect = AssertionError("priced as a repo")),
         ):
             charged = self.route._estimate_gguf_required_gb(
@@ -1922,6 +1934,10 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             patch.object(mc, "list_gguf_variants", lambda repo, hf_token = None: ([variant], False)),
             patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
             patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            # These price DRAFTERS, and the remote compute buffers are charged whatever the
+            # drafter turns out to be, so silence them the way the KV estimate above is
+            # silenced rather than restating their size in every expected total.
+            patch.object(self.route, "_remote_compute_reserve_gb", return_value = 0.0),
             patch("huggingface_hub.model_info", side_effect = AssertionError("priced as a repo")),
         ):
             charged = self.route._estimate_gguf_required_gb(
@@ -1935,6 +1951,104 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
                 ],
             )
         self.assertAlmostEqual(charged, 4.0, places = 6)
+
+    def test_the_remote_compute_reserve_is_charged_and_scales(self):
+        """The buffers the drafter tests silence. A remote header cannot be read, so the
+        output buffer is reserved as if the model enables embeddings: llama.cpp keeps one
+        per slot then, not one per slot past the first, and skipping it entirely let the
+        guard admit a load that then OOMs the training job it protects."""
+        from core.inference.llama_cpp import LlamaCppBackend
+
+        one = self.route._remote_compute_reserve_gb(
+            mask_bytes = 0,
+            effective_ubatch = 512,
+            n_parallel = 1,
+            devices = 1,
+            tensor_parallel = False,
+        )
+        expected = (
+            self.route._ASSUMED_MAX_VOCAB
+            * 512
+            * 4
+            * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
+        ) / (1024**3)
+        self.assertAlmostEqual(one, expected, places = 9)
+        self.assertGreater(one, 0.0)
+
+        # One slot is charged, not zero: that is the embeddings assumption.
+        four = self.route._remote_compute_reserve_gb(
+            mask_bytes = 0,
+            effective_ubatch = 512,
+            n_parallel = 4,
+            devices = 1,
+            tensor_parallel = False,
+        )
+        self.assertAlmostEqual(four, one * 4, places = 9)
+
+        # Tensor mode replicates the buffer per device; a layer split folds it in once.
+        split = self.route._remote_compute_reserve_gb(
+            mask_bytes = 0,
+            effective_ubatch = 512,
+            n_parallel = 1,
+            devices = 2,
+            tensor_parallel = False,
+        )
+        tensor = self.route._remote_compute_reserve_gb(
+            mask_bytes = 0,
+            effective_ubatch = 512,
+            n_parallel = 1,
+            devices = 2,
+            tensor_parallel = True,
+        )
+        self.assertAlmostEqual(split, one, places = 9)
+        self.assertAlmostEqual(tensor, one * 2, places = 9)
+
+        # The mask rides along untouched.
+        self.assertAlmostEqual(
+            self.route._remote_compute_reserve_gb(
+                mask_bytes = 1024**3,
+                effective_ubatch = 512,
+                n_parallel = 1,
+                devices = 1,
+                tensor_parallel = False,
+            ),
+            one + 1.0,
+            places = 9,
+        )
+
+    def test_a_remote_load_without_an_explicit_ubatch_still_reserves_buffers(self):
+        """The default micro-batch stands in for the unreadable header. Without it the
+        whole compute reserve was skipped for every remote load that did not name a
+        ubatch, which is the common one."""
+        import utils.models.model_config as mc
+        from core.inference.llama_cpp import LlamaCppBackend
+
+        cfg = SimpleNamespace(
+            gguf_file = None,
+            gguf_mmproj_file = None,
+            gguf_mtp_file = None,
+            gguf_dspark_file = None,
+            gguf_dflash_file = None,
+            gguf_hf_repo = "org/repo",
+            gguf_variant = "Q4_K_M",
+        )
+        variant = SimpleNamespace(quant = "Q4_K_M", size_bytes = 4 * 1024**3)
+        seen = {}
+
+        def _reserve(**kwargs):
+            seen.update(kwargs)
+            return 0.25
+
+        with (
+            patch.object(mc, "list_gguf_variants", lambda repo, hf_token = None: ([variant], False)),
+            patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
+            patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            patch.object(self.route, "_remote_compute_reserve_gb", _reserve),
+        ):
+            charged = self.route._estimate_gguf_required_gb(cfg, speculative_type = "none")
+
+        self.assertAlmostEqual(charged, 4.25, places = 6)
+        self.assertEqual(seen.get("effective_ubatch"), LlamaCppBackend._DEFAULT_N_UBATCH)
 
     def test_the_cached_drafter_scan_reads_the_cache_studio_is_pointed_at(self):
         """A user who moved the Hugging Face cache launches llama-server against the
@@ -1989,6 +2103,10 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             patch.object(mc, "list_gguf_variants", lambda repo, hf_token = None: ([variant], False)),
             patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
             patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            # These price DRAFTERS, and the remote compute buffers are charged whatever the
+            # drafter turns out to be, so silence them the way the KV estimate above is
+            # silenced rather than restating their size in every expected total.
+            patch.object(self.route, "_remote_compute_reserve_gb", return_value = 0.0),
             patch.object(self.route, "_remote_drafter_repo_bytes", return_value = 6 * 1024**3),
         ):
             charged = self.route._estimate_gguf_required_gb(
@@ -2040,6 +2158,10 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             ),
             patch.object(self.route, "_remote_drafter_repo_bytes", return_value = 3 * 1024**3),
             patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            # These price DRAFTERS, and the remote compute buffers are charged whatever the
+            # drafter turns out to be, so silence them the way the KV estimate above is
+            # silenced rather than restating their size in every expected total.
+            patch.object(self.route, "_remote_compute_reserve_gb", return_value = 0.0),
             self._dflash_capable(),
         ):
             charged = self.route._estimate_gguf_required_gb(
@@ -2398,6 +2520,10 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
                 "huggingface_hub.model_info",
                 return_value = SimpleNamespace(siblings = self._MULTI_FAMILY_SIBLINGS),
             ),
+            # The remote compute buffers are charged whatever the drafter turns out to
+            # be, and have their own tests, so silence them rather than restating
+            # their size in the expected total.
+            patch.object(self.route, "_remote_compute_reserve_gb", return_value = 0.0),
             self._dflash_capable(),
         ):
             gb = self.route._estimate_gguf_required_gb(cfg, speculative_type = "dflash")
@@ -2430,6 +2556,10 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
                 "huggingface_hub.model_info",
                 return_value = SimpleNamespace(siblings = siblings),
             ),
+            # The remote compute buffers are charged whatever the drafter turns out to
+            # be, and have their own tests, so silence them rather than restating
+            # their size in the expected total.
+            patch.object(self.route, "_remote_compute_reserve_gb", return_value = 0.0),
             self._dflash_capable(),
         ):
             owned = self.route._estimate_gguf_required_gb(

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -492,9 +492,9 @@ def _continuation_body(monkeypatch, provider_type: str, base_url: str) -> dict:
         # chunk made this test depend on that reader ignoring the shape it was handed.
         if request.url.path.endswith("/responses"):
             content = (
-                b'event: response.output_text.delta\n'
+                b"event: response.output_text.delta\n"
                 b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n'
-                b'event: response.completed\n'
+                b"event: response.completed\n"
                 b'data: {"type":"response.completed"}\n\n'
             )
         else:

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -487,9 +487,21 @@ def _continuation_body(monkeypatch, provider_type: str, base_url: str) -> dict:
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured.update(json.loads(request.content.decode("utf-8")))
+        # Shaped to the endpoint the client chose. openai routes to /v1/responses, whose
+        # reader wants Responses events, so serving every provider a Chat Completions
+        # chunk made this test depend on that reader ignoring the shape it was handed.
+        if request.url.path.endswith("/responses"):
+            content = (
+                b'event: response.output_text.delta\n'
+                b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n'
+                b'event: response.completed\n'
+                b'data: {"type":"response.completed"}\n\n'
+            )
+        else:
+            content = b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n'
         return httpx.Response(
             200,
-            content = b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+            content = content,
             headers = {"content-type": "text/event-stream"},
         )
 
@@ -635,3 +647,61 @@ def test_kimi_no_search_fallback_requests_usage(monkeypatch):
     assert "tools" in search_body
     assert "tools" not in fallback_body
     assert fallback_body["stream_options"] == {"include_usage": True}
+
+
+def test_a_responses_event_typed_only_by_its_sse_field_is_read(monkeypatch):
+    """A Responses stream carries the type twice, in the `event:` line and in the payload's
+    `type`, and either alone is a valid event. The reader used to drop the `event:` line and
+    then raise "Responses event type is missing" on a payload that leaned on it, killing the
+    generation mid-stream. openai_codex_client already reads the field for this reason."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content = (
+                b"event: response.output_text.delta\n"
+                b'data: {"delta":"ok"}\n\n'
+                b"event: response.completed\n"
+                b"data: {}\n\n"
+            ),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = ExternalProviderClient(
+            provider_type = "openai",
+            base_url = "https://api.openai.com/v1",
+            api_key = "sk-openai-test",
+        )
+        async for chunk in client.stream_chat_completion(
+            messages = [{"role": "user", "content": "hi"}],
+            model = "gpt-5",
+        ):
+            seen.append(chunk)
+        await client.close()
+
+    _drive(run())
+    # The delta arrived rather than the stream dying on the first event, and the completion
+    # event closed it out.
+    assert any("ok" in chunk for chunk in seen), seen
+    assert any('"finish_reason": "stop"' in chunk for chunk in seen), seen
+
+
+def test_an_event_the_sse_field_does_not_type_either_is_still_rejected(monkeypatch):
+    """The field is a fallback, not a licence to guess: an event typed by neither still
+    raises, so a genuinely malformed stream is not read as if it made sense."""
+    from core.inference.openai_responses_shared import response_event_type
+
+    with pytest.raises(ValueError):
+        response_event_type({"delta": "ok"}, "")
+    assert response_event_type({"delta": "ok"}, "response.output_text.delta") == (
+        "response.output_text.delta"
+    )
+    assert response_event_type({"type": "response.completed"}, "") == "response.completed"
+    # The payload wins when both are present; the SSE field only fills a gap.
+    assert response_event_type({"type": "response.completed"}, "response.created") == (
+        "response.completed"
+    )


### PR DESCRIPTION
Backend CI has been red on every PR for a while, which is worse than the individual failures: the next real regression arrives invisible. #8590 has since taken the desktop-auth routes stub, so this is the other two causes.

### 1. A Responses event typed only by its SSE field killed the stream

A Responses stream carries its type twice, in the SSE `event:` line and in the payload's `type`, and either alone is a valid event. `openai_codex_client.py` reads the field and passes it to `response_event_type(event, event_name)`. `external_provider.py` discarded the line and called the same helper without it, so an event that leaned on the field raised `ValueError: Responses event type is missing` and took the generation down with it.

`external_provider.py` now reads the field too. The payload still wins when both are present, and an event typed by neither is still rejected, so a genuinely malformed stream is not read as if it made sense.

One test fixture was also handing a Chat Completions chunk to the Responses endpoint; it now shapes the stub to the endpoint the client actually picks, so it cannot drift again when another provider starts routing there.

### 2. Eight stale assertions after a deliberate sizing change

#8524 gave the remote sizing walk a default micro-batch. That makes the compute reserve apply to remote loads that name no ubatch, where the whole block used to be skipped, and eight `TestEstimateGgufRequiredGb` cases still assert the pre-change totals:

```
AssertionError: 4.575732421875 != 4.0 within 6 places
```

The new behaviour is the safer one, so the tests are what is stale: skipping the reserve under-reserved, and could admit a load that then OOMs the training job the guard exists to protect.

Rather than re-pinning `4.575732421875`, the reserve is extracted as `_remote_compute_reserve_gb(...)` and the eight tests silence it the way they already silence the KV estimate. They are about which drafter gets priced, and the buffers are charged whatever the drafter turns out to be. Two new tests cover the reserve on its own: how it scales across slots, devices and tensor mode, and that a remote load without an explicit ubatch still charges it.

### Verification

Each fix was checked by reverting it and confirming the new test fails, so neither is a test that would pass either way.

For regressions, the whole backend suite was run on this branch and on `main` and the failure sets diffed: exactly the CI failures disappear and nothing new appears. The ~249 that remain on both sides are this host's environment (a diffusers version mismatch, AMD-only tests on an NVIDIA box, missing optional extras) and are unrelated.
