### PR TITLE
tests: pin the remote GGUF compute reserve

### DIFF
--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1154,6 +1154,54 @@ class TestValidateRefusesDuringTraining(unittest.TestCase):
 # ── _estimate_gguf_required_gb (sizes the same weights the loader loads) ──────
 
 
+class TestRemoteGgufComputeReserve(unittest.TestCase):
+    """The compute reserve a remote GGUF estimate carries.
+
+    Every caller of it in this file patches it to zero so an exact GB total can be asserted, the
+    way they already hold _estimate_gguf_kv_gb at zero, which leaves the arithmetic itself with
+    nothing asserting it -- and it decides whether a load is refused. These pin the shape rather
+    than the magnitude, so retuning a safety factor does not break them but dropping a term does.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.route = _load_inference_route()
+
+    def _reserve(self, **kwargs):
+        return self.route._remote_gguf_compute_reserve_gb(max_seq_length = 4096, **kwargs)
+
+    def test_a_single_slot_still_reserves_an_output_buffer(self):
+        """llama-server allocates an output buffer for the one slot it runs, so a single-slot
+        estimate that reserves nothing for it under-reserves. The count was max(0, n_parallel - 1),
+        which is zero exactly there.
+
+        The total is spelled out rather than compared against a neighbouring call: the reserve is
+        linear in the slot count, so any two samples are one buffer apart under BOTH the old
+        formula and the new one, and only an absolute anchor can see the floor. The mask half is
+        the anchor; the constants come from the module, so retuning a safety factor moves this
+        test with the code while dropping a term still fails it.
+        """
+        from core.inference.llama_cpp import LlamaCppBackend
+
+        ubatch = LlamaCppBackend._DEFAULT_N_UBATCH
+        mask = 4096 * ubatch * 2 * LlamaCppBackend._CTX_COMPUTE_F16_MASK_SAFETY
+        per_slot = (
+            self.route._ASSUMED_MAX_VOCAB * ubatch * 4 * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
+        )
+        self.assertAlmostEqual(
+            self._reserve(n_parallel = 1), (mask + per_slot) / (1024**3), places = 6
+        )
+        # And one more buffer for a second slot, which pins the count as well as the floor.
+        self.assertAlmostEqual(
+            self._reserve(n_parallel = 2), (mask + 2 * per_slot) / (1024**3), places = 6
+        )
+
+    def test_diffusion_reserves_nothing(self):
+        """The default micro-batch is a llama-server notion. A diffusion estimate has no ubatch to
+        assume, and charging one would refuse loads that fit."""
+        self.assertEqual(self._reserve(n_parallel = 1, is_diffusion = True), 0.0)
+
+
 class TestEstimateGgufRequiredGb(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1184,8 +1184,7 @@ class TestRemoteGgufComputeReserve(unittest.TestCase):
 
         The total is spelled out absolutely rather than compared against a neighbouring call: the
         reserve is linear in slot count, so any two samples are one buffer apart under both the
-        old formula and the new one, and only an absolute anchor sees the floor. Constants come
-        from the module, so retuning a safety factor moves this test with the code.
+        old formula and the new one, and only an absolute anchor sees the floor.
         """
         from core.inference.llama_cpp import LlamaCppBackend
 

--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1157,10 +1157,9 @@ class TestValidateRefusesDuringTraining(unittest.TestCase):
 class TestRemoteGgufComputeReserve(unittest.TestCase):
     """The compute reserve a remote GGUF estimate carries.
 
-    Every caller of it in this file patches it to zero so an exact GB total can be asserted, the
-    way they already hold _estimate_gguf_kv_gb at zero, which leaves the arithmetic itself with
-    nothing asserting it -- and it decides whether a load is refused. These pin the shape rather
-    than the magnitude, so retuning a safety factor does not break them but dropping a term does.
+    Every other caller here patches it to zero to assert exact GB totals, so its arithmetic goes
+    unasserted even though it decides whether a load is refused. These pin the shape, not the
+    magnitude: retuning a safety factor keeps them passing, dropping a term does not.
     """
 
     @classmethod
