### PR TITLE
Studio: stop the /api/system poll from pinning a CUDA/HIP primary context

### DIFF
--- a/studio/backend/tests/data/refactor_guard/patch_targets.json
+++ b/studio/backend/tests/data/refactor_guard/patch_targets.json
@@ -934,7 +934,7 @@
   "utils.hardware.hardware._smi_query": [
     "tests/test_gpu_selection.py"
   ],
-  "utils.hardware.hardware._torch_get_per_device_info": [
+  "utils.hardware.hardware._torch_get_device_inventory": [
     "tests/test_gpu_selection.py"
   ],
   "utils.hardware.hardware._torch_get_physical_gpu_count": [

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -358,20 +358,22 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
     def test_uuid_parent_visibility_falls_back_to_torch(self):
         """UUID/MIG masks fall through nvidia to the torch fallback and
         still report visible devices using relative ordinals."""
+        # Inventory shape: this endpoint reads name and total and discards used, so
+        # it asks for the context-free helper.
         fake_torch_devices = [
             {
                 "index": 0,
                 "visible_ordinal": 0,
                 "name": "GPU-A",
                 "total_gb": 24.0,
-                "used_gb": 2.0,
+                "used_gb": None,
             },
             {
                 "index": 1,
                 "visible_ordinal": 1,
                 "name": "GPU-B",
                 "total_gb": 24.0,
-                "used_gb": 3.0,
+                "used_gb": None,
             },
         ]
         with (
@@ -379,7 +381,7 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
             patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA),
             patch("utils.hardware.hardware._torch_get_physical_gpu_count", return_value = 2),
             patch(
-                "utils.hardware.hardware._torch_get_per_device_info",
+                "utils.hardware.hardware._torch_get_device_inventory",
                 return_value = fake_torch_devices,
             ),
         ):

--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -127,9 +127,7 @@ _PROBE = textwrap.dedent(
 def _run_child(call: str):
     """Run ``call`` in a fresh interpreter; return (leaked_devices, mib_or_None)."""
     src = _PROBE + _CHILD.format(backend = str(_BACKEND_DIR), call = call)
-    proc = subprocess.run(
-        [sys.executable, "-c", src], capture_output = True, text = True, timeout = 600
-    )
+    proc = subprocess.run([sys.executable, "-c", src], capture_output = True, text = True, timeout = 600)
     assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
     leaked, mib = None, None
     for line in proc.stdout.splitlines():
@@ -177,7 +175,12 @@ class _FakeProps:
         self.total_memory = total
 
 
-def _fake_mod(totals, names = None, *, with_mem_get_info = True):
+def _fake_mod(
+    totals,
+    names = None,
+    *,
+    with_mem_get_info = True,
+):
     mod = types.SimpleNamespace()
     names = names or [f"GPU{i}" for i in range(len(totals))]
     mod.get_device_properties = lambda o: _FakeProps(names[o], totals[o])
@@ -249,10 +252,20 @@ def test_visibility_endpoint_uses_inventory_not_occupancy(monkeypatch):
         hw,
         "_torch_get_device_inventory",
         lambda ids: [
-            {"index": 0, "visible_ordinal": 0, "name": "MI300X", "total_gb": 192.0,
-             "used_gb": None},
-            {"index": 1, "visible_ordinal": 1, "name": "MI300X", "total_gb": 192.0,
-             "used_gb": None},
+            {
+                "index": 0,
+                "visible_ordinal": 0,
+                "name": "MI300X",
+                "total_gb": 192.0,
+                "used_gb": None,
+            },
+            {
+                "index": 1,
+                "visible_ordinal": 1,
+                "name": "MI300X",
+                "total_gb": 192.0,
+                "used_gb": None,
+            },
         ],
     )
     result = hw.get_backend_visible_gpu_info()
@@ -342,8 +355,7 @@ def _rocm_linux(monkeypatch, resolved):
         hw,
         "_torch_get_device_inventory",
         lambda ids: [
-            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
-             "used_gb": None}
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0, "used_gb": None}
             for i in ids
         ],
     )
@@ -376,8 +388,7 @@ def test_rocm_linux_sysfs_first_matches_the_old_torch_then_overlay_result(monkey
         hw,
         "_torch_get_per_device_info",
         lambda ids: [
-            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
-             "used_gb": 0.02}
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0, "used_gb": 0.02}
             for i in ids
         ],
     )
@@ -414,8 +425,7 @@ def test_rocm_linux_falls_back_to_torch_when_sysfs_covers_only_some(monkeypatch)
         "_torch_get_per_device_info",
         lambda ids: used.append(ids)
         or [
-            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
-             "used_gb": 1.0}
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0, "used_gb": 1.0}
             for i in ids
         ],
     )
@@ -434,8 +444,7 @@ def test_rocm_linux_falls_back_when_sysfs_knows_nothing(monkeypatch):
         "_torch_get_per_device_info",
         lambda ids: used.append(ids)
         or [
-            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
-             "used_gb": 1.0}
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0, "used_gb": 1.0}
             for i in ids
         ],
     )
@@ -459,8 +468,9 @@ def test_nvidia_torch_fallback_keeps_using_occupancy(monkeypatch):
     monkeypatch.setattr(
         hw,
         "_torch_get_per_device_info",
-        lambda ids: [{"index": 0, "visible_ordinal": 0, "name": "L40S", "total_gb": 44.0,
-                      "used_gb": 4.0}],
+        lambda ids: [
+            {"index": 0, "visible_ordinal": 0, "name": "L40S", "total_gb": 44.0, "used_gb": 4.0}
+        ],
     )
     result = hw.get_visible_gpu_utilization()
     assert result["devices"][0]["vram_used_gb"] == 4.0
@@ -478,8 +488,7 @@ def test_rocm_relative_index_skips_the_sysfs_shortcut(monkeypatch):
         "_torch_get_per_device_info",
         lambda ids: seen.append(ids)
         or [
-            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
-             "used_gb": 1.0}
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0, "used_gb": 1.0}
             for i in ids
         ],
     )
@@ -495,8 +504,10 @@ def test_rocm_windows_does_not_take_the_linux_sysfs_path(monkeypatch):
         hw,
         "_rocm_windows_per_device_vram",
         lambda ids: (
-            [{"index": i, "visible_ordinal": i, "name": "RX", "used_gb": 2.0,
-              "total_gb": 24.0} for i in ids],
+            [
+                {"index": i, "visible_ordinal": i, "name": "RX", "used_gb": 2.0, "total_gb": 24.0}
+                for i in ids
+            ],
             4.0,
         ),
     )

