### PR TITLE
Fix grouped_gemm() crash when gather_indices is omitted

### DIFF
--- a/unsloth/kernels/moe/grouped_gemm/interface.py
+++ b/unsloth/kernels/moe/grouped_gemm/interface.py
@@ -962,7 +962,8 @@ def grouped_gemm(
 
     X = X.view(-1, X.shape[-1])
     m_sizes = m_sizes.view(-1)
-    gather_indices = gather_indices.view(-1)
+    if gather_indices is not None:
+        gather_indices = gather_indices.view(-1)
 
     return GroupedGemm.apply(
         X,

--- a/unsloth/kernels/moe/tests/test_grouped_gemm.py
+++ b/unsloth/kernels/moe/tests/test_grouped_gemm.py
@@ -298,6 +298,55 @@ def test_grouped_gemm_forward_manual(
     )
 
 
+def test_grouped_gemm_gather_indices_optional_when_not_permuted():
+    """Regression for #8627: gather_indices=None must be accepted, not just
+    documented, when permute_x and permute_y are both False, since the kernel
+    never dereferences it on that path."""
+    data_config = DATA_CONFIGS[0]
+    model_config = SMALL_MODEL_CONFIGS[0]
+    topk = model_config.topk
+
+    X1, _, W1, _, gating_output = make_inputs(
+        M = data_config.bs * data_config.seq_len,
+        N = model_config.intermediate_size,
+        K = model_config.hidden_size,
+        E = model_config.num_experts,
+        topk = topk,
+        dtype = data_config.dtype,
+    )
+
+    _, topk_ids = calculate_topk(
+        gating_output,
+        topk,
+        use_sigmoid = model_config.use_sigmoid,
+        renormalize = model_config.renormalize,
+    )
+    topk_ids = topk_ids.view(-1)
+    m_sizes, gather_indices = get_routing_indices(topk_ids, num_experts = model_config.num_experts)
+
+    # permute_x=False expects X already rearranged into expert-grouped order;
+    # gather_indices is only needed here to build that layout, not passed to
+    # grouped_gemm itself.
+    X_test = permute(X1, gather_indices, topk)
+    ref_output = torch_grouped_gemm(X = X_test, W = W1, m_sizes = m_sizes)
+
+    test_output = grouped_gemm(
+        X = X_test,
+        W = W1,
+        topk = topk,
+        m_sizes = m_sizes,
+        gather_indices = None,
+        permute_x = False,
+        permute_y = False,
+        autotune = True,
+    )
+
+    atol, rtol = TOLERANCE[X_test.dtype]
+    assert torch.allclose(
+        ref_output, test_output, atol = atol, rtol = rtol
+    ), f"Grouped gemm forward failed: {(ref_output - test_output).abs().max().item():.6f}"
+
+
 @pytest.mark.parametrize(
     "kernel_config",
     KERNEL_CONFIGS_FWD,


### PR DESCRIPTION
Fixes #8627.

`grouped_gemm()` always called `gather_indices.view(-1)`, even though the docstring and the `permute_x`/`permute_y` check right above it both say it's only required when one of those flags is set. Calling it with the documented default (no `gather_indices`, `permute_x=False`, `permute_y=False`) throws `AttributeError: 'NoneType' object has no attribute 'view'` before the call ever reaches the kernel. `grouped_gemm_forward` already treats `gather_indices` as optional on that path, so the wrapper just needed to match it.

The fix is a one-line guard around the `.view(-1)` call.

Also added a regression test in `test_grouped_gemm.py` that calls `grouped_gemm()` with `gather_indices=None` on the non-permuted path (X pre-permuted to expert-grouped order) and checks the output against the torch reference implementation.

One honest caveat: I don't have a CUDA GPU on hand, and this test suite needs one (same as every other test in that file), so I wasn't able to run it myself. I checked it carefully against the existing test patterns in the same file so it should be correct, but wanted to flag that up front rather than claim something I couldn't verify.