### PR TITLE
Credit the contributor PRs behind the external-provider tool loop

### DIFF
--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -21,6 +21,26 @@ bounded buffer the client-tool passthrough uses: only a trailing partial-signal
 window or a suspected tool block is ever withheld, and a block that cannot
 become a declared call flushes verbatim. Nothing here invents a cap on how much
 model output may be held.
+
+Origins. This file is assembled out of four contributor PRs rather than written
+from scratch, and the squash merge of #8665 did not carry their authorship, so
+it is recorded here:
+
+* #8626 (khalidejaz) -- the registry capability and the hidden-entry exposure,
+  including the ``provider_runs_local_tools()`` name ``providers.py`` still
+  uses.
+* #8630 (mahiatlinux) -- most of the loop internals below: the user-turn append,
+  the tool-stream advance and drain, usage merging, the approval flush delay,
+  the budget-exhausted nudge, and the streamed tool-name rule that llama-server
+  forced. Also the browser testing against a control worktree that caught a
+  truncated turn discarding a healed call along with the text describing it.
+* #7805 (Etherll) -- the hosted-provider reach.
+* #7330 (Souravrajvi0) -- the original OpenAI-compatible framing.
+
+Two ideas from those PRs were deliberately not taken, which is worth knowing
+before anyone re-derives them: the per-connection opt-in from #8630 and the
+``studio_tool_execution`` column from #7805. #8665 shipped a static disclosure
+instead, while widening the capability from four self-hosted types to thirteen.
 """
 
 from __future__ import annotations

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11461,9 +11461,7 @@ async def _proxy_to_external_provider(
         # Model-aware: Gemini's image models drop the function catalog inside the
         # native translator, so entering the loop for them would advertise tools
         # the model is never shown and finish as if none were selected.
-        provider_model_runs_local_tools(
-            provider_type, payload.external_model or payload.model
-        )
+        provider_model_runs_local_tools(provider_type, payload.external_model or payload.model)
         and payload.stream is True
         and _explicit_studio_tool_loop_requested(payload)
         # A selection of purely hosted names is the provider's tool envelope, not


### PR DESCRIPTION
Records the four contributor PRs that #8665 was built out of. The squash merge kept only two Co-authored-by trailers, so they are not attributed anywhere in main's history, and history cannot be rewritten now.

Attribution is additive here: Co-authored-by trailers on the commit, plus an Origins note in the studio_tool_loop.py module docstring, which is the file the harvested work lives in.

- #8626 (@khalidejaz) the registry capability and hidden-entry exposure, including the provider_runs_local_tools() name still in use.
- #8630 (@mahiatlinux) most of the loop internals: the user-turn append, the tool-stream advance and drain, usage merging, the approval flush delay, the budget-exhausted nudge, and the streamed tool-name rule that llama-server forced. Also the browser testing against a control worktree, which caught several real defects before release.
- #7805 (@Etherll) the hosted-provider reach.
- #7330 (@Souravrajvi0) the original OpenAI-compatible framing.

Two ideas were deliberately not taken and the docstring says so, since otherwise the next reader will re-derive them: the per-connection opt-in from #8630 and the studio_tool_execution column from #7805.

Please squash-merge so the trailers survive.

Testing: tests/test_studio_tool_loop.py 27 passed. Docstring-only change.