### PR TITLE
Studio: give GGML_CUDA_ENABLE_UNIFIED_MEMORY a real off switch (#8651)

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -13973,7 +13973,9 @@ class LlamaCppBackend:
                     # ggml reads presence, not value, so passing a user's "0" through
                     # would ENABLE the thing they turned off (#8651). Only absence is off.
                     if env.pop("GGML_CUDA_ENABLE_UNIFIED_MEMORY", None) is not None:
-                        logger.info("Unified memory opted out: unset GGML_CUDA_ENABLE_UNIFIED_MEMORY")
+                        logger.info(
+                            "Unified memory opted out: unset GGML_CUDA_ENABLE_UNIFIED_MEMORY"
+                        )
                 elif not is_vulkan_backend and self._amd_apu_wants_unified_memory(gpu_indices):
                     _unified_env_applied = "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
                     env.setdefault("GGML_CUDA_ENABLE_UNIFIED_MEMORY", "1")

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5405,6 +5405,32 @@ class LlamaCppBackend:
         except Exception:
             return False
 
+    # Spellings of "off" for GGML_CUDA_ENABLE_UNIFIED_MEMORY. ggml never reads the
+    # value, so these mean nothing to it; we honour them on the user's behalf.
+    _UNIFIED_MEMORY_OFF = frozenset({"", "0", "false", "no", "off"})
+
+    @staticmethod
+    def _unified_memory_opted_out(env = None) -> bool:
+        """True when this launch must leave GGML_CUDA_ENABLE_UNIFIED_MEMORY *absent*.
+
+        ggml gates managed memory on `getenv(...) != nullptr`, so any value enables
+        it and `=0` is not an off switch (#8651). Two ways to opt out, both of which
+        have to end in the name being unset in the child env:
+        UNSLOTH_DISABLE_UNIFIED_MEMORY=1 (mirrors UNSLOTH_DISABLE_DC_TUNING), or a
+        falsy GGML_CUDA_ENABLE_UNIFIED_MEMORY, which is what users reasonably expect
+        to mean off. Fails open (False) so a bad env never blocks a load.
+        """
+        try:
+            source = os.environ if env is None else env
+            if str(source.get("UNSLOTH_DISABLE_UNIFIED_MEMORY", "")).strip() == "1":
+                return True
+            value = source.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY")
+            if value is None:
+                return False
+            return str(value).strip().lower() in LlamaCppBackend._UNIFIED_MEMORY_OFF
+        except Exception:
+            return False
+
     # Datacenter / professional NVIDIA parts that benefit from the llama.cpp
     # FP32-accum / P2P tunings. Whole-word (\b) so short markers don't match
     # workstation parts as substrings: "a100" must not fire on "RTX A1000".
@@ -13938,12 +13964,17 @@ class LlamaCppBackend:
                         env.setdefault("OMP_NUM_THREADS", "2")
 
                 # AMD unified-memory APUs (gfx1150/gfx1151): let llama.cpp use shared
-                # system RAM. setdefault so a user value wins. Not on Vulkan (nor DC
-                # below): gpu_indices are ggml ordinals, not CUDA/ROCm ids. Tracked by
-                # OWNERSHIP, so the arch-crash retry withdraws it only when THIS launch
-                # set it.
+                # system RAM. Not on Vulkan (nor DC below): gpu_indices are ggml
+                # ordinals, not CUDA/ROCm ids. Tracked by OWNERSHIP, so the arch-crash
+                # retry withdraws it only when THIS launch set it.
                 _unified_env_applied = False
-                if not is_vulkan_backend and self._amd_apu_wants_unified_memory(gpu_indices):
+                _unified_opt_out = self._unified_memory_opted_out(env)
+                if _unified_opt_out:
+                    # ggml reads presence, not value, so passing a user's "0" through
+                    # would ENABLE the thing they turned off (#8651). Only absence is off.
+                    if env.pop("GGML_CUDA_ENABLE_UNIFIED_MEMORY", None) is not None:
+                        logger.info("Unified memory opted out: unset GGML_CUDA_ENABLE_UNIFIED_MEMORY")
+                elif not is_vulkan_backend and self._amd_apu_wants_unified_memory(gpu_indices):
                     _unified_env_applied = "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
                     env.setdefault("GGML_CUDA_ENABLE_UNIFIED_MEMORY", "1")
                     logger.info("AMD unified-memory APU: set GGML_CUDA_ENABLE_UNIFIED_MEMORY=1")
@@ -14541,7 +14572,11 @@ class LlamaCppBackend:
                                 "Arch-crash retry targets discrete GPU(s); dropped "
                                 "GGML_CUDA_ENABLE_UNIFIED_MEMORY for the respawn."
                             )