--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -1,0 +1,535 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The /api/system poll must not pin a CUDA/HIP primary context.
+
+The frontend polls GET /api/system every 5s from the root-mounted floating
+monitor and every 3s from Settings -> Resources. Both land on
+get_backend_visible_gpu_info and get_visible_gpu_utilization. Where nvidia-smi is
+absent (ROCm, or any host without it on PATH) those used to reach
+torch.cuda.mem_get_info, which attaches a primary context worth ~612 MiB on this
+class of GPU and is never released while the process lives. An idle Studio would
+therefore lose that memory to telemetry alone.
+
+get_device_properties answers name and total capacity with no context, and it
+returns the same total mem_get_info does, so the inventory half of the poll is
+free. These tests pin that: the honest check is a FRESH process, because a
+context, once created, is never given back and any earlier test in the session
+would mask the regression.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import textwrap
+import types
+from pathlib import Path
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+
+def _maybe_stub(name: str, builder):
+    # Stub only if the real module is missing, so we never shadow it for later tests.
+    try:
+        importlib.import_module(name)
+    except ImportError:
+        sys.modules[name] = builder()
+
+
+def _build_loggers_stub():
+    m = types.ModuleType("loggers")
+    m.get_logger = lambda name: __import__("logging").getLogger(name)
+    return m
+
+
+def _build_structlog_stub():
+    m = types.ModuleType("structlog")
+    m.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")
+    return m
+
+
+_maybe_stub("loggers", _build_loggers_stub)
+_maybe_stub("structlog", _build_structlog_stub)
+
+import pytest
+
+import utils.hardware.hardware as hw  # noqa: E402
+
+
+def _has_cuda() -> bool:
+    try:
+        import torch
+    except Exception:
+        return False
+    try:
+        return bool(torch.cuda.is_available() and torch.cuda.device_count() > 0)
+    except Exception:
+        return False
+
+
+needs_cuda = pytest.mark.skipif(
+    not _has_cuda(), reason = "needs a real CUDA/HIP device to observe context creation"
+)
+
+
+# ========== Fresh-process context assertions ==========
+
+# Runs in a child interpreter: memory_reserved(i) needs no context itself (it reads
+# the allocator's stats, which are empty before one exists), so it is a safe probe.
+_CHILD = textwrap.dedent(
+    """
+    import sys
+    sys.path.insert(0, {backend!r})
+    import torch
+
+    assert sum(torch.cuda.memory_reserved(i) for i in range(torch.cuda.device_count())) == 0
+
+    import utils.hardware.hardware as hw
+    {call}
+
+    leaked = [i for i in range(torch.cuda.device_count()) if torch.cuda.memory_reserved(i)]
+    print("LEAKED:" + repr(leaked))
+    print("CONTEXT:" + repr(_probe_context()))
+    """
+)
+
+# Per-PID nvidia-smi is the ground truth: a primary context shows up as this
+# process holding memory even with nothing allocated. Absent nvidia-smi we fall
+# back to reporting None, and the test then relies on the allocator probe alone.
+_PROBE = textwrap.dedent(
+    """
+    import os, subprocess
+    def _probe_context():
+        try:
+            out = subprocess.run(
+                ["nvidia-smi", "--query-compute-apps=pid,used_memory",
+                 "--format=csv,noheader,nounits"],
+                capture_output = True, text = True, timeout = 60,
+            )
+        except Exception:
+            return None
+        if out.returncode != 0:
+            return None
+        me = str(os.getpid())
+        for line in out.stdout.splitlines():
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) >= 2 and parts[0] == me:
+                return int(parts[1])
+        return 0
+    """
+)
+
+
+def _run_child(call: str):
+    """Run ``call`` in a fresh interpreter; return (leaked_devices, mib_or_None)."""
+    src = _PROBE + _CHILD.format(backend = str(_BACKEND_DIR), call = call)
+    proc = subprocess.run(
+        [sys.executable, "-c", src], capture_output = True, text = True, timeout = 600
+    )
+    assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
+    leaked, mib = None, None
+    for line in proc.stdout.splitlines():
+        if line.startswith("LEAKED:"):
+            leaked = eval(line[len("LEAKED:") :])
+        elif line.startswith("CONTEXT:"):
+            mib = eval(line[len("CONTEXT:") :])
+    assert leaked is not None, proc.stdout
+    return leaked, mib
+
+
+@needs_cuda
+def test_backend_visible_gpu_info_creates_no_context():
+    leaked, mib = _run_child("hw.get_backend_visible_gpu_info()")
+    assert leaked == []
+    if mib is not None:
+        assert mib == 0, f"the visibility poll pinned {mib} MiB of primary context"
+
+
+@needs_cuda
+def test_clear_gpu_cache_creates_no_context_when_nothing_reserved():
+    leaked, mib = _run_child("hw.clear_gpu_cache()")
+    assert leaked == []
+    if mib is not None:
+        assert mib == 0, f"clear_gpu_cache pinned {mib} MiB of primary context"
+
+
+@needs_cuda
+def test_the_probe_would_catch_a_regression():
+    # Guards the two tests above: prove mem_get_info really does pin a context on
+    # this host, so a green run means the poll avoided it rather than that nothing
+    # could have created one.
+    leaked, mib = _run_child("__import__('torch').cuda.mem_get_info(0)")
+    if mib is None:
+        pytest.skip("no per-PID nvidia-smi accounting available to observe the context")
+    assert mib > 0, "mem_get_info created no context here, so the assertions above prove nothing"
+
+
+# ========== Inventory parity ==========
+
+
+class _FakeProps:
+    def __init__(self, name, total):
+        self.name = name
+        self.total_memory = total
+
+
+def _fake_mod(totals, names = None, *, with_mem_get_info = True):
+    mod = types.SimpleNamespace()
+    names = names or [f"GPU{i}" for i in range(len(totals))]
+    mod.get_device_properties = lambda o: _FakeProps(names[o], totals[o])
+    if with_mem_get_info:
+        # free == total - used; mirrors a driver reporting the same total both ways.
+        mod.mem_get_info = lambda o: (totals[o] - (1 << 30), totals[o])
+    mod.memory_allocated = lambda o: 1 << 30
+    return mod
+
+
+@pytest.mark.parametrize("totals", [[191505498112], [25757220864, 8589934592]])
+def test_inventory_totals_match_the_occupancy_path(monkeypatch, totals):
+    # Parity: switching the visibility endpoint to the inventory helper must not
+    # move a single displayed number. Only used_gb differs, and that field is
+    # discarded by every caller of the inventory helper.
+    mod = _fake_mod(totals)
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setattr(hw, "rocm_windows_free_is_untrusted", lambda: False)
+    indices = list(range(len(totals)))
+
+    inventory = hw._torch_get_device_inventory(indices)
+    occupancy = hw._torch_get_per_device_info(indices)
+
+    assert [d["total_gb"] for d in inventory] == [d["total_gb"] for d in occupancy]
+    assert [d["name"] for d in inventory] == [d["name"] for d in occupancy]
+    assert [d["index"] for d in inventory] == [d["index"] for d in occupancy]
+    assert [d["visible_ordinal"] for d in inventory] == [d["visible_ordinal"] for d in occupancy]
+    assert all(d["used_gb"] is None for d in inventory)
+
+
+def test_inventory_never_touches_mem_get_info(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("mem_get_info would create a primary context")
+
+    mod = _fake_mod([8589934592])
+    mod.mem_get_info = _boom
+    mod.memory_allocated = _boom
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 8.0
+
+
+def test_inventory_skips_a_device_that_fails_to_enumerate(monkeypatch):
+    def _props(o):
+        if o == 1:
+            raise RuntimeError("device lost")
+        return _FakeProps("GPU0", 8589934592)
+
+    mod = types.SimpleNamespace(get_device_properties = _props)
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    assert [d["index"] for d in hw._torch_get_device_inventory([0, 1])] == [0]
+
+
+def test_inventory_is_empty_without_torch(monkeypatch):
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (None, None))
+    assert hw._torch_get_device_inventory([0]) == []
+
+
+def test_visibility_endpoint_uses_inventory_not_occupancy(monkeypatch):
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setattr(hw, "IS_ROCM", True)  # skips the nvidia-smi shortcut
+    monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: [0, 1])
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_per_device_info",
+        lambda ids: pytest.fail("the visibility poll must not ask torch for occupancy"),
+    )
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_device_inventory",
+        lambda ids: [
+            {"index": 0, "visible_ordinal": 0, "name": "MI300X", "total_gb": 192.0,
+             "used_gb": None},
+            {"index": 1, "visible_ordinal": 1, "name": "MI300X", "total_gb": 192.0,
+             "used_gb": None},
+        ],
+    )
+    result = hw.get_backend_visible_gpu_info()
+    assert result["available"] is True
+    assert [d["memory_total_gb"] for d in result["devices"]] == [192.0, 192.0]
+    assert [d["name"] for d in result["devices"]] == ["MI300X", "MI300X"]
+    assert result["index_kind"] == "physical"
+
+
+# ========== clear_gpu_cache ==========
+
+
+def _torch_stub(reserved_by_device, calls):
+    cuda = types.SimpleNamespace(
+        is_available = lambda: True,
+        device_count = lambda: len(reserved_by_device),
+        memory_reserved = lambda i = 0: reserved_by_device[i],
+        synchronize = lambda: calls.append("synchronize"),
+        empty_cache = lambda: calls.append("empty_cache"),
+        ipc_collect = lambda: calls.append("ipc_collect"),
+    )
+    return types.SimpleNamespace(cuda = cuda)
+
+
+def test_clear_gpu_cache_skips_synchronize_with_nothing_reserved(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setitem(sys.modules, "torch", _torch_stub([0, 0], calls))
+    hw.clear_gpu_cache()
+    # Only the synchronize is skipped. empty_cache/ipc_collect need no context and
+    # are no-ops without an allocator, so they stay exactly where they were.
+    assert calls == ["empty_cache", "ipc_collect"]
+
+
+def test_clear_gpu_cache_still_drains_a_live_allocator(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setitem(sys.modules, "torch", _torch_stub([0, 4 << 30], calls))
+    hw.clear_gpu_cache()
+    # Reserved on a NON-current device still counts: summing over the visible set
+    # is what keeps a multi-GPU process from being skipped.
+    assert calls == ["synchronize", "empty_cache", "ipc_collect"]
+
+
+def test_clear_gpu_cache_still_propagates_a_sticky_cuda_fault(monkeypatch):
+    # The diffusion and video unload paths wrap this in try/finally precisely
+    # because a sticky fault has to surface, so the guard must not swallow one.
+    calls: list[str] = []
+    stub = _torch_stub([4 << 30], calls)
+
+    def _boom():
+        raise RuntimeError("CUDA error: an illegal memory access was encountered")
+
+    stub.cuda.synchronize = _boom
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setitem(sys.modules, "torch", stub)
+    with pytest.raises(RuntimeError, match = "illegal memory access"):
+        hw.clear_gpu_cache()
+
+
+def test_clear_gpu_cache_no_ops_without_cuda(monkeypatch):
+    calls: list[str] = []
+    stub = _torch_stub([0], calls)
+    stub.cuda.is_available = lambda: False
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setitem(sys.modules, "torch", stub)
+    hw.clear_gpu_cache()
+    assert calls == ["empty_cache", "ipc_collect"]
+
+
+# ========== Linux ROCm sysfs-first ==========
+
+
+def _rocm_linux(monkeypatch, resolved):
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setattr(hw, "_smi_query", lambda *a, **k: None)  # amd-smi unavailable
+    monkeypatch.setattr(hw.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(hw, "_rocm_windows_per_device_vram", lambda ids: ([], None))
+    monkeypatch.setattr(
+        hw,
+        "_get_parent_visible_gpu_spec",
+        lambda: {"raw": None, "numeric_ids": [0, 1], "supports_explicit_gpu_ids": True},
+    )
+    monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: [0, 1])
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_device_inventory",
+        lambda ids: [
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
+             "used_gb": None}
+            for i in ids
+        ],
+    )
+    monkeypatch.setattr(hw, "_rocm_system_wide_vram_by_index", lambda devs: resolved)
+
+
+def test_rocm_linux_reads_sysfs_without_asking_torch_for_occupancy(monkeypatch):
+    _rocm_linux(monkeypatch, {0: (12.0, 64.0), 1: (3.0, 64.0)})
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_per_device_info",
+        lambda ids: pytest.fail("sysfs answered in full; torch occupancy is dead weight"),
+    )
+    result = hw.get_visible_gpu_utilization()
+    assert result["available"] is True
+    assert result["index_kind"] == "physical"
+    assert [(d["vram_used_gb"], d["vram_total_gb"]) for d in result["devices"]] == [
+        (12.0, 64.0),
+        (3.0, 64.0),
+    ]
+    assert [d["vram_utilization_pct"] for d in result["devices"]] == [18.8, 4.7]
+
+
+def test_rocm_linux_sysfs_first_matches_the_old_torch_then_overlay_result(monkeypatch):
+    # Parity: the overlay overwrote torch's used AND total, so every field the old
+    # path produced for a fully covered set is reproduced without the context.
+    resolved = {0: (12.0, 64.0), 1: (3.0, 64.0)}
+    _rocm_linux(monkeypatch, resolved)
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_per_device_info",
+        lambda ids: [
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
+             "used_gb": 0.02}
+            for i in ids
+        ],
+    )
+    new = hw.get_visible_gpu_utilization()
+
+    # Recreate the old shape: torch figures, then the overlay on top.
+    old_devices = [
+        {
+            "index": i,
+            "index_kind": "physical",
+            "visible_ordinal": i,
+            "gpu_utilization_pct": None,
+            "temperature_c": None,
+            "vram_used_gb": 0.02,
+            "vram_total_gb": 64.0,
+            "vram_utilization_pct": 0.0,
+            "power_draw_w": None,
+            "power_limit_w": None,
+            "power_utilization_pct": None,
+        }
+        for i in (0, 1)
+    ]
+    hw._apply_system_wide_vram(old_devices, resolved)
+    assert new["devices"] == old_devices
+
+
+def test_rocm_linux_falls_back_to_torch_when_sysfs_covers_only_some(monkeypatch):
+    # One device uncovered (a unified-memory APU or an MI300 partition): the whole
+    # set must go back to torch rather than ship a device with no number at all.
+    _rocm_linux(monkeypatch, {0: (12.0, 64.0)})
+    used = []
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_per_device_info",
+        lambda ids: used.append(ids)
+        or [
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
+             "used_gb": 1.0}
+            for i in ids
+        ],
+    )
+    result = hw.get_visible_gpu_utilization()
+    assert used == [[0, 1]]
+    # The overlay still applies to the device sysfs does know about.
+    assert result["devices"][0]["vram_used_gb"] == 12.0
+    assert result["devices"][1]["vram_used_gb"] == 1.0
+
+
+def test_rocm_linux_falls_back_when_sysfs_knows_nothing(monkeypatch):
+    _rocm_linux(monkeypatch, {})
+    used = []
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_per_device_info",
+        lambda ids: used.append(ids)
+        or [
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
+             "used_gb": 1.0}
+            for i in ids
+        ],
+    )
+    result = hw.get_visible_gpu_utilization()
+    assert used == [[0, 1]]
+    assert [d["vram_used_gb"] for d in result["devices"]] == [1.0, 1.0]
+
+
+def test_nvidia_torch_fallback_keeps_using_occupancy(monkeypatch):
+    # No sysfs shortcut off ROCm: an NVIDIA host without nvidia-smi genuinely needs
+    # torch for live usage, so it must keep asking for it.
+    monkeypatch.setattr(hw, "IS_ROCM", False)
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setattr(hw, "_smi_query", lambda *a, **k: None)
+    monkeypatch.setattr(
+        hw,
+        "_get_parent_visible_gpu_spec",
+        lambda: {"raw": None, "numeric_ids": [0], "supports_explicit_gpu_ids": True},
+    )
+    monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: [0])
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_per_device_info",
+        lambda ids: [{"index": 0, "visible_ordinal": 0, "name": "L40S", "total_gb": 44.0,
+                      "used_gb": 4.0}],
+    )
+    result = hw.get_visible_gpu_utilization()
+    assert result["devices"][0]["vram_used_gb"] == 4.0
+
+
+def test_rocm_relative_index_skips_the_sysfs_shortcut(monkeypatch):
+    # A UUID/MIG mask makes index relative, so it is not a host ordinal sysfs can
+    # be keyed on. Same gate the overlay itself applies.
+    _rocm_linux(monkeypatch, {0: (12.0, 64.0), 1: (3.0, 64.0)})
+    monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: [])
+    monkeypatch.setattr(hw, "_torch_get_physical_gpu_count", lambda: 2)
+    seen = []
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_per_device_info",
+        lambda ids: seen.append(ids)
+        or [
+            {"index": i, "visible_ordinal": i, "name": "MI210", "total_gb": 64.0,
+             "used_gb": 1.0}
+            for i in ids
+        ],
+    )
+    result = hw.get_visible_gpu_utilization()
+    assert result["index_kind"] == "relative"
+    assert seen == [[0, 1]]
+
+
+def test_rocm_windows_does_not_take_the_linux_sysfs_path(monkeypatch):
+    _rocm_linux(monkeypatch, {0: (12.0, 64.0), 1: (3.0, 64.0)})
+    monkeypatch.setattr(hw.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        hw,
+        "_rocm_windows_per_device_vram",
+        lambda ids: (
+            [{"index": i, "visible_ordinal": i, "name": "RX", "used_gb": 2.0,
+              "total_gb": 24.0} for i in ids],
+            4.0,
+        ),
+    )
+    result = hw.get_visible_gpu_utilization()
+    assert result["vram_used_gb_aggregate"] == 4.0
+    assert [d["vram_used_gb"] for d in result["devices"]] == [2.0, 2.0]
+
+
+# ========== The refactored overlay keeps its old contract ==========
+
+
+def test_overlay_wrapper_still_mutates_in_place(monkeypatch):
+    devices = [
+        {"index": 0, "vram_used_gb": 0.02, "vram_total_gb": 64.0, "vram_utilization_pct": 0.0}
+    ]
+    monkeypatch.setattr(hw, "_rocm_system_wide_vram_by_index", lambda d: {0: (32.0, 64.0)})
+    assert hw._overlay_system_wide_vram(devices) is None
+    assert devices[0] == {
+        "index": 0,
+        "vram_used_gb": 32.0,
+        "vram_total_gb": 64.0,
+        "vram_utilization_pct": 50.0,
+    }
+
+
+def test_decision_helper_does_not_mutate(monkeypatch):
+    monkeypatch.setattr(hw.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(hw, "_rocm_kfd_gpu_pci_ids", lambda: ["0000:00:02.0"])
+    monkeypatch.setattr(hw, "_rocm_visibility_mask_active", lambda: False)
+    monkeypatch.setattr(
+        hw, "_rocm_linux_sysfs_vram_by_pci_gb", lambda: {"0000:00:02.0": (32.0, 64.0)}
+    )
+    devices = [{"index": 0, "vram_total_gb": 64.0}]
+    snapshot = dict(devices[0])
+    assert hw._rocm_system_wide_vram_by_index(devices) == {0: (32.0, 64.0)}
+    assert devices[0] == snapshot

--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -317,14 +317,28 @@ def test_rocm_apu_inventory_keeps_the_gtt_total(monkeypatch):
     assert inventory[0]["total_gb"] != round(_APU_CARVE_OUT / (1024**3), 2)
 
 
+class _FakeRocmProps(_FakeProps):
+    """Discrete card as a current ROCm runtime describes it: the flag is filled in."""
+
+    def __init__(self, name = "MI300X", total = 191505498112, arch = "gfx942", integrated = 0):
+        super().__init__(name, total)
+        self.gcnArchName = arch
+        self.is_integrated = integrated
+
+
+def _rocm_mod(props, gtt_total = _APU_GTT_TOTAL):
+    mod = types.SimpleNamespace()
+    mod.get_device_properties = lambda o: props
+    mod.mem_get_info = lambda o: (gtt_total - (2 << 30), gtt_total)
+    return mod
+
+
 def test_rocm_discrete_inventory_stays_context_free(monkeypatch):
     # Only APUs pay for mem_get_info. An MI300X must keep the free path.
-    def _boom(*a, **k):
-        raise AssertionError("mem_get_info would create a primary context")
-
-    mod = _fake_mod([191505498112], names = ["MI300X"])
-    mod.mem_get_info = _boom
+    mod = _rocm_mod(_FakeRocmProps())
+    mod.mem_get_info = lambda o: pytest.fail("mem_get_info would create a primary context")
     monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw, "_hip_runtime_version", lambda: (6, 4))
     monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
     assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 178.35
 
