### PR TITLE
Model hub: show the Meta mark for Meta's own orgs

### DIFF
--- a/studio/frontend/src/features/hub/lib/provider-logos.ts
+++ b/studio/frontend/src/features/hub/lib/provider-logos.ts
@@ -12,6 +12,9 @@
  * NVIDIA's Nemotron/Minitron/Mistral-NeMo before meta-llama/mistralai, and
  * DeepSeek-R1-Distill- before Qwen/meta-llama. Repo names are case-sensitive -
  * match the publisher's exact casing (e.g. `phi-` for v1/v2 vs `Phi-` for v3+).
+ *
+ * A provider's own Hub orgs are listed in `owners` and take its mark directly,
+ * whatever the repo is named (meta-models/Muse-Glimmer-30B -> Meta).
  */
 
 /**
@@ -51,6 +54,11 @@ export interface ProviderLogo {
 	 * (`gemma` -> `diffusiongemma-`, `gemma-3n`, not `gemmafy`). Use stems unique to one provider.
 	 */
 	stems?: readonly string[];
+	/**
+	 * The provider's own Hub orgs. Matched in full and case-insensitively, never as
+	 * a prefix, so `metavoice` is not Meta.
+	 */
+	owners?: readonly string[];
 }
 
 export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
@@ -251,6 +259,9 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 			"llama-",
 			"meta-"
 		],
+		// "Meta Inc." / "Meta Llama" / "AI at Meta". Not facebookresearch, which is
+		// an unrelated account despite the name.
+		owners: ["meta-models", "meta-llama", "facebook"],
 	},
 ];
 
@@ -294,14 +305,31 @@ export function isProviderRelabeledOwner(
 	return RELABELED_OWNERS.has(owner.toLowerCase());
 }
 
+/** Hub org -> the provider publishing under it, or null. Full-string, case-insensitive. */
+export function matchProviderLogoByOwner(
+	owner: string | null | undefined,
+): ProviderLogo | null {
+	const needle = owner?.trim().toLowerCase();
+	if (!needle) return null;
+	for (const provider of PROVIDER_LOGOS) {
+		if (provider.owners?.some((org) => org.toLowerCase() === needle)) {
+			return provider;
+		}
+	}
+	return null;
+}
+
 /**
  * Provider logo to render in place of the owner's profile picture, or null.
- * Only owners in RELABELED_OWNERS are eligible.
+ * A provider's own org takes its mark; otherwise only RELABELED_OWNERS are
+ * eligible, by repo name.
  */
 export function resolveOwnerProviderLogo(
 	owner: string | null | undefined,
 	repoName: string | null | undefined,
 ): ProviderLogo | null {
+	const byOwner = matchProviderLogoByOwner(owner);
+	if (byOwner) return byOwner;
 	if (!isProviderRelabeledOwner(owner) || !repoName) return null;
 	return matchProviderLogo(repoName);
 }

--- a/studio/frontend/tests/hub-provider-logo-owner.test.ts
+++ b/studio/frontend/tests/hub-provider-logo-owner.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PROVIDER_LOGOS,
+  matchProviderLogoByOwner,
+  resolveOwnerProviderLogo,
+} from "../src/features/hub/lib/provider-logos.ts";
+
+test("every Meta org shows the Meta mark, whatever the repo is named", () => {
+  for (const owner of ["meta-models", "meta-llama", "facebook"]) {
+    assert.equal(matchProviderLogoByOwner(owner)?.id, "meta-llama", owner);
+  }
+  // Muse Glimmer matches no prefix; the org alone decides.
+  assert.equal(
+    resolveOwnerProviderLogo("meta-models", "Muse-Glimmer-30B-GGUF")?.logoPath,
+    "/hub/profile/logo/meta.svg",
+  );
+  assert.equal(
+    resolveOwnerProviderLogo("meta-llama", "Llama-4-Scout-17B-16E-Instruct")
+      ?.logoPath,
+    "/hub/profile/logo/meta.svg",
+  );
+});
+
+test("owners match in full, never as a prefix", () => {
+  assert.equal(matchProviderLogoByOwner("META-MODELS")?.id, "meta-llama");
+  assert.equal(matchProviderLogoByOwner("  meta-models  ")?.id, "meta-llama");
+  // Unrelated accounts that merely start with the same letters stay untouched.
+  assert.equal(matchProviderLogoByOwner("metavoice"), null);
+  assert.equal(matchProviderLogoByOwner("meta-models-community"), null);
+  assert.equal(matchProviderLogoByOwner("facebookresearch"), null);
+  assert.equal(matchProviderLogoByOwner(""), null);
+  assert.equal(matchProviderLogoByOwner(null), null);
+});
+
+test("an unlisted owner is left to its Hub avatar", () => {
+  assert.equal(resolveOwnerProviderLogo("bartowski", "Qwen3-8B-GGUF"), null);
+  assert.equal(resolveOwnerProviderLogo("some-org", "Muse-Glimmer-30B"), null);
+});
+
+test("Unsloth re-uploads still resolve by repo name", () => {
+  assert.equal(
+    resolveOwnerProviderLogo("unsloth", "Llama-4-Scout-17B-16E-Instruct-GGUF")
+      ?.id,
+    "meta-llama",
+  );
+  assert.equal(
+    resolveOwnerProviderLogo("unsloth", "DeepSeek-R1-Distill-Llama-8B-GGUF")
+      ?.id,
+    "deepseek-ai",
+  );
+  assert.equal(resolveOwnerProviderLogo("unsloth", "Qwen3-30B-A3B")?.id, "qwen");
+  assert.equal(resolveOwnerProviderLogo("unsloth", undefined), null);
+});
+
+test("no org is claimed by two providers", () => {
+  const seen = new Map<string, string>();
+  for (const provider of PROVIDER_LOGOS) {
+    for (const owner of provider.owners ?? []) {
+      const key = owner.toLowerCase();
+      assert.equal(
+        seen.get(key),
+        undefined,
+        `${owner} is claimed by both ${seen.get(key)} and ${provider.id}`,
+      );
+      seen.set(key, provider.id);
+    }
+  }
+});


