### PR TITLE
Fix three frontend contract tests that main is red on

### DIFF
--- a/studio/frontend/src/components/assistant-ui/attachment.tsx
+++ b/studio/frontend/src/components/assistant-ui/attachment.tsx
@@ -337,7 +337,7 @@ const PastedTextAttachmentUI: FC<{
       </span>
       <span className="flex min-w-0 flex-col">
         <span className="truncate font-medium text-xs">{name}</span>
-        <span className="truncate text-[11px] text-muted-foreground">
+        <span className="truncate text-ui-11 text-muted-foreground">
           {/* Hover swaps the size for the action. */}
           <span className={isComposer ? "group-hover:hidden" : undefined}>
             {bytes === undefined ? "Pasted text" : formatBytes(bytes)}

--- a/tests/studio/test_chat_title_generation.py
+++ b/tests/studio/test_chat_title_generation.py
@@ -92,10 +92,15 @@ def test_tool_call_only_first_assistant_still_uses_first_user_message():
         '.filter((p): p is Extract<typeof p, { type: "text" }> => p.type === "text")'
         in extract_block
     )
+    # titleTextOf wraps extractTextParts and appends an attachment sample for a
+    # user turn (#8472), so the first user message is still what titles the
+    # thread; only the spelling of "read that message's text" changed.
     assert (
-        "const userText = extractTextParts(firstUser) || defaultTitle; const assistantText = extractTextParts(firstAssistant);"
+        "const userText = titleTextOf(firstUser) || defaultTitle; const assistantText = extractTextParts(firstAssistant);"
         in generate_block
     )
+    title_block = " ".join(_balanced_block(source, "function titleTextOf").split())
+    assert "const text = extractTextParts(m);" in title_block
     assert (
         "(await generateTitleWithModel({ userText, assistantText, })) || fallbackTitleFromUserText(userText);"
         in generate_block

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -53,6 +53,9 @@ PASSWORD_DIALOG = FRONTEND / "features/settings/components/change-password-dialo
 GENERAL_TAB = FRONTEND / "features/settings/tabs/general-tab.tsx"
 
 CLIPBOARD_FILES = FRONTEND / "features/chat/utils/clipboard-files.ts"
+# The DataTransfer reading half moved here when long pastes became attachments
+# (#8472). Both halves are still one contract, so read them as one.
+CLIPBOARD_PAYLOAD = FRONTEND / "features/chat/utils/clipboard-payload.ts"
 TAURI_CAPABILITIES = REPO / "studio/src-tauri/capabilities/default.json"
 CHAT_PAGE = FRONTEND / "features/chat/chat-page.tsx"
 TRAINING_CONFIG_ACTIONS = FRONTEND / "features/studio/wizard/config-actions.tsx"
@@ -358,7 +361,9 @@ def test_gallery_video_links_are_absolute_and_saved_natively():
 
 
 def test_clipboard_file_paste_is_bounded_and_wired_to_both_composers():
-    helper = CLIPBOARD_FILES.read_text(encoding = "utf-8")
+    helper = CLIPBOARD_FILES.read_text(encoding = "utf-8") + CLIPBOARD_PAYLOAD.read_text(
+        encoding = "utf-8"
+    )
     thread = THREAD.read_text(encoding = "utf-8")
     shared_composer = SHARED_COMPOSER.read_text(encoding = "utf-8")
     capabilities = TAURI_CAPABILITIES.read_text(encoding = "utf-8")


### PR DESCRIPTION
## What changed

`Repo tests (CPU)` is currently failing on `main`, so every branch cut from it inherits a red job it did not cause. Three tests, all of which assert against source text rather than behaviour, which is why a refactor that kept the behaviour still turned them red.

```
FAILED tests/studio/test_desktop_reliability_frontend_contract.py::test_clipboard_file_paste_is_bounded_and_wired_to_both_composers
FAILED tests/studio/test_chat_title_generation.py::test_tool_call_only_first_assistant_still_uses_first_user_message
FAILED tests/studio/test_ui_font_scale_contract.py::test_no_raw_pixel_text_utilities
```

**Clipboard paste.** The contract reads `clipboard-files.ts` and looks for `clipboardData.files`, `item.getAsFile()` and friends. #8472 moved the DataTransfer reading half into `clipboard-payload.ts` when long pastes became attachments. Every string it wants is still present, just in the sibling file, so it reads both as the one contract they always were. No behaviour change.

**Title generation.** The contract pins the exact line that reads the first user message. #8472 replaced `extractTextParts` with `titleTextOf`, which wraps it and appends an attachment sample for a user turn. The first user message still titles the thread, so the assertion follows the rename. I added one more on `titleTextOf` itself, so the new indirection cannot quietly stop reading the text and leave the test passing on a name alone.

**Font scale.** This one is a real finding rather than a stale assertion. `attachment.tsx` used a raw `text-[11px]`, which ignores the UI font size preference, so that attachment size label stayed fixed while everything around it scaled. Swapped for the `text-ui-11` token, which is the same 11px at scale 1 and scales from there.

## Testing

```
tests/studio/                     3661 passed, 3 skipped
studio/frontend  npm test         2238 passed, 0 failed
studio/frontend  npm run typecheck  clean
```