### PR TITLE
Match the export pin test to the widened exception handler

### DIFF
--- a/tests/studio/test_studio_gguf_export_script_pin.py
+++ b/tests/studio/test_studio_gguf_export_script_pin.py
@@ -38,6 +38,19 @@ def _find_pin_try(tree: ast.AST):
     return None
 
 
+# The pin catches Exception, not ImportError: a half-built unsloth_zoo raises
+# RuntimeError or AttributeError too. Anything that still catches an ImportError
+# counts, so widening the handler again does not break this test.
+_CATCHES_IMPORT_ERROR = ("ImportError", "Exception", "BaseException")
+
+
+def _catches_import_error(handler: ast.ExceptHandler) -> bool:
+    if handler.type is None:  # bare except
+        return True
+    names = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+    return any(isinstance(n, ast.Name) and n.id in _CATCHES_IMPORT_ERROR for n in names)
+
+
 def test_warning_flag_defined_at_module_scope():
     flags = {
         name: value
@@ -85,9 +98,7 @@ def test_setdefault_inside_try_block():
 def test_warning_handler_gated_on_module_flag():
     try_node = _find_pin_try(TREE)
     assert try_node is not None
-    handlers = [
-        h for h in try_node.handlers if isinstance(h.type, ast.Name) and h.type.id == "ImportError"
-    ]
+    handlers = [h for h in try_node.handlers if _catches_import_error(h)]
     assert handlers
     handler = handlers[0]
     flag_reads = []


### PR DESCRIPTION
`tests/studio/test_studio_gguf_export_script_pin.py::test_warning_handler_gated_on_module_flag` fails on main.

The test walks `export.py`'s AST for the `unsloth_zoo.llama_cpp` pin and required the handler to be `except ImportError`:

```python
handlers = [
    h for h in try_node.handlers if isinstance(h.type, ast.Name) and h.type.id == "ImportError"
]
assert handlers
```

That handler was since widened, for a good reason that is written into the code itself:

```python
except Exception:
    # Not just ImportError: a half-built unsloth_zoo raises RuntimeError or
    # AttributeError, and this pin is an optimisation, not worth failing an export.
```

The widening is right. The AST test just was not updated with it, so `handlers` came back empty and the assertion tripped.

### The change

The test now accepts any handler that would catch an `ImportError`: a bare `except`, `ImportError`, `Exception`, `BaseException`, or a tuple containing one of those. What this test is actually for is the once-per-process warning gate, not the exact exception spelling, so widening the handler again will not break it.

### It still discriminates

Checked against `export.py` in both directions, then reverted:

| probe | result |
| --- | --- |
| narrow the handler to `except ValueError`, so it no longer catches `ImportError` | 1 failed |
| remove the `_LLAMA_CPP_SCRIPTS_WARNING_EMITTED` gate | 1 failed |
| unmodified | 10 passed |

No production code changes.
