### PR TITLE
Surface an untyped Responses error frame instead of skipping it

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -5513,13 +5513,9 @@ class ExternalProviderClient:
                                 # a Responses request with Chat Completions frames, so skipping
                                 # an unrecognisable frame beats failing the whole completion.
                                 # The ChatGPT path stays strict, where the shape is guaranteed.
-                                #
-                                # An error payload is the exception. The bare
-                                # {"error": {...}} an OpenAI-compatible proxy emits mid-stream
-                                # carries no type and no event name either, so skipping it
-                                # returned a blank answer and no error at all: the whole
-                                # generation ended with zero chunks and nothing to explain it.
-                                # Raising was at least loud; this says what happened.
+                                # An error payload is the exception: the bare {"error": ...} an
+                                # OpenAI-compatible proxy emits has no type and no event name
+                                # either, so skipping it returned zero chunks and no error.
                                 if isinstance(event, dict) and isinstance(
                                     event.get("error"), (dict, str)
                                 ):

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -5513,6 +5513,20 @@ class ExternalProviderClient:
                                 # a Responses request with Chat Completions frames, so skipping
                                 # an unrecognisable frame beats failing the whole completion.
                                 # The ChatGPT path stays strict, where the shape is guaranteed.
+                                #
+                                # An error payload is the exception. The bare
+                                # {"error": {...}} an OpenAI-compatible proxy emits mid-stream
+                                # carries no type and no event name either, so skipping it
+                                # returned a blank answer and no error at all: the whole
+                                # generation ended with zero chunks and nothing to explain it.
+                                # Raising was at least loud; this says what happened.
+                                if isinstance(event.get("error"), (dict, str)):
+                                    yield _error_sse_line(
+                                        502,
+                                        _openai_response_error_message(event),
+                                        self.provider_type,
+                                    )
+                                    break
                                 continue
                             _record_openai_response_id(event)
 

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -5520,7 +5520,9 @@ class ExternalProviderClient:
                                 # returned a blank answer and no error at all: the whole
                                 # generation ended with zero chunks and nothing to explain it.
                                 # Raising was at least loud; this says what happened.
