### PR TITLE
Desktop: keep "Run Unsloth at login" when something deletes the Run value

### DIFF
--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -49,6 +49,14 @@ const IN_APP_RELAUNCH_MARKER_FILE: &str = "in-app-relaunch-v1";
 
 const CLOSE_TO_TRAY_PREFERENCE_FILE: &str = "close-to-tray-v1";
 
+/// The user's answer to "Run Unsloth at login", kept beside the OS entry rather than derived
+/// from it. The Windows entry is one HKCU Run value that outside things delete without asking:
+/// the NSIS uninstaller drops it on any non-update run (installer.nsi), and an antivirus
+/// quarantine or a registry cleaner takes it the same way. Reading the setting back off the
+/// registry alone, as this file used to, turns every one of those into a silent, permanent
+/// "off" that the user only discovers the next morning.
+const LAUNCH_AT_LOGIN_PREFERENCE_FILE: &str = "launch-at-login-v1";
+
 struct CloseToTrayState(AtomicBool);
 
 fn new_close_to_tray_state() -> CloseToTrayState {
@@ -188,6 +196,75 @@ fn write_close_to_tray_preference(config_dir: &Path, enabled: bool) -> Result<()
     })
 }
 
+fn launch_at_login_preference_path(config_dir: &Path) -> PathBuf {
+    config_dir.join(LAUNCH_AT_LOGIN_PREFERENCE_FILE)
+}
+
+/// The stored answer, or None when this install has never been told one.
+///
+/// None is not false: an install that predates this file, or one whose preference could not be
+/// read, has no record to restore from, and inventing one would enable autostart for someone who
+/// never asked. Only an explicit `true` ever puts an entry back.
+fn read_launch_at_login_preference(config_dir: &Path) -> Option<bool> {
+    let path = launch_at_login_preference_path(config_dir);
+    match fs::read_to_string(&path) {
+        Ok(value) => match value.trim().parse::<bool>() {
+            Ok(enabled) => Some(enabled),
+            Err(error) => {
+                warn!(
+                    "Ignoring invalid launch-at-login preference {}: {error}",
+                    path.display()
+                );
+                None
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            warn!(
+                "Could not read launch-at-login preference {}: {error}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+fn write_launch_at_login_preference(config_dir: &Path, enabled: bool) -> Result<(), String> {
+    fs::create_dir_all(config_dir).map_err(|error| {
+        format!(
+            "Failed to create app configuration directory {}: {error}",
+            config_dir.display()
+        )
+    })?;
+    let path = launch_at_login_preference_path(config_dir);
+    fs::write(&path, format!("{enabled}\n")).map_err(|error| {
+        format!(
+            "Failed to save launch-at-login preference {}: {error}",
+            path.display()
+        )
+    })
+}
+
+/// Record the answer without letting a failed write fail the toggle: the OS entry is the thing
+/// the user asked for and it is already written. Losing the record only costs the restore.
+fn store_launch_at_login_preference(app: &tauri::AppHandle, enabled: bool) {
+    match app.path().app_config_dir() {
+        Ok(dir) => {
+            if let Err(error) = write_launch_at_login_preference(&dir, enabled) {
+                warn!("Could not record the launch-at-login preference: {error}");
+            }
+        }
+        Err(error) => warn!("Could not determine app configuration directory: {error}"),
+    }
+}
+
+fn stored_launch_at_login_preference(app: &tauri::AppHandle) -> Option<bool> {
+    app.path()
+        .app_config_dir()
+        .ok()
+        .and_then(|dir| read_launch_at_login_preference(&dir))
+}
+
 fn initialize_close_to_tray(app: &tauri::AppHandle) {
     let enabled = app
         .path()
@@ -266,6 +343,9 @@ fn set_launch_at_login(app: tauri::AppHandle, enabled: bool) -> Result<bool, Str
     if enabled {
         harden_autostart_entry(&app);
     }
+    // After the OS write, so a failed one leaves no record to restore from, and on both arms:
+    // a stored `false` is what stops the restore from arguing with someone turning this off.
+    store_launch_at_login_preference(&app, enabled);
     autolaunch.is_enabled().map_err(|error| error.to_string())
 }
 
@@ -311,6 +391,89 @@ fn quote_windows_run_value(app: &tauri::AppHandle) {
     };
     if let Some(quoted) = quoted_windows_run_command(&value) {
         let _ = run.set_value(name, &quoted);
+    }
+}
+
+/// Whether Windows itself holds the entry disabled, from the StartupApproved bytes.
+///
+/// Task Manager's Startup tab and Settings > Apps > Startup disable an entry by writing a
+/// timestamp into the last eight bytes here; they never delete the Run value. Read the same way
+/// auto-launch reads it, or this would disagree with the `is_enabled` that sent us here: fewer
+/// than eight bytes is not a timestamp, and auto-launch treats that as enabled.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn startup_approved_disabled(bytes: &[u8]) -> bool {
+    bytes.len() >= 8 && !bytes.iter().rev().take(8).all(|byte| *byte == 0)
+}
+
+/// Restore a *deleted* entry, never a disabled one.
+///
+/// The distinction is the whole safety argument. Turning autostart off in Task Manager is a
+/// decision, and re-enabling it on the next launch would be the app overruling the user once a
+/// day. Deletion is not a decision anybody makes: no Windows UI removes the Run value, so an
+/// absent one against a stored `true` is something that happened *to* the install.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn should_restore_autostart_entry(
+    stored: Option<bool>,
+    entry_present: bool,
+    disabled: bool,
+) -> bool {
+    stored == Some(true) && !entry_present && !disabled
+}
+
+/// (Run value present, disabled by Windows). Unreadable registry reads as "present and disabled",
+/// the pair that restores nothing: a key we cannot read is not evidence anything was removed.
+#[cfg(windows)]
+fn windows_autostart_entry_state(app: &tauri::AppHandle) -> (bool, bool) {
+    use winreg::enums::{HKEY_CURRENT_USER, KEY_QUERY_VALUE};
+    use winreg::RegKey;
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let name = &app.package_info().name;
+    let Ok(run) = hkcu.open_subkey_with_flags(
+        r"Software\Microsoft\Windows\CurrentVersion\Run",
+        KEY_QUERY_VALUE,
+    ) else {
+        return (true, true);
+    };
+    let present = run.get_value::<String, _>(name).is_ok();
+    let disabled = hkcu
+        .open_subkey_with_flags(
+            r"Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run",
+            KEY_QUERY_VALUE,
+        )
+        .ok()
+        .and_then(|approved| approved.get_raw_value(name).ok())
+        // No override recorded is the state a never-touched entry is in.
+        .is_some_and(|value| startup_approved_disabled(&value.bytes));
+    (present, disabled)
+}
+
+/// Whether an autostart entry the OS reports as off should be written back.
+///
+/// Windows only, and deliberately so. Removing a login item is a first-class gesture on the other
+/// two: macOS System Settings > Login Items deletes the LaunchAgent, and GNOME's startup UI
+/// deletes the .desktop file, so a restore there would resurrect something the user just removed.
+/// Windows has no such gesture, which is why its entry going missing is a bug and not a choice.
+fn restore_missing_autostart_entry(app: &tauri::AppHandle) -> bool {
+    #[cfg(windows)]
+    {
+        let (present, disabled) = windows_autostart_entry_state(app);
+        let restore = should_restore_autostart_entry(
+            stored_launch_at_login_preference(app),
+            present,
+            disabled,
+        );
+        if restore {
+            info!(
+                "The \"Run Unsloth at login\" entry is gone but was last set to on; restoring it."
+            );
+        }
+        restore
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = app;
+        false
     }
 }
 
@@ -473,7 +636,13 @@ fn reconcile_autostart_entry(app: &tauri::AppHandle) {
         return;
     }
     let autolaunch = app.autolaunch();
-    if !autolaunch.is_enabled().unwrap_or(false) {
+    if autolaunch.is_enabled().unwrap_or(false) {
+        // Adopt an entry made before this install kept a record, so the first thing that
+        // deletes it can be undone rather than being the one loss that teaches us to care.
+        if stored_launch_at_login_preference(app).is_none() {
+            store_launch_at_login_preference(app, true);
+        }
+    } else if !restore_missing_autostart_entry(app) {
         return;
     }
     if autolaunch.enable().is_ok() {
@@ -1860,6 +2029,59 @@ mod tests {
         fs::write(close_to_tray_preference_path(dir.path()), b"maybe\n").unwrap();
 
         assert!(!read_close_to_tray_preference(dir.path()));
+    }
+
+    #[test]
+    fn launch_at_login_preference_round_trips_and_starts_with_no_record() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Not Some(false): an install that has never been told cannot be restored to anything.
+        assert_eq!(read_launch_at_login_preference(dir.path()), None);
+        write_launch_at_login_preference(dir.path(), true).unwrap();
+        assert_eq!(read_launch_at_login_preference(dir.path()), Some(true));
+        write_launch_at_login_preference(dir.path(), false).unwrap();
+        assert_eq!(read_launch_at_login_preference(dir.path()), Some(false));
+    }
+
+    #[test]
+    fn an_unreadable_launch_at_login_preference_restores_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(launch_at_login_preference_path(dir.path()), b"maybe\n").unwrap();
+
+        assert_eq!(read_launch_at_login_preference(dir.path()), None);
+        assert!(!should_restore_autostart_entry(None, false, false));
+    }
+
+    #[test]
+    fn only_a_deleted_entry_with_a_stored_yes_is_restored() {
+        // The bug this exists for: the value is gone and the user had asked for it.
+        assert!(should_restore_autostart_entry(Some(true), false, false));
+
+        // Turned off in Task Manager. The value survives, so re-enabling would overrule them.
+        assert!(!should_restore_autostart_entry(Some(true), true, true));
+        // Deleted *and* disabled: still their decision, so it stays gone.
+        assert!(!should_restore_autostart_entry(Some(true), false, true));
+        // Nothing to restore: never asked for, or turned off on purpose.
+        assert!(!should_restore_autostart_entry(None, false, false));
+        assert!(!should_restore_autostart_entry(Some(false), false, false));
+        // Already there. reconcile_autostart_entry repoints it; this decides nothing.
+        assert!(!should_restore_autostart_entry(Some(true), true, false));
+    }
+
+    /// Read the same bytes auto-launch reads, or a restore would fight the `is_enabled` it follows.
+    #[test]
+    fn startup_approved_bytes_are_read_the_way_auto_launch_reads_them() {
+        // What auto-launch's own enable() writes: a 0x02 lead and eight zero bytes after it.
+        assert!(!startup_approved_disabled(&[
+            0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ]));
+        // Disabled in Task Manager: 0x03, and the last eight bytes hold the timestamp.
+        assert!(startup_approved_disabled(&[
+            0x03, 0, 0, 0, 0x1e, 0x38, 0x9f, 0x4c, 0x7d, 0x2a, 0xdb, 0x01
+        ]));
+        // Too short to carry a timestamp, which auto-launch counts as enabled.
+        assert!(!startup_approved_disabled(&[0x02, 0, 0, 0]));
+        assert!(!startup_approved_disabled(&[]));
     }
 
     #[test]

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -318,16 +318,34 @@ fn main_window_close_action(close_to_tray: bool) -> MainWindowCloseAction {
     }
 }
 
