### PR TITLE
Studio: show live prompt and generation speed

### DIFF
--- a/studio/backend/core/inference/api_monitor.py
+++ b/studio/backend/core/inference/api_monitor.py
@@ -178,9 +178,7 @@ class ApiMonitorEntry:
             "ttft_ms": ttft_ms,
             "tok_per_sec": round(tok_per_sec, 2) if tok_per_sec is not None else None,
             "prompt_tok_per_sec": (
-                round(self.prompt_tok_per_sec, 2)
-                if self.prompt_tok_per_sec is not None
-                else None
+                round(self.prompt_tok_per_sec, 2) if self.prompt_tok_per_sec is not None else None
             ),
             # The engine's decode span, not the streamed window: an unknowable first-chunk token
             # count and reasoning tokens both inflate a streamed rate. Absent rather than guessed.

--- a/studio/backend/core/inference/api_monitor.py
+++ b/studio/backend/core/inference/api_monitor.py
@@ -103,6 +103,7 @@ class ApiMonitorEntry:
     first_decode_monotonic: Optional[float] = None
     prompt_ms: Optional[float] = None
     tok_per_sec: Optional[float] = None
+    prompt_tok_per_sec: Optional[float] = None
     # timings.predicted_ms; set only from engine timings, so its presence marks a rateable row.
     decode_ms: Optional[float] = None
     stop_reason: Optional[str] = None
@@ -176,6 +177,11 @@ class ApiMonitorEntry:
             "progress": self.progress,
             "ttft_ms": ttft_ms,
             "tok_per_sec": round(tok_per_sec, 2) if tok_per_sec is not None else None,
+            "prompt_tok_per_sec": (
+                round(self.prompt_tok_per_sec, 2)
+                if self.prompt_tok_per_sec is not None
+                else None
+            ),
             # The engine's decode span, not the streamed window: an unknowable first-chunk token
             # count and reasoning tokens both inflate a streamed rate. Absent rather than guessed.
             "decode_ms": int(self.decode_ms) if self.decode_ms is not None else None,
@@ -392,6 +398,7 @@ class ApiMonitor:
         entry_id: Optional[str],
         *,
         tok_per_sec: Optional[float] = None,
+        prompt_tok_per_sec: Optional[float] = None,
         prompt_ms: Optional[float] = None,
         decode_ms: Optional[float] = None,
         stop_reason: Optional[str] = None,
@@ -401,14 +408,17 @@ class ApiMonitor:
         # Coerce before locking: arbitrary payloads, and a raise here (this runs inside
         # streaming generators) would truncate the user's response.
         tok_per_sec = _finite_float_or_none(tok_per_sec)
+        prompt_tok_per_sec = _finite_float_or_none(prompt_tok_per_sec)
         prompt_ms = _finite_float_or_none(prompt_ms)
         decode_ms = _finite_float_or_none(decode_ms)
         with self._lock:
             entry = self._find_locked(entry_id)
             if entry is None:
                 return
-            if tok_per_sec is not None:
+            if tok_per_sec is not None and tok_per_sec >= 0:
                 entry.tok_per_sec = tok_per_sec
+            if prompt_tok_per_sec is not None and prompt_tok_per_sec >= 0:
+                entry.prompt_tok_per_sec = prompt_tok_per_sec
             if prompt_ms is not None:
                 entry.prompt_ms = prompt_ms
             # Past a day of decode it is a bad reading, not a slow model.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3255,10 +3255,10 @@ def _report_live_llama_timings(callback, chunk) -> None:
         return
     timings = chunk.get("timings")
     sample = dict(timings) if isinstance(timings, dict) else {}
+    # Live samples are not TTFT; terminal metadata retains prompt_ms for the fallback.
+    sample.pop("prompt_ms", None)
     progress = chunk.get("prompt_progress")
     if isinstance(progress, dict):
-        # Live prefill is not TTFT; keep prompt_ms for terminal engine timings only.
-        sample.pop("prompt_ms", None)
         try:
             processed = max(0.0, float(progress.get("processed", 0)))
             cached = max(0.0, float(progress.get("cache", 0)))

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -18265,14 +18265,11 @@ class LlamaCppBackend:
                         return False
                     delta = choice.get("delta")
                     if isinstance(delta, dict) and any(
-                        value not in (None, "", [])
-                        for key, value in delta.items()
-                        if key != "role"
+                        value not in (None, "", []) for key, value in delta.items() if key != "role"
                     ):
                         return False
             saw_progress = True
         return saw_progress
-
 
     @staticmethod
     def _iter_text_cancellable(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3247,6 +3247,8 @@ def _backfill_usage_from_timings(usage, timings):
         out.get("completion_tokens") or 0
     )
     return out
+
+
 def _report_live_llama_timings(callback, chunk) -> None:
     """Report request-scoped llama.cpp progress without altering the public stream."""
     if callback is None or not isinstance(chunk, dict):

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -18241,35 +18241,37 @@ class LlamaCppBackend:
                 yield response, first_token_deadline
 
     @staticmethod
-    def _is_prompt_progress_only_chunk(chunk: str) -> bool:
-        """Return true when an SSE transport chunk contains prompt progress and no output."""
-        saw_progress = False
-        for line in chunk.splitlines():
-            if not line.startswith("data:"):
+    def _sse_event_has_generated_output(event: str) -> bool:
+        """Return true when a complete SSE event carries model-generated output."""
+        payload_lines = [
+            line[5:].lstrip()
+            for line in event.splitlines()
+            if line.startswith("data:")
+        ]
+        if not payload_lines:
+            return False
+        try:
+            data = json.loads("\n".join(payload_lines))
+        except (TypeError, json.JSONDecodeError):
+            return False
+        if not isinstance(data, dict):
+            return False
+        if data.get("type") == "diffusion_frame":
+            return True
+        choices = data.get("choices")
+        if not isinstance(choices, list):
+            return False
+        for choice in choices:
+            if not isinstance(choice, dict):
                 continue
