### PR TITLE
tests: do not read a host refusal as an H3 reference-load regression

### DIFF
--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -2107,6 +2107,29 @@ def test_base_download_files_skips_the_partition_the_prequant_checkpoint_replace
     )
 
 
+def _h3_pipeline_load_is_attemptable(fam) -> bool:
+    """Whether validate_load_request can even reach a pick's own checks for an H3 pipeline here.
+
+    Two of its refusals are about the machine, not the request: Metal cannot place the modular
+    workflow at all (torch.mps exposes no mem_get_info for the auto CPU offload), and a diffusers
+    without the bundled revision has no transformer class to build. Both raise the same ValueError
+    a genuine refusal does, so a caller that reads any ValueError as "this pick was rejected"
+    reports a regression on hosts where the pick was never in question."""
+    from core.inference.diffusion_device import resolve_diffusion_device_target
+    from core.inference.diffusion_families import assert_pipeline_class_available
+
+    if resolve_diffusion_device_target().device == "mps":
+        return False
+    try:
+        assert_pipeline_class_available(fam.pipeline_class, fam.name)
+    except Exception:  # noqa: BLE001 -- an unavailable pipeline class is a host fact, not a verdict
+        return False
+    if fam.modular_workflow:
+        import diffusers
+        return hasattr(diffusers, fam.transformer_class)
+    return True
+
+
 def test_a_quantized_reference_load_resolves_the_reference_denoiser():
     # This pairing used to be refused outright: the only hosted checkpoints were fl2va denoisers,
     # and one seeded into the reference workflow would have installed cleanly, passed every
@@ -2117,23 +2140,27 @@ def test_a_quantized_reference_load_resolves_the_reference_denoiser():
 
     backend = VideoBackend()
     fam = _detect_load_family("MiniMaxAI/MiniMax-H3", None, "minimax-h3")
+    # The resolution below is a registry lookup and holds on every host; only the refusal check
+    # needs a host that can attempt the load at all.
+    check_refusal = _h3_pipeline_load_is_attemptable(fam)
     for scheme, expected in (
         ("int8", "MiniMax-H3-Ref2VA-INT8-ConvRot.pt"),
         ("fp8", "MiniMax-H3-Ref2VA-FP8.pt"),
     ):
-        try:
-            backend.validate_load_request(
-                "MiniMaxAI/MiniMax-H3",
-                family_override = "minimax-h3",
-                model_kind = "pipeline",
-                transformer_quant = scheme,
-                h3_task = "ref2va",
-            )
-        except ValueError as exc:  # pragma: no cover - only on a regression
-            pytest.fail(f"ref2va {scheme} should be loadable but was refused: {exc}")
-        except Exception:
-            # Anything past the quant check (the diffusers probe) is not this test's business.
-            pass
+        if check_refusal:
+            try:
+                backend.validate_load_request(
+                    "MiniMaxAI/MiniMax-H3",
+                    family_override = "minimax-h3",
+                    model_kind = "pipeline",
+                    transformer_quant = scheme,
+                    h3_task = "ref2va",
+                )
+            except ValueError as exc:  # pragma: no cover - only on a regression
+                pytest.fail(f"ref2va {scheme} should be loadable but was refused: {exc}")
+            except Exception:
+                # Anything past the quant check (the diffusers probe) is not this test's business.
+                pass
         source = resolve_prequant_source(fam, scheme, task = "ref2va")
         assert source.filename == expected
 

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -2114,7 +2114,14 @@ def _h3_pipeline_load_is_attemptable(fam) -> bool:
     workflow at all (torch.mps exposes no mem_get_info for the auto CPU offload), and a diffusers
     without the bundled revision has no transformer class to build. Both raise the same ValueError
     a genuine refusal does, so a caller that reads any ValueError as "this pick was rejected"
-    reports a regression on hosts where the pick was never in question."""
+    reports a regression on hosts where the pick was never in question.
+
+    No diffusers at all is the third such host, and it is a supported one: studio.txt does not
+    install diffusers (it arrives with the torch-bound ML stack), and the native sd.cpp engine
+    serves H3 without it. assert_pipeline_class_available answers only "is the installed
+    diffusers new enough", so under its default non-strict mode an unimportable one returns
+    rather than raising -- which means it cannot be the guard for this, and the probe below has
+    to carry its own."""
     from core.inference.diffusion_device import resolve_diffusion_device_target
     from core.inference.diffusion_families import assert_pipeline_class_available
 
