### PR TITLE
Stop the APU unified-memory tests inheriting the shell's GPU mask

### DIFF
--- a/studio/backend/tests/test_amd_apu_unified_memory.py
+++ b/studio/backend/tests/test_amd_apu_unified_memory.py
@@ -13,6 +13,19 @@ import pytest
 
 from core.inference.llama_cpp import LlamaCppBackend
 
+_VISIBLE_DEVICE_MASKS = ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
+
+
+@pytest.fixture(autouse = True)
+def _no_inherited_gpu_mask(monkeypatch):
+    """These tests fake a torch host and then ask about GPU ordinal 0. A mask
+    inherited from the shell remaps that ordinal onto a physical id the fake
+    host does not have, so the answer flips to False and nine tests fail. CI
+    runners carry no mask, so it only ever bites locally. The tests that are
+    about a mask still set their own, after this."""
+    for _m in _VISIBLE_DEVICE_MASKS:
+        monkeypatch.delenv(_m, raising = False)
+
 
 def _fake_torch(
     hip,


### PR DESCRIPTION
`studio/backend/tests/test_amd_apu_unified_memory.py` fakes a torch host and then asks `_amd_apu_wants_unified_memory` about GPU ordinal 0. That helper resolves an ordinal to a physical id through `HIP_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES`, which is the correct behaviour and is covered by `test_apu_guard_honors_hip_visible_devices_mask`.

The problem is the test file, not the helper. If a mask is already set in the shell, ordinal 0 resolves onto a physical id the fake host does not have, the answer flips to `False`, and nine tests fail:

```
TestTheGateStillFailsOpen::test_a_good_one_still_works
TestAmdSdkWheelsCountAsRocm::test_the_arch_map_matches_the_id_resolver  (3 cases)
TestRadeonWheelsWithoutAnArchName::test_the_probe_uses_every_fallback   (5 cases)
```

CI runners set no mask, so this never shows up in Actions. It only bites on a dev box with a GPU selected, where it looks like a real AMD regression.

Three tests in the file already clear the masks by hand. This promotes that to an autouse fixture so the whole file gets it. The tests that are about a mask still set their own afterwards, so they keep discriminating.

### Verification

| run | before | after |
| --- | --- | --- |
| `CUDA_VISIBLE_DEVICES=6 pytest tests/test_amd_apu_unified_memory.py` | 9 failed, 42 passed | 51 passed |
| `CUDA_VISIBLE_DEVICES=0,1` | 9 failed, 42 passed | 51 passed |
| no mask set | 51 passed | 51 passed |

The whole backend suite was also run twice, once with a mask and once without (23149 tests collected, minus `test_mcp_server.py` and `test_rag_ocr_fallback.py` which need `fastmcp` and `pymupdf`). Both runs now produce an identical failure set, 239 either way, so no other backend test file leaks the host mask.

No production code changes.
