### PR TITLE
Studio: run the transformer-quant smoke probe in a child so planning a download costs no VRAM

### DIFF
--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -629,6 +629,10 @@ def _child_probe_table(device: str) -> Optional[dict[str, Optional[bool]]]:
                 daemon = True,
             )
             proc.start()
+        # Adopted like every other spawn site: the bind above is the CHILD arming PDEATHSIG,
+        # which is Linux only, and the Windows job object can fail to take when Studio already
+        # runs inside an incompatible host job. This record is what is left in that case.
+        _adopt_probe_pid(proc.pid)
     except Exception as exc:  # noqa: BLE001 — no child here: probe in-process instead
         import logging
 
@@ -666,12 +670,56 @@ def _child_probe_table(device: str) -> Optional[dict[str, Optional[bool]]]:
     return table if isinstance(table, dict) else None
 
 
-def _close_probe_child(proc: Any, queue: Any) -> None:
-    """Tear the probe child and its queue down. Best-effort at every step: this runs on the
-    failure path too, and a probe that could not answer must not also raise."""
+def _adopt_probe_pid(pid: Optional[int]) -> None:
+    """Record the probe child against this process's lifetime, so the shutdown sweep and the
+    next startup can both reach it. Best-effort: a probe must not fail over its bookkeeping."""
+    try:
+        from utils.process_lifetime import adopt_pid
+        adopt_pid(pid)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _forget_probe_pid(pid: Optional[int]) -> None:
+    try:
+        from utils.process_lifetime import forget_pid
+        forget_pid(pid)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _probe_child_alive(proc: Any) -> bool:
+    """Whether the child is KNOWN to be running: a missing or never-started handle raises here,
+    and that is not a survivor."""
+    try:
+        return bool(proc is not None and proc.is_alive())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _close_probe_child(proc: Any, queue: Any) -> bool:
+    """Tear the probe child and its queue down; True once the child is confirmed dead.
+
+    Terminate then kill, as the chat worker's ``_shutdown_subprocess`` does: this child exists
+    to hand a CUDA context back, so a wedged one left alive defeats the whole probe. The
+    lifetime record is dropped only on confirmed death -- a child that outlives SIGKILL in an
+    uninterruptible driver call keeps its breadcrumb, since that record is the only remaining
+    handle on the VRAM it is holding. Best-effort at every step: this runs on the failure path
+    too, and a probe that could not answer must not also raise."""
+    try:
+        pid = proc.pid if proc is not None else None
+    except Exception:  # noqa: BLE001
+        pid = None
+
+    for stop, wait in ((lambda: proc.terminate(), 5.0), (lambda: proc.kill(), 3.0)):
+        if not _probe_child_alive(proc):
+            break
+        for step in (stop, lambda: proc.join(timeout = wait)):
+            try:
+                step()
+            except Exception:  # noqa: BLE001
+                pass
     for step in (
-        lambda: proc.terminate() if proc is not None and proc.is_alive() else None,
-        lambda: proc.join(timeout = 5.0) if proc is not None else None,
         lambda: queue.close() if queue is not None else None,
         lambda: queue.join_thread() if queue is not None else None,
     ):
@@ -679,6 +727,18 @@ def _close_probe_child(proc: Any, queue: Any) -> None:
             step()
         except Exception:  # noqa: BLE001
             pass
+
+    if _probe_child_alive(proc):
+        import logging
+
+        logging.getLogger(__name__).error(
+            "diffusion.transformer_quant: probe child pid=%s survived terminate and kill; "
+            "keeping its lifetime record so the shutdown sweep can still reach it",
+            pid,
+        )
+        return False
+    _forget_probe_pid(pid)
+    return True
 
 
 def _child_probe_entry(device: str, schemes: tuple[str, ...], out: Any) -> None:

--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -581,6 +581,12 @@ _CHILD_PROBE_TIMEOUT = 180.0
 # rather than on every miss.
 _CHILD_PROBE_UNAVAILABLE = False
 
+# Consecutive OSErrors out of the spawn before that latch is set anyway. An OSError is resource
+# pressure and clears, so it is retried; a host that raises one every time still stops paying
+# for the attempt after a few misses. Reset by the first spawn that works.
+_CHILD_PROBE_SPAWN_ERROR_LIMIT = 3
+_CHILD_PROBE_SPAWN_ERRORS = 0
+
 _CHILD_PROBE_LOCK = _threading.Lock()
 
 
