### PR TITLE
Keep the drafterless retry intact when the arch gate narrows the argv

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2915,6 +2915,27 @@ def _without_subsequence(tokens: List[str], run: List[str]) -> List[str]:
     return list(tokens)
 
 
+def _subsequence_index(tokens: List[str], run: List[str], hint: int) -> int:
+    """Where ``run`` sits in ``tokens``, given it was appended at ``hint``.
+
+    A stored index goes stale the moment anything narrows the argv ahead of it,
+    and the arch gate does exactly that (dropping ``--split-mode`` /
+    ``--tensor-split``), so the block can only ever move LEFT. Search back from
+    the hint, then forward, so a future narrowing site cannot silently shift the
+    slice and take neighbouring tokens with it.
+    """
+    span = len(tokens) - len(run)
+    if not run or span < 0:
+        return max(0, min(hint, len(tokens)))
+    for i in range(min(hint, span), -1, -1):
+        if tokens[i : i + len(run)] == run:
+            return i
+    for i in range(min(hint, span) + 1, span + 1):
+        if tokens[i : i + len(run)] == run:
+            return i
+    return max(0, min(hint, len(tokens)))
+
+
 _CPU_DEVICE_VALUES = frozenset({"cpu", "none"})
 
 
@@ -14783,7 +14804,11 @@ class LlamaCppBackend:
                         _retry_reason,
                     )
                     self._kill_process()
-                    _fb_tail = cmd[_spec_start + len(spec_flags) :]
+                    # Re-locate rather than trust _spec_start: the arch gate may have
+                    # narrowed cmd since, which slides the block left and would
+                    # otherwise slice --api-key and friends out of the tail.
+                    _spec_at = _subsequence_index(cmd, spec_flags, _spec_start)
+                    _fb_tail = cmd[_spec_at + len(spec_flags) :]
                     _fb_stripped_extras: Optional[List[str]] = None
                     # Appending --spec-default cannot clear MTP the extras or the env
                     # carry: types accumulate, so it would retry the mode that just
@@ -14813,7 +14838,7 @@ class LlamaCppBackend:
                             strip_template = False,
                             strip_split_mode = False,
                         )
-                    fallback_cmd = cmd[:_spec_start] + ["--spec-default"] + _fb_tail
+                    fallback_cmd = cmd[:_spec_at] + ["--spec-default"] + _fb_tail
                     healthy = _spawn_and_wait(fallback_cmd, label = "-retry")
                     if healthy:
                         self._speculative_type = "default"