-            payload = line[5:].strip()
-            if not payload:
-                continue
-            try:
-                data = json.loads(payload)
-            except (TypeError, json.JSONDecodeError):
-                return False
-            if not isinstance(data, dict) or not isinstance(data.get("prompt_progress"), dict):
-                return False
-            choices = data.get("choices")
-            if isinstance(choices, list):
-                for choice in choices:
-                    if not isinstance(choice, dict):
-                        continue
-                    if choice.get("finish_reason"):
-                        return False
-                    delta = choice.get("delta")
-                    if isinstance(delta, dict) and any(
-                        value not in (None, "", []) for key, value in delta.items() if key != "role"
-                    ):
-                        return False
-            saw_progress = True
-        return saw_progress
+            delta = choice.get("delta")
+            if isinstance(delta, dict) and any(
+                value not in (None, "", []) for key, value in delta.items() if key != "role"
+            ):
+                return True
+            if choice.get("text") not in (None, ""):
+                return True
+        return False
 
     @staticmethod
     def _iter_text_cancellable(
@@ -18284,6 +18286,7 @@ class LlamaCppBackend:
         if first_token_deadline is None:
             first_token_deadline = time.monotonic() + _DEFAULT_FIRST_TOKEN_TIMEOUT_S
         last_chunk_at: Optional[float] = None
+        prefill_sse_buffer = ""
         while True:
             if cancel_event is not None and cancel_event.is_set():
                 response.close()
@@ -18295,7 +18298,17 @@ class LlamaCppBackend:
                         raise httpx.ReadTimeout("The model did not produce a first token in time.")
                     LlamaCppBackend._set_stream_read_timeout(response, remaining_s)
                 chunk = next(text_iter)
-                if chunk and not LlamaCppBackend._is_prompt_progress_only_chunk(chunk):
+                starts_output = last_chunk_at is not None
+                if chunk and last_chunk_at is None:
+                    prefill_sse_buffer += chunk
+                    while match := re.search(r"(?:\r\n|\r|\n){2}", prefill_sse_buffer):
+                        event = prefill_sse_buffer[: match.start()]
+                        prefill_sse_buffer = prefill_sse_buffer[match.end() :]
+                        if LlamaCppBackend._sse_event_has_generated_output(event):
+                            starts_output = True
+                            prefill_sse_buffer = ""
+                            break
+                if chunk and starts_output:
                     if last_chunk_at is None and post_first_chunk_read_timeout_s is not None:
                         LlamaCppBackend._set_stream_read_timeout(
                             response,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3247,6 +3247,33 @@ def _backfill_usage_from_timings(usage, timings):
         out.get("completion_tokens") or 0
     )
     return out
+def _report_live_llama_timings(callback, chunk) -> None:
+    """Report request-scoped llama.cpp progress without altering the public stream."""
+    if callback is None or not isinstance(chunk, dict):
+        return
+    timings = chunk.get("timings")
+    sample = dict(timings) if isinstance(timings, dict) else {}
+    progress = chunk.get("prompt_progress")
+    if isinstance(progress, dict):
+        try:
+            processed = max(0.0, float(progress.get("processed", 0)))
+            cached = max(0.0, float(progress.get("cache", 0)))
+            elapsed_ms = float(progress.get("time_ms", 0))
+            prompt_n = max(0.0, processed - cached)
+            if math.isfinite(elapsed_ms) and elapsed_ms > 0 and math.isfinite(prompt_n):
+                sample.update(
+                    prompt_n = prompt_n,
+                    prompt_ms = elapsed_ms,
+                    prompt_per_second = prompt_n / (elapsed_ms / 1000.0),
+                )
+        except (TypeError, ValueError, OverflowError):
+            pass
+    if not sample:
+        return
+    try:
+        callback(sample)
+    except Exception:
+        logger.debug("Ignoring API monitor throughput callback failure", exc_info = True)
 
 
 # Host RAM to leave free on an integrated GPU, matching llama.cpp's own --fit
@@ -18586,6 +18613,7 @@ class LlamaCppBackend:
         continue_final_message: bool = False,
         seed: Optional[int] = None,
         promote_reasoning_only: bool = True,
+        perf_callback: Optional[Callable[[dict], None]] = None,
         _allow_respawn_retry: bool = True,
     ) -> Generator[Union[str, dict], None, None]:
         """
@@ -18622,6 +18650,9 @@ class LlamaCppBackend:
             "repeat_penalty": repetition_penalty,
             "presence_penalty": presence_penalty,
         }
+        if perf_callback is not None:
+            payload["return_progress"] = True
+            payload["timings_per_token"] = True
         # Per-request enable_thinking / reasoning_effort / preserve_thinking
         _reasoning_kw = self._request_reasoning_kwargs(
             enable_thinking, reasoning_effort, preserve_thinking
@@ -18697,6 +18728,7 @@ class LlamaCppBackend:
 
                         try:
                             data = json.loads(line[6:])
+                            _report_live_llama_timings(perf_callback, data)
                             # Diffusion frame (per-step canvas) from the shim: forward untouched so
                             # the frontend renders it in place. No assistant text, so it never enters
                             # the cumulative content.
@@ -18787,6 +18819,7 @@ class LlamaCppBackend:
                     continue_final_message = continue_final_message,
                     seed = seed,
                     promote_reasoning_only = promote_reasoning_only,
+                    perf_callback = perf_callback,
                     _allow_respawn_retry = False,
                 )
                 return
@@ -18830,6 +18863,7 @@ class LlamaCppBackend:
         bypass_permissions: bool = False,
         permission_mode: Optional[str] = None,
         promote_reasoning_only: bool = True,
+        perf_callback: Optional[Callable[[dict], None]] = None,
     ) -> Generator[dict, None, None]:
         """
         Agentic loop: let the model call tools, execute them, and continue.
@@ -19110,6 +19144,10 @@ class LlamaCppBackend:
                 "repeat_penalty": repetition_penalty,
                 "presence_penalty": presence_penalty,
             }
+
+            if perf_callback is not None:
+                payload["return_progress"] = True
+                payload["timings_per_token"] = True
             # As in the passthrough builder: if every name carried markup the catalog is
             # now empty, and "tools": [] would still advertise tool use.
             if safe_tools:
@@ -19229,6 +19267,8 @@ class LlamaCppBackend:
 
                             try:
                                 chunk_data = json.loads(line[6:])
