### PR TITLE
Studio: self-repair sidecars whose extensions were built for another Python

### DIFF
--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -60,6 +60,7 @@ from utils.transformers_version import (
     activate_transformers_for_subprocess,
     _venv_dir_is_valid,
     _venv_dir_is_valid_and_undamaged,
+    _CURRENT_EXT_TAG,
     _ensure_venv_dir,
     hf_endpoint_unreachable,
 )
@@ -1894,6 +1895,39 @@ class TestVenvDirFileIntegrity:
         venv_dir = self._make_venv(tmp_path / "venv")
         (venv_dir / "transformers" / "__init__.py").unlink()
         assert not _venv_dir_is_valid_and_undamaged(str(venv_dir), ("transformers==5.3.0",))
+
+    @pytest.mark.parametrize(
+        "ext_name",
+        [
+            "_regex.cpython-{tag}-darwin.so",
+            "_regex.cp{tag}-win_amd64.pyd",
+            "_regex.cpython-{tag}t-darwin.so",
+        ],
+    )
+    def test_extension_built_for_another_interpreter_is_detected(
+        self, tmp_path: Path, ext_name: str
+    ):
+        stale = "313" if _CURRENT_EXT_TAG != "313" else "312"
+        venv_dir = self._make_venv(
+            tmp_path / "venv",
+            files = {
+                "transformers/__init__.py": "x" * 40,
+                f"regex/{ext_name.format(tag = stale)}": "y" * 40,
+            },
+        )
+        assert not _venv_dir_is_valid_and_undamaged(str(venv_dir), ("transformers==5.3.0",))
+
+    def test_extension_for_the_running_interpreter_passes(self, tmp_path: Path):
+        venv_dir = self._make_venv(
+            tmp_path / "venv",
+            files = {
+                "transformers/__init__.py": "x" * 40,
+                f"regex/_regex.cpython-{_CURRENT_EXT_TAG}-darwin.so": "y" * 40,
+                "hf_xet/hf_xet.abi3.so": "z" * 40,
+                "yaml/_yaml.so": "w" * 40,
+            },
+        )
+        assert _venv_dir_is_valid_and_undamaged(str(venv_dir), ("transformers==5.3.0",))
 
     def test_damage_in_an_unpinned_dependency_is_detected(self, tmp_path: Path):
         """The whole dir is prepended to sys.path, so a shadowing dep breaks the

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -1907,7 +1907,10 @@ class TestVenvDirFileIntegrity:
     def test_extension_built_for_another_interpreter_is_detected(
         self, tmp_path: Path, ext_name: str
     ):
-        stale = "313" if _CURRENT_EXT_TAG != "313" else "312"
+        # Pick a stale tag by VERSION, not by whole tag: one template appends "t", so
+        # deriving it from _CURRENT_EXT_TAG directly builds "313t" -- the current tag --
+        # when the suite runs on a free-threaded 3.13, and the case asserts damage.
+        stale = "313" if _CURRENT_EXT_TAG.rstrip("t") != "313" else "312"
         venv_dir = self._make_venv(
             tmp_path / "venv",
             files = {
@@ -1923,11 +1926,79 @@ class TestVenvDirFileIntegrity:
             files = {
                 "transformers/__init__.py": "x" * 40,
                 f"regex/_regex.cpython-{_CURRENT_EXT_TAG}-darwin.so": "y" * 40,
-                "hf_xet/hf_xet.abi3.so": "z" * 40,
                 "yaml/_yaml.so": "w" * 40,
+                # Spellings the tag regex deliberately does not recognise. Each has to fail
+                # OPEN: guessing wrong here costs a several-hundred-MB re-download.
+                "regex/_regex.pypy311-pp73-x86_64-linux-gnu.so": "p" * 40,
+                "regex/_regex.graalpy311-310-native-x86_64-linux.so": "g" * 40,
+                "regex/_regex.cpython-313d-x86_64-linux-gnu.so": "d" * 40,
             },
         )
         assert _venv_dir_is_valid_and_undamaged(str(venv_dir), ("transformers==5.3.0",))
+
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            # The tag sits in a DIRECTORY component; the binary itself is untagged and fine.
+            "vendor/build.cp312/libhelper.so",
+            "pkg.cp312.libs/libfoo.so",
+            "data/v.cp39/native.pyd",
+        ],
+    )
+    def test_a_version_tag_in_a_directory_name_is_not_damage(self, tmp_path: Path, rel: str):
+        """Matching the whole RECORD path wipes the sidecar over a directory name."""
+        venv_dir = self._make_venv(
+            tmp_path / "venv",
+            files = {"transformers/__init__.py": "x" * 40, rel: "y" * 40},
+        )
+        assert _venv_dir_is_valid_and_undamaged(str(venv_dir), ("transformers==5.3.0",))
+
+    @pytest.mark.parametrize(
+        ("current_tag", "expect_damage"),
+        [("313", False), ("314", False), ("313t", True), ("314t", True)],
+    )
+    def test_stable_abi_is_damage_only_on_a_free_threaded_build(
+        self, tmp_path: Path, monkeypatch, current_tag: str, expect_damage: bool
+    ):
+        """A GIL build loads any older .abi3.so. A free-threaded one segfaults on it, and
+        the file survives an in-place interpreter swap because nothing else changes."""
+        monkeypatch.setattr("utils.transformers_version._CURRENT_EXT_TAG", current_tag)
+        venv_dir = self._make_venv(
+            tmp_path / "venv",
+            files = {
+                "transformers/__init__.py": "x" * 40,
+                "hf_xet/hf_xet.abi3.so": "z" * 40,
+                "win/_thing.abi3.pyd": "z" * 40,
+            },
+        )
+        if expect_damage:
+            assert not _venv_dir_is_valid_and_undamaged(str(venv_dir), ("transformers==5.3.0",))
+        else:
+            assert _venv_dir_is_valid_and_undamaged(str(venv_dir), ("transformers==5.3.0",))
+
+    @pytest.mark.parametrize(
+        ("current_tag", "ext_tag"),
+        [
+            # Both directions of the GIL/free-threaded swap, on a fixed pair of versions so
+            # the case cannot collapse into "current tag" on whichever build runs the suite.
+            ("313t", "313"),
+            ("313", "313t"),
+            ("314t", "314"),
+            ("314", "314t"),
+        ],
+    )
+    def test_free_threaded_mismatch_is_detected_in_both_directions(
+        self, tmp_path: Path, monkeypatch, current_tag: str, ext_tag: str
+    ):
+        monkeypatch.setattr("utils.transformers_version._CURRENT_EXT_TAG", current_tag)
+        venv_dir = self._make_venv(
+            tmp_path / "venv",
+            files = {
+                "transformers/__init__.py": "x" * 40,
+                f"regex/_regex.cpython-{ext_tag}-x86_64-linux-gnu.so": "y" * 40,
+            },
+        )
+        assert not _venv_dir_is_valid_and_undamaged(str(venv_dir), ("transformers==5.3.0",))
 
     def test_damage_in_an_unpinned_dependency_is_detected(self, tmp_path: Path):
         """The whole dir is prepended to sys.path, so a shadowing dep breaks the

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2025,8 +2025,18 @@ _SHARED_NON_RUNTIME_ROOTS = frozenset(
 )
 _INSTALLER_REWRITTEN_NAMES = frozenset(("package-lock.json",))
 # Version-tagged extension suffixes (.cpython-313-darwin.so, .cp313-win_amd64.pyd,
