### PR TITLE
Restore the #8335 WMI guard anchor broken by the RDNA 1 wrapper

### DIFF
--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -247,9 +247,11 @@ Write-Host "=== source shapes ==="
 $setupText = (Get-Content -Raw $setup) -replace "`r`n", "`n"
 
 Write-Host "the AMD WMI fallback survives a single-GPU host"
-# The trailing `\]\n` is what makes the CRLF check below bite: on a CRLF checkout the line ends
-# `[0]\r\n`, so the pattern fails rather than matching a silently empty region.
-$_wmiPat = '(?s)(\$amdGpus = @\(Get-CimInstance Win32_VideoController.*?\$ROCmGpuLabel = \$script:ROCmGpuLabels\[0\]\n)'
+# The trailing `\n` is what makes the CRLF check below bite: on a CRLF checkout the line ends
+# `\r\n`, so the pattern fails rather than matching a silently empty region. `[^\r\n]*` absorbs
+# whatever guards the assignment (#8577 wrapped it in `if (-not $HasROCm) { ... }`) WITHOUT
+# absorbing the `\r`, which would hand the CRLF check a match and retire it silently.
+$_wmiPat = '(?s)(\$amdGpus = @\(Get-CimInstance Win32_VideoController.*?\$ROCmGpuLabel = \$script:ROCmGpuLabels\[0\][^\r\n]*\n)'
 $_wmi = if ($setupText -match $_wmiPat) { $Matches[1] } else { "" }
 Check "the WMI fallback was found"        ($_wmi -ne "")
 Check "CRLF is normalised, not tolerated" (-not (($setupText -replace "`n", "`r`n") -match $_wmiPat))


### PR DESCRIPTION
`main` is currently failing `tests/studio/test_amd_venv_repair_loop.ps1`, and with it the `#8335` regression guard.

### What broke

`d5a2160ef` (#8577) wrapped the WMI label assignment so it no longer clobbers a ROCm-derived label:

```powershell
if (-not $HasROCm) { $ROCmGpuLabel = $script:ROCmGpuLabels[0] }
```

That change is correct. What it also did was end the line in `] }` rather than `]`, and the test slices the WMI fallback region out of `studio/setup.ps1` with a regex terminating in `\$script:ROCmGpuLabels\[0\]\n`. The region stopped matching, `$_wmi` became the empty string, and four checks failed:

```
FAIL  the WMI fallback was found
FAIL  the healthy/all choice is @() wrapped
FAIL  the adapter list is @() wrapped
FAIL  the healthy list is @() wrapped
```

The test runs on the 3-OS matrix in `cross-platform-parity-ci.yml`, including the Windows PowerShell 5.1 leg, which is the only leg that can see the scalar unroll #8335 was about.

### The fix

One line. The terminator now absorbs whatever guards the assignment:

```
\$ROCmGpuLabel = \$script:ROCmGpuLabels\[0\][^\r\n]*\n
```

`[^\r\n]*` rather than `[^\n]*` is load-bearing. Under `[^\n]*` the pattern would also match a CRLF checkout, which would silently retire the "CRLF is normalised, not tolerated" check sitting on the next line, and that check exists because a vacuously-passing region has bitten this repo before.

### Verification

All 21 `tests/studio/*.ps1` suites pass. Mutations on `studio/setup.sh`'s sibling `studio/setup.ps1`, applied one at a time and reverted:

| mutation | expected | result |
| --- | --- | --- |
| revert to the pre-#8577 unwrapped assignment | pass, the anchor must accept both forms | all checks passed |
| reintroduce the #8335 defect (`$wmiGpus = if (...)`, no `@()`) | fail | 2 failed |
| drop `@()` from the adapter list | fail | 4 failed |
| break the region terminator | fail | 4 failed |

The first row is the backwards-compatibility check; the second is the one that matters, since it proves the guard is catching the original defect again rather than merely matching a non-empty region.