@@ -599,7 +605,7 @@ def _child_probe_table(device: str) -> Optional[dict[str, Optional[bool]]]:
     multiprocessing, a sandbox that refuses to spawn, a timeout -- and the caller then probes
     in-process exactly as before, since refusing a load over a missing subprocess would be worse
     than the VRAM it saves."""
-    global _CHILD_PROBE_UNAVAILABLE
+    global _CHILD_PROBE_UNAVAILABLE, _CHILD_PROBE_SPAWN_ERRORS
     if _CHILD_PROBE_UNAVAILABLE:
         return None
     import time
@@ -618,8 +624,14 @@ def _child_probe_table(device: str) -> Optional[dict[str, Optional[bool]]]:
         # a forked child inherits those locks, and fork does not exist on Windows at all. A build
         # with no spawn support at all raises here, which is what the fallback is for.
         ctx = mp.get_context("spawn")
-        queue = ctx.Queue()
         with native_path_secret_removed_for_child_start():
+            # The queue is built INSIDE the scrub, as every other orchestrator here builds
+            # theirs. On POSIX the first spawn-context queue creates the named semaphores that
+            # start multiprocessing's resource tracker, and that tracker is exec'd with this
+            # process's environment and then outlives every child. Built above the scrub it
+            # would carry the native-path lease secret for the life of the backend, somewhere
+            # the child-side scrub can no longer reach.
+            queue = ctx.Queue()
             # The same entrypoint the inference worker is spawned through: it scrubs the lease
             # secret from the child and binds the child to this process's lifetime, so a wedged
             # probe cannot outlive the backend.
@@ -633,16 +645,28 @@ def _child_probe_table(device: str) -> Optional[dict[str, Optional[bool]]]:
         # which is Linux only, and the Windows job object can fail to take when Studio already
         # runs inside an incompatible host job. This record is what is left in that case.
         _adopt_probe_pid(proc.pid)
+        _CHILD_PROBE_SPAWN_ERRORS = 0
     except Exception as exc:  # noqa: BLE001 — no child here: probe in-process instead
         import logging
 
+        # An OSError here is the host being momentarily out of descriptors, process slots or
+        # /dev/shm, not a host that cannot spawn. Latching it would hold the backend on the
+        # in-process probe -- and so on the ~800 MiB this exists to avoid -- until Studio
+        # restarts, long after the pressure cleared. Only a deterministic failure (no spawn
+        # start method, a frozen build with no multiprocessing) latches on sight; a run of
+        # OSErrors latches too, so a host that always refuses is still paid for only briefly.
+        transient = isinstance(exc, OSError)
+        if transient:
+            _CHILD_PROBE_SPAWN_ERRORS += 1
+        if not transient or _CHILD_PROBE_SPAWN_ERRORS >= _CHILD_PROBE_SPAWN_ERROR_LIMIT:
+            _CHILD_PROBE_UNAVAILABLE = True
         logging.getLogger(__name__).info(
             "diffusion.transformer_quant: out-of-process probe unavailable (%s: %s); "
-            "probing in-process",
+            "probing in-process%s",
             type(exc).__name__,
             exc,
+            "" if _CHILD_PROBE_UNAVAILABLE else " and retrying the child on the next miss",
         )
-        _CHILD_PROBE_UNAVAILABLE = True
         _close_probe_child(proc, queue)
         return None
 

--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -544,14 +544,11 @@ def _scheme_supported(
             return False
     except Exception:
         return False
-    # Resolve the whole table in one throwaway child before falling back to the in-process
-    # probe. Nothing above this line allocates -- torch creates the primary CUDA context on the
-    # first ALLOCATION, not on is_available() or get_device_capability() (measured: 0 MiB after
-    # both, 614 MiB after the first tensor) -- so on a backend that has not loaded a model this
-    # is the difference between the process holding no VRAM and holding a context it can never
-    # give back. It matters because /images/download-plan calls assert_precision_available while
-    # the user is only STAGING a download, so a plan alone would cost the backend ~700 MiB for
-    # the life of the process.
+    # Resolve the whole table in one throwaway child, falling back in-process. Nothing above
+    # allocates: the context arrives on the first ALLOCATION, not on is_available() or
+    # get_device_capability() (0 MiB after both, 614 MiB after the first tensor). Worth a child
+    # because /images/download-plan calls assert_precision_available while the user is only
+    # STAGING, so a plan alone cost the backend ~700 MiB it can never give back.
     if (scheme, device) not in _SMOKE_CACHE:
         with _CHILD_PROBE_LOCK:
             # Re-checked under the lock: the route answers plans concurrently, and a burst of
@@ -625,12 +622,10 @@ def _child_probe_table(device: str) -> Optional[dict[str, Optional[bool]]]:
         # with no spawn support at all raises here, which is what the fallback is for.
         ctx = mp.get_context("spawn")
         with native_path_secret_removed_for_child_start():
-            # The queue is built INSIDE the scrub, as every other orchestrator here builds
-            # theirs. On POSIX the first spawn-context queue creates the named semaphores that
-            # start multiprocessing's resource tracker, and that tracker is exec'd with this
-            # process's environment and then outlives every child. Built above the scrub it
-            # would carry the native-path lease secret for the life of the backend, somewhere
-            # the child-side scrub can no longer reach.
+            # Inside the scrub, as every other orchestrator here builds theirs. The first
+            # spawn-context queue starts multiprocessing's resource tracker, which is exec'd
+            # with this environment and outlives every child, so building it above the scrub
+            # would strand the lease secret somewhere the child-side scrub cannot reach.
             queue = ctx.Queue()
             # The same entrypoint the inference worker is spawned through: it scrubs the lease
             # secret from the child and binds the child to this process's lifetime, so a wedged
@@ -649,12 +644,10 @@ def _child_probe_table(device: str) -> Optional[dict[str, Optional[bool]]]:
     except Exception as exc:  # noqa: BLE001 — no child here: probe in-process instead
         import logging
 
-        # An OSError here is the host being momentarily out of descriptors, process slots or
-        # /dev/shm, not a host that cannot spawn. Latching it would hold the backend on the
-        # in-process probe -- and so on the ~800 MiB this exists to avoid -- until Studio
-        # restarts, long after the pressure cleared. Only a deterministic failure (no spawn
-        # start method, a frozen build with no multiprocessing) latches on sight; a run of
-        # OSErrors latches too, so a host that always refuses is still paid for only briefly.
+        # An OSError is momentary pressure on descriptors, process slots or /dev/shm, not a
+        # host that cannot spawn; latching it would hold the backend on the in-process probe,
+        # and its ~800 MiB, until restart. Only a deterministic failure latches on sight, plus
+        # a run of OSErrors so a host that always refuses is paid for only briefly.
         transient = isinstance(exc, OSError)
         if transient:
             _CHILD_PROBE_SPAWN_ERRORS += 1

--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -730,7 +730,6 @@ def _close_probe_child(proc: Any, queue: Any) -> bool:
 
     if _probe_child_alive(proc):
         import logging
-
         logging.getLogger(__name__).error(
             "diffusion.transformer_quant: probe child pid=%s survived terminate and kill; "
             "keeping its lifetime record so the shutdown sweep can still reach it",

--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -24,6 +24,7 @@ probe is best-effort: an unsupported scheme yields None and the caller loads GGU
 from __future__ import annotations
 
 import re as _re
+import threading as _threading
 from typing import Any, Optional
 
 # stdlib-only module (no torch), so this stays inside the "imported lazily" promise above.
@@ -543,7 +544,159 @@ def _scheme_supported(
             return False
     except Exception:
         return False
+    # Resolve the whole table in one throwaway child before falling back to the in-process
+    # probe. Nothing above this line allocates -- torch creates the primary CUDA context on the
+    # first ALLOCATION, not on is_available() or get_device_capability() (measured: 0 MiB after
+    # both, 614 MiB after the first tensor) -- so on a backend that has not loaded a model this
+    # is the difference between the process holding no VRAM and holding a context it can never
+    # give back. It matters because /images/download-plan calls assert_precision_available while
+    # the user is only STAGING a download, so a plan alone would cost the backend ~700 MiB for
+    # the life of the process.
+    if (scheme, device) not in _SMOKE_CACHE:
+        with _CHILD_PROBE_LOCK:
+            # Re-checked under the lock: the route answers plans concurrently, and a burst of
+            # them must not each spawn a child that imports torch.
+            if (scheme, device) not in _SMOKE_CACHE:
+                table = _child_probe_table(device)
+                if table is not None:
+                    for name, child_verdict in table.items():
+                        # None is the child's out-of-memory: not a verdict, so not cached.
+                        if child_verdict is not None:
+                            _SMOKE_CACHE[(name, device)] = child_verdict
+                    if table.get(scheme, False) is None:
+                        # Same answer the in-process probe gives an OOM, without re-running it
+                        # here: it would meet the same full GPU and pay the context on the way.
+                        return unproven_ok
     return _smoke_probe(scheme, device, unproven_ok = unproven_ok)
+
+
+# Long enough for a cold interpreter to import torch and torchao and run every probe (measured
+# 3.9 s on a B200 host, so this is ~45x headroom for a cold page cache); short enough that a
+# child wedged in the driver does not hold the route thread forever. Overrunning it is not a
+# verdict either -- the caller falls back in-process.
+_CHILD_PROBE_TIMEOUT = 180.0
+
+# Set once the spawn machinery has been shown not to work here (frozen build without
+# multiprocessing support, a sandbox that refuses to fork/exec), so the fallback is paid once
+# rather than on every miss.
+_CHILD_PROBE_UNAVAILABLE = False
+
+_CHILD_PROBE_LOCK = _threading.Lock()
+
+
+def _child_probe_table(device: str) -> Optional[dict[str, Optional[bool]]]:
+    """Every scheme's verdict from a SHORT-LIVED child process, or None when it could not run.
+
+    The child dies with its CUDA context, which is the whole point: the context is process-wide
+    and the driver never returns it, so probing in the backend permanently costs what the probe
+    touched. Spawning is not free (3.9 s measured on a B200 host, nearly all of it importing
+    torch), so one child answers for every scheme in ``TQ_SCHEMES`` at once rather than one child
+    per ladder step: an auto ladder walking three schemes would otherwise pay it three times.
+
+    Verdicts are the child's ``_run_smoke_probe``, the same function the in-process path calls,
+    so the two cannot drift. ``None`` for a scheme is an allocator failure, which the caller
+    must not cache. ``None`` for the whole table means no child ran -- a frozen build without
+    multiprocessing, a sandbox that refuses to spawn, a timeout -- and the caller then probes
+    in-process exactly as before, since refusing a load over a missing subprocess would be worse
+    than the VRAM it saves."""
+    global _CHILD_PROBE_UNAVAILABLE
+    if _CHILD_PROBE_UNAVAILABLE:
+        return None
+    import time
+
+    proc = None
+    queue = None
+    try:
+        import multiprocessing as mp
+
+        from utils.native_path_leases import (
+            native_path_secret_removed_for_child_start,
+            run_without_native_path_secret,
+        )
+
+        # spawn, never fork: the backend is threaded (uvicorn, the arbiter, download workers) and
+        # a forked child inherits those locks, and fork does not exist on Windows at all. A build
+        # with no spawn support at all raises here, which is what the fallback is for.
+        ctx = mp.get_context("spawn")
+        queue = ctx.Queue()
+        with native_path_secret_removed_for_child_start():
+            # The same entrypoint the inference worker is spawned through: it scrubs the lease
+            # secret from the child and binds the child to this process's lifetime, so a wedged
+            # probe cannot outlive the backend.
+            proc = ctx.Process(
+                target = run_without_native_path_secret,
+                args = (__name__, "_child_probe_entry", {}, device, TQ_SCHEMES, queue),
+                daemon = True,
+            )
+            proc.start()
+    except Exception as exc:  # noqa: BLE001 — no child here: probe in-process instead
+        import logging
+
+        logging.getLogger(__name__).info(
+            "diffusion.transformer_quant: out-of-process probe unavailable (%s: %s); "
+            "probing in-process",
+            type(exc).__name__,
+            exc,
+        )
+        _CHILD_PROBE_UNAVAILABLE = True
+        _close_probe_child(proc, queue)
+        return None
+
+    table: Optional[dict[str, Optional[bool]]] = None
+    deadline = time.monotonic() + _CHILD_PROBE_TIMEOUT
+    try:
+        while True:
+            try:
+                table = queue.get(timeout = 0.5)
+                break
+            except Exception:  # noqa: BLE001 — Empty, or a queue torn down under us
+                pass
+            if not proc.is_alive():
+                # A put lands through a feeder thread, so it can still be in flight when the
+                # child has already exited; one blocking look before calling it a loss.
+                try:
+                    table = queue.get(timeout = 1.0)
+                except Exception:  # noqa: BLE001 — the child really did die empty
+                    table = None
+                break
+            if time.monotonic() >= deadline:
+                break
+    finally:
+        _close_probe_child(proc, queue)
+    return table if isinstance(table, dict) else None
+
+
+def _close_probe_child(proc: Any, queue: Any) -> None:
+    """Tear the probe child and its queue down. Best-effort at every step: this runs on the
+    failure path too, and a probe that could not answer must not also raise."""
+    for step in (
+        lambda: proc.terminate() if proc is not None and proc.is_alive() else None,
+        lambda: proc.join(timeout = 5.0) if proc is not None else None,
+        lambda: queue.close() if queue is not None else None,
+        lambda: queue.join_thread() if queue is not None else None,
+    ):
+        try:
+            step()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _child_probe_entry(device: str, schemes: tuple[str, ...], out: Any) -> None:
+    """Child side of ``_child_probe_table``: probe every scheme and post one table back.
+
+    Module-level and stdlib-signature so ``spawn`` can reach it by name. Every scheme is
+    attempted even after one fails, because the verdicts are independent and the whole point is
+    to pay the CUDA context once."""
+    table: dict[str, Optional[bool]] = {}
+    for scheme in schemes:
+        try:
+            table[scheme] = _run_smoke_probe(scheme, device)
+        except Exception:  # noqa: BLE001 — _run_smoke_probe already swallows; keep the table whole
+            table[scheme] = False
+    try:
+        out.put(table)
+    except Exception:  # noqa: BLE001 — parent gave up; nothing left to say
+        pass
 
 
 def _smoke_probe(
@@ -571,7 +724,24 @@ def _smoke_probe(
     key = (scheme, device)
     if key in _SMOKE_CACHE:
         return _SMOKE_CACHE[key]
-    ok = False
+    ok = _run_smoke_probe(scheme, device)
+    if ok is None:
+        # NOT cached, and NOT a verdict. An out-of-memory says nothing about the scheme, and
+        # the probe now runs on the ROUTE thread -- BEFORE the arbiter evicts the resident chat
+        # model, which is the whole point of raising the refusal early -- so it meets a full
+        # GPU by design. Caching it would refuse every later EXPLICIT request for this scheme
+        # for the life of the process, on a host that runs it fine once the eviction has
+        # happened; and answering "unsupported" to the pre-eviction gate (``unproven_ok``)
+        # refuses THIS load for the same reason the eviction was about to remove.
+        return unproven_ok
+    _SMOKE_CACHE[key] = ok
+    return ok
+
+
+def _run_smoke_probe(scheme: str, device: str) -> Optional[bool]:
+    """The probe body, uncached: True, False, or None for an allocator failure, which is not a
+    verdict on the scheme (see ``_smoke_probe``). Split out so the out-of-process child runs the
+    exact same code the in-process fallback does and the two verdicts cannot drift."""
     try:
         import torch
         from torchao.quantization import quantize_
@@ -584,20 +754,9 @@ def _smoke_probe(
         with torch.no_grad():
             out = lin(x)
         torch.cuda.synchronize()
-        ok = bool(torch.isfinite(out).all().item())
+        return bool(torch.isfinite(out).all().item())
     except Exception as exc:  # noqa: BLE001
-        if _is_out_of_memory(exc):
-            # NOT cached, and NOT a verdict. An out-of-memory says nothing about the scheme, and
-            # the probe now runs on the ROUTE thread -- BEFORE the arbiter evicts the resident chat
-            # model, which is the whole point of raising the refusal early -- so it meets a full
-            # GPU by design. Caching it would refuse every later EXPLICIT request for this scheme
-            # for the life of the process, on a host that runs it fine once the eviction has
-            # happened; and answering "unsupported" to the pre-eviction gate (``unproven_ok``)
-            # refuses THIS load for the same reason the eviction was about to remove.
-            return unproven_ok
-        ok = False
-    _SMOKE_CACHE[key] = ok
-    return ok
+        return None if _is_out_of_memory(exc) else False
 
 
 def _is_out_of_memory(exc: BaseException) -> bool:

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -360,6 +360,162 @@ def test_the_smoke_probe_does_not_cache_an_out_of_memory(monkeypatch):
     assert tq._smoke_probe(TQ_INT8, "cuda", unproven_ok = True) is False
 
 
+# ── out-of-process probe ────────────────────────────────────────────────────────
+#
+# The probe allocates, and a CUDA context is process-wide and never given back: measured on a
+# B200 host, one uncached probe takes the backend from 0 MiB to 806 MiB for the life of the
+# process. /images/download-plan reaches this while the user is only STAGING a download, so the
+# child is what keeps a plan from costing VRAM. Verdict parity with the in-process probe is the
+# contract; everything below pins one half of it.
+
+
+@pytest.fixture(autouse = True)
+def _reset_child_probe_state():
+    tq._SMOKE_CACHE.clear()
+    tq._CHILD_PROBE_UNAVAILABLE = False
+    yield
+    tq._SMOKE_CACHE.clear()
+    tq._CHILD_PROBE_UNAVAILABLE = False
+
+
+def test_the_child_answers_for_every_scheme_in_one_go(monkeypatch):
+    # One child, not one per ladder step: spawning costs 3.9 s on a B200 host (nearly all of it
+    # importing torch), so an auto ladder walking three schemes would otherwise pay it three times.
+    _stub_torch(monkeypatch)
+    spawns = {"n": 0}
+
+    def _table(device):
+        spawns["n"] += 1
+        return {TQ_INT8: True, TQ_FP8: True, TQ_NVFP4: False, TQ_MXFP8: False}
+
+    monkeypatch.setattr(tq, "_child_probe_table", _table)
+    monkeypatch.setattr(
+        tq, "_run_smoke_probe", lambda *a: pytest.fail("probed in-process after the child answered")
+    )
+    assert [tq._scheme_supported(s, "cuda") for s in tq.TQ_SCHEMES] == [True, True, False, False]
+    assert spawns["n"] == 1
+    assert tq._SMOKE_CACHE == {
+        (TQ_INT8, "cuda"): True,
+        (TQ_FP8, "cuda"): True,
+        (TQ_NVFP4, "cuda"): False,
+        (TQ_MXFP8, "cuda"): False,
+    }
+
+
+def test_a_child_out_of_memory_is_not_cached_and_is_not_a_verdict(monkeypatch):
+    # Same contract the in-process probe holds: a full GPU says nothing about the scheme. Falling
+    # back in-process here would be worse than useless -- it would meet the same full GPU and pay
+    # the context on the way -- so the OOM is answered without re-probing.
+    _stub_torch(monkeypatch)
+    monkeypatch.setattr(
+        tq, "_child_probe_table", lambda device: {TQ_INT8: None, TQ_FP8: True}
+    )
+    monkeypatch.setattr(
+        tq, "_run_smoke_probe", lambda *a: pytest.fail("re-probed in-process after a child OOM")
+    )
+    assert tq._scheme_supported(TQ_INT8, "cuda") is False
+    assert tq._scheme_supported(TQ_INT8, "cuda", unproven_ok = True) is True
+    assert (TQ_INT8, "cuda") not in tq._SMOKE_CACHE
+    # The schemes that DID answer are still cached; one scheme's OOM does not lose the table.
+    assert tq._SMOKE_CACHE == {(TQ_FP8, "cuda"): True}
+
+
+def test_no_child_falls_back_to_the_in_process_probe(monkeypatch):
+    # A frozen desktop build or a sandbox that refuses to spawn must still be able to load a
+    # model: the VRAM this saves is not worth failing a load over.
+    _stub_torch(monkeypatch)
+    monkeypatch.setattr(tq, "_child_probe_table", lambda device: None)
+    monkeypatch.setattr(tq, "_smoke_probe", lambda *a, **k: True)
+    assert tq._scheme_supported(TQ_INT8, "cuda") is True
+
+
+def test_a_host_without_cuda_never_spawns_a_child(monkeypatch):
+    # CPU-only, MPS and XPU hosts answer False above the child, so they pay nothing at all.
+    _stub_torch(monkeypatch, cuda_available = False)
+    monkeypatch.setattr(
+        tq, "_child_probe_table", lambda device: pytest.fail("spawned on a CUDA-less host")
+    )
+    assert tq._scheme_supported(TQ_INT8, "cuda") is False
+    # Same for an fp8 ask on a torch without the dtype.
+    _stub_torch(monkeypatch, with_fp8 = False)
+    assert tq._scheme_supported(TQ_FP8, "cuda") is False
+
+
+def test_a_cached_scheme_does_not_spawn_a_child(monkeypatch):
+    _stub_torch(monkeypatch)
+    tq._SMOKE_CACHE[(TQ_INT8, "cuda")] = True
+    monkeypatch.setattr(tq, "_child_probe_table", lambda device: pytest.fail("spawned on a hit"))
+    assert tq._scheme_supported(TQ_INT8, "cuda") is True
+
+
+def test_the_child_entry_posts_one_table_covering_every_scheme(monkeypatch):
+    # Child side. Every scheme is attempted even after one fails: the verdicts are independent
+    # and the whole point of the child is to pay the CUDA context once.
+    posted = []
+    monkeypatch.setattr(
+        tq, "_run_smoke_probe", lambda scheme, device: {TQ_INT8: True, TQ_FP8: None}.get(scheme, False)
+    )
+    tq._child_probe_entry("cuda", tq.TQ_SCHEMES, types.SimpleNamespace(put = posted.append))
+    assert posted == [{TQ_INT8: True, TQ_FP8: None, TQ_NVFP4: False, TQ_MXFP8: False}]
+
+
+def test_a_spawn_failure_is_remembered_so_it_is_paid_once(monkeypatch):
+    import multiprocessing
+
+    def _no_spawn(name):
+        raise ValueError(f"no {name} start method here")
+
+    monkeypatch.setattr(multiprocessing, "get_context", _no_spawn)
+    assert tq._child_probe_table("cuda") is None
+    assert tq._CHILD_PROBE_UNAVAILABLE is True
+    # Second time round it does not even reach multiprocessing.
+    monkeypatch.setattr(
+        multiprocessing, "get_context", lambda name: pytest.fail("retried a spawn known to fail")
+    )
+    assert tq._child_probe_table("cuda") is None
+
+
+def test_the_probe_body_separates_an_oom_from_a_verdict(monkeypatch):
+    # _run_smoke_probe is what BOTH the child and the in-process fallback call, so this three-way
+    # answer is the single place the two can be shown not to drift.
+    class _OOM(RuntimeError):
+        pass
+
+    fault = [None]
+
+    class _Lin:
+        def __init__(self, *a, **k):
+            pass
+
+        def to(self, **k):
+            return self
+
+        def __call__(self, x):
+            if fault[0] is not None:
+                raise fault[0]
+            return x
+
+    torch = types.ModuleType("torch")
+    torch.bfloat16 = "bfloat16"
+    torch.nn = types.SimpleNamespace(Linear = _Lin)
+    torch.randn = lambda *a, **k: _FakeTensor()
+    torch.isfinite = lambda t: _FakeBool(True)
+    torch.no_grad = lambda: __import__("contextlib").nullcontext()
+    torch.cuda = types.SimpleNamespace(is_available = lambda: True, synchronize = lambda: None)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    tqz = types.ModuleType("torchao.quantization")
+    tqz.quantize_ = lambda module, config, filter_fn = None: None
+    tqz.Int8DynamicActivationInt8WeightConfig = lambda: "int8cfg"
+    tqz.Float8DynamicActivationFloat8WeightConfig = lambda: "fp8cfg"
+    monkeypatch.setitem(sys.modules, "torchao.quantization", tqz)
+
+    assert tq._run_smoke_probe(TQ_INT8, "cuda") is True
+    fault[0] = _OOM("CUDA out of memory. Tried to allocate 2.00 GiB")
+    assert tq._run_smoke_probe(TQ_INT8, "cuda") is None
+    fault[0] = RuntimeError("kernel unavailable")
+    assert tq._run_smoke_probe(TQ_INT8, "cuda") is False
+
+
 def test_an_oom_is_recognised_however_it_is_spelled():
     # torch.OutOfMemoryError subclasses RuntimeError (not MemoryError) and has moved between
     # torch.cuda and torch across releases, so neither name alone is enough.

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -10,6 +10,7 @@ about the selection ladder rather than the GPU probe, so everything runs CPU-onl
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 
@@ -373,9 +374,11 @@ def test_the_smoke_probe_does_not_cache_an_out_of_memory(monkeypatch):
 def _reset_child_probe_state():
     tq._SMOKE_CACHE.clear()
     tq._CHILD_PROBE_UNAVAILABLE = False
+    tq._CHILD_PROBE_SPAWN_ERRORS = 0
     yield
     tq._SMOKE_CACHE.clear()
     tq._CHILD_PROBE_UNAVAILABLE = False
+    tq._CHILD_PROBE_SPAWN_ERRORS = 0
 
 
 def test_the_child_answers_for_every_scheme_in_one_go(monkeypatch):
@@ -574,6 +577,93 @@ def test_the_probe_child_is_adopted_so_a_shutdown_sweep_can_reach_it(
     )
     assert tq._child_probe_table("cuda") == {TQ_INT8: True}
     assert _probe_lifetime_records["adopted"] == [child.pid]
+
+
+def test_the_queue_is_built_with_the_lease_secret_already_scrubbed(
+    monkeypatch, _probe_lifetime_records
+):
+    # On POSIX the first spawn-context queue creates the named semaphores that start
+    # multiprocessing's resource tracker, and that tracker is exec'd with this process's
+    # environment and then outlives every child. Built above the scrub it carries the
+    # native-path lease secret for the life of the backend, where the child-side scrub can no
+    # longer reach it. Measured: the secret is in the tracker's /proc/<pid>/environ when the
+    # queue is built first, and absent when it is built here.
+    import multiprocessing
+
+    from utils.native_path_leases import LEASE_SECRET_ENV
+
+    secret = "x" * 64
+    monkeypatch.setenv(LEASE_SECRET_ENV, secret)
+    monkeypatch.setattr(tq, "_CHILD_PROBE_TIMEOUT", 0.0)
+    seen = {}
+
+    class _WatchingContext(_FakeSpawnContext):
+        def Queue(self):
+            seen["at_queue"] = os.environ.get(LEASE_SECRET_ENV)
+            return super().Queue()
+
+    monkeypatch.setattr(
+        multiprocessing,
+        "get_context",
+        lambda name: _WatchingContext(
+            _FakeProbeChild(dies_on = "start"), _FakeProbeQueue({TQ_INT8: True})
+        ),
+    )
+    assert tq._child_probe_table("cuda") == {TQ_INT8: True}
+    assert seen["at_queue"] is None
+    # And the parent has it back once the child is started.
+    assert os.environ.get(LEASE_SECRET_ENV) == secret
+
+
+# ── a spawn that failed but may not fail next time ──────────────────────────────
+
+
+def test_a_transient_spawn_oserror_is_retried_rather_than_latched(
+    monkeypatch, _probe_lifetime_records
+):
+    # Descriptors, process slots and /dev/shm all come back. Latching the OSError would hold the
+    # backend on the in-process probe -- and so on the ~800 MiB the child exists to avoid -- for
+    # every later miss, until Studio restarts.
+    import multiprocessing
+
+    calls = {"n": 0}
+
+    def _get_context(name):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError(24, "Too many open files")
+        return _FakeSpawnContext(
+            _FakeProbeChild(dies_on = "start"), _FakeProbeQueue({TQ_INT8: True})
+        )
+
+    monkeypatch.setattr(multiprocessing, "get_context", _get_context)
+    monkeypatch.setattr(tq, "_CHILD_PROBE_TIMEOUT", 0.0)
+    assert tq._child_probe_table("cuda") is None
+    assert tq._CHILD_PROBE_UNAVAILABLE is False
+    # The pressure clears and the next miss gets its child back.
+    assert tq._child_probe_table("cuda") == {TQ_INT8: True}
+    assert calls["n"] == 2
+    assert tq._CHILD_PROBE_SPAWN_ERRORS == 0
+
+
+def test_a_host_that_refuses_every_spawn_stops_being_asked(monkeypatch):
+    # The retry is bounded: an OSError on every attempt is indistinguishable from a sandbox that
+    # will never spawn, so the latch still lands after a short run of them.
+    import multiprocessing
+
+    calls = {"n": 0}
+
+    def _always_refuses(name):
+        calls["n"] += 1
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(multiprocessing, "get_context", _always_refuses)
+    for _ in range(tq._CHILD_PROBE_SPAWN_ERROR_LIMIT):
+        assert tq._child_probe_table("cuda") is None
+    assert tq._CHILD_PROBE_UNAVAILABLE is True
+    settled = calls["n"]
+    assert tq._child_probe_table("cuda") is None
+    assert calls["n"] == settled
 
 
 def test_a_child_that_survives_terminate_is_killed(_probe_lifetime_records):

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -536,7 +536,12 @@ class _FakeSpawnContext:
     def Queue(self):
         return self._queue
 
-    def Process(self, target = None, args = (), daemon = None):
+    def Process(
+        self,
+        target = None,
+        args = (),
+        daemon = None,
+    ):
         return self._child
 
 

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -632,9 +632,7 @@ def test_a_transient_spawn_oserror_is_retried_rather_than_latched(
         calls["n"] += 1
         if calls["n"] == 1:
             raise OSError(24, "Too many open files")
-        return _FakeSpawnContext(
-            _FakeProbeChild(dies_on = "start"), _FakeProbeQueue({TQ_INT8: True})
-        )
+        return _FakeSpawnContext(_FakeProbeChild(dies_on = "start"), _FakeProbeQueue({TQ_INT8: True}))
 
     monkeypatch.setattr(multiprocessing, "get_context", _get_context)
     monkeypatch.setattr(tq, "_CHILD_PROBE_TIMEOUT", 0.0)

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -407,9 +407,7 @@ def test_a_child_out_of_memory_is_not_cached_and_is_not_a_verdict(monkeypatch):
     # back in-process here would be worse than useless -- it would meet the same full GPU and pay
     # the context on the way -- so the OOM is answered without re-probing.
     _stub_torch(monkeypatch)
-    monkeypatch.setattr(
-        tq, "_child_probe_table", lambda device: {TQ_INT8: None, TQ_FP8: True}
-    )
+    monkeypatch.setattr(tq, "_child_probe_table", lambda device: {TQ_INT8: None, TQ_FP8: True})
     monkeypatch.setattr(
         tq, "_run_smoke_probe", lambda *a: pytest.fail("re-probed in-process after a child OOM")
     )
@@ -453,7 +451,9 @@ def test_the_child_entry_posts_one_table_covering_every_scheme(monkeypatch):
     # and the whole point of the child is to pay the CUDA context once.
     posted = []
     monkeypatch.setattr(
-        tq, "_run_smoke_probe", lambda scheme, device: {TQ_INT8: True, TQ_FP8: None}.get(scheme, False)
+        tq,
+        "_run_smoke_probe",
+        lambda scheme, device: {TQ_INT8: True, TQ_FP8: None}.get(scheme, False),
     )
     tq._child_probe_entry("cuda", tq.TQ_SCHEMES, types.SimpleNamespace(put = posted.append))
     assert posted == [{TQ_INT8: True, TQ_FP8: None, TQ_NVFP4: False, TQ_MXFP8: False}]

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -475,6 +475,133 @@ def test_a_spawn_failure_is_remembered_so_it_is_paid_once(monkeypatch):
     assert tq._child_probe_table("cuda") is None
 
 
+# ── the child's lifetime ────────────────────────────────────────────────────────
+
+
+class _FakeProbeChild:
+    """Stand-in for the spawned probe: alive from start() until sent the signal it obeys.
+
+    ``dies_on = None`` is the wedged child -- uninterruptible in the driver, surviving SIGKILL --
+    which is exactly the case that must not lose its lifetime record."""
+
+    def __init__(self, dies_on = "terminate"):
+        self.pid = 4321
+        self.alive = False
+        self.signals = []
+        self._dies_on = dies_on
+
+    def start(self):
+        self.alive = self._dies_on != "start"
+
+    def is_alive(self):
+        return self.alive
+
+    def join(self, timeout = None):
+        pass
+
+    def terminate(self):
+        self.signals.append("terminate")
+        if self._dies_on == "terminate":
+            self.alive = False
+
+    def kill(self):
+        self.signals.append("kill")
+        if self._dies_on == "kill":
+            self.alive = False
+
+
+class _FakeProbeQueue:
+    def __init__(self, table = None):
+        self._table = table
+        self.closed = False
+
+    def get(self, timeout = None):
+        if self._table is None:
+            raise ValueError("empty")
+        table, self._table = self._table, None
+        return table
+
+    def close(self):
+        self.closed = True
+
+    def join_thread(self):
+        pass
+
+
+class _FakeSpawnContext:
+    def __init__(self, child, queue):
+        self._child = child
+        self._queue = queue
+
+    def Queue(self):
+        return self._queue
+
+    def Process(self, target = None, args = (), daemon = None):
+        return self._child
+
+
+@pytest.fixture
+def _probe_lifetime_records(monkeypatch):
+    """Capture what the probe adopts and forgets, without touching the real record."""
+    import utils.process_lifetime as pl
+
+    records = {"adopted": [], "forgotten": []}
+    monkeypatch.setattr(pl, "adopt_pid", records["adopted"].append)
+    monkeypatch.setattr(pl, "forget_pid", records["forgotten"].append)
+    return records
+
+
+def test_the_probe_child_is_adopted_so_a_shutdown_sweep_can_reach_it(
+    monkeypatch, _probe_lifetime_records
+):
+    # The child-side PDEATHSIG bind is Linux only, and the Windows job object is documented to
+    # fail when Studio already runs inside an incompatible host job. In that configuration this
+    # record is the only thing left that can reach a probe still holding a CUDA context, both
+    # from the shutdown sweep and from the next startup.
+    import multiprocessing
+
+    monkeypatch.setattr(tq, "_CHILD_PROBE_TIMEOUT", 0.0)
+    child = _FakeProbeChild(dies_on = "start")
+    monkeypatch.setattr(
+        multiprocessing,
+        "get_context",
+        lambda name: _FakeSpawnContext(child, _FakeProbeQueue({TQ_INT8: True})),
+    )
+    assert tq._child_probe_table("cuda") == {TQ_INT8: True}
+    assert _probe_lifetime_records["adopted"] == [child.pid]
+
+
+def test_a_child_that_survives_terminate_is_killed(_probe_lifetime_records):
+    # Five seconds of terminate and then giving up leaves the VRAM this probe exists to hand
+    # back held for the whole 180 s timeout, or forever if the child is wedged.
+    child = _FakeProbeChild(dies_on = "kill")
+    child.start()
+    assert tq._close_probe_child(child, _FakeProbeQueue()) is True
+    assert child.signals == ["terminate", "kill"]
+    assert _probe_lifetime_records["forgotten"] == [child.pid]
+
+
+def test_a_child_that_survives_kill_keeps_its_breadcrumb_and_is_reported(_probe_lifetime_records):
+    # Same call the chat worker makes: a survivor keeps its handle rather than being dropped
+    # silently, so the sweep still has something to retry.
+    child = _FakeProbeChild(dies_on = None)
+    child.start()
+    assert tq._close_probe_child(child, _FakeProbeQueue()) is False
+    assert child.signals == ["terminate", "kill"]
+    assert _probe_lifetime_records["forgotten"] == []
+
+
+def test_a_clean_exit_forgets_the_pid(_probe_lifetime_records):
+    # The child that posted its table and exited is not signalled at all, and its record goes.
+    child = _FakeProbeChild(dies_on = "start")
+    child.start()
+    queue = _FakeProbeQueue()
+    assert tq._close_probe_child(child, queue) is True
+    assert child.signals == []
+    assert queue.closed is True
+    assert _probe_lifetime_records["forgotten"] == [child.pid]
+
+
 def test_the_probe_body_separates_an_oom_from_a_verdict(monkeypatch):
     # _run_smoke_probe is what BOTH the child and the in-process fallback call, so this three-way
     # answer is the single place the two can be shown not to drift.


### PR DESCRIPTION
`_smoke_probe` in `core/inference/diffusion_transformer_quant.py` quantises a tiny Linear and runs one forward to decide whether a scheme is usable on this host. It is a real CUDA allocation, so it opens a primary context in the Studio backend process that is never returned.

The part that makes it worth fixing is where it is reached from. `assert_precision_available` runs on the **download-plan** path, so merely planning a diffusion model download costs the backend a permanent context even if the user never loads the model. The comment already at `routes/inference.py` flags the same hazard for the training case and skips the check while a trainer holds the GPU, so the shape of this was already known.

## Measured

Fresh process, `CUDA_VISIBLE_DEVICES=5` on a B200, per-PID via `nvidia-smi --query-compute-apps` filtered to our own PID:

| stage | this PID |
| --- | ---: |
| process start | 0 MiB |
| after `import torch` | 0 MiB |
| after `is_available()` returning True | 0 MiB |
| after `get_device_capability()` | 0 MiB |
| after `get_device_name()` | 0 MiB |
| **first CUDA allocation, bare context** | **614 MiB** |
| after `_smoke_probe('int8')` | 802 MiB |
| after all four probes | 806 MiB |
| after `del` plus `gc` plus `empty_cache()` | **800 MiB** |

Only 6 MiB came back; `memory_reserved()` was 20 MiB. Worth noting that the context appears on the first **allocation**, not on `is_available()` or `get_device_capability()`, which is exactly what makes this fixable: everything above the probe in `_scheme_supported` is already free.

Reachability, live stack:

```
b.assert_precision_available(fam, model_kind="gguf", transformer_quant="fp8")
  core/inference/diffusion.py:1163      select_transformer_quant_scheme(
  diffusion_transformer_quant.py:474    _scheme_supported(requested, device, unproven_ok=...)
  diffusion_transformer_quant.py:546    _smoke_probe(scheme, device, unproven_ok=...)
```

from `POST /images/download-plan` (`routes/inference.py:22110` -> `:22164`). 0 MiB before that call, 716 MiB after.

## The change

`_smoke_probe` keeps its signature, its cache and its docstring. Its body is split into `_run_smoke_probe(scheme, device) -> Optional[bool]`, returning True, False, or None for out-of-memory, and that one function is called by **both** the child and the in-process fallback, so the two cannot drift.

`_scheme_supported` fills the table from `_child_probe_table` on a cache miss, caches every non-None verdict, returns `unproven_ok` for a None without re-probing, and otherwise falls through to the unchanged `_smoke_probe`.

One child probes **all** of `TQ_SCHEMES` and the whole table is cached. Spawn costs 3.90 / 3.98 / 3.92 s, nearly all of it importing torch, so per-scheme children would have cost about 15.8 s for the four, and an `auto` ladder walking three schemes would have paid that three times. A second pass costs 0.0000 s.

The child is spawned through `run_without_native_path_secret` under `native_path_secret_removed_for_child_start()`, the same entrypoint and `mp.get_context("spawn")` the inference worker already uses, so the lease secret is scrubbed and the child is bound to the parent's lifetime. `spawn` only, never `fork`: the backend is threaded and fork does not exist on Windows. A 180s timeout with a poll loop that notices an early child exit and then takes one last blocking look, because `Queue.put` lands via a feeder thread and can still be in flight after the child is gone.

If a child cannot be spawned at all, which is the case for frozen desktop builds and sandboxed environments, it degrades to today's in-process behaviour rather than failing the load.

The OOM semantics are preserved exactly, including the subtle part: an out-of-memory is not cached and not a verdict, and returns `unproven_ok`, because the probe runs on the route thread before the arbiter has evicted the resident chat model and therefore meets a full GPU by design.

## Parity

Both halves measured in one process, with the in-process half last so its context cannot mask the child half's reading:

| scheme | in-process (today) | out-of-process (new) | same |
| --- | --- | --- | --- |
| int8 | True | True | yes |
| fp8 | True | True | yes |
| nvfp4 | False | False | yes |
| mxfp8 | False | False | yes |

VRAM left behind: out-of-process **0 MiB**, in-process 806 MiB. End to end through `assert_precision_available` for `fp8`, `int8` and `auto`: all allowed, 0 MiB after each, against 716 MiB before. The in-process column is produced by flipping the child-unavailable flag, so it doubles as proof of the frozen-build fallback path.

CPU-only, ROCm, XPU and MPS hosts are untouched: `_scheme_supported` still returns False early when CUDA is unavailable, in process and free.

## Two bugs the new tests caught

- `mp.get_context("spawn")` was outside the `try`, so a build with no spawn start method would have raised out of `_child_probe_table` instead of degrading. Moved inside.
- Added `_CHILD_PROBE_LOCK` with a double-checked cache read. The route answers plans concurrently, and without it a burst of plan requests would each spawn a child importing torch. Today's in-process code has the same race but pays it into one shared context; the child version would have paid it N times.

## Tests

Eight added: one child covers the whole table, a child OOM is neither cached nor a verdict, no child falls back in process, a CUDA-less host never spawns, a cache hit never spawns, the child entrypoint posts one table covering every scheme, a spawn failure is remembered so it is paid once, and the three-way `_run_smoke_probe` answer.

Every test file mentioning `_scheme_supported`, `select_transformer_quant_scheme`, `auto_scheme_candidates` or `transformer_quant`, 24 files:

- before: 37 failed, 1523 passed, 8 skipped
- after: 37 failed, 1531 passed, 8 skipped

Sorted FAILED lists diff clean: zero additions, zero removals. The +8 are the new tests. The remaining failures are a pre-existing `ImportError: cannot import name 'ScalingType' from 'torch.nn.functional'`, a torchao and torch version skew on the test box that reproduces on unmodified `main`.

ruff clean on both changed files.
