### PR TITLE
fix(studio): enable microphone/camera access in Linux WebKitGTK webview

### DIFF
--- a/studio/src-tauri/Cargo.lock
+++ b/studio/src-tauri/Cargo.lock
@@ -5759,6 +5759,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
  "windows 0.62.2",

--- a/studio/src-tauri/Cargo.toml
+++ b/studio/src-tauri/Cargo.toml
@@ -58,6 +58,7 @@ glib = "0.18"
 gtk = "0.18"
 elevated-command = "1.1.2"
 webkit2gtk-sys = "2.0.2"
+webkit2gtk = "2.0.2"
 
 [target.'cfg(windows)'.dependencies]
 # Keep these versions aligned with Tauri's WebView2 controller bindings.

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -800,6 +800,40 @@ fn setup_custom_titlebar(app: &tauri::App) -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
+// WebKitGTK ships two defaults that together break voice dictation on Linux:
+// `enable-media-stream` is off, and the stock `permission-request` handler
+// denies every request it never saw a listener override, including
+// microphone/camera grabs. Neither is fixable from outside the embedding
+// application, so opt in here and auto-allow only user-media requests --
+// every other permission kind (notifications, geolocation, ...) keeps the
+// default deny.
+#[cfg(target_os = "linux")]
+fn setup_linux_media_permissions(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    use webkit2gtk::{
+        glib::Cast, PermissionRequestExt, SettingsExt, UserMediaPermissionRequest, WebViewExt,
+    };
+
+    let window = app.get_webview_window("main").ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "main window not found")
+    })?;
+    window.with_webview(|webview| {
+        let webview = webview.inner();
+        if let Some(settings) = webview.settings() {
+            settings.set_enable_media_stream(true);
+        }
+        webview.connect_permission_request(|_webview, request| {
+            match request.downcast_ref::<UserMediaPermissionRequest>() {
+                Some(request) => {
+                    request.allow();
+                    true
+                }
+                None => false,
+            }
+        });
+    })?;
+    Ok(())
+}
+
 // Compile in both Windows profiles so dependency skew fails in CI, even though
 // the guard is installed only in release builds.
 #[cfg(windows)]
@@ -1902,6 +1936,8 @@ fn main() {
             }
             #[cfg(any(target_os = "windows", target_os = "linux"))]
             setup_custom_titlebar(app)?;
+            #[cfg(target_os = "linux")]
+            setup_linux_media_permissions(app)?;
             #[cfg(all(windows, not(debug_assertions)))]
             setup_windows_browser_guards(app)?;
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

Fixes #8678. On Linux, Unsloth Desktop cannot access the microphone for voice dictation: WebKitGTK ships two defaults that together block it, and neither can be worked around from outside the embedding application.

- `enable-media-stream` is off by default on `WebKitSettings`.
- The stock `permission-request` handler denies every request that has no listener override, including `UserMediaPermissionRequest`.

## Fix

Added `setup_linux_media_permissions`, called from the existing Linux setup path alongside `setup_custom_titlebar`:

- Enables `enable-media-stream` on the main window's webview settings.
- Connects to the `permission-request` signal and auto-allows only `UserMediaPermissionRequest` (mic/camera). Every other permission kind (notifications, geolocation, etc.) keeps WebKitGTK's default deny.

`webkit2gtk` (the safe bindings crate, distinct from the already-present `webkit2gtk-sys`) is added as a direct Linux dependency, pinned to `2.0.2` — the exact version already resolved transitively via `wry`, so `Cargo.lock` only gains one dependency edge with no version changes.

## Testing

- `cargo check` / `cargo clippy` / `cargo fmt --check` all pass cleanly on a real Linux build (Debian bookworm, with `libwebkit2gtk-4.1-dev`/`libgtk-3-dev` installed) — the platform-gated code doesn't compile at all on macOS/Windows hosts, so this was verified in a Linux container rather than locally.
- No new clippy warnings or formatting diffs introduced; the only pre-existing warnings are unrelated to this change.

Have not been able to test on real hardware with a microphone — happy to have the reporter (or anyone else) confirm the fix once a build is available, per their offer on the issue.