@@ -368,6 +382,72 @@ def test_rocm_apu_sysfs_overlay_still_declines_against_the_gtt_total(monkeypatch
     inventory = hw._torch_get_device_inventory([0])
     probe = [{"index": d["index"], "vram_total_gb": d["total_gb"]} for d in inventory]
     assert hw._rocm_system_wide_vram_by_index(probe) == {}
+
+
+# ========== APUs the classifier cannot place ==========
+
+# The classifier answers unified or not-unified, never "cannot tell", and it knows an
+# APU by the driver's integrated flag or by a hardcoded gfx1150/1151/1152 set. Every
+# other iGPU therefore reads as not-unified, and taking that for discrete would publish
+# an 8 GiB-class carve-out as the whole device and hide models. clr only fills that flag
+# in from ROCm 6.1.2, so only a runtime new enough to answer gets to settle it.
+
+
+class _FakeUnclassifiedApuProps(_FakeProps):
+    """gfx1103 Phoenix: a real APU that sits outside the classifier's arch set."""
+
+    def __init__(self, total = _APU_CARVE_OUT, *, integrated = 0):
+        super().__init__("AMD Radeon 780M Graphics", total)
+        self.gcnArchName = "gfx1103"
+        if integrated is not None:
+            self.is_integrated = integrated
+
+
+def test_rocm_unclassified_apu_keeps_the_driver_total_on_an_older_runtime(monkeypatch):
+    mod = _rocm_mod(_FakeUnclassifiedApuProps())
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw, "_hip_runtime_version", lambda: (6, 1))
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 100.0
+
+
+def test_rocm_unclassified_apu_keeps_the_driver_total_without_the_flag(monkeypatch):
+    # A wheel that omits the field reads as 0 through getattr, exactly like a runtime
+    # that never set it, so the arch set is again the only signal left.
+    mod = _rocm_mod(_FakeUnclassifiedApuProps(integrated = None))
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw, "_hip_runtime_version", lambda: (6, 4))
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 100.0
+
+
+def test_rocm_props_that_cannot_be_classified_keep_the_driver_total(monkeypatch):
+    class _HostileProps(_FakeProps):
+        def __init__(self):
+            super().__init__("AMD Radeon Graphics", _APU_CARVE_OUT)
+
+        @property
+        def gcnArchName(self):
+            raise RuntimeError("properties unreadable")
+
+    mod = _rocm_mod(_HostileProps())
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw, "_hip_runtime_version", lambda: (6, 4))
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 100.0
+
+
+def test_hip_runtime_version_reads_both_wheel_spellings(monkeypatch):
+    import torch
+
+    monkeypatch.setattr(torch.version, "hip", "6.4.43483-a187df25c", raising = False)
+    assert hw._hip_runtime_version() == (6, 4)
+    # AMD SDK / Radeon wheels leave version.hip unset; the tag is in __version__.
+    monkeypatch.setattr(torch.version, "hip", None, raising = False)
+    monkeypatch.setattr(torch, "__version__", "2.9.0+rocm6.2", raising = False)
+    assert hw._hip_runtime_version() == (6, 2)
+    monkeypatch.setattr(torch, "__version__", "2.9.0+cu128", raising = False)
+    assert hw._hip_runtime_version() is None
 
 
 # ========== clear_gpu_cache ==========