-#[tauri::command]
-fn get_launch_at_login(app: tauri::AppHandle) -> Result<bool, String> {
-    use tauri_plugin_autostart::ManagerExt;
+/// The autostart state as the OS records it.
+///
+/// On Windows this reads the two keys itself rather than calling `is_enabled`, which folds them
+/// together through the trailing-bytes rule above and so reports a re-enabled entry as off.
+fn autostart_enabled(app: &tauri::AppHandle) -> Result<bool, String> {
     // is_enabled only checks the entry file exists, so a DE-disabled entry would read as on.
-    if cfg!(target_os = "linux") && linux_autostart_disabled(&app) {
+    if cfg!(target_os = "linux") && linux_autostart_disabled(app) {
         return Ok(false);
     }
-    app.autolaunch()
-        .is_enabled()
-        .map_err(|error| error.to_string())
+    #[cfg(windows)]
+    {
+        // A Run key we cannot open reads as present and disabled, which is off here and
+        // restores nothing below: an unreadable key is not evidence either way.
+        let (present, disabled) = windows_autostart_entry_state(app);
+        Ok(present && !disabled)
+    }
+    #[cfg(not(windows))]
+    {
+        use tauri_plugin_autostart::ManagerExt;
+        app.autolaunch()
+            .is_enabled()
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[tauri::command]
+fn get_launch_at_login(app: tauri::AppHandle) -> Result<bool, String> {
+    autostart_enabled(&app)
 }
 
 #[tauri::command]
@@ -346,7 +364,7 @@ fn set_launch_at_login(app: tauri::AppHandle, enabled: bool) -> Result<bool, Str
     // After the OS write, so a failed one leaves no record to restore from, and on both arms:
     // a stored `false` is what stops the restore from arguing with someone turning this off.
     store_launch_at_login_preference(&app, enabled);
-    autolaunch.is_enabled().map_err(|error| error.to_string())
+    autostart_enabled(&app)
 }
 
 fn harden_autostart_entry(app: &tauri::AppHandle) {
@@ -397,12 +415,18 @@ fn quote_windows_run_value(app: &tauri::AppHandle) {
 /// Whether Windows itself holds the entry disabled, from the StartupApproved bytes.
 ///
 /// Task Manager's Startup tab and Settings > Apps > Startup disable an entry by writing a
-/// timestamp into the last eight bytes here; they never delete the Run value. Read the same way
-/// auto-launch reads it, or this would disagree with the `is_enabled` that sent us here: fewer
-/// than eight bytes is not a timestamp, and auto-launch treats that as enabled.
+/// timestamp into the last eight bytes here; they never delete the Run value. The state lives in
+/// the FIRST byte though: 02 for enabled, 03 for disabled, and 06 for enabled again after the
+/// user switched it back on. Only 02 leaves the trailing bytes zero, so reading them, as
+/// auto-launch does, calls every re-enabled entry disabled and never recovers.
+///
+/// An absent or truncated value is not a state Windows recorded, and it starts such an entry.
 #[cfg_attr(not(windows), allow(dead_code))]
 fn startup_approved_disabled(bytes: &[u8]) -> bool {
-    bytes.len() >= 8 && !bytes.iter().rev().take(8).all(|byte| *byte == 0)
+    match bytes.first() {
+        Some(0x02) | Some(0x06) | None => false,
+        Some(_) => true,
+    }
 }
 
 /// Restore a *deleted* entry, never a disabled one.
@@ -635,8 +659,7 @@ fn reconcile_autostart_entry(app: &tauri::AppHandle) {
     if cfg!(target_os = "linux") && linux_autostart_disabled(app) {
         return;
     }
-    let autolaunch = app.autolaunch();
-    if autolaunch.is_enabled().unwrap_or(false) {
+    if autostart_enabled(app).unwrap_or(false) {
         // Adopt an entry made before this install kept a record, so the first thing that
         // deletes it can be undone rather than being the one loss that teaches us to care.
         if stored_launch_at_login_preference(app).is_none() {
@@ -645,7 +668,7 @@ fn reconcile_autostart_entry(app: &tauri::AppHandle) {
     } else if !restore_missing_autostart_entry(app) {
         return;
     }
-    if autolaunch.enable().is_ok() {
+    if app.autolaunch().enable().is_ok() {
         harden_autostart_entry(app);
     }
 }
@@ -2068,9 +2091,9 @@ mod tests {
         assert!(!should_restore_autostart_entry(Some(true), true, false));
     }
 
-    /// Read the same bytes auto-launch reads, or a restore would fight the `is_enabled` it follows.
+    /// The state is the first byte, not the trailing timestamp.
     #[test]
-    fn startup_approved_bytes_are_read_the_way_auto_launch_reads_them() {
+    fn startup_approved_bytes_are_read_from_the_state_byte() {
         // What auto-launch's own enable() writes: a 0x02 lead and eight zero bytes after it.
         assert!(!startup_approved_disabled(&[
             0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -2079,9 +2102,26 @@ mod tests {
         assert!(startup_approved_disabled(&[
             0x03, 0, 0, 0, 0x1e, 0x38, 0x9f, 0x4c, 0x7d, 0x2a, 0xdb, 0x01
         ]));
-        // Too short to carry a timestamp, which auto-launch counts as enabled.
+        // Switched back on: 0x06, and the timestamp stays. Reading the trailing bytes calls
+        // this disabled, which is how a user who toggled the entry twice lost the setting.
+        assert!(!startup_approved_disabled(&[
+            0x06, 0, 0, 0, 0x1e, 0x38, 0x9f, 0x4c, 0x7d, 0x2a, 0xdb, 0x01
+        ]));
+        // No state byte at all is no state Windows recorded, and it starts such an entry.
         assert!(!startup_approved_disabled(&[0x02, 0, 0, 0]));
         assert!(!startup_approved_disabled(&[]));
+    }
+
+    /// A re-enabled entry is present and on, so it is adopted and never restored over.
+    #[test]
+    fn a_re_enabled_entry_is_not_treated_as_deleted() {
+        let re_enabled = [
+            0x06, 0, 0, 0, 0x1e, 0x38, 0x9f, 0x4c, 0x7d, 0x2a, 0xdb, 0x01,
+        ];
+        let disabled = startup_approved_disabled(&re_enabled);
+
+        assert!(!disabled);
+        assert!(!should_restore_autostart_entry(Some(true), true, disabled));
     }
 
     #[test]


### PR DESCRIPTION
Follow up to #8575. That fixed the login autostart start *failing*; this fixes the setting *disappearing*.

## The bug

"Run Unsloth at login" was stored in exactly one place: the `HKCU\...\CurrentVersion\Run` value that `auto-launch` writes. `get_launch_at_login` read it straight back off the registry, and `reconcile_autostart_entry` returned early the moment `is_enabled()` came back false:

```rust
let autolaunch = app.autolaunch();
if !autolaunch.is_enabled().unwrap_or(false) {
    return;
}
```

So the app kept no record of its own setting. Anything that removed that value destroyed the preference permanently and silently, and the desktop had no way to know it had ever been set. The symptom is a bad one to debug: no tray icon at login, no process at all, and the toggle sitting unchecked when the user next opens Settings, as if they had never turned it on.

Nothing in the Windows UI deletes that value, but plenty of other things do:

- `installer.nsi` deletes it in the uninstaller on any run where `$UpdateMode <> 1`, which includes reinstalling over an existing install and choosing to uninstall the old version first.
- An antivirus quarantine or a registry cleaner takes it the same way.

## The fix

Keep our own record beside the OS entry, in the app config dir, the way `close-to-tray-v1` already does.

**The record is three-valued, not two.** `read_launch_at_login_preference` returns `Option<bool>`. `None`, meaning no file or an unparseable one, is deliberately not `false`: an install with no record has nothing to restore, and inventing one would switch autostart on for somebody who never asked for it. Only an explicit `true` ever puts an entry back.

**`set_launch_at_login` records the answer on both arms**, after the OS write succeeds. A stored `false` is what stops the restore from arguing with someone who has just turned the setting off.

**`reconcile_autostart_entry` writes the entry back at startup** when it is gone and the record says the user asked for it:

```rust
if autolaunch.is_enabled().unwrap_or(false) {
    if stored_launch_at_login_preference(app).is_none() {
        store_launch_at_login_preference(app, true);
    }
} else if !restore_missing_autostart_entry(app) {
    return;
}
```

That backfill is what covers installs which already have the setting on today. They adopt a record on their next launch, so the first thing that deletes the value is recoverable, rather than being the one loss that teaches us to keep a record.

## Restore a deleted entry, never a disabled one

This is the part worth reviewing closely.

Task Manager's Startup tab and Settings > Apps > Startup **disable** an entry by writing a timestamp into the last eight bytes of `StartupApproved\Run`. They never delete the `Run` value. `auto-launch`'s `is_enabled()` is `value exists && not disabled there`, which conflates the two, so keying a restore off it directly would have the app re-enabling autostart every single morning for someone who deliberately turned it off.

So `windows_autostart_entry_state` reads both keys separately, and the decision is spelled out on its own:

```rust
fn should_restore_autostart_entry(stored: Option<bool>, entry_present: bool, disabled: bool) -> bool {
    stored == Some(true) && !entry_present && !disabled
}
```

An unreadable registry reads as `(present, disabled)`, the pair that restores nothing: a key we cannot read is not evidence that anything was removed.

`startup_approved_disabled` decodes those bytes exactly the way `auto-launch` does, including treating a value shorter than eight bytes as enabled, so this cannot drift away from the `is_enabled()` that sent us here.

## Windows only, deliberately

Removing a login item is a first-class user gesture on the other two platforms. macOS System Settings > Login Items deletes the LaunchAgent, and GNOME's startup UI deletes the `.desktop` file, so a restore there would resurrect exactly what the user had just removed. `restore_missing_autostart_entry` returns `false` off Windows, and behaviour on macOS and Linux is unchanged.

Linux already had the matching guard for its own disable spelling, `Hidden=true` and `X-GNOME-Autostart-enabled=false`, and that is untouched.

## Tests

Four new tests in the existing `mod tests`:

- `launch_at_login_preference_round_trips_and_starts_with_no_record`, which pins `None` being distinct from `Some(false)`.
- `an_unreadable_launch_at_login_preference_restores_nothing`.
- `only_a_deleted_entry_with_a_stored_yes_is_restored`, covering all six combinations, including the Task Manager one.
- `startup_approved_bytes_are_read_the_way_auto_launch_reads_them`, against the real 12 byte `0x02` and `0x03` payloads.

`cargo test --bin unsloth-studio`: 360 passed, 0 failed.
