### PR TITLE
ci: stop asserting torch on the Intel Mac clean-machine leg

### DIFF
--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -355,14 +355,35 @@ jobs:
             HOME_DIR="$UNSLOTH_STUDIO_HOME"
           fi
 
-          if [ "${{ matrix.flags }}" != "--no-torch" ]; then
-            if [ "${{ matrix.delivery }}" = "tauri" ]; then
-              PY="$HOME_DIR/studio/unsloth_studio/bin/python"
-            else
-              PY="$HOME_DIR/unsloth_studio/bin/python"
+          # install.sh sets SKIP_TORCH for --no-torch AND, at install.sh:1880, for Intel
+          # Macs, where upstream no longer publishes x86_64 macOS torch wheels. Reading
+          # only matrix.flags asserted a torch the installer had deliberately skipped,
+          # so the macos-15-intel leg could never pass.
+          skip_torch=0
+          if [ "${{ matrix.flags }}" = "--no-torch" ]; then
+            skip_torch=1
+          elif [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
+            skip_torch=1
+          fi
+
+          if [ "${{ matrix.delivery }}" = "tauri" ]; then
+            PY="$HOME_DIR/studio/unsloth_studio/bin/python"
+          else
+            PY="$HOME_DIR/unsloth_studio/bin/python"
+          fi
+          [ -x "$PY" ] || { echo "::error::installer left no managed Python at $PY"; exit 1; }
+          # These representative native wheels load without the developer-only dylib patch.
+          if [ "$skip_torch" = 1 ]; then
+            "$PY" -c "import numpy, safetensors, tokenizers; print('native wheels loaded', numpy.__version__)"
+            # A skipped torch has to be genuinely absent. Silently tolerating one would
+            # hide a half-installed x86_64 wheel, which is the failure this leg exists
+            # to catch.
+            if "$PY" -c "import torch" 2>/dev/null; then
+              echo "::error::torch is importable on a leg where install.sh skips it"
+              exit 1
             fi
-            [ -x "$PY" ] || { echo "::error::installer left no managed Python at $PY"; exit 1; }
-            # These representative native wheels load without the developer-only dylib patch.
+            echo "torch correctly absent (install.sh skipped it)"
+          else
             "$PY" -c "import numpy, safetensors, tokenizers, torch; print('native wheels loaded', numpy.__version__, torch.__version__)"
           fi
           STUDIO_HOME="$HOME_DIR" bash .github/scripts/assert-llama-loads.sh


### PR DESCRIPTION
### The problem

`mac macos-15-intel / mask / file` in `Clean machine install` has been failing on `main`, not just on PRs. Recent examples: run [31687130863](https://github.com/unslothai/unsloth/actions/runs/31687130863) on `main`, and the same leg on unrelated PRs.

It always fails the same way:

```
ModuleNotFoundError: No module named 'torch'
```

That is not a broken install. It is the assert asking for something the installer deliberately does not do. Earlier in the very same job, `install.sh` prints:

```
skipping PyTorch (--no-torch or Intel Mac x86_64).
```

`install.sh:1880` sets `SKIP_TORCH=true` when `--no-torch` is passed **or** `MAC_INTEL` is true, because upstream no longer publishes x86_64 macOS torch wheels. The assert only consulted `matrix.flags`, and the Intel leg is declared with `flags: ''`, so it required a torch that was never going to be there. The leg could not pass under any circumstances.

### The change

The skip now mirrors the installer's own rule rather than restating half of it:

- `--no-torch` in `matrix.flags`, or a Darwin `x86_64` runner, means torch is expected to be absent
- when torch is skipped, the remaining native wheels (`numpy`, `safetensors`, `tokenizers`) are still imported, so the dylib-patch check the step exists for is not lost
- a skipped torch is now asserted **absent**. Previously the branch simply did nothing, which would have hidden a half-installed x86_64 wheel. That is the failure this leg is best placed to catch, so it fails the job now
- the managed-Python check moved out of the torch branch and runs on every leg, including `--no-torch`, where it previously did not run at all

### Verification

`skip_torch` resolves correctly for every leg shape in the matrix:

| flags | runner | skip_torch |
| --- | --- | --- |
| (none) | Darwin arm64 | 0, torch asserted present |
| (none) | Darwin x86_64 | 1, torch asserted absent |
| `--no-torch` | Darwin arm64 | 1, torch asserted absent |

`scripts/lint_workflow_triggers.py` passes, and the workflow still parses.

Scoped to the `macos` job in `clean-machine-install-ci.yml`; no other leg or workflow is touched.
