### PR TITLE
CI: stop asserting torch on the Intel-mac leg the installer keeps GGUF-only

### DIFF
--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -363,7 +363,17 @@ jobs:
             fi
             [ -x "$PY" ] || { echo "::error::installer left no managed Python at $PY"; exit 1; }
             # These representative native wheels load without the developer-only dylib patch.
-            "$PY" -c "import numpy, safetensors, tokenizers, torch; print('native wheels loaded', numpy.__version__, torch.__version__)"
+            # torch is exempt on exactly the hosts install.sh puts in GGUF-only mode whatever the
+            # flags say: macOS on x86_64, which is its MAC_INTEL rule and covers both a real Intel
+            # Mac and Apple Silicon under Rosetta. PyTorch dropped x86_64 macOS wheels in Jan 2024,
+            # so torch is legitimately absent there and asserting it made this leg permanently red.
+            # Narrow on purpose: the other three wheels are still asserted, and every host that
+            # DOES expect torch still fails without it.
+            if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
+              "$PY" -c "import numpy, safetensors, tokenizers; print('native wheels loaded (GGUF-only, no torch)', numpy.__version__)"
+            else
+              "$PY" -c "import numpy, safetensors, tokenizers, torch; print('native wheels loaded', numpy.__version__, torch.__version__)"
+            fi
           fi
           STUDIO_HOME="$HOME_DIR" bash .github/scripts/assert-llama-loads.sh
           # Rosetta 2 is on this runner and not on a fresh Mac, so llama-server launching


### PR DESCRIPTION
The `mac macos-15-intel / mask / file` leg of `clean-machine-install-ci.yml` has been red on `main` for at least two days, and every open PR inherits it. It has now cost triage time twice in one day, so this removes the false signal without weakening the assert anywhere it means something.

### Why it fails

The native-wheel assert runs for every leg whose flags are not `--no-torch`:

```sh
if [ "${{ matrix.flags }}" != "--no-torch" ]; then
  ...
  "$PY" -c "import numpy, safetensors, tokenizers, torch; ..."
fi
```

But `install.sh` decides GGUF-only mode from the platform, not from the flags:

```sh
if [ "$OS" = "macos" ] && [ "$_ARCH" = "x86_64" ]; then
    ...
    MAC_INTEL=true
fi
```

and then prints, in the very same job:

```
NOTE: Intel Mac (x86_64) detected.
PyTorch is unavailable for this platform (dropped Jan 2024).
Unsloth will install in GGUF-only mode.
```

So the leg installs no torch by design and the assert then fails with `ModuleNotFoundError: No module named 'torch'`. It is pre-existing: the same job fails identically on `main` in runs 31654944533 and 31619287648. The row is `experimental: true` under `continue-on-error`, and its own comment says "Informational only", which is why those `main` runs still conclude success while the job shows red.

### The fix

Exempt torch on exactly the hosts `install.sh` exempts, mirroring its `MAC_INTEL` rule (`macOS` and `uname -m` = `x86_64`). That rule deliberately covers both a real Intel Mac and Apple Silicon running under Rosetta, which `install.sh` also drops to GGUF-only.

Kept narrow on purpose:

- the other three native wheels are still asserted on that leg, so it keeps its coverage instead of being skipped wholesale
- every host that does expect torch still fails without it

Gate behaviour, checked directly:

| `uname -s` | `uname -m` | result |
| --- | --- | --- |
| Darwin | x86_64 | skip torch |
| Darwin | arm64 | assert torch |
| Linux | x86_64 | assert torch |
| Linux | aarch64 | assert torch |
| MINGW64_NT | x86_64 | assert torch |

The workflow still parses (6 jobs) and both interpreter snippets parse.

`desktop-app-clean-machine-ci.yml` carries a second copy of the same assert. It is not affected today, because its matrix runs only `macos-15` (Apple Silicon) and never an Intel leg, so it is left alone rather than changed speculatively.