+
+                                _report_live_llama_timings(perf_callback, chunk_data)
                                 _ct = chunk_data.get("timings")
                                 if _ct:
                                     _iter_timings = _ct
@@ -20273,6 +20313,10 @@ class LlamaCppBackend:
             stream_payload["seed"] = seed
         stream_payload["stream_options"] = {"include_usage": True}
 
+        if perf_callback is not None:
+            stream_payload["return_progress"] = True
+            stream_payload["timings_per_token"] = True
+
         cumulative = ""
         _last_emitted = ""
         in_thinking = False
@@ -20332,6 +20376,8 @@ class LlamaCppBackend:
 
                         try:
                             chunk_data = json.loads(line[6:])
+
+                            _report_live_llama_timings(perf_callback, chunk_data)
                             # Capture server timings/usage from final chunks.
                             _chunk_timings = chunk_data.get("timings")
                             if _chunk_timings:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -18244,9 +18244,7 @@ class LlamaCppBackend:
     def _sse_event_has_generated_output(event: str) -> bool:
         """Return true when a complete SSE event carries model-generated output."""
         payload_lines = [
-            line[5:].lstrip()
-            for line in event.splitlines()
-            if line.startswith("data:")
+            line[5:].lstrip() for line in event.splitlines() if line.startswith("data:")
         ]
         if not payload_lines:
             return False

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3257,6 +3257,8 @@ def _report_live_llama_timings(callback, chunk) -> None:
     sample = dict(timings) if isinstance(timings, dict) else {}
     progress = chunk.get("prompt_progress")
     if isinstance(progress, dict):
+        # Live prefill is not TTFT; keep prompt_ms for terminal engine timings only.
+        sample.pop("prompt_ms", None)
         try:
             processed = max(0.0, float(progress.get("processed", 0)))
             cached = max(0.0, float(progress.get("cache", 0)))
@@ -3265,7 +3267,6 @@ def _report_live_llama_timings(callback, chunk) -> None:
             if math.isfinite(elapsed_ms) and elapsed_ms > 0 and math.isfinite(prompt_n):
                 sample.update(
                     prompt_n = prompt_n,
-                    prompt_ms = elapsed_ms,
                     prompt_per_second = prompt_n / (elapsed_ms / 1000.0),
                 )
         except (TypeError, ValueError, OverflowError):
@@ -18240,6 +18241,40 @@ class LlamaCppBackend:
                 yield response, first_token_deadline
 
     @staticmethod
