### PR TITLE
tests: require the export pin fallback to cover a half-built unsloth_zoo

### DIFF
--- a/tests/studio/test_studio_gguf_export_script_pin.py
+++ b/tests/studio/test_studio_gguf_export_script_pin.py
@@ -118,9 +118,9 @@ def test_warning_handler_gated_on_module_flag():
     # AttributeError aborts the export otherwise, and a revert to ImportError alone still
     # satisfies _catches_import_error above.
     covering = [h for h in handlers if _covers_half_built_zoo(h)]
-    assert covering, (
-        "the scripts pin must fall back on a half-built unsloth_zoo, not just a missing one"
-    )
+    assert (
+        covering
+    ), "the scripts pin must fall back on a half-built unsloth_zoo, not just a missing one"
     handler = covering[0]
     flag_reads = []
     flag_writes = []

--- a/tests/studio/test_studio_gguf_export_script_pin.py
+++ b/tests/studio/test_studio_gguf_export_script_pin.py
@@ -51,6 +51,19 @@ def _catches_import_error(handler: ast.ExceptHandler) -> bool:
     return any(isinstance(n, ast.Name) and n.id in _CATCHES_IMPORT_ERROR for n in names)
 
 
+# A half-built unsloth_zoo imports and then raises RuntimeError or AttributeError, which
+# ImportError alone does not cover.
+_CATCHES_EVERYTHING = ("Exception", "BaseException")
+
+
+def _covers_half_built_zoo(handler: ast.ExceptHandler) -> bool:
+    if handler.type is None:  # bare except
+        return True
+    names = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+    caught = {n.id for n in names if isinstance(n, ast.Name)}
+    return bool(caught & set(_CATCHES_EVERYTHING)) or {"RuntimeError", "AttributeError"} <= caught
+
+
 def test_warning_flag_defined_at_module_scope():
     flags = {
         name: value
@@ -100,7 +113,15 @@ def test_warning_handler_gated_on_module_flag():
     assert try_node is not None
     handlers = [h for h in try_node.handlers if _catches_import_error(h)]
     assert handlers
-    handler = handlers[0]
+    # And it has to keep covering the half-built cases, not just the missing-module one. That is
+    # what #8603 widened the handler for: an unsloth_zoo that imports but raises RuntimeError or
+    # AttributeError aborts the export otherwise, and a revert to ImportError alone still
+    # satisfies _catches_import_error above.
+    covering = [h for h in handlers if _covers_half_built_zoo(h)]
+    assert covering, (
+        "the scripts pin must fall back on a half-built unsloth_zoo, not just a missing one"
+    )
+    handler = covering[0]
     flag_reads = []
     flag_writes = []
     warning_calls = []


### PR DESCRIPTION
## Summary

Follow-up to #8673, which matched the export pin test to the handler #8603 widened. That test asserts the handler *catches* `ImportError`, so widening never breaks it, which is the right property to keep. It also passes if the handler goes back to `except ImportError:` alone, and that is the exact state #8603 fixed: a half-built unsloth_zoo imports and then raises `RuntimeError` or `AttributeError`, which `ImportError` does not cover, so the export aborts instead of falling back with a warning.

## Changes

One extra predicate in `test_warning_handler_gated_on_module_flag`. After the existing `_catches_import_error` filter, the handler must also cover the half-built cases: catch `Exception` or `BaseException`, name both `RuntimeError` and `AttributeError` explicitly, or be a bare `except`. `_catches_import_error` and its constant are untouched, so a future widening still passes both checks.

## Validation

Each handler shape written into `studio/backend/core/export/export.py`, then the suite run:

| handler | on main | with this PR |
| --- | --- | --- |
| `except Exception:` (current) | passes | passes |
| `except (ImportError, RuntimeError, AttributeError):` | passes | passes |
| `except ImportError:` | passes | fails |
| `except (RuntimeError, AttributeError):` | fails | fails |
| `except OSError:` | fails | fails |

`tests/studio/test_studio_gguf_export_script_pin.py`: 10 passed. Ruff clean. Tests only, no production code.

Replaces #8676, which I opened before #8673 landed and which carried the same fix plus a merge commit.