--- a/studio/backend/tests/test_metal_paravirtual_guard.py
+++ b/studio/backend/tests/test_metal_paravirtual_guard.py
@@ -1227,9 +1227,7 @@ def test_the_startup_retry_drops_the_mtp_the_extras_and_the_env_carry():
     that loads fine without it. It strips the spec group, and takes the child env with
     it."""
     src = _load_model_source()
-    retry = src[
-        src.index("_fb_tail = cmd[_spec_start") : src.index("fallback_cmd = cmd[:_spec_start]")
-    ]
+    retry = src[src.index("_fb_tail = cmd[_spec_at") : src.index("fallback_cmd = cmd[:_spec_at]")]
     # Whitespace-insensitive: the guard wraps across lines once both drafters are named.
     compact = "".join(retry.split())
     assert "_extra_args_requests_mtp(extra_args,env=_launch_spec_env)" in compact

--- a/studio/backend/tests/test_spec_start_after_arch_narrowing.py
+++ b/studio/backend/tests/test_spec_start_after_arch_narrowing.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""The drafterless retry must survive the arch gate narrowing the argv (#7670).
+
+`_spec_start` is captured as a positional index just before the speculative
+flags are appended. The arch gate added in #7670 rebinds `cmd` with tokens
+REMOVED from the prefix (`--split-mode` / `--tensor-split`), which slides the
+spec block left and leaves the stored index pointing past it.
+
+Before the fix the fallback then kept `spec_flags[:N]`, re-running the drafter
+that had just failed, and sliced N tokens out of the middle of the tail. With
+the four-token narrowing that included `--api-key`, so the retry would have
+launched llama-server unauthenticated. There is no AMD hardware on any runner,
+so this drives the real helpers over a fabricated argv.
+"""
+
+from core.inference.llama_cpp import _subsequence_index, LlamaCppBackend
+
+_SPEC_FLAGS = ["--spec-type", "mtp", "--draft-max", "16"]
+
+_CMD = [
+    "llama-server",
+    "-m",
+    "model.gguf",
+    "--gpu-layers",
+    "99",
+    "--fit",
+    "off",
+    "--tensor-split",
+    "3,1",
+    "--split-mode",
+    "tensor",
+    *_SPEC_FLAGS,
+    "--chat-template-file",
+    "t.jinja",
+    "--api-key",
+    "SECRET",
+    "--cache-ram",
+    "0",
+]
+_HINT = _CMD.index("--spec-type")
+
+
+def _fallback(cmd, hint = _HINT):
+    """The shipped reconstruction, verbatim, so a drift here fails loudly."""
+    at = _subsequence_index(cmd, _SPEC_FLAGS, hint)
+    return cmd[:at] + ["--spec-default"] + cmd[at + len(_SPEC_FLAGS) :]
+
+
+def _narrowed(*flags):
+    return LlamaCppBackend._without_flags(_CMD, flags)
+
+
+def test_the_hint_still_works_when_nothing_narrowed():
+    assert _fallback(_CMD) == [
+        "llama-server",
+        "-m",
+        "model.gguf",
+        "--gpu-layers",
+        "99",
+        "--fit",
+        "off",
+        "--tensor-split",
+        "3,1",
+        "--split-mode",
+        "tensor",
+        "--spec-default",
+        "--chat-template-file",
+        "t.jinja",
+        "--api-key",
+        "SECRET",
+        "--cache-ram",
+        "0",
+    ]
+
+
+def test_the_api_key_survives_the_four_token_narrowing():
+    """The forced-CPU arm drops 4 tokens. A stale index ate --api-key SECRET,
+    so the retry would have served an unauthenticated llama-server."""
+    fb = _fallback(_narrowed("--split-mode", "-sm", "--tensor-split", "-ts"))
+    assert fb[fb.index("--api-key") + 1] == "SECRET"
+    assert "--chat-template-file" in fb and "t.jinja" in fb
+
+
+def test_the_failed_drafter_is_not_re_run_after_narrowing():
+    """llama.cpp accumulates spec types, so a surviving --spec-type would retry
+    the very mode that just failed and --spec-default could not undo it."""
+    for flags in (
+        ("--tensor-split", "-ts"),
+        ("--split-mode", "-sm"),
+        ("--split-mode", "-sm", "--tensor-split", "-ts"),
+    ):
+        fb = _fallback(_narrowed(*flags))
+        assert "--spec-type" not in fb, flags
+        assert "--draft-max" not in fb, flags
+        assert fb.count("--spec-default") == 1, flags
+
+
+def test_no_token_is_lost_by_any_narrowing():
+    for flags in (
+        ("--tensor-split", "-ts"),
+        ("--split-mode", "-sm"),
+        ("--split-mode", "-sm", "--tensor-split", "-ts"),
+    ):
+        narrowed = _narrowed(*flags)
+        fb = _fallback(narrowed)
+        expected = [t for t in narrowed if t not in _SPEC_FLAGS or t in ("16",)]
+        # Everything except the spec block itself must still be present, in order.
+        kept = [t for t in narrowed if t not in _SPEC_FLAGS]
+        assert [t for t in fb if t != "--spec-default"] == kept, flags
+        assert len(expected) >= len(kept)
+
+
+def test_the_block_is_found_even_if_it_moved_right():
+    """Defensive: the hint is a hint. A future site that INSERTS ahead of the
+    block must not corrupt the slice either."""
+    padded = ["--threads", "8", *_CMD]
+    fb = _fallback(padded)
+    assert "--spec-type" not in fb
+    assert fb[fb.index("--api-key") + 1] == "SECRET"
+
+
+def test_an_absent_block_does_not_raise():
+    stripped = [t for t in _CMD if t not in _SPEC_FLAGS]
+    at = _subsequence_index(stripped, _SPEC_FLAGS, _HINT)
+    assert 0 <= at <= len(stripped)

--- a/studio/backend/tests/test_spec_start_after_arch_narrowing.py
+++ b/studio/backend/tests/test_spec_start_after_arch_narrowing.py
@@ -104,11 +104,9 @@ def test_no_token_is_lost_by_any_narrowing():
     ):
         narrowed = _narrowed(*flags)
         fb = _fallback(narrowed)
-        expected = [t for t in narrowed if t not in _SPEC_FLAGS or t in ("16",)]
         # Everything except the spec block itself must still be present, in order.
         kept = [t for t in narrowed if t not in _SPEC_FLAGS]
         assert [t for t in fb if t != "--spec-default"] == kept, flags
-        assert len(expected) >= len(kept)
 
 
 def test_the_block_is_found_even_if_it_moved_right():