-                                if isinstance(event.get("error"), (dict, str)):
+                                if isinstance(event, dict) and isinstance(
+                                    event.get("error"), (dict, str)
+                                ):
                                     yield _error_sse_line(
                                         502,
                                         _openai_response_error_message(event),

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -716,14 +716,10 @@ def test_an_untyped_error_frame_is_surfaced_rather_than_skipped(monkeypatch):
     ``{"error": {...}}`` with no ``type`` and no SSE event name either. Skipping that ended
     the generation with zero chunks and nothing to explain it: a blank answer where the
     endpoint had said "rate limited". Before the skip existed this at least raised."""
-    body = (
-        b'data: {"error":{"message":"you are rate limited","type":"rate_limit_error"}}\n\n'
-    )
+    body = b'data: {"error":{"message":"you are rate limited","type":"rate_limit_error"}}\n\n'
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200, content = body, headers = {"content-type": "text/event-stream"}
-        )
+        return httpx.Response(200, content = body, headers = {"content-type": "text/event-stream"})
 
     _mock_http_client(monkeypatch, handler)
 
@@ -755,9 +751,7 @@ def test_a_chat_completions_frame_on_the_responses_path_is_still_skipped(monkeyp
     )
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200, content = body, headers = {"content-type": "text/event-stream"}
-        )
+        return httpx.Response(200, content = body, headers = {"content-type": "text/event-stream"})
 
     _mock_http_client(monkeypatch, handler)
 

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -711,11 +711,8 @@ def test_an_sse_event_name_does_not_carry_past_its_blank_line(monkeypatch):
 
 
 def test_an_untyped_error_frame_is_surfaced_rather_than_skipped(monkeypatch):
-    """Skipping a frame we cannot type is right for a Chat Completions chunk arriving on
-    the Responses path, but an OpenAI-compatible proxy emits its errors as a bare
-    ``{"error": {...}}`` with no ``type`` and no SSE event name either. Skipping that ended
-    the generation with zero chunks and nothing to explain it: a blank answer where the
-    endpoint had said "rate limited". Before the skip existed this at least raised."""
+    """An OpenAI-compatible proxy emits its errors as a bare ``{"error": {...}}`` with no
+    ``type`` and no SSE event name, so skipping it returned zero chunks and no error."""
     body = b'data: {"error":{"message":"you are rate limited","type":"rate_limit_error"}}\n\n'
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -775,9 +772,8 @@ def test_a_chat_completions_frame_on_the_responses_path_is_still_skipped(monkeyp
 
 @pytest.mark.parametrize("payload", [b"null", b"[]", b'"text"', b"7"])
 def test_a_valid_but_non_object_frame_is_skipped_not_fatal(monkeypatch, payload):
-    """`data: null` is valid JSON and not a dict. response_event_type rejects it, and the
-    error check that follows must not then call .get() on it: that raised AttributeError
-    and killed the stream, where the whole point of the skip is that it does not."""
+    """`data: null` and `data: []` are valid JSON but not dicts, so the error check must
+    not call .get() on them: that raised AttributeError and killed the stream."""
     body = (
         b"data: "
         + payload

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -708,3 +708,72 @@ def test_an_sse_event_name_does_not_carry_past_its_blank_line(monkeypatch):
     lines = _drive(run())
     assert not [line for line in lines if '"provider_error"' in line], lines
     assert len(_usage_chunks(lines)) == 1, lines
+
+
+def test_an_untyped_error_frame_is_surfaced_rather_than_skipped(monkeypatch):
+    """Skipping a frame we cannot type is right for a Chat Completions chunk arriving on
+    the Responses path, but an OpenAI-compatible proxy emits its errors as a bare
+    ``{"error": {...}}`` with no ``type`` and no SSE event name either. Skipping that ended
+    the generation with zero chunks and nothing to explain it: a blank answer where the
+    endpoint had said "rate limited". Before the skip existed this at least raised."""
+    body = (
+        b'data: {"error":{"message":"you are rate limited","type":"rate_limit_error"}}\n\n'
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content = body, headers = {"content-type": "text/event-stream"}
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = ExternalProviderClient(
+            provider_type = "openai",
+            base_url = "https://api.openai.com/v1",
+            api_key = "sk-openai-test",
+        )
+        out = await _collect(
+            client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}], model = "gpt-5"
+            )
+        )
+        await client.close()
+        return out
+
+    chunks = _drive(run())
+    assert chunks, "the error frame was swallowed and the answer came back empty"
+    assert any("rate limited" in str(chunk) for chunk in chunks), chunks
+
+
+def test_a_chat_completions_frame_on_the_responses_path_is_still_skipped(monkeypatch):
+    """The case the skip exists for stays skipped: no type, no event name, no error key."""
+    body = (
+        b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+        b"event: response.completed\n"
+        b'data: {"type":"response.completed"}\n\n'
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content = body, headers = {"content-type": "text/event-stream"}
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = ExternalProviderClient(
+            provider_type = "openai",
+            base_url = "https://api.openai.com/v1",
+            api_key = "sk-openai-test",
+        )
+        out = await _collect(
+            client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}], model = "gpt-5"
+            )
+        )
+        await client.close()
+        return out
+
+    chunks = _drive(run())
+    assert not any("502" in str(chunk) for chunk in chunks), chunks

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -771,3 +771,35 @@ def test_a_chat_completions_frame_on_the_responses_path_is_still_skipped(monkeyp
 
     chunks = _drive(run())
     assert not any("502" in str(chunk) for chunk in chunks), chunks
+
+
+@pytest.mark.parametrize("payload", [b"null", b"[]", b'"text"', b"7"])
+def test_a_valid_but_non_object_frame_is_skipped_not_fatal(monkeypatch, payload):
+    """`data: null` is valid JSON and not a dict. response_event_type rejects it, and the
+    error check that follows must not then call .get() on it: that raised AttributeError
+    and killed the stream, where the whole point of the skip is that it does not."""
+    body = b"data: " + payload + b"\n\nevent: response.completed\ndata: {\"type\":\"response.completed\"}\n\n"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content = body, headers = {"content-type": "text/event-stream"}
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = ExternalProviderClient(
+            provider_type = "openai",
+            base_url = "https://api.openai.com/v1",
+            api_key = "sk-openai-test",
+        )
+        out = await _collect(
+            client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}], model = "gpt-5"
+            )
+        )
+        await client.close()
+        return out
+
+    chunks = _drive(run())
+    assert not any("502" in str(chunk) for chunk in chunks), chunks

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -778,12 +778,14 @@ def test_a_valid_but_non_object_frame_is_skipped_not_fatal(monkeypatch, payload)
     """`data: null` is valid JSON and not a dict. response_event_type rejects it, and the
     error check that follows must not then call .get() on it: that raised AttributeError
     and killed the stream, where the whole point of the skip is that it does not."""
-    body = b"data: " + payload + b"\n\nevent: response.completed\ndata: {\"type\":\"response.completed\"}\n\n"
+    body = (
+        b"data: "
+        + payload
+        + b'\n\nevent: response.completed\ndata: {"type":"response.completed"}\n\n'
+    )
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200, content = body, headers = {"content-type": "text/event-stream"}
-        )
+        return httpx.Response(200, content = body, headers = {"content-type": "text/event-stream"})
 
     _mock_http_client(monkeypatch, handler)
 


### PR DESCRIPTION
Follow-up to #8608, found by re-checking that fix rather than assuming it.

#8608 made the Responses reader skip a frame it cannot type. That is right for the case it was written for: an OpenAI-compatible endpoint behind a Responses base URL answering with Chat Completions chunks. An error payload is the exception.

The bare `{"error": {...}}` such a proxy emits mid-stream carries no `type` and no SSE `event:` name either, so it took the same path. Measured on `main`:

```
CHUNKS: 0
MENTIONS RATE LIMIT: False
```

The generation ends with zero chunks and nothing to explain it, so the user sees a blank answer where the endpoint had said "rate limited". Before the skip existed the same frame raised `ValueError: Responses event type is missing`, which was at least loud.

This surfaces it through the same `_error_sse_line` the typed `response.failed` and `error` events already use. A frame with no type, no event name and no error key is still skipped, which is the case #8608 exists for.

Two tests, both of which fail without the change in the direction they pin: the error frame is surfaced, and a Chat Completions frame on the Responses path is still skipped without a 502.