@@ -1168,10 +1167,8 @@ class TestRemoteGgufComputeReserve(unittest.TestCase):
         cls.route = _load_inference_route()
 
     def _reserve(self, **kwargs):
-        # The effective micro-batch comes from _extra_args_n_ubatch, which reads LLAMA_ARG_BATCH /
-        # LLAMA_ARG_UBATCH off os.environ. A host that exports either would move it away from
-        # _DEFAULT_N_UBATCH and fail these assertions for a reason that has nothing to do with the
-        # slot count under test, so drop them for the call.
+        # Drop LLAMA_ARG_BATCH / LLAMA_ARG_UBATCH: a host exporting either moves the effective
+        # micro-batch off _DEFAULT_N_UBATCH and fails these for reasons unrelated to slot count.
         import os
         env = {
             key: value
@@ -1182,15 +1179,13 @@ class TestRemoteGgufComputeReserve(unittest.TestCase):
             return self.route._remote_gguf_compute_reserve_gb(max_seq_length = 4096, **kwargs)
 
     def test_a_single_slot_still_reserves_an_output_buffer(self):
-        """llama-server allocates an output buffer for the one slot it runs, so a single-slot
-        estimate that reserves nothing for it under-reserves. The count was max(0, n_parallel - 1),
-        which is zero exactly there.
+        """llama-server allocates an output buffer for its one slot, but the old
+        max(0, n_parallel - 1) count reserved nothing there.
 
-        The total is spelled out rather than compared against a neighbouring call: the reserve is
-        linear in the slot count, so any two samples are one buffer apart under BOTH the old
-        formula and the new one, and only an absolute anchor can see the floor. The mask half is
-        the anchor; the constants come from the module, so retuning a safety factor moves this
-        test with the code while dropping a term still fails it.
+        The total is spelled out absolutely rather than compared against a neighbouring call: the
+        reserve is linear in slot count, so any two samples are one buffer apart under both the
+        old formula and the new one, and only an absolute anchor sees the floor. Constants come
+        from the module, so retuning a safety factor moves this test with the code.
         """
         from core.inference.llama_cpp import LlamaCppBackend
 
@@ -1199,14 +1194,16 @@ class TestRemoteGgufComputeReserve(unittest.TestCase):
         per_slot = (
             self.route._ASSUMED_MAX_VOCAB * ubatch * 4 * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
         )
-        self.assertAlmostEqual(self._reserve(n_parallel = 1), (mask + per_slot) / (1024**3), places = 6)
-        # And one more buffer for a second slot, which pins the count as well as the floor.
+        self.assertAlmostEqual(
+            self._reserve(n_parallel = 1), (mask + per_slot) / (1024**3), places = 6
+        )
+        # One more buffer for a second slot, pinning the count as well as the floor.
         self.assertAlmostEqual(
             self._reserve(n_parallel = 2), (mask + 2 * per_slot) / (1024**3), places = 6
         )
 
     def test_diffusion_reserves_nothing(self):
-        """The default micro-batch is a llama-server notion. A diffusion estimate has no ubatch to
+        """The default micro-batch is a llama-server notion: a diffusion estimate has no ubatch to
         assume, and charging one would refuse loads that fit."""
         self.assertEqual(self._reserve(n_parallel = 1, is_diffusion = True), 0.0)
 

--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1168,7 +1168,19 @@ class TestRemoteGgufComputeReserve(unittest.TestCase):
         cls.route = _load_inference_route()
 
     def _reserve(self, **kwargs):
-        return self.route._remote_gguf_compute_reserve_gb(max_seq_length = 4096, **kwargs)
+        # The effective micro-batch comes from _extra_args_n_ubatch, which reads LLAMA_ARG_BATCH /
+        # LLAMA_ARG_UBATCH off os.environ. A host that exports either would move it away from
+        # _DEFAULT_N_UBATCH and fail these assertions for a reason that has nothing to do with the
+        # slot count under test, so drop them for the call.
+        import os
+
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("LLAMA_ARG_BATCH", "LLAMA_ARG_UBATCH")
+        }
+        with patch.dict(os.environ, env, clear = True):
+            return self.route._remote_gguf_compute_reserve_gb(max_seq_length = 4096, **kwargs)
 
     def test_a_single_slot_still_reserves_an_output_buffer(self):
         """llama-server allocates an output buffer for the one slot it runs, so a single-slot

--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1173,7 +1173,6 @@ class TestRemoteGgufComputeReserve(unittest.TestCase):
         # _DEFAULT_N_UBATCH and fail these assertions for a reason that has nothing to do with the
         # slot count under test, so drop them for the call.
         import os
-
         env = {
             key: value
             for key, value in os.environ.items()

--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1188,9 +1188,7 @@ class TestRemoteGgufComputeReserve(unittest.TestCase):
         per_slot = (
             self.route._ASSUMED_MAX_VOCAB * ubatch * 4 * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
         )
-        self.assertAlmostEqual(
-            self._reserve(n_parallel = 1), (mask + per_slot) / (1024**3), places = 6
-        )
+        self.assertAlmostEqual(self._reserve(n_parallel = 1), (mask + per_slot) / (1024**3), places = 6)
         # And one more buffer for a second slot, which pins the count as well as the floor.
         self.assertAlmostEqual(
             self._reserve(n_parallel = 2), (mask + 2 * per_slot) / (1024**3), places = 6

--- a/studio/backend/tests/test_chat_load_during_training.py
+++ b/studio/backend/tests/test_chat_load_during_training.py
@@ -1194,9 +1194,7 @@ class TestRemoteGgufComputeReserve(unittest.TestCase):
         per_slot = (
             self.route._ASSUMED_MAX_VOCAB * ubatch * 4 * LlamaCppBackend._COMPUTE_BUFFER_SAFETY
         )
-        self.assertAlmostEqual(
-            self._reserve(n_parallel = 1), (mask + per_slot) / (1024**3), places = 6
-        )
+        self.assertAlmostEqual(self._reserve(n_parallel = 1), (mask + per_slot) / (1024**3), places = 6)
         # One more buffer for a second slot, pinning the count as well as the floor.
         self.assertAlmostEqual(
             self._reserve(n_parallel = 2), (mask + 2 * per_slot) / (1024**3), places = 6


### PR DESCRIPTION
## Summary

`_remote_gguf_compute_reserve_gb` decides how much headroom a remote GGUF estimate reserves, and therefore whether a load is refused. Nothing asserts it.

All fifteen references to it in `test_chat_load_during_training.py` are `patch(..., return_value = 0.0)`, and grepping the suite for the constants it is built from (`_ASSUMED_MAX_VOCAB`, `out_buffer`, `output_slots`) returns nothing.

## How it got that way

#8524 changed the output-buffer slot count from `max(0, n_parallel - 1)` to `max(1, n_parallel)` and gave a non-diffusion remote estimate a default micro-batch. That is correct: llama-server allocates an output buffer for the one slot it runs, and the old count reserved nothing for it. Ten tests caught the change only as an unexplained `4.575732421875 != 4.0` and were red on main until #8641.

#8641 resolved that by extracting the term so those tests can hold it at zero, the way they already hold `_estimate_gguf_kv_gb` at zero. That is the right call for them, and it is why this PR adds coverage rather than changing anything.

## Changes

Two cases in a new `TestRemoteGgufComputeReserve`, pinning shape rather than magnitude:

- **The single-slot floor.** The total is spelled out rather than compared against a neighbouring call, because the reserve is linear in the slot count: any two samples are one buffer apart under the old formula and the new one alike, so only an absolute anchor sees the floor. Verified by reverting `_out_slots` to `max(0, n_parallel - 1)`, where this test fails and the difference-based version I wrote first still passed.
- **Diffusion reserves nothing**, since the default micro-batch is a llama-server notion and charging one would refuse loads that fit.

Constants come from the module, so retuning a safety factor moves the test with the code while dropping a term still fails it.

## Validation

`tests/test_chat_load_during_training.py`: 120 passed. Ruff clean. No production code touched.