+    def _is_prompt_progress_only_chunk(chunk: str) -> bool:
+        """Return true when an SSE transport chunk contains prompt progress and no output."""
+        saw_progress = False
+        for line in chunk.splitlines():
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if not payload:
+                continue
+            try:
+                data = json.loads(payload)
+            except (TypeError, json.JSONDecodeError):
+                return False
+            if not isinstance(data, dict) or not isinstance(data.get("prompt_progress"), dict):
+                return False
+            choices = data.get("choices")
+            if isinstance(choices, list):
+                for choice in choices:
+                    if not isinstance(choice, dict):
+                        continue
+                    if choice.get("finish_reason"):
+                        return False
+                    delta = choice.get("delta")
+                    if isinstance(delta, dict) and any(
+                        value not in (None, "", [])
+                        for key, value in delta.items()
+                        if key != "role"
+                    ):
+                        return False
+            saw_progress = True
+        return saw_progress
+
+
+    @staticmethod
     def _iter_text_cancellable(
         response: "httpx.Response",
         cancel_event: Optional[threading.Event] = None,
@@ -18263,7 +18298,7 @@ class LlamaCppBackend:
                         raise httpx.ReadTimeout("The model did not produce a first token in time.")
                     LlamaCppBackend._set_stream_read_timeout(response, remaining_s)
                 chunk = next(text_iter)
-                if chunk:
+                if chunk and not LlamaCppBackend._is_prompt_progress_only_chunk(chunk):
                     if last_chunk_at is None and post_first_chunk_read_timeout_s is not None:
                         LlamaCppBackend._set_stream_read_timeout(
                             response,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3500,6 +3500,23 @@ def _monitor_usage(
         )
 
 
+
+def _monitor_perf_callback(monitor_id: Optional[str], context_length):
+    """Build a timing sink only when a monitor row or wrapper sink can consume it."""
+    if not monitor_id and _monitor_perf_sink.get() is None:
+        return None
+
+    def _callback(timings: dict) -> None:
+        _monitor_usage(
+            monitor_id,
+            None,
+            context_length,
+            timings = timings,
+        )
+
+    return _callback
+
+
 def _monitor_call_text(name: Any, arguments: Any = None) -> str:
     call_name = str(name or "tool")
     if arguments is None or arguments == "":
@@ -12760,14 +12777,11 @@ async def openai_chat_completions(
                 )
             )
 
-        def _gguf_perf_callback(timings: dict) -> None:
-            _monitor_usage(
-                monitor_id,
-                None,
-                llama_backend.context_length,
-                timings = timings,
-            )
-
+        _gguf_perf_callback = (
+            _monitor_perf_callback(monitor_id, llama_backend.context_length)
+            if not _wants_multiple_choices(payload)
+            else None
+        )
         def _gguf_chat_delta_line(delta: ChoiceDelta, finish_reason = None) -> str:
             if delta.reasoning_content is not None and delta.content is None:
                 delta = delta.model_copy(update = {"content": ""})
@@ -19215,11 +19229,9 @@ async def anthropic_messages(
                 bypass_permissions = bool(payload.bypass_permissions),
                 permission_mode = getattr(payload, "permission_mode", None),
                 promote_reasoning_only = False,
-                perf_callback = lambda timings: _monitor_usage(
+                perf_callback = _monitor_perf_callback(
                     monitor_id,
-                    None,
                     llama_backend.context_length,
-                    timings = timings,
                 ),
             )
 
@@ -19261,11 +19273,9 @@ async def anthropic_messages(
             stop = stop,
             cancel_event = cancel_event,
             promote_reasoning_only = False,
-            perf_callback = lambda timings: _monitor_usage(
+            perf_callback = _monitor_perf_callback(
                 monitor_id,
-                None,
                 llama_backend.context_length,
-                timings = timings,
             ),
         )
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3500,7 +3500,6 @@ def _monitor_usage(
         )
 
 
-
 def _monitor_perf_callback(monitor_id: Optional[str], context_length):
     """Build a timing sink only when a monitor row or wrapper sink can consume it."""
     if not monitor_id and _monitor_perf_sink.get() is None:
@@ -12782,6 +12781,7 @@ async def openai_chat_completions(
             if not _wants_multiple_choices(payload)
             else None
         )
+
         def _gguf_chat_delta_line(delta: ChoiceDelta, finish_reason = None) -> str:
             if delta.reasoning_content is not None and delta.content is None:
                 delta = delta.model_copy(update = {"content": ""})

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3973,6 +3973,8 @@ def _direct_llama_is_busy() -> bool:
     """
     with _direct_llama_inflight_lock:
         return _direct_llama_inflight > 0
+
+
 def _monitor_queue_state() -> Optional[dict]:
     """Live slot/queue occupancy of the loaded llama-server, for the API monitor."""
     # Disabled admission takes no leases and stays at capacity 1, so a multi-slot
@@ -12765,6 +12767,7 @@ async def openai_chat_completions(
                 llama_backend.context_length,
                 timings = timings,
             )
+
         def _gguf_chat_delta_line(delta: ChoiceDelta, finish_reason = None) -> str:
             if delta.reasoning_content is not None and delta.content is None:
                 delta = delta.model_copy(update = {"content": ""})

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3466,6 +3466,14 @@ def _monitor_usage(
         sink = _monitor_perf_sink.get()
         if sink is not None:
             sink["timings"] = timings
+            outer_monitor_id = sink.get("monitor_id")
+            if outer_monitor_id:
+                _monitor_usage(
+                    outer_monitor_id,
+                    None,
+                    sink.get("context_length"),
+                    timings = timings,
+                )
     # isinstance, not truthiness: a non-dict usage would raise on .get() into the
     # streaming generator and abort the user's response.
     if isinstance(usage, dict) and usage:
@@ -16866,9 +16874,11 @@ async def _responses_non_streaming(
 
     # Catches the engine timings the suppressed inner monitor would otherwise drop.
     inner_perf: dict = {}
-
+    if monitor_id:
+        inner_perf["monitor_id"] = monitor_id
+        inner_perf["context_length"] = _monitor_context_length()
     try:
-        _sink_token = _monitor_perf_sink.set(inner_perf)
+        _sink_token = _monitor_perf_sink.set(inner_perf if monitor_id else None)
         try:
             result = await openai_chat_completions(chat_req, request)
         finally:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3476,14 +3476,16 @@ def _monitor_usage(
             total_tokens = usage.get("total_tokens"),
             context_length = context_length,
         )
-    tok_per_sec = prompt_ms = decode_ms = None
+    tok_per_sec = prompt_tok_per_sec = prompt_ms = decode_ms = None
     if isinstance(timings, dict):
         tok_per_sec = timings.get("predicted_per_second")
+        prompt_tok_per_sec = timings.get("prompt_per_second")
         prompt_ms = timings.get("prompt_ms")
         # The span the tile rates on: total tokens over total time, not a mean of per-request rates.
         decode_ms = timings.get("predicted_ms")
     if (
         tok_per_sec is not None
+        or prompt_tok_per_sec is not None
         or prompt_ms is not None
         or decode_ms is not None
         or stop_reason is not None
@@ -3491,6 +3493,7 @@ def _monitor_usage(
         api_monitor.set_perf(
             monitor_id,
             tok_per_sec = tok_per_sec,
+            prompt_tok_per_sec = prompt_tok_per_sec,
             prompt_ms = prompt_ms,
             decode_ms = decode_ms,
             stop_reason = stop_reason,
@@ -3970,8 +3973,6 @@ def _direct_llama_is_busy() -> bool:
     """
     with _direct_llama_inflight_lock:
         return _direct_llama_inflight > 0
-
-
 def _monitor_queue_state() -> Optional[dict]:
     """Live slot/queue occupancy of the loaded llama-server, for the API monitor."""
     # Disabled admission takes no leases and stays at capacity 1, so a multi-slot
@@ -12757,6 +12758,13 @@ async def openai_chat_completions(
                 )
             )
 
+        def _gguf_perf_callback(timings: dict) -> None:
+            _monitor_usage(
+                monitor_id,
+                None,
+                llama_backend.context_length,
+                timings = timings,
+            )
         def _gguf_chat_delta_line(delta: ChoiceDelta, finish_reason = None) -> str:
             if delta.reasoning_content is not None and delta.content is None:
                 delta = delta.model_copy(update = {"content": ""})
@@ -12911,6 +12919,7 @@ async def openai_chat_completions(
                     confirm_tool_calls = _effective_confirm and not bool(payload.bypass_permissions),
                     bypass_permissions = bool(payload.bypass_permissions),
                     permission_mode = payload.permission_mode,
+                    perf_callback = _gguf_perf_callback,
                 )
 
             _tool_admission_mode = "chat_tool_stream" if payload.stream else "chat_tool_nonstream"
@@ -13584,6 +13593,7 @@ async def openai_chat_completions(
                 preserve_thinking = payload.preserve_thinking,
                 continue_final_message = _continue_final_message(payload),
                 seed = _seed,
+                perf_callback = _gguf_perf_callback,
             )
 
         _gguf_sentinel = object()
@@ -19202,6 +19212,12 @@ async def anthropic_messages(
                 bypass_permissions = bool(payload.bypass_permissions),
                 permission_mode = getattr(payload, "permission_mode", None),
                 promote_reasoning_only = False,
+                perf_callback = lambda timings: _monitor_usage(
+                    monitor_id,
+                    None,
+                    llama_backend.context_length,
+                    timings = timings,
+                ),
             )
 
         if payload.stream:
@@ -19242,6 +19258,12 @@ async def anthropic_messages(
             stop = stop,
             cancel_event = cancel_event,
             promote_reasoning_only = False,
+            perf_callback = lambda timings: _monitor_usage(
+                monitor_id,
+                None,
+                llama_backend.context_length,
+                timings = timings,
+            ),
         )
 
     if payload.stream:

--- a/studio/backend/tests/test_api_monitor.py
+++ b/studio/backend/tests/test_api_monitor.py
@@ -1506,7 +1506,6 @@ def test_wants_stream_usage_reads_the_callers_opt_in(include_usage, expected):
     assert inf._wants_stream_usage(SimpleNamespace(stream_options = None)) is False
 
 
-
 def test_direct_llama_work_is_busy_without_the_admission_snapshot(monkeypatch):
     # With UNSLOTH_LLAMA_ADMISSION_CONTROL=off the queue readout is None, so a caption or
     # OCR call (which opens no row) would leave the row saying Ready while the server works.

--- a/studio/backend/tests/test_api_monitor.py
+++ b/studio/backend/tests/test_api_monitor.py
@@ -720,11 +720,18 @@ def test_set_perf_records_stats_and_snapshot_reports_them():
     )
     # set_reply never stamps TTFT; this is the case the prompt_ms fallback exists for.
     monitor.set_reply(entry_id, "hi")
-    monitor.set_perf(entry_id, tok_per_sec = 42.5, prompt_ms = 123.4, stop_reason = "length")
+    monitor.set_perf(
+        entry_id,
+        tok_per_sec = 42.5,
+        prompt_tok_per_sec = 81.25,
+        prompt_ms = 123.4,
+        stop_reason = "length",
+    )
     monitor.finish(entry_id)
 
     [entry] = monitor.snapshot()
     assert entry["tok_per_sec"] == 42.5
+    assert entry["prompt_tok_per_sec"] == 81.25
     assert entry["ttft_ms"] == 123
     assert entry["stop_reason"] == "length"
 
@@ -756,12 +763,18 @@ def test_set_perf_rejects_non_finite_values():
         model = "local-model",
         prompt = "user: hello",
     )
