### PR TITLE
Let a remote GGUF estimate be priced without its compute reserve

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -6101,6 +6101,96 @@ def _estimate_gguf_kv_gb(
         return 0.0
 
 
+def _remote_gguf_compute_reserve_gb(
+    llama_extra_args: Optional[list[str]] = None,
+    max_seq_length: int = 0,
+    n_parallel: int = 1,
+    n_batch: Optional[int] = None,
+    n_ubatch: Optional[int] = None,
+    n_devices: int = 1,
+    tensor_parallel: bool = False,
+    is_diffusion: bool = False,
+) -> float:
+    """Compute buffers a remote GGUF will reserve, in GB.
+
+    Split out of _estimate_gguf_required_gb so a caller that is pricing something
+    else, a drafter for instance, can hold it at zero the way it already holds
+    _estimate_gguf_kv_gb at zero. The arithmetic is unchanged.
+    """
+    # remote dims are unreadable; only the kq mask, linear in ubatch x ctx, can be sized here
+    from core.inference.llama_server_args import parse_ctx_override
+
+    try:
+        ctx_override = parse_ctx_override(llama_extra_args) or 0
+    except Exception:
+        ctx_override = 0
+    ctx = max(max_seq_length or 0, ctx_override)
+    effective_ubatch = (
+        None
+        if is_diffusion
+        else _extra_args_n_ubatch(
+            llama_extra_args,
+            n_ctx = ctx if ctx > 0 else None,
+            # same floor raise the loader applies at launch
+            n_batch = _emitted_n_batch(n_batch, n_parallel),
+            n_ubatch = n_ubatch,
+        )
+    )
+    if effective_ubatch is None and not is_diffusion:
+        effective_ubatch = LlamaCppBackend._DEFAULT_N_UBATCH
+    if effective_ubatch:
+        # auto context: assume the native one fits at least a full micro-batch
+        budget_ctx = ctx if ctx > 0 else effective_ubatch
+        devices = max(1, int(n_devices))
+        # A multi-device layer split materialises the KQ mask _CTX_COMPUTE_SPLIT_MULT
+        # times, the same step _compute_buffer_ctx_bytes applies locally; charging
+        # the single-copy rate under-reserved 4x. Tensor mode is already correct
+        # (measured at the single-device rate, replicated per device). n_layers is
+        # None here: the header is unread, so -ngl cannot be resolved, but -ot /
+        # -ncmoe / --no-kv-offload / -sm none still register. Without this gate the
+        # same model 409s while remote and loads once cached.
+        from core.inference.llama_cpp import _pipeline_parallel_disabled_by_args
+
+        split_mult = (
+            LlamaCppBackend._CTX_COMPUTE_SPLIT_MULT
+            if devices > 1
+            and not tensor_parallel
+            and not _pipeline_parallel_disabled_by_args(llama_extra_args, n_layers = None)
+            else 1
+        )
+        mask_bytes = (
+            budget_ctx
+            * effective_ubatch
+            * 2
+            * LlamaCppBackend._CTX_COMPUTE_F16_MASK_SAFETY
+            * devices
+            * split_mult
+        )
+        # The mask is only the context-linear half. The flat half needs the dims,
+        # which are unreadable remotely, but its dominant term needs just a vocab
+        # ceiling: llama.cpp reserves n_vocab * ubatch * 4 per slot past the first
+        # (every slot under tensor mode), so n_batch = n_ubatch = 32768 on two
+        # slots is ~32 GiB the mask does not cover. Omitting it let the guard admit
+        # an uncached load that then OOMs the training job it exists to protect.
+        # The activation scratch needs embedding_length and stays uncharged: it is
+        # the small half, and over-reserving here denies the load outright.
+        # Scaled per device only in tensor mode, mirroring the local branch: a
+        # layer split folds the flat buffer in once (_flat_buffer(False)), and
+        # only tensor mode replicates it on every card.
+        # The remote header is unknown, so reserve as if it enables embeddings.
+        _out_slots = max(1, n_parallel)
+        out_buffer_bytes = (
+            _ASSUMED_MAX_VOCAB
+            * effective_ubatch
+            * 4
+            * _out_slots
+            * (devices if tensor_parallel else 1)
+            * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
+        )
+        return (mask_bytes + out_buffer_bytes) / (1024**3)
+    return 0.0
+
+
 def _estimate_gguf_required_gb(
     config: ModelConfig,
     hf_token: Optional[str] = None,
@@ -6355,77 +6445,16 @@ def _estimate_gguf_required_gb(
             # one: this repo's listing cannot see it, local or remote, and it is
             # resident next to these weights.
             total_gb = (main_bytes + companions + _extras_bytes) / (1024**3)
-            # remote dims are unreadable; only the kq mask, linear in ubatch x ctx, can be sized here
-            from core.inference.llama_server_args import parse_ctx_override
-
-            try:
-                ctx_override = parse_ctx_override(llama_extra_args) or 0
-            except Exception:
-                ctx_override = 0
-            ctx = max(max_seq_length or 0, ctx_override)
-            effective_ubatch = (
-                None
-                if is_diffusion
-                else _extra_args_n_ubatch(
-                    llama_extra_args,
-                    n_ctx = ctx if ctx > 0 else None,
-                    # same floor raise the loader applies at launch
-                    n_batch = _emitted_n_batch(n_batch, n_parallel),
-                    n_ubatch = n_ubatch,
-                )
+            total_gb += _remote_gguf_compute_reserve_gb(
+                llama_extra_args = llama_extra_args,
+                max_seq_length = max_seq_length,
+                n_parallel = n_parallel,
+                n_batch = n_batch,
+                n_ubatch = n_ubatch,
+                n_devices = n_devices,
+                tensor_parallel = tensor_parallel,
+                is_diffusion = is_diffusion,
             )
-            if effective_ubatch is None and not is_diffusion:
-                effective_ubatch = LlamaCppBackend._DEFAULT_N_UBATCH
-            if effective_ubatch:
-                # auto context: assume the native one fits at least a full micro-batch
-                budget_ctx = ctx if ctx > 0 else effective_ubatch
-                devices = max(1, int(n_devices))
-                # A multi-device layer split materialises the KQ mask _CTX_COMPUTE_SPLIT_MULT
-                # times, the same step _compute_buffer_ctx_bytes applies locally; charging
-                # the single-copy rate under-reserved 4x. Tensor mode is already correct
-                # (measured at the single-device rate, replicated per device). n_layers is
-                # None here: the header is unread, so -ngl cannot be resolved, but -ot /
-                # -ncmoe / --no-kv-offload / -sm none still register. Without this gate the
-                # same model 409s while remote and loads once cached.
-                from core.inference.llama_cpp import _pipeline_parallel_disabled_by_args
-
-                split_mult = (
-                    LlamaCppBackend._CTX_COMPUTE_SPLIT_MULT
-                    if devices > 1
-                    and not tensor_parallel
-                    and not _pipeline_parallel_disabled_by_args(llama_extra_args, n_layers = None)
-                    else 1
-                )
-                mask_bytes = (
-                    budget_ctx
-                    * effective_ubatch
-                    * 2
-                    * LlamaCppBackend._CTX_COMPUTE_F16_MASK_SAFETY
-                    * devices
-                    * split_mult
-                )
-                # The mask is only the context-linear half. The flat half needs the dims,
-                # which are unreadable remotely, but its dominant term needs just a vocab
-                # ceiling: llama.cpp reserves n_vocab * ubatch * 4 per slot past the first
-                # (every slot under tensor mode), so n_batch = n_ubatch = 32768 on two
-                # slots is ~32 GiB the mask does not cover. Omitting it let the guard admit
-                # an uncached load that then OOMs the training job it exists to protect.
-                # The activation scratch needs embedding_length and stays uncharged: it is
-                # the small half, and over-reserving here denies the load outright.
-                # Scaled per device only in tensor mode, mirroring the local branch: a
-                # layer split folds the flat buffer in once (_flat_buffer(False)), and
-                # only tensor mode replicates it on every card.
-                # The remote header is unknown, so reserve as if it enables embeddings.
-                _out_slots = max(1, n_parallel)
-                out_buffer_bytes = (
-                    _ASSUMED_MAX_VOCAB
-                    * effective_ubatch
-                    * 4
-                    * _out_slots
-                    * (devices if tensor_parallel else 1)
-                    * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
-                )
-                total_gb += (mask_bytes + out_buffer_bytes) / (1024**3)
             return total_gb
         return None
     except Exception as e:

--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1205,6 +1205,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             )
             with (
                 patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+                patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
                 self._dspark_capable(),
             ):
                 off_gb = self.route._estimate_gguf_required_gb(
@@ -1246,6 +1247,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             )
             with (
                 patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+                patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
                 self._dspark_capable(False),
             ):
                 forced = self.route._estimate_gguf_required_gb(cfg, speculative_type = "dspark")
@@ -1371,6 +1373,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             )
             with (
                 patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+                patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
                 self._dflash_capable(),
             ):
                 plain = self.route._estimate_gguf_required_gb(cfg, speculative_type = "dflash")
@@ -1420,6 +1423,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             )
             with (
                 patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+                patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
                 self._dflash_capable(),
             ):
                 owned = self.route._estimate_gguf_required_gb(
@@ -1460,6 +1464,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             drafter.write_bytes(b"y" * 3000)
             with (
                 patch.object(mc, "list_gguf_variants", return_value = ([variant], False)),
+                patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
                 patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
                 self._dflash_capable(),
             ):
@@ -1490,6 +1495,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
 
         with (
             patch.object(mc, "list_gguf_variants", fake_list),
+            patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
             patch.object(
                 self.route, "_remote_gguf_companion_bytes", return_value = 2 * 1024**3
             ) as comp,
@@ -1892,6 +1898,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             patch.object(mc, "list_gguf_variants", lambda repo, hf_token = None: ([variant], False)),
             patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
             patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
             patch("huggingface_hub.model_info", side_effect = AssertionError("priced as a repo")),
         ):
             charged = self.route._estimate_gguf_required_gb(
@@ -1922,6 +1929,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             patch.object(mc, "list_gguf_variants", lambda repo, hf_token = None: ([variant], False)),
             patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
             patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
             patch("huggingface_hub.model_info", side_effect = AssertionError("priced as a repo")),
         ):
             charged = self.route._estimate_gguf_required_gb(
@@ -1989,6 +1997,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             patch.object(mc, "list_gguf_variants", lambda repo, hf_token = None: ([variant], False)),
             patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
             patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
             patch.object(self.route, "_remote_drafter_repo_bytes", return_value = 6 * 1024**3),
         ):
             charged = self.route._estimate_gguf_required_gb(
@@ -2040,6 +2049,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             ),
             patch.object(self.route, "_remote_drafter_repo_bytes", return_value = 3 * 1024**3),
             patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
             self._dflash_capable(),
         ):
             charged = self.route._estimate_gguf_required_gb(
@@ -2127,6 +2137,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             patch.object(self.route, "_remote_gguf_companion_bytes", return_value = 0),
             patch.object(self.route, "_remote_drafter_repo_bytes", return_value = 8 * 1024**3),
             patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+            patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
         ):
             on_gpu = self.route._estimate_gguf_required_gb(
                 cfg, speculative_type = "auto", llama_extra_args = extras
@@ -2165,6 +2176,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             )
             with (
                 patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+                patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
                 self._dspark_capable(),
             ):
                 charged = self.route._estimate_gguf_required_gb(
@@ -2198,6 +2210,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
             )
             with (
                 patch.object(self.route, "_estimate_gguf_kv_gb", return_value = 0.0),
+                patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
                 self._dspark_capable(),
             ):
                 on_gpu = self.route._estimate_gguf_required_gb(cfg, speculative_type = "auto")
@@ -2394,6 +2407,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
         )
         with (
             patch.object(mc, "list_gguf_variants", lambda repo, hf_token = None: ([variant], False)),
+            patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
             patch(
                 "huggingface_hub.model_info",
                 return_value = SimpleNamespace(siblings = self._MULTI_FAMILY_SIBLINGS),
@@ -2426,6 +2440,7 @@ class TestEstimateGgufRequiredGb(unittest.TestCase):
         siblings = [SimpleNamespace(rfilename = "dflash-kquant.gguf", size = 2 * 1024**3)]
         with (
             patch.object(mc, "list_gguf_variants", lambda repo, hf_token = None: ([variant], False)),
+            patch.object(self.route, "_remote_gguf_compute_reserve_gb", return_value = 0.0),
             patch(
                 "huggingface_hub.model_info",
                 return_value = SimpleNamespace(siblings = siblings),


### PR DESCRIPTION
Backend CI is red on `main`, and has been since #8524.

That PR gave a non-diffusion remote estimate a default ubatch and changed the output-buffer slot count from `n_parallel - 1` to `max(1, n_parallel)`, so every single-slot remote estimate now carries about 0.58 GB of compute reserve. Ten tests in `studio/backend/tests/test_chat_load_during_training.py` patch `_estimate_gguf_kv_gb` to `0.0` and then assert an exact GB total, and they were not updated with it:

```
AssertionError: 4.575732421875 != 4.0 within 6 places (0.5757324218750002 difference)
```

with the same 0.5757 offset at 10, 12 and 14 GB.

The estimator is right and the tests are stale, so the arithmetic is untouched here. The remote compute reserve moves into `_remote_gguf_compute_reserve_gb`, a pure extraction from `_estimate_gguf_required_gb`, and the tests hold it at zero the way they already hold `_estimate_gguf_kv_gb` at zero. Anything pricing something other than the model itself, a drafter for instance, can now do the same.

`studio/backend/tests/test_chat_load_during_training.py`: 118 passed, was 8 failed / 110 passed.