--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -275,6 +275,101 @@ def test_visibility_endpoint_uses_inventory_not_occupancy(monkeypatch):
     assert result["index_kind"] == "physical"
 
 
+# ========== ROCm APU totals ==========
+
+# props.total_memory and the hipMemGetInfo total are the same number everywhere
+# except a unified-memory APU, where props reports the dedicated carve-out and
+# hipMemGetInfo the GTT-spanning pool. This module already treats the larger GTT
+# figure as authoritative (_apply_unified_memory_correction adopts it over
+# amd-smi's), so the inventory must not quietly hand back the carve-out and
+# budget a 128 GiB Strix Halo as ~8 GiB.
+
+_APU_CARVE_OUT = 8 * 1024**3
+_APU_GTT_TOTAL = 100 * 1024**3
+
+
+class _FakeApuProps(_FakeProps):
+    def __init__(self, total = _APU_CARVE_OUT):
+        super().__init__("AMD Radeon 8060S Graphics", total)
+        self.gcnArchName = "gfx1151"  # Strix Halo
+        self.is_integrated = 1
+
+
+def _apu_mod(gtt_total = _APU_GTT_TOTAL, *, carve_out = _APU_CARVE_OUT):
+    mod = types.SimpleNamespace()
+    mod.get_device_properties = lambda o: _FakeApuProps(carve_out)
+    mod.mem_get_info = lambda o: (gtt_total - (2 << 30), gtt_total)
+    mod.memory_allocated = lambda o: 1 << 30
+    return mod
+
+
+def test_rocm_apu_inventory_keeps_the_gtt_total(monkeypatch):
+    mod = _apu_mod()
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setattr(hw, "rocm_windows_free_is_untrusted", lambda: False)
+
+    inventory = hw._torch_get_device_inventory([0])
+    occupancy = hw._torch_get_per_device_info([0])
+
+    assert inventory[0]["total_gb"] == occupancy[0]["total_gb"] == 100.0
+    assert inventory[0]["total_gb"] != round(_APU_CARVE_OUT / (1024**3), 2)
+
+
+def test_rocm_discrete_inventory_stays_context_free(monkeypatch):
+    # Only APUs pay for mem_get_info. An MI300X must keep the free path.
+    def _boom(*a, **k):
+        raise AssertionError("mem_get_info would create a primary context")
+
+    mod = _fake_mod([191505498112], names = ["MI300X"])
+    mod.mem_get_info = _boom
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 178.35
+
+
+def test_an_apu_shaped_name_on_cuda_stays_context_free(monkeypatch):
+    # The carve-out only exists on ROCm, so IS_ROCM gates the whole probe.
+    mod = _apu_mod()
+    mod.mem_get_info = lambda o: pytest.fail("no ROCm here, so no reason to pay for a context")
+    monkeypatch.setattr(hw, "IS_ROCM", False)
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 8.0
+
+
+def test_rocm_apu_keeps_the_carve_out_when_the_driver_total_fails(monkeypatch):
+    # Degraded, not dropped: the device still has to appear in the inventory.
+    mod = _apu_mod()
+
+    def _fail(o):
+        raise RuntimeError("hipMemGetInfo unavailable")
+
+    mod.mem_get_info = _fail
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    assert [d["total_gb"] for d in hw._torch_get_device_inventory([0])] == [8.0]
+
+
+def test_rocm_apu_sysfs_overlay_still_declines_against_the_gtt_total(monkeypatch):
+    # The sysfs-first path compares the overlay's total against the inventory's.
+    # With the carve-out there the two would agree and the overlay would adopt
+    # sysfs, shrinking the APU. Against the GTT total it declines, as documented.
+    mod = _apu_mod()
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    monkeypatch.setattr(hw, "platform", types.SimpleNamespace(system = lambda: "Linux"))
+    monkeypatch.setattr(hw, "_rocm_kfd_gpu_pci_ids", lambda: {0: "0000:03:00.0"})
+    monkeypatch.setattr(hw, "_rocm_visibility_mask_active", lambda: False)
+    monkeypatch.setattr(
+        hw, "_rocm_linux_sysfs_vram_by_pci_gb", lambda: {"0000:03:00.0": (1.0, 8.0)}
+    )
+
+    inventory = hw._torch_get_device_inventory([0])
+    probe = [{"index": d["index"], "vram_total_gb": d["total_gb"]} for d in inventory]
+    assert hw._rocm_system_wide_vram_by_index(probe) == {}
+
+
 # ========== clear_gpu_cache ==========
 
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -801,16 +801,13 @@ def clear_gpu_cache():
     if device == DeviceType.CUDA:
         import torch
 