@@ -116,7 +114,10 @@ def test_the_block_is_found_even_if_it_moved_right():
     block must not corrupt the slice either."""
     padded = ["--threads", "8", *_CMD]
     fb = _fallback(padded)
-    assert "--spec-type" not in fb
+    # The whole block goes and nothing else does: asserting only that --spec-type
+    # left would pass on a slice cut two tokens early, which eats --split-mode.
+    assert [t for t in fb if t != "--spec-default"] == [t for t in padded if t not in _SPEC_FLAGS]
+    assert fb.count("--spec-default") == 1
     assert fb[fb.index("--api-key") + 1] == "SECRET"
 
 


### PR DESCRIPTION
## Summary

`_spec_start` is a positional index into `cmd`, captured immediately before the speculative flags are appended. #7670 (merged as `5a3e9fc7a`) added five rebinds that remove tokens from the prefix ahead of it, so the stored index now points past the block it is supposed to mark.

Its two consumers slice on that index:

```python
_fb_tail = cmd[_spec_start + len(spec_flags) :]
fallback_cmd = cmd[:_spec_start] + ["--spec-default"] + _fb_tail
```

With N tokens removed below the index, the drafterless retry keeps `spec_flags[:N]` and loses N tokens out of the middle of the tail.

## Why this could not happen before #7670

The only rebind in that window was `cmd = _fa_cmd`, and `_with_flash_attn_off` is length-preserving by design. The file states the invariant twice, at `_with_flash_attn_off` ("every form is flipped in place (length preserved for downstream slices)") and again at its helper ("rewritten in place so the list length is preserved for downstream slices"). Everything else in the window is `cmd.extend`, which appends and cannot shift an index below `_spec_start`. #7670 is the first code to remove tokens from the prefix.

## Impact

Two things go wrong, and the second is the reason this is not just a correctness bug.

**The retry re-runs the drafter that just failed.** `spec_flags` begins with `--spec-type mtp` or `--model-draft <path>`, so a surviving prefix of it means the fallback carries the mode that just failed. llama.cpp accumulates spec types, so appending `--spec-default` cannot undo it. The code's own comment at the fallback site says exactly this must not happen.

**Tokens are cut out of the middle of the tail.** In the four-token narrowing, the deleted run is:

```
['--chat-template-file', 't.jinja', '--api-key', 'SECRET']
```

`--api-key` lands in the tail, so the fallback would start llama-server with no key at all.

Observed against `main` at `5a3e9fc7a`, driving the real `_without_flags` and the verbatim slice arithmetic:

```
fallback_cmd = [... '--spec-type','mtp','--draft-max','16','--spec-default','--cache-ram','0', ...]
retains the failed spec mode: True
tail tokens silently deleted: ['--chat-template-file','t.jinja','--api-key','SECRET']
```

## Reachability

Manual mode, multi-GPU ROCm host, a mixed-arch gate that narrows, a user ratio `--tensor-split 3,1`, and an MTP drafter requested. The survivors arm drops 2 tokens, and any later drafter-load failure builds the corrupted argv. The auto path via the arch-crash retry is equally reachable: `--split-mode tensor` / `--tensor-split` are emitted outside the manual block, so they reach argv in auto mode too. Note the comment near the retry ("No ratio can be live where this runs") is about the `_tensor_split` attribute, while `_without_tensor_split` scans argv, so it does not protect this.

## The fix

Re-locate the block rather than trust the index. `_subsequence_index` searches back from the hint first, since narrowing can only move the block left, then forward as a defensive fallback. A future narrowing site is safe by construction instead of relying on every author remembering to adjust an index.

Adjusting the index at each of the five removal sites would also work, but it puts the burden on the next person to add a sixth site, and this defect is what that burden looks like when it is missed once.

## Tests

`studio/backend/tests/test_spec_start_after_arch_narrowing.py`, six cases: the un-narrowed control, `--api-key` survival under the four-token narrowing, the failed drafter not being re-run under all three narrowings, no token lost under any narrowing, a block that moved right, and an absent block not raising.

Mutation check, reverting `_subsequence_index` to the stale index:

```
3 failed, 3 passed
  test_the_api_key_survives_the_four_token_narrowing
  test_the_failed_drafter_is_not_re_run_after_narrowing
  test_no_token_is_lost_by_any_narrowing
```

Counts, serial:

- arch gate suites plus the new file: **317 passed**
- `test_mtp_drafter_companion.py`: **217 passed**

There is no AMD hardware on any runner, so this drives the real helpers over a fabricated argv rather than a live host.

Follows up #7670.