-    monitor.set_perf(entry_id, tok_per_sec = float("nan"), prompt_ms = float("inf"))
-    monitor.set_perf(entry_id, tok_per_sec = "bogus", prompt_ms = None)
+    monitor.set_perf(
+        entry_id,
+        tok_per_sec = float("nan"),
+        prompt_tok_per_sec = float("inf"),
+        prompt_ms = float("inf"),
+    )
+    monitor.set_perf(entry_id, tok_per_sec = "bogus", prompt_tok_per_sec = -1, prompt_ms = None)
     monitor.finish(entry_id)
 
     [entry] = monitor.snapshot()
     assert entry["tok_per_sec"] is None
+    assert entry["prompt_tok_per_sec"] is None
     assert entry["ttft_ms"] is None
 
 
@@ -1493,6 +1506,7 @@ def test_wants_stream_usage_reads_the_callers_opt_in(include_usage, expected):
     assert inf._wants_stream_usage(SimpleNamespace(stream_options = None)) is False
 
 
+
 def test_direct_llama_work_is_busy_without_the_admission_snapshot(monkeypatch):
     # With UNSLOTH_LLAMA_ADMISSION_CONTROL=off the queue readout is None, so a caption or
     # OCR call (which opens no row) would leave the row saying Ready while the server works.
@@ -1507,6 +1521,7 @@ def test_direct_llama_work_is_busy_without_the_admission_snapshot(monkeypatch):
     app = FastAPI()
     app.include_router(inf.studio_router)
     app.dependency_overrides = {get_current_subject: lambda: "alice"}
+
     body = TestClient(app).get("/monitor").json()
 
     assert body["active_requests"] == 0
@@ -1541,13 +1556,19 @@ def test_the_decode_span_comes_only_from_engine_timings(monkeypatch):
         entry_id,
         {"prompt_tokens": 11, "completion_tokens": 50},
         4096,
-        timings = {"prompt_ms": 9000.0, "predicted_ms": 1000.0, "predicted_per_second": 50.0},
+        timings = {
+            "prompt_ms": 9000.0,
+            "prompt_per_second": 11.0,
+            "predicted_ms": 1000.0,
+            "predicted_per_second": 50.0,
+        },
     )
     monitor.finish(entry_id)
 
     [row] = monitor.snapshot()
     assert row["decode_ms"] == 1000
     assert row["completion_tokens"] / (row["decode_ms"] / 1000) == 50.0
+    assert row["prompt_tok_per_sec"] == 11.0
 
 
 def test_a_timings_only_final_chunk_still_sets_the_decode_span(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_stall_timeout.py
+++ b/studio/backend/tests/test_llama_cpp_stall_timeout.py
@@ -105,12 +105,15 @@ def test_prompt_progress_keeps_the_prefill_read_timeout():
         '"prompt_progress":{"processed":512,"cache":0,"time_ms":64}}\n\n'
     )
 
+    output = 'data: {"choices":[{"delta":{"content":"x"}}]}\n\n'
+    fragments = (progress[:32], progress[32:], output[:24], output[24:])
+
     class Response:
         request = _types.SimpleNamespace(extensions = {"timeout": {"read": _PREFILL_TIMEOUT}})
 
         @staticmethod
         def iter_text():
-            yield progress
+            yield from fragments
 
         @staticmethod
         def close():
@@ -122,8 +125,15 @@ def test_prompt_progress_keeps_the_prefill_read_timeout():
         post_first_chunk_read_timeout_s = _STALL_TIMEOUT,
     )
 
-    assert next(iterator) == progress
+    assert next(iterator) == fragments[0]
     assert Response.request.extensions["timeout"]["read"] > _STALL_TIMEOUT
+    assert next(iterator) == fragments[1]
+    assert Response.request.extensions["timeout"]["read"] > _STALL_TIMEOUT
+    # A generated-output event switches timeouts only after its delimiter is complete.
+    assert next(iterator) == fragments[2]
+    assert Response.request.extensions["timeout"]["read"] > _STALL_TIMEOUT
+    assert next(iterator) == fragments[3]
+    assert Response.request.extensions["timeout"]["read"] == _STALL_TIMEOUT
     iterator.close()
 
 