-                        elif _retry_wants_unified and "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env:
+                        elif (
+                            _retry_wants_unified
+                            and not _unified_opt_out  # the opt-out outlives the respawn
+                            and "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+                        ):
                             env["GGML_CUDA_ENABLE_UNIFIED_MEMORY"] = "1"
                             _unified_env_applied = True
                             logger.info(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5405,20 +5405,17 @@ class LlamaCppBackend:
         except Exception:
             return False
 
-    # Spellings of "off" for GGML_CUDA_ENABLE_UNIFIED_MEMORY. ggml never reads the
-    # value, so these mean nothing to it; we honour them on the user's behalf.
+    # "Off" spellings ggml itself ignores (it tests presence); we honour them.
     _UNIFIED_MEMORY_OFF = frozenset({"", "0", "false", "no", "off"})
 
     @staticmethod
     def _unified_memory_opted_out(env = None) -> bool:
-        """True when this launch must leave GGML_CUDA_ENABLE_UNIFIED_MEMORY *absent*.
+        """True when GGML_CUDA_ENABLE_UNIFIED_MEMORY must be ABSENT from this launch.
 
-        ggml gates managed memory on `getenv(...) != nullptr`, so any value enables
-        it and `=0` is not an off switch (#8651). Two ways to opt out, both of which
-        have to end in the name being unset in the child env:
-        UNSLOTH_DISABLE_UNIFIED_MEMORY=1 (mirrors UNSLOTH_DISABLE_DC_TUNING), or a
-        falsy GGML_CUDA_ENABLE_UNIFIED_MEMORY, which is what users reasonably expect
-        to mean off. Fails open (False) so a bad env never blocks a load.
+        ggml tests presence, not value, so `=0` is not an off switch (#8651). Both
+        opt-outs (UNSLOTH_DISABLE_UNIFIED_MEMORY=1, mirroring UNSLOTH_DISABLE_DC_TUNING,
+        or a falsy GGML_CUDA_ENABLE_UNIFIED_MEMORY) must end in the name unset.
+        Fails open (False) so a bad env never blocks a load.
         """
         try:
             source = os.environ if env is None else env
@@ -13965,13 +13962,13 @@ class LlamaCppBackend:
 
                 # AMD unified-memory APUs (gfx1150/gfx1151): let llama.cpp use shared
                 # system RAM. Not on Vulkan (nor DC below): gpu_indices are ggml
-                # ordinals, not CUDA/ROCm ids. Tracked by OWNERSHIP, so the arch-crash
+                # ordinals, not CUDA/ROCm ids. Ownership-tracked, so the arch-crash
                 # retry withdraws it only when THIS launch set it.
                 _unified_env_applied = False
                 _unified_opt_out = self._unified_memory_opted_out(env)
                 if _unified_opt_out:
-                    # ggml reads presence, not value, so passing a user's "0" through
-                    # would ENABLE the thing they turned off (#8651). Only absence is off.
+                    # ggml tests presence, so passing a user's "0" through would
+                    # ENABLE what they turned off (#8651). Only absence is off.
                     if env.pop("GGML_CUDA_ENABLE_UNIFIED_MEMORY", None) is not None:
                         logger.info(
                             "Unified memory opted out: unset GGML_CUDA_ENABLE_UNIFIED_MEMORY"

--- a/studio/backend/tests/test_amd_apu_unified_memory.py
+++ b/studio/backend/tests/test_amd_apu_unified_memory.py
@@ -355,9 +355,8 @@ class TestTheProbeTestsDoNotDependOnHostRam:
 
 
 class TestTheOptOutHelper:
-    """_unified_memory_opted_out, the escape hatch for #8651. ggml reads the
-    variable with getenv(...) != nullptr, so only ABSENCE is off and the helper
-    exists to work out when Studio has to make it absent."""
+    """_unified_memory_opted_out, the #8651 escape hatch. ggml tests presence, not
+    value, so only ABSENCE is off and this decides when to make it absent."""
 
     @pytest.mark.parametrize(
         "env,expected",
@@ -374,7 +373,7 @@ class TestTheOptOutHelper:
             ({"UNSLOTH_DISABLE_UNIFIED_MEMORY": "1"}, True),
             ({"UNSLOTH_DISABLE_UNIFIED_MEMORY": "0"}, False),  # exact "1", like the DC switch
             ({"UNSLOTH_DISABLE_UNIFIED_MEMORY": "yes"}, False),
-            # The switch beats a truthy value, or it is useless where it matters.
+            # The switch has to beat a truthy value.
             (
                 {
                     "UNSLOTH_DISABLE_UNIFIED_MEMORY": "1",
@@ -388,15 +387,13 @@ class TestTheOptOutHelper:
         assert LlamaCppBackend._unified_memory_opted_out(env) is expected
 
     def test_none_reads_the_process_env(self, monkeypatch):
-        """The default argument is the process env, so a shell export is honoured
-        even where no child env has been built yet."""
+        """The default arg is the process env, so a shell export is honoured."""
         monkeypatch.delenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY", raising = False)
         monkeypatch.setenv("UNSLOTH_DISABLE_UNIFIED_MEMORY", "1")
         assert LlamaCppBackend._unified_memory_opted_out() is True
 
     def test_a_hostile_env_fails_open(self):
-        """Fails open like the rest of this family: a bad env must not block a
-        load, and False is the pre-#8651 behaviour."""
+        """Fails open: a bad env must not block a load. False is pre-#8651."""
 
         class _Exploding(dict):
             def get(self, *_args, **_kwargs):

--- a/studio/backend/tests/test_amd_apu_unified_memory.py
+++ b/studio/backend/tests/test_amd_apu_unified_memory.py
@@ -352,3 +352,54 @@ class TestTheProbeTestsDoNotDependOnHostRam:
         capped = LlamaCppBackend._get_gpu_memory()
         assert rows == [(0, _B200_FREE_MIB - 1024, 0)]
         assert capped == [(0, 14_000 - 1024, 0)]
+
+
+class TestTheOptOutHelper:
+    """_unified_memory_opted_out, the escape hatch for #8651. ggml reads the
+    variable with getenv(...) != nullptr, so only ABSENCE is off and the helper
+    exists to work out when Studio has to make it absent."""
+
+    @pytest.mark.parametrize(
+        "env,expected",
+        [
+            ({}, False),  # nothing set: the default decides
+            ({"GGML_CUDA_ENABLE_UNIFIED_MEMORY": "1"}, False),
+            ({"GGML_CUDA_ENABLE_UNIFIED_MEMORY": "2"}, False),  # any value is ON to ggml
+            ({"GGML_CUDA_ENABLE_UNIFIED_MEMORY": "true"}, False),
+            ({"GGML_CUDA_ENABLE_UNIFIED_MEMORY": "0"}, True),  # the reported trap
+            ({"GGML_CUDA_ENABLE_UNIFIED_MEMORY": ""}, True),
+            ({"GGML_CUDA_ENABLE_UNIFIED_MEMORY": " Off "}, True),  # trimmed, folded
+            ({"GGML_CUDA_ENABLE_UNIFIED_MEMORY": "no"}, True),
+            ({"GGML_CUDA_ENABLE_UNIFIED_MEMORY": "false"}, True),
+            ({"UNSLOTH_DISABLE_UNIFIED_MEMORY": "1"}, True),
+            ({"UNSLOTH_DISABLE_UNIFIED_MEMORY": "0"}, False),  # exact "1", like the DC switch
+            ({"UNSLOTH_DISABLE_UNIFIED_MEMORY": "yes"}, False),
+            # The switch beats a truthy value, or it is useless where it matters.
+            (
+                {
+                    "UNSLOTH_DISABLE_UNIFIED_MEMORY": "1",
+                    "GGML_CUDA_ENABLE_UNIFIED_MEMORY": "1",
+                },
+                True,
+            ),
+        ],
+    )
+    def test_opt_out_decisions(self, env, expected):
+        assert LlamaCppBackend._unified_memory_opted_out(env) is expected
+
+    def test_none_reads_the_process_env(self, monkeypatch):
+        """The default argument is the process env, so a shell export is honoured
+        even where no child env has been built yet."""
+        monkeypatch.delenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY", raising = False)
+        monkeypatch.setenv("UNSLOTH_DISABLE_UNIFIED_MEMORY", "1")
+        assert LlamaCppBackend._unified_memory_opted_out() is True
+
+    def test_a_hostile_env_fails_open(self):
+        """Fails open like the rest of this family: a bad env must not block a
+        load, and False is the pre-#8651 behaviour."""
+
+        class _Exploding(dict):
+            def get(self, *_args, **_kwargs):
+                raise RuntimeError("no")
+
+        assert LlamaCppBackend._unified_memory_opted_out(_Exploding()) is False

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -1797,7 +1797,12 @@ class TestUnifiedMemoryOptOut:
             vendor = "amd",
         )
 
-    def _load(self, tmp_path, monkeypatch, env_extra = None):
+    def _load(
+        self,
+        tmp_path,
+        monkeypatch,
+        env_extra = None,
+    ):
         return _run_auto_load(
             monkeypatch,
             tmp_path,
@@ -1818,25 +1823,19 @@ class TestUnifiedMemoryOptOut:
         self, tmp_path, monkeypatch, probe_env, value
     ):
         """setdefault kept the user's "0", which ggml then read as enabled."""
-        _cmd, env = self._load(
-            tmp_path, monkeypatch, {"GGML_CUDA_ENABLE_UNIFIED_MEMORY": value}
-        )[0]
+        _cmd, env = self._load(tmp_path, monkeypatch, {"GGML_CUDA_ENABLE_UNIFIED_MEMORY": value})[0]
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     @pytest.mark.parametrize("value", ["1", "2", "true", "on"])
     def test_a_truthy_user_value_still_wins(self, tmp_path, monkeypatch, probe_env, value):
         """Only the off spellings are intercepted; anything else is passed through
         untouched, ownership included."""
-        _cmd, env = self._load(
-            tmp_path, monkeypatch, {"GGML_CUDA_ENABLE_UNIFIED_MEMORY": value}
-        )[0]
+        _cmd, env = self._load(tmp_path, monkeypatch, {"GGML_CUDA_ENABLE_UNIFIED_MEMORY": value})[0]
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == value
 
     def test_the_disable_switch_keeps_it_unset(self, tmp_path, monkeypatch, probe_env):
         """The switch users can find, mirroring UNSLOTH_DISABLE_DC_TUNING."""
-        _cmd, env = self._load(
-            tmp_path, monkeypatch, {"UNSLOTH_DISABLE_UNIFIED_MEMORY": "1"}
-        )[0]
+        _cmd, env = self._load(tmp_path, monkeypatch, {"UNSLOTH_DISABLE_UNIFIED_MEMORY": "1"})[0]
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     def test_the_disable_switch_also_clears_an_inherited_value(
@@ -1854,9 +1853,7 @@ class TestUnifiedMemoryOptOut:
     def test_a_non_one_disable_value_does_nothing(self, tmp_path, monkeypatch, probe_env):
         """Exact "1", like the DC switch. A guard that fired on any value would
         make the name itself a trap, which is the bug being fixed."""
-        _cmd, env = self._load(
-            tmp_path, monkeypatch, {"UNSLOTH_DISABLE_UNIFIED_MEMORY": "0"}
-        )[0]
+        _cmd, env = self._load(tmp_path, monkeypatch, {"UNSLOTH_DISABLE_UNIFIED_MEMORY": "0"})[0]
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
 
     def test_the_opt_out_survives_a_retry_onto_an_apu(self, tmp_path, monkeypatch, probe_env):

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -1778,11 +1778,9 @@ class TestArchCrashRetryOntoAnApu:
 class TestUnifiedMemoryOptOut:
     """Turning GGML_CUDA_ENABLE_UNIFIED_MEMORY off has to make it ABSENT (#8651).
 
-    ggml gates managed memory on ``getenv(...) != nullptr``, so a value of "0" is
-    still on and the reporter's only route was patching the source. The Strix Halo
-    host below is the reported one: a gfx1151 APU whose pool ROCm already reports in
-    full, where plain hipMalloc offloads all layers and the managed path does not.
-    Mock-based, no ROCm here."""
+    ggml gates on ``getenv(...) != nullptr``, so "0" is still on and the reporter's
+    only route was patching the source. The host below is the reported one: a
+    gfx1151 Strix Halo APU whose pool ROCm reports in full. Mock-based, no ROCm."""
 
     def _strix_halo(self, monkeypatch):
         _apply_os(monkeypatch, "linux", is_rocm = True)
@@ -1813,8 +1811,7 @@ class TestUnifiedMemoryOptOut:
         )
 
     def test_the_apu_still_gets_it_by_default(self, tmp_path, monkeypatch, probe_env):
-        """The baseline this must not regress: #5301 added the variable for exactly
-        this hardware, so an untouched Strix Halo keeps it."""
+        """Baseline: #5301 added the variable for exactly this hardware."""
         _cmd, env = self._load(tmp_path, monkeypatch)[0]
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
 
@@ -1828,8 +1825,7 @@ class TestUnifiedMemoryOptOut:
 
     @pytest.mark.parametrize("value", ["1", "2", "true", "on"])
     def test_a_truthy_user_value_still_wins(self, tmp_path, monkeypatch, probe_env, value):
-        """Only the off spellings are intercepted; anything else is passed through
-        untouched, ownership included."""
+        """Only off spellings are intercepted; anything else passes through."""
         _cmd, env = self._load(tmp_path, monkeypatch, {"GGML_CUDA_ENABLE_UNIFIED_MEMORY": value})[0]
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == value
 
@@ -1841,8 +1837,7 @@ class TestUnifiedMemoryOptOut:
     def test_the_disable_switch_also_clears_an_inherited_value(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """Both halves together: the switch has to beat a stale inherited "1" too,
-        or the escape hatch does nothing on the host most likely to have one."""
+        """The switch has to beat a stale inherited "1" too."""
         _cmd, env = self._load(
             tmp_path,
             monkeypatch,
@@ -1851,14 +1846,12 @@ class TestUnifiedMemoryOptOut:
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     def test_a_non_one_disable_value_does_nothing(self, tmp_path, monkeypatch, probe_env):
-        """Exact "1", like the DC switch. A guard that fired on any value would
-        make the name itself a trap, which is the bug being fixed."""
+        """Exact "1", like the DC switch: firing on any value is the same trap."""
         _cmd, env = self._load(tmp_path, monkeypatch, {"UNSLOTH_DISABLE_UNIFIED_MEMORY": "0"})[0]
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
 
     def test_the_opt_out_survives_a_retry_onto_an_apu(self, tmp_path, monkeypatch, probe_env):
-        """The arch-crash retry re-adds the variable when it lands on an APU. It
-        must not undo an opt-out the user made for the whole launch."""
+        """The retry re-adds the variable on an APU; it must not undo the opt-out."""
         _apply_os(monkeypatch, "linux", is_rocm = True)
         monkeypatch.setattr(
             LlamaCppBackend, "_rocm_unified_memory_gpu_ids", staticmethod(lambda: {1})

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -1775,6 +1775,121 @@ class TestArchCrashRetryOntoAnApu:
         assert all(env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1" for env in _retry)
 
 
+class TestUnifiedMemoryOptOut:
+    """Turning GGML_CUDA_ENABLE_UNIFIED_MEMORY off has to make it ABSENT (#8651).
+
+    ggml gates managed memory on ``getenv(...) != nullptr``, so a value of "0" is
+    still on and the reporter's only route was patching the source. The Strix Halo
+    host below is the reported one: a gfx1151 APU whose pool ROCm already reports in
+    full, where plain hipMalloc offloads all layers and the managed path does not.
+    Mock-based, no ROCm here."""
+
+    def _strix_halo(self, monkeypatch):
+        _apply_os(monkeypatch, "linux", is_rocm = True)
+        monkeypatch.setattr(
+            LlamaCppBackend, "_rocm_unified_memory_gpu_ids", staticmethod(lambda: {0})
+        )
+        monkeypatch.setattr(
+            LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 60000)
+        )
+        return _fake_torch(
+            [_device("gfx1151", free_mib = 47000, is_integrated = 1)],
+            vendor = "amd",
+        )
+
+    def _load(self, tmp_path, monkeypatch, env_extra = None):
+        return _run_auto_load(
+            monkeypatch,
+            tmp_path,
+            self._strix_halo(monkeypatch),
+            None,
+            returncode = None,
+            env_extra = env_extra,
+        )
+
+    def test_the_apu_still_gets_it_by_default(self, tmp_path, monkeypatch, probe_env):
+        """The baseline this must not regress: #5301 added the variable for exactly
+        this hardware, so an untouched Strix Halo keeps it."""
+        _cmd, env = self._load(tmp_path, monkeypatch)[0]
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    @pytest.mark.parametrize("value", ["0", "", "false", "FALSE", "no", "off", " 0 "])
+    def test_a_falsy_user_value_is_not_passed_through(
+        self, tmp_path, monkeypatch, probe_env, value
+    ):
+        """setdefault kept the user's "0", which ggml then read as enabled."""
+        _cmd, env = self._load(
+            tmp_path, monkeypatch, {"GGML_CUDA_ENABLE_UNIFIED_MEMORY": value}
+        )[0]
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    @pytest.mark.parametrize("value", ["1", "2", "true", "on"])
+    def test_a_truthy_user_value_still_wins(self, tmp_path, monkeypatch, probe_env, value):
+        """Only the off spellings are intercepted; anything else is passed through
+        untouched, ownership included."""
+        _cmd, env = self._load(
+            tmp_path, monkeypatch, {"GGML_CUDA_ENABLE_UNIFIED_MEMORY": value}
+        )[0]
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == value
+
+    def test_the_disable_switch_keeps_it_unset(self, tmp_path, monkeypatch, probe_env):
+        """The switch users can find, mirroring UNSLOTH_DISABLE_DC_TUNING."""
+        _cmd, env = self._load(
+            tmp_path, monkeypatch, {"UNSLOTH_DISABLE_UNIFIED_MEMORY": "1"}
+        )[0]
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    def test_the_disable_switch_also_clears_an_inherited_value(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """Both halves together: the switch has to beat a stale inherited "1" too,
+        or the escape hatch does nothing on the host most likely to have one."""
+        _cmd, env = self._load(
+            tmp_path,
+            monkeypatch,
+            {"UNSLOTH_DISABLE_UNIFIED_MEMORY": "1", "GGML_CUDA_ENABLE_UNIFIED_MEMORY": "1"},
+        )[0]
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    def test_a_non_one_disable_value_does_nothing(self, tmp_path, monkeypatch, probe_env):
+        """Exact "1", like the DC switch. A guard that fired on any value would
+        make the name itself a trap, which is the bug being fixed."""
+        _cmd, env = self._load(
+            tmp_path, monkeypatch, {"UNSLOTH_DISABLE_UNIFIED_MEMORY": "0"}
+        )[0]
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_the_opt_out_survives_a_retry_onto_an_apu(self, tmp_path, monkeypatch, probe_env):
+        """The arch-crash retry re-adds the variable when it lands on an APU. It
+        must not undo an opt-out the user made for the whole launch."""
+        _apply_os(monkeypatch, "linux", is_rocm = True)
+        monkeypatch.setattr(
+            LlamaCppBackend, "_rocm_unified_memory_gpu_ids", staticmethod(lambda: {1})
+        )
+        monkeypatch.setattr(
+            LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 60000)
+        )
+        torch = _fake_torch(
+            [
+                _device("gfx1030", free_mib = 40000),
+                _device("gfx1151", free_mib = 12000, is_integrated = 1),
+            ],
+            vendor = "amd",
+        )
+        launches = _run_auto_load(
+            monkeypatch,
+            tmp_path,
+            torch,
+            None,  # no marker: the proactive gate fails open, so the crash path runs
+            returncode = 1,
+            output = "ROCm error: device kernel image is invalid",
+            env_extra = {"UNSLOTH_DISABLE_UNIFIED_MEMORY": "1"},
+        )
+        _retry = [env for _c, env in launches if env.get("ROCR_VISIBLE_DEVICES") == "1"]
+        assert _retry, "the arch-crash retry did not fire"
+        assert all("GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env for _c, env in launches)
+
+
 class TestArchCrashRetryDropsDeadTensorMode:
     """Narrowing to one device makes --split-mode tensor a no-op still REPORTED as
     active: tensor_parallel drives the UI and the MTP crash watchdog. Dropping


### PR DESCRIPTION
Closes #8651.

### What happens today

`ggml/src/ggml-cuda/ggml-cuda.cu` has exactly one use site for the variable, in `ggml_cuda_device_malloc`:

```c
if (getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr) {
    err = cudaMallocManaged(ptr, size);
} else {
    err = cudaMalloc(ptr, size);
}
```

Only the variable's PRESENCE is tested, never its value. `GGML_CUDA_ENABLE_UNIFIED_MEMORY=0` therefore ENABLES managed memory. Studio set it with `env.setdefault(..., "1")` and the comment said "setdefault so a user value wins", which was true only in the sense that Studio would not overwrite a value you set. There was no value anyone could set that turned it off, so the reporter's only route was patching Studio's source.

That is a defect independent of whether the default is right for gfx1150/gfx1151, so it is what this PR fixes. The default is unchanged: #5301 added the variable for exactly this hardware, and I do not want to trade one host's bug for another's while the memory-split question is still open on the issue.

### What happens after

Two ways to opt out, both of which end with the name absent from the child env, because absence is the only off state ggml understands.

- `UNSLOTH_DISABLE_UNIFIED_MEMORY=1`, mirroring the existing `UNSLOTH_DISABLE_DC_TUNING=1`. Exact `1`, same as that switch.
- A falsy `GGML_CUDA_ENABLE_UNIFIED_MEMORY` (`0`, `false`, `no`, `off`, empty, trimmed and case-folded), which is what users reasonably expect to mean off. Studio now strips it rather than passing it through to be read as on.

Any other value is passed through untouched, ownership tracking included.

### Blast radius

The decision lives in a new `_unified_memory_opted_out` helper used only at the three env sites. `_amd_apu_wants_unified_memory` is deliberately left alone: two other consumers gate RAM admission on it (`_offloads_every_layer` and the APU RAM refusal at load time), and an env-var opt-out must not silently change what Studio believes about the hardware.

The arch-crash retry re-adds the variable when it lands on an APU, so that branch is gated too, otherwise the opt-out would not survive a respawn. The two withdrawal branches already key off `_unified_env_applied`, which is False under an opt-out, so they needed no change.

Fails open: a hostile or unreadable env answers False, which is the pre-PR behaviour.

### Tests

`studio/backend/tests/test_amd_apu_unified_memory.py`: 15 new cases over the helper, including a fail-open case.

`studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py`: 16 new launch-level cases on the reported Strix Halo shape, covering the unchanged default, every off spelling, the truthy pass-through, the switch beating an inherited value, and the opt-out surviving an arch-crash retry onto an APU.

Serial run, `-p no:randomly`:

- the two files above: 214 passed (baseline 183, +31)
- with `test_gpu_arch_gate_consumers_7624.py`, `test_datacenter_gpu_tuning.py`, `test_llama_cpp_placement.py`, `test_gpu_init_crash_message.py`, `test_model_memory_settings.py`: 886 passed, 0 failed

Eight mutations, no survivors, both directions on the guard:

| mutation | result |
| --- | --- |
| opt-out branch removed | 9 failed |
| helper always True | 19 failed |
| helper always False (pre-PR behaviour) | 18 failed |
| retry gate removed | 1 failed |
| `pop` changed to `setdefault` | 10 failed |
| `strip().lower()` dropped | 3 failed |
| disable switch loosened to any truthy value | 3 failed |
| empty string no longer counts as off | 2 failed |

`ruff check` clean, `scripts/run_ruff_format.py` applied.

### Still open on the issue

I have asked the reporter for their BIOS carve-out, `rocminfo` pool info and whether they are on WSL2 or native, so the default itself can be sized to both a large-pool Strix Halo and the small-carve-out host #5301 was solving. That is a separate change; this one is the escape hatch, which is needed either way.
