### PR TITLE
Studio: square off the MiniMax H3 mode dialog

### DIFF
--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -2899,7 +2899,9 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
           if (!open) cancelH3TaskChoice();
         }}
       >
-        <DialogContent className="max-w-lg">
+        {/* Squarer than the shared dialog's rounded-4xl: at this width the default reads as a
+            lozenge rather than a panel. The option cards step down from it so the nesting holds. */}
+        <DialogContent className="max-w-lg rounded-2xl">
           <DialogHeader>
             <DialogTitle>Choose how MiniMax H3 should generate</DialogTitle>
             <DialogDescription>
@@ -2911,7 +2913,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
             <Button
               type="button"
               variant="outline"
-              className="h-auto items-start justify-start whitespace-normal p-4 text-left"
+              className="h-auto items-start justify-start whitespace-normal rounded-xl p-4 text-left"
               onClick={() => chooseH3Task("fl2va")}
             >
               <span className="grid gap-1">
@@ -2924,7 +2926,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
             <Button
               type="button"
               variant="outline"
-              className="h-auto items-start justify-start whitespace-normal p-4 text-left"
+              className="h-auto items-start justify-start whitespace-normal rounded-xl p-4 text-left"
               onClick={() => chooseH3Task("ref2va")}
             >
               <span className="grid gap-1">


### PR DESCRIPTION
The dialog that asks which MiniMax H3 denoiser to load inherits `rounded-4xl` from the shared `DialogContent`, and its two option cards inherit `rounded-full` from the button base. At this width that reads as a lozenge rather than a panel, and the cards read as pills rather than choices.

Both are overridden locally rather than changed in the shared components, since every other dialog and button in the app is fine as it is. The panel drops to `rounded-2xl` and the cards to `rounded-xl`, so the cards still step down from the panel and the nesting holds.

Three lines, no behaviour change.

### Verification

`npm run typecheck` and a production build pass. Not checked in a running browser.