-        # Nothing reserved on any visible device means this process never built an
-        # allocator, so there is no work in flight to wait on. Skip only the
-        # synchronize: it would attach a primary context (~612 MiB, never returned
-        # while the process lives) just to idle on an empty stream.
-        # memory_reserved(i) needs no context of its own, and is_initialized() is no
-        # guard here since reading device properties already flips it. Summed over
-        # devices rather than the current one so a process that allocated only on a
-        # non-current device still gets drained. Deliberately NOT wrapped in
-        # try/except: the diffusion and video unload paths document that a sticky
-        # CUDA fault has to propagate out of here.
+        # Nothing reserved anywhere means no allocator was ever built, so there is
+        # nothing to wait on. Skip only the synchronize: it attaches a primary
+        # context (~612 MiB, never returned) to idle on an empty stream.
+        # memory_reserved needs no context; is_initialized() is useless here, since
+        # reading device properties already flips it. Summed over devices so one
+        # that allocated off the current device still drains. Deliberately NOT
+        # wrapped: the unload paths need a sticky CUDA fault to propagate.
         if torch.cuda.is_available() and any(
             torch.cuda.memory_reserved(i) for i in range(torch.cuda.device_count())
         ):
@@ -2446,13 +2443,12 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
             torch_indices = list(range(visible_count))
             index_kind = "relative"
 