-# free-threaded .cpython-314t-*). abi3 and untagged binaries carry no version and are skipped.
+# free-threaded .cpython-314t-*). Untagged binaries carry no version and are skipped, as
+# are pypy/graalpy/debug spellings, which this deliberately does not match: an unrecognised
+# name reports nothing rather than guessing, in line with the rest of the scan.
 _EXT_VERSION_TAG_RE = re.compile(r"\.(?:cpython-|cp)(\d{2,}t?)\b")
+# Stable-ABI binaries. A GIL build imports one produced by any older CPython, so they are
+# skipped there. A free-threaded build cannot: it still advertises .abi3.so in
+# EXTENSION_SUFFIXES, but the object layout differs and importing a GIL-built one takes the
+# whole interpreter down with SIGSEGV instead of raising ImportError. No installer ever puts
+# one into a free-threaded tree -- packaging offers those builds abi3t, never abi3 -- so
+# reporting it cannot loop: the reinstall fetches the cp<ver>t wheel and the next scan is
+# clean. Only a venv whose interpreter was swapped underneath it can hold one.
+_ABI3_EXT_RE = re.compile(r"\.abi3\.(?:so|pyd)$")
 _CURRENT_EXT_TAG = "{}{}{}".format(
     sys.version_info.major,
     sys.version_info.minor,
@@ -2174,10 +2184,20 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
             elif rel.endswith((".so", ".pyd")):
                 # A sidecar built by one interpreter survives a Python upgrade intact,
                 # but its compiled extensions no longer load (issue: cp313 .so under 3.14).
-                m = _EXT_VERSION_TAG_RE.search(rel)
+                # The BASENAME alone decides. rel is a whole RECORD path, and a directory
+                # component carrying a wheel-style tag (build.cp312/, pkg.cp312.libs/) says
+                # nothing about the untagged binary sitting inside it; searching the path
+                # would wipe several hundred MB over a directory name.
+                base = rel.replace("\\", "/").rsplit("/", 1)[-1]
+                m = _EXT_VERSION_TAG_RE.search(base)
                 if m and m.group(1) != _CURRENT_EXT_TAG:
                     found.append(
                         f"{name}: {rel} targets cp{m.group(1)}, interpreter is cp{_CURRENT_EXT_TAG}"
+                    )
+                elif m is None and _CURRENT_EXT_TAG.endswith("t") and _ABI3_EXT_RE.search(base):
+                    found.append(
+                        f"{name}: {rel} is a stable-ABI build, which free-threaded "
+                        f"cp{_CURRENT_EXT_TAG} cannot load"
                     )
         if len(found) >= limit:
             return found, inconclusive

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -40,6 +40,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import sysconfig
 import threading
 import time
 from pathlib import Path
@@ -2023,6 +2024,14 @@ _SHARED_NON_RUNTIME_ROOTS = frozenset(
     )
 )
 _INSTALLER_REWRITTEN_NAMES = frozenset(("package-lock.json",))
