### PR TITLE
Apply the kwarg-spacing formatter to the #8677 system poll test

### DIFF
--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -320,7 +320,13 @@ def test_rocm_apu_inventory_keeps_the_gtt_total(monkeypatch):
 class _FakeRocmProps(_FakeProps):
     """Discrete card as a current ROCm runtime describes it: the flag is filled in."""
 
-    def __init__(self, name = "MI300X", total = 191505498112, arch = "gfx942", integrated = 0):
+    def __init__(
+        self,
+        name = "MI300X",
+        total = 191505498112,
+        arch = "gfx942",
+        integrated = 0,
+    ):
         super().__init__(name, total)
         self.gcnArchName = arch
         self.is_integrated = integrated
@@ -396,7 +402,12 @@ def test_rocm_apu_sysfs_overlay_still_declines_against_the_gtt_total(monkeypatch
 class _FakeUnclassifiedApuProps(_FakeProps):
     """gfx1103 Phoenix: a real APU that sits outside the classifier's arch set."""
 
-    def __init__(self, total = _APU_CARVE_OUT, *, integrated = 0):
+    def __init__(
+        self,
+        total = _APU_CARVE_OUT,
+        *,
+        integrated = 0,
+    ):
         super().__init__("AMD Radeon 780M Graphics", total)
         self.gcnArchName = "gfx1103"
         if integrated is not None:


### PR DESCRIPTION
`test_system_poll_no_cuda_context.py` landed in #8677 with two constructor signatures the `ruff-format-with-kwargs` pre-commit hook wants wrapped. It is the only file on main the hook still modifies: running `scripts/run_ruff_format.py` over all 1571 tracked Python files on `29806d363` leaves exactly this one dirty.

That matters beyond tidiness, because pre-commit.ci reports `files were modified by this hook` and then `a conflict occurred when applying fixes to the pr` on branches that carry it, so the autofix push cannot heal them.

This is the formatter's own output, no hand edits. `tests/test_system_poll_no_cuda_context.py`: 31 passed.