### PR TITLE
Windows: stop the oversize guard tests from emptying os.environ

### DIFF
--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -1241,11 +1241,15 @@ def test_cli_guard_refuses_a_value_that_would_not_fit_in_the_environment():
     r"""A scalar that was already near the 32767-character limit crosses it once
     it names its folder in full, and a variable Windows will not accept is a
     failure to report here rather than in the next process."""
-    message, colour, chdir_calls = _guard_outcome(
-        r"C:\Windows\System32",
-        ["unsloth", "studio", "--api-only"],
-        environ_extra = {"HF_HOME": "x" * 32767},
-    )
+    # The limit is lowered rather than the value grown: the harness puts the
+    # environment through os.environ so the real ntpath reads it, and Windows
+    # refuses to store 32767 characters there before the guard ever sees them.
+    with mock.patch.object(_system_dir_guard, "_WINDOWS_ENV_VALUE_LIMIT", 64):
+        message, colour, chdir_calls = _guard_outcome(
+            r"C:\Windows\System32",
+            ["unsloth", "studio", "--api-only"],
+            environ_extra = {"HF_HOME": "x" * 80},
+        )
     assert (colour, chdir_calls) == ("red", [])
     assert "path settings" in message
     assert "HF_HOME" in message
@@ -1255,12 +1259,14 @@ def test_cli_guard_refuses_a_list_that_would_not_fit_in_the_environment():
     r"""Windows caps a variable at 32767 characters, and a list of relative
     entries can cross that once each names its folder in full. Reporting it here
     names the setting; discovering it when the next process starts does not."""
-    entries = ";".join(["entry"] * 7000)
-    message, colour, chdir_calls = _guard_outcome(
-        r"C:\Windows\System32",
-        ["unsloth", "studio", "--api-only"],
-        environ_extra = {"PYTHONPATH": entries},
-    )
+    # Same reason as the scalar above: the limit is lowered, not the value grown.
+    entries = ";".join(["entry"] * 20)
+    with mock.patch.object(_system_dir_guard, "_WINDOWS_ENV_VALUE_LIMIT", 64):
+        message, colour, chdir_calls = _guard_outcome(
+            r"C:\Windows\System32",
+            ["unsloth", "studio", "--api-only"],
+            environ_extra = {"PYTHONPATH": entries},
+        )
     assert (colour, chdir_calls) == ("red", [])
     assert "path settings" in message
     assert "PYTHONPATH" in message

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -1244,11 +1244,13 @@ def test_cli_guard_refuses_a_value_that_would_not_fit_in_the_environment():
     # The limit is lowered rather than the value grown: the harness puts the
     # environment through os.environ so the real ntpath reads it, and Windows
     # refuses to store 32767 characters there before the guard ever sees them.
+    # The value stays under the lowered limit and only crosses it once anchored,
+    # so a guard that measured the raw value would fail this.
     with mock.patch.object(_system_dir_guard, "_WINDOWS_ENV_VALUE_LIMIT", 64):
         message, colour, chdir_calls = _guard_outcome(
             r"C:\Windows\System32",
             ["unsloth", "studio", "--api-only"],
-            environ_extra = {"HF_HOME": "x" * 80},
+            environ_extra = {"HF_HOME": "x" * 50},
         )
     assert (colour, chdir_calls) == ("red", [])
     assert "path settings" in message
@@ -1259,8 +1261,9 @@ def test_cli_guard_refuses_a_list_that_would_not_fit_in_the_environment():
     r"""Windows caps a variable at 32767 characters, and a list of relative
     entries can cross that once each names its folder in full. Reporting it here
     names the setting; discovering it when the next process starts does not."""
-    # Same reason as the scalar above: the limit is lowered, not the value grown.
-    entries = ";".join(["entry"] * 20)
+    # Same reason as the scalar above: the limit is lowered, not the value grown,
+    # and the raw list fits while the anchored one does not.
+    entries = ";".join(["entry"] * 3)
     with mock.patch.object(_system_dir_guard, "_WINDOWS_ENV_VALUE_LIMIT", 64):
         message, colour, chdir_calls = _guard_outcome(
             r"C:\Windows\System32",

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -1241,11 +1241,10 @@ def test_cli_guard_refuses_a_value_that_would_not_fit_in_the_environment():
     r"""A scalar that was already near the 32767-character limit crosses it once
     it names its folder in full, and a variable Windows will not accept is a
     failure to report here rather than in the next process."""
-    # The limit is lowered rather than the value grown: the harness puts the
-    # environment through os.environ so the real ntpath reads it, and Windows
-    # refuses to store 32767 characters there before the guard ever sees them.
-    # The value stays under the lowered limit and only crosses it once anchored,
-    # so a guard that measured the raw value would fail this.
+    # The limit is lowered rather than the value grown: the harness sets the
+    # environment through os.environ, and Windows will not store 32767
+    # characters there. The value fits until it is anchored, so a guard that
+    # measured the raw value would fail this.
     with mock.patch.object(_system_dir_guard, "_WINDOWS_ENV_VALUE_LIMIT", 64):
         message, colour, chdir_calls = _guard_outcome(
             r"C:\Windows\System32",
@@ -1261,8 +1260,8 @@ def test_cli_guard_refuses_a_list_that_would_not_fit_in_the_environment():
     r"""Windows caps a variable at 32767 characters, and a list of relative
     entries can cross that once each names its folder in full. Reporting it here
     names the setting; discovering it when the next process starts does not."""
-    # Same reason as the scalar above: the limit is lowered, not the value grown,
-    # and the raw list fits while the anchored one does not.
+    # Same reason as the scalar above, and the raw list fits where the anchored
+    # one does not.
     entries = ";".join(["entry"] * 3)
     with mock.patch.object(_system_dir_guard, "_WINDOWS_ENV_VALUE_LIMIT", 64):
         message, colour, chdir_calls = _guard_outcome(


### PR DESCRIPTION
Follow-up to #8575.

### The problem

Two tests added in #8575 check that the guard refuses a path setting it cannot fit into a Windows environment variable, and they did it by building a value of 32767 characters:

```python
environ_extra = {"HF_HOME": "x" * 32767}
```

The test harness installs that environment with `mock.patch.dict(os.environ, environ, clear=True)` so the real `ntpath` reads it. On Windows the assignment raises:

```
ValueError: the environment variable is longer than 32767 characters
```

part way through applying the patch, after `clear=True` has already emptied `os.environ` and before the exception unwinds it. The process then continues with no environment at all, and fifteen unrelated tests fail on the way out:

```
FileNotFoundError: shell not found: neither %ComSpec% nor %SystemRoot% is set
```

Seventeen failures on `windows-latest` in total, two real and fifteen collateral. Linux and macOS never saw it, since neither caps a variable's length.

### The fix

Patch the limit down rather than grow the value. The branch under test is the same one, the assertions are unchanged, and the values are small enough for a real Windows environment to hold:

```python
with mock.patch.object(_system_dir_guard, "_WINDOWS_ENV_VALUE_LIMIT", 64):
    message, colour, chdir_calls = _guard_outcome(
        r"C:\Windows\System32",
        ["unsloth", "studio", "--api-only"],
        environ_extra = {"HF_HOME": "x" * 80},
    )
```

Tests only. No product code changes.

### Verification

`python -m pytest tests/test_installer_system32_guard.py` -> 175 passed.