### PR TITLE
Keep the #8577 AMD peer guards message-only, and fix the table drift they exposed

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -3312,9 +3312,12 @@ exit 0
                 } catch {}
             }
         }
-        # Unchanged on purpose: this scan fills the LABEL the arch inference reads, so its
-        # gate and cmdlet are load-bearing. Widening either turned a CPU install into a ROCm
-        # one on hosts amd-smi had already claimed.
+        # This scan fills the LABEL the arch inference reads, so its gate is load-bearing:
+        # widening it turned a CPU install into a ROCm one on hosts amd-smi had already
+        # claimed. CIM, not Get-WmiObject, which PowerShell 7 removed: the catch below is
+        # silent, so a supported Radeon named only by Windows took the CPU path there, and
+        # the report-only peer scan cannot undo that. Same class and fields as every other
+        # adapter scan in this file, and identical output under Windows PowerShell 5.1.
         if (-not $HasROCm) {
             try {
                 # ConfigManagerErrorCode 0 is "working properly". Filter on it exactly as
@@ -3325,7 +3328,7 @@ exit 0
                 # If the filter leaves none, keep the full list: code 45 ("not connected") is
                 # routine on a muxless laptop with a parked dGPU, and there is no healthy peer
                 # to prefer. @() wraps the WHOLE if so a one-element branch stays indexable.
-                $amdAdapters = @(Get-WmiObject Win32_VideoController -ErrorAction SilentlyContinue |
+                $amdAdapters = @(Get-CimInstance Win32_VideoController -ErrorAction SilentlyContinue |
                     Where-Object { $_.Name -match "AMD|Radeon" })
                 $healthyAdapters = @($amdAdapters | Where-Object {
                     ($null -eq $_.ConfigManagerErrorCode) -or ($_.ConfigManagerErrorCode -eq 0) })
@@ -3334,8 +3337,7 @@ exit 0
             } catch {}
         }
         # Peer names for the REPORT ONLY, kept apart from the scan above: that one feeds the
-        # inference, this one only the uncovered-card verdict. CIM because Get-WmiObject is
-        # gone from PowerShell 7, and a missed message is the worst this can cost.
+        # inference and runs only without a runtime, this one only the uncovered-card verdict.
         $wmiAmdNames = @()
         if (-not $ROCmGfxArch) {
             try {
@@ -3410,19 +3412,25 @@ exit 0
                 #    arm, which says exactly that. studio/setup.ps1 already scores every
                 #    adapter before it reaches its own lookup.
                 if (-not $ROCmGfxArch) {
-                    # Not under a visible-device mask: the user named the card, so the verdict
-                    # is about that one and a masked-out peer cannot answer for it. Same rule
-                    # studio/setup.ps1 applies to its own peer check.
-                    $coveredPeer = $false
                     # HIP/ROCR only: CUDA_VISIBLE_DEVICES masks NVIDIA devices and says
                     # nothing about which Radeon was chosen.
                     $unsupMasked = @($env:HIP_VISIBLE_DEVICES, $env:ROCR_VISIBLE_DEVICES) |
                         Where-Object { $null -ne $_ }
-                    foreach ($peerName in $(if ($unsupMasked) { @() } else { $wmiAmdNames })) {
-                        foreach ($row in $nameArchTable) {
-                            if ($peerName -match $row.P) { $coveredPeer = $true; break }
+                    $coveredPeer = $false
+                    if ($unsupMasked) {
+                        # A masked-out peer cannot answer for the card the user named, but the
+                        # label is only that card when there is nothing else to select: both
+                        # sources above keep adapter 0, so HIP_VISIBLE_DEVICES=1 beside a
+                        # supported peer would blame the wrong GPU. Stay quiet, rather than
+                        # guess an order Win32_VideoController does not promise matches HIP's.
+                        $coveredPeer = ($wmiAmdNames.Count -gt 1)
+                    } else {
+                        foreach ($peerName in $wmiAmdNames) {
+                            foreach ($row in $nameArchTable) {
+                                if ($peerName -match $row.P) { $coveredPeer = $true; break }
+                            }
+                            if ($coveredPeer) { break }
                         }
-                        if ($coveredPeer) { break }
                     }
                     if (-not $coveredPeer) {
                         foreach ($row in $unsupportedNameArchTable) {

--- a/install.ps1
+++ b/install.ps1
@@ -3312,13 +3312,10 @@ exit 0
                 } catch {}
             }
         }
-        # Set outside the scan: only the WMI arm fills it, but the lookup further down reads
-        # it on every AMD path, including the amd-smi ones that never enter the block.
-        $wmiAmdNames = @()
-        # Keyed on the ARCH, not on $HasROCm: amd-smi can report GPUs with no gfx token and
-        # only the first market name, which sets $HasROCm and used to skip this scan, leaving
-        # the peer guard below blind. A host with an arch never reaches that lookup anyway.
-        if (-not $ROCmGfxArch) {
+        # Unchanged on purpose: this scan fills the LABEL the arch inference reads, so its
+        # gate and cmdlet are load-bearing. Widening either turned a CPU install into a ROCm
+        # one on hosts amd-smi had already claimed.
+        if (-not $HasROCm) {
             try {
                 # ConfigManagerErrorCode 0 is "working properly". Filter on it exactly as
                 # setup.ps1's scan does: taking a card setup discards names an arch for a GPU
@@ -3328,23 +3325,26 @@ exit 0
                 # If the filter leaves none, keep the full list: code 45 ("not connected") is
                 # routine on a muxless laptop with a parked dGPU, and there is no healthy peer
                 # to prefer. @() wraps the WHOLE if so a one-element branch stays indexable.
-                # CIM, as everywhere else here: Get-WmiObject is gone from PowerShell 7, where
-                # the catch below would swallow it and leave the peer list empty. CIM is 5.1+.
-                $amdAdapters = @(Get-CimInstance Win32_VideoController -ErrorAction SilentlyContinue |
+                $amdAdapters = @(Get-WmiObject Win32_VideoController -ErrorAction SilentlyContinue |
                     Where-Object { $_.Name -match "AMD|Radeon" })
                 $healthyAdapters = @($amdAdapters | Where-Object {
                     ($null -eq $_.ConfigManagerErrorCode) -or ($_.ConfigManagerErrorCode -eq 0) })
-                $wmiAdapters = @(if ($healthyAdapters.Count -gt 0) { $healthyAdapters } else { $amdAdapters })
-                $wmiGpu = $wmiAdapters[0]
-                if ($wmiGpu) {
-                    # amd-smi's label wins when it had one; this scan is here for the peers.
-                    if (-not $HasROCm) { $ROCmGpuLabel = $wmiGpu.Name }
-                    # Every adapter's name, not just the chosen one: only the peer list tells
-                    # "this host has no ROCm-capable GPU" apart from "this host's FIRST adapter
-                    # is not the ROCm-capable one". Read by the unsupported lookup below;
-                    # nothing here picks an arch, so the choice above is untouched.
-                    $wmiAmdNames = @($wmiAdapters | ForEach-Object { $_.Name })
-                }
+                $wmiGpu = @(if ($healthyAdapters.Count -gt 0) { $healthyAdapters } else { $amdAdapters })[0]
+                if ($wmiGpu) { $ROCmGpuLabel = $wmiGpu.Name }
+            } catch {}
+        }
+        # Peer names for the REPORT ONLY, kept apart from the scan above: that one feeds the
+        # inference, this one only the uncovered-card verdict. CIM because Get-WmiObject is
+        # gone from PowerShell 7, and a missed message is the worst this can cost.
+        $wmiAmdNames = @()
+        if (-not $ROCmGfxArch) {
+            try {
+                $peerAdapters = @(Get-CimInstance Win32_VideoController -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -match "AMD|Radeon" })
+                $healthyPeers = @($peerAdapters | Where-Object {
+                    ($null -eq $_.ConfigManagerErrorCode) -or ($_.ConfigManagerErrorCode -eq 0) })
+                $usePeers = @(if ($healthyPeers.Count -gt 0) { $healthyPeers } else { $peerAdapters })
+                $wmiAmdNames = @($usePeers | ForEach-Object { $_.Name })
             } catch {}
         }
         # GPU name -> gfx arch for AMD generations Unsloth's ROCm wheels do NOT cover:

--- a/install.ps1
+++ b/install.ps1
@@ -3410,8 +3410,15 @@ exit 0
                 #    arm, which says exactly that. studio/setup.ps1 already scores every
                 #    adapter before it reaches its own lookup.
                 if (-not $ROCmGfxArch) {
+                    # Not under a visible-device mask: the user named the card, so the verdict
+                    # is about that one and a masked-out peer cannot answer for it. Same rule
+                    # studio/setup.ps1 applies to its own peer check.
                     $coveredPeer = $false
-                    foreach ($peerName in $wmiAmdNames) {
+                    # HIP/ROCR only: CUDA_VISIBLE_DEVICES masks NVIDIA devices and says
+                    # nothing about which Radeon was chosen.
+                    $unsupMasked = @($env:HIP_VISIBLE_DEVICES, $env:ROCR_VISIBLE_DEVICES) |
+                        Where-Object { $null -ne $_ }
+                    foreach ($peerName in $(if ($unsupMasked) { @() } else { $wmiAmdNames })) {
                         foreach ($row in $nameArchTable) {
                             if ($peerName -match $row.P) { $coveredPeer = $true; break }
                         }

--- a/install.sh
+++ b/install.sh
@@ -2897,7 +2897,7 @@ _infer_unsupported_amd_gfx_arch_from_gpu_name() {
         *"Radeon Pro V520"*|*"Radeon Pro 5600M"*) echo gfx1011 ;;  # RDNA 1
         *"RX 5700"*|*"RX 5600"*|*"Radeon Pro 5600 XT"*|*"Radeon Pro 5700"*|*"Radeon Pro W5700"*) echo gfx1010 ;;  # RDNA 1 (Navi 10)
         *"RX 5500"*|*"RX 5300"*|*"Radeon Pro W5500"*|*"Radeon Pro W5300"*) echo gfx1012 ;;  # RDNA 1 (Navi 14)
-        *"RX 470"*|*"RX 480"*|*"RX 570"*|*"RX 580"*|*"RX 590"*|*"Radeon Pro WX 7100"*|*"Radeon Pro WX 5100"*) echo gfx803 ;;  # Polaris 10/20/30
+        *"RX 470"|*"RX 470"[!0]*|*"RX 480"|*"RX 480"[!0]*|*"RX 570"|*"RX 570"[!0]*|*"RX 580"|*"RX 580"[!0]*|*"RX 590"|*"RX 590"[!0]*|*"Radeon Pro WX 7100"*|*"Radeon Pro WX 5100"*) echo gfx803 ;;  # Polaris 10/20/30
         *) return 1 ;;
     esac
 }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2377,10 +2377,7 @@ if (-not $HasNvidiaSmi) {
     # $HasROCm is intentionally NOT set here — we cannot confirm ROCm runtime
     # support without hipinfo or amd-smi.  The name is saved to $ROCmGpuLabel
     # so the name-based inference below can still attempt an arch lookup.
-    # Gated on the ARCH, like install.ps1: amd-smi can set $HasROCm with no arch, and gated
-    # that way the scan was skipped, so $script:ROCmGpuLabels held one name and the inference
-    # below judged a whole multi-GPU host on it. Same condition as that inference.
-    if (-not $script:ROCmGfxArch) {
+    if (-not $HasROCm) {
         try {
             # Keep every AMD adapter, not just the first: WMI orders controllers as the
             # driver stack enumerated them, so a shadowing iGPU can lead here exactly as
@@ -2404,11 +2401,26 @@ if (-not $HasNvidiaSmi) {
             $wmiGpus = @(if ($healthyGpus.Count -gt 0) { $healthyGpus } else { $amdGpus })
             if ($wmiGpus.Count -gt 0) {
                 $script:ROCmGpuLabels = @($wmiGpus | ForEach-Object { $_.Name })
-                # amd-smi's label wins when it had one; this scan is here for the peers.
-                if (-not $HasROCm) { $ROCmGpuLabel = $script:ROCmGpuLabels[0] }
+                $ROCmGpuLabel = $script:ROCmGpuLabels[0]
             }
         } catch {}
     }
+    # Peer names for the REPORT ONLY. amd-smi can confirm a runtime with no gfx token and
+    # only the first card's name, and the scan above is skipped there, so the verdict below
+    # would speak for a host it has seen one adapter of. Kept out of $script:ROCmGpuLabels
+    # deliberately: that feeds the inference, and widening it turned a CPU install into ROCm.
+    $script:ROCmPeerLabels = @()
+    if ($HasROCm -and -not $script:ROCmGfxArch) {
+        try {
+            $peerGpus = @(Get-CimInstance Win32_VideoController -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -match "AMD|Radeon" })
+            $healthyPeers = @($peerGpus | Where-Object {
+                ($null -eq $_.ConfigManagerErrorCode) -or ($_.ConfigManagerErrorCode -eq 0) })
+            $usePeers = @(if ($healthyPeers.Count -gt 0) { $healthyPeers } else { $peerGpus })
+            $script:ROCmPeerLabels = @($usePeers | ForEach-Object { $_.Name })
+        } catch {}
+    }
+
     # GPU name -> gfx arch for AMD generations Unsloth's ROCm wheels do NOT cover: RDNA 1
     # and Polaris 10/20/30 (unslothai#8529). Kept apart from $nameArchTable on purpose: it
     # only WORDS a message, never selects a wheel index or a prebuilt. AMD's TheRock ships
@@ -2498,7 +2510,18 @@ if (-not $HasNvidiaSmi) {
                 # Nothing mapped: the card may be a generation ROCm never covered rather
                 # than one we failed to recognise (unslothai#8529). $script:ROCmGfxArch
                 # stays null either way, so only the wording of the report below moves.
-                $script:ROCmUnsupportedGfxArch = Get-GfxArchFromGpuName -Name $gpuNames[$nameIdx] -Table $unsupportedNameArchTable
+                # Stay quiet when a PEER is covered: "no override can help" is false beside a
+                # card that has wheels. Read-only; never reaches $gpuNames or the inference.
+                $unsupPeerCovered = $false
+                foreach ($peerName in $script:ROCmPeerLabels) {
+                    if (Get-GfxArchFromGpuName -Name $peerName -Table $nameArchTable) {
+                        $unsupPeerCovered = $true
+                        break
+                    }
+                }
+                if (-not $unsupPeerCovered) {
+                    $script:ROCmUnsupportedGfxArch = Get-GfxArchFromGpuName -Name $gpuNames[$nameIdx] -Table $unsupportedNameArchTable
+                }
             }
         }
     }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2512,14 +2512,20 @@ if (-not $HasNvidiaSmi) {
                 # stays null either way, so only the wording of the report below moves.
                 # Stay quiet when a PEER is covered: "no override can help" is false beside a
                 # card that has wheels. Read-only; never reaches $gpuNames or the inference.
-                # Not under a mask, as the arch-borrowing rule above: the user named the card,
-                # so a masked-out peer cannot answer for it. HIP/ROCR only, unlike
-                # Test-VisibleDevicesPinned: CUDA_VISIBLE_DEVICES says nothing about which
-                # Radeon was chosen, and counting it would fire the verdict beside a covered card.
+                # HIP/ROCR only, unlike Test-VisibleDevicesPinned: CUDA_VISIBLE_DEVICES says
+                # nothing about which Radeon was chosen, and counting it would fire the verdict
+                # beside a covered card.
                 $unsupMasked = @($env:HIP_VISIBLE_DEVICES, $env:ROCR_VISIBLE_DEVICES) |
                     Where-Object { $null -ne $_ }
                 $unsupPeerCovered = $false
-                if (-not $unsupMasked) {
+                if ($unsupMasked) {
+                    # Under a mask a peer cannot answer for the named card, as the
+                    # arch-borrowing rule above. But $gpuNames is one synthesized label on the
+                    # amd-smi path, and $nameIdx cannot index a card it never saw, so a mask
+                    # onto a supported peer would be blamed on adapter 0. Unseen peer, no
+                    # verdict: Win32_VideoController does not promise HIP's order to guess with.
+                    $unsupPeerCovered = ($script:ROCmPeerLabels.Count -gt $gpuNames.Count)
+                } else {
                     foreach ($peerName in $script:ROCmPeerLabels) {
                         if (Get-GfxArchFromGpuName -Name $peerName -Table $nameArchTable) {
                             $unsupPeerCovered = $true

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2512,11 +2512,19 @@ if (-not $HasNvidiaSmi) {
                 # stays null either way, so only the wording of the report below moves.
                 # Stay quiet when a PEER is covered: "no override can help" is false beside a
                 # card that has wheels. Read-only; never reaches $gpuNames or the inference.
+                # Not under a mask, as the arch-borrowing rule above: the user named the card,
+                # so a masked-out peer cannot answer for it. HIP/ROCR only, unlike
+                # Test-VisibleDevicesPinned: CUDA_VISIBLE_DEVICES says nothing about which
+                # Radeon was chosen, and counting it would fire the verdict beside a covered card.
+                $unsupMasked = @($env:HIP_VISIBLE_DEVICES, $env:ROCR_VISIBLE_DEVICES) |
+                    Where-Object { $null -ne $_ }
                 $unsupPeerCovered = $false
-                foreach ($peerName in $script:ROCmPeerLabels) {
-                    if (Get-GfxArchFromGpuName -Name $peerName -Table $nameArchTable) {
-                        $unsupPeerCovered = $true
-                        break
+                if (-not $unsupMasked) {
+                    foreach ($peerName in $script:ROCmPeerLabels) {
+                        if (Get-GfxArchFromGpuName -Name $peerName -Table $nameArchTable) {
+                            $unsupPeerCovered = $true
+                            break
+                        }
                     }
                 }
                 if (-not $unsupPeerCovered) {

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1892,7 +1892,7 @@ elif [ "$_setup_amd_detected" = true ]; then
             *"Radeon Pro V520"*|*"Radeon Pro 5600M"*) echo gfx1011 ;;  # RDNA 1
             *"RX 5700"*|*"RX 5600"*|*"Radeon Pro 5600 XT"*|*"Radeon Pro 5700"*|*"Radeon Pro W5700"*) echo gfx1010 ;;  # RDNA 1 (Navi 10)
             *"RX 5500"*|*"RX 5300"*|*"Radeon Pro W5500"*|*"Radeon Pro W5300"*) echo gfx1012 ;;  # RDNA 1 (Navi 14)
-            *"RX 470"*|*"RX 480"*|*"RX 570"*|*"RX 580"*|*"RX 590"*|*"Radeon Pro WX 7100"*|*"Radeon Pro WX 5100"*) echo gfx803 ;;  # Polaris 10/20/30
+            *"RX 470"|*"RX 470"[!0]*|*"RX 480"|*"RX 480"[!0]*|*"RX 570"|*"RX 570"[!0]*|*"RX 580"|*"RX 580"[!0]*|*"RX 590"|*"RX 590"[!0]*|*"Radeon Pro WX 7100"*|*"Radeon Pro WX 5100"*) echo gfx803 ;;  # Polaris 10/20/30
             *) return 1 ;;
         esac
     }

--- a/tests/studio/install/test_rdna1_unsupported_message_8529.py
+++ b/tests/studio/install/test_rdna1_unsupported_message_8529.py
@@ -210,6 +210,28 @@ class TestExplicitIndexPinIsHonoured:
         assert "gfx1010" in out, "the card is still named"
         assert self._CPU_CLAIM not in out, f"a pinned index still gets the CPU-only verdict:\n{out}"
 
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {"UNSLOTH_TORCH_INDEX_URL": "   "},
+            {"UNSLOTH_TORCH_INDEX_FAMILY": "\t\n "},
+            {"UNSLOTH_TORCH_INDEX_URL": "", "UNSLOTH_TORCH_INDEX_FAMILY": " "},
+        ],
+        ids = ["url-spaces", "family-blank", "both-blank"],
+    )
+    def test_a_blank_pin_is_not_a_pin(self, env):
+        """get_torch_index_url trims both variables and treats a blank one as unset, so a
+        blank value must not suppress the CPU-only verdict here either. Dropping the
+        .strip() from the read passes every other test in this file."""
+        with patch.dict(os.environ, env, clear = False):
+            for _k in ("UNSLOTH_TORCH_INDEX_URL", "UNSLOTH_TORCH_INDEX_FAMILY"):
+                if _k not in env:
+                    os.environ.pop(_k, None)
+            _arch, out = _wmi_detect(["AMD Radeon RX 5700 XT"])
+        assert self._CPU_CLAIM in out, (
+            f"a blank pin ({env}) was read as a pin, dropping the CPU-only warning:\n{out}"
+        )
+
     def test_the_claim_is_there_without_a_pin(self):
         """The positive control: without it the test above passes on any wording."""
         with patch.dict(os.environ, {}, clear = False):

--- a/tests/studio/install/test_rdna1_unsupported_message_8529.py
+++ b/tests/studio/install/test_rdna1_unsupported_message_8529.py
@@ -228,9 +228,9 @@ class TestExplicitIndexPinIsHonoured:
                 if _k not in env:
                     os.environ.pop(_k, None)
             _arch, out = _wmi_detect(["AMD Radeon RX 5700 XT"])
-        assert self._CPU_CLAIM in out, (
-            f"a blank pin ({env}) was read as a pin, dropping the CPU-only warning:\n{out}"
-        )
+        assert (
+            self._CPU_CLAIM in out
+        ), f"a blank pin ({env}) was read as a pin, dropping the CPU-only warning:\n{out}"
 
     def test_the_claim_is_there_without_a_pin(self):
         """The positive control: without it the test above passes on any wording."""

--- a/tests/studio/install/test_unsupported_arch_routing_guards_8529.py
+++ b/tests/studio/install/test_unsupported_arch_routing_guards_8529.py
@@ -869,21 +869,46 @@ def test_setup_sh_treats_a_blank_index_pin_as_unset(url, family, pinned):
 
 _PARITY_NAMES = [
     # RDNA 1 (Navi 10 / 12 / 14), the #8529 cluster
-    "AMD Radeon RX 5700 XT", "AMD Radeon RX 5700", "AMD Radeon RX 5600 XT",
-    "AMD Radeon Pro 5600 XT", "AMD Radeon Pro 5700 XT", "AMD Radeon Pro W5700",
-    "AMD Radeon Pro V520", "AMD Radeon Pro 5600M", "AMD Radeon RX 5500 XT",
-    "AMD Radeon RX 5300", "AMD Radeon Pro W5500", "AMD Radeon Pro W5300",
+    "AMD Radeon RX 5700 XT",
+    "AMD Radeon RX 5700",
+    "AMD Radeon RX 5600 XT",
+    "AMD Radeon Pro 5600 XT",
+    "AMD Radeon Pro 5700 XT",
+    "AMD Radeon Pro W5700",
+    "AMD Radeon Pro V520",
+    "AMD Radeon Pro 5600M",
+    "AMD Radeon RX 5500 XT",
+    "AMD Radeon RX 5300",
+    "AMD Radeon Pro W5500",
+    "AMD Radeon Pro W5300",
     # Polaris 10/20/30, the #8458 cluster
-    "AMD Radeon RX 580", "AMD Radeon RX 570", "AMD Radeon RX 590",
-    "AMD Radeon RX 480", "AMD Radeon RX 470",
-    "AMD Radeon Pro WX 7100", "AMD Radeon Pro WX 5100",
+    "AMD Radeon RX 580",
+    "AMD Radeon RX 570",
+    "AMD Radeon RX 590",
+    "AMD Radeon RX 480",
+    "AMD Radeon RX 470",
+    "AMD Radeon Pro WX 7100",
+    "AMD Radeon Pro WX 5100",
     # Must map to NOTHING in every copy
-    "AMD Radeon RX 5800", "AMD Radeon RX 5900", "AMD Radeon RX 4800",
-    "AMD Radeon RX 540", "AMD Radeon RX 550", "AMD Radeon RX 560", "AMD Radeon RX 460",
-    "AMD Radeon RX 7900 XTX", "AMD Radeon RX 9070 XT", "AMD Radeon RX 6800 XT",
-    "AMD Radeon PRO W7500", "AMD Radeon 890M Graphics", "AMD Radeon 780M Graphics",
-    "AMD Instinct MI210", "AMD Radeon VII", "AMD Radeon Graphics", "Intel Arc A770",
-    "NVIDIA GeForce RTX 4090", "",
+    "AMD Radeon RX 5800",
+    "AMD Radeon RX 5900",
+    "AMD Radeon RX 4800",
+    "AMD Radeon RX 540",
+    "AMD Radeon RX 550",
+    "AMD Radeon RX 560",
+    "AMD Radeon RX 460",
+    "AMD Radeon RX 7900 XTX",
+    "AMD Radeon RX 9070 XT",
+    "AMD Radeon RX 6800 XT",
+    "AMD Radeon PRO W7500",
+    "AMD Radeon 890M Graphics",
+    "AMD Radeon 780M Graphics",
+    "AMD Instinct MI210",
+    "AMD Radeon VII",
+    "AMD Radeon Graphics",
+    "Intel Arc A770",
+    "NVIDIA GeForce RTX 4090",
+    "",
 ]
 
 
@@ -896,7 +921,10 @@ def _sh_unsupported(path: Path, func: str, names):
     script = f'{body}\nfor n in "$@"; do {func} "$n" || echo ""; done\n'
     out = subprocess.run(
         ["sh", "-c", script, "sh", *names],
-        stdout = subprocess.PIPE, stderr = subprocess.DEVNULL, text = True, timeout = 60,
+        stdout = subprocess.PIPE,
+        stderr = subprocess.DEVNULL,
+        text = True,
+        timeout = 60,
     )
     return [l.strip() for l in out.stdout.split("\n")][: len(names)]
 
@@ -917,7 +945,10 @@ def _ps_unsupported(path: Path, names):
     )
     out = subprocess.run(
         ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
-        stdout = subprocess.PIPE, stderr = subprocess.DEVNULL, text = True, timeout = 180,
+        stdout = subprocess.PIPE,
+        stderr = subprocess.DEVNULL,
+        text = True,
+        timeout = 180,
     )
     assert out.returncode == 0, f"{path.name}: the unsupported table did not evaluate"
     return [l.strip() for l in out.stdout.split("\n")][: len(names)]
@@ -935,9 +966,9 @@ def test_the_five_unsupported_tables_agree_on_every_name():
     answers = {
         "install_python_stack.py": _py_unsupported(names),
         "install.sh": _sh_unsupported(
-            _INSTALL_SH, "_infer_unsupported_amd_gfx_arch_from_gpu_name", names),
-        "setup.sh": _sh_unsupported(
-            _SETUP_SH, "_setup_unsupported_gfx_from_name", names),
+            _INSTALL_SH, "_infer_unsupported_amd_gfx_arch_from_gpu_name", names
+        ),
+        "setup.sh": _sh_unsupported(_SETUP_SH, "_setup_unsupported_gfx_from_name", names),
     }
     if shutil.which("pwsh"):
         answers["install.ps1"] = _ps_unsupported(_INSTALL_PS1, names)
@@ -951,9 +982,8 @@ def test_the_five_unsupported_tables_agree_on_every_name():
         seen = {src: got[i] for src, got in answers.items()}
         if len(set(seen.values())) > 1:
             disagreements.append((name, seen))
-    assert not disagreements, (
-        "the unsupported-arch tables have drifted apart:\n"
-        + "\n".join(f"  {n!r}: {s}" for n, s in disagreements)
+    assert not disagreements, "the unsupported-arch tables have drifted apart:\n" + "\n".join(
+        f"  {n!r}: {s}" for n, s in disagreements
     )
     # Positive control: the corpus really does exercise the tables.
     ref = answers["install.sh"]

--- a/tests/studio/install/test_unsupported_arch_routing_guards_8529.py
+++ b/tests/studio/install/test_unsupported_arch_routing_guards_8529.py
@@ -862,3 +862,101 @@ def test_setup_sh_treats_a_blank_index_pin_as_unset(url, family, pinned):
         f"setup.sh read UNSLOTH_TORCH_INDEX_URL={url!r} / _FAMILY={family!r} as "
         f"{out.stdout.strip()}"
     )
+
+
+# ── The five unsupported tables must agree, not merely exist ─────────────────
+
+
+_PARITY_NAMES = [
+    # RDNA 1 (Navi 10 / 12 / 14), the #8529 cluster
+    "AMD Radeon RX 5700 XT", "AMD Radeon RX 5700", "AMD Radeon RX 5600 XT",
+    "AMD Radeon Pro 5600 XT", "AMD Radeon Pro 5700 XT", "AMD Radeon Pro W5700",
+    "AMD Radeon Pro V520", "AMD Radeon Pro 5600M", "AMD Radeon RX 5500 XT",
+    "AMD Radeon RX 5300", "AMD Radeon Pro W5500", "AMD Radeon Pro W5300",
+    # Polaris 10/20/30, the #8458 cluster
+    "AMD Radeon RX 580", "AMD Radeon RX 570", "AMD Radeon RX 590",
+    "AMD Radeon RX 480", "AMD Radeon RX 470",
+    "AMD Radeon Pro WX 7100", "AMD Radeon Pro WX 5100",
+    # Must map to NOTHING in every copy
+    "AMD Radeon RX 5800", "AMD Radeon RX 5900", "AMD Radeon RX 4800",
+    "AMD Radeon RX 540", "AMD Radeon RX 550", "AMD Radeon RX 560", "AMD Radeon RX 460",
+    "AMD Radeon RX 7900 XTX", "AMD Radeon RX 9070 XT", "AMD Radeon RX 6800 XT",
+    "AMD Radeon PRO W7500", "AMD Radeon 890M Graphics", "AMD Radeon 780M Graphics",
+    "AMD Instinct MI210", "AMD Radeon VII", "AMD Radeon Graphics", "Intel Arc A770",
+    "NVIDIA GeForce RTX 4090", "",
+]
+
+
+def _py_unsupported(names):
+    return [stack_mod._unsupported_gfx_arch_from_gpu_name(n) or "" for n in names]
+
+
+def _sh_unsupported(path: Path, func: str, names):
+    body = textwrap.dedent(_sh_function_body(path.read_text(encoding = "utf-8"), func))
+    script = f'{body}\nfor n in "$@"; do {func} "$n" || echo ""; done\n'
+    out = subprocess.run(
+        ["sh", "-c", script, "sh", *names],
+        stdout = subprocess.PIPE, stderr = subprocess.DEVNULL, text = True, timeout = 60,
+    )
+    return [l.strip() for l in out.stdout.split("\n")][: len(names)]
+
+
+def _ps_unsupported(path: Path, names):
+    src = path.read_text(encoding = "utf-8").replace("\r\n", "\n")
+    block = _ps_block(src, "$unsupportedNameArchTable = @(", "(", ")")
+    probes = ", ".join("'" + n.replace("'", "''") + "'" for n in names)
+    script = (
+        f"{block}\n"
+        f"foreach ($n in @({probes})) {{\n"
+        f"  $hit = ''\n"
+        f"  foreach ($row in $unsupportedNameArchTable) {{\n"
+        f"    if ($n -match $row.P) {{ $hit = $row.A; break }}\n"
+        f"  }}\n"
+        f"  Write-Output $hit\n"
+        f"}}\n"
+    )
+    out = subprocess.run(
+        ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
+        stdout = subprocess.PIPE, stderr = subprocess.DEVNULL, text = True, timeout = 180,
+    )
+    assert out.returncode == 0, f"{path.name}: the unsupported table did not evaluate"
+    return [l.strip() for l in out.stdout.split("\n")][: len(names)]
+
+
+@pytest.mark.skipif(os.name == "nt", reason = "POSIX shell only")
+@pytest.mark.skipif(shutil.which("sh") is None, reason = "no POSIX sh on this host")
+def test_the_five_unsupported_tables_agree_on_every_name():
+    """Five hand-kept copies of one table is the standing risk in this area, and the
+    supported tables are already pinned to each other. The unsupported ones were not:
+    a row added to a single file (RX 540 -> gfx803 in one of the five) passed the whole
+    suite. Compare by EVALUATION, in each source's own language, so a copy that spells
+    the same rule differently still counts as agreeing."""
+    names = _PARITY_NAMES
+    answers = {
+        "install_python_stack.py": _py_unsupported(names),
+        "install.sh": _sh_unsupported(
+            _INSTALL_SH, "_infer_unsupported_amd_gfx_arch_from_gpu_name", names),
+        "setup.sh": _sh_unsupported(
+            _SETUP_SH, "_setup_unsupported_gfx_from_name", names),
+    }
+    if shutil.which("pwsh"):
+        answers["install.ps1"] = _ps_unsupported(_INSTALL_PS1, names)
+        answers["setup.ps1"] = _ps_unsupported(_SETUP_PS1, names)
+
+    for source, got in answers.items():
+        assert len(got) == len(names), f"{source}: {len(got)} answers for {len(names)} names"
+
+    disagreements = []
+    for i, name in enumerate(names):
+        seen = {src: got[i] for src, got in answers.items()}
+        if len(set(seen.values())) > 1:
+            disagreements.append((name, seen))
+    assert not disagreements, (
+        "the unsupported-arch tables have drifted apart:\n"
+        + "\n".join(f"  {n!r}: {s}" for n, s in disagreements)
+    )
+    # Positive control: the corpus really does exercise the tables.
+    ref = answers["install.sh"]
+    assert ref[names.index("AMD Radeon RX 5700 XT")] == "gfx1010"
+    assert ref[names.index("AMD Radeon RX 580")] == "gfx803"
+    assert ref[names.index("AMD Radeon RX 7900 XTX")] == ""

--- a/tests/studio/test_rdna1_unsupported_message_8529.ps1
+++ b/tests/studio/test_rdna1_unsupported_message_8529.ps1
@@ -373,7 +373,29 @@ foreach ($pair in @(
         Check "$($pair.F) does not count CUDA_VISIBLE_DEVICES" (
             -not $decl.Contains('CUDA_VISIBLE_DEVICES')
         )
+        # Yielding to the mask is only safe while the label is the pinned card: both label
+        # sources keep adapter 0, so the masked branch has to fall silent once a peer it
+        # never indexed exists.
+        $window = $text.Substring($i, [Math]::Min(1200, $text.Length - $i))
+        Check "$($pair.F) drops the verdict when the mask may name another adapter" (
+            $window -match '(ROCmPeerLabels|wmiAmdNames)\.Count -gt (1|\$gpuNames\.Count)'
+        )
     }
+}
+
+# Get-WmiObject is gone from PowerShell 7, and the scans below catch silently, so a supported
+# Radeon named only by Windows took the CPU torch path there. Ask the parser for real calls;
+# the name still appears in prose. Every adapter scan in these files is on CIM.
+foreach ($pair in @(
+    @{ F = "install.ps1";      A = $installAst },
+    @{ F = "studio/setup.ps1"; A = $setupAst }
+)) {
+    $wmiCalls = @($pair.A.FindAll({
+        param($n)
+        $n -is [System.Management.Automation.Language.CommandAst] -and
+        $n.GetCommandName() -eq 'Get-WmiObject'
+    }, $true))
+    Check "$($pair.F) scans adapters with Get-CimInstance, not Get-WmiObject" ($wmiCalls.Count -eq 0)
 }
 
 Invoke-Expression (Get-AssignmentSource $installPath '$nameArchTable')
@@ -401,6 +423,15 @@ $guardCases = @(
     # The amd-smi paths never enter the WMI scan, so the peer list is empty there.
     @{ N = "an empty peer list does not suppress the verdict"
        L = "AMD Radeon RX 5700 XT"; A = @(); E = 'gfx1010' }
+    # Under a mask the peers no longer speak for the named card, but both label sources take
+    # adapter 0, so the label is only the SELECTED card when there is nothing else to pick.
+    @{ N = "a masked lone RX 5700 XT is still named"
+       L = "AMD Radeon RX 5700 XT"; A = @("AMD Radeon RX 5700 XT"); M = "0"; E = 'gfx1010' }
+    @{ N = "a mask beside a second adapter claims nothing"
+       L = "AMD Radeon RX 5700 XT"; A = @("AMD Radeon RX 5700 XT", "AMD Radeon RX 7900 XTX"); M = "1"; E = $null }
+    # Even two uncovered peers: the arch named would still be adapter 0's, not the pinned one.
+    @{ N = "a mask beside a second uncovered adapter claims nothing"
+       L = "AMD Radeon RX 5700 XT"; A = @("AMD Radeon RX 5700 XT", "AMD Radeon RX 580"); M = "1"; E = $null }
 )
 $guardSource = $guardBlocks[0].Extent.Text
 foreach ($case in $guardCases) {
@@ -408,7 +439,9 @@ foreach ($case in $guardCases) {
     $ROCmUnsupportedGfxArch = $null
     $ROCmGpuLabel = $case.L
     $wmiAmdNames = @($case.A)
+    if ($case.M) { $env:HIP_VISIBLE_DEVICES = $case.M } else { Remove-Item Env:HIP_VISIBLE_DEVICES -ErrorAction SilentlyContinue }
     Invoke-Expression $guardSource
+    Remove-Item Env:HIP_VISIBLE_DEVICES -ErrorAction SilentlyContinue
     Check $case.N ($ROCmUnsupportedGfxArch -eq $case.E)
 }
 

--- a/tests/studio/test_rdna1_unsupported_message_8529.ps1
+++ b/tests/studio/test_rdna1_unsupported_message_8529.ps1
@@ -354,6 +354,28 @@ Check "setup.ps1's peer scan writes neither the label nor the inference list" (
     -not $setupPeerBlock.Extent.Text.Contains('$script:ROCmGpuLabels =')
 )
 
+# A mask names the card, so a masked-out peer cannot answer for it: the suppression has to
+# yield to HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES, as the arch-borrowing rule already
+# does. CUDA_VISIBLE_DEVICES must NOT count; it masks NVIDIA devices, and counting it fired
+# the verdict beside a covered Radeon on every host that sets it.
+foreach ($pair in @(
+    @{ F = "install.ps1";      P = $installPath },
+    @{ F = "studio/setup.ps1"; P = (Join-Path $root "studio/setup.ps1") }
+)) {
+    $text = (Get-Content -Raw $pair.P) -replace "`r`n", "`n"
+    $i = $text.IndexOf('$unsupMasked = @(')
+    Check "$($pair.F) yields the peer suppression to an AMD visible-device mask" ($i -ge 0)
+    if ($i -ge 0) {
+        $decl = $text.Substring($i, [Math]::Min(240, $text.Length - $i))
+        Check "$($pair.F) counts HIP and ROCR in that mask" (
+            $decl.Contains('HIP_VISIBLE_DEVICES') -and $decl.Contains('ROCR_VISIBLE_DEVICES')
+        )
+        Check "$($pair.F) does not count CUDA_VISIBLE_DEVICES" (
+            -not $decl.Contains('CUDA_VISIBLE_DEVICES')
+        )
+    }
+}
+
 Invoke-Expression (Get-AssignmentSource $installPath '$nameArchTable')
 Invoke-Expression (Get-AssignmentSource $installPath '$unsupportedNameArchTable')
 

--- a/tests/studio/test_rdna1_unsupported_message_8529.ps1
+++ b/tests/studio/test_rdna1_unsupported_message_8529.ps1
@@ -300,70 +300,58 @@ $guardBlocks = @($installAst.FindAll({
 Check "the unsupported lookup block consults the peer list" ($guardBlocks.Count -gt 0)
 
 # The cases below inject $wmiAmdNames, so they cannot see whether anything FILLS it.
-# Assert the producer separately: the WMI scan must build it from the adapter list it
-# indexed, not from the single chosen adapter.
+# Assert the producer separately, and assert what it must NOT touch: the peer list is for
+# the REPORT, so it lives in its own block and must never write the label or the arch the
+# inference reads. Widening the existing scan instead turned a CPU install into a ROCm one
+# on a host amd-smi had already claimed, which is a routing change, not a message change.
 $peerAssign = @($installAst.FindAll({
     param($n)
     $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
     $n.Left.Extent.Text -eq '$wmiAmdNames' -and
-    $n.Right.Extent.Text.Contains('$wmiAdapters')
+    $n.Right.Extent.Text.Contains('$usePeers')
 }, $true))
-Check "the WMI scan fills the peer list from every adapter" ($peerAssign.Count -eq 1)
+Check "install.ps1 fills the peer list from every adapter" ($peerAssign.Count -eq 1)
 
-# ...and it must not be gated on $HasROCm. amd-smi can report GPUs with no gfx token and
-# only the first market name, which sets $HasROCm with no arch: gated that way the scan
-# was skipped and the guard above saw an empty peer list on exactly the multi-GPU host it
-# is for. The enclosing if must test the ARCH, which is what decides whether the lookup
-# below can run at all.
-$peerScanGate = $null
+$peerBlock = $null
 foreach ($assign in $peerAssign) {
-    # Walk PAST the inner `if ($wmiGpu)`: the gate under test is the outer one, the only
-    # condition on this path that mentions either signal.
     $node = $assign.Parent
     while ($node) {
         if ($node -is [System.Management.Automation.Language.IfStatementAst]) {
-            $cond = $node.Clauses[0].Item1.Extent.Text
-            if ($cond.Contains('$ROCmGfxArch') -or $cond.Contains('$HasROCm')) {
-                $peerScanGate = $cond
-                break
-            }
+            $peerBlock = $node
+            break
         }
         $node = $node.Parent
     }
 }
-Check "the peer scan is not gated on `$HasROCm" (
-    $peerScanGate -and $peerScanGate.Contains('$ROCmGfxArch') -and -not $peerScanGate.Contains('$HasROCm')
+Check "install.ps1's peer scan writes neither the label nor the arch" (
+    $peerBlock -and
+    -not $peerBlock.Extent.Text.Contains('$ROCmGpuLabel =') -and
+    -not $peerBlock.Extent.Text.Contains('$ROCmGfxArch =')
 )
 
-# studio/setup.ps1 carries the same scan for its own inference, and had the same gate: on
-# the amd-smi market-name-only path $script:ROCmGpuLabels held one name, so $gpuNames was
-# one entry and the whole host was judged on it. Its inference runs under
-# `if (-not $script:ROCmGfxArch)`, so the scan that feeds it must run there too.
+# studio/setup.ps1 keeps its own report-only list, for the same reason: $script:ROCmGpuLabels
+# feeds $gpuNames and therefore the arch inference, so the peer names must not go there.
 $setupPath = Join-Path $root "studio/setup.ps1"
 $setupAst = [System.Management.Automation.Language.Parser]::ParseFile($setupPath, [ref]$null, [ref]$null)
-$setupPeerAssign = @($setupAst.FindAll({
+$setupPeer = @($setupAst.FindAll({
     param($n)
     $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
-    $n.Left.Extent.Text -eq '$script:ROCmGpuLabels' -and
-    $n.Right.Extent.Text.Contains('$wmiGpus')
+    $n.Left.Extent.Text -eq '$script:ROCmPeerLabels' -and
+    $n.Right.Extent.Text.Contains('$usePeers')
 }, $true))
-Check "setup.ps1 fills its peer list from every adapter" ($setupPeerAssign.Count -eq 1)
-$setupGate = $null
-foreach ($assign in $setupPeerAssign) {
+Check "setup.ps1 keeps a separate report-only peer list" ($setupPeer.Count -eq 1)
+$setupPeerBlock = $null
+foreach ($assign in $setupPeer) {
     $node = $assign.Parent
     while ($node) {
-        if ($node -is [System.Management.Automation.Language.IfStatementAst]) {
-            $cond = $node.Clauses[0].Item1.Extent.Text
-            if ($cond.Contains('$script:ROCmGfxArch') -or $cond.Contains('$HasROCm')) {
-                $setupGate = $cond
-                break
-            }
-        }
+        if ($node -is [System.Management.Automation.Language.IfStatementAst]) { $setupPeerBlock = $node; break }
         $node = $node.Parent
     }
 }
-Check "setup.ps1's peer scan is not gated on `$HasROCm" (
-    $setupGate -and $setupGate.Contains('$script:ROCmGfxArch') -and -not $setupGate.Contains('$HasROCm')
+Check "setup.ps1's peer scan writes neither the label nor the inference list" (
+    $setupPeerBlock -and
+    -not $setupPeerBlock.Extent.Text.Contains('$ROCmGpuLabel =') -and
+    -not $setupPeerBlock.Extent.Text.Contains('$script:ROCmGpuLabels =')
 )
 
 Invoke-Expression (Get-AssignmentSource $installPath '$nameArchTable')

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -95,11 +95,11 @@ def _without_the_array_wraps(src: str) -> str:
 
 
 def _amd_scan_block(src: str) -> str:
-    """The WMI fallback: the adapter list the label is read from. Gated on the ARCH,
-    not on $HasROCm, so the peer list also exists on the amd-smi market-name-only path
-    (an arch there is null while $HasROCm is true)."""
+    """The `if (-not $HasROCm)` WMI fallback: the adapter list the label is read from.
+    The report-only peer scan added for #8529 is a SEPARATE block and is deliberately not
+    covered here: it feeds no label and no arch."""
     m = re.search(
-        r"^    if \(-not \$script:ROCmGfxArch\) \{\n        try \{\n.*?^    \}\n",
+        r"^    if \(-not \$HasROCm\) \{\n        try \{\n.*?^    \}\n",
         src,
         re.DOTALL | re.MULTILINE,
     )
@@ -440,12 +440,12 @@ def test_a_user_override_is_the_escape_hatch_under_a_mask(tmp_path):
 
 
 def _installer_scan_block() -> str:
-    """install.ps1's own WMI fallback plus the name table it feeds. Gated on the ARCH,
-    not on $HasROCm: amd-smi can set the latter with no arch, and the peer list this
-    block builds has to exist on that path too."""
+    """install.ps1's own `if (-not $HasROCm)` WMI fallback plus the name table it feeds.
+    The report-only peer scan added for #8529 is a SEPARATE block, deliberately outside
+    this one: it feeds no label and no arch."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     start = src.index(
-        "        if (-not $ROCmGfxArch) {\n            try {\n                # ConfigManagerErrorCode"
+        "        if (-not $HasROCm) {\n            try {\n                # ConfigManagerErrorCode"
     )
     end = src.index("        # Capture ROCm version for wheel selection", start)
     return src[start:end]
@@ -461,10 +461,10 @@ def _run_installer_scan(tmp_path: Path, adapters: list[tuple[str, int]]) -> dict
         "\n".join(
             [
                 "$ErrorActionPreference = 'Stop'",
-                # Both names: install.ps1 asks CIM, and the old name throws as it does on
-                # PowerShell 7, so a revert fails instead of answering nothing via the catch.
+                # Both names: the routing scan asks WMI (unchanged by #8529), the
+                # report-only peer scan asks CIM. Same answer either way here.
                 f"function Get-CimInstance {{ param([Parameter(ValueFromRemainingArguments = $true)]$Rest) @({items}) }}",
-                "function Get-WmiObject { throw 'Get-WmiObject is not available in PowerShell 7' }",
+                f"function Get-WmiObject {{ param([Parameter(ValueFromRemainingArguments = $true)]$Rest) @({items}) }}",
                 "function substep { param($a, $b) }",
                 "$HasROCm = $false",
                 "$ROCmGpuLabel = $null",


### PR DESCRIPTION
Follow-up to #8577. That PR was meant to be message-only, and two of the guards I added
to it went further than that: on some AMD hosts they changed which PyTorch got installed.
This puts the scope back and closes a table drift the tests were not looking for.

## What was changing installs

**`studio/setup.ps1`.** The adapter scan was gated on `$HasROCm`, and #8577 widened that
to the arch so the peer list would exist on the amd-smi path. That variable,
`$script:ROCmGpuLabels`, feeds `$gpuNames`, which feeds the arch inference, so widening
it let the existing unpinned "borrow another adapter's arch" rule resolve an arch where
none was resolved before:

| host | before #8577 | after #8577 |
| --- | --- | --- |
| amd-smi confirms ROCm, no gfx token, CIM sees one RX 9070 XT | arch null, CPU torch | `gfx1201`, ROCm wheels |
| same, CIM sees RX 5700 XT then RX 7900 XTX | arch null, CPU torch | `gfx1100`, ROCm wheels, `--rocm-gfx gfx1100` forwarded to the llama.cpp and whisper installers |

**`install.ps1`.** The `Get-WmiObject` to `Get-CimInstance` swap did the same thing on
PowerShell 7, where the old call throws and the surrounding `catch {}` swallows it. A host
CIM can enumerate but the ROCm tools cannot went from CPU torch to a repo.amd.com index.

## What this PR does

Both scans are byte-identical to what they were before #8577 again, and the peer names
live in their own variable that only the uncovered-card verdict reads: `$wmiAmdNames` in
`install.ps1`, `$script:ROCmPeerLabels` in `studio/setup.ps1`. Neither block writes a
label or an arch, so the guards are message-only as intended.

The PowerShell 7 `Get-WmiObject` defect is therefore still present. It is real, and worth
fixing, but fixing it changes what every pwsh 7 AMD host without a HIP SDK installs, so it
belongs in its own PR rather than riding along in a wording change.

## The table drift

The five copies of the *supported* name table are pinned to each other by tests. The
*unsupported* ones added in #8577 were not, and they had already drifted: the regex copies
carry `(?!0)`, so an "RX 5800" is not Polaris, while the shell globs matched it through
`RX 580`. The shell arms now carry the same guard, written as `*"RX 580"|*"RX 580"[!0]*`
since POSIX `case` has no lookahead.

A new test compares all five tables by evaluating them in their own languages over a
shared 38-name corpus, so a copy that spells the same rule differently still counts as
agreeing. Adding a row to one file alone fails it, which is exactly the mutation that
passed the whole suite before.

## Checks

- `bash -n` on both shell installers, the PowerShell parser on both `.ps1` files, and
  `ast.parse` on `studio/install_python_stack.py`.
- `install.sh`'s index selector run at the merge base and at this head under identical
  stubs: 1920 cells, 0 stdout differences, 0 exit-code differences, 0 unexpected stderr
  differences. The harness fails closed if any run reports a missing function.
- 600 passed across the four suites this touches; 2537 passed, 2 skipped across
  `tests/studio/install` plus the Windows scan and parity suites. The three
  `test_managed_node_runtime.py` failures reproduce on `main` with these changes stashed.
- Mutation checks: appending a label or arch assignment to either peer block, restoring the
  old gate, adding a table row to one file alone, and dropping the `.strip()` from the pin
  read each fail a test.