+# Version-tagged extension suffixes (.cpython-313-darwin.so, .cp313-win_amd64.pyd,
+# free-threaded .cpython-314t-*). abi3 and untagged binaries carry no version and are skipped.
+_EXT_VERSION_TAG_RE = re.compile(r"\.(?:cpython-|cp)(\d{2,}t?)\b")
+_CURRENT_EXT_TAG = "{}{}{}".format(
+    sys.version_info.major,
+    sys.version_info.minor,
+    "t" if sysconfig.get_config_var("Py_GIL_DISABLED") else "",
+)
 
 
 def _sidecar_damaged_files(venv_dir: str, limit: int = 3) -> list[str]:
@@ -2057,9 +2066,10 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
     exactly as a truncated ``transformers/`` does. Measured on three live
     sidecars that is 7729 files instead of 7432, i.e. 4% more work.
 
-    Only shrinkage and disappearance count, and only for paths a single
-    distribution claims: when two claim one path, whichever copy landed says
-    nothing about either RECORD, in either direction. A file LARGER than
+    Shrinkage, disappearance, and compiled extensions tagged for another
+    interpreter count. Sizes are trusted only for paths a single distribution
+    claims: when two claim one path, whichever copy landed says nothing about
+    either RECORD, in either direction. A file LARGER than
     recorded is a packaging collision, not damage. Sizes are therefore compared
     after the whole scan, once multiply-owned paths are known.
 
@@ -2161,6 +2171,14 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
                 found.append(f"{name}: {rel} is not a regular file")
             elif owners[key] == 1 and recorded is not None and info.st_size < recorded:
                 found.append(f"{name}: {rel} is {info.st_size} bytes, expected {recorded}")
