### PR TITLE
ci: run the studio backend suite on macOS as well

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -121,6 +121,57 @@ jobs:
             --ignore=tests/test_studio_api.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
+  pytest-macos:
+    # The same suite on Apple Silicon. Everything above runs on ubuntu-latest only, so a test that
+    # depends on the host -- an MPS device target, a path separator, a case-insensitive filesystem
+    # -- reads as green until someone runs it on a Mac. Studio ships to Macs, and the native
+    # engine's whole reason for existing is that tier, so the gap is not a theoretical one:
+    # test_a_quantized_reference_load_resolves_the_reference_denoiser failed there for months
+    # because H3's Modular Diffusers path is refused on Metal and the test read that as a
+    # regression (fixed in the commit that added this job's sibling PR).
+    #
+    # ONE interpreter, not the four the ubuntu matrix runs. macOS runners cost ten times a Linux
+    # one in Actions minutes, and a second interpreter would re-find whatever the first found: the
+    # bugs this job exists for are about the platform, not the Python version.
+    name: (macOS, Python 3.13)
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install backend test dependencies (CPU only)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r studio/backend/requirements/studio.txt
+          pip install \
+            python-multipart aiofiles sqlalchemy cryptography psutil \
+            pyyaml jinja2 mammoth unpdf requests \
+            'numpy<3' pytest pytest-asyncio httpx \
+            soundfile librosa
+          # From PyPI, NOT the download.pytorch.org/whl/cpu index the ubuntu job uses: that index
+          # publishes Linux wheels only, so pointing macOS at it resolves nothing and the install
+          # fails outright. The PyPI macOS wheel is already CPU/MPS, there is no CUDA build to
+          # avoid.
+          pip install 'torch>=2.4,<2.11'
+          pip install 'transformers>=4.51,<5.5'
+          pip install torchao
+
+      - name: Backend tests
+        working-directory: studio/backend
+        # Same deselections as the ubuntu matrix, for the same reason: they are GPU-bound by
+        # design and no hosted runner of either OS can satisfy them.
+        run: |
+          python -m pytest tests/ -q --tb=short \
+            --ignore=tests/test_studio_api.py \
+            -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
+
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by
     # design. New tests added in covered directories are picked up


### PR DESCRIPTION
**Do not merge as-is.** I measured this before proposing it, and the measurement says the job cannot land yet. Leaving the branch and the numbers here as the record.

## What this adds

A `pytest-macos` job on `macos-15`, one interpreter, same dependency set and deselections as the ubuntu matrix. Torch comes from PyPI rather than the `download.pytorch.org/whl/cpu` index the ubuntu job uses, since that index publishes Linux wheels only.

## Why

Backend CI runs `studio/backend/tests` on `ubuntu-latest` only, so a test whose result depends on the host is green by default and stays green. `test_a_quantized_reference_load_resolves_the_reference_denoiser` read Metal's refusal of the H3 Modular Diffusers path as a regression in the pick under test, and nothing in CI could say so (fixed in #8638).

## The measurement

Run on a staging replica of this branch, full suite, `macos-15`, Python 3.13:

```
173 failed, 22714 passed, 175 skipped, 36 deselected, 72 errors   (macOS)
 10 failed, 22990 passed, 132 skipped, 36 deselected              (ubuntu, same run)
```

163 extra failures across 34 files. The largest groups:

| tests | count | cause |
|---|---|---|
| `test_rag_*` (7 files) | ~140 | `sqlite-vec` extension will not load on macOS |
| `test_chat_load_during_training.py` | 31 | already red on ubuntu, not macOS-specific |
| `test_setup_llama_cpp_backend.py` | 19 | platform install paths |
| `test_cache_case_resolution.py` | 4 | case-insensitive filesystem |
| `test_bypass_permissions.py` | 4 | Linux-only sandbox preexec |

Landing the job in this state would put a permanently red check on every PR, which is worse than the gap it closes.

## There is no useful green subset either

The obvious fallback was to scope the job to the platform-sensitive files. Every one of them is red on macOS today:

- `test_sd_cpp_engine.py` (5): the test's `Popen` recorder captures the `ps -o lstart=,comm= -p <pid>` call `process_lifetime` makes on macOS instead of the sd-cli argv, so the assertion reads `assert '--diffusion-model' in ['ps', '-o', ...]`. A real macOS-only gap in the harness for the component this job most needs to cover.
- `test_video_backend.py` (5): the oversized-load guard fires because the runner reports ~3 GB free, so these need the memory probe mocked rather than a bigger runner.
- `test_sd_cpp_args.py`, `test_video_prequant.py`, `test_video_routes.py`, `test_diffusion_*`: assorted.

## Recommendation

Fix the macOS failures in batches first, starting with `test_sd_cpp_engine.py` and `test_video_backend.py` since those cover the native engine, then land this job once a defensible scope is green. I am happy to do that work; it is a bigger piece than this PR and wanted its own decision.