--- a/studio/backend/tests/test_llama_cpp_stall_timeout.py
+++ b/studio/backend/tests/test_llama_cpp_stall_timeout.py
@@ -99,6 +99,34 @@ def test_stall_timeout_honored_after_first_token(monkeypatch):
     assert clock["t"] >= _STALL_TIMEOUT * 0.5
 
 
+def test_prompt_progress_keeps_the_prefill_read_timeout():
+    progress = (
+        'data: {"choices":[{"delta":{"role":"assistant","content":null}}],'
+        '"prompt_progress":{"processed":512,"cache":0,"time_ms":64}}\n\n'
+    )
+
+    class Response:
+        request = _types.SimpleNamespace(extensions = {"timeout": {"read": _PREFILL_TIMEOUT}})
+
+        @staticmethod
+        def iter_text():
+            yield progress
+
+        @staticmethod
+        def close():
+            return None
+
+    iterator = LlamaCppBackend._iter_text_cancellable(
+        Response(),
+        first_token_deadline = llama_cpp_mod.time.monotonic() + _PREFILL_TIMEOUT,
+        post_first_chunk_read_timeout_s = _STALL_TIMEOUT,
+    )
+
+    assert next(iterator) == progress
+    assert Response.request.extensions["timeout"]["read"] > _STALL_TIMEOUT
+    iterator.close()
+
+
 def test_prefill_timeout_used_when_no_live_override(monkeypatch):
     """Without a lowered live timeout, the wrapper honors the passed prefill timeout, so the normal first-token wait is unchanged."""
     clock = {"t": 0.0}

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -34,6 +34,18 @@ from state.tool_approvals import TOOL_REJECTED_MESSAGE, resolve_tool_decision
 
 def _sse(delta: dict) -> str:
     return "data: " + json.dumps({"choices": [{"index": 0, "delta": delta}]}) + "\n"
+def _progress(*, processed: int, cached: int, time_ms: int) -> str:
+    return "data: " + json.dumps(
+        {
+            "choices": [{"index": 0, "delta": {"role": "assistant", "content": None}}],
+            "prompt_progress": {
+                "total": processed,
+                "processed": processed,
+                "cache": cached,
+                "time_ms": time_ms,
+            },
+        }
+    ) + "\n"
 
 
 def _done() -> str:
@@ -105,6 +117,65 @@ def _make_backend(
     return backend
 
 
+def test_plain_stream_reports_request_scoped_live_prompt_and_generation_timings(monkeypatch):
+    stream = [
+        _progress(processed = 1000, cached = 100, time_ms = 100),
+        "data: " + json.dumps(
+            {
+                "choices": [{"index": 0, "delta": {"content": "OK"}}],
+                "timings": {
+                    "prompt_n": 900,
+                    "prompt_ms": 100,
+                    "prompt_per_second": 9000,
+                    "predicted_n": 4,
+                    "predicted_ms": 20,
+                    "predicted_per_second": 200,
+                },
+            }
+        ) + "\n",
+        _done(),
+    ]
+    payloads: list[dict] = []
+    samples: list[dict] = []
+    backend = _make_backend(monkeypatch, [stream], payloads)
+
+    list(
+        backend.generate_chat_completion(
+            messages = [{"role": "user", "content": "benchmark"}],
+            perf_callback = samples.append,
+        )
+    )
+
+    assert payloads[0]["return_progress"] is True
+    assert payloads[0]["timings_per_token"] is True
+    assert samples[0]["prompt_n"] == 900
+    assert samples[0]["prompt_per_second"] == 9000
+    assert samples[-1]["predicted_per_second"] == 200
+
+
+def test_tool_stream_reports_progress_without_leaking_a_content_event(monkeypatch):
+    stream = [
+        _progress(processed = 512, cached = 0, time_ms = 64),
+        _sse({"content": "done"}),
+        _done(),
+    ]
+    payloads: list[dict] = []
+    samples: list[dict] = []
+    backend = _make_backend(monkeypatch, [stream], payloads)
+
+    events = list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "benchmark"}],
+            tools = [{"type": "function", "function": {"name": "web_search"}}],
+            max_tool_iterations = 1,
+            perf_callback = samples.append,
+        )
+    )
+
+    assert payloads[0]["return_progress"] is True
+    assert payloads[0]["timings_per_token"] is True
+    assert samples[0]["prompt_per_second"] == 8000
+    assert [event["text"] for event in events if event["type"] == "content"] == ["done"]
 def _patch_successful_respawn(
     monkeypatch,
     backend,

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -34,18 +34,24 @@ from state.tool_approvals import TOOL_REJECTED_MESSAGE, resolve_tool_decision
 
 def _sse(delta: dict) -> str:
     return "data: " + json.dumps({"choices": [{"index": 0, "delta": delta}]}) + "\n"
+
+
 def _progress(*, processed: int, cached: int, time_ms: int) -> str:
-    return "data: " + json.dumps(
-        {
-            "choices": [{"index": 0, "delta": {"role": "assistant", "content": None}}],
-            "prompt_progress": {
-                "total": processed,
-                "processed": processed,
-                "cache": cached,
-                "time_ms": time_ms,
-            },
-        }
-    ) + "\n"
+    return (
+        "data: "
+        + json.dumps(
+            {
+                "choices": [{"index": 0, "delta": {"role": "assistant", "content": None}}],
+                "prompt_progress": {
+                    "total": processed,
+                    "processed": processed,
+                    "cache": cached,
+                    "time_ms": time_ms,
+                },
+            }
+        )
+        + "\n"
+    )
 
 
 def _done() -> str:
@@ -120,7 +126,8 @@ def _make_backend(
 def test_plain_stream_reports_request_scoped_live_prompt_and_generation_timings(monkeypatch):
     stream = [
         _progress(processed = 1000, cached = 100, time_ms = 100),
-        "data: " + json.dumps(
+        "data: "
+        + json.dumps(
             {
                 "choices": [{"index": 0, "delta": {"content": "OK"}}],
                 "timings": {
@@ -132,7 +139,8 @@ def test_plain_stream_reports_request_scoped_live_prompt_and_generation_timings(
                     "predicted_per_second": 200,
                 },
             }
-        ) + "\n",
+        )
+        + "\n",
         _done(),
     ]
     payloads: list[dict] = []
@@ -176,6 +184,8 @@ def test_tool_stream_reports_progress_without_leaking_a_content_event(monkeypatc
     assert payloads[0]["timings_per_token"] is True
     assert samples[0]["prompt_per_second"] == 8000
     assert [event["text"] for event in events if event["type"] == "content"] == ["done"]
+
+
 def _patch_successful_respawn(
     monkeypatch,
     backend,

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -125,7 +125,20 @@ def _make_backend(
 
 def test_plain_stream_reports_request_scoped_live_prompt_and_generation_timings(monkeypatch):
     stream = [
-        _progress(processed = 1000, cached = 100, time_ms = 100),
+        "data: "
+        + json.dumps(
+            {
+                "choices": [{"index": 0, "delta": {"role": "assistant", "content": None}}],
+                "prompt_progress": {
+                    "total": 1000,
+                    "processed": 1000,
+                    "cache": 100,
+                    "time_ms": 100,
+                },
+                "timings": {"prompt_ms": 100, "prompt_per_second": 9000},
+            }
+        )
+        + "\n",
         "data: "
         + json.dumps(
             {
@@ -158,6 +171,7 @@ def test_plain_stream_reports_request_scoped_live_prompt_and_generation_timings(
     assert payloads[0]["timings_per_token"] is True
     assert samples[0]["prompt_n"] == 900
     assert samples[0]["prompt_per_second"] == 9000
+    assert "prompt_ms" not in samples[0]
     assert samples[-1]["predicted_per_second"] == 200
 
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -171,7 +171,7 @@ def test_plain_stream_reports_request_scoped_live_prompt_and_generation_timings(
     assert payloads[0]["timings_per_token"] is True
     assert samples[0]["prompt_n"] == 900
     assert samples[0]["prompt_per_second"] == 9000
-    assert "prompt_ms" not in samples[0]
+    assert all("prompt_ms" not in sample for sample in samples)
     assert samples[-1]["predicted_per_second"] == 200
 
 

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -3625,8 +3625,18 @@ class TestGgufVisionToolRouting:
 
         calls = {"count": 0}
 
-        def _generate(**_kwargs):
+        def _generate(**kwargs):
             calls["count"] += 1
+            callback = kwargs.get("perf_callback")
+            if callback is not None:
+                callback(
+                    {
+                        "prompt_ms": 100.0,
+                        "prompt_per_second": 30.0,
+                        "predicted_ms": 20.0,
+                        "predicted_per_second": 50.0,
+                    }
+                )
             text = f"reply {calls['count']}"
             yield text
             yield {
@@ -3671,6 +3681,49 @@ class TestGgufVisionToolRouting:
         assert entry["reply"] == "Choice 1:\nreply 1\n\nChoice 2:\nreply 2"
         assert entry["completion_tokens"] == 3
         assert monitor.active_count() == 0
+
+        assert entry["prompt_tok_per_sec"] is None
+        assert entry["tok_per_sec"] is None
+        assert entry["decode_ms"] is None
+
+    def test_disabled_monitor_does_not_install_gguf_perf_callback(self, monkeypatch):
+        import routes.inference as inf_mod
+
+        captured = {}
+
+        def _generate(**kwargs):
+            captured.update(kwargs)
+            yield "reply"
+            yield {
+                "type": "metadata",
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            }
+
+        backend = SimpleNamespace(
+            is_loaded = True,
+            is_vision = False,
+            supports_tools = False,
+            _is_audio = False,
+            model_identifier = "test-gguf",
+            context_length = 4096,
+            generate_chat_completion = _generate,
+        )
+        monkeypatch.setattr(inf_mod, "api_monitor", ApiMonitor(max_entries = 3, enabled = False))
+        monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+
+        response = self._drive(
+            openai_chat_completions(
+                ChatCompletionRequest(
+                    model = "default",
+                    messages = [{"role": "user", "content": "hi"}],
+                ),
+                request = self._Request(),
+                current_subject = "test",
+            )
+        )
+
+        assert json.loads(response.body)["choices"][0]["message"]["content"] == "reply"
+        assert captured["perf_callback"] is None
 
     def test_non_streaming_gguf_cancel_drains_worker(self, monkeypatch):
         async def _run():

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -835,7 +835,7 @@ class TestResponsesNonStreamingAdapter:
         assert request.state.skip_api_monitor is False
 
     @staticmethod
-    def _run_in_process_completion(monkeypatch, monitor, timings):
+    def _run_in_process_completion(monkeypatch, monitor, timings, *, observations = None):
         """Drive the wrapper over an in-process chat completion: its own monitor row is
         suppressed and a ``ChatCompletion`` has no ``timings`` field to carry them out."""
         import routes.inference as inf_mod
@@ -851,7 +851,11 @@ class TestResponsesNonStreamingAdapter:
         async def fake_chat_completions(chat_req, request):
             assert request.state.skip_api_monitor is True
             # monitor_id is None here: this call's own row is the suppressed one.
+            if observations is not None:
+                observations["perf_callback"] = inf_mod._monitor_perf_callback(None, 4096)
             inf_mod._monitor_usage(None, usage, 4096, timings = timings)
+            if observations is not None:
+                observations["live_entries"] = monitor.snapshot()
             return inf_mod._model_json_response(
                 ChatCompletion(
                     model = "test-model",
@@ -907,6 +911,45 @@ class TestResponsesNonStreamingAdapter:
         assert entry["decode_ms"] == 1000
         # 9s of that request was queue wait and prefill; the model generated at 50 tok/s.
         assert entry["completion_tokens"] / (entry["decode_ms"] / 1000) == 50.0
+
+    def test_in_process_engine_timings_update_outer_monitor_live(self, monkeypatch):
+        monitor = ApiMonitor(max_entries = 3)
+        observations = {}
+
+        self._run_in_process_completion(
+            monkeypatch,
+            monitor,
+            {
+                "prompt_per_second": 90.0,
+                "predicted_ms": 1000.0,
+                "predicted_per_second": 50.0,
+            },
+            observations = observations,
+        )
+
+        assert observations["perf_callback"] is not None
+        [entry] = observations["live_entries"]
+        assert entry["status"] == "running"
+        assert entry["prompt_tok_per_sec"] == 90.0
+        assert entry["tok_per_sec"] == 50.0
+        assert entry["decode_ms"] == 1000
+        assert entry["ttft_ms"] is None
+
+    def test_disabled_monitor_does_not_install_responses_perf_callback(self, monkeypatch):
+        monitor = ApiMonitor(max_entries = 3, enabled = False)
+        observations = {}
+
+        self._run_in_process_completion(
+            monkeypatch,
+            monitor,
+            {"prompt_per_second": 90.0, "predicted_per_second": 50.0},
+            observations = observations,
+        )
+
+        assert observations["perf_callback"] is None
+        assert observations["live_entries"] == []
+        assert monitor.snapshot() == []
+
 
     def test_a_relayed_decode_span_does_not_outlive_its_request(self, monkeypatch):
         """The relay is scoped to one inner call, so a timing-less request inherits nothing."""

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -835,7 +835,13 @@ class TestResponsesNonStreamingAdapter:
         assert request.state.skip_api_monitor is False
 
     @staticmethod
-    def _run_in_process_completion(monkeypatch, monitor, timings, *, observations = None):
+    def _run_in_process_completion(
+        monkeypatch,
+        monitor,
+        timings,
+        *,
+        observations = None,
+    ):
         """Drive the wrapper over an in-process chat completion: its own monitor row is
         suppressed and a ``ChatCompletion`` has no ``timings`` field to carry them out."""
         import routes.inference as inf_mod
@@ -949,7 +955,6 @@ class TestResponsesNonStreamingAdapter:
         assert observations["perf_callback"] is None
         assert observations["live_entries"] == []
         assert monitor.snapshot() == []
-
 
     def test_a_relayed_decode_span_does_not_outlive_its_request(self, monkeypatch):
         """The relay is scoped to one inner call, so a timing-less request inherits nothing."""

--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -320,7 +320,13 @@ def test_rocm_apu_inventory_keeps_the_gtt_total(monkeypatch):
 class _FakeRocmProps(_FakeProps):
     """Discrete card as a current ROCm runtime describes it: the flag is filled in."""
 
-    def __init__(self, name = "MI300X", total = 191505498112, arch = "gfx942", integrated = 0):
+    def __init__(
+        self,
+        name = "MI300X",
+        total = 191505498112,
+        arch = "gfx942",
+        integrated = 0,
+    ):
         super().__init__(name, total)
         self.gcnArchName = arch
         self.is_integrated = integrated
@@ -396,7 +402,12 @@ def test_rocm_apu_sysfs_overlay_still_declines_against_the_gtt_total(monkeypatch
 class _FakeUnclassifiedApuProps(_FakeProps):
     """gfx1103 Phoenix: a real APU that sits outside the classifier's arch set."""
 
-    def __init__(self, total = _APU_CARVE_OUT, *, integrated = 0):
+    def __init__(
+        self,
+        total = _APU_CARVE_OUT,
+        *,
+        integrated = 0,
+    ):
         super().__init__("AMD Radeon 780M Graphics", total)
         self.gcnArchName = "gfx1103"
         if integrated is not None:

--- a/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
+++ b/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
@@ -18,7 +18,7 @@ import { fetchDeviceType, usePlatformStore } from "@/config/env";
 import { getInferenceStatus, unloadModel } from "@/features/chat/api/chat-api";
 import { resolveInferenceCheckpointId } from "@/features/chat/lib/apply-inference-status-to-store";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
-import type { ApiMonitorEntry } from "@/features/chat/types/api";
+import type { ApiMonitorEntry } from "@/features/chat";
 import { isExternalModelId } from "@/features/chat/external-providers";
 import { modelIdsMatch } from "@/features/hub/lib/model-identity";
 import { useSettingsDialogStore } from "@/features/settings";
@@ -388,6 +388,7 @@ function RequestDetail({
     ? (detail.reply ?? entry.reply_preview)
     : entry.reply_preview;
 
+
   return (
     <div className="flex min-w-0 flex-col gap-5 p-5">
       <header className="flex min-w-0 flex-col gap-2">
@@ -461,7 +462,11 @@ function RequestDetail({
             value: entry.decode_ms != null ? formatDuration(entry.decode_ms) : "–",
           },
           {
-            label: "Speed",
+            label: "Prompt speed",
+            value: formatTokPerSec(entry.prompt_tok_per_sec) ?? "–",
+          },
+          {
+            label: "Generation speed",
             value: formatTokPerSec(entry.tok_per_sec) ?? "–",
           },
           {

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -34,6 +34,7 @@ export {
   type ScanFolderInfo,
 } from "./api/chat-api";
 export type {
+  ApiMonitorEntry,
   BackendModelDetails,
   GgufVariantDetail,
   InferenceStatusResponse,

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -405,6 +405,8 @@ export interface ApiMonitorEntry {
   // Server-side time to first token (measured, else engine prefill).
   ttft_ms?: number | null;
   tok_per_sec?: number | null;
+  /** Final request-specific prompt rate from engine timings. */
+  prompt_tok_per_sec?: number | null;
   stop_reason?: string | null;
 }
 


### PR DESCRIPTION
## Summary

- surface request-scoped llama.cpp prompt processing and generation throughput while a request is running
- persist final prompt and generation rates in the API monitor entry
- show separate Prompt speed and Generation speed fields in the selected request detail
- keep public OpenAI/Anthropic streams unchanged and avoid engine-wide attribution glue

## Implementation

llama.cpp prompt-progress and timing events are consumed internally through a per-request callback. The monitor updates only the matching request, sanitizes malformed rates, and final engine timings replace intermediate values when the request completes.

Closes #8528

## Validation

- `python -m pytest studio/backend/tests/test_api_monitor.py studio/backend/tests/test_llama_cpp_tool_loop.py -q --tb=short` — 204 passed
- focused Ruff checks — passed
- `cd studio/frontend && npm run typecheck` — passed
- `cd studio/frontend && npm run build` — passed
- `git diff --check` — passed
- local `./install.sh --local` + Studio browser flow with a real Gemma GGUF:
  - observed live prompt and generation rates while the request was in flight
  - confirmed the same request-specific rates remained after completion