-        # Linux ROCm: sysfs first. The overlay below would replace torch's
-        # process-local figures with these same sysfs numbers anyway, so asking
-        # torch for occupancy first buys a permanent driver context and then throws
-        # the answer away. Totals come from device properties, which cost nothing
-        # and are what the overlay's 1:1 check compares against. Only taken when
-        # sysfs covers EVERY visible device; otherwise fall through to torch
-        # unchanged, so a device the overlay declines still gets a real number.
+        # Linux ROCm: sysfs first. The overlay below replaces torch's process-local
+        # figures with these same numbers anyway, so asking torch first buys a
+        # permanent context and throws the answer away. Totals come from device
+        # properties, which cost nothing and are what the overlay's check compares
+        # against. Only when sysfs covers EVERY visible device; otherwise fall
+        # through to torch, so a device the overlay declines still gets a number.
         if IS_ROCM and index_kind == "physical" and platform.system() == "Linux":
             inventory = _torch_get_device_inventory(torch_indices)
             probe = [{"index": inv["index"], "vram_total_gb": inv["total_gb"]} for inv in inventory]

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1127,8 +1127,32 @@ def trusted_mem_get_info(device: Any = None, *, module: Any = None) -> tuple[int
     return min(free_bytes, max(0, total_bytes - reserved)), total_bytes
 
 
+# clr fills hipDeviceProp_t.integrated from the HSA "agent is APU" flag only from
+# ROCm 6.1.2 on; before that an APU answers 0 exactly like a discrete card. HIP's
+# last version field is a build number, so 6.1.2 cannot be told from 6.1.0 and the
+# whole 6.1 line stays untrusted.
+_HIP_INTEGRATED_FLAG_MIN = (6, 2)
+
+
+def _hip_runtime_version() -> Optional[tuple[int, int]]:
+    """(major, minor) of the HIP runtime torch was built against, None if unreadable."""
+    try:
+        import torch
+
+        raw = getattr(torch.version, "hip", None)
+        if raw:
+            parts = str(raw).split(".")
+            return (int(parts[0]), int(parts[1]))
+        # AMD SDK / Radeon wheels leave version.hip unset; the tag is in __version__.
+        match = re.search(r"rocm(\d+)\.(\d+)", getattr(torch, "__version__", "") or "")
+        return (int(match.group(1)), int(match.group(2))) if match else None
+    except Exception as e:
+        logger.debug("HIP runtime version probe failed: %s", e)
+        return None
+
+
 def _rocm_props_total_is_carve_out(props: Any) -> bool:
-    """True when ``props.total_memory`` understates what torch can actually use.
+    """True when ``props.total_memory`` may understate what torch can actually use.
 
     On a unified-memory ROCm APU the two totals are NOT the same number:
     ``props.total_memory`` is the dedicated carve-out while ``hipMemGetInfo``'s
@@ -1139,15 +1163,29 @@ def _rocm_props_total_is_carve_out(props: Any) -> bool:
     the GTT total, so only APUs pay mem_get_info; every discrete device keeps the
     free inventory. Same classifier the training worker and the llama.cpp backend
     use, so all three agree on what an APU is.
+
+    "Not unified" is not the same answer as "discrete". That classifier knows an APU
+    by the driver's integrated flag or by a hardcoded arch set, so a gfx1103 Phoenix
+    iGPU on a runtime that leaves the flag at 0 reads as discrete and would publish
+    its carve-out as the whole device. Only a runtime that fills the flag in gets to
+    settle it; on anything older, and when the classifier itself fails, the driver
+    total is worth a context, because a total that is too small hides models.
     """
     if not IS_ROCM:
         return False
     try:
         from core.training.worker import _rocm_classify_unified_memory
-        return _rocm_classify_unified_memory(props)[1]
+        if _rocm_classify_unified_memory(props)[1]:
+            return True
     except Exception as e:
         logger.debug("ROCm unified-memory classification failed: %s", e)
-        return False
+        return True
+    hip_version = _hip_runtime_version()
+    return (
+        getattr(props, "is_integrated", None) is None
+        or hip_version is None
+        or hip_version < _HIP_INTEGRATED_FLAG_MIN
+    )
 
 
 def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any]]:

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1147,7 +1147,6 @@ def _rocm_props_total_is_carve_out(props: Any) -> bool:
         return False
     try:
         from core.training.worker import _rocm_classify_unified_memory
-
         return _rocm_classify_unified_memory(props)[1]
     except Exception as e:
         logger.debug("ROCm unified-memory classification failed: %s", e)

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -801,7 +801,21 @@ def clear_gpu_cache():
     if device == DeviceType.CUDA:
         import torch
 
-        torch.cuda.synchronize()
+        # Nothing reserved on any visible device means this process never built an
+        # allocator, so there is no work in flight to wait on. Skip only the
+        # synchronize: it would attach a primary context (~612 MiB, never returned
+        # while the process lives) just to idle on an empty stream.
+        # memory_reserved(i) needs no context of its own, and is_initialized() is no
+        # guard here since reading device properties already flips it. Summed over
+        # devices rather than the current one so a process that allocated only on a
+        # non-current device still gets drained. Deliberately NOT wrapped in
+        # try/except: the diffusion and video unload paths document that a sticky
+        # CUDA fault has to propagate out of here.
+        if torch.cuda.is_available() and any(
+            torch.cuda.memory_reserved(i) for i in range(torch.cuda.device_count())
+        ):
+            torch.cuda.synchronize()
+        # Both are no-ops without an allocator and neither creates a context.
         torch.cuda.empty_cache()
         torch.cuda.ipc_collect()
     elif device == DeviceType.XPU:
@@ -1116,8 +1130,48 @@ def trusted_mem_get_info(device: Any = None, *, module: Any = None) -> tuple[int
     return min(free_bytes, max(0, total_bytes - reserved)), total_bytes
 
 
+def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any]]:
+    """Per-GPU name and total VRAM only, without creating a driver context.
+
+    INVENTORY, not occupancy. ``get_device_properties`` is answered from the
+    driver's device list, so it costs nothing; ``mem_get_info`` has to attach a
+    primary context to the device, which is ~612 MiB the process never gives back
+    (a context is only torn down at exit). A telemetry poll every few seconds must
+    not be what pins that, so callers that need name and capacity but not live
+    occupancy come here instead of _torch_get_per_device_info.
+
+    ``props.total_memory`` is the same number ``mem_get_info`` returns as its total
+    half, so totals are unchanged. ``used_gb`` is always None, the value this
+    module already uses for "telemetry unavailable".
+    """
+    mod, _ = _torch_get_device_module()
+    if mod is None:
+        return []
+
+    devices = []
+    for ordinal, phys_idx in enumerate(device_indices):
+        try:
+            # torch ordinals are 0-based relative to CUDA_VISIBLE_DEVICES.
+            props = mod.get_device_properties(ordinal)
+            devices.append(
+                {
+                    "index": phys_idx,
+                    "visible_ordinal": ordinal,
+                    "name": props.name,
+                    "total_gb": round(props.total_memory / (1024**3), 2),
+                    "used_gb": None,
+                }
+            )
+        except Exception as e:
+            logger.debug("torch inventory probe failed for ordinal %d: %s", ordinal, e)
+    return devices
+
+
 def _torch_get_per_device_info(device_indices: list[int]) -> list[Dict[str, Any]]:
     """Query torch for per-GPU name, total VRAM, and used VRAM.
+
+    Creates a driver context on CUDA/HIP (see _torch_get_device_inventory). Only
+    call this when live occupancy is actually consumed.
 
     ``used_gb`` is ``None`` on Windows ROCm when the driver reports ``free ==
     total``: that 0 means unknown, not empty. This is the DISPLAY path, so unknown
@@ -2201,25 +2255,19 @@ def _rocm_visibility_mask_active() -> bool:
     return False
 
 
-def _overlay_system_wide_vram(devices: list[Dict[str, Any]]) -> None:
-    """Replace process-local torch VRAM with system-wide Linux ROCm figures.
+def _rocm_system_wide_vram_by_index(
+    devices: list[Dict[str, Any]],
+) -> Dict[int, tuple[float, float]]:
+    """Decide the system-wide overlay without applying it.
 
-    The torch fallback is process-local, so a model served by the separate
-    llama-server process reads as ~0 used even with the GPU full (#7072). DRM
-    sysfs gives per-card figures the kernel updates across all processes. Sources
-    are matched by the device's PHYSICAL index (never list position), and only
-    when NO visibility mask is active and the device count equals the host GPU
-    count; under any mask the index is not a verifiable host ordinal, so torch's
-    figures are kept. Best-effort, in place: a device with no matching card, or a
-    unified-memory APU whose sysfs total is below torch's GTT-backed total, keeps
-    torch's (mirrors _apply_unified_memory_correction).
-
-    Windows is intentionally not overlaid: its per-adapter perf counters cannot be
-    mapped to ROCm ordinals and miss WDDM shared memory, so the multi-GPU view
-    keeps torch there rather than risk misattributing another adapter's usage.
+    Returns ``{physical index: (used_gb, total_gb)}`` for every device sysfs can
+    speak for, and omits the ones it cannot. Split out from
+    _overlay_system_wide_vram so a caller can ask whether sysfs covers the whole
+    visible set BEFORE paying torch for occupancy it would then discard. Reads
+    only ``vram_total_gb`` off ``devices``; it never mutates them.
     """
     if not devices or platform.system() != "Linux":
-        return
+        return {}
     # Match by PCI identity, never list position: index N in KFD topology is ROCm
     # physical device N and carries its PCI address, which DRM sysfs keys on too.
     # The two gates below verify ``index`` really is a host-physical ordinal
@@ -2230,10 +2278,11 @@ def _overlay_system_wide_vram(devices: list[Dict[str, Any]]) -> None:
     #     that sets no env var yet compacts torch's indices from zero.
     pci_by_ordinal = _rocm_kfd_gpu_pci_ids()
     if not pci_by_ordinal:
-        return
+        return {}
     if _rocm_visibility_mask_active() or len(devices) != len(pci_by_ordinal):
-        return
+        return {}
     vram_by_pci = _rocm_linux_sysfs_vram_by_pci_gb()
+    resolved: Dict[int, tuple[float, float]] = {}
     for dev in devices:
         index = dev.get("index")
         if not isinstance(index, int) or not (0 <= index < len(pci_by_ordinal)):
@@ -2251,9 +2300,42 @@ def _overlay_system_wide_vram(devices: list[Dict[str, Any]]) -> None:
         # VRAM (a partition would look like it has the whole card free).
         if dev_total <= 0 or abs(total - dev_total) > 0.1 * dev_total:
             continue
+        resolved[index] = (used, total)
+    return resolved
+
+
+def _apply_system_wide_vram(
+    devices: list[Dict[str, Any]], resolved: Dict[int, tuple[float, float]]
+) -> None:
+    """Write a _rocm_system_wide_vram_by_index result onto the device dicts."""
+    for dev in devices:
+        entry = resolved.get(dev.get("index"))
+        if entry is None:
+            continue
+        used, total = entry
         dev["vram_used_gb"] = used
         dev["vram_total_gb"] = total
         dev["vram_utilization_pct"] = round((used / total) * 100, 1) if total > 0 else None
+
+
+def _overlay_system_wide_vram(devices: list[Dict[str, Any]]) -> None:
+    """Replace process-local torch VRAM with system-wide Linux ROCm figures.
+
+    The torch fallback is process-local, so a model served by the separate
+    llama-server process reads as ~0 used even with the GPU full (#7072). DRM
+    sysfs gives per-card figures the kernel updates across all processes. Sources
+    are matched by the device's PHYSICAL index (never list position), and only
+    when NO visibility mask is active and the device count equals the host GPU
+    count; under any mask the index is not a verifiable host ordinal, so torch's
+    figures are kept. Best-effort, in place: a device with no matching card, or a
+    unified-memory APU whose sysfs total is below torch's GTT-backed total, keeps
+    torch's (mirrors _apply_unified_memory_correction).
+
+    Windows is intentionally not overlaid: its per-adapter perf counters cannot be
+    mapped to ROCm ordinals and miss WDDM shared memory, so the multi-GPU view
+    keeps torch there rather than risk misattributing another adapter's usage.
+    """
+    _apply_system_wide_vram(devices, _rocm_system_wide_vram_by_index(devices))
 
 
 def get_visible_gpu_utilization() -> Dict[str, Any]:
@@ -2331,6 +2413,46 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
             visible_count = _torch_get_physical_gpu_count() or 0
             torch_indices = list(range(visible_count))
             index_kind = "relative"
+
+        # Linux ROCm: sysfs first. The overlay below would replace torch's
+        # process-local figures with these same sysfs numbers anyway, so asking
+        # torch for occupancy first buys a permanent driver context and then throws
+        # the answer away. Totals come from device properties, which cost nothing
+        # and are what the overlay's 1:1 check compares against. Only taken when
+        # sysfs covers EVERY visible device; otherwise fall through to torch
+        # unchanged, so a device the overlay declines still gets a real number.
+        if IS_ROCM and index_kind == "physical" and platform.system() == "Linux":
+            inventory = _torch_get_device_inventory(torch_indices)
+            probe = [
+                {"index": inv["index"], "vram_total_gb": inv["total_gb"]} for inv in inventory
+            ]
+            resolved = _rocm_system_wide_vram_by_index(probe)
+            if inventory and all(inv["index"] in resolved for inv in inventory):
+                devices = [
+                    {
+                        "index": inv["index"],
+                        "index_kind": index_kind,
+                        "visible_ordinal": inv["visible_ordinal"],
+                        "gpu_utilization_pct": None,
+                        "temperature_c": None,
+                        "vram_used_gb": None,
+                        "vram_total_gb": inv["total_gb"],
+                        "vram_utilization_pct": None,
+                        "power_draw_w": None,
+                        "power_limit_w": None,
+                        "power_utilization_pct": None,
+                    }
+                    for inv in inventory
+                ]
+                _apply_system_wide_vram(devices, resolved)
+                return {
+                    "available": True,
+                    "backend": _backend_label(device),
+                    "parent_visible_gpu_ids": parent_ids,
+                    "devices": devices,
+                    "index_kind": index_kind,
+                }
+
         torch_devices = _torch_get_per_device_info(torch_indices)
         if torch_devices:
             devices = []
@@ -3377,7 +3499,9 @@ def get_backend_visible_gpu_info() -> Dict[str, Any]:
             visible_count = _torch_get_physical_gpu_count() or 0
             torch_indices = list(range(visible_count))
             index_kind = "relative"
-        torch_devices = _torch_get_per_device_info(torch_indices)
+        # Inventory only: this endpoint reads name and total and discards used, so
+        # there is nothing here worth a permanent driver context.
+        torch_devices = _torch_get_device_inventory(torch_indices)
         if torch_devices:
             devices = [
                 {

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -2423,9 +2423,7 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
         # unchanged, so a device the overlay declines still gets a real number.
         if IS_ROCM and index_kind == "physical" and platform.system() == "Linux":
             inventory = _torch_get_device_inventory(torch_indices)
-            probe = [
-                {"index": inv["index"], "vram_total_gb": inv["total_gb"]} for inv in inventory
-            ]
+            probe = [{"index": inv["index"], "vram_total_gb": inv["total_gb"]} for inv in inventory]
             resolved = _rocm_system_wide_vram_by_index(probe)
             if inventory and all(inv["index"] in resolved for inv in inventory):
                 devices = [

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1130,6 +1130,30 @@ def trusted_mem_get_info(device: Any = None, *, module: Any = None) -> tuple[int
     return min(free_bytes, max(0, total_bytes - reserved)), total_bytes
 
 
+def _rocm_props_total_is_carve_out(props: Any) -> bool:
+    """True when ``props.total_memory`` understates what torch can actually use.
+
+    On a unified-memory ROCm APU the two totals are NOT the same number:
+    ``props.total_memory`` is the dedicated carve-out while ``hipMemGetInfo``'s
+    total spans the GTT pool, which is the figure the rest of this module treats
+    as authoritative (_apply_unified_memory_correction adopts it over amd-smi's
+    for exactly this reason). Reporting the carve-out would undo that correction
+    and budget a 128 GiB Strix Halo as ~8 GiB. There is no context-free source for
+    the GTT total, so only APUs pay mem_get_info; every discrete device keeps the
+    free inventory. Same classifier the training worker and the llama.cpp backend
+    use, so all three agree on what an APU is.
+    """
+    if not IS_ROCM:
+        return False
+    try:
+        from core.training.worker import _rocm_classify_unified_memory
+
+        return _rocm_classify_unified_memory(props)[1]
+    except Exception as e:
+        logger.debug("ROCm unified-memory classification failed: %s", e)
+        return False
+
+
 def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any]]:
     """Per-GPU name and total VRAM only, without creating a driver context.
 
@@ -1141,8 +1165,9 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
     occupancy come here instead of _torch_get_per_device_info.
 
     ``props.total_memory`` is the same number ``mem_get_info`` returns as its total
-    half, so totals are unchanged. ``used_gb`` is always None, the value this
-    module already uses for "telemetry unavailable".
+    half everywhere except a ROCm APU (see _rocm_props_total_is_carve_out), so
+    totals are unchanged. ``used_gb`` is always None, the value this module already
+    uses for "telemetry unavailable".
     """
     mod, _ = _torch_get_device_module()
     if mod is None:
@@ -1153,12 +1178,20 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
         try:
             # torch ordinals are 0-based relative to CUDA_VISIBLE_DEVICES.
             props = mod.get_device_properties(ordinal)
+            total_bytes = props.total_memory
+            if _rocm_props_total_is_carve_out(props) and hasattr(mod, "mem_get_info"):
+                try:
+                    total_bytes = mod.mem_get_info(ordinal)[1]
+                except Exception as e:
+                    # Keep the carve-out rather than dropping the device: an
+                    # understated total still beats no device at all.
+                    logger.debug("ROCm APU driver total failed for ordinal %d: %s", ordinal, e)
             devices.append(
                 {
                     "index": phys_idx,
                     "visible_ordinal": ordinal,
                     "name": props.name,
-                    "total_gb": round(props.total_memory / (1024**3), 2),
+                    "total_gb": round(total_bytes / (1024**3), 2),
                     "used_gb": None,
                 }
             )


### PR DESCRIPTION
`GET /api/system` reaches `_torch_get_per_device_info`, which calls `torch.cuda.mem_get_info`. That call creates a primary context the process never gives back. The endpoint is polled every 5s by the root-mounted floating monitor and every 3s by Settings, Resources, so on any host where the smi shortcut does not answer, an otherwise idle Studio permanently acquires a context from telemetry alone. On ROCm that is every install. Scoping this honestly after review: on an NVIDIA host with no nvidia-smi the net saving across the combined poll is zero, because the same request also asks `get_visible_gpu_utilization()` for live occupancy, and there is no context-free source for USED VRAM. That call is left alone deliberately (see below).

The structural cause: `_torch_get_per_device_info` conflates inventory (name and total capacity) with live occupancy (used). Only occupancy needs a context. And `get_backend_visible_gpu_info` discards `used_gb` entirely, building each device from `index`, `index_kind`, `visible_ordinal`, `name` and `total_gb` (`hardware.py:3382-3390`).

## Measured

Fresh process, per-PID via nvidia-smi, GPU 5 on a B200: `import torch`, `get_device_properties` and `memory_reserved` all cost 0 MiB; `mem_get_info` and `synchronize` cost 612 MiB, permanently.

Endpoint level, same process shape and device:

| | context | name | total_gb | index | ordinal | used_gb |
| --- | ---: | --- | ---: | ---: | ---: | --- |
| before, `_torch_get_per_device_info` | **612 MiB** | NVIDIA B200 | 178.35 | 5 | 0 | 3.49 |
| after, `_torch_get_device_inventory` | **0 MiB** | NVIDIA B200 | 178.35 | 5 | 0 | null |

Every field the caller actually consumes is identical. Raw bytes agree exactly: `get_device_properties(0).total_memory == mem_get_info(0)[1] == 191505498112`, delta 0, in both orderings.

## Three changes

**1. An inventory path that needs no context.** `_torch_get_device_inventory` answers name and total from `get_device_properties`, and `get_backend_visible_gpu_info` uses it. Nothing that genuinely needs live free memory was touched.

**2. `clear_gpu_cache` no longer synchronises a device with nothing to synchronise.** `torch.cuda.synchronize()` creates a context; `empty_cache` and `ipc_collect` do not. The guard sums `memory_reserved(i)` across `device_count()` rather than reading the current device only, so a process that allocated solely on a non-current device is not skipped. `empty_cache` and `ipc_collect` still run unconditionally, which an existing test pins.

Worth recording: I first added a `try/except` around that branch to match the XPU branch, then removed it. The missing `try/except` is deliberate and load-bearing. `diffusion.py:5652` and `video.py:5552` both comment that `clear_gpu_cache()` raises on a sticky CUDA fault, and both wrap the unload in `try/finally` to decrement a waiter counter on that raise. Swallowing there would have silently broken both.

**3. Linux ROCm tries sysfs before torch.** The sysfs branch was Windows-only, so Linux ROCm always fell to torch and then `_overlay_system_wide_vram` overwrote the result with sysfs figures anyway: a context spent producing numbers that were immediately discarded.

With one qualification found while checking: the overlay does not always overwrite. It declines per device on no PCI match, any visibility mask, a device-count mismatch, or a total mismatch over 10 percent (APU and MI300 partition cases). So sysfs-first is taken only when it covers every visible device, and otherwise the unchanged torch path runs.

## Deliberately not changed

`_reconcile_rocm_unified_memory` and `_reconcile_primary_rocm_unified_memory` also reach `_torch_get_per_device_info` from the same poll, on the ROCm path where amd-smi succeeds. They genuinely consume `used_gb`, so a ROCm APU with working amd-smi still acquires a context. Early-returning on totals alone would assume `props.total_memory` equals the `mem_get_info` total on a ROCm APU, which I cannot verify on an NVIDIA box, and getting it wrong would break the exact APU correction that code exists for. Left alone on purpose.

The same caution applies generally: totals parity is verified on NVIDIA only. In-file precedent supports it on ROCm, since `_rocm_windows_per_device_vram` already takes totals from `props` and calls them reliable, but ROCm APU and Intel XPU equality is unverified here.

## Tests

New `tests/test_system_poll_no_cuda_context.py`, 22 tests, including subprocess-based assertions that the poll path leaves the process context-free.

18 hardware, GPU, VRAM and system test files:

- before: 9 failed, 794 passed, 6 skipped
- after: 9 failed, 828 passed, 6 skipped

Identical failure names on both sides. Widened to include the diffusion and video backends: 10 failed, 1354 passed, the extra name being `test_video_backend.py::test_a_quantized_reference_load_resolves_the_reference_denoiser`, which is pre-existing at the base commit and reproduces with these changes removed.

Two existing tests needed updating because the endpoint legitimately calls a different helper now: `test_gpu_selection.py:382` patches `_torch_get_device_inventory`, and `patch_targets.json` records the rename. I hand-edited that one key rather than re-snapshotting, which would have swept in unrelated pre-existing drift.

`ruff check` clean on all three touched files.


## What this deliberately does not change

`_reconcile_rocm_unified_memory`, `_reconcile_primary_rocm_unified_memory` and
`get_visible_gpu_utilization` also reach `_torch_get_per_device_info` from the same poll, and they
genuinely consume `used_gb`: `main.py:1833` reads `vram_used_gb` and `:1843` its
`vram_utilization_pct`, which is what the floating monitor and Settings, Resources display. Device
properties answer capacity, not occupancy, so there is no context-free substitute on a host without
an smi tool, and `hardware.py:2482` is additionally the only Intel XPU path, whose branch exists to
keep a device whose free-memory query fails. Those paths keep paying for a context on purpose;
`test_nvidia_torch_fallback_keeps_using_occupancy` pins it.

So the saving is real on the ROCm and inventory paths and zero on the NVIDIA-without-nvidia-smi
occupancy path. A wrong or blank number in the UI is worse than 612 MiB.