+            elif rel.endswith((".so", ".pyd")):
+                # A sidecar built by one interpreter survives a Python upgrade intact,
+                # but its compiled extensions no longer load (issue: cp313 .so under 3.14).
+                m = _EXT_VERSION_TAG_RE.search(rel)
+                if m and m.group(1) != _CURRENT_EXT_TAG:
+                    found.append(
+                        f"{name}: {rel} targets cp{m.group(1)}, interpreter is cp{_CURRENT_EXT_TAG}"
+                    )
         if len(found) >= limit:
             return found, inconclusive
     return found, inconclusive

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5522,11 +5522,11 @@ foreach ($pkg in @("transformers==5.3.0", "huggingface_hub==1.8.0", "hf_xet==1.4
     }
 }
 if ($script:UnslothVerbose) {
-    Fast-Install --target $VenvT5_530Dir tiktoken
+    Fast-Install --target $VenvT5_530Dir --no-deps tiktoken
     $tiktokenInstallExit = $LASTEXITCODE
     $output = ""
 } else {
-    $output = Fast-Install --target $VenvT5_530Dir tiktoken | Out-String
+    $output = Fast-Install --target $VenvT5_530Dir --no-deps tiktoken | Out-String
     $tiktokenInstallExit = $LASTEXITCODE
 }
 if ($tiktokenInstallExit -ne 0) {
@@ -5557,11 +5557,11 @@ foreach ($pkg in @("transformers==5.5.0", "huggingface_hub==1.8.0", "hf_xet==1.4
     }
 }
 if ($script:UnslothVerbose) {
-    Fast-Install --target $VenvT5_550Dir tiktoken
+    Fast-Install --target $VenvT5_550Dir --no-deps tiktoken
     $tiktokenInstallExit = $LASTEXITCODE
     $output = ""
 } else {
-    $output = Fast-Install --target $VenvT5_550Dir tiktoken | Out-String
+    $output = Fast-Install --target $VenvT5_550Dir --no-deps tiktoken | Out-String
     $tiktokenInstallExit = $LASTEXITCODE
 }
 if ($tiktokenInstallExit -ne 0) {
@@ -5592,11 +5592,11 @@ foreach ($pkg in @("transformers==5.10.2", "huggingface_hub==1.8.0", "hf_xet==1.
     }
 }
 if ($script:UnslothVerbose) {
-    Fast-Install --target $VenvT5_510Dir tiktoken
+    Fast-Install --target $VenvT5_510Dir --no-deps tiktoken
     $tiktokenInstallExit = $LASTEXITCODE
     $output = ""
 } else {
-    $output = Fast-Install --target $VenvT5_510Dir tiktoken | Out-String
+    $output = Fast-Install --target $VenvT5_510Dir --no-deps tiktoken | Out-String
     $tiktokenInstallExit = $LASTEXITCODE
 }
 if ($tiktokenInstallExit -ne 0) {

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1984,7 +1984,7 @@ if [ "$_NEED_T5_INSTALL" = true ]; then
     run_quiet "install transformers 5.3.0" fast_install_sidecar --target "$VENV_T5_530_DIR" --no-deps "transformers==5.3.0"
     run_quiet "install huggingface_hub for t5_530" fast_install_sidecar --target "$VENV_T5_530_DIR" --no-deps "huggingface_hub==1.8.0"
     run_quiet "install hf_xet for t5_530" fast_install_sidecar --target "$VENV_T5_530_DIR" --no-deps "hf_xet==1.4.2"
-    run_quiet "install tiktoken for t5_530" fast_install_sidecar --target "$VENV_T5_530_DIR" "tiktoken"
+    run_quiet "install tiktoken for t5_530" fast_install_sidecar --target "$VENV_T5_530_DIR" --no-deps "tiktoken"
     step "transformers" "5.3.0 pre-installed"
 
     _assert_studio_owned_or_absent "$VENV_T5_550_DIR" "transformers 5.5 sidecar venv"
@@ -1994,7 +1994,7 @@ if [ "$_NEED_T5_INSTALL" = true ]; then
     run_quiet "install transformers 5.5.0" fast_install_sidecar --target "$VENV_T5_550_DIR" --no-deps "transformers==5.5.0"
     run_quiet "install huggingface_hub for t5_550" fast_install_sidecar --target "$VENV_T5_550_DIR" --no-deps "huggingface_hub==1.8.0"
     run_quiet "install hf_xet for t5_550" fast_install_sidecar --target "$VENV_T5_550_DIR" --no-deps "hf_xet==1.4.2"
-    run_quiet "install tiktoken for t5_550" fast_install_sidecar --target "$VENV_T5_550_DIR" "tiktoken"
+    run_quiet "install tiktoken for t5_550" fast_install_sidecar --target "$VENV_T5_550_DIR" --no-deps "tiktoken"
     step "transformers" "5.5.0 pre-installed"
 
     _assert_studio_owned_or_absent "$VENV_T5_510_DIR" "transformers 5.10 sidecar venv"
@@ -2004,7 +2004,7 @@ if [ "$_NEED_T5_INSTALL" = true ]; then
     run_quiet "install transformers 5.10.2" fast_install_sidecar --target "$VENV_T5_510_DIR" --no-deps "transformers==5.10.2"
     run_quiet "install huggingface_hub for t5_510" fast_install_sidecar --target "$VENV_T5_510_DIR" --no-deps "huggingface_hub==1.8.0"
     run_quiet "install hf_xet for t5_510" fast_install_sidecar --target "$VENV_T5_510_DIR" --no-deps "hf_xet==1.4.2"
-    run_quiet "install tiktoken for t5_510" fast_install_sidecar --target "$VENV_T5_510_DIR" "tiktoken"
+    run_quiet "install tiktoken for t5_510" fast_install_sidecar --target "$VENV_T5_510_DIR" --no-deps "tiktoken"
     step "transformers" "5.10.2 pre-installed"
 fi
 fi


### PR DESCRIPTION
After a Python upgrade (e.g. 3.13 → 3.14 via Homebrew/pyenv), the prebuilt .venv_t5_* sidecars keep compiled extensions tagged for the old interpreter. Every file is intact, so the RECORD integrity scan passes, the wipe-and-reinstall in _ensure_venv_dir never fires, and every model load on that tier fails with an opaque error:

```
cannot import name '_regex' from partially initialized module 'regex'
(most likely due to a circular import) (.../.venv_t5_530/regex/__init__.py)
```

Changes:
- _sidecar_scan now treats version-tagged extensions (.cpython-313-*.so, .cp313-*.pyd, free-threaded t tags) that don't match the running interpreter as damage, so the existing self-repair rebuilds the sidecar automatically. abi3 and untagged binaries are unaffected.
- setup.sh/setup.ps1 now install tiktoken with --no-deps, matching the other sidecar packages and the runtime rebuild path — this keeps compiled deps like regex out of the sidecar entirely (tiktoken's dep chain is how a compiled regex got in and shadowed the healthy one).