### PR DESCRIPTION
## The problem

A repo owned by one of Meta's own orgs gets no logo from the registry.

The provider logos only apply to Unsloth re-uploads, gated on `RELABELED_OWNERS`, and they match on repo name. So `unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF` picks up Meta from the `Llama-` prefix, but `meta-models/Muse-Glimmer-30B` matches nothing and falls through to the owner avatar path instead.

That path is the catch: list rows pass `remote={false}` so they never fetch the Hub profile picture, and the row renders a coloured letter tile. Muse Glimmer under `meta-models` shows a letter while the same model under `unsloth` shows the Meta mark.

Current behaviour, straight from the resolver:

```
meta-models/Muse-Glimmer-30B                  -> letter tile
meta-llama/Llama-4-Scout-17B-16E-Instruct     -> letter tile
facebook/KernelLLM                            -> letter tile
unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF   -> Meta
```

## The fix

Providers can now declare their own Hub orgs in `owners`, and an owner match runs before the repo-name rules. Meta claims three:

| Org | Hub fullname |
| --- | --- |
| `meta-models` | Meta Inc. |
| `meta-llama` | Meta Llama |
| `facebook` | AI at Meta |

Orgs match in full and case-insensitively, never as a prefix, so `metavoice` and `meta-models-community` are untouched.

`facebookresearch` is deliberately left out. Despite the name it is an unrelated account: its Hub fullname is "test" and it falls back to a gravatar, so it is not Meta.

## Blast radius

I replayed the decision over 4679 distinct models pulled across downloads, likes and trending, covering a wide spread of owners:

- 129 rows change
- 0 change from one mark to another
- 0 lose a mark

Every one of the 129 belongs to the three orgs above: `facebook` 85, `meta-llama` 40, `meta-models` 4. Nothing else moves, and nothing can: the old rule only ever returned a logo for `unsloth`, which is in no `owners` list, so those rows resolve exactly as before.

Two shades of change worth separating. In list views this is a letter tile becoming the Meta mark, which is the real fix. In the inspector, which does fetch avatars, it swaps Meta's Hub-hosted avatar for the local `meta.svg`, so it looks the same and saves a network round trip.

If you would rather keep this to the org that prompted it, dropping `facebook` from the list is a one-line edit and removes 85 of the 129.

## Testing

New `hub-provider-logo-owner.test.ts` covers the three orgs, full-string matching including the `metavoice` and `facebookresearch` near-misses, unlisted owners falling through untouched, Unsloth re-uploads still resolving by repo name, and a guard that no org is claimed by two providers. The suite fails against unmodified source.

Full frontend suite passes at 1958, typecheck is clean, and lint errors are unchanged at 141.

## Note on PR 8468

That PR also touches `provider-logos.ts` and adds an `owners` field, for a different purpose: resolving an Unsloth re-upload through its `base_model` provenance. The two overlap in that file, so whichever lands second will want a small rebase. This one stands alone and does not depend on it.