@@ -2125,9 +2132,37 @@ def _h3_pipeline_load_is_attemptable(fam) -> bool:
     except Exception:  # noqa: BLE001 -- an unavailable pipeline class is a host fact, not a verdict
         return False
     if fam.modular_workflow:
-        import diffusers
-        return hasattr(diffusers, fam.transformer_class)
+        try:
+            import diffusers
+
+            # hasattr, not the import, is what pulls in the lazy submodule, so a partially
+            # installed diffusers raises here rather than at the import statement.
+            return hasattr(diffusers, fam.transformer_class)
+        except Exception:  # noqa: BLE001 -- no importable diffusers is a host fact too
+            return False
     return True
+
+
+def test_the_h3_attemptability_probe_survives_a_host_without_diffusers(monkeypatch):
+    """The probe exists to turn host limitations into "not attemptable" instead of a red test, so
+    it must not itself raise on the most ordinary limitation of all. studio.txt installs no
+    diffusers, and assert_pipeline_class_available does NOT stand in for the check: non-strict is
+    its default and an unimportable diffusers makes it return, not raise, so control reaches the
+    modular-workflow probe below it. Unguarded, that probe raised ModuleNotFoundError straight out
+    of the helper and failed the caller before its own `except Exception` could see it."""
+    fam = _detect_load_family("MiniMaxAI/MiniMax-H3", None, "minimax-h3")
+    # H3 is modular, so the probe really does reach the import this guards.
+    assert fam.modular_workflow
+
+    original_import = builtins.__import__
+
+    def _no_diffusers_import(name, *args, **kwargs):
+        if name == "diffusers" or name.startswith("diffusers."):
+            raise ModuleNotFoundError(f"No module named '{name}'", name = name)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_diffusers_import)
+    assert _h3_pipeline_load_is_attemptable(fam) is False
 
 
 def test_a_quantized_reference_load_resolves_the_reference_denoiser():


### PR DESCRIPTION
## Summary

`test_a_quantized_reference_load_resolves_the_reference_denoiser` treats any `ValueError` out of `validate_load_request` as "ref2va `<scheme>` should be loadable but was refused". Two of that function's refusals are about the machine rather than the request:

- Metal cannot place the modular workflow at all. `_load_h3_modular_pipeline` hands every non-CPU device to `ComponentsManager.enable_auto_cpu_offload`, which reads `torch.<device>.mem_get_info`, and `torch.mps` has never exposed it (`video.py:1040`).
- A diffusers without the bundled revision has no `MiniMaxH3Transformer3DModel` to build (`video.py:1107`).

On either host the test reports a regression in a pairing that was never in question.

## Why it has not been seen in CI

`studio-backend-ci.yml` runs the backend suite on `ubuntu-latest` only, so `test_video_backend.py` has never run on macOS. Running it there is what surfaced this:

```
FAILED studio/backend/tests/test_video_backend.py::test_a_quantized_reference_load_resolves_the_reference_denoiser
  Failed: ref2va int8 should be loadable but was refused: 'minimax-h3' cannot run on Apple
  Silicon: its Modular Diffusers workflow places components through the Diffusers auto CPU
  offload, which needs a torch device exposing mem_get_info, and Metal (MPS) does not have it.
```

It also fires on any checkout carrying a different diffusers, which is the form it takes locally.

## Changes

- `_h3_pipeline_load_is_attemptable(fam)` evaluates the same two conditions the product tests: the resolved device target, and `assert_pipeline_class_available` plus the transformer class for a modular family.
- The refusal check runs only where the load can actually be attempted. The prequant resolution is a registry lookup that holds on every host, so it stays unconditional and macOS keeps covering it.

The guard is not a blanket suppression. With it forced on, the test still fails on a genuine refusal, which is how I verified it:

```
Failed: ref2va int8 should be loadable but was refused: MiniMax-H3 needs the Diffusers
revision bundled with this Studio version.
```

## Validation

- `tests/test_video_backend.py`: 214 passed (the case was red on this checkout before the change, for the diffusers-revision form).
- Ruff clean.

Worth considering separately: the reason this sat unnoticed is that the backend suite has no macOS leg. Adding one would catch this class of thing, at the cost of another job on an already busy queue, so I have left that call out of this PR.
